### PR TITLE
ARROW-1056: [Python] Ignore pandas index in parquet+hdfs test

### DIFF
--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -167,7 +167,7 @@ class HdfsTestCases(object):
 
             path = pjoin(tmpdir, '{0}.parquet'.format(i))
 
-            table = pa.Table.from_pandas(df)
+            table = pa.Table.from_pandas(df, preserve_index=False)
             with self.hdfs.open(path, 'wb') as f:
                 pq.write_table(table, f)
 


### PR DESCRIPTION
I have all the tests passing again:

```shell
$ py.test pyarrow --hdfs
===================================== test session starts =====================================
platform linux -- Python 3.5.1, pytest-3.0.6, py-1.4.31, pluggy-0.4.0
rootdir: /home/wesm/code/arrow/python, inifile: setup.cfg
collected 227 items 

pyarrow/tests/test_array.py ...........
pyarrow/tests/test_convert_builtin.py ......................
pyarrow/tests/test_convert_pandas.py ............................x....
pyarrow/tests/test_deprecations.py ..
pyarrow/tests/test_feather.py .......................x....
pyarrow/tests/test_hdfs.py ...............
pyarrow/tests/test_io.py ..................
pyarrow/tests/test_ipc.py .............x
pyarrow/tests/test_jemalloc.py ..
pyarrow/tests/test_parquet.py ...........................
pyarrow/tests/test_scalars.py ..........
pyarrow/tests/test_schema.py ..............
pyarrow/tests/test_table.py ...............
pyarrow/tests/test_tensor.py ................
```