### PR TITLE
ARROW-658: [C++] Implement a prototype in-memory arrow::Tensor type

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -792,6 +792,7 @@ set(ARROW_SRCS
   src/arrow/schema.cc
   src/arrow/status.cc
   src/arrow/table.cc
+  src/arrow/tensor.cc
   src/arrow/type.cc
   src/arrow/visitor.cc
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -65,6 +65,7 @@ ADD_ARROW_TEST(pretty_print-test)
 ADD_ARROW_TEST(status-test)
 ADD_ARROW_TEST(type-test)
 ADD_ARROW_TEST(table-test)
+ADD_ARROW_TEST(tensor-test)
 
 ADD_ARROW_BENCHMARK(builder-benchmark)
 ADD_ARROW_BENCHMARK(column-benchmark)

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -68,10 +68,6 @@ bool Buffer::Equals(const Buffer& other) const {
                                                             static_cast<size_t>(size_))));
 }
 
-std::shared_ptr<Buffer> MutableBuffer::GetImmutableView() {
-  return std::make_shared<Buffer>(this->get_shared_ptr(), 0, size());
-}
-
 PoolBuffer::PoolBuffer(MemoryPool* pool) : ResizableBuffer(nullptr, 0) {
   if (pool == nullptr) { pool = default_memory_pool(); }
   pool_ = pool;

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -43,7 +43,7 @@ class Status;
 /// of bytes that where allocated for the buffer in total.
 ///
 /// The following invariant is always true: Size < Capacity
-class ARROW_EXPORT Buffer : public std::enable_shared_from_this<Buffer> {
+class ARROW_EXPORT Buffer {
  public:
   Buffer(const uint8_t* data, int64_t size)
       : is_mutable_(false), data_(data), size_(size), capacity_(size) {}
@@ -57,8 +57,6 @@ class ARROW_EXPORT Buffer : public std::enable_shared_from_this<Buffer> {
   /// in general we expected buffers to be aligned and padded to 64 bytes.  In the future
   /// we might add utility methods to help determine if a buffer satisfies this contract.
   Buffer(const std::shared_ptr<Buffer>& parent, int64_t offset, int64_t size);
-
-  std::shared_ptr<Buffer> get_shared_ptr() { return shared_from_this(); }
 
   bool is_mutable() const { return is_mutable_; }
 
@@ -110,9 +108,6 @@ class ARROW_EXPORT MutableBuffer : public Buffer {
   }
 
   uint8_t* mutable_data() { return mutable_data_; }
-
-  /// Get a read-only view of this buffer
-  std::shared_ptr<Buffer> GetImmutableView();
 
  protected:
   MutableBuffer() : Buffer(nullptr, 0), mutable_data_(nullptr) {}

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Unit tests for DataType (and subclasses), Field, and Schema
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "arrow/buffer.h"
+#include "arrow/tensor.h"
+#include "arrow/test-util.h"
+#include "arrow/type.h"
+
+namespace arrow {
+
+TEST(TestTensor, BasicCtors) {
+  const int64_t values = 24;
+  std::vector<int64_t> shape = {4, 6};
+  std::vector<int64_t> strides = {48, 8};
+  std::vector<std::string> dim_names = {"foo", "bar"};
+
+  using T = int64_t;
+
+  std::shared_ptr<MutableBuffer> buffer;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), values * sizeof(T), &buffer));
+
+  Int64Tensor t1(buffer, shape);
+  Int64Tensor t2(buffer, shape, strides);
+  Int64Tensor t3(buffer, shape, strides, dim_names);
+
+  ASSERT_EQ(24, t1.size());
+  ASSERT_TRUE(t1.is_mutable());
+  ASSERT_FALSE(t1.has_dim_names());
+
+  ASSERT_EQ(strides, t1.strides());
+  ASSERT_EQ(strides, t2.strides());
+
+  ASSERT_EQ("foo", t3.dim_name(0));
+  ASSERT_EQ("bar", t3.dim_name(1));
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -30,6 +30,20 @@
 
 namespace arrow {
 
+TEST(TestTensor, ZeroDim) {
+  const int64_t values = 1;
+  std::vector<int64_t> shape = {};
+
+  using T = int64_t;
+
+  std::shared_ptr<MutableBuffer> buffer;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), values * sizeof(T), &buffer));
+
+  Int64Tensor t0(buffer, shape);
+
+  ASSERT_EQ(1, t0.size());
+}
+
 TEST(TestTensor, BasicCtors) {
   const int64_t values = 24;
   std::vector<int64_t> shape = {4, 6};

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -45,8 +45,8 @@ void ComputeRowMajorStrides(const FixedWidthType& type, const std::vector<int64_
 
 /// Constructor with strides and dimension names
 Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-    std::vector<int64_t> shape, std::vector<int64_t> strides,
-    std::vector<std::string> dim_names)
+    const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
+    const std::vector<std::string>& dim_names)
     : type_(type), data_(data), shape_(shape), strides_(strides), dim_names_(dim_names) {
   DCHECK(is_tensor_supported(type->type));
   if (shape.size() > 0 && strides.size() == 0) {
@@ -55,11 +55,11 @@ Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buff
 }
 
 Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-    std::vector<int64_t> shape, std::vector<int64_t> strides)
+    const std::vector<int64_t>& shape, const std::vector<int64_t>& strides)
     : Tensor(type, data, shape, strides, {}) {}
 
 Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-    std::vector<int64_t> shape)
