### PR TITLE
ARROW-508: [C++] Add basic threadsafety to normal files and memory maps

### DIFF
--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -50,6 +50,8 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   // OutputStream interface
   Status Close() override;
   Status Tell(int64_t* position) override;
+
+  // Write bytes to the stream. Thread-safe
   Status Write(const uint8_t* data, int64_t nbytes) override;
 
   int file_descriptor() const;
@@ -76,6 +78,7 @@ class ARROW_EXPORT ReadableFile : public ReadableFileInterface {
   Status Close() override;
   Status Tell(int64_t* position) override;
 
+  // Read bytes from the file. Thread-safe
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
@@ -112,16 +115,18 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
 
   Status Seek(int64_t position) override;
 
-  // Required by ReadableFileInterface, copies memory into out
+  // Required by ReadableFileInterface, copies memory into out. Not thread-safe
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override;
 
-  // Zero copy read
+  // Zero copy read. Not thread-safe
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   bool supports_zero_copy() const override;
 
+  /// Write data at the current position in the file. Thread-safe
   Status Write(const uint8_t* data, int64_t nbytes) override;
 
+  /// Write data at a particular position in the file. Thread-safe
   Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) override;
 
   // @return: the size in bytes of the memory source

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 
 #include "arrow/buffer.h"
 #include "arrow/status.h"
@@ -34,12 +35,14 @@ ReadableFileInterface::ReadableFileInterface() {
 
 Status ReadableFileInterface::ReadAt(
     int64_t position, int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
+  std::lock_guard<std::mutex> guard(lock_);
   RETURN_NOT_OK(Seek(position));
   return Read(nbytes, bytes_read, out);
 }
 
 Status ReadableFileInterface::ReadAt(
     int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) {
+  std::lock_guard<std::mutex> guard(lock_);
   RETURN_NOT_OK(Seek(position));
   return Read(nbytes, out);
 }

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -20,6 +20,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "arrow/util/macros.h"
@@ -99,14 +100,21 @@ class ARROW_EXPORT ReadableFileInterface : public InputStream, public Seekable {
 
   virtual bool supports_zero_copy() const = 0;
 
-  // Read at position, provide default implementations using Read(...), but can
-  // be overridden
+  /// Read at position, provide default implementations using Read(...), but can
+  /// be overridden
+  ///
+  /// Default implementation is thread-safe
   virtual Status ReadAt(
       int64_t position, int64_t nbytes, int64_t* bytes_read, uint8_t* out);
 
+  /// Default implementation is thread-safe
   virtual Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out);
 
+  std::mutex& lock() { return lock_; }
+
  protected:
+  std::mutex lock_;
+
   ReadableFileInterface();
 };
 


### PR DESCRIPTION
This patch is stacked on ARROW-494, so will need to be rebased. 

* Since the naive `ReadAt` implementation involves a Seek and a Read, this locks until the read is completed. 
* Normal file reads block until completion
* File writes block until completion

This covers the threadsafety requirements for parquet-cpp at least. For on-disk files, the following methods are now threadsafe:

* `ArrowInputFile::Read` and `ArrowInputFile::ReadAt`
* `ArrowOutputStream::Write`

parquet-cpp calls `Seek` in a couple places:

https://github.com/apache/parquet-cpp/blob/master/src/parquet/file/reader-internal.cc#L257

Strictly speaking, if two threads are trying to read the same file from the same input source, this could have a race condition in esoteric circumstances. I'm going to report a bug to change these to `ReadAt` which can be more easily made threadsafe