### PR TITLE
ARROW-1306: [C++] Use UTF8 filenames in local file error messages

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -143,6 +143,8 @@ struct PlatformFilename {
 
   const char* data() const { return reinterpret_cast<const char*>(utf16_path.c_str()); }
 
+  const char* utf8_data() const { return utf8_path.c_str(); }
+
   size_t length() const { return utf16_path.size(); }
 
   std::string utf8_path;

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -143,10 +143,6 @@ struct PlatformFilename {
 
   const char* data() const { return reinterpret_cast<const char*>(utf16_path.c_str()); }
 
-  const char* utf8_data() const { return utf8_path.c_str(); }
-
-  const std::string& utf8_path() const { return utf8_path; }
-
   size_t length() const { return utf16_path.size(); }
 
   std::string utf8_path;
@@ -157,19 +153,17 @@ struct PlatformFilename {
 
 struct PlatformFilename {
   static Status Init(const std::string& utf8_path, PlatformFilename* out) {
-    out->path = utf8_path;
+    out->utf8_path = utf8_path;
     return Status::OK();
   }
 
-  const char* data() const { return path.c_str(); }
+  const char* data() const { return utf8_path.c_str(); }
 
   const char* utf8_data() const { return data(); }
 
-  const std::string& utf8_path() const { return path; }
+  size_t length() const { return utf8_path.size(); }
 
-  size_t length() const { return path.size(); }
-
-  std::string path;
+  std::string utf8_path;
 };
 
 #endif

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -142,9 +142,7 @@ class PlatformFilename {
     return Status::OK();
   }
 
-  const char* data() const {
-    return reinterpret_cast<const char*>(utf16_path_.c_str());
-  }
+  const char* data() const { return reinterpret_cast<const char*>(utf16_path_.c_str()); }
 
   const char* utf8_data() const { return utf8_path_.c_str(); }
 
@@ -213,7 +211,7 @@ static inline Status FileOpenReadable(const PlatformFilename& filename, int* fd)
   errno_t errno_actual = 0;
 #if defined(_MSC_VER)
   errno_actual = _wsopen_s(fd, reinterpret_cast<const wchar_t*>(filename.data()),
-      _O_RDONLY | _O_BINARY, _SH_DENYNO, _S_IREAD);
+                           _O_RDONLY | _O_BINARY, _SH_DENYNO, _S_IREAD);
   ret = *fd;
 #else
   ret = *fd = open(filename.data(), O_RDONLY | O_BINARY);
@@ -245,8 +243,8 @@ static inline Status FileOpenWriteable(const PlatformFilename& filename, bool wr
     oflag |= _O_RDWR;
   }
 
-  errno_actual = _wsopen_s(fd, reinterpret_cast<const wchar_t*>(filename.data()),
-      oflag, _SH_DENYNO, pmode);
+  errno_actual = _wsopen_s(fd, reinterpret_cast<const wchar_t*>(filename.data()), oflag,
+                           _SH_DENYNO, pmode);
   ret = *fd;
 
 #else

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -40,10 +40,18 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
  public:
   ~FileOutputStream();
 
-  // When opening a new file, any existing file with the indicated path is
-  // truncated to 0 bytes, deleting any existing memory
+  /// \brief Open a local file for writing, truncating any existing file
+  /// \param[in] path with UTF8 encoding
+  /// \param[out] file a FileOutputStream instance
+  ///
+  /// When opening a new file, any existing file with the indicated path is
+  /// truncated to 0 bytes, deleting any existing memory
   static Status Open(const std::string& path, std::shared_ptr<FileOutputStream>* file);
 
+  /// \brief Open a local file for writing
+  /// \param[in] path with UTF8 encoding
+  /// \param[in] append append to existing file, otherwise truncate to 0 bytes
+  /// \param[out] file a FileOutputStream instance
   static Status Open(const std::string& path, bool append,
                      std::shared_ptr<FileOutputStream>* file);
 
@@ -68,10 +76,17 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
  public:
   ~ReadableFile();
 
-  // Open file, allocate memory (if needed) from default memory pool
+  /// \brief Open a local file for reading
+  /// \param[in] path with UTF8 encoding
+  /// \param[out] file ReadableFile instance
+  /// Open file, allocate memory (if needed) from default memory pool
   static Status Open(const std::string& path, std::shared_ptr<ReadableFile>* file);
 
-  // Open file with one's own memory pool for memory allocations
+  /// \brief Open a local file for reading
+  /// \param[in] path with UTF8 encoding
+  /// \param[in] pool a MemoryPool for memory allocations
+  /// \param[out] file ReadableFile instance
+  /// Open file with one's own memory pool for memory allocations
   static Status Open(const std::string& path, MemoryPool* memory_pool,
                      std::shared_ptr<ReadableFile>* file);
 

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -320,7 +320,12 @@ TEST_F(TestReadableFile, ReadAt) {
 }
 
 TEST_F(TestReadableFile, NonExistentFile) {
-  ASSERT_RAISES(IOError, ReadableFile::Open("0xDEADBEEF.txt", &file_));
+  std::string path = "0xDEADBEEF.txt";
+  Status s = ReadableFile::Open(path, &file_);
+  ASSERT_TRUE(s.IsIOError());
+
+  std::string message = s.message();
+  ASSERT_NE(std::string::npos, message.find(path));
 }
 
 class MyMemoryPool : public MemoryPool {

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -45,8 +45,8 @@ static bool FileExists(const std::string& path) {
 void InvalidParamHandler(const wchar_t* expr, const wchar_t* func,
                          const wchar_t* source_file, unsigned int source_line,
                          uintptr_t reserved) {
-  wprintf(L"Invalid parameter in function %s. Source: %s line %d expression %s",
-      func, source_file, source_line, expr);
+  wprintf(L"Invalid parameter in function %s. Source: %s line %d expression %s", func,
+          source_file, source_line, expr);
 }
 #endif
 

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -45,8 +45,8 @@ static bool FileExists(const std::string& path) {
 void InvalidParamHandler(const wchar_t* expr, const wchar_t* func,
                          const wchar_t* source_file, unsigned int source_line,
                          uintptr_t reserved) {
-  wprintf(L"Invalid parameter in funcion %s. Source: %s line %d expression %s", func,
-          source_file, source_line, expr);
+  wprintf(L"Invalid parameter in function %s. Source: %s line %d expression %s",
+      func, source_file, source_line, expr);
 }
 #endif
 

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -132,7 +132,6 @@ else:
 
 def encode_file_path(path):
     import os
-    # Windows requires utf-16le encoding for unicode file names
     if isinstance(path, unicode_type):
         # POSIX systems can handle utf-8. UTF8 is converted to utf16-le in
         # libarrow
@@ -140,6 +139,8 @@ def encode_file_path(path):
     else:
         encoded_path = path
 
+    # Windows file system requires utf-16le for file names; Arrow C++ libraries
+    # will convert utf8 to utf16
     return encoded_path
 
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1127,3 +1127,14 @@ def test_write_error_deletes_incomplete_file(tmpdir):
         pass
 
     assert not os.path.exists(filename)
+
+
+@parquet
+def test_read_non_existent_file(tmpdir):
+    import pyarrow.parquet as pq
+
+    path = 'non-existent-file.parquet'
+    try:
+        pq.read_table(path)
+    except Exception as e:
+        assert path in e.args[0]


### PR DESCRIPTION
Encoded utf16-le bytes were being written to error messages (which are output to UTF-8 consoles), resulting in unintelligible displays.

This also improves the error message when opening the file fails per ARROW-1121.