### PR TITLE
ARROW-1206: [C++] Add finer grained control of compression library support, do not expose symbols which may not be built in compression.h

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -142,8 +142,20 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     "Build with SSE4 optimizations"
     OFF)
 
+  option(ARROW_WITH_BROTLI
+    "Build with Brotli compression"
+    ON)
+
   option(ARROW_WITH_LZ4
     "Build with lz4 compression"
+    ON)
+
+  option(ARROW_WITH_SNAPPY
+    "Build with Snappy compression"
+    ON)
+
+  option(ARROW_WITH_ZLIB
+    "Build with zlib compression"
     ON)
 
   option(ARROW_WITH_ZSTD
@@ -167,19 +179,21 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 endif()
 
-if(ARROW_BUILD_TESTS)
+if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   set(ARROW_BUILD_STATIC ON)
+  set(ARROW_WITH_BROTLI ON)
   set(ARROW_WITH_LZ4 ON)
+  set(ARROW_WITH_SNAPPY ON)
+  set(ARROW_WITH_ZLIB ON)
   set(ARROW_WITH_ZSTD ON)
-else()
+endif()
+
+if(NOT ARROW_BUILD_TESTS)
   set(NO_TESTS 1)
 endif()
 
 if(NOT ARROW_BUILD_BENCHMARKS)
   set(NO_BENCHMARKS 1)
-else()
-  set(ARROW_WITH_LZ4 ON)
-  set(ARROW_WITH_ZSTD ON)
 endif()
 
 if(ARROW_HDFS)
@@ -544,15 +558,26 @@ endif()
 # Linker and Dependencies
 ############################################################
 
-set(ARROW_STATIC_LINK_LIBS
-  brotli_dec
-  brotli_enc
-  brotli_common
-  snappy
-  zlib)
+set(ARROW_STATIC_LINK_LIBS)
+
+if (ARROW_WITH_BROTLI)
+  SET(ARROW_STATIC_LINK_LIBS
+    brotli_dec
+    brotli_enc
+    brotli_common
+    ${ARROW_STATIC_LINK_LIBS})
+endif()
 
 if (ARROW_WITH_LZ4)
   SET(ARROW_STATIC_LINK_LIBS lz4_static ${ARROW_STATIC_LINK_LIBS})
+endif()
+
+if (ARROW_WITH_SNAPPY)
+  SET(ARROW_STATIC_LINK_LIBS snappy ${ARROW_STATIC_LINK_LIBS})
+endif()
+
+if (ARROW_WITH_ZLIB)
+  SET(ARROW_STATIC_LINK_LIBS zlib ${ARROW_STATIC_LINK_LIBS})
 endif()
 
 if (ARROW_WITH_ZSTD)
@@ -683,19 +708,33 @@ set(ARROW_SRCS
 
   src/arrow/util/bit-util.cc
   src/arrow/util/compression.cc
-  src/arrow/util/compression_brotli.cc
-  src/arrow/util/compression_snappy.cc
-  src/arrow/util/compression_zlib.cc
   src/arrow/util/cpu-info.cc
   src/arrow/util/decimal.cc
   src/arrow/util/key_value_metadata.cc
 )
 
+if (ARROW_WITH_BROTLI)
+  add_definitions(-DARROW_WITH_BROTLI)
+  SET(ARROW_SRCS src/arrow/util/compression_brotli.cc ${ARROW_SRCS})
+endif()
+
 if (ARROW_WITH_LZ4)
+  add_definitions(-DARROW_WITH_LZ4)
   SET(ARROW_SRCS src/arrow/util/compression_lz4.cc ${ARROW_SRCS})
 endif()
 
+if (ARROW_WITH_SNAPPY)
+  add_definitions(-DARROW_WITH_SNAPPY)
+  SET(ARROW_SRCS src/arrow/util/compression_snappy.cc ${ARROW_SRCS})
+endif()
+
+if (ARROW_WITH_ZLIB)
+  add_definitions(-DARROW_WITH_ZLIB)
+  SET(ARROW_SRCS src/arrow/util/compression_zlib.cc ${ARROW_SRCS})
+endif()
+
 if (ARROW_WITH_ZSTD)
+  add_definitions(-DARROW_WITH_ZSTD)
   SET(ARROW_SRCS src/arrow/util/compression_zstd.cc ${ARROW_SRCS})
 endif()
 

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -26,6 +26,11 @@ install(FILES
   bpacking.h
   compiler-util.h
   compression.h
+  compression_brotli.h
+  compression_lz4.h
+  compression_snappy.h
+  compression_zlib.h
+  compression_zstd.h
   cpu-info.h
   key_value_metadata.h
   hash-util.h

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -22,6 +22,26 @@
 #include <sstream>
 #include <string>
 
+#ifdef ARROW_WITH_BROTLI
+#include "arrow/util/compression_brotli.h"
+#endif
+
+#ifdef ARROW_WITH_SNAPPY
+#include "arrow/util/compression_snappy.h"
+#endif
+
+#ifdef ARROW_WITH_LZ4
+#include "arrow/util/compression_lz4.h"
+#endif
+
+#ifdef ARROW_WITH_ZLIB
+#include "arrow/util/compression_zlib.h"
+#endif
+
+#ifdef ARROW_WITH_ZSTD
+#include "arrow/util/compression_zstd.h"
+#endif
+
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
 
@@ -34,15 +54,41 @@ Status Codec::Create(Compression::type codec_type, std::unique_ptr<Codec>* resul
     case Compression::UNCOMPRESSED:
       break;
     case Compression::SNAPPY:
+#ifdef ARROW_WITH_SNAPPY
       result->reset(new SnappyCodec());
+#else
+      return Status::NotImplemented("Snappy codec support not built");
+#endif
       break;
     case Compression::GZIP:
+#ifdef ARROW_WITH_ZLIB
       result->reset(new GZipCodec());
+#else
+      return Status::NotImplemented("Gzip codec support not built");
+#endif
       break;
     case Compression::LZO:
       return Status::NotImplemented("LZO codec not implemented");
     case Compression::BROTLI:
+#ifdef ARROW_WITH_BROTLI
       result->reset(new BrotliCodec());
+#else
+      return Status::NotImplemented("Brotli codec support not built");
+#endif
+      break;
+    case Compression::LZ4:
+#ifdef ARROW_WITH_LZ4
+      result->reset(new Lz4Codec());
+#else
+      return Status::NotImplemented("LZ4 codec support not built");
+#endif
+      break;
+    case Compression::ZSTD:
+#ifdef ARROW_WITH_ZSTD
+      result->reset(new ZSTDCodec());
+#else
+      return Status::NotImplemented("ZSTD codec support not built");
+#endif
       break;
     default:
       return Status::Invalid("Unrecognized codec");

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/compression.h"
+#include "arrow/util/compression_brotli.h"
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/arrow/util/compression_brotli.h
+++ b/cpp/src/arrow/util/compression_brotli.h
@@ -15,38 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_UTIL_COMPRESSION_H
-#define ARROW_UTIL_COMPRESSION_H
+#ifndef ARROW_UTIL_COMPRESSION_BROTLI_H
+#define ARROW_UTIL_COMPRESSION_BROTLI_H
 
 #include <cstdint>
 #include <memory>
 
 #include "arrow/status.h"
-#include "arrow/util/visibility.h"
+#include "arrow/util/compression.h"
 
 namespace arrow {
 
-struct Compression {
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, ZSTD, LZ4 };
-};
-
-class ARROW_EXPORT Codec {
+// Brotli codec.
+class ARROW_EXPORT BrotliCodec : public Codec {
  public:
-  virtual ~Codec();
+  Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
+      uint8_t* output_buffer) override;
 
-  static Status Create(Compression::type codec, std::unique_ptr<Codec>* out);
+  Status Compress(int64_t input_len, const uint8_t* input, int64_t output_buffer_len,
+      uint8_t* output_buffer, int64_t* output_length) override;
 
-  virtual Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
-      uint8_t* output_buffer) = 0;
+  int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  virtual Status Compress(int64_t input_len, const uint8_t* input,
-      int64_t output_buffer_len, uint8_t* output_buffer, int64_t* output_length) = 0;
-
-  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) = 0;
-
-  virtual const char* name() const = 0;
+  const char* name() const override { return "brotli"; }
 };
 
 }  // namespace arrow
 
