### PR TITLE
ARROW-323: [Python] Opt-in to pyarrow.parquet extension rather than attempting and failing silently

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -50,6 +50,9 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   option(PYARROW_BUILD_TESTS
     "Build the PyArrow C++ googletest unit tests"
     OFF)
+  option(PYARROW_BUILD_PARQUET
+    "Build the PyArrow Parquet integration"
+    OFF)
 endif()
 
 find_program(CCACHE_FOUND ccache)
@@ -445,7 +448,10 @@ set(LINK_LIBS
   arrow_ipc
 )
 
-if(PARQUET_FOUND AND PARQUET_ARROW_FOUND)
+if (PYARROW_BUILD_PARQUET)
+  if(NOT (PARQUET_FOUND AND PARQUET_ARROW_FOUND))
+    message(FATAL_ERROR "Unable to locate Parquet libraries")
+  endif()
   ADD_THIRDPARTY_LIB(parquet_arrow
     SHARED_LIB ${PARQUET_ARROW_SHARED_LIB})
   set(LINK_LIBS

--- a/python/README.md
+++ b/python/README.md
@@ -48,7 +48,8 @@ python setup.py build_ext --inplace
 py.test pyarrow
 ```
 
-To change the build type, use the `--build-type` option:
+To change the build type, use the `--build-type` option or set
+`$PYARROW_BUILD_TYPE`:
 
 ```bash
 python setup.py build_ext --build-type=release --inplace
@@ -56,6 +57,12 @@ python setup.py build_ext --build-type=release --inplace
 
 To pass through other build options to CMake, set the environment variable
 `$PYARROW_CMAKE_OPTIONS`.
+
+#### Build the pyarrow Parquet file extension
+
+```
+export PYARROW_CMAKE_OPTIONS=-DPYARROW_BUILD_PARQUET=on
+```
 
 #### Build the documentation
 

--- a/python/README.md
+++ b/python/README.md
@@ -61,7 +61,13 @@ To pass through other build options to CMake, set the environment variable
 #### Build the pyarrow Parquet file extension
 
 To build the integration with [parquet-cpp][1], pass `--with-parquet` to
-setup.py or add `-DPYARROW_BUILD_PARQUET=on` to the general CMake options.
+the `build_ext` option in setup.py:
+
+```
+python setup.py build_ext --with-parquet install
+```
+
+Alternately, add `-DPYARROW_BUILD_PARQUET=on` to the general CMake options.
 
 ```
 export PYARROW_CMAKE_OPTIONS=-DPYARROW_BUILD_PARQUET=on

--- a/python/README.md
+++ b/python/README.md
@@ -60,6 +60,9 @@ To pass through other build options to CMake, set the environment variable
 
 #### Build the pyarrow Parquet file extension
 
+To build the integration with [parquet-cpp][1], pass `--with-parquet` to
+setup.py or add `-DPYARROW_BUILD_PARQUET=on` to the general CMake options.
+
 ```
 export PYARROW_CMAKE_OPTIONS=-DPYARROW_BUILD_PARQUET=on
 ```
@@ -70,3 +73,5 @@ export PYARROW_CMAKE_OPTIONS=-DPYARROW_BUILD_PARQUET=on
 pip install -r doc/requirements.txt
 python setup.py build_sphinx
 ```
+
+[1]: https://github.com/apache/parquet-cpp


### PR DESCRIPTION
Added a couple ways to do this, either via the `--with-parquet` command line option (preferred) or by passing through an option to CMake