### PR TITLE
ARROW-87: [C++] Add all four possible ways to encode Decimals in Parquet to schema conversion

### DIFF
--- a/cpp/src/arrow/parquet/parquet-schema-test.cc
+++ b/cpp/src/arrow/parquet/parquet-schema-test.cc
@@ -22,6 +22,7 @@
 
 #include "arrow/test-util.h"
 #include "arrow/type.h"
+#include "arrow/types/decimal.h"
 #include "arrow/util/status.h"
 
 #include "arrow/parquet/schema.h"
@@ -46,6 +47,7 @@ const auto DOUBLE = std::make_shared<DoubleType>();
 const auto UTF8 = std::make_shared<StringType>();
 const auto BINARY = std::make_shared<ListType>(
     std::make_shared<Field>("", UINT8));
+const auto DECIMAL_8_4 = std::make_shared<DecimalType>(8, 4);
 
 class TestConvertParquetSchema : public ::testing::Test {
  public:
@@ -112,6 +114,40 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
           ParquetType::FIXED_LEN_BYTE_ARRAY,
           LogicalType::NONE, 12));
   arrow_fields.push_back(std::make_shared<Field>("flba-binary", BINARY));
+
+  auto arrow_schema = std::make_shared<Schema>(arrow_fields);
+  ASSERT_OK(ConvertSchema(parquet_fields));
+
+  CheckFlatSchema(arrow_schema);
+}
+
+TEST_F(TestConvertParquetSchema, ParquetFlatDecimals) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("flba-decimal", Repetition::OPTIONAL,
+          parquet_cpp::Type::FIXED_LEN_BYTE_ARRAY,
+          parquet_cpp::LogicalType::DECIMAL, 4, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("flba-decimal", DECIMAL_8_4));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("binary-decimal", Repetition::OPTIONAL,
+          parquet_cpp::Type::BYTE_ARRAY,
+          parquet_cpp::LogicalType::DECIMAL, -1, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("binary-decimal", DECIMAL_8_4));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("int32-decimal", Repetition::OPTIONAL,
+          parquet_cpp::Type::INT32,
+          parquet_cpp::LogicalType::DECIMAL, -1, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("int32-decimal", DECIMAL_8_4));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("int64-decimal", Repetition::OPTIONAL,
+          parquet_cpp::Type::INT64,
+          parquet_cpp::LogicalType::DECIMAL, -1, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("int64-decimal", DECIMAL_8_4));
 
   auto arrow_schema = std::make_shared<Schema>(arrow_fields);
   ASSERT_OK(ConvertSchema(parquet_fields));

--- a/cpp/src/arrow/parquet/parquet-schema-test.cc
+++ b/cpp/src/arrow/parquet/parquet-schema-test.cc
@@ -127,26 +127,26 @@ TEST_F(TestConvertParquetSchema, ParquetFlatDecimals) {
 
   parquet_fields.push_back(
       PrimitiveNode::Make("flba-decimal", Repetition::OPTIONAL,
-          parquet_cpp::Type::FIXED_LEN_BYTE_ARRAY,
-          parquet_cpp::LogicalType::DECIMAL, 4, 8, 4));
+          ParquetType::FIXED_LEN_BYTE_ARRAY,
+          LogicalType::DECIMAL, 4, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("flba-decimal", DECIMAL_8_4));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("binary-decimal", Repetition::OPTIONAL,
-          parquet_cpp::Type::BYTE_ARRAY,
-          parquet_cpp::LogicalType::DECIMAL, -1, 8, 4));
+          ParquetType::BYTE_ARRAY,
+          LogicalType::DECIMAL, -1, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("binary-decimal", DECIMAL_8_4));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("int32-decimal", Repetition::OPTIONAL,
-          parquet_cpp::Type::INT32,
-          parquet_cpp::LogicalType::DECIMAL, -1, 8, 4));
+          ParquetType::INT32,
+          LogicalType::DECIMAL, -1, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("int32-decimal", DECIMAL_8_4));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("int64-decimal", Repetition::OPTIONAL,
-          parquet_cpp::Type::INT64,
-          parquet_cpp::LogicalType::DECIMAL, -1, 8, 4));
+          ParquetType::INT64,
+          LogicalType::DECIMAL, -1, 8, 4));
   arrow_fields.push_back(std::make_shared<Field>("int64-decimal", DECIMAL_8_4));
 
   auto arrow_schema = std::make_shared<Schema>(arrow_fields);

--- a/cpp/src/arrow/parquet/schema.cc
+++ b/cpp/src/arrow/parquet/schema.cc
@@ -57,6 +57,9 @@ static Status FromByteArray(const PrimitiveNode* node, TypePtr* out) {
     case LogicalType::UTF8:
       *out = UTF8;
       break;
+    case LogicalType::DECIMAL:
+      *out = MakeDecimalType(node);
+      break;
     default:
       // BINARY
       *out = BINARY;
@@ -86,6 +89,9 @@ static Status FromInt32(const PrimitiveNode* node, TypePtr* out) {
     case LogicalType::NONE:
       *out = INT32;
       break;
+    case LogicalType::DECIMAL:
+      *out = MakeDecimalType(node);
+      break;
     default:
       return Status::NotImplemented("Unhandled logical type for int32");
       break;
@@ -97,6 +103,9 @@ static Status FromInt64(const PrimitiveNode* node, TypePtr* out) {
   switch (node->logical_type()) {
     case LogicalType::NONE:
       *out = INT64;
+      break;
+    case LogicalType::DECIMAL:
+      *out = MakeDecimalType(node);
       break;
     default:
       return Status::NotImplemented("Unhandled logical type for int64");


### PR DESCRIPTION
See also: https://github.com/Parquet/parquet-format/blob/master/LogicalTypes.md#decimal
