### PR TITLE
ARROW-938: Fix Rat license warnings

### DIFF
--- a/dev/release/run-rat.sh
+++ b/dev/release/run-rat.sh
@@ -56,6 +56,7 @@ $RAT $1 \
   -e arrow-glib-overrides.txt \
   -e gtk-doc.make \
   -e "*.html" \
+  -e "*.sgml" \
   -e "*.css" \
   -e "*.png" \
   -e "*.svg" \

--- a/dev/release/setup-gpg-agent.sh
+++ b/dev/release/setup-gpg-agent.sh
@@ -1,3 +1,24 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # source me
 eval $(gpg-agent --daemon --allow-preset-passphrase)
-gpg --use-agent -s LICENSE.txt 
+gpg --use-agent -s LICENSE.txt
+rm -rf LICENSE.txt.gpg


### PR DESCRIPTION
The .sgml files are generated by the GTK-Doc in c_glib. 