### PR TITLE
ARROW-1172: [C++] Refactor to use unique_ptr for builders

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -85,7 +85,7 @@ G_BEGIN_DECLS
  */
 
 typedef struct GArrowArrayBuilderPrivate_ {
-  std::shared_ptr<arrow::ArrayBuilder> array_builder;
+  arrow::ArrayBuilder *array_builder;
 } GArrowArrayBuilderPrivate;
 
 enum {
@@ -109,7 +109,7 @@ garrow_array_builder_finalize(GObject *object)
 
   priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(object);
 
-  priv->array_builder = nullptr;
+  delete priv->array_builder;
 
   G_OBJECT_CLASS(garrow_array_builder_parent_class)->finalize(object);
 }
@@ -127,7 +127,7 @@ garrow_array_builder_set_property(GObject *object,
   switch (prop_id) {
   case PROP_ARRAY_BUILDER:
     priv->array_builder =
-      *static_cast<std::shared_ptr<arrow::ArrayBuilder> *>(g_value_get_pointer(value));
+      static_cast<arrow::ArrayBuilder *>(g_value_get_pointer(value));
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -167,11 +167,25 @@ garrow_array_builder_class_init(GArrowArrayBuilderClass *klass)
 
   spec = g_param_spec_pointer("array-builder",
                               "Array builder",
-                              "The raw std::shared<arrow::ArrayBuilder> *",
+                              "The raw arrow::ArrayBuilder *",
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_ARRAY_BUILDER, spec);
 }
+
+static GArrowArrayBuilder *
+garrow_array_builder_new(const std::shared_ptr<arrow::DataType> &type,
+                         GError **error,
+                         const char *context)
+{
+  auto memory_pool = arrow::default_memory_pool();
+  std::unique_ptr<arrow::ArrayBuilder> arrow_builder;
+  auto status = arrow::MakeBuilder(memory_pool, type, &arrow_builder);
+  if (!garrow_error_check(error, status, context)) {
+    return NULL;
+  }
+  return garrow_array_builder_new_raw(arrow_builder.release());
+};
 
 /**
  * garrow_array_builder_finish:
@@ -205,17 +219,16 @@ garrow_boolean_array_builder_class_init(GArrowBooleanArrayBuilderClass *klass)
 
 /**
  * garrow_boolean_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowBooleanArrayBuilder.
  */
 GArrowBooleanArrayBuilder *
-garrow_boolean_array_builder_new(void)
+garrow_boolean_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_boolean_builder =
-    std::make_shared<arrow::BooleanBuilder>(memory_pool);
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_boolean_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::boolean(),
+                                          error,
+                                          "[boolean-array-builder][new]");
   return GARROW_BOOLEAN_ARRAY_BUILDER(builder);
 }
 
@@ -234,7 +247,7 @@ garrow_boolean_array_builder_append(GArrowBooleanArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::BooleanBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(static_cast<bool>(value));
   return garrow_error_check(error, status, "[boolean-array-builder][append]");
@@ -253,7 +266,7 @@ garrow_boolean_array_builder_append_null(GArrowBooleanArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::BooleanBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error,
@@ -278,17 +291,16 @@ garrow_int8_array_builder_class_init(GArrowInt8ArrayBuilderClass *klass)
 
 /**
  * garrow_int8_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt8ArrayBuilder.
  */
 GArrowInt8ArrayBuilder *
-garrow_int8_array_builder_new(void)
+garrow_int8_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_int8_builder =
-    std::make_shared<arrow::Int8Builder>(memory_pool, arrow::int8());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_int8_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::int8(),
+                                          error,
+                                          "[int8-array-builder][new]");
   return GARROW_INT8_ARRAY_BUILDER(builder);
 }
 
@@ -307,7 +319,7 @@ garrow_int8_array_builder_append(GArrowInt8ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int8Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[int8-array-builder][append]");
@@ -326,7 +338,7 @@ garrow_int8_array_builder_append_null(GArrowInt8ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int8Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[int8-array-builder][append-null]");
@@ -349,17 +361,16 @@ garrow_uint8_array_builder_class_init(GArrowUInt8ArrayBuilderClass *klass)
 
 /**
  * garrow_uint8_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt8ArrayBuilder.
  */
 GArrowUInt8ArrayBuilder *
-garrow_uint8_array_builder_new(void)
+garrow_uint8_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_uint8_builder =
-    std::make_shared<arrow::UInt8Builder>(memory_pool, arrow::uint8());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_uint8_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::uint8(),
+                                          error,
+                                          "[uint8-array-builder][new]");
   return GARROW_UINT8_ARRAY_BUILDER(builder);
 }
 
@@ -378,7 +389,7 @@ garrow_uint8_array_builder_append(GArrowUInt8ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt8Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[uint8-array-builder][append]");
@@ -397,7 +408,7 @@ garrow_uint8_array_builder_append_null(GArrowUInt8ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt8Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[uint8-array-builder][append-null]");
@@ -420,17 +431,16 @@ garrow_int16_array_builder_class_init(GArrowInt16ArrayBuilderClass *klass)
 
 /**
  * garrow_int16_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt16ArrayBuilder.
  */
 GArrowInt16ArrayBuilder *
-garrow_int16_array_builder_new(void)
+garrow_int16_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_int16_builder =
-    std::make_shared<arrow::Int16Builder>(memory_pool, arrow::int16());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_int16_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::int16(),
+                                          error,
+                                          "[int16-array-builder][new]");
   return GARROW_INT16_ARRAY_BUILDER(builder);
 }
 
@@ -449,7 +459,7 @@ garrow_int16_array_builder_append(GArrowInt16ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int16Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[int16-array-builder][append]");
@@ -468,7 +478,7 @@ garrow_int16_array_builder_append_null(GArrowInt16ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int16Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[int16-array-builder][append-null]");
@@ -491,17 +501,16 @@ garrow_uint16_array_builder_class_init(GArrowUInt16ArrayBuilderClass *klass)
 
 /**
  * garrow_uint16_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt16ArrayBuilder.
  */
 GArrowUInt16ArrayBuilder *
-garrow_uint16_array_builder_new(void)
+garrow_uint16_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_uint16_builder =
-    std::make_shared<arrow::UInt16Builder>(memory_pool, arrow::uint16());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_uint16_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::uint16(),
+                                          error,
+                                          "[uint16-array-builder][new]");
   return GARROW_UINT16_ARRAY_BUILDER(builder);
 }
 
