### PR TITLE
ARROW-611: [Java] Changed TypeLayout for Time type to be 32 bit width

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/schema/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/schema/TypeLayout.java
@@ -164,7 +164,7 @@ public class TypeLayout {
 
       @Override
       public TypeLayout visit(Time type) {
-        return newFixedWidthTypeLayout(dataVector(64));
+        return newFixedWidthTypeLayout(dataVector(32));
       }
 
       @Override


### PR DESCRIPTION
TimeVector schema had the TypeLayout incorrectly set to 64-bits when the Vector is composed of 32-bit values.