### PR TITLE
ARROW-206: Expose a C++ api to compare ranges of slots between two arrays

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -56,6 +56,34 @@ TEST_F(TestArray, TestLength) {
   ASSERT_EQ(arr->length(), 100);
 }
 
+ArrayPtr MakeArrayFromValidBytes(const std::vector<uint8_t>& v, MemoryPool* pool) {
+  int32_t null_count = v.size() - std::accumulate(v.begin(), v.end(), 0);
+  std::shared_ptr<Buffer> null_buf = test::bytes_to_null_buffer(v);
+
+  BufferBuilder value_builder(pool);
+  for (size_t i = 0; i < v.size(); ++i) {
+    value_builder.Append<int32_t>(0);
+  }
+
+  ArrayPtr arr(new Int32Array(v.size(), value_builder.Finish(), null_count, null_buf));
+  return arr;
+}
+
+TEST_F(TestArray, TestEquality) {
+  auto array = MakeArrayFromValidBytes({1, 0, 1, 1, 0, 1, 0, 0}, pool_);
+  auto equal_array = MakeArrayFromValidBytes({1, 0, 1, 1, 0, 1, 0, 0}, pool_);
+  auto unequal_array = MakeArrayFromValidBytes({1, 1, 1, 1, 0, 1, 0, 0}, pool_);
+
+  EXPECT_TRUE(array->Equals(array));
+  EXPECT_TRUE(array->Equals(equal_array));
+  EXPECT_TRUE(equal_array->Equals(array));
+  EXPECT_FALSE(equal_array->Equals(unequal_array));
+  EXPECT_TRUE(array->RangeEquals(4, 8, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, 4, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, 8, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(1, 2, unequal_array));
+}
+
 TEST_F(TestArray, TestIsNull) {
   // clang-format off
   std::vector<uint8_t> null_bitmap = {1, 0, 1, 1, 0, 1, 0, 0,

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -79,10 +79,10 @@ TEST_F(TestArray, TestEquality) {
   EXPECT_TRUE(equal_array->Equals(array));
   EXPECT_FALSE(equal_array->Equals(unequal_array));
   EXPECT_FALSE(unequal_array->Equals(equal_array));
-  EXPECT_TRUE(array->RangeEquals(4, 8, unequal_array));
-  EXPECT_FALSE(array->RangeEquals(0, 4, unequal_array));
-  EXPECT_FALSE(array->RangeEquals(0, 8, unequal_array));
-  EXPECT_FALSE(array->RangeEquals(1, 2, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(4, 8, 4, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, 4, 0, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, 8, 0, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(1, 2, 1, unequal_array));
 }
 
 TEST_F(TestArray, TestIsNull) {

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -78,6 +78,7 @@ TEST_F(TestArray, TestEquality) {
   EXPECT_TRUE(array->Equals(equal_array));
   EXPECT_TRUE(equal_array->Equals(array));
   EXPECT_FALSE(equal_array->Equals(unequal_array));
+  EXPECT_FALSE(unequal_array->Equals(equal_array));
   EXPECT_TRUE(array->RangeEquals(4, 8, unequal_array));
   EXPECT_FALSE(array->RangeEquals(0, 4, unequal_array));
   EXPECT_FALSE(array->RangeEquals(0, 8, unequal_array));

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -48,6 +48,14 @@ bool Array::EqualsExact(const Array& other) const {
   return true;
 }
 
+bool Array::RangeEqualsExact(int32_t start_idx, int32_t end_idx, const Array& arr) const {
+  if (this == &arr) { return true; }
+  for (int i = start_idx; i < end_idx; ++i) {
+    if (IsNull(i) != arr.IsNull(i)) { return false; }
+  }
+  return true;
+}
+
 Status Array::Validate() const {
   return Status::OK();
 }
@@ -56,6 +64,12 @@ bool NullArray::Equals(const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
   if (Type::NA != arr->type_enum()) { return false; }
   return arr->length() == length_;
+}
+
+bool NullArray::RangeEquals(
+    int32_t start_idx, int32_t end_idx, const std::shared_ptr<Array>& arr) const {
+  if (Type::NA != arr->type_enum()) { return false; }
+  return true;
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -48,14 +48,6 @@ bool Array::EqualsExact(const Array& other) const {
   return true;
 }
 
-bool Array::RangeEqualsExact(int32_t start_idx, int32_t end_idx, const Array& arr) const {
-  if (this == &arr) { return true; }
-  for (int i = start_idx; i < end_idx; ++i) {
-    if (IsNull(i) != arr.IsNull(i)) { return false; }
-  }
-  return true;
-}
-
 Status Array::Validate() const {
   return Status::OK();
 }
@@ -67,7 +59,8 @@ bool NullArray::Equals(const std::shared_ptr<Array>& arr) const {
 }
 
 bool NullArray::RangeEquals(
-    int32_t start_idx, int32_t end_idx, const std::shared_ptr<Array>& arr) const {
+    int32_t start_idx, int32_t end_idx, int32_t other_start_index, 
+    const std::shared_ptr<Array>& arr) const {
   if (Type::NA != arr->type_enum()) { return false; }
   return true;
 }

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -58,8 +58,7 @@ bool NullArray::Equals(const std::shared_ptr<Array>& arr) const {
   return arr->length() == length_;
 }
 
-bool NullArray::RangeEquals(
-    int32_t start_idx, int32_t end_idx, int32_t other_start_index, 
+bool NullArray::RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_index,
     const std::shared_ptr<Array>& arr) const {
   if (Type::NA != arr->type_enum()) { return false; }
   return true;

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -60,6 +60,7 @@ bool NullArray::Equals(const std::shared_ptr<Array>& arr) const {
 
 bool NullArray::RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_index,
     const std::shared_ptr<Array>& arr) const {
+  if (!arr) { return false; }
   if (Type::NA != arr->type_enum()) { return false; }
   return true;
 }

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -59,6 +59,13 @@ class Array {
 
   bool EqualsExact(const Array& arr) const;
   virtual bool Equals(const std::shared_ptr<Array>& arr) const = 0;
+
+  // Compare if the range of slots specified are equal for the given array and
+  // this array.  end_idx exclusive.  These methods do not bounds check.
+  bool RangeEqualsExact(int32_t start_idx, int32_t end_idx, const Array& arr) const;
+  virtual bool RangeEquals(
+      int32_t start_idx, int32_t end_idx, const std::shared_ptr<Array>& arr) const = 0;
+
   // Determines if the array is internally consistent.  Defaults to always
   // returning Status::OK.  This can be an expensive check.
   virtual Status Validate() const;
@@ -85,10 +92,11 @@ class NullArray : public Array {
   explicit NullArray(int32_t length) : NullArray(std::make_shared<NullType>(), length) {}
 
   bool Equals(const std::shared_ptr<Array>& arr) const override;
+  bool RangeEquals(int32_t start_idx, int32_t end_idx,
+      const std::shared_ptr<Array>& arr) const override;
 };
 
 typedef std::shared_ptr<Array> ArrayPtr;
-
 }  // namespace arrow
 
 #endif

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -61,10 +61,10 @@ class Array {
   virtual bool Equals(const std::shared_ptr<Array>& arr) const = 0;
 
   // Compare if the range of slots specified are equal for the given array and
-  // this array.  end_idx exclusive.  These methods do not bounds check.
-  bool RangeEqualsExact(int32_t start_idx, int32_t end_idx, const Array& arr) const;
+  // this array.  end_idx exclusive.  This methods does not bounds check.
   virtual bool RangeEquals(
-      int32_t start_idx, int32_t end_idx, const std::shared_ptr<Array>& arr) const = 0;
+      int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
+      const std::shared_ptr<Array>& arr) const = 0;
 
   // Determines if the array is internally consistent.  Defaults to always
   // returning Status::OK.  This can be an expensive check.
@@ -92,7 +92,7 @@ class NullArray : public Array {
   explicit NullArray(int32_t length) : NullArray(std::make_shared<NullType>(), length) {}
 
   bool Equals(const std::shared_ptr<Array>& arr) const override;
-  bool RangeEquals(int32_t start_idx, int32_t end_idx,
+  bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_index,
       const std::shared_ptr<Array>& arr) const override;
 };
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -62,8 +62,7 @@ class Array {
 
   // Compare if the range of slots specified are equal for the given array and
   // this array.  end_idx exclusive.  This methods does not bounds check.
-  virtual bool RangeEquals(
-      int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
+  virtual bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const = 0;
 
   // Determines if the array is internally consistent.  Defaults to always

--- a/cpp/src/arrow/types/list-test.cc
+++ b/cpp/src/arrow/types/list-test.cc
@@ -90,10 +90,10 @@ TEST_F(TestListBuilder, Equality) {
   Int32Builder* vb = static_cast<Int32Builder*>(builder_->value_builder().get());
 
   ArrayPtr array, equal_array, unequal_array;
-  vector<int32_t> equal_offsets =  {0, 1, 2, 5};
-  vector<int32_t> equal_values = {1,2,3,4,5,2,2,2};
+  vector<int32_t> equal_offsets = {0, 1, 2, 5};
+  vector<int32_t> equal_values = {1, 2, 3, 4, 5, 2, 2, 2};
   vector<int32_t> unequal_offsets = {0, 1, 4};
-  vector<int32_t> unequal_values = {1,2,2,2,3,4,5};
+  vector<int32_t> unequal_values = {1, 2, 2, 2, 3, 4, 5};
 
   // setup two equal arrays
   ASSERT_OK(builder_->Append(equal_offsets.data(), equal_offsets.size()));
@@ -105,7 +105,7 @@ TEST_F(TestListBuilder, Equality) {
   // now an unequal one
   ASSERT_OK(builder_->Append(unequal_offsets.data(), unequal_offsets.size()));
   ASSERT_OK(vb->Append(unequal_values.data(), unequal_values.size()));
-  unequal_array = builder_->Finish();  
+  unequal_array = builder_->Finish();
 
   // Test array equality
   EXPECT_TRUE(array->Equals(array));

--- a/cpp/src/arrow/types/list-test.cc
+++ b/cpp/src/arrow/types/list-test.cc
@@ -86,6 +86,42 @@ class TestListBuilder : public TestBuilder {
   shared_ptr<ListArray> result_;
 };
 
+TEST_F(TestListBuilder, Equality) {
+  Int32Builder* vb = static_cast<Int32Builder*>(builder_->value_builder().get());
+
+  ArrayPtr array, equal_array, unequal_array;
+  vector<int32_t> equal_offsets =  {0, 1, 2, 5};
+  vector<int32_t> equal_values = {1,2,3,4,5,2,2,2};
+  vector<int32_t> unequal_offsets = {0, 1, 4};
+  vector<int32_t> unequal_values = {1,2,2,2,3,4,5};
+
+  // setup two equal arrays
+  ASSERT_OK(builder_->Append(equal_offsets.data(), equal_offsets.size()));
+  ASSERT_OK(vb->Append(equal_values.data(), equal_values.size()));
+  array = builder_->Finish();
+  ASSERT_OK(builder_->Append(equal_offsets.data(), equal_offsets.size()));
+  ASSERT_OK(vb->Append(equal_values.data(), equal_values.size()));
+  equal_array = builder_->Finish();
+  // now an unequal one
+  ASSERT_OK(builder_->Append(unequal_offsets.data(), unequal_offsets.size()));
+  ASSERT_OK(vb->Append(unequal_values.data(), unequal_values.size()));
+  unequal_array = builder_->Finish();  
+
+  // Test array equality
+  EXPECT_TRUE(array->Equals(array));
+  EXPECT_TRUE(array->Equals(equal_array));
+  EXPECT_TRUE(equal_array->Equals(array));
+  EXPECT_FALSE(equal_array->Equals(unequal_array));
+  EXPECT_FALSE(unequal_array->Equals(equal_array));
+
+  // Test range equality
+  EXPECT_TRUE(array->RangeEquals(0, 1, 0, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, 2, 0, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(1, 2, 1, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(2, 3, 2, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(3, 4, 1, unequal_array));
+}
+
 TEST_F(TestListBuilder, TestResize) {}
 
 TEST_F(TestListBuilder, TestAppendNull) {

--- a/cpp/src/arrow/types/list.cc
+++ b/cpp/src/arrow/types/list.cc
@@ -44,6 +44,21 @@ bool ListArray::Equals(const std::shared_ptr<Array>& arr) const {
   return EqualsExact(*static_cast<const ListArray*>(arr.get()));
 }
 
+bool ListArray::RangeEquals(
+    int32_t start_idx, int32_t end_idx, const std::shared_ptr<Array>& arr) const {
+  if (this == arr.get()) { return true; }
+  if (this->type_enum() != arr->type_enum()) { return false; }
+  auto other = static_cast<ListArray*>(arr.get());
+  for (int i = start_idx; i < end_idx; ++i) {
+    const bool is_null = IsNull(i);
+    if ((is_null != arr->IsNull(i)) ||
+        (!is_null && !values_->RangeEquals(offset(i), offset(i + 1), other->values()))) {
+      return false;
+    }
+  }
+  return true;
+}
+
 Status ListArray::Validate() const {
   if (length_ < 0) { return Status::Invalid("Length was negative"); }
   if (!offset_buf_) { return Status::Invalid("offset_buf_ was null"); }

--- a/cpp/src/arrow/types/list.cc
+++ b/cpp/src/arrow/types/list.cc
@@ -47,6 +47,7 @@ bool ListArray::Equals(const std::shared_ptr<Array>& arr) const {
 bool ListArray::RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
     const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
+  if (!arr) { return false; }
   if (this->type_enum() != arr->type_enum()) { return false; }
   const auto other = static_cast<ListArray*>(arr.get());
   for (int32_t i = start_idx, o_i = other_start_idx; i < end_idx; ++i, ++o_i) {

--- a/cpp/src/arrow/types/list.cc
+++ b/cpp/src/arrow/types/list.cc
@@ -44,9 +44,7 @@ bool ListArray::Equals(const std::shared_ptr<Array>& arr) const {
   return EqualsExact(*static_cast<const ListArray*>(arr.get()));
 }
 
-bool ListArray::RangeEquals(
-    int32_t start_idx, int32_t end_idx, 
-    int32_t other_start_idx, 
+bool ListArray::RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
     const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
   if (this->type_enum() != arr->type_enum()) { return false; }
@@ -55,15 +53,16 @@ bool ListArray::RangeEquals(
     const bool is_null = IsNull(i);
     if (is_null != arr->IsNull(o_i)) { return false; }
     if (is_null) continue;
-    const int32_t begin_offset = offset(i); 
-    const int32_t end_offset = offset(i+1); 
+    const int32_t begin_offset = offset(i);
+    const int32_t end_offset = offset(i + 1);
     const int32_t other_begin_offset = other->offset(o_i);
-    const int32_t other_end_offset = other->offset(o_i+1);
+    const int32_t other_end_offset = other->offset(o_i + 1);
     // Underlying can't be equal if the size isn't equal
     if (end_offset - begin_offset != other_end_offset - other_begin_offset) {
       return false;
     }
-    if (!values_->RangeEquals(begin_offset, end_offset, other_begin_offset, other->values())) {
+    if (!values_->RangeEquals(
+            begin_offset, end_offset, other_begin_offset, other->values())) {
       return false;
     }
   }

--- a/cpp/src/arrow/types/list.h
+++ b/cpp/src/arrow/types/list.h
@@ -72,6 +72,9 @@ class ListArray : public Array {
   bool EqualsExact(const ListArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
+  bool RangeEquals(
+      int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const override;
+
  protected:
   std::shared_ptr<Buffer> offset_buf_;
   const int32_t* offsets_;

--- a/cpp/src/arrow/types/list.h
+++ b/cpp/src/arrow/types/list.h
@@ -73,7 +73,7 @@ class ListArray : public Array {
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
   bool RangeEquals(
-      int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const override;
+      int32_t start_idx, int32_t end_idx, int32_t other_start_idx, const ArrayPtr& arr) const override;
 
  protected:
   std::shared_ptr<Buffer> offset_buf_;

--- a/cpp/src/arrow/types/list.h
+++ b/cpp/src/arrow/types/list.h
@@ -72,8 +72,8 @@ class ListArray : public Array {
   bool EqualsExact(const ListArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
-  bool RangeEquals(
-      int32_t start_idx, int32_t end_idx, int32_t other_start_idx, const ArrayPtr& arr) const override;
+  bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
+      const ArrayPtr& arr) const override;
 
  protected:
   std::shared_ptr<Buffer> offset_buf_;

--- a/cpp/src/arrow/types/primitive-test.cc
+++ b/cpp/src/arrow/types/primitive-test.cc
@@ -352,10 +352,10 @@ TYPED_TEST(TestPrimitiveBuilder, Equality) {
   EXPECT_FALSE(unequal_array->Equals(equal_array));
 
   // Test range equality
-  EXPECT_FALSE(array->RangeEquals(0, first_valid_idx+1, unequal_array));
-  EXPECT_FALSE(array->RangeEquals(first_valid_idx, size, unequal_array));
-  EXPECT_TRUE(array->RangeEquals(0, first_valid_idx, unequal_array));
-  EXPECT_TRUE(array->RangeEquals(first_valid_idx+1, size, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, first_valid_idx+1, 0, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(first_valid_idx, size, first_valid_idx, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(0, first_valid_idx, 0, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(first_valid_idx+1, size, first_valid_idx+1, unequal_array));
 }
 
 TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {

--- a/cpp/src/arrow/types/primitive-test.cc
+++ b/cpp/src/arrow/types/primitive-test.cc
@@ -50,7 +50,7 @@ class Array;
                                           \
     KLASS tp_copy = tp;                   \
     ASSERT_EQ(tp_copy.type, Type::ENUM);  \
-  }                                       \
+  }
 
 PRIMITIVE_TEST(Int8Type, INT8, "int8");
 PRIMITIVE_TEST(Int16Type, INT16, "int16");
@@ -248,7 +248,6 @@ TYPED_TEST_CASE(TestPrimitiveBuilder, Primitives);
 
 #define DECL_ARRAYTYPE() typedef typename TestFixture::ArrayType ArrayType;
 
-
 TYPED_TEST(TestPrimitiveBuilder, TestInit) {
   DECL_TYPE();
 
@@ -305,12 +304,9 @@ TYPED_TEST(TestPrimitiveBuilder, TestArrayDtorDealloc) {
   ASSERT_EQ(memory_before, this->pool_->bytes_allocated());
 }
 
-template<class T, class Builder>
-Status MakeArray(const vector<uint8_t>& valid_bytes,  
-                 const vector<T>& draws,
-                 int size,
-                 Builder* builder, 
-                 ArrayPtr* out) { 
+template <class T, class Builder>
+Status MakeArray(const vector<uint8_t>& valid_bytes, const vector<T>& draws, int size,
+    Builder* builder, ArrayPtr* out) {
   // Append the first 1000
   for (int i = 0; i < size; ++i) {
     if (valid_bytes[i] > 0) {
@@ -331,16 +327,16 @@ TYPED_TEST(TestPrimitiveBuilder, Equality) {
   vector<T>& draws = this->draws_;
   vector<uint8_t>& valid_bytes = this->valid_bytes_;
   ArrayPtr array, equal_array, unequal_array;
-  auto builder = this->builder_.get();  
+  auto builder = this->builder_.get();
   ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &array));
   ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &equal_array));
 
   // Make the not equal array by negating the first valid element with itself.
-  const auto first_valid = std::find_if(valid_bytes.begin(), valid_bytes.end(), 
-                                        [](uint8_t valid){ return valid > 0;});
+  const auto first_valid = std::find_if(
+      valid_bytes.begin(), valid_bytes.end(), [](uint8_t valid) { return valid > 0; });
   const int first_valid_idx = std::distance(valid_bytes.begin(), first_valid);
   // This should be true with a very high probability, but might introduce flakiness
-  ASSERT_LT(first_valid_idx, size-1); 
+  ASSERT_LT(first_valid_idx, size - 1);
   draws[first_valid_idx] = ~*reinterpret_cast<int64_t*>(&draws[first_valid_idx]);
   ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &unequal_array));
 
@@ -352,10 +348,11 @@ TYPED_TEST(TestPrimitiveBuilder, Equality) {
   EXPECT_FALSE(unequal_array->Equals(equal_array));
 
   // Test range equality
-  EXPECT_FALSE(array->RangeEquals(0, first_valid_idx+1, 0, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(0, first_valid_idx + 1, 0, unequal_array));
   EXPECT_FALSE(array->RangeEquals(first_valid_idx, size, first_valid_idx, unequal_array));
   EXPECT_TRUE(array->RangeEquals(0, first_valid_idx, 0, unequal_array));
-  EXPECT_TRUE(array->RangeEquals(first_valid_idx+1, size, first_valid_idx+1, unequal_array));
+  EXPECT_TRUE(
+      array->RangeEquals(first_valid_idx + 1, size, first_valid_idx + 1, unequal_array));
 }
 
 TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {

--- a/cpp/src/arrow/types/primitive-test.cc
+++ b/cpp/src/arrow/types/primitive-test.cc
@@ -50,7 +50,7 @@ class Array;
                                           \
     KLASS tp_copy = tp;                   \
     ASSERT_EQ(tp_copy.type, Type::ENUM);  \
-  }
+  }                                       \
 
 PRIMITIVE_TEST(Int8Type, INT8, "int8");
 PRIMITIVE_TEST(Int16Type, INT16, "int16");
@@ -248,6 +248,7 @@ TYPED_TEST_CASE(TestPrimitiveBuilder, Primitives);
 
 #define DECL_ARRAYTYPE() typedef typename TestFixture::ArrayType ArrayType;
 
+
 TYPED_TEST(TestPrimitiveBuilder, TestInit) {
   DECL_TYPE();
 
@@ -302,6 +303,59 @@ TYPED_TEST(TestPrimitiveBuilder, TestArrayDtorDealloc) {
   } while (false);
 
   ASSERT_EQ(memory_before, this->pool_->bytes_allocated());
+}
+
+template<class T, class Builder>
+Status MakeArray(const vector<uint8_t>& valid_bytes,  
+                 const vector<T>& draws,
+                 int size,
+                 Builder* builder, 
+                 ArrayPtr* out) { 
+  // Append the first 1000
+  for (int i = 0; i < size; ++i) {
+    if (valid_bytes[i] > 0) {
+      RETURN_NOT_OK(builder->Append(draws[i]));
+    } else {
+      RETURN_NOT_OK(builder->AppendNull());
+    }
+  }
+  *out = builder->Finish();
+  return Status::OK();
+}
+
+TYPED_TEST(TestPrimitiveBuilder, Equality) {
+  DECL_T();
+
+  const int size = 1000;
+  this->RandomData(size);
+  vector<T>& draws = this->draws_;
+  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  ArrayPtr array, equal_array, unequal_array;
+  auto builder = this->builder_.get();  
+  ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &array));
+  ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &equal_array));
+
+  // Make the not equal array by negating the first valid element with itself.
+  const auto first_valid = std::find_if(valid_bytes.begin(), valid_bytes.end(), 
+                                        [](uint8_t valid){ return valid > 0;});
+  const int first_valid_idx = std::distance(valid_bytes.begin(), first_valid);
+  // This should be true with a very high probability, but might introduce flakiness
+  ASSERT_LT(first_valid_idx, size-1); 
+  draws[first_valid_idx] = ~*reinterpret_cast<int64_t*>(&draws[first_valid_idx]);
+  ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &unequal_array));
+
+  // test normal equality
+  EXPECT_TRUE(array->Equals(array));
+  EXPECT_TRUE(array->Equals(equal_array));
+  EXPECT_TRUE(equal_array->Equals(array));
+  EXPECT_FALSE(equal_array->Equals(unequal_array));
+  EXPECT_FALSE(unequal_array->Equals(equal_array));
+
+  // Test range equality
+  EXPECT_FALSE(array->RangeEquals(0, first_valid_idx+1, unequal_array));
+  EXPECT_FALSE(array->RangeEquals(first_valid_idx, size, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(0, first_valid_idx, unequal_array));
+  EXPECT_TRUE(array->RangeEquals(first_valid_idx+1, size, unequal_array));
 }
 
 TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {

--- a/cpp/src/arrow/types/primitive.cc
+++ b/cpp/src/arrow/types/primitive.cc
@@ -191,8 +191,8 @@ bool BooleanArray::Equals(const ArrayPtr& arr) const {
   return EqualsExact(*static_cast<const BooleanArray*>(arr.get()));
 }
 
-bool BooleanArray::RangeEquals(
-    int32_t start_idx, int32_t end_idx, int32_t other_start_idx, const ArrayPtr& arr) const {
+bool BooleanArray::RangeEquals(int32_t start_idx, int32_t end_idx,
+    int32_t other_start_idx, const ArrayPtr& arr) const {
   if (this == arr.get()) { return true; }
   if (!arr) { return false; }
   if (this->type_enum() != arr->type_enum()) { return false; }

--- a/cpp/src/arrow/types/primitive.cc
+++ b/cpp/src/arrow/types/primitive.cc
@@ -185,10 +185,25 @@ bool BooleanArray::EqualsExact(const BooleanArray& other) const {
   }
 }
 
-bool BooleanArray::Equals(const std::shared_ptr<Array>& arr) const {
+bool BooleanArray::Equals(const ArrayPtr& arr) const {
   if (this == arr.get()) return true;
   if (Type::BOOL != arr->type_enum()) { return false; }
   return EqualsExact(*static_cast<const BooleanArray*>(arr.get()));
+}
+
+bool BooleanArray::RangeEquals(
+    int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const {
+  if (this == arr.get()) { return true; }
+  if (!arr) { return false; }
+  if (this->type_enum() != arr->type_enum()) { return false; }
+  auto other = static_cast<BooleanArray*>(arr.get());
+  for (int i = start_idx; i < end_idx; ++i) {
+    bool is_null = IsNull(i);
+    if (is_null != arr->IsNull(i) || (!is_null && Value(i) != other->Value(i))) {
+      return false;
+    }
+  }
+  return true;
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/types/primitive.cc
+++ b/cpp/src/arrow/types/primitive.cc
@@ -192,14 +192,14 @@ bool BooleanArray::Equals(const ArrayPtr& arr) const {
 }
 
 bool BooleanArray::RangeEquals(
-    int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const {
+    int32_t start_idx, int32_t end_idx, int32_t other_start_idx, const ArrayPtr& arr) const {
   if (this == arr.get()) { return true; }
   if (!arr) { return false; }
   if (this->type_enum() != arr->type_enum()) { return false; }
-  auto other = static_cast<BooleanArray*>(arr.get());
-  for (int i = start_idx; i < end_idx; ++i) {
-    bool is_null = IsNull(i);
-    if (is_null != arr->IsNull(i) || (!is_null && Value(i) != other->Value(i))) {
+  const auto other = static_cast<BooleanArray*>(arr.get());
+  for (int32_t i = start_idx, o_i = other_start_idx; i < end_idx; ++i, ++o_i) {
+    const bool is_null = IsNull(i);
+    if (is_null != arr->IsNull(o_i) || (!is_null && Value(i) != other->Value(o_i))) {
       return false;
     }
   }

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -66,6 +66,21 @@ class PrimitiveArray : public Array {
       return PrimitiveArray::EqualsExact(*static_cast<const PrimitiveArray*>(&other)); \
     }                                                                                  \
                                                                                        \
+    bool RangeEquals(                                                                  \
+        int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const override {      \
+      if (this == arr.get()) { return true; }                                          \
+      if (!arr) { return false; }                                                      \
+      if (this->type_enum() != arr->type_enum()) { return false; }                     \
+      auto other = static_cast<NAME*>(arr.get());                                      \
+      for (int i = start_idx; i < end_idx; ++i) {                                      \
+        bool is_null = IsNull(i);                                                      \
+        if (is_null != arr->IsNull(i) || (!is_null && Value(i) != other->Value(i))) {  \
+          return false;                                                                \
+        }                                                                              \
+      }                                                                                \
+      return true;                                                                     \
+    }                                                                                  \
+                                                                                       \
     const T* raw_data() const { return reinterpret_cast<const T*>(raw_data_); }        \
                                                                                        \
     T Value(int i) const { return raw_data()[i]; }                                     \
@@ -248,7 +263,9 @@ class BooleanArray : public PrimitiveArray {
       int32_t null_count = 0, const std::shared_ptr<Buffer>& null_bitmap = nullptr);
 
   bool EqualsExact(const BooleanArray& other) const;
-  bool Equals(const std::shared_ptr<Array>& arr) const override;
+  bool Equals(const ArrayPtr& arr) const override;
+  bool RangeEquals(
+      int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const override;
 
   const uint8_t* raw_data() const { return reinterpret_cast<const uint8_t*>(raw_data_); }
 

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -67,14 +67,16 @@ class PrimitiveArray : public Array {
     }                                                                                  \
                                                                                        \
     bool RangeEquals(                                                                  \
-        int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const override {      \
+        int32_t start_idx, int32_t end_idx,                                            \
+        int32_t other_start_idx,                                                       \
+        const ArrayPtr& arr) const override {                                          \
       if (this == arr.get()) { return true; }                                          \
       if (!arr) { return false; }                                                      \
       if (this->type_enum() != arr->type_enum()) { return false; }                     \
-      auto other = static_cast<NAME*>(arr.get());                                      \
-      for (int i = start_idx; i < end_idx; ++i) {                                      \
-        bool is_null = IsNull(i);                                                      \
-        if (is_null != arr->IsNull(i) || (!is_null && Value(i) != other->Value(i))) {  \
+      const auto other = static_cast<NAME*>(arr.get());                                \
+      for (int32_t i = start_idx, o_i = other_start_idx; i < end_idx; ++i, ++o_i) {    \
+        const bool is_null = IsNull(i);                                                \
+        if (is_null != arr->IsNull(o_i) || (!is_null && Value(i) != other->Value(o_i))) {  \
           return false;                                                                \
         }                                                                              \
       }                                                                                \
@@ -268,7 +270,8 @@ class BooleanArray : public PrimitiveArray {
   bool EqualsExact(const BooleanArray& other) const;
   bool Equals(const ArrayPtr& arr) const override;
   bool RangeEquals(
-      int32_t start_idx, int32_t end_idx, const ArrayPtr& arr) const override;
+      int32_t start_idx, int32_t end_idx, int32_t other_start_idx, 
+      const ArrayPtr& arr) const override;
 
   const uint8_t* raw_data() const { return reinterpret_cast<const uint8_t*>(raw_data_); }
 

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -66,9 +66,7 @@ class PrimitiveArray : public Array {
       return PrimitiveArray::EqualsExact(*static_cast<const PrimitiveArray*>(&other)); \
     }                                                                                  \
                                                                                        \
-    bool RangeEquals(                                                                  \
-        int32_t start_idx, int32_t end_idx,                                            \
-        int32_t other_start_idx,                                                       \
+    bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,      \
         const ArrayPtr& arr) const override {                                          \
       if (this == arr.get()) { return true; }                                          \
       if (!arr) { return false; }                                                      \
@@ -76,7 +74,8 @@ class PrimitiveArray : public Array {
       const auto other = static_cast<NAME*>(arr.get());                                \
       for (int32_t i = start_idx, o_i = other_start_idx; i < end_idx; ++i, ++o_i) {    \
         const bool is_null = IsNull(i);                                                \
-        if (is_null != arr->IsNull(o_i) || (!is_null && Value(i) != other->Value(o_i))) {  \
+        if (is_null != arr->IsNull(o_i) ||                                             \
+            (!is_null && Value(i) != other->Value(o_i))) {                             \
           return false;                                                                \
         }                                                                              \
       }                                                                                \
@@ -269,8 +268,7 @@ class BooleanArray : public PrimitiveArray {
 
   bool EqualsExact(const BooleanArray& other) const;
   bool Equals(const ArrayPtr& arr) const override;
-  bool RangeEquals(
-      int32_t start_idx, int32_t end_idx, int32_t other_start_idx, 
+  bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const ArrayPtr& arr) const override;
 
   const uint8_t* raw_data() const { return reinterpret_cast<const uint8_t*>(raw_data_); }

--- a/cpp/src/arrow/types/primitive.h
+++ b/cpp/src/arrow/types/primitive.h
@@ -296,7 +296,6 @@ class BooleanBuilder : public PrimitiveBuilder<BooleanType> {
 
   // Scalar append
   Status Append(bool val) {
-    // TODO(emkornfield) fix reserve/resize for BooleanBuilder
     Reserve(1);
     util::set_bit(null_bitmap_data_, length_);
     if (val) {


### PR DESCRIPTION
@wesm the need for this grew out of @fengguangyuan PR to add struct type (#66) and struct builder.  I considered a different APIs before settling on this:
1.  Add an API that took the parent bitmask (this potentially has possibility of being the most performant, but would have a more awkward contract then provided here) 
2.  Add an equality comparison for a single slot (leaves the least amount of room for optimization but it would be the simplest to implement).
3.  This API which potentially leaves some room for optimization but I think places the least requirements on the caller.

Let me know if you would prefer a different API.

WIP because I need to add more unit tests (I also need to think about if it is worth mirroring the EqualsExact in addition to the Equals method).  Which I should get to by the end of the weekend.

@fengguangyuan let me know if this makes sense to you as a way forward on your PR