+    const std::vector<int64_t>& shape)
     : Tensor(type, data, shape, {}, {}) {}
 
 const std::string& Tensor::dim_name(int i) const {
@@ -78,8 +78,8 @@ int64_t Tensor::size() const {
 
 template <typename T>
 NumericTensor<T>::NumericTensor(const std::shared_ptr<Buffer>& data,
-    std::vector<int64_t> shape, std::vector<int64_t> strides,
-    std::vector<std::string> dim_names)
+    const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
+    const std::vector<std::string>& dim_names)
     : Tensor(TypeTraits<T>::type_singleton(), data, shape, strides, dim_names),
       raw_data_(nullptr),
       mutable_raw_data_(nullptr) {
@@ -94,12 +94,12 @@ NumericTensor<T>::NumericTensor(const std::shared_ptr<Buffer>& data,
 
 template <typename T>
 NumericTensor<T>::NumericTensor(
-    const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape)
+    const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape)
     : NumericTensor(data, shape, {}, {}) {}
 
 template <typename T>
 NumericTensor<T>::NumericTensor(const std::shared_ptr<Buffer>& data,
-    std::vector<int64_t> shape, std::vector<int64_t> strides)
+    const std::vector<int64_t>& shape, const std::vector<int64_t>& strides)
     : NumericTensor(data, shape, strides, {}) {}
 
 template class NumericTensor<Int8Type>;

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/tensor.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/type.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+
+void ComputeRowMajorStrides(const FixedWidthType& type, const std::vector<int64_t>& shape,
+    std::vector<int64_t>* strides) {
+  int64_t remaining = type.bit_width() / 8;
+  for (int64_t dimsize : shape) {
+    remaining *= dimsize;
+  }
+
+  for (int64_t dimsize : shape) {
+    remaining /= dimsize;
+    strides->push_back(remaining);
+  }
+}
+
+/// Constructor with strides and dimension names
+Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+    std::vector<int64_t> shape, std::vector<int64_t> strides,
+    std::vector<std::string> dim_names)
+    : type_(type), data_(data), shape_(shape), strides_(strides), dim_names_(dim_names) {
+  DCHECK(is_tensor_supported(type->type));
+  if (shape.size() > 0 && strides.size() == 0) {
+    ComputeRowMajorStrides(static_cast<const FixedWidthType&>(*type_), shape, &strides_);
+  }
+}
+
+Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+    std::vector<int64_t> shape, std::vector<int64_t> strides)
+    : Tensor(type, data, shape, strides, {}) {}
+
+Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+    std::vector<int64_t> shape)
+    : Tensor(type, data, shape, {}, {}) {}
+
+const std::string& Tensor::dim_name(int i) const {
+  DCHECK_LT(i, static_cast<int>(dim_names_.size()));
+  return dim_names_[i];
+}
+
+int64_t Tensor::size() const {
+  if (shape_.size() == 0) { return 0; }
+  int64_t size = 1;
+  for (int64_t dimsize : shape_) {
+    size *= dimsize;
+  }
+  return size;
+}
+
+template <typename T>
+NumericTensor<T>::NumericTensor(const std::shared_ptr<Buffer>& data,
+    std::vector<int64_t> shape, std::vector<int64_t> strides,
+    std::vector<std::string> dim_names)
+    : Tensor(TypeTraits<T>::type_singleton(), data, shape, strides, dim_names),
+      raw_data_(nullptr),
+      mutable_raw_data_(nullptr) {
+  if (data_) {
+    raw_data_ = reinterpret_cast<const value_type*>(data_->data());
+    if (data_->is_mutable()) {
+      auto mut_buf = static_cast<MutableBuffer*>(data_.get());
+      mutable_raw_data_ = reinterpret_cast<value_type*>(mut_buf->mutable_data());
+    }
+  }
+}
+
+template <typename T>
+NumericTensor<T>::NumericTensor(
+    const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape)
+    : NumericTensor(data, shape, {}, {}) {}
+
+template <typename T>
+NumericTensor<T>::NumericTensor(const std::shared_ptr<Buffer>& data,
+    std::vector<int64_t> shape, std::vector<int64_t> strides)
+    : NumericTensor(data, shape, strides, {}) {}
+
+template class NumericTensor<Int8Type>;
+template class NumericTensor<UInt8Type>;
+template class NumericTensor<Int16Type>;
+template class NumericTensor<UInt16Type>;
+template class NumericTensor<Int32Type>;
+template class NumericTensor<UInt32Type>;
+template class NumericTensor<Int64Type>;
+template class NumericTensor<UInt64Type>;
+template class NumericTensor<HalfFloatType>;
+template class NumericTensor<FloatType>;
+template class NumericTensor<DoubleType>;
+
+}  // namespace arrow

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -18,6 +18,7 @@
 #include "arrow/tensor.h"
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -68,12 +69,9 @@ const std::string& Tensor::dim_name(int i) const {
 }
 
 int64_t Tensor::size() const {
-  if (shape_.size() == 0) { return 0; }
-  int64_t size = 1;
-  for (int64_t dimsize : shape_) {
-    size *= dimsize;
-  }
-  return size;
+  if (shape_.size() == 0) { return 1; }
+  return std::accumulate(
+      shape_.begin(), shape_.end(), 1, std::multiplies<int64_t>());
 }
 
 template <typename T>

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/tensor.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -69,7 +69,6 @@ const std::string& Tensor::dim_name(int i) const {
 }
 
 int64_t Tensor::size() const {
-  if (shape_.size() == 0) { return 1; }
   return std::accumulate(
       shape_.begin(), shape_.end(), 1, std::multiplies<int64_t>());
 }

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -104,7 +104,7 @@ class ARROW_EXPORT Tensor {
 };
 
 template <typename T>
