### PR TITLE
ARROW-1347: [JAVA] Return consistent child field name for List Vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -324,7 +324,7 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
 
   @Override
   public Field getField() {
-    if (getDataVector() == ZeroVector.INSTANCE) {
+    if (getDataVector() instanceof ZeroVector) {
       return new Field(name, fieldType, ImmutableList.of(new Field(DATA_VECTOR_NAME, FieldType.nullable(Null.INSTANCE), null)));
     }
     return new Field(name, fieldType, ImmutableList.of(getDataVector().getField()));

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -49,6 +49,7 @@ import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.schema.ArrowFieldNode;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.ArrowType.Null;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -323,6 +324,9 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
 
   @Override
   public Field getField() {
+    if (getDataVector() == ZeroVector.INSTANCE) {
+      return new Field(name, fieldType, ImmutableList.of(new Field(DATA_VECTOR_NAME, FieldType.nullable(Null.INSTANCE), null)));
+    }
     return new Field(name, fieldType, ImmutableList.of(getDataVector().getField()));
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -628,4 +628,16 @@ public class TestListVector {
       assertEquals(offsetAddress, buffers.get(1).memoryAddress());
     }
   }
+
+  @Test
+  public void testConsistentChildName() throws Exception {
+    try (ListVector listVector = ListVector.empty("sourceVector", allocator)) {
+      String emptyListStr = listVector.getField().toString();
+      assertTrue(emptyListStr.contains(ListVector.DATA_VECTOR_NAME));
+
+      listVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+      String emptyVectorStr = listVector.getField().toString();
+      assertTrue(emptyVectorStr.contains(ListVector.DATA_VECTOR_NAME));
+    }
+  }
 }


### PR DESCRIPTION
This makes the child fields of ListVector have consistent names of `ListVector.DATA_VECTOR_NAME`. Previously, an empty ListVector would have a child name of `ZeroVector.name` which is "[DEFAULT]".