### PR TITLE
ARROW-896: Support Jupyter Notebook in Web site

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -21,5 +21,6 @@ gem 'jekyll-bootstrap-sass'
 gem 'github-pages'
 group :jekyll_plugins do
    gem "jekyll-feed", "~> 0.6"
+   gem "jekyll-jupyter-notebook"
 end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -38,6 +38,7 @@ baseurl:
 gems:
   - jekyll-feed
   - jekyll-bootstrap-sass
+  - jekyll-jupyter-notebook
 
 bootstrap:
   assets: true


### PR DESCRIPTION
We can embed a Jupyter Notebook (`getting_started.ipynb`) in the same directory by the following code:

```markdown
{::nomarkdown}
{% jupyter_notebook getting_started.ipynb %}
{:/nomarkdown}
```