### PR TITLE
ARROW-978: [Python] - Change python documentation sphinx theme to bootstrap

### DIFF
--- a/python/doc/requirements.txt
+++ b/python/doc/requirements.txt
@@ -2,4 +2,4 @@ ipython
 matplotlib
 numpydoc
 sphinx
-sphinx_rtd_theme
+sphinx_bootstrap_theme

--- a/python/doc/source/conf.py
+++ b/python/doc/source/conf.py
@@ -28,7 +28,7 @@
 import os
 import sys
 
-import sphinx_rtd_theme
+import sphinx_bootstrap_theme
 
 sys.path.extend([
     os.path.join(os.path.dirname(__file__),
@@ -150,7 +150,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinxdoc'
+html_theme = 'bootstrap'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -159,7 +159,7 @@ html_theme = 'sphinxdoc'
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.


### PR DESCRIPTION
This sets the default HTML theme to the sphinx-bootstrap-theme. There were vestiges of the (improperly configured and thus unused) sphinx-rtd-theme which I removed.