### PR TITLE
ARROW-680: [C++] Support CMake 2 or older again

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -28,7 +28,13 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
 include(CMakeParseArguments)
 include(ExternalProject)
-include(GNUInstallDirs)
+
+if(CMAKE_MAJOR_VERSION LESS 3)
+  set(CMAKE_INSTALL_INCLUDEDIR "include")
+  set(CMAKE_INSTALL_LIBDIR "lib")
+else()
+  include(GNUInstallDirs)
+endif()
 
 set(ARROW_SO_VERSION "0")
 set(ARROW_ABI_VERSION "${ARROW_SO_VERSION}.0.0")


### PR DESCRIPTION
GNUInstallDirs in CMake 2 always uses multiarch cared library directory.

See also: https://github.com/Kitware/CMake/commit/620939e4e6f5a61cd5c0fac2704de4bfda0eb7ef