### PR TITLE
ARROW-615: [Java] Moved ByteArrayReadableSeekableByteChannel to src main o.a.a.vector.util

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ByteArrayReadableSeekableByteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ByteArrayReadableSeekableByteChannel.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.arrow.vector.file;
+package org.apache.arrow.vector.util;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowReaderWriter.java
@@ -39,6 +39,7 @@ import org.apache.arrow.vector.schema.ArrowRecordBatch;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
The ByteArrayReadableSeekableByteChannel is useful when reading an ArrowRecordBatch from a byte array with ArrowReader. Currently it is vector.file test package, this change moves the class to src/main/java/o.a.a.vector.util.  Updated test usage.