### PR TITLE
ARROW-1630: [Serialization] Support Python datetime objects

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -359,3 +359,42 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This project includes code from the NumPy project.
+
+https://github.com/numpy/numpy/blob/e1f191c46f2eebd6cb892a4bfe14d9dd43a06c4e/numpy/core/src/multiarray/multiarraymodule.c#L2910
+
+https://github.com/numpy/numpy/blob/68fd82271b9ea5a9e50d4e761061dfcca851382a/numpy/core/src/multiarray/datetime.c
+
+Copyright (c) 2005-2017, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -8,11 +8,6 @@ This product includes software from the SFrame project (BSD, 3-clause).
 * Copyright (C) 2015 Dato, Inc.
 * Copyright (c) 2009 Carnegie Mellon University.
 
-This product includes software from the Numpy project (BSD-new)
- https://github.com/numpy/numpy/blob/e1f191c46f2eebd6cb892a4bfe14d9dd43a06c4e/numpy/core/src/multiarray/multiarraymodule.c#L2910
- * Copyright (c) 1995, 1996, 1997 Jim Hugunin, hugunin@mit.edu
- * Copyright (c) 2005 Travis E. Oliphant oliphant@ee.byu.edu Brigham Young University
-
 This product includes software from the Feather project (Apache 2.0)
 https://github.com/wesm/feather
 

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -129,7 +129,8 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
       return Status::OK();
     case Type::DATE64: {
       PyDateTime_IMPORT;
-      RETURN_NOT_OK(PyDateTime_from_int(static_cast<const Date64Array&>(arr).Value(index), TimeUnit::MICRO, result));
+      RETURN_NOT_OK(PyDateTime_from_int(static_cast<const Date64Array&>(arr).Value(index),
+                                        TimeUnit::MICRO, result));
       RETURN_IF_PYERROR();
       return Status::OK();
     }

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -28,6 +28,7 @@
 #include "arrow/python/helpers.h"
 #include "arrow/python/numpy_convert.h"
 #include "arrow/python/python_to_arrow.h"
+#include "arrow/python/util/datetime.h"
 #include "arrow/table.h"
 #include "arrow/util/logging.h"
 
@@ -126,6 +127,12 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
     case Type::DOUBLE:
       *result = PyFloat_FromDouble(static_cast<const DoubleArray&>(arr).Value(index));
       return Status::OK();
