### PR TITLE
ARROW-26: Add instructions for enabling Arrow C++ Parquet adapter build

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 
 # Top level cmake dir
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  option(ARROW_WITH_PARQUET
+  option(ARROW_PARQUET
     "Build the Parquet adapter and link to libparquet"
     OFF)
 
@@ -441,7 +441,7 @@ endif (UNIX)
 #----------------------------------------------------------------------
 # Parquet adapter
 
-if(ARROW_WITH_PARQUET)
+if(ARROW_PARQUET)
   find_package(Parquet REQUIRED)
   include_directories(SYSTEM ${PARQUET_INCLUDE_DIR})
   ADD_THIRDPARTY_LIB(parquet

--- a/cpp/doc/Parquet.md
+++ b/cpp/doc/Parquet.md
@@ -1,0 +1,24 @@
+## Building Arrow-Parquet integration
+
+To build the Arrow C++'s Parquet adapter library, you must first build [parquet-cpp][1]:
+
+```bash
+# Set this to your preferred install location
+export PARQUET_HOME=$HOME/local
+
+git clone https://github.com/apache/parquet-cpp.git
+cd parquet-cpp
+source setup_build_env.sh
+cmake -DCMAKE_INSTALL_PREFIX=$PARQUET_HOME
+make -j4
+make install
+```
+
+Make sure that `$PARQUET_HOME` is set to the installation location. Now, build
+Arrow with the Parquet adapter enabled:
+
+```bash
+cmake -DARROW_PARQUET=ON
+```
+
+[1]: https://github.com/apache/parquet-cpp


### PR DESCRIPTION
This patch documents the workflow for building the optional Arrow-Parquet C++ integration. I originally thought about adding an option to build it in Arrow's thirdparty, but it immediately results in a dependency-hell situation (Parquet requires Thrift, Boost, snappy, lz4, zlib)
