### PR TITLE
ARROW-386: [Java] Respect case of struct / map field names

### DIFF
--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -90,7 +90,6 @@ package org.apache.arrow.vector.complex.writer;
     void clear();
     void copyReader(FieldReader reader);
     MapWriter rootAsMap();
-    MapWriter rootAsMap(Boolean caseSensitive);
     ListWriter rootAsList();
 
     void setPosition(int index);

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -90,6 +90,7 @@ package org.apache.arrow.vector.complex.writer;
     void clear();
     void copyReader(FieldReader reader);
     MapWriter rootAsMap();
+    MapWriter rootAsMap(Boolean caseSensitive);
     ListWriter rootAsList();
 
     void setPosition(int index);

--- a/java/vector/src/main/codegen/templates/CaseSensitiveMapWriters.java
+++ b/java/vector/src/main/codegen/templates/CaseSensitiveMapWriters.java
@@ -36,7 +36,6 @@ package org.apache.arrow.vector.complex.impl;
  */
 @SuppressWarnings("unused")
 public class ${mode}CaseSensitiveMapWriter extends ${mode}MapWriter {
-
   public ${mode}CaseSensitiveMapWriter(${containerClass} container) {
     super(container);
   }
@@ -44,6 +43,11 @@ public class ${mode}CaseSensitiveMapWriter extends ${mode}MapWriter {
   @Override
   protected String handleCase(final String input){
     return input;
+  }
+
+  @Override
+  protected NullableMapWriterFactory getNullableMapWriterFactory() {
+    return NullableMapWriterFactory.getNullableCaseSensitiveMapWriterFactoryInstance();
   }
 
 }

--- a/java/vector/src/main/codegen/templates/CaseSensitiveMapWriters.java
+++ b/java/vector/src/main/codegen/templates/CaseSensitiveMapWriters.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+<@pp.dropOutputFile />
+<#list ["Nullable", "Single"] as mode>
+<@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/${mode}CaseSensitiveMapWriter.java" />
+<#assign index = "idx()">
+<#if mode == "Single">
+<#assign containerClass = "MapVector" />
+<#else>
+<#assign containerClass = "NullableMapVector" />
+</#if>
+
+<#include "/@includes/license.ftl" />
+
+package org.apache.arrow.vector.complex.impl;
+
+<#include "/@includes/vv_imports.ftl" />
+/*
+ * This class is generated using FreeMarker and the ${.template_name} template.
+ */
+@SuppressWarnings("unused")
+public class ${mode}CaseSensitiveMapWriter extends ${mode}MapWriter {
+
+  public ${mode}CaseSensitiveMapWriter(${containerClass} container) {
+    super(container);
+  }
+
+  @Override
+  protected String handleCase(final String input){
+    return input;
+  }
+
+}
+</#list>

--- a/java/vector/src/main/codegen/templates/MapWriters.java
+++ b/java/vector/src/main/codegen/templates/MapWriters.java
@@ -95,7 +95,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
     return this.caseSensitive? input : input.toLowerCase();
   }
 
