### PR TITLE
ARROW-85: memcmp can be avoided in Equal when comparing with the same …

### DIFF
--- a/cpp/src/arrow/util/buffer-test.cc
+++ b/cpp/src/arrow/util/buffer-test.cc
@@ -54,23 +54,23 @@ TEST_F(TestBuffer, ResizeOOM) {
 }
 
 TEST_F(TestBuffer, EqualsWithSameContent) {
-	MemoryPool* pool = default_memory_pool();
-	int32_t bufferSize = 128 * 1024;
-	uint8_t* rawBuffer1 = NULL;
-	ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer1));
-	memset(rawBuffer1, 12, bufferSize);
-	uint8_t* rawBuffer2 = NULL;
-	ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer2));
-	memset(rawBuffer2, 12, bufferSize);
-	uint8_t* rawBuffer3 = NULL;
-	ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer3));
-	memset(rawBuffer3, 3, bufferSize);
+  MemoryPool* pool = default_memory_pool();
+  int32_t bufferSize = 128 * 1024;
+  uint8_t* rawBuffer1 = NULL;
+  ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer1));
+  memset(rawBuffer1, 12, bufferSize);
+  uint8_t* rawBuffer2 = NULL;
+  ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer2));
+  memset(rawBuffer2, 12, bufferSize);
+  uint8_t* rawBuffer3 = NULL;
+  ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer3));
+  memset(rawBuffer3, 3, bufferSize);
 
-	Buffer buffer1(rawBuffer1, bufferSize);
-	Buffer buffer2(rawBuffer2, bufferSize);
-	Buffer buffer3(rawBuffer3, bufferSize);
-	ASSERT_TRUE(buffer1.Equals(buffer2));
-	ASSERT_FALSE(buffer1.Equals(buffer3));
+  Buffer buffer1(rawBuffer1, bufferSize);
+  Buffer buffer2(rawBuffer2, bufferSize);
+  Buffer buffer3(rawBuffer3, bufferSize);
+  ASSERT_TRUE(buffer1.Equals(buffer2));
+  ASSERT_FALSE(buffer1.Equals(buffer3));
 }
 
 TEST_F(TestBuffer, EqualsWithSameBuffer) {

--- a/cpp/src/arrow/util/buffer-test.cc
+++ b/cpp/src/arrow/util/buffer-test.cc
@@ -53,4 +53,40 @@ TEST_F(TestBuffer, ResizeOOM) {
   ASSERT_RAISES(OutOfMemory, buf.Resize(to_alloc));
 }
 
+TEST_F(TestBuffer, EqualsWithSameContent) {
+	MemoryPool* pool = default_memory_pool();
+	int32_t bufferSize = 128 * 1024;
+	uint8_t* rawBuffer1 = NULL;
+	ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer1));
+	memset(rawBuffer1, 12, bufferSize);
+	uint8_t* rawBuffer2 = NULL;
+	ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer2));
+	memset(rawBuffer2, 12, bufferSize);
+	uint8_t* rawBuffer3 = NULL;
+	ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer3));
+	memset(rawBuffer3, 3, bufferSize);
+
+	Buffer buffer1(rawBuffer1, bufferSize);
+	Buffer buffer2(rawBuffer2, bufferSize);
+	Buffer buffer3(rawBuffer3, bufferSize);
+	ASSERT_TRUE(buffer1.Equals(buffer2));
+	ASSERT_FALSE(buffer1.Equals(buffer3));
+}
+
+TEST_F(TestBuffer, EqualsWithSameBuffer) {
+  MemoryPool* pool = default_memory_pool();
+  int32_t bufferSize = 128 * 1024;
+  uint8_t* rawBuffer = NULL;
+  ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer));
+
+  Buffer buffer1(rawBuffer, bufferSize);
+  Buffer buffer2(rawBuffer, bufferSize);
+  ASSERT_TRUE(buffer1.Equals(buffer2));
+
+  int64_t nbytes = bufferSize / 2;
+  Buffer buffer3(rawBuffer, nbytes);  
+  ASSERT_TRUE(buffer1.Equals(buffer3, nbytes));
+  ASSERT_FALSE(buffer1.Equals(buffer3, nbytes + 1));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/util/buffer-test.cc
+++ b/cpp/src/arrow/util/buffer-test.cc
@@ -55,14 +55,14 @@ TEST_F(TestBuffer, ResizeOOM) {
 
 TEST_F(TestBuffer, EqualsWithSameContent) {
   MemoryPool* pool = default_memory_pool();
-  int32_t bufferSize = 128 * 1024;
-  uint8_t* rawBuffer1 = NULL;
+  const int32_t bufferSize = 128 * 1024;
+  uint8_t* rawBuffer1;
   ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer1));
   memset(rawBuffer1, 12, bufferSize);
-  uint8_t* rawBuffer2 = NULL;
+  uint8_t* rawBuffer2;
   ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer2));
   memset(rawBuffer2, 12, bufferSize);
-  uint8_t* rawBuffer3 = NULL;
+  uint8_t* rawBuffer3;
   ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer3));
   memset(rawBuffer3, 3, bufferSize);
 
