### PR TITLE
ARROW-1447: [C++] Fix many include-what-you-use warnings

### DIFF
--- a/cpp/build-support/iwyu/iwyu-filter.awk
+++ b/cpp/build-support/iwyu/iwyu-filter.awk
@@ -67,6 +67,10 @@ BEGIN {
   # suggestions are addressed and invalid ones are taken care either by proper
   # IWYU pragmas or adding special mappings (e.g. like boost mappings).
   # muted["relative/path/to/file"]
+  muted["arrow/util/bit-util-test.cc"]
+  muted["arrow/util/rle-encoding-test.cc"]
+  muted["include/hdfs.h"]
+  muted["arrow/visitor.h"]
 }
 
 # mute all suggestions for the auto-generated files

--- a/cpp/build-support/iwyu/iwyu.sh
+++ b/cpp/build-support/iwyu/iwyu.sh
@@ -33,7 +33,8 @@ IWYU_ARGS="\
     --mapping_file=$IWYU_MAPPINGS_PATH/boost-extra.imp \
     --mapping_file=$IWYU_MAPPINGS_PATH/gflags.imp \
     --mapping_file=$IWYU_MAPPINGS_PATH/glog.imp \
-    --mapping_file=$IWYU_MAPPINGS_PATH/gtest.imp"
+    --mapping_file=$IWYU_MAPPINGS_PATH/gtest.imp \
+    --mapping_file=$IWYU_MAPPINGS_PATH/arrow-misc.imp"
 
 set -e
 

--- a/cpp/build-support/iwyu/iwyu.sh
+++ b/cpp/build-support/iwyu/iwyu.sh
@@ -26,21 +26,6 @@ trap "rm -f $IWYU_LOG" EXIT
 
 echo "Logging IWYU to $IWYU_LOG"
 
-# Build the list of updated files which are of IWYU interest.
-file_list_tmp=$(git diff --name-only \
-    $($ROOT/cpp/build-support/get-upstream-commit.sh) | grep -E '\.(c|cc|h)$')
-if [ -z "$file_list_tmp" ]; then
-  echo "IWYU verification: no updates on related files, declaring success"
-  exit 0
-fi
-
-# Adjust the path for every element in the list. The iwyu_tool.py normalizes
-# paths (via realpath) to match the records from the compilation database.
-IWYU_FILE_LIST=
-for p in $file_list_tmp; do
-  IWYU_FILE_LIST="$IWYU_FILE_LIST $ROOT/$p"
-done
-
 IWYU_MAPPINGS_PATH="$ROOT/cpp/build-support/iwyu/mappings"
 IWYU_ARGS="\
     --mapping_file=$IWYU_MAPPINGS_PATH/boost-all.imp \
@@ -57,6 +42,21 @@ if [ "$1" == "all" ]; then
        $IWYU_ARGS | awk -f $ROOT/cpp/build-support/iwyu/iwyu-filter.awk | \
        tee $IWYU_LOG
 else
+  # Build the list of updated files which are of IWYU interest.
+  file_list_tmp=$(git diff --name-only \
+      $($ROOT/cpp/build-support/get-upstream-commit.sh) | grep -E '\.(c|cc|h)$')
+  if [ -z "$file_list_tmp" ]; then
+    echo "IWYU verification: no updates on related files, declaring success"
+    exit 0
+  fi
+
+  # Adjust the path for every element in the list. The iwyu_tool.py normalizes
+  # paths (via realpath) to match the records from the compilation database.
+  IWYU_FILE_LIST=
+  for p in $file_list_tmp; do
+    IWYU_FILE_LIST="$IWYU_FILE_LIST $ROOT/$p"
+  done
+
   python $ROOT/cpp/build-support/iwyu/iwyu_tool.py -p . $IWYU_FILE_LIST  -- \
        $IWYU_ARGS | awk -f $ROOT/cpp/build-support/iwyu/iwyu-filter.awk | \
        tee $IWYU_LOG

--- a/cpp/build-support/iwyu/mappings/arrow-misc.imp
+++ b/cpp/build-support/iwyu/mappings/arrow-misc.imp
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+[
+  { symbol: ["bool", private, "<cstdint>", public ] },
+  { symbol: ["false", private, "<cstdint>", public ] },
+  { symbol: ["true", private, "<cstdint>", public ] },
+  { symbol: ["int64_t", private, "<cstdint>", public ] },
+  { symbol: ["int16_t", private, "<cstdint>", public ] },
+  { symbol: ["int32_t", private, "<cstdint>", public ] },
+  { symbol: ["uint8_t", private, "<cstdint>", public ] },
+  { symbol: ["_Node_const_iterator", private, "<flatbuffers/flatbuffers.h>", public ] },
+  { symbol: ["unordered_map<>::mapped_type", private, "<flatbuffers/flatbuffers.h>", public ] },
+  { symbol: ["__alloc_traits<>::value_type", private, "<vector>", public ] },
+  { symbol: ["move", private, "<utility>", public ] },
+  { symbol: ["pair", private, "<utility>", public ] },
+  { symbol: ["errno", private, "<cerrno>", public ] },
+  { symbol: ["posix_memalign", private, "<cstdlib>", public ] }
+]

