### PR TITLE
ARROW-374: More precise handling of bytes vs unicode in Python API

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -155,12 +155,12 @@ TYPE_FACTORY(binary, BinaryType);
 TYPE_FACTORY(date, DateType);
 
 std::shared_ptr<DataType> timestamp(TimeUnit unit) {
-  static std::shared_ptr<DataType> result = std::make_shared<TimestampType>();
+  static std::shared_ptr<DataType> result = std::make_shared<TimestampType>(unit);
   return result;
 }
 
 std::shared_ptr<DataType> time(TimeUnit unit) {
-  static std::shared_ptr<DataType> result = std::make_shared<TimeType>();
+  static std::shared_ptr<DataType> result = std::make_shared<TimeType>(unit);
   return result;
 }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -155,13 +155,11 @@ TYPE_FACTORY(binary, BinaryType);
 TYPE_FACTORY(date, DateType);
 
 std::shared_ptr<DataType> timestamp(TimeUnit unit) {
-  static std::shared_ptr<DataType> result = std::make_shared<TimestampType>(unit);
-  return result;
+  return std::make_shared<TimestampType>(unit);
 }
 
 std::shared_ptr<DataType> time(TimeUnit unit) {
-  static std::shared_ptr<DataType> result = std::make_shared<TimeType>(unit);
-  return result;
+  return std::make_shared<TimeType>(unit);
 }
 
 std::shared_ptr<DataType> list(const std::shared_ptr<DataType>& value_type) {

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -40,13 +40,14 @@ from pyarrow.scalar import (ArrayValue, Scalar, NA, NAType,
                             BooleanValue,
                             Int8Value, Int16Value, Int32Value, Int64Value,
                             UInt8Value, UInt16Value, UInt32Value, UInt64Value,
-                            FloatValue, DoubleValue, ListValue, StringValue)
+                            FloatValue, DoubleValue, ListValue,
+                            BinaryValue, StringValue)
 
 from pyarrow.schema import (null, bool_,
                             int8, int16, int32, int64,
                             uint8, uint16, uint32, uint64,
                             timestamp, date,
-                            float_, double, string,
+                            float_, double, binary, string,
                             list_, struct, field,
                             DataType, Field, Schema, schema)
 

--- a/python/pyarrow/array.pyx
+++ b/python/pyarrow/array.pyx
@@ -238,6 +238,10 @@ cdef class StringArray(Array):
     pass
 
 
+cdef class BinaryArray(Array):
+    pass
+
+
 cdef dict _array_classes = {
     Type_NA: NullArray,
     Type_BOOL: BooleanArray,
@@ -253,6 +257,7 @@ cdef dict _array_classes = {
     Type_FLOAT: FloatArray,
     Type_DOUBLE: DoubleArray,
     Type_LIST: ListArray,
+    Type_BINARY: BinaryArray,
     Type_STRING: StringArray,
     Type_TIMESTAMP: Int64Array,
 }

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -40,6 +40,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         Type_TIMESTAMP" arrow::Type::TIMESTAMP"
         Type_DATE" arrow::Type::DATE"
+        Type_BINARY" arrow::Type::BINARY"
         Type_STRING" arrow::Type::STRING"
 
         Type_LIST" arrow::Type::LIST"
@@ -161,7 +162,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CArray] values()
         shared_ptr[CDataType] value_type()
 
-    cdef cppclass CStringArray" arrow::StringArray"(CListArray):
+    cdef cppclass CBinaryArray" arrow::BinaryArray"(CListArray):
+        const uint8_t* GetValue(int i, int32_t* length)
+
+    cdef cppclass CStringArray" arrow::StringArray"(CBinaryArray):
         c_string GetString(int i)
 
     cdef cppclass CChunkedArray" arrow::ChunkedArray":

--- a/python/pyarrow/scalar.pyx
+++ b/python/pyarrow/scalar.pyx
@@ -139,8 +139,6 @@ cdef class TimestampValue(ArrayValue):
             CTimestampType* dtype = <CTimestampType*>ap.type().get()
             int64_t val = ap.Value(self.index)
 
-        print(val)
-
         if dtype.unit == TimeUnit_SECOND:
             return datetime.datetime.utcfromtimestamp(val)
         elif dtype.unit == TimeUnit_MILLI:

