### PR TITLE
ARROW-866: [Python] Normalize PyErr exc_value to be more predictable

### DIFF
--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -70,8 +70,8 @@ Status CheckPyError(StatusCode code) {
     PyErr_Fetch(&exc_type, &exc_value, &traceback);
     PyErr_NormalizeException(&exc_type, &exc_value, &traceback);
     PyObject *exc_value_str = PyObject_Str(exc_value);
-    char *c_str = PyString_AsString(exc_value_str);
-    std::string message(c_str);
+    PyObjectStringify stringified(exc_value_str);
+    std::string message(stringified.bytes);
     Py_XDECREF(exc_type);
     Py_XDECREF(exc_value);
     Py_XDECREF(exc_value_str);

--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -68,20 +68,16 @@ Status CheckPyError(StatusCode code) {
   if (PyErr_Occurred()) {
     PyObject *exc_type, *exc_value, *traceback;
     PyErr_Fetch(&exc_type, &exc_value, &traceback);
-    PyObjectStringify stringified(exc_value);
+    PyErr_NormalizeException(&exc_type, &exc_value, &traceback);
+    PyObject *exc_value_str = PyObject_Str(exc_value);
+    char *c_str = PyString_AsString(exc_value_str);
+    std::string message(c_str);
     Py_XDECREF(exc_type);
     Py_XDECREF(exc_value);
+    Py_XDECREF(exc_value_str);
     Py_XDECREF(traceback);
     PyErr_Clear();
-
-    // ARROW-866: in some esoteric cases, formatting exc_value can fail. This
-    // was encountered when calling tell() on a socket file
-    if (stringified.bytes != nullptr) {
-      std::string message(stringified.bytes);
-      return Status(code, message);
-    } else {
-      return Status(code, "Error message was null");
-    }
+    return Status(code, message);
   }
   return Status::OK();
 }


### PR DESCRIPTION
It is possible when using `PyErr_Fetch(&exc_type, &exc_value, &traceback)` for the `exc_value` to be a string, tuple or NULL.  Calling `PyErr_Normalize` after this will cause `exc_value` to always be a valid object of the same type as `exc_type` which can then be converted to a string predictably.