### PR TITLE
ARROW-627: [C++] Add compatibility macros for exported extern templates

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -445,21 +445,21 @@ Status Array::Accept(ArrayVisitor* visitor) const {
 // ----------------------------------------------------------------------
 // Instantiate templates
 
-template class NumericArray<UInt8Type>;
-template class NumericArray<UInt16Type>;
-template class NumericArray<UInt32Type>;
-template class NumericArray<UInt64Type>;
-template class NumericArray<Int8Type>;
-template class NumericArray<Int16Type>;
-template class NumericArray<Int32Type>;
-template class NumericArray<Int64Type>;
-template class NumericArray<TimestampType>;
-template class NumericArray<Date32Type>;
-template class NumericArray<Date64Type>;
-template class NumericArray<Time32Type>;
-template class NumericArray<Time64Type>;
-template class NumericArray<HalfFloatType>;
-template class NumericArray<FloatType>;
-template class NumericArray<DoubleType>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<UInt8Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<UInt16Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<UInt32Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<UInt64Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Int8Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Int16Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Int32Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Int64Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<TimestampType>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Date32Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Date64Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Time32Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<Time64Type>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<HalfFloatType>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<FloatType>;
+template class ARROW_TEMPLATE_EXPORT NumericArray<DoubleType>;
 
 }  // namespace arrow

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -484,22 +484,22 @@ class ARROW_EXPORT DictionaryArray : public Array {
 // extern templates and other details
 
 // Only instantiate these templates once
-EXTERN_TEMPLATE_CLASS NumericArray<Int8Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<UInt8Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<Int16Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<UInt16Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<Int32Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<UInt32Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<Int64Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<UInt64Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<HalfFloatType>;
-EXTERN_TEMPLATE_CLASS NumericArray<FloatType>;
-EXTERN_TEMPLATE_CLASS NumericArray<DoubleType>;
-EXTERN_TEMPLATE_CLASS NumericArray<Date32Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<Date64Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<Time32Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<Time64Type>;
-EXTERN_TEMPLATE_CLASS NumericArray<TimestampType>;
+ARROW_EXTERN_TEMPLATE NumericArray<Int8Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<UInt8Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<Int16Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<UInt16Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<Int32Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<UInt32Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<Int64Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<UInt64Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<HalfFloatType>;
+ARROW_EXTERN_TEMPLATE NumericArray<FloatType>;
+ARROW_EXTERN_TEMPLATE NumericArray<DoubleType>;
+ARROW_EXTERN_TEMPLATE NumericArray<Date32Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<Date64Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<Time32Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<Time64Type>;
+ARROW_EXTERN_TEMPLATE NumericArray<TimestampType>;
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -483,34 +483,23 @@ class ARROW_EXPORT DictionaryArray : public Array {
 // ----------------------------------------------------------------------
 // extern templates and other details
 
-// gcc and clang disagree about how to handle template visibility when you have
-// explicit specializations https://llvm.org/bugs/show_bug.cgi?id=24815
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
-#endif
-
 // Only instantiate these templates once
-extern template class ARROW_EXPORT NumericArray<Int8Type>;
-extern template class ARROW_EXPORT NumericArray<UInt8Type>;
-extern template class ARROW_EXPORT NumericArray<Int16Type>;
-extern template class ARROW_EXPORT NumericArray<UInt16Type>;
-extern template class ARROW_EXPORT NumericArray<Int32Type>;
-extern template class ARROW_EXPORT NumericArray<UInt32Type>;
-extern template class ARROW_EXPORT NumericArray<Int64Type>;
-extern template class ARROW_EXPORT NumericArray<UInt64Type>;
-extern template class ARROW_EXPORT NumericArray<HalfFloatType>;
-extern template class ARROW_EXPORT NumericArray<FloatType>;
-extern template class ARROW_EXPORT NumericArray<DoubleType>;
-extern template class ARROW_EXPORT NumericArray<Date32Type>;
-extern template class ARROW_EXPORT NumericArray<Date64Type>;
-extern template class ARROW_EXPORT NumericArray<Time32Type>;
-extern template class ARROW_EXPORT NumericArray<Time64Type>;
-extern template class ARROW_EXPORT NumericArray<TimestampType>;
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+EXTERN_TEMPLATE_CLASS NumericArray<Int8Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<UInt8Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<Int16Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<UInt16Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<Int32Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<UInt32Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<Int64Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<UInt64Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<HalfFloatType>;
+EXTERN_TEMPLATE_CLASS NumericArray<FloatType>;
+EXTERN_TEMPLATE_CLASS NumericArray<DoubleType>;
+EXTERN_TEMPLATE_CLASS NumericArray<Date32Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<Date64Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<Time32Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<Time64Type>;
+EXTERN_TEMPLATE_CLASS NumericArray<TimestampType>;
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -100,16 +100,16 @@ NumericTensor<T>::NumericTensor(const std::shared_ptr<Buffer>& data,
     const std::vector<int64_t>& shape, const std::vector<int64_t>& strides)
     : NumericTensor(data, shape, strides, {}) {}
 
-template class NumericTensor<Int8Type>;
-template class NumericTensor<UInt8Type>;
-template class NumericTensor<Int16Type>;
-template class NumericTensor<UInt16Type>;
-template class NumericTensor<Int32Type>;
-template class NumericTensor<UInt32Type>;
-template class NumericTensor<Int64Type>;
-template class NumericTensor<UInt64Type>;
-template class NumericTensor<HalfFloatType>;
-template class NumericTensor<FloatType>;
-template class NumericTensor<DoubleType>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<Int8Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<UInt8Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<Int16Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<UInt16Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<Int32Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<UInt32Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<Int64Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<UInt64Type>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<HalfFloatType>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<FloatType>;
+template class ARROW_TEMPLATE_EXPORT NumericTensor<DoubleType>;
 
 }  // namespace arrow

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -129,29 +129,18 @@ class ARROW_EXPORT NumericTensor : public Tensor {
 // ----------------------------------------------------------------------
 // extern templates and other details
 
-// gcc and clang disagree about how to handle template visibility when you have
-// explicit specializations https://llvm.org/bugs/show_bug.cgi?id=24815
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wattributes"
-#endif
-
 // Only instantiate these templates once
-extern template class ARROW_EXPORT NumericTensor<Int8Type>;
-extern template class ARROW_EXPORT NumericTensor<UInt8Type>;
-extern template class ARROW_EXPORT NumericTensor<Int16Type>;
-extern template class ARROW_EXPORT NumericTensor<UInt16Type>;
-extern template class ARROW_EXPORT NumericTensor<Int32Type>;
-extern template class ARROW_EXPORT NumericTensor<UInt32Type>;
-extern template class ARROW_EXPORT NumericTensor<Int64Type>;
-extern template class ARROW_EXPORT NumericTensor<UInt64Type>;
-extern template class ARROW_EXPORT NumericTensor<HalfFloatType>;
-extern template class ARROW_EXPORT NumericTensor<FloatType>;
-extern template class ARROW_EXPORT NumericTensor<DoubleType>;
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+EXTERN_TEMPLATE_CLASS NumericTensor<Int8Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<UInt8Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<Int16Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<UInt16Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<Int32Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<UInt32Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<Int64Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<UInt64Type>;
+EXTERN_TEMPLATE_CLASS NumericTensor<HalfFloatType>;
+EXTERN_TEMPLATE_CLASS NumericTensor<FloatType>;
+EXTERN_TEMPLATE_CLASS NumericTensor<DoubleType>;
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -130,17 +130,17 @@ class ARROW_EXPORT NumericTensor : public Tensor {
 // extern templates and other details
 
 // Only instantiate these templates once
-EXTERN_TEMPLATE_CLASS NumericTensor<Int8Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<UInt8Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<Int16Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<UInt16Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<Int32Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<UInt32Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<Int64Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<UInt64Type>;
-EXTERN_TEMPLATE_CLASS NumericTensor<HalfFloatType>;
-EXTERN_TEMPLATE_CLASS NumericTensor<FloatType>;
-EXTERN_TEMPLATE_CLASS NumericTensor<DoubleType>;
+ARROW_EXTERN_TEMPLATE NumericTensor<Int8Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<UInt8Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<Int16Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<UInt16Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<Int32Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<UInt32Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<Int64Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<UInt64Type>;
+ARROW_EXTERN_TEMPLATE NumericTensor<HalfFloatType>;
+ARROW_EXTERN_TEMPLATE NumericTensor<FloatType>;
+ARROW_EXTERN_TEMPLATE NumericTensor<DoubleType>;
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -439,7 +439,7 @@ struct ARROW_EXPORT UnionType : public NestedType {
 
 enum class DateUnit : char { DAY = 0, MILLI = 1 };
 
-struct DateType : public FixedWidthType {
+struct ARROW_EXPORT DateType : public FixedWidthType {
  public:
   DateUnit unit;
 
@@ -496,7 +496,7 @@ static inline std::ostream& operator<<(std::ostream& os, TimeUnit unit) {
   return os;
 }
 
-struct TimeType : public FixedWidthType {
+struct ARROW_EXPORT TimeType : public FixedWidthType {
  public:
   TimeUnit unit;
 

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -35,4 +35,13 @@
 #endif
 #endif  // Non-Windows
 
+// gcc and clang disagree about how to handle template visibility when you have
+// explicit specializations https://llvm.org/bugs/show_bug.cgi?id=24815
+
+#if defined(__clang__)
+  #define EXTERN_TEMPLATE_CLASS extern template class ARROW_EXPORT
+#else
+  #define EXTERN_TEMPLATE_CLASS extern template class
+#endif
+
 #endif  // ARROW_UTIL_VISIBILITY_H

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -46,7 +46,7 @@
 
 // This is a complicated topic, some reading on it:
 // http://www.codesynthesis.com/~boris/blog/2010/01/18/dll-export-cxx-templates/
-#if defined(MSVC)
+#if defined(_MSC_VER)
   #define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
 #else
   #define ARROW_TEMPLATE_EXPORT

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -39,9 +39,17 @@
 // explicit specializations https://llvm.org/bugs/show_bug.cgi?id=24815
 
 #if defined(__clang__)
-  #define EXTERN_TEMPLATE_CLASS extern template class ARROW_EXPORT
+  #define ARROW_EXTERN_TEMPLATE extern template class ARROW_EXPORT
 #else
-  #define EXTERN_TEMPLATE_CLASS extern template class
+  #define ARROW_EXTERN_TEMPLATE extern template class
+#endif
+
+// This is a complicated topic, some reading on it:
+// http://www.codesynthesis.com/~boris/blog/2010/01/18/dll-export-cxx-templates/
+#if defined(MSVC)
+  #define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
+#else
+  #define ARROW_TEMPLATE_EXPORT
 #endif
 
 #endif  // ARROW_UTIL_VISIBILITY_H


### PR DESCRIPTION
This should also reduce compiler warnings on MSVC