### PR TITLE
ARROW-1506: [C++] Add .pc for compute modules

### DIFF
--- a/cpp/src/arrow/compute/arrow-compute.pc.in
+++ b/cpp/src/arrow/compute/arrow-compute.pc.in
@@ -15,24 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Headers: top level
-install(FILES
-  api.h
-  cast.h
-  context.h
-  kernel.h
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/compute")
-
-# pkg-config support
-configure_file(arrow-compute.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/arrow-compute.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-compute.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
-
-#######################################
-# Unit tests
-#######################################
-
-ADD_ARROW_TEST(compute-test)
+Name: Apache Arrow Compute
+Description: Compute modules for Apache Arrow
+Version: @ARROW_VERSION@
+Requires: arrow


### PR DESCRIPTION
If .pc for compute modules exist, we can detect whether compute modules
are built or not by pkg-config:

    pkg-config --exists arrow-compute