### PR TITLE
ARROW-8: Add .travis.yml and test script for Arrow C++. OS X build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+sudo: required
+dist: trusty
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    - kalakris-cmake
+    packages:
+    - gcc-4.9   # Needed for C++11
+    - g++-4.9   # Needed for C++11
+    - gcov
+    - cmake
+    - valgrind
+
+matrix:
+  include:
+  - compiler: gcc
+    language: cpp
+    os: linux
+    script:
+    - $TRAVIS_BUILD_DIR/ci/travis_script_cpp.sh
+  - compiler: clang
+    language: cpp
+    os: osx
+    addons:
+    script:
+    - $TRAVIS_BUILD_DIR/ci/travis_script_cpp.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 ## Apache Arrow
 
+<table>
+  <tr>
+    <td>Build Status</td>
+    <td>
+    <a href="https://travis-ci.org/apache/arrow">
+    <img src="https://travis-ci.org/apache/arrow.svg?branch=master" alt="travis build status" />
+    </a>
+    </td>
+  </tr>
+</table>
+
 #### Powering Columnar In-Memory Analytics
 
 Arrow is a set of technologies that enable big-data systems to process and move data fast.

--- a/ci/travis_script_cpp.sh
+++ b/ci/travis_script_cpp.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+
+mkdir $TRAVIS_BUILD_DIR/cpp-build
+pushd $TRAVIS_BUILD_DIR/cpp-build
+
+CPP_DIR=$TRAVIS_BUILD_DIR/cpp
+
+# Build an isolated thirdparty
+cp -r $CPP_DIR/thirdparty .
+cp $CPP_DIR/setup_build_env.sh .
+
+if [ $TRAVIS_OS_NAME == "linux" ]; then
+  # Use a C++11 compiler on Linux
+  export CC="gcc-4.9"
+  export CXX="g++-4.9"
+fi
+
+source setup_build_env.sh
+
+echo $GTEST_HOME
+
+cmake -DCMAKE_CXX_FLAGS="-Werror" $CPP_DIR
+make lint
+make -j4
+
+if [ $TRAVIS_OS_NAME == "linux" ]; then
+  valgrind --tool=memcheck --leak-check=yes --error-exitcode=1 ctest
+else
+  ctest
+fi
+
+popd
+rm -rf cpp-build

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -44,6 +44,11 @@ if (NOT "$ENV{ARROW_GCC_ROOT}" STREQUAL "")
   set(CMAKE_CXX_COMPILER ${GCC_ROOT}/bin/g++)
 endif()
 
+if(APPLE)
+  # In newer versions of CMake, this is the default setting
+  set(CMAKE_MACOSX_RPATH 1)
+endif()
+
 # ----------------------------------------------------------------------
 # cmake options
 
@@ -68,19 +73,15 @@ endif()
 ############################################################
 
 # compiler flags that are common across debug/release builds
-#  - msse4.2: Enable sse4.2 compiler intrinsics.
 #  - Wall: Enable all warnings.
-#  - Wno-sign-compare: suppress warnings for comparison between signed and unsigned
-#    integers
-#  -Wno-deprecated: some of the gutil code includes old things like ext/hash_set, ignore that
-#  - pthread: enable multithreaded malloc
-#  - -D__STDC_FORMAT_MACROS: for PRI* print format macros
-#  -fno-strict-aliasing
-#     Assume programs do not follow strict aliasing rules.
-#     GCC cannot always verify whether strict aliasing rules are indeed followed due to
-#     fundamental limitations in escape analysis, which can result in subtle bad code generation.
-#     This has a small perf hit but worth it to avoid hard to debug crashes.
-set(CXX_COMMON_FLAGS "-std=c++11 -fno-strict-aliasing -msse3 -Wall -Wno-deprecated -pthread -D__STDC_FORMAT_MACROS")
+set(CXX_COMMON_FLAGS "-std=c++11 -msse3 -Wall")
+
+if (APPLE)
+  # Depending on the default OSX_DEPLOYMENT_TARGET (< 10.9), libstdc++ may be
+  # the default standard library which does not support C++11. libc++ is the
+  # default from 10.9 onward.
+  set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -stdlib=libc++")
+endif()
 
 # compiler flags for different build types (run 'cmake -DCMAKE_BUILD_TYPE=<type> .')
 # For all builds:
@@ -157,10 +158,6 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
   else()
     message("Running without a controlling terminal or in a dumb terminal")
   endif()
-
-  # Use libstdc++ and not libc++. The latter lacks support for tr1 in OSX
-  # and since 10.9 is now the default.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
 endif()
 
 # Sanity check linking option.
@@ -473,11 +470,15 @@ set(ARROW_SRCS
   src/arrow/type.cc
 )
 
-add_library(arrow SHARED
+set(LIBARROW_LINKAGE "SHARED")
+
+add_library(arrow
+  ${LIBARROW_LINKAGE}
   ${ARROW_SRCS}
 )
 target_link_libraries(arrow ${LINK_LIBS})
 set_target_properties(arrow PROPERTIES LINKER_LANGUAGE CXX)
 
 install(TARGETS arrow
-  LIBRARY DESTINATION lib)
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)

--- a/cpp/setup_build_env.sh
+++ b/cpp/setup_build_env.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-set -e
-
 SOURCE_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 
 ./thirdparty/download_thirdparty.sh
 ./thirdparty/build_thirdparty.sh
+source thirdparty/versions.sh
 
 export GTEST_HOME=$SOURCE_DIR/thirdparty/$GTEST_BASEDIR
 

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -26,7 +26,7 @@ set(UTIL_SRCS
 )
 
 set(UTIL_LIBS
-  rt)
+)
 
 add_library(arrow_util STATIC
   ${UTIL_SRCS}


### PR DESCRIPTION
I added Linux and OS X Travis builds for arrow-cpp. There were some build configuration issues for OS X that I had to fix to get the build passing. 
