### PR TITLE
ARROW-1074: Support lists and arrays in pandas DataFrames without explicit schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ MANIFEST
 
 cpp/.idea/
 python/.eggs/
+.vscode

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -159,13 +159,14 @@ class SeqVisitor {
     if (PySequence_Check(obj)) {
       Py_ssize_t size = PySequence_Size(obj);
       for (int64_t i = 0; i < size; ++i) {
+        OwnedRef ref;
         if (PyArray_Check(obj)) {
           auto array = reinterpret_cast<PyArrayObject*>(obj);
           auto ptr = reinterpret_cast<const char*>(PyArray_GETPTR1(array, i));
-          OwnedRef ref = OwnedRef(PyArray_GETITEM(array, ptr));
+          ref.reset(PyArray_GETITEM(array, ptr));
           RETURN_NOT_OK(VisitElem(ref, level));
         } else {
-          OwnedRef ref = OwnedRef(PySequence_GetItem(obj, i));
+          ref.reset(PySequence_GetItem(obj, i));
           RETURN_NOT_OK(VisitElem(ref, level));
         }
       }

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -164,8 +164,7 @@ class SeqVisitor {
           auto ptr = reinterpret_cast<const char*>(PyArray_GETPTR1(array, i));
           OwnedRef ref = OwnedRef(PyArray_GETITEM(array, ptr));
           RETURN_NOT_OK(VisitElem(ref, level));
-        } 
-        else {
+        } else {
           OwnedRef ref = OwnedRef(PySequence_GetItem(obj, i));
           RETURN_NOT_OK(VisitElem(ref, level));
         }
@@ -287,16 +286,13 @@ Status InferArrowSize(PyObject* obj, int64_t* size) {
 
 // Non-exhaustive type inference
 Status InferArrowType(PyObject* obj, std::shared_ptr<DataType>* out_type) {
-
   PyDateTime_IMPORT;
   SeqVisitor seq_visitor;
   RETURN_NOT_OK(seq_visitor.Visit(obj));
   RETURN_NOT_OK(seq_visitor.Validate());
 
   *out_type = seq_visitor.GetType();
-  if (*out_type == nullptr) {
-    return Status::TypeError("Unable to determine data type");
-  }
+  if (*out_type == nullptr) { return Status::TypeError("Unable to determine data type"); }
 
   return Status::OK();
 }
@@ -304,7 +300,7 @@ Status InferArrowType(PyObject* obj, std::shared_ptr<DataType>* out_type) {
 Status InferArrowTypeAndSize(
     PyObject* obj, int64_t* size, std::shared_ptr<DataType>* out_type) {
   RETURN_NOT_OK(InferArrowSize(obj, size));
-  
+
   // For 0-length sequences, refuse to guess
   if (*size == 0) {
     *out_type = null();
@@ -480,8 +476,9 @@ class FixedWidthBytesConverter
   inline Status AppendItem(const OwnedRef& item) {
     PyObject* bytes_obj;
     OwnedRef tmp;
-    Py_ssize_t expected_length = std::dynamic_pointer_cast<FixedSizeBinaryType>(
-        typed_builder_->type())->byte_width();
+    Py_ssize_t expected_length =
+        std::dynamic_pointer_cast<FixedSizeBinaryType>(typed_builder_->type())
+            ->byte_width();
     if (item.obj() == Py_None) {
       RETURN_NOT_OK(typed_builder_->AppendNull());
       return Status::OK();

--- a/cpp/src/arrow/python/builtin_convert.h
+++ b/cpp/src/arrow/python/builtin_convert.h
@@ -38,7 +38,8 @@ class Status;
 
 namespace py {
 
-ARROW_EXPORT arrow::Status InferArrowType(PyObject* obj, std::shared_ptr<arrow::DataType>* out_type);
+ARROW_EXPORT arrow::Status InferArrowType(
+    PyObject* obj, std::shared_ptr<arrow::DataType>* out_type);
 ARROW_EXPORT arrow::Status InferArrowTypeAndSize(
     PyObject* obj, int64_t* size, std::shared_ptr<arrow::DataType>* out_type);
 ARROW_EXPORT arrow::Status InferArrowSize(PyObject* obj, int64_t* size);

--- a/cpp/src/arrow/python/builtin_convert.h
+++ b/cpp/src/arrow/python/builtin_convert.h
@@ -38,6 +38,7 @@ class Status;
 
 namespace py {
 
+ARROW_EXPORT arrow::Status InferArrowType(PyObject* obj, std::shared_ptr<arrow::DataType>* out_type);
 ARROW_EXPORT arrow::Status InferArrowTypeAndSize(
     PyObject* obj, int64_t* size, std::shared_ptr<arrow::DataType>* out_type);
 ARROW_EXPORT arrow::Status InferArrowSize(PyObject* obj, int64_t* size);

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -893,6 +893,11 @@ Status PandasConverter::ConvertObjects() {
         return ConvertDates<Date32Type>();
       } else if (PyObject_IsInstance(const_cast<PyObject*>(objects[i]), Decimal.obj())) {
         return ConvertDecimals();
+      } else if (PyList_Check(objects[i])) {
+        int64_t size;
+        std::shared_ptr<DataType> inferred_type;
+        RETURN_NOT_OK(InferArrowTypeAndSize(objects[i], &size, &inferred_type));
+        return ConvertLists(inferred_type);
       } else {
         return InvalidConversion(
             const_cast<PyObject*>(objects[i]), "string, bool, float, int, date, decimal");

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -898,8 +898,7 @@ Status PandasConverter::ConvertObjects() {
         RETURN_NOT_OK(InferArrowType(objects[i], &inferred_type));
         return ConvertLists(inferred_type);
       } else {
-        return InvalidConversion(
-            const_cast<PyObject*>(objects[i]), 
+        return InvalidConversion(const_cast<PyObject*>(objects[i]),
             "string, bool, float, int, date, decimal, list, array");
       }
     }

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -893,14 +893,14 @@ Status PandasConverter::ConvertObjects() {
         return ConvertDates<Date32Type>();
       } else if (PyObject_IsInstance(const_cast<PyObject*>(objects[i]), Decimal.obj())) {
         return ConvertDecimals();
-      } else if (PyList_Check(objects[i])) {
-        int64_t size;
+      } else if (PyList_Check(objects[i]) || PyArray_Check(objects[i])) {
         std::shared_ptr<DataType> inferred_type;
-        RETURN_NOT_OK(InferArrowTypeAndSize(objects[i], &size, &inferred_type));
+        RETURN_NOT_OK(InferArrowType(objects[i], &inferred_type));
         return ConvertLists(inferred_type);
       } else {
         return InvalidConversion(
-            const_cast<PyObject*>(objects[i]), "string, bool, float, int, date, decimal");
+            const_cast<PyObject*>(objects[i]), 
+            "string, bool, float, int, date, decimal, list, array");
       }
     }
   }
@@ -1039,7 +1039,10 @@ Status PandasConverter::ConvertLists(const std::shared_ptr<DataType>& type) {
     LIST_CASE(DOUBLE, NPY_DOUBLE, DoubleType)
     LIST_CASE(STRING, NPY_OBJECT, StringType)
     default:
-      return Status::TypeError("Unknown list item type");
+      std::stringstream ss;
+      ss << "Unknown list item type: ";
+      ss << type->ToString();
+      return Status::TypeError(ss.str());
   }
 
   return Status::TypeError("Unknown list type");

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -691,3 +691,17 @@ class TestPandasConversion(unittest.TestCase):
 
         series = pd.Series(arr.to_pandas())
         tm.assert_series_equal(series, expected)
+
+    def test_lists(self):
+        data = OrderedDict([
+            ('ints', [[0], [1]]),
+            ('strs', [['a'], ['b']])
+        ])
+        df = pd.DataFrame(data)
+
+        expected_schema = pa.schema([
+            pa.field('ints', pa.list_(pa.int64())),
+            pa.field('strs', pa.list_(pa.string()))
+        ])
+
+        self._check_pandas_roundtrip(df, expected_schema=expected_schema)

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -692,16 +692,32 @@ class TestPandasConversion(unittest.TestCase):
         series = pd.Series(arr.to_pandas())
         tm.assert_series_equal(series, expected)
 
-    def test_lists(self):
+    def test_infer_lists(self):
         data = OrderedDict([
-            ('ints', [[0], [1]]),
-            ('strs', [['a'], ['b']])
+            ('nan_ints', [[None, 1], [2, 3]]),
+            ('ints', [[0, 1], [2, 3]]),
+            ('strs', [[None, 'b'], ['c', 'd']])
         ])
         df = pd.DataFrame(data)
 
         expected_schema = pa.schema([
+            pa.field('nan_ints', pa.list_(pa.int64())),
             pa.field('ints', pa.list_(pa.int64())),
             pa.field('strs', pa.list_(pa.string()))
+        ])
+
+        self._check_pandas_roundtrip(df, expected_schema=expected_schema)
+
+    def test_infer_numpy_array(self):
+        data = OrderedDict([
+            ('ints', [
+                np.array([0, 1], dtype=np.int64),
+                np.array([2, 3], dtype=np.int64)
+            ])
+        ])
+        df = pd.DataFrame(data)
+        expected_schema = pa.schema([
+            pa.field('ints', pa.list_(pa.int64()))
         ])
 
         self._check_pandas_roundtrip(df, expected_schema=expected_schema)

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -696,7 +696,7 @@ class TestPandasConversion(unittest.TestCase):
         data = OrderedDict([
             ('nan_ints', [[None, 1], [2, 3]]),
             ('ints', [[0, 1], [2, 3]]),
-            ('strs', [[None, 'b'], ['c', 'd']])
+            ('strs', [[None, u'b'], [u'c', u'd']])
         ])
         df = pd.DataFrame(data)
 


### PR DESCRIPTION
This introduces automatic type inference for lists and numpy arrays in a pandas data frame. 

Partial implementation for: https://issues.apache.org/jira/browse/ARROW-575