### PR TITLE
ARROW-1181: [Python] Parquet multiindex test should be optional

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -848,7 +848,7 @@ def test_read_multiple_files(tmpdir):
     with pytest.raises(ValueError):
         read_multiple_files(mixed_paths)
 
-
+@parquet
 def test_multiindex_duplicate_values(tmpdir):
     num_rows = 3
     numbers = list(range(num_rows))


### PR DESCRIPTION
Test `test_multiindex_duplicate_values()` fails if parquet not installed.  Added annotation which makes the test optional.