### PR TITLE
ARROW-472: [Python] Expose more C++ IO interfaces. Add equals methods to Parquet schemas. Pass Parquet metadata separately in reader

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -655,5 +655,9 @@ Status MemoryMappedFile::WriteInternal(const uint8_t* data, int64_t nbytes) {
   return Status::OK();
 }
 
+int MemoryMappedFile::file_descriptor() const {
+  return impl_->fd();
+}
+
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -188,6 +188,8 @@ static inline Status FileOpenWriteable(
   memcpy(wpath.data() + nwchars, L"\0", sizeof(wchar_t));
 
   int oflag = _O_CREAT | _O_BINARY;
+  int sh_flag = _S_IWRITE;
+  if (!write_only) { sh_flag |= _S_IREAD; }
 
   if (truncate) { oflag |= _O_TRUNC; }
 
@@ -197,7 +199,7 @@ static inline Status FileOpenWriteable(
     oflag |= _O_RDWR;
   }
 
-  errno_actual = _wsopen_s(fd, wpath.data(), oflag, _SH_DENYNO, _S_IWRITE);
+  errno_actual = _wsopen_s(fd, wpath.data(), oflag, _SH_DENYNO, sh_flag);
   ret = *fd;
 
 #else
@@ -319,7 +321,7 @@ class OSFile {
     RETURN_NOT_OK(FileOpenWriteable(path, write_only, !append, &fd_));
     path_ = path;
     is_open_ = true;
-    mode_ = write_only ? FileMode::READ : FileMode::READWRITE;
+    mode_ = write_only ? FileMode::WRITE : FileMode::READWRITE;
 
     if (append) {
       RETURN_NOT_OK(FileGetSize(fd_, &size_));
@@ -352,7 +354,7 @@ class OSFile {
   }
 
   Status Seek(int64_t pos) {
-    if (pos > size_) { pos = size_; }
+    if (pos < 0) { return Status::Invalid("Invalid position"); }
     return FileSeek(fd_, pos);
   }
 
@@ -523,17 +525,24 @@ class MemoryMappedFile::MemoryMappedFileImpl : public OSFile {
   }
 
   Status Open(const std::string& path, FileMode::type mode) {
-    int prot_flags = PROT_READ;
+    int prot_flags;
+    int map_mode;
 
     if (mode != FileMode::READ) {
-      prot_flags |= PROT_WRITE;
-      const bool append = true;
-      RETURN_NOT_OK(OSFile::OpenWriteable(path, append, mode == FileMode::WRITE));
+      // Memory mapping has permission failures if PROT_READ not set
+      prot_flags = PROT_READ | PROT_WRITE;
+      map_mode = MAP_SHARED;
+      static const bool append = true;
+      static const bool write_only = false;
+      RETURN_NOT_OK(OSFile::OpenWriteable(path, append, write_only));
+      mode_ = mode;
     } else {
+      prot_flags = PROT_READ;
+      map_mode = MAP_PRIVATE;  // Changes are not to be committed back to the file
       RETURN_NOT_OK(OSFile::OpenReadable(path));
     }
 
-    void* result = mmap(nullptr, size_, prot_flags, MAP_SHARED, fd(), 0);
+    void* result = mmap(nullptr, size_, prot_flags, map_mode, fd(), 0);
     if (result == MAP_FAILED) {
       std::stringstream ss;
       ss << "Memory mapping file failed, errno: " << errno;
@@ -548,16 +557,14 @@ class MemoryMappedFile::MemoryMappedFileImpl : public OSFile {
   int64_t size() const { return size_; }
 
   Status Seek(int64_t position) {
-    if (position < 0 || position >= size_) {
-      return Status::Invalid("position is out of bounds");
-    }
+    if (position < 0) { return Status::Invalid("position is out of bounds"); }
     position_ = position;
     return Status::OK();
   }
 
   int64_t position() { return position_; }
 
-  void advance(int64_t nbytes) { position_ = std::min(size_, position_ + nbytes); }
+  void advance(int64_t nbytes) { position_ = position_ + nbytes; }
 
   uint8_t* data() { return data_; }
 
@@ -611,16 +618,18 @@ Status MemoryMappedFile::Close() {
 }
 
 Status MemoryMappedFile::Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
-  nbytes = std::min(nbytes, impl_->size() - impl_->position());
-  std::memcpy(out, impl_->head(), nbytes);
+  nbytes = std::max<int64_t>(0, std::min(nbytes, impl_->size() - impl_->position()));
+  if (nbytes > 0) { std::memcpy(out, impl_->head(), nbytes); }
   *bytes_read = nbytes;
   impl_->advance(nbytes);
   return Status::OK();
 }
 
 Status MemoryMappedFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
-  nbytes = std::min(nbytes, impl_->size() - impl_->position());
-  *out = std::make_shared<Buffer>(impl_->head(), nbytes);
+  nbytes = std::max<int64_t>(0, std::min(nbytes, impl_->size() - impl_->position()));
+
+  const uint8_t* data = nbytes > 0 ? impl_->head() : nullptr;
+  *out = std::make_shared<Buffer>(data, nbytes);
   impl_->advance(nbytes);
   return Status::OK();
 }

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -532,8 +532,8 @@ class MemoryMappedFile::MemoryMappedFileImpl : public OSFile {
       // Memory mapping has permission failures if PROT_READ not set
       prot_flags = PROT_READ | PROT_WRITE;
       map_mode = MAP_SHARED;
-      static const bool append = true;
-      static const bool write_only = false;
+      constexpr bool append = true;
+      constexpr bool write_only = false;
       RETURN_NOT_OK(OSFile::OpenWriteable(path, append, write_only));
       mode_ = mode;
     } else {

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -127,6 +127,8 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
   // @return: the size in bytes of the memory source
   Status GetSize(int64_t* size) override;
 
+  int file_descriptor() const;
+
  private:
   explicit MemoryMappedFile(FileMode::type mode);
 

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -209,8 +209,8 @@ TEST_F(TestReadableFile, SeekTellSize) {
   ASSERT_OK(file_->Seek(100));
   ASSERT_OK(file_->Tell(&position));
 
-  // now at EOF
-  ASSERT_EQ(8, position);
+  // Can seek past end of file
+  ASSERT_EQ(100, position);
 
   int64_t size;
   ASSERT_OK(file_->GetSize(&size));

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -165,8 +165,18 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         unique_ptr[CRowGroupMetaData] RowGroup(int i)
         const SchemaDescriptor* schema()
 
+    cdef cppclass ReaderProperties:
+        pass
+
+    ReaderProperties default_reader_properties()
+
     cdef cppclass ParquetFileReader:
-        # TODO: Some default arguments are missing
+        @staticmethod
+        unique_ptr[ParquetFileReader] Open(
+            const shared_ptr[ReadableFileInterface]& file,
+            const ReaderProperties& props,
+            const shared_ptr[CFileMetaData]& metadata)
+
         @staticmethod
         unique_ptr[ParquetFileReader] OpenFile(const c_string& path)
         shared_ptr[CFileMetaData] metadata();
@@ -195,6 +205,8 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
 cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
     CStatus OpenFile(const shared_ptr[ReadableFileInterface]& file,
                      MemoryPool* allocator,
+                     const ReaderProperties& properties,
+                     const shared_ptr[CFileMetaData]& metadata,
                      unique_ptr[FileReader]* reader)
 
     cdef cppclass FileReader:

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -99,8 +99,9 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
         ParquetVersion_V2" parquet::ParquetVersion::PARQUET_2_0"
 
     cdef cppclass ColumnDescriptor:
-        shared_ptr[ColumnPath] path()
+        c_bool Equals(const ColumnDescriptor& other)
 
+        shared_ptr[ColumnPath] path()
         int16_t max_definition_level()
         int16_t max_repetition_level()
 
@@ -115,6 +116,7 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
         const ColumnDescriptor* Column(int i)
         shared_ptr[Node] schema()
         GroupNode* group()
+        c_bool Equals(const SchemaDescriptor& other)
         int num_columns()
 
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -19,8 +19,9 @@
 # distutils: language = c++
 # cython: embedsignature = True
 
-from pyarrow._parquet cimport *
+from cython.operator cimport dereference as deref
 
+from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_io cimport (ReadableFileInterface, OutputStream,
                                            FileOutputStream)
@@ -196,6 +197,12 @@ cdef class Schema:
     def __getitem__(self, i):
         return self.column(i)
 
+    def equals(self, Schema other):
+        """
+        Returns True if the Parquet schemas are equal
+        """
+        return self.schema.Equals(deref(other.schema))
+
     def column(self, i):
         if i < 0 or i >= len(self):
             raise IndexError('{0} out of bounds'.format(i))
@@ -216,6 +223,12 @@ cdef class ColumnSchema:
     cdef init_from_schema(self, Schema schema, int i):
         self.parent = schema
         self.descr = schema.schema.Column(i)
+
+    def equals(self, ColumnSchema other):
+        """
+        Returns True if the column schemas are equal
+        """
+        return self.descr.Equals(deref(other.descr))
 
     def __repr__(self):
         physical_type = self.physical_type

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -54,6 +54,10 @@ if PY2:
     range = xrange
     long = long
 
+    def guid():
+        from uuid import uuid4
+        return uuid4().get_hex()
+
     def u(s):
         return unicode(s, "unicode_escape")
 
@@ -75,6 +79,10 @@ else:
         return list(x.values())
     from decimal import Decimal
     range = range
+
+    def guid():
+        from uuid import uuid4
+        return uuid4().hex
 
     def u(s):
         return s

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -89,6 +89,24 @@ else:
         return o.decode('utf8')
 
 
+def encode_file_path(path):
+    import os
+    # Windows requires utf-16le encoding for unicode file names
+    if isinstance(path, unicode_type):
+        if os.name == 'nt':
+            # try:
+            #     encoded_path = path.encode('ascii')
+            # except:
+            encoded_path = path.encode('utf-16le')
+        else:
+            # POSIX systems can handle utf-8
+            encoded_path = path.encode('utf-8')
+    else:
+        encoded_path = path
+
+    return encoded_path
+
+
 integer_types = six.integer_types + (np.integer,)
 
 __all__ = []

--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -17,8 +17,6 @@
 
 # distutils: language = c++
 
-from cython.operator cimport dereference as deref
-
 from libc.stdint cimport *
 from libcpp cimport bool as c_bool
 from libcpp.memory cimport shared_ptr, unique_ptr

--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -17,6 +17,8 @@
 
 # distutils: language = c++
 
+from cython.operator cimport dereference as deref
+
 from libc.stdint cimport *
 from libcpp cimport bool as c_bool
 from libcpp.memory cimport shared_ptr, unique_ptr

--- a/python/pyarrow/includes/libarrow_io.pxd
+++ b/python/pyarrow/includes/libarrow_io.pxd
@@ -69,6 +69,8 @@ cdef extern from "arrow/io/interfaces.h" namespace "arrow::io" nogil:
 
 
 cdef extern from "arrow/io/file.h" namespace "arrow::io" nogil:
+
+
     cdef cppclass FileOutputStream(OutputStream):
         @staticmethod
         CStatus Open(const c_string& path, shared_ptr[FileOutputStream]* file)
@@ -82,6 +84,14 @@ cdef extern from "arrow/io/file.h" namespace "arrow::io" nogil:
         @staticmethod
         CStatus Open(const c_string& path, MemoryPool* memory_pool,
                      shared_ptr[ReadableFile]* file)
+
+        int file_descriptor()
+
+    cdef cppclass CMemoryMappedFile" arrow::io::MemoryMappedFile"\
+        (ReadWriteFileInterface):
+        @staticmethod
+        CStatus Open(const c_string& path, FileMode mode,
+                     shared_ptr[CMemoryMappedFile]* file)
 
         int file_descriptor()
 

--- a/python/pyarrow/io.pxd
+++ b/python/pyarrow/io.pxd
@@ -32,7 +32,8 @@ cdef class NativeFile:
     cdef:
         shared_ptr[ReadableFileInterface] rd_file
         shared_ptr[OutputStream] wr_file
-        bint is_readonly
+        bint is_readable
+        bint is_writeable
         bint is_open
         bint own_file
 

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -27,12 +27,13 @@ from pyarrow.includes.libarrow cimport *
 cimport pyarrow.includes.pyarrow as pyarrow
 from pyarrow.includes.libarrow_io cimport *
 
-from pyarrow.compat import frombytes, tobytes
+from pyarrow.compat import frombytes, tobytes, encode_file_path
 from pyarrow.error cimport check_status
 
 cimport cpython as cp
 
 import re
+import six
 import sys
 import threading
 import time
@@ -41,6 +42,7 @@ import time
 cdef extern from "Python.h":
     PyObject* PyBytes_FromStringAndSizeNative" PyBytes_FromStringAndSize"(
         char *v, Py_ssize_t len) except NULL
+
 
 cdef class NativeFile:
 
@@ -61,7 +63,7 @@ cdef class NativeFile:
     def close(self):
         if self.is_open:
             with nogil:
-                if self.is_readonly:
+                if self.is_readable:
                     check_status(self.rd_file.get().Close())
                 else:
                     check_status(self.wr_file.get().Close())
@@ -76,15 +78,15 @@ cdef class NativeFile:
         file[0] = <shared_ptr[OutputStream]> self.wr_file
 
     def _assert_readable(self):
-        if not self.is_readonly:
+        if not self.is_readable:
             raise IOError("only valid on readonly files")
 
         if not self.is_open:
             raise IOError("file not open")
 
     def _assert_writeable(self):
-        if self.is_readonly:
-            raise IOError("only valid on writeonly files")
+        if not self.is_writeable:
+            raise IOError("only valid on writeable files")
 
         if not self.is_open:
             raise IOError("file not open")
@@ -99,7 +101,7 @@ cdef class NativeFile:
     def tell(self):
         cdef int64_t position
         with nogil:
-            if self.is_readonly:
+            if self.is_readable:
                 check_status(self.rd_file.get().Tell(&position))
             else:
                 check_status(self.wr_file.get().Tell(&position))
@@ -179,13 +181,52 @@ cdef class PythonFileInterface(NativeFile):
 
         if mode.startswith('w'):
             self.wr_file.reset(new pyarrow.PyOutputStream(handle))
-            self.is_readonly = 0
+            self.is_readable = 0
+            self.is_writeable = 1
         elif mode.startswith('r'):
             self.rd_file.reset(new pyarrow.PyReadableFile(handle))
-            self.is_readonly = 1
+            self.is_readable = 1
+            self.is_writeable = 0
         else:
             raise ValueError('Invalid file mode: {0}'.format(mode))
 
+        self.is_open = True
+
+
+cdef class MemoryMappedFile(NativeFile):
+    """
+    Supports 'r', 'r+w', 'w' modes
+    """
+    cdef:
+        object path
+
+    def __cinit__(self, path, mode='r'):
+        self.path = path
+
+        cdef:
+            FileMode c_mode
+            shared_ptr[CMemoryMappedFile] handle
+            c_string c_path = encode_file_path(path)
+
+        if mode in ('r', 'rb'):
+            c_mode = FileMode_READ
+            self.is_readable = 1
+            self.is_writeable = 0
+        elif mode in ('w', 'wb'):
+            c_mode = FileMode_WRITE
+            self.is_readable = 0
+            self.is_writeable = 1
+        elif mode == 'r+w':
+            c_mode = FileMode_READWRITE
+            self.is_readable = 1
+            self.is_writeable = 1
+        else:
+            raise ValueError('Invalid file mode: {0}'.format(mode))
+
+        check_status(CMemoryMappedFile.Open(c_path, c_mode, &handle))
+
+        self.wr_file = <shared_ptr[OutputStream]> handle
+        self.rd_file = <shared_ptr[ReadableFileInterface]> handle
         self.is_open = True
 
 
@@ -198,7 +239,8 @@ cdef class BytesReader(NativeFile):
             raise ValueError('Must pass bytes object')
 
         self.obj = obj
-        self.is_readonly = 1
+        self.is_readable = 1
+        self.is_writeable = 0
         self.is_open = True
 
         self.rd_file.reset(new pyarrow.PyBytesReader(obj))
@@ -264,7 +306,8 @@ cdef class InMemoryOutputStream(NativeFile):
         self.buffer = allocate_buffer()
         self.wr_file.reset(new BufferOutputStream(
             <shared_ptr[ResizableBuffer]> self.buffer))
-        self.is_readonly = 0
+        self.is_readable = 0
+        self.is_writeable = 1
         self.is_open = True
 
     def get_result(self):
@@ -285,7 +328,8 @@ cdef class BufferReader(NativeFile):
         self.buffer = buffer
         self.rd_file.reset(new CBufferReader(buffer.buffer.get().data(),
                                              buffer.buffer.get().size()))
-        self.is_readonly = 1
+        self.is_readable = 1
+        self.is_writeable = 0
         self.is_open = True
 
 
@@ -311,12 +355,14 @@ cdef get_reader(object source, shared_ptr[ReadableFileInterface]* reader):
     elif not isinstance(source, NativeFile) and hasattr(source, 'read'):
         # Optimistically hope this is file-like
         source = PythonFileInterface(source, mode='r')
+    elif isinstance(source, six.string_types):
+        source = MemoryMappedFile(source, mode='r')
 
     if isinstance(source, NativeFile):
         nf = source
 
         # TODO: what about read-write sources (e.g. memory maps)
-        if not nf.is_readonly:
+        if not nf.is_readable:
             raise IOError('Native file is not readable')
 
         nf.read_handle(reader)
@@ -335,7 +381,7 @@ cdef get_writer(object source, shared_ptr[OutputStream]* writer):
     if isinstance(source, NativeFile):
         nf = source
 
-        if nf.is_readonly:
+        if nf.is_readable:
             raise IOError('Native file is not writeable')
 
         nf.write_handle(writer)
@@ -593,14 +639,16 @@ cdef class HdfsClient:
 
             out.wr_file = <shared_ptr[OutputStream]> wr_handle
 
-            out.is_readonly = False
+            out.is_readable = False
+            out.is_writeable = 1
         else:
             with nogil:
                 check_status(self.client.get()
                              .OpenReadable(c_path, &rd_handle))
 
             out.rd_file = <shared_ptr[ReadableFileInterface]> rd_handle
-            out.is_readonly = True
+            out.is_readable = True
+            out.is_writeable = 0
 
         if c_buffer_size == 0:
             c_buffer_size = 2 ** 16

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -139,7 +139,7 @@ cdef class NativeFile:
         self._assert_readable()
 
         # Allocate empty write space
-        obj = PyBytes_FromStringAndSizeNative(NULL, nbytes)
+        obj = PyBytes_FromStringAndSizeNative(NULL, c_nbytes)
 
         cdef uint8_t* buf = <uint8_t*> cp.PyBytes_AS_STRING(<object> obj)
         with nogil:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -33,7 +33,7 @@ class ParquetFile(object):
     """
     def __init__(self, source, metadata=None):
         self.reader = _parquet.ParquetReader()
-        self.reader.open(source)
+        self.reader.open(source, metadata=metadata)
 
     @property
     def metadata(self):

--- a/python/pyarrow/table.pyx
+++ b/python/pyarrow/table.pyx
@@ -22,7 +22,7 @@
 from cython.operator cimport dereference as deref
 
 from pyarrow.includes.libarrow cimport *
-from pyarrow.includes.common cimport PyObject_to_object
+from pyarrow.includes.common cimport *
 cimport pyarrow.includes.pyarrow as pyarrow
 
 import pyarrow.config

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -236,19 +236,21 @@ def test_pandas_parquet_configuration_options(tmpdir):
         pdt.assert_frame_equal(df, df_read)
 
 
-@parquet
-def test_parquet_metadata_api():
-    df = alltypes_sample(size=10000)
-    df = df.reindex(columns=sorted(df.columns))
-
+def make_sample_file(df):
     a_table = A.Table.from_pandas(df, timestamps_to_ms=True)
 
     buf = io.BytesIO()
     pq.write_table(a_table, buf, compression='snappy', version='2.0')
 
-    buf.seek(0)
-    fileh = pq.ParquetFile(buf)
+    return pq.ParquetFile(buf)
 
+
+@parquet
+def test_parquet_metadata_api():
+    df = alltypes_sample(size=10000)
+    df = df.reindex(columns=sorted(df.columns))
+
+    fileh = make_sample_file(df)
     ncols = len(df.columns)
 
     # Series of sniff tests
@@ -288,3 +290,20 @@ def test_parquet_metadata_api():
 
     assert rg_meta.num_rows == len(df)
     assert rg_meta.num_columns == ncols
+
+
+@parquet
+def test_compare_schemas():
+    df = alltypes_sample(size=10000)
+
+    fileh = make_sample_file(df)
+    fileh2 = make_sample_file(df)
+    fileh3 = make_sample_file(df[df.columns[::2]])
+
+    assert fileh.schema.equals(fileh.schema)
+    assert fileh.schema.equals(fileh2.schema)
+
+    assert not fileh.schema.equals(fileh3.schema)
+
+    assert fileh.schema[0].equals(fileh.schema[0])
+    assert not fileh.schema[0].equals(fileh.schema[1])


### PR DESCRIPTION
Also includes ARROW-471, ARROW-441. 

Needed to compare file schemas easily.

Requires PARQUET-830