### PR TITLE
ARROW-630: [C++] Create boolean batches for IPC testing, properly account for nonzero offset

### DIFF
--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -350,13 +350,15 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
 
   Status Visit(const BooleanArray& left) override {
     const auto& right = static_cast<const BooleanArray&>(right_);
+
     if (left.null_count() > 0) {
       const uint8_t* left_data = left.data()->data();
       const uint8_t* right_data = right.data()->data();
 
       for (int64_t i = 0; i < left.length(); ++i) {
         if (!left.IsNull(i) &&
-            BitUtil::GetBit(left_data, i) != BitUtil::GetBit(right_data, i)) {
+            BitUtil::GetBit(left_data, i + left.offset()) !=
+                BitUtil::GetBit(right_data, i + right.offset())) {
           result_ = false;
           return Status::OK();
         }

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -107,7 +107,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch,  \
       &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList, &MakeStringTypesRecordBatch,    \
       &MakeStruct, &MakeUnion, &MakeDictionary, &MakeDates, &MakeTimestamps, &MakeTimes, \
-      &MakeFWBinary);
+      &MakeFWBinary, &MakeBooleanBatch);
 
 class IpcTestFixture : public io::MemoryMapFixture {
  public:

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -138,6 +138,28 @@ Status MakeRandomListArray(const std::shared_ptr<Array>& child_array, int num_li
 
 typedef Status MakeRecordBatch(std::shared_ptr<RecordBatch>* out);
 
+Status MakeBooleanBatch(std::shared_ptr<RecordBatch>* out) {
+  const int length = 1000;
+
+  // Make the schema
+  auto f0 = field("f0", boolean());
+  auto f1 = field("f1", boolean());
+  std::shared_ptr<Schema> schema(new Schema({f0, f1}));
+
+  std::vector<uint8_t> values(length);
+  std::vector<uint8_t> valid_bytes(length);
+  test::random_null_bytes(length, 0.5, values.data());
+  test::random_null_bytes(length, 0.1, valid_bytes.data());
+
+  auto data = test::bytes_to_null_buffer(values);
+  auto null_bitmap = test::bytes_to_null_buffer(valid_bytes);
+
+  auto a0 = std::make_shared<BooleanArray>(length, data, null_bitmap, -1);
+  auto a1 = std::make_shared<BooleanArray>(length, data, nullptr, 0);
+  out->reset(new RecordBatch(schema, length, {a0, a1}));
+  return Status::OK();
+}
+
 Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
   const int length = 10;
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -314,7 +314,12 @@ class RecordBatchWriter : public ArrayVisitor {
   }
 
   Status Visit(const BooleanArray& array) override {
-    buffers_.push_back(array.data());
+    std::shared_ptr<Buffer> bits = array.data();
+    if (array.offset() != 0) {
+      RETURN_NOT_OK(
+          CopyBitmap(pool_, bits->data(), array.offset(), array.length(), &bits));
+    }
+    buffers_.push_back(bits);
     return Status::OK();
   }
 


### PR DESCRIPTION
This fixes a couple bugs; boolean IPC was not being tested directly like the other types (it was implicitly by integration tests, though)