### PR TITLE
ARROW-639: [C++] Invalid offset in slices

### DIFF
--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -176,7 +176,7 @@ TEST_F(TestStringArray, TestSliceGetString) {
   ASSERT_OK(builder.Finish(&array));
   auto s = array->Slice(1, 10);
   auto arr = std::dynamic_pointer_cast<StringArray>(s);
-  ASSERT_TRUE(arr->GetString(0) == "b");
+  ASSERT_EQ(arr->GetString(0), "b");
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array-string-test.cc
+++ b/cpp/src/arrow/array-string-test.cc
@@ -165,6 +165,20 @@ TEST_F(TestStringArray, CompareNullByteSlots) {
       equal_array.Array::Slice(1)->RangeEquals(0, 2, 0, equal_array2.Array::Slice(1)));
 }
 
+TEST_F(TestStringArray, TestSliceGetString) {
+  StringBuilder builder(default_memory_pool());
+
+  builder.Append("a");
+  builder.Append("b");
+  builder.Append("c");
+
+  std::shared_ptr<Array> array;
+  ASSERT_OK(builder.Finish(&array));
+  auto s = array->Slice(1, 10);
+  auto arr = std::dynamic_pointer_cast<StringArray>(s);
+  ASSERT_TRUE(arr->GetString(0) == "b");
+}
+
 // ----------------------------------------------------------------------
 // String builder tests
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -322,8 +322,8 @@ class ARROW_EXPORT BinaryArray : public Array {
     // Account for base offset
     i += offset_;
 
-    const int32_t pos = raw_value_offsets_[i + offset_];
-    *out_length = raw_value_offsets_[i + offset_ + 1] - pos;
+    const int32_t pos = raw_value_offsets_[i];
+    *out_length = raw_value_offsets_[i + 1] - pos;
     return raw_data_ + pos;
   }
 


### PR DESCRIPTION
Fix incrementing offest_ twice in Slice