### PR TITLE
ARROW-939: fix division by zero if one of the tensor dimensions is zero

### DIFF
--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -93,4 +93,13 @@ TEST(TestTensor, IsContiguous) {
   ASSERT_FALSE(t3.is_contiguous());
 }
 
+TEST(TestTensor, ZeroDimensionalTensor) {
+  std::vector<int64_t> shape = {0};
+
+  std::shared_ptr<MutableBuffer> buffer;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), 0, &buffer));
+
+  Tensor t(int64(), buffer, shape);
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -100,6 +100,7 @@ TEST(TestTensor, ZeroDimensionalTensor) {
   ASSERT_OK(AllocateBuffer(default_memory_pool(), 0, &buffer));
 
   Tensor t(int64(), buffer, shape);
+  ASSERT_TRUE(t.strides().size() == 1);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -100,7 +100,7 @@ TEST(TestTensor, ZeroDimensionalTensor) {
   ASSERT_OK(AllocateBuffer(default_memory_pool(), 0, &buffer));
 
   Tensor t(int64(), buffer, shape);
-  ASSERT_TRUE(t.strides().size() == 1);
+  ASSERT_EQ(t.strides().size(), 1);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -42,6 +42,7 @@ static void ComputeRowMajorStrides(const FixedWidthType& type,
   }
 
   if (remaining == 0) {
+    strides->assign(shape.size(), type.bit_width() / 8);
     return;
   }
 
@@ -56,6 +57,7 @@ static void ComputeColumnMajorStrides(const FixedWidthType& type,
   int64_t total = type.bit_width() / 8;
   for (int64_t dimsize : shape) {
     if (dimsize == 0) {
+      strides->assign(shape.size(), type.bit_width() / 8);
       return;
     }
   }

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -41,6 +41,10 @@ static void ComputeRowMajorStrides(const FixedWidthType& type,
     remaining *= dimsize;
   }
 
+  if (remaining == 0) {
+    return;
+  }
+
   for (int64_t dimsize : shape) {
     remaining /= dimsize;
     strides->push_back(remaining);
@@ -50,6 +54,11 @@ static void ComputeRowMajorStrides(const FixedWidthType& type,
 static void ComputeColumnMajorStrides(const FixedWidthType& type,
     const std::vector<int64_t>& shape, std::vector<int64_t>* strides) {
   int64_t total = type.bit_width() / 8;
+  for (int64_t dimsize : shape) {
+    if (dimsize == 0) {
+      return;
+    }
+  }
   for (int64_t dimsize : shape) {
     strides->push_back(total);
     total *= dimsize;


### PR DESCRIPTION
This was reported and fixed by @stephanie-wang, see https://github.com/ray-project/ray/issues/500