### PR TITLE
ARROW-701: [Java] Support Additional Date Type Metadata

### DIFF
--- a/java/vector/src/main/codegen/data/ArrowTypes.tdd
+++ b/java/vector/src/main/codegen/data/ArrowTypes.tdd
@@ -54,7 +54,7 @@
     },
     {
       name: "Date",
-      fields: []
+      fields: [{name: "unit", type: short, valueType: DateUnit}]
     },
     {
       name: "Time",

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/DateUnit.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/DateUnit.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.apache.arrow.vector.types;
+
+public enum DateUnit {
+  DAY(org.apache.arrow.flatbuf.DateUnit.DAY),
+  MILLISECOND(org.apache.arrow.flatbuf.DateUnit.MILLISECOND);
+
+  private static final DateUnit[] valuesByFlatbufId = new DateUnit[DateUnit.values().length];
+  static {
+    for (DateUnit v : DateUnit.values()) {
+      valuesByFlatbufId[v.flatbufID] = v;
+    }
+  }
+
+  private final short flatbufID;
+
+  DateUnit(short flatbufID) {
+    this.flatbufID = flatbufID;
+  }
+
+  public short getFlatbufID() {
+    return flatbufID;
+  }
+
+  public static DateUnit fromFlatbufID(short id) {
+    return valuesByFlatbufId[id];
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -107,7 +107,7 @@ public class Types {
   private static final Field UINT2_FIELD = new Field("", true, new Int(16, false), null);
   private static final Field UINT4_FIELD = new Field("", true, new Int(32, false), null);
   private static final Field UINT8_FIELD = new Field("", true, new Int(64, false), null);
-  private static final Field DATE_FIELD = new Field("", true, Date.INSTANCE, null);
+  private static final Field DATE_FIELD = new Field("", true, new Date(DateUnit.MILLISECOND), null);
   private static final Field TIME_FIELD = new Field("", true, new Time(TimeUnit.MILLISECOND, 32), null);
   private static final Field TIMESTAMPSEC_FIELD = new Field("", true, new Timestamp(TimeUnit.SECOND, "UTC"), null);
   private static final Field TIMESTAMPMILLI_FIELD = new Field("", true, new Timestamp(TimeUnit.MILLISECOND, "UTC"), null);
@@ -219,7 +219,7 @@ public class Types {
         return new BigIntWriterImpl((NullableBigIntVector) vector);
       }
     },
-    DATE(Date.INSTANCE) {
+    DATE(new Date(DateUnit.MILLISECOND)) {
       @Override
       public Field getField() {
         return DATE_FIELD;

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestSchema.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.IntervalUnit;
 import org.apache.arrow.vector.types.TimeUnit;
@@ -60,7 +61,7 @@ public class TestSchema {
         field("b", new Struct(),
             field("c", new Int(16, true)),
             field("d", new Utf8())),
-        field("e", new List(), field(null, new Date())),
+        field("e", new List(), field(null, new Date(DateUnit.MILLISECOND))),
         field("f", new FloatingPoint(FloatingPointPrecision.SINGLE)),
         field("g", new Timestamp(TimeUnit.MILLISECOND, "UTC")),
         field("h", new Timestamp(TimeUnit.MICROSECOND, null)),
@@ -68,7 +69,7 @@ public class TestSchema {
         ));
     roundTrip(schema);
     assertEquals(
-        "Schema<a: Int(8, true) not null, b: Struct<c: Int(16, true), d: Utf8>, e: List<Date>, f: FloatingPoint(SINGLE), g: Timestamp(MILLISECOND, UTC), h: Timestamp(MICROSECOND, null), i: Interval(DAY_TIME)>",
+        "Schema<a: Int(8, true) not null, b: Struct<c: Int(16, true), d: Utf8>, e: List<Date(MILLISECOND)>, f: FloatingPoint(SINGLE), g: Timestamp(MILLISECOND, UTC), h: Timestamp(MICROSECOND, null), i: Interval(DAY_TIME)>",
         schema.toString());
   }
 
@@ -85,7 +86,7 @@ public class TestSchema {
         field("h", new Binary()),
         field("i", new Bool()),
         field("j", new Decimal(5, 5)),
-        field("k", new Date()),
+        field("k", new Date(DateUnit.MILLISECOND)),
         field("l", new Time(TimeUnit.MILLISECOND, 32)),
         field("m", new Timestamp(TimeUnit.MILLISECOND, "UTC")),
         field("n", new Timestamp(TimeUnit.MICROSECOND, null)),


### PR DESCRIPTION
The format for Date type now includes metadata for units as DAYS or MILLISECONDS.  This change adds DateUnit and support for usage in metadata.  Includes round-trip JSON testing.