### PR TITLE
ARROW-369: [Python] Convert multiple record batches at once to Pandas

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -41,7 +41,7 @@ from pyarrow.schema import (null, bool_,
                             list_, struct, field,
                             DataType, Field, Schema, schema)
 
-from pyarrow.table import (Column, RecordBatch, RecordBatchList, Table, 
+from pyarrow.table import (Column, RecordBatch, RecordBatchList, Table,
                            from_pandas_dataframe)
 
 from pyarrow.version import version as __version__

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -41,7 +41,7 @@ from pyarrow.schema import (null, bool_,
                             list_, struct, field,
                             DataType, Field, Schema, schema)
 
-from pyarrow.table import (Column, RecordBatch, RecordBatchList, Table,
+from pyarrow.table import (Column, RecordBatch, dataframe_from_batches, Table,
                            from_pandas_dataframe)
 
 from pyarrow.version import version as __version__

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -41,5 +41,7 @@ from pyarrow.schema import (null, bool_,
                             list_, struct, field,
                             DataType, Field, Schema, schema)
 
-from pyarrow.table import Column, RecordBatch, Table, from_pandas_dataframe
+from pyarrow.table import (Column, RecordBatch, RecordBatchList, Table, 
+                           from_pandas_dataframe)
+
 from pyarrow.version import version as __version__

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -88,6 +88,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass CSchema" arrow::Schema":
         CSchema(const vector[shared_ptr[CField]]& fields)
+
+        c_bool Equals(const shared_ptr[CSchema]& other)
+
         const shared_ptr[CField]& field(int i)
         int num_fields()
         c_string ToString()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -155,6 +155,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CColumn(const shared_ptr[CField]& field,
                 const shared_ptr[CArray]& data)
 
+        CColumn(const shared_ptr[CField]& field,
+                const vector[shared_ptr[CArray]]& chunks)
+
         int64_t length()
         int64_t null_count()
         const c_string& name()

--- a/python/pyarrow/table.pyx
+++ b/python/pyarrow/table.pyx
@@ -417,13 +417,13 @@ cdef class RecordBatch:
 
 def dataframe_from_batches(batches):
     """
-    Convert a list of Arrow RecordBatches to one pandas.DataFrame
+    Convert a list of Arrow RecordBatches to a pandas.DataFrame
 
     Parameters
     ----------
 
     batches: list of RecordBatch
-        RecordBatch list with identical schema to be converted
+        RecordBatch list to be converted, schemas must be equal
     """
 
     cdef:
@@ -450,7 +450,8 @@ def dataframe_from_batches(batches):
         for batch in batches:
             arr = batch[i]
             c_array_chunks.push_back(arr.sp_array)
-        c_columns[i].reset(new CColumn(schema.sp_schema.get().field(i), c_array_chunks))
+        c_columns[i].reset(new CColumn(schema.sp_schema.get().field(i),
+                           c_array_chunks))
         c_array_chunks.clear()
 
     # create a Table from columns and convert to DataFrame

--- a/python/pyarrow/table.pyx
+++ b/python/pyarrow/table.pyx
@@ -432,17 +432,15 @@ def dataframe_from_batches(batches):
         shared_ptr[CTable] c_table
         Array arr
         Schema schema
-        Schema schema_comp
 
     import pandas as pd
 
     schema = batches[0].schema
 
     # check schemas are equal
-    for i in range(1, len(batches)):
-        schema_comp = batches[i].schema
-        if not schema.sp_schema.get().Equals(schema_comp.sp_schema):
-          raise ArrowException("Error converting list of RecordBatches to DataFrame, not all schemas are equal")
+    if any((not schema.equals(other.schema) for other in batches[1:])):
+        raise ArrowException("Error converting list of RecordBatches to "
+                "DataFrame, not all schemas are equal")
 
     cdef int K = batches[0].num_columns
 

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -204,9 +204,6 @@ class TestPandasConversion(unittest.TestCase):
             })
         self._check_pandas_roundtrip(df, timestamps_to_ms=False)
 
-    def test_chunked_array_conversion(self):
-        pass
-
     # def test_category(self):
     #     repeats = 1000
     #     values = [b'foo', None, u'bar', 'qux', np.nan]

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -204,6 +204,9 @@ class TestPandasConversion(unittest.TestCase):
             })
         self._check_pandas_roundtrip(df, timestamps_to_ms=False)
 
