### PR TITLE
ARROW-1235: [C++] Make operator<< for Array/Status and std::ostream inline

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -107,9 +107,10 @@ std::shared_ptr<Array> Array::Slice(int64_t offset) const {
   return Slice(offset, slice_length);
 }
 
-std::ostream& operator<<(std::ostream& os, const Array& x) {
-  DCHECK(PrettyPrint(x, 0, &os).ok());
-  return os;
+std::string Array::ToString() const {
+  std::stringstream ss;
+  DCHECK(PrettyPrint(*this, 0, &ss).ok());
+  return ss.str();
 }
 
 static inline std::shared_ptr<ArrayData> SliceData(

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -236,6 +236,9 @@ class ARROW_EXPORT Array {
 
   int num_fields() const { return static_cast<int>(data_->child_data.size()); }
 
+  /// \return PrettyPrint representation of array suitable for debugging
+  std::string ToString() const;
+
  protected:
   Array() {}
 
@@ -256,7 +259,10 @@ class ARROW_EXPORT Array {
   DISALLOW_COPY_AND_ASSIGN(Array);
 };
 
-ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Array& x);
+inline std::ostream& operator<<(std::ostream& os, const Array& x) {
+  os << x.ToString();
+  return os;
+}
 
 class ARROW_EXPORT FlatArray : public Array {
  protected:

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -259,7 +259,7 @@ class ARROW_EXPORT Array {
   DISALLOW_COPY_AND_ASSIGN(Array);
 };
 
-inline std::ostream& operator<<(std::ostream& os, const Array& x) {
+static inline std::ostream& operator<<(std::ostream& os, const Array& x) {
   os << x.ToString();
   return os;
 }

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -49,6 +49,10 @@ void CheckArray(const Array& arr, int indent, const char* expected) {
   ASSERT_OK(PrettyPrint(arr, indent, &sink));
   std::string result = sink.str();
   ASSERT_EQ(std::string(expected, strlen(expected)), result);
+
+  std::stringstream ss;
+  ss << arr;
+  ASSERT_EQ(result, ss.str());
 }
 
 template <typename TYPE, typename C_TYPE>

--- a/cpp/src/arrow/status-test.cc
+++ b/cpp/src/arrow/status-test.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <sstream>
+
 #include "gtest/gtest.h"
 
 #include "arrow/status.h"
@@ -33,6 +35,10 @@ TEST(StatusTest, TestCodeAndMessage) {
 TEST(StatusTest, TestToString) {
   Status file_error = Status::IOError("file error");
   ASSERT_EQ("IOError: file error", file_error.ToString());
+
+  std::stringstream ss;
+  ss << file_error;
+  ASSERT_EQ(file_error.ToString(), ss.str());
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -32,11 +32,6 @@ void Status::CopyFrom(const State* state) {
   }
 }
 
-std::ostream& operator<<(std::ostream& os, const Status& x) {
-  os << x.ToString();
-  return os;
-}
-
 std::string Status::CodeAsString() const {
   if (state_ == NULL) { return "OK"; }
 

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -176,7 +176,7 @@ class ARROW_EXPORT Status {
   void CopyFrom(const State* s);
 };
 
-inline std::ostream& operator<<(std::ostream& os, const Status& x) {
+static inline std::ostream& operator<<(std::ostream& os, const Status& x) {
   os << x.ToString();
   return os;
 }

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -176,7 +176,10 @@ class ARROW_EXPORT Status {
   void CopyFrom(const State* s);
 };
 
-std::ostream& operator<<(std::ostream& os, const Status& x);
+inline std::ostream& operator<<(std::ostream& os, const Status& x) {
+  os << x.ToString();
+  return os;
+}
 
 inline Status::Status(const Status& s)
     : state_((s.state_ == NULL) ? NULL : new State(*s.state_)) {}


### PR DESCRIPTION
I'm unable to reproduce the linker failure, but I think this will fix it. 