### PR TITLE
ARROW-380: [Java] optimize null count when serializing vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -72,6 +72,11 @@ public abstract class BaseValueVector implements ValueVector {
     public boolean isNull(int index) {
       return false;
     }
+
+    @Override
+    public int getNullCount() {
+      return 0;
+    }
   }
 
   public abstract static class BaseMutator implements ValueVector.Mutator {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -74,8 +74,15 @@ public abstract class BaseValueVector implements ValueVector {
     }
 
     @Override
+    // override this in case your implementation is faster, see BitVector
     public int getNullCount() {
-      return 0;
+      int nullCount = 0;
+      for (int i = 0; i < getValueCount(); i++) {
+        if (isNull(i)) {
+          nullCount ++;
+        }
+      }
+      return nullCount;
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -387,13 +387,15 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
     @Override
     public final int getNullCount() {
       int count = 0;
-      for (int i = 0; i < allocationSizeInBytes; ++i) {
+      int sizeInBytes = getSizeFromCount(valueCount);
+
+      for (int i = 0; i < sizeInBytes; ++i) {
         byte byteValue = data.getByte(i);
         // Java uses two's complement binary representation, hence 11111111_b which is -1 when converted to Int
         // will have 32bits set to 1. Masking the MSB and then adding it back solves the issue.
         count += Integer.bitCount(byteValue & 0x7F) - (byteValue >> 7);
       }
-      int nullCount = (allocationSizeInBytes * 8) - count;
+      int nullCount = (sizeInBytes * 8) - count;
       // if the valueCount is not a multiple of 8, the bits on the right were counted as null bits
       int remainder = valueCount % 8;
       nullCount -= remainder == 0 ? 0 : 8 - remainder;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -379,6 +379,21 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
       holder.isSet = 1;
       holder.value = get(index);
     }
+
+    /**
+     * Get the number of bits set to 1
+     * @return the number of bits set to 1
+     */
+    public final int getNullCount() {
+      int count = 0;
+      for (int i = 0; i < allocationSizeInBytes; ++i) {
+        byte byteValue = data.getByte(i);
+        // Java uses two's complement binary representation, hence 11111111_b which is -1 when converted to Int
+        // will have 32bits set to 1. Masking the MSB and then adding it back solves the issue.
+        count += Integer.bitCount(byteValue & 0x7F) - (byteValue >> 7);
+      }
+      return count;
+    }
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -393,7 +393,11 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
         // will have 32bits set to 1. Masking the MSB and then adding it back solves the issue.
         count += Integer.bitCount(byteValue & 0x7F) - (byteValue >> 7);
       }
-      return (allocationSizeInBytes * 8) - count;
+      int nullCount = (allocationSizeInBytes * 8) - count;
+      // if the valueCount is not a multiple of 8, the bits on the right were counted as null bits
+      int remainder = valueCount % 8;
+      nullCount -= remainder == 0 ? 0 : 8 - remainder;
+      return nullCount;
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -384,6 +384,7 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
      * Get the number of bits set to 1
      * @return the number of bits set to 1
      */
+    @Override
     public final int getNullCount() {
       int count = 0;
       for (int i = 0; i < allocationSizeInBytes; ++i) {
@@ -392,7 +393,7 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
         // will have 32bits set to 1. Masking the MSB and then adding it back solves the issue.
         count += Integer.bitCount(byteValue & 0x7F) - (byteValue >> 7);
       }
-      return count;
+      return (allocationSizeInBytes * 8) - count;
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -381,8 +381,8 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
     }
 
     /**
-     * Get the number of bits set to 1
-     * @return the number of bits set to 1
+     * Get the number nulls, this correspond to the number of bits set to 0 in the vector
+     * @return the number of bits set to 0
      */
     @Override
     public final int getNullCount() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -180,6 +180,11 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
      * Returns true if the value at the given index is null, false otherwise.
      */
     boolean isNull(int index);
+
+    /**
+     * Returns the number of null values
+     */
+    int getNullCount();
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -60,15 +60,7 @@ public class VectorUnloader {
 
   private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers) {
     Accessor accessor = vector.getAccessor();
-    int nullCount = 0;
-    // TODO: should not have to do that
-    // we can do that a lot more efficiently (for example with Long.bitCount(i))
-    for (int i = 0; i < accessor.getValueCount(); i++) {
-      if (accessor.isNull(i)) {
-        nullCount ++;
-      }
-    }
-    nodes.add(new ArrowFieldNode(accessor.getValueCount(), nullCount));
+    nodes.add(new ArrowFieldNode(accessor.getValueCount(), accessor.getNullCount()));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
     List<ArrowVectorType> expectedBuffers = vector.getField().getTypeLayout().getVectorTypes();
     if (fieldBuffers.size() != expectedBuffers.size()) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -69,6 +69,11 @@ public class ZeroVector implements FieldVector {
     public boolean isNull(int index) {
       return true;
     }
+
+    @Override
+    public int getNullCount() {
+      return 0;
+    }
   };
 
   private final Mutator defaultMutator = new Mutator() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -310,6 +310,11 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector {
     public boolean isNull(int index) {
       return bits.getAccessor().get(index) == 0;
     }
+
+    @Override
+    public int getNullCount() {
+      return bits.getAccessor().getNullCount();
+    }
   }
 
   public class Mutator extends BaseRepeatedMutator {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NullableMapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NullableMapVector.java
@@ -204,6 +204,11 @@ public class NullableMapVector extends MapVector implements FieldVector {
     }
 
     @Override
+    public int getNullCount() {
+      return bits.getAccessor().getNullCount();
+    }
+
+    @Override
     public boolean isNull(int index) {
       return isSet(index) == 0;
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -288,12 +288,15 @@ public class TestValueVector {
     try (final BitVector vector = new BitVector(EMPTY_SCHEMA_PATH, allocator)) {
       final BitVector.Mutator m = vector.getMutator();
       vector.allocateNew(1024);
+      m.setValueCount(1024);
 
       // Put and set a few values
       m.set(0, 1);
       m.set(1, 0);
       m.set(100, 0);
       m.set(1022, 1);
+
+      m.setValueCount(1024);
 
       final BitVector.Accessor accessor = vector.getAccessor();
       assertEquals(1, accessor.get(0));
@@ -337,24 +340,23 @@ public class TestValueVector {
 
       assertEquals(0, accessor.getNullCount());
 
-      // re-allocate the vector with a new (odd) size, smaller by more than a byte than the original vector
-      // this allows to ensure that we use one byte less memory than the previous one
       vector.allocateNew(1015);
+      m.setValueCount(1015);
 
       // ensure it has been zeroed
-      assertEquals(1016, accessor.getNullCount());
+      assertEquals(1015, accessor.getNullCount());
 
       m.set(0, 1);
-      m.set(1015, 1); // ensure that the last item of the last byte is allocated
+      m.set(1014, 1); // ensure that the last item of the last byte is allocated
 
-      assertEquals(1014, accessor.getNullCount());
+      assertEquals(1013, accessor.getNullCount());
 
       vector.zeroVector();
-      assertEquals(1016, accessor.getNullCount());
+      assertEquals(1015, accessor.getNullCount());
 
       // set all the array to 1
-      for (int i = 0; i < 1016; ++i) {
-        assertEquals(1016 - i, accessor.getNullCount());
+      for (int i = 0; i < 1015; ++i) {
+        assertEquals(1015 - i, accessor.getNullCount());
         m.set(i, 1);
       }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -301,7 +301,7 @@ public class TestValueVector {
       assertEquals(0, accessor.get(100));
       assertEquals(1, accessor.get(1022));
 
-      assertEquals(2, accessor.getNullCount());
+      assertEquals(1022, accessor.getNullCount());
 
       // test setting the same value twice
       m.set(0, 1);
@@ -318,7 +318,7 @@ public class TestValueVector {
       assertEquals(1, accessor.get(1));
 
       // should not change
-      assertEquals(2, accessor.getNullCount());
+      assertEquals(1022, accessor.getNullCount());
 
       // Ensure unallocated space returns 0
       assertEquals(0, accessor.get(3));
@@ -326,13 +326,13 @@ public class TestValueVector {
       m.set(1, 0);
       m.set(1022, 0);
 
-      assertEquals(0, accessor.getNullCount());
+      assertEquals(1024, accessor.getNullCount());
 
       for (int i = 0; i < 1024; ++i) {
         m.set(i, 1);
       }
 
-      assertEquals(1024, accessor.getNullCount());
+      assertEquals(0, accessor.getNullCount());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -301,6 +301,8 @@ public class TestValueVector {
       assertEquals(0, accessor.get(100));
       assertEquals(1, accessor.get(1022));
 
+      assertEquals(2, accessor.getNullCount());
+
       // test setting the same value twice
       m.set(0, 1);
       m.set(0, 1);
@@ -315,8 +317,22 @@ public class TestValueVector {
       assertEquals(0, accessor.get(0));
       assertEquals(1, accessor.get(1));
 
+      // should not change
+      assertEquals(2, accessor.getNullCount());
+
       // Ensure unallocated space returns 0
       assertEquals(0, accessor.get(3));
+
+      m.set(1, 0);
+      m.set(1022, 0);
+
+      assertEquals(0, accessor.getNullCount());
+
+      for (int i = 0; i < 1024; ++i) {
+        m.set(i, 1);
+      }
+
+      assertEquals(1024, accessor.getNullCount());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -323,12 +323,38 @@ public class TestValueVector {
       // Ensure unallocated space returns 0
       assertEquals(0, accessor.get(3));
 
+      // unset the previously set bits
       m.set(1, 0);
       m.set(1022, 0);
-
+      // this should set all the array to 0
       assertEquals(1024, accessor.getNullCount());
 
+      // set all the array to 1
       for (int i = 0; i < 1024; ++i) {
+        assertEquals(1024 - i, accessor.getNullCount());
+        m.set(i, 1);
+      }
+
+      assertEquals(0, accessor.getNullCount());
+
+      // re-allocate the vector with a new (odd) size, smaller by more than a byte than the original vector
+      // this allows to ensure that we use one byte less memory than the previous one
+      vector.allocateNew(1015);
+
+      // ensure it has been zeroed
+      assertEquals(1016, accessor.getNullCount());
+
+      m.set(0, 1);
+      m.set(1015, 1); // ensure that the last item of the last byte is allocated
+
+      assertEquals(1014, accessor.getNullCount());
+
+      vector.zeroVector();
+      assertEquals(1016, accessor.getNullCount());
+
+      // set all the array to 1
+      for (int i = 0; i < 1016; ++i) {
+        assertEquals(1016 - i, accessor.getNullCount());
         m.set(i, 1);
       }
 


### PR DESCRIPTION
I added `getNullCount()` to the `Accessor` interface. I don't know if this is the best way to achieve this. Hence, we'll have both ValueCount and NullCount immediately accessible from the accessor.