### PR TITLE
ARROW-782: [C++] API cleanup, change public member access in DataType classes to functions, use class instead of struct

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -161,7 +161,7 @@ garrow_array_builder_new_raw(std::shared_ptr<arrow::ArrayBuilder> *arrow_builder
 {
   GType type;
 
-  switch ((*arrow_builder)->type()->type) {
+  switch ((*arrow_builder)->type()->id()) {
   case arrow::Type::type::BOOL:
     type = GARROW_TYPE_BOOLEAN_ARRAY_BUILDER;
     break;

--- a/c_glib/arrow-glib/array.cpp
+++ b/c_glib/arrow-glib/array.cpp
@@ -202,7 +202,7 @@ garrow_array_get_value_data_type(GArrowArray *array)
 {
   auto arrow_array = garrow_array_get_raw(array);
   auto arrow_data_type = arrow_array->type();
-  return garrow_data_type_new_raw(arrow_data_type.get());
+  return garrow_data_type_new_raw(&arrow_data_type);
 }
 
 /**

--- a/c_glib/arrow-glib/array.cpp
+++ b/c_glib/arrow-glib/array.cpp
@@ -202,7 +202,7 @@ garrow_array_get_value_data_type(GArrowArray *array)
 {
   auto arrow_array = garrow_array_get_raw(array);
   auto arrow_data_type = arrow_array->type();
-  return garrow_data_type_new_raw(&arrow_data_type);
+  return garrow_data_type_new_raw(arrow_data_type.get());
 }
 
 /**
@@ -216,7 +216,7 @@ GArrowType
 garrow_array_get_value_type(GArrowArray *array)
 {
   auto arrow_array = garrow_array_get_raw(array);
-  return garrow_type_from_raw(arrow_array->type_enum());
+  return garrow_type_from_raw(arrow_array->type_id());
 }
 
 /**
@@ -247,7 +247,7 @@ garrow_array_new_raw(std::shared_ptr<arrow::Array> *arrow_array)
   GType type;
   GArrowArray *array;
 
-  switch ((*arrow_array)->type_enum()) {
+  switch ((*arrow_array)->type_id()) {
   case arrow::Type::type::NA:
     type = GARROW_TYPE_NULL_ARRAY;
     break;

--- a/c_glib/arrow-glib/column.cpp
+++ b/c_glib/arrow-glib/column.cpp
@@ -224,7 +224,7 @@ garrow_column_get_data_type(GArrowColumn *column)
 {
   const auto arrow_column = garrow_column_get_raw(column);
   auto arrow_data_type = arrow_column->type();
-  return garrow_data_type_new_raw(&arrow_data_type);
+  return garrow_data_type_new_raw(arrow_data_type.get());
 }
 
 /**

--- a/c_glib/arrow-glib/column.cpp
+++ b/c_glib/arrow-glib/column.cpp
@@ -224,7 +224,7 @@ garrow_column_get_data_type(GArrowColumn *column)
 {
   const auto arrow_column = garrow_column_get_raw(column);
   auto arrow_data_type = arrow_column->type();
-  return garrow_data_type_new_raw(arrow_data_type.get());
+  return garrow_data_type_new_raw(&arrow_data_type);
 }
 
 /**

--- a/c_glib/arrow-glib/data-type.cpp
+++ b/c_glib/arrow-glib/data-type.cpp
@@ -180,18 +180,18 @@ GArrowType
 garrow_data_type_type(GArrowDataType *data_type)
 {
   const auto arrow_data_type = garrow_data_type_get_raw(data_type);
-  return garrow_type_from_raw(arrow_data_type->type);
+  return garrow_type_from_raw(arrow_data_type->id());
 }
 
 G_END_DECLS
 
 GArrowDataType *
-garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
+garrow_data_type_new_raw(arrow::DataType *arrow_data_type)
 {
   GType type;
   GArrowDataType *data_type;
 
-  switch ((*arrow_data_type)->type) {
+  switch (arrow_data_type->id()) {
   case arrow::Type::type::NA:
     type = GARROW_TYPE_NULL_DATA_TYPE;
     break;

--- a/c_glib/arrow-glib/data-type.cpp
+++ b/c_glib/arrow-glib/data-type.cpp
@@ -186,12 +186,12 @@ garrow_data_type_type(GArrowDataType *data_type)
 G_END_DECLS
 
 GArrowDataType *
-garrow_data_type_new_raw(arrow::DataType *arrow_data_type)
+garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
 {
   GType type;
   GArrowDataType *data_type;
 
-  switch (arrow_data_type->id()) {
+  switch ((*arrow_data_type)->id()) {
   case arrow::Type::type::NA:
     type = GARROW_TYPE_NULL_DATA_TYPE;
     break;

--- a/c_glib/arrow-glib/data-type.hpp
+++ b/c_glib/arrow-glib/data-type.hpp
@@ -23,5 +23,5 @@
 
 #include <arrow-glib/data-type.h>
 
-GArrowDataType *garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type);
+GArrowDataType *garrow_data_type_new_raw(arrow::DataType *arrow_data_type);
 std::shared_ptr<arrow::DataType> garrow_data_type_get_raw(GArrowDataType *data_type);

--- a/c_glib/arrow-glib/data-type.hpp
+++ b/c_glib/arrow-glib/data-type.hpp
@@ -23,5 +23,5 @@
 
 #include <arrow-glib/data-type.h>
 
-GArrowDataType *garrow_data_type_new_raw(arrow::DataType *arrow_data_type);
+GArrowDataType *garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type);
 std::shared_ptr<arrow::DataType> garrow_data_type_get_raw(GArrowDataType *data_type);

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -171,7 +171,7 @@ const gchar *
 garrow_field_get_name(GArrowField *field)
 {
   const auto arrow_field = garrow_field_get_raw(field);
-  return arrow_field->name.c_str();
+  return arrow_field->name().c_str();
 }
 
 /**
@@ -184,7 +184,7 @@ GArrowDataType *
 garrow_field_get_data_type(GArrowField *field)
 {
   const auto arrow_field = garrow_field_get_raw(field);
-  return garrow_data_type_new_raw(&arrow_field->type);
+  return garrow_data_type_new_raw(arrow_field->type().get());
 }
 
 /**
@@ -197,7 +197,7 @@ gboolean
 garrow_field_is_nullable(GArrowField *field)
 {
   const auto arrow_field = garrow_field_get_raw(field);
-  return arrow_field->nullable;
+  return arrow_field->nullable();
 }
 
 /**

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -184,7 +184,8 @@ GArrowDataType *
 garrow_field_get_data_type(GArrowField *field)
 {
   const auto arrow_field = garrow_field_get_raw(field);
-  return garrow_data_type_new_raw(arrow_field->type().get());
+  auto type = arrow_field->type();
+  return garrow_data_type_new_raw(&type);
 }
 
 /**

--- a/c_glib/arrow-glib/list-array.cpp
+++ b/c_glib/arrow-glib/list-array.cpp
@@ -66,7 +66,7 @@ garrow_list_array_get_value_type(GArrowListArray *array)
   auto arrow_list_array =
     static_cast<arrow::ListArray *>(arrow_array.get());
   auto arrow_value_type = arrow_list_array->value_type();
-  return garrow_data_type_new_raw(arrow_value_type.get());
+  return garrow_data_type_new_raw(&arrow_value_type);
 }
 
 /**

--- a/c_glib/arrow-glib/list-array.cpp
+++ b/c_glib/arrow-glib/list-array.cpp
@@ -66,7 +66,7 @@ garrow_list_array_get_value_type(GArrowListArray *array)
   auto arrow_list_array =
     static_cast<arrow::ListArray *>(arrow_array.get());
   auto arrow_value_type = arrow_list_array->value_type();
-  return garrow_data_type_new_raw(&arrow_value_type);
+  return garrow_data_type_new_raw(arrow_value_type.get());
 }
 
 /**

--- a/cpp/src/arrow/array-decimal-test.cc
+++ b/cpp/src/arrow/array-decimal-test.cc
@@ -25,48 +25,6 @@
 namespace arrow {
 namespace decimal {
 
-TEST(TypesTest, TestDecimal32Type) {
-  DecimalType t1(8, 4);
-
-  ASSERT_EQ(t1.type, Type::DECIMAL);
-  ASSERT_EQ(t1.precision, 8);
-  ASSERT_EQ(t1.scale, 4);
-
-  ASSERT_EQ(t1.ToString(), std::string("decimal(8, 4)"));
-
-  // Test properties
-  ASSERT_EQ(t1.byte_width(), 4);
-  ASSERT_EQ(t1.bit_width(), 32);
-}
-
-TEST(TypesTest, TestDecimal64Type) {
-  DecimalType t1(12, 5);
-
-  ASSERT_EQ(t1.type, Type::DECIMAL);
-  ASSERT_EQ(t1.precision, 12);
-  ASSERT_EQ(t1.scale, 5);
-
-  ASSERT_EQ(t1.ToString(), std::string("decimal(12, 5)"));
-
-  // Test properties
-  ASSERT_EQ(t1.byte_width(), 8);
-  ASSERT_EQ(t1.bit_width(), 64);
-}
-
-TEST(TypesTest, TestDecimal128Type) {
-  DecimalType t1(27, 7);
-
-  ASSERT_EQ(t1.type, Type::DECIMAL);
-  ASSERT_EQ(t1.precision, 27);
-  ASSERT_EQ(t1.scale, 7);
-
-  ASSERT_EQ(t1.ToString(), std::string("decimal(27, 7)"));
-
-  // Test properties
-  ASSERT_EQ(t1.byte_width(), 16);
-  ASSERT_EQ(t1.bit_width(), 128);
-}
-
 template <typename T>
 class DecimalTestBase {
  public:

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -691,8 +691,8 @@ TEST_F(TestStringArray, TestArrayBasics) {
 TEST_F(TestStringArray, TestType) {
   std::shared_ptr<DataType> type = strings_->type();
 
-  ASSERT_EQ(Type::STRING, type->type);
-  ASSERT_EQ(Type::STRING, strings_->type_enum());
+  ASSERT_EQ(Type::STRING, type->id());
+  ASSERT_EQ(Type::STRING, strings_->type_id());
 }
 
 TEST_F(TestStringArray, TestListFunctions) {
@@ -905,8 +905,8 @@ TEST_F(TestBinaryArray, TestArrayBasics) {
 TEST_F(TestBinaryArray, TestType) {
   std::shared_ptr<DataType> type = strings_->type();
 
-  ASSERT_EQ(Type::BINARY, type->type);
-  ASSERT_EQ(Type::BINARY, strings_->type_enum());
+  ASSERT_EQ(Type::BINARY, type->id());
+  ASSERT_EQ(Type::BINARY, strings_->type_id());
 }
 
 TEST_F(TestBinaryArray, TestListFunctions) {
@@ -1679,8 +1679,8 @@ TEST_F(TestStructBuilder, TestAppendNull) {
   ASSERT_TRUE(result_->field(1)->IsNull(0));
   ASSERT_TRUE(result_->field(1)->IsNull(1));
 
-  ASSERT_EQ(Type::LIST, result_->field(0)->type_enum());
-  ASSERT_EQ(Type::INT32, result_->field(1)->type_enum());
+  ASSERT_EQ(Type::LIST, result_->field(0)->type_id());
+  ASSERT_EQ(Type::INT32, result_->field(1)->type_id());
 }
 
 TEST_F(TestStructBuilder, TestBasics) {

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -453,11 +453,11 @@ DictionaryArray::DictionaryArray(
           indices->offset()),
       dict_type_(static_cast<const DictionaryType*>(type.get())),
       indices_(indices) {
-  DCHECK_EQ(type->type, Type::DICTIONARY);
+  DCHECK_EQ(type->id(), Type::DICTIONARY);
 }
 
 Status DictionaryArray::Validate() const {
-  Type::type index_type_id = indices_->type()->type;
+  Type::type index_type_id = indices_->type()->id();
   if (!is_integer(index_type_id)) {
     return Status::Invalid("Dictionary indices must be integer type");
   }

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -312,8 +312,8 @@ bool DecimalArray::IsNegative(int64_t i) const {
 
 std::string DecimalArray::FormatValue(int64_t i) const {
   const auto type_ = std::dynamic_pointer_cast<DecimalType>(type());
-  const int precision = type_->precision;
-  const int scale = type_->scale;
+  const int precision = type_->precision();
+  const int scale = type_->scale();
   const int byte_width = byte_width_;
   const uint8_t* bytes = GetValue(i);
   switch (byte_width) {

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -80,7 +80,7 @@ class ARROW_EXPORT Array {
   int64_t null_count() const;
 
   std::shared_ptr<DataType> type() const { return type_; }
-  Type::type type_enum() const { return type_->type; }
+  Type::type type_id() const { return type_->id(); }
 
   /// Buffer for the null bitmap.
   ///
@@ -447,7 +447,7 @@ class ARROW_EXPORT UnionArray : public Array {
   const type_id_t* raw_type_ids() const { return raw_type_ids_ + offset_; }
   const int32_t* raw_value_offsets() const { return raw_value_offsets_ + offset_; }
 
-  UnionMode mode() const { return static_cast<const UnionType&>(*type_.get()).mode; }
+  UnionMode mode() const { return static_cast<const UnionType&>(*type_.get()).mode(); }
 
   std::shared_ptr<Array> child(int pos) const;
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -253,7 +253,7 @@ BooleanBuilder::BooleanBuilder(MemoryPool* pool)
 
 BooleanBuilder::BooleanBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type)
     : BooleanBuilder(pool) {
-  DCHECK_EQ(Type::BOOL, type->type);
+  DCHECK_EQ(Type::BOOL, type->id());
 }
 
 Status BooleanBuilder::Init(int64_t capacity) {
@@ -602,7 +602,7 @@ std::shared_ptr<ArrayBuilder> StructBuilder::field_builder(int pos) const {
 // TODO(wesm): come up with a less monolithic strategy
 Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
     std::shared_ptr<ArrayBuilder>* out) {
-  switch (type->type) {
+  switch (type->id()) {
     BUILDER_CASE(UINT8, UInt8Builder);
     BUILDER_CASE(INT8, Int8Builder);
     BUILDER_CASE(UINT16, UInt16Builder);
@@ -633,12 +633,12 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
     }
 
     case Type::STRUCT: {
-      std::vector<FieldPtr>& fields = type->children_;
+      const std::vector<FieldPtr>& fields = type->children();
       std::vector<std::shared_ptr<ArrayBuilder>> values_builder;
 
       for (auto it : fields) {
         std::shared_ptr<ArrayBuilder> builder;
-        RETURN_NOT_OK(MakeBuilder(pool, it->type, &builder));
+        RETURN_NOT_OK(MakeBuilder(pool, it->type(), &builder));
         values_builder.push_back(builder);
       }
       out->reset(new StructBuilder(pool, type, values_builder));

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -27,7 +27,7 @@
 namespace arrow {
 
 class Array;
-struct DataType;
+class DataType;
 class Status;
 class Tensor;
 

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -379,7 +379,7 @@ TEST_F(TestTableWriter, TimeTypes) {
 
   for (int i = 1; i < schema->num_fields(); ++i) {
     std::shared_ptr<Array> arr;
-    LoadArray(schema->field(i)->type, fields, buffers, &arr);
+    LoadArray(schema->field(i)->type(), fields, buffers, &arr);
     arrays.push_back(arr);
   }
 

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -569,13 +569,13 @@ void CheckBatchDictionaries(const RecordBatch& batch) {
   // Check that dictionaries that should be the same are the same
   auto schema = batch.schema();
 
-  const auto& t0 = static_cast<const DictionaryType&>(*schema->field(0)->type);
-  const auto& t1 = static_cast<const DictionaryType&>(*schema->field(1)->type);
+  const auto& t0 = static_cast<const DictionaryType&>(*schema->field(0)->type());
+  const auto& t1 = static_cast<const DictionaryType&>(*schema->field(1)->type());
 
   ASSERT_EQ(t0.dictionary().get(), t1.dictionary().get());
 
   // Same dictionary used for list values
-  const auto& t3 = static_cast<const ListType&>(*schema->field(3)->type);
+  const auto& t3 = static_cast<const ListType&>(*schema->field(3)->type());
   const auto& t3_value = static_cast<const DictionaryType&>(*t3.value_type());
   ASSERT_EQ(t0.dictionary().get(), t3_value.dictionary().get());
 }

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -114,13 +114,13 @@ class JsonSchemaWriter {
     writer_->StartObject();
 
     writer_->Key("name");
-    writer_->String(field.name.c_str());
+    writer_->String(field.name().c_str());
 
     writer_->Key("nullable");
-    writer_->Bool(field.nullable);
+    writer_->Bool(field.nullable());
 
     // Visit the type
-    RETURN_NOT_OK(VisitTypeInline(*field.type, this));
+    RETURN_NOT_OK(VisitTypeInline(*field.type(), this));
     writer_->EndObject();
 
     return Status::OK();
@@ -153,7 +153,7 @@ class JsonSchemaWriter {
 
   void WriteTypeMetadata(const IntervalType& type) {
     writer_->Key("unit");
-    switch (type.unit) {
+    switch (type.unit()) {
       case IntervalType::Unit::YEAR_MONTH:
         writer_->String("YEAR_MONTH");
         break;
@@ -165,23 +165,23 @@ class JsonSchemaWriter {
 
   void WriteTypeMetadata(const TimestampType& type) {
     writer_->Key("unit");
-    writer_->String(GetTimeUnitName(type.unit));
-    if (type.timezone.size() > 0) {
+    writer_->String(GetTimeUnitName(type.unit()));
+    if (type.timezone().size() > 0) {
       writer_->Key("timezone");
-      writer_->String(type.timezone);
+      writer_->String(type.timezone());
     }
   }
 
   void WriteTypeMetadata(const TimeType& type) {
     writer_->Key("unit");
-    writer_->String(GetTimeUnitName(type.unit));
+    writer_->String(GetTimeUnitName(type.unit()));
     writer_->Key("bitWidth");
     writer_->Int(type.bit_width());
   }
 
   void WriteTypeMetadata(const DateType& type) {
     writer_->Key("unit");
-    switch (type.unit) {
+    switch (type.unit()) {
       case DateUnit::DAY:
         writer_->String("DAY");
         break;
@@ -198,14 +198,14 @@ class JsonSchemaWriter {
 
   void WriteTypeMetadata(const DecimalType& type) {
     writer_->Key("precision");
-    writer_->Int(type.precision);
+    writer_->Int(type.precision());
     writer_->Key("scale");
-    writer_->Int(type.scale);
+    writer_->Int(type.scale());
   }
 
   void WriteTypeMetadata(const UnionType& type) {
     writer_->Key("mode");
-    switch (type.mode) {
+    switch (type.mode()) {
       case UnionMode::SPARSE:
         writer_->String("SPARSE");
         break;
@@ -217,8 +217,8 @@ class JsonSchemaWriter {
     // Write type ids
     writer_->Key("typeIds");
     writer_->StartArray();
-    for (size_t i = 0; i < type.type_codes.size(); ++i) {
-      writer_->Uint(type.type_codes[i]);
+    for (size_t i = 0; i < type.type_codes().size(); ++i) {
+      writer_->Uint(type.type_codes()[i]);
     }
     writer_->EndArray();
   }
@@ -461,7 +461,7 @@ class JsonArrayWriter {
     writer_->Key("children");
     writer_->StartArray();
     for (size_t i = 0; i < fields.size(); ++i) {
-      RETURN_NOT_OK(VisitArray(fields[i]->name, *arrays[i].get()));
+      RETURN_NOT_OK(VisitArray(fields[i]->name(), *arrays[i].get()));
     }
     writer_->EndArray();
     return Status::OK();
@@ -513,7 +513,7 @@ class JsonArrayWriter {
     auto type = static_cast<const UnionType*>(array.type().get());
 
     WriteIntegerField("TYPE_ID", array.raw_type_ids(), array.length());
-    if (type->mode == UnionMode::DENSE) {
+    if (type->mode() == UnionMode::DENSE) {
       WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length());
     }
     return WriteChildren(type->children(), array.children());
@@ -1026,7 +1026,7 @@ class JsonArrayReader {
     RETURN_NOT_OK(
         GetIntArray<uint8_t>(json_type_ids->value.GetArray(), length, &type_id_buffer));
 
-    if (union_type.mode == UnionMode::DENSE) {
+    if (union_type.mode() == UnionMode::DENSE) {
       const auto& json_offsets = json_array.FindMember("OFFSET");
       RETURN_NOT_ARRAY("OFFSET", json_offsets, json_array);
       RETURN_NOT_OK(
@@ -1072,9 +1072,9 @@ class JsonArrayReader {
       auto it = json_child.FindMember("name");
       RETURN_NOT_STRING("name", it, json_child);
 
-      DCHECK_EQ(it->value.GetString(), child_field->name);
+      DCHECK_EQ(it->value.GetString(), child_field->name());
       std::shared_ptr<Array> child;
-      RETURN_NOT_OK(GetArray(json_children_arr[i], child_field->type, &child));
+      RETURN_NOT_OK(GetArray(json_children_arr[i], child_field->type(), &child));
       array->emplace_back(child);
     }
 
@@ -1109,7 +1109,7 @@ class JsonArrayReader {
   case TYPE::type_id:   \
     return ReadArray<TYPE>(json_array, length, is_valid, type, array);
 
-    switch (type->type) {
+    switch (type->id()) {
       TYPE_CASE(NullType);
       TYPE_CASE(BooleanType);
       TYPE_CASE(UInt8Type);
@@ -1192,7 +1192,7 @@ Status ReadJsonArray(MemoryPool* pool, const rj::Value& json_array, const Schema
 
   std::shared_ptr<Field> result = nullptr;
   for (const std::shared_ptr<Field>& field : schema.fields()) {
-    if (field->name == name) {
+    if (field->name() == name) {
       result = field;
       break;
     }
@@ -1204,7 +1204,7 @@ Status ReadJsonArray(MemoryPool* pool, const rj::Value& json_array, const Schema
     return Status::KeyError(ss.str());
   }
 
-  return ReadJsonArray(pool, json_array, result->type, array);
+  return ReadJsonArray(pool, json_array, result->type(), array);
 }
 
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/json.cc
+++ b/cpp/src/arrow/ipc/json.cc
@@ -79,7 +79,7 @@ class JsonWriter::JsonWriterImpl {
       DCHECK_EQ(batch.num_rows(), column->length())
           << "Array length did not match record batch length";
 
-      RETURN_NOT_OK(WriteJsonArray(schema_->field(i)->name, *column, writer_.get()));
+      RETURN_NOT_OK(WriteJsonArray(schema_->field(i)->name(), *column, writer_.get()));
     }
 
     writer_->EndArray();
@@ -158,7 +158,7 @@ class JsonReader::JsonReaderImpl {
 
     std::vector<std::shared_ptr<Array>> columns(json_columns.Size());
     for (int i = 0; i < static_cast<int>(columns.size()); ++i) {
-      const std::shared_ptr<DataType>& type = schema_->field(i)->type;
+      const std::shared_ptr<DataType>& type = schema_->field(i)->type();
       RETURN_NOT_OK(ReadJsonArray(pool_, json_columns[i], type, &columns[i]));
     }
 

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -34,8 +34,8 @@ namespace arrow {
 
 class Array;
 class Buffer;
-struct DataType;
-struct Field;
+class DataType;
+class Field;
 class Schema;
 class Status;
 class Tensor;

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -97,7 +97,7 @@ static Status LoadRecordBatchFromSource(const std::shared_ptr<Schema>& schema,
   context.max_recursion_depth = max_recursion_depth;
 
   for (int i = 0; i < schema->num_fields(); ++i) {
-    RETURN_NOT_OK(LoadArray(schema->field(i)->type, &context, &arrays[i]));
+    RETURN_NOT_OK(LoadArray(schema->field(i)->type(), &context, &arrays[i]));
     DCHECK_EQ(num_rows, arrays[i]->length())
         << "Array length did not match record batch length";
   }

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -552,9 +552,9 @@ Status MakeTimestamps(std::shared_ptr<RecordBatch>* out) {
       1489272000000, 1489272000000, 1489273000000};
 
   std::shared_ptr<Array> a0, a1, a2;
-  ArrayFromVector<TimestampType, int64_t>(f0->type, is_valid, ts_values, &a0);
-  ArrayFromVector<TimestampType, int64_t>(f1->type, is_valid, ts_values, &a1);
-  ArrayFromVector<TimestampType, int64_t>(f2->type, is_valid, ts_values, &a2);
+  ArrayFromVector<TimestampType, int64_t>(f0->type(), is_valid, ts_values, &a0);
+  ArrayFromVector<TimestampType, int64_t>(f1->type(), is_valid, ts_values, &a1);
+  ArrayFromVector<TimestampType, int64_t>(f2->type(), is_valid, ts_values, &a2);
 
   ArrayVector arrays = {a0, a1, a2};
   *out = std::make_shared<RecordBatch>(schema, a0->length(), arrays);
@@ -575,10 +575,10 @@ Status MakeTimes(std::shared_ptr<RecordBatch>* out) {
       1489272000000, 1489272000000, 1489273000000};
 
   std::shared_ptr<Array> a0, a1, a2, a3;
-  ArrayFromVector<Time32Type, int32_t>(f0->type, is_valid, t32_values, &a0);
-  ArrayFromVector<Time64Type, int64_t>(f1->type, is_valid, t64_values, &a1);
-  ArrayFromVector<Time32Type, int32_t>(f2->type, is_valid, t32_values, &a2);
-  ArrayFromVector<Time64Type, int64_t>(f3->type, is_valid, t64_values, &a3);
+  ArrayFromVector<Time32Type, int32_t>(f0->type(), is_valid, t32_values, &a0);
+  ArrayFromVector<Time64Type, int64_t>(f1->type(), is_valid, t64_values, &a1);
+  ArrayFromVector<Time32Type, int32_t>(f2->type(), is_valid, t32_values, &a2);
+  ArrayFromVector<Time64Type, int64_t>(f3->type(), is_valid, t64_values, &a3);
 
   ArrayVector arrays = {a0, a1, a2, a3};
   *out = std::make_shared<RecordBatch>(schema, a0->length(), arrays);
@@ -605,8 +605,8 @@ Status MakeFWBinary(std::shared_ptr<RecordBatch>* out) {
 
   std::shared_ptr<Array> a1, a2;
 
-  FixedSizeBinaryBuilder b1(default_memory_pool(), f0->type);
-  FixedSizeBinaryBuilder b2(default_memory_pool(), f1->type);
+  FixedSizeBinaryBuilder b1(default_memory_pool(), f0->type());
+  FixedSizeBinaryBuilder b2(default_memory_pool(), f1->type());
 
   std::vector<std::string> values1 = {"foo1", "foo2", "foo3", "foo4"};
   AppendValues(is_valid, values1, &b1);

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -364,7 +364,7 @@ class RecordBatchWriter : public ArrayVisitor {
 
       // The Union type codes are not necessary 0-indexed
       uint8_t max_code = 0;
-      for (uint8_t code : type.type_codes) {
+      for (uint8_t code : type.type_codes()) {
         if (code > max_code) { max_code = code; }
       }
 
@@ -406,7 +406,7 @@ class RecordBatchWriter : public ArrayVisitor {
       for (int i = 0; i < type.num_children(); ++i) {
         std::shared_ptr<Array> child = array.child(i);
         if (array.offset() != 0) {
-          const uint8_t code = type.type_codes[i];
+          const uint8_t code = type.type_codes()[i];
           child = child->Slice(child_offsets[code], child_lengths[code]);
         }
         RETURN_NOT_OK(VisitArray(*child));

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -31,7 +31,7 @@ namespace arrow {
 
 class Array;
 class Buffer;
-struct Field;
+class Field;
 class MemoryPool;
 class RecordBatch;
 class Schema;

--- a/cpp/src/arrow/loader.h
+++ b/cpp/src/arrow/loader.h
@@ -33,7 +33,7 @@ namespace arrow {
 
 class Array;
 class Buffer;
-struct DataType;
+class DataType;
 
 // ARROW-109: We set this number arbitrarily to help catch user mistakes. For
 // deeply nested schemas, it is expected the user will indicate explicitly the

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -571,7 +571,7 @@ class DecimalConverter : public TypedConverter<arrow::DecimalBuilder> {
 
 // Dynamic constructor for sequence converters
 std::shared_ptr<SeqConverter> GetConverter(const std::shared_ptr<DataType>& type) {
-  switch (type->type) {
+  switch (type->id()) {
     case Type::BOOL:
       return std::make_shared<BoolConverter>();
     case Type::INT64:
@@ -637,7 +637,7 @@ Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>
 Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>* out,
     const std::shared_ptr<DataType>& type, int64_t size) {
   // Handle NA / NullType case
-  if (type->type == Type::NA) {
+  if (type->id() == Type::NA) {
     out->reset(new NullArray(size));
     return Status::OK();
   }

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -118,7 +118,7 @@ Status GetNumPyType(const DataType& type, int* type_num) {
     *type_num = NPY_##NPY_NAME;               \
     break;
 
-  switch (type.type) {
+  switch (type.id()) {
     NUMPY_TYPE_CASE(UINT8, UINT8);
     NUMPY_TYPE_CASE(INT8, INT8);
     NUMPY_TYPE_CASE(UINT16, UINT16);

--- a/cpp/src/arrow/python/numpy_convert.h
+++ b/cpp/src/arrow/python/numpy_convert.h
@@ -31,7 +31,7 @@
 
 namespace arrow {
 
-struct DataType;
+class DataType;
 class MemoryPool;
 class Status;
 class Tensor;

--- a/cpp/src/arrow/python/pandas_convert.h
+++ b/cpp/src/arrow/python/pandas_convert.h
@@ -32,7 +32,7 @@ namespace arrow {
 
 class Array;
 class Column;
-struct DataType;
+class DataType;
 class MemoryPool;
 class Status;
 class Table;

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -244,8 +244,8 @@ TEST_F(TestTable, Metadata) {
   ASSERT_TRUE(table_->schema()->Equals(*schema_));
 
   auto col = table_->column(0);
-  ASSERT_EQ(schema_->field(0)->name, col->name());
-  ASSERT_EQ(schema_->field(0)->type, col->type());
+  ASSERT_EQ(schema_->field(0)->name(), col->name());
+  ASSERT_EQ(schema_->field(0)->type(), col->type());
 }
 
 TEST_F(TestTable, InvalidColumns) {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -153,7 +153,7 @@ RecordBatch::RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows
     : schema_(schema), num_rows_(num_rows), columns_(std::move(columns)) {}
 
 const std::string& RecordBatch::column_name(int i) const {
-  return schema_->field(i)->name;
+  return schema_->field(i)->name();
 }
 
 bool RecordBatch::Equals(const RecordBatch& other) const {
@@ -204,7 +204,7 @@ Status RecordBatch::Validate() const {
          << " vs " << num_rows_;
       return Status::Invalid(ss.str());
     }
-    const auto& schema_type = *schema_->field(i)->type;
+    const auto& schema_type = *schema_->field(i)->type();
     if (!arr.type()->Equals(schema_type)) {
       std::stringstream ss;
       ss << "Column " << i << " type not match schema: " << arr.type()->ToString()

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -81,10 +81,10 @@ class ARROW_EXPORT Column {
   std::shared_ptr<Field> field() const { return field_; }
 
   // @returns: the column's name in the passed metadata
-  const std::string& name() const { return field_->name; }
+  const std::string& name() const { return field_->name(); }
 
   // @returns: the column's type according to the metadata
-  std::shared_ptr<DataType> type() const { return field_->type; }
+  std::shared_ptr<DataType> type() const { return field_->type(); }
 
   // @returns: the column's data as a chunked logical array
   std::shared_ptr<ChunkedArray> data() const { return data_; }

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -61,7 +61,7 @@ Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buff
     const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
     const std::vector<std::string>& dim_names)
     : type_(type), data_(data), shape_(shape), strides_(strides), dim_names_(dim_names) {
-  DCHECK(is_tensor_supported(type->type));
+  DCHECK(is_tensor_supported(type->id()));
   if (shape.size() > 0 && strides.size() == 0) {
     ComputeRowMajorStrides(static_cast<const FixedWidthType&>(*type_), shape, &strides_);
   }
@@ -105,6 +105,10 @@ bool Tensor::is_column_major() const {
   const auto& fw_type = static_cast<const FixedWidthType&>(*type_);
   ComputeColumnMajorStrides(fw_type, shape_, &f_strides);
   return strides_ == f_strides;
+}
+
+Type::type Tensor::type_id() const {
+  return type_->id();
 }
 
 bool Tensor::Equals(const Tensor& other) const {
@@ -161,7 +165,7 @@ Status ARROW_EXPORT MakeTensor(const std::shared_ptr<DataType>& type,
     const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
     const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names,
     std::shared_ptr<Tensor>* tensor) {
-  switch (type->type) {
+  switch (type->id()) {
     TENSOR_CASE(INT8, Int8Tensor);
     TENSOR_CASE(INT16, Int16Tensor);
     TENSOR_CASE(INT32, Int32Tensor);

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -98,7 +98,7 @@ class ARROW_EXPORT Tensor {
   /// AKA "Fortran order"
   bool is_column_major() const;
 
-  Type::type type_enum() const { return type_->type; }
+  Type::type type_id() const;
 
   bool Equals(const Tensor& other) const;
 

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -34,11 +34,11 @@ TEST(TestField, Basics) {
   Field f0("f0", int32());
   Field f0_nn("f0", int32(), false);
 
-  ASSERT_EQ(f0.name, "f0");
-  ASSERT_EQ(f0.type->ToString(), int32()->ToString());
+  ASSERT_EQ(f0.name(), "f0");
+  ASSERT_EQ(f0.type()->ToString(), int32()->ToString());
 
-  ASSERT_TRUE(f0.nullable);
-  ASSERT_FALSE(f0_nn.nullable);
+  ASSERT_TRUE(f0.nullable());
+  ASSERT_FALSE(f0_nn.nullable());
 }
 
 TEST(TestField, Equals) {
@@ -121,7 +121,7 @@ TEST_F(TestSchema, GetFieldByName) {
   TEST(TypesTest, TestPrimitive_##ENUM) {        \
     KLASS tp;                                    \
                                                  \
-    ASSERT_EQ(tp.type, Type::ENUM);              \
+    ASSERT_EQ(tp.id(), Type::ENUM);              \
     ASSERT_EQ(tp.ToString(), std::string(NAME)); \
   }
 
@@ -145,19 +145,19 @@ TEST(TestBinaryType, ToString) {
   StringType t2;
   EXPECT_TRUE(t1.Equals(e1));
   EXPECT_FALSE(t1.Equals(t2));
-  ASSERT_EQ(t1.type, Type::BINARY);
+  ASSERT_EQ(t1.id(), Type::BINARY);
   ASSERT_EQ(t1.ToString(), std::string("binary"));
 }
 
 TEST(TestStringType, ToString) {
   StringType str;
-  ASSERT_EQ(str.type, Type::STRING);
+  ASSERT_EQ(str.id(), Type::STRING);
   ASSERT_EQ(str.ToString(), std::string("string"));
 }
 
 TEST(TestFixedSizeBinaryType, ToString) {
   auto t = fixed_size_binary(10);
-  ASSERT_EQ(t->type, Type::FIXED_SIZE_BINARY);
+  ASSERT_EQ(t->id(), Type::FIXED_SIZE_BINARY);
   ASSERT_EQ("fixed_size_binary[10]", t->ToString());
 }
 
@@ -175,13 +175,13 @@ TEST(TestListType, Basics) {
   std::shared_ptr<DataType> vt = std::make_shared<UInt8Type>();
 
   ListType list_type(vt);
-  ASSERT_EQ(list_type.type, Type::LIST);
+  ASSERT_EQ(list_type.id(), Type::LIST);
 
   ASSERT_EQ("list", list_type.name());
   ASSERT_EQ("list<item: uint8>", list_type.ToString());
 
-  ASSERT_EQ(list_type.value_type()->type, vt->type);
-  ASSERT_EQ(list_type.value_type()->type, vt->type);
+  ASSERT_EQ(list_type.value_type()->id(), vt->id());
+  ASSERT_EQ(list_type.value_type()->id(), vt->id());
 
   std::shared_ptr<DataType> st = std::make_shared<StringType>();
   std::shared_ptr<DataType> lt = std::make_shared<ListType>(st);
@@ -313,6 +313,48 @@ TEST(TestStructType, Basics) {
   ASSERT_EQ(struct_type.ToString(), "struct<f0: int32, f1: string, f2: uint8>");
 
   // TODO(wesm): out of bounds for field(...)
+}
+
+TEST(TypesTest, TestDecimal32Type) {
+  DecimalType t1(8, 4);
+
+  ASSERT_EQ(t1.id(), Type::DECIMAL);
+  ASSERT_EQ(t1.precision(), 8);
+  ASSERT_EQ(t1.scale(), 4);
+
+  ASSERT_EQ(t1.ToString(), std::string("decimal(8, 4)"));
+
+  // Test properties
+  ASSERT_EQ(t1.byte_width(), 4);
+  ASSERT_EQ(t1.bit_width(), 32);
+}
+
+TEST(TypesTest, TestDecimal64Type) {
+  DecimalType t1(12, 5);
+
+  ASSERT_EQ(t1.id(), Type::DECIMAL);
+  ASSERT_EQ(t1.precision(), 12);
+  ASSERT_EQ(t1.scale(), 5);
+
+  ASSERT_EQ(t1.ToString(), std::string("decimal(12, 5)"));
+
+  // Test properties
+  ASSERT_EQ(t1.byte_width(), 8);
+  ASSERT_EQ(t1.bit_width(), 64);
+}
+
+TEST(TypesTest, TestDecimal128Type) {
+  DecimalType t1(27, 7);
+
+  ASSERT_EQ(t1.id(), Type::DECIMAL);
+  ASSERT_EQ(t1.precision(), 27);
+  ASSERT_EQ(t1.scale(), 7);
+
+  ASSERT_EQ(t1.ToString(), std::string("decimal(27, 7)"));
+
+  // Test properties
+  ASSERT_EQ(t1.byte_width(), 16);
+  ASSERT_EQ(t1.bit_width(), 128);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -127,13 +127,9 @@ class BufferDescr {
   int bit_width_;
 };
 
-struct ARROW_EXPORT DataType {
-  Type::type type;
-
-  std::vector<std::shared_ptr<Field>> children_;
-
-  explicit DataType(Type::type type) : type(type) {}
-
+class ARROW_EXPORT DataType {
+ public:
+  explicit DataType(Type::type id) : id_(id) {}
   virtual ~DataType();
 
   // Return whether the types are equal
@@ -155,13 +151,18 @@ struct ARROW_EXPORT DataType {
 
   virtual std::vector<BufferDescr> GetBufferLayout() const = 0;
 
- private:
+  Type::type id() const { return id_; }
+
+ protected:
+  Type::type id_;
+  std::vector<std::shared_ptr<Field>> children_;
   DISALLOW_COPY_AND_ASSIGN(DataType);
 };
 
 typedef std::shared_ptr<DataType> TypePtr;
 
-struct ARROW_EXPORT FixedWidthType : public DataType {
+class ARROW_EXPORT FixedWidthType : public DataType {
+ public:
   using DataType::DataType;
 
   virtual int bit_width() const = 0;
@@ -169,53 +170,64 @@ struct ARROW_EXPORT FixedWidthType : public DataType {
   std::vector<BufferDescr> GetBufferLayout() const override;
 };
 
-struct ARROW_EXPORT PrimitiveCType : public FixedWidthType {
+class ARROW_EXPORT PrimitiveCType : public FixedWidthType {
+ public:
   using FixedWidthType::FixedWidthType;
 };
 
-struct ARROW_EXPORT Integer : public PrimitiveCType {
+class ARROW_EXPORT Integer : public PrimitiveCType {
+ public:
   using PrimitiveCType::PrimitiveCType;
   virtual bool is_signed() const = 0;
 };
 
-struct ARROW_EXPORT FloatingPoint : public PrimitiveCType {
+class ARROW_EXPORT FloatingPoint : public PrimitiveCType {
+ public:
   using PrimitiveCType::PrimitiveCType;
   enum Precision { HALF, SINGLE, DOUBLE };
   virtual Precision precision() const = 0;
 };
 
-struct ARROW_EXPORT NestedType : public DataType {
+class ARROW_EXPORT NestedType : public DataType {
+ public:
   using DataType::DataType;
 };
 
-struct NoExtraMeta {};
+class NoExtraMeta {};
 
 // A field is a piece of metadata that includes (for now) a name and a data
 // type
-struct ARROW_EXPORT Field {
-  // Field name
-  std::string name;
-
-  // The field's data type
-  std::shared_ptr<DataType> type;
-
-  // Fields can be nullable
-  bool nullable;
-
+class ARROW_EXPORT Field {
+ public:
   Field(const std::string& name, const std::shared_ptr<DataType>& type,
       bool nullable = true)
-      : name(name), type(type), nullable(nullable) {}
+      : name_(name), type_(type), nullable_(nullable) {}
 
   bool Equals(const Field& other) const;
   bool Equals(const std::shared_ptr<Field>& other) const;
 
   std::string ToString() const;
+
+  const std::string& name() const { return name_; }
+  std::shared_ptr<DataType> type() const { return type_; }
+  bool nullable() const { return nullable_; }
+
+ private:
+  // Field name
+  std::string name_;
+
+  // The field's data type
+  std::shared_ptr<DataType> type_;
+
+  // Fields can be nullable
+  bool nullable_;
 };
 
 typedef std::shared_ptr<Field> FieldPtr;
 
 template <typename DERIVED, typename BASE, Type::type TYPE_ID, typename C_TYPE>
-struct ARROW_EXPORT CTypeImpl : public BASE {
+class ARROW_EXPORT CTypeImpl : public BASE {
+ public:
   using c_type = C_TYPE;
   static constexpr Type::type type_id = TYPE_ID;
 
@@ -230,7 +242,8 @@ struct ARROW_EXPORT CTypeImpl : public BASE {
   std::string ToString() const override { return std::string(DERIVED::name()); }
 };
 
-struct ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
+class ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
+ public:
   static constexpr Type::type type_id = Type::NA;
 
   NullType() : DataType(Type::NA) {}
@@ -244,11 +257,12 @@ struct ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
 };
 
 template <typename DERIVED, Type::type TYPE_ID, typename C_TYPE>
-struct IntegerTypeImpl : public CTypeImpl<DERIVED, Integer, TYPE_ID, C_TYPE> {
+class IntegerTypeImpl : public CTypeImpl<DERIVED, Integer, TYPE_ID, C_TYPE> {
   bool is_signed() const override { return std::is_signed<C_TYPE>::value; }
 };
 
-struct ARROW_EXPORT BooleanType : public FixedWidthType, public NoExtraMeta {
+class ARROW_EXPORT BooleanType : public FixedWidthType, public NoExtraMeta {
+ public:
   static constexpr Type::type type_id = Type::BOOL;
 
   BooleanType() : FixedWidthType(Type::BOOL) {}
@@ -260,60 +274,72 @@ struct ARROW_EXPORT BooleanType : public FixedWidthType, public NoExtraMeta {
   static std::string name() { return "bool"; }
 };
 
-struct ARROW_EXPORT UInt8Type : public IntegerTypeImpl<UInt8Type, Type::UINT8, uint8_t> {
+class ARROW_EXPORT UInt8Type : public IntegerTypeImpl<UInt8Type, Type::UINT8, uint8_t> {
+ public:
   static std::string name() { return "uint8"; }
 };
 
-struct ARROW_EXPORT Int8Type : public IntegerTypeImpl<Int8Type, Type::INT8, int8_t> {
+class ARROW_EXPORT Int8Type : public IntegerTypeImpl<Int8Type, Type::INT8, int8_t> {
+ public:
   static std::string name() { return "int8"; }
 };
 
-struct ARROW_EXPORT UInt16Type
+class ARROW_EXPORT UInt16Type
     : public IntegerTypeImpl<UInt16Type, Type::UINT16, uint16_t> {
+ public:
   static std::string name() { return "uint16"; }
 };
 
-struct ARROW_EXPORT Int16Type : public IntegerTypeImpl<Int16Type, Type::INT16, int16_t> {
+class ARROW_EXPORT Int16Type : public IntegerTypeImpl<Int16Type, Type::INT16, int16_t> {
+ public:
   static std::string name() { return "int16"; }
 };
 
-struct ARROW_EXPORT UInt32Type
+class ARROW_EXPORT UInt32Type
     : public IntegerTypeImpl<UInt32Type, Type::UINT32, uint32_t> {
+ public:
   static std::string name() { return "uint32"; }
 };
 
-struct ARROW_EXPORT Int32Type : public IntegerTypeImpl<Int32Type, Type::INT32, int32_t> {
+class ARROW_EXPORT Int32Type : public IntegerTypeImpl<Int32Type, Type::INT32, int32_t> {
+ public:
   static std::string name() { return "int32"; }
 };
 
-struct ARROW_EXPORT UInt64Type
+class ARROW_EXPORT UInt64Type
     : public IntegerTypeImpl<UInt64Type, Type::UINT64, uint64_t> {
+ public:
   static std::string name() { return "uint64"; }
 };
 
-struct ARROW_EXPORT Int64Type : public IntegerTypeImpl<Int64Type, Type::INT64, int64_t> {
+class ARROW_EXPORT Int64Type : public IntegerTypeImpl<Int64Type, Type::INT64, int64_t> {
+ public:
   static std::string name() { return "int64"; }
 };
 
-struct ARROW_EXPORT HalfFloatType
+class ARROW_EXPORT HalfFloatType
     : public CTypeImpl<HalfFloatType, FloatingPoint, Type::HALF_FLOAT, uint16_t> {
+ public:
   Precision precision() const override;
   static std::string name() { return "halffloat"; }
 };
 
-struct ARROW_EXPORT FloatType
+class ARROW_EXPORT FloatType
     : public CTypeImpl<FloatType, FloatingPoint, Type::FLOAT, float> {
+ public:
   Precision precision() const override;
   static std::string name() { return "float"; }
 };
 
-struct ARROW_EXPORT DoubleType
+class ARROW_EXPORT DoubleType
     : public CTypeImpl<DoubleType, FloatingPoint, Type::DOUBLE, double> {
+ public:
   Precision precision() const override;
   static std::string name() { return "double"; }
 };
 
-struct ARROW_EXPORT ListType : public NestedType {
+class ARROW_EXPORT ListType : public NestedType {
+ public:
   static constexpr Type::type type_id = Type::LIST;
 
   // List can contain any other logical value type
@@ -326,7 +352,7 @@ struct ARROW_EXPORT ListType : public NestedType {
 
   std::shared_ptr<Field> value_field() const { return children_[0]; }
 
-  std::shared_ptr<DataType> value_type() const { return children_[0]->type; }
+  std::shared_ptr<DataType> value_type() const { return children_[0]->type(); }
 
   Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
@@ -337,7 +363,8 @@ struct ARROW_EXPORT ListType : public NestedType {
 };
 
 // BinaryType type is represents lists of 1-byte values.
-struct ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
+class ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
+ public:
   static constexpr Type::type type_id = Type::BINARY;
 
   BinaryType() : BinaryType(Type::BINARY) {}
@@ -376,7 +403,8 @@ class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType {
 };
 
 // UTF-8 encoded strings
-struct ARROW_EXPORT StringType : public BinaryType {
+class ARROW_EXPORT StringType : public BinaryType {
+ public:
   static constexpr Type::type type_id = Type::STRING;
 
   StringType() : BinaryType(Type::STRING) {}
@@ -386,7 +414,8 @@ struct ARROW_EXPORT StringType : public BinaryType {
   static std::string name() { return "utf8"; }
 };
 
-struct ARROW_EXPORT StructType : public NestedType {
+class ARROW_EXPORT StructType : public NestedType {
+ public:
   static constexpr Type::type type_id = Type::STRUCT;
 
   explicit StructType(const std::vector<std::shared_ptr<Field>>& fields)
@@ -412,25 +441,32 @@ static inline int decimal_byte_width(int precision) {
   }
 }
 
-struct ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
+class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
+ public:
   static constexpr Type::type type_id = Type::DECIMAL;
 
-  explicit DecimalType(int precision_, int scale_)
-      : FixedSizeBinaryType(decimal_byte_width(precision_), Type::DECIMAL),
-        precision(precision_),
-        scale(scale_) {}
+  explicit DecimalType(int precision, int scale)
+      : FixedSizeBinaryType(decimal_byte_width(precision), Type::DECIMAL),
+        precision_(precision),
+        scale_(scale) {}
+
   std::vector<BufferDescr> GetBufferLayout() const override;
   Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   static std::string name() { return "decimal"; }
 
-  int precision;
-  int scale;
+  int precision() const { return precision_; }
+  int scale() const { return scale_; }
+
+ private:
+  int precision_;
+  int scale_;
 };
 
 enum class UnionMode : char { SPARSE, DENSE };
 
-struct ARROW_EXPORT UnionType : public NestedType {
+class ARROW_EXPORT UnionType : public NestedType {
+ public:
   static constexpr Type::type type_id = Type::UNION;
 
   UnionType(const std::vector<std::shared_ptr<Field>>& fields,
@@ -442,12 +478,17 @@ struct ARROW_EXPORT UnionType : public NestedType {
 
   std::vector<BufferDescr> GetBufferLayout() const override;
 
-  UnionMode mode;
+  const std::vector<uint8_t>& type_codes() const { return type_codes_; }
+
+  UnionMode mode() const { return mode_; }
+
+ private:
+  UnionMode mode_;
 
   // The type id used in the data to indicate each data type in the union. For
   // example, the first type in the union might be denoted by the id 5 (instead
   // of 0).
-  std::vector<uint8_t> type_codes;
+  std::vector<uint8_t> type_codes_;
 };
 
 // ----------------------------------------------------------------------
@@ -455,16 +496,18 @@ struct ARROW_EXPORT UnionType : public NestedType {
 
 enum class DateUnit : char { DAY = 0, MILLI = 1 };
 
-struct ARROW_EXPORT DateType : public FixedWidthType {
+class ARROW_EXPORT DateType : public FixedWidthType {
  public:
-  DateUnit unit;
+  DateUnit unit() const { return unit_; }
 
  protected:
   DateType(Type::type type_id, DateUnit unit);
+  DateUnit unit_;
 };
 
 /// Date as int32_t days since UNIX epoch
-struct ARROW_EXPORT Date32Type : public DateType {
+class ARROW_EXPORT Date32Type : public DateType {
+ public:
   static constexpr Type::type type_id = Type::DATE32;
 
   using c_type = int32_t;
@@ -478,7 +521,8 @@ struct ARROW_EXPORT Date32Type : public DateType {
 };
 
 /// Date as int64_t milliseconds since UNIX epoch
-struct ARROW_EXPORT Date64Type : public DateType {
+class ARROW_EXPORT Date64Type : public DateType {
+ public:
   static constexpr Type::type type_id = Type::DATE64;
 
   using c_type = int64_t;
@@ -512,15 +556,17 @@ static inline std::ostream& operator<<(std::ostream& os, TimeUnit unit) {
   return os;
 }
 
-struct ARROW_EXPORT TimeType : public FixedWidthType {
+class ARROW_EXPORT TimeType : public FixedWidthType {
  public:
-  TimeUnit unit;
+  TimeUnit unit() const { return unit_; }
 
  protected:
   TimeType(Type::type type_id, TimeUnit unit);
+  TimeUnit unit_;
 };
 
-struct ARROW_EXPORT Time32Type : public TimeType {
+class ARROW_EXPORT Time32Type : public TimeType {
+ public:
   static constexpr Type::type type_id = Type::TIME32;
   using c_type = int32_t;
 
@@ -532,7 +578,8 @@ struct ARROW_EXPORT Time32Type : public TimeType {
   std::string ToString() const override;
 };
 
-struct ARROW_EXPORT Time64Type : public TimeType {
+class ARROW_EXPORT Time64Type : public TimeType {
+ public:
   static constexpr Type::type type_id = Type::TIME64;
   using c_type = int64_t;
 
@@ -544,7 +591,8 @@ struct ARROW_EXPORT Time64Type : public TimeType {
   std::string ToString() const override;
 };
 
-struct ARROW_EXPORT TimestampType : public FixedWidthType {
+class ARROW_EXPORT TimestampType : public FixedWidthType {
+ public:
   using Unit = TimeUnit;
 
   typedef int64_t c_type;
@@ -553,20 +601,25 @@ struct ARROW_EXPORT TimestampType : public FixedWidthType {
   int bit_width() const override { return static_cast<int>(sizeof(int64_t) * CHAR_BIT); }
 
   explicit TimestampType(TimeUnit unit = TimeUnit::MILLI)
-      : FixedWidthType(Type::TIMESTAMP), unit(unit) {}
+      : FixedWidthType(Type::TIMESTAMP), unit_(unit) {}
 
   explicit TimestampType(TimeUnit unit, const std::string& timezone)
-      : FixedWidthType(Type::TIMESTAMP), unit(unit), timezone(timezone) {}
+      : FixedWidthType(Type::TIMESTAMP), unit_(unit), timezone_(timezone) {}
 
   Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   static std::string name() { return "timestamp"; }
 
-  TimeUnit unit;
-  std::string timezone;
+  TimeUnit unit() const { return unit_; }
+  const std::string& timezone() const { return timezone_; }
+
+ private:
+  TimeUnit unit_;
+  std::string timezone_;
 };
 
-struct ARROW_EXPORT IntervalType : public FixedWidthType {
+class ARROW_EXPORT IntervalType : public FixedWidthType {
+ public:
   enum class Unit : char { YEAR_MONTH = 0, DAY_TIME = 1 };
 
   using c_type = int64_t;
@@ -574,14 +627,17 @@ struct ARROW_EXPORT IntervalType : public FixedWidthType {
 
   int bit_width() const override { return static_cast<int>(sizeof(int64_t) * CHAR_BIT); }
 
-  Unit unit;
-
   explicit IntervalType(Unit unit = Unit::YEAR_MONTH)
-      : FixedWidthType(Type::INTERVAL), unit(unit) {}
+      : FixedWidthType(Type::INTERVAL), unit_(unit) {}
 
   Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override { return name(); }
   static std::string name() { return "date"; }
+
+  Unit unit() const { return unit_; }
+
+ private:
+  Unit unit_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -156,6 +156,8 @@ class ARROW_EXPORT DataType {
  protected:
   Type::type id_;
   std::vector<std::shared_ptr<Field>> children_;
+
+ private:
   DISALLOW_COPY_AND_ASSIGN(DataType);
 };
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -26,10 +26,10 @@ namespace arrow {
 
 class Status;
 
-struct DataType;
+class DataType;
 class Array;
 class ArrayBuilder;
-struct Field;
+class Field;
 class Tensor;
 
 class Buffer;
@@ -40,14 +40,14 @@ class Schema;
 class DictionaryType;
 class DictionaryArray;
 
-struct NullType;
+class NullType;
 class NullArray;
 
-struct BooleanType;
+class BooleanType;
 class BooleanArray;
 class BooleanBuilder;
 
-struct BinaryType;
+class BinaryType;
 class BinaryArray;
 class BinaryBuilder;
 
@@ -55,23 +55,23 @@ class FixedSizeBinaryType;
 class FixedSizeBinaryArray;
 class FixedSizeBinaryBuilder;
 
-struct StringType;
+class StringType;
 class StringArray;
 class StringBuilder;
 
-struct ListType;
+class ListType;
 class ListArray;
 class ListBuilder;
 
-struct StructType;
+class StructType;
 class StructArray;
 class StructBuilder;
 
-struct DecimalType;
+class DecimalType;
 class DecimalArray;
 class DecimalBuilder;
 
-struct UnionType;
+class UnionType;
 class UnionArray;
 
 template <typename TypeClass>
@@ -84,7 +84,7 @@ template <typename TypeClass>
 class NumericTensor;
 
 #define _NUMERIC_TYPE_DECL(KLASS)                     \
-  struct KLASS##Type;                                 \
+  class KLASS##Type;                                  \
   using KLASS##Array = NumericArray<KLASS##Type>;     \
   using KLASS##Builder = NumericBuilder<KLASS##Type>; \
   using KLASS##Tensor = NumericTensor<KLASS##Type>;
@@ -103,27 +103,27 @@ _NUMERIC_TYPE_DECL(Double);
 
 #undef _NUMERIC_TYPE_DECL
 
-struct Date64Type;
+class Date64Type;
 using Date64Array = NumericArray<Date64Type>;
 using Date64Builder = NumericBuilder<Date64Type>;
 
-struct Date32Type;
+class Date32Type;
 using Date32Array = NumericArray<Date32Type>;
 using Date32Builder = NumericBuilder<Date32Type>;
 
-struct Time32Type;
+class Time32Type;
 using Time32Array = NumericArray<Time32Type>;
 using Time32Builder = NumericBuilder<Time32Type>;
 
-struct Time64Type;
+class Time64Type;
 using Time64Array = NumericArray<Time64Type>;
 using Time64Builder = NumericBuilder<Time64Type>;
 
-struct TimestampType;
+class TimestampType;
 using TimestampArray = NumericArray<TimestampType>;
 using TimestampBuilder = NumericBuilder<TimestampType>;
 
-struct IntervalType;
+class IntervalType;
 using IntervalArray = NumericArray<IntervalType>;
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -33,7 +33,7 @@ namespace arrow {
 
 template <typename VISITOR>
 inline Status VisitTypeInline(const DataType& type, VISITOR* visitor) {
-  switch (type.type) {
+  switch (type.id()) {
     TYPE_VISIT_INLINE(NullType);
     TYPE_VISIT_INLINE(BooleanType);
     TYPE_VISIT_INLINE(Int8Type);
@@ -72,7 +72,7 @@ inline Status VisitTypeInline(const DataType& type, VISITOR* visitor) {
 
 template <typename VISITOR>
 inline Status VisitArrayInline(const Array& array, VISITOR* visitor) {
-  switch (array.type_enum()) {
+  switch (array.type_id()) {
     ARRAY_VISIT_INLINE(NullType);
     ARRAY_VISIT_INLINE(BooleanType);
     ARRAY_VISIT_INLINE(Int8Type);
@@ -111,7 +111,7 @@ inline Status VisitArrayInline(const Array& array, VISITOR* visitor) {
 
 template <typename VISITOR>
 inline Status VisitTensorInline(const Tensor& array, VISITOR* visitor) {
-  switch (array.type_enum()) {
+  switch (array.type_id()) {
     TENSOR_VISIT_INLINE(Int8Type);
     TENSOR_VISIT_INLINE(UInt8Type);
     TENSOR_VISIT_INLINE(Int16Type);

--- a/python/pyarrow/array.pyx
+++ b/python/pyarrow/array.pyx
@@ -618,7 +618,7 @@ cdef object box_array(const shared_ptr[CArray]& sp_array):
     if data_type == NULL:
         raise ValueError('Array data type was NULL')
 
-    cdef Array arr = _array_classes[data_type.type]()
+    cdef Array arr = _array_classes[data_type.id()]()
     arr.init(sp_array)
     return arr
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -61,7 +61,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         TimeUnit_NANO" arrow::TimeUnit::NANO"
 
     cdef cppclass CDataType" arrow::DataType":
-        Type type
+        Type id()
 
         c_bool Equals(const CDataType& other)
 
@@ -72,7 +72,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         int64_t length()
         int64_t null_count()
-        Type type_enum()
+        Type type_id()
 
         c_bool Equals(const CArray& arr)
         c_bool IsNull(int i)
@@ -97,14 +97,14 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         pass
 
     cdef cppclass CTimestampType" arrow::TimestampType"(CFixedWidthType):
-        TimeUnit unit
-        c_string timezone
+        TimeUnit unit()
+        const c_string& timezone()
 
     cdef cppclass CTime32Type" arrow::Time32Type"(CFixedWidthType):
-        TimeUnit unit
+        TimeUnit unit()
 
     cdef cppclass CTime64Type" arrow::Time64Type"(CFixedWidthType):
-        TimeUnit unit
+        TimeUnit unit()
 
     cdef cppclass CDictionaryType" arrow::DictionaryType"(CFixedWidthType):
         CDictionaryType(const shared_ptr[CDataType]& index_type,
@@ -149,15 +149,14 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int bit_width()
 
     cdef cppclass CDecimalType" arrow::DecimalType"(CFixedSizeBinaryType):
-        int precision
-        int scale
+        int precision()
+        int scale()
         CDecimalType(int precision, int scale)
 
     cdef cppclass CField" arrow::Field":
-        c_string name
-        shared_ptr[CDataType] type
-
-        c_bool nullable
+        const c_string& name()
+        shared_ptr[CDataType] type()
+        c_bool nullable()
 
         CField(const c_string& name, const shared_ptr[CDataType]& type,
                c_bool nullable)
@@ -307,7 +306,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         c_bool is_mutable()
         c_bool is_contiguous()
-        Type type_enum()
+        Type type_id()
         c_bool Equals(const CTensor& other)
 
     CStatus ConcatenateTables(const vector[shared_ptr[CTable]]& tables,

--- a/python/pyarrow/schema.pyx
+++ b/python/pyarrow/schema.pyx
@@ -81,13 +81,13 @@ cdef class TimestampType(DataType):
     property unit:
 
         def __get__(self):
-            return timeunit_to_string(self.ts_type.unit)
+            return timeunit_to_string(self.ts_type.unit())
 
     property tz:
 
         def __get__(self):
-            if self.ts_type.timezone.size() > 0:
-                return frombytes(self.ts_type.timezone)
+            if self.ts_type.timezone().size() > 0:
+                return frombytes(self.ts_type.timezone())
             else:
                 return None
 
@@ -119,7 +119,7 @@ cdef class Field:
     cdef init(self, const shared_ptr[CField]& field):
         self.sp_field = field
         self.field = field.get()
-        self.type = box_data_type(field.get().type)
+        self.type = box_data_type(field.get().type())
 
     @classmethod
     def from_py(cls, object name, DataType type, bint nullable=True):
@@ -137,7 +137,7 @@ cdef class Field:
     property nullable:
 
         def __get__(self):
-            return self.field.nullable
+            return self.field.nullable()
 
     property name:
 
@@ -145,7 +145,7 @@ cdef class Field:
             if box_field(self.sp_field) is None:
                 raise ReferenceError(
                     'Field not initialized (references NULL pointer)')
-            return frombytes(self.field.name)
+            return frombytes(self.field.name())
 
 
 cdef class Schema:
@@ -162,7 +162,7 @@ cdef class Schema:
 
         cdef Field result = Field()
         result.init(self.schema.field(i))
-        result.type = box_data_type(result.field.type)
+        result.type = box_data_type(result.field.type())
 
         return result
 
@@ -442,13 +442,13 @@ cdef DataType box_data_type(const shared_ptr[CDataType]& type):
     if type.get() == NULL:
         return None
 
-    if type.get().type == la.Type_DICTIONARY:
+    if type.get().id() == la.Type_DICTIONARY:
         out = DictionaryType()
-    elif type.get().type == la.Type_TIMESTAMP:
+    elif type.get().id() == la.Type_TIMESTAMP:
         out = TimestampType()
-    elif type.get().type == la.Type_FIXED_SIZE_BINARY:
+    elif type.get().id() == la.Type_FIXED_SIZE_BINARY:
         out = FixedSizeBinaryType()
-    elif type.get().type == la.Type_DECIMAL:
+    elif type.get().id() == la.Type_DECIMAL:
         out = DecimalType()
     else:
         out = DataType()


### PR DESCRIPTION
Breaking APIs isn't ideal, but this one is fairly long overdue. The DataType classes are more than passive data carriers, and Google's C++ guide recommends using class instead of struct for this. That means we should put members in protected or private scope, and access them.

I also renamed a couple of things to help with code clarity

* `DataType::type` is now `DataType::id()`
* `Array::type_enum` is not `Array::type_id`