### PR TITLE
ARROW-1556: [C++] Move verbose AssertArraysEqual function used in PARQUET-1100 into arrow/test-util.h

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -515,6 +515,7 @@ endif()
 set(ARROW_BENCHMARK_LINK_LIBS
   arrow_static
   arrow_benchmark_main
+  gtest
   ${ARROW_STATIC_LINK_LIBS})
 
 set(ARROW_LINK_LIBS

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -46,20 +46,6 @@ using std::vector;
 namespace arrow {
 namespace compute {
 
-void AssertArraysEqual(const Array& left, const Array& right) {
-  bool are_equal = ArrayEquals(left, right);
-
-  if (!are_equal) {
-    std::stringstream ss;
-
-    ss << "Left: ";
-    EXPECT_OK(PrettyPrint(left, 0, &ss));
-    ss << "\nRight: ";
-    EXPECT_OK(PrettyPrint(right, 0, &ss));
-    FAIL() << ss.str();
-  }
-}
-
 class ComputeFixture {
  public:
   ComputeFixture() : ctx_(default_memory_pool()) {}

--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -31,6 +31,7 @@
 #include "arrow/buffer.h"
 #include "arrow/builder.h"
 #include "arrow/memory_pool.h"
+#include "arrow/pretty_print.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/type.h"
@@ -277,6 +278,17 @@ Status MakeArray(const std::vector<uint8_t>& valid_bytes, const std::vector<T>& 
     }
   }
   return builder->Finish(out);
+}
+
+void AssertArraysEqual(const Array& expected, const Array& actual) {
+  if (!actual.Equals(expected)) {
+    std::stringstream pp_result;
+    std::stringstream pp_expected;
+
+    EXPECT_OK(PrettyPrint(actual, 0, &pp_result));
+    EXPECT_OK(PrettyPrint(expected, 0, &pp_expected));
+    FAIL() << "Got: \n" << pp_result.str() << "\nExpected: \n" << pp_expected.str();
+  }
 }
 
 }  // namespace arrow


### PR DESCRIPTION
We already had a variant of this in compute-test.cc, so this consolidates the code and makes it easier for thirdparty arrow users