### PR TITLE
ARROW-717: [C++] Implement IPC zero-copy round trip for tensors

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -27,11 +27,9 @@
 
 namespace arrow {
 
-Buffer::Buffer(const std::shared_ptr<Buffer>& parent, int64_t offset, int64_t size) {
-  data_ = parent->data() + offset;
-  size_ = size;
+Buffer::Buffer(const std::shared_ptr<Buffer>& parent, int64_t offset, int64_t size)
+    : Buffer(parent->data() + offset, size) {
   parent_ = parent;
-  capacity_ = size;
 }
 
 Buffer::~Buffer() {}

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -29,9 +29,13 @@ namespace arrow {
 class Array;
 struct DataType;
 class Status;
+class Tensor;
 
 /// Returns true if the arrays are exactly equal
 Status ARROW_EXPORT ArrayEquals(const Array& left, const Array& right, bool* are_equal);
+
+Status ARROW_EXPORT TensorEquals(
+    const Tensor& left, const Tensor& right, bool* are_equal);
 
 /// Returns true if the arrays are approximately equal. For non-floating point
 /// types, this is equivalent to ArrayEquals(left, right)

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -17,8 +17,8 @@
 
 // Implement Arrow file layout for IPC/RPC purposes and short-lived storage
 
-#ifndef ARROW_IPC_FILE_H
-#define ARROW_IPC_FILE_H
+#ifndef ARROW_IPC_READER_H
+#define ARROW_IPC_READER_H
 
 #include <cstdint>
 #include <memory>
@@ -33,6 +33,7 @@ class Buffer;
 class RecordBatch;
 class Schema;
 class Status;
+class Tensor;
 
 namespace io {
 
@@ -42,18 +43,6 @@ class RandomAccessFile;
 }  // namespace io
 
 namespace ipc {
-
-// Generic read functionsh; does not copy data if the input supports zero copy reads
-
-Status ReadRecordBatch(const Message& metadata, const std::shared_ptr<Schema>& schema,
-    io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out);
-
-Status ReadRecordBatch(const Message& metadata, const std::shared_ptr<Schema>& schema,
-    int max_recursion_depth, io::RandomAccessFile* file,
-    std::shared_ptr<RecordBatch>* out);
-
-Status ReadDictionary(const Message& metadata, const DictionaryTypeMap& dictionary_types,
-    io::RandomAccessFile* file, std::shared_ptr<Array>* out);
 
 class ARROW_EXPORT StreamReader {
  public:
@@ -118,11 +107,24 @@ class ARROW_EXPORT FileReader {
   std::unique_ptr<FileReaderImpl> impl_;
 };
 
+// Generic read functionsh; does not copy data if the input supports zero copy reads
+Status ARROW_EXPORT ReadRecordBatch(const Message& metadata,
+    const std::shared_ptr<Schema>& schema, io::RandomAccessFile* file,
+    std::shared_ptr<RecordBatch>* out);
+
+Status ARROW_EXPORT ReadRecordBatch(const Message& metadata,
+    const std::shared_ptr<Schema>& schema, int max_recursion_depth,
+    io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out);
+
 /// Read encapsulated message and RecordBatch
 Status ARROW_EXPORT ReadRecordBatch(const std::shared_ptr<Schema>& schema, int64_t offset,
     io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out);
 
+/// EXPERIMENTAL: Read arrow::Tensor from a contiguous message
+Status ARROW_EXPORT ReadTensor(
+    int64_t offset, io::RandomAccessFile* file, std::shared_ptr<Tensor>* out);
+
 }  // namespace ipc
 }  // namespace arrow
 
-#endif  // ARROW_IPC_FILE_H
+#endif  // ARROW_IPC_READER_H

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -17,8 +17,8 @@
 
 // Implement Arrow streaming binary format
 
-#ifndef ARROW_IPC_STREAM_H
-#define ARROW_IPC_STREAM_H
+#ifndef ARROW_IPC_WRITER_H
+#define ARROW_IPC_WRITER_H
 
 #include <cstdint>
 #include <memory>
@@ -36,6 +36,7 @@ class MemoryPool;
 class RecordBatch;
 class Schema;
 class Status;
+class Tensor;
 
 namespace io {
 
@@ -125,7 +126,12 @@ Status WriteLargeRecordBatch(const RecordBatch& batch, int64_t buffer_start_offs
     io::OutputStream* dst, int32_t* metadata_length, int64_t* body_length,
     MemoryPool* pool);
 
+/// EXPERIMENTAL: Write arrow::Tensor as a contiguous message
+/// <metadata size><metadata><tensor data>
+Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadata_length,
+    int64_t* body_length);
+
 }  // namespace ipc
 }  // namespace arrow
 
-#endif  // ARROW_IPC_STREAM_H
+#endif  // ARROW_IPC_WRITER_H

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -61,13 +61,36 @@ TEST(TestTensor, BasicCtors) {
 
   ASSERT_EQ(24, t1.size());
   ASSERT_TRUE(t1.is_mutable());
-  ASSERT_FALSE(t1.has_dim_names());
 
   ASSERT_EQ(strides, t1.strides());
   ASSERT_EQ(strides, t2.strides());
 
   ASSERT_EQ("foo", t3.dim_name(0));
   ASSERT_EQ("bar", t3.dim_name(1));
+  ASSERT_EQ("", t1.dim_name(0));
+  ASSERT_EQ("", t1.dim_name(1));
+}
+
+TEST(TestTensor, IsContiguous) {
+  const int64_t values = 24;
+  std::vector<int64_t> shape = {4, 6};
+  std::vector<int64_t> strides = {48, 8};
+
+  using T = int64_t;
+
+  std::shared_ptr<MutableBuffer> buffer;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), values * sizeof(T), &buffer));
+
+  std::vector<int64_t> c_strides = {48, 8};
+  std::vector<int64_t> f_strides = {8, 32};
+  std::vector<int64_t> noncontig_strides = {8, 8};
+  Int64Tensor t1(buffer, shape, c_strides);
+  Int64Tensor t2(buffer, shape, f_strides);
+  Int64Tensor t3(buffer, shape, noncontig_strides);
+
+  ASSERT_TRUE(t1.is_contiguous());
+  ASSERT_TRUE(t2.is_contiguous());
+  ASSERT_FALSE(t3.is_contiguous());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -73,12 +73,15 @@ class ARROW_EXPORT Tensor {
       const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
       const std::vector<std::string>& dim_names);
 
