### PR TITLE
ARROW-1612:[GLib] Update readme for mac os

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -78,7 +78,7 @@ If you use macOS with [Homebrew](https://brew.sh/), you must install `gobject-in
 ```text
 % cd c_glib
 % brew install -y gobject-introspection
-% ./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig
+% ./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH
 % make
 % sudo make install
 ```

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -71,7 +71,19 @@ GLib (replace the version number in the following commands with the one you use)
 You need to build and install Arrow C++ before you build and install
 Arrow GLib. See Arrow C++ document about how to install Arrow C++.
 
-You can build and install Arrow GLib after you install Arrow C++:
+You can build and install Arrow GLib after you install Arrow C++.
+
+If you use macOS with [Homebrew](https://brew.sh/), you must install `gobject-introspection` and set `PKG_CONFIG_PATH` before build Arrow GLib:
+
+```text
+% cd c_glib
+% brew install -y gobject-introspection
+% ./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig
+% make
+% sudo make install
+```
+
+Others:
 
 ```text
 % cd c_glib


### PR DESCRIPTION
I tried to build Arrow GLib released source archive on mac os. but build failed.
Accutally, We need to install `gobject-introspection` and set `PKG_CONFIG_PATH ` before build Arrow Glib.
so, I added some commands to README.md.
