### PR TITLE
ARROW-679: [Format] Change FieldNode, RecordBatch lengths to long, remove LargeRecordBatch. Refactoring

### DIFF
--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -163,7 +163,7 @@ class IpcTestFixture : public io::MemoryMapFixture {
 
     RETURN_NOT_OK(WriteLargeRecordBatch(
         batch, buffer_offset, mmap_.get(), &metadata_length, &body_length, pool_));
-    return ReadLargeRecordBatch(batch.schema(), 0, mmap_.get(), result);
+    return ReadRecordBatch(batch.schema(), 0, mmap_.get(), result);
   }
 
   void CheckReadResult(const RecordBatch& result, const RecordBatch& expected) {

--- a/cpp/src/arrow/ipc/metadata.cc
+++ b/cpp/src/arrow/ipc/metadata.cc
@@ -42,7 +42,6 @@ namespace ipc {
 using FBB = flatbuffers::FlatBufferBuilder;
 using DictionaryOffset = flatbuffers::Offset<flatbuf::DictionaryEncoding>;
 using FieldOffset = flatbuffers::Offset<flatbuf::Field>;
-using LargeRecordBatchOffset = flatbuffers::Offset<flatbuf::LargeRecordBatch>;
 using RecordBatchOffset = flatbuffers::Offset<flatbuf::RecordBatch>;
 using VectorLayoutOffset = flatbuffers::Offset<arrow::flatbuf::VectorLayout>;
 using Offset = flatbuffers::Offset<void>;
@@ -536,30 +535,11 @@ Status WriteSchemaMessage(
 
 using FieldNodeVector =
     flatbuffers::Offset<flatbuffers::Vector<const flatbuf::FieldNode*>>;
-using LargeFieldNodeVector =
-    flatbuffers::Offset<flatbuffers::Vector<const flatbuf::LargeFieldNode*>>;
 using BufferVector = flatbuffers::Offset<flatbuffers::Vector<const flatbuf::Buffer*>>;
 
 static Status WriteFieldNodes(
     FBB& fbb, const std::vector<FieldMetadata>& nodes, FieldNodeVector* out) {
   std::vector<flatbuf::FieldNode> fb_nodes;
-  fb_nodes.reserve(nodes.size());
-
-  for (size_t i = 0; i < nodes.size(); ++i) {
-    const FieldMetadata& node = nodes[i];
-    if (node.offset != 0) {
-      return Status::Invalid("Field metadata for IPC must have offset 0");
-    }
-    fb_nodes.emplace_back(
-        static_cast<int32_t>(node.length), static_cast<int32_t>(node.null_count));
-  }
-  *out = fbb.CreateVectorOfStructs(fb_nodes);
-  return Status::OK();
-}
-
-static Status WriteLargeFieldNodes(
-    FBB& fbb, const std::vector<FieldMetadata>& nodes, LargeFieldNodeVector* out) {
-  std::vector<flatbuf::LargeFieldNode> fb_nodes;
   fb_nodes.reserve(nodes.size());
 
   for (size_t i = 0; i < nodes.size(); ++i) {
@@ -599,19 +579,6 @@ static Status MakeRecordBatch(FBB& fbb, int32_t length, int64_t body_length,
   return Status::OK();
 }
 
-static Status MakeLargeRecordBatch(FBB& fbb, int64_t length, int64_t body_length,
-    const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
-    LargeRecordBatchOffset* offset) {
-  LargeFieldNodeVector fb_nodes;
-  BufferVector fb_buffers;
-
-  RETURN_NOT_OK(WriteLargeFieldNodes(fbb, nodes, &fb_nodes));
-  RETURN_NOT_OK(WriteBuffers(fbb, buffers, &fb_buffers));
-
-  *offset = flatbuf::CreateLargeRecordBatch(fbb, length, fb_nodes, fb_buffers);
-  return Status::OK();
-}
-
 Status WriteRecordBatchMessage(int32_t length, int64_t body_length,
     const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
     std::shared_ptr<Buffer>* out) {
@@ -620,17 +587,6 @@ Status WriteRecordBatchMessage(int32_t length, int64_t body_length,
   RETURN_NOT_OK(MakeRecordBatch(fbb, length, body_length, nodes, buffers, &record_batch));
   return WriteMessage(
       fbb, flatbuf::MessageHeader_RecordBatch, record_batch.Union(), body_length, out);
-}
-
-Status WriteLargeRecordBatchMessage(int64_t length, int64_t body_length,
-    const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
-    std::shared_ptr<Buffer>* out) {
-  FBB fbb;
-  LargeRecordBatchOffset large_batch;
-  RETURN_NOT_OK(
-      MakeLargeRecordBatch(fbb, length, body_length, nodes, buffers, &large_batch));
-  return WriteMessage(fbb, flatbuf::MessageHeader_LargeRecordBatch, large_batch.Union(),
-      body_length, out);
 }
 
 Status WriteDictionaryMessage(int64_t id, int32_t length, int64_t body_length,
@@ -895,7 +851,7 @@ class RecordBatchMetadata::RecordBatchMetadataImpl : public MessageHolder {
 
   const flatbuf::Buffer* buffer(int i) const { return buffers_->Get(i); }
 
-  int32_t length() const { return batch_->length(); }
+  int64_t length() const { return batch_->length(); }
 
   int num_buffers() const { return batch_->buffers()->size(); }
 
@@ -947,7 +903,7 @@ BufferMetadata RecordBatchMetadata::buffer(int i) const {
   return result;
 }
 
-int32_t RecordBatchMetadata::length() const {
+int64_t RecordBatchMetadata::length() const {
   return impl_->length();
 }
 

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -150,7 +150,7 @@ class ARROW_EXPORT RecordBatchMetadata {
   FieldMetadata field(int i) const;
   BufferMetadata buffer(int i) const;
 
-  int32_t length() const;
+  int64_t length() const;
   int num_buffers() const;
   int num_fields() const;
 
@@ -226,10 +226,6 @@ Status WriteSchemaMessage(
     const Schema& schema, DictionaryMemo* dictionary_memo, std::shared_ptr<Buffer>* out);
 
 Status WriteRecordBatchMessage(int32_t length, int64_t body_length,
-    const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
-    std::shared_ptr<Buffer>* out);
-
-Status WriteLargeRecordBatchMessage(int64_t length, int64_t body_length,
     const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
     std::shared_ptr<Buffer>* out);
 

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -120,12 +120,9 @@ class ARROW_EXPORT FileReader {
   std::unique_ptr<FileReaderImpl> impl_;
 };
 
-// ----------------------------------------------------------------------
-//
 
-/// EXPERIMENTAL: Read length-prefixed LargeRecordBatch metadata (64-bit array
-/// lengths) at offset and reconstruct RecordBatch
-Status ARROW_EXPORT ReadLargeRecordBatch(const std::shared_ptr<Schema>& schema,
+/// Read encapsulated message and RecordBatch
+Status ARROW_EXPORT ReadRecordBatch(const std::shared_ptr<Schema>& schema,
     int64_t offset, io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out);
 
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -45,26 +45,26 @@ class OutputStream;
 
 namespace ipc {
 
-// Write the RecordBatch (collection of equal-length Arrow arrays) to the
-// output stream in a contiguous block. The record batch metadata is written as
-// a flatbuffer (see format/Message.fbs -- the RecordBatch message type)
-// prefixed by its size, followed by each of the memory buffers in the batch
-// written end to end (with appropriate alignment and padding):
-//
-// <int32: metadata size> <uint8*: metadata> <buffers>
-//
-// Finally, the absolute offsets (relative to the start of the output stream)
-// to the end of the body and end of the metadata / data header (suffixed by
-// the header size) is returned in out-variables
-//
-// @param(in) buffer_start_offset: the start offset to use in the buffer metadata,
-// default should be 0
-//
-// @param(out) metadata_length: the size of the length-prefixed flatbuffer
-// including padding to a 64-byte boundary
-//
-// @param(out) body_length: the size of the contiguous buffer block plus
-// padding bytes
+/// Write the RecordBatch (collection of equal-length Arrow arrays) to the
+/// output stream in a contiguous block. The record batch metadata is written as
+/// a flatbuffer (see format/Message.fbs -- the RecordBatch message type)
+/// prefixed by its size, followed by each of the memory buffers in the batch
+/// written end to end (with appropriate alignment and padding):
+///
+/// <int32: metadata size> <uint8*: metadata> <buffers>
+///
+/// Finally, the absolute offsets (relative to the start of the output stream)
+/// to the end of the body and end of the metadata / data header (suffixed by
+/// the header size) is returned in out-variables
+///
+/// @param(in) buffer_start_offset the start offset to use in the buffer metadata,
+/// default should be 0
+/// @param(in) allow_64bit permit field lengths exceeding INT32_MAX. May not be
+/// readable by other Arrow implementations
+/// @param(out) metadata_length: the size of the length-prefixed flatbuffer
+/// including padding to a 64-byte boundary
+/// @param(out) body_length: the size of the contiguous buffer block plus
+/// padding bytes
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
     io::OutputStream* dst, int32_t* metadata_length, int64_t* body_length,
     MemoryPool* pool, int max_recursion_depth = kMaxNestingDepth,

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -67,7 +67,8 @@ namespace ipc {
 // padding bytes
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
     io::OutputStream* dst, int32_t* metadata_length, int64_t* body_length,
-    MemoryPool* pool, int max_recursion_depth = kMaxNestingDepth);
+    MemoryPool* pool, int max_recursion_depth = kMaxNestingDepth,
+    bool allow_64bit = false);
 
 // Write Array as a DictionaryBatch message
 Status WriteDictionary(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,
@@ -116,13 +117,11 @@ class ARROW_EXPORT FileWriter : public StreamWriter {
   std::unique_ptr<FileWriterImpl> impl_;
 };
 
-// ----------------------------------------------------------------------
-
-/// EXPERIMENTAL: Write record batch using LargeRecordBatch IPC metadata. This
-/// data may not be readable by all Arrow implementations
+/// EXPERIMENTAL: Write RecordBatch allowing lengths over INT32_MAX. This data
+/// may not be readable by all Arrow implementations
 Status WriteLargeRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
     io::OutputStream* dst, int32_t* metadata_length, int64_t* body_length,
-    MemoryPool* pool, int max_recursion_depth = kMaxNestingDepth);
+    MemoryPool* pool);
 
 }  // namespace ipc
 }  // namespace arrow

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -290,12 +290,12 @@ struct Buffer {
 struct FieldNode {
   /// The number of value slots in the Arrow array at this level of a nested
   /// tree
-  length: int;
+  length: long;
 
   /// The number of observed nulls. Fields with null_count == 0 may choose not
   /// to write their physical validity bitmap out as a materialized buffer,
   /// instead setting the length of the bitmap buffer to 0.
-  null_count: int;
+  null_count: long;
 }
 
 /// A data header describing the shared memory layout of a "record" or "row"
@@ -304,7 +304,7 @@ struct FieldNode {
 table RecordBatch {
   /// number of records / rows. The arrays in the batch should all have this
   /// length
-  length: int;
+  length: long;
 
   /// Nodes correspond to the pre-ordered flattened logical schema
   nodes: [FieldNode];
@@ -315,22 +315,6 @@ table RecordBatch {
   /// example, most primitive arrays will have 2 buffers, 1 for the validity
   /// bitmap and 1 for the values. For struct arrays, there will only be a
   /// single buffer for the validity (nulls) bitmap
-  buffers: [Buffer];
-}
-
-/// ----------------------------------------------------------------------
-/// EXPERIMENTAL: A RecordBatch type that supports data with more than 2^31 - 1
-/// elements. Arrow implementations do not need to implement this type to be
-/// compliant
-
-struct LargeFieldNode {
-  length: long;
-  null_count: long;
-}
-
-table LargeRecordBatch {
-  length: long;
-  nodes: [LargeFieldNode];
   buffers: [Buffer];
 }
 
@@ -356,7 +340,7 @@ table DictionaryBatch {
 /// which may include experimental metadata types. For maximum compatibility,
 /// it is best to send data using RecordBatch
 union MessageHeader {
-  Schema, DictionaryBatch, RecordBatch, LargeRecordBatch
+  Schema, DictionaryBatch, RecordBatch
 }
 
 table Message {

--- a/java/vector/src/main/java/org/apache/arrow/vector/schema/ArrowFieldNode.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/schema/ArrowFieldNode.java
@@ -34,7 +34,7 @@ public class ArrowFieldNode implements FBSerializable {
 
   @Override
   public int writeTo(FlatBufferBuilder builder) {
-    return FieldNode.createFieldNode(builder, length, nullCount);
+    return FieldNode.createFieldNode(builder, (long)length, (long)nullCount);
   }
 
   public int getNullCount() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/stream/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/stream/MessageSerializer.java
@@ -207,7 +207,7 @@ public class MessageSerializer {
     List<ArrowFieldNode> nodes = new ArrayList<>();
     for (int i = 0; i < nodesLength; ++i) {
       FieldNode node = recordBatchFB.nodes(i);
-      nodes.add(new ArrowFieldNode(node.length(), node.nullCount()));
+      nodes.add(new ArrowFieldNode((int)node.length(), (int)node.nullCount()));
     }
     List<ArrowBuf> buffers = new ArrayList<>();
     for (int i = 0; i < recordBatchFB.buffersLength(); ++i) {
@@ -216,7 +216,7 @@ public class MessageSerializer {
       buffers.add(vectorBuffer);
     }
     ArrowRecordBatch arrowRecordBatch =
-        new ArrowRecordBatch(recordBatchFB.length(), nodes, buffers);
+        new ArrowRecordBatch((int)recordBatchFB.length(), nodes, buffers);
     body.release();
     return arrowRecordBatch;
   }


### PR DESCRIPTION
This enables me to delete a bunch of code without losing functionality. C++ users must explicitly opt-in to writing size over INT32_MAX.

cc @julienledem. I have not added checks in Java about sizes over INT32_MAX, wasn't sure where you might want to do that. 