### PR TITLE
ARROW-866: [Python] Be robust to PyErr_Fetch returning a null exc value

### DIFF
--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -64,7 +64,7 @@ PyBuffer::~PyBuffer() {
   Py_XDECREF(obj_);
 }
 
-Status CheckPyError() {
+Status CheckPyError(StatusCode code) {
   if (PyErr_Occurred()) {
     PyObject *exc_type, *exc_value, *traceback;
     PyErr_Fetch(&exc_type, &exc_value, &traceback);
@@ -78,9 +78,9 @@ Status CheckPyError() {
     // was encountered when calling tell() on a socket file
     if (stringified.bytes != nullptr) {
       std::string message(stringified.bytes);
-      return Status::IOError(message);
+      return Status(code, message);
     } else {
-      return Status::IOError("Error message was null");
+      return Status(code, "Error message was null");
     }
   }
   return Status::OK();

--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -64,5 +64,27 @@ PyBuffer::~PyBuffer() {
   Py_XDECREF(obj_);
 }
 
+Status CheckPyError() {
+  if (PyErr_Occurred()) {
+    PyObject *exc_type, *exc_value, *traceback;
+    PyErr_Fetch(&exc_type, &exc_value, &traceback);
+    PyObjectStringify stringified(exc_value);
+    Py_XDECREF(exc_type);
+    Py_XDECREF(exc_value);
+    Py_XDECREF(traceback);
+    PyErr_Clear();
+
+    // ARROW-866: in some esoteric cases, formatting exc_value can fail. This
+    // was encountered when calling tell() on a socket file
+    if (stringified.bytes != nullptr) {
+      std::string message(stringified.bytes);
+      return Status::IOError(message);
+    } else {
+      return Status::IOError("Error message was null");
+    }
+  }
+  return Status::OK();
+}
+
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -80,11 +80,15 @@ struct ARROW_EXPORT PyObjectStringify {
     if (PyUnicode_Check(obj)) {
       bytes_obj = PyUnicode_AsUTF8String(obj);
       tmp_obj.reset(bytes_obj);
+      bytes = PyBytes_AsString(bytes_obj);
+      size = PyBytes_GET_SIZE(bytes_obj);
+    } else if (PyBytes_Check(obj)) {
+      bytes = PyBytes_AsString(obj);
+      size = PyBytes_GET_SIZE(obj);
     } else {
-      bytes_obj = obj;
+      bytes = nullptr;
+      size = -1;
     }
-    bytes = PyBytes_AsString(bytes_obj);
-    size = PyBytes_GET_SIZE(bytes_obj);
   }
 };
 

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -92,19 +92,12 @@ struct ARROW_EXPORT PyObjectStringify {
   }
 };
 
+Status CheckPyError();
+
 // TODO(wesm): We can just let errors pass through. To be explored later
-#define RETURN_IF_PYERROR()                         \
-  if (PyErr_Occurred()) {                           \
-    PyObject *exc_type, *exc_value, *traceback;     \
-    PyErr_Fetch(&exc_type, &exc_value, &traceback); \
-    PyObjectStringify stringified(exc_value);       \
-    std::string message(stringified.bytes);         \
-    Py_DECREF(exc_type);                            \
-    Py_XDECREF(exc_value);                          \
-    Py_XDECREF(traceback);                          \
-    PyErr_Clear();                                  \
-    return Status::UnknownError(message);           \
-  }
+#define RETURN_IF_PYERROR()                     \
+  RETURN_NOT_OK(CheckPyError());
+
 
 // Return the common PyArrow memory pool
 ARROW_EXPORT void set_default_memory_pool(MemoryPool* pool);

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -92,12 +92,14 @@ struct ARROW_EXPORT PyObjectStringify {
   }
 };
 
-Status CheckPyError();
+Status CheckPyError(StatusCode code = StatusCode::UnknownError);
 
 // TODO(wesm): We can just let errors pass through. To be explored later
 #define RETURN_IF_PYERROR()                     \
   RETURN_NOT_OK(CheckPyError());
 
+#define PY_RETURN_IF_ERROR(CODE)                \
+  RETURN_NOT_OK(CheckPyError(CODE));
 
 // Return the common PyArrow memory pool
 ARROW_EXPORT void set_default_memory_pool(MemoryPool* pool);

--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -56,7 +56,7 @@ Status PythonFile::Close() {
   // whence: 0 for relative to start of file, 2 for end of file
   PyObject* result = cpp_PyObject_CallMethod(file_, "close", "()");
   Py_XDECREF(result);
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
   return Status::OK();
 }
 
@@ -64,13 +64,13 @@ Status PythonFile::Seek(int64_t position, int whence) {
   // whence: 0 for relative to start of file, 2 for end of file
   PyObject* result = cpp_PyObject_CallMethod(file_, "seek", "(ii)", position, whence);
   Py_XDECREF(result);
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
   return Status::OK();
 }
 
 Status PythonFile::Read(int64_t nbytes, PyObject** out) {
   PyObject* result = cpp_PyObject_CallMethod(file_, "read", "(i)", nbytes);
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
   *out = result;
   return Status::OK();
 }
@@ -78,24 +78,24 @@ Status PythonFile::Read(int64_t nbytes, PyObject** out) {
 Status PythonFile::Write(const uint8_t* data, int64_t nbytes) {
   PyObject* py_data =
       PyBytes_FromStringAndSize(reinterpret_cast<const char*>(data), nbytes);
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
 
   PyObject* result = cpp_PyObject_CallMethod(file_, "write", "(O)", py_data);
   Py_XDECREF(py_data);
   Py_XDECREF(result);
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
   return Status::OK();
 }
 
 Status PythonFile::Tell(int64_t* position) {
   PyObject* result = cpp_PyObject_CallMethod(file_, "tell", "()");
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
 
   *position = PyLong_AsLongLong(result);
   Py_DECREF(result);
 
   // PyLong_AsLongLong can raise OverflowError
-  RETURN_IF_PYERROR();
+  PY_RETURN_IF_ERROR(StatusCode::IOError);
 
   return Status::OK();
 }

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -91,6 +91,9 @@ class ARROW_EXPORT Status {
   Status() : state_(NULL) {}
   ~Status() { delete[] state_; }
 
+  Status(StatusCode code, const std::string& msg)
+    : Status(code, msg, -1) {}
+
   // Copy the specified status.
   Status(const Status& s);
   void operator=(const Status& s);


### PR DESCRIPTION
cc @BryanCutler. This was a tricky one. I am not sure how to reproduce with our current code -- I reverted the patch from ARROW-822 to get a reproduction so I could fix this. Now, the error raised is:

```
/home/wesm/code/arrow/python/pyarrow/_error.pyx in pyarrow._error.check_status (/home/wesm/code/arrow/python/build/temp.linux-x86_64-2.7/_error.cxx:1324)()
     58             raise ArrowInvalid(message)
     59         elif status.IsIOError():
---> 60             raise ArrowIOError(message)
     61         elif status.IsOutOfMemory():
     62             raise ArrowMemoryError(message)

ArrowIOError: IOError: Error message was null
```

I'm not sure why calling `tell` on the socket object results in a bad exception state, but in any case it seems that the result of `PyErr_Fetch` cannot be relied upon to be non-null even when `PyErr_Occurred()` returns non-null