### PR TITLE
ARROW-755: [GLib] Add garrow_array_get_value_type()

### DIFF
--- a/c_glib/arrow-glib/array.cpp
+++ b/c_glib/arrow-glib/array.cpp
@@ -35,6 +35,7 @@
 #include <arrow-glib/null-array.h>
 #include <arrow-glib/string-array.h>
 #include <arrow-glib/struct-array.h>
+#include <arrow-glib/type.hpp>
 #include <arrow-glib/uint8-array.h>
 #include <arrow-glib/uint16-array.h>
 #include <arrow-glib/uint32-array.h>
@@ -175,17 +176,33 @@ garrow_array_get_n_nulls(GArrowArray *array)
 }
 
 /**
- * garrow_array_get_data_type:
+ * garrow_array_get_value_data_type:
  * @array: A #GArrowArray.
  *
- * Returns: (transfer full): The #GArrowDataType for the array.
+ * Since: 0.3.0
+ * Returns: (transfer full): The #GArrowDataType for each value of the
+ *   array.
  */
 GArrowDataType *
-garrow_array_get_data_type(GArrowArray *array)
+garrow_array_get_value_data_type(GArrowArray *array)
 {
   auto arrow_array = garrow_array_get_raw(array);
   auto arrow_data_type = arrow_array->type();
   return garrow_data_type_new_raw(&arrow_data_type);
+}
+
+/**
+ * garrow_array_get_value_type:
+ * @array: A #GArrowArray.
+ *
+ * Since: 0.3.0
+ * Returns: The #GArrowType for each value of the array.
+ */
+GArrowType
+garrow_array_get_value_type(GArrowArray *array)
+{
+  auto arrow_array = garrow_array_get_raw(array);
+  return garrow_type_from_raw(arrow_array->type_enum());
 }
 
 /**

--- a/c_glib/arrow-glib/array.h
+++ b/c_glib/arrow-glib/array.h
@@ -60,7 +60,8 @@ GType          garrow_array_get_type    (void) G_GNUC_CONST;
 gint64         garrow_array_get_length  (GArrowArray *array);
 gint64         garrow_array_get_offset  (GArrowArray *array);
 gint64         garrow_array_get_n_nulls (GArrowArray *array);
-GArrowDataType *garrow_array_get_data_type(GArrowArray *array);
+GArrowDataType *garrow_array_get_value_data_type(GArrowArray *array);
+GArrowType     garrow_array_get_value_type(GArrowArray *array);
 GArrowArray   *garrow_array_slice       (GArrowArray *array,
                                          gint64 offset,
                                          gint64 length);

--- a/c_glib/doc/reference/arrow-glib-docs.sgml
+++ b/c_glib/doc/reference/arrow-glib-docs.sgml
@@ -167,5 +167,9 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-0-3-0" role="0.3.0">
+    <title>Index of new symbols in 0.3.0</title>
+    <xi:include href="xml/api-index-0.3.0.xml"><xi:fallback /></xi:include>
+  </index>
   <xi:include href="xml/annotation-glossary.xml"><xi:fallback /></xi:include>
 </book>

--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -31,10 +31,16 @@ class TestArray < Test::Unit::TestCase
     assert_equal(2, array.n_nulls)
   end
 
-  def test_data_type
+  def test_value_data_type
     builder = Arrow::BooleanArrayBuilder.new
     array = builder.finish
-    assert_equal(Arrow::BooleanDataType.new, array.data_type)
+    assert_equal(Arrow::BooleanDataType.new, array.value_data_type)
+  end
+
+  def test_value_type
+    builder = Arrow::BooleanArrayBuilder.new
+    array = builder.finish
+    assert_equal(Arrow::Type::BOOL, array.value_type)
   end
 
   def test_slice


### PR DESCRIPTION
garrow_array_get_data_type() is renamed to
garrow_array_get_value_data_type() for consistency.
