### PR TITLE
ARROW-676: move from MinorType to FieldType in ValueVectors to carry all the relevant type bits

### DIFF
--- a/java/vector/src/main/codegen/data/ArrowTypes.tdd
+++ b/java/vector/src/main/codegen/data/ArrowTypes.tdd
@@ -14,59 +14,73 @@
   types: [
     {
       name: "Null",
-      fields: []
+      fields: [],
+      complex: false
     },
     {
       name: "Struct_",
-      fields: []
+      fields: [],
+      complex: true
     },
     {
       name: "List",
-      fields: []
+      fields: [],
+      complex: true
     },
     {
       name: "Union",
-      fields: [{name: "mode", type: short, valueType: UnionMode}, {name: "typeIds", type: "int[]"}]
+      fields: [{name: "mode", type: short, valueType: UnionMode}, {name: "typeIds", type: "int[]"}],
+      complex: true
     },
     {
       name: "Int",
-      fields: [{name: "bitWidth", type: int}, {name: "isSigned", type: boolean}]
+      fields: [{name: "bitWidth", type: int}, {name: "isSigned", type: boolean}],
+      complex: false
     },
     {
       name: "FloatingPoint",
-      fields: [{name: precision, type: short, valueType: FloatingPointPrecision}]
+      fields: [{name: precision, type: short, valueType: FloatingPointPrecision}],
+      complex: false
     },
     {
       name: "Utf8",
-      fields: []
+      fields: [],
+      complex: false
     },
     {
       name: "Binary",
-      fields: []
+      fields: [],
+      complex: false
     },
     {
       name: "Bool",
-      fields: []
+      fields: [],
+      complex: false
     },
     {
       name: "Decimal",
-      fields: [{name: "precision", type: int}, {name: "scale", type: int}]
+      fields: [{name: "precision", type: int}, {name: "scale", type: int}],
+      complex: false
     },
     {
       name: "Date",
       fields: [{name: "unit", type: short, valueType: DateUnit}]
+      complex: false
     },
     {
       name: "Time",
-      fields: [{name: "unit", type: short, valueType: TimeUnit}, {name: "bitWidth", type: int}]
+      fields: [{name: "unit", type: short, valueType: TimeUnit}, {name: "bitWidth", type: int}],
+      complex: false
     },
     {
       name: "Timestamp",
       fields: [{name: "unit", type: short, valueType: TimeUnit}, {name: "timezone", type: String}]
+      complex: false
     },
     {
       name: "Interval",
-      fields: [{name: "unit", type: short, valueType: IntervalUnit}]
+      fields: [{name: "unit", type: short, valueType: IntervalUnit}],
+      complex: false
     }
   ]
 }

--- a/java/vector/src/main/codegen/templates/MapWriters.java
+++ b/java/vector/src/main/codegen/templates/MapWriters.java
@@ -64,7 +64,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
         list(child.getName());
         break;
       case UNION:
-        UnionWriter writer = new UnionWriter(container.addOrGet(child.getName(), MinorType.UNION, UnionVector.class, null), getNullableMapWriterFactory());
+        UnionWriter writer = new UnionWriter(container.addOrGet(child.getName(), FieldType.nullable(MinorType.UNION.getType()), UnionVector.class), getNullableMapWriterFactory());
         fields.put(handleCase(child.getName()), writer);
         break;
 <#list vv.types as type><#list type.minor as minor>
