### PR TITLE
ARROW-199: [C++] Refine third party dependency

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -25,11 +25,6 @@ include(CMakeParseArguments)
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 set(THIRDPARTY_DIR "${CMAKE_SOURCE_DIR}/thirdparty")
 
-# Allow "make install" to not depend on all targets.
-#
-# Must be declared in the top-level CMakeLists.txt.
-set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
-
 find_package(ClangTools)
 if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
   # Generate a Clang compile_commands.json "compilation database" file for use

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -8,14 +8,7 @@ out-of-source builds with the latter one being preferred.
 Arrow requires a C++11-enabled compiler. On Linux, gcc 4.8 and higher should be
 sufficient.
 
-To build the thirdparty build dependencies, run:
-
-```
-./thirdparty/download_thirdparty.sh
-./thirdparty/build_thirdparty.sh
-```
-
-You can also run from the root of the C++ tree
+To build the thirdparty build dependencies, run from the root of the C++ tree
 
 ```
 source setup_build_env.sh

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -8,7 +8,15 @@ out-of-source builds with the latter one being preferred.
 Arrow requires a C++11-enabled compiler. On Linux, gcc 4.8 and higher should be
 sufficient.
 
-To build the thirdparty build dependencies, run from the root of the C++ tree
+To build the thirdparty build dependencies, run:
+
+```
+./thirdparty/download_thirdparty.sh
+./thirdparty/build_thirdparty.sh
+source ./thirdparty/set_thirdparty_env.sh
+```
+
+You can also run from the root of the C++ tree
 
 ```
 source setup_build_env.sh

--- a/cpp/setup_build_env.sh
+++ b/cpp/setup_build_env.sh
@@ -4,10 +4,6 @@ SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 ./thirdparty/download_thirdparty.sh || { echo "download_thirdparty.sh failed" ; return; }
 ./thirdparty/build_thirdparty.sh || { echo "build_thirdparty.sh failed" ; return; }
-source thirdparty/versions.sh
-
-export GTEST_HOME=$SOURCE_DIR/thirdparty/$GTEST_BASEDIR
-export GBENCHMARK_HOME=$SOURCE_DIR/thirdparty/installed
-export FLATBUFFERS_HOME=$SOURCE_DIR/thirdparty/installed
+source ./thirdparty/set_thirdparty_env.sh || { echo "build_thirdparty.sh failed" ; return; }
 
 echo "Build env initialized"

--- a/cpp/setup_build_env.sh
+++ b/cpp/setup_build_env.sh
@@ -4,6 +4,6 @@ SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
 
 ./thirdparty/download_thirdparty.sh || { echo "download_thirdparty.sh failed" ; return; }
 ./thirdparty/build_thirdparty.sh || { echo "build_thirdparty.sh failed" ; return; }
-source ./thirdparty/set_thirdparty_env.sh || { echo "build_thirdparty.sh failed" ; return; }
+source ./thirdparty/set_thirdparty_env.sh || { echo "source set_thirdparty_env.sh failed" ; return; }
 
 echo "Build env initialized"

--- a/cpp/thirdparty/set_thirdparty_env.sh
+++ b/cpp/thirdparty/set_thirdparty_env.sh
@@ -1,0 +1,12 @@
+#!/usr/bash
+
+SOURCE_DIR=$(cd "$(dirname "${BASH_SOURCE:-$0}")"; pwd)
+source $SOURCE_DIR/versions.sh
+
+if [ -z "$THIRDPARTY_DIR" ]; then
+	THIRDPARTY_DIR=$SOURCE_DIR
+fi
+
+export GTEST_HOME=$THIRDPARTY_DIR/$GTEST_BASEDIR
+export GBENCHMARK_HOME=$THIRDPARTY_DIR/installed
+export FLATBUFFERS_HOME=$THIRDPARTY_DIR/installed


### PR DESCRIPTION
  To generate makefile, run download_thirdparty.sh and build_thirdparty.sh is not enough
  source setup_build_env.sh is necessary since FLATBUFFERS_HOME must be set .
