### PR TITLE
ARROW-182: [C++] Factor out Array::Validate into a separate function

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -685,7 +685,7 @@ class TestStringArray : public ::testing::Test {
 TEST_F(TestStringArray, TestArrayBasics) {
   ASSERT_EQ(length_, strings_->length());
   ASSERT_EQ(1, strings_->null_count());
-  ASSERT_OK(strings_->Validate());
+  ASSERT_OK(ValidateArray(*strings_));
 }
 
 TEST_F(TestStringArray, TestType) {
@@ -801,7 +801,7 @@ class TestStringBuilder : public TestBuilder {
     EXPECT_OK(builder_->Finish(&out));
 
     result_ = std::dynamic_pointer_cast<StringArray>(out);
-    result_->Validate();
+    ASSERT_OK(ValidateArray(*result_));
   }
 
  protected:
@@ -899,7 +899,7 @@ class TestBinaryArray : public ::testing::Test {
 TEST_F(TestBinaryArray, TestArrayBasics) {
   ASSERT_EQ(length_, strings_->length());
   ASSERT_EQ(1, strings_->null_count());
-  ASSERT_OK(strings_->Validate());
+  ASSERT_OK(ValidateArray(*strings_));
 }
 
 TEST_F(TestBinaryArray, TestType) {
@@ -969,7 +969,7 @@ class TestBinaryBuilder : public TestBuilder {
     EXPECT_OK(builder_->Finish(&out));
 
     result_ = std::dynamic_pointer_cast<BinaryArray>(out);
-    result_->Validate();
+    ASSERT_OK(ValidateArray(*result_));
   }
 
  protected:
@@ -994,7 +994,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppend) {
     }
   }
   Done();
-  ASSERT_OK(result_->Validate());
+  ASSERT_OK(ValidateArray(*result_));
   ASSERT_EQ(reps * N, result_->length());
   ASSERT_EQ(reps, result_->null_count());
   ASSERT_EQ(reps * 6, result_->data()->size());
@@ -1354,7 +1354,7 @@ TEST_F(TestListBuilder, TestAppendNull) {
 
   Done();
 
-  ASSERT_OK(result_->Validate());
+  ASSERT_OK(ValidateArray(*result_));
   ASSERT_TRUE(result_->IsNull(0));
   ASSERT_TRUE(result_->IsNull(1));
 
@@ -1368,7 +1368,7 @@ TEST_F(TestListBuilder, TestAppendNull) {
 
 void ValidateBasicListArray(const ListArray* result, const vector<int32_t>& values,
     const vector<uint8_t>& is_valid) {
-  ASSERT_OK(result->Validate());
+  ASSERT_OK(ValidateArray(*result));
   ASSERT_EQ(1, result->null_count());
   ASSERT_EQ(0, result->values()->null_count());
 
@@ -1446,13 +1446,13 @@ TEST_F(TestListBuilder, BulkAppendInvalid) {
   }
 
   Done();
-  ASSERT_RAISES(Invalid, result_->Validate());
+  ASSERT_RAISES(Invalid, ValidateArray(*result_));
 }
 
 TEST_F(TestListBuilder, TestZeroLength) {
   // All buffers are null
   Done();
-  ASSERT_OK(result_->Validate());
+  ASSERT_OK(ValidateArray(*result_));
 }
 
 // ----------------------------------------------------------------------
@@ -1569,9 +1569,9 @@ TEST(TestDictionary, Validate) {
   std::shared_ptr<Array> arr3 = std::make_shared<DictionaryArray>(dict_type, indices3);
 
   // Only checking index type for now
-  ASSERT_OK(arr->Validate());
-  ASSERT_RAISES(Invalid, arr2->Validate());
-  ASSERT_OK(arr3->Validate());
+  ASSERT_OK(ValidateArray(*arr));
+  ASSERT_RAISES(Invalid, ValidateArray(*arr2));
+  ASSERT_OK(ValidateArray(*arr3));
 }
 
 // ----------------------------------------------------------------------
@@ -1582,7 +1582,7 @@ void ValidateBasicStructArray(const StructArray* result,
     const vector<uint8_t>& list_is_valid, const vector<int>& list_lengths,
     const vector<int>& list_offsets, const vector<int32_t>& int_values) {
   ASSERT_EQ(4, result->length());
-  ASSERT_OK(result->Validate());
+  ASSERT_OK(ValidateArray(*result));
 
   auto list_char_arr = static_cast<ListArray*>(result->field(0).get());
   auto char_arr = static_cast<Int8Array*>(list_char_arr->values().get());
@@ -1666,7 +1666,7 @@ TEST_F(TestStructBuilder, TestAppendNull) {
 
   Done();
 
-  ASSERT_OK(result_->Validate());
+  ASSERT_OK(ValidateArray(*result_));
 
   ASSERT_EQ(2, static_cast<int>(result_->fields().size()));
   ASSERT_EQ(2, result_->length());
@@ -1777,8 +1777,8 @@ TEST_F(TestStructBuilder, BulkAppendInvalid) {
   }
 
   Done();
-  // Even null bitmap of the parent Struct is not valid, Validate() will ignore it.
-  ASSERT_OK(result_->Validate());
+  // Even null bitmap of the parent Struct is not valid, validate will ignore it.
+  ASSERT_OK(ValidateArray(*result_));
 }
 
 TEST_F(TestStructBuilder, TestEquality) {
@@ -1924,7 +1924,7 @@ TEST_F(TestStructBuilder, TestEquality) {
 TEST_F(TestStructBuilder, TestZeroLength) {
   // All buffers are null
   Done();
-  ASSERT_OK(result_->Validate());
+  ASSERT_OK(ValidateArray(*result_));
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -108,11 +108,6 @@ class ARROW_EXPORT Array {
   bool RangeEquals(const Array& other, int64_t start_idx, int64_t end_idx,
       int64_t other_start_idx) const;
 
-  /// Determines if the array is internally consistent.
-  ///
-  /// Defaults to always returning Status::OK. This can be an expensive check.
-  virtual Status Validate() const;
-
   Status Accept(ArrayVisitor* visitor) const;
 
   /// Construct a zero-copy slice of the array with the indicated offset and
@@ -238,8 +233,6 @@ class ARROW_EXPORT ListArray : public Array {
     values_ = values;
   }
 
-  Status Validate() const override;
-
   // Return a shared pointer in case the requestor desires to share ownership
   // with this array.
   std::shared_ptr<Array> values() const { return values_; }
@@ -306,8 +299,6 @@ class ARROW_EXPORT BinaryArray : public Array {
     return raw_value_offsets_[i + 1] - raw_value_offsets_[i];
   }
 
-  Status Validate() const override;
-
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 
  protected:
@@ -341,8 +332,6 @@ class ARROW_EXPORT StringArray : public BinaryArray {
     const uint8_t* str = GetValue(i, &nchars);
     return std::string(reinterpret_cast<const char*>(str), nchars);
   }
-
-  Status Validate() const override;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 };
@@ -406,8 +395,6 @@ class ARROW_EXPORT StructArray : public Array {
       std::shared_ptr<Buffer> null_bitmap = nullptr, int64_t null_count = 0,
       int64_t offset = 0);
 
-  Status Validate() const override;
-
   // Return a shared pointer in case the requestor desires to share ownership
   // with this array.
   std::shared_ptr<Array> field(int pos) const;
@@ -435,8 +422,6 @@ class ARROW_EXPORT UnionArray : public Array {
       const std::shared_ptr<Buffer>& value_offsets = nullptr,
       const std::shared_ptr<Buffer>& null_bitmap = nullptr, int64_t null_count = 0,
       int64_t offset = 0);
-
-  Status Validate() const override;
 
   /// Note that this buffer does not account for any slice offset
   std::shared_ptr<Buffer> type_ids() const { return type_ids_; }
@@ -490,8 +475,6 @@ class ARROW_EXPORT DictionaryArray : public Array {
   DictionaryArray(
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& indices);
 
-  Status Validate() const override;
-
   std::shared_ptr<Array> indices() const { return indices_; }
   std::shared_ptr<Array> dictionary() const;
 
@@ -524,6 +507,16 @@ ARROW_EXTERN_TEMPLATE NumericArray<Date64Type>;
 ARROW_EXTERN_TEMPLATE NumericArray<Time32Type>;
 ARROW_EXTERN_TEMPLATE NumericArray<Time64Type>;
 ARROW_EXTERN_TEMPLATE NumericArray<TimestampType>;
+
+
+/// \brief Perform any validation checks to determine obvious inconsistencies
+/// with the array's internal data
+///
+/// This can be an expensive check.
+///
+/// \param array an Array instance
+/// \return Status
+Status ValidateArray(const Array& array);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -133,7 +133,7 @@ Status MakeRandomListArray(const std::shared_ptr<Array>& child_array, int num_li
   ListBuilder builder(pool, child_array);
   RETURN_NOT_OK(builder.Append(offsets.data(), num_lists, valid_lists.data()));
   RETURN_NOT_OK(builder.Finish(out));
-  return (*out)->Validate();
+  return ValidateArray(**out);
 }
 
 typedef Status MakeRecordBatch(std::shared_ptr<RecordBatch>* out);


### PR DESCRIPTION
This makes it easier to use templates for writing more validation logic, and also we don't need the additional array methods