### PR TITLE
ARROW-1426: [Site] Fix the title of the top page.

### DIFF
--- a/site/_includes/top.html
+++ b/site/_includes/top.html
@@ -2,14 +2,13 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-    <title>{{ page.title }}</title>
+    <title>Apache Arrow Homepage</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="generator" content="Jekyll v{{ jekyll.version }}">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}/favicon.ico">
 
-    <title>Apache Arrow Homepage</title>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic,900">
 
     <link href="{{ site.baseurl }}/css/main.css" rel="stylesheet">


### PR DESCRIPTION
The <title> of the top page is empty because top.html has 2 <title> elements
and the 1st one is converted to empty element.