### PR TITLE
ARROW-1640: Fix HTTPS failures in cmake / libcurl caused by ca-certificates clash

### DIFF
--- a/ci/travis_before_script_cpp.sh
+++ b/ci/travis_before_script_cpp.sh
@@ -47,6 +47,10 @@ if [ "$ARROW_TRAVIS_USE_TOOLCHAIN" == "1" ]; then
         curl \
         thrift-cpp \
         ninja
+
+  # HACK(wesm): We started experiencing OpenSSL failures when Miniconda was
+  # updated sometime on October 2 or October 3
+  conda update -p $CPP_TOOLCHAIN ca-certificates -c defaults
 fi
 
 if [ $TRAVIS_OS_NAME == "osx" ]; then

--- a/ci/travis_before_script_cpp.sh
+++ b/ci/travis_before_script_cpp.sh
@@ -50,7 +50,7 @@ if [ "$ARROW_TRAVIS_USE_TOOLCHAIN" == "1" ]; then
 
   # HACK(wesm): We started experiencing OpenSSL failures when Miniconda was
   # updated sometime on October 2 or October 3
-  conda update -p $CPP_TOOLCHAIN ca-certificates -c defaults
+  conda update -y -p $CPP_TOOLCHAIN ca-certificates -c defaults
 fi
 
 if [ $TRAVIS_OS_NAME == "osx" ]; then

--- a/ci/travis_install_conda.sh
+++ b/ci/travis_install_conda.sh
@@ -44,8 +44,3 @@ conda config --set remote_connect_timeout_secs 12
 conda config --add channels https://repo.continuum.io/pkgs/free
 conda config --add channels conda-forge
 conda info -a
-
-# faster builds, please
-conda install -y nomkl
-
-conda install --y conda-build jinja2 anaconda-client cmake curl


### PR DESCRIPTION
See discussion in https://github.com/apache/arrow/pull/1155

This seems to have done the trick, here is the Travis CI build running on my fork: https://travis-ci.org/wesm/arrow/builds/283203983

I will merge this as soon as it passes so that other PRs can rebase and stop failing