--- a/python/pyarrow/schema.pyx
+++ b/python/pyarrow/schema.pyx
@@ -215,6 +215,12 @@ def string():
     """
     return primitive_type(Type_STRING)
 
+def binary():
+    """
+    Binary (PyBytes-like) type
+    """
+    return primitive_type(Type_BINARY)
+
 def list_(DataType value_type):
     cdef DataType out = DataType()
     cdef shared_ptr[CDataType] list_type

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -23,6 +23,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 
+from pyarrow.compat import u
 import pyarrow as A
 
 
@@ -165,6 +166,13 @@ class TestPandasConversion(unittest.TestCase):
         values = ['foo', None, u'bar', 'qux', None]
         expected = pd.DataFrame({'strings': values * repeats})
         self._check_pandas_roundtrip(df, expected)
+
+    def test_bytes_to_binary(self):
+        values = [u('qux'), b'foo', None, 'bar', 'qux', np.nan]
+        df = pd.DataFrame({'strings': values})
+
+        table = A.from_pandas_dataframe(df)
+        assert table[0].type == A.binary()
 
     def test_timestamps_notimezone_no_nulls(self):
         df = pd.DataFrame({

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -158,14 +158,12 @@ class TestPandasConversion(unittest.TestCase):
         df = pd.DataFrame({'bools': arr})
         self._check_pandas_roundtrip(df)
 
-    def test_strings(self):
+    def test_unicode(self):
         repeats = 1000
-        values = [b'foo', None, u'bar', 'qux', np.nan]
+        values = [u('foo'), None, u('bar'), u('qux'), np.nan]
         df = pd.DataFrame({'strings': values * repeats})
 
-        values = ['foo', None, u'bar', 'qux', None]
-        expected = pd.DataFrame({'strings': values * repeats})
-        self._check_pandas_roundtrip(df, expected)
+        self._check_pandas_roundtrip(df)
 
     def test_bytes_to_binary(self):
         values = [u('qux'), b'foo', None, 'bar', 'qux', np.nan]
@@ -173,6 +171,10 @@ class TestPandasConversion(unittest.TestCase):
 
         table = A.from_pandas_dataframe(df)
         assert table[0].type == A.binary()
+
+        values2 = [b'qux', b'foo', None, b'bar', b'qux', np.nan]
+        expected = pd.DataFrame({'strings': values2})
+        self._check_pandas_roundtrip(df, expected)
 
     def test_timestamps_notimezone_no_nulls(self):
         df = pd.DataFrame({

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pyarrow.compat import unittest, u
+from pyarrow.compat import unittest, u, unicode_type
 import pyarrow as A
 
 
@@ -58,19 +58,31 @@ class TestScalars(unittest.TestCase):
         v = arr[2]
         assert v.as_py() == 3.0
 
-    def test_string(self):
-        arr = A.from_pylist(['foo', None, u('bar')])
+    def test_string_unicode(self):
+        arr = A.from_pylist([u('foo'), None, u('bar')])
 
         v = arr[0]
         assert isinstance(v, A.StringValue)
-        assert repr(v) == "'foo'"
         assert v.as_py() == 'foo'
 
         assert arr[1] is A.NA
 
         v = arr[2].as_py()
-        assert v == 'bar'
+        assert v == u('bar')
         assert isinstance(v, str)
+
+    def test_bytes(self):
+        arr = A.from_pylist([b'foo', None, u('bar')])
+
+        v = arr[0]
+        assert isinstance(v, A.BinaryValue)
+        assert v.as_py() == b'foo'
+
+        assert arr[1] is A.NA
+
+        v = arr[2].as_py()
+        assert v == b'bar'
+        assert isinstance(v, bytes)
 
     def test_list(self):
         arr = A.from_pylist([['foo', None], None, ['bar'], []])

--- a/python/src/pyarrow/helpers.cc
+++ b/python/src/pyarrow/helpers.cc
@@ -23,47 +23,33 @@ using namespace arrow;
 
 namespace pyarrow {
 
-const std::shared_ptr<NullType> NA = std::make_shared<NullType>();
-const std::shared_ptr<BooleanType> BOOL = std::make_shared<BooleanType>();
-const std::shared_ptr<UInt8Type> UINT8 = std::make_shared<UInt8Type>();
-const std::shared_ptr<UInt16Type> UINT16 = std::make_shared<UInt16Type>();
-const std::shared_ptr<UInt32Type> UINT32 = std::make_shared<UInt32Type>();
-const std::shared_ptr<UInt64Type> UINT64 = std::make_shared<UInt64Type>();
-const std::shared_ptr<Int8Type> INT8 = std::make_shared<Int8Type>();
-const std::shared_ptr<Int16Type> INT16 = std::make_shared<Int16Type>();
-const std::shared_ptr<Int32Type> INT32 = std::make_shared<Int32Type>();
-const std::shared_ptr<Int64Type> INT64 = std::make_shared<Int64Type>();
-const std::shared_ptr<DateType> DATE = std::make_shared<DateType>();
-const std::shared_ptr<TimestampType> TIMESTAMP_US = std::make_shared<TimestampType>(TimeUnit::MICRO);
-const std::shared_ptr<FloatType> FLOAT = std::make_shared<FloatType>();
-const std::shared_ptr<DoubleType> DOUBLE = std::make_shared<DoubleType>();
-const std::shared_ptr<StringType> STRING = std::make_shared<StringType>();
 
-#define GET_PRIMITIVE_TYPE(NAME, Class)         \
+#define GET_PRIMITIVE_TYPE(NAME, FACTORY)       \
   case Type::NAME:                              \
-    return NAME;                                \
+    return FACTORY();                           \
     break;
 
 std::shared_ptr<DataType> GetPrimitiveType(Type::type type) {
   switch (type) {
     case Type::NA:
-      return NA;
-    GET_PRIMITIVE_TYPE(UINT8, UInt8Type);
-    GET_PRIMITIVE_TYPE(INT8, Int8Type);
-    GET_PRIMITIVE_TYPE(UINT16, UInt16Type);
-    GET_PRIMITIVE_TYPE(INT16, Int16Type);
-    GET_PRIMITIVE_TYPE(UINT32, UInt32Type);
-    GET_PRIMITIVE_TYPE(INT32, Int32Type);
-    GET_PRIMITIVE_TYPE(UINT64, UInt64Type);
-    GET_PRIMITIVE_TYPE(INT64, Int64Type);
-    GET_PRIMITIVE_TYPE(DATE, DateType);
+      return null();
+    GET_PRIMITIVE_TYPE(UINT8, uint8);
+    GET_PRIMITIVE_TYPE(INT8, int8);
+    GET_PRIMITIVE_TYPE(UINT16, uint16);
+    GET_PRIMITIVE_TYPE(INT16, int16);
+    GET_PRIMITIVE_TYPE(UINT32, uint32);
+    GET_PRIMITIVE_TYPE(INT32, int32);
+    GET_PRIMITIVE_TYPE(UINT64, uint64);
+    GET_PRIMITIVE_TYPE(INT64, int64);
+    GET_PRIMITIVE_TYPE(DATE, date);
     case Type::TIMESTAMP:
-      return TIMESTAMP_US;
+      return arrow::timestamp(arrow::TimeUnit::MICRO);
       break;
-    GET_PRIMITIVE_TYPE(BOOL, BooleanType);
-    GET_PRIMITIVE_TYPE(FLOAT, FloatType);
-    GET_PRIMITIVE_TYPE(DOUBLE, DoubleType);
-    GET_PRIMITIVE_TYPE(STRING, StringType);
+    GET_PRIMITIVE_TYPE(BOOL, boolean);
+    GET_PRIMITIVE_TYPE(FLOAT, float32);
+    GET_PRIMITIVE_TYPE(DOUBLE, float64);
+    GET_PRIMITIVE_TYPE(BINARY, binary);
+    GET_PRIMITIVE_TYPE(STRING, utf8);
     default:
       return nullptr;
   }

--- a/python/src/pyarrow/helpers.h
+++ b/python/src/pyarrow/helpers.h
@@ -28,22 +28,6 @@ namespace pyarrow {
 using arrow::DataType;
 using arrow::Type;
 
-extern const std::shared_ptr<arrow::NullType> NA;
-extern const std::shared_ptr<arrow::BooleanType> BOOL;
-extern const std::shared_ptr<arrow::UInt8Type> UINT8;
-extern const std::shared_ptr<arrow::UInt16Type> UINT16;
-extern const std::shared_ptr<arrow::UInt32Type> UINT32;
-extern const std::shared_ptr<arrow::UInt64Type> UINT64;
-extern const std::shared_ptr<arrow::Int8Type> INT8;
-extern const std::shared_ptr<arrow::Int16Type> INT16;
-extern const std::shared_ptr<arrow::Int32Type> INT32;
-extern const std::shared_ptr<arrow::Int64Type> INT64;
-extern const std::shared_ptr<arrow::DateType> DATE;
-extern const std::shared_ptr<arrow::TimestampType> TIMESTAMP_US;
-extern const std::shared_ptr<arrow::FloatType> FLOAT;
-extern const std::shared_ptr<arrow::DoubleType> DOUBLE;
-extern const std::shared_ptr<arrow::StringType> STRING;
-
 PYARROW_EXPORT
 std::shared_ptr<DataType> GetPrimitiveType(Type::type type);
 


### PR DESCRIPTION
Python built-in types that are not all unicode become `arrow::BinaryArray` instead of `arrow::StringArray`, since we cannot be sure that the PyBytes objects are UTF-8-encoded strings. 