### PR TITLE
ARROW-1265: [Plasma] Clean up all resources on SIGTERM to keep valgrind output clean

### DIFF
--- a/cpp/src/plasma/events.cc
+++ b/cpp/src/plasma/events.cc
@@ -67,6 +67,11 @@ void EventLoop::remove_file_event(int fd) {
 
 void EventLoop::run() { aeMain(loop_); }
 
+void EventLoop::Stop() {
+  aeStop(loop_);
+  aeDeleteEventLoop(loop_);
+}
+
 int64_t EventLoop::add_timer(int64_t timeout, const TimerCallback& callback) {
   auto data = std::unique_ptr<TimerCallback>(new TimerCallback(callback));
   void* context = reinterpret_cast<void*>(data.get());

--- a/cpp/src/plasma/events.cc
+++ b/cpp/src/plasma/events.cc
@@ -21,13 +21,12 @@
 
 namespace plasma {
 
-void EventLoop::file_event_callback(aeEventLoop* loop, int fd, void* context,
-                                    int events) {
+void EventLoop::FileEventCallback(aeEventLoop* loop, int fd, void* context, int events) {
   FileCallback* callback = reinterpret_cast<FileCallback*>(context);
   (*callback)(events);
 }
 
-int EventLoop::timer_event_callback(aeEventLoop* loop, TimerID timer_id, void* context) {
+int EventLoop::TimerEventCallback(aeEventLoop* loop, TimerID timer_id, void* context) {
   TimerCallback* callback = reinterpret_cast<TimerCallback*>(context);
   return (*callback)(timer_id);
 }
@@ -36,21 +35,21 @@ constexpr int kInitialEventLoopSize = 1024;
 
 EventLoop::EventLoop() { loop_ = aeCreateEventLoop(kInitialEventLoopSize); }
 
-bool EventLoop::add_file_event(int fd, int events, const FileCallback& callback) {
+bool EventLoop::AddFileEvent(int fd, int events, const FileCallback& callback) {
   if (file_callbacks_.find(fd) != file_callbacks_.end()) {
     return false;
   }
   auto data = std::unique_ptr<FileCallback>(new FileCallback(callback));
   void* context = reinterpret_cast<void*>(data.get());
   // Try to add the file descriptor.
-  int err = aeCreateFileEvent(loop_, fd, events, EventLoop::file_event_callback, context);
+  int err = aeCreateFileEvent(loop_, fd, events, EventLoop::FileEventCallback, context);
   // If it cannot be added, increase the size of the event loop.
   if (err == AE_ERR && errno == ERANGE) {
     err = aeResizeSetSize(loop_, 3 * aeGetSetSize(loop_) / 2);
     if (err != AE_OK) {
       return false;
     }
-    err = aeCreateFileEvent(loop_, fd, events, EventLoop::file_event_callback, context);
+    err = aeCreateFileEvent(loop_, fd, events, EventLoop::FileEventCallback, context);
   }
   // In any case, test if there were errors.
   if (err == AE_OK) {
@@ -60,28 +59,28 @@ bool EventLoop::add_file_event(int fd, int events, const FileCallback& callback)
   return false;
 }
 
-void EventLoop::remove_file_event(int fd) {
+void EventLoop::RemoveFileEvent(int fd) {
   aeDeleteFileEvent(loop_, fd, AE_READABLE | AE_WRITABLE);
   file_callbacks_.erase(fd);
 }
 
-void EventLoop::run() { aeMain(loop_); }
+void EventLoop::Start() { aeMain(loop_); }
 
 void EventLoop::Stop() {
   aeStop(loop_);
   aeDeleteEventLoop(loop_);
 }
 
-int64_t EventLoop::add_timer(int64_t timeout, const TimerCallback& callback) {
+int64_t EventLoop::AddTimer(int64_t timeout, const TimerCallback& callback) {
   auto data = std::unique_ptr<TimerCallback>(new TimerCallback(callback));
   void* context = reinterpret_cast<void*>(data.get());
   int64_t timer_id =
-      aeCreateTimeEvent(loop_, timeout, EventLoop::timer_event_callback, context, NULL);
+      aeCreateTimeEvent(loop_, timeout, EventLoop::TimerEventCallback, context, NULL);
   timer_callbacks_.emplace(timer_id, std::move(data));
   return timer_id;
 }
 
-int EventLoop::remove_timer(int64_t timer_id) {
+int EventLoop::RemoveTimer(int64_t timer_id) {
   int err = aeDeleteTimeEvent(loop_, timer_id);
   timer_callbacks_.erase(timer_id);
   return err;

--- a/cpp/src/plasma/events.h
+++ b/cpp/src/plasma/events.h
@@ -83,10 +83,13 @@ class EventLoop {
   /// @return The ae.c error code. TODO(pcm): needs to be standardized
   int remove_timer(int64_t timer_id);
 
-  /// Run the event loop.
+  /// \brief Run the event loop.
   ///
   /// @return Void.
   void run();
+
+  /// \brief Stop the event loop
+  void Stop();
 
  private:
   static void file_event_callback(aeEventLoop* loop, int fd, void* context, int events);

--- a/cpp/src/plasma/events.h
+++ b/cpp/src/plasma/events.h
@@ -61,13 +61,13 @@ class EventLoop {
   /// @param events The flags for events we are listening to (read or write).
   /// @param callback The callback that will be called when the event happens.
   /// @return Returns true if the event handler was added successfully.
-  bool add_file_event(int fd, int events, const FileCallback& callback);
+  bool AddFileEvent(int fd, int events, const FileCallback& callback);
 
   /// Remove a file event handler from the event loop.
   ///
   /// @param fd The file descriptor of the event handler.
   /// @return Void.
-  void remove_file_event(int fd);
+  void RemoveFileEvent(int fd);
 
   /// Register a handler that will be called after a time slice of
   ///  "timeout" milliseconds.
@@ -75,26 +75,26 @@ class EventLoop {
   ///  @param timeout The timeout in milliseconds.
   ///  @param callback The callback for the timeout.
   ///  @return The ID of the newly created timer.
-  int64_t add_timer(int64_t timeout, const TimerCallback& callback);
+  int64_t AddTimer(int64_t timeout, const TimerCallback& callback);
 
   /// Remove a timer handler from the event loop.
   ///
   /// @param timer_id The ID of the timer that is to be removed.
   /// @return The ae.c error code. TODO(pcm): needs to be standardized
-  int remove_timer(int64_t timer_id);
+  int RemoveTimer(int64_t timer_id);
 
   /// \brief Run the event loop.
   ///
   /// @return Void.
-  void run();
+  void Start();
 
   /// \brief Stop the event loop
   void Stop();
 
  private:
-  static void file_event_callback(aeEventLoop* loop, int fd, void* context, int events);
+  static void FileEventCallback(aeEventLoop* loop, int fd, void* context, int events);
 
-  static int timer_event_callback(aeEventLoop* loop, TimerID timer_id, void* context);
+  static int TimerEventCallback(aeEventLoop* loop, TimerID timer_id, void* context);
 
   aeEventLoop* loop_;
   std::unordered_map<int, std::unique_ptr<FileCallback>> file_callbacks_;

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -663,7 +663,7 @@ static PlasmaStoreRunner* g_runner = nullptr;
 void HandleSignal(int signal) {
   if (signal == SIGTERM) {
     if (g_runner != nullptr) {
-      g_runner ->Shutdown();
+      g_runner->Shutdown();
     }
     // Report "success" to valgrind.
     exit(0);

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -127,9 +127,9 @@ class PlasmaStore {
 
   /// Disconnect a client from the PlasmaStore.
   ///
-  /// @param client The client that is disconnected.
+  /// @param client_fd The client file descriptor that is disconnected.
   /// @return Void.
-  void disconnect_client(Client* client);
+  void disconnect_client(int client_fd);
 
   void send_notifications(int client_fd);
 
@@ -166,6 +166,8 @@ class PlasmaStore {
   /// TODO(pcm): Consider putting this into the Client data structure and
   /// reorganize the code slightly.
   std::unordered_map<int, NotificationQueue> pending_notifications_;
+
+  std::unordered_map<int, std::unique_ptr<Client>> connected_clients_;
 };
 
 }  // namespace plasma


### PR DESCRIPTION
@pcmoritz this might be a little bit OCD since all of the valgrind warnings were for memory that was still reachable, but let me know what you think. 