### PR TITLE
ARROW-1344: [C++] Do not permit writing to closed BufferOutputStream

### DIFF
--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -67,6 +67,18 @@ TEST_F(TestBufferOutputStream, CloseResizes) {
   ASSERT_EQ(static_cast<int64_t>(K * data.size()), buffer_->size());
 }
 
+TEST_F(TestBufferOutputStream, WriteAfterFinish) {
+  std::string data = "data123456";
+  ASSERT_OK(stream_->Write(data));
+
+  auto buffer_stream = static_cast<BufferOutputStream*>(stream_.get());
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_OK(buffer_stream->Finish(&buffer));
+
+  ASSERT_RAISES(IOError, stream_->Write(data));
+}
+
 TEST(TestFixedSizeBufferWriter, Basics) {
   std::shared_ptr<MutableBuffer> buffer;
   ASSERT_OK(AllocateBuffer(default_memory_pool(), 1024, &buffer));

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -63,7 +63,7 @@ BufferOutputStream::~BufferOutputStream() {
 
 Status BufferOutputStream::Close() {
   if (position_ < capacity_) {
-    return buffer_->Resize(position_);
+    return buffer_->Resize(position_, false);
   } else {
     return Status::OK();
   }

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -41,6 +41,7 @@ static constexpr int64_t kBufferMinimumSize = 256;
 
 BufferOutputStream::BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer)
     : buffer_(buffer),
+      is_open_(true),
       capacity_(buffer->size()),
       position_(0),
       mutable_data_(buffer->mutable_data()) {}
@@ -72,6 +73,7 @@ Status BufferOutputStream::Finish(std::shared_ptr<Buffer>* result) {
   RETURN_NOT_OK(Close());
   *result = buffer_;
   buffer_ = nullptr;
+  is_open_ = false;
   return Status::OK();
 }
 
@@ -81,6 +83,9 @@ Status BufferOutputStream::Tell(int64_t* position) const {
 }
 
 Status BufferOutputStream::Write(const uint8_t* data, int64_t nbytes) {
+  if (ARROW_PREDICT_FALSE(!is_open_)) {
+    return Status::IOError("OutputStream is closed");
+  }
   DCHECK(buffer_);
   RETURN_NOT_OK(Reserve(nbytes));
   memcpy(mutable_data_ + position_, data, nbytes);

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -62,6 +62,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   Status Reserve(int64_t nbytes);
 
   std::shared_ptr<ResizableBuffer> buffer_;
+  bool is_open_;
   int64_t capacity_;
   int64_t position_;
   uint8_t* mutable_data_;


### PR DESCRIPTION
Since this API code path in Python, it would be better to not segfault when writing to a BufferOutputStream whose internal buffer has been closed. 