### PR TITLE
ARROW-1124: Increase numpy dependency to >=1.10.x

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 pytest
-numpy>=1.7.0
+numpy>=1.10.0
 six

--- a/python/setup.py
+++ b/python/setup.py
@@ -366,7 +366,7 @@ setup(
     },
     use_scm_version={"root": "..", "relative_to": __file__},
     setup_requires=['setuptools_scm', 'cython >= 0.23'],
-    install_requires=['numpy >= 1.9', 'six >= 1.0.0'],
+    install_requires=['numpy >= 1.10', 'six >= 1.0.0'],
     tests_require=['pytest'],
     description="Python library for Apache Arrow",
     long_description=long_description,


### PR DESCRIPTION
While we could still build with NumPy>=1.9 for Python 2, Python 3 builds
require >= 1.10 due to a bug in the C-headers.

Change-Id: I0f9e0ad72e4ce4b1c6b44883d5781347d33f7e5b