### PR TITLE
ARROW-1402: [C++] Deprecate APIs which return std::shared_ptr<MutableBuffer> in favor of std::shared_ptr<Buffer>

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -128,7 +128,7 @@ TEST_F(TestArray, SliceRecomputeNullCount) {
   ASSERT_EQ(5, slice->null_count());
 
   // No bitmap, compute 0
-  std::shared_ptr<MutableBuffer> data;
+  std::shared_ptr<Buffer> data;
   const int kBufferSize = 64;
   ASSERT_OK(AllocateBuffer(pool_, kBufferSize, &data));
   memset(data->mutable_data(), 0, kBufferSize);

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -172,7 +172,7 @@ TEST_F(TestBuffer, SliceMutableBuffer) {
   std::string data_str = "some data to slice";
   auto data = reinterpret_cast<const uint8_t*>(data_str.c_str());
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), 50, &buffer));
 
   memcpy(buffer->mutable_data(), data, data_str.size());

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -126,10 +126,18 @@ MutableBuffer::MutableBuffer(const std::shared_ptr<Buffer>& parent, const int64_
 }
 
 Status AllocateBuffer(MemoryPool* pool, const int64_t size,
-                      std::shared_ptr<MutableBuffer>* out) {
+                      std::shared_ptr<Buffer>* out) {
   auto buffer = std::make_shared<PoolBuffer>(pool);
   RETURN_NOT_OK(buffer->Resize(size));
   *out = buffer;
+  return Status::OK();
+}
+
+Status AllocateBuffer(MemoryPool* pool, const int64_t size,
+                      std::shared_ptr<MutableBuffer>* out) {
+  std::shared_ptr<Buffer> buffer;
+  RETURN_NOT_OK(AllocateBuffer(pool, size, &buffer));
+  *out = std::dynamic_pointer_cast<MutableBuffer>(buffer);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -296,16 +296,15 @@ class ARROW_EXPORT TypedBufferBuilder : public BufferBuilder {
   int64_t length() const { return size_ / sizeof(T); }
 };
 
-/// Allocate a new mutable buffer from a memory pool
+/// \brief Allocate a fixed size mutable buffer from a memory pool
 ///
 /// \param[in] pool a memory pool
 /// \param[in] size size of buffer to allocate
-/// \param[out] out the allocated buffer with padding
+/// \param[out] out the allocated buffer (contains padding)
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateBuffer(MemoryPool* pool, const int64_t size,
-                      std::shared_ptr<MutableBuffer>* out);
+Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::shared_ptr<Buffer>* out);
 
 /// Allocate resizeable buffer from a memory pool
 ///
@@ -317,6 +316,13 @@ Status AllocateBuffer(MemoryPool* pool, const int64_t size,
 ARROW_EXPORT
 Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
                                std::shared_ptr<ResizableBuffer>* out);
+
+#ifndef ARROW_NO_DEPRECATED_API
+/// \deprecated Since 0.7.0
+ARROW_EXPORT
+Status AllocateBuffer(MemoryPool* pool, const int64_t size,
+                      std::shared_ptr<MutableBuffer>* out);
+#endif
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -59,7 +59,7 @@ TEST_F(TestCudaBuffer, Allocate) {
 
 void AssertCudaBufferEquals(const CudaBuffer& buffer, const uint8_t* host_data,
                             const int64_t nbytes) {
-  std::shared_ptr<MutableBuffer> result;
+  std::shared_ptr<Buffer> result;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), nbytes, &result));
   ASSERT_OK(buffer.CopyToHost(0, buffer.size(), result->mutable_data()));
   ASSERT_EQ(0, std::memcmp(result->data(), host_data, nbytes));
@@ -108,7 +108,7 @@ TEST_F(TestCudaBuffer, DISABLED_ExportForIpc) {
 
   ASSERT_EQ(kSize, ipc_buffer->size());
 
-  std::shared_ptr<MutableBuffer> ipc_data;
+  std::shared_ptr<Buffer> ipc_data;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), kSize, &ipc_data));
   ASSERT_OK(ipc_buffer->CopyToHost(0, kSize, ipc_data->mutable_data()));
   ASSERT_EQ(0, std::memcmp(ipc_buffer->data(), host_buffer->data(), kSize));
@@ -288,7 +288,7 @@ TEST_F(TestCudaArrowIpc, BasicWriteRead) {
                             &device_batch));
 
   // Copy data from device, read batch, and compare
-  std::shared_ptr<MutableBuffer> host_buffer;
+  std::shared_ptr<Buffer> host_buffer;
   int64_t size = device_serialized->size();
   ASSERT_OK(AllocateBuffer(pool_, size, &host_buffer));
   ASSERT_OK(device_serialized->CopyToHost(0, size, host_buffer->mutable_data()));