-#endif
+#endif  // ARROW_UTIL_COMPRESSION_BROTLI_H

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/compression.h"
+#include "arrow/util/compression_lz4.h"
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/arrow/util/compression_lz4.h
+++ b/cpp/src/arrow/util/compression_lz4.h
@@ -15,38 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_UTIL_COMPRESSION_H
-#define ARROW_UTIL_COMPRESSION_H
+#ifndef ARROW_UTIL_COMPRESSION_LZ4_H
+#define ARROW_UTIL_COMPRESSION_LZ4_H
 
 #include <cstdint>
 #include <memory>
 
 #include "arrow/status.h"
-#include "arrow/util/visibility.h"
+#include "arrow/util/compression.h"
 
 namespace arrow {
 
-struct Compression {
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, ZSTD, LZ4 };
-};
-
-class ARROW_EXPORT Codec {
+// Lz4 codec.
+class ARROW_EXPORT Lz4Codec : public Codec {
  public:
-  virtual ~Codec();
+  Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
+      uint8_t* output_buffer) override;
 
-  static Status Create(Compression::type codec, std::unique_ptr<Codec>* out);
+  Status Compress(int64_t input_len, const uint8_t* input, int64_t output_buffer_len,
+      uint8_t* output_buffer, int64_t* output_length) override;
 
-  virtual Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
-      uint8_t* output_buffer) = 0;
+  int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  virtual Status Compress(int64_t input_len, const uint8_t* input,
-      int64_t output_buffer_len, uint8_t* output_buffer, int64_t* output_length) = 0;
-
-  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) = 0;
-
-  virtual const char* name() const = 0;
+  const char* name() const override { return "lz4"; }
 };
 
 }  // namespace arrow
 
