### PR TITLE
ARROW-440: [C++] Support pkg-config

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -33,6 +33,14 @@ install(FILES
   test-util.h
   DESTINATION include/arrow)
 
+# pkg-config support
+configure_file(arrow.pc.in
+  "${CMAKE_CURRENT_BINARY_DIR}/arrow.pc"
+  @ONLY)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow.pc"
+  DESTINATION "lib/pkgconfig/")
+
 #######################################
 # Unit tests
 #######################################

--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Apache Arrow
+Description: Arrow is a set of technologies that enable big-data systems to process and move data fast.
+Version: @ARROW_VERSION@
+Libs: -L${libdir} -larrow
+Cflags: -I${includedir}

--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -134,3 +134,11 @@ install(FILES
 install(TARGETS arrow_io
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
+
+# pkg-config support
+configure_file(arrow-io.pc.in
+  "${CMAKE_CURRENT_BINARY_DIR}/arrow-io.pc"
+  @ONLY)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-io.pc"
+  DESTINATION "lib/pkgconfig/")

--- a/cpp/src/arrow/io/arrow-io.pc.in
+++ b/cpp/src/arrow/io/arrow-io.pc.in
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Apache Arrow I/O
+Description: I/O interface for Arrow.
+Version: @ARROW_VERSION@
+Libs: -L${libdir} -larrow_io
+Cflags: -I${includedir}
+Requires: arrow

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -159,3 +159,11 @@ install(FILES
 install(TARGETS arrow_ipc
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
+
+# pkg-config support
+configure_file(arrow-ipc.pc.in
+  "${CMAKE_CURRENT_BINARY_DIR}/arrow-ipc.pc"
+  @ONLY)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-ipc.pc"
+  DESTINATION "lib/pkgconfig/")

--- a/cpp/src/arrow/ipc/arrow-ipc.pc.in
+++ b/cpp/src/arrow/ipc/arrow-ipc.pc.in
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Apache Arrow IPC
+Description: IPC extension for Arrow.
+Version: @ARROW_VERSION@
+Libs: -L${libdir} -larrow_ipc
+Cflags: -I${includedir}
+Requires: arrow-io


### PR DESCRIPTION
pkg-config is a tool to get build flags.

If Arrow supports pkg-config, users can set build flags easily.

For example, CMake supports pkg-config.

To support pkg-config, we just install .pc file that includes build
flags information.