### PR TITLE
ARROW-1300: [JAVA] Fix Tests for ListVector

### DIFF
--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.ArrayList;
 
 public class TestListVector {
 
@@ -92,6 +93,26 @@ public class TestListVector {
       Assert.assertFalse("should be null", reader.isSet());
       reader.setPosition(2);
       Assert.assertTrue("shouldn't be null", reader.isSet());
+
+      /* check the exact contents of vector */
+      final ListVector.Accessor accessor = outVector.getAccessor();
+
+      /* index 0 */
+      Object result = accessor.getObject(0);
+      ArrayList<Long> resultSet = (ArrayList<Long>)result;
+      assertEquals(3, resultSet.size());
+      assertEquals(new Long(1), (Long)resultSet.get(0));
+      assertEquals(new Long(2), (Long)resultSet.get(1));
+      assertEquals(new Long(3), (Long)resultSet.get(2));
+
+      /* index 1 */
+      result = accessor.getObject(1);
+      assertNull(result);
+
+      /* index 2 */
+      result = accessor.getObject(2);
+      resultSet = (ArrayList<Long>)result;
+      assertEquals(0, resultSet.size());
     }
   }
 
@@ -108,11 +129,11 @@ public class TestListVector {
 
       /* get inner vectors; bitVector and offsetVector */
       List<BufferBacked> innerVectors = listVector.getFieldInnerVectors();
-      BitVector bitVector = (BitVector)innerVectors.get(0);
-      UInt4Vector offsetVector = (UInt4Vector)innerVectors.get(1);
+      BitVector bitVector = (BitVector) innerVectors.get(0);
+      UInt4Vector offsetVector = (UInt4Vector) innerVectors.get(1);
 
       /* get the underlying data vector -- NullableBigIntVector */
-      NullableBigIntVector dataVector = (NullableBigIntVector)listVector.getDataVector();
+      NullableBigIntVector dataVector = (NullableBigIntVector) listVector.getDataVector();
 
       /* check current lastSet */
       assertEquals(Integer.toString(0), Integer.toString(listVector.getMutator().getLastSet()));
@@ -127,7 +148,7 @@ public class TestListVector {
       dataVector.getMutator().setSafe(2, 1, 12);
       offsetVector.getMutator().setSafe(index + 1, 3);
 
-      index  += 1;
+      index += 1;
 
       /* write [13, 14] to the list vector at index 1 */
       bitVector.getMutator().setSafe(index, 1);
@@ -193,41 +214,41 @@ public class TestListVector {
       final UInt4Vector.Accessor offsetAccessor = offsetVector.getAccessor();
       final ValueVector.Accessor valueAccessor = dataVector.getAccessor();
 
-      index  = 0;
+      index = 0;
       offset = offsetAccessor.get(index);
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
       Object actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(10), (Long)actual);
+      assertEquals(new Long(10), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(11), (Long)actual);
+      assertEquals(new Long(11), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(12), (Long)actual);
+      assertEquals(new Long(12), (Long) actual);
 
       index++;
       offset = offsetAccessor.get(index);
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(13), (Long)actual);
+      assertEquals(new Long(13), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(14), (Long)actual);
+      assertEquals(new Long(14), (Long) actual);
 
       index++;
       offset = offsetAccessor.get(index);
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offsetAccessor.get(index));
-      assertEquals(new Long(15), (Long)actual);
+      assertEquals(new Long(15), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(16), (Long)actual);
+      assertEquals(new Long(16), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(17), (Long)actual);
+      assertEquals(new Long(17), (Long) actual);
 
       index++;
       offset = offsetAccessor.get(index);
