### PR TITLE
ARROW-509: [Python] Add support for multithreaded Parquet reads

### DIFF
--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -213,7 +213,11 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
         FileReader(MemoryPool* pool, unique_ptr[ParquetFileReader] reader)
         CStatus ReadFlatColumn(int i, shared_ptr[CArray]* out);
         CStatus ReadFlatTable(shared_ptr[CTable]* out);
+        CStatus ReadFlatTable(const vector[int]& column_indices,
+                              shared_ptr[CTable]* out);
         const ParquetFileReader* parquet_reader();
+
+        void set_num_threads(int num_threads)
 
 
 cdef extern from "parquet/arrow/schema.h" namespace "parquet::arrow" nogil:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -18,7 +18,7 @@
 from pyarrow._parquet import (ParquetReader, FileMetaData,  # noqa
                               RowGroupMetaData, Schema, ParquetWriter)
 import pyarrow._parquet as _parquet  # noqa
-from pyarrow.table import Table, concat_tables
+from pyarrow.table import concat_tables
 
 
 class ParquetFile(object):
@@ -86,6 +86,9 @@ def read_table(source, columns=None, nthreads=1, metadata=None):
         pyarrow.io.PythonFileInterface or pyarrow.io.BufferReader.
     columns: list
         If not None, only these columns will be read from the file.
+    nthreads : int, default 1
+        Number of columns to read in parallel. Requires that the underlying
+        file source is threadsafe
     metadata : FileMetaData
         If separately computed
 
@@ -112,6 +115,9 @@ def read_multiple_files(paths, columns=None, filesystem=None, nthreads=1,
     filesystem : Filesystem, default None
         If nothing passed, paths assumed to be found in the local on-disk
         filesystem
+    nthreads : int, default 1
+        Number of columns to read in parallel. Requires that the underlying
+        file source is threadsafe
     metadata : pyarrow.parquet.FileMetaData
         Use metadata obtained elsewhere to validate file schemas
     schema : pyarrow.parquet.Schema

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -45,7 +45,7 @@ class ParquetFile(object):
     def schema(self):
         return self.metadata.schema
 
-    def read(self, nrows=None, columns=None):
+    def read(self, nrows=None, columns=None, nthreads=1):
         """
         Read a Table from Parquet format
 
@@ -53,6 +53,9 @@ class ParquetFile(object):
         ----------
         columns: list
             If not None, only these columns will be read from the file.
+        nthreads : int, default 1
+            Number of columns to read in parallel. Requires that the underlying
+            file source is threadsafe
 
         Returns
         -------
@@ -63,16 +66,16 @@ class ParquetFile(object):
             raise NotImplementedError("nrows argument")
 
         if columns is None:
-            return self.reader.read_all()
+            column_indices = None
         else:
-            column_idxs = [self.reader.column_name_idx(column)
-                           for column in columns]
-            arrays = [self.reader.read_column(column_idx)
-                      for column_idx in column_idxs]
-            return Table.from_arrays(arrays, names=columns)
+            column_indices = [self.reader.column_name_idx(column)
+                              for column in columns]
+
+        return self.reader.read(column_indices=column_indices,
+                                nthreads=nthreads)
 
 
-def read_table(source, columns=None, metadata=None):
+def read_table(source, columns=None, nthreads=1, metadata=None):
     """
     Read a Table from Parquet format
 
@@ -91,11 +94,12 @@ def read_table(source, columns=None, metadata=None):
     pyarrow.Table
         Content of the file as a table (of columns)
     """
-    return ParquetFile(source, metadata=metadata).read(columns=columns)
+    pf = ParquetFile(source, metadata=metadata)
+    return pf.read(columns=columns, nthreads=nthreads)
 
 
-def read_multiple_files(paths, columns=None, filesystem=None, metadata=None,
-                        schema=None):
+def read_multiple_files(paths, columns=None, filesystem=None, nthreads=1,
+                        metadata=None, schema=None):
     """
     Read multiple Parquet files as a single pyarrow.Table
 
@@ -147,7 +151,7 @@ def read_multiple_files(paths, columns=None, filesystem=None, metadata=None,
     tables = []
     for path, path_metadata in zip(paths, all_file_metadata):
         reader = open_file(path, meta=path_metadata)
-        table = reader.read(columns=columns)
+        table = reader.read(columns=columns, nthreads=nthreads)
         tables.append(table)
 
     all_data = concat_tables(tables)

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -321,6 +321,24 @@ def test_compare_schemas():
 
 
 @parquet
+def test_multithreaded_read():
+    df = alltypes_sample(size=10000)
+
+    table = pa.Table.from_pandas(df, timestamps_to_ms=True)
+
+    buf = io.BytesIO()
+    pq.write_table(table, buf, compression='SNAPPY', version='2.0')
+
+    buf.seek(0)
+    table1 = pq.read_table(buf, nthreads=4)
+
+    buf.seek(0)
+    table2 = pq.read_table(buf, nthreads=1)
+
+    assert table1.equals(table2)
+
+
+@parquet
 def test_pass_separate_metadata():
     # ARROW-471
     df = alltypes_sample(size=10000)


### PR DESCRIPTION
I'm getting very nice speedups on a Parquet file storing a ~4.5 GB dataset:

```
In [1]: import pyarrow.parquet as pq

In [2]: %time table = pq.read_table('/home/wesm/data/airlines_parquet/4345e5eef217aa1b-c8f16177f35fd983_1150363067_data.0.parq')
CPU times: user 8.21 s, sys: 468 ms, total: 8.68 s
Wall time: 8.68 s

In [3]: %time table = pq.read_table('/home/wesm/data/airlines_parquet/4345e5eef217aa1b-c8f16177f35fd983_1150363067_data.0.parq', nthreads=4)
CPU times: user 8.84 s, sys: 4.28 s, total: 13.1 s
Wall time: 3.91 s

In [4]: %time table = pq.read_table('/home/wesm/data/airlines_parquet/4345e5eef217aa1b-c8f16177f35fd983_1150363067_data.0.parq', nthreads=8)
CPU times: user 13.3 s, sys: 1.15 s, total: 14.4 s
Wall time: 2.86 s
```

This requires a bugfix in parquet-cpp that will come soon in a patch for PARQUET-836