### PR TITLE
ARROW-498 [C++] Add command line utilities that convert between stream and file.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -90,6 +90,10 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   option(ARROW_ALTIVEC
     "Build Arrow with Altivec"
     ON)
+
+  option(ARROW_BUILD_UTILITIES
+    "Build Arrow commandline utilities"
+    ON)
 endif()
 
 if(NOT ARROW_BUILD_TESTS)

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -68,4 +68,30 @@ if (ARROW_BUILD_BENCHMARKS)
   endif()
 endif()
 
+if (ARROW_BUILD_UTILITIES)
+  if (APPLE)
+    set(UTIL_LINK_LIBS
+      arrow_ipc_static
+      arrow_io_static
+      arrow_static
+      boost_filesystem_static
+      boost_system_static
+      dl)
+  else()
+    set(UTIL_LINK_LIBS
+      arrow_ipc_static
+      arrow_io_static
+      arrow_static
+      pthread
+      boost_filesystem_static
+      boost_system_static
+      dl)
+  endif()
+
+  add_executable(file-to-stream file-to-stream.cc)
+  target_link_libraries(file-to-stream ${UTIL_LINK_LIBS})
+  add_executable(stream-to-file stream-to-file.cc)
+  target_link_libraries(stream-to-file ${UTIL_LINK_LIBS})
+endif()
+
 ADD_ARROW_TEST(bit-util-test)

--- a/cpp/src/arrow/util/file-to-stream.cc
+++ b/cpp/src/arrow/util/file-to-stream.cc
@@ -23,38 +23,37 @@
 
 #include "arrow/util/io-util.h"
 
-using namespace arrow;
-using namespace arrow::io;
-using namespace arrow::ipc;
-using namespace std;
+namespace arrow {
 
 // Reads a file on the file system and prints to stdout the stream version of it.
 Status ConvertToStream(const char* path) {
-  shared_ptr<ReadableFile> in_file;
-  shared_ptr<ipc::FileReader> reader;
+  std::shared_ptr<io::ReadableFile> in_file;
+  std::shared_ptr<ipc::FileReader> reader;
 
-  RETURN_NOT_OK(ReadableFile::Open(path, &in_file));
-  RETURN_NOT_OK(FileReader::Open(in_file, &reader));
+  RETURN_NOT_OK(io::ReadableFile::Open(path, &in_file));
+  RETURN_NOT_OK(ipc::FileReader::Open(in_file, &reader));
 
-  StdoutStream sink;
-  shared_ptr<StreamWriter> writer;
-  RETURN_NOT_OK(StreamWriter::Open(&sink, reader->schema(), &writer));
+  io::StdoutStream sink;
+  std::shared_ptr<ipc::StreamWriter> writer;
+  RETURN_NOT_OK(ipc::StreamWriter::Open(&sink, reader->schema(), &writer));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
-    shared_ptr<RecordBatch> chunk;
+    std::shared_ptr<RecordBatch> chunk;
     RETURN_NOT_OK(reader->GetRecordBatch(i, &chunk));
     RETURN_NOT_OK(writer->WriteRecordBatch(*chunk));
   }
   return writer->Close();
 }
 
