### PR TITLE
ARROW-689: [GLib] Fix install directories

### DIFF
--- a/c_glib/Makefile.am
+++ b/c_glib/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST =					\
 	LICENSE.txt				\
 	version
 
-doc_DATA =					\
+arrow_glib_docdir = ${datarootdir}/doc/arrow-glib
+arrow_glib_doc_DATA =				\
 	README.md				\
 	LICENSE.txt

--- a/c_glib/arrow-glib/Makefile.am
+++ b/c_glib/arrow-glib/Makefile.am
@@ -403,7 +403,8 @@ stamp-ipc-enums.c: $(libarrow_ipc_glib_la_headers) ipc-enums.c.template
 	     $(libarrow_ipc_glib_la_headers)) > ipc-enums.c
 	touch $@
 
-pkginclude_HEADERS =					\
+arrow_glib_includedir = $(includedir)/arrow-glib
+arrow_glib_include_HEADERS =				\
 	$(libarrow_glib_la_headers)			\
 	$(libarrow_glib_la_cpp_headers)			\
 	$(libarrow_glib_la_generated_headers)		\


### PR DESCRIPTION
Header files should be installed into
`${PREFIX}/include/arrow-glib/` instead of
`${PREFIX}/include/apache-arrow-glib/`.

Documents should be installed into
`${PREFIX}/share/doc/arrow-glib/` instead of
`${PREFIX}/share/doc/apache-arrow-glib/`.

We needed to change install directories when we changed `AC_INIT()`'s 3rd
argument to apache-arrow-glib...