-#endif
+#endif  // ARROW_UTIL_COMPRESSION_LZ4_H

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/compression.h"
+#include "arrow/util/compression_snappy.h"
 
 // Work around warning caused by Snappy include
 #ifdef DISALLOW_COPY_AND_ASSIGN

--- a/cpp/src/arrow/util/compression_snappy.h
+++ b/cpp/src/arrow/util/compression_snappy.h
@@ -15,38 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_UTIL_COMPRESSION_H
-#define ARROW_UTIL_COMPRESSION_H
+#ifndef ARROW_UTIL_COMPRESSION_SNAPPY_H
+#define ARROW_UTIL_COMPRESSION_SNAPPY_H
 
 #include <cstdint>
 #include <memory>
 
 #include "arrow/status.h"
-#include "arrow/util/visibility.h"
+#include "arrow/util/compression.h"
 
 namespace arrow {
 
-struct Compression {
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, ZSTD, LZ4 };
-};
-
-class ARROW_EXPORT Codec {
+class ARROW_EXPORT SnappyCodec : public Codec {
  public:
-  virtual ~Codec();
+  Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
+      uint8_t* output_buffer) override;
 
-  static Status Create(Compression::type codec, std::unique_ptr<Codec>* out);
+  Status Compress(int64_t input_len, const uint8_t* input, int64_t output_buffer_len,
+      uint8_t* output_buffer, int64_t* output_length) override;
 
-  virtual Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
-      uint8_t* output_buffer) = 0;
+  int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  virtual Status Compress(int64_t input_len, const uint8_t* input,
-      int64_t output_buffer_len, uint8_t* output_buffer, int64_t* output_length) = 0;
-
-  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) = 0;
-
-  virtual const char* name() const = 0;
+  const char* name() const override { return "snappy"; }
 };
 
 }  // namespace arrow
 
