### PR TITLE
ARROW-732: [C++] Schema comparison bugs in struct and union types

### DIFF
--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -650,7 +650,7 @@ class TypeEqualsVisitor {
     for (int i = 0; i < left.num_children(); ++i) {
       if (!left.child(i)->Equals(right_.child(i))) {
         result_ = false;
-        break;
+        return Status::OK();
       }
     }
     result_ = true;
@@ -712,7 +712,7 @@ class TypeEqualsVisitor {
     for (size_t i = 0; i < left_codes.size(); ++i) {
       if (left_codes[i] != right_codes[i]) {
         result_ = false;
-        break;
+        return Status::OK();
       }
     }
     result_ = true;

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -715,6 +715,14 @@ class TypeEqualsVisitor {
         return Status::OK();
       }
     }
+
+    for (int i = 0; i < left.num_children(); ++i) {
+      if (!left.child(i)->Equals(right_.child(i))) {
+        result_ = false;
+        return Status::OK();
+      }
+    }
+
     result_ = true;
     return Status::OK();
   }

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -232,22 +232,40 @@ TEST(TestTimestampType, ToString) {
 }
 
 TEST(TestNestedType, Equals) {
-
-  auto create_nested = [](std::string inner_name, std::string struct_name) -> shared_ptr<Field> {
+  auto create_struct =
+      [](std::string inner_name, std::string struct_name) -> shared_ptr<Field> {
     auto f_type = field(inner_name, int32());
     vector<shared_ptr<Field>> fields = {f_type};
     auto s_type = std::make_shared<StructType>(fields);
     return field(struct_name, s_type);
   };
 
-  auto s0 = create_nested("f0", "s0");
-  auto s0_other = create_nested("f0", "s0");
-  auto s0_bad = create_nested("f1", "s0");
-  auto s1 = create_nested("f1", "s1");
+  auto create_union =
+      [](std::string inner_name, std::string union_name) -> shared_ptr<Field> {
+    auto f_type = field(inner_name, int32());
+    vector<shared_ptr<Field>> fields = {f_type};
+    vector<uint8_t> codes = {Type::INT32};
+    auto u_type = std::make_shared<UnionType>(fields, codes, UnionMode::SPARSE);
+    return field(union_name, u_type);
+  };
+
+  auto s0 = create_struct("f0", "s0");
+  auto s0_other = create_struct("f0", "s0");
+  auto s0_bad = create_struct("f1", "s0");
+  auto s1 = create_struct("f1", "s1");
 
   ASSERT_TRUE(s0->Equals(s0_other));
   ASSERT_FALSE(s0->Equals(s1));
   ASSERT_FALSE(s0->Equals(s0_bad));
+
+  auto u0 = create_union("f0", "u0");
+  auto u0_other = create_union("f0", "u0");
+  auto u0_bad = create_union("f1", "u0");
+  auto u1 = create_union("f1", "u1");
+
+  ASSERT_TRUE(u0->Equals(u0_other));
+  ASSERT_FALSE(u0->Equals(u1));
+  ASSERT_FALSE(u0->Equals(u0_bad));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -231,4 +231,23 @@ TEST(TestTimestampType, ToString) {
   ASSERT_EQ("timestamp[us]", t4->ToString());
 }
 
+TEST(TestNestedType, Equals) {
+
+  auto create_nested = [](std::string inner_name, std::string struct_name) -> shared_ptr<Field> {
+    auto f_type = field(inner_name, int32());
+    vector<shared_ptr<Field>> fields = {f_type};
+    auto s_type = std::make_shared<StructType>(fields);
+    return field(struct_name, s_type);
+  };
+
+  auto s0 = create_nested("f0", "s0");
+  auto s0_other = create_nested("f0", "s0");
+  auto s0_bad = create_nested("f1", "s0");
+  auto s1 = create_nested("f1", "s1");
+
+  ASSERT_TRUE(s0->Equals(s0_other));
+  ASSERT_FALSE(s0->Equals(s1));
+  ASSERT_FALSE(s0->Equals(s0_bad));
+}
+
 }  // namespace arrow


### PR DESCRIPTION
Found 2 small bugs in comparing the nested subfields in compare.cc

Fixed  and added a new test to type-test
