### PR TITLE
ARROW-477: [Java] Add support for second/microsecond/nanosecond timestamps in-memory and in IPC/JSON layer

### DIFF
--- a/java/vector/src/main/codegen/data/ValueVectorTypes.tdd
+++ b/java/vector/src/main/codegen/data/ValueVectorTypes.tdd
@@ -72,7 +72,7 @@
         { class: "Float8", javaType: "double" , boxedType: "Double", fields: [{name: "value", type: "double"}], },
         { class: "Date", javaType: "long", friendlyType: "DateTime" },
         { class: "TimeStampSec", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
-        { class: "TimeStamp", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
+        { class: "TimeStampMilli", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
         { class: "TimeStampMicro", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
         { class: "TimeStampNano", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
       ]

--- a/java/vector/src/main/codegen/data/ValueVectorTypes.tdd
+++ b/java/vector/src/main/codegen/data/ValueVectorTypes.tdd
@@ -71,7 +71,10 @@
         { class: "UInt8" },
         { class: "Float8", javaType: "double" , boxedType: "Double", fields: [{name: "value", type: "double"}], },
         { class: "Date", javaType: "long", friendlyType: "DateTime" },
-        { class: "TimeStamp", javaType: "long", friendlyType: "DateTime" }
+        { class: "TimeStampSec", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
+        { class: "TimeStamp", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
+        { class: "TimeStampMicro", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
+        { class: "TimeStampNano", javaType: "long", boxedType: "Long", friendlyType: "DateTime" }
       ]
     },
     {

--- a/java/vector/src/main/codegen/templates/ComplexReaders.java
+++ b/java/vector/src/main/codegen/templates/ComplexReaders.java
@@ -98,7 +98,7 @@ public class ${name}ReaderImpl extends AbstractFieldReader {
   }
 
   <#if minor.class == "TimeStampSec" ||
-       minor.class == "TimeStamp" ||
+       minor.class == "TimeStampMilli" ||
        minor.class == "TimeStampMicro" ||
        minor.class == "TimeStampNano">
   @Override

--- a/java/vector/src/main/codegen/templates/ComplexReaders.java
+++ b/java/vector/src/main/codegen/templates/ComplexReaders.java
@@ -96,6 +96,16 @@ public class ${name}ReaderImpl extends AbstractFieldReader {
   public ${friendlyType} read${safeType}(){
     return vector.getAccessor().getObject(idx());
   }
+
+  <#if minor.class == "TimeStampSec" ||
+       minor.class == "TimeStamp" ||
+       minor.class == "TimeStampMicro" ||
+       minor.class == "TimeStampNano">
+  @Override
+  public ${minor.boxedType} read${minor.boxedType}(){
+    return vector.getAccessor().get(idx());
+  }
+  </#if>
   
   public void copyValue(FieldWriter w){
     

--- a/java/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/java/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -499,7 +499,7 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
       return date;
     }
 
-    <#elseif minor.class == "TimeStamp">
+    <#elseif minor.class == "TimeStampMilli">
     @Override
     public ${friendlyType} getObject(int index) {
         org.joda.time.DateTime date = new org.joda.time.DateTime(get(index), org.joda.time.DateTimeZone.UTC);

--- a/java/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/java/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -490,12 +490,41 @@ public final class ${minor.class}Vector extends BaseDataValueVector implements F
         return date;
     }
 
+    <#elseif minor.class == "TimeStampSec">
+    @Override
+    public ${friendlyType} getObject(int index) {
+      long secs = java.util.concurrent.TimeUnit.SECONDS.toMillis(get(index));
+      org.joda.time.DateTime date = new org.joda.time.DateTime(secs, org.joda.time.DateTimeZone.UTC);
+      date = date.withZoneRetainFields(org.joda.time.DateTimeZone.getDefault());
+      return date;
+    }
+
     <#elseif minor.class == "TimeStamp">
     @Override
     public ${friendlyType} getObject(int index) {
         org.joda.time.DateTime date = new org.joda.time.DateTime(get(index), org.joda.time.DateTimeZone.UTC);
         date = date.withZoneRetainFields(org.joda.time.DateTimeZone.getDefault());
         return date;
+    }
+
+    <#elseif minor.class == "TimeStampMicro">
+    @Override
+    public ${friendlyType} getObject(int index) {
+      // value is truncated when converting microseconds to milliseconds in order to use DateTime type
+      long micros = java.util.concurrent.TimeUnit.MICROSECONDS.toMillis(get(index));
+      org.joda.time.DateTime date = new org.joda.time.DateTime(micros, org.joda.time.DateTimeZone.UTC);
+      date = date.withZoneRetainFields(org.joda.time.DateTimeZone.getDefault());
+      return date;
+    }
+
+    <#elseif minor.class == "TimeStampNano">
+    @Override
+    public ${friendlyType} getObject(int index) {
+      // value is truncated when converting nanoseconds to milliseconds in order to use DateTime type
+      long millis = java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(get(index));
+      org.joda.time.DateTime date = new org.joda.time.DateTime(millis, org.joda.time.DateTimeZone.UTC);
+      date = date.withZoneRetainFields(org.joda.time.DateTimeZone.getDefault());
+      return date;
     }
 
     <#elseif minor.class == "IntervalYear">

--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -102,8 +102,14 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     field = new Field(name, true, new FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE), null);
   <#elseif minor.class == "Float8">
     field = new Field(name, true, new FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE), null);
+  <#elseif minor.class == "TimeStampSec">
+    field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.SECOND), null);
   <#elseif minor.class == "TimeStamp">
     field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND), null);
+  <#elseif minor.class == "TimeStampMicro">
+    field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MICROSECOND), null);
+  <#elseif minor.class == "TimeStampNano">
+    field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.NANOSECOND), null);
   <#elseif minor.class == "IntervalDay">
     field = new Field(name, true, new Interval(org.apache.arrow.vector.types.IntervalUnit.DAY_TIME), null);
   <#elseif minor.class == "IntervalYear">