-#endif
+#endif  // ARROW_UTIL_COMPRESSION_SNAPPY_H

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/compression.h"
+#include "arrow/util/compression_zlib.h"
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/arrow/util/compression_zlib.h
+++ b/cpp/src/arrow/util/compression_zlib.h
@@ -15,38 +15,46 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_UTIL_COMPRESSION_H
-#define ARROW_UTIL_COMPRESSION_H
+#ifndef ARROW_UTIL_COMPRESSION_ZLIB_H
+#define ARROW_UTIL_COMPRESSION_ZLIB_H
 
 #include <cstdint>
 #include <memory>
 
 #include "arrow/status.h"
-#include "arrow/util/visibility.h"
+#include "arrow/util/compression.h"
 
 namespace arrow {
 
-struct Compression {
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, ZSTD, LZ4 };
-};
-
-class ARROW_EXPORT Codec {
+// GZip codec.
+class ARROW_EXPORT GZipCodec : public Codec {
  public:
-  virtual ~Codec();
+  /// Compression formats supported by the zlib library
+  enum Format {
+    ZLIB,
+    DEFLATE,
+    GZIP,
+  };
 
-  static Status Create(Compression::type codec, std::unique_ptr<Codec>* out);
+  explicit GZipCodec(Format format = GZIP);
+  virtual ~GZipCodec();
 
-  virtual Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
-      uint8_t* output_buffer) = 0;
+  Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
+      uint8_t* output_buffer) override;
 
-  virtual Status Compress(int64_t input_len, const uint8_t* input,
-      int64_t output_buffer_len, uint8_t* output_buffer, int64_t* output_length) = 0;
+  Status Compress(int64_t input_len, const uint8_t* input, int64_t output_buffer_len,
+      uint8_t* output_buffer, int64_t* output_length) override;
 
-  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) = 0;
+  int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  virtual const char* name() const = 0;
+  const char* name() const override;
+
+ private:
+  // The gzip compressor is stateful
+  class GZipCodecImpl;
+  std::unique_ptr<GZipCodecImpl> impl_;
 };
 
 }  // namespace arrow
 
-#endif
+#endif  // ARROW_UTIL_COMPRESSION_ZLIB_H

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/compression.h"
+#include "arrow/util/compression_zstd.h"
 
 #include <cstdint>
 #include <memory>

--- a/cpp/src/arrow/util/compression_zstd.h
+++ b/cpp/src/arrow/util/compression_zstd.h
@@ -15,38 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_UTIL_COMPRESSION_H
-#define ARROW_UTIL_COMPRESSION_H
+#ifndef ARROW_UTIL_COMPRESSION_ZSTD_H
+#define ARROW_UTIL_COMPRESSION_ZSTD_H
 
 #include <cstdint>
 #include <memory>
 
 #include "arrow/status.h"
-#include "arrow/util/visibility.h"
+#include "arrow/util/compression.h"
 
 namespace arrow {
 
-struct Compression {
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, LZO, BROTLI, ZSTD, LZ4 };
-};
-
-class ARROW_EXPORT Codec {
+// ZSTD codec.
+class ARROW_EXPORT ZSTDCodec : public Codec {
  public:
-  virtual ~Codec();
+  Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
+      uint8_t* output_buffer) override;
 
-  static Status Create(Compression::type codec, std::unique_ptr<Codec>* out);
+  Status Compress(int64_t input_len, const uint8_t* input, int64_t output_buffer_len,
+      uint8_t* output_buffer, int64_t* output_length) override;
 
-  virtual Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_len,
-      uint8_t* output_buffer) = 0;
+  int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  virtual Status Compress(int64_t input_len, const uint8_t* input,
-      int64_t output_buffer_len, uint8_t* output_buffer, int64_t* output_length) = 0;
-
-  virtual int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) = 0;
-
-  virtual const char* name() const = 0;
+  const char* name() const override { return "zstd"; }
 };
 
 }  // namespace arrow
 
-#endif
+#endif  // ARROW_UTIL_COMPRESSION_ZSTD_H


### PR DESCRIPTION
MSVC will fail to link arrow.dll if one or more of the compression libraries is disabled. This moves those symbols into their own header files. I also added additional options so any of the compression libraries can be disabled in user builds. If they are disabled then `arrow::Codec::Create` will fail with a helpful message

This build will still fail while the parquet-cpp build is broken

Close #810 