### PR TITLE
ARROW-188: Add numpy as install requirement

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -242,7 +242,7 @@ setup(
         'clean': clean,
         'build_ext': build_ext
     },
-    install_requires=['cython >= 0.21'],
+    install_requires=['cython >= 0.21', 'numpy >= 1.9'],
     description=DESC,
     license='Apache License, Version 2.0',
     maintainer="Apache Arrow Developers",


### PR DESCRIPTION
Successfully tested with NumPy 1.9 which should be a recent but still old version that we can support for now.
