### PR TITLE
ARROW-1338: [Python] Do not close RecordBatchWriter on dealloc in case sink is no longer valid

### DIFF
--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -163,8 +163,7 @@ cdef class _RecordBatchWriter:
         self.closed = True
 
     def __dealloc__(self):
-        if not self.closed:
-            self.close()
+        pass
 
     def _open(self, sink, Schema schema):
         cdef:
@@ -182,11 +181,24 @@ cdef class _RecordBatchWriter:
         self.closed = False
 
     def write_batch(self, RecordBatch batch):
+        """
+        Write RecordBatch to stream
+
+        Parameters
+        ----------
+        batch : RecordBatch
+        """
         with nogil:
             check_status(self.writer.get()
                          .WriteRecordBatch(deref(batch.batch)))
 
     def close(self):
+        """
+        Close stream and write end-of-stream 0 marker
+        """
+        if self.closed:
+            return
+
         with nogil:
             check_status(self.writer.get().Close())
         self.closed = True

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -277,6 +277,8 @@ def test_mock_output_stream():
 
     stream_writer1.write_batch(record_batch)
     stream_writer2.write_batch(record_batch)
+    stream_writer1.close()
+    stream_writer2.close()
 
     assert f1.size() == len(f2.get_result())
 


### PR DESCRIPTION
Also add missing close() statements to test_mock_output_stream to fix invalid writes causing core dump on OS X. 