### PR TITLE
ARROW-456: Add jemalloc based MemoryPool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - libboost-dev
     - libboost-filesystem-dev
     - libboost-system-dev
+    - libjemalloc-dev
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ build_script:
  - cd build
  # A lot of features are still deactivated as they do not build on Windows
  #  * gbenchmark doesn't build with MSVC
- - cmake -G "%GENERATOR%" -DARROW_BOOST_USE_SHARED=OFF -DARROW_IPC=OFF -DARROW_HDFS=OFF -DARROW_BUILD_BENCHMARKS=OFF ..
+ - cmake -G "%GENERATOR%" -DARROW_BOOST_USE_SHARED=OFF -DARROW_IPC=OFF -DARROW_HDFS=OFF -DARROW_BUILD_BENCHMARKS=OFF -DARROW_JEMALLOC=OFF ..
  - cmake --build . --config Debug
 
 # test_script:

--- a/ci/travis_before_script_cpp.sh
+++ b/ci/travis_before_script_cpp.sh
@@ -17,6 +17,11 @@ set -ex
 
 : ${CPP_BUILD_DIR=$TRAVIS_BUILD_DIR/cpp-build}
 
+if [ $TRAVIS_OS_NAME == "osx" ]; then
+  brew update > /dev/null
+  brew install jemalloc
+fi
+
 mkdir $CPP_BUILD_DIR
 pushd $CPP_BUILD_DIR
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,7 +28,7 @@ set(THIRDPARTY_DIR "${CMAKE_SOURCE_DIR}/thirdparty")
 
 set(GFLAGS_VERSION "2.1.2")
 set(GTEST_VERSION "1.7.0")
-set(GBENCHMARK_VERSION "1.0.0")
+set(GBENCHMARK_VERSION "1.1.0")
 set(FLATBUFFERS_VERSION "1.3.0")
 
 find_package(ClangTools)
