### PR TITLE
ARROW-1383: [C++] Add vector append variant to primitive array builders that accepts std::vector<bool>

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -608,7 +608,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVectorStdBool) {
   int64_t K = 1000;
 
   for (int64_t i = 0; i < K; ++i) {
-    is_valid.push_back(this->valid_bytes_[i]);
+    is_valid.push_back(this->valid_bytes_[i] != 0);
   }
   ASSERT_OK(this->builder_->Append(draws.data(), K, is_valid));
 
@@ -618,7 +618,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVectorStdBool) {
   // Append the next 9000
   is_valid.clear();
   for (int64_t i = K; i < size; ++i) {
-    is_valid.push_back(this->valid_bytes_[i]);
+    is_valid.push_back(this->valid_bytes_[i] != 0);
   }
 
   ASSERT_OK(this->builder_->Append(draws.data() + K, size - K, is_valid));

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -593,6 +593,42 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVector) {
   this->Check(this->builder_nn_, false);
 }
 
+TYPED_TEST(TestPrimitiveBuilder, TestAppendVectorStdBool) {
+  // ARROW-1383
+  DECL_T();
+
+  int64_t size = 10000;
+  this->RandomData(size);
+
+  vector<T>& draws = this->draws_;
+
+  std::vector<bool> is_valid;
+
+  // first slug
+  int64_t K = 1000;
+
+  for (int64_t i = 0; i < K; ++i) {
+    is_valid.push_back(this->valid_bytes_[i]);
+  }
+  ASSERT_OK(this->builder_->Append(draws.data(), K, is_valid));
+
+  ASSERT_EQ(1000, this->builder_->length());
+  ASSERT_EQ(1024, this->builder_->capacity());
+
+  // Append the next 9000
+  is_valid.clear();
+  for (int64_t i = K; i < size; ++i) {
+    is_valid.push_back(this->valid_bytes_[i]);
+  }
+
+  ASSERT_OK(this->builder_->Append(draws.data() + K, size - K, is_valid));
+
+  ASSERT_EQ(size, this->builder_->length());
+  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+
+  this->Check(this->builder_, true);
+}
+
 TYPED_TEST(TestPrimitiveBuilder, TestAdvance) {
   int64_t n = 1000;
   ASSERT_OK(this->builder_->Reserve(n));
@@ -628,6 +664,39 @@ TYPED_TEST(TestPrimitiveBuilder, TestReserve) {
   ASSERT_OK(this->builder_->Reserve(kMinBuilderCapacity));
 
   ASSERT_EQ(BitUtil::NextPower2(kMinBuilderCapacity + 100), this->builder_->capacity());
+}
+
+TEST(TestBooleanBuilder, TestStdBoolVectorAppend) {
+  BooleanBuilder builder;
+
+  std::vector<bool> values, is_valid;
+
+  const int length = 10000;
+  test::random_is_valid(length, 0.5, &values);
+  test::random_is_valid(length, 0.1, &is_valid);
+
+  const int chunksize = 1000;
+  for (int chunk = 0; chunk < length / chunksize; ++chunk) {
+    std::vector<bool> chunk_values, chunk_is_valid;
+    for (int i = chunk * chunksize; i < (chunk + 1) * chunksize; ++i) {
+      chunk_values.push_back(values[i]);
+      chunk_is_valid.push_back(is_valid[i]);
+    }
+    ASSERT_OK(builder.Append(chunk_values, chunk_is_valid));
+  }
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(builder.Finish(&result));
+
+  const auto& arr = static_cast<const BooleanArray&>(*result);
+  for (int i = 0; i < length; ++i) {
+    if (is_valid[i]) {
+      ASSERT_FALSE(arr.IsNull(i));
+      ASSERT_EQ(values[i], arr.Value(i));
+    } else {
+      ASSERT_TRUE(arr.IsNull(i));
+    }
+  }
 }
 
 template <typename TYPE>

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -738,7 +738,7 @@ Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
   RETURN_NOT_OK(Reserve(length));
 
   for (int64_t i = 0; i < length; ++i) {
-    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] > 0);
+    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] != 0);
   }
 
   // this updates length_
@@ -751,7 +751,7 @@ Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
   RETURN_NOT_OK(Reserve(length));
 
   for (int64_t i = 0; i < length; ++i) {
-    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] > 0);
+    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] != 0);
   }
 
   // this updates length_
@@ -765,7 +765,7 @@ Status BooleanBuilder::Append(const std::vector<bool>& values,
   RETURN_NOT_OK(Reserve(length));
 
   for (int64_t i = 0; i < length; ++i) {
-    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] > 0);
+    BitUtil::SetBitTo(raw_data_, length_ + i, values[i]);
   }
 
   // this updates length_

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -153,6 +153,37 @@ void ArrayBuilder::UnsafeAppendToBitmap(const uint8_t* valid_bytes, int64_t leng
   length_ += length;
 }
 
