### PR TITLE
ARROW-672: [Format] Add MetadataVersion::V3 for Arrow 0.3

### DIFF
--- a/c_glib/arrow-glib/ipc-metadata-version.cpp
+++ b/c_glib/arrow-glib/ipc-metadata-version.cpp
@@ -29,35 +29,35 @@
  * @short_description: Metadata version mapgging between Arrow and arrow-glib
  *
  * #GArrowIPCMetadataVersion provides metadata versions corresponding
- * to `arrow::ipc::MetadataVersion::type` values.
+ * to `arrow::ipc::MetadataVersion` values.
  */
 
 GArrowIPCMetadataVersion
-garrow_ipc_metadata_version_from_raw(arrow::ipc::MetadataVersion::type version)
+garrow_ipc_metadata_version_from_raw(arrow::ipc::MetadataVersion version)
 {
   switch (version) {
-  case arrow::ipc::MetadataVersion::type::V1:
+  case arrow::ipc::MetadataVersion::V1:
     return GARROW_IPC_METADATA_VERSION_V1;
-  case arrow::ipc::MetadataVersion::type::V2:
+  case arrow::ipc::MetadataVersion::V2:
     return GARROW_IPC_METADATA_VERSION_V2;
-  case arrow::ipc::MetadataVersion::type::V3:
+  case arrow::ipc::MetadataVersion::V3:
     return GARROW_IPC_METADATA_VERSION_V3;
   default:
     return GARROW_IPC_METADATA_VERSION_V3;
   }
 }
 
-arrow::ipc::MetadataVersion::type
+arrow::ipc::MetadataVersion
 garrow_ipc_metadata_version_to_raw(GArrowIPCMetadataVersion version)
 {
   switch (version) {
   case GARROW_IPC_METADATA_VERSION_V1:
-    return arrow::ipc::MetadataVersion::type::V1;
+    return arrow::ipc::MetadataVersion::V1;
   case GARROW_IPC_METADATA_VERSION_V2:
-    return arrow::ipc::MetadataVersion::type::V2;
+    return arrow::ipc::MetadataVersion::V2;
   case GARROW_IPC_METADATA_VERSION_V3:
-    return arrow::ipc::MetadataVersion::type::V3;
+    return arrow::ipc::MetadataVersion::V3;
   default:
-    return arrow::ipc::MetadataVersion::type::V3;
+    return arrow::ipc::MetadataVersion::V3;
   }
 }

--- a/c_glib/arrow-glib/ipc-metadata-version.cpp
+++ b/c_glib/arrow-glib/ipc-metadata-version.cpp
@@ -40,8 +40,10 @@ garrow_ipc_metadata_version_from_raw(arrow::ipc::MetadataVersion::type version)
     return GARROW_IPC_METADATA_VERSION_V1;
   case arrow::ipc::MetadataVersion::type::V2:
     return GARROW_IPC_METADATA_VERSION_V2;
+  case arrow::ipc::MetadataVersion::type::V3:
+    return GARROW_IPC_METADATA_VERSION_V3;
   default:
-    return GARROW_IPC_METADATA_VERSION_V2;
+    return GARROW_IPC_METADATA_VERSION_V3;
   }
 }
 
@@ -53,7 +55,9 @@ garrow_ipc_metadata_version_to_raw(GArrowIPCMetadataVersion version)
     return arrow::ipc::MetadataVersion::type::V1;
   case GARROW_IPC_METADATA_VERSION_V2:
     return arrow::ipc::MetadataVersion::type::V2;
+  case GARROW_IPC_METADATA_VERSION_V3:
+    return arrow::ipc::MetadataVersion::type::V3;
   default:
-    return arrow::ipc::MetadataVersion::type::V2;
+    return arrow::ipc::MetadataVersion::type::V3;
   }
 }

--- a/c_glib/arrow-glib/ipc-metadata-version.h
+++ b/c_glib/arrow-glib/ipc-metadata-version.h
@@ -27,13 +27,15 @@ G_BEGIN_DECLS
  * GArrowIPCMetadataVersion:
  * @GARROW_IPC_METADATA_VERSION_V1: Version 1.
  * @GARROW_IPC_METADATA_VERSION_V2: Version 2.
+ * @GARROW_IPC_METADATA_VERSION_V3: Version 3.
  *
  * They are corresponding to `arrow::ipc::MetadataVersion::type`
  * values.
  */
 typedef enum {
   GARROW_IPC_METADATA_VERSION_V1,
-  GARROW_IPC_METADATA_VERSION_V2
+  GARROW_IPC_METADATA_VERSION_V2,
+  GARROW_IPC_METADATA_VERSION_V3
 } GArrowIPCMetadataVersion;
 
 G_END_DECLS

--- a/c_glib/arrow-glib/ipc-metadata-version.hpp
+++ b/c_glib/arrow-glib/ipc-metadata-version.hpp
@@ -23,5 +23,5 @@
 
 #include <arrow-glib/ipc-metadata-version.h>
 
-GArrowIPCMetadataVersion garrow_ipc_metadata_version_from_raw(arrow::ipc::MetadataVersion::type version);
-arrow::ipc::MetadataVersion::type garrow_ipc_metadata_version_to_raw(GArrowIPCMetadataVersion version);
+GArrowIPCMetadataVersion garrow_ipc_metadata_version_from_raw(arrow::ipc::MetadataVersion version);
+arrow::ipc::MetadataVersion garrow_ipc_metadata_version_to_raw(GArrowIPCMetadataVersion version);

