### PR TITLE
ARROW-1249: [JAVA] expose fillEmpties from Nullable variable length vectors

### DIFF
--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -540,7 +540,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
 
     <#if type.major == "VarLen">
 
-    private void fillEmpties(int index){
+    public void fillEmpties(int index){
       final ${valuesName}.Mutator valuesMutator = values.getMutator();
       for (int i = lastSet + 1; i < index; i++) {
         valuesMutator.setSafe(i, emptyByteArray);


### PR DESCRIPTION
This will allow us to do some cleanup in Dremio where we have written wrapper routines using Reflection to access the fillEmpties method of mutator.

Unit tests have been added.