### PR TITLE
ARROW-478: Consolidate BytesReader and BufferReader to accept PyBytes or Buffer

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -38,8 +38,7 @@ from pyarrow.array import (Array,
 from pyarrow.error import ArrowException
 
 from pyarrow.io import (HdfsClient, HdfsFile, NativeFile, PythonFileInterface,
-                        BytesReader, Buffer, InMemoryOutputStream,
-                        BufferReader)
+                        Buffer, InMemoryOutputStream, BufferReader)
 
 from pyarrow.scalar import (ArrayValue, Scalar, NA, NAType,
                             BooleanValue,

--- a/python/pyarrow/includes/libarrow_io.pxd
+++ b/python/pyarrow/includes/libarrow_io.pxd
@@ -162,6 +162,7 @@ cdef extern from "arrow/io/hdfs.h" namespace "arrow::io" nogil:
 cdef extern from "arrow/io/memory.h" namespace "arrow::io" nogil:
     cdef cppclass CBufferReader" arrow::io::BufferReader"\
         (ReadableFileInterface):
+        CBufferReader(const shared_ptr[CBuffer]& buffer)
         CBufferReader(const uint8_t* data, int64_t nbytes)
 
     cdef cppclass BufferOutputStream(OutputStream):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -27,7 +27,7 @@ class ParquetFile(object):
     ----------
     source : str or pyarrow.io.NativeFile
         Readable source. For passing Python file objects or byte buffers,
-        see pyarrow.io.PythonFileInterface or pyarrow.io.BytesReader.
+        see pyarrow.io.PythonFileInterface or pyarrow.io.BufferReader.
     metadata : ParquetFileMetadata, default None
         Use existing metadata object, rather than reading from file.
     """
@@ -78,7 +78,7 @@ def read_table(source, columns=None):
     ----------
     source: str or pyarrow.io.NativeFile
         Readable source. For passing Python file objects or byte buffers, see
-        pyarrow.io.PythonFileInterface or pyarrow.io.BytesReader.
+        pyarrow.io.PythonFileInterface or pyarrow.io.BufferReader.
     columns: list
         If not None, only these columns will be read from the file.
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -23,7 +23,6 @@ import numpy as np
 
 from pyarrow.compat import u, guid
 import pyarrow.io as io
-import pyarrow as pa
 
 # ----------------------------------------------------------------------
 # Python file-like objects
@@ -81,7 +80,7 @@ def test_python_file_read():
 def test_bytes_reader():
     # Like a BytesIO, but zero-copy underneath for C++ consumers
     data = b'some sample data'
-    f = io.BytesReader(data)
+    f = io.BufferReader(data)
 
     assert f.tell() == 0
 
@@ -103,7 +102,7 @@ def test_bytes_reader():
 
 def test_bytes_reader_non_bytes():
     with pytest.raises(ValueError):
-        io.BytesReader(u('some sample data'))
+        io.BufferReader(u('some sample data'))
 
 
 def test_bytes_reader_retains_parent_reference():
@@ -112,7 +111,7 @@ def test_bytes_reader_retains_parent_reference():
     # ARROW-421
     def get_buffer():
         data = b'some sample data' * 1000
-        reader = io.BytesReader(data)
+        reader = io.BufferReader(data)
         reader.seek(5)
         return reader.read_buffer(6)
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -63,7 +63,7 @@ class RoundtripTest(object):
         writer.close()
 
         file_contents = self._get_source()
-        reader = ipc.ArrowFileReader(aio.BytesReader(file_contents))
+        reader = ipc.ArrowFileReader(aio.BufferReader(file_contents))
 
         assert reader.num_record_batches == num_batches
 


### PR DESCRIPTION
API simplification. I think `pyarrow::PyBytesReader` can even be removed.