--- a/cpp/src/arrow/ipc/metadata.cc
+++ b/cpp/src/arrow/ipc/metadata.cc
@@ -826,6 +826,23 @@ class Message::MessageImpl {
     }
   }
 
+  MetadataVersion version() const {
+    switch (message_->version()) {
+      case flatbuf::MetadataVersion_V1:
+        // Arrow 0.1
+        return MetadataVersion::V1;
+      case flatbuf::MetadataVersion_V2:
+        // Arrow 0.2
+        return MetadataVersion::V2;
+      case flatbuf::MetadataVersion_V3:
+        // Arrow 0.3
+        return MetadataVersion::V3;
+      // Add cases as other versions become available
+      default:
+        return MetadataVersion::V3;
+    }
+  }
+
   const void* header() const { return message_->header(); }
 
   int64_t body_length() const { return message_->bodyLength(); }
@@ -854,6 +871,10 @@ Status Message::Open(const std::shared_ptr<Buffer>& buffer, int64_t offset,
 
 Message::Type Message::type() const {
   return impl_->type();
+}
+
+MetadataVersion Message::metadata_version() const {
+  return impl_->version();
 }
 
 int64_t Message::body_length() const {

--- a/cpp/src/arrow/ipc/metadata.cc
+++ b/cpp/src/arrow/ipc/metadata.cc
@@ -50,7 +50,7 @@ using VectorLayoutOffset = flatbuffers::Offset<arrow::flatbuf::VectorLayout>;
 using Offset = flatbuffers::Offset<void>;
 using FBString = flatbuffers::Offset<flatbuffers::String>;
 
-static constexpr flatbuf::MetadataVersion kMetadataVersion = flatbuf::MetadataVersion_V2;
+static constexpr flatbuf::MetadataVersion kMetadataVersion = flatbuf::MetadataVersion_V3;
 
 static Status IntFromFlatbuffer(
     const flatbuf::Int* int_data, std::shared_ptr<DataType>* out) {

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -50,9 +50,7 @@ class RandomAccessFile;
 
 namespace ipc {
 
-struct MetadataVersion {
-  enum type { V1, V2, V3 };
-};
+enum class MetadataVersion : char { V1, V2, V3 };
 
 static constexpr const char* kArrowMagicBytes = "ARROW1";
 
@@ -133,6 +131,8 @@ class ARROW_EXPORT Message {
   int64_t body_length() const;
 
   Type type() const;
+
+  MetadataVersion metadata_version() const;
 
   const void* header() const;
 

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -51,7 +51,7 @@ class RandomAccessFile;
 namespace ipc {
 
 struct MetadataVersion {
-  enum type { V1, V2 };
+  enum type { V1, V2, V3 };
 };
 
 static constexpr const char* kArrowMagicBytes = "ARROW1";

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -335,12 +335,17 @@ class FileReader::FileReaderImpl {
   MetadataVersion::type version() const {
     switch (footer_->version()) {
       case flatbuf::MetadataVersion_V1:
+        // Arrow 0.1
         return MetadataVersion::V1;
       case flatbuf::MetadataVersion_V2:
+        // Arrow 0.2
         return MetadataVersion::V2;
+      case flatbuf::MetadataVersion_V3:
+        // Arrow 0.3
+        return MetadataVersion::V3;
       // Add cases as other versions become available
       default:
-        return MetadataVersion::V2;
+        return MetadataVersion::V3;
     }
   }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -332,7 +332,7 @@ class FileReader::FileReaderImpl {
 
   int num_record_batches() const { return footer_->recordBatches()->size(); }
 
-  MetadataVersion::type version() const {
+  MetadataVersion version() const {
     switch (footer_->version()) {
       case flatbuf::MetadataVersion_V1:
         // Arrow 0.1
@@ -459,7 +459,7 @@ int FileReader::num_record_batches() const {
   return impl_->num_record_batches();
 }
 
-MetadataVersion::type FileReader::version() const {
+MetadataVersion FileReader::version() const {
   return impl_->version();
 }
 

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -91,7 +91,7 @@ class ARROW_EXPORT FileReader {
 
   int num_record_batches() const;
 
-  MetadataVersion::type version() const;
+  MetadataVersion version() const;
 
   // Read a record batch from the file. Does not copy memory if the input
   // source supports zero-copy.

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -21,7 +21,8 @@ namespace org.apache.arrow.flatbuf;
 
 enum MetadataVersion:short {
   V1,
-  V2
+  V2,
+  V3
 }
 
 /// These are stored in the flatbuffer in the Type union below

--- a/java/vector/src/main/java/org/apache/arrow/vector/stream/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/stream/MessageSerializer.java
@@ -329,7 +329,7 @@ public class MessageSerializer {
     Message.startMessage(builder);
     Message.addHeaderType(builder, headerType);
     Message.addHeader(builder, headerOffset);
-    Message.addVersion(builder, MetadataVersion.V2);
+    Message.addVersion(builder, MetadataVersion.V3);
     Message.addBodyLength(builder, bodyLength);
     builder.finish(Message.endMessage(builder));
     return builder.dataBuffer();


### PR DESCRIPTION
As a matter of diligence, we increment the metadata version for Arrow 0.3 since we've changed the metadata format is various ways. 