### PR TITLE
ARROW-1446: [Python] Add (very slow) large memory unit test for int32 overflow in PARQUET-1090

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1239,3 +1239,17 @@ def test_write_to_dataset_with_partitions(tmpdir):
 @parquet
 def test_write_to_dataset_no_partitions(tmpdir):
     _test_write_to_dataset_no_partitions(str(tmpdir))
+
+
+@pytest.mark.large_memory
+@parquet
+def test_large_table_int32_overflow():
+    size = np.iinfo('int32').max + 1
+
+    arr = np.ones(size, dtype='uint8')
+
+    parr = pa.Array.from_pandas(arr, type=pa.uint8())
+
+    table = pa.Table.from_arrays([parr], names=['one'])
+    f = io.BytesIO()
+    _write_table(table, f)


### PR DESCRIPTION
Bug fixed in https://github.com/apache/parquet-cpp/pull/389