### PR TITLE
ARROW-865: [Python] Add unit tests validating Parquet date/time type roundtrips

### DIFF
--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -444,7 +444,7 @@ inline Status PandasConverter::ConvertData(std::shared_ptr<Buffer>* data) {
   // Handle LONGLONG->INT64 and other fun things
   int type_num_compat = cast_npy_type_compat(PyArray_DESCR(arr_)->type_num);
 
-  if (traits::npy_type != type_num_compat) {
+  if (numpy_type_size(traits::npy_type) != numpy_type_size(type_num_compat)) {
     return Status::NotImplemented("NumPy type casts not yet implemented");
   }
 

--- a/cpp/src/arrow/python/type_traits.h
+++ b/cpp/src/arrow/python/type_traits.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Internal header
+
 #include "arrow/python/platform.h"
 
 #include <cstdint>
@@ -24,6 +26,7 @@
 
 #include "arrow/builder.h"
 #include "arrow/type.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace py {
@@ -223,6 +226,51 @@ struct arrow_traits<Type::BINARY> {
   static constexpr int npy_type = NPY_OBJECT;
   static constexpr bool supports_nulls = true;
 };
+
+static inline int numpy_type_size(int npy_type) {
+  switch (npy_type) {
+    case NPY_BOOL:
+      return 1;
+    case NPY_INT8:
+      return 1;
+    case NPY_INT16:
+      return 2;
+    case NPY_INT32:
+      return 4;
+    case NPY_INT64:
+      return 8;
+#if (NPY_INT64 != NPY_LONGLONG)
+    case NPY_LONGLONG:
+      return 8;
+#endif
+    case NPY_UINT8:
+      return 1;
+    case NPY_UINT16:
+      return 2;
+    case NPY_UINT32:
+      return 4;
+    case NPY_UINT64:
+      return 8;
+#if (NPY_UINT64 != NPY_ULONGLONG)
+    case NPY_ULONGLONG:
+      return 8;
+#endif
+    case NPY_FLOAT16:
+      return 2;
+    case NPY_FLOAT32:
+      return 4;
+    case NPY_FLOAT64:
+      return 8;
+    case NPY_DATETIME:
+      return 8;
+    case NPY_OBJECT:
+      return sizeof(void*);
+    default:
+      DCHECK(false) << "unhandled numpy type";
+      break;
+  }
+  return -1;
+}
 
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/util/stl.h
+++ b/cpp/src/arrow/util/stl.h
@@ -20,7 +20,7 @@
 
 #include <vector>
 
-#include <arrow/util/logging.h>
+#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -158,7 +158,8 @@ class TestSocket(MessagingTest, unittest.TestCase):
                 connection.close()
 
         def get_result(self):
-            return(self._schema, self._table if self._do_read_all else self._batches)
+            return(self._schema, self._table if self._do_read_all
+                   else self._batches)
 
     def setUp(self):
         # NOTE: must start and stop server in test

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -349,6 +349,40 @@ def test_column_of_lists(tmpdir):
 
 
 @parquet
+def test_date_time_types(tmpdir):
+    buf = io.BytesIO()
+
+    t1 = pa.date32()
+    data1 = np.array([17259, 17260, 17261], dtype='int32')
+    a1 = pa.Array.from_pandas(data1, type=t1)
+
+    t2 = pa.date64()
+    data2 = data1.astype('int64') * 86400000
+    a2 = pa.Array.from_pandas(data2, type=t2)
+
+    t3 = pa.timestamp('us')
+    start = pd.Timestamp('2000-01-01').value / 1000
+    data3 = np.array([start, start + 1, start + 2], dtype='int64')
+    a3 = pa.Array.from_pandas(data3, type=t3)
+
+    t4 = pa.time32('s')
+    data4 = np.arange(3, dtype='i4')
+    a4 = pa.Array.from_pandas(data4, type=t4)
+
+    t5 = pa.time64('us')
+    a5 = pa.Array.from_pandas(data4.astype('int64'), type=t5)
+
+    table = pa.Table.from_arrays([a1, a2, a3, a4, a5],
+                                 ['date32', 'date64', 'timestamp[us]',
+                                  'time32[s]', 'time32[us]'])
+    pq.write_table(table, buf, version="2.0")
+    buf.seek(0)
+
+    result = pq.read_table(buf)
+    assert result.equals(table)
+
+
+@parquet
 def test_multithreaded_read():
     df = alltypes_sample(size=10000)
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -374,12 +374,18 @@ def test_date_time_types(tmpdir):
 
     table = pa.Table.from_arrays([a1, a2, a3, a4, a5],
                                  ['date32', 'date64', 'timestamp[us]',
-                                  'time32[s]', 'time32[us]'])
+                                  'time32[s]', 'time64[us]'])
+
+    # date64 as date32
+    expected = pa.Table.from_arrays([a1, a1, a3, a4, a5],
+                                    ['date32', 'date64', 'timestamp[us]',
+                                     'time32[s]', 'time64[us]'])
+
     pq.write_table(table, buf, version="2.0")
     buf.seek(0)
 
     result = pq.read_table(buf)
-    assert result.equals(table)
+    assert result.equals(expected)
 
 
 @parquet

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -365,7 +365,7 @@ def test_date_time_types(tmpdir):
     data3 = np.array([start, start + 1, start + 2], dtype='int64')
     a3 = pa.Array.from_pandas(data3, type=t3)
 
-    t4 = pa.time32('s')
+    t4 = pa.time32('ms')
     data4 = np.arange(3, dtype='i4')
     a4 = pa.Array.from_pandas(data4, type=t4)
 


### PR DESCRIPTION
Requires PARQUET-915 https://github.com/apache/parquet-cpp/pull/311