### PR TITLE
fix parquet docs on write_table options

### DIFF
--- a/python/doc/source/parquet.rst
+++ b/python/doc/source/parquet.rst
@@ -175,7 +175,7 @@ These settings can also be set on a per-column basis:
 
 .. code-block:: python
 
-   pa.write_table(table, where, compression={'foo': 'snappy', 'bar': 'gzip'},
+   pq.write_table(table, where, compression={'foo': 'snappy', 'bar': 'gzip'},
                   use_dictionary=['foo', 'bar'])
 
 Reading Multiples Files and Partitioned Datasets


### PR DESCRIPTION
Noticed this while working with parquet files, thought for a second "Oh hey, the top level pyarrow has a `write_table`? Oh, no it doesn't this is a typo"

I've now written more than my actual change. 😄  Hopefully I don't have to open a JIRA ticket for this.