### PR TITLE
ARROW-561:[JAVA][PYTHON] Update java & python dependencies to improve downstream packaging experience

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -442,11 +442,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- Mockito needs to be on the class path after JUnit (or Hamcrest) as
-           long as Mockito _contains_ older Hamcrest classes.  See arrow-2130. -->
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>
+      <scope>test</scope>
+      <!-- Mockito  contains old Hamcrest classes, causes issues with JUNIT -->
+      <exclusions>
+        <exclusion>
+         <groupId>org.hamcrest</groupId>
+          <artifactId>hamcrest-core</artifactId>
+	</exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/python/setup.py
+++ b/python/setup.py
@@ -298,6 +298,10 @@ setup(
     use_scm_version = {"root": "..", "relative_to": __file__},
     setup_requires=['setuptools_scm'],
     install_requires=['cython >= 0.23', 'numpy >= 1.9', 'six >= 1.0.0'],
+    test_requires=['pytest'],
+    extras_requires={
+        'parquet': ['parquet-cpp']
+    },
     description="Python library for Apache Arrow",
     long_description=long_description,
     classifiers=[

--- a/python/setup.py
+++ b/python/setup.py
@@ -299,9 +299,6 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=['cython >= 0.23', 'numpy >= 1.9', 'six >= 1.0.0'],
     test_requires=['pytest'],
-    extras_requires={
-        'parquet': ['parquet-cpp']
-    },
     description="Python library for Apache Arrow",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
The current build for arrow uses a interesting work around for hamcrest conflict between JUNIT and mockito which results in mockito being in the compile scope. This is not suitable for some downstream users.

Python setup file also leaves out test dependency (not overly important but useful for developers) & we can clarify parquet-cpp as an "extra" dependency for people requiring parquet support (already mentioned in the README file but good to have clarity in setup.py as well).