### PR TITLE
ARROW-1193: [C++] Support pkg-config for arrow_python.so

### DIFF
--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -95,6 +95,14 @@ install(FILES
   type_traits.h
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/python")
 
+# pkg-config support
+configure_file(arrow-python.pc.in
+  "${CMAKE_CURRENT_BINARY_DIR}/arrow-python.pc"
+  @ONLY)
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-python.pc"
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+
 if (ARROW_BUILD_TESTS)
   ADD_ARROW_TEST(python-test
     STATIC_LINK_LIBS "${ARROW_PYTHON_TEST_LINK_LIBS}")

--- a/cpp/src/arrow/python/arrow-python.pc.in
+++ b/cpp/src/arrow/python/arrow-python.pc.in
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: Apache Arrow Python
+Description: Python integration library for Apache Arrow
+Version: @ARROW_VERSION@
+Requires: arrow
+Libs: -L${libdir} -larrow_python @PYTHON_LIBRARIES@
+Cflags: -I${includedir} -I@PYTHON_INCLUDE_DIRS@

--- a/cpp/src/arrow/python/arrow-python.pc.in
+++ b/cpp/src/arrow/python/arrow-python.pc.in
@@ -23,5 +23,5 @@ Name: Apache Arrow Python
 Description: Python integration library for Apache Arrow
 Version: @ARROW_VERSION@
 Requires: arrow
-Libs: -L${libdir} -larrow_python @PYTHON_LIBRARIES@
+Libs: -L${libdir} -larrow_python
 Cflags: -I${includedir} -I@PYTHON_INCLUDE_DIRS@


### PR DESCRIPTION
I want it to create a Ruby library that integrates Python via Apache Arrow object in the same process.
[pycall](https://rubygems.org/gems/pycall) gem provides a feature to use Python objects in Ruby script in the same process. In this situation, we can change Apache Arrow data between Ruby and Python as Ruby/Python object instead of writing/reading Apache Arrow objects.