### PR TITLE
ARROW-539: [Python] Add support for reading partitioned Parquet files with Hive-like directory schemes

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -107,6 +107,13 @@ class LocalFilesystem(Filesystem):
     def ls(self, path):
         return sorted(pjoin(path, x) for x in os.listdir(path))
 
+    @implements(Filesystem.mkdir)
+    def mkdir(self, path, create_parents=True):
+        if create_parents:
+            os.makedirs(path)
+        else:
+            os.mkdir(path)
+
     @implements(Filesystem.isdir)
     def isdir(self, path):
         return os.path.isdir(path)

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -87,20 +87,10 @@ class Filesystem(object):
         -------
         table : pyarrow.Table
         """
-        from pyarrow.parquet import read_multiple_files
-
-        if self.isdir(path):
-            paths_to_read = []
-            for path in self.ls(path):
-                if path.endswith('parq') or path.endswith('parquet'):
-                    paths_to_read.append(path)
-        else:
-            paths_to_read = [path]
-
-        return read_multiple_files(paths_to_read, columns=columns,
-                                   filesystem=self, schema=schema,
-                                   metadata=metadata,
-                                   nthreads=nthreads)
+        from pyarrow.parquet import ParquetDataset
+        dataset = ParquetDataset(path, schema=schema, metadata=metadata,
+                                 filesystem=self)
+        return dataset.read(columns=columns, nthreads=nthreads)
 
 
 class LocalFilesystem(Filesystem):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -291,6 +291,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CSchema] schema()
         shared_ptr[CColumn] column(int i)
 
+        CStatus AddColumn(int i, const shared_ptr[CColumn]& column,
+                          shared_ptr[CTable]* out)
         CStatus RemoveColumn(int i, shared_ptr[CTable]* out)
 
     cdef cppclass CTensor" arrow::Tensor":

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -17,16 +17,15 @@
 
 import six
 
-from pyarrow import from_pylist
 from pyarrow._parquet import (ParquetReader, FileMetaData,  # noqa
                               RowGroupMetaData, Schema, ParquetWriter)
 import pyarrow._parquet as _parquet  # noqa
 from pyarrow.filesystem import LocalFilesystem
-from pyarrow.table import concat_tables, Table
+from pyarrow.table import concat_tables
 
-from os import path as osp
 
-EXCLUDED_PARQUET_PATHS = {'_metadata', '_common_metadata', '_SUCCESS'}
+# ----------------------------------------------------------------------
+# Reading a single Parquet file
 
 
 class ParquetFile(object):
@@ -75,7 +74,8 @@ class ParquetFile(object):
             Content of the row group as a table (of columns)
         """
         column_indices = self._get_column_indices(columns)
-        self.reader.set_num_threads(nthreads)
+        if nthreads is not None:
+            self.reader.set_num_threads(nthreads)
         return self.reader.read_row_group(i, column_indices=column_indices)
 
     def read(self, columns=None, nthreads=1):
