### PR TITLE
ARROW-1400: [Python] Adding parquet.write_to_dataset() method for writing partitioned .parquet files

### DIFF
--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -52,6 +52,10 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
     def rename(self, path, new_path):
         return super(HadoopFileSystem, self).rename(path, new_path)
 
+    @implements(FileSystem.exists)
+    def exists(self, path):
+        return super(HadoopFileSystem, self).exists(path)
+
     def ls(self, path, detail=False):
         """
         Retrieve directory contents and metadata, if requested.

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -808,6 +808,84 @@ def write_table(table, where, row_group_size=None, version='1.0',
         writer.close()
 
 
+def write_to_dataset(table, root_path, partition_cols=None,
+                     filesystem=None, preserve_index=True, **kwargs):
+    """
+    Wrapper around parquet.write_table for writing a Table to
+    Parquet format by partitions.
+    For each combination of partition columns and values,
+    a subdirectories are created in the following
+    manner:
+
+    root_dir/
+    ├── group1=value1
+    │   ├── group2=value1
+    │   │   └── <uuid>.parquet
+    │   └── group2=value2
+    │       └── <uuid>.parquet
+    ...
+    └── group1=valueN
+        ├── group2=value1
+        │   └── <uuid>.parquet
+        ...
+        └── group2=valueN
+            └──<uuid>.parquet
+
+    Parameters
+    ----------
+    table : pyarrow.Table
+    root_path : string,
+        The root directory of the dataset
+    filesystem : FileSystem, default None
+        If nothing passed, paths assumed to be found in the local on-disk
+        filesystem
+    partition_cols : list,
+        Column names by which to partition the dataset
+        Columns are partitioned in the order they are given
+    preserve_index : bool,
+        Parameter for instantiating Table; preserve pandas index or not.
+    **kwargs : dict, kwargs for write_table function.
+    """
+    from pyarrow import (
+        Table,
+        compat
+    )
+
+    if filesystem is None:
+        fs = LocalFileSystem.get_instance()
+    else:
+        fs = _ensure_filesystem(filesystem)
+
+    if not fs.isdir(root_path):
+        fs.mkdir(root_path)
+
+    if partition_cols is not None:
+        df = table.to_pandas()
+        partition_keys = [df[col] for col in partition_cols]
+        data_df = df.drop(partition_cols, axis='columns')
+        data_cols = df.columns.drop(partition_cols)
+        if len(data_cols) == 0:
+            raise ValueError("No data left to save outside partition columns")
+        for keys, subgroup in data_df.groupby(partition_keys):
+            if not isinstance(keys, tuple):
+                keys = (keys,)
+            subdir = "/".join(
+                ["{colname}={value}".format(colname=name, value=val)
+                 for name, val in zip(partition_cols, keys)])
+            subtable = Table.from_pandas(subgroup, preserve_index=preserve_index)
+            prefix = "/".join([root_path, subdir])
+            fs.mkdir(prefix)
+            outfile = compat.guid() + ".parquet"
+            full_path = "/".join([prefix, outfile])
+            with fs.open(full_path, 'wb') as f:
+                write_table(subtable, f, **kwargs)
+    else:
+        outfile = compat.guid() + ".parquet"
+        full_path = "/".join([root_path, outfile])
+        with fs.open(full_path, 'wb') as f:
+            write_table(table, f, **kwargs)
+
+
 def write_metadata(schema, where, version='1.0',
                    use_deprecated_int96_timestamps=False,
                    coerce_timestamps=None):

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -268,6 +268,20 @@ class HdfsTestCases(object):
         self.hdfs.mkdir(tmpdir)
         test_parquet._test_read_common_metadata_files(self.hdfs, tmpdir)
 
+    @test_parquet.parquet
+    def test_write_to_dataset_with_partitions(self):
+        tmpdir = pjoin(self.tmp_path, 'write-partitions-' + guid())
+        self.hdfs.mkdir(tmpdir)
+        test_parquet._test_write_to_dataset_with_partitions(
+            tmpdir, filesystem=self.hdfs)
+
+    @test_parquet.parquet
+    def test_write_to_dataset_no_partitions(self):
+        tmpdir = pjoin(self.tmp_path, 'write-no_partitions-' + guid())
+        self.hdfs.mkdir(tmpdir)
+        test_parquet._test_write_to_dataset_no_partitions(
+            tmpdir, filesystem=self.hdfs)
+
 
 class TestLibHdfs(HdfsTestCases, unittest.TestCase):
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1147,3 +1147,62 @@ def test_read_non_existent_file(tmpdir):
         pq.read_table(path)
     except Exception as e:
         assert path in e.args[0]
+
+
+@parquet
+def test_write_partitions(tmpdir):
+    # ARROW-1400
+    import pyarrow.parquet as pq
+
+    output_df = pd.DataFrame({'group1': list('aaabbbbccc'),
+                              'group2': list('eefeffgeee'),
+                              'num': list(range(10)),
+                              'date': np.arange('2017-01-01', '2017-01-11',
+                                                dtype='datetime64[D]')})
+    cols = output_df.columns.tolist()
+    partition_by = ['group1', 'group2']
+    output_table = pa.Table.from_pandas(output_df)
+    pq.write_to_dataset(output_table, str(tmpdir), partition_by)
+    input_table = pq.ParquetDataset(str(tmpdir)).read()
+    input_df = input_table.to_pandas()
+
+    # Read data back in and compare with original DataFrame
+    # Partitioned columns added to the end of the DataFrame when read
+    input_df_cols = input_df.columns.tolist()
+    assert partition_by == input_df_cols[-1 * len(partition_by):]
+
+    # Partitioned columns become 'categorical' dtypes
+    input_df = input_df[cols]
+    for col in partition_by:
+        output_df[col] = output_df[col].astype('category')
+    assert output_df.equals(input_df)
+
+
+@parquet
+def test_write_no_partitions(tmpdir):
+    # ARROW-1400
+    import pyarrow.parquet as pq
+
+    output_df = pd.DataFrame({'group1': list('aaabbbbccc'),
+                              'group2': list('eefeffgeee'),
+                              'num': list(range(10)),
+                              'date': np.arange('2017-01-01', '2017-01-11',
+                                                dtype='datetime64[D]')})
+    cols = output_df.columns.tolist()
+    output_table = pa.Table.from_pandas(output_df)
+
+    # Without partitions, append files to root_path
+    n = 5
+    for i in range(n):
+        pq.write_to_dataset(output_table, str(tmpdir))
+    output_files = [file for file in os.listdir(str(tmpdir))
+                    if file.endswith(".parquet")]
+    assert len(output_files) == n
+
+    # Deduplicated incoming DataFrame should match
+    # original outgoing Dataframe
+    input_table = pq.ParquetDataset(str(tmpdir)).read()
+    input_df = input_table.to_pandas()
+    input_df = input_df.drop_duplicates()
+    input_df = input_df[cols]
+    assert output_df.equals(input_df)


### PR DESCRIPTION
Add write_to_dataset in pyarrow.parquet that writes tables to parquet given partitioning columns.