-class NumericTensor : public Tensor {
+class ARROW_EXPORT NumericTensor : public Tensor {
  public:
   using value_type = typename T::c_type;
 
@@ -125,6 +125,33 @@ class NumericTensor : public Tensor {
   const value_type* raw_data_;
   value_type* mutable_raw_data_;
 };
+
+// ----------------------------------------------------------------------
+// extern templates and other details
+
+// gcc and clang disagree about how to handle template visibility when you have
+// explicit specializations https://llvm.org/bugs/show_bug.cgi?id=24815
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+// Only instantiate these templates once
+extern template class ARROW_EXPORT NumericTensor<Int8Type>;
+extern template class ARROW_EXPORT NumericTensor<UInt8Type>;
+extern template class ARROW_EXPORT NumericTensor<Int16Type>;
+extern template class ARROW_EXPORT NumericTensor<UInt16Type>;
+extern template class ARROW_EXPORT NumericTensor<Int32Type>;
+extern template class ARROW_EXPORT NumericTensor<UInt32Type>;
+extern template class ARROW_EXPORT NumericTensor<Int64Type>;
+extern template class ARROW_EXPORT NumericTensor<UInt64Type>;
+extern template class ARROW_EXPORT NumericTensor<HalfFloatType>;
+extern template class ARROW_EXPORT NumericTensor<FloatType>;
+extern template class ARROW_EXPORT NumericTensor<DoubleType>;
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_TENSOR_H
+#define ARROW_TENSOR_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/buffer.h"
+#include "arrow/type.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class Buffer;
+class MemoryPool;
+class MutableBuffer;
+class Status;
+
+static inline bool is_tensor_supported(Type::type type_id) {
+  switch (type_id) {
+    case Type::UINT8:
+    case Type::INT8:
+    case Type::UINT16:
+    case Type::INT16:
+    case Type::UINT32:
+    case Type::INT32:
+    case Type::UINT64:
+    case Type::INT64:
+    case Type::HALF_FLOAT:
+    case Type::FLOAT:
+    case Type::DOUBLE:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+class ARROW_EXPORT Tensor {
+ public:
+  virtual ~Tensor() = default;
+
+  /// Constructor with no dimension names or strides, data assumed to be row-major
+  Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+      std::vector<int64_t> shape);
+
+  /// Constructor with non-negative strides
+  Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+      std::vector<int64_t> shape, std::vector<int64_t> strides);
+
+  /// Constructor with strides and dimension names
+  Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+      std::vector<int64_t> shape, std::vector<int64_t> strides,
+      std::vector<std::string> dim_names);
+
+  std::shared_ptr<Buffer> data() const { return data_; }
+  const std::vector<int64_t>& shape() const { return shape_; }
+  const std::vector<int64_t>& strides() const { return strides_; }
+
+  const std::string& dim_name(int i) const;
+  bool has_dim_names() const { return shape_.size() > 0 && dim_names_.size() > 0; }
+
+  /// Total number of value cells in the tensor
+  int64_t size() const;
+
+  /// Return true if the underlying data buffer is mutable
+  bool is_mutable() const { return data_->is_mutable(); }
+
+ protected:
+  Tensor() {}
+
+  std::shared_ptr<DataType> type_;
+
+  std::shared_ptr<Buffer> data_;
+
+  std::vector<int64_t> shape_;
+  std::vector<int64_t> strides_;
+
+  /// These names are optional
+  std::vector<std::string> dim_names_;
+
+  DISALLOW_COPY_AND_ASSIGN(Tensor);
+};
+
+template <typename T>
+class NumericTensor : public Tensor {
+ public:
+  using value_type = typename T::c_type;
+
+  NumericTensor(const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape);
+
+  /// Constructor with strides and dimension names
+  NumericTensor(const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape,
+      std::vector<int64_t> strides, std::vector<std::string> dim_names);
+
+  /// Constructor with non-negative strides
+  NumericTensor(const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape,
+      std::vector<int64_t> strides);
+
+  const value_type* raw_data() const { return raw_data_; }
+  value_type* raw_data() { return mutable_raw_data_; }
+
+ private:
+  const value_type* raw_data_;
+  value_type* mutable_raw_data_;
+};
+
+}  // namespace arrow
+
+#endif  // ARROW_TENSOR_H

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -99,6 +99,7 @@ class ARROW_EXPORT Tensor {
   /// These names are optional
   std::vector<std::string> dim_names_;
 
+ private:
   DISALLOW_COPY_AND_ASSIGN(Tensor);
 };
 

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -62,16 +62,16 @@ class ARROW_EXPORT Tensor {
 
   /// Constructor with no dimension names or strides, data assumed to be row-major
   Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-      std::vector<int64_t> shape);