@@ -291,16 +312,16 @@ public class TestListVector {
       assertEquals(5, listVector.getMutator().getLastSet());
 
       /* get offsetVector */
-      UInt4Vector offsetVector = (UInt4Vector)listVector.getOffsetVector();
+      UInt4Vector offsetVector = (UInt4Vector) listVector.getOffsetVector();
 
       /* get dataVector */
-      NullableBigIntVector dataVector = (NullableBigIntVector)listVector.getDataVector();
+      NullableBigIntVector dataVector = (NullableBigIntVector) listVector.getDataVector();
 
       /* check the vector output */
       final UInt4Vector.Accessor offsetAccessor = offsetVector.getAccessor();
       final ValueVector.Accessor valueAccessor = dataVector.getAccessor();
 
-      int index  = 0;
+      int index = 0;
       int offset = 0;
       Object actual = null;
 
@@ -310,13 +331,13 @@ public class TestListVector {
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(10), (Long)actual);
+      assertEquals(new Long(10), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(11), (Long)actual);
+      assertEquals(new Long(11), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(12), (Long)actual);
+      assertEquals(new Long(12), (Long) actual);
 
       /* index 1 */
       index++;
@@ -325,10 +346,10 @@ public class TestListVector {
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(13), (Long)actual);
+      assertEquals(new Long(13), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(14), (Long)actual);
+      assertEquals(new Long(14), (Long) actual);
 
       /* index 2 */
       index++;
@@ -337,16 +358,16 @@ public class TestListVector {
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(15), (Long)actual);
+      assertEquals(new Long(15), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(16), (Long)actual);
+      assertEquals(new Long(16), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(17), (Long)actual);
+      assertEquals(new Long(17), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(18), (Long)actual);
+      assertEquals(new Long(18), (Long) actual);
 
       /* index 3 */
       index++;
@@ -355,7 +376,7 @@ public class TestListVector {
       assertEquals(Integer.toString(9), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(19), (Long)actual);
+      assertEquals(new Long(19), (Long) actual);
 
       /* index 4 */
       index++;
@@ -364,16 +385,16 @@ public class TestListVector {
       assertEquals(Integer.toString(10), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(20), (Long)actual);
+      assertEquals(new Long(20), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(21), (Long)actual);
+      assertEquals(new Long(21), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(22), (Long)actual);
+      assertEquals(new Long(22), (Long) actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(23), (Long)actual);
+      assertEquals(new Long(23), (Long) actual);
 
       /* index 5 */
       index++;
@@ -386,10 +407,10 @@ public class TestListVector {
 
         TransferPair transferPair = listVector.makeTransferPair(toVector);
 
-        int[][] transferLengths = { {0, 2},
-                                    {3, 1},
-                                    {4, 1}
-                                  };
+        int[][] transferLengths = {{0, 2},
+                {3, 1},
+                {4, 1}
+        };
 
         for (final int[] transferLength : transferLengths) {
           int start = transferLength[0];
@@ -404,26 +425,26 @@ public class TestListVector {
           transferPair.splitAndTransfer(start, splitLength);
 
           /* get offsetVector of toVector */
-          UInt4Vector offsetVector1 = (UInt4Vector)toVector.getOffsetVector();
+          UInt4Vector offsetVector1 = (UInt4Vector) toVector.getOffsetVector();
           UInt4Vector.Accessor offsetAccessor1 = offsetVector1.getAccessor();
 
           /* get dataVector of toVector */
-          NullableBigIntVector dataVector1 = (NullableBigIntVector)toVector.getDataVector();
+          NullableBigIntVector dataVector1 = (NullableBigIntVector) toVector.getDataVector();
           NullableBigIntVector.Accessor valueAccessor1 = dataVector1.getAccessor();
 
-          for(int i = 0; i < splitLength; i++) {
+          for (int i = 0; i < splitLength; i++) {
             dataLength1 = offsetAccessor.get(start + i + 1) - offsetAccessor.get(start + i);
             dataLength2 = offsetAccessor1.get(i + 1) - offsetAccessor1.get(i);
 
             assertEquals("Different data lengths at index: " + i + " and start: " + start,
-                         dataLength1, dataLength2);
+                    dataLength1, dataLength2);
 
             offset1 = offsetAccessor.get(start + i);
             offset2 = offsetAccessor1.get(i);
 
-            for(int j = 0; j < dataLength1; j++) {
+            for (int j = 0; j < dataLength1; j++) {
               assertEquals("Different data at indexes: " + offset1 + " and " + offset2,
-                           valueAccessor.getObject(offset1), valueAccessor1.getObject(offset2));
+                      valueAccessor.getObject(offset1), valueAccessor1.getObject(offset2));
 
               offset1++;
               offset2++;
@@ -431,6 +452,122 @@ public class TestListVector {
           }
         }
       }
+    }
+  }
+
+  @Test
+  public void testMultipleLists() throws Exception {
+    try (ListVector listVector = ListVector.empty("sourceVector", allocator)) {
+
+      UnionListWriter listWriter = listVector.getWriter();
+
+      /* allocate memory */
+      listWriter.allocate();
+
+      /* the dataVector that backs a listVector will also be a
+       * listVector for this test.
+       */
+
+      /* write one or more inner lists at index 0 */
+      listWriter.setPosition(0);
+      listWriter.startList();
+
+      listWriter.list().startList();
+      listWriter.list().bigInt().writeBigInt(50);
+      listWriter.list().bigInt().writeBigInt(100);
+      listWriter.list().bigInt().writeBigInt(200);
+      listWriter.list().endList();
+
+      listWriter.list().startList();
+      listWriter.list().bigInt().writeBigInt(75);
+      listWriter.list().bigInt().writeBigInt(125);
+      listWriter.list().bigInt().writeBigInt(150);
+      listWriter.list().bigInt().writeBigInt(175);
+      listWriter.list().endList();
+
+      listWriter.endList();
+
+      /* write one or more inner lists at index 1 */
+      listWriter.setPosition(1);
+      listWriter.startList();
+
+      listWriter.list().startList();
+      listWriter.list().bigInt().writeBigInt(10);
+      listWriter.list().endList();
+
+      listWriter.list().startList();
+      listWriter.list().bigInt().writeBigInt(15);
+      listWriter.list().bigInt().writeBigInt(20);
+      listWriter.list().endList();
+
+      listWriter.list().startList();
+      listWriter.list().bigInt().writeBigInt(25);
+      listWriter.list().bigInt().writeBigInt(30);
+      listWriter.list().bigInt().writeBigInt(35);
+      listWriter.list().endList();
+
+      listWriter.endList();
+
+      assertEquals(2, listVector.getMutator().getLastSet());
+
+      listVector.getMutator().setValueCount(2);
+
+      final ListVector.Accessor accessor = listVector.getAccessor();
+      assertEquals(2, accessor.getValueCount());
+
+      /* get listVector value at index 0 -- the value itself is a listvector */
+      Object result = accessor.getObject(0);
+      ArrayList<ArrayList<Long>> resultSet = (ArrayList<ArrayList<Long>>)result;
+      ArrayList<Long> list;
+
+      assertEquals(2, resultSet.size());              /* 2 inner lists at index 0 */
+      assertEquals(3, resultSet.get(0).size());       /* size of first inner list */
+      assertEquals(4, resultSet.get(1).size());      /* size of second inner list */
+
+      list = resultSet.get(0);
+      assertEquals(new Long(50), (Long)list.get(0));
+      assertEquals(new Long(100), (Long)list.get(1));
+      assertEquals(new Long(200), (Long)list.get(2));
+
+      list = resultSet.get(1);
+      assertEquals(new Long(75), (Long)list.get(0));
+      assertEquals(new Long(125), (Long)list.get(1));
+      assertEquals(new Long(150), (Long)list.get(2));
+      assertEquals(new Long(175), (Long)list.get(3));
+
+       /* get listVector value at index 1 -- the value itself is a listvector */
+      result = accessor.getObject(1);
+      resultSet = (ArrayList<ArrayList<Long>>)result;
+
+      assertEquals(3, resultSet.size());              /* 3 inner lists at index 1 */
+      assertEquals(1, resultSet.get(0).size());       /* size of first inner list */
+      assertEquals(2, resultSet.get(1).size());      /* size of second inner list */
+      assertEquals(3, resultSet.get(2).size());       /* size of third inner list */
+
+      list = resultSet.get(0);
+      assertEquals(new Long(10), (Long)list.get(0));
+
+      list = resultSet.get(1);
+      assertEquals(new Long(15), (Long)list.get(0));
+      assertEquals(new Long(20), (Long)list.get(1));
+
+      list = resultSet.get(2);
+      assertEquals(new Long(25), (Long)list.get(0));
+      assertEquals(new Long(30), (Long)list.get(1));
+      assertEquals(new Long(35), (Long)list.get(2));
+
+      /* check underlying bitVector */
+      assertFalse(accessor.isNull(0));
+      assertFalse(accessor.isNull(1));
+
+      /* check underlying offsetVector */
+      UInt4Vector offsetVector = listVector.getOffsetVector();
+      final UInt4Vector.Accessor offsetAccessor = offsetVector.getAccessor();
+
+      /* listVector has 2 lists at index 0 and 3 lists at index 1 */
+      assertEquals(0, offsetAccessor.get(0));
+      assertEquals(2, offsetAccessor.get(1));
+      assertEquals(5, offsetAccessor.get(2));
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -38,8 +38,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
+
 
 public class TestListVector {
 
@@ -433,7 +434,8 @@ public class TestListVector {
             dataLength1 = offsetAccessor.get(start + i + 1) - offsetAccessor.get(start + i);
             dataLength2 = offsetAccessor1.get(i + 1) - offsetAccessor1.get(i);
 
-            assertEquals("Different data lengths at index: " + i + " and start: " + start, dataLength1, dataLength2);
+            assertEquals("Different data lengths at index: " + i + " and start: " + start,
+                         dataLength1, dataLength2);
 
             offset1 = offsetAccessor.get(start + i);
             offset2 = offsetAccessor1.get(i);
@@ -521,15 +523,15 @@ public class TestListVector {
       assertEquals(4, resultSet.get(1).size());      /* size of second inner list */
 
       list = resultSet.get(0);
-      assertEquals(new Long(50), (Long)list.get(0));
-      assertEquals(new Long(100), (Long)list.get(1));
-      assertEquals(new Long(200), (Long)list.get(2));
+      assertEquals(new Long(50), list.get(0));
+      assertEquals(new Long(100), list.get(1));
+      assertEquals(new Long(200), list.get(2));
 
       list = resultSet.get(1);
-      assertEquals(new Long(75), (Long)list.get(0));
-      assertEquals(new Long(125), (Long)list.get(1));
-      assertEquals(new Long(150), (Long)list.get(2));
-      assertEquals(new Long(175), (Long)list.get(3));
+      assertEquals(new Long(75), list.get(0));
+      assertEquals(new Long(125), list.get(1));
+      assertEquals(new Long(150), list.get(2));
+      assertEquals(new Long(175), list.get(3));
 
        /* get listVector value at index 1 -- the value itself is a listvector */
       result = accessor.getObject(1);
@@ -541,16 +543,16 @@ public class TestListVector {
       assertEquals(3, resultSet.get(2).size());       /* size of third inner list */
 
       list = resultSet.get(0);
-      assertEquals(new Long(10), (Long)list.get(0));
+      assertEquals(new Long(10), list.get(0));
 
       list = resultSet.get(1);
-      assertEquals(new Long(15), (Long)list.get(0));
-      assertEquals(new Long(20), (Long)list.get(1));
+      assertEquals(new Long(15), list.get(0));
+      assertEquals(new Long(20), list.get(1));
 
       list = resultSet.get(2);
-      assertEquals(new Long(25), (Long)list.get(0));
-      assertEquals(new Long(30), (Long)list.get(1));
-      assertEquals(new Long(35), (Long)list.get(2));
+      assertEquals(new Long(25), list.get(0));
+      assertEquals(new Long(30), list.get(1));
+      assertEquals(new Long(35), list.get(2));
 
       /* check underlying bitVector */
       assertFalse(accessor.isNull(0));

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -129,11 +129,11 @@ public class TestListVector {
 
       /* get inner vectors; bitVector and offsetVector */
       List<BufferBacked> innerVectors = listVector.getFieldInnerVectors();
-      BitVector bitVector = (BitVector) innerVectors.get(0);
-      UInt4Vector offsetVector = (UInt4Vector) innerVectors.get(1);
+      BitVector bitVector = (BitVector)innerVectors.get(0);
+      UInt4Vector offsetVector = (UInt4Vector)innerVectors.get(1);
 
       /* get the underlying data vector -- NullableBigIntVector */
-      NullableBigIntVector dataVector = (NullableBigIntVector) listVector.getDataVector();
+      NullableBigIntVector dataVector = (NullableBigIntVector)listVector.getDataVector();
 
       /* check current lastSet */
       assertEquals(Integer.toString(0), Integer.toString(listVector.getMutator().getLastSet()));
@@ -219,36 +219,36 @@ public class TestListVector {
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
       Object actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(10), (Long) actual);
+      assertEquals(new Long(10), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(11), (Long) actual);
+      assertEquals(new Long(11), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(12), (Long) actual);
+      assertEquals(new Long(12), (Long)actual);
 
       index++;
       offset = offsetAccessor.get(index);
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(13), (Long) actual);
+      assertEquals(new Long(13), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(14), (Long) actual);
+      assertEquals(new Long(14), (Long)actual);
 
       index++;
       offset = offsetAccessor.get(index);
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offsetAccessor.get(index));
-      assertEquals(new Long(15), (Long) actual);
+      assertEquals(new Long(15), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(16), (Long) actual);
+      assertEquals(new Long(16), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(17), (Long) actual);
+      assertEquals(new Long(17), (Long)actual);
 
       index++;
       offset = offsetAccessor.get(index);
@@ -312,10 +312,10 @@ public class TestListVector {
       assertEquals(5, listVector.getMutator().getLastSet());
 
       /* get offsetVector */
-      UInt4Vector offsetVector = (UInt4Vector) listVector.getOffsetVector();
+      UInt4Vector offsetVector = (UInt4Vector)listVector.getOffsetVector();
 
       /* get dataVector */
-      NullableBigIntVector dataVector = (NullableBigIntVector) listVector.getDataVector();
+      NullableBigIntVector dataVector = (NullableBigIntVector)listVector.getDataVector();
 
       /* check the vector output */
       final UInt4Vector.Accessor offsetAccessor = offsetVector.getAccessor();
@@ -331,13 +331,13 @@ public class TestListVector {
       assertEquals(Integer.toString(0), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(10), (Long) actual);
+      assertEquals(new Long(10), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(11), (Long) actual);
+      assertEquals(new Long(11), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(12), (Long) actual);
+      assertEquals(new Long(12), (Long)actual);
 
       /* index 1 */
       index++;
@@ -346,10 +346,10 @@ public class TestListVector {
       assertEquals(Integer.toString(3), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(13), (Long) actual);
+      assertEquals(new Long(13), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(14), (Long) actual);
+      assertEquals(new Long(14), (Long)actual);
 
       /* index 2 */
       index++;
@@ -358,16 +358,16 @@ public class TestListVector {
       assertEquals(Integer.toString(5), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(15), (Long) actual);
+      assertEquals(new Long(15), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(16), (Long) actual);
+      assertEquals(new Long(16), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(17), (Long) actual);
+      assertEquals(new Long(17), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(18), (Long) actual);
+      assertEquals(new Long(18), (Long)actual);
 
       /* index 3 */
       index++;
@@ -376,7 +376,7 @@ public class TestListVector {
       assertEquals(Integer.toString(9), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(19), (Long) actual);
+      assertEquals(new Long(19), (Long)actual);
 
       /* index 4 */
       index++;
@@ -385,16 +385,16 @@ public class TestListVector {
       assertEquals(Integer.toString(10), Integer.toString(offset));
 
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(20), (Long) actual);
+      assertEquals(new Long(20), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(21), (Long) actual);
+      assertEquals(new Long(21), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(22), (Long) actual);
+      assertEquals(new Long(22), (Long)actual);
       offset++;
       actual = valueAccessor.getObject(offset);
-      assertEquals(new Long(23), (Long) actual);
+      assertEquals(new Long(23), (Long)actual);
 
       /* index 5 */
       index++;
@@ -407,10 +407,7 @@ public class TestListVector {
 
         TransferPair transferPair = listVector.makeTransferPair(toVector);
 
-        int[][] transferLengths = {{0, 2},
-                {3, 1},
-                {4, 1}
-        };
+        int[][] transferLengths = {{0, 2}, {3, 1}, {4, 1}};
 
         for (final int[] transferLength : transferLengths) {
           int start = transferLength[0];
@@ -425,26 +422,25 @@ public class TestListVector {
           transferPair.splitAndTransfer(start, splitLength);
 
           /* get offsetVector of toVector */
-          UInt4Vector offsetVector1 = (UInt4Vector) toVector.getOffsetVector();
+          UInt4Vector offsetVector1 = (UInt4Vector)toVector.getOffsetVector();
           UInt4Vector.Accessor offsetAccessor1 = offsetVector1.getAccessor();
 
           /* get dataVector of toVector */
-          NullableBigIntVector dataVector1 = (NullableBigIntVector) toVector.getDataVector();
+          NullableBigIntVector dataVector1 = (NullableBigIntVector)toVector.getDataVector();
           NullableBigIntVector.Accessor valueAccessor1 = dataVector1.getAccessor();
 
-          for (int i = 0; i < splitLength; i++) {
+          for(int i = 0; i < splitLength; i++) {
             dataLength1 = offsetAccessor.get(start + i + 1) - offsetAccessor.get(start + i);
             dataLength2 = offsetAccessor1.get(i + 1) - offsetAccessor1.get(i);
 
-            assertEquals("Different data lengths at index: " + i + " and start: " + start,
-                    dataLength1, dataLength2);
+            assertEquals("Different data lengths at index: " + i + " and start: " + start, dataLength1, dataLength2);
 
             offset1 = offsetAccessor.get(start + i);
             offset2 = offsetAccessor1.get(i);
 
-            for (int j = 0; j < dataLength1; j++) {
+            for(int j = 0; j < dataLength1; j++) {
               assertEquals("Different data at indexes: " + offset1 + " and " + offset2,
-                      valueAccessor.getObject(offset1), valueAccessor1.getObject(offset2));
+                            valueAccessor.getObject(offset1), valueAccessor1.getObject(offset2));
 
               offset1++;
               offset2++;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -452,7 +452,7 @@ public class TestListVector {
   }
 
   @Test
-  public void testMultipleLists() throws Exception {
+  public void testNestedListVector() throws Exception {
     try (ListVector listVector = ListVector.empty("sourceVector", allocator)) {
 
       UnionListWriter listWriter = listVector.getWriter();


### PR DESCRIPTION
@StevenMPhillips 

Fixed the following:

(1) TestListVector.java doesn't include tests for nested lists where the underlying dataVector for a listVector is also a listVector.

(2) The copy test in TestListVector.java only checks the bit vector contents and doesn't verify the actual contents of list vector