### PR TITLE
ARROW-207: Extend BufferAllocator interface to allow decorators around BufferAllocator

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -332,7 +332,7 @@ public class AllocationManager {
      * @return The ledger associated with the BufferAllocator.
      */
     public BufferLedger getLedgerForAllocator(BufferAllocator allocator) {
-      return associate((BaseAllocator) allocator);
+      return associate(allocator.unwrap(BaseAllocator.class));
     }
 
     /**

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -783,6 +783,16 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
   }
 
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T unwrap(Class<T> c) {
+    if (BaseAllocator.class.isAssignableFrom(c)) {
+      return (T) this;
+    }
+
+    throw new UnsupportedOperationException("Unable to unwrap type to class: " + c.getName());
+  }
+
   public static boolean isDebug() {
     return DEBUG;
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -80,6 +80,14 @@ public interface BufferAllocator extends AutoCloseable {
   public void close();
 
   /**
+   * Unwrap the class so that exposes the provided interface, if possible. Otherwise, throw Exception.
+   * @param c
+   *          The class or interface that you want this class to implement/extend.
+   * @return The instance of that class related to 'this'
+   */
+  public <T> T unwrap(Class<T> c);
+
+  /**
    * Returns the amount of memory currently allocated from this allocator.
    *
    * @return the amount of memory currently allocated


### PR DESCRIPTION
Currently AllocationManager needs BufferAllocator instance reference for accounting purposes.
Having a decorator around the BufferAllocator disturbs the accounting in AllocationManager.
Add an unwrap method to allow getting the reference to inner BufferAllocator instance and use
this method in AllocationManager to get the actual BufferAllocator.

  /**
- Unwrap the class so that exposes the provided interface, if possible. Otherwise, throw Exception.
- @param c
-          The class or interface that you want this class to implement/extend.
- @return The instance of that class related to 'this'
  */
  <T> T unwrap(Class<T> c);

@StevenMPhillips: Could you please review this patch?