@@ -520,7 +529,7 @@ garrow_uint16_array_builder_append(GArrowUInt16ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt16Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[uint16-array-builder][append]");
@@ -539,7 +548,7 @@ garrow_uint16_array_builder_append_null(GArrowUInt16ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt16Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error,
@@ -564,17 +573,16 @@ garrow_int32_array_builder_class_init(GArrowInt32ArrayBuilderClass *klass)
 
 /**
  * garrow_int32_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt32ArrayBuilder.
  */
 GArrowInt32ArrayBuilder *
-garrow_int32_array_builder_new(void)
+garrow_int32_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_int32_builder =
-    std::make_shared<arrow::Int32Builder>(memory_pool, arrow::int32());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_int32_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::int32(),
+                                          error,
+                                          "[int32-array-builder][new]");
   return GARROW_INT32_ARRAY_BUILDER(builder);
 }
 
@@ -593,7 +601,7 @@ garrow_int32_array_builder_append(GArrowInt32ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int32Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[int32-array-builder][append]");
@@ -612,7 +620,7 @@ garrow_int32_array_builder_append_null(GArrowInt32ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int32Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[int32-array-builder][append-null]");
@@ -635,17 +643,16 @@ garrow_uint32_array_builder_class_init(GArrowUInt32ArrayBuilderClass *klass)
 
 /**
  * garrow_uint32_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt32ArrayBuilder.
  */
 GArrowUInt32ArrayBuilder *
-garrow_uint32_array_builder_new(void)
+garrow_uint32_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_uint32_builder =
-    std::make_shared<arrow::UInt32Builder>(memory_pool, arrow::uint32());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_uint32_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::uint32(),
+                                          error,
+                                          "[uint32-array-builder][new]");
   return GARROW_UINT32_ARRAY_BUILDER(builder);
 }
 
@@ -664,7 +671,7 @@ garrow_uint32_array_builder_append(GArrowUInt32ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt32Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[uint32-array-builder][append]");
@@ -683,7 +690,7 @@ garrow_uint32_array_builder_append_null(GArrowUInt32ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt32Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error,
@@ -708,17 +715,16 @@ garrow_int64_array_builder_class_init(GArrowInt64ArrayBuilderClass *klass)
 
 /**
  * garrow_int64_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt64ArrayBuilder.
  */
 GArrowInt64ArrayBuilder *
-garrow_int64_array_builder_new(void)
+garrow_int64_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_int64_builder =
-    std::make_shared<arrow::Int64Builder>(memory_pool, arrow::int64());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_int64_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::int64(),
+                                          error,
+                                          "[int64-array-builder][new]");
   return GARROW_INT64_ARRAY_BUILDER(builder);
 }
 
@@ -737,7 +743,7 @@ garrow_int64_array_builder_append(GArrowInt64ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int64Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[int64-array-builder][append]");
@@ -756,7 +762,7 @@ garrow_int64_array_builder_append_null(GArrowInt64ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::Int64Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[int64-array-builder][append-null]");
@@ -779,17 +785,16 @@ garrow_uint64_array_builder_class_init(GArrowUInt64ArrayBuilderClass *klass)
 
 /**
  * garrow_uint64_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt64ArrayBuilder.
  */
 GArrowUInt64ArrayBuilder *
-garrow_uint64_array_builder_new(void)
+garrow_uint64_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_uint64_builder =
-    std::make_shared<arrow::UInt64Builder>(memory_pool, arrow::uint64());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_uint64_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::uint64(),
+                                          error,
+                                          "[uint64-array-builder][new]");
   return GARROW_UINT64_ARRAY_BUILDER(builder);
 }
 
@@ -808,7 +813,7 @@ garrow_uint64_array_builder_append(GArrowUInt64ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt64Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[uint64-array-builder][append]");
@@ -827,7 +832,7 @@ garrow_uint64_array_builder_append_null(GArrowUInt64ArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::UInt64Builder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   if (status.ok()) {
@@ -855,17 +860,16 @@ garrow_float_array_builder_class_init(GArrowFloatArrayBuilderClass *klass)
 
 /**
  * garrow_float_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowFloatArrayBuilder.
  */
 GArrowFloatArrayBuilder *
-garrow_float_array_builder_new(void)
+garrow_float_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_float_builder =
-    std::make_shared<arrow::FloatBuilder>(memory_pool, arrow::float32());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_float_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::float32(),
+                                          error,
+                                          "[float-array-builder][new]");
   return GARROW_FLOAT_ARRAY_BUILDER(builder);
 }
 
@@ -884,7 +888,7 @@ garrow_float_array_builder_append(GArrowFloatArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::FloatBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[float-array-builder][append]");
@@ -903,7 +907,7 @@ garrow_float_array_builder_append_null(GArrowFloatArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::FloatBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[float-array-builder][append-null]");
@@ -926,17 +930,16 @@ garrow_double_array_builder_class_init(GArrowDoubleArrayBuilderClass *klass)
 
 /**
  * garrow_double_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowDoubleArrayBuilder.
  */
 GArrowDoubleArrayBuilder *
-garrow_double_array_builder_new(void)
+garrow_double_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_double_builder =
-    std::make_shared<arrow::DoubleBuilder>(memory_pool, arrow::float64());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_double_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::float64(),
+                                          error,
+                                          "[double-array-builder][new]");
   return GARROW_DOUBLE_ARRAY_BUILDER(builder);
 }
 
@@ -955,7 +958,7 @@ garrow_double_array_builder_append(GArrowDoubleArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::DoubleBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value);
   return garrow_error_check(error, status, "[double-array-builder][append]");
@@ -974,7 +977,7 @@ garrow_double_array_builder_append_null(GArrowDoubleArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::DoubleBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error,
@@ -999,17 +1002,16 @@ garrow_binary_array_builder_class_init(GArrowBinaryArrayBuilderClass *klass)
 
 /**
  * garrow_binary_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowBinaryArrayBuilder.
  */
 GArrowBinaryArrayBuilder *
-garrow_binary_array_builder_new(void)
+garrow_binary_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_binary_builder =
-    std::make_shared<arrow::BinaryBuilder>(memory_pool, arrow::binary());
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_binary_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::binary(),
+                                          error,
+                                          "[binary-array-builder][new]");
   return GARROW_BINARY_ARRAY_BUILDER(builder);
 }
 
@@ -1030,7 +1032,7 @@ garrow_binary_array_builder_append(GArrowBinaryArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::BinaryBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value, length);
   return garrow_error_check(error, status, "[binary-array-builder][append]");
