### PR TITLE
ARROW-1419: [GLib] Suppress sign-conversion warnings

### DIFF
--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -36,8 +36,8 @@ AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX_11([ext], [mandatory])
 LT_INIT
 
-GARROW_CFLAGS="-Wall -Wconversion"
-GARROW_CXXFLAGS="-Wall -Wconversion"
+GARROW_CFLAGS="-Wall"
+GARROW_CXXFLAGS="-Wall"
 AC_ARG_ENABLE(debug,
   [AS_HELP_STRING([--enable-debug],
                   [Use debug flags (default=no)])],


### PR DESCRIPTION
Apache Arrow C++ uses int as result type for expression that uses
size_t. It causes sign-conversion warning but the coding style is
expected.

Example:

    .../arrow/buffer.h:296:41: warning:
          implicit conversion changes signedness: 'unsigned long' to 'int64_t'
          (aka 'long') [-Wsign-conversion]
      int64_t length() const { return size_ / sizeof(T); }
                               ~~~~~~ ~~~~~~^~~~~~~~~~~