### PR TITLE
ARROW-64: Add zsh support to C++ build scripts

### DIFF
--- a/cpp/setup_build_env.sh
+++ b/cpp/setup_build_env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SOURCE_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 ./thirdparty/download_thirdparty.sh
 ./thirdparty/build_thirdparty.sh

--- a/cpp/thirdparty/build_thirdparty.sh
+++ b/cpp/thirdparty/build_thirdparty.sh
@@ -2,7 +2,7 @@
 
 set -x
 set -e
-TP_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 source $TP_DIR/versions.sh
 PREFIX=$TP_DIR/installed

--- a/cpp/thirdparty/download_thirdparty.sh
+++ b/cpp/thirdparty/download_thirdparty.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-TP_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
+TP_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 source $TP_DIR/versions.sh
 


### PR DESCRIPTION
All scripts that have to be sourced during development currently only
support bash. This patch adds zsh support.