+      const std::vector<int64_t>& shape);
 
   /// Constructor with non-negative strides
   Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-      std::vector<int64_t> shape, std::vector<int64_t> strides);
+      const std::vector<int64_t>& shape, const std::vector<int64_t>& strides);
 
   /// Constructor with strides and dimension names
   Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-      std::vector<int64_t> shape, std::vector<int64_t> strides,
-      std::vector<std::string> dim_names);
+      const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
+      const std::vector<std::string>& dim_names);
 
   std::shared_ptr<Buffer> data() const { return data_; }
   const std::vector<int64_t>& shape() const { return shape_; }
@@ -108,15 +108,15 @@ class ARROW_EXPORT NumericTensor : public Tensor {
  public:
   using value_type = typename T::c_type;
 
-  NumericTensor(const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape);
-
-  /// Constructor with strides and dimension names
-  NumericTensor(const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape,
-      std::vector<int64_t> strides, std::vector<std::string> dim_names);
+  NumericTensor(const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape);
 
   /// Constructor with non-negative strides
-  NumericTensor(const std::shared_ptr<Buffer>& data, std::vector<int64_t> shape,
-      std::vector<int64_t> strides);
+  NumericTensor(const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
+      const std::vector<int64_t>& strides);
+
+  /// Constructor with strides and dimension names
+  NumericTensor(const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
+      const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names);
 
   const value_type* raw_data() const { return raw_data_; }
   value_type* raw_data() { return mutable_raw_data_; }

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -30,6 +30,7 @@ struct DataType;
 class Array;
 class ArrayBuilder;
 struct Field;
+class Tensor;
 
 class Buffer;
 class MemoryPool;
@@ -78,10 +79,14 @@ class NumericArray;
 template <typename TypeClass>
 class NumericBuilder;
 
-#define _NUMERIC_TYPE_DECL(KLASS)                 \
-  struct KLASS##Type;                             \
-  using KLASS##Array = NumericArray<KLASS##Type>; \
-  using KLASS##Builder = NumericBuilder<KLASS##Type>;
+template <typename TypeClass>
+class NumericTensor;
+
+#define _NUMERIC_TYPE_DECL(KLASS)                     \
+  struct KLASS##Type;                                 \
+  using KLASS##Array = NumericArray<KLASS##Type>;     \
+  using KLASS##Builder = NumericBuilder<KLASS##Type>; \
+  using KLASS##Tensor = NumericTensor<KLASS##Type>;
 
 _NUMERIC_TYPE_DECL(Int8);
 _NUMERIC_TYPE_DECL(Int16);


### PR DESCRIPTION
I haven't implemented much beyond the data container and automatically computing row major strides. If we agree on the basics, then I will implement IPC read/writes of this data structure in a follow up patch. 

cc @pcmoritz @robertnishihara @JohanMabille @sylvaincorlay