### PR TITLE
ARROW-1641: [C++] Hide std::mutex from public headers

### DIFF
--- a/cpp/src/arrow/allocator-test.cc
+++ b/cpp/src/arrow/allocator-test.cc
@@ -59,17 +59,16 @@ TEST(stl_allocator, FreeLargeMemory) {
 }
 
 TEST(stl_allocator, MaxMemory) {
-  DefaultMemoryPool pool;
+  auto pool = default_memory_pool();
 
-  ASSERT_EQ(0, pool.max_memory());
-  stl_allocator<uint8_t> alloc(&pool);
-  uint8_t* data = alloc.allocate(100);
-  uint8_t* data2 = alloc.allocate(100);
+  stl_allocator<uint8_t> alloc(pool);
+  uint8_t* data = alloc.allocate(1000);
+  uint8_t* data2 = alloc.allocate(1000);
 
-  alloc.deallocate(data, 100);
-  alloc.deallocate(data2, 100);
+  alloc.deallocate(data, 1000);
+  alloc.deallocate(data2, 1000);
 
-  ASSERT_EQ(200, pool.max_memory());
+  ASSERT_EQ(2000, pool->max_memory());
 }
 
 #endif  // ARROW_VALGRIND

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -179,7 +179,7 @@ class ARROW_EXPORT Array {
   /// boundscheck
   bool IsValid(int64_t i) const {
     return null_bitmap_data_ != nullptr &&
-      BitUtil::GetBit(null_bitmap_data_, i + data_->offset);
+           BitUtil::GetBit(null_bitmap_data_, i + data_->offset);
   }
 
   /// Size in the number of elements this array contains.

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -478,10 +478,11 @@ Status ReadableFile::ReadAt(int64_t position, int64_t nbytes,
                             std::shared_ptr<Buffer>* out) {
   std::lock_guard<std::mutex> guard(impl_->lock());
   RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, out);
+  return impl_->ReadBuffer(nbytes, out);
 }
 
 Status ReadableFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+  std::lock_guard<std::mutex> guard(impl_->lock());
   return impl_->ReadBuffer(nbytes, out);
 }
 

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -96,10 +96,11 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
+  /// \brief Thread-safe implementation of ReadAt
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                 uint8_t* out) override;
 
-  /// Default implementation is thread-safe
+  /// \brief Thread-safe implementation of ReadAt
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   Status GetSize(int64_t* size) override;

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -96,6 +96,12 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
+  Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                uint8_t* out) override;
+
+  /// Default implementation is thread-safe
+  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+
   Status GetSize(int64_t* size) override;
   Status Seek(int64_t position) override;
 
@@ -138,6 +144,12 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
 
   // Zero copy read. Not thread-safe
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+
+  Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                uint8_t* out) override;
+
+  /// Default implementation is thread-safe
+  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   bool supports_zero_copy() const override;
 

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -30,6 +30,18 @@ FileInterface::~FileInterface() {}
 
 RandomAccessFile::RandomAccessFile() { set_mode(FileMode::READ); }
 
+Status RandomAccessFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                                uint8_t* out) {
+  RETURN_NOT_OK(Seek(position));
+  return Read(nbytes, bytes_read, out);
+}
+
+Status RandomAccessFile::ReadAt(int64_t position, int64_t nbytes,
+                                std::shared_ptr<Buffer>* out) {
+  RETURN_NOT_OK(Seek(position));
+  return Read(nbytes, out);
+}
+
 Status Writeable::Write(const std::string& data) {
   return Write(reinterpret_cast<const uint8_t*>(data.c_str()),
                static_cast<int64_t>(data.size()));

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -30,20 +30,6 @@ FileInterface::~FileInterface() {}
 
 RandomAccessFile::RandomAccessFile() { set_mode(FileMode::READ); }
 
-Status RandomAccessFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                                uint8_t* out) {
-  std::lock_guard<std::mutex> guard(lock_);
-  RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, bytes_read, out);
-}
-
-Status RandomAccessFile::ReadAt(int64_t position, int64_t nbytes,
-                                std::shared_ptr<Buffer>* out) {
-  std::lock_guard<std::mutex> guard(lock_);
-  RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, out);
-}
-
 Status Writeable::Write(const std::string& data) {
   return Write(reinterpret_cast<const uint8_t*>(data.c_str()),
                static_cast<int64_t>(data.size()));

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -130,13 +130,12 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   /// Read at position, provide default implementations using Read(...), but can
   /// be overridden
   ///
-  /// Default implementation is thread-safe
+  /// Default implementation is not thread-safe
   virtual Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                        uint8_t* out) = 0;
+                        uint8_t* out);
 
