### PR TITLE
ARROW-1613: [Java] Alternative ArrowReader close to free resources but leave ReadChannel open

### DIFF
--- a/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
@@ -95,9 +95,9 @@ public class EchoServer {
     }
 
     public void run() throws IOException {
-      BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
       // Read the entire input stream and write it back
-      try (ArrowStreamReader reader = new ArrowStreamReader(socket.getInputStream(), allocator)) {
+      try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+           ArrowStreamReader reader = new ArrowStreamReader(socket.getInputStream(), allocator)) {
         VectorSchemaRoot root = reader.getVectorSchemaRoot();
         // load the first batch before instantiating the writer so that we have any dictionaries
         reader.loadNextBatch();

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileRoundtrip.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileRoundtrip.java
@@ -79,8 +79,9 @@ public class FileRoundtrip {
 
       File inFile = validateFile("input", inFileName);
       File outFile = validateFile("output", outFileName);
-      BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE); // TODO: close
-      try (FileInputStream fileInputStream = new FileInputStream(inFile);
+
+      try (BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+           FileInputStream fileInputStream = new FileInputStream(inFile);
            ArrowFileReader arrowReader = new ArrowFileReader(fileInputStream.getChannel(),
                allocator)) {
 

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
@@ -68,8 +68,5 @@ public class FileToStream {
         System.out : new FileOutputStream(new File(args[1]));
 
     convert(in, out);
-
-    in.close();
-    out.close();
   }
 }

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
@@ -68,5 +68,8 @@ public class FileToStream {
         System.out : new FileOutputStream(new File(args[1]));
 
     convert(in, out);
+
+    in.close();
+    out.close();
   }
 }

--- a/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
+++ b/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
@@ -95,9 +95,9 @@ public class EchoServerTest {
                               NullableTinyIntVector vector,
                               int batches)
       throws UnknownHostException, IOException {
-    BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
     VectorSchemaRoot root = new VectorSchemaRoot(asList(field), asList((FieldVector) vector), 0);
-    try (Socket socket = new Socket("localhost", serverPort);
+    try (BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
+         Socket socket = new Socket("localhost", serverPort);
          ArrowStreamWriter writer = new ArrowStreamWriter(root, null, socket.getOutputStream());
          ArrowStreamReader reader = new ArrowStreamReader(socket.getInputStream(), alloc)) {
       writer.start();

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
@@ -135,11 +135,19 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
 
   @Override
   public void close() throws IOException {
+    close(true);
+  }
+
+  public void close(boolean closeReadChannel) throws IOException {
     if (initialized) {
       root.close();
       for (Dictionary dictionary : dictionaries.values()) {
         dictionary.getVector().close();
       }
+    }
+
+    if (closeReadChannel) {
+      in.close();
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
@@ -141,7 +141,6 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
         dictionary.getVector().close();
       }
     }
-    in.close();
   }
 
   protected abstract Schema readSchema(T in) throws IOException;

--- a/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/file/ArrowReader.java
@@ -41,6 +41,11 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.DictionaryUtility;
 
+/**
+ * Abstract class to read ArrowRecordBatches from a ReadChannel.
+ *
+ * @param <T> Type of ReadChannel to use
+ */
 public abstract class ArrowReader<T extends ReadChannel> implements DictionaryProvider, AutoCloseable {
 
   private final T in;
@@ -58,7 +63,7 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
   }
 
   /**
-   * Returns the vector schema root. This will be loaded with new values on every call to loadNextBatch
+   * Returns the vector schema root. This will be loaded with new values on every call to loadNextBatch.
    *
    * @return the vector schema root
    * @throws IOException if reading of schema fails
@@ -69,9 +74,9 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
   }
 
   /**
-   * Returns any dictionaries
+   * Returns any dictionaries that were loaded along with ArrowRecordBatches.
    *
-   * @return dictionaries, if any
+   * @return Map of dictionaries to dictionary id, empty if no dictionaries loaded
    * @throws IOException if reading of schema fails
    */
   public Map<Long, Dictionary> getDictionaryVectors() throws IOException {
@@ -79,6 +84,12 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
     return dictionaries;
   }
 
+  /**
+   * Lookup a dictionary that has been loaded using the dictionary id.
+   *
+   * @param id Unique identifier for a dictionary
+   * @return the requested dictionary or null if not found
+   */
   @Override
   public Dictionary lookup(long id) {
     if (!initialized) {
@@ -88,7 +99,12 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
     return dictionaries.get(id);
   }
 
-  // Returns true if a batch was read, false on EOS
+  /**
+   * Load the next ArrowRecordBatch to the vector schema root if available.
+   *
+   * @return true if a batch was read, false on EOS
+   * @throws IOException
+   */
   public boolean loadNextBatch() throws IOException {
     ensureInitialized();
     // read in all dictionary batches, then stop after our first record batch
@@ -129,15 +145,33 @@ public abstract class ArrowReader<T extends ReadChannel> implements DictionaryPr
     return readBatch;
   }
 
+  /**
+   * Return the number of bytes read from the ReadChannel.
+   *
+   * @return number of bytes read
+   */
   public long bytesRead() {
     return in.bytesRead();
   }
 
+  /**
+   * Close resources, including vector schema root and dictionary vectors, and the
+   * underlying ReadChannel.
+   *
+   * @throws IOException
+   */
   @Override
   public void close() throws IOException {
     close(true);
   }
 
+  /**
+   * Close resources, including vector schema root and dictionary vectors. If the flag
+   * closeReadChannel is true then close the underlying ReadChannel, otherwise leave it open.
+   *
+   * @param closeReadChannel Flag to control if closing the underlying ReadChannel
+   * @throws IOException
+   */
   public void close(boolean closeReadChannel) throws IOException {
     if (initialized) {
       root.close();

--- a/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowReaderWriter.java
@@ -92,8 +92,8 @@ public class TestArrowReaderWriter {
 
     byte[] byteArray = out.toByteArray();
 
-    SeekableReadChannel channel = new SeekableReadChannel(new ByteArrayReadableSeekableByteChannel(byteArray));
-    try (ArrowFileReader reader = new ArrowFileReader(channel, allocator)) {
+    try (SeekableReadChannel channel = new SeekableReadChannel(new ByteArrayReadableSeekableByteChannel(byteArray));
+         ArrowFileReader reader = new ArrowFileReader(channel, allocator)) {
       Schema readSchema = reader.getVectorSchemaRoot().getSchema();
       assertEquals(schema, readSchema);
       assertTrue(readSchema.getFields().get(0).getTypeLayout().getVectorTypes().toString(), readSchema.getFields().get(0).getTypeLayout().getVectors().size() > 0);

--- a/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowStreamPipe.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/file/TestArrowStreamPipe.java
@@ -141,6 +141,7 @@ public class TestArrowStreamPipe {
         while (!done) {
           assertTrue(reader.loadNextBatch());
         }
+        reader.close();
       } catch (IOException e) {
         e.printStackTrace();
         Assert.fail(e.toString()); // have to explicitly fail since we're in a separate thread


### PR DESCRIPTION
This adds an alternative `ArrowReader.close(boolean closeReadChannel)` that if called with `false` will close reader resources such as vectors/dictionaries but leave the `ReadChannel` open. The behavior of the default `ArrowReader.close()` is unchanged.