### PR TITLE
[JAVA] fix letter case in rat plugin config

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -93,7 +93,7 @@
           </execution>
         </executions>
         <configuration>
-          <excludeSubprojects>false</excludeSubprojects>
+          <excludeSubProjects>false</excludeSubProjects>
           <excludes>
             <exclude>**/*.log</exclude>
             <exclude>**/*.css</exclude>


### PR DESCRIPTION
correct case is excludeSubProjects -> http://creadur.apache.org/rat/apache-rat-plugin/check-mojo.html#excludeSubProjects