### PR TITLE
ARROW-254: remove Bit type as it is redundant with Boolean

### DIFF
--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -99,8 +99,6 @@ static Status TypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       return Status::Invalid("Type metadata cannot be none");
     case flatbuf::Type_Int:
       return IntFromFlatbuffer(static_cast<const flatbuf::Int*>(type_data), out);
-    case flatbuf::Type_Bit:
-      return Status::NotImplemented("Type is not implemented");
     case flatbuf::Type_FloatingPoint:
       return FloatFromFlatuffer(
           static_cast<const flatbuf::FloatingPoint*>(type_data), out);

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -20,9 +20,6 @@ table Union {
   mode: UnionMode;
 }
 
-table Bit {
-}
-
 table Int {
   bitWidth: int; // 1 to 64
   is_signed: bool;
@@ -62,7 +59,6 @@ table JSONScalar {
 
 union Type {
   Int,
-  Bit,
   FloatingPoint,
   Binary,
   Utf8,


### PR DESCRIPTION
The only use of Bit is for the nullability (or validity) vector which is best understood as a boolean type.
We should remove it as it is not used.
