### PR TITLE
ARROW-1289: [Python] Add PYARROW_BUILD_PLASMA CMake option, follow semantics of --with-parquet

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -51,6 +51,9 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   option(PYARROW_BUILD_PARQUET
     "Build the PyArrow Parquet integration"
     OFF)
+  option(PYARROW_BUILD_PLASMA
+    "Build the PyArrow Plasma integration"
+    OFF)
   option(PYARROW_BUNDLE_ARROW_CPP
     "Bundle the Arrow C++ libraries"
     OFF)
@@ -157,12 +160,6 @@ include_directories(SYSTEM
 find_package(Arrow REQUIRED)
 include_directories(SYSTEM ${ARROW_INCLUDE_DIR})
 
-## Plasma
-find_package(Plasma)
-if (PLASMA_FOUND)
-  include_directories(SYSTEM ${PLASMA_INCLUDE_DIR})
-endif()
-
 function(bundle_arrow_lib library_path)
   get_filename_component(LIBRARY_DIR ${${library_path}} DIRECTORY)
   get_filename_component(LIBRARY_NAME ${${library_path}} NAME_WE)
@@ -195,9 +192,6 @@ if (PYARROW_BUNDLE_ARROW_CPP)
   file(COPY ${ARROW_INCLUDE_DIR}/arrow DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
   bundle_arrow_lib(ARROW_SHARED_LIB)
   bundle_arrow_lib(ARROW_PYTHON_SHARED_LIB)
-  if (PLASMA_FOUND)
-    bundle_arrow_lib(PLASMA_SHARED_LIB)
-  endif()
 endif()
 
 if (MSVC)
@@ -224,14 +218,9 @@ set(CYTHON_EXTENSIONS
   lib
 )
 
-if (PLASMA_FOUND)
-  set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} plasma)
-endif()
-
 set(LINK_LIBS
   arrow_shared
   arrow_python_shared
-  ${PLASMA_SHARED_LIB}
 )
 
 if (PYARROW_BUILD_PARQUET)
@@ -284,6 +273,29 @@ if (PYARROW_BUILD_PARQUET)
     _parquet)
 endif()
 
+## Plasma
+if (PYARROW_BUILD_PLASMA)
+  find_package(Plasma)
+
+  if(NOT PLASMA_FOUND)
+    message(FATAL_ERROR "Unable to locate Plasma libraries")
+  endif()
+
+  include_directories(SYSTEM ${PLASMA_INCLUDE_DIR})
+  ADD_THIRDPARTY_LIB(libplasma
+    SHARED_LIB ${PLASMA_SHARED_LIB})
+
+  if (PYARROW_BUNDLE_ARROW_CPP)
+    bundle_arrow_lib(PLASMA_SHARED_LIB)
+  endif()
+  set(LINK_LIBS
+    ${LINK_LIBS}
+    libplasma_shared)
+
+  set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} plasma)
+  file(COPY ${PLASMA_EXECUTABLE} DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY})
+endif()
+
 ############################################################
 # Setup and build Cython modules
 ############################################################
@@ -330,7 +342,3 @@ foreach(module ${CYTHON_EXTENSIONS})
 
     target_link_libraries(${module_name} ${LINK_LIBS})
 endforeach(module)
-
-if (PLASMA_FOUND)
-  file(COPY ${PLASMA_EXECUTABLE} DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY})
-endif()

--- a/python/cmake_modules/FindParquet.cmake
+++ b/python/cmake_modules/FindParquet.cmake
@@ -60,6 +60,8 @@ if(PARQUET_HOME)
         PATHS ${PARQUET_HOME} NO_DEFAULT_PATH
         PATH_SUFFIXES "lib")
     get_filename_component(PARQUET_LIBS ${PARQUET_LIBRARIES} PATH )
+    set(PARQUET_ABI_VERSION "1.0.0")
+    set(PARQUET_SO_VERSION "1")
 else()
     pkg_check_modules(PARQUET parquet)
     if (PARQUET_FOUND)

--- a/python/setup.py
+++ b/python/setup.py
@@ -143,13 +143,17 @@ class build_ext(_build_ext):
         if self.with_parquet:
             cmake_options.append('-DPYARROW_BUILD_PARQUET=on')
 
+        if self.with_plasma:
+            cmake_options.append('-DPYARROW_BUILD_PLASMA=on')
+
         if self.bundle_arrow_cpp:
             cmake_options.append('-DPYARROW_BUNDLE_ARROW_CPP=ON')
             # ARROW-1090: work around CMake rough edges
             if 'ARROW_HOME' in os.environ and sys.platform != 'win32':
-                os.environ['PKG_CONFIG_PATH'] = pjoin(os.environ['ARROW_HOME'], 'lib', 'pkgconfig')
+                pkg_config = pjoin(os.environ['ARROW_HOME'], 'lib',
+                                   'pkgconfig')
+                os.environ['PKG_CONFIG_PATH'] = pkg_config
                 del os.environ['ARROW_HOME']
-
 
         cmake_options.append('-DCMAKE_BUILD_TYPE={0}'
                              .format(self.build_type.lower()))
@@ -243,7 +247,8 @@ class build_ext(_build_ext):
             print(pjoin(build_prefix, 'include'), pjoin(build_lib, 'pyarrow'))
             if os.path.exists(pjoin(build_lib, 'pyarrow', 'include')):
                 shutil.rmtree(pjoin(build_lib, 'pyarrow', 'include'))
-            shutil.move(pjoin(build_prefix, 'include'), pjoin(build_lib, 'pyarrow'))
+            shutil.move(pjoin(build_prefix, 'include'),
+                        pjoin(build_lib, 'pyarrow'))
             move_lib("arrow")
             move_lib("arrow_python")
             if self.with_plasma:
@@ -280,7 +285,9 @@ class build_ext(_build_ext):
         if self.with_plasma:
             build_py = self.get_finalized_command('build_py')
             source = os.path.join(self.build_type, "plasma_store")
-            target = os.path.join(build_lib, build_py.get_package_dir('pyarrow'), "plasma_store")
+            target = os.path.join(build_lib,
+                                  build_py.get_package_dir('pyarrow'),
+                                  "plasma_store")
             shutil.move(source, target)
 
         os.chdir(saved_cwd)
@@ -349,6 +356,7 @@ designed to accelerate big data. It houses a set of canonical in-memory
 representations of flat and hierarchical data along with multiple
 language-bindings for structure manipulation. It also provides IPC
 and common algorithm implementations."""
+
 
 class BinaryDistribution(Distribution):
     def has_ext_modules(foo):


### PR DESCRIPTION
Now the test suite does not fail if you build the Plasma libraries but forget to pass `--with-plasma` to the Python build