### PR TITLE
ARROW-1223: [GLib] Fix function name that returns wrapped object

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -561,7 +561,7 @@ garrow_gio_input_stream_new(GInputStream *gio_input_stream)
 }
 
 /**
- * garrow_gio_input_stream_get_gio_input_stream:
+ * garrow_gio_input_stream_get_raw:
  * @input_stream: A #GArrowGIOInputStream.
  *
  * Returns: (transfer none): The wrapped #GInputStream.
@@ -569,7 +569,7 @@ garrow_gio_input_stream_new(GInputStream *gio_input_stream)
  * Since: 0.5.0
  */
 GInputStream *
-garrow_gio_input_stream_get_gio_input_stream(GArrowGIOInputStream *input_stream)
+garrow_gio_input_stream_get_raw(GArrowGIOInputStream *input_stream)
 {
   auto arrow_input_stream =
     garrow_input_stream_get_raw(GARROW_INPUT_STREAM(input_stream));

--- a/c_glib/arrow-glib/input-stream.h
+++ b/c_glib/arrow-glib/input-stream.h
@@ -279,6 +279,6 @@ struct _GArrowGIOInputStreamClass
 GType garrow_gio_input_stream_get_type(void) G_GNUC_CONST;
 
 GArrowGIOInputStream *garrow_gio_input_stream_new(GInputStream *gio_input_stream);
-GInputStream *garrow_gio_input_stream_get_gio_input_stream(GArrowGIOInputStream *input_stream);
+GInputStream *garrow_gio_input_stream_get_raw(GArrowGIOInputStream *input_stream);
 
 G_END_DECLS

--- a/c_glib/test/test-gio-input-stream.rb
+++ b/c_glib/test/test-gio-input-stream.rb
@@ -48,6 +48,6 @@ class TestGIOInputStream < Test::Unit::TestCase
   def test_getter
     input_stream = Gio::MemoryInputStream.new("Hello")
     input = Arrow::GIOInputStream.new(input_stream)
-    assert_equal(input_stream, input.gio_input_stream)
+    assert_equal(input_stream, input.raw)
   end
 end


### PR DESCRIPTION
We're using `XXX_get_raw()` as name for function that returns wrapped object.