### PR TITLE
ARROW-1541: [C++] Fix race conditions in arrow_gpu with generated Flatbuffers files. Do not put generated files in source tree

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -332,6 +332,8 @@ set(LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
 
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_OUTPUT_ROOT_DIRECTORY}")
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
 include_directories(src)
 
 ############################################################

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -60,11 +60,6 @@ if (ARROW_GPU)
   add_subdirectory(gpu)
 endif()
 
-if (ARROW_IPC)
-  add_subdirectory(ipc)
-  add_dependencies(arrow_dependencies metadata_fbs)
-endif()
-
 if (ARROW_WITH_BROTLI)
   add_definitions(-DARROW_WITH_BROTLI)
   SET(ARROW_SRCS util/compression_brotli.cc ${ARROW_SRCS})
@@ -98,7 +93,9 @@ if (NOT ARROW_BOOST_HEADER_ONLY)
 endif()
 
 if (ARROW_IPC)
-  set(ARROW_SRCS ${ARROW_SRCS}
+  add_subdirectory(ipc)
+
+  set(ARROW_IPC_SRCS
     ipc/dictionary.cc
     ipc/feather.cc
     ipc/json.cc
@@ -108,6 +105,10 @@ if (ARROW_IPC)
     ipc/reader.cc
     ipc/writer.cc
   )
+  SET(ARROW_SRCS ${ARROW_SRCS}
+    ${ARROW_IPC_SRCS})
+
+  add_dependencies(arrow_dependencies metadata_fbs)
 endif()
 
 if(NOT APPLE AND NOT MSVC)

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -32,6 +32,9 @@ set(ARROW_GPU_SRCS
   cuda_memory.cc
 )
 
+add_custom_target(arrow_gpu_sources DEPENDS ${ARROW_GPU_SRCS})
+add_dependencies(arrow_gpu_sources metadata_fbs)
+
 set(ARROW_GPU_SHARED_LINK_LIBS
   arrow_shared
   ${CUDA_LIBRARIES}
@@ -47,7 +50,7 @@ ADD_ARROW_LIB(arrow_gpu
 
 # CUDA build version
 configure_file(cuda_version.h.in
-  "${CMAKE_CURRENT_SOURCE_DIR}/cuda_version.h"
+  "${CMAKE_CURRENT_BINARY_DIR}/cuda_version.h"
   @ONLY)
 
 install(FILES

--- a/cpp/src/arrow/ipc/.gitignore
+++ b/cpp/src/arrow/ipc/.gitignore
@@ -1,1 +1,0 @@
-*_generated.h

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -46,7 +46,7 @@ set_source_files_properties(Message_generated.h PROPERTIES GENERATED TRUE)
 set_source_files_properties(feather_generated.h PROPERTIES GENERATED TRUE)
 set_source_files_properties(File_generated.h PROPERTIES GENERATED TRUE)
 
-set(OUTPUT_DIR ${CMAKE_SOURCE_DIR}/src/arrow/ipc)
+set(OUTPUT_DIR ${CMAKE_BINARY_DIR}/src/arrow/ipc)
 set(FBS_OUTPUT_FILES
   "${OUTPUT_DIR}/File_generated.h"
   "${OUTPUT_DIR}/Message_generated.h"


### PR DESCRIPTION
It's a better practice to put generated files in the build directory rather than in the main source tree. There was also a race condition with `arrow/gpu/cuda_version.h`, so fixed that also