### PR TITLE
ARROW-1194: [Python] Expose MockOutputStream in pyarrow.

### DIFF
--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -100,6 +100,23 @@ Status BufferOutputStream::Reserve(int64_t nbytes) {
 }
 
 // ----------------------------------------------------------------------
+// OutputStream that doesn't write anything
+
+Status MockOutputStream::Close() {
+  return Status::OK();
+}
+
+Status MockOutputStream::Tell(int64_t* position) {
+  *position = extent_bytes_written_;
+  return Status::OK();
+}
+
+Status MockOutputStream::Write(const uint8_t* data, int64_t nbytes) {
+  extent_bytes_written_ += nbytes;
+  return Status::OK();
+}
+
+// ----------------------------------------------------------------------
 // In-memory buffer writer
 
 static constexpr int kMemcopyDefaultNumThreads = 1;

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -67,6 +67,22 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   uint8_t* mutable_data_;
 };
 
+// A helper class to tracks the size of allocations
+class ARROW_EXPORT MockOutputStream : public OutputStream {
+ public:
+  MockOutputStream() : extent_bytes_written_(0) {}
+
+  // Implement the OutputStream interface
+  Status Close() override;
+  Status Tell(int64_t* position) override;
+  Status Write(const uint8_t* data, int64_t nbytes) override;
+
+  int64_t GetExtentBytesWritten() const { return extent_bytes_written_; }
+
+ private:
+  int64_t extent_bytes_written_;
+};
+
 /// \brief Enables random writes into a fixed-size mutable buffer
 ///
 class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -340,7 +340,7 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBuffers) {
 }
 
 void TestGetRecordBatchSize(std::shared_ptr<RecordBatch> batch) {
-  ipc::MockOutputStream mock;
+  io::MockOutputStream mock;
   int32_t mock_metadata_length = -1;
   int64_t mock_body_length = -1;
   int64_t size = -1;

--- a/cpp/src/arrow/ipc/util.h
+++ b/cpp/src/arrow/ipc/util.h
@@ -37,29 +37,6 @@ static inline int64_t PaddedLength(int64_t nbytes, int64_t alignment = kArrowAli
   return ((nbytes + alignment - 1) / alignment) * alignment;
 }
 
-// A helper class to tracks the size of allocations
-class MockOutputStream : public io::OutputStream {
- public:
-  MockOutputStream() : extent_bytes_written_(0) {}
-
-  Status Close() override { return Status::OK(); }
-
-  Status Write(const uint8_t* data, int64_t nbytes) override {
-    extent_bytes_written_ += nbytes;
-    return Status::OK();
-  }
-
-  Status Tell(int64_t* position) override {
-    *position = extent_bytes_written_;
-    return Status::OK();
-  }
-
-  int64_t GetExtentBytesWritten() const { return extent_bytes_written_; }
-
- private:
-  int64_t extent_bytes_written_;
-};
-
 }  // namespace ipc
 }  // namespace arrow
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -566,7 +566,7 @@ Status GetRecordBatchSize(const RecordBatch& batch, int64_t* size) {
   // emulates the behavior of Write without actually writing
   int32_t metadata_length = 0;
   int64_t body_length = 0;
-  MockOutputStream dst;
+  io::MockOutputStream dst;
   RETURN_NOT_OK(WriteRecordBatch(batch, 0, &dst, &metadata_length, &body_length,
       default_memory_pool(), kMaxNestingDepth, true));
   *size = dst.GetExtentBytesWritten();
@@ -577,7 +577,7 @@ Status GetTensorSize(const Tensor& tensor, int64_t* size) {
   // emulates the behavior of Write without actually writing
   int32_t metadata_length = 0;
   int64_t body_length = 0;
-  MockOutputStream dst;
+  io::MockOutputStream dst;
   RETURN_NOT_OK(WriteTensor(tensor, &dst, &metadata_length, &body_length));
   *size = dst.GetExtentBytesWritten();
   return Status::OK();

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -68,7 +68,7 @@ from pyarrow.lib import (HdfsFile, NativeFile, PythonFile,
                          frombuffer, read_tensor, write_tensor,
                          memory_map, create_memory_map,
                          get_record_batch_size, get_tensor_size,
-                         have_libhdfs, have_libhdfs3)
+                         have_libhdfs, have_libhdfs3, MockOutputStream)
 
 from pyarrow.lib import (MemoryPool, total_allocated_bytes,
                          set_memory_pool, default_memory_pool)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -540,6 +540,11 @@ cdef extern from "arrow/io/memory.h" namespace "arrow::io" nogil:
         (OutputStream):
         CBufferOutputStream(const shared_ptr[ResizableBuffer]& buffer)
 
+    cdef cppclass CMockOutputStream" arrow::io::MockOutputStream"\
+        (OutputStream):
+        CMockOutputStream()
+        int64_t GetExtentBytesWritten()
+
 
 cdef extern from "arrow/ipc/metadata.h" namespace "arrow::ipc" nogil:
     cdef cppclass SchemaMessage:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -534,6 +534,18 @@ cdef class BufferOutputStream(NativeFile):
         return pyarrow_wrap_buffer(<shared_ptr[CBuffer]> self.buffer)
 
 
+cdef class MockOutputStream(NativeFile):
+
+    def __cinit__(self):
+        self.wr_file.reset(new CMockOutputStream())
+        self.is_readable = 0
+        self.is_writeable = 1
+        self.is_open = True
+
+    def size(self):
+        return (<CMockOutputStream*>self.wr_file.get()).GetExtentBytesWritten()
+
+
 cdef class BufferReader(NativeFile):
     """
     Zero-copy reader from objects convertible to Arrow buffer


### PR DESCRIPTION
This allows you to get the size of a record batch and schema through pyarrow by writing to a mock output stream. You can then use the resulting size to allocate an appropriately sized buffer to actually write to.

Example usage.

```python
import pyarrow as pa
import pandas as pd

val = pd.DataFrame({'a': [1, 2, 3]})
record_batch = pa.RecordBatch.from_pandas(val)

# Get the size of the record batch and schema
sink = pa.MockOutputStream()
stream_writer = pa.RecordBatchStreamWriter(sink, record_batch.schema)
stream_writer.write_batch(record_batch)
size = sink.size()
```