### PR TITLE
ARROW-5: Update drill-fmpp-maven-plugin to 1.5.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,8 +36,6 @@
     <forkCount>2</forkCount>
     <jackson.version>2.7.1</jackson.version>
     <hadoop.version>2.7.1</hadoop.version>
-    <fmpp.version>0.9.15</fmpp.version>
-    <freemarker.version>2.3.21</freemarker.version>
   </properties>
 
   <scm>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -106,23 +106,7 @@
       <plugin> <!-- generate sources from fmpp -->
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
-        <version>1.4.0</version>
-        <dependencies>
-          <!-- override ${fmpp.version} defined in drill-root.pom with ${fmpp.version} defined in arrow-java-root.pom -->
-          <!-- see ARROW-5 -->
-          <dependency>
-            <groupId>net.sourceforge.fmpp</groupId>
-            <artifactId>fmpp</artifactId>
-            <version>${fmpp.version}</version>
-          </dependency>
-          <!-- override ${freemarker.version} defined in drill-root.pom with ${freemarker.version} defined in arrow-java-root.pom -->
-          <!-- see ARROW-5 -->
-          <dependency>
-            <groupId>org.freemarker</groupId>
-            <artifactId>freemarker</artifactId>
-            <version>${freemarker.version}</version>
-          </dependency>
-        </dependencies>
+        <version>1.5.0</version>
         <executions>
           <execution>
             <id>generate-fmpp</id>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -107,6 +107,22 @@
         <groupId>org.apache.drill.tools</groupId>
         <artifactId>drill-fmpp-maven-plugin</artifactId>
         <version>1.4.0</version>
+        <dependencies>
+          <!-- override ${fmpp.version} defined in drill-root.pom with ${fmpp.version} defined in arrow-java-root.pom -->
+          <!-- see ARROW-5 -->
+          <dependency>
+            <groupId>net.sourceforge.fmpp</groupId>
+            <artifactId>fmpp</artifactId>
+            <version>${fmpp.version}</version>
+          </dependency>
+          <!-- override ${freemarker.version} defined in drill-root.pom with ${freemarker.version} defined in arrow-java-root.pom -->
+          <!-- see ARROW-5 -->
+          <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>${freemarker.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>generate-fmpp</id>


### PR DESCRIPTION
Currently when we run `maven install`,  we'll get:

> org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.drill.tools:drill-fmpp-maven-plugin:1.4.0:generate (generate-fmpp) on project vector: Execution generate-fmpp of goal org.apache.drill.tools:drill-fmpp-maven-plugin:1.4.0:generate failed: Plugin org.apache.drill.tools:drill-fmpp-maven-plugin:1.4.0 or one of its dependencies could not be resolved: Failure to find org.freemarker:freemarker:jar:2.3.24-SNAPSHOT in http://repository.apache.org/snapshots was cached in the local repository, resolution will not be reattempted until the update interval of apache.snapshots has elapsed or updates are forced

Reason is: the `freemaker.version` that takes effect is the one defined by `drill-fmpp-maven-plugin` 's dependency `drill-root`(which is `2.3.24-SNAPSHOT`), rather than the one defined by `arrow-java-root`(which is `2.3.21`).

This PR adds explicit dependencies on `fmpp` and `frermaker` for `drill-fmpp-maven-plugin`, making the `fmpp.version` and `freemaker.version` defined by `arrow-java-root` to take effect.