@@ -113,7 +113,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
     FieldWriter writer = fields.get(finalName);
     if(writer == null){
       int vectorCount=container.size();
-      NullableMapVector vector = container.addOrGet(name, MinorType.MAP, NullableMapVector.class, null);
+      NullableMapVector vector = container.addOrGet(name, FieldType.nullable(MinorType.MAP.getType()), NullableMapVector.class);
       writer = new PromotableWriter(vector, container, getNullableMapWriterFactory());
       if(vectorCount != container.size()) {
         writer.allocate();
@@ -157,7 +157,7 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
     FieldWriter writer = fields.get(finalName);
     int vectorCount = container.size();
     if(writer == null) {
-      writer = new PromotableWriter(container.addOrGet(name, MinorType.LIST, ListVector.class, null), container, getNullableMapWriterFactory());
+      writer = new PromotableWriter(container.addOrGet(name, FieldType.nullable(MinorType.LIST.getType()), ListVector.class), container, getNullableMapWriterFactory());
       if (container.size() > vectorCount) {
         writer.allocate();
       }
@@ -222,7 +222,9 @@ public class ${mode}MapWriter extends AbstractFieldWriter {
     if(writer == null) {
       ValueVector vector;
       ValueVector currentVector = container.getChild(name);
-      ${vectName}Vector v = container.addOrGet(name, MinorType.${upperName}, ${vectName}Vector.class, null<#if minor.class == "Decimal"> , new int[] {precision, scale}</#if>);
+      ${vectName}Vector v = container.addOrGet(name, 
+          FieldType.nullable(<#if minor.class == "Decimal">new Decimal(precision, scale)<#else>MinorType.${upperName}.getType()</#if>),
+          ${vectName}Vector.class);
       writer = new PromotableWriter(v, container, getNullableMapWriterFactory());
       vector = v;
       if (currentVector == null || currentVector != vector) {

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -119,10 +119,22 @@ public class UnionVector implements FieldVector {
      return this.innerVectors;
   }
 
+  private String fieldName(MinorType type) {
+    return type.name().toLowerCase();
+  }
+
+  private FieldType fieldType(MinorType type) {
+    return new FieldType(true, type.getType(), null);
+  }
+
+  private <T extends FieldVector> T addOrGet(MinorType minorType, Class<T> c) {
+    return internalMap.addOrGet(fieldName(minorType), fieldType(minorType), c);
+  }
+
   public NullableMapVector getMap() {
     if (mapVector == null) {
       int vectorCount = internalMap.size();
-      mapVector = internalMap.addOrGet("map", MinorType.MAP, NullableMapVector.class, null);
+      mapVector = addOrGet(MinorType.MAP, NullableMapVector.class);
       if (internalMap.size() > vectorCount) {
         mapVector.allocateNew();
         if (callBack != null) {
@@ -144,7 +156,7 @@ public class UnionVector implements FieldVector {
   public Nullable${name}Vector get${name}Vector() {
     if (${uncappedName}Vector == null) {
       int vectorCount = internalMap.size();
-      ${uncappedName}Vector = internalMap.addOrGet("${lowerCaseName}", MinorType.${name?upper_case}, Nullable${name}Vector.class, null);
+      ${uncappedName}Vector = addOrGet(MinorType.${name?upper_case}, Nullable${name}Vector.class);
       if (internalMap.size() > vectorCount) {
         ${uncappedName}Vector.allocateNew();
         if (callBack != null) {
@@ -162,7 +174,7 @@ public class UnionVector implements FieldVector {
   public ListVector getList() {
     if (listVector == null) {
       int vectorCount = internalMap.size();
-      listVector = internalMap.addOrGet("list", MinorType.LIST, ListVector.class, null);
+      listVector = addOrGet(MinorType.LIST, ListVector.class);
       if (internalMap.size() > vectorCount) {
         listVector.allocateNew();
         if (callBack != null) {
@@ -267,7 +279,7 @@ public class UnionVector implements FieldVector {
   public FieldVector addVector(FieldVector v) {
     String name = v.getMinorType().name().toLowerCase();
     Preconditions.checkState(internalMap.getChild(name) == null, String.format("%s vector already exists", name));
-    final FieldVector newVector = internalMap.addOrGet(name, v.getMinorType(), v.getClass(), v.getField().getDictionary());
+    final FieldVector newVector = internalMap.addOrGet(name, v.getField().getFieldType(), v.getClass());
     v.makeTransferPair(newVector).transfer();
     internalMap.putChild(name, newVector);
     if (callBack != null) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
@@ -19,9 +19,10 @@ package org.apache.arrow.vector;
 
 import java.util.List;
 
-import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.vector.schema.ArrowFieldNode;
 import org.apache.arrow.vector.types.pojo.Field;
+
+import io.netty.buffer.ArrowBuf;
 
 /**
  * A vector corresponding to a Field in the schema

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -60,9 +58,7 @@ public class VectorSchemaRoot implements AutoCloseable {
   public static VectorSchemaRoot create(Schema schema, BufferAllocator allocator) {
     List<FieldVector> fieldVectors = new ArrayList<>();
     for (Field field : schema.getFields()) {
-      MinorType minorType = Types.getMinorTypeForArrowType(field.getType());
-      FieldVector vector = minorType.getNewVector(field.getName(), allocator, field.getDictionary(), null);
-      vector.initializeChildrenFromFields(field.getChildren());
+      FieldVector vector = field.createVector(allocator);
       fieldVectors.add(vector);
     }
     if (fieldVectors.size() != schema.getFields().size()) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
@@ -22,7 +22,9 @@ import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.types.Types.MinorType;
-import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.ArrowType.List;
+import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 
 /**
@@ -85,12 +87,24 @@ public abstract class AbstractContainerVector implements ValueVector {
   // return the number of child vectors
   public abstract int size();
 
-  // add a new vector with the input MajorType or return the existing vector if we already added one with the same type
-  public abstract <T extends FieldVector> T addOrGet(String name, MinorType minorType, Class<T> clazz, DictionaryEncoding dictionary, int... precisionScale);
+  // add a new vector with the input FieldType or return the existing vector if we already added one with the same name
+  public abstract <T extends FieldVector> T addOrGet(String name, FieldType fieldType, Class<T> clazz);
 
   // return the child vector with the input name
   public abstract <T extends FieldVector> T getChild(String name, Class<T> clazz);
 
   // return the child vector's ordinal in the composite container
   public abstract VectorWithOrdinal getChildVectorWithOrdinal(String name);
+
+  public NullableMapVector addOrGetMap(String name) {
+    return addOrGet(name, FieldType.nullable(new Struct()), NullableMapVector.class);
+  }
+
+  public ListVector addOrGetList(String name) {
+    return addOrGet(name, FieldType.nullable(new List()), ListVector.class);
+  }
+
+  public UnionVector addOrGetUnion(String name) {
+    return addOrGet(name, FieldType.nullable(MinorType.UNION.getType()), UnionVector.class);
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -27,8 +27,7 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.UInt4Vector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
-import org.apache.arrow.vector.types.Types.MinorType;
-import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.SchemaChangeRuntimeException;
 
@@ -154,10 +153,10 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     return vector == DEFAULT_DATA_VECTOR ? 0:1;
   }
 
-  public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(MinorType minorType, DictionaryEncoding dictionary) {
+  public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType fieldType) {
     boolean created = false;
     if (vector instanceof ZeroVector) {
-      vector = minorType.getNewVector(DATA_VECTOR_NAME, allocator, dictionary, callBack);
+      vector = fieldType.createNewSingleVector(DATA_VECTOR_NAME, allocator, callBack);
       // returned vector must have the same field
       created = true;
       if (callBack != null) {
@@ -165,9 +164,9 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
       }
     }
 
-    if (vector.getField().getType().getTypeID() != minorType.getType().getTypeID()) {
+    if (vector.getField().getType().getTypeID() != fieldType.getType().getTypeID()) {
       final String msg = String.format("Inner vector type mismatch. Requested type: [%s], actual type: [%s]",
-          minorType.getType().getTypeID(), vector.getField().getType().getTypeID());
+          fieldType.getType().getTypeID(), vector.getField().getType().getTypeID());
       throw new SchemaChangeRuntimeException(msg);
     }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -40,10 +40,10 @@ import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.schema.ArrowFieldNode;
-import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.TransferPair;
@@ -80,8 +80,7 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector {
       throw new IllegalArgumentException("Lists have only one child. Found: " + children);
     }
     Field field = children.get(0);
-    MinorType minorType = Types.getMinorTypeForArrowType(field.getType());
-    AddOrGetResult<FieldVector> addOrGetVector = addOrGetVector(minorType, field.getDictionary());
+    AddOrGetResult<FieldVector> addOrGetVector = addOrGetVector(field.getFieldType());
     if (!addOrGetVector.isCreated()) {
       throw new IllegalArgumentException("Child vector already existed: " + addOrGetVector.getVector());
     }
@@ -164,11 +163,11 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector {
 
     public TransferImpl(ListVector to) {
       this.to = to;
-      to.addOrGetVector(vector.getMinorType(), vector.getField().getDictionary());
+      to.addOrGetVector(vector.getField().getFieldType());
       pairs[0] = offsets.makeTransferPair(to.offsets);
       pairs[1] = bits.makeTransferPair(to.bits);
       if (to.getDataVector() instanceof ZeroVector) {
-        to.addOrGetVector(vector.getMinorType(), vector.getField().getDictionary());
+        to.addOrGetVector(vector.getField().getFieldType());
       }
       pairs[2] = getDataVector().makeTransferPair(to.getDataVector());
     }
@@ -241,8 +240,8 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector {
     return success;
   }
 
-  public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(MinorType minorType, DictionaryEncoding dictionary) {
-    AddOrGetResult<T> result = super.addOrGetVector(minorType, dictionary);
+  public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType fieldType) {
+    AddOrGetResult<T> result = super.addOrGetVector(fieldType);
     reader = new UnionListReader(this);
     return result;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -32,7 +32,6 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.impl.SingleMapReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.ComplexHolder;
-import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -165,7 +164,7 @@ public class MapVector extends AbstractMapVector {
         // (This is similar to what happens in ScanBatch where the children cannot be added till they are
         // read). To take care of this, we ensure that the hashCode of the MaterializedField does not
         // include the hashCode of the children but is based only on MaterializedField$key.
-        final FieldVector newVector = to.addOrGet(child, vector.getMinorType(), vector.getClass(), vector.getField().getDictionary());
+        final FieldVector newVector = to.addOrGet(child, vector.getField().getFieldType(), vector.getClass());
         if (allocate && to.size() != preSize) {
           newVector.allocateNew();
         }
@@ -318,8 +317,7 @@ public class MapVector extends AbstractMapVector {
 
   public void initializeChildrenFromFields(List<Field> children) {
     for (Field field : children) {
-      MinorType minorType = Types.getMinorTypeForArrowType(field.getType());
-      FieldVector vector = (FieldVector)this.add(field.getName(), minorType, field.getDictionary());
+      FieldVector vector = (FieldVector)this.add(field.getName(), field.getFieldType());
       vector.initializeChildrenFromFields(field.getChildren());
     }
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NullableMapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NullableMapVector.java
@@ -270,4 +270,5 @@ public class NullableMapVector extends MapVector implements FieldVector {
   public Mutator getMutator() {
     return mutator;
   }
+
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -22,7 +22,6 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.NullableMapVector;
 import org.apache.arrow.vector.complex.StateTool;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ComplexWriter;
-import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 
 import com.google.common.base.Preconditions;
@@ -150,7 +149,7 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
     case INIT:
       // TODO allow dictionaries in complex types
-      NullableMapVector map = container.addOrGet(name, MinorType.MAP, NullableMapVector.class, null);
+      NullableMapVector map = container.addOrGetMap(name);
       mapRoot = nullableMapWriterFactory.build(map);
       mapRoot.setPosition(idx());
       mode = Mode.MAP;
@@ -182,7 +181,7 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
     case INIT:
       int vectorCount = container.size();
       // TODO allow dictionaries in complex types
-      ListVector listVector = container.addOrGet(name, MinorType.LIST, ListVector.class, null);
+      ListVector listVector = container.addOrGetList(name);
       if (container.size() > vectorCount) {
         listVector.allocateNew();
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -27,6 +27,7 @@ import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
 /**
@@ -125,7 +126,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
         // ???
         return null;
       }
-      ValueVector v = listVector.addOrGetVector(type, null).getVector();
+      ValueVector v = listVector.addOrGetVector(FieldType.nullable(type.getType())).getVector();
       v.allocateNew();
       setWriter(v);
       writer.setPosition(position);
@@ -151,7 +152,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
     tp.transfer();
     if (parentContainer != null) {
       // TODO allow dictionaries in complex types
-      unionVector = parentContainer.addOrGet(name, MinorType.UNION, UnionVector.class, null);
+      unionVector = parentContainer.addOrGetUnion(name);
       unionVector.allocateNew();
     } else if (listVector != null) {
       unionVector = listVector.promoteToUnion();

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -92,45 +92,15 @@ import org.apache.arrow.vector.types.pojo.ArrowType.Time;
 import org.apache.arrow.vector.types.pojo.ArrowType.Timestamp;
 import org.apache.arrow.vector.types.pojo.ArrowType.Union;
 import org.apache.arrow.vector.types.pojo.ArrowType.Utf8;
-import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
-import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 
 public class Types {
 
-  private static final Field NULL_FIELD = new Field("", true, Null.INSTANCE, null);
-  private static final Field TINYINT_FIELD = new Field("", true, new Int(8, true), null);
-  private static final Field SMALLINT_FIELD = new Field("", true, new Int(16, true), null);
-  private static final Field INT_FIELD = new Field("", true, new Int(32, true), null);
-  private static final Field BIGINT_FIELD = new Field("", true, new Int(64, true), null);
-  private static final Field UINT1_FIELD = new Field("", true, new Int(8, false), null);
-  private static final Field UINT2_FIELD = new Field("", true, new Int(16, false), null);
-  private static final Field UINT4_FIELD = new Field("", true, new Int(32, false), null);
-  private static final Field UINT8_FIELD = new Field("", true, new Int(64, false), null);
-  private static final Field DATE_FIELD = new Field("", true, new Date(DateUnit.MILLISECOND), null);
-  private static final Field TIME_FIELD = new Field("", true, new Time(TimeUnit.MILLISECOND, 32), null);
-  private static final Field TIMESTAMPSEC_FIELD = new Field("", true, new Timestamp(TimeUnit.SECOND, "UTC"), null);
-  private static final Field TIMESTAMPMILLI_FIELD = new Field("", true, new Timestamp(TimeUnit.MILLISECOND, "UTC"), null);
-  private static final Field TIMESTAMPMICRO_FIELD = new Field("", true, new Timestamp(TimeUnit.MICROSECOND, "UTC"), null);
-  private static final Field TIMESTAMPNANO_FIELD = new Field("", true, new Timestamp(TimeUnit.NANOSECOND, "UTC"), null);
-  private static final Field INTERVALDAY_FIELD = new Field("", true, new Interval(IntervalUnit.DAY_TIME), null);
-  private static final Field INTERVALYEAR_FIELD = new Field("", true, new Interval(IntervalUnit.YEAR_MONTH), null);
-  private static final Field FLOAT4_FIELD = new Field("", true, new FloatingPoint(FloatingPointPrecision.SINGLE), null);
-  private static final Field FLOAT8_FIELD = new Field("", true, new FloatingPoint(FloatingPointPrecision.DOUBLE), null);
-  private static final Field VARCHAR_FIELD = new Field("", true, Utf8.INSTANCE, null);
-  private static final Field VARBINARY_FIELD = new Field("", true, Binary.INSTANCE, null);
-  private static final Field BIT_FIELD = new Field("", true, Bool.INSTANCE, null);
-
-
   public enum MinorType {
     NULL(Null.INSTANCE) {
       @Override
-      public Field getField() {
-        return NULL_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
         return ZeroVector.INSTANCE;
       }
 
@@ -141,13 +111,8 @@ public class Types {
     },
     MAP(Struct.INSTANCE) {
       @Override
-      public Field getField() {
-        throw new UnsupportedOperationException("Cannot get simple field for Map type");
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-         return new NullableMapVector(name, allocator, dictionary, callBack);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableMapVector(name, allocator, fieldType.getDictionary(), schemaChangeCallback);
       }
 
       @Override
@@ -157,13 +122,8 @@ public class Types {
     },
     TINYINT(new Int(8, true)) {
       @Override
-      public Field getField() {
-        return TINYINT_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableTinyIntVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableTinyIntVector(name, fieldType, allocator);
       }
 
       @Override
@@ -173,13 +133,8 @@ public class Types {
     },
     SMALLINT(new Int(16, true)) {
       @Override
-      public Field getField() {
-        return SMALLINT_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableSmallIntVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableSmallIntVector(name, fieldType, allocator);
       }
 
       @Override
@@ -189,13 +144,8 @@ public class Types {
     },
     INT(new Int(32, true)) {
       @Override
-      public Field getField() {
-        return INT_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableIntVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableIntVector(name, fieldType, allocator);
       }
 
       @Override
@@ -205,13 +155,8 @@ public class Types {
     },
     BIGINT(new Int(64, true)) {
       @Override
-      public Field getField() {
-        return BIGINT_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableBigIntVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableBigIntVector(name, fieldType, allocator);
       }
 
       @Override
@@ -221,13 +166,8 @@ public class Types {
     },
     DATE(new Date(DateUnit.MILLISECOND)) {
       @Override
-      public Field getField() {
-        return DATE_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableDateVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableDateVector(name, fieldType, allocator);
       }
 
       @Override
@@ -237,13 +177,8 @@ public class Types {
     },
     TIME(new Time(TimeUnit.MILLISECOND, 32)) {
       @Override
-      public Field getField() {
-        return TIME_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableTimeVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableTimeVector(name, fieldType, allocator);
       }
 
       @Override
@@ -254,13 +189,8 @@ public class Types {
     // time in second from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
     TIMESTAMPSEC(new Timestamp(org.apache.arrow.vector.types.TimeUnit.SECOND, "UTC")) {
       @Override
-      public Field getField() {
-        return TIMESTAMPSEC_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableTimeStampSecVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableTimeStampSecVector(name, fieldType, allocator);
       }
 
       @Override
@@ -271,13 +201,8 @@ public class Types {
     // time in millis from the Unix epoch, 00:00:00.000 on 1 January 1970, UTC.
     TIMESTAMPMILLI(new Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC")) {
       @Override
-      public Field getField() {
-        return TIMESTAMPMILLI_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableTimeStampMilliVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableTimeStampMilliVector(name, fieldType, allocator);
       }
 
       @Override
@@ -288,13 +213,8 @@ public class Types {
     // time in microsecond from the Unix epoch, 00:00:00.000000 on 1 January 1970, UTC.
     TIMESTAMPMICRO(new Timestamp(org.apache.arrow.vector.types.TimeUnit.MICROSECOND, "UTC")) {
       @Override
-      public Field getField() {
-        return TIMESTAMPMICRO_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableTimeStampMicroVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableTimeStampMicroVector(name, fieldType, allocator);
       }
 
       @Override
@@ -305,13 +225,8 @@ public class Types {
     // time in nanosecond from the Unix epoch, 00:00:00.000000000 on 1 January 1970, UTC.
     TIMESTAMPNANO(new Timestamp(org.apache.arrow.vector.types.TimeUnit.NANOSECOND, "UTC")) {
       @Override
-      public Field getField() {
-        return TIMESTAMPNANO_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableTimeStampNanoVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableTimeStampNanoVector(name, fieldType, allocator);
       }
 
       @Override
@@ -321,13 +236,8 @@ public class Types {
     },
     INTERVALDAY(new Interval(IntervalUnit.DAY_TIME)) {
       @Override
-      public Field getField() {
-        return INTERVALDAY_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableIntervalDayVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableIntervalDayVector(name, fieldType, allocator);
       }
 
       @Override
@@ -337,13 +247,8 @@ public class Types {
     },
     INTERVALYEAR(new Interval(IntervalUnit.YEAR_MONTH)) {
       @Override
-      public Field getField() {
-        return INTERVALYEAR_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableIntervalDayVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableIntervalYearVector(name, fieldType, allocator);
       }
 
       @Override
@@ -354,13 +259,8 @@ public class Types {
     //  4 byte ieee 754
     FLOAT4(new FloatingPoint(SINGLE)) {
       @Override
-      public Field getField() {
-        return FLOAT4_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableFloat4Vector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableFloat4Vector(name, fieldType, allocator);
       }
 
       @Override
@@ -371,13 +271,8 @@ public class Types {
     //  8 byte ieee 754
     FLOAT8(new FloatingPoint(DOUBLE)) {
       @Override
-      public Field getField() {
-        return FLOAT8_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableFloat8Vector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableFloat8Vector(name, fieldType, allocator);
       }
 
       @Override
@@ -387,13 +282,8 @@ public class Types {
     },
     BIT(Bool.INSTANCE) {
       @Override
-      public Field getField() {
-        return BIT_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableBitVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableBitVector(name, fieldType, allocator);
       }
 
       @Override
@@ -403,13 +293,8 @@ public class Types {
     },
     VARCHAR(Utf8.INSTANCE) {
       @Override
-      public Field getField() {
-        return VARCHAR_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableVarCharVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableVarCharVector(name, fieldType, allocator);
       }
 
       @Override
@@ -419,13 +304,8 @@ public class Types {
     },
     VARBINARY(Binary.INSTANCE) {
       @Override
-      public Field getField() {
-        return VARBINARY_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableVarBinaryVector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableVarBinaryVector(name, fieldType, allocator);
       }
 
       @Override
@@ -438,14 +318,10 @@ public class Types {
       public ArrowType getType() {
         throw new UnsupportedOperationException("Cannot get simple type for Decimal type");
       }
-      @Override
-      public Field getField() {
-        throw new UnsupportedOperationException("Cannot get simple field for Decimal type");
-      }
 
       @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableDecimalVector(name, allocator, dictionary, precisionScale[0], precisionScale[1]);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableDecimalVector(name, fieldType, allocator);
       }
 
       @Override
@@ -455,13 +331,8 @@ public class Types {
     },
     UINT1(new Int(8, false)) {
       @Override
-      public Field getField() {
-        return UINT1_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableUInt1Vector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableUInt1Vector(name, fieldType, allocator);
       }
 
       @Override
@@ -471,13 +342,8 @@ public class Types {
     },
     UINT2(new Int(16, false)) {
       @Override
-      public Field getField() {
-        return UINT2_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableUInt2Vector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableUInt2Vector(name, fieldType, allocator);
       }
 
       @Override
@@ -487,13 +353,8 @@ public class Types {
     },
     UINT4(new Int(32, false)) {
       @Override
-      public Field getField() {
-        return UINT4_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableUInt4Vector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableUInt4Vector(name, fieldType, allocator);
       }
 
       @Override
@@ -503,13 +364,8 @@ public class Types {
     },
     UINT8(new Int(64, false)) {
       @Override
-      public Field getField() {
-        return UINT8_FIELD;
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new NullableUInt8Vector(name, allocator, dictionary);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new NullableUInt8Vector(name, fieldType, allocator);
       }
 
       @Override
@@ -519,13 +375,8 @@ public class Types {
     },
     LIST(List.INSTANCE) {
       @Override
-      public Field getField() {
-        throw new UnsupportedOperationException("Cannot get simple field for List type");
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        return new ListVector(name, allocator, dictionary, callBack);
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        return new ListVector(name, allocator, fieldType.getDictionary(), schemaChangeCallback);
       }
 
       @Override
@@ -535,16 +386,11 @@ public class Types {
     },
     UNION(new Union(Sparse, null)) {
       @Override
-      public Field getField() {
-        throw new UnsupportedOperationException("Cannot get simple field for Union type");
-      }
-
-      @Override
-      public FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale) {
-        if (dictionary != null) {
+      public FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback) {
+        if (fieldType.getDictionary() != null) {
           throw new UnsupportedOperationException("Dictionary encoding not supported for complex types");
         }
-        return new UnionVector(name, allocator, callBack);
+        return new UnionVector(name, allocator, schemaChangeCallback);
       }
 
       @Override
@@ -563,9 +409,7 @@ public class Types {
       return type;
     }
 
-    public abstract Field getField();
-
-    public abstract FieldVector getNewVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack, int... precisionScale);
+    public abstract FieldVector getNewVector(String name, FieldType fieldType, BufferAllocator allocator, CallBack schemaChangeCallback);
 
     public abstract FieldWriter getNewFieldWriter(ValueVector vector);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.types.pojo;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.util.CallBack;
+
+public class FieldType {
+
+  public static FieldType nullable(ArrowType type) {
+    return new FieldType(true, type, null);
+  }
+
+  private final boolean nullable;
+  private final ArrowType type;
+  private final DictionaryEncoding dictionary;
+
+  public FieldType(boolean nullable, ArrowType type, DictionaryEncoding dictionary) {
+    super();
+    this.nullable = nullable;
+    this.type = checkNotNull(type);
+    this.dictionary = dictionary;
+  }
+
+  public boolean isNullable() {
+    return nullable;
+  }
+  public ArrowType getType() {
+    return type;
+  }
+  public DictionaryEncoding getDictionary() {
+    return dictionary;
+  }
+
+  public FieldVector createNewSingleVector(String name, BufferAllocator allocator, CallBack schemaCallBack) {
+    MinorType minorType = Types.getMinorTypeForArrowType(type);
+    return minorType.getNewVector(name, this, allocator, schemaCallBack);
+  }
+
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -17,16 +17,16 @@
  */
 package org.apache.arrow.vector;
 
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.util.DecimalUtility;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.util.DecimalUtility;
+import org.junit.Test;
 
 public class TestDecimalVector {
 
@@ -44,7 +44,7 @@ public class TestDecimalVector {
   @Test
   public void test() {
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-    NullableDecimalVector decimalVector = new NullableDecimalVector("decimal", allocator, null, 10, scale);
+    NullableDecimalVector decimalVector = TestUtils.newVector(NullableDecimalVector.class, "decimal", new ArrowType.Decimal(10, scale), allocator);
     decimalVector.allocateNew();
     BigDecimal[] values = new BigDecimal[intValues.length];
     for (int i = 0; i < intValues.length; i++) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
@@ -17,18 +17,18 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.TestUtils.newNullableVarCharVector;
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.dictionary.Dictionary;
-import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.nio.charset.StandardCharsets;
-
-import static org.junit.Assert.assertEquals;
 
 public class TestDictionaryVector {
 
@@ -51,8 +51,8 @@ public class TestDictionaryVector {
   @Test
   public void testEncodeStrings() {
     // Create a new value vector
-    try (final NullableVarCharVector vector = (NullableVarCharVector) MinorType.VARCHAR.getNewVector("foo", allocator, null, null);
-         final NullableVarCharVector dictionaryVector = (NullableVarCharVector) MinorType.VARCHAR.getNewVector("dict", allocator, null, null)) {
+    try (final NullableVarCharVector vector = newNullableVarCharVector("foo", allocator);
+         final NullableVarCharVector dictionaryVector = newNullableVarCharVector("dict", allocator);) {
       final NullableVarCharVector.Mutator m = vector.getMutator();
       vector.allocateNew(512, 5);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUtils.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUtils.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+public class TestUtils {
+
+  public static NullableVarCharVector newNullableVarCharVector(String name, BufferAllocator allocator) {
+    return (NullableVarCharVector)FieldType.nullable(new ArrowType.Utf8()).createNewSingleVector(name, allocator, null);
+  }
+
+  public static <T> T newVector(Class<T> c, String name, ArrowType type, BufferAllocator allocator) {
+    return c.cast(FieldType.nullable(type).createNewSingleVector(name, allocator, null));
+  }
+
+  public static <T> T newVector(Class<T> c, String name, MinorType type, BufferAllocator allocator) {
+    return c.cast(FieldType.nullable(type.getType()).createNewSingleVector(name, allocator, null));
+  }
+
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -17,6 +17,8 @@
  */
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.TestUtils.newNullableVarCharVector;
+import static org.apache.arrow.vector.TestUtils.newVector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -28,6 +30,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.schema.TypeLayout;
 import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.After;
 import org.junit.Assert;
@@ -86,7 +89,7 @@ public class TestValueVector {
   public void testNullableVarLen2() {
 
     // Create a new value vector for 1024 integers.
-    try (final NullableVarCharVector vector = new NullableVarCharVector(EMPTY_SCHEMA_PATH, allocator, null)) {
+    try (final NullableVarCharVector vector = newNullableVarCharVector(EMPTY_SCHEMA_PATH, allocator)) {
       final NullableVarCharVector.Mutator m = vector.getMutator();
       vector.allocateNew(1024 * 10, 1024);
 
@@ -116,7 +119,7 @@ public class TestValueVector {
   public void testNullableFixedType() {
 
     // Create a new value vector for 1024 integers.
-    try (final NullableUInt4Vector vector = new NullableUInt4Vector(EMPTY_SCHEMA_PATH, allocator, null)) {
+    try (final NullableUInt4Vector vector = newVector(NullableUInt4Vector.class, EMPTY_SCHEMA_PATH, new ArrowType.Int(32, false), allocator);) {
       final NullableUInt4Vector.Mutator m = vector.getMutator();
       vector.allocateNew(1024);
 
@@ -186,7 +189,7 @@ public class TestValueVector {
   @Test
   public void testNullableFloat() {
     // Create a new value vector for 1024 integers
-    try (final NullableFloat4Vector vector = (NullableFloat4Vector) MinorType.FLOAT4.getNewVector(EMPTY_SCHEMA_PATH, allocator, null, null)) {
+    try (final NullableFloat4Vector vector = newVector(NullableFloat4Vector.class, EMPTY_SCHEMA_PATH, MinorType.FLOAT4, allocator);) {
       final NullableFloat4Vector.Mutator m = vector.getMutator();
       vector.allocateNew(1024);
 
@@ -233,7 +236,7 @@ public class TestValueVector {
   @Test
   public void testNullableInt() {
     // Create a new value vector for 1024 integers
-    try (final NullableIntVector vector = (NullableIntVector) MinorType.INT.getNewVector(EMPTY_SCHEMA_PATH, allocator, null, null)) {
+    try (final NullableIntVector vector = newVector(NullableIntVector.class, EMPTY_SCHEMA_PATH, MinorType.INT, allocator)) {
       final NullableIntVector.Mutator m = vector.getMutator();
       vector.allocateNew(1024);
 
@@ -403,7 +406,7 @@ public class TestValueVector {
   @Test
   public void testReAllocNullableFixedWidthVector() {
     // Create a new value vector for 1024 integers
-    try (final NullableFloat4Vector vector = (NullableFloat4Vector) MinorType.FLOAT4.getNewVector(EMPTY_SCHEMA_PATH, allocator, null, null)) {
+    try (final NullableFloat4Vector vector = newVector(NullableFloat4Vector.class, EMPTY_SCHEMA_PATH, MinorType.FLOAT4, allocator)) {
       final NullableFloat4Vector.Mutator m = vector.getMutator();
       vector.allocateNew(1024);
 
@@ -436,7 +439,7 @@ public class TestValueVector {
   @Test
   public void testReAllocNullableVariableWidthVector() {
     // Create a new value vector for 1024 integers
-    try (final NullableVarCharVector vector = (NullableVarCharVector) MinorType.VARCHAR.getNewVector(EMPTY_SCHEMA_PATH, allocator, null, null)) {
+    try (final NullableVarCharVector vector = newVector(NullableVarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
       final NullableVarCharVector.Mutator m = vector.getMutator();
       vector.allocateNew();
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
@@ -27,7 +27,6 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.NullableMapVector;
 import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeID;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.junit.After;
@@ -53,7 +52,7 @@ public class TestPromotableWriter {
   public void testPromoteToUnion() throws Exception {
 
     try (final MapVector container = new MapVector(EMPTY_SCHEMA_PATH, allocator, null);
-         final NullableMapVector v = container.addOrGet("test", MinorType.MAP, NullableMapVector.class, null);
+         final NullableMapVector v = container.addOrGetMap("test");
          final PromotableWriter writer = new PromotableWriter(v, container)) {
 
       container.allocateNew();

--- a/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowReaderWriter.java
@@ -24,11 +24,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,13 +35,10 @@ import org.apache.arrow.flatbuf.RecordBatch;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.NullableIntVector;
-import org.apache.arrow.vector.NullableTinyIntVector;
+import org.apache.arrow.vector.TestUtils;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.schema.ArrowFieldNode;
 import org.apache.arrow.vector.schema.ArrowRecordBatch;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -78,8 +72,8 @@ public class TestArrowReaderWriter {
   @Test
   public void test() throws IOException {
     Schema schema = new Schema(asList(new Field("testField", true, new ArrowType.Int(8, true), Collections.<Field>emptyList())));
-    MinorType minorType = Types.getMinorTypeForArrowType(schema.getFields().get(0).getType());
-    FieldVector vector = minorType.getNewVector("testField", allocator, null,null);
+    ArrowType type = schema.getFields().get(0).getType();
+    FieldVector vector = TestUtils.newVector(FieldVector.class, "testField", type, allocator);
     vector.initializeChildrenFromFields(schema.getFields().get(0).getChildren());
 
     byte[] validity = new byte[] { (byte) 255, 0};


### PR DESCRIPTION
I'm adding all the Type information to the vector with FieldType.
This avoids losing information and carrying around extra type metadata that can not go in the MinorType enum (for example: decimals' precision and dictionary encoding)