### PR TITLE
ARROW-800: [C++] Boost headers being transitively included in pyarrow

### DIFF
--- a/cpp/src/arrow/array-decimal-test.cc
+++ b/cpp/src/arrow/array-decimal-test.cc
@@ -23,6 +23,7 @@
 #include "arrow/util/decimal.h"
 
 namespace arrow {
+namespace decimal {
 
 TEST(TypesTest, TestDecimal32Type) {
   DecimalType t1(8, 4);
@@ -221,4 +222,5 @@ INSTANTIATE_TEST_CASE_P(Decimal128BuilderTest, Decimal128BuilderTest,
     ::testing::Range(
         DecimalPrecision<int128_t>::minimum, DecimalPrecision<int128_t>::maximum));
 
+}  // namespace decimal
 }  // namespace arrow

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -310,7 +310,7 @@ bool DecimalArray::IsNegative(int64_t i) const {
   return sign_bitmap_data_ != nullptr ? BitUtil::GetBit(sign_bitmap_data_, i) : false;
 }
 
-std::string DecimalArray::Value(int64_t i) const {
+std::string DecimalArray::FormatValue(int64_t i) const {
   const auto type_ = std::dynamic_pointer_cast<DecimalType>(type());
   const int precision = type_->precision;
   const int scale = type_->scale;
@@ -318,19 +318,19 @@ std::string DecimalArray::Value(int64_t i) const {
   const uint8_t* bytes = GetValue(i);
   switch (byte_width) {
     case 4: {
-      Decimal32 value;
-      FromBytes(bytes, &value);
-      return ToString(value, precision, scale);
+      decimal::Decimal32 value;
+      decimal::FromBytes(bytes, &value);
+      return decimal::ToString(value, precision, scale);
     }
     case 8: {
-      Decimal64 value;
-      FromBytes(bytes, &value);
-      return ToString(value, precision, scale);
+      decimal::Decimal64 value;
+      decimal::FromBytes(bytes, &value);
+      return decimal::ToString(value, precision, scale);
     }
     case 16: {
-      Decimal128 value;
-      FromBytes(bytes, IsNegative(i), &value);
-      return ToString(value, precision, scale);
+      decimal::Decimal128 value;
+      decimal::FromBytes(bytes, IsNegative(i), &value);
+      return decimal::ToString(value, precision, scale);
     }
     default: {
       DCHECK(false) << "Invalid byte width: " << byte_width;

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -311,9 +311,9 @@ bool DecimalArray::IsNegative(int64_t i) const {
 }
 
 std::string DecimalArray::Value(int64_t i) const {
-  auto type_ = std::dynamic_pointer_cast<DecimalType>(type());
-  int precision = type_->precision;
-  int scale = type_->scale;
+  const auto type_ = std::dynamic_pointer_cast<DecimalType>(type());
+  const int precision = type_->precision;
+  const int scale = type_->scale;
   const int byte_width = byte_width_;
   const uint8_t* bytes = GetValue(i);
   switch (byte_width) {

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -310,24 +310,34 @@ bool DecimalArray::IsNegative(int64_t i) const {
   return sign_bitmap_data_ != nullptr ? BitUtil::GetBit(sign_bitmap_data_, i) : false;
 }
 
-template <typename T>
-ARROW_EXPORT Decimal<T> DecimalArray::Value(int64_t i) const {
-  Decimal<T> result;
-  FromBytes(GetValue(i), &result);
-  return result;
+std::string DecimalArray::Value(int64_t i) const {
+  auto type_ = std::dynamic_pointer_cast<DecimalType>(type());
+  int precision = type_->precision;
+  int scale = type_->scale;
+  const int byte_width = byte_width_;
+  const uint8_t* bytes = GetValue(i);
+  switch (byte_width) {
+    case 4: {
+      Decimal32 value;
+      FromBytes(bytes, &value);
+      return ToString(value, precision, scale);
+    }
+    case 8: {
+      Decimal64 value;
+      FromBytes(bytes, &value);
+      return ToString(value, precision, scale);
+    }
+    case 16: {
+      Decimal128 value;
+      FromBytes(bytes, IsNegative(i), &value);
+      return ToString(value, precision, scale);
+    }
+    default: {
+      DCHECK(false) << "Invalid byte width: " << byte_width;
+      return "";
+    }
+  }
 }
-
-template ARROW_EXPORT Decimal32 DecimalArray::Value(int64_t i) const;
-template ARROW_EXPORT Decimal64 DecimalArray::Value(int64_t i) const;
-
-template <>
-ARROW_EXPORT Decimal128 DecimalArray::Value(int64_t i) const {
-  Decimal128 result;
-  FromBytes(GetValue(i), IsNegative(i), &result);
-  return result;
-}
-
-template ARROW_EXPORT Decimal128 DecimalArray::Value(int64_t i) const;
 
 std::shared_ptr<Array> DecimalArray::Slice(int64_t offset, int64_t length) const {
   ConformSliceParams(offset_, length_, &offset, &length);

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -384,8 +384,7 @@ class ARROW_EXPORT DecimalArray : public FixedSizeBinaryArray {
 
   bool IsNegative(int64_t i) const;
 
-  template <typename T>
-  ARROW_EXPORT Decimal<T> Value(int64_t i) const;
+  ARROW_EXPORT std::string Value(int64_t i) const;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -384,7 +384,7 @@ class ARROW_EXPORT DecimalArray : public FixedSizeBinaryArray {
 
   bool IsNegative(int64_t i) const;
 
-  ARROW_EXPORT std::string Value(int64_t i) const;
+  std::string Value(int64_t i) const;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -384,7 +384,7 @@ class ARROW_EXPORT DecimalArray : public FixedSizeBinaryArray {
 
   bool IsNegative(int64_t i) const;
 
-  std::string Value(int64_t i) const;
+  std::string FormatValue(int64_t i) const;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -332,7 +332,7 @@ DecimalBuilder::DecimalBuilder(MemoryPool* pool, const std::shared_ptr<DataType>
       sign_bitmap_data_(nullptr) {}
 
 template <typename T>
-ARROW_EXPORT Status DecimalBuilder::Append(const Decimal<T>& val) {
+ARROW_EXPORT Status DecimalBuilder::Append(const decimal::Decimal<T>& val) {
   DCHECK_EQ(sign_bitmap_, nullptr) << "sign_bitmap_ is not null";
   DCHECK_EQ(sign_bitmap_data_, nullptr) << "sign_bitmap_data_ is not null";
 
@@ -340,11 +340,11 @@ ARROW_EXPORT Status DecimalBuilder::Append(const Decimal<T>& val) {
   return FixedSizeBinaryBuilder::Append(reinterpret_cast<const uint8_t*>(&val.value));
 }
 
-template ARROW_EXPORT Status DecimalBuilder::Append(const Decimal32& val);
-template ARROW_EXPORT Status DecimalBuilder::Append(const Decimal64& val);
+template ARROW_EXPORT Status DecimalBuilder::Append(const decimal::Decimal32& val);
+template ARROW_EXPORT Status DecimalBuilder::Append(const decimal::Decimal64& val);
 
 template <>
-ARROW_EXPORT Status DecimalBuilder::Append(const Decimal128& value) {
+ARROW_EXPORT Status DecimalBuilder::Append(const decimal::Decimal128& value) {
   DCHECK_NE(sign_bitmap_, nullptr) << "sign_bitmap_ is null";
   DCHECK_NE(sign_bitmap_data_, nullptr) << "sign_bitmap_data_ is null";
 
@@ -352,7 +352,7 @@ ARROW_EXPORT Status DecimalBuilder::Append(const Decimal128& value) {
   uint8_t stack_bytes[16] = {0};
   uint8_t* bytes = stack_bytes;
   bool is_negative;
-  ToBytes(value, &bytes, &is_negative);
+  decimal::ToBytes(value, &bytes, &is_negative);
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Append(bytes));
 
   // TODO(phillipc): calculate the proper storage size here (do we have a function to do
@@ -363,7 +363,7 @@ ARROW_EXPORT Status DecimalBuilder::Append(const Decimal128& value) {
   return Status::OK();
 }
 
-template ARROW_EXPORT Status DecimalBuilder::Append(const Decimal128& val);
+template ARROW_EXPORT Status DecimalBuilder::Append(const decimal::Decimal128& val);
 
 Status DecimalBuilder::Init(int64_t capacity) {
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Init(capacity));

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -37,8 +37,12 @@ namespace arrow {
 
 class Array;
 
+namespace decimal {
+
 template <typename T>
 struct Decimal;
+
+}  // namespace decimal
 
 static constexpr int64_t kMinBuilderCapacity = 1 << 5;
 
@@ -421,7 +425,7 @@ class ARROW_EXPORT DecimalBuilder : public FixedSizeBinaryBuilder {
   explicit DecimalBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type);
 
   template <typename T>
-  ARROW_EXPORT Status Append(const Decimal<T>& val);
+  ARROW_EXPORT Status Append(const decimal::Decimal<T>& val);
 
   Status Init(int64_t capacity) override;
   Status Resize(int64_t capacity) override;

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -523,7 +523,7 @@ class ListConverter : public TypedConverter<ListBuilder> {
 
 #define DECIMAL_CONVERT_CASE(bit_width, item, builder)        \
   case bit_width: {                                           \
-    arrow::Decimal##bit_width out;                            \
+    arrow::decimal::Decimal##bit_width out;                            \
     RETURN_NOT_OK(PythonDecimalToArrowDecimal((item), &out)); \
     RETURN_NOT_OK((builder)->Append(out));                    \
     break;                                                    \

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -523,7 +523,7 @@ class ListConverter : public TypedConverter<ListBuilder> {
 
 #define DECIMAL_CONVERT_CASE(bit_width, item, builder)        \
   case bit_width: {                                           \
-    arrow::decimal::Decimal##bit_width out;                            \
+    arrow::decimal::Decimal##bit_width out;                   \
     RETURN_NOT_OK(PythonDecimalToArrowDecimal((item), &out)); \
     RETURN_NOT_OK((builder)->Append(out));                    \
     break;                                                    \

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -74,7 +74,7 @@ Status ImportFromModule(const OwnedRef& module, const std::string& name, OwnedRe
 }
 
 template <typename T>
-Status PythonDecimalToArrowDecimal(PyObject* python_decimal, Decimal<T>* arrow_decimal) {
+Status PythonDecimalToArrowDecimal(PyObject* python_decimal, decimal::Decimal<T>* arrow_decimal) {
   // Call Python's str(decimal_object)
   OwnedRef str_obj(PyObject_Str(python_decimal));
   RETURN_IF_PYERROR();
@@ -92,11 +92,11 @@ Status PythonDecimalToArrowDecimal(PyObject* python_decimal, Decimal<T>* arrow_d
 }
 
 template Status PythonDecimalToArrowDecimal(
-    PyObject* python_decimal, Decimal32* arrow_decimal);
+    PyObject* python_decimal, decimal::Decimal32* arrow_decimal);
 template Status PythonDecimalToArrowDecimal(
-    PyObject* python_decimal, Decimal64* arrow_decimal);
+    PyObject* python_decimal, decimal::Decimal64* arrow_decimal);
 template Status PythonDecimalToArrowDecimal(
-    PyObject* python_decimal, Decimal128* arrow_decimal);
+    PyObject* python_decimal, decimal::Decimal128* arrow_decimal);
 
 Status InferDecimalPrecisionAndScale(
     PyObject* python_decimal, int* precision, int* scale) {
@@ -111,7 +111,7 @@ Status InferDecimalPrecisionAndScale(
   auto size = str.size;
 
   std::string c_string(bytes, size);
-  return FromString(c_string, static_cast<Decimal32*>(nullptr), precision, scale);
+  return FromString(c_string, static_cast<decimal::Decimal32*>(nullptr), precision, scale);
 }
 
 Status DecimalFromString(

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -74,7 +74,8 @@ Status ImportFromModule(const OwnedRef& module, const std::string& name, OwnedRe
 }
 
 template <typename T>
-Status PythonDecimalToArrowDecimal(PyObject* python_decimal, decimal::Decimal<T>* arrow_decimal) {
+Status PythonDecimalToArrowDecimal(
+    PyObject* python_decimal, decimal::Decimal<T>* arrow_decimal) {
   // Call Python's str(decimal_object)
   OwnedRef str_obj(PyObject_Str(python_decimal));
   RETURN_IF_PYERROR();
@@ -111,7 +112,8 @@ Status InferDecimalPrecisionAndScale(
   auto size = str.size;
 
   std::string c_string(bytes, size);
-  return FromString(c_string, static_cast<decimal::Decimal32*>(nullptr), precision, scale);
+  return FromString(
+      c_string, static_cast<decimal::Decimal32*>(nullptr), precision, scale);
 }
 
 Status DecimalFromString(

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -47,7 +47,8 @@ Status ImportFromModule(
     const OwnedRef& module, const std::string& module_name, OwnedRef* ref);
 
 template <typename T>
-Status PythonDecimalToArrowDecimal(PyObject* python_decimal, decimal::Decimal<T>* arrow_decimal);
+Status PythonDecimalToArrowDecimal(
+    PyObject* python_decimal, decimal::Decimal<T>* arrow_decimal);
 
 Status InferDecimalPrecisionAndScale(
     PyObject* python_decimal, int* precision = nullptr, int* scale = nullptr);

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -29,8 +29,12 @@
 
 namespace arrow {
 
+namespace decimal {
+
 template <typename T>
 struct Decimal;
+
+}  // namespace decimal
 
 namespace py {
 
@@ -43,7 +47,7 @@ Status ImportFromModule(
     const OwnedRef& module, const std::string& module_name, OwnedRef* ref);
 
 template <typename T>
-Status PythonDecimalToArrowDecimal(PyObject* python_decimal, Decimal<T>* arrow_decimal);
+Status PythonDecimalToArrowDecimal(PyObject* python_decimal, decimal::Decimal<T>* arrow_decimal);
 
 Status InferDecimalPrecisionAndScale(
     PyObject* python_decimal, int* precision = nullptr, int* scale = nullptr);

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -530,7 +530,7 @@ Status PandasConverter::ConvertDates() {
 
 #define CONVERT_DECIMAL_CASE(bit_width, builder, object)      \
   case bit_width: {                                           \
-    decimal::Decimal##bit_width d;                                     \
+    decimal::Decimal##bit_width d;                            \
     RETURN_NOT_OK(PythonDecimalToArrowDecimal((object), &d)); \
     RETURN_NOT_OK((builder).Append(d));                       \
     break;                                                    \

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -530,7 +530,7 @@ Status PandasConverter::ConvertDates() {
 
 #define CONVERT_DECIMAL_CASE(bit_width, builder, object)      \
   case bit_width: {                                           \
-    Decimal##bit_width d;                                     \
+    decimal::Decimal##bit_width d;                                     \
     RETURN_NOT_OK(PythonDecimalToArrowDecimal((object), &d)); \
     RETURN_NOT_OK((builder).Append(d));                       \
     break;                                                    \
@@ -620,7 +620,7 @@ Status PandasConverter::ConvertObjectFixedWidthBytes(
 
 template <typename T>
 Status validate_precision(int precision) {
-  constexpr static const int maximum_precision = DecimalPrecision<T>::maximum;
+  constexpr static const int maximum_precision = decimal::DecimalPrecision<T>::maximum;
   if (!(precision > 0 && precision <= maximum_precision)) {
     std::stringstream ss;
     ss << "Invalid precision: " << precision << ". Minimum is 1, maximum is "
@@ -636,7 +636,7 @@ Status RawDecimalToString(
   DCHECK_NE(bytes, nullptr);
   DCHECK_NE(result, nullptr);
   RETURN_NOT_OK(validate_precision<T>(precision));
-  Decimal<T> decimal;
+  decimal::Decimal<T> decimal;
   FromBytes(bytes, &decimal);
   *result = ToString(decimal, precision, scale);
   return Status::OK();
@@ -651,8 +651,8 @@ Status RawDecimalToString(const uint8_t* bytes, int precision, int scale,
     bool is_negative, std::string* result) {
   DCHECK_NE(bytes, nullptr);
   DCHECK_NE(result, nullptr);
-  RETURN_NOT_OK(validate_precision<int128_t>(precision));
-  Decimal128 decimal;
+  RETURN_NOT_OK(validate_precision<boost::multiprecision::int128_t>(precision));
+  decimal::Decimal128 decimal;
   FromBytes(bytes, is_negative, &decimal);
   *result = ToString(decimal, precision, scale);
   return Status::OK();

--- a/cpp/src/arrow/python/python-test.cc
+++ b/cpp/src/arrow/python/python-test.cc
@@ -63,8 +63,8 @@ TEST(DecimalTest, TestPythonDecimalToArrowDecimal128) {
   ASSERT_NE(pydecimal.obj(), nullptr);
   ASSERT_EQ(PyErr_Occurred(), nullptr);
 
-  Decimal128 arrow_decimal;
-  int128_t boost_decimal(decimal_string);
+  decimal::Decimal128 arrow_decimal;
+  boost::multiprecision::int128_t boost_decimal(decimal_string);
   PyObject* obj = pydecimal.obj();
   ASSERT_OK(PythonDecimalToArrowDecimal(obj, &arrow_decimal));
   ASSERT_EQ(boost_decimal, arrow_decimal.value);

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -147,7 +147,7 @@ std::shared_ptr<DataType> ARROW_EXPORT binary();
 
 std::shared_ptr<DataType> ARROW_EXPORT date32();
 std::shared_ptr<DataType> ARROW_EXPORT date64();
-std::shared_ptr<DataType> ARROW_EXPORT decimal(int precision, int scale);
+std::shared_ptr<DataType> ARROW_EXPORT decimal_type(int precision, int scale);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -22,7 +22,6 @@
 # Headers: top level
 install(FILES
   bit-util.h
-  decimal.h
   logging.h
   macros.h
   random.h

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -23,6 +23,7 @@
 #include "arrow/test-util.h"
 
 namespace arrow {
+namespace decimal {
 
 template <typename T>
 class DecimalTest : public ::testing::Test {
@@ -158,4 +159,5 @@ TEST(DecimalTest, TestDecimal128StringAndBytesRoundTrip) {
 
   ASSERT_EQ(expected.value, result.value);
 }
+}  // namespace decimal
 }  // namespace arrow

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -20,6 +20,7 @@
 #include <boost/regex.hpp>
 
 namespace arrow {
+namespace decimal {
 
 static const boost::regex DECIMAL_PATTERN("(\\+?|-?)((0*)(\\d*))(\\.(\\d+))?");
 
@@ -138,4 +139,5 @@ void ToBytes(const Decimal128& decimal, uint8_t** bytes, bool* is_negative) {
   *is_negative = backend.isneg();
 }
 
+}  // namespace decimal
 }  // namespace arrow

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -31,29 +31,30 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 namespace arrow {
+namespace decimal {
 
 using boost::multiprecision::int128_t;
 
-template <typename T>
+template<typename T>
 struct ARROW_EXPORT Decimal;
 
 ARROW_EXPORT void StringToInteger(
-    const std::string& whole, const std::string& fractional, int8_t sign, int32_t* out);
+    const std::string &whole, const std::string &fractional, int8_t sign, int32_t *out);
 ARROW_EXPORT void StringToInteger(
-    const std::string& whole, const std::string& fractional, int8_t sign, int64_t* out);
+    const std::string &whole, const std::string &fractional, int8_t sign, int64_t *out);
 ARROW_EXPORT void StringToInteger(
-    const std::string& whole, const std::string& fractional, int8_t sign, int128_t* out);
+    const std::string &whole, const std::string &fractional, int8_t sign, int128_t *out);
 
-template <typename T>
-ARROW_EXPORT Status FromString(const std::string& s, Decimal<T>* out,
-    int* precision = nullptr, int* scale = nullptr);
+template<typename T>
+ARROW_EXPORT Status FromString(const std::string &s, Decimal<T> *out,
+                               int *precision = nullptr, int *scale = nullptr);
 
-template <typename T>
+template<typename T>
 struct ARROW_EXPORT Decimal {
   Decimal() : value() {}
-  explicit Decimal(const std::string& s) : value() { FromString(s, this); }
-  explicit Decimal(const char* s) : Decimal(std::string(s)) {}
-  explicit Decimal(const T& value) : value(value) {}
+  explicit Decimal(const std::string &s) : value() { FromString(s, this); }
+  explicit Decimal(const char *s) : Decimal(std::string(s)) {}
+  explicit Decimal(const T &value) : value(value) {}
 
   using value_type = T;
   value_type value;
@@ -63,38 +64,38 @@ using Decimal32 = Decimal<int32_t>;
 using Decimal64 = Decimal<int64_t>;
 using Decimal128 = Decimal<int128_t>;
 
-template <typename T>
+template<typename T>
 struct ARROW_EXPORT DecimalPrecision {};
 
-template <>
+template<>
 struct ARROW_EXPORT DecimalPrecision<int32_t> {
   constexpr static const int minimum = 1;
   constexpr static const int maximum = 9;
 };
 
-template <>
+template<>
 struct ARROW_EXPORT DecimalPrecision<int64_t> {
   constexpr static const int minimum = 10;
   constexpr static const int maximum = 18;
 };
 
-template <>
+template<>
 struct ARROW_EXPORT DecimalPrecision<int128_t> {
   constexpr static const int minimum = 19;
   constexpr static const int maximum = 38;
 };
 
-template <typename T>
+template<typename T>
 ARROW_EXPORT std::string ToString(
-    const Decimal<T>& decimal_value, int precision, int scale) {
+    const Decimal<T> &decimal_value, int precision, int scale) {
   T value = decimal_value.value;
 
   // Decimal values are sent to clients as strings so in the interest of
   // speed the string will be created without the using stringstream with the
   // whole/fractional_part().
   size_t last_char_idx = precision + (scale > 0)  // Add a space for decimal place
-                         + (scale == precision)   // Add a space for leading 0
-                         + (value < 0);           // Add a space for negative sign
+      + (scale == precision)   // Add a space for leading 0
+      + (value < 0);           // Add a space for negative sign
   std::string str = std::string(last_char_idx, '0');
   // Start filling in the values in reverse order by taking the last digit
   // of the value. Use a positive value and worry about the sign later. At this
@@ -131,14 +132,15 @@ ARROW_EXPORT std::string ToString(
 }
 
 /// Conversion from raw bytes to a Decimal value
-ARROW_EXPORT void FromBytes(const uint8_t* bytes, Decimal32* value);
-ARROW_EXPORT void FromBytes(const uint8_t* bytes, Decimal64* value);
-ARROW_EXPORT void FromBytes(const uint8_t* bytes, bool is_negative, Decimal128* decimal);
+ARROW_EXPORT void FromBytes(const uint8_t *bytes, Decimal32 *value);
+ARROW_EXPORT void FromBytes(const uint8_t *bytes, Decimal64 *value);
+ARROW_EXPORT void FromBytes(const uint8_t *bytes, bool is_negative, Decimal128 *decimal);
 
 /// Conversion from a Decimal value to raw bytes
-ARROW_EXPORT void ToBytes(const Decimal32& value, uint8_t** bytes);
-ARROW_EXPORT void ToBytes(const Decimal64& value, uint8_t** bytes);
-ARROW_EXPORT void ToBytes(const Decimal128& decimal, uint8_t** bytes, bool* is_negative);
+ARROW_EXPORT void ToBytes(const Decimal32 &value, uint8_t **bytes);
+ARROW_EXPORT void ToBytes(const Decimal64 &value, uint8_t **bytes);
+ARROW_EXPORT void ToBytes(const Decimal128 &decimal, uint8_t **bytes, bool *is_negative);
 
+}  // namespace decimal
 }  // namespace arrow
 #endif  // ARROW_DECIMAL_H

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -35,26 +35,26 @@ namespace decimal {
 
 using boost::multiprecision::int128_t;
 
-template<typename T>
+template <typename T>
 struct ARROW_EXPORT Decimal;
 
 ARROW_EXPORT void StringToInteger(
-    const std::string &whole, const std::string &fractional, int8_t sign, int32_t *out);
+    const std::string& whole, const std::string& fractional, int8_t sign, int32_t* out);
 ARROW_EXPORT void StringToInteger(
-    const std::string &whole, const std::string &fractional, int8_t sign, int64_t *out);
+    const std::string& whole, const std::string& fractional, int8_t sign, int64_t* out);
 ARROW_EXPORT void StringToInteger(
-    const std::string &whole, const std::string &fractional, int8_t sign, int128_t *out);
+    const std::string& whole, const std::string& fractional, int8_t sign, int128_t* out);
 
-template<typename T>
-ARROW_EXPORT Status FromString(const std::string &s, Decimal<T> *out,
-                               int *precision = nullptr, int *scale = nullptr);
+template <typename T>
+ARROW_EXPORT Status FromString(const std::string& s, Decimal<T>* out,
+    int* precision = nullptr, int* scale = nullptr);
 
-template<typename T>
+template <typename T>
 struct ARROW_EXPORT Decimal {
   Decimal() : value() {}
-  explicit Decimal(const std::string &s) : value() { FromString(s, this); }
-  explicit Decimal(const char *s) : Decimal(std::string(s)) {}
-  explicit Decimal(const T &value) : value(value) {}
+  explicit Decimal(const std::string& s) : value() { FromString(s, this); }
+  explicit Decimal(const char* s) : Decimal(std::string(s)) {}
+  explicit Decimal(const T& value) : value(value) {}
 
   using value_type = T;
   value_type value;
@@ -64,38 +64,38 @@ using Decimal32 = Decimal<int32_t>;
 using Decimal64 = Decimal<int64_t>;
 using Decimal128 = Decimal<int128_t>;
 
-template<typename T>
+template <typename T>
 struct ARROW_EXPORT DecimalPrecision {};
 
-template<>
+template <>
 struct ARROW_EXPORT DecimalPrecision<int32_t> {
   constexpr static const int minimum = 1;
   constexpr static const int maximum = 9;
 };
 
-template<>
+template <>
 struct ARROW_EXPORT DecimalPrecision<int64_t> {
   constexpr static const int minimum = 10;
   constexpr static const int maximum = 18;
 };
 
-template<>
+template <>
 struct ARROW_EXPORT DecimalPrecision<int128_t> {
   constexpr static const int minimum = 19;
   constexpr static const int maximum = 38;
 };
 
-template<typename T>
+template <typename T>
 ARROW_EXPORT std::string ToString(
-    const Decimal<T> &decimal_value, int precision, int scale) {
+    const Decimal<T>& decimal_value, int precision, int scale) {
   T value = decimal_value.value;
 
   // Decimal values are sent to clients as strings so in the interest of
   // speed the string will be created without the using stringstream with the
   // whole/fractional_part().
   size_t last_char_idx = precision + (scale > 0)  // Add a space for decimal place
-      + (scale == precision)   // Add a space for leading 0
-      + (value < 0);           // Add a space for negative sign
+                         + (scale == precision)   // Add a space for leading 0
+                         + (value < 0);           // Add a space for negative sign
   std::string str = std::string(last_char_idx, '0');
   // Start filling in the values in reverse order by taking the last digit
   // of the value. Use a positive value and worry about the sign later. At this
@@ -132,14 +132,14 @@ ARROW_EXPORT std::string ToString(
 }
 
 /// Conversion from raw bytes to a Decimal value
-ARROW_EXPORT void FromBytes(const uint8_t *bytes, Decimal32 *value);
-ARROW_EXPORT void FromBytes(const uint8_t *bytes, Decimal64 *value);
-ARROW_EXPORT void FromBytes(const uint8_t *bytes, bool is_negative, Decimal128 *decimal);
+ARROW_EXPORT void FromBytes(const uint8_t* bytes, Decimal32* value);
+ARROW_EXPORT void FromBytes(const uint8_t* bytes, Decimal64* value);
+ARROW_EXPORT void FromBytes(const uint8_t* bytes, bool is_negative, Decimal128* decimal);
 
 /// Conversion from a Decimal value to raw bytes
-ARROW_EXPORT void ToBytes(const Decimal32 &value, uint8_t **bytes);
-ARROW_EXPORT void ToBytes(const Decimal64 &value, uint8_t **bytes);
-ARROW_EXPORT void ToBytes(const Decimal128 &decimal, uint8_t **bytes, bool *is_negative);
+ARROW_EXPORT void ToBytes(const Decimal32& value, uint8_t** bytes);
+ARROW_EXPORT void ToBytes(const Decimal64& value, uint8_t** bytes);
+ARROW_EXPORT void ToBytes(const Decimal128& decimal, uint8_t** bytes, bool* is_negative);
 
 }  // namespace decimal
 }  // namespace arrow

--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -51,11 +51,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool IsTypeError()
 
 
-cdef extern from "arrow/util/decimal.h" namespace "arrow" nogil:
-    cdef cppclass int128_t:
-        pass
-
-
 cdef inline object PyObject_to_object(PyObject* o):
     # Cast to "object" increments reference count
     cdef object result = <object> o

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -60,11 +60,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         TimeUnit_MICRO" arrow::TimeUnit::MICRO"
         TimeUnit_NANO" arrow::TimeUnit::NANO"
 
-    cdef cppclass Decimal[T]:
-        Decimal(const T&)
-
-    cdef c_string ToString[T](const Decimal[T]&, int, int)
-
     cdef cppclass CDataType" arrow::DataType":
         Type type
 
@@ -226,7 +221,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         const uint8_t* GetValue(int i)
 
     cdef cppclass CDecimalArray" arrow::DecimalArray"(CFixedSizeBinaryArray):
-        Decimal[T] Value[T](int i)
+        c_string Value(int i)
 
     cdef cppclass CListArray" arrow::ListArray"(CArray):
         const int32_t* raw_value_offsets()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -221,7 +221,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         const uint8_t* GetValue(int i)
 
     cdef cppclass CDecimalArray" arrow::DecimalArray"(CFixedSizeBinaryArray):
-        c_string Value(int i)
+        c_string FormatValue(int i)
 
     cdef cppclass CListArray" arrow::ListArray"(CArray):
         const int32_t* raw_value_offsets()

--- a/python/pyarrow/scalar.pyx
+++ b/python/pyarrow/scalar.pyx
@@ -17,7 +17,6 @@
 
 from pyarrow.schema cimport DataType, box_data_type
 
-from pyarrow.includes.common cimport int128_t
 from pyarrow.compat import frombytes
 import pyarrow.schema as schema
 import decimal
@@ -213,13 +212,7 @@ cdef class DecimalValue(ArrayValue):
             int bit_width = t.bit_width()
             int precision = t.precision
             int scale = t.scale
-            c_string s
-        if bit_width == 32:
-            s = ToString[int32_t](ap.Value[int32_t](self.index), precision, scale)
-        elif bit_width == 64:
-            s = ToString[int64_t](ap.Value[int64_t](self.index), precision, scale)
-        elif bit_width == 128:
-            s = ToString[int128_t](ap.Value[int128_t](self.index), precision, scale)
+            c_string s = ap.Value(self.index)
         return decimal.Decimal(s.decode('utf8'))
 
 

--- a/python/pyarrow/scalar.pyx
+++ b/python/pyarrow/scalar.pyx
@@ -212,7 +212,7 @@ cdef class DecimalValue(ArrayValue):
             int bit_width = t.bit_width()
             int precision = t.precision
             int scale = t.scale
-            c_string s = ap.Value(self.index)
+            c_string s = ap.FormatValue(self.index)
         return decimal.Decimal(s.decode('utf8'))
 
 


### PR DESCRIPTION
thanks to @wesm for suggesting the idea of returning `std::string` and doing the dispatching in c++.