### PR TITLE
ARROW-1511: [C++] Promote ArrayData, MakeArray to public API, deprecate MakePrimitiveArray

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -598,6 +598,7 @@ class ArrayDataWrapper {
 
 }  // namespace internal
 
+// Remove enclosing namespace after 0.7.0
 Status MakeArray(const std::shared_ptr<ArrayData>& data, std::shared_ptr<Array>* out) {
   internal::ArrayDataWrapper wrapper_visitor(data, out);
   return VisitTypeInline(*data->type, &wrapper_visitor);

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -52,9 +52,8 @@ struct Decimal;
 // ----------------------------------------------------------------------
 // Generic array data container
 
-namespace internal {
-
-/// \brief Mutable internal container for generic Arrow array data
+/// \class ArrayData
+/// \brief Mutable container for generic Arrow array data
 ///
 /// This data structure is a self-contained representation of the memory and
 /// metadata inside an Arrow array data structure (called vectors in Java). The
@@ -148,6 +147,14 @@ struct ARROW_EXPORT ArrayData {
 ARROW_EXPORT
 Status MakeArray(const std::shared_ptr<ArrayData>& data, std::shared_ptr<Array>* out);
 
+namespace internal {
+
+#ifndef ARROW_NO_DEPRECATED_API
+// \deprecated since 0.7.0
+using ArrayData = ::arrow::ArrayData;
+using MakeArray = ::arrow::MakeArray;
+#endif
+
 }  // namespace internal
 
 // ----------------------------------------------------------------------
@@ -232,7 +239,7 @@ class ARROW_EXPORT Array {
   /// Slice from offset until end of the array
   std::shared_ptr<Array> Slice(int64_t offset) const;
 
-  std::shared_ptr<internal::ArrayData> data() const { return data_; }
+  std::shared_ptr<ArrayData> data() const { return data_; }
 
   int num_fields() const { return static_cast<int>(data_->child_data.size()); }
 
@@ -242,11 +249,11 @@ class ARROW_EXPORT Array {
  protected:
   Array() {}
 
-  std::shared_ptr<internal::ArrayData> data_;
+  std::shared_ptr<ArrayData> data_;
   const uint8_t* null_bitmap_data_;
 
   /// Protected method for constructors
-  inline void SetData(const std::shared_ptr<internal::ArrayData>& data) {
+  inline void SetData(const std::shared_ptr<ArrayData>& data) {
     if (data->buffers.size() > 0 && data->buffers[0]) {
       null_bitmap_data_ = data->buffers[0]->data();
     } else {
@@ -274,11 +281,11 @@ class ARROW_EXPORT NullArray : public FlatArray {
  public:
   using TypeClass = NullType;
 
-  explicit NullArray(const std::shared_ptr<internal::ArrayData>& data) { SetData(data); }
+  explicit NullArray(const std::shared_ptr<ArrayData>& data) { SetData(data); }
   explicit NullArray(int64_t length);
 
  private:
-  inline void SetData(const std::shared_ptr<internal::ArrayData>& data) {
+  inline void SetData(const std::shared_ptr<ArrayData>& data) {
     null_bitmap_data_ = nullptr;
     data->null_count = data->length;
     data_ = data;
@@ -302,13 +309,13 @@ class ARROW_EXPORT PrimitiveArray : public FlatArray {
  protected:
   PrimitiveArray() {}
 
-  inline void SetData(const std::shared_ptr<internal::ArrayData>& data) {
+  inline void SetData(const std::shared_ptr<ArrayData>& data) {
     auto values = data->buffers[1];
     this->Array::SetData(data);
     raw_values_ = values == nullptr ? nullptr : values->data();
   }
 
-  explicit inline PrimitiveArray(const std::shared_ptr<internal::ArrayData>& data) {
+  explicit inline PrimitiveArray(const std::shared_ptr<ArrayData>& data) {
     SetData(data);
   }
 
@@ -321,7 +328,7 @@ class ARROW_EXPORT NumericArray : public PrimitiveArray {
   using TypeClass = TYPE;
   using value_type = typename TypeClass::c_type;
 
-  explicit NumericArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit NumericArray(const std::shared_ptr<ArrayData>& data);
 
   // Only enable this constructor without a type argument for types without additional
   // metadata
@@ -348,7 +355,7 @@ class ARROW_EXPORT BooleanArray : public PrimitiveArray {
  public:
   using TypeClass = BooleanType;
 
-  explicit BooleanArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit BooleanArray(const std::shared_ptr<ArrayData>& data);
 
   BooleanArray(int64_t length, const std::shared_ptr<Buffer>& data,
                const std::shared_ptr<Buffer>& null_bitmap = nullptr,
@@ -370,7 +377,7 @@ class ARROW_EXPORT ListArray : public Array {
  public:
   using TypeClass = ListType;
 
-  explicit ListArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit ListArray(const std::shared_ptr<ArrayData>& data);
 
   ListArray(const std::shared_ptr<DataType>& type, int64_t length,
             const std::shared_ptr<Buffer>& value_offsets,
@@ -410,7 +417,7 @@ class ARROW_EXPORT ListArray : public Array {
   }
 
  protected:
-  void SetData(const std::shared_ptr<internal::ArrayData>& data);
+  void SetData(const std::shared_ptr<ArrayData>& data);
   const int32_t* raw_value_offsets_;
 
  private:
@@ -424,7 +431,7 @@ class ARROW_EXPORT BinaryArray : public FlatArray {
  public:
   using TypeClass = BinaryType;
 
-  explicit BinaryArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit BinaryArray(const std::shared_ptr<ArrayData>& data);
 
   BinaryArray(int64_t length, const std::shared_ptr<Buffer>& value_offsets,
               const std::shared_ptr<Buffer>& data,
@@ -463,7 +470,7 @@ class ARROW_EXPORT BinaryArray : public FlatArray {
   BinaryArray() {}
 
   /// Protected method for constructors
-  void SetData(const std::shared_ptr<internal::ArrayData>& data);
+  void SetData(const std::shared_ptr<ArrayData>& data);
 
   // Constructor that allows sub-classes/builders to propagate there logical type up the
   // class hierarchy.
@@ -481,7 +488,7 @@ class ARROW_EXPORT StringArray : public BinaryArray {
  public:
   using TypeClass = StringType;
 
-  explicit StringArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit StringArray(const std::shared_ptr<ArrayData>& data);
 
   StringArray(int64_t length, const std::shared_ptr<Buffer>& value_offsets,
               const std::shared_ptr<Buffer>& data,
@@ -504,7 +511,7 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
  public:
   using TypeClass = FixedSizeBinaryType;
 
-  explicit FixedSizeBinaryArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit FixedSizeBinaryArray(const std::shared_ptr<ArrayData>& data);
 
   FixedSizeBinaryArray(const std::shared_ptr<DataType>& type, int64_t length,
                        const std::shared_ptr<Buffer>& data,
@@ -517,7 +524,7 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
   int32_t byte_width() const { return byte_width_; }
 
  protected:
-  inline void SetData(const std::shared_ptr<internal::ArrayData>& data) {
+  inline void SetData(const std::shared_ptr<ArrayData>& data) {
     this->PrimitiveArray::SetData(data);
     byte_width_ = static_cast<const FixedSizeBinaryType&>(*type()).byte_width();
   }
@@ -533,8 +540,8 @@ class ARROW_EXPORT DecimalArray : public FixedSizeBinaryArray {
 
   using FixedSizeBinaryArray::FixedSizeBinaryArray;
 
-  /// \brief Construct DecimalArray from internal::ArrayData instance
-  explicit DecimalArray(const std::shared_ptr<internal::ArrayData>& data);
+  /// \brief Construct DecimalArray from ArrayData instance
+  explicit DecimalArray(const std::shared_ptr<ArrayData>& data);
 
   std::string FormatValue(int64_t i) const;
 };
@@ -546,7 +553,7 @@ class ARROW_EXPORT StructArray : public Array {
  public:
   using TypeClass = StructType;
 
-  explicit StructArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit StructArray(const std::shared_ptr<ArrayData>& data);
 
   StructArray(const std::shared_ptr<DataType>& type, int64_t length,
               const std::vector<std::shared_ptr<Array>>& children,
@@ -570,7 +577,7 @@ class ARROW_EXPORT UnionArray : public Array {
   using TypeClass = UnionType;
   using type_id_t = uint8_t;
 
-  explicit UnionArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit UnionArray(const std::shared_ptr<ArrayData>& data);
 
   UnionArray(const std::shared_ptr<DataType>& type, int64_t length,
              const std::vector<std::shared_ptr<Array>>& children,
@@ -593,7 +600,7 @@ class ARROW_EXPORT UnionArray : public Array {
   std::shared_ptr<Array> child(int pos) const;
 
  protected:
-  void SetData(const std::shared_ptr<internal::ArrayData>& data);
+  void SetData(const std::shared_ptr<ArrayData>& data);
 
   const type_id_t* raw_type_ids_;
   const int32_t* raw_value_offsets_;
@@ -624,7 +631,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
  public:
   using TypeClass = DictionaryType;
 
-  explicit DictionaryArray(const std::shared_ptr<internal::ArrayData>& data);
+  explicit DictionaryArray(const std::shared_ptr<ArrayData>& data);
 
   DictionaryArray(const std::shared_ptr<DataType>& type,
                   const std::shared_ptr<Array>& indices);
@@ -635,7 +642,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   const DictionaryType* dict_type() const { return dict_type_; }
 
  private:
-  void SetData(const std::shared_ptr<internal::ArrayData>& data);
+  void SetData(const std::shared_ptr<ArrayData>& data);
 
   const DictionaryType* dict_type_;
   std::shared_ptr<Array> indices_;
@@ -669,20 +676,26 @@ ARROW_EXTERN_TEMPLATE NumericArray<TimestampType>;
 ///
 /// \param array an Array instance
 /// \return Status
-Status ARROW_EXPORT ValidateArray(const Array& array);
+ARROW_EXPORT
+Status ValidateArray(const Array& array);
+
+#ifndef ARROW_NO_DEPRECATED_API
+// \deprecated Since 0.7.0
 
 /// Create new arrays for logical types that are backed by primitive arrays.
-Status ARROW_EXPORT MakePrimitiveArray(const std::shared_ptr<DataType>& type,
-                                       int64_t length,
-                                       const std::shared_ptr<Buffer>& data,
-                                       const std::shared_ptr<Buffer>& null_bitmap,
-                                       int64_t null_count, int64_t offset,
-                                       std::shared_ptr<Array>* out);
+ARROW_EXPORT
+Status MakePrimitiveArray(const std::shared_ptr<DataType>& type, int64_t length,
+                          const std::shared_ptr<Buffer>& data,
+                          const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
+                          int64_t offset, std::shared_ptr<Array>* out);
 
-Status ARROW_EXPORT
-MakePrimitiveArray(const std::shared_ptr<DataType>& type,
-                   const std::vector<std::shared_ptr<Buffer>>& buffers, int64_t length,
-                   int64_t null_count, int64_t offset, std::shared_ptr<Array>* out);
+ARROW_EXPORT
+Status MakePrimitiveArray(const std::shared_ptr<DataType>& type,
+                          const std::vector<std::shared_ptr<Buffer>>& buffers,
+                          int64_t length, int64_t null_count, int64_t offset,
+                          std::shared_ptr<Array>* out);
+
+#endif
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -144,6 +144,10 @@ struct ARROW_EXPORT ArrayData {
   std::vector<std::shared_ptr<ArrayData>> child_data;
 };
 
+/// \brief Create a strongly-typed Array instance from generic ArrayData
+/// \param[in] data the array contents
+/// \param[out] out the resulting Array instance
+/// \return Status
 ARROW_EXPORT
 Status MakeArray(const std::shared_ptr<ArrayData>& data, std::shared_ptr<Array>* out);
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -151,16 +151,6 @@ struct ARROW_EXPORT ArrayData {
 ARROW_EXPORT
 Status MakeArray(const std::shared_ptr<ArrayData>& data, std::shared_ptr<Array>* out);
 
-namespace internal {
-
-#ifndef ARROW_NO_DEPRECATED_API
-// \deprecated since 0.7.0
-using ArrayData = ::arrow::ArrayData;
-using MakeArray = ::arrow::MakeArray;
-#endif
-
-}  // namespace internal
-
 // ----------------------------------------------------------------------
 // User array accessor types
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -41,7 +41,6 @@
 namespace arrow {
 
 using internal::AdaptiveIntBuilderBase;
-using internal::ArrayData;
 using internal::WrappedBinary;
 
 Status ArrayBuilder::AppendToBitmap(bool is_valid) {

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -704,7 +704,7 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
   static constexpr int64_t kMaximumCapacity = std::numeric_limits<int32_t>::max() - 1;
 
   Status AppendNextOffset();
-  Status FinishInternal(std::shared_ptr<internal::ArrayData>* out);
+  Status FinishInternal(std::shared_ptr<ArrayData>* out);
   void Reset();
 };
 

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -706,7 +706,7 @@ Status Cast(FunctionContext* ctx, const Array& array,
   auto out_data = std::make_shared<ArrayData>(out_type, array.length());
 
   RETURN_NOT_OK(func->Call(ctx, array, out_data.get()));
-  return internal::MakeArray(out_data, out);
+  return MakeArray(out_data, out);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -44,9 +44,6 @@
 using std::vector;
 
 namespace arrow {
-
-using internal::ArrayData;
-
 namespace compute {
 
 void AssertArraysEqual(const Array& left, const Array& right) {

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -21,9 +21,6 @@
 #include "arrow/array.h"
 
 namespace arrow {
-
-using internal::ArrayData;
-
 namespace compute {
 
 class FunctionContext;

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -368,11 +368,11 @@ TEST_F(TestTableWriter, TimeTypes) {
   std::vector<std::shared_ptr<Buffer>> buffers = {prim_values.null_bitmap(),
                                                   prim_values.values()};
 
-  std::vector<std::shared_ptr<internal::ArrayData>> arrays;
+  std::vector<std::shared_ptr<ArrayData>> arrays;
   arrays.push_back(date_array->data());
 
   for (int i = 1; i < schema->num_fields(); ++i) {
-    arrays.emplace_back(std::make_shared<internal::ArrayData>(
+    arrays.emplace_back(std::make_shared<ArrayData>(
         schema->field(i)->type(), values->length(), buffers, values->null_count(), 0));
   }
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -368,7 +368,10 @@ class TableReader::TableReaderImpl {
     }
 
     buffers.push_back(SliceBuffer(buffer, offset, buffer->size() - offset));
-    return MakePrimitiveArray(type, buffers, meta->length(), meta->null_count(), 0, out);
+
+    auto arr_data =
+        std::make_shared<ArrayData>(type, meta->length(), buffers, meta->null_count());
+    return MakeArray(arr_data, out);
   }
 
   bool HasDescription() const { return metadata_->HasDescription(); }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -74,7 +74,7 @@ class IpcComponentSource {
     }
   }
 
-  Status GetFieldMetadata(int field_index, internal::ArrayData* out) {
+  Status GetFieldMetadata(int field_index, ArrayData* out) {
     auto nodes = metadata_->nodes();
     // pop off a field
     if (field_index >= static_cast<int>(nodes->size())) {
@@ -106,11 +106,11 @@ struct ArrayLoaderContext {
 };
 
 static Status LoadArray(const std::shared_ptr<DataType>& type,
-                        ArrayLoaderContext* context, internal::ArrayData* out);
+                        ArrayLoaderContext* context, ArrayData* out);
 
 class ArrayLoader {
  public:
-  ArrayLoader(const std::shared_ptr<DataType>& type, internal::ArrayData* out,
+  ArrayLoader(const std::shared_ptr<DataType>& type, ArrayData* out,
               ArrayLoaderContext* context)
       : type_(type), context_(context), out_(out) {}
 
@@ -168,7 +168,7 @@ class ArrayLoader {
     return GetBuffer(context_->buffer_index++, &out_->buffers[2]);
   }
 
-  Status LoadChild(const Field& field, internal::ArrayData* out) {
+  Status LoadChild(const Field& field, ArrayData* out) {
     ArrayLoader loader(field.type(), out, context_);
     --context_->max_recursion_depth;
     RETURN_NOT_OK(loader.Load());
@@ -180,7 +180,7 @@ class ArrayLoader {
     out_->child_data.reserve(static_cast<int>(child_fields.size()));
 
     for (const auto& child_field : child_fields) {
-      auto field_array = std::make_shared<internal::ArrayData>();
+      auto field_array = std::make_shared<ArrayData>();
       RETURN_NOT_OK(LoadChild(*child_field.get(), field_array.get()));
       out_->child_data.emplace_back(field_array);
     }
@@ -257,11 +257,11 @@ class ArrayLoader {
   ArrayLoaderContext* context_;
 
   // Used in visitor pattern
-  internal::ArrayData* out_;
+  ArrayData* out_;
 };
 
 static Status LoadArray(const std::shared_ptr<DataType>& type,
-                        ArrayLoaderContext* context, internal::ArrayData* out) {
+                        ArrayLoaderContext* context, ArrayData* out) {
   ArrayLoader loader(type, out, context);
   return loader.Load();
 }
@@ -291,9 +291,9 @@ static Status LoadRecordBatchFromSource(const std::shared_ptr<Schema>& schema,
   context.buffer_index = 0;
   context.max_recursion_depth = max_recursion_depth;
 
-  std::vector<std::shared_ptr<internal::ArrayData>> arrays(schema->num_fields());
+  std::vector<std::shared_ptr<ArrayData>> arrays(schema->num_fields());
   for (int i = 0; i < schema->num_fields(); ++i) {
-    auto arr = std::make_shared<internal::ArrayData>();
+    auto arr = std::make_shared<ArrayData>();
     RETURN_NOT_OK(LoadArray(schema->field(i)->type(), &context, arr.get()));
     DCHECK_EQ(num_rows, arr->length) << "Array length did not match record batch length";
     arrays[i] = std::move(arr);

--- a/cpp/src/arrow/python/pandas_to_arrow.cc
+++ b/cpp/src/arrow/python/pandas_to_arrow.cc
@@ -57,10 +57,6 @@
 #include "arrow/python/util/datetime.h"
 
 namespace arrow {
-
-using internal::ArrayData;
-using internal::MakeArray;
-
 namespace py {
 
 using internal::NumPyTypeSize;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -30,8 +30,6 @@
 
 namespace arrow {
 
-using internal::ArrayData;
-
 // ----------------------------------------------------------------------
 // ChunkedArray and Column methods
 
@@ -199,7 +197,7 @@ RecordBatch::RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows
 
 std::shared_ptr<Array> RecordBatch::column(int i) const {
   if (!boxed_columns_[i]) {
-    DCHECK(internal::MakeArray(columns_[i], &boxed_columns_[i]).ok());
+    DCHECK(MakeArray(columns_[i], &boxed_columns_[i]).ok());
   }
   return boxed_columns_[i];
 }

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -135,12 +135,12 @@ class ARROW_EXPORT RecordBatch {
   /// should be equal to the length of each field
   /// \param columns the data for the batch's columns
   RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows,
-              std::vector<std::shared_ptr<internal::ArrayData>>&& columns);
+              std::vector<std::shared_ptr<ArrayData>>&& columns);
 
   /// \brief Construct record batch by copying vector of array data
   /// \since 0.5.0
   RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows,
-              const std::vector<std::shared_ptr<internal::ArrayData>>& columns);
+              const std::vector<std::shared_ptr<ArrayData>>& columns);
 
   /// \brief Determine if two record batches are exactly equal
   /// \return true if batches are equal
@@ -158,7 +158,7 @@ class ARROW_EXPORT RecordBatch {
   /// \return an Array object
   std::shared_ptr<Array> column(int i) const;
 
-  std::shared_ptr<internal::ArrayData> column_data(int i) const { return columns_[i]; }
+  std::shared_ptr<ArrayData> column_data(int i) const { return columns_[i]; }
 
   /// \brief Name in i-th column
   const std::string& column_name(int i) const;
@@ -197,7 +197,7 @@ class ARROW_EXPORT RecordBatch {
 
   std::shared_ptr<Schema> schema_;
   int64_t num_rows_;
-  std::vector<std::shared_ptr<internal::ArrayData>> columns_;
+  std::vector<std::shared_ptr<ArrayData>> columns_;
 
   // Caching boxed array data
   mutable std::vector<std::shared_ptr<Array>> boxed_columns_;


### PR DESCRIPTION
Since `ArrayData` will become more exposed to users with the advent of `arrow::compute`, it should be a part of the public API. 