### PR TITLE
ARROW-1550: [Python] Explicitly close owned file handles in ParquetWriter.close to avoid Windows flakiness

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -668,7 +668,7 @@ cdef class ParquetWriter:
         with nogil:
             check_status(self.writer.get().Close())
             if self.own_sink:
-                self.sink.get().Close()
+                check_status(self.sink.get().Close())
 
     def write_table(self, Table table, row_group_size=None):
         cdef CTable* ctable = table.table

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -562,6 +562,7 @@ cdef class ParquetWriter:
     cdef:
         unique_ptr[FileWriter] writer
         shared_ptr[OutputStream] sink
+        bint own_sink
 
     cdef readonly:
         object use_dictionary
@@ -588,8 +589,10 @@ cdef class ParquetWriter:
                 check_status(FileOutputStream.Open(c_where,
                                                    &filestream))
             self.sink = <shared_ptr[OutputStream]> filestream
+            self.own_sink = True
         else:
             get_writer(where, &self.sink)
+            self.own_sink = False
 
         self.use_dictionary = use_dictionary
         self.compression = compression
@@ -664,6 +667,8 @@ cdef class ParquetWriter:
     def close(self):
         with nogil:
             check_status(self.writer.get().Close())
+            if self.own_sink:
+                self.sink.get().Close()
 
     def write_table(self, Table table, row_group_size=None):
         cdef CTable* ctable = table.table

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1202,9 +1202,6 @@ def test_write_error_deletes_incomplete_file(tmpdir):
     except pa.ArrowException:
         pass
 
-    # Ensure that object has been destructed; this causes test failures on
-    # Windows
-    gc.collect()
     assert not os.path.exists(filename)
 
 


### PR DESCRIPTION
I can reproduce this failure locally, but I'm unsure why this just now started happening. The 0.7.0 release build passed (https://ci.appveyor.com/project/ApacheSoftwareFoundation/arrow/build/1.0.3357/job/477b1iicmwuy51l8) and there haven't been related code changes since then. Either way it's better to close the sink explicitly