### PR TITLE
ARROW-1653: [Plasma] Use static cast to avoid compiler warning.

### DIFF
--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -99,7 +99,7 @@ Status ReadMessage(int fd, int64_t* type, std::vector<uint8_t>* buffer) {
                                sizeof(length_temp)),
                      *type = DISCONNECT_CLIENT);
   // The length must be read as an int64_t, but it should be used as a size_t.
-  size_t length = length_temp;
+  size_t length = std::static_cast<size_t>(length_temp);
   if (length > buffer->size()) {
     buffer->resize(length);
   }

--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -99,7 +99,7 @@ Status ReadMessage(int fd, int64_t* type, std::vector<uint8_t>* buffer) {
                                sizeof(length_temp)),
                      *type = DISCONNECT_CLIENT);
   // The length must be read as an int64_t, but it should be used as a size_t.
-  size_t length = std::static_cast<size_t>(length_temp);
+  size_t length = static_cast<size_t>(length_temp);
   if (length > buffer->size()) {
     buffer->resize(length);
   }


### PR DESCRIPTION
See https://github.com/apache/arrow/pull/1172#discussion_r142931449