### PR TITLE
ARROW-946: [GLib] Use "new" instead of "open" for constructor name

### DIFF
--- a/c_glib/arrow-glib/file-reader.cpp
+++ b/c_glib/arrow-glib/file-reader.cpp
@@ -131,16 +131,16 @@ garrow_file_reader_class_init(GArrowFileReaderClass *klass)
 }
 
 /**
- * garrow_file_reader_open:
+ * garrow_file_reader_new:
  * @input_stream: The seekable input stream to read data.
  * @error: (nullable): Return locatipcn for a #GError or %NULL.
  *
- * Returns: (nullable) (transfer full): A newly opened
- *   #GArrowFileReader or %NULL on error.
+ * Returns: (nullable): A newly created #GArrowFileReader or %NULL on
+ *   error.
  */
 GArrowFileReader *
-garrow_file_reader_open(GArrowSeekableInputStream *input_stream,
-                        GError **error)
+garrow_file_reader_new(GArrowSeekableInputStream *input_stream,
+                       GError **error)
 {
   auto arrow_random_access_file =
     garrow_seekable_input_stream_get_raw(input_stream);

--- a/c_glib/arrow-glib/file-reader.h
+++ b/c_glib/arrow-glib/file-reader.h
@@ -70,8 +70,8 @@ struct _GArrowFileReaderClass
 
 GType garrow_file_reader_get_type(void) G_GNUC_CONST;
 
-GArrowFileReader *garrow_file_reader_open(GArrowSeekableInputStream *input_stream,
-                                          GError **error);
+GArrowFileReader *garrow_file_reader_new(GArrowSeekableInputStream *input_stream,
+                                         GError **error);
 
 GArrowSchema *garrow_file_reader_get_schema(GArrowFileReader *file_reader);
 guint garrow_file_reader_get_n_record_batches(GArrowFileReader *file_reader);

--- a/c_glib/arrow-glib/file-writer.cpp
+++ b/c_glib/arrow-glib/file-writer.cpp
@@ -57,18 +57,18 @@ garrow_file_writer_class_init(GArrowFileWriterClass *klass)
 }
 
 /**
- * garrow_file_writer_open:
+ * garrow_file_writer_new:
  * @sink: The output of the writer.
  * @schema: The schema of the writer.
  * @error: (nullable): Return locatipcn for a #GError or %NULL.
  *
- * Returns: (nullable) (transfer full): A newly opened
- *   #GArrowFileWriter or %NULL on error.
+ * Returns: (nullable): A newly created #GArrowFileWriter or %NULL on
+ *   error.
  */
 GArrowFileWriter *
