### PR TITLE
ARROW-1467: [JAVA] Fix reset() and allocateNew() in Nullable Value Vectors t…

### DIFF
--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -269,7 +269,6 @@ protected final static byte[] emptyByteArray = new byte[]{};
 
   public void reset() {
     bits.zeroVector();
-    values.reset();
     mutator.reset();
     accessor.reset();
   }

--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -267,6 +267,13 @@ protected final static byte[] emptyByteArray = new byte[]{};
     values.reAlloc();
   }
 
+  public void reset() {
+    bits.zeroVector();
+    values.reset();
+    mutator.reset();
+    accessor.reset();
+  }
+
   <#if type.major == "VarLen">
   @Override
   public void allocateNew(int totalBytes, int valueCount) {
@@ -277,12 +284,6 @@ protected final static byte[] emptyByteArray = new byte[]{};
       clear();
       throw e;
     }
-    bits.zeroVector();
-    mutator.reset();
-    accessor.reset();
-  }
-
-  public void reset() {
     bits.zeroVector();
     mutator.reset();
     accessor.reset();
@@ -303,17 +304,11 @@ protected final static byte[] emptyByteArray = new byte[]{};
   public void allocateNew(int valueCount) {
     try {
       values.allocateNew(valueCount);
-      bits.allocateNew(valueCount+1);
+      bits.allocateNew(valueCount);
     } catch(OutOfMemoryException e) {
       clear();
       throw e;
     }
-    bits.zeroVector();
-    mutator.reset();
-    accessor.reset();
-  }
-
-  public void reset() {
     bits.zeroVector();
     mutator.reset();
     accessor.reset();


### PR DESCRIPTION
cc @jacques-n , @icexelloss , @BryanCutler 

Things fixed:

1)

allocateNew() in NullableValueVectors allocates extra memory for the validity vector of fixed-width vectors. Instead of doing bits.allocateNew(valueCount + 1), we should simply do bits.allocateNew(valueCount).

AFAIK, the only case where we need an additional valueCount is for the offsetVector and we already do that. Additional valueCount for the validity vector is not needed.

(2)

reset() method should call reset() on the underlying value vector to re-initialize the state (allocation monitor, reader index etc) and zero out the buffers. Right now we just reset the validity vector.