### PR TITLE
ARROW-698: Add flag to FileWriter::WriteRecordBatch for writing record batches with lengths over INT32_MAX

### DIFF
--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -87,7 +87,7 @@ class ARROW_EXPORT StreamWriter {
   static Status Open(io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
       std::shared_ptr<StreamWriter>* out);
 
-  virtual Status WriteRecordBatch(const RecordBatch& batch);
+  virtual Status WriteRecordBatch(const RecordBatch& batch, bool allow_64bit = false);
 
   /// Perform any logic necessary to finish the stream. User is responsible for
   /// closing the actual OutputStream
@@ -108,7 +108,7 @@ class ARROW_EXPORT FileWriter : public StreamWriter {
   static Status Open(io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
       std::shared_ptr<FileWriter>* out);
 
-  Status WriteRecordBatch(const RecordBatch& batch) override;
+  Status WriteRecordBatch(const RecordBatch& batch, bool allow_64bit = false) override;
   Status Close() override;
 
  private:

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -232,16 +232,16 @@ TEST(TestTimestampType, ToString) {
 }
 
 TEST(TestNestedType, Equals) {
-  auto create_struct =
-      [](std::string inner_name, std::string struct_name) -> shared_ptr<Field> {
+  auto create_struct = [](
+      std::string inner_name, std::string struct_name) -> shared_ptr<Field> {
     auto f_type = field(inner_name, int32());
     vector<shared_ptr<Field>> fields = {f_type};
     auto s_type = std::make_shared<StructType>(fields);
     return field(struct_name, s_type);
   };
 
-  auto create_union =
-      [](std::string inner_name, std::string union_name) -> shared_ptr<Field> {
+  auto create_union = [](
+      std::string inner_name, std::string union_name) -> shared_ptr<Field> {
     auto f_type = field(inner_name, int32());
     vector<shared_ptr<Field>> fields = {f_type};
     vector<uint8_t> codes = {Type::INT32};

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -39,17 +39,17 @@
 // explicit specializations https://llvm.org/bugs/show_bug.cgi?id=24815
 
 #if defined(__clang__)
-  #define ARROW_EXTERN_TEMPLATE extern template class ARROW_EXPORT
+#define ARROW_EXTERN_TEMPLATE extern template class ARROW_EXPORT
 #else
-  #define ARROW_EXTERN_TEMPLATE extern template class
+#define ARROW_EXTERN_TEMPLATE extern template class
 #endif
 
 // This is a complicated topic, some reading on it:
 // http://www.codesynthesis.com/~boris/blog/2010/01/18/dll-export-cxx-templates/
 #if defined(_MSC_VER)
-  #define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
+#define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
 #else
-  #define ARROW_TEMPLATE_EXPORT
+#define ARROW_TEMPLATE_EXPORT
 #endif
 
 #endif  // ARROW_UTIL_VISIBILITY_H


### PR DESCRIPTION
cc @pcmoritz 