### PR TITLE
ARROW-521: [C++] Track peak allocations in default memory pool

### DIFF
--- a/cpp/src/arrow/array-primitive-test.cc
+++ b/cpp/src/arrow/array-primitive-test.cc
@@ -242,7 +242,8 @@ void TestPrimitiveBuilder<PBoolean>::Check(
 }
 
 typedef ::testing::Types<PBoolean, PUInt8, PUInt16, PUInt32, PUInt64, PInt8, PInt16,
-    PInt32, PInt64, PFloat, PDouble> Primitives;
+    PInt32, PInt64, PFloat, PDouble>
+    Primitives;
 
 TYPED_TEST_CASE(TestPrimitiveBuilder, Primitives);
 

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -67,7 +67,7 @@ TEST_F(TestBuffer, Resize) {
 }
 
 TEST_F(TestBuffer, ResizeOOM) {
-  // This test doesn't play nice with AddressSanitizer
+// This test doesn't play nice with AddressSanitizer
 #ifndef ADDRESS_SANITIZER
   // realloc fails, even though there may be no explicit limit
   PoolBuffer buf;

--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -144,8 +144,10 @@ static Status ValidateArrowVsJson(
 
   if (!json_schema->Equals(arrow_schema)) {
     std::stringstream ss;
-    ss << "JSON schema: \n" << json_schema->ToString() << "\n"
-       << "Arrow schema: \n" << arrow_schema->ToString();
+    ss << "JSON schema: \n"
+       << json_schema->ToString() << "\n"
+       << "Arrow schema: \n"
+       << arrow_schema->ToString();
 
     if (FLAGS_verbose) { std::cout << ss.str() << std::endl; }
     return Status::Invalid("Schemas did not match");

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -59,6 +59,23 @@ TEST(DefaultMemoryPoolDeathTest, FreeLargeMemory) {
   pool->Free(data, 100);
 }
 
+TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
+  DefaultMemoryPool pool;
+
+  ASSERT_EQ(0, pool.max_memory());
+
+  uint8_t* data;
+  ASSERT_OK(pool.Allocate(100, &data));
+
+  uint8_t* data2;
+  ASSERT_OK(pool.Allocate(100, &data2));
+
+  pool.Free(data, 100);
+  pool.Free(data2, 100);
+
+  ASSERT_EQ(200, pool.max_memory());
+}
+
 #endif  // ARROW_VALGRIND
 
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -63,11 +63,10 @@ class ARROW_EXPORT MemoryPool {
   ///
   /// \return Maximum bytes allocated. If not known (or not implemented),
   /// returns -1
-  int64_t max_memory() const;
+  virtual int64_t max_memory() const;
 
  protected:
   MemoryPool();
-  std::atomic<int64_t> max_memory_;
 };
 
 class ARROW_EXPORT DefaultMemoryPool : public MemoryPool {
@@ -82,9 +81,12 @@ class ARROW_EXPORT DefaultMemoryPool : public MemoryPool {
 
   int64_t bytes_allocated() const override;
 
+  int64_t max_memory() const override;
+
  private:
-  mutable std::mutex pool_lock_;
-  int64_t bytes_allocated_;
+  mutable std::mutex lock_;
+  std::atomic<int64_t> bytes_allocated_;
+  std::atomic<int64_t> max_memory_;
 };
 
 ARROW_EXPORT MemoryPool* default_memory_pool();

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -18,7 +18,9 @@
 #ifndef ARROW_UTIL_MEMORY_POOL_H
 #define ARROW_UTIL_MEMORY_POOL_H
 
+#include <atomic>
 #include <cstdint>
+#include <mutex>
 
 #include "arrow/util/visibility.h"
 
@@ -56,6 +58,33 @@ class ARROW_EXPORT MemoryPool {
   /// The number of bytes that were allocated and not yet free'd through
   /// this allocator.
   virtual int64_t bytes_allocated() const = 0;
+
+  /// Return peak memory allocation in this memory pool
+  ///
+  /// \return Maximum bytes allocated. If not known (or not implemented),
+  /// returns -1
+  int64_t max_memory() const;
+
+ protected:
+  MemoryPool();
+  std::atomic<int64_t> max_memory_;
+};
+
+class ARROW_EXPORT DefaultMemoryPool : public MemoryPool {
+ public:
+  DefaultMemoryPool();
+  virtual ~DefaultMemoryPool();
+
+  Status Allocate(int64_t size, uint8_t** out) override;
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;
+
+  void Free(uint8_t* buffer, int64_t size) override;
+
+  int64_t bytes_allocated() const override;
+
+ private:
+  mutable std::mutex pool_lock_;
+  int64_t bytes_allocated_;
 };
 
 ARROW_EXPORT MemoryPool* default_memory_pool();

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -106,7 +106,8 @@ Status Table::FromRecordBatches(const std::string& name,
     if (!batches[i]->schema()->Equals(schema)) {
       std::stringstream ss;
       ss << "Schema at index " << static_cast<int>(i) << " was different: \n"
-         << schema->ToString() << "\nvs\n" << batches[i]->schema()->ToString();
+         << schema->ToString() << "\nvs\n"
+         << batches[i]->schema()->ToString();
       return Status::Invalid(ss.str());
     }
   }
@@ -138,7 +139,8 @@ Status ConcatenateTables(const std::string& output_name,
     if (!tables[i]->schema()->Equals(schema)) {
       std::stringstream ss;
       ss << "Schema at index " << static_cast<int>(i) << " was different: \n"
-         << schema->ToString() << "\nvs\n" << tables[i]->schema()->ToString();
+         << schema->ToString() << "\nvs\n"
+         << tables[i]->schema()->ToString();
       return Status::Invalid(ss.str());
     }
   }

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -118,9 +118,9 @@ class CerrLog {
 class FatalLog : public CerrLog {
  public:
   explicit FatalLog(int /* severity */)  // NOLINT
-      : CerrLog(ARROW_FATAL) {}          // NOLINT
+      : CerrLog(ARROW_FATAL){}           // NOLINT
 
-  [[noreturn]] ~FatalLog() {
+            [[noreturn]] ~FatalLog() {
     if (has_logged_) { std::cerr << std::endl; }
     std::exit(1);
   }

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -25,6 +25,6 @@
   TypeName& operator=(const TypeName&) = delete
 #endif
 
-#define UNUSED(x) (void) x
+#define UNUSED(x) (void)x
 
 #endif  // ARROW_UTIL_MACROS_H


### PR DESCRIPTION
This should enable us to remove the `parquet::MemoryAllocator` implementation in parquet-cpp