### PR TITLE
ARROW-513: [C++] Fixing Appveyor / MSVC build

### DIFF
--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -42,7 +42,7 @@ struct ObjectType {
   enum type { FILE, DIRECTORY };
 };
 
-class FileSystemClient {
+class ARROW_EXPORT FileSystemClient {
  public:
   virtual ~FileSystemClient() {}
 };
@@ -64,7 +64,7 @@ class ARROW_EXPORT FileInterface {
   DISALLOW_COPY_AND_ASSIGN(FileInterface);
 };
 
-class Seekable {
+class ARROW_EXPORT Seekable {
  public:
   virtual Status Seek(int64_t position) = 0;
 };
@@ -76,7 +76,7 @@ class ARROW_EXPORT Writeable {
   Status Write(const std::string& data);
 };
 
-class Readable {
+class ARROW_EXPORT Readable {
  public:
   virtual Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) = 0;
 
@@ -84,12 +84,12 @@ class Readable {
   virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) = 0;
 };
 
-class OutputStream : virtual public FileInterface, public Writeable {
+class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writeable {
  protected:
   OutputStream() {}
 };
 
-class InputStream : virtual public FileInterface, public Readable {
+class ARROW_EXPORT InputStream : virtual public FileInterface, public Readable {
  protected:
   InputStream() {}
 };
@@ -118,7 +118,7 @@ class ARROW_EXPORT ReadableFileInterface : public InputStream, public Seekable {
   ReadableFileInterface();
 };
 
-class WriteableFileInterface : public OutputStream, public Seekable {
+class ARROW_EXPORT WriteableFileInterface : public OutputStream, public Seekable {
  public:
   virtual Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) = 0;
 
@@ -126,8 +126,8 @@ class WriteableFileInterface : public OutputStream, public Seekable {
   WriteableFileInterface() { set_mode(FileMode::READ); }
 };
 
-class ReadWriteFileInterface : public ReadableFileInterface,
-                               public WriteableFileInterface {
+class ARROW_EXPORT ReadWriteFileInterface : public ReadableFileInterface,
+                                            public WriteableFileInterface {
  protected:
   ReadWriteFileInterface() { ReadableFileInterface::set_mode(FileMode::READWRITE); }
 };

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -341,14 +341,12 @@ TEST_F(TestReadableFile, ThreadSafety) {
   std::atomic<int> correct_count(0);
   const int niter = 10000;
 
-  auto ReadData = [&correct_count, &data, niter, this] () {
+  auto ReadData = [&correct_count, &data, niter, this]() {
     std::shared_ptr<Buffer> buffer;
 
     for (int i = 0; i < niter; ++i) {
       ASSERT_OK(file_->ReadAt(0, 3, &buffer));
-      if (0 == memcmp(data.c_str(), buffer->data(), 3)) {
-        correct_count += 1;
-      }
+      if (0 == memcmp(data.c_str(), buffer->data(), 3)) { correct_count += 1; }
     }
   };
 
@@ -498,20 +496,18 @@ TEST_F(TestMemoryMappedFile, ThreadSafety) {
 
   std::shared_ptr<MemoryMappedFile> file;
   ASSERT_OK(MemoryMappedFile::Open(path, FileMode::READWRITE, &file));
-  ASSERT_OK(file->Write(reinterpret_cast<const uint8_t*>(data.c_str()),
-          static_cast<int64_t>(data.size())));
+  ASSERT_OK(file->Write(
+      reinterpret_cast<const uint8_t*>(data.c_str()), static_cast<int64_t>(data.size())));
 
   std::atomic<int> correct_count(0);
   const int niter = 10000;
 
-  auto ReadData = [&correct_count, &data, niter, &file] () {
+  auto ReadData = [&correct_count, &data, niter, &file]() {
     std::shared_ptr<Buffer> buffer;
 
     for (int i = 0; i < niter; ++i) {
       ASSERT_OK(file->ReadAt(0, 3, &buffer));
-      if (0 == memcmp(data.c_str(), buffer->data(), 3)) {
-        correct_count += 1;
-      }
+      if (0 == memcmp(data.c_str(), buffer->data(), 3)) { correct_count += 1; }
     }
   };
 

--- a/cpp/src/arrow/ipc/file.cc
+++ b/cpp/src/arrow/ipc/file.cc
@@ -158,6 +158,9 @@ Status FileFooter::GetSchema(std::shared_ptr<Schema>* out) const {
 // ----------------------------------------------------------------------
 // File writer implementation
 
+FileWriter::FileWriter(io::OutputStream* sink, const std::shared_ptr<Schema>& schema)
+    : StreamWriter(sink, schema) {}
+
 Status FileWriter::Open(io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
     std::shared_ptr<FileWriter>* out) {
   *out = std::shared_ptr<FileWriter>(new FileWriter(sink, schema));  // ctor is private

--- a/cpp/src/arrow/ipc/file.h
+++ b/cpp/src/arrow/ipc/file.h
@@ -78,7 +78,7 @@ class ARROW_EXPORT FileWriter : public StreamWriter {
   Status Close() override;
 
  private:
-  using StreamWriter::StreamWriter;
+  FileWriter(io::OutputStream* sink, const std::shared_ptr<Schema>& schema);
 
   Status Start() override;
 

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -85,12 +85,12 @@ class ARROW_EXPORT SchemaMetadata {
 };
 
 // Field metadata
-struct FieldMetadata {
+struct ARROW_EXPORT FieldMetadata {
   int32_t length;
   int32_t null_count;
 };
 
-struct BufferMetadata {
+struct ARROW_EXPORT BufferMetadata {
   int32_t page;
   int64_t offset;
   int64_t length;
@@ -149,7 +149,7 @@ class ARROW_EXPORT Message {
   std::unique_ptr<MessageImpl> impl_;
 };
 
-struct FileBlock {
+struct ARROW_EXPORT FileBlock {
   FileBlock() {}
   FileBlock(int64_t offset, int32_t metadata_length, int64_t body_length)
       : offset(offset), metadata_length(metadata_length), body_length(body_length) {}

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -68,24 +68,20 @@ if (ARROW_BUILD_BENCHMARKS)
   endif()
 endif()
 
-if (ARROW_BUILD_UTILITIES)
-  if (APPLE)
+if (ARROW_IPC AND ARROW_BUILD_UTILITIES)
+  set(UTIL_LINK_LIBS
+    arrow_ipc_static
+    arrow_io_static
+    arrow_static
+    boost_filesystem_static
+    boost_system_static
+    dl)
+
+  if (NOT APPLE)
     set(UTIL_LINK_LIBS
-      arrow_ipc_static
-      arrow_io_static
-      arrow_static
+      ${UTIL_LINK_LIBS}
       boost_filesystem_static
-      boost_system_static
-      dl)
-  else()
-    set(UTIL_LINK_LIBS
-      arrow_ipc_static
-      arrow_io_static
-      arrow_static
-      pthread
-      boost_filesystem_static
-      boost_system_static
-      dl)
+      boost_system_static)
   endif()
 
   add_executable(file-to-stream file-to-stream.cc)

--- a/cpp/src/arrow/util/file-to-stream.cc
+++ b/cpp/src/arrow/util/file-to-stream.cc
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <iostream>
 #include "arrow/io/file.h"
 #include "arrow/ipc/file.h"
 #include "arrow/ipc/stream.h"
 #include "arrow/status.h"
+#include <iostream>
 
 #include "arrow/util/io-util.h"
 
@@ -44,7 +44,7 @@ Status ConvertToStream(const char* path) {
   return writer->Close();
 }
 
-} // namespace arrow
+}  // namespace arrow
 
 int main(int argc, char** argv) {
   if (argc != 2) {

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -18,8 +18,8 @@
 #ifndef ARROW_UTIL_IO_UTIL_H
 #define ARROW_UTIL_IO_UTIL_H
 
-#include <iostream>
 #include "arrow/buffer.h"
+#include <iostream>
 
 namespace arrow {
 namespace io {
@@ -27,13 +27,11 @@ namespace io {
 // Output stream that just writes to stdout.
 class StdoutStream : public OutputStream {
  public:
-  StdoutStream() : pos_(0) {
-    set_mode(FileMode::WRITE);
-  }
+  StdoutStream() : pos_(0) { set_mode(FileMode::WRITE); }
   virtual ~StdoutStream() {}
 
   Status Close() { return Status::OK(); }
-  Status Tell(int64_t* position)  {
+  Status Tell(int64_t* position) {
     *position = pos_;
     return Status::OK();
   }
@@ -43,6 +41,7 @@ class StdoutStream : public OutputStream {
     std::cout.write(reinterpret_cast<const char*>(data), nbytes);
     return Status::OK();
   }
+
  private:
   int64_t pos_;
 };
@@ -50,13 +49,11 @@ class StdoutStream : public OutputStream {
 // Input stream that just reads from stdin.
 class StdinStream : public InputStream {
  public:
-  StdinStream() : pos_(0) {
-    set_mode(FileMode::READ);
-  }
+  StdinStream() : pos_(0) { set_mode(FileMode::READ); }
   virtual ~StdinStream() {}
 
   Status Close() { return Status::OK(); }
-  Status Tell(int64_t* position)  {
+  Status Tell(int64_t* position) {
     *position = pos_;
     return Status::OK();
   }
@@ -86,8 +83,7 @@ class StdinStream : public InputStream {
   int64_t pos_;
 };
 
-} // namespace io
-} // namespace arrow
+}  // namespace io
+}  // namespace arrow
 
-#endif // ARROW_UTIL_IO_UTIL_H
-
+#endif  // ARROW_UTIL_IO_UTIL_H

--- a/cpp/src/arrow/util/stream-to-file.cc
+++ b/cpp/src/arrow/util/stream-to-file.cc
@@ -15,11 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <iostream>
+#include "arrow/ipc/stream.h"
 #include "arrow/io/file.h"
 #include "arrow/ipc/file.h"
-#include "arrow/ipc/stream.h"
 #include "arrow/status.h"
+#include <iostream>
 
 #include "arrow/util/io-util.h"
 
@@ -46,7 +46,7 @@ Status ConvertToFile() {
   return writer->Close();
 }
 
-} // namespace arrow
+}  // namespace arrow
 
 int main(int argc, char** argv) {
   arrow::Status status = arrow::ConvertToFile();

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -20,7 +20,7 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #if defined(_MSC_VER)
-#pragma warning(disable: 4251)
+#pragma warning(disable : 4251)
 #else
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -19,6 +19,11 @@
 #define ARROW_UTIL_VISIBILITY_H
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(_MSC_VER)
+#pragma warning(disable: 4251)
+#else
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
 #define ARROW_EXPORT __declspec(dllexport)
 #define ARROW_NO_EXPORT
 #else  // Not Windows


### PR DESCRIPTION
Visual Studio 2015 (MSVC 19.0) seems to have a compiler bug with inheriting private ctors. It didn't like the private `using StreamWriter::StreamWriter` in the `FileWriter` implementation. This is not consistent with Microsoft's Modern C++ support matrix https://msdn.microsoft.com/en-us/library/hh567368.aspx, so perhaps they now support inheriting *public* constructors.