### PR TITLE
ARROW-1355: [Java] Make Arrow buildable with jdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,11 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
   - language: java
     os: linux
+    jdk: openjdk9
+    script:
+    - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
+  - language: java
+    os: linux
     env: ARROW_TEST_GROUP=integration
     jdk: openjdk7
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
   - language: java
     os: linux
+    env: ARROW_TRAVIS_SKIP_SITE=yes
     jdk: oraclejdk9
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
   - language: java
     os: linux
-    jdk: openjdk9
+    jdk: oraclejdk9
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
   - language: java

--- a/ci/travis_script_java.sh
+++ b/ci/travis_script_java.sh
@@ -24,8 +24,7 @@ JAVA_DIR=${TRAVIS_BUILD_DIR}/java
 pushd $JAVA_DIR
 
 export MAVEN_OPTS="$MAVEN_OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
-mvn -B test
 mvn -B install
-mvn -B site
+[ "${ARROW_TRAVIS_SKIP_SITE}" = "yes" ] || mvn -B site
 
 popd

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -333,15 +333,15 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.6.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
+          <version>3.0.0-M1</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.17</version>
+          <version>2.20</version>
           <configuration>
             <enableAssertions>true</enableAssertions>
             <forkCount>${forkCount}</forkCount>
@@ -537,7 +537,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>3.0.0-M1</version>
         <reportSets>
           <reportSet><!-- by default, id = "default" -->
             <reports><!-- select non-aggregate reports -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -279,7 +279,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>6.15</version>
+              <version>6.19</version>
             </dependency>
             <dependency>
               <groupId>com.google.guava</groupId>
@@ -493,9 +493,9 @@
 
     <dependency>
       <!-- JMockit needs to be on class path before JUnit. -->
-      <groupId>com.googlecode.jmockit</groupId>
+      <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
-      <version>1.7</version>
+      <version>1.33</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -57,7 +57,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.0.0</version>
           <configuration>
             <descriptorRefs>
               <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
Make Arrow buildable with jdk9:
- upgrade checkstyle plugin to 6.19
- upgrade assembly plugin to 3.0.0
- update jmockit version to 1.33

Also add travis entry to build using Oracle JDK9 EA