### PR TITLE
ARROW-421: [Python] Retain parent reference in PyBytesReader 

### DIFF
--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -79,6 +79,8 @@ class ARROW_EXPORT BufferReader : public ReadableFileInterface {
 
   bool supports_zero_copy() const override;
 
+  std::shared_ptr<Buffer> buffer() const { return buffer_; }
+
  private:
   std::shared_ptr<Buffer> buffer_;
   const uint8_t* data_;

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -156,7 +156,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         int num_columns()
         int64_t num_rows()
         int num_row_groups()
-        int32_t version()
+        ParquetVersion version()
         const c_string created_by()
         int num_schema_elements()
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -138,11 +138,11 @@ cdef class FileMetaData:
     property format_version:
 
         def __get__(self):
-            cdef int version = self.metadata.version()
-            if version == 2:
-                return '2.0'
-            elif version == 1:
+            cdef ParquetVersion version = self.metadata.version()
+            if version == ParquetVersion_V1:
                 return '1.0'
+            if version == ParquetVersion_V2:
+                return '2.0'
             else:
                 print('Unrecognized file version, assuming 1.0: {0}'
                       .format(version))

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1,4 +1,4 @@
-# Licensed to the Apache Sftware Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Sftware Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -66,6 +66,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CBuffer" arrow::Buffer":
         uint8_t* data()
         int64_t size()
+        shared_ptr[CBuffer] parent()
 
     cdef cppclass ResizableBuffer(CBuffer):
         CStatus Resize(int64_t nbytes)

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -123,10 +123,16 @@ cdef class NativeFile:
         with nogil:
             check_status(self.wr_file.get().Write(buf, bufsize))
 
-    def read(self, int64_t nbytes):
+    def read(self, nbytes=None):
         cdef:
+            int64_t c_nbytes
             int64_t bytes_read = 0
             PyObject* obj
+
+        if nbytes is None:
+            c_nbytes = self.size() - self.tell()
+        else:
+            c_nbytes = nbytes
 
         self._assert_readable()
 
@@ -135,16 +141,34 @@ cdef class NativeFile:
 
         cdef uint8_t* buf = <uint8_t*> cp.PyBytes_AS_STRING(<object> obj)
         with nogil:
-            check_status(self.rd_file.get().Read(nbytes, &bytes_read, buf))
+            check_status(self.rd_file.get().Read(c_nbytes, &bytes_read, buf))
 
-        if bytes_read < nbytes:
+        if bytes_read < c_nbytes:
             cp._PyBytes_Resize(&obj, <Py_ssize_t> bytes_read)
 
         return PyObject_to_object(obj)
 
+    def buffer_read(self, nbytes=None):
+        cdef:
+            int64_t c_nbytes
+            int64_t bytes_read = 0
+            shared_ptr[CBuffer] output
+        self._assert_readable()
+
+        if nbytes is None:
+            c_nbytes = self.size() - self.tell()
+        else:
+            c_nbytes = nbytes
+
+        with nogil:
+            check_status(self.rd_file.get().ReadB(c_nbytes, &output))
+
+        return wrap_buffer(output)
+
 
 # ----------------------------------------------------------------------
 # Python file-like objects
+
 
 cdef class PythonFileInterface(NativeFile):
     cdef:
@@ -199,6 +223,16 @@ cdef class Buffer:
         def __get__(self):
             return self.buffer.get().size()
 
+    property parent:
+
+        def __get__(self):
+            cdef shared_ptr[CBuffer] parent_buf = self.buffer.get().parent()
+
+            if parent_buf.get() == NULL:
+                return None
+            else:
+                return wrap_buffer(parent_buf)
+
     def __getitem__(self, key):
         # TODO(wesm): buffer slicing
         raise NotImplementedError
@@ -207,6 +241,12 @@ cdef class Buffer:
         return cp.PyBytes_FromStringAndSize(
             <const char*>self.buffer.get().data(),
             self.buffer.get().size())
+
+
+cdef wrap_buffer(const shared_ptr[CBuffer]& buffer):
+    cdef Buffer result = Buffer()
+    result.buffer = buffer
+    return result
 
 
 cdef shared_ptr[PoolBuffer] allocate_buffer():

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -148,7 +148,7 @@ cdef class NativeFile:
 
         return PyObject_to_object(obj)
 
-    def buffer_read(self, nbytes=None):
+    def read_buffer(self, nbytes=None):
         cdef:
             int64_t c_nbytes
             int64_t bytes_read = 0

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -110,7 +110,7 @@ def test_bytes_reader_retains_parent_reference():
         data = b'some sample data' * 1000
         reader = io.BytesReader(data)
         reader.seek(5)
-        return reader.buffer_read(6)
+        return reader.read_buffer(6)
 
     buf = get_buffer()
     gc.collect()

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -102,6 +102,20 @@ def test_bytes_reader_non_bytes():
         io.BytesReader(u('some sample data'))
 
 
+def test_bytes_reader_retains_parent_reference():
+    import gc
+
+    # ARROW-421
+    def get_buffer():
+        data = b'some sample data' * 1000
+        reader = io.BytesReader(data)
+        reader.seek(5)
+        return reader.buffer_read(6)
+
+    buf = get_buffer()
+    gc.collect()
+    assert buf.to_pybytes() == b'sample'
+    assert buf.parent is not None
 
 # ----------------------------------------------------------------------
 # Buffers

--- a/python/src/pyarrow/io.cc
+++ b/python/src/pyarrow/io.cc
@@ -203,14 +203,8 @@ Status PyOutputStream::Write(const uint8_t* data, int64_t nbytes) {
 // A readable file that is backed by a PyBytes
 
 PyBytesReader::PyBytesReader(PyObject* obj)
-    : arrow::io::BufferReader(reinterpret_cast<const uint8_t*>(PyBytes_AS_STRING(obj)),
-          PyBytes_GET_SIZE(obj)),
-      obj_(obj) {
-  Py_INCREF(obj_);
-}
+    : arrow::io::BufferReader(std::make_shared<PyBytesBuffer>(obj)) {}
 
-PyBytesReader::~PyBytesReader() {
-  Py_DECREF(obj_);
-}
+PyBytesReader::~PyBytesReader() {}
 
 }  // namespace pyarrow

--- a/python/src/pyarrow/io.h
+++ b/python/src/pyarrow/io.h
@@ -22,6 +22,8 @@
 #include "arrow/io/memory.h"
 
 #include "pyarrow/config.h"
+
+#include "pyarrow/common.h"
 #include "pyarrow/visibility.h"
 
 namespace arrow {
@@ -87,9 +89,6 @@ class PYARROW_EXPORT PyBytesReader : public arrow::io::BufferReader {
  public:
   explicit PyBytesReader(PyObject* obj);
   virtual ~PyBytesReader();
-
- private:
-  PyObject* obj_;
 };
 
 // TODO(wesm): seekable output files


### PR DESCRIPTION
Pass Buffer to BufferReader so that zero-copy slices retain reference to PyBytesBuffer, which prevents the bytes object from being garbage collected prematurely. Also added some helper tools for inspecting Arrow Buffer objects in Python. 

Close #278 