### PR TITLE
ARROW-1515: [GLib] Detect version directly

### DIFF
--- a/c_glib/.gitignore
+++ b/c_glib/.gitignore
@@ -33,7 +33,6 @@ Makefile.in
 /libtool
 /m4/
 /stamp-h1
-/version
 /arrow-glib/enums.c
 /arrow-glib/enums.h
 /arrow-glib/stamp-*

--- a/c_glib/Makefile.am
+++ b/c_glib/Makefile.am
@@ -24,8 +24,7 @@ SUBDIRS =					\
 
 EXTRA_DIST =					\
 	README.md				\
-	test					\
-	version
+	test
 
 arrow_glib_docdir = ${datarootdir}/doc/arrow-glib
 arrow_glib_doc_DATA =				\

--- a/c_glib/autogen.sh
+++ b/c_glib/autogen.sh
@@ -20,11 +20,6 @@
 set -u
 set -e
 
-ruby \
-    -e 'print ARGF.read.scan(/^  <version>(.+?)<\/version>/)[0][0]' \
-    ../java/pom.xml > \
-    version
-
 mkdir -p m4
 
 gtkdocize --copy --docdir doc/reference

--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -17,7 +17,10 @@
 
 AC_PREREQ(2.65)
 
-m4_define([arrow_glib_version], m4_include(version))
+m4_define([arrow_glib_version],
+           m4_esyscmd(grep "^  <version>" "$(dirname $0)/../java/pom.xml" | \
+                        sed -e 's/\(^  <version>\|<\/version>$\)//g' | \
+                        tr -d '\n'))
 AC_INIT([arrow-glib],
         arrow_glib_version,
         [https://issues.apache.org/jira/browse/ARROW],


### PR DESCRIPTION
Running ./autogen.sh isn't required for version update in java/pom.xml.