### PR TITLE
ARROW-578: [C++] Add -DARROW_CXXFLAGS=... option to make CMake more consistent

### DIFF
--- a/ci/travis_before_script_cpp.sh
+++ b/ci/travis_before_script_cpp.sh
@@ -36,11 +36,11 @@ CMAKE_COMMON_FLAGS="\
 if [ $TRAVIS_OS_NAME == "linux" ]; then
     cmake -DARROW_TEST_MEMCHECK=on \
           $CMAKE_COMMON_FLAGS \
-          -DCMAKE_CXX_FLAGS="-Werror" \
+          -DARROW_CXXFLAGS=-Werror \
           $CPP_DIR
 else
     cmake $CMAKE_COMMON_FLAGS \
-          -DCMAKE_CXX_FLAGS="-Werror" \
+          -DARROW_CXXFLAGS=-Werror \
           $CPP_DIR
 fi
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -57,6 +57,9 @@ endif(CCACHE_FOUND)
 
 # Top level cmake dir
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(ARROW_CXXFLAGS "" CACHE STRING
+    "Compiler flags to append when compiling Arrow")
+
   option(ARROW_BUILD_STATIC
     "Build the libarrow static libraries"
     ON)
@@ -120,7 +123,7 @@ endif()
 include(SetupCxxFlags)
 
 # Add common flags
-set(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${ARROW_CXXFLAGS} ${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
 
 # Determine compiler version
 include(CompilerInfo)


### PR DESCRIPTION
I've had issues on CMake 2.8.x with `-DCMAKE_CXX_FLAGS=$MY_CXXFLAGS` not passing on the flags to the compiler. But it seems to work properly in our Travis CI setup, so go figure. 

Some Google searches seem to confirm this is a known issue, and having a specific "user flags" option is a way around it. We just did the same thing in parquet-cpp.