### PR TITLE
ARROW-1174: [GLib] Fix ListArray test failure

### DIFF
--- a/c_glib/test/run-test.rb
+++ b/c_glib/test/run-test.rb
@@ -32,6 +32,15 @@ ENV["GI_TYPELIB_PATH"] = [
 require "gi"
 
 Arrow = GI.load("Arrow")
+module Arrow
+  class Buffer
+    alias_method :initialize_raw, :initialize
+    def initialize(data)
+      initialize_raw(data)
+      @data = data
+    end
+  end
+end
 
 require "tempfile"
 require_relative "helper/buildable"


### PR DESCRIPTION
Data passed into `Arrow::Buffer` isn't owned by `Arrow::Buffer`. It's GLib bindings spec for optimization.
We should keep `Arrow::Buffer` data until `Arrow::Buffer` is alive.