### PR TITLE
ARROW-856: Also read compiler info from stdout

### DIFF
--- a/cpp/cmake_modules/CompilerInfo.cmake
+++ b/cpp/cmake_modules/CompilerInfo.cmake
@@ -21,7 +21,11 @@ if (NOT MSVC)
   set(COMPILER_GET_VERSION_SWITCH "-v")
 endif()
 
+message(INFO "Compiler command: ${CMAKE_CXX_COMPILER}")
+# Some gcc seem to output their version on stdout, most do it on stderr, simply
+# merge both pipes into a single variable
 execute_process(COMMAND "${CMAKE_CXX_COMPILER}" ${COMPILER_GET_VERSION_SWITCH}
+                OUTPUT_VARIABLE COMPILER_VERSION_FULL
                 ERROR_VARIABLE COMPILER_VERSION_FULL)
 message(INFO "Compiler version: ${COMPILER_VERSION_FULL}")
 message(INFO "Compiler id: ${CMAKE_CXX_COMPILER_ID}")


### PR DESCRIPTION
As I cannot reproduce the problem, this may not the be the correct solution. Still due to the output of `gcc -v` in the ticket, it is very likely that some systems print the info on stdout. Also the additional message should improve debugging.