### PR TITLE
ARROW-434: [Python] Correctly handle Python file objects in Parquet read/write paths

### DIFF
--- a/python/pyarrow/io.pxd
+++ b/python/pyarrow/io.pxd
@@ -42,3 +42,6 @@ cdef class NativeFile:
     # suite of Arrow C++ libraries
     cdef read_handle(self, shared_ptr[ReadableFileInterface]* file)
     cdef write_handle(self, shared_ptr[OutputStream]* file)
+
+cdef get_reader(object source, shared_ptr[ReadableFileInterface]* reader)
+cdef get_writer(object source, shared_ptr[OutputStream]* writer)


### PR DESCRIPTION
While we'd enabled Python file objects for IPC file reader/writer, they hadn't been enabled in the Parquet read/write paths. For example:

```python
with open(filename, 'wb') as f:
    A.parquet.write_table(arrow_table, f, version="1.0")

data = io.BytesIO(open(filename, 'rb').read())

table_read = pq.read_table(data)
```

There was a separate bug reported in ARROW-434, but that's a Parquet type mapping issue, will be fixed in PARQUET-812. 