### PR TITLE
Fix a typo in plasma.md

### DIFF
--- a/cpp/apidoc/tutorials/plasma.md
+++ b/cpp/apidoc/tutorials/plasma.md
@@ -391,7 +391,7 @@ the next newly available object:
 ```cpp
 // Receive notification of the next newly available object.
 // Notification information is stored in object_id, data_size, and metadata_size
-ObjectID new_object_id;
+ObjectID object_id;
 int64_t data_size;
 int64_t metadata_size;
 ARROW_CHECK_OK(client.GetNotification(fd, &object_id, &data_size, &metadata_size));


### PR DESCRIPTION
`new_object_id` is not used in `ARROW_CHECK_OK`.
So, I think better use `object_id` instead `new_object_id` in this comment.