@@ -96,7 +96,8 @@ class ParquetFile(object):
             Content of the file as a table (of columns)
         """
         column_indices = self._get_column_indices(columns)
-        self.reader.set_num_threads(nthreads)
+        if nthreads is not None:
+            self.reader.set_num_threads(nthreads)
         return self.reader.read_all(column_indices=column_indices)
 
     def _get_column_indices(self, column_names):
@@ -107,23 +108,9 @@ class ParquetFile(object):
                     for column in column_names]
 
 
-class ParquetPartitionSet(object):
-
-    def __init__(self, keys=None):
-        self.keys = keys or []
-        self.key_indices = {k: i for i, k in enumerate(self.keys)}
-
-    def get_index(self, key):
-        if key in self.key_indices:
-            return self.key_indices[key]
-        else:
-            index = len(self.key_indices)
-            self.key_indices[key] = index
-            return index
-
-    @property
-    def is_sorted(self):
-        return list(self.keys) == sorted(self.keys)
+# ----------------------------------------------------------------------
+# Metadata container providing instructions about reading a single Parquet
+# file, possibly part of a partitioned dataset
 
 
 class ParquetDatasetPiece(object):
@@ -153,6 +140,12 @@ class ParquetDatasetPiece(object):
     def __ne__(self, other):
         return not (self == other)
 
+    def __repr__(self):
+        return ('{0}({1!r}, row_group={2!r}, partition_keys={3!r})'
+                .format(type(self).__name__, self.path,
+                        self.row_group,
+                        self.partition_keys))
+
     def __str__(self):
         result = ''
 
@@ -171,7 +164,7 @@ class ParquetDatasetPiece(object):
     def open(self, open_file_func):
         return open_file_func(self.path)
 
-    def read(self, open_file_func, columns=None, nthreads=None):
+    def read(self, open_file_func, columns=None, nthreads=1):
         reader = self.open(open_file_func)
 
         if self.row_group is not None:
@@ -189,6 +182,127 @@ def _is_parquet_file(path):
     return path.endswith('parq') or path.endswith('parquet')
 
 
+class PartitionSet(object):
+
+    def __init__(self, name, keys=None):
+        self.name = name
+        self.keys = keys or []
+        self.key_indices = {k: i for i, k in enumerate(self.keys)}
+
+    def get_index(self, key):
+        if key in self.key_indices:
+            return self.key_indices[key]
+        else:
+            index = len(self.key_indices)
+            self.keys.append(key)
+            self.key_indices[key] = index
+            return index
+
+    @property
+    def is_sorted(self):
+        return list(self.keys) == sorted(self.keys)
+
+
+class ParquetPartitions(object):
+
+    def __init__(self):
+        self.levels = []
+        self.partition_names = set()
+
+    def get_index(self, level, name, key):
+        if level == len(self.levels):
+            if name in self.partition_names:
+                raise ValueError('{0} was the name of the partition in '
+                                 'another level'.format(name))
+
+            part_set = PartitionSet(name)
+            self.levels.append(part_set)
+            self.partition_names.add(name)
+
+        return self.levels[level].get_index(key)
+
+
+def is_string(x):
+    return isinstance(x, six.string_types)
+
+
+class ParquetManifest(object):
+    """
+
+    """
+    def __init__(self, dirpath, filesystem=None, pathsep='/'):
+        self.filesystem = filesystem or LocalFilesystem.get_instance()
+        self.pathsep = pathsep
+        self.dirpath = dirpath
+        self.partitions = ParquetPartitions()
+        self.pieces = []
+
+        self.common_metadata_path = None
+        self.metadata_path = None
+
+        self._visit_level(0, self.dirpath, [])
+
+    def _visit_level(self, level, base_path, part_keys):
+        directories = []
+        files = []
+        fs = self.filesystem
+
+        if not fs.isdir(base_path):
+            raise ValueError('"{0}" is not a directory'.format(base_path))
+
+        for path in sorted(fs.ls(base_path)):
+            if fs.isfile(path):
+                if _is_parquet_file(path):
+                    files.append(path)
+                elif path == '_common_metadata':
+                    self.common_metadata_path = path
+                elif path == '_metadata':
+                    self.metadata_path = path
+                else:
+                    print('Ignoring path: {0}'.format(path))
+            elif fs.isdir(path):
+                directories.append(path)
+
+        if len(files) > 0 and len(directories) > 0:
+            raise ValueError('Found files in an intermediate '
+                             'directory: {0}'.format(base_path))
+        elif len(directories) > 0:
+            self._visit_directories(level, directories, part_keys)
+        else:
+            self._push_pieces(files, part_keys)
+
+    def _visit_directories(self, level, directories, part_keys):
+        for path in directories:
+            head, tail = _path_split(path, self.pathsep)
+            name, key = _parse_hive_partition(tail)
+
+            index = self.partitions.get_index(level, name, key)
+            dir_part_keys = part_keys + [(name, index)]
+            self._visit_level(level + 1, path, dir_part_keys)
+
+    def _push_pieces(self, files, part_keys):
+        for path in files:
+            piece = ParquetDatasetPiece(path, partition_keys=part_keys)
+            self.pieces.append(piece)
+
+
+def _parse_hive_partition(value):
+    if '=' not in value:
+        raise ValueError('Directory name did not appear to be a '
+                         'partition: {0}'.format(value))
+    return value.split('=', 1)
+
+
+def _path_split(path, sep):
+    i = path.rfind(sep) + 1
+    head, tail = path[:i], path[i:]
+    head = head.rstrip(sep)
+    return head, tail
+
+
+EXCLUDED_PARQUET_PATHS = {'_SUCCESS'}
+
+
 class ParquetDataset(object):
     """
     Encapsulates details of reading a complete Parquet dataset possibly
