### PR TITLE
ARROW-256: [Format] Add a version number to the IPC/RPC metadata

### DIFF
--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -295,7 +295,8 @@ Status WriteDataHeader(int32_t length, int64_t body_length,
 }
 
 Status MessageBuilder::Finish() {
-  auto message = flatbuf::CreateMessage(fbb_, header_type_, header_, body_length_);
+  auto message = flatbuf::CreateMessage(fbb_, kMetadataVersion,
+      header_type_, header_, body_length_);
   fbb_.Finish(message);
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -37,6 +37,8 @@ class Status;
 
 namespace ipc {
 
+static constexpr flatbuf::MetadataVersion kMetadataVersion = flatbuf::MetadataVersion_V1;
+
 Status FieldFromFlatbuffer(const flatbuf::Field* field, std::shared_ptr<Field>* out);
 
 class MessageBuilder {

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -37,7 +37,8 @@ class Status;
 
 namespace ipc {
 
-static constexpr flatbuf::MetadataVersion kMetadataVersion = flatbuf::MetadataVersion_V1;
+static constexpr flatbuf::MetadataVersion kMetadataVersion =
+  flatbuf::MetadataVersion_V1_SNAPSHOT;
 
 Status FieldFromFlatbuffer(const flatbuf::Field* field, std::shared_ptr<Field>* out);
 

--- a/format/File.fbs
+++ b/format/File.fbs
@@ -7,6 +7,7 @@ namespace org.apache.arrow.flatbuf;
 ///
 
 table Footer {
+  version: org.apache.arrow.flatbuf.MetadataVersion;
 
   schema: org.apache.arrow.flatbuf.Schema;
 

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -1,5 +1,9 @@
 namespace org.apache.arrow.flatbuf;
 
+enum MetadataVersion:short {
+  V1
+}
+
 /// ----------------------------------------------------------------------
 /// Logical types and their metadata (if any)
 ///
@@ -237,6 +241,7 @@ union MessageHeader {
 }
 
 table Message {
+  version: org.apache.arrow.flatbuf.MetadataVersion;
   header: MessageHeader;
   bodyLength: long;
 }

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -1,7 +1,7 @@
 namespace org.apache.arrow.flatbuf;
 
 enum MetadataVersion:short {
-  V1
+  V1_SNAPSHOT
 }
 
 /// ----------------------------------------------------------------------


### PR DESCRIPTION
See "Schema evolution examples" in https://google.github.io/flatbuffers/flatbuffers_guide_writing_schema.html. In the future, if we need to add some other message types (like `RecordBatchV2`), then this should permit this without too much trouble.
