### PR TITLE
ARROW-1358: Update sha{1, 256, 512} checksums per latest ASF release policy

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -98,7 +98,9 @@ ${SOURCE_DIR}/run-rat.sh ${tarball}
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
 gpg --print-md MD5 ${tarball} > ${tarball}.md5
-shasum $tarball > ${tarball}.sha
+sha1sum $tarball > ${tarball}.sha1
+sha256sum $tarball > ${tarball}.sha256
+sha512sum $tarball > ${tarball}.sha512
 
 # check out the arrow RC folder
 svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow tmp


### PR DESCRIPTION
See http://www.apache.org/dev/release-distribution#sigs-and-sums