### PR TITLE
ARROW-360: C++: Add method to shrink PoolBuffer using realloc

### DIFF
--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -184,7 +184,7 @@ static inline void random_ascii(int n, uint32_t seed, uint8_t* out) {
 
 template <typename T>
 void rand_uniform_int(int n, uint32_t seed, T min_value, T max_value, T* out) {
-  DCHECK(out);
+  DCHECK(out || (n == 0));
   std::mt19937 gen(seed);
   std::uniform_int_distribution<T> d(min_value, max_value);
   for (int i = 0; i < n; ++i) {


### PR DESCRIPTION
Added no explicit unit test for this as I want to keep the freedom to
the allocator in the future to advise the PoolBuffer on an acceptable
minimal size. In some cases it might be worth it to occupy a whole
page.

Resizing to a smaller size is tested though, so we already have a unit test ensuring that this code runs smoothly.