### PR TITLE
ARROW-55: [Python] Fix unit tests in 2.7

### DIFF
--- a/python/src/pyarrow/common.h
+++ b/python/src/pyarrow/common.h
@@ -24,7 +24,7 @@ namespace arrow { class MemoryPool; }
 
 namespace pyarrow {
 
-#define PYARROW_IS_PY2 PY_MAJOR_VERSION < 2
+#define PYARROW_IS_PY2 PY_MAJOR_VERSION <= 2
 
 #define RETURN_ARROW_NOT_OK(s) do {             \
     arrow::Status _s = (s);                     \


### PR DESCRIPTION
Fixing the #define check for Python 2 makes all unit tests pass in Python 2.7.
