### PR TITLE
ARROW-75: Fix handling of empty strings

### DIFF
--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -168,7 +168,9 @@ class PrimitiveBuilder : public ArrayBuilder {
       int32_t new_capacity = util::next_power2(length_ + length);
       RETURN_NOT_OK(Resize(new_capacity));
     }
-    if (length > 0) memcpy(raw_buffer() + length_, values, length * elsize_);
+    if (length > 0) { 
+      memcpy(raw_buffer() + length_, values, length * elsize_);
+    }
 
     if (null_bytes != nullptr) {
       AppendNulls(null_bytes, length);

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -168,7 +168,7 @@ class PrimitiveBuilder : public ArrayBuilder {
       int32_t new_capacity = util::next_power2(length_ + length);
       RETURN_NOT_OK(Resize(new_capacity));
     }
-    memcpy(raw_buffer() + length_, values, length * elsize_);
+    if (length > 0) memcpy(raw_buffer() + length_, values, length * elsize_);
 
     if (null_bytes != nullptr) {
       AppendNulls(null_bytes, length);

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -168,7 +168,7 @@ class PrimitiveBuilder : public ArrayBuilder {
       int32_t new_capacity = util::next_power2(length_ + length);
       RETURN_NOT_OK(Resize(new_capacity));
     }
-    if (length > 0) { 
+    if (length > 0) {
       memcpy(raw_buffer() + length_, values, length * elsize_);
     }
 

--- a/cpp/src/arrow/types/string-test.cc
+++ b/cpp/src/arrow/types/string-test.cc
@@ -181,7 +181,7 @@ class TestStringBuilder : public TestBuilder {
 };
 
 TEST_F(TestStringBuilder, TestScalarAppend) {
-  std::vector<std::string> strings = {"a", "bb", "", "", "ccc"};
+  std::vector<std::string> strings = {"", "bb", "a", "", "ccc"};
   std::vector<uint8_t> is_null = {0, 0, 0, 1, 0};
 
   int N = strings.size();

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -39,13 +39,13 @@ class TestArrayAPI(unittest.TestCase):
         assert result == expected
 
     def test_string_format(self):
-        arr = pyarrow.from_pylist(['foo', None, 'bar'])
+        arr = pyarrow.from_pylist(['foo', None, ''])
         result = fmt.array_format(arr)
         expected = """\
 [
   'foo',
   NA,
-  'bar'
+  ''
 ]"""
         assert result == expected
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -39,13 +39,13 @@ class TestArrayAPI(unittest.TestCase):
         assert result == expected
 
     def test_string_format(self):
-        arr = pyarrow.from_pylist(['foo', None, ''])
+        arr = pyarrow.from_pylist(['', None, 'foo'])
         result = fmt.array_format(arr)
         expected = """\
 [
-  'foo',
+  '',
   NA,
-  ''
+  'foo'
 ]"""
         assert result == expected
 


### PR DESCRIPTION
Fixes [ARROW-75](https://issues.apache.org/jira/browse/ARROW-75) (and changes Python tests to verify that behavior).
