### PR TITLE
ARROW-92: Arrow to Parquet Schema conversion

### DIFF
--- a/cpp/src/arrow/parquet/parquet-schema-test.cc
+++ b/cpp/src/arrow/parquet/parquet-schema-test.cc
@@ -217,7 +217,7 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
 
   // TODO: String types need to be clarified a bit more in the Arrow spec
   parquet_fields.push_back(PrimitiveNode::Make(
-     "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8));
+      "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8));
   arrow_fields.push_back(std::make_shared<Field>("string", UTF8));
 
   ASSERT_OK(ConvertSchema(arrow_fields));

--- a/cpp/src/arrow/parquet/parquet-schema-test.cc
+++ b/cpp/src/arrow/parquet/parquet-schema-test.cc
@@ -161,6 +161,106 @@ TEST_F(TestConvertParquetSchema, UnsupportedThings) {
   }
 }
 
+class TestConvertArrowSchema : public ::testing::Test {
+ public:
+  virtual void SetUp() {}
+
+  void CheckFlatSchema(const std::vector<NodePtr>& nodes) {
+    NodePtr schema_node = GroupNode::Make("schema", Repetition::REPEATED, nodes);
+    const GroupNode* expected_schema_node =
+        static_cast<const GroupNode*>(schema_node.get());
+    const GroupNode* result_schema_node =
+        static_cast<const GroupNode*>(result_schema_->schema().get());
+
+    ASSERT_EQ(expected_schema_node->field_count(),
+            result_schema_node->field_count());
+
+    for (int i = 0; i < expected_schema_node->field_count(); i++) {
+      auto lhs = result_schema_node->field(i);
+      auto rhs = expected_schema_node->field(i);
+      EXPECT_TRUE(lhs->Equals(rhs.get()));
+    }
+  }
+
+  Status ConvertSchema(const std::vector<std::shared_ptr<Field>>& fields) {
+    arrow_schema_ = std::make_shared<Schema>(fields);
+    return ToParquetSchema(arrow_schema_.get(), &result_schema_);
+  }
+
+ protected:
+  std::shared_ptr<Schema> arrow_schema_;
+  std::shared_ptr<::parquet::SchemaDescriptor> result_schema_;
+};
+
+TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("boolean", Repetition::REQUIRED, ParquetType::BOOLEAN));
+  arrow_fields.push_back(std::make_shared<Field>("boolean", BOOL, false));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("int32", Repetition::REQUIRED, ParquetType::INT32));
+  arrow_fields.push_back(std::make_shared<Field>("int32", INT32, false));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("int64", Repetition::REQUIRED, ParquetType::INT64));
+  arrow_fields.push_back(std::make_shared<Field>("int64", INT64, false));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("float", Repetition::OPTIONAL, ParquetType::FLOAT));
+  arrow_fields.push_back(std::make_shared<Field>("float", FLOAT));
+
+  parquet_fields.push_back(
+      PrimitiveNode::Make("double", Repetition::OPTIONAL, ParquetType::DOUBLE));
+  arrow_fields.push_back(std::make_shared<Field>("double", DOUBLE));
+
+  // TODO: String types need to be clarified a bit more in the Arrow spec
+  // parquet_fields.push_back(PrimitiveNode::Make(
+  //    "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8));
+  // arrow_fields.push_back(std::make_shared<Field>("string", UTF8));
+
+  // TODO: At the moment we have not enough information in the BINARY type in Arrow
+  // parquet_fields.push_back(
+  //     PrimitiveNode::Make("binary", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY));
+  // arrow_fields.push_back(std::make_shared<Field>("binary", BINARY));
+
+  // parquet_fields.push_back(PrimitiveNode::Make("flba-binary", Repetition::OPTIONAL,
+  //     ParquetType::FIXED_LEN_BYTE_ARRAY, LogicalType::NONE, 12));
+  // arrow_fields.push_back(std::make_shared<Field>("flba-binary", BINARY));
+
+  ASSERT_OK(ConvertSchema(arrow_fields));
+
+  CheckFlatSchema(parquet_fields);
+}
+
+TEST_F(TestConvertArrowSchema, ParquetFlatDecimals) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  /*parquet_fields.push_back(PrimitiveNode::Make("flba-decimal", Repetition::OPTIONAL,
+      ParquetType::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 4, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("flba-decimal", DECIMAL_8_4));
+
+  parquet_fields.push_back(PrimitiveNode::Make("binary-decimal", Repetition::OPTIONAL,
+      ParquetType::BYTE_ARRAY, LogicalType::DECIMAL, -1, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("binary-decimal", DECIMAL_8_4));
+
+  parquet_fields.push_back(PrimitiveNode::Make("int32-decimal", Repetition::OPTIONAL,
+      ParquetType::INT32, LogicalType::DECIMAL, -1, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("int32-decimal", DECIMAL_8_4));
+
+  parquet_fields.push_back(PrimitiveNode::Make("int64-decimal", Repetition::OPTIONAL,
+      ParquetType::INT64, LogicalType::DECIMAL, -1, 8, 4));
+  arrow_fields.push_back(std::make_shared<Field>("int64-decimal", DECIMAL_8_4));
+
+  CheckFlatSchema(arrow_schema);*/
+  ASSERT_OK(ConvertSchema(arrow_fields));
+
+  CheckFlatSchema(parquet_fields);
+}
+
 TEST(TestNodeConversion, DateAndTime) {}
 
 }  // namespace parquet

