### PR TITLE
ARROW-774: [GLib] Remove needless LICENSE.txt copy

### DIFF
--- a/c_glib/Makefile.am
+++ b/c_glib/Makefile.am
@@ -24,10 +24,8 @@ SUBDIRS =					\
 
 EXTRA_DIST =					\
 	README.md				\
-	LICENSE.txt				\
 	version
 
 arrow_glib_docdir = ${datarootdir}/doc/arrow-glib
 arrow_glib_doc_DATA =				\
-	README.md				\
-	LICENSE.txt
+	README.md

--- a/c_glib/autogen.sh
+++ b/c_glib/autogen.sh
@@ -25,8 +25,6 @@ ruby \
     ../java/pom.xml > \
     version
 
-cp ../LICENSE.txt ./
-
 mkdir -p m4
 
 gtkdocize --copy --docdir doc/reference


### PR DESCRIPTION
"make dist" result is included in source archive. LICENSE.txt is also
included the source archive.