+    def test_chunked_array_conversion(self):
+        pass
+
     # def test_category(self):
     #     repeats = 1000
     #     values = [b'foo', None, u'bar', 'qux', np.nan]

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from pandas.util.testing import assert_frame_equal
 import pandas as pd
+import pytest
 
 import pyarrow as pa
 
@@ -73,16 +74,15 @@ def test_recordbatchlist_to_pandas():
     assert_frame_equal(data, result)
 
 
-def test_recordbatchlist_errors():
+def test_recordbatchlist_schema_equals():
     data1 = pd.DataFrame({'c1': np.array([1], dtype='uint32')})
     data2 = pd.DataFrame({'c1': np.array([4.0, 5.0], dtype='float64')})
 
     batch1 = pa.RecordBatch.from_pandas(data1)
     batch2 = pa.RecordBatch.from_pandas(data2)
 
-    # TODO: Enable when subclass of unittest.testcase
-    #with self.assertRaises(pyarrow.ArrowException):
-    #    self.assertRaises(pa.dataframe_from_batches([batch1, batch2]))
+    with pytest.raises(pa.ArrowException):
+        pa.dataframe_from_batches([batch1, batch2])
 
 
 def test_table_basics():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -51,20 +51,25 @@ def test_recordbatch_from_to_pandas():
 
 
 def test_recordbatchlist_to_pandas():
