### PR TITLE
ARROW-196: Add conda recipe and ensure that libarrow_parquet is installed as well

### DIFF
--- a/cpp/conda.recipe/build.sh
+++ b/cpp/conda.recipe/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cd $RECIPE_DIR
+
+# Build dependencies
+export FLATBUFFERS_HOME=$PREFIX
+export PARQUET_HOME=$PREFIX
+
+cd ..
+
+mkdir conda-build
+
+cp -r thirdparty conda-build/
+
+cd conda-build
+pwd
+
+# Build googletest for running unit tests
+./thirdparty/download_thirdparty.sh
+./thirdparty/build_thirdparty.sh gtest
+
+source thirdparty/versions.sh
+export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
+
+cmake \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DARROW_IPC=on \
+    -DARROW_PARQUET=on \
+    ..
+
+make
+ctest -L unittest
+make install

--- a/cpp/conda.recipe/meta.yaml
+++ b/cpp/conda.recipe/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: arrow-cpp
+  version: "0.1"
+
+build:
+  number: {{environ.get('TRAVIS_BUILD_NUMBER', 0)}}    # [unix]
+  skip: true  # [win]
+
+requirements:
+  build:
+    - cmake
+    - flatbuffers
+    - parquet-cpp
+    - thrift-cpp
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libarrow.so
+    - test -f $PREFIX/lib/libarrow_parquet.so
+    - test -f $PREFIX/include/arrow/api.h
+
+about:
+  home: http://github.com/apache/arrow
+  license: Apache 2.0
+  summary: 'C++ libraries for the reference Apache Arrow implementation'

--- a/cpp/src/arrow/parquet/CMakeLists.txt
+++ b/cpp/src/arrow/parquet/CMakeLists.txt
@@ -42,4 +42,11 @@ ARROW_TEST_LINK_LIBRARIES(parquet-reader-test arrow_parquet)
 
 # Headers: top level
 install(FILES
+  reader.h
+  schema.h
+  utils.h
   DESTINATION include/arrow/parquet)
+
+install(TARGETS arrow_parquet
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)


### PR DESCRIPTION
This depends on PARQUET-614, and enables a conda-installable package version of libarrow and its current additional add-on library `libarrow_parquet`. 
