### PR TITLE
ARROW-1366: [Plasma] Define entry point for the plasma store

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -105,6 +105,16 @@ from pyarrow.ipc import (Message, MessageReader,
 
 localfs = LocalFileSystem.get_instance()
 
+# Entry point for starting the plasma store
+
+def start_plasma_store():
+    import os
+    import pyarrow
+    import subprocess
+    import sys
+    plasma_store_executable = os.path.join(pyarrow.__path__[0], "plasma_store")
+    process = subprocess.Popen([plasma_store_executable] + sys.argv[1:])
+    process.wait()
 
 # ----------------------------------------------------------------------
 # 0.4.0 deprecations

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -107,7 +107,13 @@ localfs = LocalFileSystem.get_instance()
 
 # Entry point for starting the plasma store
 
-def start_plasma_store():
+def _plasma_store_entry_point():
+    """Entry point for starting the plasma store.
+
+    This can be used by invoking e. g. ``plasma_store -s /tmp/plasma -m 1000000000``
+    from the command line and will start the plasma_store executable with the
+    given arguments.
+    """
     import os
     import pyarrow
     import subprocess

--- a/python/setup.py
+++ b/python/setup.py
@@ -384,7 +384,7 @@ setup(
     },
     entry_points = {
         'console_scripts': [
-            'plasma_store = pyarrow:start_plasma_store'
+            'plasma_store = pyarrow:_plasma_store_entry_point'
         ]
     },
     use_scm_version={"root": "..", "relative_to": __file__},

--- a/python/setup.py
+++ b/python/setup.py
@@ -382,6 +382,11 @@ setup(
         'clean': clean,
         'build_ext': build_ext
     },
+    entry_points = {
+        'console_scripts': [
+            'plasma_store = pyarrow:start_plasma_store'
+        ]
+    },
     use_scm_version={"root": "..", "relative_to": __file__},
     setup_requires=['setuptools_scm', 'cython >= 0.23'],
     install_requires=['numpy >= 1.10', 'six >= 1.0.0'],


### PR DESCRIPTION
The method for starting the Plasma store is already documented in https://arrow.apache.org/docs/python/plasma.html. So far it only worked if the store was installed with "make install" from the C++ sources. This makes it also possible to start it if the pyarrow wheels are installed.