### PR TITLE
ARROW-1381: [Python] Use FixedSizeBufferWriter in SerializedPyObject.to_buffer

### DIFF
--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -181,12 +181,14 @@ cdef class SerializedPyObject:
         # also unpack the list the object was wrapped in in serialize
         return PyObject_to_object(result)[0]
 
-    def to_buffer(self):
+    def to_buffer(self, nthreads=1):
         """
         Write serialized data as Buffer
         """
         cdef Buffer output = allocate_buffer(self.total_bytes)
         sink = FixedSizeBufferWriter(output)
+        if nthreads > 1:
+            sink.set_memcopy_threads(nthreads)
         self.write_to(sink)
         return output
 

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -185,9 +185,10 @@ cdef class SerializedPyObject:
         """
         Write serialized data as Buffer
         """
-        sink = BufferOutputStream()
+        cdef Buffer output = allocate_buffer(self.total_bytes)
+        sink = FixedSizeBufferWriter(output)
         self.write_to(sink)
-        return sink.get_result()
+        return output
 
 
 def serialize(object value, SerializationContext context=None):

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -237,6 +237,14 @@ def test_primitive_serialization(large_memory_map):
             serialization_roundtrip(obj, mmap)
 
 
+def test_serialize_to_buffer():
+    for nthreads in [1, 4]:
+        for value in COMPLEX_OBJECTS:
+            buf = pa.serialize(value).to_buffer(nthreads=nthreads)
+            result = pa.deserialize(buf)
+            assert_equal(value, result)
+
+
 def test_complex_serialization(large_memory_map):
     with pa.memory_map(large_memory_map, mode="r+") as mmap:
         for obj in COMPLEX_OBJECTS:


### PR DESCRIPTION
With this setup:

```
import numpy as np
import pyarrow as pa

objects = [np.random.randn(500, 500) for i in range(400)]
serialized = pa.serialize(objects)
```

I have before:

```
In [3]: %timeit buf = serialized.to_buffer()
201 ms ± 1.87 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

and after:

```
In [4]: %timeit buf = serialized.to_buffer()
81.1 ms ± 233 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

I added an `nthreads` option but note that when the objects are small, multithreading makes things slower due to the overhead of launching threads. I think the 1MB threshold in `arrow/io/memory.cc` may be too small, we might do some benchmarking to find a better default crossover point for switching between parallel and serial memcpy:

```
In [2]: %timeit buf = serialized.to_buffer(nthreads=4)
134 ms ± 1.38 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

cc @pcmoritz @robertnishihara 