### PR TITLE
ARROW-1361: [Java] Adding methods to get type param values in NullableValueVector

### DIFF
--- a/java/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/java/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -67,6 +67,12 @@ public final class ${className} extends BaseDataValueVector implements FixedWidt
     this.${typeParam.name} = ${typeParam.name};
     </#list>
   }
+
+    <#list typeParams as typeParam>
+  public ${typeParam.type} get${typeParam.name?cap_first}() {
+    return ${typeParam.name};
+  }
+    </#list>
   <#else>
   public ${className}(String name, BufferAllocator allocator) {
     super(name, allocator);
@@ -80,12 +86,12 @@ public final class ${className} extends BaseDataValueVector implements FixedWidt
 
   @Override
   public Field getField() {
-        throw new UnsupportedOperationException("internal vector");
+    throw new UnsupportedOperationException("internal vector");
   }
 
   @Override
   public FieldReader getReader(){
-        throw new UnsupportedOperationException("non-nullable vectors cannot be used in readers");
+    throw new UnsupportedOperationException("non-nullable vectors cannot be used in readers");
   }
 
   @Override
@@ -287,7 +293,7 @@ public final class ${className} extends BaseDataValueVector implements FixedWidt
 
   public void copyFromSafe(int fromIndex, int thisIndex, ${className} from){
     while(thisIndex >= getValueCapacity()) {
-        reAlloc();
+      reAlloc();
     }
     copyFrom(fromIndex, thisIndex, from);
   }

--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -65,7 +65,9 @@ protected final static byte[] emptyByteArray = new byte[]{};
   <#if minor.typeParams??>
     <#assign typeParams = minor.typeParams?reverse>
     <#list typeParams as typeParam>
-  private final ${typeParam.type} ${typeParam.name};
+  public ${typeParam.type} get${typeParam.name?cap_first}() {
+    return values.get${typeParam.name?cap_first}();
+  }
     </#list>
 
   /**
@@ -97,7 +99,7 @@ protected final static byte[] emptyByteArray = new byte[]{};
     <#assign typeParams = minor.typeParams?reverse>
     ${minor.arrowType} arrowType = (${minor.arrowType})fieldType.getType();
     <#list typeParams as typeParam>
-    this.${typeParam.name} = arrowType.get${typeParam.name?cap_first}();
+    ${typeParam.type} ${typeParam.name} = arrowType.get${typeParam.name?cap_first}();
     </#list>
     this.values = new ${valuesName}(valuesField, allocator<#list typeParams as typeParam>, ${typeParam.name}</#list>);
     <#else>
@@ -331,7 +333,7 @@ protected final static byte[] emptyByteArray = new byte[]{};
 
   @Override
   public TransferPair getTransferPair(String ref, BufferAllocator allocator, CallBack callBack) {
-        return getTransferPair(ref, allocator);
+    return getTransferPair(ref, allocator);
   }
 
   @Override

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -41,15 +41,17 @@ public class TestDecimalVector {
     }
   }
 
-  private int scale = 3;
-
   @Test
   public void test() {
+    int precision = 10;
+    int scale = 3;
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-    NullableDecimalVector decimalVector = TestUtils.newVector(NullableDecimalVector.class, "decimal", new ArrowType.Decimal(10, scale), allocator);
-    try (NullableDecimalVector oldConstructor = new NullableDecimalVector("decimal", allocator, 10, scale);) {
+    NullableDecimalVector decimalVector = TestUtils.newVector(NullableDecimalVector.class, "decimal", new ArrowType.Decimal(precision, scale), allocator);
+    try (NullableDecimalVector oldConstructor = new NullableDecimalVector("decimal", allocator, precision, scale);) {
       assertEquals(decimalVector.getField().getType(), oldConstructor.getField().getType());
     }
+    assertEquals(decimalVector.getPrecision(), precision);
+    assertEquals(decimalVector.getScale(), scale);
     decimalVector.allocateNew();
     BigDecimal[] values = new BigDecimal[intValues.length];
     for (int i = 0; i < intValues.length; i++) {


### PR DESCRIPTION
Adding type param getters to `NullableValueVectors` as a convenience over getting the Field and casting the type to get the param values.  These getters just call the  inner vector `FixedValueVectors` which also contains these param values.  Since `NullableValueVectors` does not use the param variables except during initialization they are removed here.