### PR TITLE
ARROW-1190: [JAVA] Fixing VectorLoader for duplicate field names

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -55,10 +55,8 @@ public class VectorLoader {
   public void load(ArrowRecordBatch recordBatch) {
     Iterator<ArrowBuf> buffers = recordBatch.getBuffers().iterator();
     Iterator<ArrowFieldNode> nodes = recordBatch.getNodes().iterator();
-    List<Field> fields = root.getSchema().getFields();
-    for (Field field: fields) {
-      FieldVector fieldVector = root.getVector(field.getName());
-      loadBuffers(fieldVector, field, buffers, nodes);
+    for (FieldVector fieldVector: root.getFieldVectors()) {
+      loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes);
     }
     root.setRowCount(recordBatch.getLength());
     if (nodes.hasNext() || buffers.hasNext()) {


### PR DESCRIPTION
VectorLoader was corrupting data when some of the fields had same name in which case only one of that vectors got properly loaded. This PR resolves the problem by avoiding by-name field lookups.