### PR TITLE
ARROW-769: [GLib] Support building without installed Arrow C++

### DIFF
--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -61,9 +61,42 @@ AM_PATH_GLIB_2_0([2.32.4], [], [], [gobject])
 GOBJECT_INTROSPECTION_REQUIRE([1.32.1])
 GTK_DOC_CHECK([1.18-2])
 
-PKG_CHECK_MODULES([ARROW], [arrow])
-PKG_CHECK_MODULES([ARROW_IO], [arrow-io])
-PKG_CHECK_MODULES([ARROW_IPC], [arrow-ipc])
+AC_ARG_WITH(arrow-cpp-build-type,
+  [AS_HELP_STRING([--with-arrow-cpp-build-type=TYPE],
+                  [-DCMAKE_BUILD_TYPE option value for Arrow C++ (default=Release)])],
+  [GARROW_ARROW_CPP_BUILD_TYPE="$withval"],
+  [GARROW_ARROW_CPP_BUILD_TYPE="Release"])
+
+AC_ARG_WITH(arrow-cpp-build-dir,
+  [AS_HELP_STRING([--with-arrow-cpp-build-dir=PATH],
+                  [Use this option to build with not installed Arrow C++])],
+  [GARROW_ARROW_CPP_BUILD_DIR="$withval"],
+  [GARROW_ARROW_CPP_BUILD_DIR=""])
+if test "x$GARROW_ARROW_CPP_BUILD_DIR" = "x"; then
+  PKG_CHECK_MODULES([ARROW], [arrow])
+  PKG_CHECK_MODULES([ARROW_IO], [arrow-io])
+  PKG_CHECK_MODULES([ARROW_IPC], [arrow-ipc])
+else
+  ARROW_INCLUDE_DIR="\$(abs_top_srcdir)/../cpp/src"
+  ARROW_LIB_DIR="${GARROW_ARROW_CPP_BUILD_DIR}/${GARROW_ARROW_CPP_BUILD_TYPE}"
+
+  ARROW_CFLAGS="-I${ARROW_INCLUDE_DIR}"
+  ARROW_IO_CFLAGS="-I${ARROW_INCLUDE_DIR}"
+  ARROW_IPC_CFLAGS="-I${ARROW_INCLUDE_DIR}"
+  ARROW_LIBS="-L${ARROW_LIB_DIR} -larrow"
+  ARROW_IO_LIBS="-L${ARROW_LIB_DIR} -larrow_io"
+  ARROW_IPC_LIBS="-L${ARROW_LIB_DIR} -larrow_ipc"
+
+  AC_SUBST(ARROW_LIB_DIR)
+
+  AC_SUBST(ARROW_CFLAGS)
+  AC_SUBST(ARROW_IO_CFLAGS)
+  AC_SUBST(ARROW_IPC_CFLAGS)
+  AC_SUBST(ARROW_LIBS)
+  AC_SUBST(ARROW_IO_LIBS)
+  AC_SUBST(ARROW_IPC_LIBS)
+fi
+
 
 AC_CONFIG_FILES([
   Makefile


### PR DESCRIPTION
It doesn't require "make install"-ed Arrow C++ to build Arrow GLib.
But it requires "make"-ed Arrow C++.

This is useful to build packages.