### PR TITLE
ARROW-1527: Fix Travis CI JDK9 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,10 @@ matrix:
     jdk: oraclejdk9
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
+    addons:
+      apt:
+        packages:
+          - oracle-java9-installer
   - language: java
     os: linux
     env: ARROW_TEST_GROUP=integration


### PR DESCRIPTION
Update `.travis.yml` to install JDK9 package as it seems it is not
part of the default trusty image.