### PR TITLE
ARROW-723: [Python] Ensure that passing chunk_size=0 when writing Parquet file does not enter infinite loop

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -468,6 +468,9 @@ cdef ParquetCompression compression_from_name(object name):
         return ParquetCompression_UNCOMPRESSED
 
 
+cdef int MIN_ROW_GROUP_SIZE = 1000
+
+
 cdef class ParquetWriter:
     cdef:
         shared_ptr[WriterProperties] properties
@@ -540,8 +543,11 @@ cdef class ParquetWriter:
 
         if row_group_size is None:
             row_group_size = ctable.num_rows()
+        elif row_group_size == 0:
+            row_group_size = MIN_ROW_GROUP_SIZE
 
         cdef int c_row_group_size = row_group_size
+
         with nogil:
             check_status(WriteTable(deref(ctable), self.allocator,
                                     self.sink, c_row_group_size,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -468,9 +468,6 @@ cdef ParquetCompression compression_from_name(object name):
         return ParquetCompression_UNCOMPRESSED
 
 
-cdef int MIN_ROW_GROUP_SIZE = 1000
-
-
 cdef class ParquetWriter:
     cdef:
         shared_ptr[WriterProperties] properties
@@ -541,10 +538,10 @@ cdef class ParquetWriter:
     def write_table(self, Table table, row_group_size=None):
         cdef CTable* ctable = table.table
 
-        if row_group_size is None:
+        if row_group_size is None or row_group_size == -1:
             row_group_size = ctable.num_rows()
         elif row_group_size == 0:
-            row_group_size = MIN_ROW_GROUP_SIZE
+            raise ValueError('Row group size cannot be 0')
 
         cdef int c_row_group_size = row_group_size
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -187,7 +187,7 @@ def write_table(table, sink, chunk_size=None, version='1.0',
     ----------
     table : pyarrow.Table
     sink: string or pyarrow.io.NativeFile
-    chunk_size : int
+    chunk_size : int, default None
         The maximum number of rows in each Parquet RowGroup. As a default,
         we will write a single RowGroup per file.
     version : {"1.0", "2.0"}, default "1.0"

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -371,12 +371,15 @@ def test_min_chunksize():
     table = pa.Table.from_pandas(data.reset_index())
 
     buf = io.BytesIO()
-    pq.write_table(table, buf, chunk_size=0)
+    pq.write_table(table, buf, chunk_size=-1)
 
     buf.seek(0)
     result = pq.read_table(buf)
 
     assert result.equals(table)
+
+    with pytest.raises(ValueError):
+        pq.write_table(table, buf, chunk_size=0)
 
 
 @parquet

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -366,6 +366,20 @@ def test_multithreaded_read():
 
 
 @parquet
+def test_min_chunksize():
+    data = pd.DataFrame([np.arange(4)], columns=['A', 'B', 'C', 'D'])
+    table = pa.Table.from_pandas(data.reset_index())
+
+    buf = io.BytesIO()
+    pq.write_table(table, buf, chunk_size=0)
+
+    buf.seek(0)
+    result = pq.read_table(buf)
+
+    assert result.equals(table)
+
+
+@parquet
 def test_pass_separate_metadata():
     # ARROW-471
     df = alltypes_sample(size=10000)


### PR DESCRIPTION
This should also be fixed in parquet-cpp, will open a JIRA.