### PR TITLE
ARROW-1185: [C++] Status class cleanup, warn_unused_result attribute and Clang warning fixes

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -341,3 +341,21 @@ Copyright: 2013 Daniel Lemire
 Home page: http://lemire.me/en/
 Project page: https://github.com/lemire/FrameOfReference
 License: Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This project includes code from the TensorFlow project
+
+Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/cpp/src/arrow/array-decimal-test.cc
+++ b/cpp/src/arrow/array-decimal-test.cc
@@ -41,25 +41,27 @@ class DecimalTestBase {
     size_t null_count = 0;
 
     size_t size = draw.size();
-    builder->Reserve(size);
+    ASSERT_OK(builder->Reserve(size));
 
     for (size_t i = 0; i < size; ++i) {
       if (valid_bytes[i]) {
-        builder->Append(draw[i]);
+        ASSERT_OK(builder->Append(draw[i]));
       } else {
-        builder->AppendNull();
+        ASSERT_OK(builder->AppendNull());
         ++null_count;
       }
     }
 
     std::shared_ptr<Buffer> expected_sign_bitmap;
     if (!sign_bitmap.empty()) {
-      BitUtil::BytesToBits(sign_bitmap, &expected_sign_bitmap);
+      ASSERT_OK(BitUtil::BytesToBits(sign_bitmap, &expected_sign_bitmap));
     }
 
     auto raw_bytes = data(draw, byte_width);
     auto expected_data = std::make_shared<Buffer>(raw_bytes.data(), size * byte_width);
-    auto expected_null_bitmap = test::bytes_to_null_buffer(valid_bytes);
+    std::shared_ptr<Buffer> expected_null_bitmap;
+    ASSERT_OK(BitUtil::BytesToBits(valid_bytes, &expected_null_bitmap));
+
     int64_t expected_null_count = test::null_count(valid_bytes);
     auto expected = std::make_shared<DecimalArray>(type, size, expected_data,
         expected_null_bitmap, expected_null_count, offset, expected_sign_bitmap);
@@ -170,14 +172,14 @@ TEST_P(Decimal128BuilderTest, WithNulls) {
 }
 
 INSTANTIATE_TEST_CASE_P(Decimal32BuilderTest, Decimal32BuilderTest,
-    ::testing::Range(DecimalPrecision<int32_t>::minimum,
-                            DecimalPrecision<int32_t>::maximum));
+    ::testing::Range(
+        DecimalPrecision<int32_t>::minimum, DecimalPrecision<int32_t>::maximum));
 INSTANTIATE_TEST_CASE_P(Decimal64BuilderTest, Decimal64BuilderTest,
-    ::testing::Range(DecimalPrecision<int64_t>::minimum,
-                            DecimalPrecision<int64_t>::maximum));
+    ::testing::Range(
+        DecimalPrecision<int64_t>::minimum, DecimalPrecision<int64_t>::maximum));
 INSTANTIATE_TEST_CASE_P(Decimal128BuilderTest, Decimal128BuilderTest,
-    ::testing::Range(DecimalPrecision<int128_t>::minimum,
-                            DecimalPrecision<int128_t>::maximum));
+    ::testing::Range(
+        DecimalPrecision<int128_t>::minimum, DecimalPrecision<int128_t>::maximum));
 
 }  // namespace decimal
 }  // namespace arrow

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -25,12 +25,6 @@ namespace arrow {
 
 constexpr int64_t kFinalSize = 256;
 
-#define ABORT_NOT_OK(s)                              \
-  do {                                               \
-    ::arrow::Status _s = (s);                        \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) { exit(-1); } \
-  } while (0);
-
 static void BM_BuildPrimitiveArrayNoNulls(
     benchmark::State& state) {  // NOLINT non-const reference
   // 2 MiB block

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -897,7 +897,7 @@ ARROW_EXPORT Status DecimalBuilder::Append(const decimal::Decimal128& value) {
 Status DecimalBuilder::Init(int64_t capacity) {
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Init(capacity));
   if (byte_width_ == 16) {
-    AllocateResizableBuffer(pool_, null_bitmap_->size(), &sign_bitmap_);
+    RETURN_NOT_OK(AllocateResizableBuffer(pool_, null_bitmap_->size(), &sign_bitmap_));
     sign_bitmap_data_ = sign_bitmap_->mutable_data();
     memset(sign_bitmap_data_, 0, static_cast<size_t>(sign_bitmap_->capacity()));
   }

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -111,6 +111,7 @@
 #include "arrow/buffer.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace io {
@@ -434,7 +435,7 @@ ReadableFile::ReadableFile(MemoryPool* pool) {
 }
 
 ReadableFile::~ReadableFile() {
-  impl_->Close();
+  DCHECK(impl_->Close().ok());
 }
 
 Status ReadableFile::Open(const std::string& path, std::shared_ptr<ReadableFile>* file) {
@@ -497,7 +498,7 @@ FileOutputStream::FileOutputStream() {
 
 FileOutputStream::~FileOutputStream() {
   // This can fail; better to explicitly call close
-  impl_->Close();
+  DCHECK(impl_->Close().ok());
 }
 
 Status FileOutputStream::Open(
@@ -538,7 +539,7 @@ class MemoryMappedFile::MemoryMap : public MutableBuffer {
   ~MemoryMap() {
     if (file_->is_open()) {
       munmap(mutable_data_, static_cast<size_t>(size_));
-      file_->Close();
+      DCHECK(file_->Close().ok());
     }
   }
 

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -27,6 +27,7 @@
 #include "arrow/io/hdfs.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace io {
@@ -191,7 +192,7 @@ HdfsReadableFile::HdfsReadableFile(MemoryPool* pool) {
 }
 
 HdfsReadableFile::~HdfsReadableFile() {
-  impl_->Close();
+  DCHECK(impl_->Close().ok());
 }
 
 Status HdfsReadableFile::Close() {
@@ -271,7 +272,7 @@ HdfsOutputStream::HdfsOutputStream() {
 }
 
 HdfsOutputStream::~HdfsOutputStream() {
-  impl_->Close();
+  DCHECK(impl_->Close().ok());
 }
 
 Status HdfsOutputStream::Close() {

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -125,12 +125,12 @@ TEST_F(TestFileOutputStream, Close) {
   ASSERT_OK(file_->Write(reinterpret_cast<const uint8_t*>(data), strlen(data)));
 
   int fd = file_->file_descriptor();
-  file_->Close();
+  ASSERT_OK(file_->Close());
 
   ASSERT_TRUE(FileIsClosed(fd));
 
   // Idempotent
-  file_->Close();
+  ASSERT_OK(file_->Close());
 
   std::shared_ptr<ReadableFile> rd_file;
   ASSERT_OK(ReadableFile::Open(path_, &rd_file));
@@ -215,12 +215,12 @@ TEST_F(TestReadableFile, Close) {
   OpenFile();
 
   int fd = file_->file_descriptor();
-  file_->Close();
+  ASSERT_OK(file_->Close());
 
   ASSERT_TRUE(FileIsClosed(fd));
 
   // Idempotent
-  file_->Close();
+  ASSERT_OK(file_->Close());
 }
 
 TEST_F(TestReadableFile, SeekTellSize) {
@@ -446,7 +446,7 @@ TEST_F(TestMemoryMappedFile, ReadOnly) {
     ASSERT_OK(rwmmap->Write(buffer.data(), buffer_size));
     position += buffer_size;
   }
-  rwmmap->Close();
+  ASSERT_OK(rwmmap->Close());
 
   std::shared_ptr<MemoryMappedFile> rommap;
   ASSERT_OK(MemoryMappedFile::Open(path, FileMode::READ, &rommap));
@@ -459,7 +459,7 @@ TEST_F(TestMemoryMappedFile, ReadOnly) {
     ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size));
     position += buffer_size;
   }
-  rommap->Close();
+  ASSERT_OK(rommap->Close());
 }
 
 TEST_F(TestMemoryMappedFile, DISABLED_ReadWriteOver4GbFile) {
@@ -481,7 +481,7 @@ TEST_F(TestMemoryMappedFile, DISABLED_ReadWriteOver4GbFile) {
     ASSERT_OK(rwmmap->Write(buffer.data(), buffer_size));
     position += buffer_size;
   }
-  rwmmap->Close();
+  ASSERT_OK(rwmmap->Close());
 
   std::shared_ptr<MemoryMappedFile> rommap;
   ASSERT_OK(MemoryMappedFile::Open(path, FileMode::READ, &rommap));
@@ -494,7 +494,7 @@ TEST_F(TestMemoryMappedFile, DISABLED_ReadWriteOver4GbFile) {
     ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size));
     position += buffer_size;
   }
-  rommap->Close();
+  ASSERT_OK(rommap->Close());
 }
 
 TEST_F(TestMemoryMappedFile, RetainMemoryMapReference) {

--- a/cpp/src/arrow/io/io-hdfs-test.cc
+++ b/cpp/src/arrow/io/io-hdfs-test.cc
@@ -87,10 +87,9 @@ class TestHdfsClient : public ::testing::Test {
     LibHdfsShim* driver_shim;
 
     client_ = nullptr;
-    scratch_dir_ =
-        boost::filesystem::unique_path(
-            boost::filesystem::temp_directory_path() / "arrow-hdfs/scratch-%%%%")
-            .string();
+    scratch_dir_ = boost::filesystem::unique_path(
+        boost::filesystem::temp_directory_path() / "arrow-hdfs/scratch-%%%%")
+                       .string();
 
     loaded_driver_ = false;
 

--- a/cpp/src/arrow/io/io-memory-benchmark.cc
+++ b/cpp/src/arrow/io/io-memory-benchmark.cc
@@ -29,15 +29,15 @@ static void BM_SerialMemcopy(benchmark::State& state) {  // NOLINT non-const ref
   constexpr int64_t kTotalSize = 100 * 1024 * 1024;      // 100MB
 
   auto buffer1 = std::make_shared<PoolBuffer>(default_memory_pool());
-  buffer1->Resize(kTotalSize);
+  ABORT_NOT_OK(buffer1->Resize(kTotalSize));
 
   auto buffer2 = std::make_shared<PoolBuffer>(default_memory_pool());
-  buffer2->Resize(kTotalSize);
+  ABORT_NOT_OK(buffer2->Resize(kTotalSize));
   test::random_bytes(kTotalSize, 0, buffer2->mutable_data());
 
   while (state.KeepRunning()) {
     io::FixedSizeBufferWriter writer(buffer1);
-    writer.Write(buffer2->data(), buffer2->size());
+    ABORT_NOT_OK(writer.Write(buffer2->data(), buffer2->size()));
   }
   state.SetBytesProcessed(int64_t(state.iterations()) * kTotalSize);
 }
@@ -46,16 +46,16 @@ static void BM_ParallelMemcopy(benchmark::State& state) {  // NOLINT non-const r
   constexpr int64_t kTotalSize = 100 * 1024 * 1024;        // 100MB
 
   auto buffer1 = std::make_shared<PoolBuffer>(default_memory_pool());
-  buffer1->Resize(kTotalSize);
+  ABORT_NOT_OK(buffer1->Resize(kTotalSize));
 
   auto buffer2 = std::make_shared<PoolBuffer>(default_memory_pool());
-  buffer2->Resize(kTotalSize);
+  ABORT_NOT_OK(buffer2->Resize(kTotalSize));
   test::random_bytes(kTotalSize, 0, buffer2->mutable_data());
 
   while (state.KeepRunning()) {
     io::FixedSizeBufferWriter writer(buffer1);
     writer.set_memcopy_threads(4);
-    writer.Write(buffer2->data(), buffer2->size());
+    ABORT_NOT_OK(writer.Write(buffer2->data(), buffer2->size()));
   }
   state.SetBytesProcessed(int64_t(state.iterations()) * kTotalSize);
 }

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -121,16 +121,16 @@ TEST(TestMemcopy, ParallelMemcopy) {
     int64_t total_size = 3 * 1024 * 1024 + std::rand() % 100;
 
     auto buffer1 = std::make_shared<PoolBuffer>(default_memory_pool());
-    buffer1->Resize(total_size);
+    ASSERT_OK(buffer1->Resize(total_size));
 
     auto buffer2 = std::make_shared<PoolBuffer>(default_memory_pool());
-    buffer2->Resize(total_size);
+    ASSERT_OK(buffer2->Resize(total_size));
     test::random_bytes(total_size, 0, buffer2->mutable_data());
 
     io::FixedSizeBufferWriter writer(buffer1);
     writer.set_memcopy_threads(4);
     writer.set_memcopy_threshold(1024 * 1024);
-    writer.Write(buffer2->data(), buffer2->size());
+    ASSERT_OK(writer.Write(buffer2->data(), buffer2->size()));
 
     ASSERT_EQ(0, memcmp(buffer1->data(), buffer2->data(), buffer1->size()));
   }

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -55,7 +55,7 @@ Status BufferOutputStream::Create(int64_t initial_capacity, MemoryPool* pool,
 
 BufferOutputStream::~BufferOutputStream() {
   // This can fail, better to explicitly call close
-  if (buffer_) { Close(); }
+  if (buffer_) { DCHECK(Close().ok()); }
 }
 
 Status BufferOutputStream::Close() {

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -50,7 +50,7 @@ class TestTableBuilder : public ::testing::Test {
   void SetUp() { tb_.reset(new TableBuilder(1000)); }
 
   virtual void Finish() {
-    tb_->Finish();
+    ASSERT_OK(tb_->Finish());
 
     table_.reset(new TableMetadata());
     ASSERT_OK(table_->Open(tb_->GetBuffer()));
@@ -107,7 +107,7 @@ TEST_F(TestTableBuilder, AddPrimitiveColumn) {
   std::string user_meta = "as you wish";
   cb->SetUserMetadata(user_meta);
 
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   cb = tb_->AddColumn("f1");
 
@@ -118,7 +118,7 @@ TEST_F(TestTableBuilder, AddPrimitiveColumn) {
   values2.total_bytes = 10000;
 
   cb->SetValues(values2);
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   Finish();
 
@@ -148,12 +148,12 @@ TEST_F(TestTableBuilder, AddCategoryColumn) {
   std::unique_ptr<ColumnBuilder> cb = tb_->AddColumn("c0");
   cb->SetValues(values1);
   cb->SetCategory(levels);
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   cb = tb_->AddColumn("c1");
   cb->SetValues(values1);
   cb->SetCategory(levels, true);
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   Finish();
 
@@ -182,7 +182,7 @@ TEST_F(TestTableBuilder, AddTimestampColumn) {
   std::unique_ptr<ColumnBuilder> cb = tb_->AddColumn("c0");
   cb->SetValues(values1);
   cb->SetTimestamp(TimeUnit::MILLI);
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   cb = tb_->AddColumn("c1");
 
@@ -190,7 +190,7 @@ TEST_F(TestTableBuilder, AddTimestampColumn) {
 
   cb->SetValues(values1);
   cb->SetTimestamp(TimeUnit::SECOND, tz);
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   Finish();
 
@@ -216,7 +216,7 @@ TEST_F(TestTableBuilder, AddDateColumn) {
   std::unique_ptr<ColumnBuilder> cb = tb_->AddColumn("d0");
   cb->SetValues(values1);
   cb->SetDate();
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
 
   Finish();
 
@@ -233,7 +233,7 @@ TEST_F(TestTableBuilder, AddTimeColumn) {
   std::unique_ptr<ColumnBuilder> cb = tb_->AddColumn("c0");
   cb->SetValues(values1);
   cb->SetTime(TimeUnit::SECOND);
-  cb->Finish();
+  ASSERT_OK(cb->Finish());
   Finish();
 
   auto col = table_->column(0);
@@ -379,7 +379,7 @@ TEST_F(TestTableWriter, TimeTypes) {
 
   for (int i = 1; i < schema->num_fields(); ++i) {
     std::shared_ptr<Array> arr;
-    LoadArray(schema->field(i)->type(), fields, buffers, &arr);
+    ASSERT_OK(LoadArray(schema->field(i)->type(), fields, buffers, &arr));
     arrays.push_back(arr);
   }
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -498,7 +498,7 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
 
   Status Finalize() {
     RETURN_NOT_OK(CheckStarted());
-    metadata_.Finish();
+    RETURN_NOT_OK(metadata_.Finish());
 
     auto buffer = metadata_.GetBuffer();
 
@@ -655,8 +655,7 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
   Status Append(const std::string& name, const Array& values) {
     current_column_ = metadata_.AddColumn(name);
     RETURN_NOT_OK(values.Accept(this));
-    current_column_->Finish();
-    return Status::OK();
+    return current_column_->Finish();
   }
 
  private:

--- a/cpp/src/arrow/ipc/ipc-json-test.cc
+++ b/cpp/src/arrow/ipc/ipc-json-test.cc
@@ -224,10 +224,10 @@ void MakeBatchArrays(const std::shared_ptr<Schema>& schema, const int num_rows,
   StringBuilder string_builder(default_memory_pool());
   for (int i = 0; i < num_rows; ++i) {
     if (!is_valid[i]) {
-      string_builder.AppendNull();
+      ASSERT_OK(string_builder.AppendNull());
     } else {
       test::random_ascii(kBufferSize, seed++, buffer);
-      string_builder.Append(buffer, kBufferSize);
+      ASSERT_OK(string_builder.Append(buffer, kBufferSize));
     }
   }
   std::shared_ptr<Array> v3;

--- a/cpp/src/arrow/ipc/ipc-read-write-benchmark.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-benchmark.cc
@@ -46,13 +46,13 @@ std::shared_ptr<RecordBatch> MakeRecordBatch(int64_t total_size, int64_t num_fie
   typename TypeTraits<TYPE>::BuilderType builder(pool, type);
   for (size_t i = 0; i < values.size(); ++i) {
     if (is_valid[i]) {
-      builder.Append(values[i]);
+      ABORT_NOT_OK(builder.Append(values[i]));
     } else {
-      builder.AppendNull();
+      ABORT_NOT_OK(builder.AppendNull());
     }
   }
   std::shared_ptr<Array> array;
-  builder.Finish(&array);
+  ABORT_NOT_OK(builder.Finish(&array));
 
   ArrayVector arrays;
   std::vector<std::shared_ptr<Field>> fields;
@@ -72,7 +72,7 @@ static void BM_WriteRecordBatch(benchmark::State& state) {  // NOLINT non-const 
   constexpr int64_t kTotalSize = 1 << 20;
 
   auto buffer = std::make_shared<PoolBuffer>(default_memory_pool());
-  buffer->Resize(kTotalSize & 2);
+  ABORT_NOT_OK(buffer->Resize(kTotalSize & 2));
   auto record_batch = MakeRecordBatch<Int64Type>(kTotalSize, state.range(0));
 
   while (state.KeepRunning()) {
@@ -80,7 +80,7 @@ static void BM_WriteRecordBatch(benchmark::State& state) {  // NOLINT non-const 
     int32_t metadata_length;
     int64_t body_length;
     if (!ipc::WriteRecordBatch(*record_batch, 0, &stream, &metadata_length, &body_length,
-             default_memory_pool())
+            default_memory_pool())
              .ok()) {
       state.SkipWithError("Failed to write!");
     }
@@ -93,7 +93,7 @@ static void BM_ReadRecordBatch(benchmark::State& state) {  // NOLINT non-const r
   constexpr int64_t kTotalSize = 1 << 20;
 
   auto buffer = std::make_shared<PoolBuffer>(default_memory_pool());
-  buffer->Resize(kTotalSize & 2);
+  ABORT_NOT_OK(buffer->Resize(kTotalSize & 2));
   auto record_batch = MakeRecordBatch<Int64Type>(kTotalSize, state.range(0));
 
   io::BufferOutputStream stream(buffer);
@@ -101,7 +101,7 @@ static void BM_ReadRecordBatch(benchmark::State& state) {  // NOLINT non-const r
   int32_t metadata_length;
   int64_t body_length;
   if (!ipc::WriteRecordBatch(*record_batch, 0, &stream, &metadata_length, &body_length,
-           default_memory_pool())
+          default_memory_pool())
            .ok()) {
     state.SkipWithError("Failed to write!");
   }

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -974,12 +974,12 @@ class ArrayReader {
     DCHECK_EQ(static_cast<int32_t>(json_data_arr.Size()), length_);
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
-        builder.AppendNull();
+        RETURN_NOT_OK(builder.AppendNull());
         continue;
       }
 
       const rj::Value& val = json_data_arr[i];
-      builder.Append(UnboxValue<T>(val));
+      RETURN_NOT_OK(builder.Append(UnboxValue<T>(val)));
     }
 
     return builder.Finish(&result_);
@@ -1000,14 +1000,14 @@ class ArrayReader {
     auto byte_buffer = std::make_shared<PoolBuffer>(pool_);
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
-        builder.AppendNull();
+        RETURN_NOT_OK(builder.AppendNull());
         continue;
       }
 
       const rj::Value& val = json_data_arr[i];
       DCHECK(val.IsString());
       if (std::is_base_of<StringType, T>::value) {
-        builder.Append(val.GetString());
+        RETURN_NOT_OK(builder.Append(val.GetString()));
       } else {
         std::string hex_string = val.GetString();
 
@@ -1048,7 +1048,7 @@ class ArrayReader {
 
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
-        builder.AppendNull();
+        RETURN_NOT_OK(builder.AppendNull());
         continue;
       }
 

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -87,10 +87,10 @@ TEST_F(TestPrettyPrint, FixedSizeBinaryType) {
   auto type = fixed_size_binary(3);
   FixedSizeBinaryBuilder builder(default_memory_pool(), type);
 
-  builder.Append(values[0]);
-  builder.Append(values[1]);
-  builder.Append(values[2]);
-  builder.Finish(&array);
+  ASSERT_OK(builder.Append(values[0]));
+  ASSERT_OK(builder.Append(values[1]));
+  ASSERT_OK(builder.Append(values[2]));
+  ASSERT_OK(builder.Finish(&array));
 
   CheckArray(*array, 0, ex);
 }

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -464,9 +464,8 @@ class FixedWidthBytesConverter
   inline Status AppendItem(const OwnedRef& item) {
     PyObject* bytes_obj;
     OwnedRef tmp;
-    Py_ssize_t expected_length =
-        std::dynamic_pointer_cast<FixedSizeBinaryType>(typed_builder_->type())
-            ->byte_width();
+    Py_ssize_t expected_length = std::dynamic_pointer_cast<FixedSizeBinaryType>(
+        typed_builder_->type())->byte_width();
     if (item.obj() == Py_None) {
       RETURN_NOT_OK(typed_builder_->AppendNull());
       return Status::OK();
@@ -518,7 +517,7 @@ class ListConverter : public TypedConverterVisitor<ListBuilder, ListConverter> {
     if (item.obj() == Py_None) {
       return typed_builder_->AppendNull();
     } else {
-      typed_builder_->Append();
+      RETURN_NOT_OK(typed_builder_->Append());
       PyObject* item_obj = item.obj();
       int64_t list_size = static_cast<int64_t>(PySequence_Size(item_obj));
       return value_converter_->AppendData(item_obj, list_size);
@@ -607,8 +606,7 @@ Status ListConverter::Init(ArrayBuilder* builder) {
     return Status::NotImplemented("value type not implemented");
   }
 
-  value_converter_->Init(typed_builder_->value_builder());
-  return Status::OK();
+  return value_converter_->Init(typed_builder_->value_builder());
 }
 
 Status AppendPySequence(PyObject* obj, int64_t size,
@@ -620,8 +618,7 @@ Status AppendPySequence(PyObject* obj, int64_t size,
     ss << "No type converter implemented for " << type->ToString();
     return Status::NotImplemented(ss.str());
   }
-  converter->Init(builder);
-
+  RETURN_NOT_OK(converter->Init(builder));
   return converter->AppendData(obj, size);
 }
 

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -537,9 +537,9 @@ Status PandasConverter::ConvertDates() {
   for (int64_t i = 0; i < length_; ++i) {
     obj = objects[i];
     if (PyDate_CheckExact(obj)) {
-      date_builder.Append(UnboxDate<ArrowType>::Unbox(obj));
+      RETURN_NOT_OK(date_builder.Append(UnboxDate<ArrowType>::Unbox(obj)));
     } else if (PandasObjectIsNull(obj)) {
-      date_builder.AppendNull();
+      RETURN_NOT_OK(date_builder.AppendNull());
     } else {
       return InvalidConversion(obj, "date");
     }
@@ -592,7 +592,7 @@ Status PandasConverter::ConvertDecimals() {
           break;
       }
     } else if (PandasObjectIsNull(object)) {
-      decimal_builder.AppendNull();
+      RETURN_NOT_OK(decimal_builder.AppendNull());
     } else {
       return InvalidConversion(object, "decimal.Decimal");
     }
@@ -939,7 +939,7 @@ inline Status PandasConverter::ConvertTypedLists(const std::shared_ptr<DataType>
       int64_t size = PyArray_DIM(numpy_array, 0);
       auto data = reinterpret_cast<const T*>(PyArray_DATA(numpy_array));
       if (traits::supports_nulls) {
-        null_bitmap_->Resize(size, false);
+        RETURN_NOT_OK(null_bitmap_->Resize(size, false));
         // TODO(uwe): A bitmap would be more space-efficient but the Builder API doesn't
         // currently support this.
         // ValuesToBitmap<ITEM_TYPE>(data, size, null_bitmap_->mutable_data());
@@ -2423,7 +2423,7 @@ class ArrowDeserializer {
   }
 
   Status Visit(const StructType& type) {
-    AllocateOutput(NPY_OBJECT);
+    RETURN_NOT_OK(AllocateOutput(NPY_OBJECT));
     auto out_values = reinterpret_cast<PyObject**>(PyArray_DATA(arr_));
     return ConvertStruct(data_, out_values);
   }

--- a/cpp/src/arrow/python/python-test.cc
+++ b/cpp/src/arrow/python/python-test.cc
@@ -77,7 +77,7 @@ TEST(PandasConversionTest, TestObjectBlockWriteFails) {
   const char value[] = {'\xf1', '\0'};
 
   for (int i = 0; i < 1000; ++i) {
-    builder.Append(value, static_cast<int32_t>(strlen(value)));
+    ASSERT_OK(builder.Append(value, static_cast<int32_t>(strlen(value))));
   }
 
   std::shared_ptr<Array> arr;

--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -59,6 +59,12 @@
     EXPECT_TRUE(s.ok());        \
   } while (0)
 
+#define ABORT_NOT_OK(s)                              \
+  do {                                               \
+    ::arrow::Status _s = (s);                        \
+    if (ARROW_PREDICT_FALSE(!_s.ok())) { exit(-1); } \
+  } while (0);
+
 namespace arrow {
 
 using ArrayVector = std::vector<std::shared_ptr<Array>>;
@@ -174,14 +180,6 @@ static inline int64_t null_count(const std::vector<uint8_t>& valid_bytes) {
     if (valid_bytes[i] == 0) { ++result; }
   }
   return result;
-}
-
-std::shared_ptr<Buffer> bytes_to_null_buffer(const std::vector<uint8_t>& bytes) {
-  std::shared_ptr<Buffer> out;
-
-  // TODO(wesm): error checking
-  BitUtil::BytesToBits(bytes, &out);
-  return out;
 }
 
 Status MakeRandomInt32PoolBuffer(int64_t length, MemoryPool* pool,

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -188,7 +188,7 @@ TEST_F(TestSchema, TestAddMetadata) {
       new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
   auto schema = std::make_shared<Schema>(fields);
   std::shared_ptr<Schema> new_schema;
-  schema->AddMetadata(metadata, &new_schema);
+  ASSERT_OK(schema->AddMetadata(metadata, &new_schema));
   ASSERT_TRUE(metadata->Equals(*new_schema->metadata()));
 
   // Not copied

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -34,7 +34,7 @@
 
 namespace arrow {
 
-void BitUtil::BytesToBits(const std::vector<uint8_t>& bytes, uint8_t* bits) {
+void BitUtil::FillBitsFromBytes(const std::vector<uint8_t>& bytes, uint8_t* bits) {
   for (size_t i = 0; i < bytes.size(); ++i) {
     if (bytes[i] > 0) { SetBit(bits, i); }
   }
@@ -48,7 +48,7 @@ Status BitUtil::BytesToBits(
   RETURN_NOT_OK(AllocateBuffer(default_memory_pool(), bit_length, &buffer));
 
   memset(buffer->mutable_data(), 0, static_cast<size_t>(bit_length));
-  BytesToBits(bytes, buffer->mutable_data());
+  FillBitsFromBytes(bytes, buffer->mutable_data());
 
   *out = buffer;
   return Status::OK();

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -441,7 +441,7 @@ static T ShiftRightLogical(T v, int shift) {
   return static_cast<typename make_unsigned<T>::type>(v) >> shift;
 }
 
-void BytesToBits(const std::vector<uint8_t>& bytes, uint8_t* bits);
+void FillBitsFromBytes(const std::vector<uint8_t>& bytes, uint8_t* bits);
 ARROW_EXPORT Status BytesToBits(const std::vector<uint8_t>&, std::shared_ptr<Buffer>*);
 
 }  // namespace BitUtil

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -249,7 +249,7 @@ TYPED_TEST(DecimalZerosTest, LeadingZerosNoDecimalPoint) {
   Decimal<TypeParam> d;
   int precision;
   int scale;
-  FromString(string_value, &d, &precision, &scale);
+  ASSERT_OK(FromString(string_value, &d, &precision, &scale));
   ASSERT_EQ(precision, 7);
   ASSERT_EQ(scale, 0);
   ASSERT_EQ(d.value, 0);
@@ -260,7 +260,7 @@ TYPED_TEST(DecimalZerosTest, LeadingZerosDecimalPoint) {
   Decimal<TypeParam> d;
   int precision;
   int scale;
-  FromString(string_value, &d, &precision, &scale);
+  ASSERT_OK(FromString(string_value, &d, &precision, &scale));
   // We explicitly do not support this for now, otherwise this would be ASSERT_EQ
   ASSERT_NE(precision, 7);
 
@@ -273,7 +273,7 @@ TYPED_TEST(DecimalZerosTest, NoLeadingZerosDecimalPoint) {
   Decimal<TypeParam> d;
   int precision;
   int scale;
-  FromString(string_value, &d, &precision, &scale);
+  ASSERT_OK(FromString(string_value, &d, &precision, &scale));
   ASSERT_EQ(precision, 5);
   ASSERT_EQ(scale, 5);
   ASSERT_EQ(d.value, 0);

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -51,7 +51,7 @@ ARROW_EXPORT Status FromString(const std::string& s, Decimal<T>* out,
 template <typename T>
 struct ARROW_EXPORT Decimal {
   Decimal() : value() {}
-  explicit Decimal(const std::string& s) : value() { FromString(s, this); }
+  explicit Decimal(const std::string& s) : value() { DCHECK(FromString(s, this).ok()); }
   explicit Decimal(const char* s) : Decimal(std::string(s)) {}
   explicit Decimal(const T& value) : value(value) {}
 

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -41,4 +41,12 @@
 #define ARROW_PREDICT_TRUE(x) x
 #endif
 
+#if (defined(__GNUC__) || defined(__APPLE__))
+#define ARROW_MUST_USE_RESULT __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+#define ARROW_MUST_USE_RESULT
+#else
+#define ARROW_MUST_USE_RESULT
+#endif
+
 #endif  // ARROW_UTIL_MACROS_H

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -404,8 +404,10 @@ void PlasmaStore::connect_client(int listener_sock) {
   Client* client = new Client(client_fd);
   // Add a callback to handle events on this socket.
   // TODO(pcm): Check return value.
-  loop_->add_file_event(
-      client_fd, kEventLoopRead, [this, client](int events) { process_message(client); });
+  loop_->add_file_event(client_fd, kEventLoopRead, [this, client](int events) {
+    Status s = process_message(client);
+    if (!s.ok()) { ARROW_LOG(FATAL) << "Failed to process file event: " << s; }
+  });
   ARROW_LOG(DEBUG) << "New connection with fd " << client_fd;
 }
 


### PR DESCRIPTION
This was tedious, but overdue. The Status class in Arrow as originally imported from Apache Kudu, which had been modified from standard use in Google projects. I simplified the implementation to bring it more in line with the Status implementation used in TensorFlow.

This also addresses ARROW-111 by providing an attribute to warn in Clang if a Status is ignored