### PR TITLE
ARROW-278: [Format] Rename Tuple to Struct_ in flatbuffers IDL

### DIFF
--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -115,7 +115,7 @@ static Status TypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       }
       *out = std::make_shared<ListType>(children[0]);
       return Status::OK();
-    case flatbuf::Type_Tuple:
+    case flatbuf::Type_Struct_:
       *out = std::make_shared<StructType>(children);
       return Status::OK();
     case flatbuf::Type_Union:
@@ -153,7 +153,7 @@ static Status StructToFlatbuffer(FBB& fbb, const std::shared_ptr<DataType>& type
     RETURN_NOT_OK(FieldToFlatbuffer(fbb, type->child(i), &field));
     out_children->push_back(field);
   }
-  *offset = flatbuf::CreateTuple(fbb).Union();
+  *offset = flatbuf::CreateStruct_(fbb).Union();
   return Status::OK();
 }
 
@@ -197,7 +197,7 @@ static Status TypeToFlatbuffer(FBB& fbb, const std::shared_ptr<DataType>& type,
       *out_type = flatbuf::Type_List;
       return ListToFlatbuffer(fbb, type, children, offset);
     case Type::STRUCT:
-      *out_type = flatbuf::Type_Tuple;
+      *out_type = flatbuf::Type_Struct_;
       return StructToFlatbuffer(fbb, type, children, offset);
     default:
       *out_type = flatbuf::Type_NONE;  // Make clang-tidy happy

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -8,10 +8,10 @@ namespace org.apache.arrow.flatbuf;
 table Null {
 }
 
-/// A Tuple in the flatbuffer metadata is the same as an Arrow Struct
-/// (according to the physical memory layout). We used Tuple here as Struct is
-/// a reserved word in Flatbuffers
-table Tuple {
+/// A Struct_ in the flatbuffer metadata is the same as an Arrow Struct
+/// (according to the physical memory layout). We used Struct_ here as
+/// Struct is a reserved word in Flatbuffers
+table Struct_ {
 }
 
 table List {
@@ -87,7 +87,7 @@ union Type {
   IntervalDay,
   IntervalYear,
   List,
-  Tuple,
+  Struct_,
   Union,
   JSONScalar
 }

--- a/java/vector/src/main/codegen/data/ArrowTypes.tdd
+++ b/java/vector/src/main/codegen/data/ArrowTypes.tdd
@@ -21,7 +21,7 @@
       fields: []
     },
     {
-      name: "Tuple",
+      name: "Struct_",
       fields: []
     },
     {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.ComplexHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
-import org.apache.arrow.vector.types.pojo.ArrowType.Tuple;
+import org.apache.arrow.vector.types.pojo.ArrowType.Struct_;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.JsonStringHashMap;
@@ -290,7 +290,7 @@ public class MapVector extends AbstractMapVector {
     for (ValueVector child : getChildren()) {
       children.add(child.getField());
     }
-    return new Field(name, false, Tuple.INSTANCE, children);
+    return new Field(name, false, Struct_.INSTANCE, children);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/schema/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/schema/TypeLayout.java
@@ -45,7 +45,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType.IntervalYear;
 import org.apache.arrow.vector.types.pojo.ArrowType.Null;
 import org.apache.arrow.vector.types.pojo.ArrowType.Time;
 import org.apache.arrow.vector.types.pojo.ArrowType.Timestamp;
-import org.apache.arrow.vector.types.pojo.ArrowType.Tuple;
+import org.apache.arrow.vector.types.pojo.ArrowType.Struct_;
 import org.apache.arrow.vector.types.pojo.ArrowType.Union;
 import org.apache.arrow.vector.types.pojo.ArrowType.Utf8;
 
@@ -54,7 +54,7 @@ import com.google.common.base.Preconditions;
 /**
  * The layout of vectors for a given type
  * It defines its own vectors followed by the vectors for the children
- * if it is a nested type (Tuple, List, Union)
+ * if it is a nested type (Struct_, List, Union)
  */
 public class TypeLayout {
 
@@ -88,7 +88,7 @@ public class TypeLayout {
         return new TypeLayout(vectors);
       }
 
-      @Override public TypeLayout visit(Tuple type) {
+      @Override public TypeLayout visit(Struct_ type) {
         List<VectorLayout> vectors = asList(
             validityVector()
             );

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -84,7 +84,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType.List;
 import org.apache.arrow.vector.types.pojo.ArrowType.Null;
 import org.apache.arrow.vector.types.pojo.ArrowType.Time;
 import org.apache.arrow.vector.types.pojo.ArrowType.Timestamp;
-import org.apache.arrow.vector.types.pojo.ArrowType.Tuple;
+import org.apache.arrow.vector.types.pojo.ArrowType.Struct_;
 import org.apache.arrow.vector.types.pojo.ArrowType.Union;
 import org.apache.arrow.vector.types.pojo.ArrowType.Utf8;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -131,7 +131,7 @@ public class Types {
         return null;
       }
     },
-    MAP(Tuple.INSTANCE) {
+    MAP(Struct_.INSTANCE) {
       @Override
       public Field getField() {
         throw new UnsupportedOperationException("Cannot get simple field for Map type");

--- a/java/vector/src/test/java/org/apache/arrow/vector/pojo/TestConvert.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/pojo/TestConvert.java
@@ -26,7 +26,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType.FloatingPoint;
 import org.apache.arrow.vector.types.pojo.ArrowType.Int;
 import org.apache.arrow.vector.types.pojo.ArrowType.List;
 import org.apache.arrow.vector.types.pojo.ArrowType.Timestamp;
-import org.apache.arrow.vector.types.pojo.ArrowType.Tuple;
+import org.apache.arrow.vector.types.pojo.ArrowType.Struct_;
 import org.apache.arrow.vector.types.pojo.ArrowType.Union;
 import org.apache.arrow.vector.types.pojo.ArrowType.Utf8;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -53,7 +53,7 @@ public class TestConvert {
     childrenBuilder.add(new Field("child1", true, Utf8.INSTANCE, null));
     childrenBuilder.add(new Field("child2", true, new FloatingPoint(SINGLE), ImmutableList.<Field>of()));
 
-    Field initialField = new Field("a", true, Tuple.INSTANCE, childrenBuilder.build());
+    Field initialField = new Field("a", true, Struct_.INSTANCE, childrenBuilder.build());
     run(initialField);
   }
 
@@ -71,7 +71,7 @@ public class TestConvert {
     ImmutableList.Builder<Field> childrenBuilder = ImmutableList.builder();
     childrenBuilder.add(new Field("child1", true, Utf8.INSTANCE, null));
     childrenBuilder.add(new Field("child2", true, new FloatingPoint(SINGLE), ImmutableList.<Field>of()));
-    childrenBuilder.add(new Field("child3", true, new Tuple(), ImmutableList.<Field>of(
+    childrenBuilder.add(new Field("child3", true, new Struct_(), ImmutableList.<Field>of(
         new Field("child3.1", true, Utf8.INSTANCE, null),
         new Field("child3.2", true, new FloatingPoint(DOUBLE), ImmutableList.<Field>of())
         )));


### PR DESCRIPTION
"Struct" is a reserved keyword in generated bindings for C++. We had used "Tuple" to sidestep this but we discussed and decided to mangle "Struct" instead in the Flatbuffers.
