### PR TITLE
ARROW-1103: [Python] Support read_pandas (with index metadata) on directory of Parquet files

### DIFF
--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -983,9 +983,9 @@ Status DecimalBuilder::Finish(std::shared_ptr<Array>* out) {
 
 ListBuilder::ListBuilder(MemoryPool* pool, std::unique_ptr<ArrayBuilder> value_builder,
     const std::shared_ptr<DataType>& type)
-    : ArrayBuilder(pool,
-          type ? type : std::static_pointer_cast<DataType>(
-                            std::make_shared<ListType>(value_builder->type()))),
+    : ArrayBuilder(
+          pool, type ? type : std::static_pointer_cast<DataType>(
+                                  std::make_shared<ListType>(value_builder->type()))),
       offsets_builder_(pool),
       value_builder_(std::move(value_builder)) {}
 

--- a/cpp/src/arrow/ipc/metadata.h
+++ b/cpp/src/arrow/ipc/metadata.h
@@ -200,13 +200,20 @@ class ARROW_EXPORT Message {
 ARROW_EXPORT std::string FormatMessageType(Message::Type type);
 
 /// \brief Abstract interface for a sequence of messages
+/// \since 0.5.0
 class ARROW_EXPORT MessageReader {
  public:
   virtual ~MessageReader() = default;
 
+  /// \brief Read next Message from the interface
+  ///
+  /// \param[out] message an arrow::ipc::Message instance
+  /// \return Status
   virtual Status ReadNextMessage(std::unique_ptr<Message>* message) = 0;
 };
 
+/// \brief Implementation of MessageReader that reads from InputStream
+/// \since 0.5.0
 class ARROW_EXPORT InputStreamMessageReader : public MessageReader {
  public:
   explicit InputStreamMessageReader(const std::shared_ptr<io::InputStream>& stream)

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -44,8 +44,8 @@ static inline bool IsPyInteger(PyObject* obj) {
 #endif
 }
 
-Status InvalidConversion(PyObject* obj, const std::string& expected_types,
-    std::ostream* out) {
+Status InvalidConversion(
+    PyObject* obj, const std::string& expected_types, std::ostream* out) {
   OwnedRef type(PyObject_Type(obj));
   RETURN_IF_PYERROR();
   DCHECK_NE(type.obj(), nullptr);
@@ -65,8 +65,7 @@ Status InvalidConversion(PyObject* obj, const std::string& expected_types,
   std::string cpp_type_name(bytes, size);
 
   (*out) << "Got Python object of type " << cpp_type_name
-         << " but can only handle these types: "
-         << expected_types;
+         << " but can only handle these types: " << expected_types;
   return Status::OK();
 }
 
@@ -104,7 +103,7 @@ class ScalarVisitor {
     } else {
       // TODO(wesm): accumulate error information somewhere
       static std::string supported_types =
-        "bool, float, integer, date, datetime, bytes, unicode";
+          "bool, float, integer, date, datetime, bytes, unicode";
       std::stringstream ss;
       ss << "Error inferring Arrow data type for collection of Python objects. ";
       RETURN_NOT_OK(InvalidConversion(obj, supported_types, &ss));

--- a/cpp/src/arrow/python/pandas_convert.cc
+++ b/cpp/src/arrow/python/pandas_convert.cc
@@ -552,8 +552,7 @@ Status PandasConverter::ConvertDates() {
       RETURN_NOT_OK(date_builder.AppendNull());
     } else {
       std::stringstream ss;
-      ss << "Error converting from Python objects to "
-         << type_->ToString() << ": ";
+      ss << "Error converting from Python objects to " << type_->ToString() << ": ";
       RETURN_NOT_OK(InvalidConversion(obj, "datetime.date", &ss));
       return Status::Invalid(ss.str());
     }
@@ -608,8 +607,7 @@ Status PandasConverter::ConvertDecimals() {
       RETURN_NOT_OK(decimal_builder.AppendNull());
     } else {
       std::stringstream ss;
-      ss << "Error converting from Python objects to "
-         << type_->ToString() << ": ";
+      ss << "Error converting from Python objects to " << type_->ToString() << ": ";
       RETURN_NOT_OK(InvalidConversion(object, "decimal.Decimal", &ss));
       return Status::Invalid(ss.str());
     }
@@ -637,8 +635,7 @@ Status PandasConverter::ConvertTimes() {
       RETURN_NOT_OK(builder.AppendNull());
     } else {
       std::stringstream ss;
-      ss << "Error converting from Python objects to "
-         << type_->ToString() << ": ";
+      ss << "Error converting from Python objects to " << type_->ToString() << ": ";
       RETURN_NOT_OK(InvalidConversion(obj, "datetime.time", &ss));
       return Status::Invalid(ss.str());
     }
@@ -696,8 +693,7 @@ Status PandasConverter::ConvertObjectFloats() {
       RETURN_NOT_OK(builder.Append(val));
     } else {
       std::stringstream ss;
-      ss << "Error converting from Python objects to "
-         << type_->ToString() << ": ";
+      ss << "Error converting from Python objects to " << type_->ToString() << ": ";
       RETURN_NOT_OK(InvalidConversion(obj, "float", &ss));
       return Status::Invalid(ss.str());
     }
@@ -732,8 +728,7 @@ Status PandasConverter::ConvertObjectIntegers() {
       RETURN_NOT_OK(builder.Append(val));
     } else {
       std::stringstream ss;
-      ss << "Error converting from Python objects to "
-         << type_->ToString() << ": ";
+      ss << "Error converting from Python objects to " << type_->ToString() << ": ";
       RETURN_NOT_OK(InvalidConversion(obj, "integer", &ss));
       return Status::Invalid(ss.str());
     }
@@ -902,8 +897,7 @@ Status PandasConverter::ConvertBooleans() {
       BitUtil::SetBit(null_bitmap_data_, i);
     } else {
       std::stringstream ss;
-      ss << "Error converting from Python objects to "
-         << type_->ToString() << ": ";
+      ss << "Error converting from Python objects to " << type_->ToString() << ": ";
       RETURN_NOT_OK(InvalidConversion(obj, "bool", &ss));
       return Status::Invalid(ss.str());
     }
@@ -990,7 +984,7 @@ Status PandasConverter::ConvertObjects() {
         return ConvertLists(inferred_type);
       } else {
         const std::string supported_types =
-          "string, bool, float, int, date, time, decimal, list, array";
+            "string, bool, float, int, date, time, decimal, list, array";
         std::stringstream ss;
         ss << "Error inferring Arrow type for Python object array. ";
         RETURN_NOT_OK(InvalidConversion(obj, supported_types, &ss));

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -31,9 +31,14 @@
 
 namespace arrow {
 
+std::shared_ptr<Field> Field::AddMetadata(
+    const std::shared_ptr<const KeyValueMetadata>& metadata) const {
+  return std::make_shared<Field>(name_, type_, nullable_, metadata);
+}
+
 Status Field::AddMetadata(const std::shared_ptr<const KeyValueMetadata>& metadata,
     std::shared_ptr<Field>* out) const {
-  *out = std::make_shared<Field>(name_, type_, nullable_, metadata);
+  *out = AddMetadata(metadata);
   return Status::OK();
 }
 
@@ -294,9 +299,14 @@ Status Schema::AddField(
   return Status::OK();
 }
 
+std::shared_ptr<Schema> Schema::AddMetadata(
+    const std::shared_ptr<const KeyValueMetadata>& metadata) const {
+  return std::make_shared<Schema>(fields_, metadata);
+}
+
 Status Schema::AddMetadata(const std::shared_ptr<const KeyValueMetadata>& metadata,
     std::shared_ptr<Schema>* out) const {
-  *out = std::make_shared<Schema>(fields_, metadata);
+  *out = AddMetadata(metadata);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -210,9 +210,12 @@ class ARROW_EXPORT Field {
 
   std::shared_ptr<const KeyValueMetadata> metadata() const { return metadata_; }
 
+  /// \deprecated
   Status AddMetadata(const std::shared_ptr<const KeyValueMetadata>& metadata,
       std::shared_ptr<Field>* out) const;
 
+  std::shared_ptr<Field> AddMetadata(
+      const std::shared_ptr<const KeyValueMetadata>& metadata) const;
   std::shared_ptr<Field> RemoveMetadata() const;
 
   bool Equals(const Field& other) const;
@@ -690,39 +693,56 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 // ----------------------------------------------------------------------
 // Schema
 
+/// \class Schema
+/// \brief Sequence of arrow::Field objects describing the columns of a record
+/// batch or table data structure
 class ARROW_EXPORT Schema {
  public:
   explicit Schema(const std::vector<std::shared_ptr<Field>>& fields,
       const std::shared_ptr<const KeyValueMetadata>& metadata = nullptr);
   virtual ~Schema() = default;
 
-  // Returns true if all of the schema fields are equal
+  /// Returns true if all of the schema fields are equal
   bool Equals(const Schema& other) const;
 
-  // Return the ith schema element. Does not boundscheck
+  /// Return the ith schema element. Does not boundscheck
   std::shared_ptr<Field> field(int i) const { return fields_[i]; }
 
-  // Returns nullptr if name not found
+  /// Returns nullptr if name not found
   std::shared_ptr<Field> GetFieldByName(const std::string& name) const;
 
-  // Returns -1 if name not found
+  /// Returns -1 if name not found
   int64_t GetFieldIndex(const std::string& name) const;
 
   const std::vector<std::shared_ptr<Field>>& fields() const { return fields_; }
+
+  /// \brief The custom key-value metadata, if any
+  ///
+  /// \return metadata may be nullptr
   std::shared_ptr<const KeyValueMetadata> metadata() const { return metadata_; }
 
-  // Render a string representation of the schema suitable for debugging
+  /// \brief Render a string representation of the schema suitable for debugging
   std::string ToString() const;
 
   Status AddField(
       int i, const std::shared_ptr<Field>& field, std::shared_ptr<Schema>* out) const;
   Status RemoveField(int i, std::shared_ptr<Schema>* out) const;
 
+  /// \deprecated
   Status AddMetadata(const std::shared_ptr<const KeyValueMetadata>& metadata,
       std::shared_ptr<Schema>* out) const;
 
+  /// \brief Replace key-value metadata with new metadata
+  ///
+  /// \param[in] metadata new KeyValueMetadata
+  /// \return new Schema
+  std::shared_ptr<Schema> AddMetadata(
+      const std::shared_ptr<const KeyValueMetadata>& metadata) const;
+
+  /// \brief Return copy of Schema without the KeyValueMetadata
   std::shared_ptr<Schema> RemoveMetadata() const;
 
+  /// \brief Return the number of fields (columns) in the schema
   int num_fields() const { return static_cast<int>(fields_.size()); }
 
  private:

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -103,7 +103,8 @@ class NullLog {
 class CerrLog {
  public:
   CerrLog(int severity)  // NOLINT(runtime/explicit)
-      : severity_(severity), has_logged_(false) {}
+      : severity_(severity),
+        has_logged_(false) {}
 
   virtual ~CerrLog() {
     if (has_logged_) { std::cerr << std::endl; }

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -38,8 +38,8 @@ to_flatbuffer(flatbuffers::FlatBufferBuilder* fbb, const ObjectID* object_ids,
 Status PlasmaReceive(int sock, int64_t message_type, std::vector<uint8_t>* buffer) {
   int64_t type;
   RETURN_NOT_OK(ReadMessage(sock, &type, buffer));
-  ARROW_CHECK(type == message_type)
-      << "type = " << type << ", message_type = " << message_type;
+  ARROW_CHECK(type == message_type) << "type = " << type
+                                    << ", message_type = " << message_type;
   return Status::OK();
 }
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -423,10 +423,13 @@ cdef class ParquetReader:
     def set_num_threads(self, int nthreads):
         self.reader.get().set_num_threads(nthreads)
 
-    def read_row_group(self, int i, column_indices=None):
+    def read_row_group(self, int i, column_indices=None, nthreads=None):
         cdef:
             shared_ptr[CTable] ctable
             vector[int] c_column_indices
+
+        if nthreads:
+            self.set_num_threads(nthreads)
 
         if column_indices is not None:
             for index in column_indices:
@@ -442,10 +445,13 @@ cdef class ParquetReader:
                              .ReadRowGroup(i, &ctable))
         return pyarrow_wrap_table(ctable)
 
-    def read_all(self, column_indices=None):
+    def read_all(self, column_indices=None, nthreads=None):
         cdef:
             shared_ptr[CTable] ctable
             vector[int] c_column_indices
+
+        if nthreads:
+            self.set_num_threads(nthreads)
 
         if column_indices is not None:
             for index in column_indices:

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -63,7 +63,7 @@ class Filesystem(object):
         raise NotImplementedError
 
     def read_parquet(self, path, columns=None, metadata=None, schema=None,
-                     nthreads=1):
+                     nthreads=1, use_pandas_metadata=False):
         """
         Read Parquet data from path in file system. Can read from a single file
         or a directory of files
@@ -82,6 +82,9 @@ class Filesystem(object):
         nthreads : int, default 1
             Number of columns to read in parallel. If > 1, requires that the
             underlying file source is threadsafe
+        use_pandas_metadata : boolean, default False
+            If True and file has custom pandas schema metadata, ensure that
+            index columns are also loaded
 
         Returns
         -------
@@ -90,7 +93,8 @@ class Filesystem(object):
         from pyarrow.parquet import ParquetDataset
         dataset = ParquetDataset(path, schema=schema, metadata=metadata,
                                  filesystem=self)
-        return dataset.read(columns=columns, nthreads=nthreads)
+        return dataset.read(columns=columns, nthreads=nthreads,
+                            use_pandas_metadata=use_pandas_metadata)
 
     @property
     def pathsep(self):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -197,8 +197,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
                c_bool nullable, const shared_ptr[CKeyValueMetadata]& metadata)
 
         # Removed const in Cython so don't have to cast to get code to generate
-        CStatus AddMetadata(const shared_ptr[CKeyValueMetadata]& metadata,
-                            shared_ptr[CField]* out)
+        shared_ptr[CField] AddMetadata(
+            const shared_ptr[CKeyValueMetadata]& metadata)
         shared_ptr[CField] RemoveMetadata()
 
 
@@ -224,8 +224,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_string ToString()
 
         # Removed const in Cython so don't have to cast to get code to generate
-        CStatus AddMetadata(const shared_ptr[CKeyValueMetadata]& metadata,
-                            shared_ptr[CSchema]* out)
+        shared_ptr[CSchema] AddMetadata(
+            const shared_ptr[CKeyValueMetadata]& metadata)
         shared_ptr[CSchema] RemoveMetadata()
 
     cdef cppclass CBooleanArray" arrow::BooleanArray"(CArray):
@@ -346,6 +346,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int num_columns()
         int64_t num_rows()
 
+        shared_ptr[CRecordBatch] ReplaceSchemaMetadata(
+            const shared_ptr[CKeyValueMetadata]& metadata)
+
         shared_ptr[CRecordBatch] Slice(int64_t offset)
         shared_ptr[CRecordBatch] Slice(int64_t offset, int64_t length)
 
@@ -369,6 +372,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CStatus AddColumn(int i, const shared_ptr[CColumn]& column,
                           shared_ptr[CTable]* out)
         CStatus RemoveColumn(int i, shared_ptr[CTable]* out)
+
+        shared_ptr[CTable] ReplaceSchemaMetadata(
+            const shared_ptr[CKeyValueMetadata]& metadata)
 
     cdef cppclass CTensor" arrow::Tensor":
         shared_ptr[CDataType] type()

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -45,10 +45,14 @@ class ParquetFile(object):
         see pyarrow.io.PythonFileInterface or pyarrow.io.BufferReader.
     metadata : ParquetFileMetadata, default None
         Use existing metadata object, rather than reading from file.
+    common_metadata : ParquetFileMetadata, default None
+        Will be used in reads for pandas schema metadata if not found in the
+        main file's metadata, no other uses at the moment
     """
-    def __init__(self, source, metadata=None):
+    def __init__(self, source, metadata=None, common_metadata=None):
         self.reader = ParquetReader()
         self.reader.open(source, metadata=metadata)
+        self.common_metadata = common_metadata
 
     @property
     def metadata(self):
@@ -62,7 +66,8 @@ class ParquetFile(object):
     def num_row_groups(self):
         return self.reader.num_row_groups
 
-    def read_row_group(self, i, columns=None, nthreads=1):
+    def read_row_group(self, i, columns=None, nthreads=1,
+                       use_pandas_metadata=False):
         """
         Read a single row group from a Parquet file
 
@@ -73,18 +78,21 @@ class ParquetFile(object):
         nthreads : int, default 1
             Number of columns to read in parallel. If > 1, requires that the
             underlying file source is threadsafe
+        use_pandas_metadata : boolean, default False
+            If True and file has custom pandas schema metadata, ensure that
+            index columns are also loaded
 
         Returns
         -------
         pyarrow.table.Table
             Content of the row group as a table (of columns)
         """
-        column_indices = self._get_column_indices(columns)
-        if nthreads is not None:
-            self.reader.set_num_threads(nthreads)
-        return self.reader.read_row_group(i, column_indices=column_indices)
+        column_indices = self._get_column_indices(
+            columns, use_pandas_metadata=use_pandas_metadata)
+        return self.reader.read_row_group(i, column_indices=column_indices,
+                                          nthreads=nthreads)
 
-    def read(self, columns=None, nthreads=1):
+    def read(self, columns=None, nthreads=1, use_pandas_metadata=False):
         """
         Read a Table from Parquet format
 
@@ -95,40 +103,48 @@ class ParquetFile(object):
         nthreads : int, default 1
             Number of columns to read in parallel. If > 1, requires that the
             underlying file source is threadsafe
+        use_pandas_metadata : boolean, default False
+            If True and file has custom pandas schema metadata, ensure that
+            index columns are also loaded
 
         Returns
         -------
         pyarrow.table.Table
             Content of the file as a table (of columns)
         """
-        column_indices = self._get_column_indices(columns)
-        if nthreads is not None:
-            self.reader.set_num_threads(nthreads)
+        column_indices = self._get_column_indices(
+            columns, use_pandas_metadata=use_pandas_metadata)
+        return self.reader.read_all(column_indices=column_indices,
+                                    nthreads=nthreads)
 
-        return self.reader.read_all(column_indices=column_indices)
-
-    def read_pandas(self, columns=None, nthreads=1):
-        column_indices = self._get_column_indices(columns)
-        custom_metadata = self.metadata.metadata
-
-        if custom_metadata and b'pandas' in custom_metadata:
-            index_columns = json.loads(
-                custom_metadata[b'pandas'].decode('utf8')
-            )['index_columns']
-        else:
-            index_columns = []
-
-        if column_indices is not None and index_columns:
-            column_indices += map(self.reader.column_name_idx, index_columns)
-
-        if nthreads is not None:
-            self.reader.set_num_threads(nthreads)
-        return self.reader.read_all(column_indices=column_indices)
-
-    def _get_column_indices(self, column_names):
+    def _get_column_indices(self, column_names, use_pandas_metadata=False):
         if column_names is None:
             return None
-        return list(map(self.reader.column_name_idx, column_names))
+
+        indices = list(map(self.reader.column_name_idx, column_names))
+
+        if use_pandas_metadata:
+            file_keyvalues = self.metadata.metadata
+            common_keyvalues = (self.common_metadata.metadata
+                                if self.common_metadata is not None
+                                else None)
+
+            if file_keyvalues and b'pandas' in file_keyvalues:
+                index_columns = _get_pandas_index_columns(file_keyvalues)
+            elif common_keyvalues and b'pandas' in common_keyvalues:
+                index_columns = _get_pandas_index_columns(common_keyvalues)
+            else:
+                index_columns = []
+
+            if indices is not None and index_columns:
+                indices += map(self.reader.column_name_idx, index_columns)
+
+        return indices
+
+
+def _get_pandas_index_columns(keyvalues):
+    return (json.loads(keyvalues[b'pandas'].decode('utf8'))
+            ['index_columns'])
 
 
 # ----------------------------------------------------------------------
@@ -205,7 +221,7 @@ class ParquetDatasetPiece(object):
         return reader
 
     def read(self, columns=None, nthreads=1, partitions=None,
-             open_file_func=None, file=None):
+             open_file_func=None, file=None, use_pandas_metadata=False):
         """
         Read this piece as a pyarrow.Table
 
@@ -218,6 +234,8 @@ class ParquetDatasetPiece(object):
         open_file_func : function, default None
             A function that knows how to construct a ParquetFile object given
             the file path in this piece
+        file : file-like object
+            passed to ParquetFile
 
         Returns
         -------
@@ -509,6 +527,11 @@ class ParquetDataset(object):
         (self.pieces, self.partitions,
          self.metadata_path) = _make_manifest(path_or_paths, self.fs)
 
+        if self.metadata_path is not None:
+            self.common_metadata = ParquetFile(self.metadata_path).metadata
+        else:
+            self.common_metadata = None
+
         self.metadata = metadata
         self.schema = schema
 
@@ -540,7 +563,7 @@ class ParquetDataset(object):
                                  .format(piece, file_metadata.schema,
                                          self.schema))
 
-    def read(self, columns=None, nthreads=1):
+    def read(self, columns=None, nthreads=1, use_pandas_metadata=False):
         """
         Read multiple Parquet files as a single pyarrow.Table
 
@@ -551,6 +574,8 @@ class ParquetDataset(object):
         nthreads : int, default 1
             Number of columns to read in parallel. Requires that the underlying
             file source is threadsafe
+        use_pandas_metadata : bool, default False
+            Passed through to each dataset piece
 
         Returns
         -------
@@ -563,20 +588,39 @@ class ParquetDataset(object):
         for piece in self.pieces:
             table = piece.read(columns=columns, nthreads=nthreads,
                                partitions=self.partitions,
-                               open_file_func=open_file)
+                               open_file_func=open_file,
+                               use_pandas_metadata=use_pandas_metadata)
             tables.append(table)
 
         all_data = lib.concat_tables(tables)
+
+        if use_pandas_metadata:
+            # We need to ensure that this metadata is set in the Table's schema
+            # so that Table.to_pandas will construct pandas.DataFrame with the
+            # right index
+            common_metadata = self._get_common_pandas_metadata()
+            if common_metadata:
+                all_data = all_data.add_schema_metadata(common_metadata)
+
         return all_data
+
+    def _get_common_pandas_metadata(self):
+        if self.common_metadata is None:
+            return None
+
+        keyvalues = self.common_metadata.metadata
+        return keyvalues.get(b'pandas', None)
 
     def _get_open_file_func(self):
         if self.fs is None or isinstance(self.fs, LocalFilesystem):
             def open_file(path, meta=None):
-                return ParquetFile(path, metadata=meta)
+                return ParquetFile(path, metadata=meta,
+                                   common_metadata=self.common_metadata)
         else:
             def open_file(path, meta=None):
                 return ParquetFile(self.fs.open(path, mode='rb'),
-                                   metadata=meta)
+                                   metadata=meta,
+                                   common_metadata=self.common_metadata)
         return open_file
 
 
@@ -613,7 +657,8 @@ def _make_manifest(path_or_paths, fs, pathsep='/'):
     return pieces, partitions, metadata_path
 
 
-def read_table(source, columns=None, nthreads=1, metadata=None):
+def read_table(source, columns=None, nthreads=1, metadata=None,
+               use_pandas_metadata=False):
     """
     Read a Table from Parquet format
 
@@ -630,6 +675,9 @@ def read_table(source, columns=None, nthreads=1, metadata=None):
         file source is threadsafe
     metadata : FileMetaData
         If separately computed
+    use_pandas_metadata : boolean, default False
+        If True and file has custom pandas schema metadata, ensure that
+        index columns are also loaded
 
     Returns
     -------
@@ -643,13 +691,14 @@ def read_table(source, columns=None, nthreads=1, metadata=None):
                                    metadata=metadata)
 
     pf = ParquetFile(source, metadata=metadata)
-    return pf.read(columns=columns, nthreads=nthreads)
+    return pf.read(columns=columns, nthreads=nthreads,
+                   use_pandas_metadata=use_pandas_metadata)
 
 
 def read_pandas(source, columns=None, nthreads=1, metadata=None):
     """
-    Read a Table from Parquet format, reconstructing the index values if
-    available.
+    Read a Table from Parquet format, also reading DataFrame index values if
+    known in the file metadata
 
     Parameters
     ----------
@@ -671,16 +720,8 @@ def read_pandas(source, columns=None, nthreads=1, metadata=None):
         Content of the file as a Table of Columns, including DataFrame indexes
         as Columns.
     """
-    if is_string(source):
-        fs = LocalFilesystem.get_instance()
-        if fs.isdir(source):
-            raise NotImplementedError(
-                'Reading a directory of Parquet files with DataFrame index '
-                'metadata is not yet supported'
-            )
-
-    pf = ParquetFile(source, metadata=metadata)
-    return pf.read_pandas(columns=columns, nthreads=nthreads)
+    return read_table(source, columns=columns, nthreads=nthreads,
+                      metadata=metadata, use_pandas_metadata=True)
 
 
 def write_table(table, where, row_group_size=None, version='1.0',

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -602,8 +602,11 @@ class ParquetDataset(object):
             # so that Table.to_pandas will construct pandas.DataFrame with the
             # right index
             common_metadata = self._get_common_pandas_metadata()
-            if common_metadata:
-                all_data = all_data.replace_schema_metadata(common_metadata)
+            current_metadata = all_data.schema.metadata or {}
+
+            if common_metadata and b'pandas' not in current_metadata:
+                all_data = all_data.replace_schema_metadata({
+                    b'pandas': common_metadata})
 
         return all_data
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -388,6 +388,30 @@ cdef class RecordBatch:
         self._check_nullptr()
         return self.batch.num_rows()
 
+    def replace_schema_metadata(self, dict metadata=None):
+        """
+        EXPERIMENTAL: Create shallow copy of record batch by replacing schema
+        key-value metadata with the indicated new metadata (which may be None,
+        which deletes any existing metadata
+
+        Parameters
+        ----------
+        metadata : dict, default None
+
+        Returns
+        -------
+        shallow_copy : RecordBatch
+        """
+        cdef shared_ptr[CKeyValueMetadata] c_meta
+        if metadata is not None:
+            convert_metadata(metadata, &c_meta)
+
+        cdef shared_ptr[CRecordBatch] new_batch
+        with nogil:
+            new_batch = self.batch.ReplaceSchemaMetadata(c_meta)
+
+        return pyarrow_wrap_batch(new_batch)
+
     @property
     def num_columns(self):
         """
@@ -623,6 +647,30 @@ cdef class Table:
                 "Table object references a NULL pointer. Not initialized."
             )
         return 0
+
+    def replace_schema_metadata(self, dict metadata=None):
+        """
+        EXPERIMENTAL: Create shallow copy of table by replacing schema
+        key-value metadata with the indicated new metadata (which may be None,
+        which deletes any existing metadata
+
+        Parameters
+        ----------
+        metadata : dict, default None
+
+        Returns
+        -------
+        shallow_copy : Table
+        """
+        cdef shared_ptr[CKeyValueMetadata] c_meta
+        if metadata is not None:
+            convert_metadata(metadata, &c_meta)
+
+        cdef shared_ptr[CTable] new_table
+        with nogil:
+            new_table = self.table.ReplaceSchemaMetadata(c_meta)
+
+        return pyarrow_wrap_table(new_table)
 
     def equals(self, Table other):
         """

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -873,7 +873,6 @@ def test_dataset_read_pandas(tmpdir):
 
         path = pjoin(dirpath, '{0}.parquet'.format(i))
 
-        # Write index, but obliterate the metadata
         table = pa.Table.from_pandas(df)
         _write_table(table, path)
         test_data.append(table)
@@ -888,10 +887,52 @@ def test_dataset_read_pandas(tmpdir):
     tm.assert_frame_equal(result, expected)
 
 
-# @parquet
-# def test_dataset_pandas_common_metadata(tmpdir):
-#     table_for_metadata = pa.Table.from_pandas(df)
-#     pq.write_metadata(table_for_metadata.schema, pjoin(dirpath, '_metadata'))
+@parquet
+def test_dataset_read_pandas_common_metadata(tmpdir):
+    # ARROW-1103
+    import pyarrow.parquet as pq
+
+    nfiles = 5
+    size = 5
+
+    dirpath = tmpdir.join(guid()).strpath
+    os.mkdir(dirpath)
+
+    test_data = []
+    frames = []
+    paths = []
+    for i in range(nfiles):
+        df = _test_dataframe(size, seed=i)
+        df.index = pd.Index(np.arange(i * size, (i + 1) * size))
+        df.index.name = 'index'
+
+        path = pjoin(dirpath, '{0}.parquet'.format(i))
+
+        df_ex_index = df.reset_index(drop=True)
+        df_ex_index['index'] = df.index
+        table = pa.Table.from_pandas(df_ex_index,
+                                     preserve_index=False)
+
+        # Obliterate metadata
+        table = table.replace_schema_metadata(None)
+        assert table.schema.metadata is None
+
+        _write_table(table, path)
+        test_data.append(table)
+        frames.append(df)
+        paths.append(path)
+
+    # Write _metadata common file
+    table_for_metadata = pa.Table.from_pandas(df)
+    pq.write_metadata(table_for_metadata.schema,
+                      pjoin(dirpath, '_metadata'))
+
+    dataset = pq.ParquetDataset(dirpath)
+    columns = ['uint8', 'strings']
+    result = dataset.read_pandas(columns=columns).to_pandas()
+    expected = pd.concat([x[columns] for x in frames])
+
+    tm.assert_frame_equal(result, expected)
 
 
 @parquet

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -809,9 +809,6 @@ def test_read_multiple_files(tmpdir):
 
     assert result.equals(expected)
 
-    with pytest.raises(NotImplementedError):
-        pq.read_pandas(dirpath)
-
     # Read with provided metadata
     metadata = pq.ParquetFile(paths[0]).metadata
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -255,7 +255,7 @@ cdef class Field:
 
         cdef shared_ptr[CField] new_field
         with nogil:
-            check_status(self.field.AddMetadata(c_meta, &new_field))
+            new_field = self.field.AddMetadata(c_meta)
 
         return pyarrow_wrap_field(new_field)
 
@@ -368,7 +368,7 @@ cdef class Schema:
 
         cdef shared_ptr[CSchema] new_schema
         with nogil:
-            check_status(self.schema.AddMetadata(c_meta, &new_schema))
+            new_schema = self.schema.AddMetadata(c_meta)
 
         return pyarrow_wrap_schema(new_schema)
 


### PR DESCRIPTION
Also fixes ARROW-1041, a case where the `_metadata` file contains the pandas schema metadata but the individual dataset fragments do not.