### PR TITLE
ARROW-455: [C++] Add dtor to BufferOutputStream that calls Close()

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -476,6 +476,7 @@ FileOutputStream::FileOutputStream() {
 }
 
 FileOutputStream::~FileOutputStream() {
+  // This can fail; better to explicitly call close
   impl_->Close();
 }
 

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -42,17 +42,28 @@ class TestBufferOutputStream : public ::testing::Test {
   std::unique_ptr<OutputStream> stream_;
 };
 
+TEST_F(TestBufferOutputStream, DtorCloses) {
+  std::string data = "data123456";
+
+  const int K = 100;
+  for (int i = 0; i < K; ++i) {
+    EXPECT_OK(stream_->Write(data));
+  }
+
+  stream_ = nullptr;
+  ASSERT_EQ(static_cast<int64_t>(K * data.size()), buffer_->size());
+}
+
 TEST_F(TestBufferOutputStream, CloseResizes) {
   std::string data = "data123456";
 
-  const int64_t nbytes = static_cast<int64_t>(data.size());
   const int K = 100;
   for (int i = 0; i < K; ++i) {
     EXPECT_OK(stream_->Write(data));
   }
 
   ASSERT_OK(stream_->Close());
-  ASSERT_EQ(K * nbytes, buffer_->size());
+  ASSERT_EQ(static_cast<int64_t>(K * data.size()), buffer_->size());
 }
 
 TEST(TestBufferReader, RetainParentReference) {

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -43,6 +43,11 @@ BufferOutputStream::BufferOutputStream(const std::shared_ptr<ResizableBuffer>& b
       position_(0),
       mutable_data_(buffer->mutable_data()) {}
 
+BufferOutputStream::~BufferOutputStream() {
+  // This can fail, better to explicitly call close
+  Close();
+}
+
 Status BufferOutputStream::Close() {
   if (position_ < capacity_) {
     return buffer_->Resize(position_);

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -43,6 +43,8 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
  public:
   explicit BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer);
 
+  ~BufferOutputStream();
+
   // Implement the OutputStream interface
   Status Close() override;
   Status Tell(int64_t* position) override;


### PR DESCRIPTION
Since `Close()` can technically fail, it's better to call it yourself (and it's idempotent), but this will help avoid a common class of bugs in small-scale use cases. 

An alternative here is that we could remove all `Close()` calls from all destructors and possibly add a `DCHECK(!is_open_)` to the base dtor to force the user to close handles. The downside of this is that it makes RAII more difficult, so I'd prefer to leave the close-in-dtor even though it can fail in unusual scenarios. 