### PR TITLE
ARROW-239: Test reading remainder of file in HDFS with read() with no args

### DIFF
--- a/python/pyarrow/schema.pyx
+++ b/python/pyarrow/schema.pyx
@@ -22,6 +22,8 @@
 # distutils: language = c++
 # cython: embedsignature = True
 
+from cython.operator cimport dereference as deref
+
 from pyarrow.compat import frombytes, tobytes
 from pyarrow.includes.libarrow cimport (CDataType, CStructType, CListType,
                                         Type_NA, Type_BOOL,
@@ -31,7 +33,7 @@ from pyarrow.includes.libarrow cimport (CDataType, CStructType, CListType,
                                         Type_UINT64, Type_INT64,
                                         Type_TIMESTAMP, Type_DATE,
                                         Type_FLOAT, Type_DOUBLE,
-                                        Type_STRING, Type_BINARY, 
+                                        Type_STRING, Type_BINARY,
                                         TimeUnit_SECOND, TimeUnit_MILLI,
                                         TimeUnit_MICRO, TimeUnit_NANO,
                                         Type, TimeUnit)
@@ -57,9 +59,9 @@ cdef class DataType:
 
     def __richcmp__(DataType self, DataType other, int op):
         if op == cpython.Py_EQ:
-            return self.type.Equals(other.sp_type)
+            return self.type.Equals(deref(other.type))
         elif op == cpython.Py_NE:
-            return not self.type.Equals(other.sp_type)
+            return not self.type.Equals(deref(other.type))
         else:
             raise TypeError('Invalid comparison')
 

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -126,6 +126,18 @@ class HdfsTestCases(object):
             result = f.read(10)
             assert result == data
 
+    def test_hdfs_read_whole_file(self):
+        path = pjoin(self.tmp_path, 'read-whole-file')
+
+        data = b'foo' * 1000
+        with self.hdfs.open(path, 'wb') as f:
+            f.write(data)
+
+        with self.hdfs.open(path, 'rb') as f:
+            result = f.read()
+
+        assert result == data
+
 
 class TestLibHdfs(HdfsTestCases, unittest.TestCase):
 


### PR DESCRIPTION
This was already fixed, but adding a unit test to verify. 