### PR TITLE
ARROW-828: [C++] Add new dependency to README

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -31,6 +31,7 @@ On Ubuntu/Debian you can install the requirements with:
 sudo apt-get install cmake \
      libboost-dev \
      libboost-filesystem-dev \
+     libboost-regex-dev \
      libboost-system-dev
 ```
 


### PR DESCRIPTION
`libboost-regex-dev` is required to build on Ubuntu; added to `apt` install command.