@@ -1049,7 +1051,7 @@ garrow_binary_array_builder_append_null(GArrowBinaryArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::BinaryBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error,
@@ -1074,17 +1076,16 @@ garrow_string_array_builder_class_init(GArrowStringArrayBuilderClass *klass)
 
 /**
  * garrow_string_array_builder_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowStringArrayBuilder.
  */
 GArrowStringArrayBuilder *
-garrow_string_array_builder_new(void)
+garrow_string_array_builder_new(GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_string_builder =
-    std::make_shared<arrow::StringBuilder>(memory_pool);
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_string_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto builder = garrow_array_builder_new(arrow::utf8(),
+                                          error,
+                                          "[string-array-builder][new]");
   return GARROW_STRING_ARRAY_BUILDER(builder);
 }
 
@@ -1103,7 +1104,7 @@ garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::StringBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value,
                                       static_cast<gint32>(strlen(value)));
@@ -1111,9 +1112,36 @@ garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
 }
 
 
-G_DEFINE_TYPE(GArrowListArrayBuilder,
-              garrow_list_array_builder,
-              GARROW_TYPE_ARRAY_BUILDER)
+typedef struct GArrowListArrayBuilderPrivate_ {
+  GArrowArrayBuilder *value_builder;
+} GArrowListArrayBuilderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowListArrayBuilder,
+                           garrow_list_array_builder,
+                           GARROW_TYPE_ARRAY_BUILDER)
+
+#define GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(obj)              \
+  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
+                               GARROW_TYPE_LIST_ARRAY_BUILDER,  \
+                               GArrowListArrayBuilderPrivate))
+
+static void
+garrow_list_array_builder_dispose(GObject *object)
+{
+  GArrowListArrayBuilderPrivate *priv;
+
+  priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(object);
+
+  if (priv->value_builder) {
+    GArrowArrayBuilderPrivate *value_builder_priv;
+    value_builder_priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(priv->value_builder);
+    value_builder_priv->array_builder = nullptr;
+    g_object_unref(priv->value_builder);
+    priv->value_builder = NULL;
+  }
+
+  G_OBJECT_CLASS(garrow_list_array_builder_parent_class)->dispose(object);
+}
 
 static void
 garrow_list_array_builder_init(GArrowListArrayBuilder *builder)
@@ -1123,23 +1151,37 @@ garrow_list_array_builder_init(GArrowListArrayBuilder *builder)
 static void
 garrow_list_array_builder_class_init(GArrowListArrayBuilderClass *klass)
 {
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_list_array_builder_dispose;
 }
 
 /**
  * garrow_list_array_builder_new:
- * @value_builder: A #GArrowArrayBuilder for value array.
+ * @data_type: A #GArrowListDataType for value.
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowListArrayBuilder.
  */
 GArrowListArrayBuilder *
-garrow_list_array_builder_new(GArrowArrayBuilder *value_builder)
+garrow_list_array_builder_new(GArrowListDataType *data_type,
+                              GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_value_builder = garrow_array_builder_get_raw(value_builder);
-  auto arrow_list_builder =
-    std::make_shared<arrow::ListBuilder>(memory_pool, arrow_value_builder);
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_list_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  if (!GARROW_IS_LIST_DATA_TYPE(data_type)) {
+    g_set_error(error,
+                GARROW_ERROR,
+                GARROW_ERROR_INVALID,
+                "[list-array-builder][new] data type must be list data type");
+    return NULL;
+  }
+
+  auto arrow_data_type =
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto builder = garrow_array_builder_new(arrow_data_type,
+                                          error,
+                                          "[list-array-builder][new]");
   return GARROW_LIST_ARRAY_BUILDER(builder);
 }
 
@@ -1192,7 +1234,7 @@ garrow_list_array_builder_append(GArrowListArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::ListBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append();
   return garrow_error_check(error, status, "[list-array-builder][append]");
@@ -1213,7 +1255,7 @@ garrow_list_array_builder_append_null(GArrowListArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::ListBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error, status, "[list-array-builder][append-null]");
@@ -1223,22 +1265,59 @@ garrow_list_array_builder_append_null(GArrowListArrayBuilder *builder,
  * garrow_list_array_builder_get_value_builder:
  * @builder: A #GArrowListArrayBuilder.
  *
- * Returns: (transfer full): The #GArrowArrayBuilder for values.
+ * Returns: (transfer none): The #GArrowArrayBuilder for values.
  */
 GArrowArrayBuilder *
 garrow_list_array_builder_get_value_builder(GArrowListArrayBuilder *builder)
 {
-  auto arrow_builder =
-    static_cast<arrow::ListBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
-  auto arrow_value_builder = arrow_builder->value_builder();
-  return garrow_array_builder_new_raw(&arrow_value_builder);
+  GArrowListArrayBuilderPrivate *priv;
+
+  priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(builder);
+  if (!priv->value_builder) {
+    auto arrow_builder =
+      static_cast<arrow::ListBuilder *>(
+        garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
+    auto arrow_value_builder = arrow_builder->value_builder();
+    priv->value_builder = garrow_array_builder_new_raw(arrow_value_builder);
+  }
+  return priv->value_builder;
 }
 
 
-G_DEFINE_TYPE(GArrowStructArrayBuilder,
-              garrow_struct_array_builder,
-              GARROW_TYPE_ARRAY_BUILDER)
+typedef struct GArrowStructArrayBuilderPrivate_ {
+  GList *field_builders;
+} GArrowStructArrayBuilderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowStructArrayBuilder,
+                           garrow_struct_array_builder,
+                           GARROW_TYPE_ARRAY_BUILDER)
+
+#define GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(obj)                    \
+  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                                   \
+                               GARROW_TYPE_STRUCT_ARRAY_BUILDER,        \
+                               GArrowStructArrayBuilderPrivate))
+
+static void
+garrow_struct_array_builder_dispose(GObject *object)
+{
+  GArrowStructArrayBuilderPrivate *priv;
+  GList *node;
+
+  priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(object);
+
+  for (node = priv->field_builders; node; node = g_list_next(node)) {
+    auto field_builder = static_cast<GArrowArrayBuilder *>(node->data);
+    GArrowArrayBuilderPrivate *field_builder_priv;
+
+    field_builder_priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(field_builder);
+    field_builder_priv->array_builder = nullptr;
+    g_object_unref(field_builder);
+  }
+  g_list_free(priv->field_builders);
+  priv->field_builders = NULL;
+
+  G_OBJECT_CLASS(garrow_struct_array_builder_parent_class)->dispose(object);
+}
 
 static void
 garrow_struct_array_builder_init(GArrowStructArrayBuilder *builder)
