### PR TITLE
ARROW-65: Be less restrictive on PYTHON_LIBRARY search paths

### DIFF
--- a/python/cmake_modules/FindPythonLibsNew.cmake
+++ b/python/cmake_modules/FindPythonLibsNew.cmake
@@ -166,7 +166,7 @@ else()
     find_library(PYTHON_LIBRARY
         NAMES "python${PYTHON_LIBRARY_SUFFIX}"
         PATHS ${_PYTHON_LIBS_SEARCH}
-        NO_DEFAULT_PATH)
+        NO_SYSTEM_ENVIRONMENT_PATH)
     message(STATUS "Found Python lib ${PYTHON_LIBRARY}")
 endif()
 


### PR DESCRIPTION
Current CMake FindPythonLibs also uses this option instead of NO_DEFAULT_PATH.
