### PR TITLE
ARROW-1245: [Integration] Enable JavaTester in Integration tests

### DIFF
--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -945,7 +945,7 @@ def get_static_json_files():
 
 
 def run_all_tests(debug=False):
-    testers = [CPPTester(debug=debug)]  # , JavaTester(debug=debug)]
+    testers = [CPPTester(debug=debug), JavaTester(debug=debug)]
     static_json_files = get_static_json_files()
     generated_json_files = get_generated_json_files()
     json_files = static_json_files + generated_json_files


### PR DESCRIPTION
JavaTester was commented out, probably accidentally from a previous commit, this re-enables it.