--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -104,7 +104,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     field = new Field(name, true, new FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE), null);
   <#elseif minor.class == "TimeStampSec">
     field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.SECOND), null);
-  <#elseif minor.class == "TimeStamp">
+  <#elseif minor.class == "TimeStampMilli">
     field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND), null);
   <#elseif minor.class == "TimeStampMicro">
     field = new Field(name, true, new org.apache.arrow.vector.types.pojo.ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MICROSECOND), null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileReader.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TimeStampSecVector;
-import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.TimeStampMicroVector;
 import org.apache.arrow.vector.TimeStampNanoVector;
 import org.apache.arrow.vector.TinyIntVector;
@@ -205,8 +205,8 @@ public class JsonFileReader implements AutoCloseable {
     case TIMESTAMPSEC:
       ((TimeStampSecVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
       break;
-    case TIMESTAMP:
-      ((TimeStampVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
+    case TIMESTAMPMILLI:
+      ((TimeStampMilliVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
       break;
     case TIMESTAMPMICRO:
       ((TimeStampMicroVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileReader.java
@@ -37,7 +37,10 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeStampSecVector;
 import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.UInt1Vector;
 import org.apache.arrow.vector.UInt2Vector;
@@ -199,9 +202,18 @@ public class JsonFileReader implements AutoCloseable {
     case VARCHAR:
       ((VarCharVector)valueVector).getMutator().setSafe(i, parser.readValueAs(String.class).getBytes(UTF_8));
       break;
+    case TIMESTAMPSEC:
+      ((TimeStampSecVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
+      break;
     case TIMESTAMP:
       ((TimeStampVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
       break;
+    case TIMESTAMPMICRO:
+      ((TimeStampMicroVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
+      break;
+    case TIMESTAMPNANO:
+      ((TimeStampNanoVector)valueVector).getMutator().set(i, parser.readValueAs(Long.class));
+    break;
     default:
       throw new UnsupportedOperationException("minor type: " + valueVector.getMinorType());
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileWriter.java
@@ -139,7 +139,10 @@ public class JsonFileWriter implements AutoCloseable {
 
   private void writeValueToGenerator(ValueVector valueVector, int i) throws IOException {
     switch (valueVector.getMinorType()) {
+      case TIMESTAMPSEC:
       case TIMESTAMP:
+      case TIMESTAMPMICRO:
+      case TIMESTAMPNANO:
         generator.writeNumber(((TimeStampVector)valueVector).getAccessor().get(i));
         break;
       case BIT:

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/json/JsonFileWriter.java
@@ -24,7 +24,10 @@ import java.util.List;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ValueVector.Accessor;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -140,10 +143,16 @@ public class JsonFileWriter implements AutoCloseable {
   private void writeValueToGenerator(ValueVector valueVector, int i) throws IOException {
     switch (valueVector.getMinorType()) {
       case TIMESTAMPSEC:
-      case TIMESTAMP:
+        generator.writeNumber(((TimeStampSecVector)valueVector).getAccessor().get(i));
+        break;
+      case TIMESTAMPMILLI:
+        generator.writeNumber(((TimeStampMilliVector)valueVector).getAccessor().get(i));
+        break;
       case TIMESTAMPMICRO:
+        generator.writeNumber(((TimeStampMicroVector)valueVector).getAccessor().get(i));
+        break;
       case TIMESTAMPNANO:
-        generator.writeNumber(((TimeStampVector)valueVector).getAccessor().get(i));
+        generator.writeNumber(((TimeStampNanoVector)valueVector).getAccessor().get(i));
         break;
       case BIT:
         generator.writeNumber(((BitVector)valueVector).getAccessor().get(i));

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -33,7 +33,10 @@ import org.apache.arrow.vector.NullableIntVector;
 import org.apache.arrow.vector.NullableIntervalDayVector;
 import org.apache.arrow.vector.NullableIntervalYearVector;
 import org.apache.arrow.vector.NullableSmallIntVector;
+import org.apache.arrow.vector.NullableTimeStampSecVector;
 import org.apache.arrow.vector.NullableTimeStampVector;
+import org.apache.arrow.vector.NullableTimeStampMicroVector;
+import org.apache.arrow.vector.NullableTimeStampNanoVector;
 import org.apache.arrow.vector.NullableTimeVector;
 import org.apache.arrow.vector.NullableTinyIntVector;
 import org.apache.arrow.vector.NullableUInt1Vector;
@@ -58,7 +61,10 @@ import org.apache.arrow.vector.complex.impl.IntervalDayWriterImpl;
 import org.apache.arrow.vector.complex.impl.IntervalYearWriterImpl;
 import org.apache.arrow.vector.complex.impl.NullableMapWriter;
 import org.apache.arrow.vector.complex.impl.SmallIntWriterImpl;
+import org.apache.arrow.vector.complex.impl.TimeStampSecWriterImpl;
 import org.apache.arrow.vector.complex.impl.TimeStampWriterImpl;
+import org.apache.arrow.vector.complex.impl.TimeStampMicroWriterImpl;
+import org.apache.arrow.vector.complex.impl.TimeStampNanoWriterImpl;
 import org.apache.arrow.vector.complex.impl.TimeWriterImpl;
 import org.apache.arrow.vector.complex.impl.TinyIntWriterImpl;
 import org.apache.arrow.vector.complex.impl.UInt1WriterImpl;
@@ -102,7 +108,10 @@ public class Types {
   private static final Field UINT8_FIELD = new Field("", true, new Int(64, false), null);
   private static final Field DATE_FIELD = new Field("", true, Date.INSTANCE, null);
   private static final Field TIME_FIELD = new Field("", true, Time.INSTANCE, null);
+  private static final Field TIMESTAMPSEC_FIELD = new Field("", true, new Timestamp(TimeUnit.SECOND), null);
   private static final Field TIMESTAMP_FIELD = new Field("", true, new Timestamp(TimeUnit.MILLISECOND), null);
+  private static final Field TIMESTAMPMICRO_FIELD = new Field("", true, new Timestamp(TimeUnit.MICROSECOND), null);
+  private static final Field TIMESTAMPNANO_FIELD = new Field("", true, new Timestamp(TimeUnit.NANOSECOND), null);
   private static final Field INTERVALDAY_FIELD = new Field("", true, new Interval(IntervalUnit.DAY_TIME), null);
   private static final Field INTERVALYEAR_FIELD = new Field("", true, new Interval(IntervalUnit.YEAR_MONTH), null);
   private static final Field FLOAT4_FIELD = new Field("", true, new FloatingPoint(FloatingPointPrecision.SINGLE), null);
@@ -241,6 +250,23 @@ public class Types {
         return new TimeWriterImpl((NullableTimeVector) vector);
       }
     },
+    // time in microsecond from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
+    TIMESTAMPSEC(new Timestamp(org.apache.arrow.vector.types.TimeUnit.SECOND)) {
+      @Override
+      public Field getField() {
+        return TIMESTAMPSEC_FIELD;
+      }
+
+      @Override
+      public FieldVector getNewVector(String name, BufferAllocator allocator, CallBack callBack, int... precisionScale) {
+        return new NullableTimeStampSecVector(name, allocator);
+      }
+
+      @Override
+      public FieldWriter getNewFieldWriter(ValueVector vector) {
+        return new TimeStampSecWriterImpl((NullableTimeStampSecVector) vector);
+      }
+    },
     // time in millis from the Unix epoch, 00:00:00.000 on 1 January 1970, UTC.
     TIMESTAMP(new Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND)) {
       @Override
@@ -256,6 +282,40 @@ public class Types {
       @Override
       public FieldWriter getNewFieldWriter(ValueVector vector) {
         return new TimeStampWriterImpl((NullableTimeStampVector) vector);
+      }
+    },
+    // time in microsecond from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
+    TIMESTAMPMICRO(new Timestamp(org.apache.arrow.vector.types.TimeUnit.MICROSECOND)) {
+      @Override
+      public Field getField() {
+        return TIMESTAMPMICRO_FIELD;
+      }
+
+      @Override
+      public FieldVector getNewVector(String name, BufferAllocator allocator, CallBack callBack, int... precisionScale) {
+        return new NullableTimeStampMicroVector(name, allocator);
+      }
+
+      @Override
+      public FieldWriter getNewFieldWriter(ValueVector vector) {
+        return new TimeStampMicroWriterImpl((NullableTimeStampMicroVector) vector);
+      }
+    },
+    // time in nanosecond from the Unix epoch, 00:00:00.000000000 on 1 January 1970, UTC.
+    TIMESTAMPNANO(new Timestamp(org.apache.arrow.vector.types.TimeUnit.NANOSECOND)) {
+      @Override
+      public Field getField() {
+        return TIMESTAMPNANO_FIELD;
+      }
+
+      @Override
+      public FieldVector getNewVector(String name, BufferAllocator allocator, CallBack callBack, int... precisionScale) {
+        return new NullableTimeStampNanoVector(name, allocator);
+      }
+
+      @Override
+      public FieldWriter getNewFieldWriter(ValueVector vector) {
+        return new TimeStampNanoWriterImpl((NullableTimeStampNanoVector) vector);
       }
     },
     INTERVALDAY(new Interval(IntervalUnit.DAY_TIME)) {
@@ -579,10 +639,18 @@ public class Types {
       }
 
       @Override public MinorType visit(Timestamp type) {
-        if (type.getUnit() != TimeUnit.MILLISECOND) {
-          throw new UnsupportedOperationException("Only milliseconds supported: " + type);
+        switch (type.getUnit()) {
+          case SECOND:
+            return MinorType.TIMESTAMPSEC;
+          case MILLISECOND:
+            return MinorType.TIMESTAMP;
+          case MICROSECOND:
+            return MinorType.TIMESTAMPMICRO;
+          case NANOSECOND:
+            return MinorType.TIMESTAMPNANO;
+          default:
+            throw new IllegalArgumentException("unknown unit: " + type);
         }
-        return MinorType.TIMESTAMP;
       }
 
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -34,7 +34,7 @@ import org.apache.arrow.vector.NullableIntervalDayVector;
 import org.apache.arrow.vector.NullableIntervalYearVector;
 import org.apache.arrow.vector.NullableSmallIntVector;
 import org.apache.arrow.vector.NullableTimeStampSecVector;
-import org.apache.arrow.vector.NullableTimeStampVector;
+import org.apache.arrow.vector.NullableTimeStampMilliVector;
 import org.apache.arrow.vector.NullableTimeStampMicroVector;
 import org.apache.arrow.vector.NullableTimeStampNanoVector;
 import org.apache.arrow.vector.NullableTimeVector;
@@ -62,7 +62,7 @@ import org.apache.arrow.vector.complex.impl.IntervalYearWriterImpl;
 import org.apache.arrow.vector.complex.impl.NullableMapWriter;
 import org.apache.arrow.vector.complex.impl.SmallIntWriterImpl;
 import org.apache.arrow.vector.complex.impl.TimeStampSecWriterImpl;
-import org.apache.arrow.vector.complex.impl.TimeStampWriterImpl;
+import org.apache.arrow.vector.complex.impl.TimeStampMilliWriterImpl;
 import org.apache.arrow.vector.complex.impl.TimeStampMicroWriterImpl;
 import org.apache.arrow.vector.complex.impl.TimeStampNanoWriterImpl;
 import org.apache.arrow.vector.complex.impl.TimeWriterImpl;
@@ -109,7 +109,7 @@ public class Types {
   private static final Field DATE_FIELD = new Field("", true, Date.INSTANCE, null);
   private static final Field TIME_FIELD = new Field("", true, Time.INSTANCE, null);
   private static final Field TIMESTAMPSEC_FIELD = new Field("", true, new Timestamp(TimeUnit.SECOND), null);
-  private static final Field TIMESTAMP_FIELD = new Field("", true, new Timestamp(TimeUnit.MILLISECOND), null);
+  private static final Field TIMESTAMPMILLI_FIELD = new Field("", true, new Timestamp(TimeUnit.MILLISECOND), null);
   private static final Field TIMESTAMPMICRO_FIELD = new Field("", true, new Timestamp(TimeUnit.MICROSECOND), null);
   private static final Field TIMESTAMPNANO_FIELD = new Field("", true, new Timestamp(TimeUnit.NANOSECOND), null);
   private static final Field INTERVALDAY_FIELD = new Field("", true, new Interval(IntervalUnit.DAY_TIME), null);
@@ -268,20 +268,20 @@ public class Types {
       }
     },
     // time in millis from the Unix epoch, 00:00:00.000 on 1 January 1970, UTC.
-    TIMESTAMP(new Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND)) {
+    TIMESTAMPMILLI(new Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND)) {
       @Override
       public Field getField() {
-        return TIMESTAMP_FIELD;
+        return TIMESTAMPMILLI_FIELD;
       }
 
       @Override
       public FieldVector getNewVector(String name, BufferAllocator allocator, CallBack callBack, int... precisionScale) {
-        return new NullableTimeStampVector(name, allocator);
+        return new NullableTimeStampMilliVector(name, allocator);
       }
 
       @Override
       public FieldWriter getNewFieldWriter(ValueVector vector) {
-        return new TimeStampWriterImpl((NullableTimeStampVector) vector);
+        return new TimeStampMilliWriterImpl((NullableTimeStampMilliVector) vector);
       }
     },
     // time in microsecond from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
@@ -643,7 +643,7 @@ public class Types {
           case SECOND:
             return MinorType.TIMESTAMPSEC;
           case MILLISECOND:
-            return MinorType.TIMESTAMP;
+            return MinorType.TIMESTAMPMILLI;
           case MICROSECOND:
             return MinorType.TIMESTAMPMICRO;
           case NANOSECOND:

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -250,7 +250,7 @@ public class Types {
         return new TimeWriterImpl((NullableTimeVector) vector);
       }
     },
-    // time in microsecond from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
+    // time in second from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
     TIMESTAMPSEC(new Timestamp(org.apache.arrow.vector.types.TimeUnit.SECOND)) {
       @Override
       public Field getField() {

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -567,6 +567,16 @@ public class TestComplexWriter {
 
   @Test
   public void timeStampWriters() throws Exception {
+    // test values
+    final long expectedNanos = 981173106123456789L;
+    final long expectedMicros = 981173106123456L;
+    final long expectedMillis = 981173106123L;
+    final long expectedSecs = 981173106L;
+    final DateTime expectedSecDateTime = new DateTime(2001, 2, 3, 4, 5, 6, 0).withZoneRetainFields(DateTimeZone.getDefault());
+    final DateTime expectedMilliDateTime = new DateTime(2001, 2, 3, 4, 5, 6, 123).withZoneRetainFields(DateTimeZone.getDefault());
+    final DateTime expectedMicroDateTime = expectedMilliDateTime;
+    final DateTime expectedNanoDateTime = expectedMilliDateTime;
+
     // write
     MapVector parent = new MapVector("parent", allocator, null);
     ComplexWriter writer = new ComplexWriterImpl("root", parent);
@@ -574,28 +584,28 @@ public class TestComplexWriter {
 
     TimeStampSecWriter timeStampSecWriter = rootWriter.timeStampSec("sec");
     timeStampSecWriter.setPosition(0);
-    timeStampSecWriter.writeTimeStampSec(0L);
+    timeStampSecWriter.writeTimeStampSec(expectedSecs);
 
-    TimeStampWriter timeStampWriter = rootWriter.timeStamp("millis");
+    TimeStampWriter timeStampWriter = rootWriter.timeStamp("milli");
     timeStampWriter.setPosition(1);
-    timeStampWriter.writeTimeStamp(1L);
+    timeStampWriter.writeTimeStamp(expectedMillis);
 
     TimeStampMicroWriter timeStampMicroWriter = rootWriter.timeStampMicro("micro");
     timeStampMicroWriter.setPosition(2);
-    timeStampMicroWriter.writeTimeStampMicro(2000L);
+    timeStampMicroWriter.writeTimeStampMicro(expectedMicros);
 
     TimeStampNanoWriter timeStampNanoWriter = rootWriter.timeStampNano("nano");
     timeStampNanoWriter.setPosition(3);
-    timeStampNanoWriter.writeTimeStampNano(3000000L);
+    timeStampNanoWriter.writeTimeStampNano(expectedNanos);
 
     // schema
     Field secField = parent.getField().getChildren().get(0).getChildren().get(0);
     Assert.assertEquals("sec", secField.getName());
     Assert.assertEquals(ArrowType.Timestamp.TYPE_TYPE, secField.getType().getTypeID());
 
-    Field millisField = parent.getField().getChildren().get(0).getChildren().get(1);
-    Assert.assertEquals("millis", millisField.getName());
-    Assert.assertEquals(ArrowType.Timestamp.TYPE_TYPE, millisField.getType().getTypeID());
+    Field milliField = parent.getField().getChildren().get(0).getChildren().get(1);
+    Assert.assertEquals("milli", milliField.getName());
+    Assert.assertEquals(ArrowType.Timestamp.TYPE_TYPE, milliField.getType().getTypeID());
 
     Field microField = parent.getField().getChildren().get(0).getChildren().get(2);
     Assert.assertEquals("micro", microField.getName());
@@ -611,29 +621,29 @@ public class TestComplexWriter {
     FieldReader secReader = rootReader.reader("sec");
     secReader.setPosition(0);
     DateTime secDateTime = secReader.readDateTime();
-    Assert.assertEquals(new DateTime(0L, DateTimeZone.UTC).withZoneRetainFields(DateTimeZone.getDefault()), secDateTime);
+    Assert.assertEquals(expectedSecDateTime, secDateTime);
     long secLong = secReader.readLong();
-    Assert.assertEquals(0L, secLong);
+    Assert.assertEquals(expectedSecs, secLong);
 
-    FieldReader millisReader = rootReader.reader("millis");
-    millisReader.setPosition(1);
-    DateTime millisDateTime = millisReader.readDateTime();
-    Assert.assertEquals(new DateTime(1L, DateTimeZone.UTC).withZoneRetainFields(DateTimeZone.getDefault()), millisDateTime);
-    long millisLong = millisReader.readLong();
-    Assert.assertEquals(1L, millisLong);
+    FieldReader milliReader = rootReader.reader("milli");
+    milliReader.setPosition(1);
+    DateTime milliDateTime = milliReader.readDateTime();
+    Assert.assertEquals(expectedMilliDateTime, milliDateTime);
+    long milliLong = milliReader.readLong();
+    Assert.assertEquals(expectedMillis, milliLong);
 
     FieldReader microReader = rootReader.reader("micro");
     microReader.setPosition(2);
     DateTime microDateTime = microReader.readDateTime();
-    Assert.assertEquals(new DateTime(2L, DateTimeZone.UTC).withZoneRetainFields(DateTimeZone.getDefault()), microDateTime);
+    Assert.assertEquals(expectedMicroDateTime, microDateTime);
     long microLong = microReader.readLong();
-    Assert.assertEquals(2000L, microLong);
+    Assert.assertEquals(expectedMicros, microLong);
 
     FieldReader nanoReader = rootReader.reader("nano");
     nanoReader.setPosition(3);
     DateTime nanoDateTime = nanoReader.readDateTime();
-    Assert.assertEquals(new DateTime(3L, DateTimeZone.UTC).withZoneRetainFields(DateTimeZone.getDefault()), nanoDateTime);
+    Assert.assertEquals(expectedNanoDateTime, nanoDateTime);
     long nanoLong = nanoReader.readLong();
-    Assert.assertEquals(3000000L, nanoLong);
+    Assert.assertEquals(expectedNanos, nanoLong);
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -586,9 +586,9 @@ public class TestComplexWriter {
     timeStampSecWriter.setPosition(0);
     timeStampSecWriter.writeTimeStampSec(expectedSecs);
 
-    TimeStampWriter timeStampWriter = rootWriter.timeStamp("milli");
+    TimeStampMilliWriter timeStampWriter = rootWriter.timeStampMilli("milli");
     timeStampWriter.setPosition(1);
-    timeStampWriter.writeTimeStamp(expectedMillis);
+    timeStampWriter.writeTimeStampMilli(expectedMillis);
 
     TimeStampMicroWriter timeStampMicroWriter = rootWriter.timeStampMicro("micro");
     timeStampMicroWriter.setPosition(2);

--- a/java/vector/src/test/java/org/apache/arrow/vector/file/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/file/BaseFileTest.java
@@ -33,7 +33,7 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.complex.writer.BigIntWriter;
 import org.apache.arrow.vector.complex.writer.IntWriter;
-import org.apache.arrow.vector.holders.NullableTimeStampHolder;
+import org.apache.arrow.vector.holders.NullableTimeStampMilliHolder;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Assert;
@@ -100,7 +100,7 @@ public class BaseFileTest {
       listWriter.endList();
       mapWriter.setPosition(i);
       mapWriter.start();
-      mapWriter.timeStamp("timestamp").writeTimeStamp(i);
+      mapWriter.timeStampMilli("timestamp").writeTimeStampMilli(i);
       mapWriter.end();
     }
     writer.setValueCount(count);
@@ -130,7 +130,7 @@ public class BaseFileTest {
       }
       Assert.assertEquals(Long.valueOf(i), root.getVector("bigInt").getAccessor().getObject(i));
       Assert.assertEquals(i % 3, ((List<?>)root.getVector("list").getAccessor().getObject(i)).size());
-      NullableTimeStampHolder h = new NullableTimeStampHolder();
+      NullableTimeStampMilliHolder h = new NullableTimeStampMilliHolder();
       FieldReader mapReader = root.getVector("map").getReader();
       mapReader.setPosition(i);
       mapReader.reader("timestamp").read(h);
@@ -167,7 +167,7 @@ public class BaseFileTest {
         Assert.assertEquals(i % 3, unionReader.size());
         break;
       case 3:
-        NullableTimeStampHolder h = new NullableTimeStampHolder();
+        NullableTimeStampMilliHolder h = new NullableTimeStampMilliHolder();
         unionReader.reader("timestamp").read(h);
         Assert.assertEquals(i, h.value);
         break;
@@ -209,7 +209,7 @@ public class BaseFileTest {
       case 3:
         mapWriter.setPosition(i);
         mapWriter.start();
-        mapWriter.timeStamp("timestamp").writeTimeStamp(i);
+        mapWriter.timeStampMilli("timestamp").writeTimeStampMilli(i);
         mapWriter.end();
         break;
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/pojo/TestConvert.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/pojo/TestConvert.java
@@ -80,7 +80,7 @@ public class TestConvert {
     childrenBuilder.add(new Field("child4", true, new List(), ImmutableList.<Field>of(
         new Field("child4.1", true, Utf8.INSTANCE, null)
         )));
-    childrenBuilder.add(new Field("child5", true, new Union(UnionMode.Sparse, new int[] { MinorType.TIMESTAMP.ordinal(), MinorType.FLOAT8.ordinal() } ), ImmutableList.<Field>of(
+    childrenBuilder.add(new Field("child5", true, new Union(UnionMode.Sparse, new int[] { MinorType.TIMESTAMPMILLI.ordinal(), MinorType.FLOAT8.ordinal() } ), ImmutableList.<Field>of(
         new Field("child5.1", true, new Timestamp(TimeUnit.MILLISECOND), null),
         new Field("child5.2", true, new FloatingPoint(DOUBLE), ImmutableList.<Field>of())
         )));


### PR DESCRIPTION
Changes include:
- add support for TimeStamp data type with second/microsecond/nanosecond time units
- add an additional readLong() method to timestamp readers to support reading raw long values
- add a simple test case for timestamp readers and writers