### PR TITLE
ARROW-1327: [Python] Always release GIL before calling check_status in Cython

### DIFF
--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -660,6 +660,7 @@ Status AppendPySequence(PyObject* obj, int64_t size,
 }
 
 Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>* out) {
+  PyAcquireGIL lock;
   std::shared_ptr<DataType> type;
   int64_t size;
   RETURN_NOT_OK(InferArrowTypeAndSize(obj, &size, &type));
@@ -668,6 +669,7 @@ Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>
 
 Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>* out,
                          const std::shared_ptr<DataType>& type, int64_t size) {
+  PyAcquireGIL lock;
   // Handle NA / NullType case
   if (type->id() == Type::NA) {
     out->reset(new NullArray(size));

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -686,7 +686,10 @@ Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>
 Status ConvertPySequence(PyObject* obj, MemoryPool* pool, std::shared_ptr<Array>* out,
                          const std::shared_ptr<DataType>& type) {
   int64_t size;
-  RETURN_NOT_OK(InferArrowSize(obj, &size));
+  {
+    PyAcquireGIL lock;
+    RETURN_NOT_OK(InferArrowSize(obj, &size));
+  }
   return ConvertPySequence(obj, pool, out, type, size);
 }
 

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -202,6 +202,8 @@ Status NumPyDtypeToArrow(PyObject* dtype, std::shared_ptr<DataType>* out) {
 #undef TO_ARROW_TYPE_CASE
 
 Status NdarrayToTensor(MemoryPool* pool, PyObject* ao, std::shared_ptr<Tensor>* out) {
+  PyAcquireGIL lock;
+
   if (!PyArray_Check(ao)) {
     return Status::TypeError("Did not pass ndarray object");
   }
@@ -234,6 +236,8 @@ Status NdarrayToTensor(MemoryPool* pool, PyObject* ao, std::shared_ptr<Tensor>* 
 }
 
 Status TensorToNdarray(const Tensor& tensor, PyObject* base, PyObject** out) {
+  PyAcquireGIL lock;
+
   int type_num;
   RETURN_NOT_OK(GetNumPyType(*tensor.type(), &type_num));
   PyArray_Descr* dtype = PyArray_DescrNewFromType(type_num);

--- a/python/pyarrow/feather.pxi
+++ b/python/pyarrow/feather.pxi
@@ -44,7 +44,8 @@ cdef class FeatherWriter:
         if self.num_rows < 0:
             self.num_rows = 0
         self.writer.get().SetNumRows(self.num_rows)
-        check_status(self.writer.get().Finalize())
+        with nogil:
+            check_status(self.writer.get().Finalize())
 
     def write_array(self, object name, object col, object mask=None):
         cdef Array arr

--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -29,7 +29,8 @@ except ImportError:
 
 def have_libhdfs():
     try:
-        check_status(HaveLibHdfs())
+        with nogil:
+            check_status(HaveLibHdfs())
         return True
     except:
         return False
@@ -37,7 +38,8 @@ def have_libhdfs():
 
 def have_libhdfs3():
     try:
-        check_status(HaveLibHdfs3())
+        with nogil:
+            check_status(HaveLibHdfs3())
         return True
     except:
         return False
@@ -73,10 +75,12 @@ cdef class HadoopFileSystem:
             conf.kerb_ticket = tobytes(kerb_ticket)
 
         if driver == 'libhdfs':
-            check_status(HaveLibHdfs())
+            with nogil:
+                check_status(HaveLibHdfs())
             conf.driver = HdfsDriver_LIBHDFS
         else:
-            check_status(HaveLibHdfs3())
+            with nogil:
+                check_status(HaveLibHdfs3())
             conf.driver = HdfsDriver_LIBHDFS3
 
         with nogil:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -447,7 +447,8 @@ cdef class MemoryMappedFile(NativeFile):
         else:
             raise ValueError('Invalid file mode: {0}'.format(mode))
 
-        check_status(CMemoryMappedFile.Open(c_path, c_mode, &handle))
+        with nogil:
+            check_status(CMemoryMappedFile.Open(c_path, c_mode, &handle))
 
         self.wr_file = <shared_ptr[OutputStream]> handle
         self.rd_file = <shared_ptr[RandomAccessFile]> handle
@@ -642,7 +643,8 @@ cdef class BufferOutputStream(NativeFile):
         self.is_open = True
 
     def get_result(self):
-        check_status(self.wr_file.get().Close())
+        with nogil:
+            check_status(self.wr_file.get().Close())
         self.is_open = False
         return pyarrow_wrap_buffer(<shared_ptr[CBuffer]> self.buffer)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -168,8 +168,9 @@ cdef class Column:
         cdef:
             PyObject* out
 
-        check_status(libarrow.ConvertColumnToPandas(self.sp_column,
-                                                    self, &out))
+        with nogil:
+            check_status(libarrow.ConvertColumnToPandas(self.sp_column,
+                                                        self, &out))
 
         return pd.Series(wrap_array_output(out), name=self.name)
 


### PR DESCRIPTION
This should prevent deadlock in some multithreaded or subinterpreter contexts. We can be more mindful of this in the future