### PR TITLE
ARROW-550: [Format] Draft experimental Tensor flatbuffer message type

### DIFF
--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -114,6 +114,7 @@ set(FBS_SRC
   ${CMAKE_SOURCE_DIR}/../format/Message.fbs
   ${CMAKE_SOURCE_DIR}/../format/File.fbs
   ${CMAKE_SOURCE_DIR}/../format/Schema.fbs
+  ${CMAKE_SOURCE_DIR}/../format/Tensor.fbs
   ${CMAKE_CURRENT_SOURCE_DIR}/feather.fbs)
 
 foreach(FIL ${FBS_SRC})

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -16,6 +16,7 @@
 // under the License.
 
 include "Schema.fbs";
+include "Tensor.fbs";
 
 namespace org.apache.arrow.flatbuf;
 
@@ -82,7 +83,7 @@ table DictionaryBatch {
 /// which may include experimental metadata types. For maximum compatibility,
 /// it is best to send data using RecordBatch
 union MessageHeader {
-  Schema, DictionaryBatch, RecordBatch
+  Schema, DictionaryBatch, RecordBatch, Tensor
 }
 
 table Message {

--- a/format/Tensor.fbs
+++ b/format/Tensor.fbs
@@ -32,7 +32,7 @@ table TensorDim {
   name: string;
 }
 
-enum TensorOrder : short {
+enum TensorOrder : byte {
   /// Higher dimensions vary first when traversing data in byte-contiguous
   /// order, aka "C order"
   ROW_MAJOR,

--- a/format/Tensor.fbs
+++ b/format/Tensor.fbs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// EXPERIMENTAL: Metadata for n-dimensional arrays, aka "tensors" or
+/// "ndarrays". Arrow implementations in general are not required to implement
+/// this type
+
+include "Schema.fbs";
+
+namespace org.apache.arrow.flatbuf;
+
+/// Shape data for a single axis in a tensor
+table TensorDim {
+  /// Length of dimension
+  size: long;
+
+  /// Name of the dimension, optional
+  name: string;
+}
+
+table Tensor {
+  /// The type of data contained in a value cell. Currently only fixed-width
+  /// value types are supported, no strings or nested types
+  type: Type;
+
+  /// The dimensions of the tensor, optionally named
+  shape: [TensorDim];
+
+  /// The size of a memory increment necessary to advance 1 cell along a given
+  /// axis. If the strides member is null or has 0 length, then the strides
+  /// will be computed from the shape according to row major order
+  strides: [long];
+
+  /// The location and size of the tensor's data
+  data: Buffer;
+}
+
+root_type Tensor;

--- a/format/Tensor.fbs
+++ b/format/Tensor.fbs
@@ -32,6 +32,16 @@ table TensorDim {
   name: string;
 }
 
+enum TensorOrder : short {
+  /// Higher dimensions vary first when traversing data in byte-contiguous
+  /// order, aka "C order"
+  ROW_MAJOR,
+
+  /// Lower dimensions vary first when traversing data in byte-contiguous
+  /// order, aka "Fortran order"
+  COLUMN_MAJOR
+}
+
 table Tensor {
   /// The type of data contained in a value cell. Currently only fixed-width
   /// value types are supported, no strings or nested types
@@ -40,10 +50,8 @@ table Tensor {
   /// The dimensions of the tensor, optionally named
   shape: [TensorDim];
 
-  /// The size of a memory increment necessary to advance 1 cell along a given
-  /// axis. If the strides member is null or has 0 length, then the strides
-  /// will be computed from the shape according to row major order
-  strides: [long];
+  /// The memory order of the tensor's data
+  order: TensorOrder;
 
   /// The location and size of the tensor's data
   data: Buffer;

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -110,8 +110,9 @@
               <argument>-o</argument>
               <argument>${flatc.generated.files}</argument>
               <argument>../../format/Schema.fbs</argument>
-              <argument>../../format/Message.fbs</argument>
+              <argument>../../format/Tensor.fbs</argument>
               <argument>../../format/File.fbs</argument>
+              <argument>../../format/Message.fbs</argument>
             </arguments>
           </configuration>
         </execution>


### PR DESCRIPTION
Tensor-like data occurs very frequently in scientific computing and machine learning applications that are mostly implemented in C and C++. Arrow's C++ memory management and shared memory utilities can help serve these use cases for zero-copy data transfer to other tensor-like data structures (like NumPy ndarrays, or the tensor objects used in machine learning libraries like TensorFlow or Torch).

The Tensor data structure is loosely modeled after NumPy's ndarray object and TensorFlow's tensor protocol buffers type (https://github.com/tensorflow/tensorflow/blob/754048a0453a04a761e112ae5d99c149eb9910dd/tensorflow/core/framework/tensor.proto). 

cc @pcmoritz @robertnishihara @sylvaincorlay @JohanMabille 