### PR TITLE
ARROW-612: [Java] Added not null to Field.toString output

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
@@ -185,6 +185,9 @@ public class Field {
     if (!children.isEmpty()) {
       sb.append("<").append(Joiner.on(", ").join(children)).append(">");
     }
+    if (!nullable) {
+      sb.append(" not null");
+    }
     return sb.toString();
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
@@ -53,7 +53,7 @@ public class TestSchema {
         ));
     roundTrip(schema);
     assertEquals(
-        "Schema<a: Int(8, true), b: Struct<c: Int(16, true), d: Utf8>, e: List<Date>, f: FloatingPoint(SINGLE), g: Timestamp(MILLISECOND), h: Interval(DAY_TIME)>",
+        "Schema<a: Int(8, true) not null, b: Struct<c: Int(16, true), d: Utf8>, e: List<Date>, f: FloatingPoint(SINGLE), g: Timestamp(MILLISECOND), h: Interval(DAY_TIME)>",
         schema.toString());
   }
 


### PR DESCRIPTION
Changed `Field.toString` method to include an additional `not null` description only if the nullable flag is not set.  Changed test to update expected string output.