### PR TITLE
ARROW-1441:  [Site] Add Ruby to Flexible section

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -22,7 +22,7 @@ D (Single input multiple data) operations included in modern processors, for nat
         </div>
         <div class="col-lg-4">
           <h2>Flexible</h2>
-          <p>Arrow acts as a new high-performance interface between various systems. It is also focused on supporting a wide variety of industry-standard programming languages. Java, C, C++, Python, Ruby are underway and more languages are expected soon.</p>
+          <p>Arrow acts as a new high-performance interface between various systems. It is also focused on supporting a wide variety of industry-standard programming languages. Java, C, C++, Python, Ruby, and JavaScript implementations are in progress and more languages are welcome.</p>
         </div>
         <div class="col-lg-4">
           <h2>Standard</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -22,7 +22,7 @@ D (Single input multiple data) operations included in modern processors, for nat
         </div>
         <div class="col-lg-4">
           <h2>Flexible</h2>
-          <p>Arrow acts as a new high-performance interface between various systems. It is also focused on supporting a wide variety of industry-standard programming languages. Java, C, C++, Python are underway and more languages are expected soon.</p>
+          <p>Arrow acts as a new high-performance interface between various systems. It is also focused on supporting a wide variety of industry-standard programming languages. Java, C, C++, Python, Ruby are underway and more languages are expected soon.</p>
         </div>
         <div class="col-lg-4">
           <h2>Standard</h2>


### PR DESCRIPTION
2017-05-08 C (GLib) Bindings, with support for Ruby, Lua, and more release.
There is a Ruby binding called red-arrow.
How about adding Ruby to the top page Flexible section?
https://arrow.apache.org/

issue link is [here](https://issues.apache.org/jira/browse/ARROW-1441)