### PR TITLE
ARROW-1418: [Python] Introduce SerializationContext to register custom serialization callbacks

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -95,10 +95,10 @@ python_version_tests() {
   conda install -y -q pip numpy pandas cython flake8
 
   # Fail fast on style checks
-  flake8 pyarrow
+  flake8 --count pyarrow
 
   # Check Cython files with some checks turned off
-  flake8 --config=.flake8.cython pyarrow
+  flake8 --count --config=.flake8.cython pyarrow
 
   # Build C++ libraries
   rebuild_arrow_libraries

--- a/cpp/src/arrow/python/arrow_to_python.h
+++ b/cpp/src/arrow/python/arrow_to_python.h
@@ -49,6 +49,11 @@ ARROW_EXPORT
 Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out);
 
 /// \brief Reconstruct Python object from Arrow-serialized representation
+/// \param[in] context Serialization context which contains custom serialization
+/// and deserialization callbacks. Can be any Python object with a
+/// _serialize_callback method for serialization and a _deserialize_callback
+/// method for deserialization. If context is None, no custom serialization
+/// will be attempted.
 /// \param[in] object
 /// \param[in] base a Python object holding the underlying data that any NumPy
 /// arrays will reference, to avoid premature deallocation
@@ -56,8 +61,8 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out);
 /// \return Status
 /// This acquires the GIL
 ARROW_EXPORT
-Status DeserializeObject(const SerializedPyObject& object, PyObject* base,
-                         PyObject** out);
+Status DeserializeObject(PyObject* context, const SerializedPyObject& object,
+                         PyObject* base, PyObject** out);
 
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/python/python_to_arrow.h
+++ b/cpp/src/arrow/python/python_to_arrow.h
@@ -44,18 +44,12 @@ struct ARROW_EXPORT SerializedPyObject {
   std::vector<std::shared_ptr<Tensor>> tensors;
 };
 
-/// \brief Register callback functions to perform conversions to or from other
-/// Python representations en route to/from deserialization
-///
-/// \param[in] serialize_callback a Python callable
-/// \param[in] deserialize_callback a Python callable
-///
-/// Analogous to Python custom picklers / unpicklers
-ARROW_EXPORT
-void set_serialization_callbacks(PyObject* serialize_callback,
-                                 PyObject* deserialize_callback);
-
 /// \brief Serialize Python sequence as a RecordBatch plus
+/// \param[in] context Serialization context which contains custom serialization
+/// and deserialization callbacks. Can be any Python object with a
+/// _serialize_callback method for serialization and a _deserialize_callback
+/// method for deserialization. If context is None, no custom serialization
+/// will be attempted.
 /// \param[in] sequence a Python sequence object to serialize to Arrow data
 /// structures
 /// \param[out] out the serialized representation
