### PR TITLE
ARROW-427: [C++] Implement dictionary array type

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -47,6 +47,7 @@ install(
 
 ADD_ARROW_TEST(array-test)
 ADD_ARROW_TEST(array-decimal-test)
+ADD_ARROW_TEST(array-dictionary-test)
 ADD_ARROW_TEST(array-list-test)
 ADD_ARROW_TEST(array-primitive-test)
 ADD_ARROW_TEST(array-string-test)
@@ -58,6 +59,5 @@ ADD_ARROW_TEST(pretty_print-test)
 ADD_ARROW_TEST(schema-test)
 ADD_ARROW_TEST(status-test)
 ADD_ARROW_TEST(table-test)
-ADD_ARROW_TEST(type-test)
 
 ADD_ARROW_BENCHMARK(column-benchmark)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -58,5 +58,6 @@ ADD_ARROW_TEST(pretty_print-test)
 ADD_ARROW_TEST(schema-test)
 ADD_ARROW_TEST(status-test)
 ADD_ARROW_TEST(table-test)
+ADD_ARROW_TEST(type-test)
 
 ADD_ARROW_BENCHMARK(column-benchmark)

--- a/cpp/src/arrow/array-dictionary-test.cc
+++ b/cpp/src/arrow/array-dictionary-test.cc
@@ -37,16 +37,16 @@ TEST(TestDictionaryType, Basics) {
   ArrayFromVector<Int32Type, int32_t>(int32(), values, &dict);
 
   std::shared_ptr<DictionaryType> type1 =
-      std::dynamic_pointer_cast<DictionaryType>(dictionary(dict, Type::INT16));
-  DictionaryType type2(dict, Type::INT16);
+      std::dynamic_pointer_cast<DictionaryType>(dictionary(int16(), dict));
+  DictionaryType type2(int16(), dict);
 
-  ASSERT_EQ(Type::INT16, type1->index_type());
+  ASSERT_TRUE(int16()->Equals(type1->index_type()));
   ASSERT_TRUE(type1->dictionary()->Equals(dict));
 
-  ASSERT_EQ(Type::INT16, type2.index_type());
+  ASSERT_TRUE(int16()->Equals(type2.index_type()));
   ASSERT_TRUE(type2.dictionary()->Equals(dict));
 
-  ASSERT_EQ("dictionary<int32>", type1->ToString());
+  ASSERT_EQ("dictionary<int32, int16>", type1->ToString());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array-dictionary-test.cc
+++ b/cpp/src/arrow/array-dictionary-test.cc
@@ -31,7 +31,7 @@
 
 namespace arrow {
 
-TEST(TestDictionaryType, Basics) {
+TEST(TestDictionary, Basics) {
   std::vector<int32_t> values = {100, 1000, 10000, 100000};
   std::shared_ptr<Array> dict;
   ArrayFromVector<Int32Type, int32_t>(int32(), values, &dict);
@@ -49,7 +49,7 @@ TEST(TestDictionaryType, Basics) {
   ASSERT_EQ("dictionary<int32, int16>", type1->ToString());
 }
 
-TEST(TestDictionaryType, Equals) {
+TEST(TestDictionary, Equals) {
   std::vector<bool> is_valid = {true, true, false, true, true, true};
 
   std::shared_ptr<Array> dict;
@@ -93,6 +93,36 @@ TEST(TestDictionaryType, Equals) {
   // RangeEquals
   ASSERT_TRUE(arr->RangeEquals(3, 6, 3, arr4));
   ASSERT_FALSE(arr->RangeEquals(1, 3, 1, arr4));
+}
+
+TEST(TestDictionary, Validate) {
+  std::vector<bool> is_valid = {true, true, false, true, true, true};
+
+  std::shared_ptr<Array> dict;
+  std::vector<std::string> dict_values = {"foo", "bar", "baz"};
+  ArrayFromVector<StringType, std::string>(utf8(), dict_values, &dict);
+  std::shared_ptr<DataType> dict_type = dictionary(int16(), dict);
+
+  std::shared_ptr<Array> indices;
+  std::vector<uint8_t> indices_values = {1, 2, 0, 0, 2, 0};
+  ArrayFromVector<UInt8Type, uint8_t>(uint8(), is_valid, indices_values, &indices);
+
+  std::shared_ptr<Array> indices2;
+  std::vector<float> indices2_values = {1., 2., 0., 0., 2., 0.};
+  ArrayFromVector<FloatType, float>(float32(), is_valid, indices2_values, &indices2);
+
+  std::shared_ptr<Array> indices3;
+  std::vector<int64_t> indices3_values = {1, 2, 0, 0, 2, 0};
+  ArrayFromVector<Int64Type, int64_t>(int64(), is_valid, indices3_values, &indices3);
+
+  std::shared_ptr<Array> arr = std::make_shared<DictionaryArray>(dict_type, indices);
+  std::shared_ptr<Array> arr2 = std::make_shared<DictionaryArray>(dict_type, indices2);
+  std::shared_ptr<Array> arr3 = std::make_shared<DictionaryArray>(dict_type, indices3);
+
+  // Only checking index type for now
+  ASSERT_OK(arr->Validate());
+  ASSERT_RAISES(Invalid, arr2->Validate());
+  ASSERT_OK(arr3->Validate());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array-primitive-test.cc
+++ b/cpp/src/arrow/array-primitive-test.cc
@@ -135,7 +135,7 @@ class TestPrimitiveBuilder : public TestBuilder {
     ASSERT_EQ(nullptr, builder->data());
 
     ASSERT_EQ(ex_null_count, result->null_count());
-    ASSERT_TRUE(result->Equals(*expected.get()));
+    ASSERT_TRUE(result->EqualsExact(*expected.get()));
   }
 
  protected:
@@ -238,7 +238,7 @@ void TestPrimitiveBuilder<PBoolean>::Check(
     bool actual = BitUtil::GetBit(result->raw_data(), i);
     ASSERT_EQ(static_cast<bool>(draws_[i]), actual) << i;
   }
-  ASSERT_TRUE(result->Equals(*expected.get()));
+  ASSERT_TRUE(result->EqualsExact(*expected.get()));
 }
 
 typedef ::testing::Types<PBoolean, PUInt8, PUInt16, PUInt32, PUInt64, PInt8, PInt16,

--- a/cpp/src/arrow/array-primitive-test.cc
+++ b/cpp/src/arrow/array-primitive-test.cc
@@ -135,7 +135,7 @@ class TestPrimitiveBuilder : public TestBuilder {
     ASSERT_EQ(nullptr, builder->data());
 
     ASSERT_EQ(ex_null_count, result->null_count());
-    ASSERT_TRUE(result->EqualsExact(*expected.get()));
+    ASSERT_TRUE(result->Equals(*expected.get()));
   }
 
  protected:
@@ -238,7 +238,7 @@ void TestPrimitiveBuilder<PBoolean>::Check(
     bool actual = BitUtil::GetBit(result->raw_data(), i);
     ASSERT_EQ(static_cast<bool>(draws_[i]), actual) << i;
   }
-  ASSERT_TRUE(result->EqualsExact(*expected.get()));
+  ASSERT_TRUE(result->Equals(*expected.get()));
 }
 
 typedef ::testing::Types<PBoolean, PUInt8, PUInt16, PUInt32, PUInt64, PInt8, PInt16,

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -36,8 +36,8 @@ TEST(TypesTest, BinaryType) {
   BinaryType t1;
   BinaryType e1;
   StringType t2;
-  EXPECT_TRUE(t1.Equals(&e1));
-  EXPECT_FALSE(t1.Equals(&t2));
+  EXPECT_TRUE(t1.Equals(e1));
+  EXPECT_FALSE(t1.Equals(t2));
   ASSERT_EQ(t1.type, Type::BINARY);
   ASSERT_EQ(t1.ToString(), std::string("binary"));
 }

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -613,7 +613,11 @@ DictionaryArray::DictionaryArray(
 }
 
 Status DictionaryArray::Validate() const {
-  return Status::NotImplemented("TODO(wesm)");
+  Type::type index_type_id = indices_->type()->type;
+  if (!is_integer(index_type_id)) {
+    return Status::Invalid("Dictionary indices must be integer type");
+  }
+  return Status::OK();
 }
 
 std::shared_ptr<Array> DictionaryArray::dictionary() const {

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -634,8 +634,10 @@ bool DictionaryArray::Equals(const std::shared_ptr<Array>& arr) const {
 
 bool DictionaryArray::RangeEquals(int32_t start_idx, int32_t end_idx,
     int32_t other_start_idx, const std::shared_ptr<Array>& arr) const {
-  DCHECK(false) << "Not implemented";
-  return false;
+  if (Type::DICTIONARY != arr->type_enum()) { return false; }
+  const auto& dict_other = static_cast<const DictionaryArray&>(*arr.get());
+  if (!dictionary()->Equals(dict_other.dictionary())) { return false; }
+  return indices_->RangeEquals(start_idx, end_idx, other_start_idx, dict_other.indices());
 }
 
 Status DictionaryArray::Accept(ArrayVisitor* visitor) const {

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -54,10 +54,10 @@ Array::Array(const std::shared_ptr<DataType>& type, int32_t length, int32_t null
 bool Array::BaseEquals(const std::shared_ptr<Array>& other) const {
   if (this == other.get()) { return true; }
   if (!other) { return false; }
-  return BaseEquals(*other.get());
+  return EqualsExact(*other.get());
 }
 
-bool Array::BaseEquals(const Array& other) const {
+bool Array::EqualsExact(const Array& other) const {
   if (this == &other) { return true; }
   if (length_ != other.length_ || null_count_ != other.null_count_ ||
       type_enum() != other.type_enum()) {
@@ -105,8 +105,8 @@ PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int32_t le
   raw_data_ = data == nullptr ? nullptr : data_->data();
 }
 
-bool PrimitiveArray::Equals(const PrimitiveArray& other) const {
-  if (!Array::BaseEquals(other)) { return false; }
+bool PrimitiveArray::EqualsExact(const PrimitiveArray& other) const {
+  if (!Array::EqualsExact(other)) { return false; }
 
   if (null_count_ > 0) {
     const uint8_t* this_data = raw_data_;
@@ -132,7 +132,7 @@ bool PrimitiveArray::Equals(const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
   if (!arr) { return false; }
   if (this->type_enum() != arr->type_enum()) { return false; }
-  return Equals(static_cast<const PrimitiveArray&>(*arr.get()));
+  return EqualsExact(static_cast<const PrimitiveArray&>(*arr.get()));
 }
 
 template <typename T>
@@ -167,7 +167,7 @@ BooleanArray::BooleanArray(const std::shared_ptr<DataType>& type, int32_t length
     const std::shared_ptr<Buffer>& null_bitmap)
     : PrimitiveArray(type, length, data, null_count, null_bitmap) {}
 
-bool BooleanArray::Equals(const BooleanArray& other) const {
+bool BooleanArray::EqualsExact(const BooleanArray& other) const {
   if (this == &other) return true;
   if (null_count_ != other.null_count_) { return false; }
 
@@ -193,7 +193,7 @@ bool BooleanArray::Equals(const BooleanArray& other) const {
 bool BooleanArray::Equals(const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) return true;
   if (Type::BOOL != arr->type_enum()) { return false; }
-  return Equals(*static_cast<const BooleanArray*>(arr.get()));
+  return EqualsExact(static_cast<const BooleanArray&>(*arr.get()));
 }
 
 bool BooleanArray::RangeEquals(int32_t start_idx, int32_t end_idx,
@@ -218,7 +218,7 @@ Status BooleanArray::Accept(ArrayVisitor* visitor) const {
 // ----------------------------------------------------------------------
 // ListArray
 
-bool ListArray::Equals(const ListArray& other) const {
+bool ListArray::EqualsExact(const ListArray& other) const {
   if (this == &other) { return true; }
   if (null_count_ != other.null_count_) { return false; }
 
@@ -239,7 +239,7 @@ bool ListArray::Equals(const ListArray& other) const {
 bool ListArray::Equals(const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
   if (this->type_enum() != arr->type_enum()) { return false; }
-  return Equals(*static_cast<const ListArray*>(arr.get()));
+  return EqualsExact(static_cast<const ListArray&>(*arr.get()));
 }
 
 bool ListArray::RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
@@ -350,8 +350,8 @@ Status BinaryArray::Validate() const {
   return Status::OK();
 }
 
-bool BinaryArray::Equals(const BinaryArray& other) const {
-  if (!Array::BaseEquals(other)) { return false; }
+bool BinaryArray::EqualsExact(const BinaryArray& other) const {
+  if (!Array::EqualsExact(other)) { return false; }
 
   bool equal_offsets =
       offsets_buffer_->Equals(*other.offsets_buffer_, (length_ + 1) * sizeof(int32_t));
@@ -365,7 +365,7 @@ bool BinaryArray::Equals(const BinaryArray& other) const {
 bool BinaryArray::Equals(const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
   if (this->type_enum() != arr->type_enum()) { return false; }
-  return Equals(*static_cast<const BinaryArray*>(arr.get()));
+  return EqualsExact(static_cast<const BinaryArray&>(*arr.get()));
 }
 
 bool BinaryArray::RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
@@ -624,16 +624,15 @@ std::shared_ptr<Array> DictionaryArray::dictionary() const {
   return dict_type_->dictionary();
 }
 
-bool DictionaryArray::Equals(const DictionaryArray& other) const {
+bool DictionaryArray::EqualsExact(const DictionaryArray& other) const {
   if (!dictionary()->Equals(other.dictionary())) { return false; }
-  if (!Array::BaseEquals(other)) { return false; }
   return indices_->Equals(other.indices());
 }
 
 bool DictionaryArray::Equals(const std::shared_ptr<Array>& arr) const {
   if (this == arr.get()) { return true; }
   if (Type::DICTIONARY != arr->type_enum()) { return false; }
-  return Equals(static_cast<const DictionaryArray&>(*arr.get()));
+  return EqualsExact(static_cast<const DictionaryArray&>(*arr.get()));
 }
 
 bool DictionaryArray::RangeEquals(int32_t start_idx, int32_t end_idx,

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -93,7 +93,7 @@ class ARROW_EXPORT Array {
   const uint8_t* null_bitmap_data() const { return null_bitmap_data_; }
 
   bool BaseEquals(const std::shared_ptr<Array>& arr) const;
-  bool BaseEquals(const Array& arr) const;
+  bool EqualsExact(const Array& arr) const;
   virtual bool Equals(const std::shared_ptr<Array>& arr) const = 0;
   virtual bool ApproxEquals(const std::shared_ptr<Array>& arr) const;
 
@@ -148,7 +148,7 @@ class ARROW_EXPORT PrimitiveArray : public Array {
 
   std::shared_ptr<Buffer> data() const { return data_; }
 
-  bool Equals(const PrimitiveArray& other) const;
+  bool EqualsExact(const PrimitiveArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
  protected:
@@ -173,8 +173,8 @@ class ARROW_EXPORT NumericArray : public PrimitiveArray {
       const std::shared_ptr<Buffer>& null_bitmap = nullptr)
       : PrimitiveArray(type, length, data, null_count, null_bitmap) {}
 
-  bool Equals(const NumericArray<TypeClass>& other) const {
-    return PrimitiveArray::Equals(static_cast<const PrimitiveArray&>(other));
+  bool EqualsExact(const NumericArray<TypeClass>& other) const {
+    return PrimitiveArray::EqualsExact(static_cast<const PrimitiveArray&>(other));
   }
 
   bool ApproxEquals(const std::shared_ptr<Array>& arr) const override {
@@ -286,7 +286,7 @@ class ARROW_EXPORT BooleanArray : public PrimitiveArray {
       const std::shared_ptr<Buffer>& data, int32_t null_count = 0,
       const std::shared_ptr<Buffer>& null_bitmap = nullptr);
 
-  bool Equals(const BooleanArray& other) const;
+  bool EqualsExact(const BooleanArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -334,7 +334,7 @@ class ARROW_EXPORT ListArray : public Array {
   int32_t value_offset(int i) const { return offsets_[i]; }
   int32_t value_length(int i) const { return offsets_[i + 1] - offsets_[i]; }
 
-  bool Equals(const ListArray& other) const;
+  bool EqualsExact(const ListArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
@@ -385,7 +385,7 @@ class ARROW_EXPORT BinaryArray : public Array {
   int32_t value_offset(int i) const { return offsets_[i]; }
   int32_t value_length(int i) const { return offsets_[i + 1] - offsets_[i]; }
 
-  bool Equals(const BinaryArray& other) const;
+  bool EqualsExact(const BinaryArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -448,7 +448,7 @@ class ARROW_EXPORT StructArray : public Array {
 
   const std::vector<std::shared_ptr<Array>>& fields() const { return field_arrays_; }
 
-  bool Equals(const StructArray& other) const;
+  bool EqualsExact(const StructArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -489,7 +489,7 @@ class ARROW_EXPORT UnionArray : public Array {
 
   const std::vector<std::shared_ptr<Array>>& children() const { return children_; }
 
-  bool Equals(const UnionArray& other) const;
+  bool EqualsExact(const UnionArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -542,7 +542,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   std::shared_ptr<Array> indices() const { return indices_; }
   std::shared_ptr<Array> dictionary() const;
 
-  bool Equals(const DictionaryArray& other) const;
+  bool EqualsExact(const DictionaryArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -26,6 +26,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/bit-util.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -35,6 +36,34 @@ namespace arrow {
 class MemoryPool;
 class MutableBuffer;
 class Status;
+
+class ArrayVisitor {
+ public:
+  virtual Status Visit(const NullArray& array) = 0;
+  virtual Status Visit(const BooleanArray& array) = 0;
+  virtual Status Visit(const Int8Array& array) = 0;
+  virtual Status Visit(const Int16Array& array) = 0;
+  virtual Status Visit(const Int32Array& array) = 0;
+  virtual Status Visit(const Int64Array& array) = 0;
+  virtual Status Visit(const UInt8Array& array) = 0;
+  virtual Status Visit(const UInt16Array& array) = 0;
+  virtual Status Visit(const UInt32Array& array) = 0;
+  virtual Status Visit(const UInt64Array& array) = 0;
+  virtual Status Visit(const HalfFloatArray& array) = 0;
+  virtual Status Visit(const FloatArray& array) = 0;
+  virtual Status Visit(const DoubleArray& array) = 0;
+  virtual Status Visit(const StringArray& array) = 0;
+  virtual Status Visit(const BinaryArray& array) = 0;
+  virtual Status Visit(const DateArray& array) = 0;
+  virtual Status Visit(const TimeArray& array) = 0;
+  virtual Status Visit(const TimestampArray& array) = 0;
+  virtual Status Visit(const IntervalArray& array) = 0;
+  virtual Status Visit(const DecimalArray& array) = 0;
+  virtual Status Visit(const ListArray& array) = 0;
+  virtual Status Visit(const StructArray& array) = 0;
+  virtual Status Visit(const UnionArray& array) = 0;
+  virtual Status Visit(const DictionaryArray& type) = 0;
+};
 
 // Immutable data array with some logical type and some length. Any memory is
 // owned by the respective Buffer instance (or its parents).

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -498,14 +498,14 @@ class ARROW_EXPORT DictionaryArray : public Array {
  public:
   using TypeClass = DictionaryType;
 
-  DictionaryArray(const std::shared_ptr<DataType>& type, int32_t length,
-      const std::shared_ptr<Buffer>& indices, int32_t null_count = 0,
-      const std::shared_ptr<Buffer>& null_bitmap = nullptr);
+  DictionaryArray(
+      const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& indices);
 
   // Alternate ctor; other attributes (like null count) are inherited from the
   // passed indices array
-  DictionaryArray(
-      const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& indices);
+  static Status FromBuffer(const std::shared_ptr<DataType>& type, int32_t length,
+      const std::shared_ptr<Buffer>& indices, int32_t null_count,
+      const std::shared_ptr<Buffer>& null_bitmap, std::shared_ptr<DictionaryArray>* out);
 
   Status Validate() const override;
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -63,7 +63,8 @@ class ARROW_EXPORT Array {
 
   const uint8_t* null_bitmap_data() const { return null_bitmap_data_; }
 
-  bool EqualsExact(const Array& arr) const;
+  bool BaseEquals(const std::shared_ptr<Array>& arr) const;
+  bool BaseEquals(const Array& arr) const;
   virtual bool Equals(const std::shared_ptr<Array>& arr) const = 0;
   virtual bool ApproxEquals(const std::shared_ptr<Array>& arr) const;
 
@@ -118,7 +119,7 @@ class ARROW_EXPORT PrimitiveArray : public Array {
 
   std::shared_ptr<Buffer> data() const { return data_; }
 
-  bool EqualsExact(const PrimitiveArray& other) const;
+  bool Equals(const PrimitiveArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
  protected:
@@ -143,12 +144,12 @@ class ARROW_EXPORT NumericArray : public PrimitiveArray {
       const std::shared_ptr<Buffer>& null_bitmap = nullptr)
       : PrimitiveArray(type, length, data, null_count, null_bitmap) {}
 
-  bool EqualsExact(const NumericArray<TypeClass>& other) const {
-    return PrimitiveArray::EqualsExact(static_cast<const PrimitiveArray&>(other));
+  bool Equals(const NumericArray<TypeClass>& other) const {
+    return PrimitiveArray::Equals(static_cast<const PrimitiveArray&>(other));
   }
 
   bool ApproxEquals(const std::shared_ptr<Array>& arr) const override {
-    return Equals(arr);
+    return PrimitiveArray::Equals(arr);
   }
 
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
@@ -256,7 +257,7 @@ class ARROW_EXPORT BooleanArray : public PrimitiveArray {
       const std::shared_ptr<Buffer>& data, int32_t null_count = 0,
       const std::shared_ptr<Buffer>& null_bitmap = nullptr);
 
-  bool EqualsExact(const BooleanArray& other) const;
+  bool Equals(const BooleanArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -304,7 +305,7 @@ class ARROW_EXPORT ListArray : public Array {
   int32_t value_offset(int i) const { return offsets_[i]; }
   int32_t value_length(int i) const { return offsets_[i + 1] - offsets_[i]; }
 
-  bool EqualsExact(const ListArray& other) const;
+  bool Equals(const ListArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
 
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
@@ -355,7 +356,7 @@ class ARROW_EXPORT BinaryArray : public Array {
   int32_t value_offset(int i) const { return offsets_[i]; }
   int32_t value_length(int i) const { return offsets_[i + 1] - offsets_[i]; }
 
-  bool EqualsExact(const BinaryArray& other) const;
+  bool Equals(const BinaryArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -418,7 +419,7 @@ class ARROW_EXPORT StructArray : public Array {
 
   const std::vector<std::shared_ptr<Array>>& fields() const { return field_arrays_; }
 
-  bool EqualsExact(const StructArray& other) const;
+  bool Equals(const StructArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -459,7 +460,7 @@ class ARROW_EXPORT UnionArray : public Array {
 
   const std::vector<std::shared_ptr<Array>>& children() const { return children_; }
 
-  bool EqualsExact(const UnionArray& other) const;
+  bool Equals(const UnionArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;
@@ -512,7 +513,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   std::shared_ptr<Array> indices() const { return indices_; }
   std::shared_ptr<Array> dictionary() const;
 
-  bool EqualsExact(const DictionaryArray& other) const;
+  bool Equals(const DictionaryArray& other) const;
   bool Equals(const std::shared_ptr<Array>& arr) const override;
   bool RangeEquals(int32_t start_idx, int32_t end_idx, int32_t other_start_idx,
       const std::shared_ptr<Array>& arr) const override;

--- a/cpp/src/arrow/ipc/adapter.cc
+++ b/cpp/src/arrow/ipc/adapter.cc
@@ -288,6 +288,13 @@ class RecordBatchWriter : public ArrayVisitor {
     return Status::OK();
   }
 
+  Status Visit(const DictionaryArray& array) override {
+    // Dictionary written out separately
+    const auto& indices = static_cast<const PrimitiveArray&>(*array.indices().get());
+    buffers_.push_back(indices.data());
+    return Status::OK();
+  }
+
   // Do not copy this vector. Ownership must be retained elsewhere
   const std::vector<std::shared_ptr<Array>>& columns_;
   int32_t num_rows_;
@@ -539,6 +546,10 @@ class ArrayLoader : public TypeVisitor {
         type_ids, offsets, field_meta.null_count, null_bitmap);
     return Status::OK();
   }
+
+  Status Visit(const DictionaryType& type) override {
+    return Status::NotImplemented("dictionary");
+  };
 };
 
 class RecordBatchReader {

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -334,6 +334,14 @@ class JsonSchemaWriter : public TypeVisitor {
     return Status::OK();
   }
 
+  Status Visit(const DictionaryType& type) override {
+    // WriteName("dictionary", type);
+    // WriteChildren(type.children());
+    // WriteBufferLayout(type.GetBufferLayout());
+    // return Status::OK();
+    return Status::NotImplemented("dictionary type");
+  }
+
  private:
   const Schema& schema_;
   RjWriter* writer_;
@@ -544,6 +552,10 @@ class JsonArrayWriter : public ArrayVisitor {
       WriteIntegerField("OFFSET", array.raw_offsets(), array.length());
     }
     return WriteChildren(type->children(), array.children());
+  }
+
+  Status Visit(const DictionaryArray& array) override {
+    return Status::NotImplemented("dictionary");
   }
 
  private:
@@ -1043,6 +1055,7 @@ class JsonArrayReader {
       TYPE_CASE(ListType);
       TYPE_CASE(StructType);
       TYPE_CASE(UnionType);
+      NOT_IMPLEMENTED_CASE(DICTIONARY);
       default:
         std::stringstream ss;
         ss << type->ToString();

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -34,7 +34,7 @@
 
 namespace arrow {
 
-class TestArrayPrinter : public ::testing::Test {
+class TestPrettyPrint : public ::testing::Test {
  public:
   void SetUp() {}
 
@@ -44,32 +44,22 @@ class TestArrayPrinter : public ::testing::Test {
   std::ostringstream sink_;
 };
 
-template <typename TYPE, typename C_TYPE>
-void CheckPrimitive(int indent, const std::vector<bool>& is_valid,
-    const std::vector<C_TYPE>& values, const char* expected) {
+void CheckArray(const Array& arr, int indent, const char* expected) {
   std::ostringstream sink;
-
-  MemoryPool* pool = default_memory_pool();
-  typename TypeTraits<TYPE>::BuilderType builder(pool, std::make_shared<TYPE>());
-
-  for (size_t i = 0; i < values.size(); ++i) {
-    if (is_valid[i]) {
-      ASSERT_OK(builder.Append(values[i]));
-    } else {
-      ASSERT_OK(builder.AppendNull());
-    }
-  }
-
-  std::shared_ptr<Array> array;
-  ASSERT_OK(builder.Finish(&array));
-
-  ASSERT_OK(PrettyPrint(*array.get(), indent, &sink));
-
+  ASSERT_OK(PrettyPrint(arr, indent, &sink));
   std::string result = sink.str();
   ASSERT_EQ(std::string(expected, strlen(expected)), result);
 }
 
-TEST_F(TestArrayPrinter, PrimitiveType) {
+template <typename TYPE, typename C_TYPE>
+void CheckPrimitive(int indent, const std::vector<bool>& is_valid,
+    const std::vector<C_TYPE>& values, const char* expected) {
+  std::shared_ptr<Array> array;
+  ArrayFromVector<TYPE, C_TYPE>(std::make_shared<TYPE>(), is_valid, values, &array);
+  CheckArray(*array.get(), indent, expected);
+}
+
+TEST_F(TestPrettyPrint, PrimitiveType) {
   std::vector<bool> is_valid = {true, true, false, true, false};
 
   std::vector<int32_t> values = {0, 1, 2, 3, 4};
@@ -79,6 +69,27 @@ TEST_F(TestArrayPrinter, PrimitiveType) {
   std::vector<std::string> values2 = {"foo", "bar", "", "baz", ""};
   static const char* ex2 = R"expected(["foo", "bar", null, "baz", null])expected";
   CheckPrimitive<StringType, std::string>(0, is_valid, values2, ex2);
+}
+
+TEST_F(TestPrettyPrint, DictionaryType) {
+  std::vector<bool> is_valid = {true, true, false, true, true, true};
+
+  std::shared_ptr<Array> dict;
+  std::vector<std::string> dict_values = {"foo", "bar", "baz"};
+  ArrayFromVector<StringType, std::string>(utf8(), dict_values, &dict);
+  std::shared_ptr<DataType> dict_type = dictionary(int16(), dict);
+
+  std::shared_ptr<Array> indices;
+  std::vector<int16_t> indices_values = {1, 2, -1, 0, 2, 0};
+  ArrayFromVector<Int16Type, int16_t>(int16(), is_valid, indices_values, &indices);
+  auto arr = std::make_shared<DictionaryArray>(dict_type, indices);
+
+  static const char* expected = R"expected(
+-- is_valid: [true, true, false, true, true, true]
+-- dictionary: ["foo", "bar", "baz"]
+-- indices: [1, 2, null, 0, 2, 0])expected";
+
+  CheckArray(*arr.get(), 0, expected);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -217,6 +217,10 @@ class ArrayPrinter : public ArrayVisitor {
     return PrintChildren(array.children());
   }
 
+  Status Visit(const DictionaryArray& array) override {
+    return Status::NotImplemented("dictionary");
+  }
+
   void Write(const char* data) { (*sink_) << data; }
 
   void Write(const std::string& data) { (*sink_) << data; }

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -218,7 +218,15 @@ class ArrayPrinter : public ArrayVisitor {
   }
 
   Status Visit(const DictionaryArray& array) override {
-    return Status::NotImplemented("dictionary");
+    RETURN_NOT_OK(WriteValidityBitmap(array));
+
+    Newline();
+    Write("-- dictionary: ");
+    RETURN_NOT_OK(PrettyPrint(*array.dictionary().get(), indent_ + 2, sink_));
+
+    Newline();
+    Write("-- indices: ");
+    return PrettyPrint(*array.indices().get(), indent_ + 2, sink_);
   }
 
   void Write(const char* data) { (*sink_) << data; }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -37,64 +37,64 @@ namespace arrow {
 struct Type {
   enum type {
     // A degenerate NULL type represented as 0 bytes/bits
-    NA = 0,
+    NA,
 
     // A boolean value represented as 1 bit
-    BOOL = 1,
+    BOOL,
 
     // Little-endian integer types
-    UINT8 = 2,
-    INT8 = 3,
-    UINT16 = 4,
-    INT16 = 5,
-    UINT32 = 6,
-    INT32 = 7,
-    UINT64 = 8,
-    INT64 = 9,
+    UINT8,
+    INT8,
+    UINT16,
+    INT16,
+    UINT32,
+    INT32,
+    UINT64,
+    INT64,
 
     // 2-byte floating point value
-    HALF_FLOAT = 10,
+    HALF_FLOAT,
 
     // 4-byte floating point value
-    FLOAT = 11,
+    FLOAT,
 
     // 8-byte floating point value
-    DOUBLE = 12,
+    DOUBLE,
 
     // UTF8 variable-length string as List<Char>
-    STRING = 13,
+    STRING,
 
     // Variable-length bytes (no guarantee of UTF8-ness)
-    BINARY = 14,
+    BINARY,
 
     // By default, int32 days since the UNIX epoch
-    DATE = 16,
+    DATE,
 
     // Exact timestamp encoded with int64 since UNIX epoch
     // Default unit millisecond
-    TIMESTAMP = 17,
+    TIMESTAMP,
 
     // Exact time encoded with int64, default unit millisecond
-    TIME = 18,
+    TIME,
 
     // YEAR_MONTH or DAY_TIME interval in SQL style
-    INTERVAL = 19,
+    INTERVAL,
 
     // Precision- and scale-based decimal type. Storage type depends on the
     // parameters.
-    DECIMAL = 20,
+    DECIMAL,
 
     // A list of some logical data type
-    LIST = 30,
+    LIST,
 
     // Struct of logical types
-    STRUCT = 31,
+    STRUCT,
 
     // Unions of logical types
-    UNION = 32,
+    UNION,
 
     // Dictionary aka Category type
-    DICTIONARY = 50,
+    DICTIONARY
   };
 };
 
@@ -110,6 +110,34 @@ class BufferDescr {
  private:
   BufferType type_;
   int bit_width_;
+};
+
+class TypeVisitor {
+ public:
+  virtual Status Visit(const NullType& type) = 0;
+  virtual Status Visit(const BooleanType& type) = 0;
+  virtual Status Visit(const Int8Type& type) = 0;
+  virtual Status Visit(const Int16Type& type) = 0;
+  virtual Status Visit(const Int32Type& type) = 0;
+  virtual Status Visit(const Int64Type& type) = 0;
+  virtual Status Visit(const UInt8Type& type) = 0;
+  virtual Status Visit(const UInt16Type& type) = 0;
+  virtual Status Visit(const UInt32Type& type) = 0;
+  virtual Status Visit(const UInt64Type& type) = 0;
+  virtual Status Visit(const HalfFloatType& type) = 0;
+  virtual Status Visit(const FloatType& type) = 0;
+  virtual Status Visit(const DoubleType& type) = 0;
+  virtual Status Visit(const StringType& type) = 0;
+  virtual Status Visit(const BinaryType& type) = 0;
+  virtual Status Visit(const DateType& type) = 0;
+  virtual Status Visit(const TimeType& type) = 0;
+  virtual Status Visit(const TimestampType& type) = 0;
+  virtual Status Visit(const IntervalType& type) = 0;
+  virtual Status Visit(const DecimalType& type) = 0;
+  virtual Status Visit(const ListType& type) = 0;
+  virtual Status Visit(const StructType& type) = 0;
+  virtual Status Visit(const UnionType& type) = 0;
+  virtual Status Visit(const DictionaryType& type) = 0;
 };
 
 struct ARROW_EXPORT DataType {
@@ -550,6 +578,35 @@ std::shared_ptr<Field> ARROW_EXPORT field(const std::string& name,
 
 // ----------------------------------------------------------------------
 //
+
+static inline bool is_integer(Type::type type_id) {
+  switch (type_id) {
+    case Type::UINT8:
+    case Type::INT8:
+    case Type::UINT16:
+    case Type::INT16:
+    case Type::UINT32:
+    case Type::INT32:
+    case Type::UINT64:
+    case Type::INT64:
+      return true;
+    default:
+      break;
+  };
+  return false;
+}
+
+static inline bool is_floating(Type::type type_id) {
+  switch (type_id) {
+    case Type::HALF_FLOAT:
+    case Type::FLOAT:
+    case Type::DOUBLE:
+      return true;
+    default:
+      break;
+  };
+  return false;
+}
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -592,7 +592,7 @@ static inline bool is_integer(Type::type type_id) {
       return true;
     default:
       break;
-  };
+  }
   return false;
 }
 
@@ -604,7 +604,7 @@ static inline bool is_floating(Type::type type_id) {
       return true;
     default:
       break;
-  };
+  }
   return false;
 }
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -32,6 +32,9 @@ class MemoryPool;
 class RecordBatch;
 class Schema;
 
+class DictionaryType;
+class DictionaryArray;
+
 struct NullType;
 class NullArray;
 
@@ -126,6 +129,7 @@ class TypeVisitor {
   virtual Status Visit(const ListType& type) = 0;
   virtual Status Visit(const StructType& type) = 0;
   virtual Status Visit(const UnionType& type) = 0;
+  virtual Status Visit(const DictionaryType& type) = 0;
 };
 
 class ArrayVisitor {
@@ -153,6 +157,7 @@ class ArrayVisitor {
   virtual Status Visit(const ListArray& array) = 0;
   virtual Status Visit(const StructArray& array) = 0;
   virtual Status Visit(const UnionArray& array) = 0;
+  virtual Status Visit(const DictionaryArray& type) = 0;
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -104,62 +104,6 @@ using TimestampBuilder = NumericBuilder<TimestampType>;
 struct IntervalType;
 using IntervalArray = NumericArray<IntervalType>;
 
-class TypeVisitor {
- public:
-  virtual Status Visit(const NullType& type) = 0;
-  virtual Status Visit(const BooleanType& type) = 0;
-  virtual Status Visit(const Int8Type& type) = 0;
-  virtual Status Visit(const Int16Type& type) = 0;
-  virtual Status Visit(const Int32Type& type) = 0;
-  virtual Status Visit(const Int64Type& type) = 0;
-  virtual Status Visit(const UInt8Type& type) = 0;
-  virtual Status Visit(const UInt16Type& type) = 0;
-  virtual Status Visit(const UInt32Type& type) = 0;
-  virtual Status Visit(const UInt64Type& type) = 0;
-  virtual Status Visit(const HalfFloatType& type) = 0;
-  virtual Status Visit(const FloatType& type) = 0;
-  virtual Status Visit(const DoubleType& type) = 0;
-  virtual Status Visit(const StringType& type) = 0;
-  virtual Status Visit(const BinaryType& type) = 0;
-  virtual Status Visit(const DateType& type) = 0;
-  virtual Status Visit(const TimeType& type) = 0;
-  virtual Status Visit(const TimestampType& type) = 0;
-  virtual Status Visit(const IntervalType& type) = 0;
-  virtual Status Visit(const DecimalType& type) = 0;
-  virtual Status Visit(const ListType& type) = 0;
-  virtual Status Visit(const StructType& type) = 0;
-  virtual Status Visit(const UnionType& type) = 0;
-  virtual Status Visit(const DictionaryType& type) = 0;
-};
-
-class ArrayVisitor {
- public:
-  virtual Status Visit(const NullArray& array) = 0;
-  virtual Status Visit(const BooleanArray& array) = 0;
-  virtual Status Visit(const Int8Array& array) = 0;
-  virtual Status Visit(const Int16Array& array) = 0;
-  virtual Status Visit(const Int32Array& array) = 0;
-  virtual Status Visit(const Int64Array& array) = 0;
-  virtual Status Visit(const UInt8Array& array) = 0;
-  virtual Status Visit(const UInt16Array& array) = 0;
-  virtual Status Visit(const UInt32Array& array) = 0;
-  virtual Status Visit(const UInt64Array& array) = 0;
-  virtual Status Visit(const HalfFloatArray& array) = 0;
-  virtual Status Visit(const FloatArray& array) = 0;
-  virtual Status Visit(const DoubleArray& array) = 0;
-  virtual Status Visit(const StringArray& array) = 0;
-  virtual Status Visit(const BinaryArray& array) = 0;
-  virtual Status Visit(const DateArray& array) = 0;
-  virtual Status Visit(const TimeArray& array) = 0;
-  virtual Status Visit(const TimestampArray& array) = 0;
-  virtual Status Visit(const IntervalArray& array) = 0;
-  virtual Status Visit(const DecimalArray& array) = 0;
-  virtual Status Visit(const ListArray& array) = 0;
-  virtual Status Visit(const StructArray& array) = 0;
-  virtual Status Visit(const UnionArray& array) = 0;
-  virtual Status Visit(const DictionaryArray& type) = 0;
-};
-
 }  // namespace arrow
 
 #endif  // ARROW_TYPE_FWD_H

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -256,7 +256,7 @@ table RecordBatch {
 /// For sending dictionary encoding information. Any Field can be
 /// dictionary-encoded, but in this case none of its children may be
 /// dictionary-encoded.
-/// There is one dictionary batch per dictionary
+/// There is one vector / column per dictionary
 ///
 
 table DictionaryBatch {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -55,7 +55,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CDataType" arrow::DataType":
         Type type
 
-        c_bool Equals(const CDataType* other)
+        c_bool Equals(const shared_ptr[CDataType]& other)
+        c_bool Equals(const CDataType& other)
 
         c_string ToString()
 

--- a/python/pyarrow/includes/parquet.pxd
+++ b/python/pyarrow/includes/parquet.pxd
@@ -98,7 +98,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         # TODO: Some default arguments are missing
         @staticmethod
         unique_ptr[ParquetFileReader] OpenFile(const c_string& path)
-        const FileMetaData* metadata();
+        shared_ptr[FileMetaData] metadata();
 
 
 cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:

--- a/python/pyarrow/parquet.pyx
+++ b/python/pyarrow/parquet.pyx
@@ -98,8 +98,8 @@ cdef class ParquetReader:
             Integer index of the position of the column
         """
         cdef:
-            const FileMetaData* metadata = (self.reader.get()
-                                            .parquet_reader().metadata())
+            const FileMetaData* metadata = (self.reader.get().parquet_reader()
+                                            .metadata().get())
             int i = 0
 
         if self.column_idx_map is None:

--- a/python/pyarrow/schema.pyx
+++ b/python/pyarrow/schema.pyx
@@ -45,9 +45,9 @@ cdef class DataType:
 
     def __richcmp__(DataType self, DataType other, int op):
         if op == cpython.Py_EQ:
-            return self.type.Equals(other.type)
+            return self.type.Equals(other.sp_type)
         elif op == cpython.Py_NE:
-            return not self.type.Equals(other.type)
+            return not self.type.Equals(other.sp_type)
         else:
             raise TypeError('Invalid comparison')
 


### PR DESCRIPTION
I thought some about this and thought that it made sense to store the reference to the dictionary values themselves in the data type object, similar to `CategoricalDtype` in pandas. This will be at least adequate for the Feather file format merge. 

In the IPC metadata, there is no explicit dictionary type -- an array can be dictionary encoded or not. On JIRA we've discussed adding a dictionary type flag indicating whether or not the dictionary values/categories are ordered (also called "ordinal") or unordered (also called "nominal"). That hasn't been done yet. 