### PR TITLE
ARROW-598: [Python]  Add support for converting pyarrow.Buffer to a memoryview with zero copy

### DIFF
--- a/python/pyarrow/io.pxd
+++ b/python/pyarrow/io.pxd
@@ -25,6 +25,8 @@ from pyarrow.includes.libarrow_io cimport (ReadableFileInterface,
 cdef class Buffer:
     cdef:
         shared_ptr[CBuffer] buffer
+        Py_ssize_t shape[1]
+        Py_ssize_t strides[1]
 
     cdef init(self, const shared_ptr[CBuffer]& buffer)
 

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -459,13 +459,11 @@ cdef class Buffer:
         buffer.itemsize = 1
         buffer.len = self.size
         buffer.ndim = 1
+        buffer.obj = self
         buffer.readonly = 1
         buffer.shape = self.shape
         buffer.strides = self.strides
         buffer.suboffsets = NULL
-
-    def __releasebuffer__(self, cp.Py_buffer* buffer):
-        pass
 
 cdef shared_ptr[PoolBuffer] allocate_buffer(CMemoryPool* pool):
     cdef shared_ptr[PoolBuffer] result

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -459,7 +459,7 @@ cdef class Buffer:
         buffer.itemsize = 1
         buffer.len = self.size
         buffer.ndim = 1
-        buffer.readonly = 0
+        buffer.readonly = 1
         buffer.shape = self.shape
         buffer.strides = self.strides
         buffer.suboffsets = NULL

--- a/python/pyarrow/io.pyx
+++ b/python/pyarrow/io.pyx
@@ -39,7 +39,6 @@ from pyarrow.table cimport (RecordBatch, batch_from_cbatch,
                             table_from_ctable)
 
 cimport cpython as cp
-from cpython cimport Py_buffer
 
 import re
 import six
@@ -421,6 +420,8 @@ cdef class Buffer:
 
     cdef init(self, const shared_ptr[CBuffer]& buffer):
         self.buffer = buffer
+        self.shape[0] = self.size
+        self.strides[0] = <Py_ssize_t>(1)
 
     def __len__(self):
         return self.size
@@ -450,8 +451,6 @@ cdef class Buffer:
             self.buffer.get().size())
 
     def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
-        self.shape[0] = self.size
-        self.strides[0] = <Py_ssize_t>(1)
 
         buffer.buf = <char *>self.buffer.get().data()
         buffer.format = 'b'

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -135,6 +135,16 @@ def test_buffer_bytes():
 
     assert result == val
 
+def test_buffer_memoryview_bytes():
+    val = b'some data'
+
+    buf = io.buffer_from_bytes(val)
+    assert isinstance(buf, io.Buffer)
+
+    result = buf.to_memoryview().tobytes()
+
+    assert result == val
+
 
 def test_memory_output_stream():
     # 10 bytes
@@ -150,6 +160,7 @@ def test_memory_output_stream():
 
     assert len(buf) == len(val) * K
     assert buf.to_pybytes() == val * K
+    assert buf.to_memoryview().tobytes() == val * K
 
 
 def test_inmemory_write_after_closed():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -141,7 +141,7 @@ def test_buffer_memoryview_bytes():
     buf = io.buffer_from_bytes(val)
     assert isinstance(buf, io.Buffer)
 
-    result = buf.to_memoryview().tobytes()
+    result = memoryview(buf)
 
     assert result == val
 
@@ -160,7 +160,6 @@ def test_memory_output_stream():
 
     assert len(buf) == len(val) * K
     assert buf.to_pybytes() == val * K
-    assert buf.to_memoryview().tobytes() == val * K
 
 
 def test_inmemory_write_after_closed():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -135,7 +135,7 @@ def test_buffer_bytes():
 
     assert result == val
 
-def test_buffer_memoryview_bytes():
+def test_buffer_memoryview():
     val = b'some data'
 
     buf = io.buffer_from_bytes(val)
@@ -144,6 +144,20 @@ def test_buffer_memoryview_bytes():
     result = memoryview(buf)
 
     assert result == val
+
+
+def test_buffer_memoryview_is_immutable():
+    val = b'some data'
+
+    buf = io.buffer_from_bytes(val)
+    assert isinstance(buf, io.Buffer)
+
+    result = memoryview(buf)
+
+    assert result[:4] == b'some'
+    with pytest.raises(TypeError) as exc:
+        result[0] = b'h'
+        assert 'cannot modify read-only' in str(exc.value)
 
 
 def test_memory_output_stream():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -196,13 +196,13 @@ def test_buffer_protocol_ref_counting():
     as_bytes = bytes(buf)
 
     def add_temporary_reference(buf):
-        m = memoryview(buf)
+        m = bytearray(buf)
         del(buf)
         gc.collect()
         assert m == val
 
     add_temporary_reference(buf)
-    m = memoryview(as_bytes)
+    m = bytearray(buf)
     assert m == val
 
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -195,14 +195,13 @@ def test_buffer_protocol_ref_counting():
     buf = io.buffer_from_bytes(val)
     as_bytes = bytes(buf)
 
-    def add_temporary_reference():
-        nonlocal buf
+    def add_temporary_reference(buf):
         m = memoryview(buf)
         del(buf)
         gc.collect()
         assert m == val
 
-    add_temporary_reference()
+    add_temporary_reference(buf)
     m = memoryview(as_bytes)
     assert m == val
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -191,19 +191,12 @@ def test_inmemory_write_after_closed():
 def test_buffer_protocol_ref_counting():
     import gc
 
-    val = b'data'
-    buf = io.buffer_from_bytes(val)
-    as_bytes = bytes(buf)
+    def make_buffer(bytes_obj):
+        return bytearray(io.buffer_from_bytes(bytes_obj))
 
-    def add_temporary_reference(buf):
-        m = bytearray(buf)
-        del(buf)
-        gc.collect()
-        assert m == val
-
-    add_temporary_reference(buf)
-    m = bytearray(buf)
-    assert m == val
+    buf = make_buffer(b'foo')
+    gc.collect()
+    assert buf == b'foo'
 
 
 


### PR DESCRIPTION
WIP, as tests are not all done and I'm assuming we'll need to keep a reference to the underlying buffer so it doesn't get gc'ed.