### PR TITLE
Fix ARROW-1429

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -532,7 +532,7 @@ class ParquetDataset(object):
          self.metadata_path) = _make_manifest(path_or_paths, self.fs)
 
         if self.metadata_path is not None:
-            self.common_metadata = ParquetFile(self.metadata_path).metadata
+            self.common_metadata = ParquetFile(self.fs.open(self.metadata_path)).metadata
         else:
             self.common_metadata = None
 


### PR DESCRIPTION
When reading a parquet dataset from HDFS using `pyarrow.hdfs.HadoopFileSystem.read_parquet()`, pyarrow tries to load the `_metadata` file from the local file system instead of from HDFS.