### PR TITLE
ARROW-1156: [C++/Python] Expand casting API, add UnaryKernel callable. Use Cast in appropriate places when converting from pandas

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -126,6 +126,9 @@ interfaces in this library as needed.
 The CUDA toolchain used to build the library can be customized by using the
 `$CUDA_HOME` environment variable.
 
+This library is still in Alpha stages, and subject to API changes without
+deprecation warnings.
+
 ### API documentation
 
 To generate the (html) API documentation, run the following command in the apidoc

--- a/cpp/build-support/iwyu/mappings/arrow-misc.imp
+++ b/cpp/build-support/iwyu/mappings/arrow-misc.imp
@@ -24,9 +24,10 @@
   { symbol: ["uint8_t", private, "<cstdint>", public ] },
   { symbol: ["_Node_const_iterator", private, "<flatbuffers/flatbuffers.h>", public ] },
   { symbol: ["unordered_map<>::mapped_type", private, "<flatbuffers/flatbuffers.h>", public ] },
-  { symbol: ["__alloc_traits<>::value_type", private, "<vector>", public ] },
   { symbol: ["move", private, "<utility>", public ] },
   { symbol: ["pair", private, "<utility>", public ] },
   { symbol: ["errno", private, "<cerrno>", public ] },
-  { symbol: ["posix_memalign", private, "<cstdlib>", public ] }
+  { symbol: ["posix_memalign", private, "<cstdlib>", public ] },
+  { include: ["<ext/alloc_traits.h>", private, "<vector>", public ] },
+  { include: ["<string.h>", private, "<cstring>", public ] }
 ]

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -88,47 +88,47 @@ struct ARROW_EXPORT ArrayData {
   ArrayData() {}
 
   ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
+            int64_t null_count = kUnknownNullCount, int64_t offset = 0)
+      : type(type), length(length), null_count(null_count), offset(offset) {}
+
+  ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
             const std::vector<std::shared_ptr<Buffer>>& buffers,
             int64_t null_count = kUnknownNullCount, int64_t offset = 0)
-      : type(type),
-        length(length),
-        buffers(buffers),
-        null_count(null_count),
-        offset(offset) {}
+      : ArrayData(type, length, null_count, offset) {
+    this->buffers = buffers;
+  }
 
   ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
             std::vector<std::shared_ptr<Buffer>>&& buffers,
             int64_t null_count = kUnknownNullCount, int64_t offset = 0)
-      : type(type),
-        length(length),
-        buffers(std::move(buffers)),
-        null_count(null_count),
-        offset(offset) {}
+      : ArrayData(type, length, null_count, offset) {
+    this->buffers = std::move(buffers);
+  }
 
   // Move constructor
   ArrayData(ArrayData&& other) noexcept
       : type(std::move(other.type)),
         length(other.length),
-        buffers(std::move(other.buffers)),
         null_count(other.null_count),
         offset(other.offset),
+        buffers(std::move(other.buffers)),
         child_data(std::move(other.child_data)) {}
 
   ArrayData(const ArrayData& other) noexcept
       : type(other.type),
         length(other.length),
-        buffers(other.buffers),
         null_count(other.null_count),
         offset(other.offset),
+        buffers(other.buffers),
         child_data(other.child_data) {}
 
   // Move assignment
   ArrayData& operator=(ArrayData&& other) {
     type = std::move(other.type);
     length = other.length;
-    buffers = std::move(other.buffers);
     null_count = other.null_count;
     offset = other.offset;
+    buffers = std::move(other.buffers);
     child_data = std::move(other.child_data);
     return *this;
   }
