### PR TITLE
ARROW-20: Add null_count_ member to array containers, remove nullable_ member

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 # For CMAKE_BUILD_TYPE=Release
 #   -O3: Enable all compiler optimizations
 #   -g: Enable symbols for profiler tools (TODO: remove for shipping)
-set(CXX_FLAGS_DEBUG "-ggdb")
+set(CXX_FLAGS_DEBUG "-ggdb -O0")
 set(CXX_FLAGS_FASTDEBUG "-ggdb -O1")
 set(CXX_FLAGS_RELEASE "-O3 -g -DNDEBUG")
 

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -17,6 +17,8 @@
 
 #include "arrow/array.h"
 
+#include <cstdint>
+
 #include "arrow/util/buffer.h"
 
 namespace arrow {
@@ -24,18 +26,17 @@ namespace arrow {
 // ----------------------------------------------------------------------
 // Base array class
 
-Array::Array(const TypePtr& type, int64_t length,
+Array::Array(const TypePtr& type, int32_t length, int32_t null_count,
     const std::shared_ptr<Buffer>& nulls) {
-  Init(type, length, nulls);
+  Init(type, length, null_count, nulls);
 }
 
-void Array::Init(const TypePtr& type, int64_t length,
+void Array::Init(const TypePtr& type, int32_t length, int32_t null_count,
     const std::shared_ptr<Buffer>& nulls) {
   type_ = type;
   length_ = length;
+  null_count_ = null_count;
   nulls_ = nulls;
-
-  nullable_ = type->nullable;
   if (nulls_) {
     null_bits_ = nulls_->data();
   }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -25,34 +25,29 @@
 
 namespace arrow {
 
-Status ArrayBuilder::Init(int64_t capacity) {
+Status ArrayBuilder::Init(int32_t capacity) {
   capacity_ = capacity;
+  int32_t to_alloc = util::ceil_byte(capacity) / 8;
+  nulls_ = std::make_shared<PoolBuffer>(pool_);
+  RETURN_NOT_OK(nulls_->Resize(to_alloc));
+  null_bits_ = nulls_->mutable_data();
+  memset(null_bits_, 0, to_alloc);
+  return Status::OK();
+}
 
-  if (nullable_) {
-    int64_t to_alloc = util::ceil_byte(capacity) / 8;
-    nulls_ = std::make_shared<PoolBuffer>(pool_);
-    RETURN_NOT_OK(nulls_->Resize(to_alloc));
-    null_bits_ = nulls_->mutable_data();
-    memset(null_bits_, 0, to_alloc);
+Status ArrayBuilder::Resize(int32_t new_bits) {
+  int32_t new_bytes = util::ceil_byte(new_bits) / 8;
+  int32_t old_bytes = nulls_->size();
+  RETURN_NOT_OK(nulls_->Resize(new_bytes));
+  null_bits_ = nulls_->mutable_data();
+  if (old_bytes < new_bytes) {
+    memset(null_bits_ + old_bytes, 0, new_bytes - old_bytes);
   }
   return Status::OK();
 }
 
-Status ArrayBuilder::Resize(int64_t new_bits) {
-  if (nullable_) {
-    int64_t new_bytes = util::ceil_byte(new_bits) / 8;
-    int64_t old_bytes = nulls_->size();
-    RETURN_NOT_OK(nulls_->Resize(new_bytes));
-    null_bits_ = nulls_->mutable_data();
-    if (old_bytes < new_bytes) {
-      memset(null_bits_ + old_bytes, 0, new_bytes - old_bytes);
-    }
-  }
-  return Status::OK();
-}
-
-Status ArrayBuilder::Advance(int64_t elements) {
-  if (nullable_ && length_ + elements > capacity_) {
+Status ArrayBuilder::Advance(int32_t elements) {
+  if (length_ + elements > capacity_) {
     return Status::Invalid("Builder must be expanded");
   }
   length_ += elements;

--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -84,6 +84,16 @@ void random_nulls(int64_t n, double pct_null, std::vector<bool>* nulls) {
   }
 }
 
+static inline int null_count(const std::vector<uint8_t>& nulls) {
+  int result = 0;
+  for (size_t i = 0; i < nulls.size(); ++i) {
+    if (nulls[i] > 0) {
+      ++result;
+    }
+  }
+  return result;
+}
+
 std::shared_ptr<Buffer> bytes_to_null_buffer(uint8_t* bytes, int length) {
   std::shared_ptr<Buffer> out;
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -57,11 +57,9 @@ struct LayoutType {
 // either a primitive physical type (bytes or bits of some fixed size), a
 // nested type consisting of other data types, or another data type (e.g. a
 // timestamp encoded as an int64)
-//
-// Any data type can be nullable
 
 enum class TypeEnum: char {
-  // A degerate NULL type represented as 0 bytes/bits
+  // A degenerate NULL type represented as 0 bytes/bits
   NA = 0,
 
   // Little-endian integer types
@@ -138,14 +136,12 @@ enum class TypeEnum: char {
 
 struct DataType {
   TypeEnum type;
-  bool nullable;
 
-  explicit DataType(TypeEnum type, bool nullable = true)
-      : type(type), nullable(nullable) {}
+  explicit DataType(TypeEnum type)
+      : type(type) {}
 
   virtual bool Equals(const DataType* other) {
-    return (this == other) || (this->type == other->type &&
-        this->nullable == other->nullable);
+    return this == other || this->type == other->type;
   }
 
   virtual std::string ToString() const = 0;

--- a/cpp/src/arrow/types/collection.h
+++ b/cpp/src/arrow/types/collection.h
@@ -29,7 +29,7 @@ template <TypeEnum T>
 struct CollectionType : public DataType {
   std::vector<TypePtr> child_types_;
 
-  explicit CollectionType(bool nullable = true) : DataType(T, nullable) {}
+  CollectionType() : DataType(T) {}
 
   const TypePtr& child(int i) const {
     return child_types_[i];

--- a/cpp/src/arrow/types/datetime.h
+++ b/cpp/src/arrow/types/datetime.h
@@ -31,12 +31,12 @@ struct DateType : public DataType {
 
   Unit unit;
 
-  explicit DateType(Unit unit = Unit::DAY, bool nullable = true)
-      : DataType(TypeEnum::DATE, nullable),
+  explicit DateType(Unit unit = Unit::DAY)
+      : DataType(TypeEnum::DATE),
         unit(unit) {}
 
   DateType(const DateType& other)
-      : DateType(other.unit, other.nullable) {}
+      : DateType(other.unit) {}
 
   static char const *name() {
     return "date";
@@ -58,12 +58,12 @@ struct TimestampType : public DataType {
 
   Unit unit;
 
-  explicit TimestampType(Unit unit = Unit::MILLI, bool nullable = true)
-      : DataType(TypeEnum::TIMESTAMP, nullable),
+  explicit TimestampType(Unit unit = Unit::MILLI)
+      : DataType(TypeEnum::TIMESTAMP),
         unit(unit) {}
 
   TimestampType(const TimestampType& other)
-      : TimestampType(other.unit, other.nullable) {}
+      : TimestampType(other.unit) {}
 
   static char const *name() {
     return "timestamp";

--- a/cpp/src/arrow/types/json.h
+++ b/cpp/src/arrow/types/json.h
@@ -28,8 +28,8 @@ struct JSONScalar : public DataType {
   static TypePtr dense_type;
   static TypePtr sparse_type;
 
-  explicit JSONScalar(bool dense = true, bool nullable = true)
-      : DataType(TypeEnum::JSON_SCALAR, nullable),
+  explicit JSONScalar(bool dense = true)
+      : DataType(TypeEnum::JSON_SCALAR),
         dense(dense) {}
 };
 

--- a/cpp/src/arrow/types/list-test.cc
+++ b/cpp/src/arrow/types/list-test.cc
@@ -44,11 +44,7 @@ TEST(TypesTest, TestListType) {
   std::shared_ptr<DataType> vt = std::make_shared<UInt8Type>();
 
   ListType list_type(vt);
-  ListType list_type_nn(vt, false);
-
   ASSERT_EQ(list_type.type, TypeEnum::LIST);
-  ASSERT_TRUE(list_type.nullable);
-  ASSERT_FALSE(list_type_nn.nullable);
 
   ASSERT_EQ(list_type.name(), string("list"));
   ASSERT_EQ(list_type.ToString(), string("list<uint8>"));
@@ -132,8 +128,8 @@ TEST_F(TestListBuilder, TestBasics) {
 
   Done();
 
-  ASSERT_TRUE(result_->nullable());
-  ASSERT_TRUE(result_->values()->nullable());
+  ASSERT_EQ(1, result_->null_count());
+  ASSERT_EQ(0, result_->values()->null_count());
 
   ASSERT_EQ(3, result_->length());
   vector<int32_t> ex_offsets = {0, 3, 3, 7};
@@ -152,10 +148,6 @@ TEST_F(TestListBuilder, TestBasics) {
     ASSERT_EQ(values[i], varr->Value(i));
   }
 }
-
-TEST_F(TestListBuilder, TestBasicsNonNullable) {
-}
-
 
 TEST_F(TestListBuilder, TestZeroLength) {
   // All buffers are null

--- a/cpp/src/arrow/types/primitive.cc
+++ b/cpp/src/arrow/types/primitive.cc
@@ -26,20 +26,23 @@ namespace arrow {
 // ----------------------------------------------------------------------
 // Primitive array base
 
-void PrimitiveArray::Init(const TypePtr& type, int64_t length,
+void PrimitiveArray::Init(const TypePtr& type, int32_t length,
     const std::shared_ptr<Buffer>& data,
+    int32_t null_count,
     const std::shared_ptr<Buffer>& nulls) {
-  Array::Init(type, length, nulls);
+  Array::Init(type, length, null_count, nulls);
   data_ = data;
   raw_data_ = data == nullptr? nullptr : data_->data();
 }
 
 bool PrimitiveArray::Equals(const PrimitiveArray& other) const {
   if (this == &other) return true;
-  if (type_->nullable != other.type_->nullable) return false;
+  if (null_count_ != other.null_count_) {
+    return false;
+  }
 
   bool equal_data = data_->Equals(*other.data_, length_);
-  if (type_->nullable) {
+  if (null_count_ > 0) {
     return equal_data &&
       nulls_->Equals(*other.nulls_, util::ceil_byte(length_) / 8);
   } else {

--- a/cpp/src/arrow/types/string.cc
+++ b/cpp/src/arrow/types/string.cc
@@ -35,6 +35,6 @@ std::string VarcharType::ToString() const {
   return s.str();
 }
 
-TypePtr StringBuilder::value_type_ = TypePtr(new UInt8Type(false));
+TypePtr StringBuilder::value_type_ = TypePtr(new UInt8Type());
 
 } // namespace arrow

--- a/cpp/src/arrow/types/struct-test.cc
+++ b/cpp/src/arrow/types/struct-test.cc
@@ -43,11 +43,7 @@ TEST(TestStructType, Basics) {
 
   vector<Field> fields = {f0, f1, f2};
 
-  StructType struct_type(fields, true);
-  StructType struct_type_nn(fields, false);
-
-  ASSERT_TRUE(struct_type.nullable);
-  ASSERT_FALSE(struct_type_nn.nullable);
+  StructType struct_type(fields);
 
   ASSERT_TRUE(struct_type.field(0).Equals(f0));
   ASSERT_TRUE(struct_type.field(1).Equals(f1));

--- a/cpp/src/arrow/types/struct.h
+++ b/cpp/src/arrow/types/struct.h
@@ -29,9 +29,8 @@ namespace arrow {
 struct StructType : public DataType {
   std::vector<Field> fields_;
 
-  StructType(const std::vector<Field>& fields,
-      bool nullable = true)
-      : DataType(TypeEnum::STRUCT, nullable) {
+  explicit StructType(const std::vector<Field>& fields)
+      : DataType(TypeEnum::STRUCT) {
     fields_ = fields;
   }
 

--- a/cpp/src/arrow/types/test-common.h
+++ b/cpp/src/arrow/types/test-common.h
@@ -36,15 +36,13 @@ class TestBuilder : public ::testing::Test {
   void SetUp() {
     pool_ = GetDefaultMemoryPool();
     type_ = TypePtr(new UInt8Type());
-    type_nn_ = TypePtr(new UInt8Type(false));
     builder_.reset(new UInt8Builder(pool_, type_));
-    builder_nn_.reset(new UInt8Builder(pool_, type_nn_));
+    builder_nn_.reset(new UInt8Builder(pool_, type_));
   }
  protected:
   MemoryPool* pool_;
 
   TypePtr type_;
-  TypePtr type_nn_;
   unique_ptr<ArrayBuilder> builder_;
   unique_ptr<ArrayBuilder> builder_nn_;
 };

--- a/cpp/src/arrow/types/union.h
+++ b/cpp/src/arrow/types/union.h
@@ -33,9 +33,8 @@ class Buffer;
 struct DenseUnionType : public CollectionType<TypeEnum::DENSE_UNION> {
   typedef CollectionType<TypeEnum::DENSE_UNION> Base;
 
-  DenseUnionType(const std::vector<TypePtr>& child_types,
-      bool nullable = true)
-      : Base(nullable) {
+  explicit DenseUnionType(const std::vector<TypePtr>& child_types) :
+      Base() {
     child_types_ = child_types;
   }
 
@@ -46,9 +45,8 @@ struct DenseUnionType : public CollectionType<TypeEnum::DENSE_UNION> {
 struct SparseUnionType : public CollectionType<TypeEnum::SPARSE_UNION> {
   typedef CollectionType<TypeEnum::SPARSE_UNION> Base;
 
-  SparseUnionType(const std::vector<TypePtr>& child_types,
-      bool nullable = true)
-      : Base(nullable) {
+  explicit SparseUnionType(const std::vector<TypePtr>& child_types) :
+      Base() {
     child_types_ = child_types;
   }
 

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -25,7 +25,9 @@ namespace arrow {
 
 void util::bytes_to_bits(uint8_t* bytes, int length, uint8_t* bits) {
   for (int i = 0; i < length; ++i) {
-    set_bit(bits, i, static_cast<bool>(bytes[i]));
+    if (static_cast<bool>(bytes[i])) {
+      set_bit(bits, i);
+    }
   }
 }
 

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -41,8 +41,8 @@ static inline bool get_bit(const uint8_t* bits, int i) {
   return bits[i / 8] & (1 << (i % 8));
 }
 
-static inline void set_bit(uint8_t* bits, int i, bool is_set) {
-  bits[i / 8] |= (1 << (i % 8)) * is_set;
+static inline void set_bit(uint8_t* bits, int i) {
+  bits[i / 8] |= 1 << (i % 8);
 }
 
 static inline int64_t next_power2(int64_t n) {


### PR DESCRIPTION
Based off of ARROW-19.

After some contemplation / discussion, I believe it would be better to track nullability at the schema metadata level (if at all!) rather than making it a property of the data structures. This allows the data containers to be "plain ol' data" and thus both nullable data with `null_count == 0` and non-nullable data (implicitly `null_count == 0`) can be treated as semantically equivalent in algorithms code. 

If it is deemed useful we can validate (cheaply) that physical data meets the metadata requirements (e.g. non-nullable type metadata cannot be associated with data containers having nulls). 
