### PR TITLE
ARROW-445: arrow_ipc_objlib depends on Flatbuffer generated files

### DIFF
--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -143,7 +143,7 @@ add_custom_command(
 )
 
 add_custom_target(metadata_fbs DEPENDS ${FBS_OUTPUT_FILES})
-add_dependencies(arrow_objlib metadata_fbs)
+add_dependencies(arrow_ipc_objlib metadata_fbs)
 
 # Headers: top level
 install(FILES


### PR DESCRIPTION
This is needed as before the depedency was done through the arrow
library on which arrow_ipc depends. But as the arrow_objlib target is
not linked to anything else, it can actually be built independently.
This would lead to races where the flatbuffer generated files were not
existing during arrow_ipc compilation.