-garrow_file_writer_open(GArrowOutputStream *sink,
-                            GArrowSchema *schema,
-                            GError **error)
+garrow_file_writer_new(GArrowOutputStream *sink,
+                       GArrowSchema *schema,
+                       GError **error)
 {
   std::shared_ptr<arrow::ipc::FileWriter> arrow_file_writer;
   auto status =

--- a/c_glib/arrow-glib/file-writer.h
+++ b/c_glib/arrow-glib/file-writer.h
@@ -65,9 +65,9 @@ struct _GArrowFileWriterClass
 
 GType garrow_file_writer_get_type(void) G_GNUC_CONST;
 
-GArrowFileWriter *garrow_file_writer_open(GArrowOutputStream *sink,
-                                                 GArrowSchema *schema,
-                                                 GError **error);
+GArrowFileWriter *garrow_file_writer_new(GArrowOutputStream *sink,
+                                         GArrowSchema *schema,
+                                         GError **error);
 
 gboolean garrow_file_writer_write_record_batch(GArrowFileWriter *file_writer,
                                                    GArrowRecordBatch *record_batch,

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -184,18 +184,18 @@ garrow_file_output_stream_class_init(GArrowFileOutputStreamClass *klass)
 }
 
 /**
- * garrow_file_output_stream_open:
+ * garrow_file_output_stream_new:
  * @path: The path of the file output stream.
  * @append: Whether the path is opened as append mode or recreate mode.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
- * Returns: (nullable) (transfer full): A newly opened
- *   #GArrowFileOutputStream or %NULL on error.
+ * Returns: (nullable): A newly opened #GArrowFileOutputStream or
+ *   %NULL on error.
  */
 GArrowFileOutputStream *
-garrow_file_output_stream_open(const gchar *path,
-                               gboolean append,
-                               GError **error)
+garrow_file_output_stream_new(const gchar *path,
+                              gboolean append,
+                              GError **error)
 {
   std::shared_ptr<arrow::io::FileOutputStream> arrow_file_output_stream;
   auto status =

--- a/c_glib/arrow-glib/output-stream.h
+++ b/c_glib/arrow-glib/output-stream.h
@@ -118,9 +118,9 @@ struct _GArrowFileOutputStreamClass
 
 GType garrow_file_output_stream_get_type(void) G_GNUC_CONST;
 
-GArrowFileOutputStream *garrow_file_output_stream_open(const gchar *path,
-                                                       gboolean append,
-                                                       GError **error);
+GArrowFileOutputStream *garrow_file_output_stream_new(const gchar *path,
+                                                      gboolean append,
+                                                      GError **error);
 
 
 #define GARROW_TYPE_BUFFER_OUTPUT_STREAM        \

--- a/c_glib/arrow-glib/stream-reader.cpp
+++ b/c_glib/arrow-glib/stream-reader.cpp
@@ -132,16 +132,16 @@ garrow_stream_reader_class_init(GArrowStreamReaderClass *klass)
 }
 
 /**
- * garrow_stream_reader_open:
+ * garrow_stream_reader_new:
  * @stream: The stream to be read.
  * @error: (nullable): Return locatipcn for a #GError or %NULL.
  *
- * Returns: (nullable) (transfer full): A newly opened
- *   #GArrowStreamReader or %NULL on error.
+ * Returns: (nullable): A newly created #GArrowStreamReader or %NULL
+ *   on error.
  */
 GArrowStreamReader *
-garrow_stream_reader_open(GArrowInputStream *stream,
-                              GError **error)
+garrow_stream_reader_new(GArrowInputStream *stream,
+                         GError **error)
 {
   std::shared_ptr<arrow::ipc::StreamReader> arrow_stream_reader;
   auto status =

--- a/c_glib/arrow-glib/stream-reader.h
+++ b/c_glib/arrow-glib/stream-reader.h
@@ -70,8 +70,8 @@ struct _GArrowStreamReaderClass
 
 GType garrow_stream_reader_get_type(void) G_GNUC_CONST;
 
-GArrowStreamReader *garrow_stream_reader_open(GArrowInputStream *stream,
-                                                     GError **error);
+GArrowStreamReader *garrow_stream_reader_new(GArrowInputStream *stream,
+                                             GError **error);
 
 GArrowSchema *garrow_stream_reader_get_schema(GArrowStreamReader *stream_reader);
 GArrowRecordBatch *garrow_stream_reader_get_next_record_batch(GArrowStreamReader *stream_reader,

--- a/c_glib/arrow-glib/stream-writer.cpp
+++ b/c_glib/arrow-glib/stream-writer.cpp
@@ -132,18 +132,18 @@ garrow_stream_writer_class_init(GArrowStreamWriterClass *klass)
 }
 
 /**
- * garrow_stream_writer_open:
+ * garrow_stream_writer_new:
  * @sink: The output of the writer.
  * @schema: The schema of the writer.
  * @error: (nullable): Return locatipcn for a #GError or %NULL.
  *
- * Returns: (nullable) (transfer full): A newly opened
- *   #GArrowStreamWriter or %NULL on error.
+ * Returns: (nullable): A newly created #GArrowStreamWriter or %NULL on
+ *   error.
  */
 GArrowStreamWriter *
-garrow_stream_writer_open(GArrowOutputStream *sink,
-                              GArrowSchema *schema,
-                              GError **error)
+garrow_stream_writer_new(GArrowOutputStream *sink,
+                         GArrowSchema *schema,
+                         GError **error)
 {
   std::shared_ptr<arrow::ipc::StreamWriter> arrow_stream_writer;
   auto status =

--- a/c_glib/arrow-glib/stream-writer.h
+++ b/c_glib/arrow-glib/stream-writer.h
@@ -69,9 +69,9 @@ struct _GArrowStreamWriterClass
 
 GType garrow_stream_writer_get_type(void) G_GNUC_CONST;
 
-GArrowStreamWriter *garrow_stream_writer_open(GArrowOutputStream *sink,
-                                                     GArrowSchema *schema,
-                                                     GError **error);
+GArrowStreamWriter *garrow_stream_writer_new(GArrowOutputStream *sink,
+                                             GArrowSchema *schema,
+                                             GError **error);
 
 gboolean garrow_stream_writer_write_record_batch(GArrowStreamWriter *stream_writer,
                                                      GArrowRecordBatch *record_batch,

--- a/c_glib/example/lua/read-batch.lua
+++ b/c_glib/example/lua/read-batch.lua
@@ -21,7 +21,7 @@ local Arrow = lgi.Arrow
 local input_path = arg[1] or "/tmp/batch.arrow";
 
 local input = Arrow.MemoryMappedInputStream.new(input_path)
-local reader = Arrow.FileReader.open(input)
+local reader = Arrow.FileReader.new(input)
 
 for i = 0, reader:get_n_record_batches() - 1 do
    local record_batch = reader:get_record_batch(i)

--- a/c_glib/example/lua/read-stream.lua
+++ b/c_glib/example/lua/read-stream.lua
@@ -21,7 +21,7 @@ local Arrow = lgi.Arrow
 local input_path = arg[1] or "/tmp/stream.arrow";
 
 local input = Arrow.MemoryMappedInputStream.new(input_path)
-local reader = Arrow.StreamReader.open(input)
+local reader = Arrow.StreamReader.new(input)
 
 local i = 0
 while true do

--- a/c_glib/example/lua/write-batch.lua
+++ b/c_glib/example/lua/write-batch.lua
@@ -34,8 +34,8 @@ local fields = {
 }
 local schema = Arrow.Schema.new(fields)
 
-local output = Arrow.FileOutputStream.open(output_path, false)
-local writer = Arrow.FileWriter.open(output, schema)
+local output = Arrow.FileOutputStream.new(output_path, false)
+local writer = Arrow.FileWriter.new(output, schema)
 
 function build_array(builder, values)
    for _, value in pairs(values) do

--- a/c_glib/example/lua/write-stream.lua
+++ b/c_glib/example/lua/write-stream.lua
@@ -34,8 +34,8 @@ local fields = {
 }
 local schema = Arrow.Schema.new(fields)
 
-local output = Arrow.FileOutputStream.open(output_path, false)
-local writer = Arrow.StreamWriter.open(output, schema)
+local output = Arrow.FileOutputStream.new(output_path, false)
+local writer = Arrow.StreamWriter.new(output, schema)
 
 function build_array(builder, values)
    for _, value in pairs(values) do

--- a/c_glib/example/read-batch.c
+++ b/c_glib/example/read-batch.c
@@ -103,8 +103,8 @@ main(int argc, char **argv)
   {
     GArrowFileReader *reader;
 
-    reader = garrow_file_reader_open(GARROW_SEEKABLE_INPUT_STREAM(input),
-                                     &error);
+    reader = garrow_file_reader_new(GARROW_SEEKABLE_INPUT_STREAM(input),
+                                    &error);
     if (!reader) {
       g_print("failed to open file reader: %s\n", error->message);
       g_error_free(error);

--- a/c_glib/example/read-stream.c
+++ b/c_glib/example/read-stream.c
@@ -102,8 +102,8 @@ main(int argc, char **argv)
   {
     GArrowStreamReader *reader;
 
-    reader = garrow_stream_reader_open(GARROW_INPUT_STREAM(input),
-                                       &error);
+    reader = garrow_stream_reader_new(GARROW_INPUT_STREAM(input),
+                                      &error);
     if (!reader) {
       g_print("failed to open stream reader: %s\n", error->message);
       g_error_free(error);

--- a/c_glib/test/test-file-output-stream.rb
+++ b/c_glib/test/test-file-output-stream.rb
@@ -16,12 +16,12 @@
 # under the License.
 
 class TestFileOutputStream < Test::Unit::TestCase
-  sub_test_case(".open") do
+  sub_test_case(".new") do
     def test_create
       tempfile = Tempfile.open("arrow-io-file-output-stream")
       tempfile.write("Hello")
       tempfile.close
-      file = Arrow::FileOutputStream.open(tempfile.path, false)
+      file = Arrow::FileOutputStream.new(tempfile.path, false)
       file.close
       assert_equal("", File.read(tempfile.path))
     end
@@ -30,7 +30,7 @@ class TestFileOutputStream < Test::Unit::TestCase
       tempfile = Tempfile.open("arrow-io-file-output-stream")
       tempfile.write("Hello")
       tempfile.close
-      file = Arrow::FileOutputStream.open(tempfile.path, true)
+      file = Arrow::FileOutputStream.new(tempfile.path, true)
       file.close
       assert_equal("Hello", File.read(tempfile.path))
     end

--- a/c_glib/test/test-file-writer.rb
+++ b/c_glib/test/test-file-writer.rb
@@ -18,11 +18,11 @@
 class TestFileWriter < Test::Unit::TestCase
   def test_write_record_batch
     tempfile = Tempfile.open("arrow-ipc-file-writer")
-    output = Arrow::FileOutputStream.open(tempfile.path, false)
+    output = Arrow::FileOutputStream.new(tempfile.path, false)
     begin
       field = Arrow::Field.new("enabled", Arrow::BooleanDataType.new)
       schema = Arrow::Schema.new([field])
-      file_writer = Arrow::FileWriter.open(output, schema)
+      file_writer = Arrow::FileWriter.new(output, schema)
       begin
         record_batch = Arrow::RecordBatch.new(schema, 0, [])
         file_writer.write_record_batch(record_batch)
@@ -35,7 +35,7 @@ class TestFileWriter < Test::Unit::TestCase
 
     input = Arrow::MemoryMappedInputStream.new(tempfile.path)
     begin
-      file_reader = Arrow::FileReader.open(input)
+      file_reader = Arrow::FileReader.new(input)
       assert_equal(["enabled"],
                    file_reader.schema.fields.collect(&:name))
     ensure

--- a/c_glib/test/test-stream-writer.rb
+++ b/c_glib/test/test-stream-writer.rb
@@ -20,11 +20,11 @@ class TestStreamWriter < Test::Unit::TestCase
 
   def test_write_record_batch
     tempfile = Tempfile.open("arrow-ipc-stream-writer")
-    output = Arrow::FileOutputStream.open(tempfile.path, false)
+    output = Arrow::FileOutputStream.new(tempfile.path, false)
     begin
       field = Arrow::Field.new("enabled", Arrow::BooleanDataType.new)
       schema = Arrow::Schema.new([field])
-      stream_writer = Arrow::StreamWriter.open(output, schema)
+      stream_writer = Arrow::StreamWriter.new(output, schema)
       begin
         columns = [
           build_boolean_array([true]),
@@ -40,7 +40,7 @@ class TestStreamWriter < Test::Unit::TestCase
 
     input = Arrow::MemoryMappedInputStream.new(tempfile.path)
     begin
-      stream_reader = Arrow::StreamReader.open(input)
+      stream_reader = Arrow::StreamReader.new(input)
       assert_equal(["enabled"],
                    stream_reader.schema.fields.collect(&:name))
       assert_equal(true,


### PR DESCRIPTION
Because "new" is the standard constructor name.