### PR TITLE
ARROW-826: [C++/Python] Fix compilation error on Mac with -DARROW_PYTHON=on

### DIFF
--- a/cpp/src/arrow/python/config.h
+++ b/cpp/src/arrow/python/config.h
@@ -18,6 +18,7 @@
 #ifndef ARROW_PYTHON_CONFIG_H
 #define ARROW_PYTHON_CONFIG_H
 
+#include <iostream>
 #include <Python.h>
 
 #include "arrow/python/numpy_interop.h"


### PR DESCRIPTION
This fixes https://github.com/ray-project/ray/issues/461