### PR TITLE
ARROW-1461: [C++] Disable builds using LLVM apt repo until installation issues resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,9 +95,9 @@ matrix:
     env: ARROW_TEST_GROUP=integration
     jdk: openjdk7
     before_script:
-    - source $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
-    - export CC="clang-4.0"
-    - export CXX="clang++-4.0"
+    # - source $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
+    # - export CC="clang-4.0"
+    # - export CXX="clang++-4.0"
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_script_integration.sh

--- a/ci/travis_install_clang_tools.sh
+++ b/ci/travis_install_clang_tools.sh
@@ -19,6 +19,6 @@
 
 wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
 sudo apt-add-repository -y \
-     "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-4.0 main"
+     "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main"
 sudo apt-get update
 sudo apt-get install clang-4.0 clang-format-4.0 clang-tidy-4.0


### PR DESCRIPTION
It looks like llvm.org made some changes to their apt repository in the last 48 hours and this has been causing our builds to fail. We can re-enable builds using .deb packages from apt.llvm.org at a later time