### PR TITLE
ARROW-9: Rename some unchanged "Drill" to "Arrow" (follow-up)  

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -63,7 +63,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
 
   /**
    * Allocates new buffers. ValueVector implements logic to determine how much to allocate.
-   * @return Returns true if allocation was succesful.
+   * @return Returns true if allocation was successful.
    */
   boolean allocateNewSafe();
 
@@ -71,7 +71,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
 
   /**
    * Set the initial record capacity
-   * @param numRecords
+   * @param numRecords the initial record capacity.
    */
   void setInitialCapacity(int numRecords);
 
@@ -87,7 +87,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   void close();
 
   /**
-   * Release the underlying DrillBuf and reset the ValueVector to empty.
+   * Release the underlying ArrowBuf and reset the ValueVector to empty.
    */
   void clear();
 
@@ -198,7 +198,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   }
 
   /**
-   * An abstractiong that is used to write into this vector instance.
+   * An abstracting that is used to write into this vector instance.
    */
   interface Mutator {
     /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -198,7 +198,7 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   }
 
   /**
-   * An abstracting that is used to write into this vector instance.
+   * An abstraction that is used to write into this vector instance.
    */
   interface Mutator {
     /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-9

There is a unchanged one from "Drill" to "Arrow" at `ValueVector` and minor typos are fixed.
