### PR TITLE
ARROW-1229: [GLib] Use "read" instead of "get" for reading record batch

### DIFF
--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -166,10 +166,30 @@ garrow_record_batch_reader_get_schema(GArrowRecordBatchReader *reader)
  *   The next record batch in the stream or %NULL on end of stream.
  *
  * Since: 0.4.0
+ *
+ * Deprecated: 0.5.0:
+ *   Use garrow_record_batch_reader_read_next_record_batch() instead.
  */
 GArrowRecordBatch *
 garrow_record_batch_reader_get_next_record_batch(GArrowRecordBatchReader *reader,
                                                  GError **error)
+{
+  return garrow_record_batch_reader_read_next_record_batch(reader, error);
+}
+
+/**
+ * garrow_record_batch_reader_read_next_record_batch:
+ * @reader: A #GArrowRecordBatchReader.
+ * @error: (nullable): Return locatipcn for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full):
+ *   The next record batch in the stream or %NULL on end of stream.
+ *
+ * Since: 0.5.0
+ */
+GArrowRecordBatch *
+garrow_record_batch_reader_read_next_record_batch(GArrowRecordBatchReader *reader,
+                                                  GError **error)
 {
   auto arrow_reader = garrow_record_batch_reader_get_raw(reader);
   std::shared_ptr<arrow::RecordBatch> arrow_record_batch;
@@ -177,7 +197,7 @@ garrow_record_batch_reader_get_next_record_batch(GArrowRecordBatchReader *reader
 
   if (garrow_error_check(error,
                          status,
-                         "[record-batch-reader][get-next-record-batch]")) {
+                         "[record-batch-reader][read-next-record-batch]")) {
     if (arrow_record_batch == nullptr) {
       return NULL;
     } else {
@@ -402,11 +422,33 @@ garrow_record_batch_file_reader_get_version(GArrowRecordBatchFileReader *reader)
  *   The i-th record batch in the file or %NULL on error.
  *
  * Since: 0.4.0
+ *
+ * Deprecated: 0.5.0:
+ *   Use garrow_record_batch_file_reader_read_record_batch() instead.
  */
 GArrowRecordBatch *
 garrow_record_batch_file_reader_get_record_batch(GArrowRecordBatchFileReader *reader,
                                                  guint i,
                                                  GError **error)
+{
+  return garrow_record_batch_file_reader_read_record_batch(reader, i, error);
+}
+
+/**
+ * garrow_record_batch_file_reader_read_record_batch:
+ * @reader: A #GArrowRecordBatchFileReader.
+ * @i: The index of the target record batch.
+ * @error: (nullable): Return locatipcn for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full):
+ *   The i-th record batch in the file or %NULL on error.
+ *
+ * Since: 0.5.0
+ */
+GArrowRecordBatch *
+garrow_record_batch_file_reader_read_record_batch(GArrowRecordBatchFileReader *reader,
+                                                  guint i,
+                                                  GError **error)
 {
   auto arrow_reader = garrow_record_batch_file_reader_get_raw(reader);
   std::shared_ptr<arrow::RecordBatch> arrow_record_batch;
@@ -414,7 +456,7 @@ garrow_record_batch_file_reader_get_record_batch(GArrowRecordBatchFileReader *re
 
   if (garrow_error_check(error,
                          status,
-                         "[record-batch-file-reader][get-record-batch]")) {
+                         "[record-batch-file-reader][read-record-batch]")) {
     return garrow_record_batch_new_raw(&arrow_record_batch);
   } else {
     return NULL;

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -76,7 +76,13 @@ GType garrow_record_batch_reader_get_type(void) G_GNUC_CONST;
 
 GArrowSchema *garrow_record_batch_reader_get_schema(
   GArrowRecordBatchReader *reader);
+#ifndef GARROW_DISABLE_DEPRECATED
+G_GNUC_DEPRECATED_FOR(garrow_record_batch_reader_read_next_record_batch)
 GArrowRecordBatch *garrow_record_batch_reader_get_next_record_batch(
+  GArrowRecordBatchReader *reader,
+  GError **error);
+#endif
+GArrowRecordBatch *garrow_record_batch_reader_read_next_record_batch(
   GArrowRecordBatchReader *reader,
   GError **error);
 
@@ -188,7 +194,14 @@ guint garrow_record_batch_file_reader_get_n_record_batches(
   GArrowRecordBatchFileReader *reader);
 GArrowMetadataVersion garrow_record_batch_file_reader_get_version(
   GArrowRecordBatchFileReader *reader);
+#ifndef GARROW_DISABLE_DEPRECATED
+G_GNUC_DEPRECATED_FOR(garrow_record_batch_file_reader_read_record_batch)
 GArrowRecordBatch *garrow_record_batch_file_reader_get_record_batch(
+  GArrowRecordBatchFileReader *reader,
+  guint i,
+  GError **error);
+#endif
+GArrowRecordBatch *garrow_record_batch_file_reader_read_record_batch(
   GArrowRecordBatchFileReader *reader,
   guint i,
   GError **error);

--- a/c_glib/example/Makefile.am
+++ b/c_glib/example/Makefile.am
@@ -20,7 +20,8 @@ SUBDIRS	=					\
 
 AM_CPPFLAGS =					\
 	-I$(top_builddir)			\
-	-I$(top_srcdir)
+	-I$(top_srcdir)				\
+	-DGARROW_DISABLE_DEPRECATED
 
 AM_CFLAGS =					\
 	$(GLIB_CFLAGS)				\

--- a/c_glib/example/go/read-batch.go
+++ b/c_glib/example/go/read-batch.go
@@ -89,9 +89,9 @@ func main() {
 	var i uint32
 	nRecordBatches := reader.GetNRecordBatches()
 	for i = 0; i < nRecordBatches; i++ {
-		recordBatch, err := reader.GetRecordBatch(i)
+		recordBatch, err := reader.ReadRecordBatch(i)
 		if err != nil {
-			log.Fatalf("Failed to get record batch[%d]: %v", i, err)
+			log.Fatalf("Failed to read record batch[%d]: %v", i, err)
 		}
 		fmt.Println(strings.Repeat("=", 40))
 		fmt.Printf("record-batch[%d]:\n", i)

--- a/c_glib/example/go/read-stream.go
+++ b/c_glib/example/go/read-stream.go
@@ -87,9 +87,9 @@ func main() {
 		log.Fatalf("Failed to parse data: %v", err)
 	}
 	for i := 0; true; i++ {
-		recordBatch, err := reader.GetNextRecordBatch()
+		recordBatch, err := reader.ReadNextRecordBatch()
 		if err != nil {
-			log.Fatalf("Failed to get next record batch: %v", err)
+			log.Fatalf("Failed to read next record batch: %v", err)
 		}
 		if recordBatch == nil {
 			break

--- a/c_glib/example/lua/read-batch.lua
+++ b/c_glib/example/lua/read-batch.lua
@@ -24,7 +24,7 @@ local input = Arrow.MemoryMappedInputStream.new(input_path)
 local reader = Arrow.RecordBatchFileReader.new(input)
 
 for i = 0, reader:get_n_record_batches() - 1 do
-   local record_batch = reader:get_record_batch(i)
+   local record_batch = reader:read_record_batch(i)
    print(string.rep("=", 40))
    print("record-batch["..i.."]:")
    for j = 0, record_batch:get_n_columns() - 1 do

--- a/c_glib/example/lua/read-stream.lua
+++ b/c_glib/example/lua/read-stream.lua
@@ -25,7 +25,7 @@ local reader = Arrow.RecordBatchStreamReader.new(input)
 
 local i = 0
 while true do
-   local record_batch = reader:get_next_record_batch()
+   local record_batch = reader:read_next_record_batch()
    if not record_batch then
       break
    end

--- a/c_glib/example/lua/stream-to-torch-tensor.lua
+++ b/c_glib/example/lua/stream-to-torch-tensor.lua
@@ -81,7 +81,7 @@ local reader = Arrow.RecordBatchStreamReader.new(input)
 
 local i = 0
 while true do
-   local record_batch = reader:get_next_record_batch()
+   local record_batch = reader:read_next_record_batch()
    if not record_batch then
       break
    end

--- a/c_glib/example/read-batch.c
+++ b/c_glib/example/read-batch.c
@@ -121,7 +121,7 @@ main(int argc, char **argv)
         GArrowRecordBatch *record_batch;
 
         record_batch =
-          garrow_record_batch_file_reader_get_record_batch(reader, i, &error);
+          garrow_record_batch_file_reader_read_record_batch(reader, i, &error);
         if (!record_batch) {
           g_print("failed to open file reader: %s\n", error->message);
           g_error_free(error);

--- a/c_glib/example/read-stream.c
+++ b/c_glib/example/read-stream.c
@@ -118,7 +118,7 @@ main(int argc, char **argv)
       GArrowRecordBatch *record_batch;
 
       record_batch =
-        garrow_record_batch_reader_get_next_record_batch(reader, &error);
+        garrow_record_batch_reader_read_next_record_batch(reader, &error);
       if (error) {
         g_print("failed to get record batch: %s\n", error->message);
         g_error_free(error);

--- a/c_glib/test/test-stream-writer.rb
+++ b/c_glib/test/test-stream-writer.rb
@@ -44,8 +44,8 @@ class TestStreamWriter < Test::Unit::TestCase
       assert_equal(["enabled"],
                    stream_reader.schema.fields.collect(&:name))
       assert_equal(true,
-                   stream_reader.next_record_batch.get_column(0).get_value(0))
-      assert_nil(stream_reader.next_record_batch)
+                   stream_reader.read_next_record_batch.get_column(0).get_value(0))
+      assert_nil(stream_reader.read_next_record_batch)
     ensure
       input.close
     end


### PR DESCRIPTION
It follows C++ API change.