### PR TITLE
ARROW-21: Implement a simple in-memory Schema data structure

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -467,6 +467,8 @@ set(LINK_LIBS
 set(ARROW_SRCS
   src/arrow/array.cc
   src/arrow/builder.cc
+  src/arrow/field.cc
+  src/arrow/schema.cc
   src/arrow/type.cc
 )
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -30,4 +30,4 @@ install(FILES
 set(ARROW_TEST_LINK_LIBS arrow_test_util ${ARROW_MIN_TEST_LIBS})
 
 ADD_ARROW_TEST(array-test)
-ADD_ARROW_TEST(field-test)
+ADD_ARROW_TEST(schema-test)

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -62,8 +62,8 @@ class Array {
   int32_t length() const { return length_;}
   int32_t null_count() const { return null_count_;}
 
-  const TypePtr& type() const { return type_;}
-  TypeEnum type_enum() const { return type_->type;}
+  const std::shared_ptr<DataType>& type() const { return type_;}
+  LogicalType::type logical_type() const { return type_->type;}
 
   const std::shared_ptr<Buffer>& nulls() const {
     return nulls_;

--- a/cpp/src/arrow/field.cc
+++ b/cpp/src/arrow/field.cc
@@ -15,24 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
-#include <memory>
-#include <string>
-
 #include "arrow/field.h"
-#include "arrow/type.h"
-#include "arrow/types/integer.h"
 
-using std::string;
+#include <sstream>
+#include <string>
 
 namespace arrow {
 
-TEST(TestField, Basics) {
-  TypePtr ftype = TypePtr(new Int32Type());
-  Field f0("f0", ftype);
-
-  ASSERT_EQ(f0.name, "f0");
-  ASSERT_EQ(f0.type->ToString(), ftype->ToString());
+std::string Field::ToString() const {
+  std::stringstream ss;
+  ss << this->name << " " << this->type->ToString();
+  return ss.str();
 }
 
 } // namespace arrow

--- a/cpp/src/arrow/field.h
+++ b/cpp/src/arrow/field.h
@@ -35,12 +35,27 @@ struct Field {
   TypePtr type;
 
   Field(const std::string& name, const TypePtr& type) :
-      name(name), type(type) {}
+      name(name),
+      type(type) {}
+
+  bool operator==(const Field& other) const {
+    return this->Equals(other);
+  }
+
+  bool operator!=(const Field& other) const {
+    return !this->Equals(other);
+  }
 
   bool Equals(const Field& other) const {
     return (this == &other) || (this->name == other.name &&
         this->type->Equals(other.type.get()));
   }
+
+  bool nullable() const {
+    return this->type->nullable;
+  }
+
+  std::string ToString() const;
 };
 
 } // namespace arrow

--- a/cpp/src/arrow/schema-test.cc
+++ b/cpp/src/arrow/schema-test.cc
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/field.h"
+#include "arrow/schema.h"
+#include "arrow/type.h"
+#include "arrow/types/string.h"
+
+using std::shared_ptr;
+using std::vector;
+
+namespace arrow {
+
+TEST(TestField, Basics) {
+  shared_ptr<DataType> ftype = std::make_shared<Int32Type>();
+  shared_ptr<DataType> ftype_nn = std::make_shared<Int32Type>(false);
+  Field f0("f0", ftype);
+  Field f0_nn("f0", ftype_nn);
+
+  ASSERT_EQ(f0.name, "f0");
+  ASSERT_EQ(f0.type->ToString(), ftype->ToString());
+
+  ASSERT_TRUE(f0.nullable());
+  ASSERT_FALSE(f0_nn.nullable());
+}
+
+TEST(TestField, Equals) {
+  shared_ptr<DataType> ftype = std::make_shared<Int32Type>();
+  shared_ptr<DataType> ftype_nn = std::make_shared<Int32Type>(false);
+
+  Field f0("f0", ftype);
+  Field f0_nn("f0", ftype_nn);
+  Field f0_other("f0", ftype);
+
+  ASSERT_EQ(f0, f0_other);
+  ASSERT_NE(f0, f0_nn);
+}
+
+class TestSchema : public ::testing::Test {
+ public:
+  void SetUp() {}
+};
+
+TEST_F(TestSchema, Basics) {
+  auto f0 = std::make_shared<Field>("f0", std::make_shared<Int32Type>());
+
+  auto f1 = std::make_shared<Field>("f1", std::make_shared<UInt8Type>(false));
+  auto f1_optional = std::make_shared<Field>("f1", std::make_shared<UInt8Type>());
+
+  auto f2 = std::make_shared<Field>("f2", std::make_shared<StringType>());
+
+  vector<shared_ptr<Field> > fields = {f0, f1, f2};
+  auto schema = std::make_shared<Schema>(fields);
+
+  ASSERT_EQ(3, schema->num_fields());
+  ASSERT_EQ(f0, schema->field(0));
+  ASSERT_EQ(f1, schema->field(1));
+  ASSERT_EQ(f2, schema->field(2));
+
+  auto schema2 = std::make_shared<Schema>(fields);
+
+  vector<shared_ptr<Field> > fields3 = {f0, f1_optional, f2};
+  auto schema3 = std::make_shared<Schema>(fields3);
+  ASSERT_TRUE(schema->Equals(schema2));
+  ASSERT_FALSE(schema->Equals(schema3));
+
+  ASSERT_TRUE(schema->Equals(*schema2.get()));
+  ASSERT_FALSE(schema->Equals(*schema3.get()));
+}
+
+TEST_F(TestSchema, ToString) {
+  auto f0 = std::make_shared<Field>("f0", std::make_shared<Int32Type>());
+  auto f1 = std::make_shared<Field>("f1", std::make_shared<UInt8Type>(false));
+  auto f2 = std::make_shared<Field>("f2", std::make_shared<StringType>());
+  auto f3 = std::make_shared<Field>("f3",
+      std::make_shared<ListType>(std::make_shared<Int16Type>()));
+
+  vector<shared_ptr<Field> > fields = {f0, f1, f2, f3};
+  auto schema = std::make_shared<Schema>(fields);
+
+  std::string result = schema->ToString();
+  std::string expected = R"(f0 ?int32
+f1 uint8
+f2 ?string
+f3 ?list<?int16>
+)";
+
+  ASSERT_EQ(expected, result);
+}
+
+} // namespace arrow

--- a/cpp/src/arrow/schema.cc
+++ b/cpp/src/arrow/schema.cc
@@ -15,16 +15,44 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_TYPES_BINARY_H
-#define ARROW_TYPES_BINARY_H
+#include "arrow/schema.h"
 
+#include <memory>
 #include <string>
+#include <sstream>
 #include <vector>
 
-#include "arrow/type.h"
+#include "arrow/field.h"
 
 namespace arrow {
 
-} // namespace arrow
+Schema::Schema(const std::vector<std::shared_ptr<Field> >& fields) :
+    fields_(fields) {}
 
-#endif // ARROW_TYPES_BINARY_H
+bool Schema::Equals(const Schema& other) const {
+  if (this == &other) return true;
+  if (num_fields() != other.num_fields()) {
+    return false;
+  }
+  for (int i = 0; i < num_fields(); ++i) {
+    if (!field(i)->Equals(*other.field(i).get())) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Schema::Equals(const std::shared_ptr<Schema>& other) const {
+  return Equals(*other.get());
+}
+
+std::string Schema::ToString() const {
+  std::stringstream buffer;
+
+  for (auto field : fields_) {
+    buffer << field->ToString() << std::endl;
+  }
+  return buffer.str();
+}
+
+} // namespace arrow

--- a/cpp/src/arrow/schema.h
+++ b/cpp/src/arrow/schema.h
@@ -15,16 +15,42 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_TYPES_BINARY_H
-#define ARROW_TYPES_BINARY_H
+#ifndef ARROW_SCHEMA_H
+#define ARROW_SCHEMA_H
 
+#include <memory>
 #include <string>
 #include <vector>
 
+#include "arrow/field.h"
 #include "arrow/type.h"
 
 namespace arrow {
 
+class Schema {
+ public:
+  explicit Schema(const std::vector<std::shared_ptr<Field> >& fields);
+
+  // Returns true if all of the schema fields are equal
+  bool Equals(const Schema& other) const;
+  bool Equals(const std::shared_ptr<Schema>& other) const;
+
+  // Return the ith schema element. Does not boundscheck
+  const std::shared_ptr<Field>& field(int i) const {
+    return fields_[i];
+  }
+
+  // Render a string representation of the schema suitable for debugging
+  std::string ToString() const;
+
+  int num_fields() const {
+    return fields_.size();
+  }
+
+ private:
+  std::vector<std::shared_ptr<Field> > fields_;
+};
+
 } // namespace arrow
 
-#endif // ARROW_TYPES_BINARY_H
+#endif  // ARROW_FIELD_H

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -52,96 +52,98 @@ struct LayoutType {
   explicit LayoutType(LayoutEnum type) : type(type) {}
 };
 
-
 // Data types in this library are all *logical*. They can be expressed as
 // either a primitive physical type (bytes or bits of some fixed size), a
 // nested type consisting of other data types, or another data type (e.g. a
 // timestamp encoded as an int64)
+struct LogicalType {
+  enum type {
+    // A degenerate NULL type represented as 0 bytes/bits
+    NA = 0,
 
-enum class TypeEnum: char {
-  // A degenerate NULL type represented as 0 bytes/bits
-  NA = 0,
+    // Little-endian integer types
+    UINT8 = 1,
+    INT8 = 2,
+    UINT16 = 3,
+    INT16 = 4,
+    UINT32 = 5,
+    INT32 = 6,
+    UINT64 = 7,
+    INT64 = 8,
 
-  // Little-endian integer types
-  UINT8 = 1,
-  INT8 = 2,
-  UINT16 = 3,
-  INT16 = 4,
-  UINT32 = 5,
-  INT32 = 6,
-  UINT64 = 7,
-  INT64 = 8,
+    // A boolean value represented as 1 byte
+    BOOL = 9,
 
-  // A boolean value represented as 1 byte
-  BOOL = 9,
+    // A boolean value represented as 1 bit
+    BIT = 10,
 
-  // A boolean value represented as 1 bit
-  BIT = 10,
+    // 4-byte floating point value
+    FLOAT = 11,
 
-  // 4-byte floating point value
-  FLOAT = 11,
+    // 8-byte floating point value
+    DOUBLE = 12,
 
-  // 8-byte floating point value
-  DOUBLE = 12,
+    // CHAR(N): fixed-length UTF8 string with length N
+    CHAR = 13,
 
-  // CHAR(N): fixed-length UTF8 string with length N
-  CHAR = 13,
+    // UTF8 variable-length string as List<Char>
+    STRING = 14,
 
-  // UTF8 variable-length string as List<Char>
-  STRING = 14,
+    // VARCHAR(N): Null-terminated string type embedded in a CHAR(N + 1)
+    VARCHAR = 15,
 
-  // VARCHAR(N): Null-terminated string type embedded in a CHAR(N + 1)
-  VARCHAR = 15,
+    // Variable-length bytes (no guarantee of UTF8-ness)
+    BINARY = 16,
 
-  // Variable-length bytes (no guarantee of UTF8-ness)
-  BINARY = 16,
+    // By default, int32 days since the UNIX epoch
+    DATE = 17,
 
-  // By default, int32 days since the UNIX epoch
-  DATE = 17,
+    // Exact timestamp encoded with int64 since UNIX epoch
+    // Default unit millisecond
+    TIMESTAMP = 18,
 
-  // Exact timestamp encoded with int64 since UNIX epoch
-  // Default unit millisecond
-  TIMESTAMP = 18,
+    // Timestamp as double seconds since the UNIX epoch
+    TIMESTAMP_DOUBLE = 19,
 
-  // Timestamp as double seconds since the UNIX epoch
-  TIMESTAMP_DOUBLE = 19,
+    // Exact time encoded with int64, default unit millisecond
+    TIME = 20,
 
-  // Exact time encoded with int64, default unit millisecond
-  TIME = 20,
+    // Precision- and scale-based decimal type. Storage type depends on the
+    // parameters.
+    DECIMAL = 21,
 
-  // Precision- and scale-based decimal type. Storage type depends on the
-  // parameters.
-  DECIMAL = 21,
+    // Decimal value encoded as a text string
+    DECIMAL_TEXT = 22,
 
-  // Decimal value encoded as a text string
-  DECIMAL_TEXT = 22,
+    // A list of some logical data type
+    LIST = 30,
 
-  // A list of some logical data type
-  LIST = 30,
+    // Struct of logical types
+    STRUCT = 31,
 
-  // Struct of logical types
-  STRUCT = 31,
+    // Unions of logical types
+    DENSE_UNION = 32,
+    SPARSE_UNION = 33,
 
-  // Unions of logical types
-  DENSE_UNION = 32,
-  SPARSE_UNION = 33,
+    // Union<Null, Int32, Double, String, Bool>
+    JSON_SCALAR = 50,
 
-  // Union<Null, Int32, Double, String, Bool>
-  JSON_SCALAR = 50,
-
-  // User-defined type
-  USER = 60
+    // User-defined type
+    USER = 60
+  };
 };
 
-
 struct DataType {
-  TypeEnum type;
+  LogicalType::type type;
+  bool nullable;
 
-  explicit DataType(TypeEnum type)
-      : type(type) {}
+  explicit DataType(LogicalType::type type, bool nullable = true) :
+      type(type),
+      nullable(nullable) {}
 
   virtual bool Equals(const DataType* other) {
-    return this == other || this->type == other->type;
+    return this == other || (this->type == other->type &&
+        this->nullable == other->nullable);
   }
 
   virtual std::string ToString() const = 0;
@@ -169,6 +171,77 @@ struct ListLayoutType : public LayoutType {
   explicit ListLayoutType(const LayoutPtr& value_type)
       : LayoutType(LayoutEnum::BYTE),
         value_type(value_type) {}
+};
+
+template <typename Derived>
+struct PrimitiveType : public DataType {
+  explicit PrimitiveType(bool nullable = true)
+      : DataType(Derived::type_enum, nullable) {}
+
+  virtual std::string ToString() const {
+    std::string result;
+    if (nullable) {
+      result.append("?");
+    }
+    result.append(static_cast<const Derived*>(this)->name());
+    return result;
+  }
+};
+
+#define PRIMITIVE_DECL(TYPENAME, C_TYPE, ENUM, SIZE, NAME)          \
+  typedef C_TYPE c_type;                                            \
+  static constexpr LogicalType::type type_enum = LogicalType::ENUM; \
+  static constexpr int size = SIZE;                                 \
+                                                                    \
+  explicit TYPENAME(bool nullable = true)                           \
+      : PrimitiveType<TYPENAME>(nullable) {}                        \
+                                                                    \
+  static const char* name() {                                       \
+    return NAME;                                                    \
+  }
+
+struct BooleanType : public PrimitiveType<BooleanType> {
+  PRIMITIVE_DECL(BooleanType, uint8_t, BOOL, 1, "bool");
+};
+
+struct UInt8Type : public PrimitiveType<UInt8Type> {
+  PRIMITIVE_DECL(UInt8Type, uint8_t, UINT8, 1, "uint8");
+};
+
+struct Int8Type : public PrimitiveType<Int8Type> {
+  PRIMITIVE_DECL(Int8Type, int8_t, INT8, 1, "int8");
+};
+
+struct UInt16Type : public PrimitiveType<UInt16Type> {
+  PRIMITIVE_DECL(UInt16Type, uint16_t, UINT16, 2, "uint16");
+};
+
+struct Int16Type : public PrimitiveType<Int16Type> {
+  PRIMITIVE_DECL(Int16Type, int16_t, INT16, 2, "int16");
+};
+
+struct UInt32Type : public PrimitiveType<UInt32Type> {
+  PRIMITIVE_DECL(UInt32Type, uint32_t, UINT32, 4, "uint32");
+};
+
+struct Int32Type : public PrimitiveType<Int32Type> {
+  PRIMITIVE_DECL(Int32Type, int32_t, INT32, 4, "int32");
+};
+
+struct UInt64Type : public PrimitiveType<UInt64Type> {
+  PRIMITIVE_DECL(UInt64Type, uint64_t, UINT64, 8, "uint64");
+};
+
+struct Int64Type : public PrimitiveType<Int64Type> {
+  PRIMITIVE_DECL(Int64Type, int64_t, INT64, 8, "int64");
+};
+
+struct FloatType : public PrimitiveType<FloatType> {
+  PRIMITIVE_DECL(FloatType, float, FLOAT, 4, "float");
+};
+
+struct DoubleType : public PrimitiveType<DoubleType> {
+  PRIMITIVE_DECL(DoubleType, double, DOUBLE, 8, "double");
 };
 
 } // namespace arrow

--- a/cpp/src/arrow/types/boolean.h
+++ b/cpp/src/arrow/types/boolean.h
@@ -22,10 +22,6 @@
 
 namespace arrow {
 
-struct BooleanType : public PrimitiveType<BooleanType> {
-  PRIMITIVE_DECL(BooleanType, uint8_t, BOOL, 1, "bool");
-};
-
 typedef PrimitiveArrayImpl<BooleanType> BooleanArray;
 
 // typedef PrimitiveBuilder<BooleanType, BooleanArray> BooleanBuilder;

--- a/cpp/src/arrow/types/collection.h
+++ b/cpp/src/arrow/types/collection.h
@@ -25,7 +25,7 @@
 
 namespace arrow {
 
-template <TypeEnum T>
+template <LogicalType::type T>
 struct CollectionType : public DataType {
   std::vector<TypePtr> child_types_;
 

--- a/cpp/src/arrow/types/construct.cc
+++ b/cpp/src/arrow/types/construct.cc
@@ -33,7 +33,7 @@ class ArrayBuilder;
 // difficult
 
 #define BUILDER_CASE(ENUM, BuilderType)                                 \
-    case TypeEnum::ENUM:                                                \
+    case LogicalType::ENUM:                                             \
       *out = static_cast<ArrayBuilder*>(new BuilderType(pool, type));   \
       return Status::OK();
 
@@ -56,7 +56,7 @@ Status make_builder(MemoryPool* pool, const TypePtr& type,
 
     BUILDER_CASE(STRING, StringBuilder);
 
-    case TypeEnum::LIST:
+    case LogicalType::LIST:
       {
         ListType* list_type = static_cast<ListType*>(type.get());
         ArrayBuilder* value_builder;

--- a/cpp/src/arrow/types/datetime.h
+++ b/cpp/src/arrow/types/datetime.h
@@ -31,8 +31,8 @@ struct DateType : public DataType {
 
   Unit unit;
 
-  explicit DateType(Unit unit = Unit::DAY)
-      : DataType(TypeEnum::DATE),
+  explicit DateType(Unit unit = Unit::DAY, bool nullable = true)
+      : DataType(LogicalType::DATE, nullable),
         unit(unit) {}
 
   DateType(const DateType& other)
@@ -58,8 +58,8 @@ struct TimestampType : public DataType {
 
   Unit unit;
 
-  explicit TimestampType(Unit unit = Unit::MILLI)
-      : DataType(TypeEnum::TIMESTAMP),
+  explicit TimestampType(Unit unit = Unit::MILLI, bool nullable = true)
+      : DataType(LogicalType::TIMESTAMP, nullable),
         unit(unit) {}
 
   TimestampType(const TimestampType& other)

--- a/cpp/src/arrow/types/floating.h
+++ b/cpp/src/arrow/types/floating.h
@@ -21,16 +21,9 @@
 #include <string>
 
 #include "arrow/types/primitive.h"
+#include "arrow/type.h"
 
 namespace arrow {
-
-struct FloatType : public PrimitiveType<FloatType> {
-  PRIMITIVE_DECL(FloatType, float, FLOAT, 4, "float");
-};
-
-struct DoubleType : public PrimitiveType<DoubleType> {
-  PRIMITIVE_DECL(DoubleType, double, DOUBLE, 8, "double");
-};
 
 typedef PrimitiveArrayImpl<FloatType> FloatArray;
 typedef PrimitiveArrayImpl<DoubleType> DoubleArray;

--- a/cpp/src/arrow/types/integer.h
+++ b/cpp/src/arrow/types/integer.h
@@ -22,40 +22,9 @@
 #include <string>
 
 #include "arrow/types/primitive.h"
+#include "arrow/type.h"
 
 namespace arrow {
-
-struct UInt8Type : public PrimitiveType<UInt8Type> {
-  PRIMITIVE_DECL(UInt8Type, uint8_t, UINT8, 1, "uint8");
-};
-
-struct Int8Type : public PrimitiveType<Int8Type> {
-  PRIMITIVE_DECL(Int8Type, int8_t, INT8, 1, "int8");
-};
-
-struct UInt16Type : public PrimitiveType<UInt16Type> {
-  PRIMITIVE_DECL(UInt16Type, uint16_t, UINT16, 2, "uint16");
-};
-
-struct Int16Type : public PrimitiveType<Int16Type> {
-  PRIMITIVE_DECL(Int16Type, int16_t, INT16, 2, "int16");
-};
-
-struct UInt32Type : public PrimitiveType<UInt32Type> {
-  PRIMITIVE_DECL(UInt32Type, uint32_t, UINT32, 4, "uint32");
-};
-
-struct Int32Type : public PrimitiveType<Int32Type> {
-  PRIMITIVE_DECL(Int32Type, int32_t, INT32, 4, "int32");
-};
-
-struct UInt64Type : public PrimitiveType<UInt64Type> {
-  PRIMITIVE_DECL(UInt64Type, uint64_t, UINT64, 8, "uint64");
-};
-
-struct Int64Type : public PrimitiveType<Int64Type> {
-  PRIMITIVE_DECL(Int64Type, int64_t, INT64, 8, "int64");
-};
 
 // Array containers
 

--- a/cpp/src/arrow/types/json.h
+++ b/cpp/src/arrow/types/json.h
@@ -28,8 +28,8 @@ struct JSONScalar : public DataType {
   static TypePtr dense_type;
   static TypePtr sparse_type;
 
-  explicit JSONScalar(bool dense = true)
-      : DataType(TypeEnum::JSON_SCALAR),
+  explicit JSONScalar(bool dense = true, bool nullable = true)
+      : DataType(LogicalType::JSON_SCALAR, nullable),
         dense(dense) {}
 };
 

--- a/cpp/src/arrow/types/list-test.cc
+++ b/cpp/src/arrow/types/list-test.cc
@@ -44,19 +44,19 @@ TEST(TypesTest, TestListType) {
   std::shared_ptr<DataType> vt = std::make_shared<UInt8Type>();
 
   ListType list_type(vt);
-  ASSERT_EQ(list_type.type, TypeEnum::LIST);
+  ASSERT_EQ(list_type.type, LogicalType::LIST);
 
   ASSERT_EQ(list_type.name(), string("list"));
-  ASSERT_EQ(list_type.ToString(), string("list<uint8>"));
+  ASSERT_EQ(list_type.ToString(), string("?list<?uint8>"));
 
   ASSERT_EQ(list_type.value_type->type, vt->type);
   ASSERT_EQ(list_type.value_type->type, vt->type);
 
-  std::shared_ptr<DataType> st = std::make_shared<StringType>();
-  std::shared_ptr<DataType> lt = std::make_shared<ListType>(st);
+  std::shared_ptr<DataType> st = std::make_shared<StringType>(false);
+  std::shared_ptr<DataType> lt = std::make_shared<ListType>(st, false);
   ASSERT_EQ(lt->ToString(), string("list<string>"));
 
-  ListType lt2(lt);
+  ListType lt2(lt, false);
   ASSERT_EQ(lt2.ToString(), string("list<list<string>>"));
 }
 

--- a/cpp/src/arrow/types/list.cc
+++ b/cpp/src/arrow/types/list.cc
@@ -24,6 +24,9 @@ namespace arrow {
 
 std::string ListType::ToString() const {
   std::stringstream s;
+  if (this->nullable) {
+    s << "?";
+  }
   s << "list<" << value_type->ToString() << ">";
   return s.str();
 }

--- a/cpp/src/arrow/types/list.h
+++ b/cpp/src/arrow/types/list.h
@@ -40,8 +40,8 @@ struct ListType : public DataType {
   // List can contain any other logical value type
   TypePtr value_type;
 
-  explicit ListType(const TypePtr& value_type)
-      : DataType(TypeEnum::LIST),
+  explicit ListType(const TypePtr& value_type, bool nullable = true)
+      : DataType(LogicalType::LIST, nullable),
         value_type(value_type) {}
 
   static char const *name() {
@@ -50,7 +50,6 @@ struct ListType : public DataType {
 
   virtual std::string ToString() const;
 };
-
 
 class ListArray : public Array {
  public:

--- a/cpp/src/arrow/types/primitive-test.cc
+++ b/cpp/src/arrow/types/primitive-test.cc
@@ -54,11 +54,11 @@ TEST(TypesTest, TestBytesType) {
   TEST(TypesTest, TestPrimitive_##ENUM) {       \
     KLASS tp;                                   \
                                                 \
-    ASSERT_EQ(tp.type, TypeEnum::ENUM);         \
+    ASSERT_EQ(tp.type, LogicalType::ENUM);      \
     ASSERT_EQ(tp.name(), string(NAME));         \
                                                 \
     KLASS tp_copy = tp;                         \
-    ASSERT_EQ(tp_copy.type, TypeEnum::ENUM);    \
+    ASSERT_EQ(tp_copy.type, LogicalType::ENUM); \
   }
 
 PRIMITIVE_TEST(Int8Type, INT8, "int8");

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -34,28 +34,6 @@ namespace arrow {
 
 class MemoryPool;
 
-template <typename Derived>
-struct PrimitiveType : public DataType {
-  PrimitiveType()
-      : DataType(Derived::type_enum) {}
-
-  virtual std::string ToString() const {
-    return std::string(static_cast<const Derived*>(this)->name());
-  }
-};
-
-#define PRIMITIVE_DECL(TYPENAME, C_TYPE, ENUM, SIZE, NAME)  \
-  typedef C_TYPE c_type;                                    \
-  static constexpr TypeEnum type_enum = TypeEnum::ENUM;     \
-  static constexpr int size = SIZE;                         \
-                                                            \
-  TYPENAME()                                                \
-      : PrimitiveType<TYPENAME>() {}                        \
-                                                            \
-  static const char* name() {                               \
-    return NAME;                                            \
-  }
-
 
 // Base class for fixed-size logical types
 class PrimitiveArray : public Array {

--- a/cpp/src/arrow/types/string-test.cc
+++ b/cpp/src/arrow/types/string-test.cc
@@ -38,14 +38,14 @@ class Buffer;
 TEST(TypesTest, TestCharType) {
   CharType t1(5);
 
-  ASSERT_EQ(t1.type, TypeEnum::CHAR);
+  ASSERT_EQ(t1.type, LogicalType::CHAR);
   ASSERT_EQ(t1.size, 5);
 
   ASSERT_EQ(t1.ToString(), std::string("char(5)"));
 
   // Test copy constructor
   CharType t2 = t1;
-  ASSERT_EQ(t2.type, TypeEnum::CHAR);
+  ASSERT_EQ(t2.type, LogicalType::CHAR);
   ASSERT_EQ(t2.size, 5);
 }
 
@@ -53,7 +53,7 @@ TEST(TypesTest, TestCharType) {
 TEST(TypesTest, TestVarcharType) {
   VarcharType t1(5);
 
-  ASSERT_EQ(t1.type, TypeEnum::VARCHAR);
+  ASSERT_EQ(t1.type, LogicalType::VARCHAR);
   ASSERT_EQ(t1.size, 5);
   ASSERT_EQ(t1.physical_type.size, 6);
 
@@ -61,14 +61,14 @@ TEST(TypesTest, TestVarcharType) {
 
   // Test copy constructor
   VarcharType t2 = t1;
-  ASSERT_EQ(t2.type, TypeEnum::VARCHAR);
+  ASSERT_EQ(t2.type, LogicalType::VARCHAR);
   ASSERT_EQ(t2.size, 5);
   ASSERT_EQ(t2.physical_type.size, 6);
 }
 
 TEST(TypesTest, TestStringType) {
   StringType str;
-  ASSERT_EQ(str.type, TypeEnum::STRING);
+  ASSERT_EQ(str.type, LogicalType::STRING);
   ASSERT_EQ(str.name(), std::string("string"));
 }
 
@@ -128,8 +128,8 @@ TEST_F(TestStringContainer, TestArrayBasics) {
 TEST_F(TestStringContainer, TestType) {
   TypePtr type = strings_.type();
 
-  ASSERT_EQ(TypeEnum::STRING, type->type);
-  ASSERT_EQ(TypeEnum::STRING, strings_.type_enum());
+  ASSERT_EQ(LogicalType::STRING, type->type);
+  ASSERT_EQ(LogicalType::STRING, strings_.logical_type());
 }
 
 

--- a/cpp/src/arrow/types/string.h
+++ b/cpp/src/arrow/types/string.h
@@ -40,8 +40,8 @@ struct CharType : public DataType {
 
   BytesType physical_type;
 
-  explicit CharType(int size)
-      : DataType(TypeEnum::CHAR),
+  explicit CharType(int size, bool nullable = true)
+      : DataType(LogicalType::CHAR, nullable),
         size(size),
         physical_type(BytesType(size)) {}
 
@@ -58,8 +58,8 @@ struct VarcharType : public DataType {
 
   BytesType physical_type;
 
-  explicit VarcharType(int size)
-      : DataType(TypeEnum::VARCHAR),
+  explicit VarcharType(int size, bool nullable = true)
+      : DataType(LogicalType::VARCHAR, nullable),
         size(size),
         physical_type(BytesType(size + 1)) {}
   VarcharType(const VarcharType& other)
@@ -73,25 +73,25 @@ static const LayoutPtr physical_string = LayoutPtr(new ListLayoutType(byte1));
 
 // String is a logical type consisting of a physical list of 1-byte values
 struct StringType : public DataType {
-  StringType()
-      : DataType(TypeEnum::STRING) {}
+  explicit StringType(bool nullable = true)
+      : DataType(LogicalType::STRING, nullable) {}
 
   StringType(const StringType& other)
       : StringType() {}
-
-  const LayoutPtr& physical_type() {
-    return physical_string;
-  }
 
   static char const *name() {
     return "string";
   }
 
   virtual std::string ToString() const {
-    return name();
+    std::string result;
+    if (nullable) {
+      result.append("?");
+    }
+    result.append(name());
+    return result;
   }
 };
-
 
 // TODO: add a BinaryArray layer in between
 class StringArray : public ListArray {

--- a/cpp/src/arrow/types/struct-test.cc
+++ b/cpp/src/arrow/types/struct-test.cc
@@ -49,7 +49,7 @@ TEST(TestStructType, Basics) {
   ASSERT_TRUE(struct_type.field(1).Equals(f1));
   ASSERT_TRUE(struct_type.field(2).Equals(f2));
 
-  ASSERT_EQ(struct_type.ToString(), "struct<f0: int32, f1: string, f2: uint8>");
+  ASSERT_EQ(struct_type.ToString(), "?struct<f0: ?int32, f1: ?string, f2: ?uint8>");
 
   // TODO: out of bounds for field(...)
 }

--- a/cpp/src/arrow/types/struct.cc
+++ b/cpp/src/arrow/types/struct.cc
@@ -26,6 +26,7 @@ namespace arrow {
 
 std::string StructType::ToString() const {
   std::stringstream s;
+  if (nullable) s << "?";
   s << "struct<";
   for (size_t i = 0; i < fields_.size(); ++i) {
     if (i > 0) s << ", ";

--- a/cpp/src/arrow/types/struct.h
+++ b/cpp/src/arrow/types/struct.h
@@ -29,8 +29,8 @@ namespace arrow {
 struct StructType : public DataType {
   std::vector<Field> fields_;
 
-  explicit StructType(const std::vector<Field>& fields)
-      : DataType(TypeEnum::STRUCT) {
+  explicit StructType(const std::vector<Field>& fields, bool nullable = true)
+      : DataType(LogicalType::STRUCT, nullable) {
     fields_ = fields;
   }
 

--- a/cpp/src/arrow/types/union.h
+++ b/cpp/src/arrow/types/union.h
@@ -30,8 +30,8 @@ namespace arrow {
 
 class Buffer;
 
-struct DenseUnionType : public CollectionType<TypeEnum::DENSE_UNION> {
-  typedef CollectionType<TypeEnum::DENSE_UNION> Base;
+struct DenseUnionType : public CollectionType<LogicalType::DENSE_UNION> {
+  typedef CollectionType<LogicalType::DENSE_UNION> Base;
 
   explicit DenseUnionType(const std::vector<TypePtr>& child_types) :
       Base() {
@@ -42,8 +42,8 @@ struct DenseUnionType : public CollectionType<TypeEnum::DENSE_UNION> {
 };
 
 
-struct SparseUnionType : public CollectionType<TypeEnum::SPARSE_UNION> {
-  typedef CollectionType<TypeEnum::SPARSE_UNION> Base;
+struct SparseUnionType : public CollectionType<LogicalType::SPARSE_UNION> {
+  typedef CollectionType<LogicalType::SPARSE_UNION> Base;
 
   explicit SparseUnionType(const std::vector<TypePtr>& child_types) :
       Base() {


### PR DESCRIPTION
I also have restored the `nullable` bit to the type metadata only (for the moment mainly to facilitate schema testing / round-trips to Parquet and other media with required/optional distinction) and done some miscellaneous refactoring (`TypeEnum` is renamed to `LogicalType`). 
