### PR TITLE
ARROW-573: [C++/Python] Implement IPC metadata handling for ordered dictionaries, pandas conversions

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1881,15 +1881,18 @@ TEST(TestDictionary, Basics) {
 
   std::shared_ptr<DictionaryType> type1 =
       std::dynamic_pointer_cast<DictionaryType>(dictionary(int16(), dict));
-  DictionaryType type2(int16(), dict);
+
+  auto type2 =
+      std::dynamic_pointer_cast<DictionaryType>(::arrow::dictionary(int16(), dict, true));
 
   ASSERT_TRUE(int16()->Equals(type1->index_type()));
   ASSERT_TRUE(type1->dictionary()->Equals(dict));
 
-  ASSERT_TRUE(int16()->Equals(type2.index_type()));
-  ASSERT_TRUE(type2.dictionary()->Equals(dict));
+  ASSERT_TRUE(int16()->Equals(type2->index_type()));
+  ASSERT_TRUE(type2->dictionary()->Equals(dict));
 
-  ASSERT_EQ("dictionary<values=int32, indices=int16>", type1->ToString());
+  ASSERT_EQ("dictionary<values=int32, indices=int16, ordered=0>", type1->ToString());
+  ASSERT_EQ("dictionary<values=int32, indices=int16, ordered=1>", type2->ToString());
 }
 
 TEST(TestDictionary, Equals) {

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -824,7 +824,8 @@ class TypeEqualsVisitor {
   Status Visit(const DictionaryType& left) {
     const auto& right = static_cast<const DictionaryType&>(right_);
     result_ = left.index_type()->Equals(right.index_type()) &&
-              left.dictionary()->Equals(right.dictionary());
+              left.dictionary()->Equals(right.dictionary()) &&
+              (left.ordered() == right.ordered());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/ipc/metadata.cc
+++ b/cpp/src/arrow/ipc/metadata.cc
@@ -492,7 +492,8 @@ static DictionaryOffset GetDictionaryEncoding(FBB& fbb, const DictionaryType& ty
   auto index_type_offset = flatbuf::CreateInt(fbb, fw_index_type.bit_width(), true);
 
   // TODO(wesm): ordered dictionaries
-  return flatbuf::CreateDictionaryEncoding(fbb, dictionary_id, index_type_offset);
+  return flatbuf::CreateDictionaryEncoding(fbb, dictionary_id, index_type_offset,
+                                           type.ordered());
 }
 
 static Status FieldToFlatbuffer(FBB& fbb, const std::shared_ptr<Field>& field,
@@ -551,7 +552,7 @@ static Status FieldFromFlatbuffer(const flatbuf::Field* field,
 
     std::shared_ptr<DataType> index_type;
     RETURN_NOT_OK(IntFromFlatbuffer(encoding->indexType(), &index_type));
-    type = std::make_shared<DictionaryType>(index_type, dictionary);
+    type = ::arrow::dictionary(index_type, dictionary, encoding->isOrdered());
   }
   *out = std::make_shared<Field>(field->name()->str(), type, field->nullable());
   return Status::OK();

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -462,7 +462,7 @@ Status MakeDictionary(std::shared_ptr<RecordBatch>* out) {
   ArrayFromVector<StringType, std::string>(dict2_values, &dict2);
 
   auto f0_type = arrow::dictionary(arrow::int32(), dict1);
-  auto f1_type = arrow::dictionary(arrow::int8(), dict1);
+  auto f1_type = arrow::dictionary(arrow::int8(), dict1, true);
   auto f2_type = arrow::dictionary(arrow::int32(), dict2);
 
   std::shared_ptr<Array> indices0, indices1, indices2;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -236,7 +236,7 @@ std::shared_ptr<Array> DictionaryType::dictionary() const { return dictionary_; 
 std::string DictionaryType::ToString() const {
   std::stringstream ss;
   ss << "dictionary<values=" << dictionary_->type()->ToString()
-     << ", indices=" << index_type_->ToString() << ">";
+     << ", indices=" << index_type_->ToString() << ", ordered=" << ordered_ << ">";
   return ss.str();
 }
 
@@ -427,8 +427,9 @@ std::shared_ptr<DataType> union_(const std::vector<std::shared_ptr<Field>>& chil
 }
 
 std::shared_ptr<DataType> dictionary(const std::shared_ptr<DataType>& index_type,
-                                     const std::shared_ptr<Array>& dict_values) {
-  return std::make_shared<DictionaryType>(index_type, dict_values);
+                                     const std::shared_ptr<Array>& dict_values,
+                                     bool ordered) {
+  return std::make_shared<DictionaryType>(index_type, dict_values, ordered);
 }
 
 std::shared_ptr<Field> field(const std::string& name,

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -777,8 +777,9 @@ std::shared_ptr<DataType> ARROW_EXPORT
 union_(const std::vector<std::shared_ptr<Field>>& child_fields,
        const std::vector<uint8_t>& type_codes, UnionMode mode = UnionMode::SPARSE);
 
-std::shared_ptr<DataType> ARROW_EXPORT dictionary(
-    const std::shared_ptr<DataType>& index_type, const std::shared_ptr<Array>& values);
+std::shared_ptr<DataType> ARROW_EXPORT
+dictionary(const std::shared_ptr<DataType>& index_type,
+           const std::shared_ptr<Array>& values, bool ordered = false);
 
 std::shared_ptr<Field> ARROW_EXPORT field(
     const std::string& name, const std::shared_ptr<DataType>& type, bool nullable = true,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -92,6 +92,10 @@ else()
   # Cython generates some bitshift expressions that MSVC does not like in
   # __Pyx_PyFloat_DivideObjC
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4293")
+
+  # Converting to/from C++ bool is pretty wonky in Cython. The C4800 warning
+  # seem harmless, and probably not worth the effort of working around it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4800")
 endif()
 
 if ("${COMPILER_FAMILY}" STREQUAL "clang")

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -132,10 +132,12 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass CDictionaryType" arrow::DictionaryType"(CFixedWidthType):
         CDictionaryType(const shared_ptr[CDataType]& index_type,
-                        const shared_ptr[CArray]& dictionary)
+                        const shared_ptr[CArray]& dictionary,
+                        c_bool ordered)
 
         shared_ptr[CDataType] index_type()
         shared_ptr[CArray] dictionary()
+        c_bool ordered()
 
     shared_ptr[CDataType] ctimestamp" arrow::timestamp"(TimeUnit unit)
     shared_ptr[CDataType] ctimestamp" arrow::timestamp"(

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -284,9 +284,10 @@ def table_to_blockmanager(table, nthreads=1):
         block_arr = item['block']
         placement = item['placement']
         if 'dictionary' in item:
+            ordered = block_table.schema[placement[0]].type.ordered
             cat = pd.Categorical(block_arr,
                                  categories=item['dictionary'],
-                                 ordered=False, fastpath=True)
+                                 ordered=ordered, fastpath=True)
             block = _int.make_block(cat, placement=placement,
                                     klass=_int.CategoricalBlock,
                                     fastpath=True)

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -536,6 +536,9 @@ class TestPandasConversion(unittest.TestCase):
         df = pd.DataFrame({'cat_strings': pd.Categorical(v1 * repeats),
                            'cat_ints': pd.Categorical(v2 * repeats),
                            'cat_binary': pd.Categorical(v3 * repeats),
+                           'cat_strings_ordered': pd.Categorical(
+                               v1 * repeats, categories=['bar', 'qux', 'foo'],
+                               ordered=True),
                            'ints': v2 * repeats,
                            'ints2': v2 * repeats,
                            'strings': v1 * repeats,

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -97,6 +97,11 @@ cdef class DictionaryType(DataType):
         DataType.init(self, type)
         self.dict_type = <const CDictionaryType*> type.get()
 
+    property ordered:
+
+        def __get__(self):
+            return self.dict_type.ordered()
+
 
 cdef class ListType(DataType):
 
@@ -798,7 +803,8 @@ cpdef ListType list_(value_type):
     return out
 
 
-cpdef DictionaryType dictionary(DataType index_type, Array dictionary):
+cpdef DictionaryType dictionary(DataType index_type, Array dictionary,
+                                bint ordered=False):
     """
     Dictionary (categorical, or simply encoded) type
 
@@ -814,7 +820,8 @@ cpdef DictionaryType dictionary(DataType index_type, Array dictionary):
     cdef DictionaryType out = DictionaryType()
     cdef shared_ptr[CDataType] dict_type
     dict_type.reset(new CDictionaryType(index_type.sp_type,
-                                        dictionary.sp_array))
+                                        dictionary.sp_array,
+                                        ordered == 1))
     out.init(dict_type)
     return out
 


### PR DESCRIPTION
This was an oversight in the IPC implementation and pandas conversion path, and has been fixed.