### PR TITLE
ARROW-421: [Python] PyBytesReader keep refcount on PyBytes object for zero-copy read

### DIFF
--- a/python/src/pyarrow/io.h
+++ b/python/src/pyarrow/io.h
@@ -88,8 +88,11 @@ class PYARROW_EXPORT PyBytesReader : public arrow::io::BufferReader {
   explicit PyBytesReader(PyObject* obj);
   virtual ~PyBytesReader();
 
+  arrow::Status Read(int64_t nbytes, std::shared_ptr<arrow::Buffer>* out) override;
+
  private:
   PyObject* obj_;
+  bool hasZeroCopyRef_;
 };
 
 // TODO(wesm): seekable output files


### PR DESCRIPTION
Changed pyarrow::PyBytesReader to hold a reference count on the parent PyBytes object when doing a zero-copy read to prevent premature garbage collection.  Without holding a reference count and reading a `RecordBatch`, for example, the read bytes can be cleaned up before the batch is consumed.