+    case Type::DATE64: {
+      PyDateTime_IMPORT;
+      RETURN_NOT_OK(PyDateTime_from_int(static_cast<const Date64Array&>(arr).Value(index), TimeUnit::MICRO, result));
+      RETURN_IF_PYERROR();
+      return Status::OK();
+    }
     case Type::STRUCT: {
       const auto& s = static_cast<const StructArray&>(arr);
       const auto& l = static_cast<const ListArray&>(*s.field(0));

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -128,7 +128,6 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
       *result = PyFloat_FromDouble(static_cast<const DoubleArray&>(arr).Value(index));
       return Status::OK();
     case Type::DATE64: {
-      PyDateTime_IMPORT;
       RETURN_NOT_OK(PyDateTime_from_int(static_cast<const Date64Array&>(arr).Value(index),
                                         TimeUnit::MICRO, result));
       RETURN_IF_PYERROR();
@@ -256,6 +255,7 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
 Status DeserializeObject(PyObject* context, const SerializedPyObject& obj, PyObject* base,
                          PyObject** out) {
   PyAcquireGIL lock;
+  PyDateTime_IMPORT;
   return DeserializeList(context, *obj.batch->column(0), 0, obj.batch->num_rows(), base,
                          obj.tensors, out);
 }

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -434,7 +434,6 @@ Status Append(PyObject* context, PyObject* elem, SequenceBuilder* builder,
               std::vector<PyObject*>* sublists, std::vector<PyObject*>* subtuples,
               std::vector<PyObject*>* subdicts, std::vector<PyObject*>* subsets,
               std::vector<PyObject*>* tensors_out) {
-  PyDateTime_IMPORT;
   // The bool case must precede the int case (PyInt_Check passes for bools)
   if (PyBool_Check(elem)) {
     RETURN_NOT_OK(builder->AppendBool(elem == Py_True));
@@ -670,6 +669,7 @@ std::shared_ptr<RecordBatch> MakeBatch(std::shared_ptr<Array> data) {
 
 Status SerializeObject(PyObject* context, PyObject* sequence, SerializedPyObject* out) {
   PyAcquireGIL lock;
+  PyDateTime_IMPORT;
   std::vector<PyObject*> sequences = {sequence};
   std::shared_ptr<Array> array;
   std::vector<PyObject*> py_tensors;

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -36,6 +36,7 @@
 #include "arrow/python/helpers.h"
 #include "arrow/python/numpy_convert.h"
 #include "arrow/python/platform.h"
+#include "arrow/python/util/datetime.h"
 #include "arrow/tensor.h"
 #include "arrow/util/logging.h"
 
@@ -59,6 +60,7 @@ class SequenceBuilder {
         strings_(pool),
         floats_(::arrow::float32(), pool),
         doubles_(::arrow::float64(), pool),
+        date64s_(::arrow::date64(), pool),
         tensor_indices_(::arrow::int32(), pool),
         list_offsets_({0}),
         tuple_offsets_({0}),
@@ -123,6 +125,11 @@ class SequenceBuilder {
   /// Appending a double to the sequence
   Status AppendDouble(const double data) {
     return AppendPrimitive(data, &double_tag_, &doubles_);
+  }
+
+  /// Appending a Date64 timestamp to the sequence
+  Status AppendDate64(const int64_t timestamp) {
+    return AppendPrimitive(timestamp, &date64_tag_, &date64s_);
   }
 
   /// Appending a tensor to the sequence
@@ -217,6 +224,7 @@ class SequenceBuilder {
     RETURN_NOT_OK(AddElement(bytes_tag_, &bytes_));
     RETURN_NOT_OK(AddElement(float_tag_, &floats_));
     RETURN_NOT_OK(AddElement(double_tag_, &doubles_));
+    RETURN_NOT_OK(AddElement(date64_tag_, &date64s_));
     RETURN_NOT_OK(AddElement(tensor_tag_, &tensor_indices_));
 
     RETURN_NOT_OK(AddSubsequence(list_tag_, list_data, list_offsets_, "list"));
@@ -244,6 +252,7 @@ class SequenceBuilder {
   StringBuilder strings_;
   FloatBuilder floats_;
   DoubleBuilder doubles_;
+  Date64Builder date64s_;
 
   // We use an Int32Builder here to distinguish the tensor indices from
   // the ints_ above (see the case Type::INT32 in get_value in python.cc).
@@ -267,6 +276,7 @@ class SequenceBuilder {
   int8_t bytes_tag_ = -1;
   int8_t float_tag_ = -1;
   int8_t double_tag_ = -1;
+  int8_t date64_tag_ = -1;
 
   int8_t tensor_tag_ = -1;
   int8_t list_tag_ = -1;
@@ -424,6 +434,7 @@ Status Append(PyObject* context, PyObject* elem, SequenceBuilder* builder,
               std::vector<PyObject*>* sublists, std::vector<PyObject*>* subtuples,
               std::vector<PyObject*>* subdicts, std::vector<PyObject*>* subsets,
               std::vector<PyObject*>* tensors_out) {
+  PyDateTime_IMPORT;
   // The bool case must precede the int case (PyInt_Check passes for bools)
   if (PyBool_Check(elem)) {
     RETURN_NOT_OK(builder->AppendBool(elem == Py_True));
@@ -485,6 +496,9 @@ Status Append(PyObject* context, PyObject* elem, SequenceBuilder* builder,
                                  subdicts, tensors_out));
   } else if (elem == Py_None) {
     RETURN_NOT_OK(builder->AppendNone());
+  } else if (PyDateTime_CheckExact(elem)) {
+    PyDateTime_DateTime* datetime = reinterpret_cast<PyDateTime_DateTime*>(elem);
+    RETURN_NOT_OK(builder->AppendDate64(PyDateTime_to_us(datetime)));
   } else {
     // Attempt to serialize the object using the custom callback.
     PyObject* serialized_object;

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -33,12 +33,12 @@ namespace py {
 // https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/datetime.c
 
 // Days per month, regular year and leap year
-static int _days_per_month_table[2][12] = {
+static int64_t _days_per_month_table[2][12] = {
     { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
     { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
 };
 
-static int is_leapyear(int64_t year) {
+static bool is_leapyear(int64_t year) {
     return (year & 0x3) == 0 && // year % 4 == 0
            ((year % 100) != 0 ||
             (year % 400) == 0);
@@ -48,9 +48,9 @@ static int is_leapyear(int64_t year) {
 static int64_t get_days_from_date(int64_t date_year,
                                   int64_t date_month,
                                   int64_t date_day) {
-    int i, month;
+    int64_t i, month;
     int64_t year, days = 0;
-    int *month_lengths;
+    int64_t *month_lengths;
 
     year = date_year - 1970;
     days = year * 365;
@@ -142,7 +142,7 @@ static void get_date_from_days(int64_t days,
                                int64_t* date_year,
                                int64_t* date_month,
                                int64_t* date_day) {
-    int *month_lengths, i;
+    int64_t *month_lengths, i;
 
     *date_year = days_to_yearsdays(&days);
     month_lengths = _days_per_month_table[is_leapyear(*date_year)];
@@ -234,8 +234,13 @@ static inline Status PyDateTime_from_int(int64_t val, const TimeUnit::type unit,
   hour = split_time(hour, 24, &total_days);
   int64_t year = 0, month = 0, day = 0;
   get_date_from_days(total_days, &year, &month, &day);
-  *out = PyDateTime_FromDateAndTime(year, month, day, hour,
-                                    minute, second, microsecond);
+  *out = PyDateTime_FromDateAndTime(static_cast<int32_t>(year),
+                                    static_cast<int32_t>(month),
+                                    static_cast<int32_t>(day),
+                                    static_cast<int32_t>(hour),
+                                    static_cast<int32_t>(minute),
+                                    static_cast<int32_t>(second),
+                                    static_cast<int32_t>(microsecond));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -28,6 +28,73 @@
 namespace arrow {
 namespace py {
 
+// Days per month, regular year and leap year
+static int _days_per_month_table[2][12] = {
+    { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 },
+    { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }
+};
+
+static int is_leapyear(int64_t year) {
+    return (year & 0x3) == 0 && // year % 4 == 0
+           ((year % 100) != 0 ||
+            (year % 400) == 0);
+}
+
+// Calculates the days offset from the 1970 epoch.
+static int64_t get_days_from_date(int64_t date_year,
+                                  int64_t date_month,
+                                  int64_t date_day) {
+    int i, month;
+    int64_t year, days = 0;
+    int *month_lengths;
+
+    year = date_year - 1970;
+    days = year * 365;
+
+    // Adjust for leap years
+    if (days >= 0) {
+        // 1968 is the closest leap year before 1970.
+        // Exclude the current year, so add 1.
+        year += 1;
+        // Add one day for each 4 years
+        days += year / 4;
+        // 1900 is the closest previous year divisible by 100
+        year += 68;
+        // Subtract one day for each 100 years
+        days -= year / 100;
+        // 1600 is the closest previous year divisible by 400
+        year += 300;
+        // Add one day for each 400 years
+        days += year / 400;
+    } else {
+        // 1972 is the closest later year after 1970.
+        // Include the current year, so subtract 2.
+        year -= 2;
+        // Subtract one day for each 4 years
+        days += year / 4;
+        // 2000 is the closest later year divisible by 100
+        year -= 28;
+        // Add one day for each 100 years
+        days -= year / 100;
+        // 2000 is also the closest later year divisible by 400
+        // Subtract one day for each 400 years
+        days += year / 400;
+    }
+
+    month_lengths = _days_per_month_table[is_leapyear(date_year)];
+    month = date_month - 1;
+
+    // Add the months
+    for (i = 0; i < month; ++i) {
+        days += month_lengths[i];
+    }
+
+    // Add the days
+    days += date_day - 1;
+
+    return days;
+}
+
 static inline int64_t PyTime_to_us(PyObject* pytime) {
   return (static_cast<int64_t>(PyDateTime_TIME_GET_HOUR(pytime)) * 3600000000LL +
           static_cast<int64_t>(PyDateTime_TIME_GET_MINUTE(pytime)) * 60000000LL +
@@ -99,7 +166,7 @@ static inline Status PyDateTime_from_int(int64_t val, const TimeUnit::type unit,
       break;
   }
   // Now val is in seconds and we are going to do the inverse of what
-  // PyDateTime_to_us does. Note also that this is probably not threadsafe.
+  // PyDateTime_to_us does.
   time_t t = static_cast<time_t>(val);
   struct tm datetime;
   struct tm* result = gmtime_r(&t, &datetime);
@@ -112,49 +179,29 @@ static inline Status PyDateTime_from_int(int64_t val, const TimeUnit::type unit,
 }
 
 static inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
-  struct tm date;
-  memset(&date, 0, sizeof(struct tm));
-  date.tm_year = PyDateTime_GET_YEAR(pydate) - 1900;
-  date.tm_mon = PyDateTime_GET_MONTH(pydate) - 1;
-  date.tm_mday = PyDateTime_GET_DAY(pydate);
-  struct tm epoch;
-  memset(&epoch, 0, sizeof(struct tm));
-
-  epoch.tm_year = 70;
-  epoch.tm_mday = 1;
-#ifdef _MSC_VER
-  // Milliseconds since the epoch
-  const int64_t current_timestamp = static_cast<int64_t>(_mkgmtime64(&date));
-  const int64_t epoch_timestamp = static_cast<int64_t>(_mkgmtime64(&epoch));
-  return (current_timestamp - epoch_timestamp) * 1000LL;
-#else
-  return lrint(difftime(mktime(&date), mktime(&epoch)) * 1000);
-#endif
+  int64_t total_seconds = 0;
+  total_seconds += PyDateTime_DATE_GET_SECOND(pydate);
+  total_seconds += PyDateTime_DATE_GET_MINUTE(pydate) * 60;
+  total_seconds += PyDateTime_DATE_GET_HOUR(pydate) * 3600;
+  int64_t days = get_days_from_date(PyDateTime_GET_YEAR(pydate),
+                                    PyDateTime_GET_MONTH(pydate),
+                                    PyDateTime_GET_DAY(pydate));
+  total_seconds += days * 24 * 3600;
+  return total_seconds * 1000;
 }
 
 static inline int64_t PyDateTime_to_us(PyDateTime_DateTime* pydatetime) {
-  struct tm datetime;
-  memset(&datetime, 0, sizeof(struct tm));
-  datetime.tm_year = PyDateTime_GET_YEAR(pydatetime) - 1900;
-  datetime.tm_mon = PyDateTime_GET_MONTH(pydatetime) - 1;
-  datetime.tm_mday = PyDateTime_GET_DAY(pydatetime);
-  datetime.tm_hour = PyDateTime_DATE_GET_HOUR(pydatetime);
-  datetime.tm_min = PyDateTime_DATE_GET_MINUTE(pydatetime);
-  datetime.tm_sec = PyDateTime_DATE_GET_SECOND(pydatetime);
+  int64_t total_seconds = 0;
+  total_seconds += PyDateTime_DATE_GET_SECOND(pydatetime);
+  total_seconds += PyDateTime_DATE_GET_MINUTE(pydatetime) * 60;
+  total_seconds += PyDateTime_DATE_GET_HOUR(pydatetime) * 3600;
+  int64_t days = get_days_from_date(PyDateTime_GET_YEAR(pydatetime),
+                                    PyDateTime_GET_MONTH(pydatetime),
+                                    PyDateTime_GET_DAY(pydatetime));
+  total_seconds += days * 24 * 3600;
   int us = PyDateTime_DATE_GET_MICROSECOND(pydatetime);
-  struct tm epoch;
-  memset(&epoch, 0, sizeof(struct tm));
-  epoch.tm_year = 70;
-  epoch.tm_mday = 1;
-#ifdef _MSC_VER
-  // Microseconds since the epoch
-  const int64_t current_timestamp = static_cast<int64_t>(_mkgmtime64(&datetime));
-  const int64_t epoch_timestamp = static_cast<int64_t>(_mkgmtime64(&epoch));
-  return (current_timestamp - epoch_timestamp) * 1000000L + us;
-#else
-  return static_cast<int64_t>(
-      llrint(difftime(mktime(&datetime), mktime(&epoch))) * 1000000 + us);
-#endif
+
+  return total_seconds * 1000000 + us;
 }
 
 static inline int32_t PyDate_to_days(PyDateTime_Date* pydate) {

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -97,18 +97,12 @@ static inline Status PyDateTime_from_int(int64_t val, const TimeUnit::type unit,
       break;
   }
   // Now val is in seconds and we are going to do the inverse of what
-  // PyDateTime_to_us does. Note that localtime is the inverse of mktime.
-  // Note also that this is probably not threadsafe.
+  // PyDateTime_to_us does. Note also that this is probably not threadsafe.
   time_t t = static_cast<time_t>(val);
-  struct tm epoch;
-  memset(&epoch, 0, sizeof(struct tm));
-  epoch.tm_year = 70;
-  epoch.tm_mday = 1;
-  t += mktime(&epoch);
-  struct tm* datetime = localtime(&t);
+  struct tm* datetime = gmtime(&t);
   *out = PyDateTime_FromDateAndTime(datetime->tm_year + 1900, datetime->tm_mon + 1,
                                     datetime->tm_mday, datetime->tm_hour,
-                                    datetime->tm_min, datetime->tm_sec,
+                                    datetime->tm_min, std::min(59, datetime->tm_sec),
                                     microsecond);
   return Status::OK();
 }

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -326,7 +326,10 @@ def test_datetime_serialization(large_memory_map):
             datetime.datetime(year=1989, month=11, day=9),
             # Another random date
             datetime.datetime(year=2011, month=6, day=3, hour=4,
-                              minute=55, second=44)]
+                              minute=0, second=3),
+            # Another random date
+            datetime.datetime(year=1970, month=1, day=3, hour=4,
+                              minute=0, second=0)]
     with pa.memory_map(large_memory_map, mode="r+") as mmap:
         for d in data:
             serialization_roundtrip(d, mmap)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -20,6 +20,7 @@ from __future__ import division
 import pytest
 
 from collections import namedtuple, OrderedDict, defaultdict
+import datetime
 import string
 import sys
 
@@ -309,6 +310,17 @@ def test_numpy_serialization(large_memory_map):
                   "int32", "uint32", "float32", "float64"]:
             obj = np.random.randint(0, 10, size=(100, 100)).astype(t)
             serialization_roundtrip(obj, mmap)
+
+
+def test_datetime_serialization(large_memory_map):
+    data = [datetime.datetime(year=1911, month=6, day=3, hour=4,
+                              minute=55, second=44),
+            datetime.datetime(year=1911, month=2, day=3),
+            datetime.datetime(year=2011, month=6, day=3, hour=3,
+                              minute=55, second=44)]
+    with pa.memory_map(large_memory_map, mode="r+") as mmap:
+        for d in data:
+            serialization_roundtrip(d, mmap)
 
 
 def test_numpy_immutable(large_memory_map):

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -313,10 +313,20 @@ def test_numpy_serialization(large_memory_map):
 
 
 def test_datetime_serialization(large_memory_map):
-    data = [datetime.datetime(year=1911, month=6, day=3, hour=4,
+    data = [# Principia Mathematica published
+            # datetime.datetime(year=1687, month=7, day=5),
+            # (this is currently not working)
+            # Some random date
+            datetime.datetime(year=1911, month=6, day=3, hour=4,
                               minute=55, second=44),
-            datetime.datetime(year=1911, month=2, day=3),
-            datetime.datetime(year=2011, month=6, day=3, hour=3,
+            # End of WWI
+            datetime.datetime(year=1918, month=11, day=11),
+            # Beginning of UNIX time
+            datetime.datetime(year=1970, month=1, day=1),
+            # The Berlin wall falls
+            datetime.datetime(year=1989, month=11, day=9),
+            # Another random date
+            datetime.datetime(year=2011, month=6, day=3, hour=4,
                               minute=55, second=44)]
     with pa.memory_map(large_memory_map, mode="r+") as mmap:
         for d in data:

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -314,8 +314,7 @@ def test_numpy_serialization(large_memory_map):
 
 def test_datetime_serialization(large_memory_map):
     data = [# Principia Mathematica published
-            # datetime.datetime(year=1687, month=7, day=5),
-            # (this is currently not working)
+            datetime.datetime(year=1687, month=7, day=5),
             # Some random date
             datetime.datetime(year=1911, month=6, day=3, hour=4,
                               minute=55, second=44),


### PR DESCRIPTION
An additional pair of eyes would be helpful, somewhat strangely the tests are passing for some datetime objects and not for others.