### PR TITLE
ARROW-822: [Python] StreamWriter Wrapper for Socket and File-like Objects without tell()

### DIFF
--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -189,7 +189,7 @@ bool PyReadableFile::supports_zero_copy() const {
 // ----------------------------------------------------------------------
 // Output stream
 
-PyOutputStream::PyOutputStream(PyObject* file) {
+PyOutputStream::PyOutputStream(PyObject* file) : position_(0) {
   file_.reset(new PythonFile(file));
 }
 
@@ -201,12 +201,13 @@ Status PyOutputStream::Close() {
 }
 
 Status PyOutputStream::Tell(int64_t* position) {
-  PyAcquireGIL lock;
-  return file_->Tell(position);
+  *position = position_;
+  return Status::OK();
 }
 
 Status PyOutputStream::Write(const uint8_t* data, int64_t nbytes) {
   PyAcquireGIL lock;
+  position_ += nbytes;
   return file_->Write(data, nbytes);
 }
 

--- a/cpp/src/arrow/python/io.h
+++ b/cpp/src/arrow/python/io.h
@@ -82,6 +82,7 @@ class ARROW_EXPORT PyOutputStream : public io::OutputStream {
 
  private:
   std::unique_ptr<PythonFile> file_;
+  int64_t position_;
 };
 
 // A zero-copy reader backed by a PyBuffer object

--- a/python/pyarrow/_io.pyx
+++ b/python/pyarrow/_io.pyx
@@ -936,6 +936,44 @@ cdef class HdfsFile(NativeFile):
 # ----------------------------------------------------------------------
 # File and stream readers and writers
 
+class _StreamSinkWrapper(object):
+    """
+    Wrapper for writable stream to ensure implements "tell". This will
+    initialize stream at position 0 and increment after each write.
+    """
+
+    def __init__(self, sink):
+        self._sink = sink
+        self._position = 0
+
+    def close(self):
+        self._sink.close()
+
+    def flush(self):
+        self._sink.flush()
+
+    def tell(self):
+        return self._position
+
+    def write(self, data):
+        data = str(data)
+        self._sink.write(data)
+        self._position += len(data)
+
+    @staticmethod
+    def check(sink):
+        import socket
+        if isinstance(sink, socket.socket):
+            # Use a buffer of 0 to flush after each write, otherwise it is
+            # possible to close socket without flushing
+            sink_file = sink.makefile("wb", 0)
+            return _StreamSinkWrapper(sink_file)
+        if not hasattr(sink, "tell"):
+            return _StreamSinkWrapper(sink)
+        else:
+            return sink
+
+
 cdef class _StreamWriter:
     cdef:
         shared_ptr[CStreamWriter] writer
@@ -950,7 +988,7 @@ cdef class _StreamWriter:
             self.close()
 
     def _open(self, sink, Schema schema):
-        get_writer(sink, &self.sink)
+        get_writer(_StreamSinkWrapper.check(sink), &self.sink)
 
         with nogil:
             check_status(CStreamWriter.Open(self.sink.get(), schema.sp_schema,

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -17,6 +17,8 @@
 
 import io
 import pytest
+import socket
+import threading
 
 import numpy as np
 
@@ -123,6 +125,83 @@ class TestStream(MessagingTest, unittest.TestCase):
 
         result = reader.read_all()
         expected = pa.Table.from_batches(batches)
+        assert result.equals(expected)
+
+
+class TestSocket(MessagingTest, unittest.TestCase):
+
+    class EchoServer(threading.Thread):
+
+        def init(self, do_read_all):
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.bind(('127.0.0.1', 0))
+            self._sock.listen(1)
+            host, port = self._sock.getsockname()
+            self._do_read_all = do_read_all
+            self._schema = None
+            self._batches = []
+            self._table = None
+            return port
+
+        def run(self):
+            connection, client_address = self._sock.accept()
+            try:
+                source = connection.makefile(mode='rb')
+                reader = pa.StreamReader(source)
+                self._schema = reader.schema
+                if self._do_read_all:
+                    self._table = reader.read_all()
+                else:
+                    for i, batch in enumerate(reader):
+                        self._batches.append(batch)
+            finally:
+                connection.close()
+
+        def get_result(self):
+            return(self._schema, self._table if self._do_read_all else self._batches)
+
+    def setUp(self):
+        # NOTE: must start and stop server in test
+        pass
+
+    def startClientServer(self, do_read_all):
+        self._server = TestSocket.EchoServer()
+        port = self._server.init(do_read_all)
+        self._server.start()
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.connect(('127.0.0.1', port))
+        self.sink = self._get_sink()
+
+    def stopClientServer(self):
+        import struct
+        self.sink.write(struct.pack('i', 0))
+        self.sink.flush()
+        self._sock.close()
+        self._server.join()
+        return self._server.get_result()
+
+    def _get_sink(self):
+        return self._sock.makefile(mode='wb')
+
+    def _get_writer(self, sink, schema):
+        return pa.StreamWriter(sink, schema)
+
+    def test_simple_roundtrip(self):
+        self.startClientServer(do_read_all=False)
+        writer_batches = self.write_batches()
+        reader_schema, reader_batches = self.stopClientServer()
+
+        assert reader_schema.equals(writer_batches[0].schema)
+        assert len(reader_batches) == len(writer_batches)
+        for i, batch in enumerate(writer_batches):
+            assert reader_batches[i].equals(batch)
+
+    def test_read_all(self):
+        self.startClientServer(do_read_all=True)
+        writer_batches = self.write_batches()
+        _, result = self.stopClientServer()
+
+        expected = pa.Table.from_batches(writer_batches)
         assert result.equals(expected)
 
 


### PR DESCRIPTION
Added a wrapper for StreamWriter to implement the required tell() method so that python sockets and file-like objects can be used as sinks.  The tell() method will report the position by starting at 0 when the StreamWriter is created and incrementing by number of bytes after each write.

Added unittests that use local socket as the source/sink for streaming.