### PR TITLE
ARROW-801: Provide direct access to underlying buffer memory addresses

### DIFF
--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -435,6 +435,25 @@ protected final static byte[] emptyByteArray = new byte[]{};
     <#if type.major == "VarLen">mutator.lastSet = thisIndex;</#if>
   }
 
+  @Override
+  public long getValidityBufferAddress() {
+    return (bits.getBuffer().memoryAddress());
+  }
+
+  @Override
+  public long getDataBufferAddress() {
+    return (values.getBuffer().memoryAddress());
+  }
+
+  @Override
+  public long getOffsetBufferAddress() {
+    <#if type.major != "VarLen">
+        throw new UnsupportedOperationException();
+    <#else>
+        return (values.getOffsetAddr());
+    </#if>
+  }
+
   public final class Accessor extends BaseDataValueVector.BaseAccessor <#if type.major = "VarLen">implements VariableWidthVector.VariableWidthAccessor</#if> {
     final BitVector.Accessor bAccessor = bits.getAccessor();
     final ${valuesName}.Accessor vAccessor = values.getAccessor();

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -132,6 +132,21 @@ public class UnionVector implements FieldVector {
     return internalMap.addOrGet(fieldName(minorType), fieldType(minorType), c);
   }
 
+  @Override
+  public long getValidityBufferAddress() {
+    return typeVector.getBuffer().memoryAddress();
+  }
+
+  @Override
+  public long getDataBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getOffsetBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
   public NullableMapVector getMap() {
     if (mapVector == null) {
       int vectorCount = internalMap.size();

--- a/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FieldVector.java
@@ -66,4 +66,25 @@ public interface FieldVector extends ValueVector {
    * @return the inner vectors for this field as defined by the TypeLayout
    */
   List<BufferBacked> getFieldInnerVectors();
+
+  /**
+   * Gets the starting address of the underlying buffer associated with validity vector
+   *
+   * @return buffer address
+   */
+  public long getValidityBufferAddress();
+
+  /**
+   * Gets the starting address of the underlying buffer associated with data vector
+   *
+   * @return buffer address
+   */
+  public long getDataBufferAddress();
+
+  /**
+   * Gets the starting address of the underlying buffer associated with offset vector
+   *
+   * @return buffer address
+   */
+  public long getOffsetBufferAddress();
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -229,4 +229,19 @@ public class ZeroVector implements FieldVector {
   public List<BufferBacked> getFieldInnerVectors() {
     return Collections.emptyList();
   }
+
+  @Override
+  public long getValidityBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getDataBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getOffsetBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -293,6 +293,21 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
     return vector;
   }
 
+  @Override
+  public long getValidityBufferAddress() {
+    return (bits.getBuffer().memoryAddress());
+  }
+
+  @Override
+  public long getDataBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getOffsetBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
   public class Accessor extends BaseValueVector.BaseAccessor {
 
     @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -178,6 +178,21 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     return new TransferImpl((ListVector) target);
   }
 
+  @Override
+  public long getValidityBufferAddress() {
+    return (bits.getBuffer().memoryAddress());
+  }
+
+  @Override
+  public long getDataBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getOffsetBufferAddress() {
+    return (offsets.getBuffer().memoryAddress());
+  }
+
   private class TransferImpl implements TransferPair {
 
     ListVector to;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NullableMapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NullableMapVector.java
@@ -231,6 +231,21 @@ public class NullableMapVector extends MapVector implements FieldVector {
     super.reAlloc();
   }
 
+  @Override
+  public long getValidityBufferAddress() {
+    return bits.getBuffer().memoryAddress();
+  }
+
+  @Override
+  public long getDataBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getOffsetBufferAddress() {
+    throw new UnsupportedOperationException();
+  }
+
   public final class Accessor extends MapVector.Accessor {
     final BitVector.Accessor bAccessor = bits.getAccessor();
 


### PR DESCRIPTION
Added following methods at FieldVector interface

public long getValidityBufferAddress();
public long getDataBufferAddress();
public long getOffsetBufferAddress();

Couple of points:

For the UnionVector, we don't have an explicit BitVector and the typeVector also acts as a validity vector during get(), isNull(). So getValidityBufferAddress() returns the address of buffer associated with typeVector.

Both ListVector and FixedSizeListVector are backed by a FieldVector which acts as the dataVector. Right now the getDataBufferAddress() is unsupported for these two vectors but I think that we could just simply delegate this call to the dataVector instead of throwing exception