-  /// Default implementation is thread-safe
-  virtual Status ReadAt(int64_t position, int64_t nbytes,
-                        std::shared_ptr<Buffer>* out) = 0;
+  /// Default implementation is not thread-safe
+  virtual Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out);
 
  protected:
   RandomAccessFile();

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -20,7 +20,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -133,16 +132,13 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   ///
   /// Default implementation is thread-safe
   virtual Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                        uint8_t* out);
+                        uint8_t* out) = 0;
 
   /// Default implementation is thread-safe
-  virtual Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out);
-
-  std::mutex& lock() { return lock_; }
+  virtual Status ReadAt(int64_t position, int64_t nbytes,
+                        std::shared_ptr<Buffer>* out) = 0;
 
  protected:
-  std::mutex lock_;
-
   RandomAccessFile();
 };
 

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -59,39 +59,36 @@ TEST(DefaultMemoryPoolDeathTest, FreeLargeMemory) {
 }
 
 TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
-  DefaultMemoryPool pool;
-
-  ASSERT_EQ(0, pool.max_memory());
+  MemoryPool* pool = default_memory_pool();
 
   uint8_t* data;
-  ASSERT_OK(pool.Allocate(100, &data));
+  ASSERT_OK(pool->Allocate(100, &data));
 
   uint8_t* data2;
-  ASSERT_OK(pool.Allocate(100, &data2));
+  ASSERT_OK(pool->Allocate(100, &data2));
 
-  pool.Free(data, 100);
-  pool.Free(data2, 100);
+  pool->Free(data, 100);
+  pool->Free(data2, 100);
 
-  ASSERT_EQ(200, pool.max_memory());
+  ASSERT_EQ(200, pool->max_memory());
 }
 
 #endif  // ARROW_VALGRIND
 
 TEST(LoggingMemoryPool, Logging) {
-  DefaultMemoryPool pool;
-  LoggingMemoryPool lp(&pool);
+  MemoryPool* pool = default_memory_pool();
 
-  ASSERT_EQ(0, lp.max_memory());
+  LoggingMemoryPool lp(pool);
 
   uint8_t* data;
-  ASSERT_OK(pool.Allocate(100, &data));
+  ASSERT_OK(pool->Allocate(100, &data));
 
   uint8_t* data2;
-  ASSERT_OK(pool.Allocate(100, &data2));
+  ASSERT_OK(pool->Allocate(100, &data2));
 
-  pool.Free(data, 100);
-  pool.Free(data2, 100);
+  pool->Free(data, 100);
+  pool->Free(data2, 100);
 
-  ASSERT_EQ(200, pool.max_memory());
+  ASSERT_EQ(200, pool->max_memory());
 }
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -20,7 +20,6 @@
 
 #include <atomic>
 #include <cstdint>
-#include <mutex>
 
 #include "arrow/util/visibility.h"
 
@@ -67,26 +66,6 @@ class ARROW_EXPORT MemoryPool {
 
  protected:
   MemoryPool();
-};
-
-class ARROW_EXPORT DefaultMemoryPool : public MemoryPool {
- public:
-  DefaultMemoryPool();
-  virtual ~DefaultMemoryPool();
-
-  Status Allocate(int64_t size, uint8_t** out) override;
-  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;
-
-  void Free(uint8_t* buffer, int64_t size) override;
-
-  int64_t bytes_allocated() const override;
-
-  int64_t max_memory() const override;
-
- private:
-  mutable std::mutex lock_;
-  std::atomic<int64_t> bytes_allocated_;
-  std::atomic<int64_t> max_memory_;
 };
 
 class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {

--- a/cpp/src/arrow/python/io.h
+++ b/cpp/src/arrow/python/io.h
@@ -32,22 +32,7 @@ class MemoryPool;
 
 namespace py {
 
-// A common interface to a Python file-like object. Must acquire GIL before
-// calling any methods
-class ARROW_EXPORT PythonFile {
- public:
-  explicit PythonFile(PyObject* file);
-  ~PythonFile();
-
-  Status Close();
-  Status Seek(int64_t position, int whence);
-  Status Read(int64_t nbytes, PyObject** out);
-  Status Tell(int64_t* position);
-  Status Write(const uint8_t* data, int64_t nbytes);
-
- private:
-  PyObject* file_;
-};
+class ARROW_NO_EXPORT PythonFile;
 
 class ARROW_EXPORT PyReadableFile : public io::RandomAccessFile {
  public:
@@ -58,6 +43,13 @@ class ARROW_EXPORT PyReadableFile : public io::RandomAccessFile {
 
   Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override;
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+
+  // Thread-safe version
+  Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                uint8_t* out) override;
+
+  // Thread-safe version
+  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   Status GetSize(int64_t* size) override;
 


### PR DESCRIPTION
This was one part of ARROW-1134 that we can push through. I had to do some refactoring since there was a mutex in one of the base file interfaces. It doesn't appear that this will impact parquet-cpp or other Arrow users