### PR TITLE
ARROW-491: [Format / C++] Add FixedWidthBinary type to format, C++ implementation

### DIFF
--- a/cpp/src/arrow/array-list-test.cc
+++ b/cpp/src/arrow/array-list-test.cc
@@ -36,26 +36,6 @@ using std::vector;
 
 namespace arrow {
 
-TEST(TypesTest, TestListType) {
-  std::shared_ptr<DataType> vt = std::make_shared<UInt8Type>();
-
-  ListType list_type(vt);
-  ASSERT_EQ(list_type.type, Type::LIST);
-
-  ASSERT_EQ(list_type.name(), string("list"));
-  ASSERT_EQ(list_type.ToString(), string("list<item: uint8>"));
-
-  ASSERT_EQ(list_type.value_type()->type, vt->type);
-  ASSERT_EQ(list_type.value_type()->type, vt->type);
-
-  std::shared_ptr<DataType> st = std::make_shared<StringType>();
-  std::shared_ptr<DataType> lt = std::make_shared<ListType>(st);
-  ASSERT_EQ(lt->ToString(), string("list<item: string>"));
-
-  ListType lt2(lt);
-  ASSERT_EQ(lt2.ToString(), string("list<item: list<item: string>>"));
-}
-
 // ----------------------------------------------------------------------
 // List tests
 

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -33,22 +33,6 @@ namespace arrow {
 
 class Buffer;
 
-TEST(TypesTest, BinaryType) {
-  BinaryType t1;
-  BinaryType e1;
-  StringType t2;
-  EXPECT_TRUE(t1.Equals(e1));
-  EXPECT_FALSE(t1.Equals(t2));
-  ASSERT_EQ(t1.type, Type::BINARY);
-  ASSERT_EQ(t1.ToString(), std::string("binary"));
-}
-
-TEST(TypesTest, TestStringType) {
-  StringType str;
-  ASSERT_EQ(str.type, Type::STRING);
-  ASSERT_EQ(str.ToString(), std::string("string"));
-}
-
 // ----------------------------------------------------------------------
 // String container
 

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -458,4 +458,7 @@ TEST_F(TestBinaryArray, LengthZeroCtor) {
   BinaryArray array(0, nullptr, nullptr);
 }
 
+// ----------------------------------------------------------------------
+// FixedWidthBinary tests
+
 }  // namespace arrow

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -586,6 +586,12 @@ TEST_F(TestFWBinaryArray, ZeroSize) {
   std::shared_ptr<Array> array;
   ASSERT_OK(builder.Finish(&array));
 
+  const auto& fw_array = static_cast<const FixedWidthBinaryArray&>(*array);
+
+  // data is never allocated
+  ASSERT_TRUE(fw_array.data() == nullptr);
+  ASSERT_EQ(0, fw_array.byte_width());
+
   ASSERT_EQ(6, array->length());
   ASSERT_EQ(3, array->null_count());
 }

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -286,9 +286,7 @@ FixedWidthBinaryArray::FixedWidthBinaryArray(const std::shared_ptr<DataType>& ty
       raw_data_(nullptr) {
   DCHECK(type->type == Type::FIXED_WIDTH_BINARY);
   byte_width_ = static_cast<const FixedWidthBinaryType&>(*type).byte_width();
-  if (data) {
-    raw_data_ = data->data();
-  }
+  if (data) { raw_data_ = data->data(); }
 }
 
 std::shared_ptr<Array> FixedWidthBinaryArray::Slice(

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -128,10 +128,6 @@ std::shared_ptr<Array> NullArray::Slice(int64_t offset, int64_t length) const {
   return std::make_shared<NullArray>(length);
 }
 
-Status NullArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 // ----------------------------------------------------------------------
 // Primitive array base
 
@@ -144,32 +140,11 @@ PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t le
 }
 
 template <typename T>
-Status NumericArray<T>::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
-template <typename T>
 std::shared_ptr<Array> NumericArray<T>::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
   return std::make_shared<NumericArray<T>>(
       type_, length, data_, null_bitmap_, kUnknownNullCount, offset);
 }
-
-template class NumericArray<UInt8Type>;
-template class NumericArray<UInt16Type>;
-template class NumericArray<UInt32Type>;
-template class NumericArray<UInt64Type>;
-template class NumericArray<Int8Type>;
-template class NumericArray<Int16Type>;
-template class NumericArray<Int32Type>;
-template class NumericArray<Int64Type>;
-template class NumericArray<TimestampType>;
-template class NumericArray<DateType>;
-template class NumericArray<Date32Type>;
-template class NumericArray<TimeType>;
-template class NumericArray<HalfFloatType>;
-template class NumericArray<FloatType>;
-template class NumericArray<DoubleType>;
 
 // ----------------------------------------------------------------------
 // BooleanArray
@@ -178,10 +153,6 @@ BooleanArray::BooleanArray(int64_t length, const std::shared_ptr<Buffer>& data,
     const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count, int64_t offset)
     : PrimitiveArray(std::make_shared<BooleanType>(), length, data, null_bitmap,
           null_count, offset) {}
-
-Status BooleanArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
 
 std::shared_ptr<Array> BooleanArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
@@ -244,10 +215,6 @@ Status ListArray::Validate() const {
   return Status::OK();
 }
 
-Status ListArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 std::shared_ptr<Array> ListArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
   return std::make_shared<ListArray>(
@@ -285,10 +252,6 @@ Status BinaryArray::Validate() const {
   return Status::OK();
 }
 
-Status BinaryArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 std::shared_ptr<Array> BinaryArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
   return std::make_shared<BinaryArray>(
@@ -306,14 +269,33 @@ Status StringArray::Validate() const {
   return BinaryArray::Validate();
 }
 
-Status StringArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 std::shared_ptr<Array> StringArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
   return std::make_shared<StringArray>(
       length, value_offsets_, data_, null_bitmap_, kUnknownNullCount, offset);
+}
+
+// ----------------------------------------------------------------------
+// Fixed width binary
+
+FixedWidthBinaryArray::FixedWidthBinaryArray(const std::shared_ptr<DataType>& type,
+    int64_t length, const std::shared_ptr<Buffer>& data,
+    const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count, int64_t offset)
+    : Array(type, length, null_bitmap, null_count, offset),
+      data_(data),
+      raw_data_(nullptr) {
+  DCHECK(type->type == Type::FIXED_WIDTH_BINARY);
+  byte_width_ = static_cast<const FixedWidthBinaryType&>(*type).byte_width();
+  if (data) {
+    raw_data_ = data->data();
+  }
+}
+
+std::shared_ptr<Array> FixedWidthBinaryArray::Slice(
+    int64_t offset, int64_t length) const {
+  ConformSliceParams(offset_, length_, &offset, &length);
+  return std::make_shared<FixedWidthBinaryArray>(
+      type_, length, data_, null_bitmap_, kUnknownNullCount, offset);
 }
 
 // ----------------------------------------------------------------------
@@ -368,10 +350,6 @@ Status StructArray::Validate() const {
   return Status::OK();
 }
 
-Status StructArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 std::shared_ptr<Array> StructArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
   return std::make_shared<StructArray>(
@@ -413,10 +391,6 @@ Status UnionArray::Validate() const {
   return Status::OK();
 }
 
-Status UnionArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 std::shared_ptr<Array> UnionArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);
   return std::make_shared<UnionArray>(type_, length, children_, type_ids_, value_offsets_,
@@ -447,17 +421,54 @@ std::shared_ptr<Array> DictionaryArray::dictionary() const {
   return dict_type_->dictionary();
 }
 
-Status DictionaryArray::Accept(ArrayVisitor* visitor) const {
-  return visitor->Visit(*this);
-}
-
 std::shared_ptr<Array> DictionaryArray::Slice(int64_t offset, int64_t length) const {
   std::shared_ptr<Array> sliced_indices = indices_->Slice(offset, length);
   return std::make_shared<DictionaryArray>(type_, sliced_indices);
 }
 
 // ----------------------------------------------------------------------
-// Default implementations of ArrayVisitor methods
+// Implement ArrayVisitor methods
+
+Status NullArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status BooleanArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+template <typename T>
+Status NumericArray<T>::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status BinaryArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status StringArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status FixedWidthBinaryArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status ListArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status StructArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status UnionArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
+
+Status DictionaryArray::Accept(ArrayVisitor* visitor) const {
+  return visitor->Visit(*this);
+}
 
 #define ARRAY_VISITOR_DEFAULT(ARRAY_CLASS)                   \
   Status ArrayVisitor::Visit(const ARRAY_CLASS& array) {     \
@@ -477,8 +488,9 @@ ARRAY_VISITOR_DEFAULT(UInt64Array);
 ARRAY_VISITOR_DEFAULT(HalfFloatArray);
 ARRAY_VISITOR_DEFAULT(FloatArray);
 ARRAY_VISITOR_DEFAULT(DoubleArray);
-ARRAY_VISITOR_DEFAULT(StringArray);
 ARRAY_VISITOR_DEFAULT(BinaryArray);
+ARRAY_VISITOR_DEFAULT(StringArray);
+ARRAY_VISITOR_DEFAULT(FixedWidthBinaryArray);
 ARRAY_VISITOR_DEFAULT(DateArray);
 ARRAY_VISITOR_DEFAULT(Date32Array);
 ARRAY_VISITOR_DEFAULT(TimeArray);
@@ -492,5 +504,24 @@ ARRAY_VISITOR_DEFAULT(DictionaryArray);
 Status ArrayVisitor::Visit(const DecimalArray& array) {
   return Status::NotImplemented("decimal");
 }
+
+// ----------------------------------------------------------------------
+// Instantiate templates
+
+template class NumericArray<UInt8Type>;
+template class NumericArray<UInt16Type>;
+template class NumericArray<UInt32Type>;
+template class NumericArray<UInt64Type>;
+template class NumericArray<Int8Type>;
+template class NumericArray<Int16Type>;
+template class NumericArray<Int32Type>;
+template class NumericArray<Int64Type>;
+template class NumericArray<TimestampType>;
+template class NumericArray<DateType>;
+template class NumericArray<Date32Type>;
+template class NumericArray<TimeType>;
+template class NumericArray<HalfFloatType>;
+template class NumericArray<FloatType>;
+template class NumericArray<DoubleType>;
 
 }  // namespace arrow

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -57,6 +57,7 @@ class ARROW_EXPORT ArrayVisitor {
   virtual Status Visit(const DoubleArray& array);
   virtual Status Visit(const StringArray& array);
   virtual Status Visit(const BinaryArray& array);
+  virtual Status Visit(const FixedWidthBinaryArray& array);
   virtual Status Visit(const DateArray& array);
   virtual Status Visit(const Date32Array& array);
   virtual Status Visit(const TimeArray& array);
@@ -384,6 +385,37 @@ class ARROW_EXPORT StringArray : public BinaryArray {
   Status Accept(ArrayVisitor* visitor) const override;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
+};
+
+// ----------------------------------------------------------------------
+// Fixed width binary
+
+class ARROW_EXPORT FixedWidthBinaryArray : public Array {
+ public:
+  using TypeClass = FixedWidthBinaryType;
+
+  FixedWidthBinaryArray(const std::shared_ptr<DataType>& type, int64_t length,
+      const std::shared_ptr<Buffer>& data,
+      const std::shared_ptr<Buffer>& null_bitmap = nullptr, int64_t null_count = 0,
+      int64_t offset = 0);
+
+  const uint8_t* GetValue(int64_t i) const {
+    return raw_data_ + (i + offset_) * byte_width_;
+  }
+
+  /// Note that this buffer does not account for any slice offset
+  std::shared_ptr<Buffer> data() const { return data_; }
+
+  int32_t byte_width() const { return byte_width_; }
+
+  Status Accept(ArrayVisitor* visitor) const override;
+
+  std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
+
+ protected:
+  int32_t byte_width_;
+  std::shared_ptr<Buffer> data_;
+  const uint8_t* raw_data_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -408,6 +408,8 @@ class ARROW_EXPORT FixedWidthBinaryArray : public Array {
 
   int32_t byte_width() const { return byte_width_; }
 
+  const uint8_t* raw_data() const { return raw_data_; }
+
   Status Accept(ArrayVisitor* visitor) const override;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -170,6 +170,14 @@ class ARROW_EXPORT BufferBuilder {
     return Status::OK();
   }
 
+  // Advance pointer and zero out memory
+  Status Advance(int64_t length) {
+    if (capacity_ < length + size_) { RETURN_NOT_OK(Resize(length + size_)); }
+    memset(data_ + size_, 0, static_cast<size_t>(length));
+    size_ += length;
+    return Status::OK();
+  }
+
   template <typename T>
   Status Append(T arithmetic_value) {
     static_assert(std::is_arithmetic<T>::value,

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -157,6 +157,8 @@ class ARROW_EXPORT BufferBuilder {
 
   /// Resizes the buffer to the nearest multiple of 64 bytes per Layout.md
   Status Resize(int64_t elements) {
+    // Resize(0) is a no-op
+    if (elements == 0) { return Status::OK(); }
     if (capacity_ == 0) { buffer_ = std::make_shared<PoolBuffer>(pool_); }
     RETURN_NOT_OK(buffer_->Resize(elements));
     capacity_ = buffer_->capacity();

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -450,14 +450,14 @@ Status FixedWidthBinaryBuilder::Append(const uint8_t* value) {
 }
 
 Status FixedWidthBinaryBuilder::Append(
-    const uint8_t* data, int32_t length, const uint8_t* valid_bytes) {
+    const uint8_t* data, int64_t length, const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
   UnsafeAppendToBitmap(valid_bytes, length);
   return byte_builder_.Append(data, length * byte_width_);
 }
 
 Status FixedWidthBinaryBuilder::Append(const std::string& value) {
-  return Append(value.c_str());
+  return Append(reinterpret_cast<const uint8_t*>(value.c_str()));
 }
 
 Status FixedWidthBinaryBuilder::AppendNull() {
@@ -468,7 +468,7 @@ Status FixedWidthBinaryBuilder::AppendNull() {
 
 Status FixedWidthBinaryBuilder::Init(int64_t elements) {
   DCHECK_LT(elements, std::numeric_limits<int64_t>::max());
-  RETURN_NOT_OK(FixedWidthBinaryBuilder::Init(elements));
+  RETURN_NOT_OK(ArrayBuilder::Init(elements));
   return byte_builder_.Resize(elements * byte_width_);
 }
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -396,7 +396,7 @@ class ARROW_EXPORT FixedWidthBinaryBuilder : public ArrayBuilder {
 
   Status Append(const uint8_t* value);
   Status Append(
-      const uint8_t* data, int32_t length, const uint8_t* valid_bytes = nullptr);
+      const uint8_t* data, int64_t length, const uint8_t* valid_bytes = nullptr);
   Status Append(const std::string& value);
   Status AppendNull();
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -46,7 +46,7 @@ static constexpr int64_t kMinBuilderCapacity = 1 << 5;
 /// the null count.
 class ARROW_EXPORT ArrayBuilder {
  public:
-  explicit ArrayBuilder(MemoryPool* pool, const TypePtr& type)
+  explicit ArrayBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type)
       : pool_(pool),
         type_(type),
         null_bitmap_(nullptr),
@@ -140,7 +140,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
  public:
   using value_type = typename Type::c_type;
 
-  explicit PrimitiveBuilder(MemoryPool* pool, const TypePtr& type)
+  explicit PrimitiveBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type)
       : ArrayBuilder(pool, type), data_(nullptr), raw_data_(nullptr) {}
 
   using ArrayBuilder::Advance;
@@ -313,11 +313,11 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
   /// Use this constructor to incrementally build the value array along with offsets and
   /// null bitmap.
   ListBuilder(MemoryPool* pool, std::shared_ptr<ArrayBuilder> value_builder,
-      const TypePtr& type = nullptr);
+      const std::shared_ptr<DataType>& type = nullptr);
 
   /// Use this constructor to build the list with a pre-existing values array
-  ListBuilder(
-      MemoryPool* pool, std::shared_ptr<Array> values, const TypePtr& type = nullptr);
+  ListBuilder(MemoryPool* pool, std::shared_ptr<Array> values,
+      const std::shared_ptr<DataType>& type = nullptr);
 
   Status Init(int64_t elements) override;
   Status Resize(int64_t capacity) override;
@@ -328,24 +328,13 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
   /// If passed, valid_bytes is of equal length to values, and any zero byte
   /// will be considered as a null for that slot
   Status Append(
-      const int32_t* offsets, int64_t length, const uint8_t* valid_bytes = nullptr) {
-    RETURN_NOT_OK(Reserve(length));
-    UnsafeAppendToBitmap(valid_bytes, length);
-    offset_builder_.UnsafeAppend<int32_t>(offsets, length);
-    return Status::OK();
-  }
+      const int32_t* offsets, int64_t length, const uint8_t* valid_bytes = nullptr);
 
   /// Start a new variable-length list slot
   ///
   /// This function should be called before beginning to append elements to the
   /// value builder
-  Status Append(bool is_valid = true) {
-    RETURN_NOT_OK(Reserve(1));
-    UnsafeAppendToBitmap(is_valid);
-    RETURN_NOT_OK(
-        offset_builder_.Append<int32_t>(static_cast<int32_t>(value_builder_->length())));
-    return Status::OK();
-  }
+  Status Append(bool is_valid = true);
 
   Status AppendNull() { return Append(false); }
 
@@ -362,11 +351,10 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
 // ----------------------------------------------------------------------
 // Binary and String
 
-// BinaryBuilder : public ListBuilder
 class ARROW_EXPORT BinaryBuilder : public ListBuilder {
  public:
   explicit BinaryBuilder(MemoryPool* pool);
-  explicit BinaryBuilder(MemoryPool* pool, const TypePtr& type);
+  explicit BinaryBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type);
 
   Status Append(const uint8_t* value, int32_t length) {
     RETURN_NOT_OK(ListBuilder::Append());
@@ -397,6 +385,28 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status Finish(std::shared_ptr<Array>* out) override;
 
   Status Append(const std::vector<std::string>& values, uint8_t* null_bytes);
+};
+
+// ----------------------------------------------------------------------
+// FixedWidthBinaryBuilder
+
+class ARROW_EXPORT FixedWidthBinaryBuilder : public ArrayBuilder {
+ public:
+  FixedWidthBinaryBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type);
+
+  Status Append(const uint8_t* value);
+  Status Append(
+      const uint8_t* data, int32_t length, const uint8_t* valid_bytes = nullptr);
+  Status Append(const std::string& value);
+  Status AppendNull();
+
+  Status Init(int64_t elements) override;
+  Status Resize(int64_t capacity) override;
+  Status Finish(std::shared_ptr<Array>* out) override;
+
+ protected:
+  int32_t byte_width_;
+  BufferBuilder byte_builder_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/ipc/adapter.cc
+++ b/cpp/src/arrow/ipc/adapter.cc
@@ -304,6 +304,17 @@ class RecordBatchWriter : public ArrayVisitor {
     return Status::OK();
   }
 
+  Status Visit(const FixedWidthBinaryArray& array) override {
+    auto data = array.data();
+    int32_t width = array.byte_width();
+
+    if (array.offset() != 0) {
+      data = SliceBuffer(data, array.offset() * width, width * array.length());
+    }
+    buffers_.push_back(data);
+    return Status::OK();
+  }
+
   Status Visit(const BooleanArray& array) override {
     buffers_.push_back(array.data());
     return Status::OK();

--- a/cpp/src/arrow/ipc/ipc-adapter-test.cc
+++ b/cpp/src/arrow/ipc/ipc-adapter-test.cc
@@ -175,8 +175,8 @@ INSTANTIATE_TEST_CASE_P(
     RoundTripTests, TestRecordBatchParam,
     ::testing::Values(&MakeIntRecordBatch, &MakeStringTypesRecordBatch,
         &MakeNonNullRecordBatch, &MakeZeroLengthRecordBatch, &MakeListRecordBatch,
-        &MakeDeeplyNestedList, &MakeStruct, &MakeUnion, &MakeDictionary, &MakeDates,
-        &MakeTimestamps, &MakeTimes));
+        &MakeDeeplyNestedList, &MakeStruct, &MakeUnion, &MakeDictionary, &MakeDate,
+        &MakeTimestamps, &MakeTimes, &MakeFWBinary));
 
 void TestGetRecordBatchSize(std::shared_ptr<RecordBatch> batch) {
   ipc::MockOutputStream mock;

--- a/cpp/src/arrow/ipc/ipc-file-test.cc
+++ b/cpp/src/arrow/ipc/ipc-file-test.cc
@@ -43,7 +43,10 @@ namespace arrow {
 namespace ipc {
 
 void CompareBatch(const RecordBatch& left, const RecordBatch& right) {
-  ASSERT_TRUE(left.schema()->Equals(right.schema()));
+  if (!left.schema()->Equals(right.schema())) {
+    FAIL() << "Left schema: " << left.schema()->ToString()
+           << "\nRight schema: " << right.schema()->ToString();
+  }
   ASSERT_EQ(left.num_columns(), right.num_columns())
       << left.schema()->ToString() << " result: " << right.schema()->ToString();
   EXPECT_EQ(left.num_rows(), right.num_rows());
@@ -180,7 +183,8 @@ TEST_P(TestStreamFormat, RoundTrip) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
       &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList, &MakeStringTypesRecordBatch,   \
-      &MakeStruct, &MakeUnion, &MakeDictionary);
+      &MakeStruct, &MakeUnion, &MakeDictionary, &MakeDate, &MakeTimestamps, &MakeTimes, \
+      &MakeFWBinary);
 
 INSTANTIATE_TEST_CASE_P(FileRoundTripTests, TestFileFormat, BATCH_CASES());
 INSTANTIATE_TEST_CASE_P(StreamRoundTripTests, TestStreamFormat, BATCH_CASES());

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -38,8 +38,8 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit-util.h"
-#include "arrow/util/io-util.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
 namespace ipc {

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -38,12 +38,11 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit-util.h"
+#include "arrow/util/io-util.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {
 namespace ipc {
-
-static const char* kAsciiTable = "0123456789ABCDEF";
 
 using RjArray = rj::Value::ConstArray;
 using RjObject = rj::Value::ConstObject;
@@ -401,14 +400,7 @@ class JsonArrayWriter : public ArrayVisitor {
       if (std::is_base_of<StringArray, T>::value) {
         writer_->String(buf, length);
       } else {
-        std::string hex_string;
-        hex_string.reserve(length * 2);
-        for (int32_t j = 0; j < length; ++j) {
-          // Convert to 2 base16 digits
-          hex_string.push_back(kAsciiTable[buf[j] >> 4]);
-          hex_string.push_back(kAsciiTable[buf[j] & 15]);
-        }
-        writer_->String(hex_string);
+        writer_->String(HexEncode(buf, length));
       }
     }
   }
@@ -759,20 +751,6 @@ class JsonSchemaReader {
  private:
   const rj::Value& json_schema_;
 };
-
-static inline Status ParseHexValue(const char* data, uint8_t* out) {
-  char c1 = data[0];
-  char c2 = data[1];
-
-  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
-  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
-
-  // Error checking
-  if (*pos1 != c1 || *pos2 != c2) { return Status::Invalid("Encountered non-hex digit"); }
-
-  *out = static_cast<uint8_t>((pos1 - kAsciiTable) << 4 | (pos2 - kAsciiTable));
-  return Status::OK();
-}
 
 template <typename T>
 inline typename std::enable_if<IsSignedInt<T>::value, typename T::c_type>::type

--- a/cpp/src/arrow/loader.cc
+++ b/cpp/src/arrow/loader.cc
@@ -157,6 +157,18 @@ class ArrayLoader : public TypeVisitor {
 
   Status Visit(const BinaryType& type) override { return LoadBinary<BinaryArray>(); }
 
+  Status Visit(const FixedWidthBinaryType& type) override {
+    FieldMetadata field_meta;
+    std::shared_ptr<Buffer> null_bitmap, data;
+
+    RETURN_NOT_OK(LoadCommon(&field_meta, &null_bitmap));
+    RETURN_NOT_OK(GetBuffer(context_->buffer_index++, &data));
+
+    result_ = std::make_shared<FixedWidthBinaryArray>(
+        type_, field_meta.length, data, null_bitmap, field_meta.null_count);
+    return Status::OK();
+  }
+
   Status Visit(const ListType& type) override {
     FieldMetadata field_meta;
     std::shared_ptr<Buffer> null_bitmap, offsets;

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -56,7 +56,7 @@ void CheckPrimitive(int indent, const std::vector<bool>& is_valid,
     const std::vector<C_TYPE>& values, const char* expected) {
   std::shared_ptr<Array> array;
   ArrayFromVector<TYPE, C_TYPE>(is_valid, values, &array);
-  CheckArray(*array.get(), indent, expected);
+  CheckArray(*array, indent, expected);
 }
 
 TEST_F(TestPrettyPrint, PrimitiveType) {
@@ -69,6 +69,30 @@ TEST_F(TestPrettyPrint, PrimitiveType) {
   std::vector<std::string> values2 = {"foo", "bar", "", "baz", ""};
   static const char* ex2 = R"expected(["foo", "bar", null, "baz", null])expected";
   CheckPrimitive<StringType, std::string>(0, is_valid, values2, ex2);
+}
+
+TEST_F(TestPrettyPrint, BinaryType) {
+  std::vector<bool> is_valid = {true, true, false, true, false};
+  std::vector<std::string> values = {"foo", "bar", "", "baz", ""};
+  static const char* ex = R"expected([666F6F, 626172, null, 62617A, null])expected";
+  CheckPrimitive<BinaryType, std::string>(0, is_valid, values, ex);
+}
+
+TEST_F(TestPrettyPrint, FixedWidthBinaryType) {
+  std::vector<bool> is_valid = {true, true, false, true, false};
+  std::vector<std::string> values = {"foo", "bar", "baz"};
+  static const char* ex = R"expected([666F6F, 626172, 62617A])expected";
+
+  std::shared_ptr<Array> array;
+  auto type = fixed_width_binary(3);
+  FixedWidthBinaryBuilder builder(default_memory_pool(), type);
+
+  builder.Append(values[0]);
+  builder.Append(values[1]);
+  builder.Append(values[2]);
+  builder.Finish(&array);
+
+  CheckArray(*array, 0, ex);
 }
 
 TEST_F(TestPrettyPrint, DictionaryType) {

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -26,7 +26,7 @@
 #include "arrow/table.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/io-util.h"
+#include "arrow/util/string.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -26,6 +26,7 @@
 #include "arrow/table.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/io-util.h"
 
 namespace arrow {
 
@@ -66,9 +67,9 @@ class ArrayPrinter : public ArrayVisitor {
     }
   }
 
-  // String (Utf8), Binary
+  // String (Utf8)
   template <typename T>
-  typename std::enable_if<std::is_base_of<BinaryArray, T>::value, void>::type
+  typename std::enable_if<std::is_same<StringArray, T>::value, void>::type
   WriteDataValues(const T& array) {
     int32_t length;
     for (int i = 0; i < array.length(); ++i) {
@@ -78,6 +79,37 @@ class ArrayPrinter : public ArrayVisitor {
       } else {
         const char* buf = reinterpret_cast<const char*>(array.GetValue(i, &length));
         (*sink_) << "\"" << std::string(buf, length) << "\"";
+      }
+    }
+  }
+
+  // Binary
+  template <typename T>
+  typename std::enable_if<std::is_same<BinaryArray, T>::value, void>::type
+  WriteDataValues(const T& array) {
+    int32_t length;
+    for (int i = 0; i < array.length(); ++i) {
+      if (i > 0) { (*sink_) << ", "; }
+      if (array.IsNull(i)) {
+        Write("null");
+      } else {
+        const char* buf = reinterpret_cast<const char*>(array.GetValue(i, &length));
+        (*sink_) << HexEncode(buf, length);
+      }
+    }
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_same<FixedWidthBinaryArray, T>::value, void>::type
+  WriteDataValues(const T& array) {
+    int32_t width = array.byte_width();
+    for (int i = 0; i < array.length(); ++i) {
+      if (i > 0) { (*sink_) << ", "; }
+      if (array.IsNull(i)) {
+        Write("null");
+      } else {
+        const char* buf = reinterpret_cast<const char*>(array.GetValue(i));
+        (*sink_) << HexEncode(buf, width);
       }
     }
   }
@@ -100,15 +132,7 @@ class ArrayPrinter : public ArrayVisitor {
   void CloseArray() { (*sink_) << "]"; }
 
   template <typename T>
-  Status WritePrimitive(const T& array) {
-    OpenArray();
-    WriteDataValues(array);
-    CloseArray();
-    return Status::OK();
-  }
-
-  template <typename T>
-  Status WriteVarBytes(const T& array) {
+  Status WriteArray(const T& array) {
     OpenArray();
     WriteDataValues(array);
     CloseArray();
@@ -117,39 +141,41 @@ class ArrayPrinter : public ArrayVisitor {
 
   Status Visit(const NullArray& array) override { return Status::OK(); }
 
-  Status Visit(const BooleanArray& array) override { return WritePrimitive(array); }
+  Status Visit(const BooleanArray& array) override { return WriteArray(array); }
 
-  Status Visit(const Int8Array& array) override { return WritePrimitive(array); }
+  Status Visit(const Int8Array& array) override { return WriteArray(array); }
 
-  Status Visit(const Int16Array& array) override { return WritePrimitive(array); }
+  Status Visit(const Int16Array& array) override { return WriteArray(array); }
 
-  Status Visit(const Int32Array& array) override { return WritePrimitive(array); }
+  Status Visit(const Int32Array& array) override { return WriteArray(array); }
 
-  Status Visit(const Int64Array& array) override { return WritePrimitive(array); }
+  Status Visit(const Int64Array& array) override { return WriteArray(array); }
 
-  Status Visit(const UInt8Array& array) override { return WritePrimitive(array); }
+  Status Visit(const UInt8Array& array) override { return WriteArray(array); }
 
-  Status Visit(const UInt16Array& array) override { return WritePrimitive(array); }
+  Status Visit(const UInt16Array& array) override { return WriteArray(array); }
 
-  Status Visit(const UInt32Array& array) override { return WritePrimitive(array); }
+  Status Visit(const UInt32Array& array) override { return WriteArray(array); }
 
-  Status Visit(const UInt64Array& array) override { return WritePrimitive(array); }
+  Status Visit(const UInt64Array& array) override { return WriteArray(array); }
 
-  Status Visit(const HalfFloatArray& array) override { return WritePrimitive(array); }
+  Status Visit(const HalfFloatArray& array) override { return WriteArray(array); }
 
-  Status Visit(const FloatArray& array) override { return WritePrimitive(array); }
+  Status Visit(const FloatArray& array) override { return WriteArray(array); }
 
-  Status Visit(const DoubleArray& array) override { return WritePrimitive(array); }
+  Status Visit(const DoubleArray& array) override { return WriteArray(array); }
 
-  Status Visit(const StringArray& array) override { return WriteVarBytes(array); }
+  Status Visit(const StringArray& array) override { return WriteArray(array); }
 
-  Status Visit(const BinaryArray& array) override { return WriteVarBytes(array); }
+  Status Visit(const BinaryArray& array) override { return WriteArray(array); }
 
-  Status Visit(const DateArray& array) override { return WritePrimitive(array); }
+  Status Visit(const FixedWidthBinaryArray& array) override { return WriteArray(array); }
 
-  Status Visit(const Date32Array& array) override { return WritePrimitive(array); }
+  Status Visit(const DateArray& array) override { return WriteArray(array); }
 
-  Status Visit(const TimeArray& array) override { return WritePrimitive(array); }
+  Status Visit(const Date32Array& array) override { return WriteArray(array); }
+
+  Status Visit(const TimeArray& array) override { return WriteArray(array); }
 
   Status Visit(const TimestampArray& array) override {
     return Status::NotImplemented("timestamp");

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -121,6 +121,48 @@ TEST_F(TestSchema, GetFieldByName) {
   ASSERT_TRUE(result == nullptr);
 }
 
+TEST(TestBinaryType, ToString) {
+  BinaryType t1;
+  BinaryType e1;
+  StringType t2;
+  EXPECT_TRUE(t1.Equals(e1));
+  EXPECT_FALSE(t1.Equals(t2));
+  ASSERT_EQ(t1.type, Type::BINARY);
+  ASSERT_EQ(t1.ToString(), std::string("binary"));
+}
+
+TEST(TestStringType, ToString) {
+  StringType str;
+  ASSERT_EQ(str.type, Type::STRING);
+  ASSERT_EQ(str.ToString(), std::string("string"));
+}
+
+TEST(TestFixedWidthBinaryType, ToString) {
+  auto t = fixed_width_binary(10);
+  ASSERT_EQ(t->type, Type::FIXED_WIDTH_BINARY);
+  ASSERT_EQ("fixed_width_binary[10]", t->ToString());
+}
+
+TEST(TestListType, Basics) {
+  std::shared_ptr<DataType> vt = std::make_shared<UInt8Type>();
+
+  ListType list_type(vt);
+  ASSERT_EQ(list_type.type, Type::LIST);
+
+  ASSERT_EQ("list", list_type.name());
+  ASSERT_EQ("list<item: uint8>", list_type.ToString());
+
+  ASSERT_EQ(list_type.value_type()->type, vt->type);
+  ASSERT_EQ(list_type.value_type()->type, vt->type);
+
+  std::shared_ptr<DataType> st = std::make_shared<StringType>();
+  std::shared_ptr<DataType> lt = std::make_shared<ListType>(st);
+  ASSERT_EQ("list<item: string>", lt->ToString());
+
+  ListType lt2(lt);
+  ASSERT_EQ("list<item: list<item: string>>", lt2.ToString());
+}
+
 TEST(TestTimeType, Equals) {
   TimeType t1;
   TimeType t2;

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -143,6 +143,16 @@ TEST(TestFixedWidthBinaryType, ToString) {
   ASSERT_EQ("fixed_width_binary[10]", t->ToString());
 }
 
+TEST(TestFixedWidthBinaryType, Equals) {
+  auto t1 = fixed_width_binary(10);
+  auto t2 = fixed_width_binary(10);
+  auto t3 = fixed_width_binary(3);
+
+  ASSERT_TRUE(t1->Equals(t1));
+  ASSERT_TRUE(t1->Equals(t2));
+  ASSERT_FALSE(t1->Equals(t3));
+}
+
 TEST(TestListType, Basics) {
   std::shared_ptr<DataType> vt = std::make_shared<UInt8Type>();
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -93,7 +93,10 @@ int FixedWidthBinaryType::bit_width() const {
 }
 
 std::string FixedWidthBinaryType::ToString() const {
-  return "fixed_width_binary";
+  std::stringstream ss;
+  ss << "fixed_width_binary["
+     << byte_width_ << "]";
+  return ss.str();
 }
 
 std::string StructType::ToString() const {
@@ -245,7 +248,7 @@ TYPE_FACTORY(binary, BinaryType);
 TYPE_FACTORY(date, DateType);
 TYPE_FACTORY(date32, Date32Type);
 
-std::shared_ptr<DataType> fixed_width_binary(int byte_width) {
+std::shared_ptr<DataType> fixed_width_binary(int32_t byte_width) {
   return std::make_shared<FixedWidthBinaryType>(byte_width);
 }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -88,6 +88,14 @@ std::string BinaryType::ToString() const {
   return std::string("binary");
 }
 
+int FixedWidthBinaryType::bit_width() const {
+  return 8 * byte_width();
+}
+
+std::string FixedWidthBinaryType::ToString() const {
+  return "fixed_width_binary";
+}
+
 std::string StructType::ToString() const {
   std::stringstream s;
   s << "struct<";
@@ -200,6 +208,7 @@ std::string NullType::ToString() const {
 ACCEPT_VISITOR(NullType);
 ACCEPT_VISITOR(BooleanType);
 ACCEPT_VISITOR(BinaryType);
+ACCEPT_VISITOR(FixedWidthBinaryType);
 ACCEPT_VISITOR(StringType);
 ACCEPT_VISITOR(ListType);
 ACCEPT_VISITOR(StructType);
@@ -235,6 +244,10 @@ TYPE_FACTORY(utf8, StringType);
 TYPE_FACTORY(binary, BinaryType);
 TYPE_FACTORY(date, DateType);
 TYPE_FACTORY(date32, Date32Type);
+
+std::shared_ptr<DataType> fixed_width_binary(int byte_width) {
+  return std::make_shared<FixedWidthBinaryType>(byte_width);
+}
 
 std::shared_ptr<DataType> timestamp(TimeUnit unit) {
   return std::make_shared<TimestampType>(unit);
@@ -296,6 +309,10 @@ std::vector<BufferDescr> BinaryType::GetBufferLayout() const {
   return {kValidityBuffer, kOffsetBuffer, kValues8};
 }
 
+std::vector<BufferDescr> FixedWidthBinaryType::GetBufferLayout() const {
+  return {kValidityBuffer, BufferDescr(BufferType::DATA, byte_width_ * 8)};
+}
+
 std::vector<BufferDescr> ListType::GetBufferLayout() const {
   return {kValidityBuffer, kOffsetBuffer};
 }
@@ -346,6 +363,7 @@ TYPE_VISITOR_DEFAULT(FloatType);
 TYPE_VISITOR_DEFAULT(DoubleType);
 TYPE_VISITOR_DEFAULT(StringType);
 TYPE_VISITOR_DEFAULT(BinaryType);
+TYPE_VISITOR_DEFAULT(FixedWidthBinaryType);
 TYPE_VISITOR_DEFAULT(DateType);
 TYPE_VISITOR_DEFAULT(Date32Type);
 TYPE_VISITOR_DEFAULT(TimeType);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -94,8 +94,7 @@ int FixedWidthBinaryType::bit_width() const {
 
 std::string FixedWidthBinaryType::ToString() const {
   std::stringstream ss;
-  ss << "fixed_width_binary["
-     << byte_width_ << "]";
+  ss << "fixed_width_binary[" << byte_width_ << "]";
   return ss.str();
 }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -372,7 +372,7 @@ class ARROW_EXPORT FixedWidthBinaryType : public FixedWidthType {
  public:
   static constexpr Type::type type_id = Type::FIXED_WIDTH_BINARY;
 
-  FixedWidthBinaryType(int32_t byte_width)
+  explicit FixedWidthBinaryType(int32_t byte_width)
       : FixedWidthType(Type::FIXED_WIDTH_BINARY), byte_width_(byte_width) {}
 
   Status Accept(TypeVisitor* visitor) const override;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -373,8 +373,7 @@ class ARROW_EXPORT FixedWidthBinaryType : public FixedWidthType {
   static constexpr Type::type type_id = Type::FIXED_WIDTH_BINARY;
 
   FixedWidthBinaryType(int32_t byte_width)
-    : FixedWidthType(Type::FIXED_WIDTH_BINARY),
-      byte_width_(byte_width) {}
+      : FixedWidthType(Type::FIXED_WIDTH_BINARY), byte_width_(byte_width) {}
 
   Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -372,7 +372,7 @@ class ARROW_EXPORT FixedWidthBinaryType : public FixedWidthType {
  public:
   static constexpr Type::type type_id = Type::FIXED_WIDTH_BINARY;
 
-  FixedWidthBinaryType(int byte_width)
+  FixedWidthBinaryType(int32_t byte_width)
     : FixedWidthType(Type::FIXED_WIDTH_BINARY),
       byte_width_(byte_width) {}
 
@@ -381,11 +381,11 @@ class ARROW_EXPORT FixedWidthBinaryType : public FixedWidthType {
 
   std::vector<BufferDescr> GetBufferLayout() const override;
 
-  int byte_width() const { return byte_width_; }
+  int32_t byte_width() const { return byte_width_; }
   int bit_width() const override;
 
  protected:
-  int byte_width_;
+  int32_t byte_width_;
 };
 
 // UTF-8 encoded strings
@@ -577,6 +577,8 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 
 // ----------------------------------------------------------------------
 // Factory functions
+
+std::shared_ptr<DataType> ARROW_EXPORT fixed_width_binary(int32_t byte_width);
 
 std::shared_ptr<DataType> ARROW_EXPORT list(const std::shared_ptr<Field>& value_type);
 std::shared_ptr<DataType> ARROW_EXPORT list(const std::shared_ptr<DataType>& value_type);

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -67,6 +67,9 @@ struct Type {
     // Variable-length bytes (no guarantee of UTF8-ness)
     BINARY,
 
+    // Fixed-width binary. Each value occupies the same number of bytes
+    FIXED_WIDTH_BINARY,
+
     // int64_t milliseconds since the UNIX epoch
     DATE,
 
@@ -134,6 +137,7 @@ class ARROW_EXPORT TypeVisitor {
   virtual Status Visit(const DoubleType& type);
   virtual Status Visit(const StringType& type);
   virtual Status Visit(const BinaryType& type);
+  virtual Status Visit(const FixedWidthBinaryType& type);
   virtual Status Visit(const DateType& type);
   virtual Status Visit(const Date32Type& type);
   virtual Status Visit(const TimeType& type);
@@ -346,7 +350,7 @@ struct ARROW_EXPORT ListType : public DataType, public NoExtraMeta {
   std::vector<BufferDescr> GetBufferLayout() const override;
 };
 
-// BinaryType type is reprsents lists of 1-byte values.
+// BinaryType type is represents lists of 1-byte values.
 struct ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
   static constexpr Type::type type_id = Type::BINARY;
 
@@ -363,7 +367,28 @@ struct ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
   explicit BinaryType(Type::type logical_type) : DataType(logical_type) {}
 };
 
-// UTF encoded strings
+// BinaryType type is represents lists of 1-byte values.
+class ARROW_EXPORT FixedWidthBinaryType : public FixedWidthType {
+ public:
+  static constexpr Type::type type_id = Type::FIXED_WIDTH_BINARY;
+
+  FixedWidthBinaryType(int byte_width)
+    : FixedWidthType(Type::FIXED_WIDTH_BINARY),
+      byte_width_(byte_width) {}
+
+  Status Accept(TypeVisitor* visitor) const override;
+  std::string ToString() const override;
+
+  std::vector<BufferDescr> GetBufferLayout() const override;
+
+  int byte_width() const { return byte_width_; }
+  int bit_width() const override;
+
+ protected:
+  int byte_width_;
+};
+
+// UTF-8 encoded strings
 struct ARROW_EXPORT StringType : public BinaryType {
   static constexpr Type::type type_id = Type::STRING;
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -48,6 +48,10 @@ struct BinaryType;
 class BinaryArray;
 class BinaryBuilder;
 
+struct FixedWidthBinaryType;
+class FixedWidthBinaryArray;
+class FixedWidthBinaryBuilder;
+
 struct StringType;
 class StringArray;
 class StringBuilder;

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -48,7 +48,7 @@ struct BinaryType;
 class BinaryArray;
 class BinaryBuilder;
 
-struct FixedWidthBinaryType;
+class FixedWidthBinaryType;
 class FixedWidthBinaryArray;
 class FixedWidthBinaryBuilder;
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -228,6 +228,13 @@ struct TypeTraits<BinaryType> {
   static inline std::shared_ptr<DataType> type_singleton() { return binary(); }
 };
 
+template <>
+struct TypeTraits<FixedWidthBinaryType> {
+  using ArrayType = FixedWidthBinaryArray;
+  using BuilderType = FixedWidthBinaryBuilder;
+  constexpr static bool is_parameter_free = false;
+};
+
 // Not all type classes have a c_type
 template <typename T>
 struct as_void {

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -18,43 +18,13 @@
 #ifndef ARROW_UTIL_IO_UTIL_H
 #define ARROW_UTIL_IO_UTIL_H
 
-#include <algorithm>
 #include <iostream>
-#include <string>
 
 #include "arrow/buffer.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/status.h"
 
 namespace arrow {
-
-static const char* kAsciiTable = "0123456789ABCDEF";
-
-static inline std::string HexEncode(const char* data, int32_t length) {
-  std::string hex_string;
-  hex_string.reserve(length * 2);
-  for (int32_t j = 0; j < length; ++j) {
-    // Convert to 2 base16 digits
-    hex_string.push_back(kAsciiTable[data[j] >> 4]);
-    hex_string.push_back(kAsciiTable[data[j] & 15]);
-  }
-  return hex_string;
-}
-
-static inline Status ParseHexValue(const char* data, uint8_t* out) {
-  char c1 = data[0];
-  char c2 = data[1];
-
-  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
-  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
-
-  // Error checking
-  if (*pos1 != c1 || *pos2 != c2) { return Status::Invalid("Encountered non-hex digit"); }
-
-  *out = static_cast<uint8_t>((pos1 - kAsciiTable) << 4 | (pos2 - kAsciiTable));
-  return Status::OK();
-}
-
 namespace io {
 
 // Output stream that just writes to stdout.

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -18,10 +18,43 @@
 #ifndef ARROW_UTIL_IO_UTIL_H
 #define ARROW_UTIL_IO_UTIL_H
 
-#include "arrow/buffer.h"
+#include <algorithm>
 #include <iostream>
+#include <string>
+
+#include "arrow/buffer.h"
+#include "arrow/io/interfaces.h"
+#include "arrow/status.h"
 
 namespace arrow {
+
+static const char* kAsciiTable = "0123456789ABCDEF";
+
+static inline std::string HexEncode(const char* data, int32_t length) {
+  std::string hex_string;
+  hex_string.reserve(length * 2);
+  for (int32_t j = 0; j < length; ++j) {
+    // Convert to 2 base16 digits
+    hex_string.push_back(kAsciiTable[data[j] >> 4]);
+    hex_string.push_back(kAsciiTable[data[j] & 15]);
+  }
+  return hex_string;
+}
+
+static inline Status ParseHexValue(const char* data, uint8_t* out) {
+  char c1 = data[0];
+  char c2 = data[1];
+
+  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
+  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
+
+  // Error checking
+  if (*pos1 != c1 || *pos2 != c2) { return Status::Invalid("Encountered non-hex digit"); }
+
+  *out = static_cast<uint8_t>((pos1 - kAsciiTable) << 4 | (pos2 - kAsciiTable));
+  return Status::OK();
+}
+
 namespace io {
 
 // Output stream that just writes to stdout.

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_UTIL_STRING_UTIL_H
+#define ARROW_UTIL_STRING_UTIL_H
+
+#include <algorithm>
+#include <string>
+
+#include "arrow/status.h"
+
+namespace arrow {
+
+static const char* kAsciiTable = "0123456789ABCDEF";
+
+static inline std::string HexEncode(const char* data, int32_t length) {
+  std::string hex_string;
+  hex_string.reserve(length * 2);
+  for (int32_t j = 0; j < length; ++j) {
+    // Convert to 2 base16 digits
+    hex_string.push_back(kAsciiTable[data[j] >> 4]);
+    hex_string.push_back(kAsciiTable[data[j] & 15]);
+  }
+  return hex_string;
+}
+
+static inline Status ParseHexValue(const char* data, uint8_t* out) {
+  char c1 = data[0];
+  char c2 = data[1];
+
+  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
+  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
+
+  // Error checking
+  if (*pos1 != c1 || *pos2 != c2) { return Status::Invalid("Encountered non-hex digit"); }
+
+  *out = static_cast<uint8_t>((pos1 - kAsciiTable) << 4 | (pos2 - kAsciiTable));
+  return Status::OK();
+}
+
+}  // namespace arrow
+
+#endif  // ARROW_UTIL_STRING_UTIL_H

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -68,6 +68,11 @@ table Utf8 {
 table Binary {
 }
 
+table FixedWidthBinary {
+  /// Number of bytes per value
+  byteWidth: int;
+}
+
 table Bool {
 }
 
@@ -113,7 +118,8 @@ union Type {
   Interval,
   List,
   Struct_,
-  Union
+  Union,
+  FixedWidthBinary
 }
 
 /// ----------------------------------------------------------------------


### PR DESCRIPTION
I have a bunch more work to do on the C++ implementation:

- [x] Test builder class
- [x] Test array API (slice, etc.)
- [x] Implement/test ArrayEquals/ArrayRangeEquals
- [x] Implement `PrettyPrint` (may want to encode to hexadecimal, I don't think that BinaryArray prints properly right now for non-ASCII/UTF8 data)
- [x] Add IPC roundtrip tests

In the meantime, @julienledem @nongli or others could you look at the changes to the format Flatbuffers and let me know if that looks right to you? Thanks