+void ArrayBuilder::UnsafeAppendToBitmap(const std::vector<bool>& is_valid) {
+  int64_t byte_offset = length_ / 8;
+  int64_t bit_offset = length_ % 8;
+  uint8_t bitset = null_bitmap_data_[byte_offset];
+
+  const int64_t length = static_cast<int64_t>(is_valid.size());
+
+  for (int64_t i = 0; i < length; ++i) {
+    if (bit_offset == 8) {
+      bit_offset = 0;
+      null_bitmap_data_[byte_offset] = bitset;
+      byte_offset++;
+      // TODO: Except for the last byte, this shouldn't be needed
+      bitset = null_bitmap_data_[byte_offset];
+    }
+
+    if (is_valid[i]) {
+      bitset |= BitUtil::kBitmask[bit_offset];
+    } else {
+      bitset &= BitUtil::kFlippedBitmask[bit_offset];
+      ++null_count_;
+    }
+
+    bit_offset++;
+  }
+  if (bit_offset != 0) {
+    null_bitmap_data_[byte_offset] = bitset;
+  }
+  length_ += length;
+}
+
 void ArrayBuilder::UnsafeSetNotNull(int64_t length) {
   const int64_t new_length = length + length_;
 
@@ -238,6 +269,23 @@ Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
 
   // length_ is update by these
   ArrayBuilder::UnsafeAppendToBitmap(valid_bytes, length);
+
+  return Status::OK();
+}
+
+template <typename T>
+Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
+                                   const std::vector<bool>& is_valid) {
+  RETURN_NOT_OK(Reserve(length));
+  DCHECK_EQ(length, static_cast<int64_t>(is_valid.size()));
+
+  if (length > 0) {
+    std::memcpy(raw_data_ + length_, values,
+                static_cast<std::size_t>(TypeTraits<T>::bytes_required(length)));
+  }
+
+  // length_ is update by these
+  ArrayBuilder::UnsafeAppendToBitmap(is_valid);
 
   return Status::OK();
 }
@@ -690,20 +738,38 @@ Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
   RETURN_NOT_OK(Reserve(length));
 
   for (int64_t i = 0; i < length; ++i) {
-    // Skip reading from unitialised memory
-    // TODO: This actually is only to keep valgrind happy but may or may not
-    // have a performance impact.
-    if ((valid_bytes != nullptr) && !valid_bytes[i]) continue;
-
-    if (values[i] > 0) {
-      BitUtil::SetBit(raw_data_, length_ + i);
-    } else {
-      BitUtil::ClearBit(raw_data_, length_ + i);
-    }
+    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] > 0);
   }
 
   // this updates length_
   ArrayBuilder::UnsafeAppendToBitmap(valid_bytes, length);
+  return Status::OK();
+}
+
+Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
+                              const std::vector<bool>& is_valid) {
+  RETURN_NOT_OK(Reserve(length));
+
+  for (int64_t i = 0; i < length; ++i) {
+    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] > 0);
+  }
+
+  // this updates length_
+  ArrayBuilder::UnsafeAppendToBitmap(is_valid);
+  return Status::OK();
+}
+
+Status BooleanBuilder::Append(const std::vector<bool>& values,
+                              const std::vector<bool>& is_valid) {
+  const int64_t length = static_cast<int64_t>(values.size());
+  RETURN_NOT_OK(Reserve(length));
+
+  for (int64_t i = 0; i < length; ++i) {
+    BitUtil::SetBitTo(raw_data_, length_ + i, values[i] > 0);
+  }
+
+  // this updates length_
+  ArrayBuilder::UnsafeAppendToBitmap(is_valid);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -64,7 +64,7 @@
 #if !defined(MANUALLY_ALIGNED_STRUCT)
 #if defined(_MSC_VER)
 #define MANUALLY_ALIGNED_STRUCT(alignment) \
-  __pragma(pack(1));                             \
+  __pragma(pack(1));                       \
   struct __declspec(align(alignment))
 #define STRUCT_END(name, size) \
   __pragma(pack());            \
@@ -77,6 +77,6 @@
 #else
 #error Unknown compiler, please define structure alignment macros
 #endif
-#endif // !defined(MANUALLY_ALIGNED_STRUCT)
+#endif  // !defined(MANUALLY_ALIGNED_STRUCT)
 
 #endif  // ARROW_UTIL_MACROS_H


### PR DESCRIPTION
Other libraries may have null indicators in the form of bits or bytes. `std::vector<bool>` is a bit-packed container like Arrow's internal representation. 