@@ -1248,35 +1327,36 @@ garrow_struct_array_builder_init(GArrowStructArrayBuilder *builder)
 static void
 garrow_struct_array_builder_class_init(GArrowStructArrayBuilderClass *klass)
 {
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_struct_array_builder_dispose;
 }
 
 /**
  * garrow_struct_array_builder_new:
  * @data_type: #GArrowStructDataType for the struct.
- * @field_builders: (element-type GArrowArray): #GArrowArrayBuilders
- *   for fields.
+ * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowStructArrayBuilder.
  */
 GArrowStructArrayBuilder *
 garrow_struct_array_builder_new(GArrowStructDataType *data_type,
-                                GList *field_builders)
+                                GError **error)
 {
-  auto memory_pool = arrow::default_memory_pool();
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
-  std::vector<std::shared_ptr<arrow::ArrayBuilder>> arrow_field_builders;
-  for (GList *node = field_builders; node; node = g_list_next(node)) {
-    auto field_builder = static_cast<GArrowArrayBuilder *>(node->data);
-    auto arrow_field_builder = garrow_array_builder_get_raw(field_builder);
-    arrow_field_builders.push_back(arrow_field_builder);
+  if (!GARROW_IS_STRUCT_DATA_TYPE(data_type)) {
+    g_set_error(error,
+                GARROW_ERROR,
+                GARROW_ERROR_INVALID,
+                "[struct-array-builder][new] data type must be struct data type");
+    return NULL;
   }
 
-  auto arrow_struct_builder =
-    std::make_shared<arrow::StructBuilder>(memory_pool,
-                                           arrow_data_type,
-                                           arrow_field_builders);
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder = arrow_struct_builder;
-  auto builder = garrow_array_builder_new_raw(&arrow_builder);
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto builder = garrow_array_builder_new(arrow_data_type,
+                                          error,
+                                          "[struct-array-builder][new]");
   return GARROW_STRUCT_ARRAY_BUILDER(builder);
 }
 
@@ -1304,7 +1384,7 @@ garrow_struct_array_builder_append(GArrowStructArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::StructBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append();
   return garrow_error_check(error, status, "[struct-array-builder][append]");
@@ -1325,7 +1405,7 @@ garrow_struct_array_builder_append_null(GArrowStructArrayBuilder *builder,
 {
   auto arrow_builder =
     static_cast<arrow::StructBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->AppendNull();
   return garrow_error_check(error,
@@ -1338,51 +1418,56 @@ garrow_struct_array_builder_append_null(GArrowStructArrayBuilder *builder,
  * @builder: A #GArrowStructArrayBuilder.
  * @i: The index of the field in the struct.
  *
- * Returns: (transfer full): The #GArrowArrayBuilder for the i-th field.
+ * Returns: (transfer none): The #GArrowArrayBuilder for the i-th field.
  */
 GArrowArrayBuilder *
 garrow_struct_array_builder_get_field_builder(GArrowStructArrayBuilder *builder,
                                               gint i)
 {
-  auto arrow_builder =
-    static_cast<arrow::StructBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
-  auto arrow_field_builder = arrow_builder->field_builder(i);
-  return garrow_array_builder_new_raw(&arrow_field_builder);
+  auto field_builders = garrow_struct_array_builder_get_field_builders(builder);
+  auto field_builder = g_list_nth_data(field_builders, i);
+  return static_cast<GArrowArrayBuilder *>(field_builder);
 }
 
 /**
  * garrow_struct_array_builder_get_field_builders:
  * @builder: A #GArrowStructArrayBuilder.
  *
- * Returns: (element-type GArrowArray) (transfer full):
+ * Returns: (element-type GArrowArray) (transfer none):
  *   The #GArrowArrayBuilder for all fields.
  */
 GList *
 garrow_struct_array_builder_get_field_builders(GArrowStructArrayBuilder *builder)
 {
-  auto arrow_struct_builder =
-    static_cast<arrow::StructBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)).get());
+  GArrowStructArrayBuilderPrivate *priv;
 
-  GList *field_builders = NULL;
-  for (auto arrow_field_builder : arrow_struct_builder->field_builders()) {
-    auto field_builder = garrow_array_builder_new_raw(&arrow_field_builder);
-    field_builders = g_list_prepend(field_builders, field_builder);
+  priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(builder);
+  if (!priv->field_builders) {
+    auto arrow_struct_builder =
+      static_cast<arrow::StructBuilder *>(
+        garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
+
+    GList *field_builders = NULL;
+    for (int i = 0; i < arrow_struct_builder->num_fields(); ++i) {
+      auto arrow_field_builder = arrow_struct_builder->field_builder(i);
+      auto field_builder = garrow_array_builder_new_raw(arrow_field_builder);
+      field_builders = g_list_prepend(field_builders, field_builder);
+    }
+    priv->field_builders = g_list_reverse(field_builders);
   }
 
-  return g_list_reverse(field_builders);
+  return priv->field_builders;
 }
 
 
 G_END_DECLS
 
 GArrowArrayBuilder *
-garrow_array_builder_new_raw(std::shared_ptr<arrow::ArrayBuilder> *arrow_builder)
+garrow_array_builder_new_raw(arrow::ArrayBuilder *arrow_builder)
 {
   GType type;
 
-  switch ((*arrow_builder)->type()->id()) {
+  switch (arrow_builder->type()->id()) {
   case arrow::Type::type::BOOL:
     type = GARROW_TYPE_BOOLEAN_ARRAY_BUILDER;
     break;
@@ -1440,7 +1525,7 @@ garrow_array_builder_new_raw(std::shared_ptr<arrow::ArrayBuilder> *arrow_builder
   return builder;
 }
 
-std::shared_ptr<arrow::ArrayBuilder>
+arrow::ArrayBuilder *
 garrow_array_builder_get_raw(GArrowArrayBuilder *builder)
 {
   GArrowArrayBuilderPrivate *priv;

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -219,15 +219,14 @@ garrow_boolean_array_builder_class_init(GArrowBooleanArrayBuilderClass *klass)
 
 /**
  * garrow_boolean_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowBooleanArrayBuilder.
  */
 GArrowBooleanArrayBuilder *
-garrow_boolean_array_builder_new(GError **error)
+garrow_boolean_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::boolean(),
-                                          error,
+                                          NULL,
                                           "[boolean-array-builder][new]");
   return GARROW_BOOLEAN_ARRAY_BUILDER(builder);
 }
@@ -291,15 +290,14 @@ garrow_int8_array_builder_class_init(GArrowInt8ArrayBuilderClass *klass)
 
 /**
  * garrow_int8_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt8ArrayBuilder.
  */
 GArrowInt8ArrayBuilder *
-garrow_int8_array_builder_new(GError **error)
+garrow_int8_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::int8(),
-                                          error,
+                                          NULL,
                                           "[int8-array-builder][new]");
   return GARROW_INT8_ARRAY_BUILDER(builder);
 }
@@ -361,15 +359,14 @@ garrow_uint8_array_builder_class_init(GArrowUInt8ArrayBuilderClass *klass)
 
 /**
  * garrow_uint8_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt8ArrayBuilder.
  */
 GArrowUInt8ArrayBuilder *
-garrow_uint8_array_builder_new(GError **error)
+garrow_uint8_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::uint8(),
-                                          error,
+                                          NULL,
                                           "[uint8-array-builder][new]");
   return GARROW_UINT8_ARRAY_BUILDER(builder);
 }
@@ -431,15 +428,14 @@ garrow_int16_array_builder_class_init(GArrowInt16ArrayBuilderClass *klass)
 
 /**
  * garrow_int16_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt16ArrayBuilder.
  */
 GArrowInt16ArrayBuilder *
-garrow_int16_array_builder_new(GError **error)
+garrow_int16_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::int16(),
-                                          error,
+                                          NULL,
                                           "[int16-array-builder][new]");
   return GARROW_INT16_ARRAY_BUILDER(builder);
 }
@@ -501,15 +497,14 @@ garrow_uint16_array_builder_class_init(GArrowUInt16ArrayBuilderClass *klass)
 
 /**
  * garrow_uint16_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt16ArrayBuilder.
  */
 GArrowUInt16ArrayBuilder *
-garrow_uint16_array_builder_new(GError **error)
+garrow_uint16_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::uint16(),
-                                          error,
+                                          NULL,
                                           "[uint16-array-builder][new]");
   return GARROW_UINT16_ARRAY_BUILDER(builder);
 }