@@ -197,7 +311,7 @@ class ParquetDataset(object):
     Parameters
     ----------
     path_or_paths : str or List[str]
-        One or more file paths
+        A directory name, single file name, or list of file names
     filesystem : Filesystem, default None
         If nothing passed, paths assumed to be found in the local on-disk
         filesystem
@@ -211,24 +325,17 @@ class ParquetDataset(object):
     """
     def __init__(self, path_or_paths, filesystem=None, schema=None,
                  metadata=None, split_row_groups=False, validate_schema=True):
-        from pyarrow.filesystem import LocalFilesystem
         if filesystem is None:
             self.fs = LocalFilesystem.get_instance()
         else:
             self.fs = filesystem
 
-        if isinstance(path_or_paths, six.string_types):
-            path_or_paths = [path_or_paths]
+        self.pieces, self.partitions = _make_manifest(path_or_paths, self.fs)
 
-        if len(path_or_paths) == 0:
-            raise ValueError('Must pass at least one file path')
-
-        self.paths = path_or_paths
         self.metadata = metadata
         self.schema = schema
 
         self.split_row_groups = split_row_groups
-        self.pieces = self.get_dataset_pieces()
 
         if validate_schema:
             self.validate_schemas()
@@ -250,32 +357,7 @@ class ParquetDataset(object):
                                  .format(piece, file_metadata.schema,
                                          self.schema))
 
-    def get_dataset_pieces(self):
-        pieces = []
-
-        for path in self.paths:
-            self._visit_path(path)
-            pieces.extend(path_pieces)
-
-        return pieces
-
-    def _visit_path(self, path, pieces):
-        part_keys = None
-
-        def _push_piece(path):
-            if _is_parquet_file(path):
-                piece = ParquetDatasetPiece(path, partition_keys=part_keys)
-                pieces.append(piece)
-
-        if self.fs.isdir(path):
-            for path in self.fs.ls(path):
-                _push_piece(path)
-        else:
-            _push_piece(path)
-
-        return paths_to_read
-
-    def read(self, columns=None, nthreads=None):
+    def read(self, columns=None, nthreads=1):
         """
         Read multiple Parquet files as a single pyarrow.Table
 
@@ -310,71 +392,34 @@ class ParquetDataset(object):
             def open_file(path, meta=None):
                 return ParquetFile(self.fs.open(path, mode='rb'),
                                    metadata=meta)
+        return open_file
 
 
-class _ParquetDirectoryListing(object):
-    """
+def _make_manifest(path_or_paths, fs, pathsep='/'):
+    partitions = None
 
-    """
-    def __init__(self, filesystem, dirpath):
-        self.filesystem = filesystem
-        self.dirpath = dirpath
-        self.partitions = []
+    if is_string(path_or_paths) and fs.isdir(path_or_paths):
+        manifest = ParquetManifest(path_or_paths, filesystem=fs,
+                                   pathsep=pathsep)
+        pieces = manifest.pieces
+        partitions = manifest.partitions
+    else:
+        if not isinstance(path_or_paths, list):
+            path_or_paths = [path_or_paths]
 
-    def _visit_level(self, level):
-        paths =
+        # List of paths
+        if len(path_or_paths) == 0:
+            raise ValueError('Must pass at least one file path')
 
+        pieces = []
+        for path in path_or_paths:
+            if not fs.isfile(path):
+                raise IOError('Passed non-file path: {0}'
+                              .format(path))
+            piece = ParquetDatasetPiece(path)
+            pieces.append(piece)
 
