### PR TITLE
ARROW-1159: [C++] Use dllimport for visibility when not building Arrow library

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -30,6 +30,10 @@ if (MSVC)
   # insecure, like std::getenv
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
+  # Use __declspec(dllexport) during library build, other users of the Arrow
+  # headers will see dllimport
+  add_definitions(-DARROW_EXPORTING)
+
   if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # clang-cl
     set(CXX_COMMON_FLAGS "-EHsc")

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -24,7 +24,13 @@
 #else
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
+
+#ifdef ARROW_EXPORTING
 #define ARROW_EXPORT __declspec(dllexport)
+#else
+#define ARROW_EXPORT __declspec(dllimport)
+#endif
+
 #define ARROW_NO_EXPORT
 #else  // Not Windows
 #ifndef ARROW_EXPORT


### PR DESCRIPTION
This should fix the linking issues currently in https://ci.appveyor.com/project/ApacheSoftwareFoundation/parquet-cpp/build/1.0.173/job/90ahlb7eoxlch3yj