### PR TITLE
ARROW-623: Fix segfault in __repr__ of empty field

### DIFF
--- a/python/pyarrow/schema.pyx
+++ b/python/pyarrow/schema.pyx
@@ -111,6 +111,9 @@ cdef class Field:
     property name:
 
         def __get__(self):
+            if box_field(self.sp_field) is None:
+                raise ReferenceError(
+                    'Field not initialized (references NULL pointer)')
             return frombytes(self.field.name)
 
 

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -87,3 +87,10 @@ baz: list<item: int8>"""
         del fields[-1]
         sch3 = A.schema(fields)
         assert not sch1.equals(sch3)
+
+
+class TestField(unittest.TestCase):
+    def test_empty_field(self):
+        f = arrow.Field()
+        with self.assertRaises(ReferenceError):
+            repr(f)


### PR DESCRIPTION
Small fix for not segfaulting when printing an empty field.