### PR TITLE
ARROW-1331: [JAVA] include package statement

### DIFF
--- a/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+package org.apache.arrow.vector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;


### PR DESCRIPTION
TestSplitAndTransfer was merged as part of https://github.com/apache/arrow/pull/955
However, the class did not have the package statement.

This small patch fixes that.