### PR TITLE
ARROW-809: [C++] Do not write excess bytes in IPC writer after slicing arrays

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -838,8 +838,9 @@ if (${CLANG_FORMAT_FOUND})
     `find ${CMAKE_CURRENT_SOURCE_DIR}/src -name \\*.cc -or -name \\*.h |
     sed -e '/_generated/g' |
     sed -e '/windows_compatibility.h/g' |
-    sed -e '/config.h/g' |
-    sed -e '/platform.h/g'`)
+    sed -e '/config.h/g' |   # python/config.h
+    sed -e '/platform.h/g'`  # python/platform.h
+    )
 
   # runs clang format and exits with a non-zero exit code if any files need to be reformatted
   add_custom_target(check-format ${BUILD_SUPPORT_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_BIN} 0

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -460,14 +460,8 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
       return Status::OK();
     }
 
-    if (left.offset() == 0 && right.offset() == 0) {
-      result_ = left.values()->Equals(right.values());
-    } else {
-      // One of the arrays is sliced
-      result_ = left.values()->RangeEquals(left.value_offset(0),
-          left.value_offset(left.length()), right.value_offset(0), right.values());
-    }
-
+    result_ = left.values()->RangeEquals(left.value_offset(0),
+        left.value_offset(left.length()), right.value_offset(0), right.values());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -310,6 +310,12 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBuffers) {
   ASSERT_OK(MakeRandomInt32Array(500, false, pool, &a0));
   ASSERT_OK(MakeRandomListArray(a0, 200, false, pool, &a1));
   CheckArray(a1);
+
+  // Struct
+  auto struct_type = struct_({field("f0", a0->type())});
+  std::vector<std::shared_ptr<Array>> struct_children = {a0};
+  a1 = std::make_shared<StructArray>(struct_type, a0->length(), struct_children);
+  CheckArray(a1);
 }
 
 void TestGetRecordBatchSize(std::shared_ptr<RecordBatch> batch) {

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -316,6 +316,15 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBuffers) {
   std::vector<std::shared_ptr<Array>> struct_children = {a0};
   a1 = std::make_shared<StructArray>(struct_type, a0->length(), struct_children);
   CheckArray(a1);
+
+  // Union
+  auto union_type = union_({field("f0", a0->type())}, {0});
+  std::vector<int32_t> type_codes(a0->length());
+  std::shared_ptr<Buffer> codes_buffer;
+  ASSERT_OK(test::CopyBufferFromVector(type_codes, &codes_buffer));
+  a1 = std::make_shared<UnionArray>(
+      union_type, a0->length(), struct_children, codes_buffer);
+  CheckArray(a1);
 }
 
 void TestGetRecordBatchSize(std::shared_ptr<RecordBatch> batch) {

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -275,7 +275,7 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBuffers) {
     auto f0 = field("f0", array->type());
     auto schema = std::shared_ptr<Schema>(new Schema({f0}));
     RecordBatch batch(schema, array->length(), {array});
-    auto sliced_batch = batch.Slice(0, 2);
+    auto sliced_batch = batch.Slice(0, 5);
 
     int64_t full_size;
     int64_t sliced_size;
@@ -288,20 +288,28 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBuffers) {
     this->CheckRoundtrip(*sliced_batch, 1 << 20);
   };
 
-  std::shared_ptr<Array> array;
+  std::shared_ptr<Array> a0, a1;
   auto pool = default_memory_pool();
 
-  ASSERT_OK(MakeRandomInt32Array(500, false, pool, &array));
-  CheckArray(array);
+  // Integer
+  ASSERT_OK(MakeRandomInt32Array(500, false, pool, &a0));
+  CheckArray(a0);
 
+  // String / Binary
   {
-    auto s = MakeRandomBinaryArray<StringBuilder, char>(500, false, pool, &array);
+    auto s = MakeRandomBinaryArray<StringBuilder, char>(500, false, pool, &a0);
     ASSERT_TRUE(s.ok());
   }
-  CheckArray(array);
+  CheckArray(a0);
 
-  ASSERT_OK(MakeRandomBooleanArray(10000, false, &array));
-  CheckArray(array);
+  // Boolean
+  ASSERT_OK(MakeRandomBooleanArray(10000, false, &a0));
+  CheckArray(a0);
+
+  // List
+  ASSERT_OK(MakeRandomInt32Array(500, false, pool, &a0));
+  ASSERT_OK(MakeRandomListArray(a0, 200, false, pool, &a1));
+  CheckArray(a1);
 }
 
 void TestGetRecordBatchSize(std::shared_ptr<RecordBatch> batch) {

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -329,7 +329,7 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBuffers) {
   // Dense union
   auto dense_union_type = union_({field("f0", a0->type())}, {0}, UnionMode::DENSE);
   std::vector<int32_t> type_offsets;
-  for (int64_t i = 0; i < a0->length(); ++i) {
+  for (int32_t i = 0; i < a0->length(); ++i) {
     type_offsets.push_back(i);
   }
   std::shared_ptr<Buffer> offsets_buffer;

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -138,26 +138,38 @@ Status MakeRandomListArray(const std::shared_ptr<Array>& child_array, int num_li
 
 typedef Status MakeRecordBatch(std::shared_ptr<RecordBatch>* out);
 
-Status MakeBooleanBatch(std::shared_ptr<RecordBatch>* out) {
-  const int length = 1000;
+Status MakeRandomBooleanArray(
+    const int length, bool include_nulls, std::shared_ptr<Array>* out) {
+  std::vector<uint8_t> values(length);
+  test::random_null_bytes(length, 0.5, values.data());
+  auto data = test::bytes_to_null_buffer(values);
 
+  if (include_nulls) {
+    std::vector<uint8_t> valid_bytes(length);
+    auto null_bitmap = test::bytes_to_null_buffer(valid_bytes);
+    test::random_null_bytes(length, 0.1, valid_bytes.data());
+    *out = std::make_shared<BooleanArray>(length, data, null_bitmap, -1);
+  } else {
+    *out = std::make_shared<BooleanArray>(length, data, nullptr, 0);
+  }
+  return Status::OK();
+}
+
+Status MakeBooleanBatchSized(const int length, std::shared_ptr<RecordBatch>* out) {
   // Make the schema
   auto f0 = field("f0", boolean());
   auto f1 = field("f1", boolean());
   std::shared_ptr<Schema> schema(new Schema({f0, f1}));
 
-  std::vector<uint8_t> values(length);
-  std::vector<uint8_t> valid_bytes(length);
-  test::random_null_bytes(length, 0.5, values.data());
-  test::random_null_bytes(length, 0.1, valid_bytes.data());
-
-  auto data = test::bytes_to_null_buffer(values);
-  auto null_bitmap = test::bytes_to_null_buffer(valid_bytes);
-
-  auto a0 = std::make_shared<BooleanArray>(length, data, null_bitmap, -1);
-  auto a1 = std::make_shared<BooleanArray>(length, data, nullptr, 0);
+  std::shared_ptr<Array> a0, a1;
+  RETURN_NOT_OK(MakeRandomBooleanArray(length, true, &a0));
+  RETURN_NOT_OK(MakeRandomBooleanArray(length, false, &a1));
   out->reset(new RecordBatch(schema, length, {a0, a1}));
   return Status::OK();
+}
+
+Status MakeBooleanBatch(std::shared_ptr<RecordBatch>* out) {
+  return MakeBooleanBatchSized(1000, out);
 }
 
 Status MakeIntBatchSized(int length, std::shared_ptr<RecordBatch>* out) {
@@ -181,14 +193,14 @@ Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
 
 template <class Builder, class RawType>
 Status MakeRandomBinaryArray(
-    int64_t length, MemoryPool* pool, std::shared_ptr<Array>* out) {
+    int64_t length, bool include_nulls, MemoryPool* pool, std::shared_ptr<Array>* out) {
   const std::vector<std::string> values = {
       "", "", "abc", "123", "efg", "456!@#!@#", "12312"};
   Builder builder(pool);
   const size_t values_len = values.size();
   for (int64_t i = 0; i < length; ++i) {
     int64_t values_index = i % values_len;
-    if (values_index == 0) {
+    if (include_nulls && values_index == 0) {
       RETURN_NOT_OK(builder.AppendNull());
     } else {
       const std::string& value = values[values_index];
@@ -212,12 +224,12 @@ Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch>* out) {
 
   // Quirk with RETURN_NOT_OK macro and templated functions
   {
-    auto s = MakeRandomBinaryArray<StringBuilder, char>(length, pool, &a0);
+    auto s = MakeRandomBinaryArray<StringBuilder, char>(length, true, pool, &a0);
     RETURN_NOT_OK(s);
   }
 
   {
-    auto s = MakeRandomBinaryArray<BinaryBuilder, uint8_t>(length, pool, &a1);
+    auto s = MakeRandomBinaryArray<BinaryBuilder, uint8_t>(length, true, pool, &a1);
     RETURN_NOT_OK(s);
   }
   out->reset(new RecordBatch(schema, length, {a0, a1}));

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -160,9 +160,7 @@ Status MakeBooleanBatch(std::shared_ptr<RecordBatch>* out) {
   return Status::OK();
 }
 
-Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
-  const int length = 10;
-
+Status MakeIntBatchSized(int length, std::shared_ptr<RecordBatch>* out) {
   // Make the schema
   auto f0 = field("f0", int32());
   auto f1 = field("f1", int32());
@@ -175,6 +173,10 @@ Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
   RETURN_NOT_OK(MakeRandomInt32Array(length, true, pool, &a1));
   out->reset(new RecordBatch(schema, length, {a0, a1}));
   return Status::OK();
+}
+
+Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
+  return MakeIntBatchSized(10, out);
 }
 
 template <class Builder, class RawType>

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -349,7 +349,7 @@ class RecordBatchWriter : public ArrayVisitor {
   Status Visit(const StructArray& array) override {
     --max_recursion_depth_;
     for (std::shared_ptr<Array> field : array.fields()) {
-      if (array.offset() != 0) {
+      if (array.offset() != 0 || array.length() < field->length()) {
         // If offset is non-zero, slice the child array
         field = field->Slice(array.offset(), array.length());
       }

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -162,10 +162,8 @@ class ArrayPrinter {
 
     Newline();
     Write("-- values: ");
-    auto values = array.values();
-    if (array.offset() != 0) {
-      values = values->Slice(array.value_offset(0), array.value_offset(array.length()));
-    }
+    auto values =
+        array.values()->Slice(array.value_offset(0), array.value_offset(array.length()));
     RETURN_NOT_OK(PrettyPrint(*values, indent_ + 2, sink_));
 
     return Status::OK();

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -32,8 +32,8 @@ static inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
   struct tm epoch = {0};
   epoch.tm_year = 70;
   epoch.tm_mday = 1;
-  // Milliseconds since the epoch
 #ifdef _MSC_VER
+  // Milliseconds since the epoch
   const int64_t current_timestamp = static_cast<int64_t>(_mkgmtime64(&date));
   const int64_t epoch_timestamp = static_cast<int64_t>(_mkgmtime64(&epoch));
   return (current_timestamp - epoch_timestamp) * 1000LL;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -180,11 +180,11 @@ bool RecordBatch::ApproxEquals(const RecordBatch& other) const {
   return true;
 }
 
-std::shared_ptr<RecordBatch> RecordBatch::Slice(int64_t offset) {
+std::shared_ptr<RecordBatch> RecordBatch::Slice(int64_t offset) const {
   return Slice(offset, this->num_rows() - offset);
 }
 
-std::shared_ptr<RecordBatch> RecordBatch::Slice(int64_t offset, int64_t length) {
+std::shared_ptr<RecordBatch> RecordBatch::Slice(int64_t offset, int64_t length) const {
   std::vector<std::shared_ptr<Array>> arrays;
   arrays.reserve(num_columns());
   for (const auto& field : columns_) {

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -137,8 +137,8 @@ class ARROW_EXPORT RecordBatch {
   int64_t num_rows() const { return num_rows_; }
 
   /// Slice each of the arrays in the record batch and construct a new RecordBatch object
-  std::shared_ptr<RecordBatch> Slice(int64_t offset);
-  std::shared_ptr<RecordBatch> Slice(int64_t offset, int64_t length);
+  std::shared_ptr<RecordBatch> Slice(int64_t offset) const;
+  std::shared_ptr<RecordBatch> Slice(int64_t offset, int64_t length) const;
 
   /// Returns error status is there is something wrong with the record batch
   /// contents, like a schema/array mismatch or inconsistent lengths


### PR DESCRIPTION
cc @itaiin