### PR TITLE
ARROW-15: Fix a naming typo for memory.AllocationManager.AllocationOutcome

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
@@ -247,7 +247,7 @@ class Accountant implements AutoCloseable {
     /**
      * Allocation succeeded but only because the allocator was forced to move beyond a limit.
      */
-    FORCED_SUCESS(true),
+    FORCED_SUCCESS(true),
 
     /**
      * Allocation failed because the local allocator's limits were exceeded.


### PR DESCRIPTION
Rename FORCED_SUCESS to FORCED_SUC**_C_**ESS in memory.AllocationManager.AllocationOutcome.
