### PR TITLE
ARROW-102: Add java support to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     - gcc-4.9   # Needed for C++11
     - g++-4.9   # Needed for C++11
     - gdb
-    - gcov
     - ccache
     - cmake
     - valgrind
@@ -60,6 +59,11 @@ matrix:
     before_install:
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_conda_build.sh
+  - language: java
+    os: linux
+    jdk: oraclejdk7
+    script:
+    - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
 
 before_install:
 - ulimit -c unlimited -S

--- a/ci/travis_script_java.sh
+++ b/ci/travis_script_java.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+JAVA_DIR=${TRAVIS_BUILD_DIR}/java
+
+pushd $JAVA_DIR
+
+mvn -B test
+
+popd

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -297,7 +297,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.17</version>
           <configuration>
-            <argLine>-ea</argLine>
+            <enableAssertions>true</enableAssertions>
             <forkCount>${forkCount}</forkCount>
             <reuseForks>true</reuseForks>
             <systemPropertyVariables>


### PR DESCRIPTION
Add java support to Travis CI using oracle JDK7 on a Linux host.