-  public boolean getCaseSensitivity() {
+  public boolean isCaseSensitive() {
     return this.caseSensitive;
   }
 

--- a/java/vector/src/main/codegen/templates/MapWriters.java
+++ b/java/vector/src/main/codegen/templates/MapWriters.java
@@ -66,7 +66,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
         break;
       case UNION:
         UnionWriter writer = new UnionWriter(container.addOrGet(child.getName(), MinorType.UNION, UnionVector.class));
-        fields.put(child.getName().toLowerCase(), writer);
+        fields.put(child.getName(), writer);
         break;
 <#list vv.types as type><#list type.minor as minor>
 <#assign lowerName = minor.class?uncap_first />
@@ -102,7 +102,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
 
   @Override
   public MapWriter map(String name) {
-      FieldWriter writer = fields.get(name.toLowerCase());
+      FieldWriter writer = fields.get(name);
     if(writer == null){
       int vectorCount=container.size();
       NullableMapVector vector = container.addOrGet(name, MinorType.MAP, NullableMapVector.class);
@@ -111,7 +111,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
         writer.allocate();
       }
       writer.setPosition(idx());
-      fields.put(name.toLowerCase(), writer);
+      fields.put(name, writer);
     } else {
       if (writer instanceof PromotableWriter) {
         // ensure writers are initialized
@@ -145,7 +145,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
 
   @Override
   public ListWriter list(String name) {
-    FieldWriter writer = fields.get(name.toLowerCase());
+    FieldWriter writer = fields.get(name);
     int vectorCount = container.size();
     if(writer == null) {
       writer = new PromotableWriter(container.addOrGet(name, MinorType.LIST, ListVector.class), container);
@@ -153,7 +153,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
         writer.allocate();
       }
       writer.setPosition(idx());
-      fields.put(name.toLowerCase(), writer);
+      fields.put(name, writer);
     } else {
       if (writer instanceof PromotableWriter) {
         // ensure writers are initialized
@@ -199,7 +199,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
   <#if minor.class?starts_with("Decimal") >
   public ${minor.class}Writer ${lowerName}(String name) {
     // returns existing writer
-    final FieldWriter writer = fields.get(name.toLowerCase());
+    final FieldWriter writer = fields.get(name);
     assert writer != null;
     return writer;
   }
@@ -209,7 +209,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
   @Override
   public ${minor.class}Writer ${lowerName}(String name) {
   </#if>
-    FieldWriter writer = fields.get(name.toLowerCase());
+    FieldWriter writer = fields.get(name);
     if(writer == null) {
       ValueVector vector;
       ValueVector currentVector = container.getChild(name);
@@ -220,7 +220,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
         vector.allocateNewSafe();
       } 
       writer.setPosition(idx());
-      fields.put(name.toLowerCase(), writer);
+      fields.put(name, writer);
     } else {
       if (writer instanceof PromotableWriter) {
         // ensure writers are initialized

--- a/java/vector/src/main/codegen/templates/MapWriters.java
+++ b/java/vector/src/main/codegen/templates/MapWriters.java
@@ -154,7 +154,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
   @Override
   public ListWriter list(String name) {
     String finalName = handleCase(name);
-    FieldWriter writer = fields.get(handleCase(finalName));
+    FieldWriter writer = fields.get(finalName);
     int vectorCount = container.size();
     if(writer == null) {
       writer = new PromotableWriter(container.addOrGet(name, MinorType.LIST, ListVector.class), container, getNullableMapWriterFactory());

--- a/java/vector/src/main/codegen/templates/MapWriters.java
+++ b/java/vector/src/main/codegen/templates/MapWriters.java
@@ -48,16 +48,14 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
 
   protected final ${containerClass} container;
   private final Map<String, FieldWriter> fields = Maps.newHashMap();
-  private final boolean caseSensitive;
 
-  public ${mode}MapWriter(${containerClass} container, boolean caseSensitive) {
+  public ${mode}MapWriter(${containerClass} container) {
     <#if mode == "Single">
     if (container instanceof NullableMapVector) {
       throw new IllegalArgumentException("Invalid container: " + container);
     }
     </#if>
     this.container = container;
-    this.caseSensitive = caseSensitive;
     for (Field child : container.getField().getChildren()) {
       switch (Types.getMinorTypeForArrowType(child.getType())) {
       case MAP:
@@ -87,16 +85,8 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
     }
   }
 
-  public ${mode}MapWriter(${containerClass} container) {
-    this(container, false);
-  }
-
-  private String handleCase(final String input) {
-    return this.caseSensitive? input : input.toLowerCase();
-  }
-
-  public boolean isCaseSensitive() {
-    return this.caseSensitive;
+  protected String handleCase(final String input) {
+    return input.toLowerCase();
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -43,8 +43,12 @@ public class UnionListWriter extends AbstractFieldWriter {
   private int lastIndex = 0;
 
   public UnionListWriter(ListVector vector) {
+    this(vector, NullableMapWriterFactory.getNullableMapWriterFactoryInstance());
+  }
+
+  public UnionListWriter(ListVector vector, NullableMapWriterFactory nullableMapWriterFactory) {
     this.vector = vector;
-    this.writer = new PromotableWriter(vector.getDataVector(), vector);
+    this.writer = new PromotableWriter(vector.getDataVector(), vector, nullableMapWriterFactory);
     this.offsets = vector.getOffsetVector();
   }
 

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -136,6 +136,7 @@ public class UnionVector implements FieldVector {
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
   <#assign fields = minor.fields!type.fields />
   <#assign uncappedName = name?uncap_first/>
+  <#assign lowerCaseName = name?lower_case/>
   <#if !minor.class?starts_with("Decimal")>
 
   private Nullable${name}Vector ${uncappedName}Vector;
@@ -143,7 +144,7 @@ public class UnionVector implements FieldVector {
   public Nullable${name}Vector get${name}Vector() {
     if (${uncappedName}Vector == null) {
       int vectorCount = internalMap.size();
-      ${uncappedName}Vector = internalMap.addOrGet("${uncappedName}", MinorType.${name?upper_case}, Nullable${name}Vector.class);
+      ${uncappedName}Vector = internalMap.addOrGet("${lowerCaseName}", MinorType.${name?upper_case}, Nullable${name}Vector.class);
       if (internalMap.size() > vectorCount) {
         ${uncappedName}Vector.allocateNew();
         if (callBack != null) {

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.vector.complex.impl.NullableMapWriterFactory;
+
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/UnionWriter.java" />
 
@@ -38,9 +40,15 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
   private MapWriter mapWriter;
   private UnionListWriter listWriter;
   private List<BaseWriter> writers = Lists.newArrayList();
+  private final NullableMapWriterFactory nullableMapWriterFactory;
 
   public UnionWriter(UnionVector vector) {
+    this(vector, NullableMapWriterFactory.getNullableMapWriterFactoryInstance());
+  }
+
+  public UnionWriter(UnionVector vector, NullableMapWriterFactory nullableMapWriterFactory) {
     data = vector;
+    this.nullableMapWriterFactory = nullableMapWriterFactory;
   }
 
   @Override
@@ -76,7 +84,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
 
   private MapWriter getMapWriter() {
     if (mapWriter == null) {
-      mapWriter = new NullableMapWriter(data.getMap());
+      mapWriter = nullableMapWriterFactory.build(data.getMap());
       mapWriter.setPosition(idx());
       writers.add(mapWriter);
     }
@@ -90,7 +98,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
 
   private ListWriter getListWriter() {
     if (listWriter == null) {
-      listWriter = new UnionListWriter(data.getList());
+      listWriter = new UnionListWriter(data.getList(), nullableMapWriterFactory);
       listWriter.setPosition(idx());
       writers.add(listWriter);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractMapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractMapVector.java
@@ -155,7 +155,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    */
   @Override
   public <T extends FieldVector> T getChild(String name, Class<T> clazz) {
-    final ValueVector v = vectors.get(name.toLowerCase());
+    final ValueVector v = vectors.get(name);
     if (v == null) {
       return null;
     }
@@ -191,7 +191,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    */
   protected void putVector(String name, FieldVector vector) {
     final ValueVector old = vectors.put(
-        Preconditions.checkNotNull(name, "field name cannot be null").toLowerCase(),
+        Preconditions.checkNotNull(name, "field name cannot be null"),
         Preconditions.checkNotNull(vector, "vector cannot be null")
     );
     if (old != null && old != vector) {
@@ -254,7 +254,7 @@ public abstract class AbstractMapVector extends AbstractContainerVector {
    */
   @Override
   public VectorWithOrdinal getChildVectorWithOrdinal(String name) {
-    final int ordinal = vectors.getOrdinal(name.toLowerCase());
+    final int ordinal = vectors.getOrdinal(name);
     if (ordinal < 0) {
       return null;
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -139,17 +139,22 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
   }
 
   @Override
-  public MapWriter rootAsMap() {
+  public MapWriter rootAsMap(Boolean caseSensitive) {
     switch(mode){
 
     case INIT:
       NullableMapVector map = container.addOrGet(name, MinorType.MAP, NullableMapVector.class);
-      mapRoot = new NullableMapWriter(map);
+      boolean caseSensitivityPrimitive = caseSensitive == null? false : caseSensitive;
+      mapRoot = new NullableMapWriter(map, caseSensitivityPrimitive);
       mapRoot.setPosition(idx());
       mode = Mode.MAP;
       break;
 
     case MAP:
+      if (caseSensitive != null && caseSensitive != mapRoot.getCaseSensitivity()) {
+        throw new IllegalArgumentException("Writer has been initialized with case sensitivity of \"" +
+            String.valueOf(mapRoot.getCaseSensitivity()) + "\"");
+      }
       break;
 
     default:
@@ -157,6 +162,11 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
     }
 
     return mapRoot;
+  }
+
+  @Override
+  public MapWriter rootAsMap() {
+    return rootAsMap(null);
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -150,7 +150,7 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
     case INIT:
       NullableMapVector map = container.addOrGet(name, MinorType.MAP, NullableMapVector.class);
-      mapRoot = new NullableMapWriter(map, this.caseSensitive);
+      mapRoot = this.caseSensitive? new NullableCaseSensitiveMapWriter(map) : new NullableMapWriter(map);
       mapRoot.setPosition(idx());
       mode = Mode.MAP;
       break;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -37,13 +37,19 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
   Mode mode = Mode.INIT;
   private final String name;
   private final boolean unionEnabled;
+  private final boolean caseSensitive;
 
   private enum Mode { INIT, MAP, LIST };
 
-  public ComplexWriterImpl(String name, MapVector container, boolean unionEnabled){
+  public ComplexWriterImpl(String name, MapVector container, boolean unionEnabled, boolean caseSensitive){
     this.name = name;
     this.container = container;
     this.unionEnabled = unionEnabled;
+    this.caseSensitive = caseSensitive;
+  }
+
+  public ComplexWriterImpl(String name, MapVector container, boolean unionEnabled) {
+    this(name, container, unionEnabled, false);
   }
 
   public ComplexWriterImpl(String name, MapVector container){
@@ -139,22 +145,17 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
   }
 
   @Override
-  public MapWriter rootAsMap(Boolean caseSensitive) {
+  public MapWriter rootAsMap() {
     switch(mode){
 
     case INIT:
       NullableMapVector map = container.addOrGet(name, MinorType.MAP, NullableMapVector.class);
-      boolean caseSensitivityPrimitive = caseSensitive == null? false : caseSensitive;
-      mapRoot = new NullableMapWriter(map, caseSensitivityPrimitive);
+      mapRoot = new NullableMapWriter(map, this.caseSensitive);
       mapRoot.setPosition(idx());
       mode = Mode.MAP;
       break;
 
     case MAP:
-      if (caseSensitive != null && caseSensitive != mapRoot.getCaseSensitivity()) {
-        throw new IllegalArgumentException("Writer has been initialized with case sensitivity of \"" +
-            String.valueOf(mapRoot.getCaseSensitivity()) + "\"");
-      }
       break;
 
     default:
@@ -163,12 +164,6 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
     return mapRoot;
   }
-
-  @Override
-  public MapWriter rootAsMap() {
-    return rootAsMap(null);
-  }
-
 
   @Override
   public void allocate() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableMapWriterFactory.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableMapWriterFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.complex.impl;
+
+import org.apache.arrow.vector.complex.NullableMapVector;
+
+public class NullableMapWriterFactory {
+    private final boolean caseSensitive;
+    private static final NullableMapWriterFactory nullableMapWriterFactory = new NullableMapWriterFactory(false);
+    private static final NullableMapWriterFactory nullableCaseSensitiveWriterFactory = new NullableMapWriterFactory(true);
+
+    public NullableMapWriterFactory(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+    }
+
+    public NullableMapWriter build(NullableMapVector container) {
+        return this.caseSensitive? new NullableCaseSensitiveMapWriter(container) : new NullableMapWriter(container);
+    }
+
+    public static NullableMapWriterFactory getNullableMapWriterFactoryInstance() {
+        return nullableMapWriterFactory;
+    }
+
+    public static NullableMapWriterFactory getNullableCaseSensitiveMapWriterFactoryInstance() {
+        return nullableCaseSensitiveWriterFactory;
+    }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -23,7 +23,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -484,5 +486,26 @@ public class TestComplexWriter {
     Assert.assertEquals(64, intType.getBitWidth());
     Assert.assertTrue(intType.getIsSigned());
     Assert.assertEquals(ArrowTypeID.Utf8, field.getChildren().get(1).getType().getTypeID());
+  }
+
+  @Test
+  public void mapWriterMixedCaseFieldNames() {
+    MapVector parent = new MapVector("parent", allocator, null);
+    ComplexWriter writer = new ComplexWriterImpl("root", parent);
+    MapWriter rootWriter = writer.rootAsMap();
+    rootWriter.bigInt("int_field");
+    rootWriter.bigInt("Int_Field");
+    rootWriter.float4("float_field");
+    rootWriter.float4("Float_Field");
+
+    List<Field> fields = parent.getField().getChildren().get(0).getChildren();
+    Set<String> fieldNames = new HashSet<>();
+    for (Field field: fields) {
+      fieldNames.add(field.getName());
+    }
+    Assert.assertTrue(fieldNames.contains("int_field"));
+    Assert.assertTrue(fieldNames.contains("Int_Field"));
+    Assert.assertTrue(fieldNames.contains("float_field"));
+    Assert.assertTrue(fieldNames.contains("Float_Field"));
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -492,8 +492,8 @@ public class TestComplexWriter {
   public void mapWriterMixedCaseFieldNames() {
     // test case-sensitive MapWriter
     MapVector parent = new MapVector("parent", allocator, null);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    MapWriter rootWriterCaseSensitive = writer.rootAsMap(true);
+    ComplexWriter writer = new ComplexWriterImpl("root", parent, false, true);
+    MapWriter rootWriterCaseSensitive = writer.rootAsMap();
     rootWriterCaseSensitive.bigInt("int_field");
     rootWriterCaseSensitive.bigInt("Int_Field");
     rootWriterCaseSensitive.float4("float_field");
@@ -510,14 +510,9 @@ public class TestComplexWriter {
     Assert.assertTrue(fieldNamesCaseSensitive.contains("float_field"));
     Assert.assertTrue(fieldNamesCaseSensitive.contains("Float_Field"));
 
-    try {
-      writer.rootAsMap(false);
-      Assert.fail("IllegalArgumentException expected");
-    } catch (IllegalArgumentException ignored) {}
-
     // test case-insensitive MapWriter
-    ComplexWriter writerCaseInsensitive = new ComplexWriterImpl("rootCaseInsensitive", parent);
-    MapWriter rootWriterCaseInsensitive = writerCaseInsensitive.rootAsMap(false);
+    ComplexWriter writerCaseInsensitive = new ComplexWriterImpl("rootCaseInsensitive", parent, false, false);
+    MapWriter rootWriterCaseInsensitive = writerCaseInsensitive.rootAsMap();
 
     rootWriterCaseInsensitive.bigInt("int_field");
     rootWriterCaseInsensitive.bigInt("Int_Field");

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -490,22 +490,47 @@ public class TestComplexWriter {
 
   @Test
   public void mapWriterMixedCaseFieldNames() {
+    // test case-sensitive MapWriter
     MapVector parent = new MapVector("parent", allocator, null);
     ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    MapWriter rootWriter = writer.rootAsMap();
-    rootWriter.bigInt("int_field");
-    rootWriter.bigInt("Int_Field");
-    rootWriter.float4("float_field");
-    rootWriter.float4("Float_Field");
+    MapWriter rootWriterCaseSensitive = writer.rootAsMap(true);
+    rootWriterCaseSensitive.bigInt("int_field");
+    rootWriterCaseSensitive.bigInt("Int_Field");
+    rootWriterCaseSensitive.float4("float_field");
+    rootWriterCaseSensitive.float4("Float_Field");
 
-    List<Field> fields = parent.getField().getChildren().get(0).getChildren();
-    Set<String> fieldNames = new HashSet<>();
-    for (Field field: fields) {
-      fieldNames.add(field.getName());
+    List<Field> fieldsCaseSensitive = parent.getField().getChildren().get(0).getChildren();
+    Set<String> fieldNamesCaseSensitive = new HashSet<>();
+    for (Field field: fieldsCaseSensitive) {
+      fieldNamesCaseSensitive.add(field.getName());
     }
-    Assert.assertTrue(fieldNames.contains("int_field"));
-    Assert.assertTrue(fieldNames.contains("Int_Field"));
-    Assert.assertTrue(fieldNames.contains("float_field"));
-    Assert.assertTrue(fieldNames.contains("Float_Field"));
+    Assert.assertEquals(4, fieldNamesCaseSensitive.size());
+    Assert.assertTrue(fieldNamesCaseSensitive.contains("int_field"));
+    Assert.assertTrue(fieldNamesCaseSensitive.contains("Int_Field"));
+    Assert.assertTrue(fieldNamesCaseSensitive.contains("float_field"));
+    Assert.assertTrue(fieldNamesCaseSensitive.contains("Float_Field"));
+
+    try {
+      writer.rootAsMap(false);
+      Assert.fail("IllegalArgumentException expected");
+    } catch (IllegalArgumentException ignored) {}
+
+    // test case-insensitive MapWriter
+    ComplexWriter writerCaseInsensitive = new ComplexWriterImpl("rootCaseInsensitive", parent);
+    MapWriter rootWriterCaseInsensitive = writerCaseInsensitive.rootAsMap(false);
+
+    rootWriterCaseInsensitive.bigInt("int_field");
+    rootWriterCaseInsensitive.bigInt("Int_Field");
+    rootWriterCaseInsensitive.float4("float_field");
+    rootWriterCaseInsensitive.float4("Float_Field");
+
+    List<Field> fieldsCaseInsensitive = parent.getField().getChildren().get(1).getChildren();
+    Set<String> fieldNamesCaseInsensitive = new HashSet<>();
+    for (Field field: fieldsCaseInsensitive) {
+      fieldNamesCaseInsensitive.add(field.getName());
+    }
+    Assert.assertEquals(2, fieldNamesCaseInsensitive.size());
+    Assert.assertTrue(fieldNamesCaseInsensitive.contains("int_field"));
+    Assert.assertTrue(fieldNamesCaseInsensitive.contains("float_field"));
   }
 }


### PR DESCRIPTION
Changes include:
- Remove all toLowerCase() calls on field names in MapWriters.java template file, so that the writers can respect case of the field names.
- Use lower-case keys for internalMap in UnionVector instead of camel-case (e.g. bigInt -> bigint). p.s. I don't know what is the original purpose of using camel case here. It did not conflict because all field names are converted to lower cases in the past.
- Add a simple test case of MapWriter with mixed-case field names.