### PR TITLE
ARROW-346: Use conda environment to build API docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: python/doc/environment.yml

--- a/python/doc/conf.py
+++ b/python/doc/conf.py
@@ -42,7 +42,12 @@ cmd_line_template = "sphinx-apidoc -f -e -o {outputdir} {moduledir}"
 cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
 apidoc.main(cmd_line.split(" "))
 
-sys.path.insert(0, os.path.abspath('..'))
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+
+if not on_rtd:
+    # Hack: On RTD we use the pyarrow package from conda-forge as we cannot
+    # build pyarrow there.
+    sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/python/doc/environment.yml
+++ b/python/doc/environment.yml
@@ -1,0 +1,8 @@
+channels:
+- defaults
+- conda-forge
+dependencies:
+- arrow-cpp
+- parquet-cpp
+- pyarrow
+- numpydoc

--- a/python/doc/environment.yml
+++ b/python/doc/environment.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 channels:
 - defaults
 - conda-forge


### PR DESCRIPTION
As we cannot currently build pyarrow on readthedocs, we have to resort
to building the API docs for the latest version of pyarrow on
conda-forge. All other documentation will though be pulled directly from
the source code.

