### PR TITLE
ARROW-402: avoid empty buffers

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -53,7 +53,6 @@ public final class BitVector extends BaseDataValueVector implements FixedWidthVe
   public void load(ArrowFieldNode fieldNode, ArrowBuf data) {
     // When the vector is all nulls or all defined, the content of the buffer can be omitted
     if (data.readableBytes() == 0 && fieldNode.getLength() != 0) {
-      data.release();
       int count = fieldNode.getLength();
       allocateNew(count);
       int n = getSizeFromCount(count);

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
@@ -139,10 +139,7 @@ public class ArrowReader implements AutoCloseable {
     for (int i = 0; i < recordBatchFB.buffersLength(); ++i) {
       Buffer bufferFB = recordBatchFB.buffers(i);
       LOGGER.debug(String.format("Buffer in RecordBatch at %d, length: %d", bufferFB.offset(), bufferFB.length()));
-      ArrowBuf vectorBuffer =
-          bufferFB.length() == 0 ?
-              allocator.getEmpty()
-              : body.slice((int)bufferFB.offset(), (int)bufferFB.length());
+      ArrowBuf vectorBuffer = body.slice((int)bufferFB.offset(), (int)bufferFB.length());
       buffers.add(vectorBuffer);
     }
     ArrowRecordBatch arrowRecordBatch = new ArrowRecordBatch(recordBatchFB.length(), nodes, buffers);

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
@@ -139,7 +139,10 @@ public class ArrowReader implements AutoCloseable {
     for (int i = 0; i < recordBatchFB.buffersLength(); ++i) {
       Buffer bufferFB = recordBatchFB.buffers(i);
       LOGGER.debug(String.format("Buffer in RecordBatch at %d, length: %d", bufferFB.offset(), bufferFB.length()));
-      ArrowBuf vectorBuffer = body.slice((int)bufferFB.offset(), (int)bufferFB.length());
+      ArrowBuf vectorBuffer =
+          bufferFB.length() == 0 ?
+              allocator.getEmpty()
+              : body.slice((int)bufferFB.offset(), (int)bufferFB.length());
       buffers.add(vectorBuffer);
     }
     ArrowRecordBatch arrowRecordBatch = new ArrowRecordBatch(recordBatchFB.length(), nodes, buffers);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -112,7 +112,8 @@ public class TestVectorUnloadLoad {
         new Field("intNull", true, new ArrowType.Int(32, true), Collections.<Field>emptyList())
         ));
     int count = 10;
-    ArrowBuf validity = allocator.getEmpty();
+    // using Allocator.getEmpty() turns off ref counting
+    ArrowBuf validity = allocator.buffer(10).slice(0, 0);
     ArrowBuf values = allocator.buffer(count * 4); // integers
     for (int i = 0; i < count; i++) {
       values.setInt(i * 4, i);
@@ -153,6 +154,7 @@ public class TestVectorUnloadLoad {
       assertFalse(intDefinedVector.getAccessor().isNull(count + 10));
       assertEquals(1234, intDefinedVector.getAccessor().get(count + 10));
     } finally {
+      validity.release();
       values.release();
     }
   }


### PR DESCRIPTION
I'm not sure what's wrong with the accounting of empty buffers.
This seems to fix the issue. Feel free to use it to get unblocked.
allocator.getEmpty() is special and doesn't get accounted since it does not use memory.
@jacques-n: any insight?