### PR TITLE
ARROW-1048: Use existing LD_LIBRARY_PATH in source release script to accommodate non-system toolchain libs

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -74,7 +74,7 @@ cd ${extract_dir}/c_glib
 ./configure \
   PKG_CONFIG_PATH=$cpp_install_dir/lib/pkgconfig \
   --enable-gtk-doc
-LD_LIBRARY_PATH=$cpp_install_dir/lib make -j8
+LD_LIBRARY_PATH=$cpp_install_dir/lib:$LD_LIBRARY_PATH make -j8
 make dist
 tar xzf *.tar.gz
 rm *.tar.gz
@@ -114,4 +114,3 @@ echo "Success! The release candidate is available here:"
 echo "  https://dist.apache.org/repos/dist/dev/arrow/${tagrc}"
 echo ""
 echo "Commit SHA1: ${release_hash}"
-


### PR DESCRIPTION
Tripped on this again when cutting the 0.4.1 rc0. cc @kou 