### PR TITLE
ARROW-836: add test for pandas conversion of timedelta, currently unimplemented

### DIFF
--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -18,6 +18,7 @@
 
 from collections import OrderedDict
 
+import pytest
 import datetime
 import unittest
 import decimal
@@ -411,6 +412,18 @@ class TestPandasConversion(unittest.TestCase):
         expected = datetime.date(2017, 4, 3)
         assert a1[0].as_py() == expected
         assert a2[0].as_py() == expected
+
+    @pytest.mark.xfail(reason="not supported ATM",
+                       raises=NotImplementedError)
+    def test_timedelta(self):
+        # TODO(jreback): Pandas only support ns resolution
+        # Arrow supports ??? for resolution
+        df = pd.DataFrame({
+            'timedelta': np.arange(start=0, stop=3*86400000,
+                                   step=86400000,
+                                   dtype='timedelta64[ms]')
+            })
+        pa.Table.from_pandas(df)
 
     def test_column_of_arrays(self):
         df, schema = dataframe_with_arrays()

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -14,6 +14,7 @@
 
 import os
 import unittest
+import pytest
 
 from numpy.testing import assert_array_equal
 import numpy as np
@@ -317,6 +318,15 @@ class TestFeatherReader(unittest.TestCase):
                                     None,
                                     pd.datetime(2016, 1, 3)]})
         df['with_tz'] = df.test.dt.tz_localize('utc')
+
+        self._check_pandas_roundtrip(df, null_counts=[1, 1])
+
+    @pytest.mark.xfail(reason="not supported ATM",
+                       raises=NotImplementedError)
+    def test_timedelta_with_nulls(self):
+        df = pd.DataFrame({'test': [pd.Timedelta('1 day'),
+                                    None,
+                                    pd.Timedelta('3 day')]})
 
         self._check_pandas_roundtrip(df, null_counts=[1, 1])
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/16004