### PR TITLE
ARROW-424: [C++] Make ReadAt, Write HDFS functions threadsafe

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -508,7 +508,6 @@ ARROW_EXTERN_TEMPLATE NumericArray<Time32Type>;
 ARROW_EXTERN_TEMPLATE NumericArray<Time64Type>;
 ARROW_EXTERN_TEMPLATE NumericArray<TimestampType>;
 
-
 /// \brief Perform any validation checks to determine obvious inconsistencies
 /// with the array's internal data
 ///


### PR DESCRIPTION
This also fixes the HDFS test suite to actually use libhdfs3 (it was not by accident)