### PR TITLE
ARROW-1226: [C++] Docs cleaning in arrow/ipc. Doxyfile fixes, move ipc/metadata-internal.h symbols to internal NS

### DIFF
--- a/cpp/apidoc/Doxyfile
+++ b/cpp/apidoc/Doxyfile
@@ -188,7 +188,7 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH  = ../src
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -71,7 +71,7 @@ if ("${UPPERCASE_BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
   elseif ("${COMPILER_FAMILY}" STREQUAL "clang")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Weverything -Wno-c++98-compat \
 -Wno-c++98-compat-pedantic -Wno-deprecated -Wno-weak-vtables -Wno-padded \
--Wno-unused-parameter -Wno-undef \
+-Wno-comma -Wno-unused-parameter -Wno-undef \
 -Wno-shadow -Wno-switch-enum -Wno-exit-time-destructors \
 -Wno-global-constructors -Wno-weak-template-vtables -Wno-undefined-reinterpret-cast \
 -Wno-implicit-fallthrough -Wno-unreachable-code-return \

--- a/cpp/src/arrow/ipc/dictionary.h
+++ b/cpp/src/arrow/ipc/dictionary.h
@@ -38,26 +38,30 @@ namespace ipc {
 using DictionaryMap = std::unordered_map<int64_t, std::shared_ptr<Array>>;
 using DictionaryTypeMap = std::unordered_map<int64_t, std::shared_ptr<Field>>;
 
-// Memoization data structure for handling shared dictionaries
+/// \brief Memoization data structure for handling shared dictionaries
 class ARROW_EXPORT DictionaryMemo {
  public:
   DictionaryMemo();
 
-  // Returns KeyError if dictionary not found
+  /// \brief Returns KeyError if dictionary not found
   Status GetDictionary(int64_t id, std::shared_ptr<Array>* dictionary) const;
 
-  /// Return id for dictionary, computing new id if necessary
+  /// \brief Return id for dictionary, computing new id if necessary
   int64_t GetId(const std::shared_ptr<Array>& dictionary);
 
+  /// \brief Return true if dictionary array object is in this memo
   bool HasDictionary(const std::shared_ptr<Array>& dictionary) const;
+
+  /// \brief Return true if we have a dictionary for the input id
   bool HasDictionaryId(int64_t id) const;
 
-  // Add a dictionary to the memo with a particular id. Returns KeyError if
-  // that dictionary already exists
+  /// \brief Add a dictionary to the memo with a particular id. Returns
+  /// KeyError if that dictionary already exists
   Status AddDictionary(int64_t id, const std::shared_ptr<Array>& dictionary);
 
   const DictionaryMap& id_to_dictionary() const { return id_to_dictionary_; }
 
+  /// \brief The number of dictionaries stored in the memo
   int size() const { return static_cast<int>(id_to_dictionary_.size()); }
 
  private:

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -48,28 +48,47 @@ static constexpr const int kFeatherVersion = 2;
 // ----------------------------------------------------------------------
 // Metadata accessor classes
 
+/// \class TableReader
+/// \brief An interface for reading columns from Feather files
 class ARROW_EXPORT TableReader {
  public:
   TableReader();
   ~TableReader();
 
+  /// \brief Open a Feather file from a RandomAccessFile interface
+  ///
+  /// \param[in] source a RandomAccessFile instance
+  /// \param[out] out the table reader
   static Status Open(const std::shared_ptr<io::RandomAccessFile>& source,
                      std::unique_ptr<TableReader>* out);
 
-  // Optional table description
-  //
-  // This does not return a const std::string& because a string has to be
-  // copied from the flatbuffer to be able to return a non-flatbuffer type
+  /// \brief Optional table description
+  ///
+  /// This does not return a const std::string& because a string has to be
+  /// copied from the flatbuffer to be able to return a non-flatbuffer type
   std::string GetDescription() const;
+
+  /// \brief Return true if the table has a description field populated
   bool HasDescription() const;
 
+  /// \brief Return the version number of the Feather file
   int version() const;
 
+  /// \brief Return the number of rows in the file
   int64_t num_rows() const;
+
+  /// \brief Return the number of columns in the file
   int64_t num_columns() const;
 
   std::string GetColumnName(int i) const;
 
+  /// \brief Read a column from the file as an arrow::Column.
+  ///
+  /// \param[in] i the column index to read
+  /// \param[out] out the returned column
+  /// \return Status
+  ///
+  /// This function is zero-copy if the file source supports zero-copy reads
   Status GetColumn(int i, std::shared_ptr<Column>* out);
 
  private:
@@ -77,19 +96,34 @@ class ARROW_EXPORT TableReader {
   std::unique_ptr<TableReaderImpl> impl_;
 };
 
+/// \class TableWriter
+/// \brief Interface for writing Feather files
 class ARROW_EXPORT TableWriter {
  public:
   ~TableWriter();
 
+  /// \brief Create a new TableWriter that writes to an OutputStream
+  /// \param[in] stream an output stream
+  /// \param[out] out the returned table writer
+  /// \return Status
   static Status Open(const std::shared_ptr<io::OutputStream>& stream,
                      std::unique_ptr<TableWriter>* out);
 
+  /// \brief Set the description field in the file metadata
   void SetDescription(const std::string& desc);
+
+  /// \brief Set the number of rows in the file
   void SetNumRows(int64_t num_rows);
 
+  /// \brief Append a column to the file
+  ///
+  /// \param[in] name the column name
+  /// \param[in] values the column values as a contiguous arrow::Array
+  /// \return Status
   Status Append(const std::string& name, const Array& values);
 
-  // We are done, write the file metadata and footer
+  /// \brief Finalize the file by writing the file metadata and footer
+  /// \return Status
   Status Finalize();
 
  private:

--- a/cpp/src/arrow/ipc/json.h
+++ b/cpp/src/arrow/ipc/json.h
@@ -35,14 +35,29 @@ class Schema;
 
 namespace ipc {
 
+/// \class JsonWriter
+/// \brief Write the JSON representation of an Arrow record batch file or stream
+///
+/// This is used for integration testing
 class ARROW_EXPORT JsonWriter {
  public:
   ~JsonWriter();
 
+  /// \brief Create a new JSON writer that writes to memory
+  ///
+  /// \param[in] schema the schema of record batches
+  /// \param[out] out the returned writer object
+  /// \return Status
   static Status Open(const std::shared_ptr<Schema>& schema,
                      std::unique_ptr<JsonWriter>* out);
 
+  /// \brief Append a record batch
   Status WriteRecordBatch(const RecordBatch& batch);
+
+  /// \brief Finish the JSON payload and return as a std::string
+  ///
+  /// \param[out] result the JSON as as a std::string
+  /// \return Status
   Status Finish(std::string* result);
 
  private:
@@ -53,23 +68,41 @@ class ARROW_EXPORT JsonWriter {
   std::unique_ptr<JsonWriterImpl> impl_;
 };
 
-// TODO(wesm): Read from a file stream rather than an in-memory buffer
+/// \class JsonReader
+/// \brief Read the JSON representation of an Arrow record batch file or stream
+///
+/// This is used for integration testing
 class ARROW_EXPORT JsonReader {
  public:
   ~JsonReader();
 
+  /// \brief Create a new JSON reader
+  ///
+  /// \param[in] pool a MemoryPool to use for buffer allocations
+  /// \param[in] data a Buffer containing the JSON data
+  /// \param[out] out the returned reader object
+  /// \return Status
   static Status Open(MemoryPool* pool, const std::shared_ptr<Buffer>& data,
                      std::unique_ptr<JsonReader>* reader);
 
-  // Use the default memory pool
+  /// \brief Create a new JSON reader that uses the default memory pool
+  ///
+  /// \param[in] data a Buffer containing the JSON data
+  /// \param[out] out the returned reader object
+  /// \return Status
   static Status Open(const std::shared_ptr<Buffer>& data,
                      std::unique_ptr<JsonReader>* reader);
 
+  /// \brief Return the schema read from the JSON
   std::shared_ptr<Schema> schema() const;
 
+  /// \brief Return the number of record batches
   int num_record_batches() const;
 
-  // Read a record batch from the file
+  /// \brief Read a particular record batch from the file
+  ///
+  /// \param[in] i the record batch index, does not boundscheck
+  /// \param[out] batch the read record batch
   Status ReadRecordBatch(int i, std::shared_ptr<RecordBatch>* batch) const;
 
  private:

--- a/cpp/src/arrow/ipc/json.h
+++ b/cpp/src/arrow/ipc/json.h
@@ -80,7 +80,7 @@ class ARROW_EXPORT JsonReader {
   ///
   /// \param[in] pool a MemoryPool to use for buffer allocations
   /// \param[in] data a Buffer containing the JSON data
-  /// \param[out] out the returned reader object
+  /// \param[out] reader the returned reader object
   /// \return Status
   static Status Open(MemoryPool* pool, const std::shared_ptr<Buffer>& data,
                      std::unique_ptr<JsonReader>* reader);
@@ -88,7 +88,7 @@ class ARROW_EXPORT JsonReader {
   /// \brief Create a new JSON reader that uses the default memory pool
   ///
   /// \param[in] data a Buffer containing the JSON data
-  /// \param[out] out the returned reader object
+  /// \param[out] reader the returned reader object
   /// \return Status
   static Status Open(const std::shared_ptr<Buffer>& data,
                      std::unique_ptr<JsonReader>* reader);

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -44,7 +44,7 @@ class Message::MessageImpl {
     message_ = flatbuf::GetMessage(metadata_->data());
 
     // Check that the metadata version is supported
-    if (message_->version() < kMinMetadataVersion) {
+    if (message_->version() < internal::kMinMetadataVersion) {
       return Status::Invalid("Old metadata version not supported");
     }
 
@@ -166,7 +166,7 @@ Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStrea
 
 Status Message::SerializeTo(io::OutputStream* file, int64_t* output_length) const {
   int32_t metadata_length = 0;
-  RETURN_NOT_OK(WriteMessage(*metadata(), file, &metadata_length));
+  RETURN_NOT_OK(internal::WriteMessage(*metadata(), file, &metadata_length));
 
   *output_length = metadata_length;
 

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -53,6 +53,7 @@ constexpr int kMaxNestingDepth = 64;
 // individual fields metadata can be retrieved from very large schema without
 //
 
+/// \class Message
 /// \brief An IPC message including metadata and body
 class ARROW_EXPORT Message {
  public:
@@ -70,6 +71,7 @@ class ARROW_EXPORT Message {
   /// \param[in] metadata a buffer containing the Flatbuffer metadata
   /// \param[in] body a buffer containing the message body, which may be nullptr
   /// \param[out] out the created message
+  /// \return Status
   static Status Open(const std::shared_ptr<Buffer>& metadata,
                      const std::shared_ptr<Buffer>& body, std::unique_ptr<Message>* out);
 
@@ -77,6 +79,7 @@ class ARROW_EXPORT Message {
   /// \param[in] metadata containing a serialized Message flatbuffer
   /// \param[in] stream an InputStream
   /// \param[out] out the created Message
+  /// \return Status
   ///
   /// \note If stream supports zero-copy, this is zero-copy
   static Status ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStream* stream,
@@ -98,8 +101,10 @@ class ARROW_EXPORT Message {
   /// \return buffer is nullptr if no body
   std::shared_ptr<Buffer> body() const;
 
+  /// \brief The Message type
   Type type() const;
 
+  /// \brief The Message metadata version
   MetadataVersion metadata_version() const;
 
   const void* header() const;

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -46,6 +46,7 @@ namespace arrow {
 namespace flatbuf = org::apache::arrow::flatbuf;
 
 namespace ipc {
+namespace internal {
 
 using FBB = flatbuffers::FlatBufferBuilder;
 using DictionaryOffset = flatbuffers::Offset<flatbuf::DictionaryEncoding>;
@@ -933,5 +934,6 @@ Status WriteMessage(const Buffer& message, io::OutputStream* file,
   return Status::OK();
 }
 
+}  // namespace internal
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -45,6 +45,7 @@ class OutputStream;
 }  // namespace io
 
 namespace ipc {
+namespace internal {
 
 static constexpr flatbuf::MetadataVersion kCurrentMetadataVersion =
     flatbuf::MetadataVersion_V3;
@@ -130,6 +131,7 @@ Status WriteDictionaryMessage(const int64_t id, const int64_t length,
                               const std::vector<BufferMetadata>& buffers,
                               std::shared_ptr<Buffer>* out);
 
+}  // namespace internal
 }  // namespace ipc
 }  // namespace arrow
 

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -48,6 +48,10 @@ using RecordBatchReader = ::arrow::RecordBatchReader;
 
 /// \class RecordBatchStreamReader
 /// \brief Synchronous batch stream reader that reads from io::InputStream
+///
+/// This class reads the schema (plus any dictionaries) as the first messages
+/// in the stream, followed by record batches. For more granular zero-copy
+/// reads see the ReadRecordBatch functions
 class ARROW_EXPORT RecordBatchStreamReader : public RecordBatchReader {
  public:
   virtual ~RecordBatchStreamReader();
@@ -68,11 +72,16 @@ class ARROW_EXPORT RecordBatchStreamReader : public RecordBatchReader {
   /// \return Status
   static Status Open(io::InputStream* stream, std::shared_ptr<RecordBatchReader>* out);
 
-  /// \brief Version of Open that retains ownership of stream
+  /// \brief Open stream and retain ownership of stream object
+  /// \param[in] stream the input stream
+  /// \param[out] the batch reader
+  /// \return Status
   static Status Open(const std::shared_ptr<io::InputStream>& stream,
                      std::shared_ptr<RecordBatchReader>* out);
 
+  /// \brief Returns the schema read from the stream
   std::shared_ptr<Schema> schema() const override;
+
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override;
 
  private:
@@ -88,11 +97,12 @@ class ARROW_EXPORT RecordBatchFileReader {
   ~RecordBatchFileReader();
 
   /// \brief Open a RecordBatchFileReader
-  // Open a file-like object that is assumed to be self-contained; i.e., the
-  // end of the file interface is the end of the Arrow file. Note that there
-  // can be any amount of data preceding the Arrow-formatted data, because we
-  // need only locate the end of the Arrow file stream to discover the metadata
-  // and then proceed to read the data into memory.
+  ///
+  /// Open a file-like object that is assumed to be self-contained; i.e., the
+  /// end of the file interface is the end of the Arrow file. Note that there
+  /// can be any amount of data preceding the Arrow-formatted data, because we
+  /// need only locate the end of the Arrow file stream to discover the metadata
+  /// and then proceed to read the data into memory.
   static Status Open(io::RandomAccessFile* file,
                      std::shared_ptr<RecordBatchFileReader>* reader);
 
@@ -102,31 +112,42 @@ class ARROW_EXPORT RecordBatchFileReader {
   /// metadata footer). The metadata must have been written with memory offsets
   /// relative to the start of the containing file
   ///
-  /// @param file the data source
-  /// @param footer_offset the position of the end of the Arrow "file"
+  /// \param[in] file the data source
+  /// \param[in] footer_offset the position of the end of the Arrow file
+  /// \param[out] reader the returned reader
+  /// \return Status
   static Status Open(io::RandomAccessFile* file, int64_t footer_offset,
                      std::shared_ptr<RecordBatchFileReader>* reader);
 
   /// \brief Version of Open that retains ownership of file
+  ///
+  /// \param[in] file the data source
+  /// \param[out] reader the returned reader
+  /// \return Status
   static Status Open(const std::shared_ptr<io::RandomAccessFile>& file,
                      std::shared_ptr<RecordBatchFileReader>* reader);
 
   /// \brief Version of Open that retains ownership of file
+  ///
+  /// \param[in] file the data source
+  /// \param[in] footer_offset the position of the end of the Arrow file
+  /// \param[out] reader the returned reader
+  /// \return Status
   static Status Open(const std::shared_ptr<io::RandomAccessFile>& file,
                      int64_t footer_offset,
                      std::shared_ptr<RecordBatchFileReader>* reader);
 
-  /// The schema includes any dictionaries
+  /// \brief The schema read from the file
   std::shared_ptr<Schema> schema() const;
 
-  /// Returns number of record batches in the file
+  /// \brief Returns the number of record batches in the file
   int num_record_batches() const;
 
-  /// Returns MetadataVersion in the file metadata
+  /// \brief Return the metadata version from the file metadata
   MetadataVersion version() const;
 
-  /// Read a record batch from the file. Does not copy memory if the input
-  /// source supports zero-copy.
+  /// \brief Read a particular record batch from the file. Does not copy memory
+  /// if the input source supports zero-copy.
   ///
   /// \param[in] i the index of the record batch to return
   /// \param[out] batch the read batch
@@ -142,10 +163,12 @@ class ARROW_EXPORT RecordBatchFileReader {
 
 // Generic read functions; does not copy data if the input supports zero copy reads
 
-/// \brief Read Schema from stream serialized as a sequence of IPC messages
+/// \brief Read Schema from stream serialized as a sequence of one or more IPC
+/// messages
 ///
 /// \param[in] stream an InputStream
 /// \param[out] out the output Schema
+/// \return Status
 ///
 /// If record batches follow the schema, it is better to use
 /// RecordBatchStreamReader
@@ -158,6 +181,7 @@ Status ReadSchema(io::InputStream* stream, std::shared_ptr<Schema>* out);
 /// \param[in] schema the record batch schema
 /// \param[in] stream the file where the batch is located
 /// \param[out] out the read record batch
+/// \return Status
 ARROW_EXPORT
 Status ReadRecordBatch(const std::shared_ptr<Schema>& schema, io::InputStream* stream,
                        std::shared_ptr<RecordBatch>* out);
@@ -168,11 +192,12 @@ Status ReadRecordBatch(const std::shared_ptr<Schema>& schema, io::InputStream* s
 /// \param[in] schema the record batch schema
 /// \param[in] file a random access file
 /// \param[out] out the read record batch
+/// \return Status
 ARROW_EXPORT
 Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& schema,
                        io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out);
 
-/// \brief Read record batch from fully encapulated Message
+/// \brief Read record batch from encapulated Message
 ///
 /// \param[in] message a message instance containing metadata and body
 /// \param[in] schema the record batch schema
@@ -189,6 +214,7 @@ Status ReadRecordBatch(const Message& message, const std::shared_ptr<Schema>& sc
 /// \param[in] file a random access file
 /// \param[in] max_recursion_depth the maximum permitted nesting depth
 /// \param[out] out the read record batch
+/// \return Status
 ARROW_EXPORT
 Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& schema,
                        int max_recursion_depth, io::RandomAccessFile* file,
@@ -199,6 +225,7 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
 /// \param[in] offset the file location of the start of the message
 /// \param[in] file the file where the batch is located
 /// \param[out] out the read tensor
+/// \return Status
 ARROW_EXPORT
 Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
                   std::shared_ptr<Tensor>* out);

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -74,7 +74,7 @@ class ARROW_EXPORT RecordBatchStreamReader : public RecordBatchReader {
 
   /// \brief Open stream and retain ownership of stream object
   /// \param[in] stream the input stream
-  /// \param[out] the batch reader
+  /// \param[out] out the batch reader
   /// \return Status
   static Status Open(const std::shared_ptr<io::InputStream>& stream,
                      std::shared_ptr<RecordBatchReader>* out);

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -27,8 +27,7 @@ namespace py {
 
 #define GET_PRIMITIVE_TYPE(NAME, FACTORY) \
   case Type::NAME:                        \
-    return FACTORY();                     \
-    break;
+    return FACTORY()
 
 std::shared_ptr<DataType> GetPrimitiveType(Type::type type) {
   switch (type) {

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -96,12 +96,13 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
     PROPERTY COMPILE_FLAGS
     " -Wno-parentheses-equality \
 -Wno-shorten-64-to-32 \
--Wno-unused-macros ")
+-Wno-unused-macros")
 
   set_property(SOURCE thirdparty/xxhash.cc
     APPEND_STRING
     PROPERTY COMPILE_FLAGS
-    "-Wno-unused-macros")
+    "-Wno-unused-macros \
+-Wno-unreachable-code")
 endif()
 
 if ("${COMPILER_FAMILY}" STREQUAL "gcc")


### PR DESCRIPTION
There were also some compiler warnings with clang-4.0 that I fixed here. 