-def _iter_parquet(root_dir, fs, ext='.parq'):
-    """Yield all parquet files under root_dir"""
-    if not fs.isdir(root_dir):
-        raise ValueError('"{0}" is not a directory'.format(root_dir))
-
-    for path in fs.ls(root_dir):
-        if fs.isfile(path) and path.endswith(ext):
-            yield path
-        if fs.isdir(path):
-            for p in _iter_parquet(path, fs, ext):
-                yield p
-
-
-def _partitions(path, root, path_separator):
-    """
-    >>> partitions('/root/x=1/y=2/x.parq')
-    {'x': '1', 'y': '2'}
-    """
-    parts = {}
-    # '/root/x=1/y=2/x.parq' -> '/x=1/y=2'
-    inner = osp.dirname(path[len(root):])
-    while True:
-        head, tail = osp.split(inner)
-        if '=' not in tail:
-            raise ValueError('sub directory without = in {0!r}'.format(path))
-        key, value = tail.split('=', maxsplit=1)
-        if key in parts:
-            raise ValueError(
-                'partition {0!r} appears twice in {1!r}'.format(key, path))
-        parts[key] = value
-        # /, \ or ''
-        if len(head) < 2:
-            return parts
-        inner = head
-
-
-def _add_parts(table, parts, part_fields):
-    """Add data from directory partitions to table"""
-    size = len(table)
-    names = []
-    arrays = []
-    for i, field in enumerate(table.schema):
-        names.append(field.name)
-        arrays.append(table.column(i))
-
-    for name in part_fields:
-        arrays.append(from_pylist([parts[name]] * size))
-        names.append(name)
-
-    return Table.from_arrays(arrays, names, table.name)
+    return pieces, partitions
 
 
 def read_table(source, columns=None, nthreads=1, metadata=None):
@@ -400,7 +445,7 @@ def read_table(source, columns=None, nthreads=1, metadata=None):
     pyarrow.Table
         Content of the file as a table (of columns)
     """
-    if isinstance(source, six.string_types):
+    if is_string(source):
         fs = LocalFilesystem.get_instance()
         if fs.isdir(source):
             return fs.read_parquet(source, columns=columns,

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -428,7 +428,7 @@ class ParquetDataset(object):
         return all_data
 
     def _get_open_file_func(self):
-        if self.fs is None:
+        if self.fs is None or isinstance(self.fs, LocalFilesystem):
             def open_file(path, meta=None):
                 return ParquetFile(path, metadata=meta)
         else:

--- a/python/pyarrow/table.pxd
+++ b/python/pyarrow/table.pxd
@@ -58,5 +58,6 @@ cdef class RecordBatch:
     cdef init(self, const shared_ptr[CRecordBatch]& table)
     cdef _check_nullptr(self)
 
+cdef object box_column(const shared_ptr[CColumn]& ccolumn)
 cdef api object table_from_ctable(const shared_ptr[CTable]& ctable)
 cdef api object batch_from_cbatch(const shared_ptr[CRecordBatch]& cbatch)

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -431,6 +431,19 @@ def test_read_single_row_group():
     pdt.assert_frame_equal(df[cols], result.to_pandas())
 
 
+def test_parquet_piece_formatting():
+    path = '/baz.parq'
+
+    piece1 = pq.ParquetDatasetPiece(path)
+    piece2 = pq.ParquetDatasetPiece(path, row_group=1)
+    piece3 = pq.ParquetDatasetPiece(
+        path, row_group=1, partition_keys=[('foo', 0), ('bar', 1)])
+
+    assert str(piece1) == path
+    assert str(piece2) == '/baz.parq | row_group=1'
+    assert str(piece3) == 'partition[foo=0, bar=1] /baz.parq | row_group=1'
+
+
 @parquet
 def test_read_multiple_files(tmpdir):
     nfiles = 10

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from os.path import join as pjoin
+import datetime
 import io
 import os
 import pytest
@@ -458,6 +459,10 @@ def test_partition_set_dictionary_type():
 
     assert isinstance(set1.dictionary, pa.StringArray)
     assert isinstance(set2.dictionary, pa.IntegerArray)
+
+    set3 = pq.PartitionSet('key2', [datetime.datetime(2007, 1, 1)])
+    with pytest.raises(TypeError):
+        set3.dictionary
 
 
 @parquet


### PR DESCRIPTION
I probably didn't get all the use cases, but this should be a good start.

First, the directory structure is walked to determine the distinct partition keys. These keys are later used as the dictionary for `arrow::DictionaryArray` objects which are constructed. 

I also created the `ParquetDatasetPiece` class to enable distributed processing of file components in frameworks like Dask. We may need to address pickling of the `ParquetPartitions` object (which must be passed to `ParquetDatasetPiece.read` so the right array metadata can be constructed. 