+  std::shared_ptr<DataType> type() const { return type_; }
   std::shared_ptr<Buffer> data() const { return data_; }
+
   const std::vector<int64_t>& shape() const { return shape_; }
   const std::vector<int64_t>& strides() const { return strides_; }
 
+  int ndim() const { return static_cast<int>(shape_.size()); }
+
   const std::string& dim_name(int i) const;
-  bool has_dim_names() const { return shape_.size() > 0 && dim_names_.size() > 0; }
 
   /// Total number of value cells in the tensor
   int64_t size() const;
@@ -86,13 +89,17 @@ class ARROW_EXPORT Tensor {
   /// Return true if the underlying data buffer is mutable
   bool is_mutable() const { return data_->is_mutable(); }
 
+  bool is_contiguous() const;
+
+  Type::type type_enum() const { return type_->type; }
+
+  bool Equals(const Tensor& other) const;
+
  protected:
   Tensor() {}
 
   std::shared_ptr<DataType> type_;
-
   std::shared_ptr<Buffer> data_;
-
   std::vector<int64_t> shape_;
   std::vector<int64_t> strides_;
 
@@ -125,6 +132,11 @@ class ARROW_EXPORT NumericTensor : public Tensor {
   const value_type* raw_data_;
   value_type* mutable_raw_data_;
 };
+
+Status ARROW_EXPORT MakeTensor(const std::shared_ptr<DataType>& type,
+    const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
+    const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names,
+    std::shared_ptr<Tensor>* tensor);
 
 // ----------------------------------------------------------------------
 // extern templates and other details

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -38,6 +38,7 @@ template <>
 struct TypeTraits<UInt8Type> {
   using ArrayType = UInt8Array;
   using BuilderType = UInt8Builder;
+  using TensorType = UInt8Tensor;
   static inline int64_t bytes_required(int64_t elements) { return elements; }
   constexpr static bool is_parameter_free = true;
   static inline std::shared_ptr<DataType> type_singleton() { return uint8(); }
@@ -47,6 +48,7 @@ template <>
 struct TypeTraits<Int8Type> {
   using ArrayType = Int8Array;
   using BuilderType = Int8Builder;
+  using TensorType = Int8Tensor;
   static inline int64_t bytes_required(int64_t elements) { return elements; }
   constexpr static bool is_parameter_free = true;
   static inline std::shared_ptr<DataType> type_singleton() { return int8(); }
@@ -56,6 +58,7 @@ template <>
 struct TypeTraits<UInt16Type> {
   using ArrayType = UInt16Array;
   using BuilderType = UInt16Builder;
+  using TensorType = UInt16Tensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(uint16_t);
@@ -68,6 +71,7 @@ template <>
 struct TypeTraits<Int16Type> {
   using ArrayType = Int16Array;
   using BuilderType = Int16Builder;
+  using TensorType = Int16Tensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(int16_t);
@@ -80,6 +84,7 @@ template <>
 struct TypeTraits<UInt32Type> {
   using ArrayType = UInt32Array;
   using BuilderType = UInt32Builder;
+  using TensorType = UInt32Tensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(uint32_t);
@@ -92,6 +97,7 @@ template <>
 struct TypeTraits<Int32Type> {
   using ArrayType = Int32Array;
   using BuilderType = Int32Builder;
+  using TensorType = Int32Tensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(int32_t);
@@ -104,6 +110,7 @@ template <>
 struct TypeTraits<UInt64Type> {
   using ArrayType = UInt64Array;
   using BuilderType = UInt64Builder;
+  using TensorType = UInt64Tensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(uint64_t);
@@ -116,6 +123,7 @@ template <>
 struct TypeTraits<Int64Type> {
   using ArrayType = Int64Array;
   using BuilderType = Int64Builder;
+  using TensorType = Int64Tensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(int64_t);
@@ -185,6 +193,7 @@ template <>
 struct TypeTraits<HalfFloatType> {
   using ArrayType = HalfFloatArray;
   using BuilderType = HalfFloatBuilder;
+  using TensorType = HalfFloatTensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return elements * sizeof(uint16_t);
@@ -197,6 +206,7 @@ template <>
 struct TypeTraits<FloatType> {
   using ArrayType = FloatArray;
   using BuilderType = FloatBuilder;
+  using TensorType = FloatTensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return static_cast<int64_t>(elements * sizeof(float));
@@ -209,6 +219,7 @@ template <>
 struct TypeTraits<DoubleType> {
   using ArrayType = DoubleArray;
   using BuilderType = DoubleBuilder;
+  using TensorType = DoubleTensor;
 
   static inline int64_t bytes_required(int64_t elements) {
     return static_cast<int64_t>(elements * sizeof(double));

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -22,6 +22,7 @@
 
 #include "arrow/array.h"
 #include "arrow/status.h"
+#include "arrow/tensor.h"
 #include "arrow/type.h"
 
 namespace arrow {
@@ -97,6 +98,31 @@ inline Status VisitArrayInline(const Array& array, VISITOR* visitor) {
     ARRAY_VISIT_INLINE(StructType);
     ARRAY_VISIT_INLINE(UnionType);
     ARRAY_VISIT_INLINE(DictionaryType);
+    default:
+      break;
+  }
+  return Status::NotImplemented("Type not implemented");
+}
+
+#define TENSOR_VISIT_INLINE(TYPE_CLASS) \
+  case TYPE_CLASS::type_id:             \
+    return visitor->Visit(              \
+        static_cast<const typename TypeTraits<TYPE_CLASS>::TensorType&>(array));
+
+template <typename VISITOR>
+inline Status VisitTensorInline(const Tensor& array, VISITOR* visitor) {
+  switch (array.type_enum()) {
+    TENSOR_VISIT_INLINE(Int8Type);
+    TENSOR_VISIT_INLINE(UInt8Type);
+    TENSOR_VISIT_INLINE(Int16Type);
+    TENSOR_VISIT_INLINE(UInt16Type);
+    TENSOR_VISIT_INLINE(Int32Type);
+    TENSOR_VISIT_INLINE(UInt32Type);
+    TENSOR_VISIT_INLINE(Int64Type);
+    TENSOR_VISIT_INLINE(UInt64Type);
+    TENSOR_VISIT_INLINE(HalfFloatType);
+    TENSOR_VISIT_INLINE(FloatType);
+    TENSOR_VISIT_INLINE(DoubleType);
     default:
       break;
   }

--- a/format/Tensor.fbs
+++ b/format/Tensor.fbs
@@ -32,16 +32,6 @@ table TensorDim {
   name: string;
 }
 
-enum TensorOrder : byte {
-  /// Higher dimensions vary first when traversing data in byte-contiguous
-  /// order, aka "C order"
-  ROW_MAJOR,
-
-  /// Lower dimensions vary first when traversing data in byte-contiguous
-  /// order, aka "Fortran order"
-  COLUMN_MAJOR
-}
-
 table Tensor {
   /// The type of data contained in a value cell. Currently only fixed-width
   /// value types are supported, no strings or nested types
@@ -50,8 +40,8 @@ table Tensor {
   /// The dimensions of the tensor, optionally named
   shape: [TensorDim];
 
-  /// The memory order of the tensor's data
-  order: TensorOrder;
+  /// Non-negative byte offsets to advance one value cell along each dimension
+  strides: [long];
 
   /// The location and size of the tensor's data
   data: Buffer;


### PR DESCRIPTION
This patch provides:

```python
WriteTensor(tensor, file, &metadata_length, &body_length));
std::shared_ptr<Tensor> result;
ReadTensor(offset, file, &result));
```

Also implemented `Tensor::Equals` and did some refactoring / code simplification in compare.cc