### PR TITLE
ARROW-1054: [Python] Fix test failure on pandas 0.19.2, some refactoring

### DIFF
--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -1102,7 +1102,7 @@ static inline PyObject* NewArray1DFromType(
 
   set_numpy_metadata(type, arrow_type, descr);
   return PyArray_NewFromDescr(&PyArray_Type, descr, 1, dims, nullptr, data,
-      NPY_ARRAY_OWNDATA | NPY_ARRAY_CARRAY, nullptr);
+      NPY_ARRAY_OWNDATA | NPY_ARRAY_CARRAY | NPY_ARRAY_WRITEABLE, nullptr);
 }
 
 class PandasBlock {

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -158,4 +158,5 @@ def deserialize_pandas(buf, nthreads=1):
     """
     buffer_reader = pa.BufferReader(buf)
     reader = pa.RecordBatchFileReader(buffer_reader)
-    return reader.read_all().to_pandas(nthreads=nthreads)
+    table = reader.read_all()
+    return table.to_pandas(nthreads=nthreads)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import itertools
 import json
 
 import six


### PR DESCRIPTION
For esoteric reasons, `MultiIndex.from_arrays` rejects non-writeable NumPy arrays. This problem isn't present in pandas 0.20.1