--- a/cpp/src/arrow/allocator-test.cc
+++ b/cpp/src/arrow/allocator-test.cc
@@ -15,10 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "gtest/gtest.h"
+#include <cstdint>
+#include <limits>
+#include <new>
+
+#include <gtest/gtest.h>
 
 #include "arrow/allocator.h"
-#include "arrow/test-util.h"
+#include "arrow/memory_pool.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array-decimal-test.cc
+++ b/cpp/src/arrow/array-decimal-test.cc
@@ -15,15 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/type.h"
-#include "gtest/gtest.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
+#include <gtest/gtest.h>
+
+#include "arrow/array.h"
 #include "arrow/builder.h"
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
 #include "arrow/test-util.h"
+#include "arrow/type.h"
+#include "arrow/util/bit-util.h"
 #include "arrow/util/decimal.h"
 
+using std::size_t;
+
 namespace arrow {
+
+class Buffer;
+
 namespace decimal {
+
+class Int128;
 
 template <typename T>
 class DecimalTestBase {

--- a/cpp/src/arrow/array-decimal-test.cc
+++ b/cpp/src/arrow/array-decimal-test.cc
@@ -39,8 +39,6 @@ class Buffer;
 
 namespace decimal {
 
-class Int128;
-
 template <typename T>
 class DecimalTestBase {
  public:

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -16,12 +16,15 @@
 // under the License.
 
 #include <cstdint>
+#include <cstring>
 #include <limits>
+#include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "arrow/buffer.h"
+#include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/test-util.h"
 

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -18,7 +18,6 @@
 #include "arrow/buffer.h"
 
 #include <cstdint>
-#include <limits>
 
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -18,11 +18,11 @@
 #ifndef ARROW_BUFFER_H
 #define ARROW_BUFFER_H
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 #include "arrow/status.h"
 #include "arrow/util/bit-util.h"
@@ -32,7 +32,6 @@
 namespace arrow {
 
 class MemoryPool;
-class Status;
 
 // ----------------------------------------------------------------------
 // Buffer classes

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -59,7 +59,7 @@
 
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/types.h>  // IWYU pragma: keep
 
 #ifndef _MSC_VER  // POSIX-like platforms
 
@@ -107,7 +107,8 @@
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
 
-#include <boost/filesystem.hpp>  // NOLINT
+#include <boost/filesystem.hpp>           // NOLINT
+#include <boost/system/system_error.hpp>  // NOLINT
 
 namespace fs = boost::filesystem;
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -45,6 +45,18 @@
 #include <sys/mman.h>
 #endif
 
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <sstream>  // IWYU pragma: keep
+
+#if defined(_MSC_VER)
+#include <codecvt>
+#include <locale>
+#endif
+
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -70,22 +82,6 @@
 #endif
 
 // ----------------------------------------------------------------------
-// C++ standard library
-
-#include <algorithm>
-#include <cstring>
-#include <iostream>
-#include <limits>
-#include <mutex>
-#include <sstream>
-#include <vector>
-
-#if defined(_MSC_VER)
-#include <codecvt>
-#include <locale>
-#endif
-
-// ----------------------------------------------------------------------
 // file compatibility stuff
 
 #if defined(__MINGW32__)  // MinGW
@@ -95,8 +91,6 @@
 #else  // POSIX / Linux
 // nothing
 #endif
-
-#include <cstdio>
 
 // POSIX systems do not have this
 #ifndef O_BINARY

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -25,7 +25,6 @@
 #include <string>
 
 #include "arrow/io/interfaces.h"
-#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {

--- a/cpp/src/arrow/io/hdfs-internal.cc
+++ b/cpp/src/arrow/io/hdfs-internal.cc
@@ -32,11 +32,12 @@
 
 #include <cstdint>
 #include <cstdlib>
-#include <iostream>
 #include <mutex>
-#include <sstream>
+#include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <vector>
+
+#include <dlfcn.h>
 
 #include <boost/filesystem.hpp>  // NOLINT
 

--- a/cpp/src/arrow/io/hdfs-internal.cc
+++ b/cpp/src/arrow/io/hdfs-internal.cc
@@ -37,7 +37,9 @@
 #include <string>
 #include <vector>
 
+#ifndef _WIN32
 #include <dlfcn.h>
+#endif
 
 #include <boost/filesystem.hpp>  // NOLINT
 

--- a/cpp/src/arrow/io/hdfs-internal.cc
+++ b/cpp/src/arrow/io/hdfs-internal.cc
@@ -30,17 +30,17 @@
 
 #include "arrow/io/hdfs-internal.h"
 
+#include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <mutex>
 #include <sstream>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include <boost/filesystem.hpp>  // NOLINT
 
 #include "arrow/status.h"
-#include "arrow/util/visibility.h"
 
 namespace fs = boost::filesystem;
 

--- a/cpp/src/arrow/io/hdfs-internal.h
+++ b/cpp/src/arrow/io/hdfs-internal.h
@@ -21,10 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#ifndef _WIN32
-#include <dlfcn.h>  // IWYU pragma: keep
-#endif
-
 #include <hdfs.h>
 
 #include "arrow/io/windows_compatibility.h"  // IWYU pragma: keep

--- a/cpp/src/arrow/io/hdfs-internal.h
+++ b/cpp/src/arrow/io/hdfs-internal.h
@@ -18,14 +18,21 @@
 #ifndef ARROW_IO_HDFS_INTERNAL
 #define ARROW_IO_HDFS_INTERNAL
 
+#include <cstddef>
+#include <cstdint>
+
 #ifndef _WIN32
-#include <dlfcn.h>
+#include <dlfcn.h>  // IWYU pragma: keep
 #endif
 
 #include <hdfs.h>
 
-#include "arrow/io/windows_compatibility.h"
+#include "arrow/io/windows_compatibility.h"  // IWYU pragma: keep
 #include "arrow/util/visibility.h"
+
+using std::size_t;
+
+struct hdfsBuilder;
 
 namespace arrow {
 

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -18,7 +18,10 @@
 #include <hdfs.h>
 
 #include <algorithm>
+#include <cerrno>
+#include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <sstream>
 #include <string>
 
@@ -28,6 +31,8 @@
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
+
+using std::size_t;
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -30,11 +30,11 @@
 namespace arrow {
 
 class Buffer;
+class MemoryPool;
 class Status;
 
 namespace io {
 
-class HadoopFileSystem;
 class HdfsReadableFile;
 class HdfsOutputStream;
 

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -21,7 +21,6 @@
 #include <memory>
 #include <mutex>
 
-#include "arrow/buffer.h"
 #include "arrow/status.h"
 
 namespace arrow {

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -30,7 +30,6 @@
 namespace arrow {
 
 class Buffer;
-class MemoryPool;
 class Status;
 
 namespace io {

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -16,23 +16,30 @@
 // under the License.
 
 #include <atomic>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <memory>
+#include <sstream>  // IWYU pragma: keep
+#include <string>
+#include <thread>
+#include <vector>
+
 #ifndef _MSC_VER
 #include <fcntl.h>
 #endif
-#include <fstream>
-#include <memory>
-#include <sstream>
-#include <string>
-#include <thread>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
+#include "arrow/buffer.h"
 #include "arrow/io/file.h"
+#include "arrow/io/interfaces.h"
 #include "arrow/io/test-common.h"
 #include "arrow/memory_pool.h"
+#include "arrow/status.h"
+#include "arrow/test-util.h"
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -21,6 +21,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>  // IWYU pragma: keep
 #include <memory>
 #include <sstream>  // IWYU pragma: keep
 #include <string>

--- a/cpp/src/arrow/io/io-hdfs-test.cc
+++ b/cpp/src/arrow/io/io-hdfs-test.cc
@@ -15,18 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <atomic>
+#include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
-#include <sstream>
+#include <memory>
+#include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <thread>
+#include <vector>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>  // NOLINT
 
+#include "arrow/buffer.h"
 #include "arrow/io/hdfs-internal.h"
 #include "arrow/io/hdfs.h"
+#include "arrow/io/interfaces.h"
 #include "arrow/status.h"
 #include "arrow/test-util.h"
 

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -16,17 +16,19 @@
 // under the License.
 
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <string>
-#include <vector>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
+#include "arrow/buffer.h"
+#include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
-#include "arrow/io/test-common.h"
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
+#include "arrow/test-util.h"
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -18,17 +18,13 @@
 #include "arrow/io/memory.h"
 
 #include <algorithm>
-#include <cerrno>
 #include <cstdint>
-#include <cstdio>
 #include <cstring>
-#include <sstream>
-#include <string>
 
 #include "arrow/buffer.h"
-#include "arrow/io/interfaces.h"
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/memory.h"
 
 namespace arrow {

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -23,16 +23,14 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <string>
 
 #include "arrow/io/interfaces.h"
-
-#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
 class Buffer;
+class MemoryPool;
 class ResizableBuffer;
 class Status;
 

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -20,10 +20,9 @@
 #include <cstdint>
 #include <memory>
 #include <sstream>
+#include <utility>
 
-#include "arrow/array.h"
 #include "arrow/status.h"
-#include "arrow/type.h"
 
 namespace arrow {
 namespace ipc {

--- a/cpp/src/arrow/ipc/dictionary.h
+++ b/cpp/src/arrow/ipc/dictionary.h
@@ -22,9 +22,7 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <unordered_map>
-#include <vector>
 
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
@@ -33,16 +31,7 @@
 namespace arrow {
 
 class Array;
-class Buffer;
 class Field;
-
-namespace io {
-
-class InputStream;
-class OutputStream;
-class RandomAccessFile;
-
-}  // namespace io
 
 namespace ipc {
 

--- a/cpp/src/arrow/ipc/feather-internal.h
+++ b/cpp/src/arrow/ipc/feather-internal.h
@@ -22,6 +22,7 @@
 #define ARROW_IPC_FEATHER_INTERNAL_H
 
 #include <cstdint>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -19,9 +19,8 @@
 
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <memory>
-#include <sstream>
+#include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <vector>
 
@@ -32,7 +31,7 @@
 #include "arrow/io/interfaces.h"
 #include "arrow/ipc/feather-internal.h"
 #include "arrow/ipc/feather_generated.h"
-#include "arrow/ipc/util.h"
+#include "arrow/ipc/util.h"  // IWYU pragma: keep
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/type.h"

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -17,7 +17,6 @@
 
 #include "arrow/ipc/feather.h"
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <iostream>
@@ -30,13 +29,16 @@
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"
-#include "arrow/io/file.h"
+#include "arrow/io/interfaces.h"
 #include "arrow/ipc/feather-internal.h"
 #include "arrow/ipc/feather_generated.h"
+#include "arrow/ipc/util.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
+#include "arrow/type.h"
 #include "arrow/util/bit-util.h"
 #include "arrow/util/logging.h"
+#include "arrow/visitor.h"
 
 namespace arrow {
 namespace ipc {

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -24,14 +24,12 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <vector>
 
-#include "arrow/type.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
-class Buffer;
+class Array;
 class Column;
 class Status;
 

--- a/cpp/src/arrow/ipc/file-to-stream.cc
+++ b/cpp/src/arrow/ipc/file-to-stream.cc
@@ -16,6 +16,9 @@
 // under the License.
 
 #include <iostream>
+#include <memory>
+#include <string>
+
 #include "arrow/io/file.h"
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
@@ -24,6 +27,9 @@
 #include "arrow/util/io-util.h"
 
 namespace arrow {
+
+class RecordBatch;
+
 namespace ipc {
 
 // Reads a file on the file system and prints to stdout the stream version of it.

--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <fstream>  // IWYU pragma: keep
 #include <iostream>
 #include <memory>
 #include <string>

--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -15,14 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 
-#include "gflags/gflags.h"
-#include "gtest/gtest.h"
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
 
 #include <boost/filesystem.hpp>  // NOLINT
 
@@ -47,6 +49,8 @@ DEFINE_bool(verbose, true, "Verbose output");
 namespace fs = boost::filesystem;
 
 namespace arrow {
+
+class Buffer;
 
 bool file_exists(const char* path) {
   std::ifstream handle(path);

--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -16,9 +16,7 @@
 // under the License.
 
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -17,23 +17,17 @@
 
 #include "arrow/ipc/json-internal.h"
 
-#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
-#include <iostream>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <type_traits>
 #include <vector>
 
-#include "rapidjson/stringbuffer.h"
-#include "rapidjson/writer.h"
-
 #include "arrow/array.h"
 #include "arrow/builder.h"
-#include "arrow/ipc/metadata-internal.h"
-#include "arrow/memory_pool.h"
+#include "arrow/ipc/dictionary.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/type.h"

--- a/cpp/src/arrow/ipc/json-internal.h
+++ b/cpp/src/arrow/ipc/json-internal.h
@@ -30,7 +30,7 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
-#include "arrow/type_fwd.h"
+#include "arrow/type_fwd.h"  // IWYU pragma: export
 #include "arrow/util/visibility.h"
 
 namespace rj = rapidjson;

--- a/cpp/src/arrow/ipc/json.cc
+++ b/cpp/src/arrow/ipc/json.cc
@@ -17,12 +17,10 @@
 
 #include "arrow/ipc/json.h"
 
-#include <cstdint>
+#include <cstddef>
 #include <memory>
 #include <string>
-#include <vector>
 
-#include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/ipc/json-internal.h"
 #include "arrow/memory_pool.h"
@@ -30,6 +28,8 @@
 #include "arrow/table.h"
 #include "arrow/type.h"
 #include "arrow/util/logging.h"
+
+using std::size_t;
 
 namespace arrow {
 namespace ipc {

--- a/cpp/src/arrow/ipc/json.h
+++ b/cpp/src/arrow/ipc/json.h
@@ -22,18 +22,17 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
+#include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-namespace io {
 
-class OutputStream;
-class RandomAccessFile;
-
-}  // namespace io
+class Buffer;
+class MemoryPool;
+class RecordBatch;
+class Schema;
 
 namespace ipc {
 

--- a/cpp/src/arrow/ipc/json.h
+++ b/cpp/src/arrow/ipc/json.h
@@ -24,7 +24,6 @@
 #include <string>
 
 #include "arrow/status.h"
-#include "arrow/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -22,17 +22,13 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <vector>
 
-#include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/io/interfaces.h"
+#include "arrow/ipc/Message_generated.h"
+#include "arrow/ipc/Schema_generated.h"
 #include "arrow/ipc/metadata-internal.h"
-#include "arrow/ipc/util.h"
 #include "arrow/status.h"
-#include "arrow/tensor.h"
-#include "arrow/type.h"
-#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace ipc {

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -23,8 +23,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
@@ -32,9 +30,7 @@
 
 namespace arrow {
 
-class Array;
 class Buffer;
-class Field;
 
 namespace io {
 
@@ -56,8 +52,6 @@ constexpr int kMaxNestingDepth = 64;
 // Read interface classes. We do not fully deserialize the flatbuffers so that
 // individual fields metadata can be retrieved from very large schema without
 //
-
-class Message;
 
 /// \brief An IPC message including metadata and body
 class ARROW_EXPORT Message {

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -22,8 +22,9 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
-#include "flatbuffers/flatbuffers.h"
+#include <flatbuffers/flatbuffers.h>
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -17,22 +17,27 @@
 
 #include "arrow/ipc/metadata-internal.h"
 
-#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include "flatbuffers/flatbuffers.h"
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/io/interfaces.h"
+#include "arrow/ipc/File_generated.h"
+#include "arrow/ipc/Message_generated.h"
+#include "arrow/ipc/Tensor_generated.h"
+#include "arrow/ipc/dictionary.h"
 #include "arrow/ipc/util.h"
 #include "arrow/status.h"
 #include "arrow/tensor.h"
 #include "arrow/type.h"
+#include "arrow/util/bit-util.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -46,8 +46,6 @@ class OutputStream;
 
 namespace ipc {
 
-class DictionaryMemo;
-
 static constexpr flatbuf::MetadataVersion kCurrentMetadataVersion =
     flatbuf::MetadataVersion_V3;
 

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -23,23 +23,15 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
-#include "arrow/ipc/File_generated.h"
-#include "arrow/ipc/Message_generated.h"
-#include "arrow/ipc/Tensor_generated.h"
+#include "arrow/ipc/Schema_generated.h"
 #include "arrow/ipc/dictionary.h"
-#include "arrow/ipc/message.h"
-#include "arrow/util/macros.h"
-#include "arrow/util/visibility.h"
 
 namespace arrow {
 
-class Array;
 class Buffer;
 class DataType;
-class Field;
 class Schema;
 class Status;
 class Tensor;
@@ -48,13 +40,13 @@ namespace flatbuf = org::apache::arrow::flatbuf;
 
 namespace io {
 
-class InputStream;
 class OutputStream;
-class RandomAccessFile;
 
 }  // namespace io
 
 namespace ipc {
+
+class DictionaryMemo;
 
 static constexpr flatbuf::MetadataVersion kCurrentMetadataVersion =
     flatbuf::MetadataVersion_V3;

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -21,13 +21,19 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <vector>
 
+#include <flatbuffers/flatbuffers.h>  // IWYU pragma: export
+
+#include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
 #include "arrow/ipc/File_generated.h"
 #include "arrow/ipc/Message_generated.h"
+#include "arrow/ipc/Schema_generated.h"
+#include "arrow/ipc/dictionary.h"
 #include "arrow/ipc/message.h"
 #include "arrow/ipc/metadata-internal.h"
 #include "arrow/ipc/util.h"
@@ -35,7 +41,6 @@
 #include "arrow/table.h"
 #include "arrow/tensor.h"
 #include "arrow/type.h"
-#include "arrow/util/bit-util.h"
 #include "arrow/util/logging.h"
 #include "arrow/visitor_inline.h"
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -41,6 +41,7 @@
 #include "arrow/table.h"
 #include "arrow/tensor.h"
 #include "arrow/type.h"
+#include "arrow/util/bit-util.h"
 #include "arrow/util/logging.h"
 #include "arrow/visitor_inline.h"
 

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -22,7 +22,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <vector>
 
 #include "arrow/ipc/message.h"
 #include "arrow/util/visibility.h"

--- a/cpp/src/arrow/ipc/stream-to-file.cc
+++ b/cpp/src/arrow/ipc/stream-to-file.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <iostream>
-#include "arrow/io/file.h"
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/status.h"

--- a/cpp/src/arrow/ipc/stream-to-file.cc
+++ b/cpp/src/arrow/ipc/stream-to-file.cc
@@ -16,6 +16,9 @@
 // under the License.
 
 #include <iostream>
+#include <memory>
+#include <string>
+
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/status.h"
@@ -23,6 +26,9 @@
 #include "arrow/util/io-util.h"
 
 namespace arrow {
+
+class RecordBatch;
+
 namespace ipc {
 
 // Converts a stream from stdin to a file written to standard out.

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -15,10 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/memory_pool-test.h"
-
 #include <cstdint>
-#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "arrow/memory_pool-test.h"
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/memory_pool-test.h
+++ b/cpp/src/arrow/memory_pool-test.h
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "gtest/gtest.h"
-
+#include <cstdint>
 #include <limits>
 
+#include <gtest/gtest.h>
+
 #include "arrow/memory_pool.h"
+#include "arrow/status.h"
 #include "arrow/test-util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -17,12 +17,13 @@
 
 #include "arrow/memory_pool.h"
 
-#include <stdlib.h>
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <mutex>
-#include <sstream>
+#include <sstream>  // IWYU pragma: keep
 
 #include "arrow/status.h"
 #include "arrow/util/logging.h"

--- a/cpp/src/arrow/python/pandas_to_arrow.cc
+++ b/cpp/src/arrow/python/pandas_to_arrow.cc
@@ -515,7 +515,7 @@ inline Status PandasConverter::ConvertData<Date32Type>(std::shared_ptr<Buffer>* 
       CopyStrided(input, length_, stride_elements, output);
     } else {
       // TODO(wesm): int32 overflow checks
-      for (int64_t i= 0; i < length_; ++i) {
+      for (int64_t i = 0; i < length_; ++i) {
         *output++ = static_cast<int32_t>(*input++);
       }
     }

--- a/cpp/src/arrow/status-test.cc
+++ b/cpp/src/arrow/status-test.cc
@@ -17,10 +17,9 @@
 
 #include <sstream>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "arrow/status.h"
-#include "arrow/test-util.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -15,8 +15,8 @@
 #ifndef ARROW_STATUS_H_
 #define ARROW_STATUS_H_
 
-#include <cstdint>
 #include <cstring>
+#include <iosfwd>
 #include <string>
 
 #include "arrow/util/macros.h"

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -29,15 +29,7 @@
 
 namespace arrow {
 
-namespace internal {
-
-struct ArrayData;
-
-}  // namespace internal
-
-class Array;
-class Column;
-class Schema;
+class KeyValueMetadata;
 class Status;
 
 using ArrayVector = std::vector<std::shared_ptr<Array>>;

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -17,13 +17,15 @@
 
 // Unit tests for DataType (and subclasses), Field, and Schema
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "arrow/buffer.h"
+#include "arrow/memory_pool.h"
 #include "arrow/tensor.h"
 #include "arrow/test-util.h"
 #include "arrow/type.h"

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -17,7 +17,6 @@
 
 #include "arrow/tensor.h"
 
-#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -25,11 +24,9 @@
 #include <string>
 #include <vector>
 
-#include "arrow/array.h"
-#include "arrow/buffer.h"
 #include "arrow/compare.h"
+#include "arrow/status.h"
 #include "arrow/type.h"
-#include "arrow/type_traits.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -25,15 +25,10 @@
 
 #include "arrow/buffer.h"
 #include "arrow/type.h"
-#include "arrow/type_traits.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-
-class Buffer;
-class MemoryPool;
-class Status;
 
 static inline bool is_tensor_supported(Type::type type_id) {
   switch (type_id) {

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -17,14 +17,16 @@
 
 // Unit tests for DataType (and subclasses), Field, and Schema
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 #include "arrow/test-util.h"
 #include "arrow/type.h"
+#include "arrow/util/key_value_metadata.h"
 
 using std::shared_ptr;
 using std::vector;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -27,7 +27,7 @@
 #include <vector>
 
 #include "arrow/status.h"
-#include "arrow/type_fwd.h"
+#include "arrow/type_fwd.h"  // IWYU pragma: export
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <climits>
 #include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <iostream>
+#include <cstring>
 #include <limits>
+#include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
-#include <boost/utility.hpp>
+#include <boost/utility.hpp>  // IWYU pragma: export
 
 #include "arrow/buffer.h"
 #include "arrow/test-util.h"

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -27,6 +27,8 @@
 #include <boost/utility.hpp>  // IWYU pragma: export
 
 #include "arrow/buffer.h"
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
 #include "arrow/test-util.h"
 #include "arrow/util/bit-stream-utils.h"
 #include "arrow/util/bit-util.h"

--- a/cpp/src/arrow/util/compression-test.cc
+++ b/cpp/src/arrow/util/compression-test.cc
@@ -15,13 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <gtest/gtest.h>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
-#include "arrow/status.h"
-#include "arrow/test-common.h"
+#include <gtest/gtest.h>
+
+#include "arrow/test-util.h"
 #include "arrow/util/compression.h"
 
 using std::string;

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -17,10 +17,7 @@
 
 #include "arrow/util/compression.h"
 
-#include <cstdint>
 #include <memory>
-#include <sstream>
-#include <string>
 
 #ifdef ARROW_WITH_BROTLI
 #include "arrow/util/compression_brotli.h"
@@ -43,7 +40,6 @@
 #endif
 
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -17,16 +17,14 @@
 
 #include "arrow/util/compression_brotli.h"
 
+#include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <sstream>
-#include <string>
 
 #include <brotli/decode.h>
 #include <brotli/encode.h>
+#include <brotli/types.h>
 
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
 
 namespace arrow {
 
@@ -35,7 +33,7 @@ namespace arrow {
 
 Status BrotliCodec::Decompress(int64_t input_len, const uint8_t* input,
                                int64_t output_len, uint8_t* output_buffer) {
-  size_t output_size = output_len;
+  std::size_t output_size = output_len;
   if (BrotliDecoderDecompress(input_len, input, &output_size, output_buffer) !=
       BROTLI_DECODER_RESULT_SUCCESS) {
     return Status::IOError("Corrupt brotli compressed data.");
@@ -50,7 +48,7 @@ int64_t BrotliCodec::MaxCompressedLen(int64_t input_len, const uint8_t* input) {
 Status BrotliCodec::Compress(int64_t input_len, const uint8_t* input,
                              int64_t output_buffer_len, uint8_t* output_buffer,
                              int64_t* output_length) {
-  size_t output_len = output_buffer_len;
+  std::size_t output_len = output_buffer_len;
   // TODO: Make quality configurable. We use 8 as a default as it is the best
   //       trade-off for Parquet workload
   if (BrotliEncoderCompress(8, BROTLI_DEFAULT_WINDOW, BROTLI_DEFAULT_MODE, input_len,

--- a/cpp/src/arrow/util/compression_brotli.h
+++ b/cpp/src/arrow/util/compression_brotli.h
@@ -19,10 +19,10 @@
 #define ARROW_UTIL_COMPRESSION_BROTLI_H
 
 #include <cstdint>
-#include <memory>
 
 #include "arrow/status.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -18,14 +18,10 @@
 #include "arrow/util/compression_lz4.h"
 
 #include <cstdint>
-#include <memory>
-#include <sstream>
-#include <string>
 
 #include <lz4.h>
 
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_lz4.h
+++ b/cpp/src/arrow/util/compression_lz4.h
@@ -19,10 +19,10 @@
 #define ARROW_UTIL_COMPRESSION_LZ4_H
 
 #include <cstdint>
-#include <memory>
 
 #include "arrow/status.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -22,15 +22,15 @@
 #undef DISALLOW_COPY_AND_ASSIGN
 #endif
 
+#include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <sstream>
-#include <string>
 
 #include <snappy.h>
 
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
+
+using std::size_t;
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_snappy.h
+++ b/cpp/src/arrow/util/compression_snappy.h
@@ -19,10 +19,10 @@
 #define ARROW_UTIL_COMPRESSION_SNAPPY_H
 
 #include <cstdint>
-#include <memory>
 
 #include "arrow/status.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -18,10 +18,12 @@
 #include "arrow/util/compression_zlib.h"
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <sstream>
 #include <string>
 
+#include <zconf.h>
 #include <zlib.h>
 
 #include "arrow/status.h"

--- a/cpp/src/arrow/util/compression_zlib.h
+++ b/cpp/src/arrow/util/compression_zlib.h
@@ -23,6 +23,7 @@
 
 #include "arrow/status.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -17,15 +17,14 @@
 
 #include "arrow/util/compression_zstd.h"
 
+#include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <sstream>
-#include <string>
 
 #include <zstd.h>
 
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+
+using std::size_t;
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/compression_zstd.h
+++ b/cpp/src/arrow/util/compression_zstd.h
@@ -19,10 +19,10 @@
 #define ARROW_UTIL_COMPRESSION_ZSTD_H
 
 #include <cstdint>
-#include <memory>
 
 #include "arrow/status.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/cpu-info.cc
+++ b/cpp/src/arrow/util/cpu-info.cc
@@ -43,9 +43,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <fstream>
-#include <iostream>
 #include <mutex>
-#include <sstream>
 #include <string>
 
 #include "arrow/util/logging.h"

--- a/cpp/src/arrow/util/cpu-info.cc
+++ b/cpp/src/arrow/util/cpu-info.cc
@@ -38,7 +38,8 @@
 
 #endif
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 #include <algorithm>
 #include <cstdint>

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -16,11 +16,15 @@
 // under the License.
 //
 
-#include "arrow/util/decimal.h"
+#include <cstdint>
+#include <cstring>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
+#include "arrow/status.h"
 #include "arrow/test-util.h"
+#include "arrow/util/decimal.h"
+#include "arrow/util/int128.h"
 
 namespace arrow {
 namespace decimal {

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -17,14 +17,13 @@
 //
 
 #include <cstdint>
-#include <cstring>
+#include <string>
 
 #include <gtest/gtest.h>
 
 #include "arrow/status.h"
 #include "arrow/test-util.h"
 #include "arrow/util/decimal.h"
-#include "arrow/util/int128.h"
 
 namespace arrow {
 namespace decimal {

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -15,9 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cctype>
+#include <cmath>
 #include <sstream>
 
 #include "arrow/util/decimal.h"
+#include "arrow/util/int128.h"
 
 namespace arrow {
 namespace decimal {

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -18,15 +18,14 @@
 #ifndef ARROW_DECIMAL_H
 #define ARROW_DECIMAL_H
 
-#include <cmath>
+#include <cstdint>
 #include <cstdlib>
-#include <iterator>
 #include <string>
 
 #include "arrow/status.h"
-#include "arrow/util/bit-util.h"
-#include "arrow/util/int128.h"
+#include "arrow/util/int128.h"  // IWYU pragma: export
 #include "arrow/util/logging.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace decimal {

--- a/cpp/src/arrow/util/int128.cc
+++ b/cpp/src/arrow/util/int128.cc
@@ -18,9 +18,8 @@
 
 #include <algorithm>
 #include <cmath>
-#include <iomanip>
+#include <cstring>
 #include <limits>
-#include <sstream>
 
 #ifdef _MSC_VER
 #include <intrin.h>

--- a/cpp/src/arrow/util/int128.h
+++ b/cpp/src/arrow/util/int128.h
@@ -19,9 +19,11 @@
 #ifndef ARROW_INT128_H
 #define ARROW_INT128_H
 
+#include <cstdint>
 #include <string>
 
 #include "arrow/status.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace decimal {

--- a/cpp/src/arrow/util/key-value-metadata-test.cc
+++ b/cpp/src/arrow/util/key-value-metadata-test.cc
@@ -15,11 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "gtest/gtest.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <gtest/gtest.h>
 
 #include "arrow/util/key_value_metadata.h"
-
-#include "arrow/test-util.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -16,9 +16,13 @@
 // under the License.
 
 #include <algorithm>
+#include <cstddef>
+#include <utility>
 
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
+
+using std::size_t;
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -18,6 +18,7 @@
 #ifndef ARROW_UTIL_KEY_VALUE_METADATA_H
 #define ARROW_UTIL_KEY_VALUE_METADATA_H
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -18,7 +18,6 @@
 #ifndef ARROW_UTIL_KEY_VALUE_METADATA_H
 #define ARROW_UTIL_KEY_VALUE_METADATA_H
 
-#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/cpp/src/arrow/util/rle-encoding-test.cc
+++ b/cpp/src/arrow/util/rle-encoding-test.cc
@@ -17,16 +17,17 @@
 
 // From Apache Impala (incubating) as of 2016-01-29
 
-#include <gtest/gtest.h>
-#include <stdio.h>
-
-#include <boost/utility.hpp>  // IWYU pragma: export
-
 #include <cstdint>
+#include <cstring>
 #include <random>
 #include <vector>
 
+#include <gtest/gtest.h>
+
+#include <boost/utility.hpp>  // IWYU pragma: export
+
 #include "arrow/util/bit-stream-utils.h"
+#include "arrow/util/bit-util.h"
 #include "arrow/util/rle-encoding.h"
 
 using std::vector;

--- a/cpp/src/arrow/util/rle-encoding-test.cc
+++ b/cpp/src/arrow/util/rle-encoding-test.cc
@@ -15,17 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// From Apache Impala as of 2016-01-29
+// From Apache Impala (incubating) as of 2016-01-29
 
 #include <gtest/gtest.h>
-#include <math.h>
 #include <stdio.h>
-#include <stdlib.h>
 
-#include <boost/utility.hpp>
+#include <boost/utility.hpp>  // IWYU pragma: export
 
 #include <cstdint>
-#include <iostream>
 #include <random>
 #include <vector>
 

--- a/cpp/src/arrow/util/stl-util-test.cc
+++ b/cpp/src/arrow/util/stl-util-test.cc
@@ -15,14 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/stl.h"
-
-#include <cstdint>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
-#include "arrow/test-util.h"
+#include "arrow/util/stl.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/visitor.cc
+++ b/cpp/src/arrow/visitor.cc
@@ -17,6 +17,8 @@
 
 #include "arrow/visitor.h"
 
+#include <memory>
+
 #include "arrow/array.h"
 #include "arrow/status.h"
 #include "arrow/type.h"


### PR DESCRIPTION
There's still some work to deal with some things that IWYU is reporting incorrectly, but we can do that later