### PR TITLE
ARROW-1310: [JAVA] revert changes made in ARROW-886

### DIFF
--- a/java/vector/src/main/codegen/templates/VariableLengthVectors.java
+++ b/java/vector/src/main/codegen/templates/VariableLengthVectors.java
@@ -352,7 +352,6 @@ public final class ${className} extends BaseDataValueVector implements VariableW
   }
 
   public void reAlloc() {
-    offsetVector.reAlloc();
     final long newAllocationSize = allocationSizeInBytes*2L;
     if (newAllocationSize > MAX_ALLOCATION_SIZE)  {
       throw new OversizedAllocationException("Unable to expand the buffer. Max allowed buffer size is reached.");

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -73,31 +73,6 @@ public class TestVectorReAlloc {
   }
 
   @Test
-  public void testVariableLengthType() {
-    try (final VarCharVector vector = new VarCharVector("", allocator)) {
-      final VarCharVector.Mutator m = vector.getMutator();
-      // note: capacity ends up being - 1 due to offsets vector
-      vector.setInitialCapacity(511);
-      vector.allocateNew();
-
-      assertEquals(511, vector.getValueCapacity());
-
-      try {
-        m.set(512, "foo".getBytes(StandardCharsets.UTF_8));
-        Assert.fail("Expected out of bounds exception");
-      } catch (Exception e) {
-        // ok
-      }
-
-      vector.reAlloc();
-      assertEquals(1023, vector.getValueCapacity());
-
-      m.set(512, "foo".getBytes(StandardCharsets.UTF_8));
-      assertEquals("foo", new String(vector.getAccessor().get(512), StandardCharsets.UTF_8));
-    }
-  }
-
-  @Test
   public void testNullableType() {
     try (final NullableVarCharVector vector = new NullableVarCharVector("", allocator)) {
       final NullableVarCharVector.Mutator m = vector.getMutator();
@@ -114,7 +89,7 @@ public class TestVectorReAlloc {
       }
 
       vector.reAlloc();
-      assertEquals(1024, vector.getValueCapacity());
+      assertEquals(1023, vector.getValueCapacity());
 
       m.set(512, "foo".getBytes(StandardCharsets.UTF_8));
       assertEquals("foo", new String(vector.getAccessor().get(512), StandardCharsets.UTF_8));


### PR DESCRIPTION
@elahrvivaz , @StevenMPhillips 

Reverting the changes made for ARROW-886 -- https://github.com/apache/arrow/pull/591 

(1) Don't explicitly reallocate the offsetVector in realloc() function of Variable Length Vectors.   If we call setSafe() on variable length vector, it will internally invoke setSafe() on the corresponding offsetVector and the latter function can decide whether to reallocate the offsetVector or not.

(2) Doing (1) will break the unit test added as part of PR 591 so we need to remove that as well.