### PR TITLE
 ARROW-193: typos "int his" fix to "in this"

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
@@ -30,7 +30,7 @@ public interface VariableWidthVector extends ValueVector{
   void allocateNew(int totalBytes, int valueCount);
 
   /**
-   * Provide the maximum amount of variable width bytes that can be stored int his vector.
+   * Provide the maximum amount of variable width bytes that can be stored in this vector.
    * @return
    */
   int getByteCapacity();


### PR DESCRIPTION
For the instruction , typos "int his" is fixed to "in this"
