### PR TITLE
ARROW-956: [Python] compat with pandas >= 0.20.0

### DIFF
--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -42,7 +42,7 @@ try:
 
         pdapi = pd.api.types
     elif pdver < '0.19.0':
-        from pandas.core.dtypes import DatetimeTZDtype
+        from pandas.types.dtypes import DatetimeTZDtype
         pdapi = pd.core.common
     else:
         from pandas.types.dtypes import DatetimeTZDtype

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -34,19 +34,14 @@ try:
     import pandas as pd
     pdver = LooseVersion(pd.__version__)
     if pdver >= '0.20.0':
-        try:
-            from pandas.api.types import DatetimeTZDtype
-        except AttributeError:
-            # can be removed once 0.20.0 is released
-            from pandas.core.dtypes.dtypes import DatetimeTZDtype
-
+        from pandas.api.types import DatetimeTZDtype
         pdapi = pd.api.types
-    elif pdver < '0.19.0':
+    elif pdver >= '0.19.0':
         from pandas.types.dtypes import DatetimeTZDtype
-        pdapi = pd.core.common
+        pdapi = pd.api.types
     else:
         from pandas.types.dtypes import DatetimeTZDtype
-        pdapi = pd.api.types
+        pdapi = pd.core.common
 
     PandasSeries = pd.Series
     Categorical = pd.Categorical


### PR DESCRIPTION
ARROW-944: [Python] compat with pandas < 0.19.0