### PR TITLE
ARROW-1584: [C++/Python] Support Null type in IPC round trips, fix serialize_pandas on empty DataFrame

### DIFF
--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -121,7 +121,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
                     &MakeStringTypesRecordBatch, &MakeStruct, &MakeUnion,               \
                     &MakeDictionary, &MakeDates, &MakeTimestamps, &MakeTimes,           \
-                    &MakeFWBinary, &MakeDecimal, &MakeBooleanBatch);
+                    &MakeFWBinary, &MakeNull, &MakeDecimal, &MakeBooleanBatch);
 
 static int g_file_number = 0;
 

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -229,6 +229,9 @@ static Status TypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
   switch (type) {
     case flatbuf::Type_NONE:
       return Status::Invalid("Type metadata cannot be none");
+    case flatbuf::Type_Null:
+      *out = null();
+      return Status::OK();
     case flatbuf::Type_Int:
       return IntFromFlatbuffer(static_cast<const flatbuf::Int*>(type_data), out);
     case flatbuf::Type_FloatingPoint:
@@ -353,6 +356,10 @@ static Status TypeToFlatbuffer(FBB& fbb, const DataType& type,
   }
 
   switch (value_type->id()) {
+    case Type::NA:
+      *out_type = flatbuf::Type_Null;
+      *offset = flatbuf::CreateNull(fbb).Union();
+      break;
     case Type::BOOL:
       *out_type = flatbuf::Type_Bool;
       *offset = flatbuf::CreateBool(fbb).Union();

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -187,7 +187,11 @@ class ArrayLoader {
     return Status::OK();
   }
 
-  Status Visit(const NullType& type) { return Status::NotImplemented("null"); }
+  Status Visit(const NullType& type) {
+    out_->buffers = {nullptr};
+    RETURN_NOT_OK(LoadCommon());
+    return Status::OK();
+  }
 
   template <typename T>
   typename std::enable_if<std::is_base_of<FixedWidthType, T>::value &&

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -188,8 +188,9 @@ class ArrayLoader {
   }
 
   Status Visit(const NullType& type) {
-    out_->buffers = {nullptr};
+    out_->buffers.resize(1);
     RETURN_NOT_OK(LoadCommon());
+    RETURN_NOT_OK(GetBuffer(context_->buffer_index++, &out_->buffers[0]));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -708,7 +708,8 @@ Status MakeNull(std::shared_ptr<RecordBatch>* out) {
   auto a1 = std::make_shared<NullArray>(10);
 
   std::vector<int64_t> int_values = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-  std::vector<bool> is_valid = {true, true, true, false, false, true, true, true, true, true};
+  std::vector<bool> is_valid = {true, true, true, false, false,
+                                true, true, true, true,  true};
   std::shared_ptr<Array> a2;
   ArrayFromVector<Int64Type, int64_t>(f1->type(), is_valid, int_values, &a2);
 

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -697,6 +697,17 @@ Status MakeDecimal(std::shared_ptr<RecordBatch>* out) {
   return Status::OK();
 }
 
+Status MakeNull(std::shared_ptr<RecordBatch>* out) {
+  auto f0 = field("f0", null());
+  auto schema = ::arrow::schema({f0});
+
+  auto a1 = std::make_shared<NullArray>(10);
+
+  ArrayVector arrays = {a1};
+  *out = std::make_shared<RecordBatch>(schema, a1->length(), arrays);
+  return Status::OK();
+}
+
 }  // namespace ipc
 }  // namespace arrow
 

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -699,11 +699,20 @@ Status MakeDecimal(std::shared_ptr<RecordBatch>* out) {
 
 Status MakeNull(std::shared_ptr<RecordBatch>* out) {
   auto f0 = field("f0", null());
-  auto schema = ::arrow::schema({f0});
+
+  // Also put a non-null field to make sure we handle the null array buffers properly
+  auto f1 = field("f1", int64());
+
+  auto schema = ::arrow::schema({f0, f1});
 
   auto a1 = std::make_shared<NullArray>(10);
 
-  ArrayVector arrays = {a1};
+  std::vector<int64_t> int_values = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  std::vector<bool> is_valid = {true, true, true, false, false, true, true, true, true, true};
+  std::shared_ptr<Array> a2;
+  ArrayFromVector<Int64Type, int64_t>(f1->type(), is_valid, int_values, &a2);
+
+  ArrayVector arrays = {a1, a2};
   *out = std::make_shared<RecordBatch>(schema, a1->length(), arrays);
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -321,6 +321,11 @@ class RecordBatchSerializer : public ArrayVisitor {
     return Status::OK();
   }
 
+  Status Visit(const NullArray& array) override {
+    buffers_.push_back(nullptr);
+    return Status::OK();
+  }
+
 #define VISIT_FIXED_WIDTH(TYPE) \
   Status Visit(const TYPE& array) override { return VisitFixedWidth<TYPE>(array); }
 

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -470,8 +470,7 @@ class UInt8Converter : public TypedConverterVisitor<UInt8Builder, UInt8Converter
   inline Status AppendItem(const OwnedRef& item) {
     uint64_t val = static_cast<uint64_t>(PyLong_AsLongLong(item.obj()));
 
-    if (ARROW_PREDICT_FALSE(val > std::numeric_limits<uint8_t>::max() ||
-                            val < std::numeric_limits<uint8_t>::min())) {
+    if (ARROW_PREDICT_FALSE(val > std::numeric_limits<uint8_t>::max())) {
       return Status::Invalid(
           "Cannot coerce values to array type that would "
           "lose data");
@@ -486,8 +485,7 @@ class UInt16Converter : public TypedConverterVisitor<UInt16Builder, UInt16Conver
   inline Status AppendItem(const OwnedRef& item) {
     uint64_t val = static_cast<uint64_t>(PyLong_AsLongLong(item.obj()));
 
-    if (ARROW_PREDICT_FALSE(val > std::numeric_limits<uint16_t>::max() ||
-                            val < std::numeric_limits<uint16_t>::min())) {
+    if (ARROW_PREDICT_FALSE(val > std::numeric_limits<uint16_t>::max())) {
       return Status::Invalid(
           "Cannot coerce values to array type that would "
           "lose data");
@@ -502,8 +500,7 @@ class UInt32Converter : public TypedConverterVisitor<UInt32Builder, UInt32Conver
   inline Status AppendItem(const OwnedRef& item) {
     uint64_t val = static_cast<uint64_t>(PyLong_AsLongLong(item.obj()));
 
-    if (ARROW_PREDICT_FALSE(val > std::numeric_limits<uint32_t>::max() ||
-                            val < std::numeric_limits<uint32_t>::min())) {
+    if (ARROW_PREDICT_FALSE(val > std::numeric_limits<uint32_t>::max())) {
       return Status::Invalid(
           "Cannot coerce values to array type that would "
           "lose data");

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -344,6 +344,12 @@ def test_get_record_batch_size():
     assert pa.get_record_batch_size(batch) > (N * itemsize)
 
 
+def _check_serialize_pandas_round_trip(df, nthreads=1):
+    buf = pa.serialize_pandas(df)
+    result = pa.deserialize_pandas(buf, nthreads=nthreads)
+    assert_frame_equal(result, df)
+
+
 def test_pandas_serialize_round_trip():
     index = pd.Index([1, 2, 3], name='my_index')
     columns = ['foo', 'bar']
@@ -351,9 +357,7 @@ def test_pandas_serialize_round_trip():
         {'foo': [1.5, 1.6, 1.7], 'bar': list('abc')},
         index=index, columns=columns
     )
-    buf = pa.serialize_pandas(df)
-    result = pa.deserialize_pandas(buf)
-    assert_frame_equal(result, df)
+    _check_serialize_pandas_round_trip(df)
 
 
 def test_pandas_serialize_round_trip_nthreads():
@@ -363,9 +367,7 @@ def test_pandas_serialize_round_trip_nthreads():
         {'foo': [1.5, 1.6, 1.7], 'bar': list('abc')},
         index=index, columns=columns
     )
-    buf = pa.serialize_pandas(df)
-    result = pa.deserialize_pandas(buf, nthreads=2)
-    assert_frame_equal(result, df)
+    _check_serialize_pandas_round_trip(df, nthreads=2)
 
 
 def test_pandas_serialize_round_trip_multi_index():
@@ -379,9 +381,12 @@ def test_pandas_serialize_round_trip_multi_index():
         index=index,
         columns=columns,
     )
-    buf = pa.serialize_pandas(df)
-    result = pa.deserialize_pandas(buf)
-    assert_frame_equal(result, df)
+    _check_serialize_pandas_round_trip(df)
+
+
+def test_serialize_pandas_empty_dataframe():
+    df = pd.DataFrame()
+    _check_serialize_pandas_round_trip(df)
 
 
 @pytest.mark.xfail(

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -295,11 +295,13 @@ def test_custom_serialization(large_memory_map):
         for obj in CUSTOM_OBJECTS:
             serialization_roundtrip(obj, mmap)
 
+
 def test_default_dict_serialization(large_memory_map):
-    cloudpickle = pytest.importorskip("cloudpickle")
+    pytest.importorskip("cloudpickle")
     with pa.memory_map(large_memory_map, mode="r+") as mmap:
         obj = defaultdict(lambda: 0, [("hello", 1), ("world", 2)])
         serialization_roundtrip(obj, mmap)
+
 
 def test_numpy_serialization(large_memory_map):
     with pa.memory_map(large_memory_map, mode="r+") as mmap:


### PR DESCRIPTION
cc @TomAugspurger @cpcloud -- this turned out to be caused by the index in the empty DataFrame having null type:

```
In [3]: arr = pa.array([])

In [4]: arr.type
Out[4]: DataType(null)

In [5]: arr = pa.array([None, None, None])

In [6]: arr
Out[6]: 
<pyarrow.lib.NullArray object at 0x7f28d3d205e8>
[
  NA,
  NA,
  NA
]
```

This type had been unhandled in the IPC machinery, so this resolves ARROW-1637. We need to implement integration tests for this type to make sure such data can be accurately messages between Java and C++/Python