### PR TITLE
ARROW-1239: [JAVA] upgrading git-commit-id-plugin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -231,7 +231,7 @@
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
-        <version>2.1.9</version>
+        <version>2.2.2</version>
         <executions>
           <execution>
             <id>for-jars</id>


### PR DESCRIPTION
Currently used version of the git-commit-id-plugin maven plugin (2.1.9) doesn't work with recent git structures. This is for majority of the users not manifested since Arrow has the java maven root in the project subdirectory  (`/java`) instead of top level so this plugin normally doesn't kick in if maven is executed from the subdirectory (usual case - ie `cd java; mvn install` - works fine) as the plugin doesn't see the `.git` directory but it does kick in and fail if executed from the main arrow top level dir as `mvn -f java/pom.xml install` (where the `.git` sits):

```
$ mvn -f java/pom.xml package
...
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:2.1.9:revision (for-jars) on project arrow-java-root: Execution for-jars of goal pl.project13.maven:git-commit-id-plugin:2.1.9:revision failed: Bare Repository has neither a working tree, nor an index -> [Help 1]
```

Simple fix is upgrading the plugin to recent version (the minimal working version appears to be 2.1.13).

This is required for seamless integration with Jenkins (ARROW-1234).