### PR TITLE
ARROW-737: [C++] Enable mutable buffer slices, SliceMutableBuffer function

### DIFF
--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -168,4 +168,21 @@ TEST_F(TestBuffer, SliceBuffer) {
   ASSERT_EQ(2, buf.use_count());
 }
 
+TEST_F(TestBuffer, SliceMutableBuffer) {
+  std::string data_str = "some data to slice";
+  auto data = reinterpret_cast<const uint8_t*>(data_str.c_str());
+
+  std::shared_ptr<MutableBuffer> buffer;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), 50, &buffer));
+
+  memcpy(buffer->mutable_data(), data, data_str.size());
+
+  std::shared_ptr<Buffer> slice = SliceMutableBuffer(buffer, 5, 10);
+  ASSERT_TRUE(slice->is_mutable());
+  ASSERT_EQ(10, slice->size());
+
+  Buffer expected(data + 5, 10);
+  ASSERT_TRUE(slice->Equals(expected));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -27,11 +27,6 @@
 
 namespace arrow {
 
-Buffer::Buffer(const std::shared_ptr<Buffer>& parent, int64_t offset, int64_t size)
-    : Buffer(parent->data() + offset, size) {
-  parent_ = parent;
-}
-
 Buffer::~Buffer() {}
 
 Status Buffer::Copy(
@@ -114,6 +109,18 @@ Status PoolBuffer::Resize(int64_t new_size, bool shrink_to_fit) {
   }
   size_ = new_size;
   return Status::OK();
+}
+
+std::shared_ptr<Buffer> SliceMutableBuffer(
+    const std::shared_ptr<Buffer>& buffer, int64_t offset, int64_t length) {
+  return std::make_shared<MutableBuffer>(buffer, offset, length);
+}
+
+MutableBuffer::MutableBuffer(
+    const std::shared_ptr<Buffer>& parent, int64_t offset, int64_t size)
+    : MutableBuffer(parent->mutable_data() + offset, size) {
+  DCHECK(parent->is_mutable()) << "Must pass mutable buffer";
+  parent_ = parent;
 }
 
 Status AllocateBuffer(


### PR DESCRIPTION
This patch also results in better microperformance on my laptop. 

```
Run on (4 X 1200 MHz CPU s)
2017-04-01 22:35:30
Benchmark                                                  Time           CPU Iterations
----------------------------------------------------------------------------------------
BM_WriteRecordBatch/1/min_time:1.000/real_time         53617 ns      53423 ns      26903   18.2136GB/s
BM_WriteRecordBatch/4/min_time:1.000/real_time         48118 ns      47999 ns      26823    20.295GB/s
BM_WriteRecordBatch/16/min_time:1.000/real_time        46679 ns      46562 ns      30409   20.9209GB/s
BM_WriteRecordBatch/64/min_time:1.000/real_time        50583 ns      50344 ns      27308   19.3061GB/s
BM_WriteRecordBatch/256/min_time:1.000/real_time       93474 ns      93259 ns      11720   10.4474GB/s
BM_WriteRecordBatch/1024/min_time:1.000/real_time     254056 ns     253461 ns       5434   3.84389GB/s
BM_WriteRecordBatch/4k/min_time:1.000/real_time       892292 ns     888924 ns       1210   1120.71MB/s
BM_WriteRecordBatch/8k/min_time:1.000/real_time      1799323 ns    1795023 ns        754   555.764MB/s
BM_ReadRecordBatch/1/min_time:1.000/real_time           2501 ns       2452 ns     586633   390.521GB/s
BM_ReadRecordBatch/4/min_time:1.000/real_time           6921 ns       5577 ns     227670   141.095GB/s
BM_ReadRecordBatch/16/min_time:1.000/real_time         15561 ns      14505 ns      67493    62.758GB/s
BM_ReadRecordBatch/64/min_time:1.000/real_time         48583 ns      48242 ns      30070   20.1008GB/s
BM_ReadRecordBatch/256/min_time:1.000/real_time       184637 ns     183306 ns       6660    5.2891GB/s
BM_ReadRecordBatch/1024/min_time:1.000/real_time      734128 ns     729692 ns       1905   1.33024GB/s
BM_ReadRecordBatch/4k/min_time:1.000/real_time       3027028 ns    3008020 ns        445   330.357MB/s
BM_ReadRecordBatch/8k/min_time:1.000/real_time       6472022 ns    6426801 ns        211   154.511MB/s
```

before

```
Run on (4 X 1200 MHz CPU s)
2017-04-01 22:37:36
Benchmark                                                  Time           CPU Iterations
----------------------------------------------------------------------------------------
BM_WriteRecordBatch/1/min_time:1.000/real_time         59317 ns      59202 ns      22727   16.4633GB/s
BM_WriteRecordBatch/4/min_time:1.000/real_time         56322 ns      56191 ns      24944   17.3389GB/s
BM_WriteRecordBatch/16/min_time:1.000/real_time        52027 ns      51880 ns      26682   18.7703GB/s
BM_WriteRecordBatch/64/min_time:1.000/real_time        56324 ns      56202 ns      24724   17.3384GB/s
BM_WriteRecordBatch/256/min_time:1.000/real_time      108096 ns     107868 ns      11284   9.03423GB/s
BM_WriteRecordBatch/1024/min_time:1.000/real_time     279508 ns     278730 ns       4957   3.49386GB/s
BM_WriteRecordBatch/4k/min_time:1.000/real_time      1013229 ns    1009772 ns       1191   986.944MB/s
BM_WriteRecordBatch/8k/min_time:1.000/real_time      2011309 ns    2005377 ns        661   497.189MB/s
BM_ReadRecordBatch/1/min_time:1.000/real_time           2507 ns       2501 ns     558949   389.563GB/s
BM_ReadRecordBatch/4/min_time:1.000/real_time           5120 ns       5110 ns     275798   190.735GB/s
BM_ReadRecordBatch/16/min_time:1.000/real_time         15800 ns      15706 ns      85481   61.8072GB/s
BM_ReadRecordBatch/64/min_time:1.000/real_time         55678 ns      55476 ns      25022   17.5393GB/s
BM_ReadRecordBatch/256/min_time:1.000/real_time       218083 ns     217596 ns       6163   4.47794GB/s
BM_ReadRecordBatch/1024/min_time:1.000/real_time      875861 ns     873419 ns       1591   1.11497GB/s
BM_ReadRecordBatch/4k/min_time:1.000/real_time       3545586 ns    3538141 ns        383   282.041MB/s
BM_ReadRecordBatch/8k/min_time:1.000/real_time       7118830 ns    7104433 ns        194   140.473MB/s
```