### PR TITLE
ARROW-1452: [C++] Restore DISALLOW_COPY_AND_ASSIGN usages removed in ARROW-1452 patch

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -254,6 +254,9 @@ class ARROW_EXPORT Array {
     }
     data_ = data;
   }
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(Array);
 };
 
 static inline std::ostream& operator<<(std::ostream& os, const Array& x) {

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -79,6 +79,9 @@ class ARROW_EXPORT FileInterface {
   FileInterface() {}
   FileMode::type mode_;
   void set_mode(FileMode::type mode) { mode_ = mode; }
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(FileInterface);
 };
 
 class ARROW_EXPORT Seekable {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -157,6 +157,9 @@ class ARROW_EXPORT DataType {
  protected:
   Type::type id_;
   std::vector<std::shared_ptr<Field>> children_;
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(DataType);
 };
 
 // TODO(wesm): Remove this from parquet-cpp

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -20,8 +20,8 @@
 
 // From Google gutil
 #ifndef ARROW_DISALLOW_COPY_AND_ASSIGN
-#define ARROW_DISALLOW_COPY_AND_ASSIGN(TypeName)    \
-  TypeName(const TypeName&) = delete;               \
+#define ARROW_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  TypeName(const TypeName&) = delete;            \
   void operator=(const TypeName&) = delete
 #endif
 

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -20,9 +20,9 @@
 
 // From Google gutil
 #ifndef ARROW_DISALLOW_COPY_AND_ASSIGN
-#define ARROW_DISALLOW_COPY_AND_ASSIGN(TypeName) \
-  TypeName(const TypeName&) = delete;            \
-  TypeName& operator=(const TypeName&) = delete
+#define ARROW_DISALLOW_COPY_AND_ASSIGN(TypeName)    \
+  TypeName(const TypeName&) = delete;               \
+  void operator=(const TypeName&) = delete
 #endif
 
 #define ARROW_UNUSED(x) (void)x


### PR DESCRIPTION
Also updated the definition of DISALLOW_COPY_AND_ASSIGN to use the one from Apache Kudu, which has seen significantly more scrutiny than ours (https://github.com/apache/kudu/blob/master/src/kudu/gutil/macros.h#L96). 