### PR TITLE
ARROW-1417: [Python] Allow more generic filesystem objects to be passed to ParquetDataset

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -16,13 +16,14 @@
 # under the License.
 
 import os
+import inspect
 import json
 
 import six
 
 import numpy as np
 
-from pyarrow.filesystem import FileSystem, LocalFileSystem
+from pyarrow.filesystem import FileSystem, LocalFileSystem, S3FSWrapper
 from pyarrow._parquet import (ParquetReader, FileMetaData,  # noqa
                               RowGroupMetaData, ParquetSchema,
                               ParquetWriter)
@@ -645,13 +646,21 @@ class ParquetDataset(object):
 
 
 def _ensure_filesystem(fs):
-    if not isinstance(fs, FileSystem):
-        if type(fs).__name__ == 'S3FileSystem':
-            from pyarrow.filesystem import S3FSWrapper
-            return S3FSWrapper(fs)
+    if not issubclass(fs, FileSystem):
+
+        if not isinstance(fs, type):
+            fs_type = type(fs)
         else:
-            raise IOError('Unrecognized filesystem: {0}'
-                          .format(type(fs)))
+            fs_type = fs
+
+        for mro in inspect.getmro(fs_type):
+            if mro.__name__ is 'S3FileSystem':
+                return S3FSWrapper(fs)
+            # In case its a simple LocalFileSystem (e.g. dask) use native arrow FS
+            elif mro.__name__ is 'LocalFileSystem':
+                return LocalFileSystem.get_instance()
+
+        raise IOError('Unrecognized filesystem: {0}'.format(fs_type))
     else:
         return fs
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -646,13 +646,12 @@ class ParquetDataset(object):
 
 
 def _ensure_filesystem(fs):
-    if not issubclass(fs, FileSystem):
+    if not isinstance(fs, type):
+        fs_type = type(fs)
+    else:
+        fs_type = fs
 
-        if not isinstance(fs, type):
-            fs_type = type(fs)
-        else:
-            fs_type = fs
-
+    if not issubclass(fs_type, FileSystem):
         for mro in inspect.getmro(fs_type):
             if mro.__name__ is 'S3FileSystem':
                 return S3FSWrapper(fs)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -646,11 +646,9 @@ class ParquetDataset(object):
 
 
 def _ensure_filesystem(fs):
-    if not isinstance(fs, type):
-        fs_type = type(fs)
-    else:
-        fs_type = fs
+    fs_type = type(fs)
 
+    # If the arrow filesystem was subclassed, assume it supports the full interface and return it
     if not issubclass(fs_type, FileSystem):
         for mro in inspect.getmro(fs_type):
             if mro.__name__ is 'S3FileSystem':


### PR DESCRIPTION
This way, the `ParquetDataset` accepts both `S3FileSystem` and `LocalFileSystem` objects as they are used in `dask`. By using `issubclass`, external libraries may write their own FS wrappers by inheriting from the arrow FS.

I tested the integration with dask and this will fix the issue blocking https://github.com/dask/dask/pull/2527