### PR TITLE
ARROW-486: [C++] Use virtual inheritance for diamond inheritance

### DIFF
--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -83,12 +83,12 @@ class Readable {
   virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) = 0;
 };
 
-class OutputStream : public FileInterface, public Writeable {
+class OutputStream : virtual public FileInterface, public Writeable {
  protected:
   OutputStream() {}
 };
 
-class InputStream : public FileInterface, public Readable {
+class InputStream : virtual public FileInterface, public Readable {
  protected:
   InputStream() {}
 };

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -419,5 +419,10 @@ TEST_F(TestMemoryMappedFile, InvalidFile) {
       IOError, MemoryMappedFile::Open(non_existent_path, FileMode::READ, &result));
 }
 
+TEST_F(TestMemoryMappedFile, CastableToFileInterface) {
+  std::shared_ptr<MemoryMappedFile> memory_mapped_file;
+  std::shared_ptr<FileInterface> file = memory_mapped_file;
+}
+
 }  // namespace io
 }  // namespace arrow


### PR DESCRIPTION
arrow::io::ReadWriteFileInterface inheritances arrow::io::FileInterface
as diamond style via:

  * ReadableFileInterface -> InputStream -> FileInterface
  * WriteableFileInterface -> OutputStream -> FileInterface

If we have diamond inheritance, we can't cast subclasses of
arrow::io::ReadWriteFileInterface such as arrow::io::MemoryMappedFile to
arrow::io::FileInterface.

C++:

    #include <arrow/io/file.h>

    int
    main(void)
    {
      std::shared_ptr<arrow::io::MemoryMappedFile> memory_mapped_file;

      std::shared_ptr<arrow::io::FileInterface> file = memory_mapped_file;

      return 0;
    }

Build result:

    a.cc: In function 'int main()':
    a.cc:8:52: error: conversion from 'std::shared_ptr<arrow::io::MemoryMappedFile>' to non-scalar type 'std::shared_ptr<arrow::io::FileInterface>' requested
       std::shared_ptr<arrow::io::FileInterface> file = memory_mapped_file;
                                                        ^~~~~~~~~~~~~~~~~~

We can resolve it by using virtual inheritance.