### PR TITLE
ARROW-622 [Python] deprecate timestamps_to_ms in .from_pandas()

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -121,6 +121,8 @@ cdef class Array:
             compatibility with other functionality like Parquet I/O which
             only supports milliseconds.
 
+            .. deprecated:: 0.7.0
+
         memory_pool: MemoryPool, optional
             Specific memory pool to use to allocate the resulting Arrow array.
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -723,6 +723,9 @@ cdef class Table:
             Convert datetime columns to ms resolution. This is needed for
             compability with other functionality like Parquet I/O which
             only supports milliseconds.
+
+            .. deprecated:: 0.7.0
+
         schema : pyarrow.Schema, optional
             The expected schema of the Arrow Table. This can be used to
             indicate the type of columns if we cannot infer it automatically.


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/17438

this was not fully resolved in https://github.com/apache/arrow/pull/944 