+} // namespace arrow
+
 int main(int argc, char** argv) {
   if (argc != 2) {
-    cerr << "Usage: file-to-stream <input arrow file>" << endl;
+    std::cerr << "Usage: file-to-stream <input arrow file>" << std::endl;
     return 1;
   }
-  Status status = ConvertToStream(argv[1]);
+  arrow::Status status = arrow::ConvertToStream(argv[1]);
   if (!status.ok()) {
-    cerr << "Could not convert to stream: " << status.ToString() << endl;
+    std::cerr << "Could not convert to stream: " << status.ToString() << std::endl;
     return 1;
   }
   return 0;

--- a/cpp/src/arrow/util/file-to-stream.cc
+++ b/cpp/src/arrow/util/file-to-stream.cc
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <iostream>
+#include "arrow/io/file.h"
+#include "arrow/ipc/file.h"
+#include "arrow/ipc/stream.h"
+#include "arrow/status.h"
+
+#include "arrow/util/io-util.h"
+
+using namespace arrow;
+using namespace arrow::io;
+using namespace arrow::ipc;
+using namespace std;
+
+// Reads a file on the file system and prints to stdout the stream version of it.
+Status ConvertToStream(const char* path) {
+  shared_ptr<ReadableFile> in_file;
+  shared_ptr<ipc::FileReader> reader;
+
+  RETURN_NOT_OK(ReadableFile::Open(path, &in_file));
+  RETURN_NOT_OK(FileReader::Open(in_file, &reader));
+
+  StdoutStream sink;
+  shared_ptr<StreamWriter> writer;
+  RETURN_NOT_OK(StreamWriter::Open(&sink, reader->schema(), &writer));
+  for (int i = 0; i < reader->num_record_batches(); ++i) {
+    shared_ptr<RecordBatch> chunk;
+    RETURN_NOT_OK(reader->GetRecordBatch(i, &chunk));
+    RETURN_NOT_OK(writer->WriteRecordBatch(*chunk));
+  }
+  return writer->Close();
+}
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    cerr << "Usage: file-to-stream <input arrow file>" << endl;
+    return 1;
+  }
+  Status status = ConvertToStream(argv[1]);
+  if (!status.ok()) {
+    cerr << "Could not convert to stream: " << status.ToString() << endl;
+    return 1;
+  }
+  return 0;
+}

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -21,7 +21,8 @@
 #include <iostream>
 #include "arrow/buffer.h"
 
-namespace arrow { namespace io {
+namespace arrow {
+namespace io {
 
 // Output stream that just writes to stdout.
 class StdoutStream : public OutputStream {
@@ -84,7 +85,9 @@ class StdinStream : public InputStream {
  private:
   long pos_;
 };
-}}
 
-#endif
+} // namespace io
+} // namespace arrow
+
+#endif // ARROW_UTIL_IO_UTIL_H
 

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -44,7 +44,7 @@ class StdoutStream : public OutputStream {
     return Status::OK();
   }
  private:
-  long pos_;
+  int64_t pos_;
 };
 
 // Input stream that just reads from stdin.
@@ -83,7 +83,7 @@ class StdinStream : public InputStream {
   }
 
  private:
-  long pos_;
+  int64_t pos_;
 };
 
 } // namespace io

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_UTIL_IO_UTIL_H
+#define ARROW_UTIL_IO_UTIL_H
+
+#include <iostream>
+#include "arrow/buffer.h"
+
+namespace arrow { namespace io {
+
+// Output stream that just writes to stdout.
+class StdoutStream : public OutputStream {
+ public:
+  StdoutStream() : pos_(0) {
+    set_mode(FileMode::WRITE);
+  }
+  virtual ~StdoutStream() {}
+
+  Status Close() { return Status::OK(); }
+  Status Tell(int64_t* position)  {
+    *position = pos_;
+    return Status::OK();
+  }
+
+  Status Write(const uint8_t* data, int64_t nbytes) {
+    pos_ += nbytes;
+    std::cout.write(reinterpret_cast<const char*>(data), nbytes);
+    return Status::OK();
+  }
+ private:
+  long pos_;
+};
+
+// Input stream that just reads from stdin.
+class StdinStream : public InputStream {
+ public:
+  StdinStream() : pos_(0) {
+    set_mode(FileMode::READ);
+  }
+  virtual ~StdinStream() {}
+
+  Status Close() { return Status::OK(); }
+  Status Tell(int64_t* position)  {
+    *position = pos_;
+    return Status::OK();
+  }
+
+  virtual Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
+    std::cin.read(reinterpret_cast<char*>(out), nbytes);
+    if (std::cin) {
+      *bytes_read = nbytes;
+      pos_ += nbytes;
+    } else {
+      *bytes_read = 0;
+    }
+    return Status::OK();
+  }
+
+  virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+    auto buffer = std::make_shared<PoolBuffer>(nullptr);
+    RETURN_NOT_OK(buffer->Resize(nbytes));
+    int64_t bytes_read;
+    RETURN_NOT_OK(Read(nbytes, &bytes_read, buffer->mutable_data()));
+    RETURN_NOT_OK(buffer->Resize(bytes_read, false));
+    *out = buffer;
+    return Status::OK();
+  }
+
+ private:
+  long pos_;
+};
+}}
+
+#endif
+