--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
@@ -78,7 +78,7 @@ Status ReadMessage(CudaBufferReader* reader, MemoryPool* pool,
     return Status::OK();
   }
 
-  std::shared_ptr<MutableBuffer> metadata;
+  std::shared_ptr<Buffer> metadata;
   RETURN_NOT_OK(AllocateBuffer(pool, message_length, &metadata));
   RETURN_NOT_OK(reader->Read(message_length, &bytes_read, metadata->mutable_data()));
   if (bytes_read != message_length) {

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -59,7 +59,7 @@ Status CudaIpcMemHandle::FromBuffer(const void* opaque_handle,
 }
 
 Status CudaIpcMemHandle::Serialize(MemoryPool* pool, std::shared_ptr<Buffer>* out) const {
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   constexpr size_t kHandleSize = sizeof(CUipcMemHandle);
   RETURN_NOT_OK(AllocateBuffer(pool, static_cast<int64_t>(kHandleSize), &buffer));
   memcpy(buffer->mutable_data(), &impl_->ipc_handle, kHandleSize);

--- a/cpp/src/arrow/io/io-hdfs-test.cc
+++ b/cpp/src/arrow/io/io-hdfs-test.cc
@@ -353,7 +353,7 @@ TYPED_TEST(TestHadoopFileSystem, LargeFile) {
   std::shared_ptr<HdfsReadableFile> file;
   ASSERT_OK(this->client_->OpenReadable(path, &file));
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(nullptr, size, &buffer));
 
   int64_t bytes_read = 0;
@@ -366,7 +366,7 @@ TYPED_TEST(TestHadoopFileSystem, LargeFile) {
   std::shared_ptr<HdfsReadableFile> file2;
   ASSERT_OK(this->client_->OpenReadable(path, 1 << 18, &file2));
 
-  std::shared_ptr<MutableBuffer> buffer2;
+  std::shared_ptr<Buffer> buffer2;
   ASSERT_OK(AllocateBuffer(nullptr, size, &buffer2));
 
   ASSERT_OK(file2->Read(size, &bytes_read, buffer2->mutable_data()));

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -68,7 +68,7 @@ TEST_F(TestBufferOutputStream, CloseResizes) {
 }
 
 TEST(TestFixedSizeBufferWriter, Basics) {
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), 1024, &buffer));
 
   FixedSizeBufferWriter writer(buffer);
@@ -101,7 +101,7 @@ TEST(TestBufferReader, RetainParentReference) {
   std::shared_ptr<Buffer> slice1;
   std::shared_ptr<Buffer> slice2;
   {
-    std::shared_ptr<MutableBuffer> buffer;
+    std::shared_ptr<Buffer> buffer;
     ASSERT_OK(AllocateBuffer(nullptr, static_cast<int64_t>(data.size()), &buffer));
     std::memcpy(buffer->mutable_data(), data.c_str(), data.size());
     BufferReader reader(buffer);

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -38,8 +38,7 @@ class Status;
 
 namespace io {
 
-// An output stream that writes to a MutableBuffer, such as one obtained from a
-// memory map
+// \brief An output stream that writes to a resizable buffer
 class ARROW_EXPORT BufferOutputStream : public OutputStream {
  public:
   explicit BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer);
@@ -67,7 +66,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   uint8_t* mutable_data_;
 };
 
-// A helper class to tracks the size of allocations
+// \brief A helper class to tracks the size of allocations
 class ARROW_EXPORT MockOutputStream : public OutputStream {
  public:
   MockOutputStream() : extent_bytes_written_(0) {}
@@ -84,7 +83,6 @@ class ARROW_EXPORT MockOutputStream : public OutputStream {
 };
 
 /// \brief Enables random writes into a fixed-size mutable buffer
-///
 class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
  public:
   /// Input buffer must be mutable, will abort if not
@@ -113,6 +111,8 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
   int64_t memcopy_threshold_;
 };
 
+/// \class BufferReader
+/// \brief Random access zero-copy reads on an arrow::Buffer
 class ARROW_EXPORT BufferReader : public RandomAccessFile {
  public:
   explicit BufferReader(const std::shared_ptr<Buffer>& buffer);

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -273,7 +273,7 @@ TEST_P(TestIpcRoundTrip, ZeroLengthArrays) {
   CheckRoundtrip(*zero_length_batch, 1 << 20);
 
   // ARROW-544: check binary array
-  std::shared_ptr<MutableBuffer> value_offsets;
+  std::shared_ptr<Buffer> value_offsets;
   ASSERT_OK(AllocateBuffer(pool_, sizeof(int32_t), &value_offsets));
   *reinterpret_cast<int32_t*>(value_offsets->mutable_data()) = 0;
 

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -952,7 +952,7 @@ class ArrayReader {
                            std::shared_ptr<Buffer>* validity_buffer) {
     int length = static_cast<int>(is_valid.size());
 
-    std::shared_ptr<MutableBuffer> out_buffer;
+    std::shared_ptr<Buffer> out_buffer;
     RETURN_NOT_OK(GetEmptyBitmap(pool_, length, &out_buffer));
     uint8_t* bitmap = out_buffer->mutable_data();
 
@@ -1056,7 +1056,7 @@ class ArrayReader {
     int32_t byte_width = type.byte_width();
 
     // Allocate space for parsed values
-    std::shared_ptr<MutableBuffer> byte_buffer;
+    std::shared_ptr<Buffer> byte_buffer;
     RETURN_NOT_OK(AllocateBuffer(pool_, byte_width, &byte_buffer));
     uint8_t* byte_buffer_data = byte_buffer->mutable_data();
 
@@ -1084,7 +1084,7 @@ class ArrayReader {
   template <typename T>
   Status GetIntArray(const RjArray& json_array, const int32_t length,
                      std::shared_ptr<Buffer>* out) {
-    std::shared_ptr<MutableBuffer> buffer;
+    std::shared_ptr<Buffer> buffer;
     RETURN_NOT_OK(AllocateBuffer(pool_, length * sizeof(T), &buffer));
 
     T* values = reinterpret_cast<T*>(buffer->mutable_data());

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -272,7 +272,7 @@ class RecordBatchSerializer : public ArrayVisitor {
       // zero. We must a) create a new offsets array with shifted offsets and
       // b) slice the values array accordingly
 
-      std::shared_ptr<MutableBuffer> shifted_offsets;
+      std::shared_ptr<Buffer> shifted_offsets;
       RETURN_NOT_OK(AllocateBuffer(pool_, sizeof(int32_t) * (array.length() + 1),
                                    &shifted_offsets));
 
@@ -425,7 +425,7 @@ class RecordBatchSerializer : public ArrayVisitor {
         const uint8_t* type_ids = array.raw_type_ids();
 
         // Allocate the shifted offsets
-        std::shared_ptr<MutableBuffer> shifted_offsets_buffer;
+        std::shared_ptr<Buffer> shifted_offsets_buffer;
         RETURN_NOT_OK(
             AllocateBuffer(pool_, length * sizeof(int32_t), &shifted_offsets_buffer));
         int32_t* shifted_offsets =
@@ -897,7 +897,7 @@ Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
                             std::shared_ptr<Buffer>* out) {
   int64_t size = 0;
   RETURN_NOT_OK(GetRecordBatchSize(batch, &size));
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   RETURN_NOT_OK(AllocateBuffer(pool, size, &buffer));
 
   io::FixedSizeBufferWriter stream(buffer);

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -36,7 +36,7 @@ TEST(TestTensor, ZeroDim) {
 
   using T = int64_t;
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), values * sizeof(T), &buffer));
 
   Tensor t0(int64(), buffer, shape);
@@ -52,7 +52,7 @@ TEST(TestTensor, BasicCtors) {
 
   using T = int64_t;
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), values * sizeof(T), &buffer));
 
   Tensor t1(int64(), buffer, shape);
@@ -78,7 +78,7 @@ TEST(TestTensor, IsContiguous) {
 
   using T = int64_t;
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), values * sizeof(T), &buffer));
 
   std::vector<int64_t> c_strides = {48, 8};
@@ -96,7 +96,7 @@ TEST(TestTensor, IsContiguous) {
 TEST(TestTensor, ZeroDimensionalTensor) {
   std::vector<int64_t> shape = {0};
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), 0, &buffer));
 
   Tensor t(int64(), buffer, shape);

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -33,7 +33,6 @@ namespace arrow {
 
 class Buffer;
 class MemoryPool;
-class MutableBuffer;
 class Status;
 
 static inline bool is_tensor_supported(Type::type type_id) {

--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -124,7 +124,7 @@ static inline Status GetBitmapFromVector(const std::vector<T>& is_valid,
                                          std::shared_ptr<Buffer>* result) {
   size_t length = is_valid.size();
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   RETURN_NOT_OK(GetEmptyBitmap(default_memory_pool(), length, &buffer));
 
   uint8_t* bitmap = buffer->mutable_data();

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -102,7 +102,7 @@ TEST(BitUtilTests, TestCountSetBits) {
 TEST(BitUtilTests, TestCopyBitmap) {
   const int kBufferSize = 1000;
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), kBufferSize, &buffer));
   memset(buffer->mutable_data(), 0, kBufferSize);
   test::random_bytes(kBufferSize, 0, buffer->mutable_data());

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -46,7 +46,7 @@ Status BitUtil::BytesToBits(const std::vector<uint8_t>& bytes,
                             std::shared_ptr<Buffer>* out) {
   int64_t bit_length = BitUtil::BytesForBits(bytes.size());
 
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   RETURN_NOT_OK(AllocateBuffer(default_memory_pool(), bit_length, &buffer));
 
   memset(buffer->mutable_data(), 0, static_cast<size_t>(bit_length));
@@ -97,16 +97,23 @@ int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length) {
   return count;
 }
 
-Status GetEmptyBitmap(MemoryPool* pool, int64_t length,
-                      std::shared_ptr<MutableBuffer>* result) {
+Status GetEmptyBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>* result) {
   RETURN_NOT_OK(AllocateBuffer(pool, BitUtil::BytesForBits(length), result));
   memset((*result)->mutable_data(), 0, static_cast<size_t>((*result)->size()));
   return Status::OK();
 }
 
+Status GetEmptyBitmap(MemoryPool* pool, int64_t length,
+                      std::shared_ptr<MutableBuffer>* result) {
+  std::shared_ptr<Buffer> buffer;
+  RETURN_NOT_OK(GetEmptyBitmap(pool, length, &buffer));
+  *result = std::dynamic_pointer_cast<MutableBuffer>(buffer);
+  return Status::OK();
+}
+
 Status CopyBitmap(MemoryPool* pool, const uint8_t* data, int64_t offset, int64_t length,
                   std::shared_ptr<Buffer>* out) {
-  std::shared_ptr<MutableBuffer> buffer;
+  std::shared_ptr<Buffer> buffer;
   RETURN_NOT_OK(GetEmptyBitmap(pool, length, &buffer));
   uint8_t* dest = buffer->mutable_data();
   for (int64_t i = 0; i < length; ++i) {

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -387,8 +387,8 @@ ARROW_EXPORT Status BytesToBits(const std::vector<uint8_t>&, std::shared_ptr<Buf
 // ----------------------------------------------------------------------
 // Bitmap utilities
 
-Status ARROW_EXPORT GetEmptyBitmap(MemoryPool* pool, int64_t length,
-                                   std::shared_ptr<MutableBuffer>* result);
+ARROW_EXPORT
+Status GetEmptyBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>* result);
 
 /// Copy a bit range of an existing bitmap
 ///
@@ -399,8 +399,9 @@ Status ARROW_EXPORT GetEmptyBitmap(MemoryPool* pool, int64_t length,
 /// \param[out] out the resulting copy
 ///
 /// \return Status message
-Status ARROW_EXPORT CopyBitmap(MemoryPool* pool, const uint8_t* bitmap, int64_t offset,
-                               int64_t length, std::shared_ptr<Buffer>* out);
+ARROW_EXPORT
+Status CopyBitmap(MemoryPool* pool, const uint8_t* bitmap, int64_t offset, int64_t length,
+                  std::shared_ptr<Buffer>* out);
 
 /// Compute the number of 1's in the given data array
 ///
@@ -409,12 +410,20 @@ Status ARROW_EXPORT CopyBitmap(MemoryPool* pool, const uint8_t* bitmap, int64_t 
 /// \param[in] length the number of bits to inspect in the bitmap relative to the offset
 ///
 /// \return The number of set (1) bits in the range
-int64_t ARROW_EXPORT CountSetBits(const uint8_t* data, int64_t bit_offset,
-                                  int64_t length);
+ARROW_EXPORT
+int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length);
 
-bool ARROW_EXPORT BitmapEquals(const uint8_t* left, int64_t left_offset,
-                               const uint8_t* right, int64_t right_offset,
-                               int64_t bit_length);
+ARROW_EXPORT
+bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+                  int64_t right_offset, int64_t bit_length);
+
+#ifndef ARROW_NO_DEPRECATED_API
+/// \deprecated Since 0.7.0
+ARROW_EXPORT
+Status GetEmptyBitmap(MemoryPool* pool, int64_t length,
+                      std::shared_ptr<MutableBuffer>* result);
+#endif
+
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_BIT_UTIL_H


### PR DESCRIPTION
My view is that exposing this detail serves only to complicate the user API, since instances of the base class are permitted to be mutable (when `buffer->mutable_data()` is not null).

These APIs are used in parquet-cpp, but the build here should pass if the deprecations are handled properly. I will submit a patch there to fix these -- that patch can go in after parquet-cpp 1.3.0 to avoid any disruptions (so parquet-cpp will work fine with either Arrow 0.6.0 or 0.7.0). 