### PR TITLE
ARROW-1427: [GLib] Add arrow cpp link to readme

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -19,7 +19,7 @@
 
 # Arrow GLib
 
-Arrow GLib is a wrapper library for Arrow C++. Arrow GLib provides C
+Arrow GLib is a wrapper library for [Arrow C++](https://github.com/apache/arrow/tree/master/cpp). Arrow GLib provides C
 API.
 
 Arrow GLib supports


### PR DESCRIPTION
I added a link to "Arrow C++" to readme of Arrow GLib.
It is a little hard to find to install Arrow C++ before using Arrow GLib for the bigginer.