@@ -75,15 +75,16 @@ TEST_F(TestBuffer, EqualsWithSameContent) {
 
 TEST_F(TestBuffer, EqualsWithSameBuffer) {
   MemoryPool* pool = default_memory_pool();
-  int32_t bufferSize = 128 * 1024;
-  uint8_t* rawBuffer = NULL;
+  const int32_t bufferSize = 128 * 1024;
+  uint8_t* rawBuffer;
   ASSERT_OK(pool->Allocate(bufferSize, &rawBuffer));
+  memset(rawBuffer, 111, bufferSize);
 
   Buffer buffer1(rawBuffer, bufferSize);
   Buffer buffer2(rawBuffer, bufferSize);
   ASSERT_TRUE(buffer1.Equals(buffer2));
 
-  int64_t nbytes = bufferSize / 2;
+  const int64_t nbytes = bufferSize / 2;
   Buffer buffer3(rawBuffer, nbytes);
   ASSERT_TRUE(buffer1.Equals(buffer3, nbytes));
   ASSERT_FALSE(buffer1.Equals(buffer3, nbytes + 1));

--- a/cpp/src/arrow/util/buffer-test.cc
+++ b/cpp/src/arrow/util/buffer-test.cc
@@ -71,6 +71,10 @@ TEST_F(TestBuffer, EqualsWithSameContent) {
   Buffer buffer3(rawBuffer3, bufferSize);
   ASSERT_TRUE(buffer1.Equals(buffer2));
   ASSERT_FALSE(buffer1.Equals(buffer3));
+
+  pool->Free(rawBuffer1, bufferSize);
+  pool->Free(rawBuffer2, bufferSize);
+  pool->Free(rawBuffer3, bufferSize);
 }
 
 TEST_F(TestBuffer, EqualsWithSameBuffer) {
@@ -88,6 +92,8 @@ TEST_F(TestBuffer, EqualsWithSameBuffer) {
   Buffer buffer3(rawBuffer, nbytes);
   ASSERT_TRUE(buffer1.Equals(buffer3, nbytes));
   ASSERT_FALSE(buffer1.Equals(buffer3, nbytes + 1));
+
+  pool->Free(rawBuffer, bufferSize);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/buffer-test.cc
+++ b/cpp/src/arrow/util/buffer-test.cc
@@ -84,7 +84,7 @@ TEST_F(TestBuffer, EqualsWithSameBuffer) {
   ASSERT_TRUE(buffer1.Equals(buffer2));
 
   int64_t nbytes = bufferSize / 2;
-  Buffer buffer3(rawBuffer, nbytes);  
+  Buffer buffer3(rawBuffer, nbytes);
   ASSERT_TRUE(buffer1.Equals(buffer3, nbytes));
   ASSERT_FALSE(buffer1.Equals(buffer3, nbytes + 1));
 }

--- a/cpp/src/arrow/util/buffer.h
+++ b/cpp/src/arrow/util/buffer.h
@@ -56,7 +56,7 @@ class Buffer : public std::enable_shared_from_this<Buffer> {
   }
 
   bool Equals(const Buffer& other) const {
-    return this == &other || 
+    return this == &other ||
 		(size_ == other.size_ && (data_ == other.data_ ||
 			!memcmp(data_, other.data_, size_)));
   }

--- a/cpp/src/arrow/util/buffer.h
+++ b/cpp/src/arrow/util/buffer.h
@@ -52,11 +52,13 @@ class Buffer : public std::enable_shared_from_this<Buffer> {
   // up to the number of compared bytes
   bool Equals(const Buffer& other, int64_t nbytes) const {
     return this == &other || (size_ >= nbytes && other.size_ >= nbytes &&
-                                 !memcmp(data_, other.data_, nbytes));
+        (data_ == other.data_ || !memcmp(data_, other.data_, nbytes)));
   }
 
   bool Equals(const Buffer& other) const {
-    return this == &other || (size_ == other.size_ && !memcmp(data_, other.data_, size_));
+    return this == &other || 
+		(size_ == other.size_ && (data_ == other.data_ ||
+			!memcmp(data_, other.data_, size_)));
   }
 
   const uint8_t* data() const { return data_; }

--- a/cpp/src/arrow/util/buffer.h
+++ b/cpp/src/arrow/util/buffer.h
@@ -51,14 +51,15 @@ class Buffer : public std::enable_shared_from_this<Buffer> {
   // Return true if both buffers are the same size and contain the same bytes
   // up to the number of compared bytes
   bool Equals(const Buffer& other, int64_t nbytes) const {
-    return this == &other || (size_ >= nbytes && other.size_ >= nbytes &&
-        (data_ == other.data_ || !memcmp(data_, other.data_, nbytes)));
+    return this == &other ||
+           (size_ >= nbytes && other.size_ >= nbytes &&
+               (data_ == other.data_ || !memcmp(data_, other.data_, nbytes)));
   }
 
   bool Equals(const Buffer& other) const {
     return this == &other ||
-		(size_ == other.size_ && (data_ == other.data_ ||
-			!memcmp(data_, other.data_, size_)));
+           (size_ == other.size_ &&
+               (data_ == other.data_ || !memcmp(data_, other.data_, size_)));
   }
 
   const uint8_t* data() const { return data_; }


### PR DESCRIPTION
Avoid memcmp when possible, if the two underlying buffers are the same.
