### PR TITLE
ARROW-1138: Travis: Use OpenJDK7 instead of OracleJDK7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ addons:
     - gtk-doc-tools
     - autoconf-archive
     - libgirepository1.0-dev
-    - openjdk-7-jdk
-    - openjdk-7-jre
 
 services:
   - docker
@@ -62,13 +60,13 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_script_manylinux.sh
   - language: java
     os: linux
-    jdk: oraclejdk7
+    jdk: openjdk7
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
   - language: java
     os: linux
     env: ARROW_TEST_GROUP=integration
-    jdk: oraclejdk7
+    jdk: openjdk7
     before_script:
     - export CC="gcc-4.9"
     - export CXX="g++-4.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ addons:
     - gtk-doc-tools
     - autoconf-archive
     - libgirepository1.0-dev
+    - openjdk-7-jdk
+    - openjdk-7-jre
+
 services:
   - docker
 


### PR DESCRIPTION
Will merge on green build to unbreak Travis but it would be very helpful if a Java expert can review this change.