@@ -573,15 +568,14 @@ garrow_int32_array_builder_class_init(GArrowInt32ArrayBuilderClass *klass)
 
 /**
  * garrow_int32_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt32ArrayBuilder.
  */
 GArrowInt32ArrayBuilder *
-garrow_int32_array_builder_new(GError **error)
+garrow_int32_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::int32(),
-                                          error,
+                                          NULL,
                                           "[int32-array-builder][new]");
   return GARROW_INT32_ARRAY_BUILDER(builder);
 }
@@ -643,15 +637,14 @@ garrow_uint32_array_builder_class_init(GArrowUInt32ArrayBuilderClass *klass)
 
 /**
  * garrow_uint32_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt32ArrayBuilder.
  */
 GArrowUInt32ArrayBuilder *
-garrow_uint32_array_builder_new(GError **error)
+garrow_uint32_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::uint32(),
-                                          error,
+                                          NULL,
                                           "[uint32-array-builder][new]");
   return GARROW_UINT32_ARRAY_BUILDER(builder);
 }
@@ -715,15 +708,14 @@ garrow_int64_array_builder_class_init(GArrowInt64ArrayBuilderClass *klass)
 
 /**
  * garrow_int64_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowInt64ArrayBuilder.
  */
 GArrowInt64ArrayBuilder *
-garrow_int64_array_builder_new(GError **error)
+garrow_int64_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::int64(),
-                                          error,
+                                          NULL,
                                           "[int64-array-builder][new]");
   return GARROW_INT64_ARRAY_BUILDER(builder);
 }
@@ -785,15 +777,14 @@ garrow_uint64_array_builder_class_init(GArrowUInt64ArrayBuilderClass *klass)
 
 /**
  * garrow_uint64_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowUInt64ArrayBuilder.
  */
 GArrowUInt64ArrayBuilder *
-garrow_uint64_array_builder_new(GError **error)
+garrow_uint64_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::uint64(),
-                                          error,
+                                          NULL,
                                           "[uint64-array-builder][new]");
   return GARROW_UINT64_ARRAY_BUILDER(builder);
 }
@@ -860,15 +851,14 @@ garrow_float_array_builder_class_init(GArrowFloatArrayBuilderClass *klass)
 
 /**
  * garrow_float_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowFloatArrayBuilder.
  */
 GArrowFloatArrayBuilder *
-garrow_float_array_builder_new(GError **error)
+garrow_float_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::float32(),
-                                          error,
+                                          NULL,
                                           "[float-array-builder][new]");
   return GARROW_FLOAT_ARRAY_BUILDER(builder);
 }
@@ -930,15 +920,14 @@ garrow_double_array_builder_class_init(GArrowDoubleArrayBuilderClass *klass)
 
 /**
  * garrow_double_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowDoubleArrayBuilder.
  */
 GArrowDoubleArrayBuilder *
-garrow_double_array_builder_new(GError **error)
+garrow_double_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::float64(),
-                                          error,
+                                          NULL,
                                           "[double-array-builder][new]");
   return GARROW_DOUBLE_ARRAY_BUILDER(builder);
 }
@@ -1002,15 +991,14 @@ garrow_binary_array_builder_class_init(GArrowBinaryArrayBuilderClass *klass)
 
 /**
  * garrow_binary_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowBinaryArrayBuilder.
  */
 GArrowBinaryArrayBuilder *
-garrow_binary_array_builder_new(GError **error)
+garrow_binary_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::binary(),
-                                          error,
+                                          NULL,
                                           "[binary-array-builder][new]");
   return GARROW_BINARY_ARRAY_BUILDER(builder);
 }
@@ -1076,15 +1064,14 @@ garrow_string_array_builder_class_init(GArrowStringArrayBuilderClass *klass)
 
 /**
  * garrow_string_array_builder_new:
- * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowStringArrayBuilder.
  */
 GArrowStringArrayBuilder *
