### PR TITLE
ARROW-231 [C++]: Add typed Resize to PoolBuffer

### DIFF
--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -66,6 +66,25 @@ TEST_F(TestBuffer, Resize) {
   ASSERT_EQ(128, buf.capacity());
 }
 
+TEST_F(TestBuffer, TypedResize) {
+  PoolBuffer buf;
+
+  ASSERT_EQ(0, buf.size());
+  ASSERT_OK(buf.TypedResize<double>(100));
+  ASSERT_EQ(800, buf.size());
+  ASSERT_OK(buf.TypedResize<double>(200));
+  ASSERT_EQ(1600, buf.size());
+
+  ASSERT_OK(buf.TypedResize<double>(50, true));
+  ASSERT_EQ(400, buf.size());
+  ASSERT_EQ(448, buf.capacity());
+
+  ASSERT_OK(buf.TypedResize<double>(100));
+  ASSERT_EQ(832, buf.capacity());
+  ASSERT_OK(buf.TypedResize<double>(50, false));
+  ASSERT_EQ(832, buf.capacity());
+}
+
 TEST_F(TestBuffer, ResizeOOM) {
 // This test doesn't play nice with AddressSanitizer
 #ifndef ADDRESS_SANITIZER

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -133,6 +133,16 @@ class ARROW_EXPORT ResizableBuffer : public MutableBuffer {
   /// It does not change buffer's reported size.
   virtual Status Reserve(int64_t new_capacity) = 0;
 
+  template <class T>
+  Status TypedResize(int64_t new_nb_elements, bool shrink_to_fit = true) {
+    return Resize(sizeof(T) * new_nb_elements, shrink_to_fit);
+  }
+
+  template <class T>
+  Status TypedReserve(int64_t new_nb_elements) {
+    return Reserve(sizeof(T) * new_nb_elements);
+  }
+
  protected:
   ResizableBuffer(uint8_t* data, int64_t size) : MutableBuffer(data, size) {}
 };


### PR DESCRIPTION
I also added a typed Reserve to be consistent. Let me know what you think.