### PR TITLE
ARROW-688: [C++] Use CMAKE_INSTALL_INCLUDEDIR for consistency

### DIFF
--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -109,7 +109,7 @@ install(FILES
   hdfs.h
   interfaces.h
   memory.h
-  DESTINATION include/arrow/io)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/io")
 
 # pkg-config support
 configure_file(arrow-io.pc.in

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -144,7 +144,7 @@ install(FILES
   metadata.h
   reader.h
   writer.h
-  DESTINATION include/arrow/ipc)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/ipc")
 
 # pkg-config support
 configure_file(arrow-ipc.pc.in

--- a/cpp/src/arrow/jemalloc/CMakeLists.txt
+++ b/cpp/src/arrow/jemalloc/CMakeLists.txt
@@ -104,7 +104,7 @@ ARROW_BENCHMARK_LINK_LIBRARIES(jemalloc-builder-benchmark
 # Headers: top level
 install(FILES
   memory_pool.h
-  DESTINATION include/arrow/jemalloc)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/jemalloc")
 
 # pkg-config support
 configure_file(arrow-jemalloc.pc.in


### PR DESCRIPTION
Using CMAKE_INSTALL_INCLUDEDIR isn't required. It's just for
consistency. We already used CMAKE_INSTALL_INCLUDEDIR at
cpp/src/arrow/CMakeLists.txt.

Or we can revert CMAKE_INSTALL_INCLUDEDIR change at cpp/src/arrow/CMakeLists.txt.