@@ -63,7 +57,7 @@ void set_serialization_callbacks(PyObject* serialize_callback,
 ///
 /// Release GIL before calling
 ARROW_EXPORT
-Status SerializeObject(PyObject* sequence, SerializedPyObject* out);
+Status SerializeObject(PyObject* context, PyObject* sequence, SerializedPyObject* out);
 
 /// \brief Write serialized Python object to OutputStream
 /// \param[in] object a serialized Python object to write out

--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -207,6 +207,7 @@ Interprocess Communication and Serialization
    deserialize_from
    read_serialized
    SerializedPyObject
+   SerializationContext
 
 .. _api.memory_pool:
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -91,7 +91,7 @@ from pyarrow.lib import (ArrowException,
 # Serialization
 from pyarrow.lib import (deserialize_from, deserialize,
                          serialize, serialize_to, read_serialized,
-                         SerializedPyObject,
+                         SerializedPyObject, SerializationContext,
                          SerializationException, DeserializationException)
 
 from pyarrow.filesystem import FileSystem, LocalFileSystem

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -797,19 +797,18 @@ cdef extern from "arrow/python/api.h" namespace 'arrow::py' nogil:
         shared_ptr[CRecordBatch] batch
         vector[shared_ptr[CTensor]] tensors
 
-    CStatus SerializeObject(object sequence, CSerializedPyObject* out)
+    CStatus SerializeObject(object context, object sequence,
+                            CSerializedPyObject* out)
 
     CStatus WriteSerializedObject(const CSerializedPyObject& obj,
                                   OutputStream* dst)
 
-    CStatus DeserializeObject(const CSerializedPyObject& obj,
+    CStatus DeserializeObject(object context,
+                              const CSerializedPyObject& obj,
                               PyObject* base, PyObject** out)
 
     CStatus ReadSerializedObject(RandomAccessFile* src,
                                  CSerializedPyObject* out)
-
-    void set_serialization_callbacks(object serialize_callback,
-                                     object deserialize_callback)
 
 
 cdef extern from 'arrow/python/init.h':

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -43,93 +43,98 @@ class DeserializationException(Exception):
         self.type_id = type_id
 
 
-# Types with special serialization handlers
-type_to_type_id = dict()
-whitelisted_types = dict()
-types_to_pickle = set()
-custom_serializers = dict()
-custom_deserializers = dict()
+cdef class SerializationContext:
+    cdef:
+        object type_to_type_id
+        object whitelisted_types
+        object types_to_pickle
+        object custom_serializers
+        object custom_deserializers
 
+    def __init__(self):
+        # Types with special serialization handlers
+        self.type_to_type_id = dict()
+        self.whitelisted_types = dict()
+        self.types_to_pickle = set()
+        self.custom_serializers = dict()
+        self.custom_deserializers = dict()
 
-def register_type(type, type_id, pickle=False,
-                  custom_serializer=None, custom_deserializer=None):
-    """Add type to the list of types we can serialize.
+    def register_type(self, type_, type_id, pickle=False,
+                      custom_serializer=None, custom_deserializer=None):
+        """EXPERIMENTAL: Add type to the list of types we can serialize.
 
-    Parameters
-    ----------
-    type :type
-        The type that we can serialize.
-    type_id : bytes
-        A string of bytes used to identify the type.
-    pickle : bool
-        True if the serialization should be done with pickle.
-        False if it should be done efficiently with Arrow.
-    custom_serializer : callable
-        This argument is optional, but can be provided to
-        serialize objects of the class in a particular way.
-    custom_deserializer : callable
-        This argument is optional, but can be provided to
-        deserialize objects of the class in a particular way.
-    """
-    type_to_type_id[type] = type_id
-    whitelisted_types[type_id] = type
-    if pickle:
-        types_to_pickle.add(type_id)
-    if custom_serializer is not None:
-        custom_serializers[type_id] = custom_serializer
-        custom_deserializers[type_id] = custom_deserializer
+        Parameters
+        ----------
+        type_ : TypeType
+            The type that we can serialize.
+        type_id : bytes
+            A string of bytes used to identify the type.
+        pickle : bool
+            True if the serialization should be done with pickle.
+            False if it should be done efficiently with Arrow.
+        custom_serializer : callable
+            This argument is optional, but can be provided to
+            serialize objects of the class in a particular way.
+        custom_deserializer : callable
+            This argument is optional, but can be provided to
+            deserialize objects of the class in a particular way.
+        """
+        self.type_to_type_id[type_] = type_id
+        self.whitelisted_types[type_id] = type_
+        if pickle:
+            self.types_to_pickle.add(type_id)
+        if custom_serializer is not None:
+            self.custom_serializers[type_id] = custom_serializer
+            self.custom_deserializers[type_id] = custom_deserializer
 
-
-def _serialization_callback(obj):
-    if type(obj) not in type_to_type_id:
-        raise SerializationException("pyarrow does not know how to "
-                                     "serialize objects of type {}."
-                                     .format(type(obj)),
-                                     obj)
-    type_id = type_to_type_id[type(obj)]
-    if type_id in types_to_pickle:
-        serialized_obj = {"data": pickle.dumps(obj), "pickle": True}
-    elif type_id in custom_serializers:
-        serialized_obj = {"data": custom_serializers[type_id](obj)}
-    else:
-        if is_named_tuple(type(obj)):
-            serialized_obj = {}
-            serialized_obj["_pa_getnewargs_"] = obj.__getnewargs__()
-        elif hasattr(obj, "__dict__"):
-            serialized_obj = obj.__dict__
+    def _serialize_callback(self, obj):
+        if type(obj) not in self.type_to_type_id:
+            raise SerializationException("pyarrow does not know how to "
+                                         "serialize objects of type {}."
+                                         .format(type(obj)),
+                                         obj)
+        type_id = self.type_to_type_id[type(obj)]
+        if type_id in self.types_to_pickle:
+            serialized_obj = {"data": pickle.dumps(obj), "pickle": True}
+        elif type_id in self.custom_serializers:
+            serialized_obj = {"data": self.custom_serializers[type_id](obj)}
         else:
-            raise SerializationException("We do not know how to serialize "
-                                         "the object '{}'".format(obj), obj)
-    return dict(serialized_obj, **{"_pytype_": type_id})
-
-
-def _deserialization_callback(serialized_obj):
-    type_id = serialized_obj["_pytype_"]
-
-    if "pickle" in serialized_obj:
-        # The object was pickled, so unpickle it.
-        obj = pickle.loads(serialized_obj["data"])
-    else:
-        assert type_id not in types_to_pickle
-        if type_id not in whitelisted_types:
-            raise "error"
-        type = whitelisted_types[type_id]
-        if type_id in custom_deserializers:
-            obj = custom_deserializers[type_id](serialized_obj["data"])
-        else:
-            # In this case, serialized_obj should just be the __dict__ field.
-            if "_pa_getnewargs_" in serialized_obj:
-                obj = type.__new__(type, *serialized_obj["_pa_getnewargs_"])
+            if is_named_tuple(type(obj)):
+                serialized_obj = {}
+                serialized_obj["_pa_getnewargs_"] = obj.__getnewargs__()
+            elif hasattr(obj, "__dict__"):
+                serialized_obj = obj.__dict__
             else:
-                obj = type.__new__(type)
-                serialized_obj.pop("_pytype_")
-                obj.__dict__.update(serialized_obj)
-    return obj
+                msg = "We do not know how to serialize " \
+                      "the object '{}'".format(obj)
+                raise SerializationException(msg, obj)
+        return dict(serialized_obj, **{"_pytype_": type_id})
 
+    def _deserialize_callback(self, serialized_obj):
+        type_id = serialized_obj["_pytype_"]
 
-set_serialization_callbacks(_serialization_callback,
-                            _deserialization_callback)
-
+        if "pickle" in serialized_obj:
+            # The object was pickled, so unpickle it.
+            obj = pickle.loads(serialized_obj["data"])
+        else:
+            assert type_id not in self.types_to_pickle
+            if type_id not in self.whitelisted_types:
+                raise "error"
+            type_ = self.whitelisted_types[type_id]
+            if type_id in self.custom_deserializers:
+                obj = self.custom_deserializers[type_id](
+                    serialized_obj["data"])
+            else:
+                # In this case, serialized_obj should just be
+                # the __dict__ field.
+                if "_pa_getnewargs_" in serialized_obj:
+                    obj = type_.__new__(
+                        type_, *serialized_obj["_pa_getnewargs_"])
+                else:
+                    obj = type_.__new__(type_)
+                    serialized_obj.pop("_pytype_")
+                    obj.__dict__.update(serialized_obj)
+        return obj
 
 cdef class SerializedPyObject:
     """
@@ -162,15 +167,15 @@ cdef class SerializedPyObject:
         with nogil:
             check_status(WriteSerializedObject(self.data, stream))
 
-    def deserialize(self):
+    def deserialize(self, SerializationContext context=None):
         """
         Convert back to Python object
         """
         cdef PyObject* result
 
         with nogil:
-            check_status(DeserializeObject(self.data, <PyObject*> self.base,
-                                           &result))
+            check_status(DeserializeObject(context, self.data,
+                                           <PyObject*> self.base, &result))
 
         # PyObject_to_object is necessary to avoid a memory leak;
         # also unpack the list the object was wrapped in in serialize
@@ -185,13 +190,15 @@ cdef class SerializedPyObject:
         return sink.get_result()
 
 
-def serialize(object value):
+def serialize(object value, SerializationContext context=None):
     """EXPERIMENTAL: Serialize a Python sequence
 
     Parameters
     ----------
     value: object
         Python object for the sequence that is to be serialized.
+    context : SerializationContext
+        Custom serialization and deserialization context
 
     Returns
     -------
@@ -200,11 +207,11 @@ def serialize(object value):
     cdef SerializedPyObject serialized = SerializedPyObject()
     wrapped_value = [value]
     with nogil:
-        check_status(SerializeObject(wrapped_value, &serialized.data))
+        check_status(SerializeObject(context, wrapped_value, &serialized.data))
     return serialized
 
 
-def serialize_to(object value, sink):
+def serialize_to(object value, sink, SerializationContext context=None):
     """EXPERIMENTAL: Serialize a Python sequence to a file.
 
     Parameters
@@ -213,8 +220,10 @@ def serialize_to(object value, sink):
         Python object for the sequence that is to be serialized.
     sink: NativeFile or file-like
         File the sequence will be written to.
+    context : SerializationContext
+        Custom serialization and deserialization context
     """
-    serialized = serialize(value)
+    serialized = serialize(value, context)
     serialized.write_to(sink)
 
 
@@ -244,7 +253,7 @@ def read_serialized(source, base=None):
     return serialized
 
 
-def deserialize_from(source, object base):
+def deserialize_from(source, object base, SerializationContext context=None):
     """EXPERIMENTAL: Deserialize a Python sequence from a file.
 
     Parameters
@@ -254,6 +263,8 @@ def deserialize_from(source, object base):
     base: object
         This object will be the base object of all the numpy arrays
         contained in the sequence.
+    context : SerializationContext
+        Custom serialization and deserialization context
 
     Returns
     -------
@@ -261,10 +272,10 @@ def deserialize_from(source, object base):
         Python object for the deserialized sequence.
     """
     serialized = read_serialized(source, base=base)
-    return serialized.deserialize()
+    return serialized.deserialize(context)
 
 
-def deserialize(obj):
+def deserialize(obj, SerializationContext context=None):
     """
     EXPERIMENTAL: Deserialize Python object from Buffer or other Python object
     supporting the buffer protocol
@@ -272,10 +283,12 @@ def deserialize(obj):
     Parameters
     ----------
     obj : pyarrow.Buffer or Python object supporting buffer protocol
+    context : SerializationContext
+        Custom serialization and deserialization context
 
     Returns
     -------
     deserialized : object
     """
     source = BufferReader(obj)
-    return deserialize_from(source, obj)
+    return deserialize_from(source, obj, context)


### PR DESCRIPTION
This gets rid of the global serialize and deserialize callbacks and exposes the functionality to provide custom callbacks to the user.