### PR TITLE
ARROW-1525: [C++] New compare functions that return boolean instead of Status

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -248,11 +248,11 @@ to avoid failures due to compiler warnings.
 Note that the clang-tidy target may take a while to run.  You might consider
 running clang-tidy separately on the files you have added/changed before
 invoking the make target to reduce iteration time.  Also, it might generate warnings
-that aren't valid.  To avoid these you can use add a line comment `// NOLINT`. If
+that aren't valid.  To avoid these you can add a line comment `// NOLINT`. If
 NOLINT doesn't suppress the warnings, you add the file in question to
 the .clang-tidy-ignore file.  This will allow `make check-clang-tidy` to pass in
-travis-CI (but still surface the potential warnings in `make clang-tidy`).   Ideally,
-both of these options would be used rarely.  Current known uses-cases whent hey are required:
+travis-CI (but still surface the potential warnings in `make clang-tidy`). Ideally,
+both of these options would be used rarely. Current known uses-cases when they are required:
 
 *  Parameterized tests in google test.
 

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -53,12 +53,7 @@ int64_t Array::null_count() const {
 }
 
 bool Array::Equals(const Array& arr) const {
-  bool are_equal = false;
-  Status error = ArrayEquals(*this, arr, &are_equal);
-  if (!error.ok()) {
-    DCHECK(false) << "Arrays not comparable: " << error.ToString();
-  }
-  return are_equal;
+  return ArrayEquals(*this, arr);
 }
 
 bool Array::Equals(const std::shared_ptr<Array>& arr) const {
@@ -69,12 +64,7 @@ bool Array::Equals(const std::shared_ptr<Array>& arr) const {
 }
 
 bool Array::ApproxEquals(const Array& arr) const {
-  bool are_equal = false;
-  Status error = ArrayApproxEquals(*this, arr, &are_equal);
-  if (!error.ok()) {
-    DCHECK(false) << "Arrays not comparable: " << error.ToString();
-  }
-  return are_equal;
+  return ArrayApproxEquals(*this, arr);
 }
 
 bool Array::ApproxEquals(const std::shared_ptr<Array>& arr) const {
@@ -94,13 +84,7 @@ bool Array::RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_
 
 bool Array::RangeEquals(const Array& other, int64_t start_idx, int64_t end_idx,
                         int64_t other_start_idx) const {
-  bool are_equal = false;
-  Status error =
-      ArrayRangeEquals(*this, other, start_idx, end_idx, other_start_idx, &are_equal);
-  if (!error.ok()) {
-    DCHECK(false) << "Arrays not comparable: " << error.ToString();
-  }
-  return are_equal;
+  return ArrayRangeEquals(*this, other, start_idx, end_idx, other_start_idx);
 }
 
 static inline std::shared_ptr<ArrayData> SliceData(const ArrayData& data, int64_t offset,

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -31,25 +31,49 @@ class DataType;
 class Status;
 class Tensor;
 
+#ifndef ARROW_NO_DEPRECATED_API
 /// Returns true if the arrays are exactly equal
+/// \deprecated Since 0.8.0
 Status ARROW_EXPORT ArrayEquals(const Array& left, const Array& right, bool* are_equal);
 
+/// \deprecated Since 0.8.0
 Status ARROW_EXPORT TensorEquals(const Tensor& left, const Tensor& right,
                                  bool* are_equal);
 
 /// Returns true if the arrays are approximately equal. For non-floating point
 /// types, this is equivalent to ArrayEquals(left, right)
+/// \deprecated Since 0.8.0
 Status ARROW_EXPORT ArrayApproxEquals(const Array& left, const Array& right,
                                       bool* are_equal);
 
 /// Returns true if indicated equal-length segment of arrays is exactly equal
+/// \deprecated Since 0.8.0
 Status ARROW_EXPORT ArrayRangeEquals(const Array& left, const Array& right,
                                      int64_t start_idx, int64_t end_idx,
                                      int64_t other_start_idx, bool* are_equal);
 
 /// Returns true if the type metadata are exactly equal
+/// \deprecated Since 0.8.0
 Status ARROW_EXPORT TypeEquals(const DataType& left, const DataType& right,
                                bool* are_equal);
+#endif
+
+/// Returns true if the arrays are exactly equal
+bool ARROW_EXPORT ArrayEquals(const Array& left, const Array& right);
+
+bool ARROW_EXPORT TensorEquals(const Tensor& left, const Tensor& right);
+
+/// Returns true if the arrays are approximately equal. For non-floating point
+/// types, this is equivalent to ArrayEquals(left, right)
+bool ARROW_EXPORT ArrayApproxEquals(const Array& left, const Array& right);
+
+/// Returns true if indicated equal-length segment of arrays is exactly equal
+bool ARROW_EXPORT ArrayRangeEquals(const Array& left, const Array& right,
+                                   int64_t start_idx, int64_t end_idx,
+                                   int64_t other_start_idx);
+
+/// Returns true if the type metadata are exactly equal
+bool ARROW_EXPORT TypeEquals(const DataType& left, const DataType& right);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -47,8 +47,7 @@ namespace arrow {
 namespace compute {
 
 void AssertArraysEqual(const Array& left, const Array& right) {
-  bool are_equal = false;
-  ASSERT_OK(ArrayEquals(left, right, &are_equal));
+  bool are_equal = ArrayEquals(left, right);
 
   if (!are_equal) {
     std::stringstream ss;

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -118,12 +118,7 @@ bool Tensor::is_column_major() const {
 Type::type Tensor::type_id() const { return type_->id(); }
 
 bool Tensor::Equals(const Tensor& other) const {
-  bool are_equal = false;
-  Status error = TensorEquals(*this, other, &are_equal);
-  if (!error.ok()) {
-    DCHECK(false) << "Tensors not comparable: " << error.ToString();
-  }
-  return are_equal;
+  return TensorEquals(*this, other);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -83,12 +83,7 @@ std::string Field::ToString() const {
 DataType::~DataType() {}
 
 bool DataType::Equals(const DataType& other) const {
-  bool are_equal = false;
-  Status error = TypeEquals(*this, other, &are_equal);
-  if (!error.ok()) {
-    DCHECK(false) << "Types not comparable: " << error.ToString();
-  }
-  return are_equal;
+  return TypeEquals(*this, other);
 }
 
 bool DataType::Equals(const std::shared_ptr<DataType>& other) const {


### PR DESCRIPTION
Comparison should always succeed so, it makes better sense to return boolean
values as the result of comparison instead of Status.
This changeset introduces a set of new compare functions and deprecates the
current ones.

Author: Amir Malekpour <a.malekpour@gmail.com>