### PR TITLE
ARROW-1244: Exclude C++ Plasma source tree when creating source release 

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -88,6 +88,12 @@ rm -rf ${tag}
 git archive $release_hash --prefix ${tag}/ | tar xf -
 rm -rf ${tag}/c_glib
 mv tmp-c_glib ${tag}/c_glib
+
+# ARROW-1244 Remove cpp/src/plasma from source release until after IP clearance
+# is resolved
+rm -rf ${tag}/cpp/src/plasma
+
+# Create new tarball from modified source directory
 tar czf ${tarball} ${tag}
 rm -rf ${tag}
 


### PR DESCRIPTION
We must undergo an IP clearance process with Apache Incubator before this code can be included in an Apache Arrow release. 