### PR TITLE
ARROW-1537: [C++] Support building with full path install_name on macOS

### DIFF
--- a/ci/travis_before_script_c_glib.sh
+++ b/ci/travis_before_script_c_glib.sh
@@ -77,12 +77,6 @@ pushd $ARROW_C_GLIB_DIR
 export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$ARROW_CPP_INSTALL/lib/pkgconfig
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ARROW_CPP_INSTALL/lib
 
-if [ $TRAVIS_OS_NAME == "osx" ]; then
-  install_name_tool \
-    -id $ARROW_CPP_INSTALL/lib/libarrow.dylib \
-    $ARROW_CPP_INSTALL/lib/libarrow.dylib
-fi
-
 CONFIGURE_OPTIONS="--prefix=$ARROW_C_GLIB_INSTALL"
 if [ $TRAVIS_OS_NAME != "osx" ]; then
   CONFIGURE_OPTIONS="$CONFIGURE_OPTIONS --enable-gtk-doc"

--- a/ci/travis_before_script_cpp.sh
+++ b/ci/travis_before_script_cpp.sh
@@ -70,7 +70,8 @@ if [ $only_library_mode == "yes" ]; then
   CMAKE_COMMON_FLAGS="\
 $CMAKE_COMMON_FLAGS \
 -DARROW_BUILD_TESTS=OFF \
--DARROW_BUILD_UTILITIES=OFF"
+-DARROW_BUILD_UTILITIES=OFF \
+-DARROW_INSTALL_NAME_RPATH=OFF"
 fi
 
 # Use Ninja for faster builds when using toolchain

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -150,6 +150,10 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     "Build Arrow libraries with RATH set to \$ORIGIN"
     OFF)
 
+  option(ARROW_INSTALL_NAME_RPATH
+    "Build Arrow libraries with install_name set to @rpath"
+    ON)
+
   option(ARROW_PLASMA
     "Build the plasma object store along with Arrow"
     OFF)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -176,10 +176,15 @@ function(ADD_ARROW_LIB LIB_NAME)
   endif()
 
   if (APPLE)
-      set_target_properties(${LIB_NAME}_shared
+    if (ARROW_INSTALL_NAME_RPATH)
+      set(_lib_install_name "@rpath")
+    else()
+      set(_lib_install_name "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+    endif()
+    set_target_properties(${LIB_NAME}_shared
       PROPERTIES
       BUILD_WITH_INSTALL_RPATH ON
-      INSTALL_NAME_DIR "@rpath")
+      INSTALL_NAME_DIR "${_lib_install_name}")
   endif()
 
 endfunction()


### PR DESCRIPTION
If you use `@rpath` for install_name (default), you can use the
DYLD_LIBRARY_PATH environment variable to find libarrow.dylib. But the
DYLD_LIBRARY_PATH environment variable isn't inherited to sub process by
System Integration Protection (SIP). It's difficult to use
libarrow.dylib.

You can use full path install_name by -DARROW_INSTALL_NAME_RPATH=OFF
CMake option. If you use it, you can find libarrow.dylib without
DYLD_LIBRARY_PATH environment variable.