-garrow_string_array_builder_new(GError **error)
+garrow_string_array_builder_new(void)
 {
   auto builder = garrow_array_builder_new(arrow::utf8(),
-                                          error,
+                                          NULL,
                                           "[string-array-builder][new]");
   return GARROW_STRING_ARRAY_BUILDER(builder);
 }

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -110,7 +110,7 @@ struct _GArrowBooleanArrayBuilderClass
 
 GType garrow_boolean_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowBooleanArrayBuilder *garrow_boolean_array_builder_new(GError **error);
+GArrowBooleanArrayBuilder *garrow_boolean_array_builder_new(void);
 
 gboolean garrow_boolean_array_builder_append(GArrowBooleanArrayBuilder *builder,
                                              gboolean value,
@@ -161,7 +161,7 @@ struct _GArrowInt8ArrayBuilderClass
 
 GType garrow_int8_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt8ArrayBuilder *garrow_int8_array_builder_new(GError **error);
+GArrowInt8ArrayBuilder *garrow_int8_array_builder_new(void);
 
 gboolean garrow_int8_array_builder_append(GArrowInt8ArrayBuilder *builder,
                                           gint8 value,
@@ -212,7 +212,7 @@ struct _GArrowUInt8ArrayBuilderClass
 
 GType garrow_uint8_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt8ArrayBuilder *garrow_uint8_array_builder_new(GError **error);
+GArrowUInt8ArrayBuilder *garrow_uint8_array_builder_new(void);
 
 gboolean garrow_uint8_array_builder_append(GArrowUInt8ArrayBuilder *builder,
                                            guint8 value,
@@ -263,7 +263,7 @@ struct _GArrowInt16ArrayBuilderClass
 
 GType garrow_int16_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt16ArrayBuilder *garrow_int16_array_builder_new(GError **error);
+GArrowInt16ArrayBuilder *garrow_int16_array_builder_new(void);
 
 gboolean garrow_int16_array_builder_append(GArrowInt16ArrayBuilder *builder,
                                            gint16 value,
@@ -314,7 +314,7 @@ struct _GArrowUInt16ArrayBuilderClass
 
 GType garrow_uint16_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt16ArrayBuilder *garrow_uint16_array_builder_new(GError **error);
+GArrowUInt16ArrayBuilder *garrow_uint16_array_builder_new(void);
 
 gboolean garrow_uint16_array_builder_append(GArrowUInt16ArrayBuilder *builder,
                                             guint16 value,
@@ -365,7 +365,7 @@ struct _GArrowInt32ArrayBuilderClass
 
 GType garrow_int32_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt32ArrayBuilder *garrow_int32_array_builder_new(GError **error);
+GArrowInt32ArrayBuilder *garrow_int32_array_builder_new(void);
 
 gboolean garrow_int32_array_builder_append(GArrowInt32ArrayBuilder *builder,
                                            gint32 value,
@@ -416,7 +416,7 @@ struct _GArrowUInt32ArrayBuilderClass
 
 GType garrow_uint32_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt32ArrayBuilder *garrow_uint32_array_builder_new(GError **error);
+GArrowUInt32ArrayBuilder *garrow_uint32_array_builder_new(void);
 
 gboolean garrow_uint32_array_builder_append(GArrowUInt32ArrayBuilder *builder,
                                             guint32 value,
@@ -467,7 +467,7 @@ struct _GArrowInt64ArrayBuilderClass
 
 GType garrow_int64_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt64ArrayBuilder *garrow_int64_array_builder_new(GError **error);
+GArrowInt64ArrayBuilder *garrow_int64_array_builder_new(void);
 
 gboolean garrow_int64_array_builder_append(GArrowInt64ArrayBuilder *builder,
                                            gint64 value,
@@ -518,7 +518,7 @@ struct _GArrowUInt64ArrayBuilderClass
 
 GType garrow_uint64_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt64ArrayBuilder *garrow_uint64_array_builder_new(GError **error);
+GArrowUInt64ArrayBuilder *garrow_uint64_array_builder_new(void);
 
 gboolean garrow_uint64_array_builder_append(GArrowUInt64ArrayBuilder *builder,
                                             guint64 value,
@@ -569,7 +569,7 @@ struct _GArrowFloatArrayBuilderClass
 
 GType garrow_float_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowFloatArrayBuilder *garrow_float_array_builder_new(GError **error);
+GArrowFloatArrayBuilder *garrow_float_array_builder_new(void);
 
 gboolean garrow_float_array_builder_append(GArrowFloatArrayBuilder *builder,
                                            gfloat value,
@@ -620,7 +620,7 @@ struct _GArrowDoubleArrayBuilderClass
 
 GType garrow_double_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowDoubleArrayBuilder *garrow_double_array_builder_new(GError **error);
+GArrowDoubleArrayBuilder *garrow_double_array_builder_new(void);
 
 gboolean garrow_double_array_builder_append(GArrowDoubleArrayBuilder *builder,
                                             gdouble value,
@@ -671,7 +671,7 @@ struct _GArrowBinaryArrayBuilderClass
 
 GType garrow_binary_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowBinaryArrayBuilder *garrow_binary_array_builder_new(GError **error);
+GArrowBinaryArrayBuilder *garrow_binary_array_builder_new(void);
 
 gboolean garrow_binary_array_builder_append(GArrowBinaryArrayBuilder *builder,
                                             const guint8 *value,
@@ -723,7 +723,7 @@ struct _GArrowStringArrayBuilderClass
 
 GType garrow_string_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowStringArrayBuilder *garrow_string_array_builder_new(GError **error);
+GArrowStringArrayBuilder *garrow_string_array_builder_new(void);
 
 gboolean garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                             const gchar *value,

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -110,7 +110,7 @@ struct _GArrowBooleanArrayBuilderClass
 
 GType garrow_boolean_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowBooleanArrayBuilder *garrow_boolean_array_builder_new(void);
+GArrowBooleanArrayBuilder *garrow_boolean_array_builder_new(GError **error);
 
 gboolean garrow_boolean_array_builder_append(GArrowBooleanArrayBuilder *builder,
                                              gboolean value,
@@ -161,7 +161,7 @@ struct _GArrowInt8ArrayBuilderClass
 
 GType garrow_int8_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt8ArrayBuilder *garrow_int8_array_builder_new(void);
+GArrowInt8ArrayBuilder *garrow_int8_array_builder_new(GError **error);
 
 gboolean garrow_int8_array_builder_append(GArrowInt8ArrayBuilder *builder,
                                           gint8 value,
@@ -212,7 +212,7 @@ struct _GArrowUInt8ArrayBuilderClass
 
 GType garrow_uint8_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt8ArrayBuilder *garrow_uint8_array_builder_new(void);
+GArrowUInt8ArrayBuilder *garrow_uint8_array_builder_new(GError **error);
 
 gboolean garrow_uint8_array_builder_append(GArrowUInt8ArrayBuilder *builder,
                                            guint8 value,
@@ -263,7 +263,7 @@ struct _GArrowInt16ArrayBuilderClass
 
 GType garrow_int16_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt16ArrayBuilder *garrow_int16_array_builder_new(void);
+GArrowInt16ArrayBuilder *garrow_int16_array_builder_new(GError **error);
 
 gboolean garrow_int16_array_builder_append(GArrowInt16ArrayBuilder *builder,
                                            gint16 value,
@@ -314,7 +314,7 @@ struct _GArrowUInt16ArrayBuilderClass
 
 GType garrow_uint16_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt16ArrayBuilder *garrow_uint16_array_builder_new(void);
+GArrowUInt16ArrayBuilder *garrow_uint16_array_builder_new(GError **error);
 
 gboolean garrow_uint16_array_builder_append(GArrowUInt16ArrayBuilder *builder,
                                             guint16 value,
@@ -365,7 +365,7 @@ struct _GArrowInt32ArrayBuilderClass
 
 GType garrow_int32_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt32ArrayBuilder *garrow_int32_array_builder_new(void);
+GArrowInt32ArrayBuilder *garrow_int32_array_builder_new(GError **error);
 
 gboolean garrow_int32_array_builder_append(GArrowInt32ArrayBuilder *builder,
                                            gint32 value,
@@ -416,7 +416,7 @@ struct _GArrowUInt32ArrayBuilderClass
 
 GType garrow_uint32_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt32ArrayBuilder *garrow_uint32_array_builder_new(void);
+GArrowUInt32ArrayBuilder *garrow_uint32_array_builder_new(GError **error);
 
 gboolean garrow_uint32_array_builder_append(GArrowUInt32ArrayBuilder *builder,
                                             guint32 value,
@@ -467,7 +467,7 @@ struct _GArrowInt64ArrayBuilderClass
 
 GType garrow_int64_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowInt64ArrayBuilder *garrow_int64_array_builder_new(void);
+GArrowInt64ArrayBuilder *garrow_int64_array_builder_new(GError **error);
 
 gboolean garrow_int64_array_builder_append(GArrowInt64ArrayBuilder *builder,
                                            gint64 value,
@@ -518,7 +518,7 @@ struct _GArrowUInt64ArrayBuilderClass
 
 GType garrow_uint64_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowUInt64ArrayBuilder *garrow_uint64_array_builder_new(void);
+GArrowUInt64ArrayBuilder *garrow_uint64_array_builder_new(GError **error);
 
 gboolean garrow_uint64_array_builder_append(GArrowUInt64ArrayBuilder *builder,
                                             guint64 value,
@@ -569,7 +569,7 @@ struct _GArrowFloatArrayBuilderClass
 
 GType garrow_float_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowFloatArrayBuilder *garrow_float_array_builder_new(void);
+GArrowFloatArrayBuilder *garrow_float_array_builder_new(GError **error);
 
 gboolean garrow_float_array_builder_append(GArrowFloatArrayBuilder *builder,
                                            gfloat value,
@@ -620,7 +620,7 @@ struct _GArrowDoubleArrayBuilderClass
 
 GType garrow_double_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowDoubleArrayBuilder *garrow_double_array_builder_new(void);
+GArrowDoubleArrayBuilder *garrow_double_array_builder_new(GError **error);
 
 gboolean garrow_double_array_builder_append(GArrowDoubleArrayBuilder *builder,
                                             gdouble value,
@@ -671,7 +671,7 @@ struct _GArrowBinaryArrayBuilderClass
 
 GType garrow_binary_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowBinaryArrayBuilder *garrow_binary_array_builder_new(void);
+GArrowBinaryArrayBuilder *garrow_binary_array_builder_new(GError **error);
 
 gboolean garrow_binary_array_builder_append(GArrowBinaryArrayBuilder *builder,
                                             const guint8 *value,
@@ -723,7 +723,7 @@ struct _GArrowStringArrayBuilderClass
 
 GType garrow_string_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowStringArrayBuilder *garrow_string_array_builder_new(void);
+GArrowStringArrayBuilder *garrow_string_array_builder_new(GError **error);
 
 gboolean garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                             const gchar *value,
@@ -772,7 +772,8 @@ struct _GArrowListArrayBuilderClass
 
 GType garrow_list_array_builder_get_type(void) G_GNUC_CONST;
 
-GArrowListArrayBuilder *garrow_list_array_builder_new(GArrowArrayBuilder *value_builder);
+GArrowListArrayBuilder *garrow_list_array_builder_new(GArrowListDataType *data_type,
+                                                      GError **error);
 
 gboolean garrow_list_array_builder_append(GArrowListArrayBuilder *builder,
                                           GError **error);
@@ -825,7 +826,7 @@ struct _GArrowStructArrayBuilderClass
 GType garrow_struct_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowStructArrayBuilder *garrow_struct_array_builder_new(GArrowStructDataType *data_type,
-                                                          GList *field_builders);
+                                                          GError **error);
 
 gboolean garrow_struct_array_builder_append(GArrowStructArrayBuilder *builder,
                                             GError **error);

--- a/c_glib/arrow-glib/array-builder.hpp
+++ b/c_glib/arrow-glib/array-builder.hpp
@@ -22,5 +22,5 @@
 #include <arrow-glib/array.hpp>
 #include <arrow-glib/array-builder.h>
 
-GArrowArrayBuilder *garrow_array_builder_new_raw(std::shared_ptr<arrow::ArrayBuilder> *arrow_builder);
-std::shared_ptr<arrow::ArrayBuilder> garrow_array_builder_get_raw(GArrowArrayBuilder *builder);
+GArrowArrayBuilder *garrow_array_builder_new_raw(arrow::ArrayBuilder *arrow_builder);
+arrow::ArrayBuilder *garrow_array_builder_get_raw(GArrowArrayBuilder *builder);

--- a/c_glib/example/build.c
+++ b/c_glib/example/build.c
@@ -31,12 +31,7 @@ main(int argc, char **argv)
     gboolean success = TRUE;
     GError *error = NULL;
 
-    builder = garrow_int32_array_builder_new(&error);
-    if (error) {
-      g_print("failed to create array builder: %s\n", error->message);
-      g_error_free(error);
-      return EXIT_FAILURE;
-    }
+    builder = garrow_int32_array_builder_new();
     if (success) {
       success = garrow_int32_array_builder_append(builder, 29, &error);
     }

--- a/c_glib/example/build.c
+++ b/c_glib/example/build.c
@@ -31,7 +31,12 @@ main(int argc, char **argv)
     gboolean success = TRUE;
     GError *error = NULL;
 
-    builder = garrow_int32_array_builder_new();
+    builder = garrow_int32_array_builder_new(&error);
+    if (error) {
+      g_print("failed to create array builder: %s\n", error->message);
+      g_error_free(error);
+      return EXIT_FAILURE;
+    }
     if (success) {
       success = garrow_int32_array_builder_append(builder, 29, &error);
     }

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -69,9 +69,11 @@ module Helper
       build_array(Arrow::StringArrayBuilder, values)
     end
 
-    def build_list_array(value_builder_class, values_list)
-      value_builder = value_builder_class.new
-      builder = Arrow::ListArrayBuilder.new(value_builder)
+    def build_list_array(value_data_type, values_list)
+      value_field = Arrow::Field.new("value", value_data_type)
+      data_type = Arrow::ListDataType.new(value_field)
+      builder = Arrow::ListArrayBuilder.new(data_type)
+      value_builder = builder.value_builder
       values_list.each do |values|
         if values.nil?
           builder.append_null
@@ -90,13 +92,8 @@ module Helper
     end
 
     def build_struct_array(fields, structs)
-      field_builders = fields.collect do |field|
-        data_type_name = field.data_type.class.name
-        builder_name = data_type_name.gsub(/DataType/, "ArrayBuilder")
-        Arrow.const_get(builder_name).new
-      end
       data_type = Arrow::StructDataType.new(fields)
-      builder = Arrow::StructArrayBuilder.new(data_type, field_builders)
+      builder = Arrow::StructArrayBuilder.new(data_type)
       structs.each do |struct|
         if struct.nil?
           builder.append_null

--- a/c_glib/test/test-list-array.rb
+++ b/c_glib/test/test-list-array.rb
@@ -22,7 +22,7 @@ class TestListArray < Test::Unit::TestCase
     value_offsets = Arrow::Buffer.new([0, 2, 5, 5].pack("l*"))
     data = Arrow::Buffer.new([1, 2, 3, 4, 5].pack("c*"))
     values = Arrow::Int8Array.new(5, data, nil, 0)
-    assert_equal(build_list_array(Arrow::Int8ArrayBuilder,
+    assert_equal(build_list_array(Arrow::Int8DataType.new,
                                   [[1, 2], [3, 4, 5], nil]),
                  Arrow::ListArray.new(3,
                                       value_offsets,
@@ -32,7 +32,9 @@ class TestListArray < Test::Unit::TestCase
   end
 
   def test_value
-    builder = Arrow::ListArrayBuilder.new(Arrow::Int8ArrayBuilder.new)
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::ListDataType.new(field)
+    builder = Arrow::ListArrayBuilder.new(data_type)
     value_builder = builder.value_builder
 
     builder.append
@@ -51,7 +53,9 @@ class TestListArray < Test::Unit::TestCase
   end
 
   def test_value_type
-    builder = Arrow::ListArrayBuilder.new(Arrow::Int8ArrayBuilder.new)
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::ListDataType.new(field)
+    builder = Arrow::ListArrayBuilder.new(data_type)
     array = builder.finish
     assert_equal(Arrow::Int8DataType.new, array.value_type)
   end

--- a/c_glib/test/test-struct-array.rb
+++ b/c_glib/test/test-struct-array.rb
@@ -55,11 +55,7 @@ class TestStructArray < Test::Unit::TestCase
       Arrow::Field.new("enabled", Arrow::BooleanDataType.new),
     ]
     data_type = Arrow::StructDataType.new(fields)
-    field_builders = [
-      Arrow::Int8ArrayBuilder.new,
-      Arrow::BooleanArrayBuilder.new,
-    ]
-    builder = Arrow::StructArrayBuilder.new(data_type, field_builders)
+    builder = Arrow::StructArrayBuilder.new(data_type)
 
     builder.append
     builder.get_field_builder(0).append(-29)

--- a/cpp/src/arrow/python/builtin_convert.h
+++ b/cpp/src/arrow/python/builtin_convert.h
@@ -42,9 +42,8 @@ ARROW_EXPORT arrow::Status InferArrowTypeAndSize(
     PyObject* obj, int64_t* size, std::shared_ptr<arrow::DataType>* out_type);
 ARROW_EXPORT arrow::Status InferArrowSize(PyObject* obj, int64_t* size);
 
-ARROW_EXPORT arrow::Status AppendPySequence(PyObject* obj,
-    const std::shared_ptr<arrow::DataType>& type,
-    const std::shared_ptr<arrow::ArrayBuilder>& builder, int64_t size);
+ARROW_EXPORT arrow::Status AppendPySequence(PyObject* obj, int64_t size,
+    const std::shared_ptr<arrow::DataType>& type, arrow::ArrayBuilder* builder);
 
 // Type and size inference
 ARROW_EXPORT

--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -756,7 +756,7 @@ def get_generated_json_files():
         generate_primitive_case([0, 0, 0]),
         generate_datetime_case(),
         generate_nested_case(),
-        # generate_dictionary_case()
+        generate_dictionary_case()
     ]
 
     generated_paths = []
@@ -943,7 +943,7 @@ def get_static_json_files():
 
 
 def run_all_tests(debug=False):
-    testers = [CPPTester(debug=debug), JavaTester(debug=debug)]
+    testers = [CPPTester(debug=debug)]  # , JavaTester(debug=debug)]
     static_json_files = get_static_json_files()
     generated_json_files = get_generated_json_files()
     json_files = static_json_files + generated_json_files


### PR DESCRIPTION
The intent is to make the API simpler and perhaps in some cases more performant (since sharing ownership of builders is not too common, there won't be a need to deal with atomic reference counts). I happened on this when looking at ARROW-1114 where there might be quite a bit of overhead dealing with `std::vector<std::shared_ptr<ArrayBuilder>>`