### PR TITLE
ARROW-396: [Python] Add pyarrow.schema.Schema.equals

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -88,6 +88,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass CSchema" arrow::Schema":
         CSchema(const vector[shared_ptr[CField]]& fields)
+
+        c_bool Equals(const shared_ptr[CSchema]& other)
+
         const shared_ptr[CField]& field(int i)
         int num_fields()
         c_string ToString()

--- a/python/pyarrow/schema.pyx
+++ b/python/pyarrow/schema.pyx
@@ -110,6 +110,15 @@ cdef class Schema:
         self.schema = schema.get()
         self.sp_schema = schema
 
+    def equals(self, other):
+        """
+        Test if this schema is equal to the other
+        """
+        cdef Schema _other
+        _other = other
+
+        return self.sp_schema.get().Equals(_other.sp_schema)
+
     @classmethod
     def from_fields(cls, fields):
         cdef:

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -69,3 +69,20 @@ class TestTypes(unittest.TestCase):
 foo: int32
 bar: string
 baz: list<item: int8>"""
+
+    def test_schema_equals(self):
+        fields = [
+            A.field('foo', A.int32()),
+            A.field('bar', A.string()),
+            A.field('baz', A.list_(A.int8()))
+        ]
+
+        sch1 = A.schema(fields)
+        print(dir(sch1))
+        sch2 = A.schema(fields)
+        assert sch1.equals(sch2)
+
+        del fields[-1]
+        sch3 = A.schema(fields)
+        assert not sch1.equals(sch3)
+


### PR DESCRIPTION
Added pyarrow api for `Schema.equals` to check if 2 schema's are equal and corresponding test case.