### PR TITLE
ARROW-1115: [C++] use CCACHE_FOUND value

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -57,8 +57,8 @@ endif()
 
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_FOUND})
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
 endif(CCACHE_FOUND)
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## summary

for C++ Project

use `CCACHE_FOUND` value when `cmake` build.
Because an error occurs in macOS environment with Homebrew installation.

## error detail
Even if `/usr/local/bin` is not included in the PATH environment variable, `find_program` will return `/usr/local/bin/ccache`. In that case, `ccache` (not `/usr/local/bin/ccache`) will be used as the ccache's program name.
As a result the build will fail.

## reference
https://github.com/Homebrew/homebrew-core/pull/14105