@@ -72,6 +72,10 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 
   option(ARROW_IPC
     "Build the Arrow IPC extensions"
+    ON)
+
+  option(ARROW_JEMALLOC
+    "Build the Arrow jemalloc-based allocator"
     ON)
 
   option(ARROW_BOOST_USE_SHARED
@@ -236,6 +240,16 @@ function(ADD_ARROW_BENCHMARK_DEPENDENCIES REL_BENCHMARK_NAME)
   get_filename_component(BENCMARK_NAME ${REL_BENCHMARK_NAME} NAME_WE)
 
   add_dependencies(${BENCHMARK_NAME} ${ARGN})
+endfunction()
+
+# A wrapper for target_link_libraries() that is compatible with NO_BENCHMARKS.
+function(ARROW_BENCHMARK_LINK_LIBRARIES REL_BENCHMARK_NAME)
+  if(NO_TESTS)
+    return()
+  endif()
+  get_filename_component(BENCHMARK_NAME ${REL_BENCHMARK_NAME} NAME_WE)
+
+  target_link_libraries(${BENCHMARK_NAME} ${ARGN})
 endfunction()
 
 
@@ -526,7 +540,11 @@ if(ARROW_BUILD_BENCHMARKS)
     set(GBENCHMARK_CMAKE_ARGS
           "-DCMAKE_BUILD_TYPE=Release"
           "-DCMAKE_INSTALL_PREFIX:PATH=${GBENCHMARK_PREFIX}"
+          "-DBENCHMARK_ENABLE_TESTING=OFF"
           "-DCMAKE_CXX_FLAGS=-fPIC ${GBENCHMARK_CMAKE_CXX_FLAGS}")
+    if (APPLE)
+      set(GBENCHMARK_CMAKE_ARGS ${GBENCHMARK_CMAKE_ARGS} "-DBENCHMARK_USE_LIBCXX=ON")
+    endif()
     if (CMAKE_VERSION VERSION_GREATER "3.2")
       # BUILD_BYPRODUCTS is a 3.2+ feature
       ExternalProject_Add(gbenchmark_ep
@@ -574,6 +592,12 @@ else()
 endif()
 message(STATUS "RapidJSON include dir: ${RAPIDJSON_INCLUDE_DIR}")
 include_directories(SYSTEM ${RAPIDJSON_INCLUDE_DIR})
+
+if (ARROW_JEMALLOC)
+  find_package(jemalloc REQUIRED)
+  ADD_THIRDPARTY_LIB(jemalloc
+      SHARED_LIB ${JEMALLOC_SHARED_LIB})
+endif()
 
 ## Google PerfTools
 ##
@@ -736,6 +760,10 @@ ADD_ARROW_LIB(arrow
 add_subdirectory(src/arrow)
 add_subdirectory(src/arrow/io)
 add_subdirectory(src/arrow/util)
+
+if(ARROW_JEMALLOC)
+  add_subdirectory(src/arrow/jemalloc)
+endif()
 
 #----------------------------------------------------------------------
 # IPC library

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -60,6 +60,7 @@ variables
 * Google Benchmark: `GBENCHMARK_HOME` (only required if building benchmarks)
 * Flatbuffers: `FLATBUFFERS_HOME` (only required for the IPC extensions)
 * Hadoop: `HADOOP_HOME` (only required for the HDFS I/O extensions)
+* jemalloc: `JEMALLOC_HOME` (only required for the jemalloc-based memory pool)
 
 ## Continuous Integration
 

--- a/cpp/cmake_modules/Findjemalloc.cmake
+++ b/cpp/cmake_modules/Findjemalloc.cmake
@@ -1,0 +1,86 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tries to find jemalloc headers and libraries.
+#
+# Usage of this module as follows:
+#
+#  find_package(jemalloc)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  JEMALLOC_HOME -
+#   When set, this path is inspected instead of standard library locations as
+#   the root of the jemalloc installation.  The environment variable
+#   JEMALLOC_HOME overrides this veriable.
+#
+# This module defines
+#  JEMALLOC_INCLUDE_DIR, directory containing headers
+#  JEMALLOC_SHARED_LIB, path to libjemalloc.so/dylib
+#  JEMALLOC_FOUND, whether flatbuffers has been found
+
+if( NOT "$ENV{JEMALLOC_HOME}" STREQUAL "")
+    file( TO_CMAKE_PATH "$ENV{JEMALLOC_HOME}" _native_path )
+    list( APPEND _jemalloc_roots ${_native_path} )
+elseif ( JEMALLOC_HOME )
+    list( APPEND _jemalloc_roots ${JEMALLOC_HOME} )
+endif()
+
+set(LIBJEMALLOC_NAMES jemalloc libjemalloc.so.1 libjemalloc.so.2 libjemalloc.dylib)
+
+# Try the parameterized roots, if they exist
+if ( _jemalloc_roots )
+    find_path( JEMALLOC_INCLUDE_DIR NAMES jemalloc/jemalloc.h
+        PATHS ${_jemalloc_roots} NO_DEFAULT_PATH
+        PATH_SUFFIXES "include" )
+    find_library( JEMALLOC_SHARED_LIB NAMES ${LIBJEMALLOC_NAMES}
+        PATHS ${_jemalloc_roots} NO_DEFAULT_PATH
+        PATH_SUFFIXES "lib" )
+else ()
+    find_path( JEMALLOC_INCLUDE_DIR NAMES jemalloc/jemalloc.h )
+    message(STATUS ${JEMALLOC_INCLUDE_DIR})
+    find_library( JEMALLOC_SHARED_LIB NAMES ${LIBJEMALLOC_NAMES})
+    message(STATUS ${JEMALLOC_SHARED_LIB})
+endif ()
+
+if (JEMALLOC_INCLUDE_DIR AND JEMALLOC_SHARED_LIB)
+  set(JEMALLOC_FOUND TRUE)
+else ()
+  set(JEMALLOC_FOUND FALSE)
+endif ()
+
+if (JEMALLOC_FOUND)
+    if (NOT jemalloc_FIND_QUIETLY)
+      message(STATUS "Found the jemalloc library: ${JEMALLOC_LIBRARIES}")
+  endif ()
+else ()
+  if (NOT jemalloc_FIND_QUIETLY)
+    set(JEMALLOC_ERR_MSG "Could not find the jemalloc library. Looked in ")
+    if ( _flatbuffers_roots )
+      set(JEMALLOC_ERR_MSG "${JEMALLOC_ERR_MSG} in ${_jemalloc_roots}.")
+    else ()
+      set(JEMALLOC_ERR_MSG "${JEMALLOC_ERR_MSG} system search paths.")
+    endif ()
+    if (jemalloc_FIND_REQUIRED)
+      message(FATAL_ERROR "${JEMALLOC_ERR_MSG}")
+    else (jemalloc_FIND_REQUIRED)
+      message(STATUS "${JEMALLOC_ERR_MSG}")
+    endif (jemalloc_FIND_REQUIRED)
+  endif ()
+endif ()
+
+mark_as_advanced(
+  JEMALLOC_INCLUDE_DIR
+  JEMALLOC_SHARED_LIB
+)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -59,4 +59,5 @@ ADD_ARROW_TEST(schema-test)
 ADD_ARROW_TEST(status-test)
 ADD_ARROW_TEST(table-test)
 
+ADD_ARROW_BENCHMARK(builder-benchmark)
 ADD_ARROW_BENCHMARK(column-benchmark)

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -80,13 +80,11 @@ Status PoolBuffer::Reserve(int64_t new_capacity) {
     uint8_t* new_data;
     new_capacity = BitUtil::RoundUpToMultipleOf64(new_capacity);
     if (mutable_data_) {
-      RETURN_NOT_OK(pool_->Allocate(new_capacity, &new_data));
-      memcpy(new_data, mutable_data_, size_);
-      pool_->Free(mutable_data_, capacity_);
+      RETURN_NOT_OK(pool_->Reallocate(capacity_, new_capacity, &mutable_data_));
     } else {
       RETURN_NOT_OK(pool_->Allocate(new_capacity, &new_data));
+      mutable_data_ = new_data;
     }
-    mutable_data_ = new_data;
     data_ = mutable_data_;
     capacity_ = new_capacity;
   }

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -25,37 +25,42 @@ namespace arrow {
 
 constexpr int64_t kFinalSize = 256;
 
-static void BM_BuildPrimitiveArrayNoNulls(benchmark::State& state) {  // NOLINT non-const reference
-  // 1 MiB block
+static void BM_BuildPrimitiveArrayNoNulls(
+    benchmark::State& state) {  // NOLINT non-const reference
+  // 2 MiB block
   std::vector<int64_t> data(256 * 1024, 100);
   while (state.KeepRunning()) {
     Int64Builder builder(default_memory_pool(), arrow::int64());
     for (int i = 0; i < kFinalSize; i++) {
-      // Build up an array of 256 MiB in size 
+      // Build up an array of 512 MiB in size
       builder.Append(data.data(), data.size(), nullptr);
     }
     std::shared_ptr<Array> out;
     builder.Finish(&out);
   }
-  state.SetBytesProcessed(state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
+  state.SetBytesProcessed(
+      state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
 }
 
-BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);;
+BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);
+;
 
-static void BM_BuildVectorNoNulls(benchmark::State& state) {  // NOLINT non-const reference
-  // 1 MiB block
+static void BM_BuildVectorNoNulls(
+    benchmark::State& state) {  // NOLINT non-const reference
+  // 2 MiB block
   std::vector<int64_t> data(256 * 1024, 100);
   while (state.KeepRunning()) {
     std::vector<int64_t> builder;
     for (int i = 0; i < kFinalSize; i++) {
-      // Build up an array of 256 MiB in size 
+      // Build up an array of 512 MiB in size
       builder.insert(builder.end(), data.cbegin(), data.cend());
     }
   }
-  state.SetBytesProcessed(state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
+  state.SetBytesProcessed(
+      state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
 }
 
-BENCHMARK(BM_BuildVectorNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);;
+BENCHMARK(BM_BuildVectorNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);
+;
 
 }  // namespace arrow
-

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -43,7 +43,6 @@ static void BM_BuildPrimitiveArrayNoNulls(
 }
 
 BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);
-;
 
 static void BM_BuildVectorNoNulls(
     benchmark::State& state) {  // NOLINT non-const reference
@@ -61,6 +60,5 @@ static void BM_BuildVectorNoNulls(
 }
 
 BENCHMARK(BM_BuildVectorNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);
-;
 
 }  // namespace arrow

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/builder.h"
+#include "arrow/memory_pool.h"
+#include "arrow/test-util.h"
+
+namespace arrow {
+
+constexpr int64_t kFinalSize = 256;
+
+static void BM_BuildPrimitiveArrayNoNulls(benchmark::State& state) {  // NOLINT non-const reference
+  // 1 MiB block
+  std::vector<int64_t> data(256 * 1024, 100);
+  while (state.KeepRunning()) {
+    Int64Builder builder(default_memory_pool(), arrow::int64());
+    for (int i = 0; i < kFinalSize; i++) {
+      // Build up an array of 256 MiB in size 
+      builder.Append(data.data(), data.size(), nullptr);
+    }
+    std::shared_ptr<Array> out;
+    builder.Finish(&out);
+  }
+  state.SetBytesProcessed(state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
+}
+
+BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);;
+
+static void BM_BuildVectorNoNulls(benchmark::State& state) {  // NOLINT non-const reference
+  // 1 MiB block
+  std::vector<int64_t> data(256 * 1024, 100);
+  while (state.KeepRunning()) {
+    std::vector<int64_t> builder;
+    for (int i = 0; i < kFinalSize; i++) {
+      // Build up an array of 256 MiB in size 
+      builder.insert(builder.end(), data.cbegin(), data.cend());
+    }
+  }
+  state.SetBytesProcessed(state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
+}
+
+BENCHMARK(BM_BuildVectorNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);;
+
+}  // namespace arrow
+

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -136,10 +136,8 @@ Status PrimitiveBuilder<T>::Init(int32_t capacity) {
 
   int64_t nbytes = TypeTraits<T>::bytes_required(capacity);
   RETURN_NOT_OK(data_->Resize(nbytes));
-#ifdef ARROW_VALGRIND
   // TODO(emkornfield) valgrind complains without this
   memset(data_->mutable_data(), 0, nbytes);
-#endif
 
   raw_data_ = reinterpret_cast<value_type*>(data_->mutable_data());
   return Status::OK();
@@ -154,16 +152,12 @@ Status PrimitiveBuilder<T>::Resize(int32_t capacity) {
     RETURN_NOT_OK(Init(capacity));
   } else {
     RETURN_NOT_OK(ArrayBuilder::Resize(capacity));
-#ifdef ARROW_VALGRIND
     const int64_t old_bytes = data_->size();
-#endif
     const int64_t new_bytes = TypeTraits<T>::bytes_required(capacity);
     RETURN_NOT_OK(data_->Resize(new_bytes));
     raw_data_ = reinterpret_cast<value_type*>(data_->mutable_data());
-#ifdef ARROW_VALGRIND
     // TODO(emkornfield) valgrind complains without this
     memset(data_->mutable_data() + old_bytes, 0, new_bytes - old_bytes);
-#endif
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -136,8 +136,10 @@ Status PrimitiveBuilder<T>::Init(int32_t capacity) {
 
   int64_t nbytes = TypeTraits<T>::bytes_required(capacity);
   RETURN_NOT_OK(data_->Resize(nbytes));
+#ifdef ARROW_VALGRIND
   // TODO(emkornfield) valgrind complains without this
   memset(data_->mutable_data(), 0, nbytes);
+#endif
 
   raw_data_ = reinterpret_cast<value_type*>(data_->mutable_data());
   return Status::OK();
@@ -152,11 +154,16 @@ Status PrimitiveBuilder<T>::Resize(int32_t capacity) {
     RETURN_NOT_OK(Init(capacity));
   } else {
     RETURN_NOT_OK(ArrayBuilder::Resize(capacity));
+#ifdef ARROW_VALGRIND
     const int64_t old_bytes = data_->size();
+#endif
     const int64_t new_bytes = TypeTraits<T>::bytes_required(capacity);
     RETURN_NOT_OK(data_->Resize(new_bytes));
     raw_data_ = reinterpret_cast<value_type*>(data_->mutable_data());
+#ifdef ARROW_VALGRIND
+    // TODO(emkornfield) valgrind complains without this
     memset(data_->mutable_data() + old_bytes, 0, new_bytes - old_bytes);
+#endif
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/column-benchmark.cc
+++ b/cpp/src/arrow/column-benchmark.cc
@@ -37,7 +37,7 @@ std::shared_ptr<Array> MakePrimitive(int32_t length, int32_t null_count = 0) {
 static void BM_BuildInt32ColumnByChunk(
     benchmark::State& state) {  // NOLINT non-const reference
   ArrayVector arrays;
-  for (int chunk_n = 0; chunk_n < state.range_x(); ++chunk_n) {
+  for (int chunk_n = 0; chunk_n < state.range(0); ++chunk_n) {
     arrays.push_back(MakePrimitive<Int32Array>(100, 10));
   }
   const auto INT32 = std::make_shared<Int32Type>();

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -45,8 +45,8 @@ Status ReadableFileInterface::ReadAt(
 }
 
 Status Writeable::Write(const std::string& data) {
-  return Write(reinterpret_cast<const uint8_t*>(data.c_str()),
-      static_cast<int64_t>(data.size()));
+  return Write(
+      reinterpret_cast<const uint8_t*>(data.c_str()), static_cast<int64_t>(data.size()));
 }
 
 }  // namespace io

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -291,6 +291,9 @@ class MyMemoryPool : public MemoryPool {
   }
 
   void Free(uint8_t* buffer, int64_t size) override { std::free(buffer); }
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
+    *ptr = reinterpret_cast<uint8_t*>(std::realloc(*ptr, new_size));
+  }
 
   int64_t bytes_allocated() const override { return -1; }
 

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -291,8 +291,17 @@ class MyMemoryPool : public MemoryPool {
   }
 
   void Free(uint8_t* buffer, int64_t size) override { std::free(buffer); }
+
   Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
     *ptr = reinterpret_cast<uint8_t*>(std::realloc(*ptr, new_size));
+
+    if (*ptr == NULL) {
+      std::stringstream ss;
+      ss << "realloc of size " << new_size << " failed";
+      return Status::OutOfMemory(ss.str());
+    }
+
+
     return Status::OK();
   }
 

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -293,6 +293,7 @@ class MyMemoryPool : public MemoryPool {
   void Free(uint8_t* buffer, int64_t size) override { std::free(buffer); }
   Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
     *ptr = reinterpret_cast<uint8_t*>(std::realloc(*ptr, new_size));
+    return Status::OK();
   }
 
   int64_t bytes_allocated() const override { return -1; }

--- a/cpp/src/arrow/jemalloc/CMakeLists.txt
+++ b/cpp/src/arrow/jemalloc/CMakeLists.txt
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# ----------------------------------------------------------------------
+# arrow_jemalloc : Arrow jemalloc-based allocator
+
+include_directories(SYSTEM "{JEMALLOC_INCLUDE_DIR}")
+
+# arrow_jemalloc library
+set(ARROW_JEMALLOC_STATIC_LINK_LIBS
+  arrow_static
+  jemalloc
+)
+set(ARROW_JEMALLOC_SHARED_LINK_LIBS
+  arrow_shared
+  jemalloc
+)
+
+if (ARROW_BUILD_STATIC)
+  set(ARROW_JEMALLOC_TEST_LINK_LIBS
+    arrow_jemalloc_static)
+else()
+  set(ARROW_jemalloc_TEST_LINK_LIBS
+    arrow_jemalloc_shared)
+endif()
+
+set(ARROW_JEMALLOC_SRCS
+  memory_pool.cc
+)
+
+if(NOT APPLE)
+  # Localize thirdparty symbols using a linker version script. This hides them
+  # from the client application. The OS X linker does not support the
+  # version-script option.
+  set(ARROW_JEMALLOC_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+endif()
+
+ADD_ARROW_LIB(arrow_jemalloc
+  SOURCES ${ARROW_JEMALLOC_SRCS}
+  SHARED_LINK_FLAGS ${ARROW_JEMALLOC_LINK_FLAGS}
+  SHARED_LINK_LIBS ${ARROW_JEMALLOC_SHARED_LINK_LIBS}
+  SHARED_PRIVATE_LINK_LIBS ${ARROW_JEMALLOC_SHARED_PRIVATE_LINK_LIBS}
+  STATIC_LINK_LIBS ${ARROW_JEMALLOC_STATIC_LINK_LIBS}
+  STATIC_PRIVATE_LINK_LIBS ${ARROW_JEMALLOC_STATIC_PRIVATE_LINK_LIBS}
+)
+
+ADD_ARROW_TEST(jemalloc-memory_pool-test)
+ARROW_TEST_LINK_LIBRARIES(jemalloc-memory_pool-test
+  ${ARROW_JEMALLOC_TEST_LINK_LIBS})
+
+ADD_ARROW_BENCHMARK(jemalloc-builder-benchmark)
+ARROW_BENCHMARK_LINK_LIBRARIES(jemalloc-builder-benchmark
+  ${ARROW_JEMALLOC_TEST_LINK_LIBS})
+
+# Headers: top level
+install(FILES
+  memory_pool.h
+  DESTINATION include/arrow/jemalloc)
+
+# pkg-config support
+configure_file(arrow-jemalloc.pc.in
+  "${CMAKE_CURRENT_BINARY_DIR}/arrow-jemalloc.pc"
+  @ONLY)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-jemalloc.pc"
+  DESTINATION "lib/pkgconfig/")

--- a/cpp/src/arrow/jemalloc/arrow-jemalloc.pc.in
+++ b/cpp/src/arrow/jemalloc/arrow-jemalloc.pc.in
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: Apache Arrow jemalloc-based allocator
+Description: jemalloc allocator for Arrow.
+Version: @ARROW_VERSION@
+Libs: -L${libdir} -larrow_jemalloc
+Cflags: -I${includedir}
+Requires: arrow

--- a/cpp/src/arrow/jemalloc/jemalloc-builder-benchmark.cc
+++ b/cpp/src/arrow/jemalloc/jemalloc-builder-benchmark.cc
@@ -43,6 +43,5 @@ static void BM_BuildPrimitiveArrayNoNulls(
 }
 
 BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);
-;
 
 }  // namespace arrow

--- a/cpp/src/arrow/jemalloc/jemalloc-builder-benchmark.cc
+++ b/cpp/src/arrow/jemalloc/jemalloc-builder-benchmark.cc
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/builder.h"
+#include "arrow/jemalloc/memory_pool.h"
+#include "arrow/test-util.h"
+
+namespace arrow {
+
+constexpr int64_t kFinalSize = 256;
+
+static void BM_BuildPrimitiveArrayNoNulls(benchmark::State& state) {  // NOLINT non-const reference
+  // 1 MiB block
+  std::vector<int64_t> data(256 * 1024, 100);
+  while (state.KeepRunning()) {
+    Int64Builder builder(jemalloc::MemoryPool::default_pool(), arrow::int64());
+    for (int i = 0; i < kFinalSize; i++) {
+      // Build up an array of 256 MiB in size 
+      builder.Append(data.data(), data.size(), nullptr);
+    }
+    std::shared_ptr<Array> out;
+    builder.Finish(&out);
+  }
+  state.SetBytesProcessed(state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
+}
+
+BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);;
+
+}  // namespace arrow
+

--- a/cpp/src/arrow/jemalloc/jemalloc-builder-benchmark.cc
+++ b/cpp/src/arrow/jemalloc/jemalloc-builder-benchmark.cc
@@ -25,22 +25,24 @@ namespace arrow {
 
 constexpr int64_t kFinalSize = 256;
 
-static void BM_BuildPrimitiveArrayNoNulls(benchmark::State& state) {  // NOLINT non-const reference
-  // 1 MiB block
+static void BM_BuildPrimitiveArrayNoNulls(
+    benchmark::State& state) {  // NOLINT non-const reference
+  // 2 MiB block
   std::vector<int64_t> data(256 * 1024, 100);
   while (state.KeepRunning()) {
     Int64Builder builder(jemalloc::MemoryPool::default_pool(), arrow::int64());
     for (int i = 0; i < kFinalSize; i++) {
-      // Build up an array of 256 MiB in size 
+      // Build up an array of 512 MiB in size
       builder.Append(data.data(), data.size(), nullptr);
     }
     std::shared_ptr<Array> out;
     builder.Finish(&out);
   }
-  state.SetBytesProcessed(state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
+  state.SetBytesProcessed(
+      state.iterations() * data.size() * sizeof(int64_t) * kFinalSize);
 }
 
-BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);;
+BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMillisecond);
+;
 
 }  // namespace arrow
-

--- a/cpp/src/arrow/jemalloc/jemalloc-memory_pool-test.cc
+++ b/cpp/src/arrow/jemalloc/jemalloc-memory_pool-test.cc
@@ -21,31 +21,29 @@
 #include "gtest/gtest.h"
 
 #include "arrow/jemalloc/memory_pool.h"
-#include "arrow/status.h"
-#include "arrow/test-util.h"
+#include "arrow/memory_pool-test.h"
 
 namespace arrow {
 namespace jemalloc {
 namespace test {
 
-TEST(JemallocMemoryPool, MemoryTracking) {
-  MemoryPool* pool = ::arrow::jemalloc::MemoryPool::default_pool();
+class TestJemallocMemoryPool : public ::arrow::test::TestMemoryPoolBase {
+ public:
+  ::arrow::MemoryPool* memory_pool() override {
+    return ::arrow::jemalloc::MemoryPool::default_pool();
+  }
+};
 
-  uint8_t* data;
-  ASSERT_OK(pool->Allocate(100, &data));
-  EXPECT_EQ(static_cast<uint64_t>(0), reinterpret_cast<uint64_t>(data) % 64);
-  ASSERT_EQ(100, pool->bytes_allocated());
-
-  pool->Free(data, 100);
-  ASSERT_EQ(0, pool->bytes_allocated());
+TEST_F(TestJemallocMemoryPool, MemoryTracking) {
+  this->TestMemoryTracking();
 }
 
-TEST(JemallocMemoryPool, OOM) {
-  MemoryPool* pool = ::arrow::jemalloc::MemoryPool::default_pool();
+TEST_F(TestJemallocMemoryPool, OOM) {
+  this->TestOOM();
+}
 
-  uint8_t* data;
-  int64_t to_alloc = std::numeric_limits<int64_t>::max();
-  ASSERT_RAISES(OutOfMemory, pool->Allocate(to_alloc, &data));
+TEST_F(TestJemallocMemoryPool, Reallocate) {
+  this->TestReallocate();
 }
 
 }  // namespace test

--- a/cpp/src/arrow/jemalloc/jemalloc-memory_pool-test.cc
+++ b/cpp/src/arrow/jemalloc/jemalloc-memory_pool-test.cc
@@ -51,4 +51,3 @@ TEST(JemallocMemoryPool, OOM) {
 }  // namespace test
 }  // namespace jemalloc
 }  // namespace arrow
-

--- a/cpp/src/arrow/jemalloc/jemalloc-memory_pool-test.cc
+++ b/cpp/src/arrow/jemalloc/jemalloc-memory_pool-test.cc
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cstdint>
+#include <limits>
+
+#include "gtest/gtest.h"
+
+#include "arrow/jemalloc/memory_pool.h"
+#include "arrow/status.h"
+#include "arrow/test-util.h"
+
+namespace arrow {
+namespace jemalloc {
+namespace test {
+
+TEST(JemallocMemoryPool, MemoryTracking) {
+  MemoryPool* pool = ::arrow::jemalloc::MemoryPool::default_pool();
+
+  uint8_t* data;
+  ASSERT_OK(pool->Allocate(100, &data));
+  EXPECT_EQ(static_cast<uint64_t>(0), reinterpret_cast<uint64_t>(data) % 64);
+  ASSERT_EQ(100, pool->bytes_allocated());
+
+  pool->Free(data, 100);
+  ASSERT_EQ(0, pool->bytes_allocated());
+}
+
+TEST(JemallocMemoryPool, OOM) {
+  MemoryPool* pool = ::arrow::jemalloc::MemoryPool::default_pool();
+
+  uint8_t* data;
+  int64_t to_alloc = std::numeric_limits<int64_t>::max();
+  ASSERT_RAISES(OutOfMemory, pool->Allocate(to_alloc, &data));
+}
+
+}  // namespace test
+}  // namespace jemalloc
+}  // namespace arrow
+

--- a/cpp/src/arrow/jemalloc/memory_pool.cc
+++ b/cpp/src/arrow/jemalloc/memory_pool.cc
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/jemalloc/memory_pool.h"
+
+#include <sstream>
+
+#include <jemalloc/jemalloc.h>
+
+#include "arrow/status.h"
+
+constexpr size_t kAlignment = 64;
+
+namespace arrow {
+namespace jemalloc {
+
+MemoryPool* MemoryPool::default_pool() {
+  static MemoryPool pool;
+  return &pool;
+}
+
+MemoryPool::MemoryPool() : allocated_size_(0) {}
+
+MemoryPool::~MemoryPool() {};
+  
+Status MemoryPool::Allocate(int64_t size, uint8_t** out) {
+  *out = reinterpret_cast<uint8_t*>(mallocx(size, MALLOCX_ALIGN(kAlignment)));
+  if (*out == NULL) {
+    std::stringstream ss;
+    ss << "malloc of size " << size << " failed";
+    return Status::OutOfMemory(ss.str());
+  } 
+  allocated_size_ += size;
+  return Status::OK();
+}
+
+void MemoryPool::Free(uint8_t* buffer, int64_t size) {
+  allocated_size_ -= size;
+  free(buffer);
+}
+
+int64_t MemoryPool::bytes_allocated() const {
+  return allocated_size_.load();
+}
+
+} // jemalloc
+} // arrow

--- a/cpp/src/arrow/jemalloc/memory_pool.cc
+++ b/cpp/src/arrow/jemalloc/memory_pool.cc
@@ -35,7 +35,7 @@ MemoryPool* MemoryPool::default_pool() {
 
 MemoryPool::MemoryPool() : allocated_size_(0) {}
 
-MemoryPool::~MemoryPool(){};
+MemoryPool::~MemoryPool() {}
 
 Status MemoryPool::Allocate(int64_t size, uint8_t** out) {
   *out = reinterpret_cast<uint8_t*>(mallocx(size, MALLOCX_ALIGN(kAlignment)));
@@ -70,5 +70,5 @@ int64_t MemoryPool::bytes_allocated() const {
   return allocated_size_.load();
 }
 
-}  // jemalloc
-}  // arrow
+}  // namespace jemalloc
+}  // namespace arrow

--- a/cpp/src/arrow/jemalloc/memory_pool.cc
+++ b/cpp/src/arrow/jemalloc/memory_pool.cc
@@ -35,16 +35,29 @@ MemoryPool* MemoryPool::default_pool() {
 
 MemoryPool::MemoryPool() : allocated_size_(0) {}
 
-MemoryPool::~MemoryPool() {};
-  
+MemoryPool::~MemoryPool(){};
+
 Status MemoryPool::Allocate(int64_t size, uint8_t** out) {
   *out = reinterpret_cast<uint8_t*>(mallocx(size, MALLOCX_ALIGN(kAlignment)));
   if (*out == NULL) {
     std::stringstream ss;
     ss << "malloc of size " << size << " failed";
     return Status::OutOfMemory(ss.str());
-  } 
+  }
   allocated_size_ += size;
+  return Status::OK();
+}
+
+Status MemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
+  *ptr = reinterpret_cast<uint8_t*>(rallocx(*ptr, new_size, MALLOCX_ALIGN(kAlignment)));
+  if (*ptr == NULL) {
+    std::stringstream ss;
+    ss << "realloc of size " << new_size << " failed";
+    return Status::OutOfMemory(ss.str());
+  }
+
+  allocated_size_ += new_size - old_size;
+
   return Status::OK();
 }
 
@@ -57,5 +70,5 @@ int64_t MemoryPool::bytes_allocated() const {
   return allocated_size_.load();
 }
 
-} // jemalloc
-} // arrow
+}  // jemalloc
+}  // arrow

--- a/cpp/src/arrow/jemalloc/memory_pool.h
+++ b/cpp/src/arrow/jemalloc/memory_pool.h
@@ -20,7 +20,7 @@
 #ifndef ARROW_JEMALLOC_MEMORY_POOL_H
 #define ARROW_JEMALLOC_MEMORY_POOL_H
 
-#include "arrow/memory_pool.h" 
+#include "arrow/memory_pool.h"
 
 #include <atomic>
 
@@ -32,14 +32,15 @@ namespace jemalloc {
 
 class ARROW_EXPORT MemoryPool : public ::arrow::MemoryPool {
  public:
-  static MemoryPool* default_pool(); 
+  static MemoryPool* default_pool();
 
   MemoryPool(MemoryPool const&) = delete;
-  MemoryPool& operator=(MemoryPool const&) = delete; 
+  MemoryPool& operator=(MemoryPool const&) = delete;
 
   virtual ~MemoryPool();
 
   Status Allocate(int64_t size, uint8_t** out) override;
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;
   void Free(uint8_t* buffer, int64_t size) override;
 
   int64_t bytes_allocated() const override;
@@ -49,7 +50,6 @@ class ARROW_EXPORT MemoryPool : public ::arrow::MemoryPool {
 
   std::atomic<int64_t> allocated_size_;
 };
-
 
 }  // namespace jemalloc
 }  // namespace arrow

--- a/cpp/src/arrow/jemalloc/memory_pool.h
+++ b/cpp/src/arrow/jemalloc/memory_pool.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Public API for the jemalloc-based allocator
+
+#ifndef ARROW_JEMALLOC_MEMORY_POOL_H
+#define ARROW_JEMALLOC_MEMORY_POOL_H
+
+#include "arrow/memory_pool.h" 
+
+#include <atomic>
+
+namespace arrow {
+
+class Status;
+
+namespace jemalloc {
+
+class ARROW_EXPORT MemoryPool : public ::arrow::MemoryPool {
+ public:
+  static MemoryPool* default_pool(); 
+
+  MemoryPool(MemoryPool const&) = delete;
+  MemoryPool& operator=(MemoryPool const&) = delete; 
+
+  virtual ~MemoryPool();
+
+  Status Allocate(int64_t size, uint8_t** out) override;
+  void Free(uint8_t* buffer, int64_t size) override;
+
+  int64_t bytes_allocated() const override;
+
+ private:
+  MemoryPool();
+
+  std::atomic<int64_t> allocated_size_;
+};
+
+
+}  // namespace jemalloc
+}  // namespace arrow
+
+#endif  // ARROW_JEMALLOC_MEMORY_POOL_H

--- a/cpp/src/arrow/jemalloc/symbols.map
+++ b/cpp/src/arrow/jemalloc/symbols.map
@@ -1,0 +1,30 @@
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License. See accompanying LICENSE file.
+
+{
+  # Symbols marked as 'local' are not exported by the DSO and thus may not
+  # be used by client applications.
+  local:
+    # devtoolset / static-libstdc++ symbols
+    __cxa_*;
+
+    extern "C++" {
+      # boost
+      boost::*;
+
+      # devtoolset or -static-libstdc++ - the Red Hat devtoolset statically
+      # links c++11 symbols into binaries so that the result may be executed on
+      # a system with an older libstdc++ which doesn't include the necessary
+      # c++11 symbols.
+      std::*;
+    };
+};

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -15,35 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/memory_pool-test.h"
+
 #include <cstdint>
 #include <limits>
 
-#include "gtest/gtest.h"
-
-#include "arrow/memory_pool.h"
-#include "arrow/status.h"
-#include "arrow/test-util.h"
-
 namespace arrow {
 
-TEST(DefaultMemoryPool, MemoryTracking) {
-  MemoryPool* pool = default_memory_pool();
+class TestDefaultMemoryPool : public ::arrow::test::TestMemoryPoolBase {
+ public:
+  ::arrow::MemoryPool* memory_pool() override { return ::arrow::default_memory_pool(); }
+};
 
-  uint8_t* data;
-  ASSERT_OK(pool->Allocate(100, &data));
-  EXPECT_EQ(static_cast<uint64_t>(0), reinterpret_cast<uint64_t>(data) % 64);
-  ASSERT_EQ(100, pool->bytes_allocated());
-
-  pool->Free(data, 100);
-  ASSERT_EQ(0, pool->bytes_allocated());
+TEST_F(TestDefaultMemoryPool, MemoryTracking) {
+  this->TestMemoryTracking();
 }
 
-TEST(DefaultMemoryPool, OOM) {
-  MemoryPool* pool = default_memory_pool();
+TEST_F(TestDefaultMemoryPool, OOM) {
+  this->TestOOM();
+}
 
-  uint8_t* data;
-  int64_t to_alloc = std::numeric_limits<int64_t>::max();
-  ASSERT_RAISES(OutOfMemory, pool->Allocate(to_alloc, &data));
+TEST_F(TestDefaultMemoryPool, Reallocate) {
+  this->TestReallocate();
 }
 
 // Death tests and valgrind are known to not play well 100% of the time. See

--- a/cpp/src/arrow/memory_pool-test.h
+++ b/cpp/src/arrow/memory_pool-test.h
@@ -17,6 +17,8 @@
 
 #include "gtest/gtest.h"
 
+#include <limits>
+
 #include "arrow/memory_pool.h"
 #include "arrow/test-util.h"
 

--- a/cpp/src/arrow/memory_pool-test.h
+++ b/cpp/src/arrow/memory_pool-test.h
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "gtest/gtest.h"
+
+#include "arrow/memory_pool.h"
+#include "arrow/test-util.h"
+
+namespace arrow {
+
+namespace test {
+
+class TestMemoryPoolBase : public ::testing::Test {
+ public:
+  virtual ::arrow::MemoryPool* memory_pool() = 0;
+
+  void TestMemoryTracking() {
+    auto pool = memory_pool();
+
+    uint8_t* data;
+    ASSERT_OK(pool->Allocate(100, &data));
+    EXPECT_EQ(static_cast<uint64_t>(0), reinterpret_cast<uint64_t>(data) % 64);
+    ASSERT_EQ(100, pool->bytes_allocated());
+
+    pool->Free(data, 100);
+    ASSERT_EQ(0, pool->bytes_allocated());
+  }
+
+  void TestOOM() {
+    auto pool = memory_pool();
+
+    uint8_t* data;
+    int64_t to_alloc = std::numeric_limits<int64_t>::max();
+    ASSERT_RAISES(OutOfMemory, pool->Allocate(to_alloc, &data));
+  }
+
+  void TestReallocate() {
+    auto pool = memory_pool();
+
+    uint8_t* data;
+    ASSERT_OK(pool->Allocate(10, &data));
+    ASSERT_EQ(10, pool->bytes_allocated());
+    data[0] = 35;
+    data[9] = 12;
+
+    // Expand
+    ASSERT_OK(pool->Reallocate(10, 20, &data));
+    ASSERT_EQ(data[9], 12);
+    ASSERT_EQ(20, pool->bytes_allocated());
+
+    // Shrink
+    ASSERT_OK(pool->Reallocate(20, 5, &data));
+    ASSERT_EQ(data[0], 35);
+    ASSERT_EQ(5, pool->bytes_allocated());
+
+    // Free
+    pool->Free(data, 5);
+    ASSERT_EQ(0, pool->bytes_allocated());
+  }
+};
+
+}  // namespace test
+}  // namespace arrow

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -67,6 +67,7 @@ class InternalMemoryPool : public MemoryPool {
   virtual ~InternalMemoryPool();
 
   Status Allocate(int64_t size, uint8_t** out) override;
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;
 
   void Free(uint8_t* buffer, int64_t size) override;
 
@@ -81,6 +82,28 @@ Status InternalMemoryPool::Allocate(int64_t size, uint8_t** out) {
   std::lock_guard<std::mutex> guard(pool_lock_);
   RETURN_NOT_OK(AllocateAligned(size, out));
   bytes_allocated_ += size;
+
+  return Status::OK();
+}
+
+Status InternalMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
+  std::lock_guard<std::mutex> guard(pool_lock_);
+
+  // Note: We cannot use realloc() here as it doesn't guarantee alignment.
+
+  // Allocate new chunk
+  uint8_t* out;
+  RETURN_NOT_OK(AllocateAligned(new_size, &out));
+  // Copy contents and release old memory chunk
+  memcpy(out, *ptr, std::min(new_size, old_size));
+#ifdef _MSC_VER
+  _aligned_free(*ptr);
+#else
+  std::free(*ptr);
+#endif
+  *ptr = out;
+
+  bytes_allocated_ += new_size - old_size;
 
   return Status::OK();
 }

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/memory_pool.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <mutex>
 #include <sstream>

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -31,6 +31,7 @@ class ARROW_EXPORT MemoryPool {
   virtual ~MemoryPool();
 
   virtual Status Allocate(int64_t size, uint8_t** out) = 0;
+  virtual Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) = 0;
   virtual void Free(uint8_t* buffer, int64_t size) = 0;
 
   virtual int64_t bytes_allocated() const = 0;

--- a/python/src/pyarrow/common.cc
+++ b/python/src/pyarrow/common.cc
@@ -47,6 +47,20 @@ class PyArrowMemoryPool : public arrow::MemoryPool {
     return Status::OK();
   }
 
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
+    *ptr = reinterpret_cast<uint8_t*>(std::realloc(*ptr, new_size));
+
+    if (*ptr == NULL) {
+      std::stringstream ss;
+      ss << "realloc of size " << new_size << " failed";
+      return Status::OutOfMemory(ss.str());
+    }
+
+    bytes_allocated_ += new_size - old_size;
+
+    return Status::OK();
+  }
+
   int64_t bytes_allocated() const override {
     std::lock_guard<std::mutex> guard(pool_lock_);
     return bytes_allocated_;


### PR DESCRIPTION
Runtimes of the `builder-benchmark`:

```
BM_BuildPrimitiveArrayNoNulls/repeats:3               901 ms        889 ms          1   576.196MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3               833 ms        829 ms          1     617.6MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3               825 ms        821 ms          1   623.855MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3_mean          853 ms        846 ms          1   605.884MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3_stddev         34 ms         30 ms          0    21.147MB/s
BM_BuildVectorNoNulls/repeats:3                       712 ms        701 ms          1   729.866MB/s
BM_BuildVectorNoNulls/repeats:3                       671 ms        670 ms          1   764.464MB/s
BM_BuildVectorNoNulls/repeats:3                       688 ms        681 ms          1   751.285MB/s
BM_BuildVectorNoNulls/repeats:3_mean                  690 ms        684 ms          1   748.538MB/s
BM_BuildVectorNoNulls/repeats:3_stddev                 17 ms         13 ms          0   14.2578MB/s
```

With an aligned `Reallocate`, the jemalloc version is 50% faster and even outperforms `std::vector`:

```
BM_BuildPrimitiveArrayNoNulls/repeats:3               565 ms        559 ms          1   916.516MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3               540 ms        537 ms          1   952.727MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3               544 ms        543 ms          1   942.948MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3_mean          550 ms        546 ms          1   937.397MB/s
BM_BuildPrimitiveArrayNoNulls/repeats:3_stddev         11 ms          9 ms          0   15.2949MB/s
```