### PR TITLE
ARROW-276: [JAVA] Nullable Vectors should extend BaseValueVector and not Bas…

### DIFF
--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -44,9 +44,10 @@ import org.apache.arrow.flatbuf.Precision;
  * NB: this class is automatically generated from ${.template_name} and ValueVectorTypes.tdd using FreeMarker.
  */
 @SuppressWarnings("unused")
-public final class ${className} extends BaseDataValueVector implements <#if type.major == "VarLen">VariableWidth<#else>FixedWidth</#if>Vector, NullableVector, FieldVector {
+public final class ${className} extends BaseValueVector implements <#if type.major == "VarLen">VariableWidth<#else>FixedWidth</#if>Vector, NullableVector, FieldVector {
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(${className}.class);
 
+protected final static byte[] emptyByteArray = new byte[]{};
   private final FieldReader reader = new ${minor.class}ReaderImpl(${className}.this);
 
   private final String bitsField = "$bits$";
@@ -217,7 +218,6 @@ public final class ${className} extends BaseDataValueVector implements <#if type
         + bits.getBufferSizeFor(valueCount);
   }
 
-  @Override
   public ArrowBuf getBuffer() {
     return values.getBuffer();
   }
@@ -286,7 +286,6 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     bits.zeroVector();
     mutator.reset();
     accessor.reset();
-    super.reset();
   }
 
   @Override
@@ -314,12 +313,10 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     accessor.reset();
   }
 
-  @Override
   public void reset() {
     bits.zeroVector();
     mutator.reset();
     accessor.reset();
-    super.reset();
   }
 
   /**
@@ -331,6 +328,11 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     values.zeroVector();
   }
   </#if>
+
+  @Override
+  public TransferPair getTransferPair(String ref, BufferAllocator allocator, CallBack callBack) {
+        return getTransferPair(ref, allocator);
+  }
 
   @Override
   public TransferPair getTransferPair(BufferAllocator allocator){

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseDataValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseDataValueVector.java
@@ -30,8 +30,6 @@ import org.apache.arrow.vector.util.TransferPair;
 
 public abstract class BaseDataValueVector extends BaseValueVector implements BufferBacked {
 
-  protected final static byte[] emptyByteArray = new byte[]{}; // Nullable vectors use this
-
   public static void load(ArrowFieldNode fieldNode, List<BufferBacked> vectors, List<ArrowBuf> buffers) {
     int expectedSize = vectors.size();
     if (buffers.size() != expectedSize) {


### PR DESCRIPTION
Fixing the inheritance tree:

Nullable <Fixed-length | Var-Length>Vectors do not use "ArrowBuf data" field in BaseDataValueVector. Therefore, they should extend BaseValueVector class..