### PR TITLE
ARROW-637: [Format] Add timezone to Timestamp metadata, comments describing the semantics

### DIFF
--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -99,7 +99,7 @@ table Timestamp {
   ///
   /// * If the time zone is null or equal to an empty string, the data is "time
   ///   zone naive" and shall be displayed *as is* to the user, not localized
-  ///   to the locale of the user's. This data can be though of as UTC but
+  ///   to the locale of the user. This data can be though of as UTC but
   ///   without having "UTC" as the time zone, it is not considered to be
   ///   localized to any time zone
   ///

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -94,8 +94,14 @@ table Time {
 table Timestamp {
   unit: TimeUnit;
 
-  /// The time zone is a string indicating the name of a time zone as used in
-  /// the Olson time zone database (the "tz database" or "tzdata").
+  /// The time zone is a string indicating the name of a time zone, one of:
+  ///
+  /// * As used in the Olson time zone database (the "tz database" or
+  ///   "tzdata"), such as "America/New_York"
+  /// * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30
+  ///
+  /// Whether a timezone string is present indicates different semantics about
+  /// the data:
   ///
   /// * If the time zone is null or equal to an empty string, the data is "time
   ///   zone naive" and shall be displayed *as is* to the user, not localized
@@ -103,11 +109,11 @@ table Timestamp {
   ///   without having "UTC" as the time zone, it is not considered to be
   ///   localized to any time zone
   ///
-  /// * If the time zone is set to a valid value, such as "US/Eastern" or
-  ///   "America/New_York", values can be displayed as "localized" to that time
-  ///   zone, even though the underlying 64-bit integers are identical to the
-  ///   same data stored in UTC. Converting between time zones is a
-  ///   metadata-only operation and does not change the underlying values
+  /// * If the time zone is set to a valid value, values can be displayed as
+  ///   "localized" to that time zone, even though the underlying 64-bit
+  ///   integers are identical to the same data stored in UTC. Converting
+  ///   between time zones is a metadata-only operation and does not change the
+  ///   underlying values
   timezone: string;
 }
 

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -93,6 +93,22 @@ table Time {
 /// time from the Unix epoch, 00:00:00.000 on 1 January 1970, UTC.
 table Timestamp {
   unit: TimeUnit;
+
+  /// The time zone is a string indicating the name of a time zone as used in
+  /// the Olson time zone database (the "tz database" or "tzdata").
+  ///
+  /// * If the time zone is null or equal to an empty string, the data is "time
+  ///   zone naive" and shall be displayed *as is* to the user, not localized
+  ///   to the locale of the user's. This data can be though of as UTC but
+  ///   without having "UTC" as the time zone, it is not considered to be
+  ///   localized to any time zone
+  ///
+  /// * If the time zone is set to a valid value, such as "US/Eastern" or
+  ///   "America/New_York", values can be displayed as "localized" to that time
+  ///   zone, even though the underlying 64-bit integers are identical to the
+  ///   same data stored in UTC. Converting between time zones is a
+  ///   metadata-only operation and does not change the underlying values
+  timezone: string;
 }
 
 enum IntervalUnit: short { YEAR_MONTH, DAY_TIME}


### PR DESCRIPTION
cc @julianhyde @julienledem for comment. This makes Arrow semantically equivalent to datetime objects in Python, and I believe the SQL standard