### PR TITLE
ARROW-1405: [Python] Expose LoggingMemoryPool in Python API

### DIFF
--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -17,12 +17,13 @@
 
 #include "arrow/memory_pool.h"
 
-#include <stdlib.h>
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <mutex>
-#include <sstream>
+#include <sstream>  // IWYU pragma: keep
 
 #include "arrow/status.h"
 #include "arrow/util/logging.h"

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -17,13 +17,12 @@
 
 #include "arrow/memory_pool.h"
 
+#include <stdlib.h>
 #include <algorithm>
-#include <cerrno>
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
 #include <mutex>
-#include <sstream>  // IWYU pragma: keep
+#include <sstream>
 
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
@@ -162,20 +161,20 @@ LoggingMemoryPool::LoggingMemoryPool(MemoryPool* pool) : pool_(pool) {}
 
 Status LoggingMemoryPool::Allocate(int64_t size, uint8_t** out) {
   Status s = pool_->Allocate(size, out);
-  std::cout << "Allocate: size = " << size << " - out = " << *out << std::endl;
+  std::cout << "Allocate: size = " << size << std::endl;
   return s;
 }
 
 Status LoggingMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
   Status s = pool_->Reallocate(old_size, new_size, ptr);
-  std::cout << "Reallocate: old_size = " << old_size << " - new_size = " << new_size
-            << " - ptr = " << *ptr << std::endl;
+  std::cout << "Reallocate: old_size = " << old_size
+            << " - new_size = " << new_size << std::endl;
   return s;
 }
 
 void LoggingMemoryPool::Free(uint8_t* buffer, int64_t size) {
   pool_->Free(buffer, size);
-  std::cout << "Free: buffer = " << buffer << " - size = " << size << std::endl;
+  std::cout << "Free: size = " << size << std::endl;
 }
 
 int64_t LoggingMemoryPool::bytes_allocated() const {

--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -222,6 +222,7 @@ Memory Pools
    default_memory_pool
    total_allocated_bytes
    set_memory_pool
+   log_memory_allocations
 
 .. _api.type_classes:
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -76,9 +76,12 @@ from pyarrow.lib import (HdfsFile, NativeFile, PythonFile,
                          have_libhdfs, have_libhdfs3, MockOutputStream)
 
 from pyarrow.lib import (MemoryPool, total_allocated_bytes,
-                         set_memory_pool, default_memory_pool)
+                         set_memory_pool, default_memory_pool,
+                         log_memory_allocations)
+
 from pyarrow.lib import (ChunkedArray, Column, RecordBatch, Table,
                          concat_tables)
+
 from pyarrow.lib import (ArrowException,
                          ArrowKeyError,
                          ArrowInvalid,

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -35,10 +35,6 @@ cdef class MemoryPool:
     cdef void init(self, CMemoryPool* pool)
 
 
-cdef class LoggingMemoryPool(MemoryPool):
-    pass
-
-
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool)
 
 

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -61,6 +61,14 @@ cdef LoggingMemoryPool _logging_memory_pool = (
 
 
 def log_memory_allocations(enable=True):
+    """
+    Enable or disable memory allocator logging for debugging purposes
+
+    Parameters
+    ----------
+    enable : boolean, default True
+        Pass False to disable logging
+    """
     if enable:
         set_memory_pool(_logging_memory_pool)
     else:

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -36,7 +36,12 @@ cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool):
 
 
 cdef class LoggingMemoryPool(MemoryPool):
-    pass
+    cdef:
+        unique_ptr[CLoggingMemoryPool] logging_pool
+
+    def __cinit__(self, MemoryPool pool):
+        self.logging_pool.reset(new CLoggingMemoryPool(pool.pool))
+        self.init(self.logging_pool.get())
 
 
 def default_memory_pool():
@@ -48,6 +53,18 @@ def default_memory_pool():
 
 def set_memory_pool(MemoryPool pool):
     c_set_default_memory_pool(pool.pool)
+
+
+cdef MemoryPool _default_memory_pool = default_memory_pool()
+cdef LoggingMemoryPool _logging_memory_pool = (
+    LoggingMemoryPool(_default_memory_pool))
+
+
+def log_memory_allocations(enable=True):
+    if enable:
+        set_memory_pool(_logging_memory_pool)
+    else:
+        set_memory_pool(_default_memory_pool)
 
 
 def total_allocated_bytes():


### PR DESCRIPTION
I removed some output of pointer contents in the LoggingMemoryPool implementation which was showing up as garbage in the console. Example:

```
n [1]: import pyarrow as pa

In [2]: import pyarrow.parquet as pq

In [3]: pa.log_memory_allocations(True)

In [4]: t = pq.read_table('/home/wesm/Downloads/part-00000-6570e34b-b42c-4a39-8adf-21d3a97fb87d.snappy.parquet')
Allocate: size = 320
Allocate: size = 64
Allocate: size = 192
Free: size = 192
Allocate: size = 320
Allocate: size = 64
Allocate: size = 192
Allocate: size = 192
Allocate: size = 1152
Allocate: size = 64
Allocate: size = 64
Allocate: size = 64
Reallocate: old_size = 64 - new_size = 128
Reallocate: old_size = 128 - new_size = 192
Reallocate: old_size = 192 - new_size = 320
Reallocate: old_size = 320 - new_size = 576
Reallocate: old_size = 64 - new_size = 128
Reallocate: old_size = 576 - new_size = 1088
Reallocate: old_size = 128 - new_size = 256
```