### PR TITLE
ARROW-109: [C++] Add nesting stress tests up to 500 recursion depth

### DIFF
--- a/cpp/src/arrow/ipc/adapter.h
+++ b/cpp/src/arrow/ipc/adapter.h
@@ -47,8 +47,10 @@ namespace ipc {
 
 // ----------------------------------------------------------------------
 // Write path
-// We have trouble decoding flatbuffers if the size i > 70, so 64 is a nice round number
-// TODO(emkornfield) investigate this more
+//
+// ARROW-109: We set this number arbitrarily to help catch user mistakes. For
+// deeply nested schemas, it is expected the user will indicate explicitly the
+// maximum allowed recursion depth
 constexpr int kMaxIpcRecursionDepth = 64;
 
 // Write the RecordBatch (collection of equal-length Arrow arrays) to the


### PR DESCRIPTION
There doesn't appear to be any limit to the nesting depth permitted in the flatbuffers. I think what @emkornfield was running into was the size of the IPC payload exceeding the size of the memory map that was being allocated to accommodate it. I expanded the memory map size and was able to write schemas with 1000 and 5000 levels of nesting. I left a unit test with 500 depth which doesn't take too long to run.