### PR TITLE
ARROW-502 [C++/Python]: Logging memory pool

### DIFF
--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -78,4 +78,21 @@ TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
 
 #endif  // ARROW_VALGRIND
 
+TEST(LoggingMemoryPool, Logging) {
+  DefaultMemoryPool pool;
+  LoggingMemoryPool lp(&pool);
+
+  ASSERT_EQ(0, lp.max_memory());
+
+  uint8_t* data;
+  ASSERT_OK(pool.Allocate(100, &data));
+
+  uint8_t* data2;
+  ASSERT_OK(pool.Allocate(100, &data2));
+
+  pool.Free(data, 100);
+  pool.Free(data2, 100);
+
+  ASSERT_EQ(200, pool.max_memory());
+}
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <sstream>
 #include <stdlib.h>
+#include <iostream>
 
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
@@ -134,4 +135,38 @@ MemoryPool* default_memory_pool() {
   return &default_memory_pool_;
 }
 
+LoggingMemoryPool::LoggingMemoryPool(MemoryPool* pool)
+  : pool_(pool) {
+}
+
+Status LoggingMemoryPool::Allocate(int64_t size, uint8_t** out) {
+  Status s = pool_->Allocate(size, out);
+  std::cout << "Allocate: size = "<< size << " - out = " << *out << std::endl;
+  return s;
+}
+
+Status LoggingMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
+  Status s = pool_->Reallocate(old_size, new_size, ptr);
+  std::cout << "Reallocate: old_size = " << old_size << " - new_size = " << new_size
+    << " - ptr = " << *ptr << std::endl;
+  return s;
+}
+
+
+void LoggingMemoryPool::Free(uint8_t* buffer, int64_t size) {
+  pool_->Free(buffer, size);
+  std::cout << "Free: buffer = " << buffer << " - size = " << size << std::endl;
+}
+
+int64_t LoggingMemoryPool::bytes_allocated() const {
+  int64_t nb_bytes = pool_->bytes_allocated();
+  std::cout << "bytes_allocated: " << nb_bytes << std::endl;
+  return nb_bytes;
+}
+
+int64_t LoggingMemoryPool::max_memory() const {
+  int64_t mem = pool_->max_memory();
+  std::cout << "max_memory: " << mem << std::endl;
+  return mem;
+}
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -135,23 +135,20 @@ MemoryPool* default_memory_pool() {
   return &default_memory_pool_;
 }
 
-LoggingMemoryPool::LoggingMemoryPool(MemoryPool* pool)
-  : pool_(pool) {
-}
+LoggingMemoryPool::LoggingMemoryPool(MemoryPool* pool) : pool_(pool) {}
 
 Status LoggingMemoryPool::Allocate(int64_t size, uint8_t** out) {
   Status s = pool_->Allocate(size, out);
-  std::cout << "Allocate: size = "<< size << " - out = " << *out << std::endl;
+  std::cout << "Allocate: size = " << size << " - out = " << *out << std::endl;
   return s;
 }
 
 Status LoggingMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
   Status s = pool_->Reallocate(old_size, new_size, ptr);
   std::cout << "Reallocate: old_size = " << old_size << " - new_size = " << new_size
-    << " - ptr = " << *ptr << std::endl;
+            << " - ptr = " << *ptr << std::endl;
   return s;
 }
-
 
 void LoggingMemoryPool::Free(uint8_t* buffer, int64_t size) {
   pool_->Free(buffer, size);

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -89,6 +89,24 @@ class ARROW_EXPORT DefaultMemoryPool : public MemoryPool {
   std::atomic<int64_t> max_memory_;
 };
 
+class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
+ public:
+  explicit LoggingMemoryPool(MemoryPool* pool);
+  virtual ~LoggingMemoryPool() = default;
+
+  Status Allocate(int64_t size, uint8_t** out) override;
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;
+
+  void Free(uint8_t* buffer, int64_t size) override;
+
+  int64_t bytes_allocated() const override;
+
+  int64_t max_memory() const override;
+
+ private:
+  MemoryPool* pool_;
+};
+
 ARROW_EXPORT MemoryPool* default_memory_pool();
 
 }  // namespace arrow

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -104,6 +104,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CMemoryPool" arrow::MemoryPool":
         int64_t bytes_allocated()
 
+    cdef cppclass CLoggingMemoryPool" arrow::LoggingMemoryPool"(CMemoryPool):
+        CLoggingMemoryPool(CMemoryPool*)
+        
     cdef cppclass CBuffer" arrow::Buffer":
         uint8_t* data()
         int64_t size()

--- a/python/pyarrow/memory.pxd
+++ b/python/pyarrow/memory.pxd
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pyarrow.includes.libarrow cimport CMemoryPool
+from pyarrow.includes.libarrow cimport CMemoryPool, CLoggingMemoryPool
 
 
 cdef class MemoryPool:
@@ -23,5 +23,8 @@ cdef class MemoryPool:
         CMemoryPool* pool
 
     cdef init(self, CMemoryPool* pool)
+
+cdef class LoggingMemoryPool(MemoryPool):
+    cdef init(self, CLoggingMemoryPool* pool)
 
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool)

--- a/python/pyarrow/memory.pxd
+++ b/python/pyarrow/memory.pxd
@@ -25,6 +25,6 @@ cdef class MemoryPool:
     cdef init(self, CMemoryPool* pool)
 
 cdef class LoggingMemoryPool(MemoryPool):
-    cdef init(self, CLoggingMemoryPool* pool)
+    pass
 
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool)

--- a/python/pyarrow/memory.pyx
+++ b/python/pyarrow/memory.pyx
@@ -19,7 +19,7 @@
 # distutils: language = c++
 # cython: embedsignature = True
 
-from pyarrow.includes.libarrow cimport CMemoryPool
+from pyarrow.includes.libarrow cimport CMemoryPool, CLoggingMemoryPool
 from pyarrow.includes.pyarrow cimport set_default_memory_pool, get_memory_pool
 
 cdef class MemoryPool:
@@ -34,6 +34,10 @@ cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool):
         return get_memory_pool()
     else:
         return memory_pool.pool
+
+cdef class LoggingMemoryPool(MemoryPool):
+    cdef init(self, CLoggingMemoryPool* pool):
+        MemoryPool.init(pool)
 
 def default_pool():
     cdef: 

--- a/python/pyarrow/memory.pyx
+++ b/python/pyarrow/memory.pyx
@@ -36,8 +36,7 @@ cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool):
         return memory_pool.pool
 
 cdef class LoggingMemoryPool(MemoryPool):
-    cdef init(self, CLoggingMemoryPool* pool):
-        MemoryPool.init(pool)
+    pass
 
 def default_pool():
     cdef: 


### PR DESCRIPTION
This is a simple decorator on MemoryPool that logs it call to ``std::cout``. I can improve it later if you need to log to other supports. Are you ok with the current logging format ?

Also, I'm not a cython expert so I hope the implementation of ``CLoggingMemoryPool`` is correct.