### PR TITLE
ARROW-1392: [C++] Add GPU IO interfaces for CUDA

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -405,7 +405,7 @@ namespace garrow {
       }
     }
 
-    arrow::Status Tell(int64_t *position) override {
+    arrow::Status Tell(int64_t *position) const override {
       if (!G_IS_SEEKABLE(input_stream_)) {
         std::string message("[gio-input-stream][tell] "
                             "not seekable input stream: <");

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -312,7 +312,7 @@ namespace garrow {
       }
     }
 
-    arrow::Status Tell(int64_t *position) override {
+    arrow::Status Tell(int64_t *position) const override {
       if (!G_IS_SEEKABLE(output_stream_)) {
         std::string message("[gio-output-stream][tell] "
                             "not seekable output stream: <");

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -101,15 +101,26 @@ all of these variables. Note that `ARROW_BUILD_TOOLCHAIN` will not set
 `BOOST_ROOT`, so if you have custom Boost installation, you must set this
 environment variable separately.
 
-### Building Python integration library
+### Building Python integration library (optional)
 
-The `arrow_python` shared library can be built by passing `-DARROW_PYTHON=on`
-to CMake. This must be installed or in your library load path to be able to
-build pyarrow, the Arrow Python bindings.
+The optional `arrow_python` shared library can be built by passing
+`-DARROW_PYTHON=on` to CMake. This must be installed or in your library load
+path to be able to build pyarrow, the Arrow Python bindings.
 
 The Python library must be built against the same Python version for which you
 are building pyarrow, e.g. Python 2.7 or Python 3.6. NumPy must also be
 installed.
+
+### Building GPU extension library (optional)
+
+The optional `arrow_gpu` shared library can be built by passing
+`-DARROW_GPU=on`. This requires a CUDA installation to build, and to use many
+of the functions you must have a functioning GPU. Currently only CUDA
+functionality is supported, though if there is demand we can also add OpenCL
+interfaces in this library as needed.
+
+The CUDA toolchain used to build the library can be customized by using the
+`$CUDA_HOME` environment variable.
 
 ### API documentation
 

--- a/cpp/apidoc/Doxyfile
+++ b/cpp/apidoc/Doxyfile
@@ -2084,7 +2084,7 @@ PREDEFINED = __attribute__(x)= \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED = ARROW_MEMORY_POOL_ARG
+EXPAND_AS_DEFINED = ARROW_MEMORY_POOL_DEFAULT
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -54,12 +54,6 @@ struct Decimal;
 
 static constexpr int64_t kMinBuilderCapacity = 1 << 5;
 
-#ifdef ARROW_NO_DEFAULT_MEMORY_POOL
-#define ARROW_MEMORY_POOL_ARG pool
-#else
-#define ARROW_MEMORY_POOL_ARG pool = default_memory_pool()
-#endif
-
 /// Base class for all data array builders.
 //
 /// This class provides a facilities for incrementally building the null bitmap
@@ -167,7 +161,8 @@ class ARROW_EXPORT ArrayBuilder {
 
 class ARROW_EXPORT NullBuilder : public ArrayBuilder {
  public:
-  explicit NullBuilder(MemoryPool* ARROW_MEMORY_POOL_ARG) : ArrayBuilder(null(), pool) {}
+  explicit NullBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+      : ArrayBuilder(null(), pool) {}
 
   Status AppendNull() {
     ++null_count_;
@@ -236,8 +231,8 @@ class ARROW_EXPORT NumericBuilder : public PrimitiveBuilder<T> {
 
   template <typename T1 = T>
   explicit NumericBuilder(
-      typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type
-          ARROW_MEMORY_POOL_ARG)
+      typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type pool
+          ARROW_MEMORY_POOL_DEFAULT)
       : PrimitiveBuilder<T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
   using PrimitiveBuilder<T>::Append;
@@ -368,7 +363,7 @@ inline uint8_t ExpandedUIntSize(uint64_t val, uint8_t current_int_size) {
 
 class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveUIntBuilder(MemoryPool* ARROW_MEMORY_POOL_ARG);
+  explicit AdaptiveUIntBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   using ArrayBuilder::Advance;
 
@@ -427,7 +422,7 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
 class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveIntBuilder(MemoryPool* ARROW_MEMORY_POOL_ARG);
+  explicit AdaptiveIntBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   using ArrayBuilder::Advance;
 
@@ -486,7 +481,7 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
 class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
  public:
-  explicit BooleanBuilder(MemoryPool* ARROW_MEMORY_POOL_ARG);
+  explicit BooleanBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   explicit BooleanBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
 
@@ -607,7 +602,7 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
 /// \brief Builder class for variable-length binary data
 class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
  public:
-  explicit BinaryBuilder(MemoryPool* ARROW_MEMORY_POOL_ARG);
+  explicit BinaryBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
 #ifndef ARROW_NO_DEPRECATED_API
   /// \deprecated Since 0.6.0
@@ -656,7 +651,7 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
 class ARROW_EXPORT StringBuilder : public BinaryBuilder {
  public:
   using BinaryBuilder::BinaryBuilder;
-  explicit StringBuilder(MemoryPool* ARROW_MEMORY_POOL_ARG);
+  explicit StringBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   using BinaryBuilder::Append;
 
@@ -676,7 +671,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
 #endif
 
   FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& type,
-                         MemoryPool* ARROW_MEMORY_POOL_ARG);
+                         MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   Status Append(const uint8_t* value);
   Status Append(const uint8_t* data, int64_t length,
@@ -699,7 +694,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
 class ARROW_EXPORT DecimalBuilder : public FixedSizeBinaryBuilder {
  public:
   explicit DecimalBuilder(const std::shared_ptr<DataType>& type,
-                          MemoryPool* ARROW_MEMORY_POOL_ARG);
+                          MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
 #ifndef ARROW_NO_DEPRECATED_API
   /// \deprecated Since 0.6.0

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -80,9 +80,26 @@ set(ARROW_GPU_SHARED_LINK_LIBS
   arrow_shared
 )
 
-cuda_add_library(arrow_gpu SHARED
+add_library(arrow_gpu_objlib OBJECT
   ${ARROW_GPU_SRCS}
 )
+set_property(TARGET arrow_gpu_objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+if (ARROW_BUILD_SHARED)
+  cuda_add_library(arrow_gpu_shared SHARED $<TARGET_OBJECTS:arrow_gpu_objlib>)
+  install(TARGETS arrow_gpu_shared
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+if (ARROW_BUILD_STATIC)
+  add_library(arrow_gpu_static STATIC $<TARGET_OBJECTS:arrow_gpu_objlib>)
+  install(TARGETS arrow_gpu_static
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 install(FILES
   cuda_common.h
@@ -99,8 +116,8 @@ install(
 
 if (ARROW_BUILD_TESTS)
   set(ARROW_GPU_TEST_LINK_LIBS
-    ${ARROW_TEST_LINK_LIBS}
-    arrow_gpu)
+    arrow_gpu_shared
+    ${ARROW_TEST_LINK_LIBS})
   ADD_ARROW_CUDA_TEST(cuda-test
     STATIC_LINK_LIBS ${ARROW_GPU_TEST_LINK_LIBS})
 endif()

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -114,10 +114,19 @@ install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-gpu.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
+set(ARROW_GPU_TEST_LINK_LIBS
+  arrow_gpu_shared
+  ${ARROW_TEST_LINK_LIBS})
+
 if (ARROW_BUILD_TESTS)
-  set(ARROW_GPU_TEST_LINK_LIBS
-    arrow_gpu_shared
-    ${ARROW_TEST_LINK_LIBS})
   ADD_ARROW_CUDA_TEST(cuda-test
     STATIC_LINK_LIBS ${ARROW_GPU_TEST_LINK_LIBS})
+endif()
+
+if (ARROW_BUILD_BENCHMARKS)
+  cuda_add_executable(cuda-benchmark cuda-benchmark.cc)
+  target_link_libraries(cuda-benchmark
+    arrow_gpu_shared
+    gtest
+    ${ARROW_BENCHMARK_LINK_LIBS})
 endif()

--- a/cpp/src/arrow/gpu/cuda-benchmark.cc
+++ b/cpp/src/arrow/gpu/cuda-benchmark.cc
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/memory_pool.h"
+#include "arrow/test-util.h"
+
+#include "arrow/gpu/cuda_memory.h"
+
+namespace arrow {
+namespace gpu {
+
+constexpr int64_t kGpuNumber = 0;
+
+static void CudaBufferWriterBenchmark(benchmark::State& state, const int64_t total_bytes,
+                                      const int64_t chunksize,
+                                      const int64_t buffer_size) {
+  std::shared_ptr<CudaBuffer> device_buffer;
+  ABORT_NOT_OK(AllocateCudaBuffer(kGpuNumber, total_bytes, &device_buffer));
+  CudaBufferWriter writer(device_buffer);
+
+  if (buffer_size > 0) {
+    ABORT_NOT_OK(writer.SetBufferSize(buffer_size));
+  }
+
+  std::shared_ptr<PoolBuffer> buffer;
+  ASSERT_OK(test::MakeRandomBytePoolBuffer(total_bytes, default_memory_pool(), &buffer));
+
+  const uint8_t* host_data = buffer->data();
+  while (state.KeepRunning()) {
+    int64_t bytes_written = 0;
+    ABORT_NOT_OK(writer.Seek(0));
+    while (bytes_written < total_bytes) {
+      int64_t bytes_to_write = std::min(chunksize, total_bytes - bytes_written);
+      ABORT_NOT_OK(writer.Write(host_data + bytes_written, bytes_to_write));
+      bytes_written += bytes_to_write;
+    }
+  }
+  state.SetBytesProcessed(int64_t(state.iterations()) * total_bytes);
+}
+
+static void BM_Writer_Buffered(benchmark::State& state) {
+  // 128MB
+  const int64_t kTotalBytes = 1 << 27;
+
+  // 8MB
+  const int64_t kBufferSize = 1 << 23;
+
+  CudaBufferWriterBenchmark(state, kTotalBytes, state.range(0), kBufferSize);
+}
+
+static void BM_Writer_Unbuffered(benchmark::State& state) {
+  // 128MB
+  const int64_t kTotalBytes = 1 << 27;
+  CudaBufferWriterBenchmark(state, kTotalBytes, state.range(0), 0);
+}
+
+// Vary chunk write size from 256 bytes to 64K
+BENCHMARK(BM_Writer_Buffered)
+    ->RangeMultiplier(16)
+    ->Range(1 << 8, 1 << 16)
+    ->MinTime(1.0)
+    ->UseRealTime();
+
+BENCHMARK(BM_Writer_Unbuffered)
+    ->RangeMultiplier(4)
+    ->RangeMultiplier(16)
+    ->Range(1 << 8, 1 << 16)
+    ->MinTime(1.0)
+    ->UseRealTime();
+
+}  // namespace gpu
+}  // namespace arrow

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -45,7 +45,7 @@ void AssertCudaBufferEquals(const CudaBuffer& buffer, const uint8_t* host_data,
                             const int64_t nbytes) {
   std::shared_ptr<MutableBuffer> result;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), nbytes, &result));
-  ASSERT_OK(buffer.CopyToHost(result->mutable_data()));
+  ASSERT_OK(buffer.CopyToHost(0, buffer.size(), result->mutable_data()));
   ASSERT_EQ(0, std::memcmp(result->data(), host_data, nbytes));
 }
 
@@ -162,6 +162,46 @@ TEST_F(TestCudaBufferWriter, EdgeCases) {
 
   // Check that everything was written
   AssertCudaBufferEquals(*device_buffer_, host_data, 1000);
+}
+
+TEST(TestCudaBufferReader, Basics) {
+  std::shared_ptr<CudaBuffer> device_buffer;
+
+  const int64_t size = 1000;
+  ASSERT_OK(AllocateCudaBuffer(kGpuNumber, size, &device_buffer));
+
+  std::shared_ptr<PoolBuffer> buffer;
+  ASSERT_OK(test::MakeRandomBytePoolBuffer(1000, default_memory_pool(), &buffer));
+  const uint8_t* host_data = buffer->data();
+
+  ASSERT_OK(device_buffer->CopyFromHost(0, host_data, 1000));
+
+  CudaBufferReader reader(device_buffer);
+
+  // Read to host memory
+  uint8_t stack_buffer[100] = {0};
+  int64_t bytes_read = 0;
+  ASSERT_OK(reader.Seek(950));
+
+  int64_t position = 0;
+  ASSERT_OK(reader.Tell(&position));
+  ASSERT_EQ(950, position);
+
+  ASSERT_OK(reader.Read(100, &bytes_read, stack_buffer));
+  ASSERT_EQ(50, bytes_read);
+  ASSERT_EQ(0, std::memcmp(stack_buffer, host_data + 950, 50));
+  ASSERT_OK(reader.Tell(&position));
+  ASSERT_EQ(1000, position);
+
+  ASSERT_OK(reader.Seek(925));
+  std::shared_ptr<Buffer> tmp;
+  ASSERT_OK(reader.Read(100, &tmp));
+  ASSERT_EQ(75, tmp->size());
+  ASSERT_OK(reader.Tell(&position));
+  ASSERT_EQ(1000, position);
+
+  ASSERT_OK(std::dynamic_pointer_cast<CudaBuffer>(tmp)->CopyToHost(0, 75, stack_buffer));
+  ASSERT_EQ(0, std::memcmp(stack_buffer, host_data + 925, 75));
 }
 
 }  // namespace gpu

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -157,11 +157,8 @@ TEST_F(TestCudaBufferWriter, EdgeCases) {
   ASSERT_OK(writer_->Write(host_data + 510, 390));
   ASSERT_OK(writer_->Write(host_data + 900, 100));
 
-  // Seek to beginning flushes buffered bytes
-  ASSERT_OK(writer_->Seek(0));
-  ASSERT_OK(writer_->Tell(&position));
-  ASSERT_EQ(0, position);
-  ASSERT_EQ(0, writer_->num_bytes_buffered());
+  // Close flushes
+  ASSERT_OK(writer_->Close());
 
   // Check that everything was written
   AssertCudaBufferEquals(*device_buffer_, host_data, 1000);

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -29,6 +29,8 @@
 namespace arrow {
 namespace gpu {
 
+constexpr int kGpuNumber = 0;
+
 class TestCudaBuffer : public ::testing::Test {};
 
 TEST_F(TestCudaBuffer, Allocate) {
@@ -39,6 +41,120 @@ TEST_F(TestCudaBuffer, Allocate) {
 
   ASSERT_OK(AllocateCudaBuffer(device, kSize, &buffer));
   ASSERT_EQ(kSize, buffer->size());
+}
+
+TEST_F(TestCudaBuffer, CopyFromHost) {}
+
+class TestCudaBufferWriter : public ::testing::Test {
+ public:
+  void Allocate(const int64_t size) {
+    ASSERT_OK(AllocateCudaBuffer(kGpuNumber, size, &device_buffer_));
+    writer_.reset(new CudaBufferWriter(device_buffer_));
+  }
+
+  void TestWrites(const int64_t total_bytes, const int64_t chunksize,
+                  const int64_t buffer_size = 0) {
+    std::shared_ptr<PoolBuffer> buffer;
+    ASSERT_OK(
+        test::MakeRandomBytePoolBuffer(total_bytes, default_memory_pool(), &buffer));
+
+    if (buffer_size > 0) {
+      ASSERT_OK(writer_->SetBufferSize(buffer_size));
+    }
+
+    int64_t position = 0;
+    ASSERT_OK(writer_->Tell(&position));
+    ASSERT_EQ(0, position);
+
+    const uint8_t* host_data = buffer->data();
+    ASSERT_OK(writer_->Write(host_data, chunksize));
+    ASSERT_OK(writer_->Tell(&position));
+    ASSERT_EQ(chunksize, position);
+
+    ASSERT_OK(writer_->Seek(0));
+    ASSERT_OK(writer_->Tell(&position));
+    ASSERT_EQ(0, position);
+
+    while (position < total_bytes) {
+      int64_t bytes_to_write = std::min(chunksize, total_bytes - position);
+      ASSERT_OK(writer_->Write(host_data + position, bytes_to_write));
+      position += bytes_to_write;
+    }
+
+    ASSERT_OK(writer_->Flush());
+
+    std::shared_ptr<MutableBuffer> result;
+    ASSERT_OK(AllocateBuffer(default_memory_pool(), total_bytes, &result));
+
+    ASSERT_OK(device_buffer_->CopyToHost(result->mutable_data()));
+
+    ASSERT_EQ(0, std::memcmp(result->data(), buffer->data(), total_bytes));
+  }
+
+ protected:
+  std::shared_ptr<CudaBuffer> device_buffer_;
+  std::unique_ptr<CudaBufferWriter> writer_;
+};
+
+TEST_F(TestCudaBufferWriter, UnbufferedWrites) {
+  const int64_t kTotalSize = 1 << 16;
+  Allocate(kTotalSize);
+  TestWrites(kTotalSize, 1000);
+}
+
+TEST_F(TestCudaBufferWriter, BufferedWrites) {
+  const int64_t kTotalSize = 1 << 16;
+  Allocate(kTotalSize);
+  TestWrites(kTotalSize, 1000, 1 << 12);
+}
+
+TEST_F(TestCudaBufferWriter, EdgeCases) {
+  Allocate(1000);
+
+  std::shared_ptr<PoolBuffer> buffer;
+  ASSERT_OK(test::MakeRandomBytePoolBuffer(1000, default_memory_pool(), &buffer));
+  const uint8_t* host_data = buffer->data();
+
+  ASSERT_EQ(0, writer_->buffer_size());
+  ASSERT_OK(writer_->SetBufferSize(100));
+  ASSERT_EQ(100, writer_->buffer_size());
+
+  // Write 0 bytes
+  int64_t position = 0;
+  ASSERT_OK(writer_->Write(host_data, 0));
+  ASSERT_OK(writer_->Tell(&position));
+  ASSERT_EQ(0, position);
+
+  // Write some data, then change buffer size
+  ASSERT_OK(writer_->Write(host_data, 10));
+  ASSERT_OK(writer_->SetBufferSize(200));
+  ASSERT_EQ(200, writer_->buffer_size());
+
+  ASSERT_EQ(0, writer_->num_bytes_buffered());
+
+  // Write more than buffer size
+  ASSERT_OK(writer_->Write(host_data + 10, 300));
+  ASSERT_EQ(0, writer_->num_bytes_buffered());
+
+  // Write exactly buffer size
+  ASSERT_OK(writer_->Write(host_data + 310, 200));
+  ASSERT_EQ(0, writer_->num_bytes_buffered());
+
+  // Write rest of bytes
+  ASSERT_OK(writer_->Write(host_data + 510, 390));
+  ASSERT_OK(writer_->Write(host_data + 900, 100));
+
+  // Seek to beginning flushes buffered bytes
+  ASSERT_OK(writer_->Seek(0));
+  ASSERT_OK(writer_->Tell(&position));
+  ASSERT_EQ(0, position);
+  ASSERT_EQ(0, writer_->num_bytes_buffered());
+
+  // Check that everything was written
+  std::shared_ptr<MutableBuffer> result;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), 1000, &result));
+  ASSERT_OK(device_buffer_->CopyToHost(result->mutable_data()));
+  ASSERT_EQ(0, std::memcmp(result->data(), host_data, 1000));
 }
 
 }  // namespace gpu

--- a/cpp/src/arrow/gpu/cuda_common.h
+++ b/cpp/src/arrow/gpu/cuda_common.h
@@ -20,6 +20,8 @@
 #ifndef ARROW_GPU_CUDA_COMMON_H
 #define ARROW_GPU_CUDA_COMMON_H
 
+#include <sstream>
+
 #include <cuda_runtime_api.h>
 
 namespace arrow {
@@ -32,12 +34,15 @@ namespace gpu {
     (void)ret;            \
   } while (0)
 
-#define CUDA_RETURN_NOT_OK(STMT)                              \
-  do {                                                        \
-    cudaError_t ret = (STMT);                                 \
-    if (ret != cudaSuccess) {                                 \
-      return Status::IOError("Cuda API call failed: " #STMT); \
-    }                                                         \
+#define CUDA_RETURN_NOT_OK(STMT)                                       \
+  do {                                                                 \
+    cudaError_t ret = (STMT);                                          \
+    if (ret != cudaSuccess) {                                          \
+      std::stringstream ss;                                            \
+      ss << "Cuda API call in " << __FILE__ << " at line " << __LINE__ \
+         << " failed: " << #STMT;                                      \
+      return Status::IOError(ss.str());                                \
+    }                                                                  \
   } while (0)
 
 }  // namespace gpu

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -100,6 +100,8 @@ CudaBufferWriter::CudaBufferWriter(const std::shared_ptr<CudaBuffer>& buffer)
 
 CudaBufferWriter::~CudaBufferWriter() {}
 
+Status CudaBufferWriter::Close() { return Flush(); }
+
 Status CudaBufferWriter::Flush() {
   if (buffer_size_ > 0 && buffer_position_ > 0) {
     // Only need to flush when the write has been buffered

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -37,14 +37,14 @@ CudaBuffer::~CudaBuffer() {
   }
 }
 
-Status CudaBuffer::CopyToHost(uint8_t* out) {
+Status CudaBuffer::CopyToHost(uint8_t* out) const {
   CUDA_RETURN_NOT_OK(cudaMemcpy(out, data_, size_, cudaMemcpyDeviceToHost));
   return Status::OK();
 }
 
 Status CudaBuffer::CopyFromHost(const int64_t position, const uint8_t* data,
                                 int64_t nbytes) {
-  DCHECK_LT(nbytes, size_ - position) << "Copy would overflow buffer";
+  DCHECK_LE(nbytes, size_ - position) << "Copy would overflow buffer";
   CUDA_RETURN_NOT_OK(
       cudaMemcpy(mutable_data_ + position, data, nbytes, cudaMemcpyHostToDevice));
   return Status::OK();

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -43,7 +43,7 @@ class ARROW_EXPORT CudaBuffer : public MutableBuffer {
   /// \brief Copy memory from GPU device to CPU host
   /// \param[out] out a pre-allocated output buffer
   /// \return Status
-  Status CopyToHost(uint8_t* out);
+  Status CopyToHost(uint8_t* out) const;
 
   /// \brief Copy memory to device at position
   /// \param[in] position start position to copy bytes
@@ -108,7 +108,10 @@ class ARROW_EXPORT CudaBufferWriter : public io::FixedSizeBufferWriter {
   /// By default writes are unbuffered
   Status SetBufferSize(const int64_t buffer_size);
 
+  /// \brief Returns size of host (CPU) buffer, 0 for unbuffered
   int64_t buffer_size() const { return buffer_size_; }
+
+  /// \brief Returns number of bytes buffered on host
   int64_t num_bytes_buffered() const { return buffer_position_; }
 
  private:

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -94,6 +94,9 @@ class ARROW_EXPORT CudaBufferWriter : public io::FixedSizeBufferWriter {
   explicit CudaBufferWriter(const std::shared_ptr<CudaBuffer>& buffer);
   ~CudaBufferWriter();
 
+  /// \brief Close writer and flush buffered bytes to GPU
+  Status Close() override;
+
   /// \brief Flush buffered bytes to GPU
   Status Flush() override;
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -440,7 +440,7 @@ Status ReadableFile::Open(const std::string& path, MemoryPool* memory_pool,
 
 Status ReadableFile::Close() { return impl_->Close(); }
 
-Status ReadableFile::Tell(int64_t* pos) { return impl_->Tell(pos); }
+Status ReadableFile::Tell(int64_t* pos) const { return impl_->Tell(pos); }
 
 Status ReadableFile::Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
   return impl_->Read(nbytes, bytes_read, out);
@@ -492,7 +492,7 @@ Status FileOutputStream::Open(const std::string& path, bool append,
 
 Status FileOutputStream::Close() { return impl_->Close(); }
 
-Status FileOutputStream::Tell(int64_t* pos) { return impl_->Tell(pos); }
+Status FileOutputStream::Tell(int64_t* pos) const { return impl_->Tell(pos); }
 
 Status FileOutputStream::Write(const uint8_t* data, int64_t length) {
   return impl_->Write(data, length);
@@ -612,7 +612,7 @@ Status MemoryMappedFile::GetSize(int64_t* size) {
   return Status::OK();
 }
 
-Status MemoryMappedFile::Tell(int64_t* position) {
+Status MemoryMappedFile::Tell(int64_t* position) const {
   *position = memory_map_->position();
   return Status::OK();
 }

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -57,7 +57,7 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
 
   // OutputStream interface
   Status Close() override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
 
   // Write bytes to the stream. Thread-safe
   Status Write(const uint8_t* data, int64_t nbytes) override;
@@ -91,7 +91,7 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
                      std::shared_ptr<ReadableFile>* file);
 
   Status Close() override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
 
   // Read bytes from the file. Thread-safe
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
@@ -130,7 +130,7 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
 
   Status Close() override;
 
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
 
   Status Seek(int64_t position) override;
 

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -230,7 +230,7 @@ Status HdfsReadableFile::GetSize(int64_t* size) { return impl_->GetSize(size); }
 
 Status HdfsReadableFile::Seek(int64_t position) { return impl_->Seek(position); }
 
-Status HdfsReadableFile::Tell(int64_t* position) { return impl_->Tell(position); }
+Status HdfsReadableFile::Tell(int64_t* position) const { return impl_->Tell(position); }
 
 // ----------------------------------------------------------------------
 // File writing
@@ -284,7 +284,7 @@ Status HdfsOutputStream::Write(const uint8_t* buffer, int64_t nbytes) {
 
 Status HdfsOutputStream::Flush() { return impl_->Flush(); }
 
-Status HdfsOutputStream::Tell(int64_t* position) { return impl_->Tell(position); }
+Status HdfsOutputStream::Tell(int64_t* position) const { return impl_->Tell(position); }
 
 // ----------------------------------------------------------------------
 // HDFS client

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -199,7 +199,7 @@ class ARROW_EXPORT HdfsReadableFile : public RandomAccessFile {
   bool supports_zero_copy() const override;
 
   Status Seek(int64_t position) override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
 
   void set_memory_pool(MemoryPool* pool);
 
@@ -228,7 +228,7 @@ class ARROW_EXPORT HdfsOutputStream : public OutputStream {
 
   Status Flush() override;
 
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
 
  private:
   class ARROW_NO_EXPORT HdfsOutputStreamImpl;

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -72,7 +72,7 @@ class ARROW_EXPORT FileInterface {
  public:
   virtual ~FileInterface() = 0;
   virtual Status Close() = 0;
-  virtual Status Tell(int64_t* position) = 0;
+  virtual Status Tell(int64_t* position) const = 0;
 
   FileMode::type mode() const { return mode_; }
 
@@ -94,7 +94,7 @@ class ARROW_EXPORT Writeable {
  public:
   virtual Status Write(const uint8_t* data, int64_t nbytes) = 0;
 
-  // Default implementation is a no-op
+  /// \brief Flush buffered bytes, if any
   virtual Status Flush();
 
   Status Write(const std::string& data);

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -75,7 +75,7 @@ Status BufferOutputStream::Finish(std::shared_ptr<Buffer>* result) {
   return Status::OK();
 }
 
-Status BufferOutputStream::Tell(int64_t* position) {
+Status BufferOutputStream::Tell(int64_t* position) const {
   *position = position_;
   return Status::OK();
 }
@@ -104,9 +104,12 @@ Status BufferOutputStream::Reserve(int64_t nbytes) {
 // ----------------------------------------------------------------------
 // OutputStream that doesn't write anything
 
-Status MockOutputStream::Close() { return Status::OK(); }
+Status MockOutputStream::Close() {
+  // no-op
+  return Status::OK();
+}
 
-Status MockOutputStream::Tell(int64_t* position) {
+Status MockOutputStream::Tell(int64_t* position) const {
   *position = extent_bytes_written_;
   return Status::OK();
 }
@@ -128,6 +131,7 @@ FixedSizeBufferWriter::FixedSizeBufferWriter(const std::shared_ptr<Buffer>& buff
     : memcopy_num_threads_(kMemcopyDefaultNumThreads),
       memcopy_blocksize_(kMemcopyDefaultBlocksize),
       memcopy_threshold_(kMemcopyDefaultThreshold) {
+  DCHECK(buffer) << "Buffer was nullptr";
   buffer_ = buffer;
   DCHECK(buffer->is_mutable()) << "Must pass mutable buffer";
   mutable_data_ = buffer->mutable_data();
@@ -138,7 +142,7 @@ FixedSizeBufferWriter::FixedSizeBufferWriter(const std::shared_ptr<Buffer>& buff
 FixedSizeBufferWriter::~FixedSizeBufferWriter() {}
 
 Status FixedSizeBufferWriter::Close() {
-  // No-op
+  // no-op
   return Status::OK();
 }
 
@@ -150,7 +154,7 @@ Status FixedSizeBufferWriter::Seek(int64_t position) {
   return Status::OK();
 }
 
-Status FixedSizeBufferWriter::Tell(int64_t* position) {
+Status FixedSizeBufferWriter::Tell(int64_t* position) const {
   *position = position_;
   return Status::OK();
 }
@@ -201,7 +205,7 @@ Status BufferReader::Close() {
   return Status::OK();
 }
 
-Status BufferReader::Tell(int64_t* position) {
+Status BufferReader::Tell(int64_t* position) const {
   *position = position_;
   return Status::OK();
 }

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -51,7 +51,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
 
   // Implement the OutputStream interface
   Status Close() override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
   Status Write(const uint8_t* data, int64_t nbytes) override;
 
   /// Close the stream and return the buffer
@@ -74,7 +74,7 @@ class ARROW_EXPORT MockOutputStream : public OutputStream {
 
   // Implement the OutputStream interface
   Status Close() override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
   Status Write(const uint8_t* data, int64_t nbytes) override;
 
   int64_t GetExtentBytesWritten() const { return extent_bytes_written_; }
@@ -93,7 +93,7 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
 
   Status Close() override;
   Status Seek(int64_t position) override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
   Status Write(const uint8_t* data, int64_t nbytes) override;
   Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) override;
 
@@ -101,7 +101,7 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
   void set_memcopy_blocksize(int64_t blocksize);
   void set_memcopy_threshold(int64_t threshold);
 
- private:
+ protected:
   std::mutex lock_;
   std::shared_ptr<Buffer> buffer_;
   uint8_t* mutable_data_;
@@ -120,8 +120,7 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
   virtual ~BufferReader();
 
   Status Close() override;
-  Status Tell(int64_t* position) override;
-
+  Status Tell(int64_t* position) const override;
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
 
   // Zero copy read
@@ -134,7 +133,7 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
 
   std::shared_ptr<Buffer> buffer() const { return buffer_; }
 
- private:
+ protected:
   std::shared_ptr<Buffer> buffer_;
   const uint8_t* data_;
   int64_t size_;

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -109,6 +109,12 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
 
 ARROW_EXPORT MemoryPool* default_memory_pool();
 
+#ifdef ARROW_NO_DEFAULT_MEMORY_POOL
+#define ARROW_MEMORY_POOL_DEFAULT
+#else
+#define ARROW_MEMORY_POOL_DEFAULT = default_memory_pool()
+#endif
+
 }  // namespace arrow
 
 #endif  // ARROW_MEMORY_POOL_H

--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -113,7 +113,7 @@ Status PyReadableFile::Seek(int64_t position) {
   return file_->Seek(position, 0);
 }
 
-Status PyReadableFile::Tell(int64_t* position) {
+Status PyReadableFile::Tell(int64_t* position) const {
   PyAcquireGIL lock;
   return file_->Tell(position);
 }
@@ -177,7 +177,7 @@ Status PyOutputStream::Close() {
   return file_->Close();
 }
 
-Status PyOutputStream::Tell(int64_t* position) {
+Status PyOutputStream::Tell(int64_t* position) const {
   *position = position_;
   return Status::OK();
 }

--- a/cpp/src/arrow/python/io.h
+++ b/cpp/src/arrow/python/io.h
@@ -63,7 +63,7 @@ class ARROW_EXPORT PyReadableFile : public io::RandomAccessFile {
 
   Status Seek(int64_t position) override;
 
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
 
   bool supports_zero_copy() const override;
 
@@ -77,7 +77,7 @@ class ARROW_EXPORT PyOutputStream : public io::OutputStream {
   virtual ~PyOutputStream();
 
   Status Close() override;
-  Status Tell(int64_t* position) override;
+  Status Tell(int64_t* position) const override;
   Status Write(const uint8_t* data, int64_t nbytes) override;
 
  private:

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -33,13 +33,14 @@ class StdoutStream : public OutputStream {
   StdoutStream() : pos_(0) { set_mode(FileMode::WRITE); }
   virtual ~StdoutStream() {}
 
-  Status Close() { return Status::OK(); }
-  Status Tell(int64_t* position) {
+  Status Close() override { return Status::OK(); }
+
+  Status Tell(int64_t* position) const override {
     *position = pos_;
     return Status::OK();
   }
 
-  Status Write(const uint8_t* data, int64_t nbytes) {
+  Status Write(const uint8_t* data, int64_t nbytes) override {
     pos_ += nbytes;
     std::cout.write(reinterpret_cast<const char*>(data), nbytes);
     return Status::OK();
@@ -55,13 +56,14 @@ class StdinStream : public InputStream {
   StdinStream() : pos_(0) { set_mode(FileMode::READ); }
   virtual ~StdinStream() {}
 
-  Status Close() { return Status::OK(); }
-  Status Tell(int64_t* position) {
+  Status Close() override { return Status::OK(); }
+
+  Status Tell(int64_t* position) const override {
     *position = pos_;
     return Status::OK();
   }
 
-  virtual Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
+  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override {
     std::cin.read(reinterpret_cast<char*>(out), nbytes);
     if (std::cin) {
       *bytes_read = nbytes;
@@ -72,7 +74,7 @@ class StdinStream : public InputStream {
     return Status::OK();
   }
 
-  virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override {
     auto buffer = std::make_shared<PoolBuffer>(nullptr);
     RETURN_NOT_OK(buffer->Resize(nbytes));
     int64_t bytes_read;


### PR DESCRIPTION
This makes it easy to write from host to device and read from device to host. We also need a zero-copy device reader for IPC purposes (where we don't want to move any data to the host), can do that in a subsequent patch. 