--- a/cpp/src/arrow/parquet/parquet-schema-test.cc
+++ b/cpp/src/arrow/parquet/parquet-schema-test.cc
@@ -172,8 +172,7 @@ class TestConvertArrowSchema : public ::testing::Test {
     const GroupNode* result_schema_node =
         static_cast<const GroupNode*>(result_schema_->schema().get());
 
-    ASSERT_EQ(expected_schema_node->field_count(),
-            result_schema_node->field_count());
+    ASSERT_EQ(expected_schema_node->field_count(), result_schema_node->field_count());
 
     for (int i = 0; i < expected_schema_node->field_count(); i++) {
       auto lhs = result_schema_node->field(i);
@@ -217,18 +216,9 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
   arrow_fields.push_back(std::make_shared<Field>("double", DOUBLE));
 
   // TODO: String types need to be clarified a bit more in the Arrow spec
-  // parquet_fields.push_back(PrimitiveNode::Make(
-  //    "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8));
-  // arrow_fields.push_back(std::make_shared<Field>("string", UTF8));
-
-  // TODO: At the moment we have not enough information in the BINARY type in Arrow
-  // parquet_fields.push_back(
-  //     PrimitiveNode::Make("binary", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY));
-  // arrow_fields.push_back(std::make_shared<Field>("binary", BINARY));
-
-  // parquet_fields.push_back(PrimitiveNode::Make("flba-binary", Repetition::OPTIONAL,
-  //     ParquetType::FIXED_LEN_BYTE_ARRAY, LogicalType::NONE, 12));
-  // arrow_fields.push_back(std::make_shared<Field>("flba-binary", BINARY));
+  parquet_fields.push_back(PrimitiveNode::Make(
+     "string", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, LogicalType::UTF8));
+  arrow_fields.push_back(std::make_shared<Field>("string", UTF8));
 
   ASSERT_OK(ConvertSchema(arrow_fields));
 
@@ -239,23 +229,8 @@ TEST_F(TestConvertArrowSchema, ParquetFlatDecimals) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;
 
-  /*parquet_fields.push_back(PrimitiveNode::Make("flba-decimal", Repetition::OPTIONAL,
-      ParquetType::FIXED_LEN_BYTE_ARRAY, LogicalType::DECIMAL, 4, 8, 4));
-  arrow_fields.push_back(std::make_shared<Field>("flba-decimal", DECIMAL_8_4));
+  // TODO: Test Decimal Arrow -> Parquet conversion
 
-  parquet_fields.push_back(PrimitiveNode::Make("binary-decimal", Repetition::OPTIONAL,
-      ParquetType::BYTE_ARRAY, LogicalType::DECIMAL, -1, 8, 4));
-  arrow_fields.push_back(std::make_shared<Field>("binary-decimal", DECIMAL_8_4));
-
-  parquet_fields.push_back(PrimitiveNode::Make("int32-decimal", Repetition::OPTIONAL,
-      ParquetType::INT32, LogicalType::DECIMAL, -1, 8, 4));
-  arrow_fields.push_back(std::make_shared<Field>("int32-decimal", DECIMAL_8_4));
-
-  parquet_fields.push_back(PrimitiveNode::Make("int64-decimal", Repetition::OPTIONAL,
-      ParquetType::INT64, LogicalType::DECIMAL, -1, 8, 4));
-  arrow_fields.push_back(std::make_shared<Field>("int64-decimal", DECIMAL_8_4));
-
-  CheckFlatSchema(arrow_schema);*/
   ASSERT_OK(ConvertSchema(arrow_fields));
 
   CheckFlatSchema(parquet_fields);

--- a/cpp/src/arrow/parquet/schema.cc
+++ b/cpp/src/arrow/parquet/schema.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/parquet/schema.h"
 
+#include <string>
 #include <vector>
 
 #include "parquet/api/schema.h"

--- a/cpp/src/arrow/parquet/schema.cc
+++ b/cpp/src/arrow/parquet/schema.cc
@@ -21,11 +21,13 @@
 #include <vector>
 
 #include "parquet/api/schema.h"
+#include "parquet/exception.h"
 
 #include "arrow/types/decimal.h"
 #include "arrow/types/string.h"
 #include "arrow/util/status.h"
 
+using parquet::ParquetException;
 using parquet::Repetition;
 using parquet::schema::Node;
 using parquet::schema::NodePtr;
@@ -38,6 +40,11 @@ using parquet::LogicalType;
 namespace arrow {
 
 namespace parquet {
+
+#define PARQUET_CATCH_NOT_OK(s) \
+  try {                         \
+    (s);                        \
+  } catch (const ParquetException& e) { return Status::Invalid(e.what()); }
 
 const auto BOOL = std::make_shared<BooleanType>();
 const auto UINT8 = std::make_shared<UInt8Type>();
@@ -300,7 +307,7 @@ Status ToParquetSchema(
 
   NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, nodes);
   *out = std::make_shared<::parquet::SchemaDescriptor>();
-  (*out)->Init(schema);
+  PARQUET_CATCH_NOT_OK((*out)->Init(schema));
 
   return Status::OK();
 }

--- a/cpp/src/arrow/parquet/schema.h
+++ b/cpp/src/arrow/parquet/schema.h
@@ -36,6 +36,8 @@ Status NodeToField(const ::parquet::schema::NodePtr& node, std::shared_ptr<Field
 Status FromParquetSchema(
     const ::parquet::SchemaDescriptor* parquet_schema, std::shared_ptr<Schema>* out);
 
+Status FieldToNode(const std::shared_ptr<Field>& field, ::parquet::schema::NodePtr* out);
+
 Status ToParquetSchema(
     const Schema* arrow_schema, std::shared_ptr<::parquet::SchemaDescriptor>* out);
 

--- a/cpp/src/arrow/parquet/schema.h
+++ b/cpp/src/arrow/parquet/schema.h
@@ -36,6 +36,9 @@ Status NodeToField(const ::parquet::schema::NodePtr& node, std::shared_ptr<Field
 Status FromParquetSchema(
     const ::parquet::SchemaDescriptor* parquet_schema, std::shared_ptr<Schema>* out);
 
+Status ToParquetSchema(
+    const Schema* arrow_schema, std::shared_ptr<::parquet::SchemaDescriptor>* out);
+
 }  // namespace parquet
 
 }  // namespace arrow


### PR DESCRIPTION
My current WIP state. To make the actual schema conversion complete, we probably need the physical structure too as Arrow schemas only care about logical types whereas Parquet schema is about logical and physical types.
