### PR TITLE
ARROW-605: [C++] Refactor IPC adapter code into generic ArrayLoader class. Add Date32Type

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -799,6 +799,7 @@ set(ARROW_SRCS
   src/arrow/builder.cc
   src/arrow/column.cc
   src/arrow/compare.cc
+  src/arrow/loader.cc
   src/arrow/memory_pool.cc
   src/arrow/pretty_print.cc
   src/arrow/schema.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -19,10 +19,11 @@
 install(FILES
   api.h
   array.h
-  column.h
-  compare.h
   buffer.h
   builder.h
+  column.h
+  compare.h
+  loader.h
   memory_pool.h
   pretty_print.h
   schema.h

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -101,7 +101,7 @@ TEST_F(TestStringArray, TestType) {
   TypePtr type = strings_->type();
 
   ASSERT_EQ(Type::STRING, type->type);
-  ASSERT_EQ(Type::STRING, strings_->type_id());
+  ASSERT_EQ(Type::STRING, strings_->type_enum());
 }
 
 TEST_F(TestStringArray, TestListFunctions) {
@@ -301,7 +301,7 @@ TEST_F(TestBinaryArray, TestType) {
   TypePtr type = strings_->type();
 
   ASSERT_EQ(Type::BINARY, type->type);
-  ASSERT_EQ(Type::BINARY, strings_->type_id());
+  ASSERT_EQ(Type::BINARY, strings_->type_enum());
 }
 
 TEST_F(TestBinaryArray, TestListFunctions) {

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -101,7 +101,7 @@ TEST_F(TestStringArray, TestType) {
   TypePtr type = strings_->type();
 
   ASSERT_EQ(Type::STRING, type->type);
-  ASSERT_EQ(Type::STRING, strings_->type_enum());
+  ASSERT_EQ(Type::STRING, strings_->type_id());
 }
 
 TEST_F(TestStringArray, TestListFunctions) {
@@ -301,7 +301,7 @@ TEST_F(TestBinaryArray, TestType) {
   TypePtr type = strings_->type();
 
   ASSERT_EQ(Type::BINARY, type->type);
-  ASSERT_EQ(Type::BINARY, strings_->type_enum());
+  ASSERT_EQ(Type::BINARY, strings_->type_id());
 }
 
 TEST_F(TestBinaryArray, TestListFunctions) {

--- a/cpp/src/arrow/array-struct-test.cc
+++ b/cpp/src/arrow/array-struct-test.cc
@@ -158,8 +158,8 @@ TEST_F(TestStructBuilder, TestAppendNull) {
   ASSERT_TRUE(result_->field(1)->IsNull(0));
   ASSERT_TRUE(result_->field(1)->IsNull(1));
 
-  ASSERT_EQ(Type::LIST, result_->field(0)->type_enum());
-  ASSERT_EQ(Type::INT32, result_->field(1)->type_enum());
+  ASSERT_EQ(Type::LIST, result_->field(0)->type_id());
+  ASSERT_EQ(Type::INT32, result_->field(1)->type_id());
 }
 
 TEST_F(TestStructBuilder, TestBasics) {

--- a/cpp/src/arrow/array-struct-test.cc
+++ b/cpp/src/arrow/array-struct-test.cc
@@ -158,8 +158,8 @@ TEST_F(TestStructBuilder, TestAppendNull) {
   ASSERT_TRUE(result_->field(1)->IsNull(0));
   ASSERT_TRUE(result_->field(1)->IsNull(1));
 
-  ASSERT_EQ(Type::LIST, result_->field(0)->type_id());
-  ASSERT_EQ(Type::INT32, result_->field(1)->type_id());
+  ASSERT_EQ(Type::LIST, result_->field(0)->type_enum());
+  ASSERT_EQ(Type::INT32, result_->field(1)->type_enum());
 }
 
 TEST_F(TestStructBuilder, TestBasics) {

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -107,7 +107,7 @@ class ARROW_EXPORT Array {
   int64_t null_count() const;
 
   std::shared_ptr<DataType> type() const { return type_; }
-  Type::type type_id() const { return type_->type; }
+  Type::type type_enum() const { return type_->type; }
 
   /// Buffer for the null bitmap.
   ///

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -58,6 +58,7 @@ class ARROW_EXPORT ArrayVisitor {
   virtual Status Visit(const StringArray& array);
   virtual Status Visit(const BinaryArray& array);
   virtual Status Visit(const DateArray& array);
+  virtual Status Visit(const Date32Array& array);
   virtual Status Visit(const TimeArray& array);
   virtual Status Visit(const TimestampArray& array);
   virtual Status Visit(const IntervalArray& array);
@@ -106,7 +107,7 @@ class ARROW_EXPORT Array {
   int64_t null_count() const;
 
   std::shared_ptr<DataType> type() const { return type_; }
-  Type::type type_enum() const { return type_->type; }
+  Type::type type_id() const { return type_->type; }
 
   /// Buffer for the null bitmap.
   ///
@@ -485,12 +486,6 @@ class ARROW_EXPORT DictionaryArray : public Array {
   DictionaryArray(
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& indices);
 
-  // Alternate ctor; other attributes (like null count) are inherited from the
-  // passed indices array
-  static Status FromBuffer(const std::shared_ptr<DataType>& type, int64_t length,
-      const std::shared_ptr<Buffer>& indices, const std::shared_ptr<Buffer>& null_bitmap,
-      int64_t null_count, int64_t offset, std::shared_ptr<DictionaryArray>* out);
-
   Status Validate() const override;
 
   std::shared_ptr<Array> indices() const { return indices_; }
@@ -531,20 +526,12 @@ extern template class ARROW_EXPORT NumericArray<FloatType>;
 extern template class ARROW_EXPORT NumericArray<DoubleType>;
 extern template class ARROW_EXPORT NumericArray<TimestampType>;
 extern template class ARROW_EXPORT NumericArray<DateType>;
+extern template class ARROW_EXPORT NumericArray<Date32Type>;
 extern template class ARROW_EXPORT NumericArray<TimeType>;
 
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-
-// ----------------------------------------------------------------------
-// Helper functions
-
-// Create new arrays for logical types that are backed by primitive arrays.
-Status ARROW_EXPORT MakePrimitiveArray(const std::shared_ptr<DataType>& type,
-    int64_t length, const std::shared_ptr<Buffer>& data,
-    const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count, int64_t offset,
-    std::shared_ptr<Array>* out);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -238,6 +238,7 @@ template class PrimitiveBuilder<Int16Type>;
 template class PrimitiveBuilder<Int32Type>;
 template class PrimitiveBuilder<Int64Type>;
 template class PrimitiveBuilder<DateType>;
+template class PrimitiveBuilder<Date32Type>;
 template class PrimitiveBuilder<TimestampType>;
 template class PrimitiveBuilder<TimeType>;
 template class PrimitiveBuilder<HalfFloatType>;

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -233,6 +233,7 @@ using Int64Builder = NumericBuilder<Int64Type>;
 using TimestampBuilder = NumericBuilder<TimestampType>;
 using TimeBuilder = NumericBuilder<TimeType>;
 using DateBuilder = NumericBuilder<DateType>;
+using Date32Builder = NumericBuilder<Date32Type>;
 
 using HalfFloatBuilder = NumericBuilder<HalfFloatType>;
 using FloatBuilder = NumericBuilder<FloatType>;

--- a/cpp/src/arrow/column.cc
+++ b/cpp/src/arrow/column.cc
@@ -97,6 +97,9 @@ Column::Column(const std::shared_ptr<Field>& field, const std::shared_ptr<Array>
   }
 }
 
+Column::Column(const std::string& name, const std::shared_ptr<Array>& data)
+    : Column(::arrow::field(name, data->type()), data) {}
+
 Column::Column(
     const std::shared_ptr<Field>& field, const std::shared_ptr<ChunkedArray>& data)
     : field_(field), data_(data) {}

--- a/cpp/src/arrow/column.h
+++ b/cpp/src/arrow/column.h
@@ -69,6 +69,9 @@ class ARROW_EXPORT Column {
 
   Column(const std::shared_ptr<Field>& field, const std::shared_ptr<Array>& data);
 
+  /// Construct from name and array
+  Column(const std::string& name, const std::shared_ptr<Array>& data);
+
   int64_t length() const { return data_->length(); }
 
   int64_t null_count() const { return data_->null_count(); }

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -145,6 +145,10 @@ class RangeEqualsVisitor : public ArrayVisitor {
 
   Status Visit(const DateArray& left) override { return CompareValues<DateArray>(left); }
 
+  Status Visit(const Date32Array& left) override {
+    return CompareValues<Date32Array>(left);
+  }
+
   Status Visit(const TimeArray& left) override { return CompareValues<TimeArray>(left); }
 
   Status Visit(const TimestampArray& left) override {
@@ -381,6 +385,8 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
 
   Status Visit(const DateArray& left) override { return ComparePrimitive(left); }
 
+  Status Visit(const Date32Array& left) override { return ComparePrimitive(left); }
+
   Status Visit(const TimeArray& left) override { return ComparePrimitive(left); }
 
   Status Visit(const TimestampArray& left) override { return ComparePrimitive(left); }
@@ -533,7 +539,7 @@ class ApproxEqualsVisitor : public ArrayEqualsVisitor {
 
 static bool BaseDataEquals(const Array& left, const Array& right) {
   if (left.length() != right.length() || left.null_count() != right.null_count() ||
-      left.type_enum() != right.type_enum()) {
+      left.type_id() != right.type_id()) {
     return false;
   }
   if (left.null_count() > 0) {
@@ -563,7 +569,7 @@ Status ArrayRangeEquals(const Array& left, const Array& right, int64_t left_star
     int64_t left_end_idx, int64_t right_start_idx, bool* are_equal) {
   if (&left == &right) {
     *are_equal = true;
-  } else if (left.type_enum() != right.type_enum()) {
+  } else if (left.type_id() != right.type_id()) {
     *are_equal = false;
   } else if (left.length() == 0) {
     *are_equal = true;
@@ -622,7 +628,7 @@ class TypeEqualsVisitor : public TypeVisitor {
 
   Status Visit(const TimestampType& left) override {
     const auto& right = static_cast<const TimestampType&>(right_);
-    result_ = left.unit == right.unit;
+    result_ = left.unit == right.unit && left.timezone == right.timezone;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -539,7 +539,7 @@ class ApproxEqualsVisitor : public ArrayEqualsVisitor {
 
 static bool BaseDataEquals(const Array& left, const Array& right) {
   if (left.length() != right.length() || left.null_count() != right.null_count() ||
-      left.type_id() != right.type_id()) {
+      left.type_enum() != right.type_enum()) {
     return false;
   }
   if (left.null_count() > 0) {
@@ -569,7 +569,7 @@ Status ArrayRangeEquals(const Array& left, const Array& right, int64_t left_star
     int64_t left_end_idx, int64_t right_start_idx, bool* are_equal) {
   if (&left == &right) {
     *are_equal = true;
-  } else if (left.type_id() != right.type_id()) {
+  } else if (left.type_enum() != right.type_enum()) {
     *are_equal = false;
   } else if (left.length() == 0) {
     *are_equal = true;

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -43,12 +43,18 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
  public:
   explicit BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer);
 
+  static Status Create(int64_t initial_capacity, MemoryPool* pool,
+      std::shared_ptr<BufferOutputStream>* out);
+
   ~BufferOutputStream();
 
   // Implement the OutputStream interface
   Status Close() override;
   Status Tell(int64_t* position) override;
   Status Write(const uint8_t* data, int64_t nbytes) override;
+
+  /// Close the stream and return the buffer
+  Status Finish(std::shared_ptr<Buffer>* result);
 
  private:
   // Ensures there is sufficient space available to write nbytes

--- a/cpp/src/arrow/ipc/adapter.h
+++ b/cpp/src/arrow/ipc/adapter.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "arrow/ipc/metadata.h"
+#include "arrow/loader.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -47,11 +48,6 @@ namespace ipc {
 
 // ----------------------------------------------------------------------
 // Write path
-//
-// ARROW-109: We set this number arbitrarily to help catch user mistakes. For
-// deeply nested schemas, it is expected the user will indicate explicitly the
-// maximum allowed recursion depth
-constexpr int kMaxIpcRecursionDepth = 64;
 
 // Write the RecordBatch (collection of equal-length Arrow arrays) to the
 // output stream in a contiguous block. The record batch metadata is written as
@@ -75,7 +71,7 @@ constexpr int kMaxIpcRecursionDepth = 64;
 // padding bytes
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
     io::OutputStream* dst, int32_t* metadata_length, int64_t* body_length,
-    MemoryPool* pool, int max_recursion_depth = kMaxIpcRecursionDepth);
+    MemoryPool* pool, int max_recursion_depth = kMaxNestingDepth);
 
 // Write Array as a DictionaryBatch message
 Status WriteDictionary(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,

--- a/cpp/src/arrow/ipc/metadata.cc
+++ b/cpp/src/arrow/ipc/metadata.cc
@@ -289,6 +289,7 @@ FieldMetadata RecordBatchMetadata::field(int i) const {
   FieldMetadata result;
   result.length = node->length();
   result.null_count = node->null_count();
+  result.offset = 0;
   return result;
 }
 

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "arrow/loader.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
@@ -133,12 +134,6 @@ class ARROW_EXPORT SchemaMetadata {
   std::unique_ptr<SchemaMetadataImpl> impl_;
 
   DISALLOW_COPY_AND_ASSIGN(SchemaMetadata);
-};
-
-// Field metadata
-struct ARROW_EXPORT FieldMetadata {
-  int32_t length;
-  int32_t null_count;
 };
 
 struct ARROW_EXPORT BufferMetadata {

--- a/cpp/src/arrow/loader.cc
+++ b/cpp/src/arrow/loader.cc
@@ -1,0 +1,285 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/loader.h"
+
+#include <cstdint>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/type.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class Array;
+struct DataType;
+class Status;
+
+class ArrayLoader : public TypeVisitor {
+ public:
+  ArrayLoader(const std::shared_ptr<DataType>& type, ArrayLoaderContext* context)
+      : type_(type), context_(context) {}
+
+  Status Load(std::shared_ptr<Array>* out) {
+    if (context_->max_recursion_depth <= 0) {
+      return Status::Invalid("Max recursion depth reached");
+    }
+
+    // Load the array
+    RETURN_NOT_OK(type_->Accept(this));
+
+    *out = std::move(result_);
+    return Status::OK();
+  }
+
+  Status GetBuffer(int buffer_index, std::shared_ptr<Buffer>* out) {
+    return context_->source->GetBuffer(buffer_index, out);
+  }
+
+  Status LoadCommon(FieldMetadata* field_meta, std::shared_ptr<Buffer>* null_bitmap) {
+    // This only contains the length and null count, which we need to figure
+    // out what to do with the buffers. For example, if null_count == 0, then
+    // we can skip that buffer without reading from shared memory
+    RETURN_NOT_OK(
+        context_->source->GetFieldMetadata(context_->field_index++, field_meta));
+
+    // extract null_bitmap which is common to all arrays
+    if (field_meta->null_count == 0) {
+      *null_bitmap = nullptr;
+    } else {
+      RETURN_NOT_OK(GetBuffer(context_->buffer_index, null_bitmap));
+    }
+    context_->buffer_index++;
+    return Status::OK();
+  }
+
+  template <typename TYPE>
+  Status LoadPrimitive() {
+    using ArrayType = typename TypeTraits<TYPE>::ArrayType;
+
+    FieldMetadata field_meta;
+    std::shared_ptr<Buffer> null_bitmap, data;
+
+    RETURN_NOT_OK(LoadCommon(&field_meta, &null_bitmap));
+    if (field_meta.length > 0) {
+      RETURN_NOT_OK(GetBuffer(context_->buffer_index++, &data));
+    } else {
+      context_->buffer_index++;
+      data.reset(new Buffer(nullptr, 0));
+    }
+    result_ = std::make_shared<ArrayType>(type_, field_meta.length, data, null_bitmap,
+        field_meta.null_count, field_meta.offset);
+    return Status::OK();
+  }
+
+  template <typename CONTAINER>
+  Status LoadBinary() {
+    FieldMetadata field_meta;
+    std::shared_ptr<Buffer> null_bitmap, offsets, values;
+
+    RETURN_NOT_OK(LoadCommon(&field_meta, &null_bitmap));
+    if (field_meta.length > 0) {
+      RETURN_NOT_OK(GetBuffer(context_->buffer_index++, &offsets));
+      RETURN_NOT_OK(GetBuffer(context_->buffer_index++, &values));
+    } else {
+      context_->buffer_index += 2;
+      offsets = values = nullptr;
+    }
+
+    result_ = std::make_shared<CONTAINER>(
+        field_meta.length, offsets, values, null_bitmap, field_meta.null_count);
+    return Status::OK();
+  }
+
+  Status LoadChild(const Field& field, std::shared_ptr<Array>* out) {
+    ArrayLoader loader(field.type, context_);
+    --context_->max_recursion_depth;
+    RETURN_NOT_OK(loader.Load(out));
+    ++context_->max_recursion_depth;
+    return Status::OK();
+  }
+
+  Status LoadChildren(std::vector<std::shared_ptr<Field>> child_fields,
+      std::vector<std::shared_ptr<Array>>* arrays) {
+    arrays->reserve(static_cast<int>(child_fields.size()));
+
+    for (const auto& child_field : child_fields) {
+      std::shared_ptr<Array> field_array;
+      RETURN_NOT_OK(LoadChild(*child_field.get(), &field_array));
+      arrays->emplace_back(field_array);
+    }
+    return Status::OK();
+  }
+
+#define VISIT_PRIMITIVE(TYPE) \
+  Status Visit(const TYPE& type) override { return LoadPrimitive<TYPE>(); }
+
+  VISIT_PRIMITIVE(BooleanType);
+  VISIT_PRIMITIVE(Int8Type);
+  VISIT_PRIMITIVE(Int16Type);
+  VISIT_PRIMITIVE(Int32Type);
+  VISIT_PRIMITIVE(Int64Type);
+  VISIT_PRIMITIVE(UInt8Type);
+  VISIT_PRIMITIVE(UInt16Type);
+  VISIT_PRIMITIVE(UInt32Type);
+  VISIT_PRIMITIVE(UInt64Type);
+  VISIT_PRIMITIVE(HalfFloatType);
+  VISIT_PRIMITIVE(FloatType);
+  VISIT_PRIMITIVE(DoubleType);
+  VISIT_PRIMITIVE(DateType);
+  VISIT_PRIMITIVE(Date32Type);
+  VISIT_PRIMITIVE(TimeType);
+  VISIT_PRIMITIVE(TimestampType);
+
+#undef VISIT_PRIMITIVE
+
+  Status Visit(const StringType& type) override { return LoadBinary<StringArray>(); }
+
+  Status Visit(const BinaryType& type) override { return LoadBinary<BinaryArray>(); }
+
+  Status Visit(const ListType& type) override {
+    FieldMetadata field_meta;
+    std::shared_ptr<Buffer> null_bitmap, offsets;
+
+    RETURN_NOT_OK(LoadCommon(&field_meta, &null_bitmap));
+    if (field_meta.length > 0) {
+      RETURN_NOT_OK(GetBuffer(context_->buffer_index, &offsets));
+    } else {
+      offsets = nullptr;
+    }
+    ++context_->buffer_index;
+
+    const int num_children = type.num_children();
+    if (num_children != 1) {
+      std::stringstream ss;
+      ss << "Wrong number of children: " << num_children;
+      return Status::Invalid(ss.str());
+    }
+    std::shared_ptr<Array> values_array;
+
+    RETURN_NOT_OK(LoadChild(*type.child(0).get(), &values_array));
+
+    result_ = std::make_shared<ListArray>(type_, field_meta.length, offsets, values_array,
+        null_bitmap, field_meta.null_count);
+    return Status::OK();
+  }
+
+  Status Visit(const StructType& type) override {
+    FieldMetadata field_meta;
+    std::shared_ptr<Buffer> null_bitmap;
+    RETURN_NOT_OK(LoadCommon(&field_meta, &null_bitmap));
+
+    std::vector<std::shared_ptr<Array>> fields;
+    RETURN_NOT_OK(LoadChildren(type.children(), &fields));
+
+    result_ = std::make_shared<StructArray>(
+        type_, field_meta.length, fields, null_bitmap, field_meta.null_count);
+    return Status::OK();
+  }
+
+  Status Visit(const UnionType& type) override {
+    FieldMetadata field_meta;
+    std::shared_ptr<Buffer> null_bitmap, type_ids, offsets;
+
+    RETURN_NOT_OK(LoadCommon(&field_meta, &null_bitmap));
+    if (field_meta.length > 0) {
+      RETURN_NOT_OK(GetBuffer(context_->buffer_index, &type_ids));
+      if (type.mode == UnionMode::DENSE) {
+        RETURN_NOT_OK(GetBuffer(context_->buffer_index + 1, &offsets));
+      }
+    }
+    context_->buffer_index += type.mode == UnionMode::DENSE ? 2 : 1;
+
+    std::vector<std::shared_ptr<Array>> fields;
+    RETURN_NOT_OK(LoadChildren(type.children(), &fields));
+
+    result_ = std::make_shared<UnionArray>(type_, field_meta.length, fields, type_ids,
+        offsets, null_bitmap, field_meta.null_count);
+    return Status::OK();
+  }
+
+  Status Visit(const DictionaryType& type) override {
+    std::shared_ptr<Array> indices;
+    RETURN_NOT_OK(LoadArray(type.index_type(), context_, &indices));
+    result_ = std::make_shared<DictionaryArray>(type_, indices);
+    return Status::OK();
+  };
+
+  std::shared_ptr<Array> result() const { return result_; }
+
+ private:
+  const std::shared_ptr<DataType> type_;
+  ArrayLoaderContext* context_;
+
+  // Used in visitor pattern
+  std::shared_ptr<Array> result_;
+};
+
+Status ARROW_EXPORT LoadArray(const std::shared_ptr<DataType>& type,
+    ArrayComponentSource* source, std::shared_ptr<Array>* out) {
+  ArrayLoaderContext context;
+  context.source = source;
+  context.field_index = context.buffer_index = 0;
+  context.max_recursion_depth = kMaxNestingDepth;
+  return LoadArray(type, &context, out);
+}
+
+Status ARROW_EXPORT LoadArray(const std::shared_ptr<DataType>& type,
+    ArrayLoaderContext* context, std::shared_ptr<Array>* out) {
+  ArrayLoader loader(type, context);
+  RETURN_NOT_OK(loader.Load(out));
+
+  return Status::OK();
+}
+
+class InMemorySource : public ArrayComponentSource {
+ public:
+  InMemorySource(const std::vector<FieldMetadata>& fields,
+      const std::vector<std::shared_ptr<Buffer>>& buffers)
+      : fields_(fields), buffers_(buffers) {}
+
+  Status GetBuffer(int buffer_index, std::shared_ptr<Buffer>* out) {
+    DCHECK(buffer_index < static_cast<int>(buffers_.size()));
+    *out = buffers_[buffer_index];
+    return Status::OK();
+  }
+
+  Status GetFieldMetadata(int field_index, FieldMetadata* metadata) {
+    DCHECK(field_index < static_cast<int>(fields_.size()));
+    *metadata = fields_[field_index];
+    return Status::OK();
+  }
+
+ private:
+  const std::vector<FieldMetadata>& fields_;
+  const std::vector<std::shared_ptr<Buffer>>& buffers_;
+};
+
+Status ARROW_EXPORT LoadArray(const std::shared_ptr<DataType>& type,
+    const std::vector<FieldMetadata>& fields,
+    const std::vector<std::shared_ptr<Buffer>>& buffers, std::shared_ptr<Array>* out) {
+  InMemorySource source(fields, buffers);
+  return LoadArray(type, &source, out);
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/loader.h
+++ b/cpp/src/arrow/loader.h
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Function for constructing Array array objects from metadata and raw memory
+// buffers
+
+#ifndef ARROW_LOADER_H
+#define ARROW_LOADER_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/status.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class Array;
+class Buffer;
+struct DataType;
+
+// ARROW-109: We set this number arbitrarily to help catch user mistakes. For
+// deeply nested schemas, it is expected the user will indicate explicitly the
+// maximum allowed recursion depth
+constexpr int kMaxNestingDepth = 64;
+
+struct ARROW_EXPORT FieldMetadata {
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+};
+
+/// Implement this to create new types of Arrow data loaders
+class ARROW_EXPORT ArrayComponentSource {
+ public:
+  virtual ~ArrayComponentSource() = default;
+
+  virtual Status GetBuffer(int buffer_index, std::shared_ptr<Buffer>* out) = 0;
+  virtual Status GetFieldMetadata(int field_index, FieldMetadata* metadata) = 0;
+};
+
+/// Bookkeeping struct for loading array objects from their constituent pieces of raw data
+///
+/// The field_index and buffer_index are incremented in the ArrayLoader
+/// based on how much of the batch is "consumed" (through nested data
+/// reconstruction, for example)
+struct ArrayLoaderContext {
+  ArrayComponentSource* source;
+  int buffer_index;
+  int field_index;
+  int max_recursion_depth;
+};
+
+/// Construct an Array container from type metadata and a collection of memory
+/// buffers
+///
+/// \param[in] field the data type of the array being loaded
+/// \param[in] source an implementation of ArrayComponentSource
+/// \param[out] out the constructed array
+/// \return Status indicating success or failure
+Status ARROW_EXPORT LoadArray(const std::shared_ptr<DataType>& type,
+    ArrayComponentSource* source, std::shared_ptr<Array>* out);
+
+Status ARROW_EXPORT LoadArray(const std::shared_ptr<DataType>& field,
+    ArrayLoaderContext* context, std::shared_ptr<Array>* out);
+
+Status ARROW_EXPORT LoadArray(const std::shared_ptr<DataType>& type,
+    const std::vector<FieldMetadata>& fields,
+    const std::vector<std::shared_ptr<Buffer>>& buffers, std::shared_ptr<Array>* out);
+
+}  // namespace arrow
+
+#endif  // ARROW_LOADER_H

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -145,9 +145,11 @@ class ArrayPrinter : public ArrayVisitor {
 
   Status Visit(const BinaryArray& array) override { return WriteVarBytes(array); }
 
-  Status Visit(const DateArray& array) override { return Status::NotImplemented("date"); }
+  Status Visit(const DateArray& array) override { return WritePrimitive(array); }
 
-  Status Visit(const TimeArray& array) override { return Status::NotImplemented("time"); }
+  Status Visit(const Date32Array& array) override { return WritePrimitive(array); }
+
+  Status Visit(const TimeArray& array) override { return WritePrimitive(array); }
 
   Status Visit(const TimestampArray& array) override {
     return Status::NotImplemented("timestamp");

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -106,6 +106,10 @@ std::string DateType::ToString() const {
   return std::string("date");
 }
 
+std::string Date32Type::ToString() const {
+  return std::string("date32");
+}
+
 // ----------------------------------------------------------------------
 // Union type
 
@@ -135,11 +139,12 @@ std::string UnionType::ToString() const {
 // ----------------------------------------------------------------------
 // DictionaryType
 
-DictionaryType::DictionaryType(
-    const std::shared_ptr<DataType>& index_type, const std::shared_ptr<Array>& dictionary)
+DictionaryType::DictionaryType(const std::shared_ptr<DataType>& index_type,
+    const std::shared_ptr<Array>& dictionary, bool ordered)
     : FixedWidthType(Type::DICTIONARY),
       index_type_(index_type),
-      dictionary_(dictionary) {}
+      dictionary_(dictionary),
+      ordered_(ordered) {}
 
 int DictionaryType::bit_width() const {
   return static_cast<const FixedWidthType*>(index_type_.get())->bit_width();
@@ -178,6 +183,7 @@ ACCEPT_VISITOR(StructType);
 ACCEPT_VISITOR(DecimalType);
 ACCEPT_VISITOR(UnionType);
 ACCEPT_VISITOR(DateType);
+ACCEPT_VISITOR(Date32Type);
 ACCEPT_VISITOR(TimeType);
 ACCEPT_VISITOR(TimestampType);
 ACCEPT_VISITOR(IntervalType);
@@ -205,9 +211,14 @@ TYPE_FACTORY(float64, DoubleType);
 TYPE_FACTORY(utf8, StringType);
 TYPE_FACTORY(binary, BinaryType);
 TYPE_FACTORY(date, DateType);
+TYPE_FACTORY(date32, Date32Type);
 
 std::shared_ptr<DataType> timestamp(TimeUnit unit) {
   return std::make_shared<TimestampType>(unit);
+}
+
+std::shared_ptr<DataType> timestamp(const std::string& timezone, TimeUnit unit) {
+  return std::make_shared<TimestampType>(timezone, unit);
 }
 
 std::shared_ptr<DataType> time(TimeUnit unit) {
@@ -313,6 +324,7 @@ TYPE_VISITOR_DEFAULT(DoubleType);
 TYPE_VISITOR_DEFAULT(StringType);
 TYPE_VISITOR_DEFAULT(BinaryType);
 TYPE_VISITOR_DEFAULT(DateType);
+TYPE_VISITOR_DEFAULT(Date32Type);
 TYPE_VISITOR_DEFAULT(TimeType);
 TYPE_VISITOR_DEFAULT(TimestampType);
 TYPE_VISITOR_DEFAULT(IntervalType);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -54,9 +54,7 @@ bool DataType::Equals(const DataType& other) const {
 }
 
 bool DataType::Equals(const std::shared_ptr<DataType>& other) const {
-  if (!other) {
-    return false;
-  }
+  if (!other) { return false; }
   return Equals(*other.get());
 }
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -95,6 +95,10 @@ struct DateType;
 using DateArray = NumericArray<DateType>;
 using DateBuilder = NumericBuilder<DateType>;
 
+struct Date32Type;
+using Date32Array = NumericArray<Date32Type>;
+using Date32Builder = NumericBuilder<Date32Type>;
+
 struct TimeType;
 using TimeArray = NumericArray<TimeType>;
 using TimeBuilder = NumericBuilder<TimeType>;
@@ -125,6 +129,7 @@ std::shared_ptr<DataType> ARROW_EXPORT float64();
 std::shared_ptr<DataType> ARROW_EXPORT utf8();
 std::shared_ptr<DataType> ARROW_EXPORT binary();
 std::shared_ptr<DataType> ARROW_EXPORT date();
+std::shared_ptr<DataType> ARROW_EXPORT date32();
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -135,7 +135,7 @@ struct TypeTraits<Date32Type> {
   using ArrayType = Date32Array;
   using BuilderType = Date32Builder;
 
-  static inline int64_t bytes_required(int32_t elements) {
+  static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = true;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -131,6 +131,18 @@ struct TypeTraits<DateType> {
 };
 
 template <>
+struct TypeTraits<Date32Type> {
+  using ArrayType = Date32Array;
+  using BuilderType = Date32Builder;
+
+  static inline int64_t bytes_required(int32_t elements) {
+    return elements * sizeof(int32_t);
+  }
+  constexpr static bool is_parameter_free = true;
+  static inline std::shared_ptr<DataType> type_singleton() { return date32(); }
+};
+
+template <>
 struct TypeTraits<TimestampType> {
   using ArrayType = TimestampArray;
   // using BuilderType = TimestampBuilder;

--- a/python/pyarrow/table.pyx
+++ b/python/pyarrow/table.pyx
@@ -359,7 +359,8 @@ cdef class RecordBatch:
         """
         Number of rows
 
-        Due to the definition of a RecordBatch, all columns have the same number of rows.
+        Due to the definition of a RecordBatch, all columns have the same
+        number of rows.
 
         Returns
         -------

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -81,7 +81,11 @@ class TestPandasConversion(unittest.TestCase):
         arr = A.Array.from_pandas(values, timestamps_to_ms=timestamps_to_ms,
                                   field=field)
         result = arr.to_pandas()
-        tm.assert_series_equal(pd.Series(result), pd.Series(values), check_names=False)
+
+        assert arr.null_count == pd.isnull(values).sum()
+
+        tm.assert_series_equal(pd.Series(result), pd.Series(values),
+                               check_names=False)
 
     def test_float_no_nulls(self):
         data = {}


### PR DESCRIPTION
These are various changes introduced to support the Feather merge in ARROW-452 #361 