### PR TITLE
ARROW-1090: Improve build_ext usability with --bundle-arrow-cpp

### DIFF
--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -171,6 +171,14 @@ You should be able to run the unit tests with:
 
    ====================== 181 passed, 17 skipped in 0.98 seconds ===========
 
+You can build a wheel by running:
+
+.. code-block:: shell
+   python setup.py build_ext --build-type=$ARROW_BUILD_TYPE \
+          --with-parquet --with-jemalloc --bundle-arrow-cpp bdist_wheel
+
+Again, if you did not build parquet-cpp, you should omit ``--with-parquet``.
+
 Windows
 =======
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -148,6 +148,11 @@ class build_ext(_build_ext):
 
         if self.bundle_arrow_cpp:
             cmake_options.append('-DPYARROW_BUNDLE_ARROW_CPP=ON')
+            # ARROW-1090: work around CMake rough edges
+            if 'ARROW_HOME' in os.environ:
+                os.environ['PKG_CONFIG_PATH'] = pjoin(os.environ['ARROW_HOME'], 'lib', 'pkgconfig')
+                del os.environ['ARROW_HOME']
+
 
         cmake_options.append('-DCMAKE_BUILD_TYPE={0}'
                              .format(self.build_type.lower()))

--- a/python/setup.py
+++ b/python/setup.py
@@ -149,7 +149,7 @@ class build_ext(_build_ext):
         if self.bundle_arrow_cpp:
             cmake_options.append('-DPYARROW_BUNDLE_ARROW_CPP=ON')
             # ARROW-1090: work around CMake rough edges
-            if 'ARROW_HOME' in os.environ:
+            if 'ARROW_HOME' in os.environ and sys.platform != 'win32':
                 os.environ['PKG_CONFIG_PATH'] = pjoin(os.environ['ARROW_HOME'], 'lib', 'pkgconfig')
                 del os.environ['ARROW_HOME']
 


### PR DESCRIPTION
This is based on a blackbox understanding of the build toolchain. It might be cleaner to update `FindArrow.cmake`, but I'm not sure what the consequences of that would be. This shouldn't be able to do much harm, since this codepath would previously crash.