### PR TITLE
ARROW-1352: [Integration] Added specific formatting for producer consumer output

### DIFF
--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -789,8 +789,10 @@ class IntegrationRunner(object):
             self._compare_implementations(producer, consumer)
 
     def _compare_implementations(self, producer, consumer):
-        print('-- {0} producing, {1} consuming'.format(producer.name,
+        print('##########################################################')
+        print('{0} producing, {1} consuming'.format(producer.name,
                                                        consumer.name))
+        print('##########################################################')
 
         for json_path in self.json_files:
             print('==========================================================')


### PR DESCRIPTION
Changed output of integration tests to give a specific format when indicating producer/consumer.  The new output will look like this:

```
-- Creating binary inputs
-- Validating file
-- Validating stream
##########################################################
Java producing, C++ consuming
##########################################################
==========================================================
Testing file /home/bryan/git/arrow/integration/data/struct_example.json
==========================================================
-- Creating binary inputs
-- Validating file
-- Validating stream
```