### PR TITLE
ARROW-393: [JAVA] JSON file reader fails to set the buffer size on String data vector

### DIFF
--- a/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
@@ -80,7 +80,7 @@ public class Integration {
           Schema schema = footer.getSchema();
           LOGGER.debug("Input file size: " + arrowFile.length());
           LOGGER.debug("Found schema: " + schema);
-          try (JsonFileWriter writer = new JsonFileWriter(jsonFile);) {
+          try (JsonFileWriter writer = new JsonFileWriter(jsonFile, JsonFileWriter.config().pretty(true));) {
             writer.start(schema);
             List<ArrowBlock> recordBatches = footer.getRecordBatches();
             for (ArrowBlock rbBlock : recordBatches) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileReader.java
@@ -22,6 +22,7 @@ import static com.fasterxml.jackson.core.JsonToken.END_OBJECT;
 import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.arrow.vector.schema.ArrowVectorType.OFFSET;
 
 import java.io.File;
 import java.io.IOException;
@@ -128,15 +129,12 @@ public class JsonFileReader implements AutoCloseable {
         valueVector.allocateNew();
         Mutator mutator = valueVector.getMutator();
 
-        int innerVectorCount = count;
-        if (vectorType.getName() == "OFFSET") {
-          innerVectorCount++;
-        }
-        mutator.setValueCount(innerVectorCount);
+        int innerVectorCount = vectorType.equals(OFFSET) ? count + 1 : count;
         for (int i = 0; i < innerVectorCount; i++) {
           parser.nextToken();
           setValueFromParser(valueVector, i);
         }
+        mutator.setValueCount(innerVectorCount);
         readToken(END_ARRAY);
       }
       // if children

--- a/java/vector/src/main/java/org/apache/arrow/vector/schema/ArrowVectorType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/schema/ArrowVectorType.java
@@ -81,4 +81,19 @@ public class ArrowVectorType {
   public String toString() {
     return getName();
   }
+
+  @Override
+  public int hashCode() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof ArrowVectorType) {
+      ArrowVectorType other = (ArrowVectorType) obj;
+      return type == other.type;
+    }
+    return false;
+  }
+
 }


### PR DESCRIPTION
Fixed by calling setValueCount after setting the values instead of before.
Since we set the inner vectors of NullableVarCharVector directly we don't have to worry about it's lastSet field and the way null values are handled.