### PR TITLE
ARROW-209: [C++] Triage builds due to unavailable LLVM apt repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     - kalakris-cmake
-    - llvm-toolchain-precise-3.7
     packages:
     - clang-format-3.7
     - clang-tidy-3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ addons:
     - ubuntu-toolchain-r-test
     - kalakris-cmake
     packages:
-    - clang-format-3.7
-    - clang-tidy-3.7
     - gcc-4.9   # Needed for C++11
     - g++-4.9   # Needed for C++11
     - gdb

--- a/ci/travis_script_cpp.sh
+++ b/ci/travis_script_cpp.sh
@@ -7,10 +7,14 @@ set -e
 pushd $CPP_BUILD_DIR
 
 make lint
-if [ $TRAVIS_OS_NAME == "linux" ]; then
-  make check-format
-  make check-clang-tidy
-fi
+
+# ARROW-209: checks depending on the LLVM toolchain are disabled temporarily
+# until we are able to install the full LLVM toolchain in Travis CI again
+
+# if [ $TRAVIS_OS_NAME == "linux" ]; then
+#   make check-format
+#   make check-clang-tidy
+# fi
 
 ctest -L unittest
 


### PR DESCRIPTION
For now, this unblocks builds until we can resolve the LLVM apt issue. 
