### PR TITLE
ARROW-839: [Python] Use mktime variant that is reliable on MSVC

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -837,7 +837,9 @@ if (${CLANG_FORMAT_FOUND})
   add_custom_target(format ${BUILD_SUPPORT_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_BIN} 1
     `find ${CMAKE_CURRENT_SOURCE_DIR}/src -name \\*.cc -or -name \\*.h |
     sed -e '/_generated/g' |
-    sed -e '/windows_compatibility.h/g'`)
+    sed -e '/windows_compatibility.h/g' |
+    sed -e '/config.h/g' |
+    sed -e '/platform.h/g'`)
 
   # runs clang format and exits with a non-zero exit code if any files need to be reformatted
   add_custom_target(check-format ${BUILD_SUPPORT_DIR}/run-clang-format.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CLANG_FORMAT_BIN} 0

--- a/cpp/src/arrow/python/platform.h
+++ b/cpp/src/arrow/python/platform.h
@@ -21,8 +21,8 @@
 #ifndef ARROW_PYTHON_PLATFORM_H
 #define ARROW_PYTHON_PLATFORM_H
 
-#include <Python.h>
 #include <iostream>
+#include <Python.h>
 
 // Work around C2528 error
 #if _MSC_VER >= 1900

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -33,7 +33,13 @@ static inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
   epoch.tm_year = 70;
   epoch.tm_mday = 1;
   // Milliseconds since the epoch
+#ifdef _MSC_VER
+  const int64_t current_timestamp = static_cast<int64_t>(_mkgmtime64(&date));
+  const int64_t epoch_timestamp = static_cast<int64_t>(_mkgmtime64(&epoch));
+  return (current_timestamp - epoch_timestamp) * 1000LL;
+#else
   return lrint(difftime(mktime(&date), mktime(&epoch)) * 1000);
+#endif
 }
 
 static inline int32_t PyDate_to_days(PyDateTime_Date* pydate) {

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -14,6 +14,8 @@
 
 ## Developer guide for conda users
 
+### Linux and macOS
+
 First, set up your thirdparty C++ toolchain using libraries from conda-forge:
 
 ```shell
@@ -134,3 +136,49 @@ pyarrow/tests/test_tensor.py ................
 
 ====================== 181 passed, 17 skipped in 0.98 seconds =======================
 ```
+
+### Windows
+
+First, make sure you can [build the C++ library][1].
+
+Now, we need to build and install the C++ libraries someplace.
+
+```shell
+mkdir cpp\build
+cd cpp\build
+set ARROW_HOME=C:\thirdparty
+cmake -G "Visual Studio 14 2015 Win64" ^
+      -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DARROW_BUILD_TESTS=off ^
+      -DARROW_PYTHON=on ..
+cmake --build . --target INSTALL --config Release
+cd ..\..
+```
+
+After that, we must put the install directory's bin path in our `%PATH%`:
+
+```shell
+set PATH=%ARROW_HOME%\bin;%PATH%
+```
+
+Now, we can build pyarrow:
+
+```shell
+cd python
+python setup.py build_ext --inplace
+```
+
+#### Running C++ unit tests with Python
+
+Getting `python-test.exe` to run is a bit tricky because your `%PYTHONPATH%`
+must be configured given the active conda environment:
+
+```shell
+set CONDA_ENV=C:\Users\wesm\Miniconda\envs\arrow-test
+set PYTHONPATH=%CONDA_ENV%\Lib;%CONDA_ENV%\Lib\site-packages;%CONDA_ENV%\python35.zip;%CONDA_ENV%\DLLs;%CONDA_ENV%
+```
+
+Now `python-test.exe` or simply `ctest` (to run all tests) should work.
+
+[1]: https://github.com/apache/arrow/blob/master/cpp/doc/Windows.md


### PR DESCRIPTION
This also reverts an unintentional regression from https://github.com/apache/arrow/pull/544 when code from config.h was moved to platform.h