### PR TITLE
ARROW-756: [C++] MSVC build fixes and cleanup, remove -fPIC flag from EP builds on Windows, Dev docs

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -446,22 +446,29 @@ if(ARROW_BUILD_TESTS)
   if("$ENV{GTEST_HOME}" STREQUAL "")
     if(APPLE)
       set(GTEST_CMAKE_CXX_FLAGS "-fPIC -DGTEST_USE_OWN_TR1_TUPLE=1 -Wno-unused-value -Wno-ignored-attributes")
-    else()
+    elseif(NOT MSVC)
       set(GTEST_CMAKE_CXX_FLAGS "-fPIC")
     endif()
     string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_BUILD_TYPE)
     set(GTEST_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}} ${GTEST_CMAKE_CXX_FLAGS}")
+    if(MSVC)
+        # Disable too much warnings as build failure reason
+        string(REPLACE "-Wall" "" GTEST_CMAKE_CXX_FLAGS "${GTEST_CMAKE_CXX_FLAGS}")
+    endif()
 
     set(GTEST_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest_ep-prefix/src/googletest_ep")
     set(GTEST_INCLUDE_DIR "${GTEST_PREFIX}/include")
     set(GTEST_STATIC_LIB "${GTEST_PREFIX}/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
     set(GTEST_VENDORED 1)
+    set(GTEST_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                         -Dgtest_force_shared_crt=ON
+                         -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS})
 
     if (CMAKE_VERSION VERSION_GREATER "3.2")
       # BUILD_BYPRODUCTS is a 3.2+ feature
       ExternalProject_Add(googletest_ep
         URL "https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz"
-        CMAKE_ARGS -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS} -Dgtest_force_shared_crt=ON
+        CMAKE_ARGS ${GTEST_CMAKE_ARGS}
         # googletest doesn't define install rules, so just build in the
         # source dir and don't try to install.  See its README for
         # details.
@@ -471,7 +478,7 @@ if(ARROW_BUILD_TESTS)
     else()
       ExternalProject_Add(googletest_ep
         URL "https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz"
-        CMAKE_ARGS -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS} -Dgtest_force_shared_crt=ON
+        CMAKE_ARGS ${GTEST_CMAKE_ARGS}
         # googletest doesn't define install rules, so just build in the
         # source dir and don't try to install.  See its README for
         # details.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -146,9 +146,11 @@ include(BuildUtils)
 include(SetupCxxFlags)
 
 # Add common flags
-set(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_COMMON_FLAGS}")
 set(EP_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "${ARROW_CXXFLAGS} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARROW_CXXFLAGS}")
+
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 # Determine compiler version
 include(CompilerInfo)
@@ -451,10 +453,6 @@ if(ARROW_BUILD_TESTS)
     endif()
     string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_BUILD_TYPE)
     set(GTEST_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}} ${GTEST_CMAKE_CXX_FLAGS}")