@@ -139,9 +139,9 @@ struct ARROW_EXPORT ArrayData {
 
   std::shared_ptr<DataType> type;
   int64_t length;
-  std::vector<std::shared_ptr<Buffer>> buffers;
   int64_t null_count;
   int64_t offset;
+  std::vector<std::shared_ptr<Buffer>> buffers;
   std::vector<std::shared_ptr<ArrayData>> child_data;
 };
 

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -19,6 +19,7 @@
 install(FILES
   cast.h
   context.h
+  kernel.h
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/compute")
 
 #######################################

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 # Headers: top level
 install(FILES
+  api.h
   cast.h
   context.h
   kernel.h

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_COMPUTE_API_H
+#define ARROW_COMPUTE_API_H
+
+#include "arrow/compute/cast.h"
+#include "arrow/compute/context.h"
+#include "arrow/compute/kernel.h"
+
+#endif  // ARROW_COMPUTE_API_H

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -24,10 +24,12 @@
 #include <sstream>
 #include <type_traits>
 
+#include "arrow/array.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/logging.h"
 
 #include "arrow/compute/context.h"
+#include "arrow/compute/kernel.h"
 
 namespace arrow {
 namespace compute {
@@ -64,14 +66,12 @@ struct CastFunctor {};
 // Indicated no computation required
 template <typename O, typename I>
 struct CastFunctor<O, I, typename std::enable_if<is_zero_copy_cast<O, I>::value>::type> {
-  void operator()(FunctionContext* ctx, const CastOptions& options,
-                  const ArrayData& input, ArrayData* output) {
-    output->type = input.type;
-    output->buffers = input.buffers;
-    output->length = input.length;
-    output->offset = input.offset;
-    output->null_count = input.null_count;
-    output->child_data = input.child_data;
+  void operator()(FunctionContext* ctx, const CastOptions& options, const Array& input,
+                  ArrayData* output) {
+    auto in_data = input.data();
+    output->null_count = input.null_count();
+    output->buffers = in_data->buffers;
+    output->child_data = in_data->child_data;
   }
 };
 
@@ -79,10 +79,10 @@ struct CastFunctor<O, I, typename std::enable_if<is_zero_copy_cast<O, I>::value>
 // Null to other things
 
 template <typename T>
-struct CastFunctor<T, NullType,
-                   typename std::enable_if<std::is_base_of<FixedWidthType, T>::value>::type> {
-  void operator()(FunctionContext* ctx, const CastOptions& options,
-                  const ArrayData& input, ArrayData* output) {
+struct CastFunctor<T, NullType, typename std::enable_if<
+                                    std::is_base_of<FixedWidthType, T>::value>::type> {
+  void operator()(FunctionContext* ctx, const CastOptions& options, const Array& input,
+                  ArrayData* output) {
     // Simply initialize data to 0
     auto buf = output->buffers[1];
     memset(buf->mutable_data(), 0, buf->size());
@@ -96,14 +96,14 @@ struct CastFunctor<T, NullType,
 template <typename T>
 struct CastFunctor<T, BooleanType,
                    typename std::enable_if<std::is_base_of<Number, T>::value>::type> {
-  void operator()(FunctionContext* ctx, const CastOptions& options,
-                  const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options, const Array& input,
+                  ArrayData* output) {
     using c_type = typename T::c_type;
-    const uint8_t* data = input.buffers[1]->data();
+    const uint8_t* data = input.data()->buffers[1]->data();
     auto out = reinterpret_cast<c_type*>(output->buffers[1]->mutable_data());
     constexpr auto kOne = static_cast<c_type>(1);
     constexpr auto kZero = static_cast<c_type>(0);
-    for (int64_t i = 0; i < input.length; ++i) {
+    for (int64_t i = 0; i < input.length(); ++i) {
       *out++ = BitUtil::GetBit(data, i) ? kOne : kZero;
     }
   }
@@ -146,12 +146,12 @@ template <typename O, typename I>
 struct CastFunctor<O, I, typename std::enable_if<std::is_same<BooleanType, O>::value &&
                                                  std::is_base_of<Number, I>::value &&
                                                  !std::is_same<O, I>::value>::type> {
-  void operator()(FunctionContext* ctx, const CastOptions& options,
-                  const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options, const Array& input,
+                  ArrayData* output) {
     using in_type = typename I::c_type;
-    auto in_data = reinterpret_cast<const in_type*>(input.buffers[1]->data());
+    auto in_data = reinterpret_cast<const in_type*>(input.data()->buffers[1]->data());
     uint8_t* out_data = reinterpret_cast<uint8_t*>(output->buffers[1]->mutable_data());
-    for (int64_t i = 0; i < input.length; ++i) {
+    for (int64_t i = 0; i < input.length(); ++i) {
       BitUtil::SetBitTo(out_data, i, (*in_data++) != 0);
     }
   }
@@ -160,24 +160,26 @@ struct CastFunctor<O, I, typename std::enable_if<std::is_same<BooleanType, O>::v
 template <typename O, typename I>
 struct CastFunctor<O, I,
                    typename std::enable_if<is_integer_downcast<O, I>::value>::type> {
-  void operator()(FunctionContext* ctx, const CastOptions& options,
-                  const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options, const Array& input,
+                  ArrayData* output) {
     using in_type = typename I::c_type;
     using out_type = typename O::c_type;
 
-    auto in_offset = input.offset;
+    auto in_offset = input.offset();
 
-    auto in_data = reinterpret_cast<const in_type*>(input.buffers[1]->data()) + in_offset;
+    const auto& input_buffers = input.data()->buffers;
+
+    auto in_data = reinterpret_cast<const in_type*>(input_buffers[1]->data()) + in_offset;
     auto out_data = reinterpret_cast<out_type*>(output->buffers[1]->mutable_data());
 
     if (!options.allow_int_overflow) {
       constexpr in_type kMax = static_cast<in_type>(std::numeric_limits<out_type>::max());
       constexpr in_type kMin = static_cast<in_type>(std::numeric_limits<out_type>::min());
 
-      if (input.null_count > 0) {
-        const uint8_t* is_valid = input.buffers[0]->data();
+      if (input.null_count() > 0) {
+        const uint8_t* is_valid = input_buffers[0]->data();
         int64_t is_valid_offset = in_offset;
-        for (int64_t i = 0; i < input.length; ++i) {
+        for (int64_t i = 0; i < input.length(); ++i) {
           if (ARROW_PREDICT_FALSE(BitUtil::GetBit(is_valid, is_valid_offset++) &&
                                   (*in_data > kMax || *in_data < kMin))) {
             ctx->SetStatus(Status::Invalid("Integer value out of bounds"));
@@ -185,7 +187,7 @@ struct CastFunctor<O, I,
           *out_data++ = static_cast<out_type>(*in_data++);
         }
       } else {
-        for (int64_t i = 0; i < input.length; ++i) {
+        for (int64_t i = 0; i < input.length(); ++i) {
           if (ARROW_PREDICT_FALSE(*in_data > kMax || *in_data < kMin)) {
             ctx->SetStatus(Status::Invalid("Integer value out of bounds"));
           }
@@ -193,7 +195,7 @@ struct CastFunctor<O, I,
         }
       }
     } else {
-      for (int64_t i = 0; i < input.length; ++i) {
+      for (int64_t i = 0; i < input.length(); ++i) {
         *out_data++ = static_cast<out_type>(*in_data++);
       }
     }
@@ -204,14 +206,14 @@ template <typename O, typename I>
 struct CastFunctor<O, I,
                    typename std::enable_if<is_numeric_cast<O, I>::value &&
                                            !is_integer_downcast<O, I>::value>::type> {
-  void operator()(FunctionContext* ctx, const CastOptions& options,
-                  const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options, const Array& input,
+                  ArrayData* output) {
     using in_type = typename I::c_type;
     using out_type = typename O::c_type;
 
-    auto in_data = reinterpret_cast<const in_type*>(input.buffers[1]->data());
+    auto in_data = reinterpret_cast<const in_type*>(input.data()->buffers[1]->data());
     auto out_data = reinterpret_cast<out_type*>(output->buffers[1]->mutable_data());
-    for (int64_t i = 0; i < input.length; ++i) {
+    for (int64_t i = 0; i < input.length(); ++i) {
       *out_data++ = static_cast<out_type>(*in_data++);
     }
   }
@@ -219,31 +221,38 @@ struct CastFunctor<O, I,
 
 // ----------------------------------------------------------------------
 
-CastKernel::CastKernel(const CastOptions& options, const CastFunction& func,
-                       bool is_zero_copy)
-    : options_(options), func_(func), is_zero_copy_(is_zero_copy) {}
+typedef std::function<void(FunctionContext*, const CastOptions& options, const Array&,
+                           ArrayData*)>
+    CastFunction;
 
-static Status AllocateLike(FunctionContext* ctx, const ArrayData& in_data,
-                           ArrayData* out) {
+static Status AllocateIfNotPreallocated(FunctionContext* ctx, const Array& input,
+                                        ArrayData* out) {
   if (!is_primitive(out->type->id())) {
     return Status::NotImplemented(out->type->ToString());
   }
 
   const auto& fw_type = static_cast<const FixedWidthType&>(*out->type);
 
-  out->null_count = in_data.null_count;
+  const int64_t length = input.length();
 
-  // Propagate null bitmap
-  // TODO(wesm): handling null bitmap when input type is NullType
-  out->buffers.clear();
+  out->null_count = input.null_count();
 
   // Propagate bitmap unless we are null type
-  std::shared_ptr<Buffer> validity_bitmap = in_data.buffers[0];
-  if (in_data.type->id() == Type::NA) {
-    int64_t bitmap_size = BitUtil::BytesForBits(in_data.length);
+  std::shared_ptr<Buffer> validity_bitmap = input.data()->buffers[0];
+  if (input.type_id() == Type::NA) {
+    int64_t bitmap_size = BitUtil::BytesForBits(length);
     RETURN_NOT_OK(ctx->Allocate(bitmap_size, &validity_bitmap));
     memset(validity_bitmap->mutable_data(), 0, bitmap_size);
   }
+
+  if (out->buffers.size() == 2) {
+    // Assuming preallocated, propagage bitmap and move on
+    out->buffers[0] = validity_bitmap;
+    return Status::OK();
+  } else {
+    DCHECK_EQ(0, out->buffers.size());
+  }
+
   out->buffers.push_back(validity_bitmap);
 
   std::shared_ptr<Buffer> out_data;
@@ -252,9 +261,9 @@ static Status AllocateLike(FunctionContext* ctx, const ArrayData& in_data,
   int64_t buffer_size = 0;
 
   if (bit_width == 1) {
-    buffer_size = BitUtil::BytesForBits(in_data.length);
+    buffer_size = BitUtil::BytesForBits(length);
   } else if (bit_width % 8 == 0) {
-    buffer_size = in_data.length * fw_type.bit_width() / 8;
+    buffer_size = length * fw_type.bit_width() / 8;
   } else {
     DCHECK(false);
   }
@@ -267,26 +276,34 @@ static Status AllocateLike(FunctionContext* ctx, const ArrayData& in_data,
   return Status::OK();
 }
 
-void CastKernel::operator()(FunctionContext* ctx, const ArrayData& input,
-                            ArrayData* out) {
-  if (!is_zero_copy_) {
-    Status s = AllocateLike(ctx, input, out);
-    if (ARROW_PREDICT_FALSE(!s.ok())) {
-      ctx->SetStatus(s);
-      return;
-    }
-  }
-  func_(ctx, options_, input, out);
-}
+class CastKernel : public UnaryKernel {
+ public:
+  CastKernel(const CastOptions& options, const CastFunction& func, bool is_zero_copy)
+      : options_(options), func_(func), is_zero_copy_(is_zero_copy) {}
 
-#define CAST_CASE(InType, OutType)                                                      \
-  case OutType::type_id:                                                                \
-    is_zero_copy = is_zero_copy_cast<OutType, InType>::value;                           \
-    func = [](FunctionContext* ctx, const CastOptions& options, const ArrayData& input, \
-              ArrayData* out) {                                                         \
-      CastFunctor<OutType, InType> func;                                                \
-      func(ctx, options, input, out);                                                   \
-    };                                                                                  \
+  Status Call(FunctionContext* ctx, const Array& input, ArrayData* out) override {
+    if (!is_zero_copy_) {
+      RETURN_NOT_OK(AllocateIfNotPreallocated(ctx, input, out));
+    }
+    func_(ctx, options_, input, out);
+    RETURN_IF_ERROR(ctx);
+    return Status::OK();
+  }
+
+ private:
+  CastOptions options_;
+  CastFunction func_;
+  bool is_zero_copy_;
+};
+
+#define CAST_CASE(InType, OutType)                                                  \
+  case OutType::type_id:                                                            \
+    is_zero_copy = is_zero_copy_cast<OutType, InType>::value;                       \
+    func = [](FunctionContext* ctx, const CastOptions& options, const Array& input, \
+              ArrayData* out) {                                                     \
+      CastFunctor<OutType, InType> func;                                            \
+      func(ctx, options, input, out);                                               \
+    };                                                                              \
     break;
 
 #define NUMERIC_CASES(FN, IN_TYPE) \
@@ -302,12 +319,12 @@ void CastKernel::operator()(FunctionContext* ctx, const ArrayData& input,
   FN(IN_TYPE, FloatType);          \
   FN(IN_TYPE, DoubleType);
 
-#define NULL_CASES(FN, IN_TYPE)                 \
-  NUMERIC_CASES(FN, IN_TYPE)                    \
-  FN(NullType, Time32Type);                     \
-  FN(NullType, Date32Type);                     \
-  FN(NullType, TimestampType);                  \
-  FN(NullType, Time64Type);                     \
+#define NULL_CASES(FN, IN_TYPE) \
+  NUMERIC_CASES(FN, IN_TYPE)    \
+  FN(NullType, Time32Type);     \
+  FN(NullType, Date32Type);     \
+  FN(NullType, TimestampType);  \
+  FN(NullType, Time64Type);     \
   FN(NullType, Date64Type);
 
 #define INT32_CASES(FN, IN_TYPE) \
@@ -331,20 +348,20 @@ void CastKernel::operator()(FunctionContext* ctx, const ArrayData& input,
 
 #define TIMESTAMP_CASES(FN, IN_TYPE) FN(TimestampType, TimestampType);
 
-#define GET_CAST_FUNCTION(CASE_GENERATOR, InType)                                      \
-  static std::unique_ptr<CastKernel> Get##InType##CastFunc(                            \
-      const std::shared_ptr<DataType>& out_type, const CastOptions& options) {         \
-    CastFunction func;                                                                 \
-    bool is_zero_copy = false;                                                         \
-    switch (out_type->id()) {                                                          \
-      CASE_GENERATOR(CAST_CASE, InType);                                               \
-      default:                                                                         \
-        break;                                                                         \
-    }                                                                                  \
-    if (func != nullptr) {                                                             \
-      return std::unique_ptr<CastKernel>(new CastKernel(options, func, is_zero_copy)); \
-    }                                                                                  \
-    return nullptr;                                                                    \
+#define GET_CAST_FUNCTION(CASE_GENERATOR, InType)                                       \
+  static std::unique_ptr<UnaryKernel> Get##InType##CastFunc(                            \
+      const std::shared_ptr<DataType>& out_type, const CastOptions& options) {          \
+    CastFunction func;                                                                  \
+    bool is_zero_copy = false;                                                          \
+    switch (out_type->id()) {                                                           \
+      CASE_GENERATOR(CAST_CASE, InType);                                                \
+      default:                                                                          \
+        break;                                                                          \
+    }                                                                                   \
+    if (func != nullptr) {                                                              \
+      return std::unique_ptr<UnaryKernel>(new CastKernel(options, func, is_zero_copy)); \
+    }                                                                                   \
+    return nullptr;                                                                     \
   }
 
 GET_CAST_FUNCTION(NULL_CASES, NullType);
@@ -371,7 +388,7 @@ GET_CAST_FUNCTION(TIMESTAMP_CASES, TimestampType);
     break
 
 Status GetCastFunction(const DataType& in_type, const std::shared_ptr<DataType>& out_type,
-                       const CastOptions& options, std::unique_ptr<CastKernel>* kernel) {
+                       const CastOptions& options, std::unique_ptr<UnaryKernel>* kernel) {
   switch (in_type.id()) {
     CAST_FUNCTION_CASE(NullType);
     CAST_FUNCTION_CASE(BooleanType);
@@ -406,21 +423,13 @@ Status Cast(FunctionContext* ctx, const Array& array,
             const std::shared_ptr<DataType>& out_type, const CastOptions& options,
             std::shared_ptr<Array>* out) {
   // Dynamic dispatch to obtain right cast function
-  std::unique_ptr<CastKernel> func;
+  std::unique_ptr<UnaryKernel> func;
   RETURN_NOT_OK(GetCastFunction(*array.type(), out_type, options, &func));
 
-  // TODO(wesm): Must force computation of unknown null counts
-  ARROW_UNUSED(array.null_count());
-
   // Allocate memory for output
-  auto out_data = std::make_shared<ArrayData>();
-  out_data->type = out_type;
-  out_data->length = array.length();
-  out_data->offset = 0;
+  auto out_data = std::make_shared<ArrayData>(out_type, array.length());
 
-  (*func)(ctx, *array.data(), out_data.get());
-
-  RETURN_IF_ERROR(ctx);
+  RETURN_NOT_OK(func->Call(ctx, array, out_data.get()));
   return internal::MakeArray(out_data, out);
 }
 

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -32,20 +32,40 @@
 namespace arrow {
 namespace compute {
 
-struct CastContext {
-  FunctionContext* func_ctx;
-  CastOptions options;
+// ----------------------------------------------------------------------
+// Zero copy casts
+
+template <typename O, typename I, typename Enable = void>
+struct is_zero_copy_cast {
+  static constexpr bool value = false;
 };
 
-typedef std::function<void(CastContext*, const ArrayData&, ArrayData*)> CastFunction;
+template <typename O, typename I>
+struct is_zero_copy_cast<O, I, typename std::enable_if<std::is_same<I, O>::value>::type> {
+  static constexpr bool value = true;
+};
+
+// From integers to date/time types with zero copy
+template <typename O, typename I>
+struct is_zero_copy_cast<
+    O, I, typename std::enable_if<std::is_base_of<Integer, I>::value &&
+                                  (std::is_base_of<TimeType, O>::value ||
+                                   std::is_base_of<DateType, O>::value ||
+                                   std::is_base_of<TimestampType, O>::value)>::type> {
+  using O_T = typename O::c_type;
+  using I_T = typename I::c_type;
+
+  static constexpr bool value = sizeof(O_T) == sizeof(I_T);
+};
 
 template <typename OutType, typename InType, typename Enable = void>
 struct CastFunctor {};
 
-// Type is the same, no computation required
+// Indicated no computation required
 template <typename O, typename I>
-struct CastFunctor<O, I, typename std::enable_if<std::is_same<I, O>::value>::type> {
-  void operator()(CastContext* ctx, const ArrayData& input, ArrayData* output) {
+struct CastFunctor<O, I, typename std::enable_if<is_zero_copy_cast<O, I>::value>::type> {
+  void operator()(FunctionContext* ctx, const CastOptions& options,
+                  const ArrayData& input, ArrayData* output) {
     output->type = input.type;
     output->buffers = input.buffers;
     output->length = input.length;
@@ -61,8 +81,9 @@ struct CastFunctor<O, I, typename std::enable_if<std::is_same<I, O>::value>::typ
 template <typename T>
 struct CastFunctor<T, NullType,
                    typename std::enable_if<!std::is_same<T, NullType>::value>::type> {
-  void operator()(CastContext* ctx, const ArrayData& input, ArrayData* output) {
-    ctx->func_ctx->SetStatus(Status::NotImplemented("NullType"));
+  void operator()(FunctionContext* ctx, const CastOptions& options,
+                  const ArrayData& input, ArrayData* output) {
+    ctx->SetStatus(Status::NotImplemented("NullType"));
   }
 };
 
@@ -73,7 +94,8 @@ struct CastFunctor<T, NullType,
 template <typename T>
 struct CastFunctor<T, BooleanType,
                    typename std::enable_if<std::is_base_of<Number, T>::value>::type> {
-  void operator()(CastContext* ctx, const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options,
+                  const ArrayData& input, ArrayData* output) {
     using c_type = typename T::c_type;
     const uint8_t* data = input.buffers[1]->data();
     auto out = reinterpret_cast<c_type*>(output->buffers[1]->mutable_data());
@@ -122,7 +144,8 @@ template <typename O, typename I>
 struct CastFunctor<O, I, typename std::enable_if<std::is_same<BooleanType, O>::value &&
                                                  std::is_base_of<Number, I>::value &&
                                                  !std::is_same<O, I>::value>::type> {
-  void operator()(CastContext* ctx, const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options,
+                  const ArrayData& input, ArrayData* output) {
     using in_type = typename I::c_type;
     auto in_data = reinterpret_cast<const in_type*>(input.buffers[1]->data());
     uint8_t* out_data = reinterpret_cast<uint8_t*>(output->buffers[1]->mutable_data());
@@ -135,7 +158,8 @@ struct CastFunctor<O, I, typename std::enable_if<std::is_same<BooleanType, O>::v
 template <typename O, typename I>
 struct CastFunctor<O, I,
                    typename std::enable_if<is_integer_downcast<O, I>::value>::type> {
-  void operator()(CastContext* ctx, const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options,
+                  const ArrayData& input, ArrayData* output) {
     using in_type = typename I::c_type;
     using out_type = typename O::c_type;
 
@@ -144,7 +168,7 @@ struct CastFunctor<O, I,
     auto in_data = reinterpret_cast<const in_type*>(input.buffers[1]->data()) + in_offset;
     auto out_data = reinterpret_cast<out_type*>(output->buffers[1]->mutable_data());
 
-    if (!ctx->options.allow_int_overflow) {
+    if (!options.allow_int_overflow) {
       constexpr in_type kMax = static_cast<in_type>(std::numeric_limits<out_type>::max());
       constexpr in_type kMin = static_cast<in_type>(std::numeric_limits<out_type>::min());
 
@@ -154,14 +178,14 @@ struct CastFunctor<O, I,
         for (int64_t i = 0; i < input.length; ++i) {
           if (ARROW_PREDICT_FALSE(BitUtil::GetBit(is_valid, is_valid_offset++) &&
                                   (*in_data > kMax || *in_data < kMin))) {
-            ctx->func_ctx->SetStatus(Status::Invalid("Integer value out of bounds"));
+            ctx->SetStatus(Status::Invalid("Integer value out of bounds"));
           }
           *out_data++ = static_cast<out_type>(*in_data++);
         }
       } else {
         for (int64_t i = 0; i < input.length; ++i) {
           if (ARROW_PREDICT_FALSE(*in_data > kMax || *in_data < kMin)) {
-            ctx->func_ctx->SetStatus(Status::Invalid("Integer value out of bounds"));
+            ctx->SetStatus(Status::Invalid("Integer value out of bounds"));
           }
           *out_data++ = static_cast<out_type>(*in_data++);
         }
@@ -178,7 +202,8 @@ template <typename O, typename I>
 struct CastFunctor<O, I,
                    typename std::enable_if<is_numeric_cast<O, I>::value &&
                                            !is_integer_downcast<O, I>::value>::type> {
-  void operator()(CastContext* ctx, const ArrayData& input, ArrayData* output) {
+  void operator()(FunctionContext* ctx, const CastOptions& options,
+                  const ArrayData& input, ArrayData* output) {
     using in_type = typename I::c_type;
     using out_type = typename O::c_type;
 
@@ -192,12 +217,67 @@ struct CastFunctor<O, I,
 
 // ----------------------------------------------------------------------
 
-#define CAST_CASE(InType, OutType)                                            \
-  case OutType::type_id:                                                      \
-    return [type](CastContext* ctx, const ArrayData& input, ArrayData* out) { \
-      CastFunctor<OutType, InType> func;                                      \
-      func(ctx, input, out);                                                  \
+CastKernel::CastKernel(const CastOptions& options, const CastFunction& func,
+                       bool is_zero_copy)
+    : options_(options), func_(func), is_zero_copy_(is_zero_copy) {}
+
+static Status AllocateLike(FunctionContext* ctx, const ArrayData& in_data,
+                           ArrayData* out) {
+  if (!is_primitive(out->type->id())) {
+    return Status::NotImplemented(out->type->ToString());
+  }
+
+  const auto& fw_type = static_cast<const FixedWidthType&>(*out->type);
+
+  out->null_count = in_data.null_count;
+
+  // Propagate null bitmap
+  // TODO(wesm): handling null bitmap when input type is NullType
+  out->buffers.clear();
+  out->buffers.push_back(in_data.buffers[0]);
+
+  std::shared_ptr<Buffer> out_data;
+
+  int bit_width = fw_type.bit_width();
+  int64_t buffer_size = 0;
+
+  if (bit_width == 1) {
+    buffer_size = BitUtil::BytesForBits(in_data.length);
+  } else if (bit_width % 8 == 0) {
+    buffer_size = in_data.length * fw_type.bit_width() / 8;
+  } else {
+    DCHECK(false);
+  }
+
+  RETURN_NOT_OK(ctx->Allocate(buffer_size, &out_data));
+  memset(out_data->mutable_data(), 0, buffer_size);
+
+  out->buffers.push_back(out_data);
+
+  return Status::OK();
+}
+
+void CastKernel::operator()(FunctionContext* ctx, const ArrayData& input,
+                            ArrayData* out) {
+  if (!is_zero_copy_) {
+    Status s = AllocateLike(ctx, input, out);
+    if (ARROW_PREDICT_FALSE(!s.ok())) {
+      ctx->SetStatus(s);
+      return;
     }
+  }
+  func_(ctx, options_, input, out);
+}
+
+#define CAST_CASE(InType, OutType)                                                      \
+  case OutType::type_id:                                                                \
+    is_zero_copy = is_zero_copy_cast<OutType, InType>::value;                           \
+    func = [](FunctionContext* ctx, const CastOptions& options, const ArrayData& input, \
+              ArrayData* out) {                                                         \
+      CastFunctor<OutType, InType> func;                                                \
+      func(ctx, options, input, out);                                                   \
+    };                                                                                  \
+    break;
 
 #define NUMERIC_CASES(FN, IN_TYPE) \
   FN(IN_TYPE, BooleanType);        \
@@ -212,36 +292,67 @@ struct CastFunctor<O, I,
   FN(IN_TYPE, FloatType);          \
   FN(IN_TYPE, DoubleType);
 
-#define GET_CAST_FUNCTION(CapType)                                                    \
-  static CastFunction Get##CapType##CastFunc(const std::shared_ptr<DataType>& type) { \
-    switch (type->id()) {                                                             \
-      NUMERIC_CASES(CAST_CASE, CapType);                                              \
-      default:                                                                        \
-        break;                                                                        \
-    }                                                                                 \
-    return nullptr;                                                                   \
+#define INT32_CASES(FN, IN_TYPE) \
+  NUMERIC_CASES(FN, IN_TYPE)     \
+  FN(Int32Type, Time32Type);     \
+  FN(Int32Type, Date32Type);
+
+#define INT64_CASES(FN, IN_TYPE) \
+  NUMERIC_CASES(FN, IN_TYPE)     \
+  FN(Int64Type, TimestampType);  \
+  FN(Int64Type, Time64Type);     \
+  FN(Int64Type, Date64Type);
+
+#define DATE32_CASES(FN, IN_TYPE) FN(Date32Type, Date32Type);
+
+#define DATE64_CASES(FN, IN_TYPE) FN(Date64Type, Date64Type);
+
+#define TIME32_CASES(FN, IN_TYPE) FN(Time32Type, Time32Type);
+
+#define TIME64_CASES(FN, IN_TYPE) FN(Time64Type, Time64Type);
+
+#define TIMESTAMP_CASES(FN, IN_TYPE) FN(TimestampType, TimestampType);
+
+#define GET_CAST_FUNCTION(CASE_GENERATOR, InType)                                      \
+  static std::unique_ptr<CastKernel> Get##InType##CastFunc(                            \
+      const std::shared_ptr<DataType>& out_type, const CastOptions& options) {         \
+    CastFunction func;                                                                 \
+    bool is_zero_copy = false;                                                         \
+    switch (out_type->id()) {                                                          \
+      CASE_GENERATOR(CAST_CASE, InType);                                               \
+      default:                                                                         \
+        break;                                                                         \
+    }                                                                                  \
+    if (func != nullptr) {                                                             \
+      return std::unique_ptr<CastKernel>(new CastKernel(options, func, is_zero_copy)); \
+    }                                                                                  \
+    return nullptr;                                                                    \
   }
 
-#define CAST_FUNCTION_CASE(CapType)          \
-  case CapType::type_id:                     \
-    *out = Get##CapType##CastFunc(out_type); \
+GET_CAST_FUNCTION(NUMERIC_CASES, BooleanType);
+GET_CAST_FUNCTION(NUMERIC_CASES, UInt8Type);
+GET_CAST_FUNCTION(NUMERIC_CASES, Int8Type);
+GET_CAST_FUNCTION(NUMERIC_CASES, UInt16Type);
+GET_CAST_FUNCTION(NUMERIC_CASES, Int16Type);
+GET_CAST_FUNCTION(NUMERIC_CASES, UInt32Type);
+GET_CAST_FUNCTION(INT32_CASES, Int32Type);
+GET_CAST_FUNCTION(NUMERIC_CASES, UInt64Type);
+GET_CAST_FUNCTION(INT64_CASES, Int64Type);
+GET_CAST_FUNCTION(NUMERIC_CASES, FloatType);
+GET_CAST_FUNCTION(NUMERIC_CASES, DoubleType);
+GET_CAST_FUNCTION(DATE32_CASES, Date32Type);
+GET_CAST_FUNCTION(DATE64_CASES, Date64Type);
+GET_CAST_FUNCTION(TIME32_CASES, Time32Type);
+GET_CAST_FUNCTION(TIME64_CASES, Time64Type);
+GET_CAST_FUNCTION(TIMESTAMP_CASES, TimestampType);
+
+#define CAST_FUNCTION_CASE(InType)                      \
+  case InType::type_id:                                 \
+    *kernel = Get##InType##CastFunc(out_type, options); \
     break
 
-GET_CAST_FUNCTION(BooleanType);
-GET_CAST_FUNCTION(UInt8Type);
-GET_CAST_FUNCTION(Int8Type);
-GET_CAST_FUNCTION(UInt16Type);
-GET_CAST_FUNCTION(Int16Type);
-GET_CAST_FUNCTION(UInt32Type);
-GET_CAST_FUNCTION(Int32Type);
-GET_CAST_FUNCTION(UInt64Type);
-GET_CAST_FUNCTION(Int64Type);
-GET_CAST_FUNCTION(FloatType);
-GET_CAST_FUNCTION(DoubleType);
-
-static Status GetCastFunction(const DataType& in_type,
-                              const std::shared_ptr<DataType>& out_type,
-                              CastFunction* out) {
+Status GetCastFunction(const DataType& in_type, const std::shared_ptr<DataType>& out_type,
+                       const CastOptions& options, std::unique_ptr<CastKernel>* kernel) {
   switch (in_type.id()) {
     CAST_FUNCTION_CASE(BooleanType);
     CAST_FUNCTION_CASE(UInt8Type);
@@ -254,10 +365,15 @@ static Status GetCastFunction(const DataType& in_type,
     CAST_FUNCTION_CASE(Int64Type);
     CAST_FUNCTION_CASE(FloatType);
     CAST_FUNCTION_CASE(DoubleType);
+    CAST_FUNCTION_CASE(Date32Type);
+    CAST_FUNCTION_CASE(Date64Type);
+    CAST_FUNCTION_CASE(Time32Type);
+    CAST_FUNCTION_CASE(Time64Type);
+    CAST_FUNCTION_CASE(TimestampType);
     default:
       break;
   }
-  if (*out == nullptr) {
+  if (*kernel == nullptr) {
     std::stringstream ss;
     ss << "No cast implemented from " << in_type.ToString() << " to "
        << out_type->ToString();
@@ -266,63 +382,26 @@ static Status GetCastFunction(const DataType& in_type,
   return Status::OK();
 }
 
-static Status AllocateLike(FunctionContext* ctx, const Array& array,
-                           const std::shared_ptr<DataType>& out_type,
-                           std::shared_ptr<ArrayData>* out) {
-  if (!is_primitive(out_type->id())) {
-    return Status::NotImplemented(out_type->ToString());
-  }
-
-  const auto& fw_type = static_cast<const FixedWidthType&>(*out_type);
-
-  auto result = std::make_shared<ArrayData>();
-  result->type = out_type;
-  result->length = array.length();
-  result->offset = 0;
-  result->null_count = array.null_count();
-
-  // Propagate null bitmap
-  // TODO(wesm): handling null bitmap when input type is NullType
-  result->buffers.push_back(array.data()->buffers[0]);
-
-  std::shared_ptr<Buffer> out_data;
-
-  int bit_width = fw_type.bit_width();
-
-  if (bit_width == 1) {
-    RETURN_NOT_OK(ctx->Allocate(BitUtil::BytesForBits(array.length()), &out_data));
-  } else if (bit_width % 8 == 0) {
-    RETURN_NOT_OK(ctx->Allocate(array.length() * fw_type.bit_width() / 8, &out_data));
-  } else {
-    DCHECK(false);
-  }
-  result->buffers.push_back(out_data);
-
-  *out = result;
-  return Status::OK();
-}
-
-static Status Cast(CastContext* cast_ctx, const Array& array,
-                   const std::shared_ptr<DataType>& out_type,
-                   std::shared_ptr<Array>* out) {
-  // Dynamic dispatch to obtain right cast function
-  CastFunction func;
-  RETURN_NOT_OK(GetCastFunction(*array.type(), out_type, &func));
-
-  // Allocate memory for output
-  std::shared_ptr<ArrayData> out_data;
-  RETURN_NOT_OK(AllocateLike(cast_ctx->func_ctx, array, out_type, &out_data));
-
-  func(cast_ctx, *array.data(), out_data.get());
-  RETURN_IF_ERROR(cast_ctx->func_ctx);
-  return internal::MakeArray(out_data, out);
-}
-
 Status Cast(FunctionContext* ctx, const Array& array,
             const std::shared_ptr<DataType>& out_type, const CastOptions& options,
             std::shared_ptr<Array>* out) {
-  CastContext cast_ctx{ctx, options};
-  return Cast(&cast_ctx, array, out_type, out);
+  // Dynamic dispatch to obtain right cast function
+  std::unique_ptr<CastKernel> func;
+  RETURN_NOT_OK(GetCastFunction(*array.type(), out_type, options, &func));
+
+  // TODO(wesm): Must force computation of unknown null counts
+  ARROW_UNUSED(array.null_count());
+
+  // Allocate memory for output
+  auto out_data = std::make_shared<ArrayData>();
+  out_data->type = out_type;
+  out_data->length = array.length();
+  out_data->offset = 0;
+
+  (*func)(ctx, *array.data(), out_data.get());
+
+  RETURN_IF_ERROR(ctx);
+  return internal::MakeArray(out_data, out);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -18,15 +18,21 @@
 #include "arrow/compute/cast.h"
 
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <limits>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <type_traits>
 
 #include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bit-util.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
 
 #include "arrow/compute/context.h"
 #include "arrow/compute/kernel.h"
@@ -426,7 +432,7 @@ Status Cast(FunctionContext* ctx, const Array& array,
   std::unique_ptr<UnaryKernel> func;
   RETURN_NOT_OK(GetCastFunction(*array.type(), out_type, options, &func));
 
-  // Allocate memory for output
+  // Data structure for output
   auto out_data = std::make_shared<ArrayData>(out_type, array.length());
 
   RETURN_NOT_OK(func->Call(ctx, array, out_data.get()));

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -20,12 +20,13 @@
 
 #include <memory>
 
-#include "arrow/array.h"
+#include "arrow/status.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
-using internal::ArrayData;
+class Array;
+class DataType;
 
 namespace compute {
 

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -23,6 +23,8 @@
 #include "arrow/array.h"
 #include "arrow/util/visibility.h"
 
+#include "arrow/compute/kernel.h"
+
 namespace arrow {
 
 using internal::ArrayData;
@@ -30,42 +32,17 @@ using internal::ArrayData;
 namespace compute {
 
 class FunctionContext;
+class UnaryKernel;
 
 struct CastOptions {
   bool allow_int_overflow;
-};
-
-typedef std::function<void(FunctionContext*, const CastOptions& options, const ArrayData&,
-                           ArrayData*)>
-    CastFunction;
-
-class ARROW_EXPORT OpKernel {
- public:
-  virtual ~OpKernel() = default;
-};
-
-class ARROW_EXPORT UnaryKernel : public OpKernel {
- public:
-  virtual void operator()(FunctionContext* ctx, const ArrayData& input,
-                          ArrayData* out) = 0;
-};
-
-class ARROW_EXPORT CastKernel : public UnaryKernel {
- public:
-  CastKernel(const CastOptions& options, const CastFunction& func, bool is_zero_copy);
-  void operator()(FunctionContext* ctx, const ArrayData& input, ArrayData* out) override;
-
- private:
-  CastOptions options_;
-  CastFunction func_;
-  bool is_zero_copy_;
 };
 
 /// \since 0.7.0
 /// \note API not yet finalized
 ARROW_EXPORT
 Status GetCastFunction(const DataType& in_type, const std::shared_ptr<DataType>& to_type,
-                       const CastOptions& options, std::unique_ptr<CastKernel>* kernel);
+                       const CastOptions& options, std::unique_ptr<UnaryKernel>* kernel);
 
 /// \brief Cast from one array type to another
 /// \param[in] context

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -33,6 +33,8 @@ class FunctionContext;
 class UnaryKernel;
 
 struct CastOptions {
+  CastOptions() : allow_int_overflow(false) {}
+
   bool allow_int_overflow;
 };
 

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -35,6 +35,38 @@ struct CastOptions {
   bool allow_int_overflow;
 };
 
+typedef std::function<void(FunctionContext*, const CastOptions& options, const ArrayData&,
+                           ArrayData*)>
+    CastFunction;
+
+class ARROW_EXPORT OpKernel {
+ public:
+  virtual ~OpKernel() = default;
+};
+
+class ARROW_EXPORT UnaryKernel : public OpKernel {
+ public:
+  virtual void operator()(FunctionContext* ctx, const ArrayData& input,
+                          ArrayData* out) = 0;
+};
+
+class ARROW_EXPORT CastKernel : public UnaryKernel {
+ public:
+  CastKernel(const CastOptions& options, const CastFunction& func, bool is_zero_copy);
+  void operator()(FunctionContext* ctx, const ArrayData& input, ArrayData* out) override;
+
+ private:
+  CastOptions options_;
+  CastFunction func_;
+  bool is_zero_copy_;
+};
+
+/// \since 0.7.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Status GetCastFunction(const DataType& in_type, const std::shared_ptr<DataType>& to_type,
+                       const CastOptions& options, std::unique_ptr<CastKernel>* kernel);
+
 /// \brief Cast from one array type to another
 /// \param[in] context
 /// \param[in] array

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -324,9 +324,6 @@ TEST_F(TestCast, UnsupportedTarget) {
 }
 
 TEST_F(TestCast, DateTimeZeroCopy) {
-  CastOptions options;
-  options.allow_int_overflow = false;
-
   vector<bool> is_valid = {true, false, true, true, true};
 
   std::shared_ptr<Array> arr;

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -341,5 +341,21 @@ TEST_F(TestCast, DateTimeZeroCopy) {
   CheckZeroCopy(*arr, timestamp(TimeUnit::NANO));
 }
 
+TEST_F(TestCast, FromNull) {
+  // Null casts to everything
+  const int length = 10;
+
+  NullArray arr(length);
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(Cast(&ctx_, arr, int32(), {}, &result));
+
+  ASSERT_EQ(length, result->length());
+  ASSERT_EQ(length, result->null_count());
+
+  // OK to look at bitmaps
+  AssertArraysEqual(*result, *result);
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -43,6 +43,9 @@
 using std::vector;
 
 namespace arrow {
+
+using internal::ArrayData;
+
 namespace compute {
 
 void AssertArraysEqual(const Array& left, const Array& right) {
@@ -99,13 +102,12 @@ class TestCast : public ComputeFixture, public ::testing::Test {
     ASSERT_RAISES(Invalid, Cast(&ctx_, *input, out_type, options, &result));
   }
 
-  void CheckZeroCopy(const Array& input,
-                     const std::shared_ptr<DataType>& out_type) {
+  void CheckZeroCopy(const Array& input, const std::shared_ptr<DataType>& out_type) {
     std::shared_ptr<Array> result;
     ASSERT_OK(Cast(&ctx_, input, out_type, {}, &result));
     AssertBufferSame(input, *result, 0);
     AssertBufferSame(input, *result, 1);
-  };
+  }
 
   template <typename InType, typename I_TYPE, typename OutType, typename O_TYPE>
   void CheckCase(const std::shared_ptr<DataType>& in_type,
@@ -355,6 +357,44 @@ TEST_F(TestCast, FromNull) {
 
   // OK to look at bitmaps
   AssertArraysEqual(*result, *result);
+}
+
+TEST_F(TestCast, PreallocatedMemory) {
+  CastOptions options;
+  options.allow_int_overflow = false;
+
+  vector<bool> is_valid = {true, false, true, true, true};
+
+  const int64_t length = 5;
+
+  std::shared_ptr<Array> arr;
+  vector<int32_t> v1 = {0, 70000, 2000, 1000, 0};
+  vector<int64_t> e1 = {0, 70000, 2000, 1000, 0};
+  ArrayFromVector<Int32Type, int32_t>(int32(), is_valid, v1, &arr);
+
+  auto out_type = int64();
+
+  std::unique_ptr<UnaryKernel> kernel;
+  ASSERT_OK(GetCastFunction(*int32(), out_type, options, &kernel));
+
+  auto out_data = std::make_shared<ArrayData>(out_type, length);
+
+  std::shared_ptr<Buffer> out_values;
+  ASSERT_OK(this->ctx_.Allocate(length * sizeof(int64_t), &out_values));
+
+  out_data->buffers.push_back(nullptr);
+  out_data->buffers.push_back(out_values);
+
+  ASSERT_OK(kernel->Call(&this->ctx_, *arr, out_data.get()));
+
+  // Buffer address unchanged
+  ASSERT_EQ(out_values.get(), out_data->buffers[1].get());
+
+  std::shared_ptr<Array> result, expected;
+  ASSERT_OK(MakeArray(out_data, &result));
+  ArrayFromVector<Int64Type, int64_t>(int64(), is_valid, e1, &expected);
+
+  AssertArraysEqual(*expected, *result);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -39,6 +39,7 @@
 
 #include "arrow/compute/cast.h"
 #include "arrow/compute/context.h"
+#include "arrow/compute/kernel.h"
 
 using std::vector;
 

--- a/cpp/src/arrow/compute/context.h
+++ b/cpp/src/arrow/compute/context.h
@@ -18,6 +18,7 @@
 #ifndef ARROW_COMPUTE_CONTEXT_H
 #define ARROW_COMPUTE_CONTEXT_H
 
+#include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/visibility.h"
@@ -35,7 +36,7 @@ namespace compute {
 /// \brief Container for variables and options used by function evaluation
 class ARROW_EXPORT FunctionContext {
  public:
-  explicit FunctionContext(MemoryPool* pool);
+  explicit FunctionContext(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
   MemoryPool* memory_pool() const;
 
   /// \brief Allocate buffer from the context's memory pool

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -15,48 +15,35 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_COMPUTE_CAST_H
-#define ARROW_COMPUTE_CAST_H
+#ifndef ARROW_COMPUTE_KERNEL_H
+#define ARROW_COMPUTE_KERNEL_H
 
-#include <memory>
-
-#include "arrow/array.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
+class Array;
 using internal::ArrayData;
 
 namespace compute {
 
 class FunctionContext;
-class UnaryKernel;
 
-struct CastOptions {
-  bool allow_int_overflow;
+/// \class OpKernel
+/// \brief Base class for operator kernels
+class ARROW_EXPORT OpKernel {
+ public:
+  virtual ~OpKernel() = default;
 };
 
-/// \since 0.7.0
-/// \note API not yet finalized
-ARROW_EXPORT
-Status GetCastFunction(const DataType& in_type, const std::shared_ptr<DataType>& to_type,
-                       const CastOptions& options, std::unique_ptr<UnaryKernel>* kernel);
-
-/// \brief Cast from one array type to another
-/// \param[in] context
-/// \param[in] array
-/// \param[in] to_type
-/// \param[in] options
-/// \param[out] out
-///
-/// \since 0.7.0
-/// \note API not yet finalized
-ARROW_EXPORT
-Status Cast(FunctionContext* context, const Array& array,
-            const std::shared_ptr<DataType>& to_type, const CastOptions& options,
-            std::shared_ptr<Array>* out);
+/// \class UnaryKernel
+/// \brief An array-valued function of a single input argument
+class ARROW_EXPORT UnaryKernel : public OpKernel {
+ public:
+  virtual Status Call(FunctionContext* ctx, const Array& input, ArrayData* out) = 0;
+};
 
 }  // namespace compute
 }  // namespace arrow
 
-#endif  // ARROW_COMPUTE_CAST_H
+#endif  // ARROW_COMPUTE_KERNEL_H

--- a/cpp/src/arrow/python/numpy_convert.h
+++ b/cpp/src/arrow/python/numpy_convert.h
@@ -57,10 +57,7 @@ bool is_contiguous(PyObject* array);
 ARROW_EXPORT
 Status NumPyDtypeToArrow(PyObject* dtype, std::shared_ptr<DataType>* out);
 
-ARROW_EXPORT
 Status GetTensorType(PyObject* dtype, std::shared_ptr<DataType>* out);
-
-ARROW_EXPORT
 Status GetNumPyType(const DataType& type, int* type_num);
 
 ARROW_EXPORT Status NdarrayToTensor(MemoryPool* pool, PyObject* ao,

--- a/cpp/src/arrow/python/pandas_to_arrow.cc
+++ b/cpp/src/arrow/python/pandas_to_arrow.cc
@@ -906,7 +906,7 @@ Status PandasConverter::ConvertObjectsInfer() {
       return ConvertLists(inferred_type);
     } else {
       const std::string supported_types =
-        "string, bool, float, int, date, time, decimal, list, array";
+          "string, bool, float, int, date, time, decimal, list, array";
       std::stringstream ss;
       ss << "Error inferring Arrow type for Python object array. ";
       RETURN_NOT_OK(InvalidConversion(obj, supported_types, &ss));

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -131,8 +131,8 @@ cdef class Array:
             CCastOptions options
             shared_ptr[CArray] result
 
-        if safe:
-            options.allow_int_overflow = 0
+        if not safe:
+            options.allow_int_overflow = 1
 
         with nogil:
             check_status(Cast(_context(), self.ap[0], target_type.sp_type,

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -88,6 +88,19 @@ def _normalize_slice(object arrow_obj, slice key):
         return arrow_obj.slice(start, stop - start)
 
 
+cdef class _FunctionContext:
+    cdef:
+        unique_ptr[CFunctionContext] ctx
+
+    def __cinit__(self):
+        self.ctx.reset(new CFunctionContext(c_default_memory_pool()))
+
+cdef _FunctionContext _global_ctx = _FunctionContext()
+
+cdef CFunctionContext* _context() nogil:
+    return _global_ctx.ctx.get()
+
+
 cdef class Array:
 
     cdef void init(self, const shared_ptr[CArray]& sp_array):
@@ -98,6 +111,34 @@ cdef class Array:
     def _debug_print(self):
         with nogil:
             check_status(DebugPrint(deref(self.ap), 0))
+
+    def cast(self, DataType target_type, safe=True):
+        """
+        Cast array values to another data type
+
+        Parameters
+        ----------
+        target_type : DataType
+            Type to cast to
+        safe : boolean, default True
+            Check for overflows or other unsafe conversions
+
+        Returns
+        -------
+        casted : Array
+        """
+        cdef:
+            CCastOptions options
+            shared_ptr[CArray] result
+
+        if safe:
+            options.allow_int_overflow = 0
+
+        with nogil:
+            check_status(Cast(_context(), self.ap[0], target_type.sp_type,
+                              options, &result))
+
+        return pyarrow_wrap_array(result)
 
     @staticmethod
     def from_pandas(obj, mask=None, DataType type=None,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -706,9 +706,6 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
                             InputStream* stream,
                             shared_ptr[CRecordBatch]* out)
 
-
-cdef extern from "arrow/ipc/feather.h" namespace "arrow::ipc::feather" nogil:
-
     cdef cppclass CFeatherWriter" arrow::ipc::feather::TableWriter":
         @staticmethod
         CStatus Open(const shared_ptr[OutputStream]& stream,
@@ -735,6 +732,21 @@ cdef extern from "arrow/ipc/feather.h" namespace "arrow::ipc::feather" nogil:
 
         CStatus GetColumn(int i, shared_ptr[CColumn]* out)
         c_string GetColumnName(int i)
+
+
+cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
+
+    cdef cppclass CFunctionContext" arrow::compute::FunctionContext":
+        CFunctionContext()
+        CFunctionContext(CMemoryPool* pool)
+
+    cdef cppclass CCastOptions" arrow::compute::CastOptions":
+        c_bool allow_int_overflow
+
+    CStatus Cast(CFunctionContext* context, const CArray& array,
+                 const shared_ptr[CDataType]& to_type,
+                 const CCastOptions& options,
+                 shared_ptr[CArray]* out)
 
 
 cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -288,6 +288,17 @@ class TestPandasConversion(unittest.TestCase):
         schema = pa.schema([field])
         self._check_pandas_roundtrip(df, expected_schema=schema)
 
+    def test_all_nulls_to_numeric(self):
+        arr = np.array([None], dtype=object)
+
+        def _check_type(t):
+            a2 = pa.Array.from_pandas(arr, type=t)
+            assert a2.type == t
+            assert a2[0].as_py() is None
+
+        _check_type(pa.int32())
+        _check_type(pa.float64())
+
     def test_unicode(self):
         repeats = 1000
         values = [u'foo', None, u'bar', u'mañana', np.nan]

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -288,7 +288,7 @@ class TestPandasConversion(unittest.TestCase):
         schema = pa.schema([field])
         self._check_pandas_roundtrip(df, expected_schema=schema)
 
-    def test_all_nulls_to_numeric(self):
+    def test_all_nulls_cast_numeric(self):
         arr = np.array([None], dtype=object)
 
         def _check_type(t):

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -239,6 +239,15 @@ class TestPandasConversion(unittest.TestCase):
 
         tm.assert_frame_equal(result, ex_frame)
 
+    def test_array_from_pandas_type_cast(self):
+        arr = np.arange(10, dtype='int64')
+
+        target_type = pa.int8()
+
+        result = pa.Array.from_pandas(arr, type=target_type)
+        expected = pa.Array.from_pandas(arr.astype('int8'))
+        assert result.equals(expected)
+
     def test_boolean_no_nulls(self):
         num_values = 100
 


### PR DESCRIPTION
cc @cloud-fan 

With this patch we now try to cast to indicated type on ingest of objects from pandas:

```
In [3]: arr = np.array([None] * 5)

In [4]: pa.Array.from_pandas(arr)
Out[4]: 
<pyarrow.lib.NullArray object at 0x7f6cf1485d18>
[
  NA,
  NA,
  NA,
  NA,
  NA
]

In [5]: pa.Array.from_pandas(arr, type=pa.int32())
Out[5]: 
<pyarrow.lib.Int32Array object at 0x7f6cf1485d68>
[
  NA,
  NA,
  NA,
  NA,
  NA
]
```

I also added zero-copy casts from integers of the right size to each of the date and time types.

Includes refactoring for ARROW-1481.