### PR TITLE
ARROW-786: [Format] In-memory format for 128-bit Decimals, handling of sign bit

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -742,6 +742,7 @@ set(ARROW_SRCS
   src/arrow/util/compression.cc
   src/arrow/util/cpu-info.cc
   src/arrow/util/decimal.cc
+  src/arrow/util/int128.cc
   src/arrow/util/key_value_metadata.cc
 )
 

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -367,34 +367,25 @@ DecimalArray::DecimalArray(const std::shared_ptr<DataType>& type, int64_t length
       std::make_shared<ArrayData>(type, length, std::move(buffers), null_count, offset));
 }
 
-const uint8_t* DecimalArray::GetValue(int64_t i) const {
-  return raw_values_ + (i + data_->offset) * byte_width();
-}
+#define DECIMAL_TO_STRING_CASE(bits, bytes, precision, scale) \
+  case bits: {                                                \
+    decimal::Decimal##bits value;                             \
+    decimal::FromBytes((bytes), &value);                      \
+    return decimal::ToString(value, (precision), (scale));    \
+  }
 
 std::string DecimalArray::FormatValue(int64_t i) const {
   const auto& type_ = static_cast<const DecimalType&>(*type());
   const int precision = type_.precision();
   const int scale = type_.scale();
-  const int byte_width = type_.byte_width();
-  const uint8_t* bytes = raw_values_ + (i + data_->offset) * byte_width;
-  switch (byte_width) {
-    case 4: {
-      decimal::Decimal32 value;
-      decimal::FromBytes(bytes, &value);
-      return decimal::ToString(value, precision, scale);
-    }
-    case 8: {
-      decimal::Decimal64 value;
-      decimal::FromBytes(bytes, &value);
-      return decimal::ToString(value, precision, scale);
-    }
-    case 16: {
-      decimal::Decimal128 value;
-      decimal::FromBytes(bytes, &value);
-      return decimal::ToString(value, precision, scale);
-    }
+  const int bit_width = type_.bit_width();
+  const uint8_t* bytes = GetValue(i);
+  switch (bit_width) {
+    DECIMAL_TO_STRING_CASE(32, bytes, precision, scale)
+    DECIMAL_TO_STRING_CASE(64, bytes, precision, scale)
+    DECIMAL_TO_STRING_CASE(128, bytes, precision, scale)
     default: {
-      DCHECK(false) << "Invalid byte width: " << byte_width;
+      DCHECK(false) << "Invalid bit width: " << bit_width;
       return "";
     }
   }

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -161,7 +161,7 @@ PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t le
 
 const uint8_t* PrimitiveArray::raw_values() const {
   return raw_values_ +
-         offset() * static_cast<const FixedWidthType&>(*type()).bit_width() / 8;
+         offset() * static_cast<const FixedWidthType&>(*type()).bit_width() / CHAR_BIT;
 }
 
 template <typename T>

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -348,18 +348,8 @@ const uint8_t* FixedSizeBinaryArray::GetValue(int64_t i) const {
 DecimalArray::DecimalArray(const std::shared_ptr<internal::ArrayData>& data)
     : FixedSizeBinaryArray(data) {
   DCHECK_EQ(data->type->id(), Type::DECIMAL);
-  SetData(data);
 }
 
-DecimalArray::DecimalArray(const std::shared_ptr<DataType>& type, int64_t length,
-                           const std::shared_ptr<Buffer>& data,
-                           const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
-                           int64_t offset)
-    : FixedSizeBinaryArray(type, length, data, null_bitmap, null_count, offset) {
-  BufferVector buffers = {null_bitmap, data};
-  SetData(
-      std::make_shared<ArrayData>(type, length, std::move(buffers), null_count, offset));
-}
 
 #define DECIMAL_TO_STRING_CASE(bits, bytes, precision, scale) \
   case bits: {                                                \

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -350,7 +350,6 @@ DecimalArray::DecimalArray(const std::shared_ptr<internal::ArrayData>& data)
   DCHECK_EQ(data->type->id(), Type::DECIMAL);
 }
 
-
 #define DECIMAL_TO_STRING_CASE(bits, bytes, precision, scale) \
   case bits: {                                                \
     decimal::Decimal##bits value;                             \

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -323,7 +323,6 @@ std::shared_ptr<Array> StringArray::Slice(int64_t offset, int64_t length) const 
 
 FixedSizeBinaryArray::FixedSizeBinaryArray(
     const std::shared_ptr<internal::ArrayData>& data) {
-  DCHECK_EQ(data->type->id(), Type::FIXED_SIZE_BINARY);
   SetData(data);
 }
 
@@ -346,22 +345,17 @@ const uint8_t* FixedSizeBinaryArray::GetValue(int64_t i) const {
 // ----------------------------------------------------------------------
 // Decimal
 
-DecimalArray::DecimalArray(const std::shared_ptr<internal::ArrayData>& data) {
+DecimalArray::DecimalArray(const std::shared_ptr<internal::ArrayData>& data)
+    : FixedSizeBinaryArray(data) {
   DCHECK_EQ(data->type->id(), Type::DECIMAL);
   SetData(data);
-}
-
-void DecimalArray::SetData(const std::shared_ptr<ArrayData>& data) {
-  auto fixed_size_data = data->buffers[1];
-  this->Array::SetData(data);
-
-  raw_values_ = fixed_size_data != nullptr ? fixed_size_data->data() : nullptr;
 }
 
 DecimalArray::DecimalArray(const std::shared_ptr<DataType>& type, int64_t length,
                            const std::shared_ptr<Buffer>& data,
                            const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
-                           int64_t offset) {
+                           int64_t offset)
+    : FixedSizeBinaryArray(type, length, data, null_bitmap, null_count, offset) {
   BufferVector buffers = {null_bitmap, data};
   SetData(
       std::make_shared<ArrayData>(type, length, std::move(buffers), null_count, offset));

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -538,13 +538,10 @@ class ARROW_EXPORT DecimalArray : public FixedSizeBinaryArray {
  public:
   using TypeClass = DecimalType;
 
+  using FixedSizeBinaryArray::FixedSizeBinaryArray;
+
   /// \brief Construct DecimalArray from internal::ArrayData instance
   explicit DecimalArray(const std::shared_ptr<internal::ArrayData>& data);
-
-  DecimalArray(const std::shared_ptr<DataType>& type, int64_t length,
-               const std::shared_ptr<Buffer>& data,
-               const std::shared_ptr<Buffer>& null_bitmap = nullptr,
-               int64_t null_count = 0, int64_t offset = 0);
 
   std::string FormatValue(int64_t i) const;
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -521,8 +521,6 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
 
   int32_t byte_width() const { return byte_width_; }
 
-  const uint8_t* raw_values() const { return raw_values_ + byte_width_ * data_->offset; }
-
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 
  protected:
@@ -536,9 +534,9 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
 
 // ----------------------------------------------------------------------
 // DecimalArray
-class ARROW_EXPORT DecimalArray : public FlatArray {
+class ARROW_EXPORT DecimalArray : public FixedSizeBinaryArray {
  public:
-  using TypeClass = Type;
+  using TypeClass = DecimalType;
 
   /// \brief Construct DecimalArray from internal::ArrayData instance
   explicit DecimalArray(const std::shared_ptr<internal::ArrayData>& data);
@@ -548,25 +546,9 @@ class ARROW_EXPORT DecimalArray : public FlatArray {
                const std::shared_ptr<Buffer>& null_bitmap = nullptr,
                int64_t null_count = 0, int64_t offset = 0);
 
-  const uint8_t* GetValue(int64_t i) const;
-
   std::string FormatValue(int64_t i) const;
 
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
-
-  /// \brief The main decimal data
-  std::shared_ptr<Buffer> values() const { return data_->buffers[1]; }
-
-  int32_t byte_width() const {
-    return static_cast<const DecimalType&>(*type()).byte_width();
-  }
-
-  /// \brief Return pointer to value data, accounting for any offset
-  const uint8_t* raw_values() const { return raw_values_ + byte_width() * data_->offset; }
-
- private:
-  void SetData(const std::shared_ptr<internal::ArrayData>& data);
-  const uint8_t* raw_values_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -546,10 +546,7 @@ class ARROW_EXPORT DecimalArray : public FlatArray {
   DecimalArray(const std::shared_ptr<DataType>& type, int64_t length,
                const std::shared_ptr<Buffer>& data,
                const std::shared_ptr<Buffer>& null_bitmap = nullptr,
-               int64_t null_count = 0, int64_t offset = 0,
-               const std::shared_ptr<Buffer>& sign_bitmap = nullptr);
-
-  bool IsNegative(int64_t i) const;
+               int64_t null_count = 0, int64_t offset = 0);
 
   const uint8_t* GetValue(int64_t i) const;
 
@@ -558,11 +555,7 @@ class ARROW_EXPORT DecimalArray : public FlatArray {
   std::shared_ptr<Array> Slice(int64_t offset, int64_t length) const override;
 
   /// \brief The main decimal data
-  /// For 32/64-bit decimal this is everything
   std::shared_ptr<Buffer> values() const { return data_->buffers[1]; }
-
-  /// Only needed for 128 bit Decimals
-  std::shared_ptr<Buffer> sign_bitmap() const { return data_->buffers[2]; }
 
   int32_t byte_width() const {
     return static_cast<const DecimalType&>(*type()).byte_width();
@@ -574,7 +567,6 @@ class ARROW_EXPORT DecimalArray : public FlatArray {
  private:
   void SetData(const std::shared_ptr<internal::ArrayData>& data);
   const uint8_t* raw_values_;
-  const uint8_t* sign_bitmap_data_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -704,15 +704,7 @@ class ARROW_EXPORT DecimalBuilder : public FixedSizeBinaryBuilder {
   template <typename T>
   ARROW_EXPORT Status Append(const decimal::Decimal<T>& val);
 
-  Status Init(int64_t capacity) override;
-  Status Resize(int64_t capacity) override;
   Status Finish(std::shared_ptr<Array>* out) override;
-
- private:
-  /// We only need these for 128 bit decimals, because boost stores the sign
-  /// separate from the underlying bytes.
-  std::shared_ptr<ResizableBuffer> sign_bitmap_;
-  uint8_t* sign_bitmap_data_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -257,37 +257,7 @@ class RangeEqualsVisitor {
   }
 
   Status Visit(const DecimalArray& left) {
-    const auto& right = static_cast<const DecimalArray&>(right_);
-
-    int32_t width = left.byte_width();
-
-    const uint8_t* left_data = nullptr;
-    const uint8_t* right_data = nullptr;
-
-    if (left.values()) {
-      left_data = left.raw_values();
-    }
-
-    if (right.values()) {
-      right_data = right.raw_values();
-    }
-
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      const bool is_null = left.IsNull(i);
-      if (is_null != right.IsNull(o_i)) {
-        result_ = false;
-        return Status::OK();
-      }
-      if (is_null) continue;
-
-      if (std::memcmp(left_data + width * i, right_data + width * o_i, width)) {
-        result_ = false;
-        return Status::OK();
-      }
-    }
-    result_ = true;
-    return Status::OK();
+    return Visit(static_cast<const FixedSizeBinaryArray&>(left));
   }
 
   Status Visit(const NullArray& left) {
@@ -341,7 +311,7 @@ class RangeEqualsVisitor {
 
 static bool IsEqualPrimitive(const PrimitiveArray& left, const PrimitiveArray& right) {
   const auto& size_meta = dynamic_cast<const FixedWidthType&>(*left.type());
-  const int byte_width = size_meta.bit_width() / 8;
+  const int byte_width = size_meta.bit_width() / CHAR_BIT;
 
   const uint8_t* left_data = nullptr;
   const uint8_t* right_data = nullptr;
@@ -372,6 +342,14 @@ static bool IsEqualPrimitive(const PrimitiveArray& left, const PrimitiveArray& r
 template <typename T>
 static inline bool CompareBuiltIn(const Array& left, const Array& right, const T* ldata,
                                   const T* rdata) {
+  if (ldata == nullptr && rdata == nullptr) {
+    return true;
+  }
+
+  if (ldata == nullptr || rdata == nullptr) {
+    return false;
+  }
+
   if (left.null_count() > 0) {
     for (int64_t i = 0; i < left.length(); ++i) {
       if (left.IsNull(i) != right.IsNull(i)) {
@@ -381,55 +359,9 @@ static inline bool CompareBuiltIn(const Array& left, const Array& right, const T
       }
     }
     return true;
-  } else {
-    return memcmp(ldata, rdata, sizeof(T) * left.length()) == 0;
-  }
-}
-
-static bool IsEqualDecimal(const DecimalArray& left, const DecimalArray& right) {
-  const uint8_t* left_data = nullptr;
-  const uint8_t* right_data = nullptr;
-
-  if (left.values() != nullptr) {
-    left_data = left.raw_values();
   }
 
-  if (right.values() != nullptr) {
-    right_data = right.raw_values();
-  }
-
-  const int32_t byte_width = left.byte_width();
-  if (byte_width == 4) {
-    return CompareBuiltIn<int32_t>(left, right,
-                                   reinterpret_cast<const int32_t*>(left_data),
-                                   reinterpret_cast<const int32_t*>(right_data));
-  }
-
-  if (byte_width == 8) {
-    return CompareBuiltIn<int64_t>(left, right,
-                                   reinterpret_cast<const int64_t*>(left_data),
-                                   reinterpret_cast<const int64_t*>(right_data));
-  }
-
-  // 128-bit
-  for (int64_t i = 0; i < left.length(); ++i) {
-    const bool left_null = left.IsNull(i);
-    const bool right_null = right.IsNull(i);
-
-    // one of left or right value is not null
-    if (left_null != right_null) {
-      return false;
-    }
-
-    // both are not null and their respective elements are byte for byte equal
-    if (!left_null && !right_null && memcmp(left_data, right_data, byte_width) != 0) {
-      return false;
-    }
-
-    left_data += byte_width;
-    right_data += byte_width;
-  }
-  return true;
+  return memcmp(ldata, rdata, sizeof(T) * left.length()) == 0;
 }
 
 class ArrayEqualsVisitor : public RangeEqualsVisitor {
@@ -471,11 +403,6 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
                           Status>::type
   Visit(const T& left) {
     result_ = IsEqualPrimitive(left, static_cast<const PrimitiveArray&>(right_));
-    return Status::OK();
-  }
-
-  Status Visit(const DecimalArray& left) {
-    result_ = IsEqualDecimal(left, static_cast<const DecimalArray&>(right_));
     return Status::OK();
   }
 
@@ -578,6 +505,27 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
       result_ = left.indices()->Equals(right.indices());
     }
     return Status::OK();
+  }
+
+  Status Visit(const DecimalArray& left) {
+    const int byte_width = left.byte_width();
+    if (byte_width == 4) {
+      result_ = CompareBuiltIn<int32_t>(
+          left, right_, reinterpret_cast<const int32_t*>(left.raw_values()),
+          reinterpret_cast<const int32_t*>(
+              static_cast<const DecimalArray&>(right_).raw_values()));
+      return Status::OK();
+    }
+
+    if (byte_width == 8) {
+      result_ = CompareBuiltIn<int64_t>(
+          left, right_, reinterpret_cast<const int64_t*>(left.raw_values()),
+          reinterpret_cast<const int64_t*>(
+              static_cast<const DecimalArray&>(right_).raw_values()));
+      return Status::OK();
+    }
+
+    return RangeEqualsVisitor::Visit(left);
   }
 
   template <typename T>
@@ -812,7 +760,7 @@ Status TensorEquals(const Tensor& left, const Tensor& right, bool* are_equal) {
     }
 
     const auto& size_meta = dynamic_cast<const FixedWidthType&>(*left.type());
-    const int byte_width = size_meta.bit_width() / 8;
+    const int byte_width = size_meta.bit_width() / CHAR_BIT;
     DCHECK_GT(byte_width, 0);
 
     const uint8_t* left_data = left.data()->data();

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -604,7 +604,8 @@ static Status ConvertTimes(PandasOptions options, const ChunkedArray& data,
 
 template <typename T>
 Status ValidateDecimalPrecision(int precision) {
-  constexpr static const int maximum_precision = decimal::DecimalPrecision<T>::maximum;
+  constexpr static const int maximum_precision =
+      decimal::DecimalPrecision<typename T::value_type>::maximum;
   if (!(precision > 0 && precision <= maximum_precision)) {
     std::stringstream ss;
     ss << "Invalid precision: " << precision << ". Minimum is 1, maximum is "
@@ -620,27 +621,24 @@ Status RawDecimalToString(const uint8_t* bytes, int precision, int scale,
   DCHECK_NE(bytes, nullptr);
   DCHECK_NE(result, nullptr);
   RETURN_NOT_OK(ValidateDecimalPrecision<T>(precision));
-  decimal::Decimal<T> decimal;
-  FromBytes(bytes, &decimal);
-  *result = ToString(decimal, precision, scale);
+  T decimal;
+  decimal::FromBytes(bytes, &decimal);
+  *result = decimal::ToString(decimal, precision, scale);
   return Status::OK();
 }
 
-template Status RawDecimalToString<int32_t>(const uint8_t*, int, int,
-                                            std::string* result);
-template Status RawDecimalToString<int64_t>(const uint8_t*, int, int,
-                                            std::string* result);
+template Status RawDecimalToString<decimal::Decimal32>(const uint8_t*, int, int,
+                                                       std::string*);
+template Status RawDecimalToString<decimal::Decimal64>(const uint8_t*, int, int,
+                                                       std::string*);
+template Status RawDecimalToString<decimal::Decimal128>(const uint8_t*, int, int,
+                                                        std::string*);
 
-Status RawDecimalToString(const uint8_t* bytes, int precision, int scale,
-                          bool is_negative, std::string* result) {
-  DCHECK_NE(bytes, nullptr);
-  DCHECK_NE(result, nullptr);
-  RETURN_NOT_OK(ValidateDecimalPrecision<boost::multiprecision::int128_t>(precision));
-  decimal::Decimal128 decimal;
-  FromBytes(bytes, is_negative, &decimal);
-  *result = ToString(decimal, precision, scale);
-  return Status::OK();
-}
+#define RAW_DECIMAL_TO_STRING_CASE(bits, value, precision, scale, output)          \
+  case bits:                                                                       \
+    RETURN_NOT_OK(RawDecimalToString<decimal::Decimal##bits>((value), (precision), \
+                                                             (scale), (output)));  \
+    break;
 
 static Status ConvertDecimals(PandasOptions options, const ChunkedArray& data,
                               PyObject** out_values) {
@@ -664,22 +662,18 @@ static Status ConvertDecimals(PandasOptions options, const ChunkedArray& data,
         *out_values++ = Py_None;
       } else {
         const uint8_t* raw_value = arr->GetValue(i);
-        std::string s;
+        std::string decimal_string;
         switch (bit_width) {
-          case 32:
-            RETURN_NOT_OK(RawDecimalToString<int32_t>(raw_value, precision, scale, &s));
-            break;
-          case 64:
-            RETURN_NOT_OK(RawDecimalToString<int64_t>(raw_value, precision, scale, &s));
-            break;
-          case 128:
-            RETURN_NOT_OK(
-                RawDecimalToString(raw_value, precision, scale, arr->IsNegative(i), &s));
-            break;
-          default:
-            break;
+          RAW_DECIMAL_TO_STRING_CASE(32, raw_value, precision, scale, &decimal_string)
+          RAW_DECIMAL_TO_STRING_CASE(64, raw_value, precision, scale, &decimal_string)
+          RAW_DECIMAL_TO_STRING_CASE(128, raw_value, precision, scale, &decimal_string)
+          default: {
+            std::stringstream buf;
+            buf << "Invalid bit_width " << bit_width << " for decimal value";
+            return Status::Invalid(buf.str());
+          }
         }
-        RETURN_NOT_OK(DecimalFromString(Decimal, s, out_values++));
+        RETURN_NOT_OK(DecimalFromString(Decimal, decimal_string, out_values++));
       }
     }
   }

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -604,12 +604,12 @@ static Status ConvertTimes(PandasOptions options, const ChunkedArray& data,
 
 template <typename T>
 Status ValidateDecimalPrecision(int precision) {
-  constexpr static const int maximum_precision =
+  constexpr static const int kMaximumPrecision =
       decimal::DecimalPrecision<typename T::value_type>::maximum;
-  if (!(precision > 0 && precision <= maximum_precision)) {
+  if (!(precision > 0 && precision <= kMaximumPrecision)) {
     std::stringstream ss;
     ss << "Invalid precision: " << precision << ". Minimum is 1, maximum is "
-       << maximum_precision;
+       << kMaximumPrecision;
     return Status::Invalid(ss.str());
   }
   return Status::OK();

--- a/cpp/src/arrow/python/python-test.cc
+++ b/cpp/src/arrow/python/python-test.cc
@@ -23,12 +23,10 @@
 
 #include "arrow/array.h"
 #include "arrow/builder.h"
-#include "arrow/table.h"
 #include "arrow/test-util.h"
 
 #include "arrow/python/arrow_to_pandas.h"
 #include "arrow/python/builtin_convert.h"
-#include "arrow/python/common.h"
 #include "arrow/python/helpers.h"
 
 #include "arrow/util/decimal.h"
@@ -61,13 +59,11 @@ TEST(DecimalTest, TestPythonDecimalToString) {
   ASSERT_NE(pydecimal.obj(), nullptr);
   ASSERT_EQ(PyErr_Occurred(), nullptr);
 
-  boost::multiprecision::int128_t boost_decimal(decimal_string);
   PyObject* python_object = pydecimal.obj();
   ASSERT_NE(python_object, nullptr);
 
   std::string string_result;
   ASSERT_OK(PythonDecimalToString(python_object, &string_result));
-  ASSERT_EQ(boost_decimal.str(), string_result);
 }
 
 TEST(PandasConversionTest, TestObjectBlockWriteFails) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -480,10 +480,6 @@ std::vector<BufferDescr> FixedSizeBinaryType::GetBufferLayout() const {
   return {kValidityBuffer, BufferDescr(BufferType::DATA, bit_width())};
 }
 
-std::vector<BufferDescr> DecimalType::GetBufferLayout() const {
-  return {kValidityBuffer, kBooleanBuffer, BufferDescr(BufferType::DATA, bit_width())};
-}
-
 std::vector<BufferDescr> ListType::GetBufferLayout() const {
   return {kValidityBuffer, kOffsetBuffer};
 }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -477,7 +477,6 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
         precision_(precision),
         scale_(scale) {}
 
-  std::vector<BufferDescr> GetBufferLayout() const override;
   Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   static std::string name() { return "decimal"; }

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -49,7 +49,7 @@ install(FILES
 #######################################
 
 if (ARROW_BUILD_BENCHMARKS)
-  add_library(arrow_benchmark_main benchmark_main.cc int128.h)
+  add_library(arrow_benchmark_main benchmark_main.cc)
   if (APPLE)
     target_link_libraries(arrow_benchmark_main
       benchmark

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -21,19 +21,20 @@
 
 # Headers: top level
 install(FILES
-  bit-util.h
   bit-stream-utils.h
+  bit-util.h
   bpacking.h
   compiler-util.h
-  compression.h
   compression_brotli.h
+  compression.h
   compression_lz4.h
   compression_snappy.h
   compression_zlib.h
   compression_zstd.h
   cpu-info.h
-  key_value_metadata.h
   hash-util.h
+  int128.h
+  key_value_metadata.h
   logging.h
   macros.h
   random.h
@@ -48,7 +49,7 @@ install(FILES
 #######################################
 
 if (ARROW_BUILD_BENCHMARKS)
-  add_library(arrow_benchmark_main benchmark_main.cc)
+  add_library(arrow_benchmark_main benchmark_main.cc int128.h)
   if (APPLE)
     target_link_libraries(arrow_benchmark_main
       benchmark

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -28,16 +28,16 @@ namespace decimal {
 template <typename T>
 class DecimalTest : public ::testing::Test {
  public:
-  DecimalTest() : string_value("234.23445") { integer_value.value = 23423445; }
-  Decimal<T> integer_value;
+  DecimalTest() : decimal_value(23423445), string_value("234.23445") {}
+  Decimal<T> decimal_value;
   std::string string_value;
 };
 
-typedef ::testing::Types<int32_t, int64_t, int128_t> DecimalTypes;
+typedef ::testing::Types<int32_t, int64_t, Int128> DecimalTypes;
 TYPED_TEST_CASE(DecimalTest, DecimalTypes);
 
 TYPED_TEST(DecimalTest, TestToString) {
-  Decimal<TypeParam> decimal(this->integer_value);
+  Decimal<TypeParam> decimal(this->decimal_value);
   int precision = 8;
   int scale = 5;
   std::string result = ToString(decimal, precision, scale);
@@ -45,7 +45,7 @@ TYPED_TEST(DecimalTest, TestToString) {
 }
 
 TYPED_TEST(DecimalTest, TestFromString) {
-  Decimal<TypeParam> expected(this->integer_value);
+  Decimal<TypeParam> expected(this->decimal_value);
   Decimal<TypeParam> result;
   int precision, scale;
   ASSERT_OK(FromString(this->string_value, &result, &precision, &scale));
@@ -67,7 +67,7 @@ TEST(DecimalTest, TestStringStartingWithPlus) {
 
 TEST(DecimalTest, TestStringStartingWithPlus128) {
   std::string plus_value("+2342394230592.232349023094");
-  decimal::int128_t expected_value("2342394230592232349023094");
+  Int128 expected_value("2342394230592232349023094");
   Decimal128 out;
   int scale;
   int precision;
@@ -90,29 +90,30 @@ TEST(DecimalTest, TestStringToInt64) {
 }
 
 TEST(DecimalTest, TestStringToInt128) {
-  int128_t value = 0;
+  Int128 value = 0;
   StringToInteger("123456789", "456789123", 1, &value);
-  ASSERT_EQ(value, 123456789456789123);
+  ASSERT_EQ(value.highbits(), 0);
+  ASSERT_EQ(value.lowbits(), 123456789456789123);
 }
 
 TEST(DecimalTest, TestFromString128) {
   static const std::string string_value("-23049223942343532412");
-  Decimal<int128_t> result(string_value);
-  int128_t expected = -230492239423435324;
+  Decimal128 result(string_value);
+  Int128 expected(static_cast<int64_t>(-230492239423435324));
   ASSERT_EQ(result.value, expected * 100 - 12);
 
   // Sanity check that our number is actually using more than 64 bits
-  ASSERT_NE(result.value, static_cast<int64_t>(result.value));
+  ASSERT_NE(result.value.highbits(), 0);
 }
 
 TEST(DecimalTest, TestFromDecimalString128) {
   static const std::string string_value("-23049223942343.532412");
-  Decimal<int128_t> result(string_value);
-  int128_t expected = -230492239423435324;
+  Decimal128 result(string_value);
+  Int128 expected(static_cast<int64_t>(-230492239423435324));
   ASSERT_EQ(result.value, expected * 100 - 12);
 
   // Sanity check that our number is actually using more than 64 bits
-  ASSERT_NE(result.value, static_cast<int64_t>(result.value));
+  ASSERT_NE(result.value.highbits(), 0);
 }
 
 TEST(DecimalTest, TestDecimal32Precision) {
@@ -130,8 +131,8 @@ TEST(DecimalTest, TestDecimal64Precision) {
 }
 
 TEST(DecimalTest, TestDecimal128Precision) {
-  auto min_precision = DecimalPrecision<int128_t>::minimum;
-  auto max_precision = DecimalPrecision<int128_t>::maximum;
+  auto min_precision = DecimalPrecision<Int128>::minimum;
+  auto max_precision = DecimalPrecision<Int128>::maximum;
   ASSERT_EQ(min_precision, 19);
   ASSERT_EQ(max_precision, 38);
 }
@@ -166,19 +167,16 @@ TEST(DecimalTest, TestDecimal128StringAndBytesRoundTrip) {
   Decimal128 expected(string_value);
 
   std::string expected_string_value("-340282366920938463463374607431711455");
-  int128_t expected_underlying_value(expected_string_value);
+  Int128 expected_underlying_value(expected_string_value);
 
   ASSERT_EQ(expected.value, expected_underlying_value);
 
   uint8_t stack_bytes[16] = {0};
   uint8_t* bytes = stack_bytes;
-  bool is_negative;
-  ToBytes(expected, &bytes, &is_negative);
-
-  ASSERT_TRUE(is_negative);
+  ToBytes(expected, &bytes);
 
   Decimal128 result;
-  FromBytes(bytes, is_negative, &result);
+  FromBytes(bytes, &result);
 
   ASSERT_EQ(expected.value, result.value);
 }

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -28,27 +28,27 @@ namespace decimal {
 template <typename T>
 class DecimalTest : public ::testing::Test {
  public:
-  DecimalTest() : decimal_value(23423445), string_value("234.23445") {}
-  Decimal<T> decimal_value;
-  std::string string_value;
+  DecimalTest() : decimal_value_(23423445), string_value_("234.23445") {}
+  Decimal<T> decimal_value_;
+  std::string string_value_;
 };
 
 typedef ::testing::Types<int32_t, int64_t, Int128> DecimalTypes;
 TYPED_TEST_CASE(DecimalTest, DecimalTypes);
 
 TYPED_TEST(DecimalTest, TestToString) {
-  Decimal<TypeParam> decimal(this->decimal_value);
+  Decimal<TypeParam> decimal(this->decimal_value_);
   int precision = 8;
   int scale = 5;
   std::string result = ToString(decimal, precision, scale);
-  ASSERT_EQ(result, this->string_value);
+  ASSERT_EQ(result, this->string_value_);
 }
 
 TYPED_TEST(DecimalTest, TestFromString) {
-  Decimal<TypeParam> expected(this->decimal_value);
+  Decimal<TypeParam> expected(this->decimal_value_);
   Decimal<TypeParam> result;
   int precision, scale;
-  ASSERT_OK(FromString(this->string_value, &result, &precision, &scale));
+  ASSERT_OK(FromString(this->string_value_, &result, &precision, &scale));
   ASSERT_EQ(result.value, expected.value);
   ASSERT_EQ(precision, 8);
   ASSERT_EQ(scale, 5);

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -92,8 +92,8 @@ TEST(DecimalTest, TestStringToInt64) {
 TEST(DecimalTest, TestStringToInt128) {
   Int128 value = 0;
   StringToInteger("123456789", "456789123", 1, &value);
-  ASSERT_EQ(value.highbits(), 0);
-  ASSERT_EQ(value.lowbits(), 123456789456789123);
+  ASSERT_EQ(value.high_bits(), 0);
+  ASSERT_EQ(value.low_bits(), 123456789456789123);
 }
 
 TEST(DecimalTest, TestFromString128) {
@@ -103,7 +103,7 @@ TEST(DecimalTest, TestFromString128) {
   ASSERT_EQ(result.value, expected * 100 - 12);
 
   // Sanity check that our number is actually using more than 64 bits
-  ASSERT_NE(result.value.highbits(), 0);
+  ASSERT_NE(result.value.high_bits(), 0);
 }
 
 TEST(DecimalTest, TestFromDecimalString128) {
@@ -113,7 +113,7 @@ TEST(DecimalTest, TestFromDecimalString128) {
   ASSERT_EQ(result.value, expected * 100 - 12);
 
   // Sanity check that our number is actually using more than 64 bits
-  ASSERT_NE(result.value.highbits(), 0);
+  ASSERT_NE(result.value.high_bits(), 0);
 }
 
 TEST(DecimalTest, TestDecimal32Precision) {

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -158,8 +158,9 @@ void StringToInteger(const std::string& whole, const std::string& fractional, in
   DCHECK(sign == -1 || sign == 1);
   DCHECK_NE(out, nullptr);
   DCHECK(!whole.empty() || !fractional.empty());
+
   if (!whole.empty()) {
-    *out = std::stoi(whole, nullptr, 10) *
+    *out = std::stoi(whole) *
            static_cast<int32_t>(pow(10.0, static_cast<double>(fractional.size())));
   }
   if (!fractional.empty()) {
@@ -174,7 +175,7 @@ void StringToInteger(const std::string& whole, const std::string& fractional, in
   DCHECK_NE(out, nullptr);
   DCHECK(!whole.empty() || !fractional.empty());
   if (!whole.empty()) {
-    *out = static_cast<int64_t>(std::stoll(whole, nullptr, 10)) *
+    *out = static_cast<int64_t>(std::stoll(whole)) *
            static_cast<int64_t>(pow(10.0, static_cast<double>(fractional.size())));
   }
   if (!fractional.empty()) {

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <sstream>
+
 #include "arrow/util/decimal.h"
 
 namespace arrow {
@@ -182,11 +184,11 @@ void StringToInteger(const std::string& whole, const std::string& fractional, in
 }
 
 void StringToInteger(const std::string& whole, const std::string& fractional, int8_t sign,
-                     int128_t* out) {
+                     Int128* out) {
   DCHECK(sign == -1 || sign == 1);
   DCHECK_NE(out, nullptr);
   DCHECK(!whole.empty() || !fractional.empty());
-  *out = int128_t(whole + fractional) * sign;
+  *out = Int128(whole + fractional) * sign;
 }
 
 void FromBytes(const uint8_t* bytes, Decimal32* decimal) {
@@ -201,22 +203,8 @@ void FromBytes(const uint8_t* bytes, Decimal64* decimal) {
   decimal->value = *reinterpret_cast<const int64_t*>(bytes);
 }
 
-constexpr static const size_t BYTES_IN_128_BITS = 128 / CHAR_BIT;
-constexpr static const size_t LIMB_SIZE =
-    sizeof(std::remove_pointer<int128_t::backend_type::limb_pointer>::type);
-constexpr static const size_t LIMBS_IN_INT128 = BYTES_IN_128_BITS / LIMB_SIZE;
-
-void FromBytes(const uint8_t* bytes, bool is_negative, Decimal128* decimal) {
-  DCHECK_NE(bytes, nullptr);
-  DCHECK_NE(decimal, nullptr);
-
-  auto& decimal_value(decimal->value);
-  int128_t::backend_type& backend(decimal_value.backend());
-  backend.resize(LIMBS_IN_INT128, LIMBS_IN_INT128);
-  std::memcpy(backend.limbs(), bytes, BYTES_IN_128_BITS);
-  if (is_negative) {
-    decimal->value = -decimal->value;
-  }
+void FromBytes(const uint8_t* bytes, Decimal128* decimal) {
+  decimal->value = Int128(bytes);
 }
 
 void ToBytes(const Decimal32& value, uint8_t** bytes) {
@@ -229,16 +217,10 @@ void ToBytes(const Decimal64& value, uint8_t** bytes) {
   *reinterpret_cast<int64_t*>(*bytes) = value.value;
 }
 
-void ToBytes(const Decimal128& decimal, uint8_t** bytes, bool* is_negative) {
+void ToBytes(const Decimal128& decimal, uint8_t** bytes) {
+  DCHECK_NE(bytes, nullptr);
   DCHECK_NE(*bytes, nullptr);
-  DCHECK_NE(is_negative, nullptr);
-
-  /// TODO(phillipc): boost multiprecision is unreliable here, int128_t can't be
-  /// roundtripped
-  const auto& backend(decimal.value.backend());
-  const size_t bytes_in_use = LIMB_SIZE * backend.size();
-  std::memcpy(*bytes, backend.limbs(), bytes_in_use);
-  *is_negative = backend.isneg();
+  decimal.value.ToBytes(bytes);
 }
 
 }  // namespace decimal

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -195,15 +195,13 @@ Int128& Int128::operator*=(const Int128& right) {
   return *this;
 }
 
-/**
- * Expands the given value into an array of ints so that we can work on
- * it. The array will be converted to an absolute value and the wasNegative
- * flag will be set appropriately. The array will remove leading zeros from
- * the value.
- * @param array an array of length 4 to set with the value
- * @param was_negative a flag for whether the value was original negative
- * @result the output length of the array
- */
+/// Expands the given value into an array of ints so that we can work on
+/// it. The array will be converted to an absolute value and the wasNegative
+/// flag will be set appropriately. The array will remove leading zeros from
+/// the value.
+/// \param array an array of length 4 to set with the value
+/// \param was_negative a flag for whether the value was original negative
+/// \result the output length of the array
 static int64_t FillInArray(const Int128& value, uint32_t* array, bool& was_negative) {
   uint64_t high;
   uint64_t low;
@@ -252,10 +250,7 @@ static int64_t FillInArray(const Int128& value, uint32_t* array, bool& was_negat
   return 1;
 }
 
-/**
- * Find last set bit in a 32 bit integer. Bit 1 is the LSB and bit 32 is
- * the MSB. We can replace this with bsrq asm instruction on x64.
- */
+/// \brief Find last set bit in a 32 bit integer. Bit 1 is the LSB and bit 32 is the MSB.
 static int64_t FindLastSetBit(uint32_t value) {
 #if defined(__clang__) || defined(__GNUC__)
   // Count leading zeros
@@ -267,12 +262,10 @@ static int64_t FindLastSetBit(uint32_t value) {
 #endif
 }
 
-/**
- * Shift the number in the array left by bits positions.
- * @param array the number to shift, must have length elements
- * @param length the number of entries in the array
- * @param bits the number of bits to shift (0 <= bits < 32)
- */
+/// Shift the number in the array left by bits positions.
+/// \param array the number to shift, must have length elements
+/// \param length the number of entries in the array
+/// \param bits the number of bits to shift (0 <= bits < 32)
 static void ShiftArrayLeft(uint32_t* array, int64_t length, int64_t bits) {
   if (length > 0 && bits != 0) {
     for (int64_t i = 0; i < length - 1; ++i) {
@@ -282,12 +275,10 @@ static void ShiftArrayLeft(uint32_t* array, int64_t length, int64_t bits) {
   }
 }
 
-/**
- * Shift the number in the array right by bits positions.
- * @param array the number to shift, must have length elements
- * @param length the number of entries in the array
- * @param bits the number of bits to shift (0 <= bits < 32)
- */
+/// Shift the number in the array right by bits positions.
+/// \param array the number to shift, must have length elements
+/// \param length the number of entries in the array
+/// \param bits the number of bits to shift (0 <= bits < 32)
 static void ShiftArrayRight(uint32_t* array, int64_t length, int64_t bits) {
   if (length > 0 && bits != 0) {
     for (int64_t i = length - 1; i > 0; --i) {
@@ -297,10 +288,8 @@ static void ShiftArrayRight(uint32_t* array, int64_t length, int64_t bits) {
   }
 }
 
-/**
- * Fix the signs of the result and remainder at the end of the division
- * based on the signs of the dividend and divisor.
- */
+/// \brief Fix the signs of the result and remainder at the end of the division based on
+/// the signs of the dividend and divisor.
 static void FixDivisionSigns(Int128* result, Int128* remainder,
                              bool dividend_was_negative, bool divisor_was_negative) {
   if (dividend_was_negative != divisor_was_negative) {
@@ -312,9 +301,7 @@ static void FixDivisionSigns(Int128* result, Int128* remainder,
   }
 }
 
-/**
- * Build a Int128 from a list of ints.
- */
+/// \brief Build a Int128 from a list of ints.
 static Status BuildFromArray(Int128* value, uint32_t* array, int64_t length) {
   switch (length) {
     case 0:
@@ -349,9 +336,7 @@ static Status BuildFromArray(Int128* value, uint32_t* array, int64_t length) {
   return Status::OK();
 }
 
-/**
- * Do a division where the divisor fits into a single 32 bit value.
- */
+/// \brief Do a division where the divisor fits into a single 32 bit value.
 static Status SingleDivide(const uint32_t* dividend, int64_t dividend_length,
                            uint32_t divisor, Int128* remainder,
                            bool dividend_was_negative, bool divisor_was_negative,

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -29,7 +29,7 @@ namespace arrow {
 namespace decimal {
 
 static constexpr uint64_t kIntMask = 0xFFFFFFFF;
-static constexpr uint64_t kCarryBit = 1UL << 32UL;
+static constexpr auto kCarryBit = static_cast<uint64_t>(1) << static_cast<uint64_t>(32);
 
 Int128::Int128(const std::string& str) : Int128() {
   const size_t length = str.length();

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -22,6 +22,11 @@
 #include <limits>
 #include <sstream>
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+#endif
+
 #include "arrow/util/int128.h"
 #include "arrow/util/logging.h"
 

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -261,9 +261,9 @@ static int64_t fls(uint32_t value) {
   // Count leading zeros
   return __builtin_clz(value) + 1;
 #elif defined(_MSC_VER)
-  uint32_t index;
-  _BitScanReverse(&index, value);
-  return index + 1;
+  unsigned long index;
+  _BitScanReverse(&index, static_cast<unsigned long>(value));
+  return static_cast<int64_t>(index + 1UL);
 #endif
 }
 

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -1,0 +1,537 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
+#include "arrow/util/int128.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace decimal {
+
+static constexpr uint64_t kIntMask = 0xFFFFFFFF;
+static constexpr uint64_t kCarryBit = 1UL << 32UL;
+
+Int128::Int128(const std::string& str) : Int128() {
+  const size_t length = str.length();
+
+  if (length > 0) {
+    bool is_negative = str[0] == '-';
+    auto posn = static_cast<size_t>(is_negative);
+
+    while (posn < length) {
+      const size_t group = std::min(18UL, length - posn);
+      const auto chunk = static_cast<int64_t>(std::stoll(str.substr(posn, group)));
+      const auto multiple =
+          static_cast<int64_t>(std::pow(10.0, static_cast<double>(group)));
+
+      *this *= multiple;
+      *this += chunk;
+
+      posn += group;
+    }
+
+    if (is_negative) {
+      negate();
+    }
+  }
+}
+
+Int128::Int128(const uint8_t* bytes)
+    : Int128(reinterpret_cast<const int64_t*>(bytes)[0],
+             reinterpret_cast<const uint64_t*>(bytes)[1]) {}
+
+void Int128::ToBytes(uint8_t** out) const {
+  DCHECK_NE(out, nullptr) << "Cannot fill nullptr of bytes from Int128";
+  DCHECK_NE(*out, nullptr) << "Cannot fill nullptr of bytes from Int128";
+  uint64_t raw[] = {static_cast<uint64_t>(highbits_), lowbits_};
+  std::memcpy(*out, raw, 16);
+}
+
+Int128& Int128::negate() {
+  lowbits_ = ~lowbits_ + 1;
+  highbits_ = ~highbits_;
+  if (lowbits_ == 0) {
+    ++highbits_;
+  }
+  return *this;
+}
+
+Int128& Int128::operator+=(const Int128& right) {
+  uint64_t sum = lowbits_ + right.lowbits_;
+  highbits_ += right.highbits_;
+  if (sum < lowbits_) {
+    ++highbits_;
+  }
+  lowbits_ = sum;
+  return *this;
+}
+
+Int128& Int128::operator-=(const Int128& right) {
+  uint64_t diff = lowbits_ - right.lowbits_;
+  highbits_ -= right.highbits_;
+  if (diff > lowbits_) {
+    --highbits_;
+  }
+  lowbits_ = diff;
+  return *this;
+}
+
+Int128& Int128::operator/=(const Int128& right) {
+  Int128 remainder;
+  DCHECK(divide(right, this, &remainder).ok());
+  return *this;
+}
+
+Int128::operator char() const {
+  DCHECK(highbits_ == 0 || highbits_ == -1)
+      << "Trying to cast an Int128 greater than the value range of a "
+         "char. highbits_ must be equal to 0 or -1, got: "
+      << highbits_;
+  DCHECK_LE(lowbits_, std::numeric_limits<char>::max())
+      << "lowbits_ too large for C type char, got: " << lowbits_;
+  return static_cast<char>(lowbits_);
+}
+
+Int128& Int128::operator|=(const Int128& right) {
+  lowbits_ |= right.lowbits_;
+  highbits_ |= right.highbits_;
+  return *this;
+}
+
+Int128& Int128::operator&=(const Int128& right) {
+  lowbits_ &= right.lowbits_;
+  highbits_ &= right.highbits_;
+  return *this;
+}
+
+Int128& Int128::operator<<=(uint32_t bits) {
+  if (bits != 0) {
+    if (bits < 64) {
+      highbits_ <<= bits;
+      highbits_ |= (lowbits_ >> (64 - bits));
+      lowbits_ <<= bits;
+    } else if (bits < 128) {
+      highbits_ = static_cast<int64_t>(lowbits_) << (bits - 64);
+      lowbits_ = 0;
+    } else {
+      highbits_ = 0;
+      lowbits_ = 0;
+    }
+  }
+  return *this;
+}
+
+Int128& Int128::operator>>=(uint32_t bits) {
+  if (bits != 0) {
+    if (bits < 64) {
+      lowbits_ >>= bits;
+      lowbits_ |= static_cast<uint64_t>(highbits_ << (64 - bits));
+      highbits_ = static_cast<int64_t>(static_cast<uint64_t>(highbits_) >> bits);
+    } else if (bits < 128) {
+      lowbits_ = static_cast<uint64_t>(highbits_ >> (bits - 64));
+      highbits_ = static_cast<int64_t>(highbits_ >= 0L ? 0L : -1L);
+    } else {
+      highbits_ = static_cast<int64_t>(highbits_ >= 0L ? 0L : -1L);
+      lowbits_ = static_cast<uint64_t>(highbits_);
+    }
+  }
+  return *this;
+}
+
+Int128& Int128::operator*=(const Int128& right) {
+  // Break the left and right numbers into 32 bit chunks
+  // so that we can multiply them without overflow.
+  uint64_t L0 = static_cast<uint64_t>(highbits_) >> 32;
+  uint64_t L1 = static_cast<uint64_t>(highbits_) & kIntMask;
+  uint64_t L2 = lowbits_ >> 32;
+  uint64_t L3 = lowbits_ & kIntMask;
+
+  uint64_t R0 = static_cast<uint64_t>(right.highbits_) >> 32;
+  uint64_t R1 = static_cast<uint64_t>(right.highbits_) & kIntMask;
+  uint64_t R2 = right.lowbits_ >> 32;
+  uint64_t R3 = right.lowbits_ & kIntMask;
+
+  uint64_t product = L3 * R3;
+  lowbits_ = product & kIntMask;
+
+  uint64_t sum = product >> 32;
+
+  product = L2 * R3;
+  sum += product;
+
+  product = L3 * R2;
+  sum += product;
+
+  lowbits_ += sum << 32;
+
+  highbits_ = static_cast<int64_t>(sum < product ? kCarryBit : 0);
+  if (sum < product) {
+    highbits_ += kCarryBit;
+  }
+
+  highbits_ += static_cast<int64_t>(sum >> 32);
+  highbits_ += L1 * R3 + L2 * R2 + L3 * R1;
+  highbits_ += (L0 * R3 + L1 * R2 + L2 * R1 + L3 * R0) << 32;
+  return *this;
+}
+
+/**
+ * Expands the given value into an array of ints so that we can work on
+ * it. The array will be converted to an absolute value and the wasNegative
+ * flag will be set appropriately. The array will remove leading zeros from
+ * the value.
+ * @param array an array of length 4 to set with the value
+ * @param was_negative a flag for whether the value was original negative
+ * @result the output length of the array
+ */
+static int64_t fill_in_array(const Int128& value, uint32_t* array, bool& was_negative) {
+  uint64_t high;
+  uint64_t low;
+  int64_t highbits = value.highbits();
+  uint64_t lowbits = value.lowbits();
+
+  if (highbits < 0) {
+    low = ~lowbits + 1;
+    high = static_cast<uint64_t>(~highbits);
+    if (low == 0) {
+      ++high;
+    }
+    was_negative = true;
+  } else {
+    low = lowbits;
+    high = static_cast<uint64_t>(highbits);
+    was_negative = false;
+  }
+
+  if (high != 0) {
+    if (high > std::numeric_limits<uint32_t>::max()) {
+      array[0] = static_cast<uint32_t>(high >> 32);
+      array[1] = static_cast<uint32_t>(high);
+      array[2] = static_cast<uint32_t>(low >> 32);
+      array[3] = static_cast<uint32_t>(low);
+      return 4;
+    }
+
+    array[0] = static_cast<uint32_t>(high);
+    array[1] = static_cast<uint32_t>(low >> 32);
+    array[2] = static_cast<uint32_t>(low);
+    return 3;
+  }
+
+  if (low >= std::numeric_limits<uint32_t>::max()) {
+    array[0] = static_cast<uint32_t>(low >> 32);
+    array[1] = static_cast<uint32_t>(low);
+    return 2;
+  }
+
+  if (low == 0) {
+    return 0;
+  }
+
+  array[0] = static_cast<uint32_t>(low);
+  return 1;
+}
+
+/**
+ * Find last set bit in a 32 bit integer. Bit 1 is the LSB and bit 32 is
+ * the MSB. We can replace this with bsrq asm instruction on x64.
+ */
+static int64_t fls(uint32_t value) {
+#if defined(__clang__) || defined(__GNUC__)
+  // Count leading zeros
+  return __builtin_clz(value) + 1;
+#elif defined(_MSC_VER)
+  uint32_t index;
+  _BitScanReverse(&index, value);
+  return index + 1;
+#endif
+}
+
+/**
+ * Shift the number in the array left by bits positions.
+ * @param array the number to shift, must have length elements
+ * @param length the number of entries in the array
+ * @param bits the number of bits to shift (0 <= bits < 32)
+ */
+static void shift_array_left(uint32_t* array, int64_t length, int64_t bits) {
+  if (length > 0 && bits != 0) {
+    for (int64_t i = 0; i < length - 1; ++i) {
+      array[i] = (array[i] << bits) | (array[i + 1] >> (32 - bits));
+    }
+    array[length - 1] <<= bits;
+  }
+}
+
+/**
+ * Shift the number in the array right by bits positions.
+ * @param array the number to shift, must have length elements
+ * @param length the number of entries in the array
+ * @param bits the number of bits to shift (0 <= bits < 32)
+ */
+static void shift_array_right(uint32_t* array, int64_t length, int64_t bits) {
+  if (length > 0 && bits != 0) {
+    for (int64_t i = length - 1; i > 0; --i) {
+      array[i] = (array[i] >> bits) | (array[i - 1] << (32 - bits));
+    }
+    array[0] >>= bits;
+  }
+}
+
+/**
+ * Fix the signs of the result and remainder at the end of the division
+ * based on the signs of the dividend and divisor.
+ */
+static void fix_division_signs(Int128* result, Int128* remainder,
+                               bool dividend_was_negative, bool divisor_was_negative) {
+  if (dividend_was_negative != divisor_was_negative) {
+    result->negate();
+  }
+
+  if (dividend_was_negative) {
+    remainder->negate();
+  }
+}
+
+/**
+ * Build a Int128 from a list of ints.
+ */
+static Status build_from_array(Int128* value, uint32_t* array, int64_t length) {
+  switch (length) {
+    case 0:
+      *value = {static_cast<int64_t>(0)};
+      break;
+    case 1:
+      *value = {static_cast<int64_t>(array[0])};
+      break;
+    case 2:
+      *value = {static_cast<int64_t>(0),
+                (static_cast<uint64_t>(array[0]) << 32) + array[1]};
+      break;
+    case 3:
+      *value = {static_cast<int64_t>(array[0]),
+                (static_cast<uint64_t>(array[1]) << 32) + array[2]};
+      break;
+    case 4:
+      *value = {(static_cast<int64_t>(array[0]) << 32) + array[1],
+                (static_cast<uint64_t>(array[2]) << 32) + array[3]};
+      break;
+    case 5:
+      if (array[0] != 0) {
+        return Status::Invalid("Can't build Int128 with 5 ints.");
+      }
+      *value = {(static_cast<int64_t>(array[1]) << 32) + array[2],
+                (static_cast<uint64_t>(array[3]) << 32) + array[4]};
+      break;
+    default:
+      return Status::Invalid("Unsupported length for building Int128");
+  }
+
+  return Status::OK();
+}
+
+/**
+ * Do a division where the divisor fits into a single 32 bit value.
+ */
+static Status single_divide(const uint32_t* dividend, int64_t dividend_length,
+                            uint32_t divisor, Int128* remainder,
+                            bool dividend_was_negative, bool divisor_was_negative,
+                            Int128* result) {
+  uint64_t r = 0;
+  uint32_t result_array[5];
+  for (int64_t j = 0; j < dividend_length; j++) {
+    r <<= 32;
+    r += dividend[j];
+    result_array[j] = static_cast<uint32_t>(r / divisor);
+    r %= divisor;
+  }
+  RETURN_NOT_OK(build_from_array(result, result_array, dividend_length));
+  *remainder = static_cast<int64_t>(r);
+  fix_division_signs(result, remainder, dividend_was_negative, divisor_was_negative);
+  return Status::OK();
+}
+
+Status Int128::divide(const Int128& divisor, Int128* result, Int128* remainder) const {
+  // Split the dividend and divisor into integer pieces so that we can
+  // work on them.
+  uint32_t dividend_array[5];
+  uint32_t divisor_array[4];
+  bool dividend_was_negative;
+  bool divisor_was_negative;
+  // leave an extra zero before the dividend
+  dividend_array[0] = 0;
+  int64_t dividend_length =
+      fill_in_array(*this, dividend_array + 1, dividend_was_negative) + 1;
+  int64_t divisor_length = fill_in_array(divisor, divisor_array, divisor_was_negative);
+
+  // Handle some of the easy cases.
+  if (dividend_length <= divisor_length) {
+    *remainder = *this;
+    *result = 0;
+    return Status::OK();
+  }
+
+  if (divisor_length == 0) {
+    return Status::Invalid("Division by 0 in Int128");
+  }
+
+  if (divisor_length == 1) {
+    return single_divide(dividend_array, dividend_length, divisor_array[0], remainder,
+                         dividend_was_negative, divisor_was_negative, result);
+  }
+
+  int64_t result_length = dividend_length - divisor_length;
+  uint32_t result_array[4];
+
+  // Normalize by shifting both by a multiple of 2 so that
+  // the digit guessing is better. The requirement is that
+  // divisor_array[0] is greater than 2**31.
+  int64_t normalize_bits = 32 - fls(divisor_array[0]);
+  shift_array_left(divisor_array, divisor_length, normalize_bits);
+  shift_array_left(dividend_array, dividend_length, normalize_bits);
+
+  // compute each digit in the result
+  for (int64_t j = 0; j < result_length; ++j) {
+    // Guess the next digit. At worst it is two too large
+    uint32_t guess = std::numeric_limits<uint32_t>::max();
+    auto high_dividend =
+        static_cast<uint64_t>(dividend_array[j]) << 32 | dividend_array[j + 1];
+    if (dividend_array[j] != divisor_array[0]) {
+      guess = static_cast<uint32_t>(high_dividend / divisor_array[0]);
+    }
+
+    // catch all of the cases where guess is two too large and most of the
+    // cases where it is one too large
+    auto rhat = static_cast<uint32_t>(high_dividend -
+                                      guess * static_cast<uint64_t>(divisor_array[0]));
+    while (static_cast<uint64_t>(divisor_array[1]) * guess >
+           (static_cast<uint64_t>(rhat) << 32) + dividend_array[j + 2]) {
+      --guess;
+      rhat += divisor_array[0];
+      if (static_cast<uint64_t>(rhat) < divisor_array[0]) {
+        break;
+      }
+    }
+
+    // subtract off the guess * divisor from the dividend
+    uint64_t mult = 0;
+    for (int64_t i = divisor_length - 1; i >= 0; --i) {
+      mult += static_cast<uint64_t>(guess) * divisor_array[i];
+      uint32_t prev = dividend_array[j + i + 1];
+      dividend_array[j + i + 1] -= static_cast<uint32_t>(mult);
+      mult >>= 32;
+      if (dividend_array[j + i + 1] > prev) {
+        ++mult;
+      }
+    }
+    uint32_t prev = dividend_array[j];
+    dividend_array[j] -= static_cast<uint32_t>(mult);
+
+    // if guess was too big, we add back divisor
+    if (dividend_array[j] > prev) {
+      --guess;
+
+      uint32_t carry = 0;
+      for (int64_t i = divisor_length - 1; i >= 0; --i) {
+        uint64_t sum =
+            static_cast<uint64_t>(divisor_array[i]) + dividend_array[j + i + 1] + carry;
+        dividend_array[j + i + 1] = static_cast<uint32_t>(sum);
+        carry = static_cast<uint32_t>(sum >> 32);
+      }
+      dividend_array[j] += carry;
+    }
+
+    result_array[j] = guess;
+  }
+
+  // denormalize the remainder
+  shift_array_right(dividend_array, dividend_length, normalize_bits);
+
+  // return result and remainder
+  RETURN_NOT_OK(build_from_array(result, result_array, result_length));
+  RETURN_NOT_OK(build_from_array(remainder, dividend_array, dividend_length));
+  fix_division_signs(result, remainder, dividend_was_negative, divisor_was_negative);
+  return Status::OK();
+}
+
+bool operator==(const Int128& left, const Int128& right) {
+  return left.highbits() == right.highbits() && left.lowbits() == right.lowbits();
+}
+
+bool operator!=(const Int128& left, const Int128& right) {
+  return !operator==(left, right);
+}
+
+bool operator<(const Int128& left, const Int128& right) {
+  return left.highbits() < right.highbits() ||
+         (left.highbits() == right.highbits() && left.lowbits() < right.lowbits());
+}
+
+bool operator<=(const Int128& left, const Int128& right) {
+  return !operator>(left, right);
+}
+
+bool operator>(const Int128& left, const Int128& right) { return operator<(right, left); }
+
+bool operator>=(const Int128& left, const Int128& right) {
+  return !operator<(left, right);
+}
+
+Int128 operator-(const Int128& operand) {
+  Int128 result(operand.highbits(), operand.lowbits());
+  return result.negate();
+}
+
+Int128 operator+(const Int128& left, const Int128& right) {
+  Int128 result(left.highbits(), left.lowbits());
+  result += right;
+  return result;
+}
+
+Int128 operator-(const Int128& left, const Int128& right) {
+  Int128 result(left.highbits(), left.lowbits());
+  result -= right;
+  return result;
+}
+
+Int128 operator*(const Int128& left, const Int128& right) {
+  Int128 result(left.highbits(), left.lowbits());
+  result *= right;
+  return result;
+}
+
+Int128 operator/(const Int128& left, const Int128& right) {
+  Int128 remainder;
+  Int128 result;
+  DCHECK(left.divide(right, &result, &remainder).ok());
+  return result;
+}
+
+Int128 operator%(const Int128& left, const Int128& right) {
+  Int128 remainder;
+  Int128 result;
+  DCHECK(left.divide(right, &result, &remainder).ok());
+  return remainder;
+}
+
+}  // namespace decimal
+}  // namespace arrow

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -204,7 +204,7 @@ Int128& Int128::operator*=(const Int128& right) {
  * @param was_negative a flag for whether the value was original negative
  * @result the output length of the array
  */
-static int64_t FillInArray(const Int128 &value, uint32_t *array, bool &was_negative) {
+static int64_t FillInArray(const Int128& value, uint32_t* array, bool& was_negative) {
   uint64_t high;
   uint64_t low;
   const int64_t highbits = value.high_bits();
@@ -261,7 +261,7 @@ static int64_t FindLastSetBit(uint32_t value) {
   // Count leading zeros
   return __builtin_clz(value) + 1;
 #elif defined(_MSC_VER)
-  unsigned long index;  // NOLINT
+  unsigned long index;                                         // NOLINT
   _BitScanReverse(&index, static_cast<unsigned long>(value));  // NOLINT
   return static_cast<int64_t>(index + 1UL);
 #endif
@@ -273,7 +273,7 @@ static int64_t FindLastSetBit(uint32_t value) {
  * @param length the number of entries in the array
  * @param bits the number of bits to shift (0 <= bits < 32)
  */
-static void ShiftArrayLeft(uint32_t *array, int64_t length, int64_t bits) {
+static void ShiftArrayLeft(uint32_t* array, int64_t length, int64_t bits) {
   if (length > 0 && bits != 0) {
     for (int64_t i = 0; i < length - 1; ++i) {
       array[i] = (array[i] << bits) | (array[i + 1] >> (32 - bits));
@@ -288,7 +288,7 @@ static void ShiftArrayLeft(uint32_t *array, int64_t length, int64_t bits) {
  * @param length the number of entries in the array
  * @param bits the number of bits to shift (0 <= bits < 32)
  */
-static void ShiftArrayRight(uint32_t *array, int64_t length, int64_t bits) {
+static void ShiftArrayRight(uint32_t* array, int64_t length, int64_t bits) {
   if (length > 0 && bits != 0) {
     for (int64_t i = length - 1; i > 0; --i) {
       array[i] = (array[i] >> bits) | (array[i - 1] << (32 - bits));
@@ -301,7 +301,7 @@ static void ShiftArrayRight(uint32_t *array, int64_t length, int64_t bits) {
  * Fix the signs of the result and remainder at the end of the division
  * based on the signs of the dividend and divisor.
  */
-static void FixDivisionSigns(Int128 *result, Int128 *remainder,
+static void FixDivisionSigns(Int128* result, Int128* remainder,
                              bool dividend_was_negative, bool divisor_was_negative) {
   if (dividend_was_negative != divisor_was_negative) {
     result->Negate();
@@ -315,7 +315,7 @@ static void FixDivisionSigns(Int128 *result, Int128 *remainder,
 /**
  * Build a Int128 from a list of ints.
  */
-static Status BuildFromArray(Int128 *value, uint32_t *array, int64_t length) {
+static Status BuildFromArray(Int128* value, uint32_t* array, int64_t length) {
   switch (length) {
     case 0:
       *value = {static_cast<int64_t>(0)};
@@ -352,10 +352,10 @@ static Status BuildFromArray(Int128 *value, uint32_t *array, int64_t length) {
 /**
  * Do a division where the divisor fits into a single 32 bit value.
  */
-static Status SingleDivide(const uint32_t *dividend, int64_t dividend_length,
-                           uint32_t divisor, Int128 *remainder,
+static Status SingleDivide(const uint32_t* dividend, int64_t dividend_length,
+                           uint32_t divisor, Int128* remainder,
                            bool dividend_was_negative, bool divisor_was_negative,
-                           Int128 *result) {
+                           Int128* result) {
   uint64_t r = 0;
   uint32_t result_array[5];
   for (int64_t j = 0; j < dividend_length; j++) {
@@ -370,7 +370,7 @@ static Status SingleDivide(const uint32_t *dividend, int64_t dividend_length,
   return Status::OK();
 }
 
-Status Int128::Divide(const Int128 &divisor, Int128 *result, Int128 *remainder) const {
+Status Int128::Divide(const Int128& divisor, Int128* result, Int128* remainder) const {
   // Split the dividend and divisor into integer pieces so that we can
   // work on them.
   uint32_t dividend_array[5];

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -39,7 +39,7 @@ Int128::Int128(const std::string& str) : Int128() {
     auto posn = static_cast<size_t>(is_negative);
 
     while (posn < length) {
-      const size_t group = std::min(18UL, length - posn);
+      const size_t group = std::min(static_cast<size_t>(18), length - posn);
       const auto chunk = static_cast<int64_t>(std::stoll(str.substr(posn, group)));
       const auto multiple =
           static_cast<int64_t>(std::pow(10.0, static_cast<double>(group)));

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -63,7 +63,7 @@ Int128::Int128(const uint8_t* bytes)
 void Int128::ToBytes(uint8_t** out) const {
   DCHECK_NE(out, nullptr) << "Cannot fill nullptr of bytes from Int128";
   DCHECK_NE(*out, nullptr) << "Cannot fill nullptr of bytes from Int128";
-  uint64_t raw[] = {static_cast<uint64_t>(high_bits_), low_bits_};
+  const uint64_t raw[] = {static_cast<uint64_t>(high_bits_), low_bits_};
   std::memcpy(*out, raw, 16);
 }
 

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -261,8 +261,8 @@ static int64_t FindLastSetBit(uint32_t value) {
   // Count leading zeros
   return __builtin_clz(value) + 1;
 #elif defined(_MSC_VER)
-  unsigned long index;
-  _BitScanReverse(&index, static_cast<unsigned long>(value));
+  unsigned long index;  // NOLINT
+  _BitScanReverse(&index, static_cast<unsigned long>(value));  // NOLINT
   return static_cast<int64_t>(index + 1UL);
 #endif
 }

--- a/cpp/src/arrow/util/int128.h
+++ b/cpp/src/arrow/util/int128.h
@@ -33,7 +33,7 @@ namespace decimal {
 /// Semi-numerical Algorithms section 4.3.1.
 ///
 /// Adapted from the Apache ORC C++ implementation
-class Int128 {
+class ARROW_EXPORT Int128 {
  public:
   constexpr Int128() : Int128(0, 0) {}
 
@@ -108,19 +108,19 @@ class Int128 {
   uint64_t low_bits_;
 };
 
-bool operator==(const Int128& left, const Int128& right);
-bool operator!=(const Int128& left, const Int128& right);
-bool operator<(const Int128& left, const Int128& right);
-bool operator<=(const Int128& left, const Int128& right);
-bool operator>(const Int128& left, const Int128& right);
-bool operator>=(const Int128& left, const Int128& right);
-
-Int128 operator-(const Int128& operand);
-Int128 operator+(const Int128& left, const Int128& right);
-Int128 operator-(const Int128& left, const Int128& right);
-Int128 operator*(const Int128& left, const Int128& right);
-Int128 operator/(const Int128& left, const Int128& right);
-Int128 operator%(const Int128& left, const Int128& right);
+ARROW_EXPORT bool operator==(const Int128& left, const Int128& right);
+ARROW_EXPORT bool operator!=(const Int128& left, const Int128& right);
+ARROW_EXPORT bool operator<(const Int128& left, const Int128& right);
+ARROW_EXPORT bool operator<=(const Int128& left, const Int128& right);
+ARROW_EXPORT bool operator>(const Int128& left, const Int128& right);
+ARROW_EXPORT bool operator>=(const Int128& left, const Int128& right);
+ARROW_EXPORT
+ARROW_EXPORT Int128 operator-(const Int128& operand);
+ARROW_EXPORT Int128 operator+(const Int128& left, const Int128& right);
+ARROW_EXPORT Int128 operator-(const Int128& left, const Int128& right);
+ARROW_EXPORT Int128 operator*(const Int128& left, const Int128& right);
+ARROW_EXPORT Int128 operator/(const Int128& left, const Int128& right);
+ARROW_EXPORT Int128 operator%(const Int128& left, const Int128& right);
 
 }  // namespace decimal
 }  // namespace arrow

--- a/cpp/src/arrow/util/int128.h
+++ b/cpp/src/arrow/util/int128.h
@@ -114,7 +114,7 @@ ARROW_EXPORT bool operator<(const Int128& left, const Int128& right);
 ARROW_EXPORT bool operator<=(const Int128& left, const Int128& right);
 ARROW_EXPORT bool operator>(const Int128& left, const Int128& right);
 ARROW_EXPORT bool operator>=(const Int128& left, const Int128& right);
-ARROW_EXPORT
+
 ARROW_EXPORT Int128 operator-(const Int128& operand);
 ARROW_EXPORT Int128 operator+(const Int128& left, const Int128& right);
 ARROW_EXPORT Int128 operator-(const Int128& left, const Int128& right);

--- a/cpp/src/arrow/util/int128.h
+++ b/cpp/src/arrow/util/int128.h
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ARROW_INT128_H
+#define ARROW_INT128_H
+
+#include <string>
+
+#include "arrow/status.h"
+
+namespace arrow {
+namespace decimal {
+
+/**
+ * Represents a signed 128-bit integer in two's complement.
+ * Calculations wrap around and overflow is ignored.
+ *
+ * For a discussion of the algorithms, look at Knuth's volume 2,
+ * Semi-numerical Algorithms section 4.3.1.
+ *
+ * Adapted from the Apache ORC C++ implementation
+ */
+class Int128 {
+ public:
+  constexpr Int128() : Int128(0, 0) {}
+
+  /**
+   * Convert a signed 64 bit value into an Int128.
+   * @param right
+   */
+  constexpr Int128(int64_t value)
+      : Int128(value >= 0 ? 0 : -1, static_cast<uint64_t>(value)) {}
+
+  /**
+   * Convert a signed 32 bit value into an Int128.
+   * @param right
+   */
+  constexpr Int128(int32_t value) : Int128(static_cast<int64_t>(value)) {}
+
+  /**
+   * Create from the two's complement representation.
+   * @param high
+   * @param low
+   */
+  constexpr Int128(int64_t high, uint64_t low) : highbits_(high), lowbits_(low) {}
+
+  /**
+   * Parse the number from a base 10 string representation.
+   * @param value
+   */
+  explicit Int128(const std::string& value);
+
+  /**
+   * Create from an array of bytes
+   * @param bytes
+   */
+  explicit Int128(const uint8_t* bytes);
+
+  Int128& negate();
+
+  /**
+   * Add a number to this one. The result is truncated to 128 bits.
+   * @param right the number to add
+   * @return *this
+   */
+  Int128& operator+=(const Int128& right);
+
+  /**
+   * Subtract a number from this one. The result is truncated to 128 bits.
+   * @param right the number to subtract
+   * @return *this
+   */
+  Int128& operator-=(const Int128& right);
+
+  /**
+   * Multiply this number by a number. The result is truncated to 128 bits.
+   * @param right the number to multiply by
+   * @return *this
+   */
+  Int128& operator*=(const Int128& right);
+
+  /**
+   * Divide this number by right and return the result. This operation is
+   * not destructive.
+   *
+   * The answer rounds to zero. Signs work like:
+   *    21 /  5 ->  4,  1
+   *   -21 /  5 -> -4, -1
+   *    21 / -5 -> -4,  1
+   *   -21 / -5 ->  4, -1
+   * @param right the number to divide by
+   * @param remainder the remainder after the division
+   */
+  Status divide(const Int128& divisor, Int128* result, Int128* remainder) const;
+
+  Int128& operator/=(const Int128& right);
+
+  /**
+   * Cast the value to char. This is used when converting the value a string.
+   * @return char
+   */
+  explicit operator char() const;
+
+  /**
+   * Bitwise or between two Int128.
+   * @param right the number to or in
+   * @return *this
+   */
+  Int128& operator|=(const Int128& right);
+
+  /**
+   * Bitwise and between two Int128.
+   * @param right the number to and in
+   * @return *this
+   */
+  Int128& operator&=(const Int128& right);
+
+  /**
+   * Shift left by the given number of bits.
+   * Values larger than 2 ** 127 will shift into the sign bit.
+   * @param bits
+   */
+  Int128& operator<<=(uint32_t bits);
+
+  /**
+   * Shift right by the given number of bits. Negative values will
+   * sign extend and fill with one bits.
+   * @param bits
+   */
+  Int128& operator>>=(uint32_t bits);
+
+  /**
+   * Get the high bits of the two's complement representation of the number.
+   */
+  int64_t highbits() const { return highbits_; }
+
+  /**
+   * Get the low bits of the two's complement representation of the number.
+   */
+  uint64_t lowbits() const { return lowbits_; }
+
+  /**
+   * Get the raw bytes of the value
+   * @param[out] out Pointer to an already allocated array of bytes. Must not be nullptr.
+   */
+  void ToBytes(uint8_t** out) const;
+
+ private:
+  int64_t highbits_;
+  uint64_t lowbits_;
+};
+
+bool operator==(const Int128& left, const Int128& right);
+bool operator!=(const Int128& left, const Int128& right);
+bool operator<(const Int128& left, const Int128& right);
+bool operator<=(const Int128& left, const Int128& right);
+bool operator>(const Int128& left, const Int128& right);
+bool operator>=(const Int128& left, const Int128& right);
+
+Int128 operator-(const Int128& operand);
+Int128 operator+(const Int128& left, const Int128& right);
+Int128 operator-(const Int128& left, const Int128& right);
+Int128 operator*(const Int128& left, const Int128& right);
+Int128 operator/(const Int128& left, const Int128& right);
+Int128 operator%(const Int128& left, const Int128& right);
+
+}  // namespace decimal
+}  // namespace arrow
+
+#endif  //  ARROW_INT128_H

--- a/cpp/src/arrow/util/int128.h
+++ b/cpp/src/arrow/util/int128.h
@@ -74,7 +74,7 @@ class Int128 {
   ///  -21 / -5 ->  4, -1
   /// @param right the number to divide by
   /// @param remainder the remainder after the division
-  Status Divide(const Int128 &divisor, Int128 *result, Int128 *remainder) const;
+  Status Divide(const Int128& divisor, Int128* result, Int128* remainder) const;
 
   /// \brief In-place division.
   Int128& operator/=(const Int128& right);

--- a/cpp/src/arrow/util/int128.h
+++ b/cpp/src/arrow/util/int128.h
@@ -26,143 +26,86 @@
 namespace arrow {
 namespace decimal {
 
-/**
- * Represents a signed 128-bit integer in two's complement.
- * Calculations wrap around and overflow is ignored.
- *
- * For a discussion of the algorithms, look at Knuth's volume 2,
- * Semi-numerical Algorithms section 4.3.1.
- *
- * Adapted from the Apache ORC C++ implementation
- */
+/// Represents a signed 128-bit integer in two's complement.
+/// Calculations wrap around and overflow is ignored.
+///
+/// For a discussion of the algorithms, look at Knuth's volume 2,
+/// Semi-numerical Algorithms section 4.3.1.
+///
+/// Adapted from the Apache ORC C++ implementation
 class Int128 {
  public:
   constexpr Int128() : Int128(0, 0) {}
 
-  /**
-   * Convert a signed 64 bit value into an Int128.
-   * @param right
-   */
+  /// \brief Convert a signed 64 bit value into an Int128.
   constexpr Int128(int64_t value)
       : Int128(value >= 0 ? 0 : -1, static_cast<uint64_t>(value)) {}
 
-  /**
-   * Convert a signed 32 bit value into an Int128.
-   * @param right
-   */
+  /// \brief Convert a signed 32 bit value into an Int128.
   constexpr Int128(int32_t value) : Int128(static_cast<int64_t>(value)) {}
 
-  /**
-   * Create from the two's complement representation.
-   * @param high
-   * @param low
-   */
-  constexpr Int128(int64_t high, uint64_t low) : highbits_(high), lowbits_(low) {}
+  /// \brief Create an Int128 from the two's complement representation.
+  constexpr Int128(int64_t high, uint64_t low) : high_bits_(high), low_bits_(low) {}
 
-  /**
-   * Parse the number from a base 10 string representation.
-   * @param value
-   */
+  /// \brief Parse the number from a base 10 string representation.
   explicit Int128(const std::string& value);
 
-  /**
-   * Create from an array of bytes
-   * @param bytes
-   */
+  /// \brief Create an Int128 from an array of bytes
   explicit Int128(const uint8_t* bytes);
 
-  Int128& negate();
+  /// \brief Negate the current value
+  Int128& Negate();
 
-  /**
-   * Add a number to this one. The result is truncated to 128 bits.
-   * @param right the number to add
-   * @return *this
-   */
+  /// \brief Add a number to this one. The result is truncated to 128 bits.
   Int128& operator+=(const Int128& right);
 
-  /**
-   * Subtract a number from this one. The result is truncated to 128 bits.
-   * @param right the number to subtract
-   * @return *this
-   */
+  /// \brief Subtract a number from this one. The result is truncated to 128 bits.
   Int128& operator-=(const Int128& right);
 
-  /**
-   * Multiply this number by a number. The result is truncated to 128 bits.
-   * @param right the number to multiply by
-   * @return *this
-   */
+  /// \brief Multiply this number by another number. The result is truncated to 128 bits.
   Int128& operator*=(const Int128& right);
 
-  /**
-   * Divide this number by right and return the result. This operation is
-   * not destructive.
-   *
-   * The answer rounds to zero. Signs work like:
-   *    21 /  5 ->  4,  1
-   *   -21 /  5 -> -4, -1
-   *    21 / -5 -> -4,  1
-   *   -21 / -5 ->  4, -1
-   * @param right the number to divide by
-   * @param remainder the remainder after the division
-   */
-  Status divide(const Int128& divisor, Int128* result, Int128* remainder) const;
+  /// Divide this number by right and return the result. This operation is
+  /// not destructive.
+  /// The answer rounds to zero. Signs work like:
+  ///   21 /  5 ->  4,  1
+  ///  -21 /  5 -> -4, -1
+  ///   21 / -5 -> -4,  1
+  ///  -21 / -5 ->  4, -1
+  /// @param right the number to divide by
+  /// @param remainder the remainder after the division
+  Status Divide(const Int128 &divisor, Int128 *result, Int128 *remainder) const;
 
+  /// \brief In-place division.
   Int128& operator/=(const Int128& right);
 
-  /**
-   * Cast the value to char. This is used when converting the value a string.
-   * @return char
-   */
+  /// \brief Cast the value to char. This is used when converting the value a string.
   explicit operator char() const;
 
-  /**
-   * Bitwise or between two Int128.
-   * @param right the number to or in
-   * @return *this
-   */
+  /// \brief Bitwise or between two Int128.
   Int128& operator|=(const Int128& right);
 
-  /**
-   * Bitwise and between two Int128.
-   * @param right the number to and in
-   * @return *this
-   */
+  /// \brief Bitwise and between two Int128.
   Int128& operator&=(const Int128& right);
 
-  /**
-   * Shift left by the given number of bits.
-   * Values larger than 2 ** 127 will shift into the sign bit.
-   * @param bits
-   */
+  /// \brief Shift left by the given number of bits.
   Int128& operator<<=(uint32_t bits);
 
-  /**
-   * Shift right by the given number of bits. Negative values will
-   * sign extend and fill with one bits.
-   * @param bits
-   */
+  /// \brief Shift right by the given number of bits. Negative values will
   Int128& operator>>=(uint32_t bits);
 
-  /**
-   * Get the high bits of the two's complement representation of the number.
-   */
-  int64_t highbits() const { return highbits_; }
+  /// \brief Get the high bits of the two's complement representation of the number.
+  int64_t high_bits() const { return high_bits_; }
 
-  /**
-   * Get the low bits of the two's complement representation of the number.
-   */
-  uint64_t lowbits() const { return lowbits_; }
+  /// \brief Get the low bits of the two's complement representation of the number.
+  uint64_t low_bits() const { return low_bits_; }
 
-  /**
-   * Get the raw bytes of the value
-   * @param[out] out Pointer to an already allocated array of bytes. Must not be nullptr.
-   */
+  /// \brief Put the raw bytes of the value into a pointer to uint8_t.
   void ToBytes(uint8_t** out) const;
 
  private:
-  int64_t highbits_;
-  uint64_t lowbits_;
+  int64_t high_bits_;
+  uint64_t low_bits_;
 };
 
 bool operator==(const Int128& left, const Int128& right);


### PR DESCRIPTION
* Reimplement Decimal128 types to use the Int128 type as the underlying integer
representation, adapted from the Apache ORC project's C++ in memory format.
This enables us to write integration tests and results in an in-memory
Decimal128 format that is compatible with the Java implementation
* Additionaly, this PR also fixes Decimal slice comparison and adds related
regression tests
* Follow-ups include ARROW-695 (C++ Decimal integration tests), ARROW-696 (JSON
read/write support for decimals) and ARROW-1238 (Java Decimal integration
tests).