### PR TITLE
ARROW-1192: [JAVA] Use buffer slice for splitAndTransfer in List and Union Vectors.

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -321,10 +321,8 @@ public class UnionVector implements FieldVector {
 
     @Override
     public void splitAndTransfer(int startIndex, int length) {
-      to.allocateNew();
-      for (int i = 0; i < length; i++) {
-        to.copyFromSafe(startIndex + i, i, org.apache.arrow.vector.complex.UnionVector.this);
-      }
+      internalMapVectorTransferPair.splitAndTransfer(startIndex, length);
+      typeVectorTransferPair.splitAndTransfer(startIndex, length);
       to.getMutator().setValueCount(length);
     }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -19,6 +19,8 @@ package org.apache.arrow.vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.ListVector;
@@ -30,6 +32,7 @@ import org.apache.arrow.vector.holders.NullableBigIntHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.*;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.util.TransferPair;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -232,6 +235,202 @@ public class TestListVector {
 
       actual = valueAccessor.getObject(offsetAccessor.get(index));
       assertNull(actual);
+    }
+  }
+
+  @Test
+  public void testSplitAndTransfer() throws Exception {
+    try (ListVector listVector = ListVector.empty("sourceVector", allocator)) {
+
+      /* Explicitly add the dataVector */
+      MinorType type = MinorType.BIGINT;
+      listVector.addOrGetVector(FieldType.nullable(type.getType()));
+
+      UnionListWriter listWriter = listVector.getWriter();
+
+      /* allocate memory */
+      listWriter.allocate();
+
+      /* populate data */
+      listWriter.setPosition(0);
+      listWriter.startList();
+      listWriter.bigInt().writeBigInt(10);
+      listWriter.bigInt().writeBigInt(11);
+      listWriter.bigInt().writeBigInt(12);
+      listWriter.endList();
+
+      listWriter.setPosition(1);
+      listWriter.startList();
+      listWriter.bigInt().writeBigInt(13);
+      listWriter.bigInt().writeBigInt(14);
+      listWriter.endList();
+
+      listWriter.setPosition(2);
+      listWriter.startList();
+      listWriter.bigInt().writeBigInt(15);
+      listWriter.bigInt().writeBigInt(16);
+      listWriter.bigInt().writeBigInt(17);
+      listWriter.bigInt().writeBigInt(18);
+      listWriter.endList();
+
+      listWriter.setPosition(3);
+      listWriter.startList();
+      listWriter.bigInt().writeBigInt(19);
+      listWriter.endList();
+
+      listWriter.setPosition(4);
+      listWriter.startList();
+      listWriter.bigInt().writeBigInt(20);
+      listWriter.bigInt().writeBigInt(21);
+      listWriter.bigInt().writeBigInt(22);
+      listWriter.bigInt().writeBigInt(23);
+      listWriter.endList();
+
+      listVector.getMutator().setValueCount(5);
+
+      assertEquals(5, listVector.getMutator().getLastSet());
+
+      /* get offsetVector */
+      UInt4Vector offsetVector = (UInt4Vector)listVector.getOffsetVector();
+
+      /* get dataVector */
+      NullableBigIntVector dataVector = (NullableBigIntVector)listVector.getDataVector();
+
+      /* check the vector output */
+      final UInt4Vector.Accessor offsetAccessor = offsetVector.getAccessor();
+      final ValueVector.Accessor valueAccessor = dataVector.getAccessor();
+
+      int index  = 0;
+      int offset = 0;
+      Object actual = null;
+
+      /* index 0 */
+      assertFalse(listVector.getAccessor().isNull(index));
+      offset = offsetAccessor.get(index);
+      assertEquals(Integer.toString(0), Integer.toString(offset));
+
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(10), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(11), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(12), (Long)actual);
+
+      /* index 1 */
+      index++;
+      assertFalse(listVector.getAccessor().isNull(index));
+      offset = offsetAccessor.get(index);
+      assertEquals(Integer.toString(3), Integer.toString(offset));
+
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(13), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(14), (Long)actual);
+
+      /* index 2 */
+      index++;
+      assertFalse(listVector.getAccessor().isNull(index));
+      offset = offsetAccessor.get(index);
+      assertEquals(Integer.toString(5), Integer.toString(offset));
+
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(15), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(16), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(17), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(18), (Long)actual);
+
+      /* index 3 */
+      index++;
+      assertFalse(listVector.getAccessor().isNull(index));
+      offset = offsetAccessor.get(index);
+      assertEquals(Integer.toString(9), Integer.toString(offset));
+
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(19), (Long)actual);
+
+      /* index 4 */
+      index++;
+      assertFalse(listVector.getAccessor().isNull(index));
+      offset = offsetAccessor.get(index);
+      assertEquals(Integer.toString(10), Integer.toString(offset));
+
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(20), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(21), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(22), (Long)actual);
+      offset++;
+      actual = valueAccessor.getObject(offset);
+      assertEquals(new Long(23), (Long)actual);
+
+      /* index 5 */
+      index++;
+      assertTrue(listVector.getAccessor().isNull(index));
+      offset = offsetAccessor.get(index);
+      assertEquals(Integer.toString(14), Integer.toString(offset));
+
+      /* do split and transfer */
+      try (ListVector toVector = ListVector.empty("toVector", allocator)) {
+
+        TransferPair transferPair = listVector.makeTransferPair(toVector);
+
+        int[][] transferLengths = { {0, 2},
+                                    {3, 1},
+                                    {4, 1}
+                                  };
+
+        for (final int[] transferLength : transferLengths) {
+          int start = transferLength[0];
+          int splitLength = transferLength[1];
+
+          int dataLength1 = 0;
+          int dataLength2 = 0;
+
+          int offset1 = 0;
+          int offset2 = 0;
+
+          transferPair.splitAndTransfer(start, splitLength);
+
+          /* get offsetVector of toVector */
+          UInt4Vector offsetVector1 = (UInt4Vector)toVector.getOffsetVector();
+          UInt4Vector.Accessor offsetAccessor1 = offsetVector1.getAccessor();
+
+          /* get dataVector of toVector */
+          NullableBigIntVector dataVector1 = (NullableBigIntVector)toVector.getDataVector();
+          NullableBigIntVector.Accessor valueAccessor1 = dataVector1.getAccessor();
+
+          for(int i = 0; i < splitLength; i++) {
+            dataLength1 = offsetAccessor.get(start + i + 1) - offsetAccessor.get(start + i);
+            dataLength2 = offsetAccessor1.get(i + 1) - offsetAccessor1.get(i);
+
+            assertEquals("Different data lengths at index: " + i + " and start: " + start,
+                         dataLength1, dataLength2);
+
+            offset1 = offsetAccessor.get(start + i);
+            offset2 = offsetAccessor1.get(i);
+
+            for(int j = 0; j < dataLength1; j++) {
+              assertEquals("Different data at indexes: " + offset1 + " and " + offset2,
+                           valueAccessor.getObject(offset1), valueAccessor1.getObject(offset2));
+
+              offset1++;
+              offset2++;
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
@jacques-n 
@StevenMPhillips 

PR for the original change-set https://github.com/dremio/arrow/commit/75396ba07f58eb122110edb33ee2305bcdc122d7
with corresponding unit tests.

