### PR TITLE
ARROW-112: Changed constexprs to kValue naming.

### DIFF
--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -33,7 +33,7 @@ class Array;
 class MemoryPool;
 class PoolBuffer;
 
-static constexpr int32_t MIN_BUILDER_CAPACITY = 1 << 5;
+static constexpr int32_t kMinBuilderCapacity = 1 << 5;
 
 // Base class for all data array builders.
 // This class provides a facilities for incrementally building the null bitmap

--- a/cpp/src/arrow/types/json.cc
+++ b/cpp/src/arrow/types/json.cc
@@ -30,8 +30,8 @@ static const TypePtr String(new StringType());
 static const TypePtr Double(new DoubleType());
 static const TypePtr Bool(new BooleanType());
 
-static const std::vector<TypePtr> json_types = {Null, Int32, String, Double, Bool};
-TypePtr JSONScalar::dense_type = TypePtr(new DenseUnionType(json_types));
-TypePtr JSONScalar::sparse_type = TypePtr(new SparseUnionType(json_types));
+static const std::vector<TypePtr> kJsonTypes = {Null, Int32, String, Double, Bool};
+TypePtr JSONScalar::dense_type = TypePtr(new DenseUnionType(kJsonTypes));
+TypePtr JSONScalar::sparse_type = TypePtr(new SparseUnionType(kJsonTypes));
 
 }  // namespace arrow

--- a/cpp/src/arrow/types/primitive-test.cc
+++ b/cpp/src/arrow/types/primitive-test.cc
@@ -461,7 +461,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAdvance) {
 TYPED_TEST(TestPrimitiveBuilder, TestResize) {
   DECL_TYPE();
 
-  int cap = MIN_BUILDER_CAPACITY * 2;
+  int cap = kMinBuilderCapacity * 2;
 
   ASSERT_OK(this->builder_->Reserve(cap));
   ASSERT_EQ(cap, this->builder_->capacity());
@@ -473,13 +473,13 @@ TYPED_TEST(TestPrimitiveBuilder, TestResize) {
 TYPED_TEST(TestPrimitiveBuilder, TestReserve) {
   ASSERT_OK(this->builder_->Reserve(10));
   ASSERT_EQ(0, this->builder_->length());
-  ASSERT_EQ(MIN_BUILDER_CAPACITY, this->builder_->capacity());
+  ASSERT_EQ(kMinBuilderCapacity, this->builder_->capacity());
 
   ASSERT_OK(this->builder_->Reserve(90));
   ASSERT_OK(this->builder_->Advance(100));
-  ASSERT_OK(this->builder_->Reserve(MIN_BUILDER_CAPACITY));
+  ASSERT_OK(this->builder_->Reserve(kMinBuilderCapacity));
 
-  ASSERT_EQ(util::next_power2(MIN_BUILDER_CAPACITY + 100), this->builder_->capacity());
+  ASSERT_EQ(util::next_power2(kMinBuilderCapacity + 100), this->builder_->capacity());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/types/primitive.cc
+++ b/cpp/src/arrow/types/primitive.cc
@@ -86,7 +86,7 @@ Status PrimitiveBuilder<T>::Init(int32_t capacity) {
 template <typename T>
 Status PrimitiveBuilder<T>::Resize(int32_t capacity) {
   // XXX: Set floor size for now
-  if (capacity < MIN_BUILDER_CAPACITY) { capacity = MIN_BUILDER_CAPACITY; }
+  if (capacity < kMinBuilderCapacity) { capacity = kMinBuilderCapacity; }
 
   if (capacity_ == 0) {
     RETURN_NOT_OK(Init(capacity));

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -43,22 +43,22 @@ static inline int64_t ceil_2bytes(int64_t size) {
   return (size + 15) & ~15;
 }
 
-static constexpr uint8_t BITMASK[] = {1, 2, 4, 8, 16, 32, 64, 128};
+static constexpr uint8_t kBitmask[] = {1, 2, 4, 8, 16, 32, 64, 128};
 
 static inline bool get_bit(const uint8_t* bits, int i) {
-  return static_cast<bool>(bits[i / 8] & BITMASK[i % 8]);
+  return static_cast<bool>(bits[i / 8] & kBitmask[i % 8]);
 }
 
 static inline bool bit_not_set(const uint8_t* bits, int i) {
-  return (bits[i / 8] & BITMASK[i % 8]) == 0;
+  return (bits[i / 8] & kBitmask[i % 8]) == 0;
 }
 
 static inline void clear_bit(uint8_t* bits, int i) {
-  bits[i / 8] &= ~BITMASK[i % 8];
+  bits[i / 8] &= ~kBitmask[i % 8];
 }
 
 static inline void set_bit(uint8_t* bits, int i) {
-  bits[i / 8] |= BITMASK[i % 8];
+  bits[i / 8] |= kBitmask[i % 8];
 }
 
 static inline int64_t next_power2(int64_t n) {

--- a/cpp/src/arrow/util/buffer.h
+++ b/cpp/src/arrow/util/buffer.h
@@ -142,8 +142,6 @@ class ARROW_EXPORT PoolBuffer : public ResizableBuffer {
   MemoryPool* pool_;
 };
 
-static constexpr int64_t MIN_BUFFER_CAPACITY = 1024;
-
 class BufferBuilder {
  public:
   explicit BufferBuilder(MemoryPool* pool)


### PR DESCRIPTION
Consistent with Google style.
