### PR TITLE
ARROW-1603: [C++] Add BinaryArray::GetString helper method

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1045,6 +1045,18 @@ TEST_F(TestBinaryArray, TestGetValue) {
   }
 }
 
+TEST_F(TestBinaryArray, TestGetString) {
+  for (size_t i = 0; i < expected_.size(); ++i) {
+    if (valid_bytes_[i] == 0) {
+      ASSERT_TRUE(strings_->IsNull(i));
+    } else {
+      std::string val = strings_->GetString(i);
+      ASSERT_EQ(0, std::memcmp(expected_[i].data(), val.c_str(),
+                               val.size()));
+    }
+  }
+}
+
 TEST_F(TestBinaryArray, TestEqualsEmptyStrings) {
   BinaryBuilder builder;
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -444,6 +444,17 @@ class ARROW_EXPORT BinaryArray : public FlatArray {
     return raw_data_ + pos;
   }
 
+  /// \brief Get binary value as a std::string
+  ///
+  /// \param i the value index
+  /// \return the value copied into a std::string
+  std::string GetString(int64_t i) const {
+    int32_t length = 0;
+    const uint8_t* bytes = GetValue(i, &length);
+    return std::string(reinterpret_cast<const char*>(bytes),
+                       static_cast<size_t>(length));
+  }
+
   /// Note that this buffer does not account for any slice offset
   std::shared_ptr<Buffer> value_offsets() const { return data_->buffers[1]; }
 


### PR DESCRIPTION
In some applications it is useful to get values as `std::string`