--- a/cpp/src/arrow/util/stream-to-file.cc
+++ b/cpp/src/arrow/util/stream-to-file.cc
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <iostream>
+#include "arrow/io/file.h"
+#include "arrow/ipc/file.h"
+#include "arrow/ipc/stream.h"
+#include "arrow/status.h"
+
+#include "arrow/util/io-util.h"
+
+using namespace arrow;
+using namespace arrow::io;
+using namespace arrow::ipc;
+using namespace std;
+
+// Converts a stream from stdin to a file written to standard out.
+// A typical usage would be:
+// $ <program that produces streaming output> | stream-to-file > file.arrow
+Status ConvertToFile() {
+  shared_ptr<InputStream> input(new StdinStream);
+  shared_ptr<StreamReader> reader;
+  RETURN_NOT_OK(StreamReader::Open(input, &reader));
+
+  StdoutStream sink;
+  shared_ptr<FileWriter> writer;
+  RETURN_NOT_OK(FileWriter::Open(&sink, reader->schema(), &writer));
+
+  shared_ptr<RecordBatch> batch;
+  while (true) {
+    RETURN_NOT_OK(reader->GetNextRecordBatch(&batch));
+    if (batch == nullptr) break;
+    RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
+  }
+  return writer->Close();
+}
+
+int main(int argc, char** argv) {
+  Status status = ConvertToFile();
+  if (!status.ok()) {
+    cerr << "Could not convert to file: " << status.ToString() << endl;
+    return 1;
+  }
+  return 0;
+}

--- a/cpp/src/arrow/util/stream-to-file.cc
+++ b/cpp/src/arrow/util/stream-to-file.cc
@@ -23,24 +23,21 @@
 
 #include "arrow/util/io-util.h"
 
-using namespace arrow;
-using namespace arrow::io;
-using namespace arrow::ipc;
-using namespace std;
+namespace arrow {
 
 // Converts a stream from stdin to a file written to standard out.
 // A typical usage would be:
 // $ <program that produces streaming output> | stream-to-file > file.arrow
 Status ConvertToFile() {
-  shared_ptr<InputStream> input(new StdinStream);
-  shared_ptr<StreamReader> reader;
-  RETURN_NOT_OK(StreamReader::Open(input, &reader));
+  std::shared_ptr<io::InputStream> input(new io::StdinStream);
+  std::shared_ptr<ipc::StreamReader> reader;
+  RETURN_NOT_OK(ipc::StreamReader::Open(input, &reader));
 
-  StdoutStream sink;
-  shared_ptr<FileWriter> writer;
-  RETURN_NOT_OK(FileWriter::Open(&sink, reader->schema(), &writer));
+  io::StdoutStream sink;
+  std::shared_ptr<ipc::FileWriter> writer;
+  RETURN_NOT_OK(ipc::FileWriter::Open(&sink, reader->schema(), &writer));
 
-  shared_ptr<RecordBatch> batch;
+  std::shared_ptr<RecordBatch> batch;
   while (true) {
     RETURN_NOT_OK(reader->GetNextRecordBatch(&batch));
     if (batch == nullptr) break;
@@ -49,10 +46,12 @@ Status ConvertToFile() {
   return writer->Close();
 }
 
+} // namespace arrow
+
 int main(int argc, char** argv) {
-  Status status = ConvertToFile();
+  arrow::Status status = arrow::ConvertToFile();
   if (!status.ok()) {
-    cerr << "Could not convert to file: " << status.ToString() << endl;
+    std::cerr << "Could not convert to file: " << status.ToString() << std::endl;
     return 1;
   }
   return 0;


### PR DESCRIPTION
These are in the style of unix utilities using stdin/stdout for argument passing.
This makes it easy to chain them together and I think are using for getting started
or testing. As an example, this command line tests a round trip:
 $ build/debug/file-to-stream /tmp/arrow-file | build/debug/stream-to-file > /tmp/copy
 $ diff /tmp/arrow-file /tmp/copy

If we had the same in java, this would make it pretty convenient for integration
testing.