### PR TITLE
ARROW-447: Always return unicode objects for UTF-8 strings

### DIFF
--- a/python/pyarrow/scalar.pyx
+++ b/python/pyarrow/scalar.pyx
@@ -168,7 +168,7 @@ cdef class StringValue(ArrayValue):
 
     def as_py(self):
         cdef CStringArray* ap = <CStringArray*> self.sp_array.get()
-        return frombytes(ap.GetString(self.index))
+        return ap.GetString(self.index).decode('utf-8')
 
 
 cdef class BinaryValue(ArrayValue):

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -72,12 +73,12 @@ class TestConvertList(unittest.TestCase):
         assert arr.to_pylist() == data
 
     def test_unicode(self):
-        data = [u('foo'), u('bar'), None, u('arrow')]
+        data = [u'foo', u'bar', None, u'mañana']
         arr = pyarrow.from_pylist(data)
         assert len(arr) == 4
         assert arr.null_count == 1
         assert arr.type == pyarrow.string()
-        assert arr.to_pylist() == [u('foo'), u('bar'), None, u('arrow')]
+        assert arr.to_pylist() == data
 
     def test_bytes(self):
         u1 = b'ma\xc3\xb1ana'

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -183,7 +184,7 @@ class TestPandasConversion(unittest.TestCase):
 
     def test_unicode(self):
         repeats = 1000
-        values = [u('foo'), None, u('bar'), u('qux'), np.nan]
+        values = [u'foo', None, u'bar', u'mañana', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
 
         self._check_pandas_roundtrip(df)

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -59,7 +60,7 @@ class TestScalars(unittest.TestCase):
         assert v.as_py() == 3.0
 
     def test_string_unicode(self):
-        arr = A.from_pylist([u('foo'), None, u('bar')])
+        arr = A.from_pylist([u'foo', None, u'mañana'])
 
         v = arr[0]
         assert isinstance(v, A.StringValue)
@@ -68,8 +69,8 @@ class TestScalars(unittest.TestCase):
         assert arr[1] is A.NA
 
         v = arr[2].as_py()
-        assert v == u('bar')
-        assert isinstance(v, str)
+        assert v == u'mañana'
+        assert isinstance(v, unicode_type)
 
     def test_bytes(self):
         arr = A.from_pylist([b'foo', None, u('bar')])

--- a/python/src/pyarrow/adapters/pandas.cc
+++ b/python/src/pyarrow/adapters/pandas.cc
@@ -603,11 +603,7 @@ struct WrapBytes {};
 template <>
 struct WrapBytes<arrow::StringArray> {
   static inline PyObject* Wrap(const uint8_t* data, int64_t length) {
-#if PY_MAJOR_VERSION >= 3
     return PyUnicode_FromStringAndSize(reinterpret_cast<const char*>(data), length);
-#else
-    return PyString_FromStringAndSize(reinterpret_cast<const char*>(data), length);
-#endif
   }
 };
 


### PR DESCRIPTION
As the u() function was not working with Unicode characters, this uses
the u'' literal again which was re-introduced with Python 3.3. Thus the
tests will fail with Python3 < 3.3