### PR TITLE
ARROW-1086: include additional pxd files during package build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -349,7 +349,7 @@ setup(
     name="pyarrow",
     packages=['pyarrow', 'pyarrow.tests'],
     zip_safe=False,
-    package_data={'pyarrow': ['*.pxd', '*.pyx']},
+    package_data={'pyarrow': ['*.pxd', '*.pyx', 'includes/*.pxd']},
     include_package_data=True,
     distclass=BinaryDistribution,
     # Dummy extension to trigger build_ext


### PR DESCRIPTION
Since this is purely a packaging change, I believe I would need to change`travis_script_python.sh` in order test it (build a wheel, set up a new conda environment and install the wheel, etc). Not sure if that's worth doing? Happy to take a stab if it is.