-    # NOTE - dtype='uint32' is converted to float64 when not zero copy
-    data = pd.DataFrame({
-        'c1': np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype='float64'),
-        'c2': ['foo', 'bar', None, 'baz', 'qux']
+    data1 = pd.DataFrame({
+        'c1': np.array([1, 1, 2], dtype='uint32'),
+        'c2': np.array([1.0, 2.0, 3.0], dtype='float64'),
+        'c3': [True, None, False],
+        'c4': ['foo', 'bar', None]
     })
 
-    split = int(len(data) / 2)
-    data1 = data[:split]
-    data2 = data[split:]
+    data2 = pd.DataFrame({
+        'c1': np.array([3, 5], dtype='uint32'),
+        'c2': np.array([4.0, 5.0], dtype='float64'),
+        'c3': [True, True],
+        'c4': ['baz', 'qux']
+    })
 
     batch1 = pa.RecordBatch.from_pandas(data1)
     batch2 = pa.RecordBatch.from_pandas(data2)
 
     result = pa.RecordBatchList.to_pandas([batch1, batch2])
+    data = pd.concat([data1, data2], ignore_index=True)
     assert_frame_equal(data, result)
 
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -68,7 +68,7 @@ def test_recordbatchlist_to_pandas():
     batch1 = pa.RecordBatch.from_pandas(data1)
     batch2 = pa.RecordBatch.from_pandas(data2)
 
-    result = pa.RecordBatchList.to_pandas([batch1, batch2])
+    result = pa.dataframe_from_batches([batch1, batch2])
     data = pd.concat([data1, data2], ignore_index=True)
     assert_frame_equal(data, result)
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -50,6 +50,24 @@ def test_recordbatch_from_to_pandas():
     assert_frame_equal(data, result)
 
 
+def test_recordbatchlist_to_pandas():
+    # NOTE - dtype='uint32' is converted to float64 when not zero copy
+    data = pd.DataFrame({
+        'c1': np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype='float64'),
+        'c2': ['foo', 'bar', None, 'baz', 'qux']
+    })
+
+    split = int(len(data) / 2)
+    data1 = data[:split]
+    data2 = data[split:]
+
+    batch1 = pa.RecordBatch.from_pandas(data1)
+    batch2 = pa.RecordBatch.from_pandas(data2)
+
+    result = pa.RecordBatchList.to_pandas([batch1, batch2])
+    assert_frame_equal(data, result)
+
+
 def test_table_basics():
     data = [
         pa.from_pylist(range(5)),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -73,6 +73,18 @@ def test_recordbatchlist_to_pandas():
     assert_frame_equal(data, result)
 
 
+def test_recordbatchlist_errors():
+    data1 = pd.DataFrame({'c1': np.array([1], dtype='uint32')})
+    data2 = pd.DataFrame({'c1': np.array([4.0, 5.0], dtype='float64')})
+
+    batch1 = pa.RecordBatch.from_pandas(data1)
+    batch2 = pa.RecordBatch.from_pandas(data2)
+
+    # TODO: Enable when subclass of unittest.testcase
+    #with self.assertRaises(pyarrow.ArrowException):
+    #    self.assertRaises(pa.dataframe_from_batches([batch1, batch2]))
+
+
 def test_table_basics():
     data = [
         pa.from_pylist(range(5)),

--- a/python/src/pyarrow/adapters/pandas.cc
+++ b/python/src/pyarrow/adapters/pandas.cc
@@ -597,14 +597,10 @@ class ArrowDeserializer {
 
   Status Convert(PyObject** out) {
     const std::shared_ptr<arrow::ChunkedArray> data = col_->data();
-    if (data->num_chunks() > 1) {
-      return Status::NotImplemented("Chunked column conversion NYI");
-    }
 
-    auto chunk = data->chunk(0);
-
-    RETURN_NOT_OK(ConvertValues<TYPE>(chunk));
+    RETURN_NOT_OK(ConvertValues<TYPE>(data));
     *out = reinterpret_cast<PyObject*>(out_);
+
     return Status::OK();
   }
 
@@ -634,7 +630,7 @@ class ArrowDeserializer {
 
     if (out_ == NULL) {
       // Error occurred, trust that SimpleNew set the error state
-      return Status::OK();
+      return Status::OK();//Invalid("Error in PyArray_SimpleNewFromData");
     }
 
     set_numpy_metadata(type, col_->type().get(), out_);
@@ -654,27 +650,54 @@ class ArrowDeserializer {
   }
 
   template <int T2>
-  inline typename std::enable_if<
-    arrow_traits<T2>::is_pandas_numeric_nullable, Status>::type
-  ConvertValues(const std::shared_ptr<Array>& arr) {
+  Status ConvertValuesZeroCopy(std::shared_ptr<Array> arr) {
     typedef typename arrow_traits<T2>::T T;
 
     arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
         arr.get());
     const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
 
-    if (arr->null_count() > 0) {
-      RETURN_NOT_OK(AllocateOutput(arrow_traits<T2>::npy_type));
+    // Zero-Copy. We can pass the data pointer directly to NumPy.
+    void* data = const_cast<T*>(in_values);
+    int type = arrow_traits<TYPE>::npy_type;
+    RETURN_NOT_OK(OutputFromData(type, data));
 
-      T* out_values = reinterpret_cast<T*>(PyArray_DATA(out_));
-      for (int64_t i = 0; i < arr->length(); ++i) {
-        out_values[i] = arr->IsNull(i) ? arrow_traits<T2>::na_value : in_values[i];
+    return Status::OK();
+  }
+
+  template <int T2>
+  inline typename std::enable_if<
+    arrow_traits<T2>::is_pandas_numeric_nullable, Status>::type
+  ConvertValues(const std::shared_ptr<arrow::ChunkedArray>& data) {
+    typedef typename arrow_traits<T2>::T T;
+    bool has_null_values = data->null_count() > 0;
+    size_t chunk_offset = 0;
+
+    if (data->num_chunks() == 1 && !has_null_values) {
+      return ConvertValuesZeroCopy<TYPE>(data->chunk(0));
+    }
+
+    RETURN_NOT_OK(AllocateOutput(arrow_traits<T2>::npy_type));
+
+    for (int c = 0; c < data->num_chunks(); c++) {
+      const std::shared_ptr<Array> arr = data->chunk(c);
+      arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
+          arr.get());
+      const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
+      T* out_values = reinterpret_cast<T*>(PyArray_DATA(out_)) + chunk_offset;
+
+      if (has_null_values) {
+        for (int64_t i = 0; i < arr->length(); ++i) {
+          out_values[i] = arr->IsNull(i) ? arrow_traits<T2>::na_value : in_values[i];
+        }
+      } else {
+        // TODO - copy entire chunck?
+        for (int64_t i = 0; i < arr->length(); ++i) {
+          out_values[i] = in_values[i];
+        }
       }
-    } else {
-      // Zero-Copy. We can pass the data pointer directly to NumPy.
-      void* data = const_cast<T*>(in_values);
-      int type = arrow_traits<TYPE>::npy_type;
-      RETURN_NOT_OK(OutputFromData(type, data));
+
+      chunk_offset += arr->length();
     }
 
     return Status::OK();
@@ -684,27 +707,37 @@ class ArrowDeserializer {
   template <int T2>
   inline typename std::enable_if<
     arrow_traits<T2>::is_pandas_numeric_not_nullable, Status>::type
-  ConvertValues(const std::shared_ptr<Array>& arr) {
+  ConvertValues(const std::shared_ptr<arrow::ChunkedArray>& data) {
     typedef typename arrow_traits<T2>::T T;
+    bool has_null_values = data->null_count() > 0;
+    size_t chunk_offset = 0;
 
-    arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
-        arr.get());
+    if (data->num_chunks() == 1 && !has_null_values) {
+      return ConvertValuesZeroCopy<TYPE>(data->chunk(0));
+    }
 
-    const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
+    // TODO - why cast to double?
+    RETURN_NOT_OK(AllocateOutput(NPY_FLOAT64));
 
-    if (arr->null_count() > 0) {
-      RETURN_NOT_OK(AllocateOutput(NPY_FLOAT64));
-
+    for (int c = 0; c < data->num_chunks(); c++) {
+      const std::shared_ptr<Array> arr = data->chunk(c);
+      arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
+          arr.get());
+      const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
       // Upcast to double, set NaN as appropriate
-      double* out_values = reinterpret_cast<double*>(PyArray_DATA(out_));
-      for (int i = 0; i < arr->length(); ++i) {
-        out_values[i] = prim_arr->IsNull(i) ? NAN : in_values[i];
+      double* out_values = reinterpret_cast<double*>(PyArray_DATA(out_)) + chunk_offset;
+
+      if (arr->null_count() > 0) {
+        for (int i = 0; i < arr->length(); ++i) {
+          out_values[i] = prim_arr->IsNull(i) ? NAN : in_values[i];
+        }
+      } else {
+        for (int i = 0; i < arr->length(); ++i) {
+          out_values[i] = in_values[i];
+        }
       }
-    } else {
-      // Zero-Copy. We can pass the data pointer directly to NumPy.
-      void* data = const_cast<T*>(in_values);
-      int type = arrow_traits<TYPE>::npy_type;
-      RETURN_NOT_OK(OutputFromData(type, data));
+
+      chunk_offset += arr->length();
     }
 
     return Status::OK();
@@ -714,35 +747,48 @@ class ArrowDeserializer {
   template <int T2>
   inline typename std::enable_if<
     arrow_traits<T2>::is_boolean, Status>::type
-  ConvertValues(const std::shared_ptr<Array>& arr) {
+  ConvertValues(const std::shared_ptr<arrow::ChunkedArray>& data) {
+    size_t chunk_offset = 0;
     PyAcquireGIL lock;
 
-    arrow::BooleanArray* bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
-
-    if (arr->null_count() > 0) {
+    if (data->null_count() > 0) {
       RETURN_NOT_OK(AllocateOutput(NPY_OBJECT));
 
-      PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_));
-      for (int64_t i = 0; i < arr->length(); ++i) {
-        if (bool_arr->IsNull(i)) {
-          Py_INCREF(Py_None);
-          out_values[i] = Py_None;
-        } else if (bool_arr->Value(i)) {
-          // True
-          Py_INCREF(Py_True);
-          out_values[i] = Py_True;
-        } else {
-          // False
-          Py_INCREF(Py_False);
-          out_values[i] = Py_False;
+      for (int c = 0; c < data->num_chunks(); c++) {
+        const std::shared_ptr<Array> arr = data->chunk(c);
+        arrow::BooleanArray* bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
+        PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_)) + chunk_offset;
+
+        for (int64_t i = 0; i < arr->length(); ++i) {
+          if (bool_arr->IsNull(i)) {
+            Py_INCREF(Py_None);
+            out_values[i] = Py_None;
+          } else if (bool_arr->Value(i)) {
+            // True
+            Py_INCREF(Py_True);
+            out_values[i] = Py_True;
+          } else {
+            // False
+            Py_INCREF(Py_False);
+            out_values[i] = Py_False;
+          }
         }
+
+        chunk_offset += bool_arr->length();
       }
     } else {
       RETURN_NOT_OK(AllocateOutput(arrow_traits<TYPE>::npy_type));
 
-      uint8_t* out_values = reinterpret_cast<uint8_t*>(PyArray_DATA(out_));
-      for (int64_t i = 0; i < arr->length(); ++i) {
-        out_values[i] = static_cast<uint8_t>(bool_arr->Value(i));
+      for (int c = 0; c < data->num_chunks(); c++) {
+        const std::shared_ptr<Array> arr = data->chunk(c);
+        arrow::BooleanArray* bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
+        uint8_t* out_values = reinterpret_cast<uint8_t*>(PyArray_DATA(out_)) + chunk_offset;
+
+        for (int64_t i = 0; i < arr->length(); ++i) {
+          out_values[i] = static_cast<uint8_t>(bool_arr->Value(i));
+        }
+
+        chunk_offset += bool_arr->length();
       }
     }
 
@@ -753,42 +799,49 @@ class ArrowDeserializer {
   template <int T2>
   inline typename std::enable_if<
     T2 == arrow::Type::STRING, Status>::type
-  ConvertValues(const std::shared_ptr<Array>& arr) {
+  ConvertValues(const std::shared_ptr<arrow::ChunkedArray>& data) {
+    size_t chunk_offset = 0;
     PyAcquireGIL lock;
 
     RETURN_NOT_OK(AllocateOutput(NPY_OBJECT));
 
-    PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_));
+    for (int c = 0; c < data->num_chunks(); c++) {
+      const std::shared_ptr<Array> arr = data->chunk(c);
+      arrow::StringArray* string_arr = static_cast<arrow::StringArray*>(arr.get());
+      PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_)) + chunk_offset;
 
-    arrow::StringArray* string_arr = static_cast<arrow::StringArray*>(arr.get());
+      const uint8_t* data_ptr;
+      int32_t length;
+      if (data->null_count() > 0) {
+        for (int64_t i = 0; i < arr->length(); ++i) {
+          if (string_arr->IsNull(i)) {
+            Py_INCREF(Py_None);
+            out_values[i] = Py_None;
+          } else {
+            data_ptr = string_arr->GetValue(i, &length);
 
-    const uint8_t* data;
-    int32_t length;
-    if (arr->null_count() > 0) {
-      for (int64_t i = 0; i < arr->length(); ++i) {
-        if (string_arr->IsNull(i)) {
-          Py_INCREF(Py_None);
-          out_values[i] = Py_None;
-        } else {
-          data = string_arr->GetValue(i, &length);
-
-          out_values[i] = make_pystring(data, length);
+            out_values[i] = make_pystring(data_ptr, length);
+            if (out_values[i] == nullptr) {
+              return Status::UnknownError("String initialization failed");
+            }
+          }
+        }
+      } else {
+        for (int64_t i = 0; i < arr->length(); ++i) {
+          data_ptr = string_arr->GetValue(i, &length);
+          out_values[i] = make_pystring(data_ptr, length);
           if (out_values[i] == nullptr) {
             return Status::UnknownError("String initialization failed");
           }
         }
       }
-    } else {
-      for (int64_t i = 0; i < arr->length(); ++i) {
-        data = string_arr->GetValue(i, &length);
-        out_values[i] = make_pystring(data, length);
-        if (out_values[i] == nullptr) {
-          return Status::UnknownError("String initialization failed");
-        }
-      }
+
+      chunk_offset += string_arr->length();
     }
+
     return Status::OK();
   }
+
  private:
   std::shared_ptr<Column> col_;
   PyObject* py_ref_;

--- a/python/src/pyarrow/adapters/pandas.cc
+++ b/python/src/pyarrow/adapters/pandas.cc
@@ -653,9 +653,8 @@ class ArrowDeserializer {
   Status ConvertValuesZeroCopy(std::shared_ptr<Array> arr) {
     typedef typename arrow_traits<T2>::T T;
 
-    arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
-        arr.get());
-    const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
+    auto prim_arr = static_cast<arrow::PrimitiveArray*>(arr.get());
+    auto in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
 
     // Zero-Copy. We can pass the data pointer directly to NumPy.
     void* data = const_cast<T*>(in_values);
@@ -680,10 +679,9 @@ class ArrowDeserializer {
 
     for (int c = 0; c < data->num_chunks(); c++) {
       const std::shared_ptr<Array> arr = data->chunk(c);
-      arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
-          arr.get());
-      const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
-      T* out_values = reinterpret_cast<T*>(PyArray_DATA(out_)) + chunk_offset;
+      auto prim_arr = static_cast<arrow::PrimitiveArray*>(arr.get());
+      auto in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
+      auto out_values = reinterpret_cast<T*>(PyArray_DATA(out_)) + chunk_offset;
 
       if (arr->null_count() > 0) {
         for (int64_t i = 0; i < arr->length(); ++i) {
@@ -716,11 +714,10 @@ class ArrowDeserializer {
 
       for (int c = 0; c < data->num_chunks(); c++) {
         const std::shared_ptr<Array> arr = data->chunk(c);
-        arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
-            arr.get());
-        const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
+        auto prim_arr = static_cast<arrow::PrimitiveArray*>(arr.get());
+        auto in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
         // Upcast to double, set NaN as appropriate
-        double* out_values = reinterpret_cast<double*>(PyArray_DATA(out_)) + chunk_offset;
+        auto out_values = reinterpret_cast<double*>(PyArray_DATA(out_)) + chunk_offset;
 
         for (int i = 0; i < arr->length(); ++i) {
           out_values[i] = prim_arr->IsNull(i) ? NAN : in_values[i];
@@ -733,10 +730,9 @@ class ArrowDeserializer {
 
       for (int c = 0; c < data->num_chunks(); c++) {
         const std::shared_ptr<Array> arr = data->chunk(c);
-        arrow::PrimitiveArray* prim_arr = static_cast<arrow::PrimitiveArray*>(
-            arr.get());
-        const T* in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
-        T* out_values = reinterpret_cast<T*>(PyArray_DATA(out_)) + chunk_offset;
+        auto prim_arr = static_cast<arrow::PrimitiveArray*>(arr.get());
+        auto in_values = reinterpret_cast<const T*>(prim_arr->data()->data());
+        auto out_values = reinterpret_cast<T*>(PyArray_DATA(out_)) + chunk_offset;
 
         memcpy(out_values, in_values, sizeof(T) * arr->length());
 
@@ -760,8 +756,8 @@ class ArrowDeserializer {
 
       for (int c = 0; c < data->num_chunks(); c++) {
         const std::shared_ptr<Array> arr = data->chunk(c);
-        arrow::BooleanArray* bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
-        PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_)) + chunk_offset;
+        auto bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
+        auto out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_)) + chunk_offset;
 
         for (int64_t i = 0; i < arr->length(); ++i) {
           if (bool_arr->IsNull(i)) {
@@ -785,8 +781,8 @@ class ArrowDeserializer {
 
       for (int c = 0; c < data->num_chunks(); c++) {
         const std::shared_ptr<Array> arr = data->chunk(c);
-        arrow::BooleanArray* bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
-        uint8_t* out_values = reinterpret_cast<uint8_t*>(PyArray_DATA(out_)) + chunk_offset;
+        auto bool_arr = static_cast<arrow::BooleanArray*>(arr.get());
+        auto out_values = reinterpret_cast<uint8_t*>(PyArray_DATA(out_)) + chunk_offset;
 
         for (int64_t i = 0; i < arr->length(); ++i) {
           out_values[i] = static_cast<uint8_t>(bool_arr->Value(i));
@@ -811,8 +807,8 @@ class ArrowDeserializer {
 
     for (int c = 0; c < data->num_chunks(); c++) {
       const std::shared_ptr<Array> arr = data->chunk(c);
-      arrow::StringArray* string_arr = static_cast<arrow::StringArray*>(arr.get());
-      PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_)) + chunk_offset;
+      auto string_arr = static_cast<arrow::StringArray*>(arr.get());
+      auto out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_)) + chunk_offset;
 
       const uint8_t* data_ptr;
       int32_t length;


### PR DESCRIPTION
Modified Pandas adapter to handle columns with multiple chunks with `ConvertColumnToPandas`.  This modifies the pyarrow public API by adding a class `RecordBatchList` and static method `toPandas` which takes a list of Arrow RecordBatches and outputs a Pandas DataFrame. 

Adds unit test in test_table.py to do the conversion for each column with typed specialization.