### PR TITLE
ARROW-731: [C++] Add shared library related versions to .pc

### DIFF
--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -19,6 +19,9 @@ prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
+so_version=@ARROW_SO_VERSION@
+abi_version=@ARROW_ABI_VERSION@
+
 Name: Apache Arrow
 Description: Arrow is a set of technologies that enable big-data systems to process and move data fast.
 Version: @ARROW_VERSION@

--- a/cpp/src/arrow/io/arrow-io.pc.in
+++ b/cpp/src/arrow/io/arrow-io.pc.in
@@ -19,6 +19,9 @@ prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
+so_version=@ARROW_SO_VERSION@
+abi_version=@ARROW_ABI_VERSION@
+
 Name: Apache Arrow I/O
 Description: I/O interface for Arrow.
 Version: @ARROW_VERSION@

--- a/cpp/src/arrow/ipc/arrow-ipc.pc.in
+++ b/cpp/src/arrow/ipc/arrow-ipc.pc.in
@@ -19,6 +19,9 @@ prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
+so_version=@ARROW_SO_VERSION@
+abi_version=@ARROW_ABI_VERSION@
+
 Name: Apache Arrow IPC
 Description: IPC extension for Arrow.
 Version: @ARROW_VERSION@

--- a/cpp/src/arrow/jemalloc/arrow-jemalloc.pc.in
+++ b/cpp/src/arrow/jemalloc/arrow-jemalloc.pc.in
@@ -19,6 +19,9 @@ prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
+so_version=@ARROW_SO_VERSION@
+abi_version=@ARROW_ABI_VERSION@
+
 Name: Apache Arrow jemalloc-based allocator
 Description: jemalloc allocator for Arrow.
 Version: @ARROW_VERSION@


### PR DESCRIPTION
They can be used to find real shared library path in parquet-cpp.

See also https://github.com/apache/parquet-cpp/pull/276#issuecomment-289816148