### PR TITLE
ARROW-1236: Fix lib path in pkg-config file

### DIFF
--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -16,7 +16,7 @@
 # under the License.
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 so_version=@ARROW_SO_VERSION@

--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -15,9 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 so_version=@ARROW_SO_VERSION@
 abi_version=@ARROW_ABI_VERSION@

--- a/cpp/src/arrow/python/arrow-python.pc.in
+++ b/cpp/src/arrow/python/arrow-python.pc.in
@@ -16,7 +16,7 @@
 # under the License.
 
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: Apache Arrow Python

--- a/cpp/src/arrow/python/arrow-python.pc.in
+++ b/cpp/src/arrow/python/arrow-python.pc.in
@@ -15,9 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: Apache Arrow Python
 Description: Python integration library for Apache Arrow


### PR DESCRIPTION
The `CMAKE_INSTALL_LIBDIR` already contains the prefix on a default
installation (such as in the conda-forge package) and therefore
prepending the prefix results in the wrong path.

While apparently it is not clear what this variable should be
(https://bugzilla.redhat.com/show_bug.cgi?id=795542), it seems that
it's used as an absolute path in the rest of the project.