-    if(MSVC)
-        # Disable too much warnings as build failure reason
-        string(REPLACE "-Wall" "" GTEST_CMAKE_CXX_FLAGS "${GTEST_CMAKE_CXX_FLAGS}")
-    endif()
 
     set(GTEST_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/googletest_ep-prefix/src/googletest_ep")
     set(GTEST_INCLUDE_DIR "${GTEST_PREFIX}/include")
@@ -563,9 +561,9 @@ if(ARROW_BUILD_BENCHMARKS)
 
   if("$ENV{GBENCHMARK_HOME}" STREQUAL "")
     if(APPLE)
-      set(GBENCHMARK_CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
-    else()
-      set(GBENCHMARK_CMAKE_CXX_FLAGS "--std=c++11")
+      set(GBENCHMARK_CMAKE_CXX_FLAGS "-fPIC -std=c++11 -stdlib=libc++")
+    elseif(NOT MSVC)
+      set(GBENCHMARK_CMAKE_CXX_FLAGS "-fPIC --std=c++11")
     endif()
 
     set(GBENCHMARK_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/gbenchmark_ep/src/gbenchmark_ep-install")
@@ -576,7 +574,7 @@ if(ARROW_BUILD_BENCHMARKS)
           "-DCMAKE_BUILD_TYPE=Release"
           "-DCMAKE_INSTALL_PREFIX:PATH=${GBENCHMARK_PREFIX}"
           "-DBENCHMARK_ENABLE_TESTING=OFF"
-          "-DCMAKE_CXX_FLAGS=-fPIC ${GBENCHMARK_CMAKE_CXX_FLAGS}")
+          "-DCMAKE_CXX_FLAGS=${GBENCHMARK_CMAKE_CXX_FLAGS}")
     if (APPLE)
       set(GBENCHMARK_CMAKE_ARGS ${GBENCHMARK_CMAKE_ARGS} "-DBENCHMARK_USE_LIBCXX=ON")
     endif()
@@ -627,6 +625,13 @@ else()
 endif()
 message(STATUS "RapidJSON include dir: ${RAPIDJSON_INCLUDE_DIR}")
 include_directories(SYSTEM ${RAPIDJSON_INCLUDE_DIR})
+
+#----------------------------------------------------------------------
+
+if (MSVC)
+  # jemalloc is not supported on Windows
+  set(ARROW_JEMALLOC off)
+endif()
 
 if (ARROW_JEMALLOC)
   find_package(jemalloc)
@@ -847,12 +852,10 @@ if(ARROW_IPC)
     ExternalProject_Add(flatbuffers_ep
       URL "https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.tar.gz"
       CMAKE_ARGS
-        "-DCMAKE_CXX_FLAGS=-fPIC"
         "-DCMAKE_INSTALL_PREFIX:PATH=${FLATBUFFERS_PREFIX}"
         "-DFLATBUFFERS_BUILD_TESTS=OFF")
 
     set(FLATBUFFERS_INCLUDE_DIR "${FLATBUFFERS_PREFIX}/include")
-    set(FLATBUFFERS_STATIC_LIB "${FLATBUFFERS_PREFIX}/libflatbuffers.a")
     set(FLATBUFFERS_COMPILER "${FLATBUFFERS_PREFIX}/bin/flatc")
     set(FLATBUFFERS_VENDORED 1)
   else()
@@ -861,16 +864,8 @@ if(ARROW_IPC)
   endif()
 
   message(STATUS "Flatbuffers include dir: ${FLATBUFFERS_INCLUDE_DIR}")
-  message(STATUS "Flatbuffers static library: ${FLATBUFFERS_STATIC_LIB}")
   message(STATUS "Flatbuffers compiler: ${FLATBUFFERS_COMPILER}")
   include_directories(SYSTEM ${FLATBUFFERS_INCLUDE_DIR})
-  ADD_THIRDPARTY_LIB(flatbuffers
-    STATIC_LIB ${FLATBUFFERS_STATIC_LIB})
-
-  if(FLATBUFFERS_VENDORED)
-    add_dependencies(flatbuffers flatbuffers_ep)
-  endif()
-
   add_subdirectory(src/arrow/ipc)
 endif()
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -40,6 +40,8 @@ On OS X, you can use [Homebrew][1]:
 brew install boost cmake
 ```
 
+If you are developing on Windows, see the [Windows developer guide][2].
+
 ## Building Arrow
 
 Simple debug build:
@@ -124,3 +126,4 @@ both of these options would be used rarely.  Current known uses-cases whent hey 
 *  Parameterized tests in google test.
 
 [1]: https://brew.sh/
+[2]: https://github.com/apache/arrow/blob/master/cpp/doc/Windows.md

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -24,19 +24,32 @@ CHECK_CXX_COMPILER_FLAG("-msse3" CXX_SUPPORTS_SSE3)
 CHECK_CXX_COMPILER_FLAG("-maltivec" CXX_SUPPORTS_ALTIVEC)
 
 # compiler flags that are common across debug/release builds
-#  - Wall: Enable all warnings.
-set(CXX_COMMON_FLAGS "-Wall")
 
-if (NOT MSVC)
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -std=c++11")
+if (MSVC)
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # clang-cl
+    set(CXX_COMMON_FLAGS "-EHsc")
+  elseif(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 19)
+    message(FATAL_ERROR "Only MSVC 2015 (Version 19.0) and later are supported
+    by Arrow. Found version ${CMAKE_CXX_COMPILER_VERSION}.")
+  else()
+    # Fix annoying D9025 warning
+    string(REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
+    # Set desired warning level (e.g. set /W4 for more warnings)
+    set(CXX_COMMON_FLAGS "/W3")
+  endif()
+else()
+  set(CXX_COMMON_FLAGS "-Wall -std=c++11")
 endif()
 
 # Only enable additional instruction sets if they are supported
 if (CXX_SUPPORTS_SSE3 AND ARROW_SSE3)
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -msse3")
+  set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -msse3")
 endif()
+
 if (CXX_SUPPORTS_ALTIVEC AND ARROW_ALTIVEC)
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -maltivec")
+  set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -maltivec")
 endif()
 
 if (APPLE)

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -25,7 +25,11 @@ CHECK_CXX_COMPILER_FLAG("-maltivec" CXX_SUPPORTS_ALTIVEC)
 
 # compiler flags that are common across debug/release builds
 #  - Wall: Enable all warnings.
-set(CXX_COMMON_FLAGS "-std=c++11 -Wall")
+set(CXX_COMMON_FLAGS "-Wall")
+
+if (NOT MSVC)
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -std=c++11")
+endif()
 
 # Only enable additional instruction sets if they are supported
 if (CXX_SUPPORTS_SSE3 AND ARROW_SSE3)

--- a/cpp/doc/Windows.md
+++ b/cpp/doc/Windows.md
@@ -48,7 +48,7 @@ Now, you can bootstrap a build environment
 conda create -n arrow-dev cmake git boost
 ```
 
-## Building
+## Building with NMake
 
 Activate your conda build environment:
 
@@ -67,6 +67,16 @@ nmake
 ```
 
 When using conda, only release builds are currently supported.
+
+## Build using Visual Studio (MSVC) Solution Files
+
+To build on the command line by instead generating a MSVC solution, instead
+run:
+
+```
+cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . --config Release
+```
 
 [1]: https://conda.io/miniconda.html
 [2]: https://conda-forge.github.io/

--- a/cpp/doc/Windows.md
+++ b/cpp/doc/Windows.md
@@ -1,0 +1,73 @@
+<!---
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+
+# Developing Arrow C++ on Windows
+
+## System setup, conda, and conda-forge
+
+Since some of the Arrow developers work in the Python ecosystem, we are
+investing time in maintaining the thirdparty build dependencies for Arrow and
+related C++ libraries using the conda package manager. Others are free to add
+other development instructions for Windows here.
+
+### Visual Studio
+
+Microsoft provides the free Visual Studio 2017 Community edition. When doing
+development, you must launch the developer command prompt using
+
+```"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64```
+
+It's easiest to configure a console emulator like [cmder][3] to automatically
+launch this when starting a new development console.
+
+### conda and package toolchain
+
+[Miniconda][1] is a minimal Python distribution including the conda package
+manager. To get started, download and install a 64-bit distribution.
+
+We recommend using packages from [conda-forge][2]
+
+```shell
+conda config --add channels conda-forge
+```
+
+Now, you can bootstrap a build environment
+
+```shell
+conda create -n arrow-dev cmake git boost
+```
+
+## Building
+
+Activate your conda build environment:
+
+```
+activate arrow-dev
+```
+
+Now, do an out of source build using `nmake`:
+
+```
+cd cpp
+mkdir build
+cd build
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+nmake
+```
+
+When using conda, only release builds are currently supported.
+
+[1]: https://conda.io/miniconda.html
+[2]: https://conda-forge.github.io/
+[3]: http://cmder.net/


### PR DESCRIPTION
Includes existing patch for ARROW-757 and closes #492 

With this patch I'm able to build with

```
cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release ..
nmake
```