### PR TITLE
ARROW-1294: [C++] Pin cmake=3.8.0 in MSVC toolchain build

### DIFF
--- a/ci/msvc-build.bat
+++ b/ci/msvc-build.bat
@@ -51,9 +51,16 @@ conda create -n arrow -q -y python=%PYTHON% ^
       six pytest setuptools numpy pandas cython ^
       thrift-cpp
 
+@rem ARROW-1294 CMake 3.9.0 in conda-forge breaks the build
+set ARROW_CMAKE_VERSION=3.8.0
+
 if "%JOB%" == "Toolchain" (
+
   conda install -n arrow -q -y -c conda-forge ^
-      flatbuffers rapidjson cmake git boost-cpp ^
+      flatbuffers rapidjson ^
+      cmake=%ARROW_CMAKE_VERSION% ^
+      git ^
+      boost-cpp ^
       snappy zlib brotli gflags lz4-c zstd
 )
 


### PR DESCRIPTION
See https://github.com/conda-forge/cmake-feedstock/issues/38. Not sure the origin of the build failure but we will pin at 3.8.0 for now