### PR TITLE
ARROW-1594: [Python] Multithreaded conversions to Arrow in from_pandas

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -68,6 +68,10 @@ popd
 # Other stuff pip install
 pushd $ARROW_PYTHON_DIR
 
+if [ "$PYTHON_VERSION" == "2.7" ]; then
+  pip install futures
+fi
+
 pip install -r requirements.txt
 python setup.py build_ext --with-parquet --with-plasma \
        install --single-version-externally-managed --record=record.text

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -142,19 +142,21 @@ def open_file(source, footer_offset=None):
     return RecordBatchFileReader(source, footer_offset=footer_offset)
 
 
-def serialize_pandas(df):
+def serialize_pandas(df, nthreads=None):
     """Serialize a pandas DataFrame into a buffer protocol compatible object.
 
     Parameters
     ----------
     df : pandas.DataFrame
+    nthreads : int, default None
+        Number of threads to use for conversion to Arrow, default all CPUs
 
     Returns
     -------
     buf : buffer
         An object compatible with the buffer protocol
     """
-    batch = pa.RecordBatch.from_pandas(df)
+    batch = pa.RecordBatch.from_pandas(df, nthreads=nthreads)
     sink = pa.BufferOutputStream()
     writer = pa.RecordBatchStreamWriter(sink, batch.schema)
     writer.write_batch(batch)
@@ -162,15 +164,16 @@ def serialize_pandas(df):
     return sink.get_result()
 
 
-def deserialize_pandas(buf, nthreads=1):
+def deserialize_pandas(buf, nthreads=None):
     """Deserialize a buffer protocol compatible object into a pandas DataFrame.
 
     Parameters
     ----------
     buf : buffer
         An object compatible with the buffer protocol
-    nthreads : int, optional
-        The number of threads to use to convert the buffer to a DataFrame.
+    nthreads : int, defualt None
+        The number of threads to use to convert the buffer to a DataFrame,
+        default all CPUs
 
     Returns
     -------

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -290,17 +290,17 @@ def _column_name_to_strings(name):
     return str(name)
 
 
-def dataframe_to_arrays(df, schema, preserve_index):
+def dataframe_to_arrays(df, schema, preserve_index, nthreads=1):
     names = []
-    arrays = []
     index_columns = []
-    types = []
     type = None
 
     if preserve_index:
         n = len(getattr(df.index, 'levels', [df.index]))
         index_columns.extend(df.index.get_level_values(i) for i in range(n))
 
+    columns_to_convert = []
+    convert_types = []
     for name in df.columns:
         col = df[name]
         if not isinstance(name, six.string_types):
@@ -310,16 +310,30 @@ def dataframe_to_arrays(df, schema, preserve_index):
             field = schema.field_by_name(name)
             type = getattr(field, "type", None)
 
-        array = pa.array(col, from_pandas=True, type=type)
-        arrays.append(array)
+        columns_to_convert.append(col)
+        convert_types.append(type)
         names.append(name)
-        types.append(array.type)
 
     for i, column in enumerate(index_columns):
-        array = pa.array(column)
-        arrays.append(array)
+        columns_to_convert.append(column)
+        convert_types.append(None)
         names.append(index_level_name(column, i))
-        types.append(array.type)
+
+    def convert_column(col, ty):
+        return pa.array(col, from_pandas=True, type=ty)
+
+    if nthreads == 1:
+        arrays = [convert_column(c, t)
+                  for c, t in zip(columns_to_convert,
+                                  convert_types)]
+    else:
+        from concurrent import futures
+        with futures.ThreadPoolExecutor(nthreads) as executor:
+            arrays = list(executor.map(convert_column,
+                                       columns_to_convert,
+                                       convert_types))
+
+    types = [x.type for x in arrays]
 
     metadata = construct_metadata(
         df, names, index_columns, preserve_index, types

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -319,6 +319,16 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1):
         convert_types.append(None)
         names.append(index_level_name(column, i))
 
+    # NOTE(wesm): If nthreads=None, then we use a heuristic to decide whether
+    # using a thread pool is worth it. Currently the heuristic is whether the
+    # nrows > 100 * ncols.
+    if nthreads is None:
+        nrows, ncols = len(df), len(df.columns)
+        if nrows > ncols * 100:
+            nthreads = pa.cpu_count()
+        else:
+            nthreads = 1
+
     def convert_column(col, ty):
         return pa.array(col, from_pandas=True, type=ty)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -570,7 +570,7 @@ cdef class RecordBatch:
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
             ``RecordBatch``.
-        nthreads : int, default to system CPU count
+        nthreads : int, default None (may use up to system CPU count threads)
             If greater than 1, convert columns to Arrow in parallel using
             indicated number of threads
 
@@ -578,8 +578,6 @@ cdef class RecordBatch:
         -------
         pyarrow.RecordBatch
         """
-        if nthreads is None:
-            nthreads = cpu_count()
         names, arrays, metadata = pdcompat.dataframe_to_arrays(
             df, schema, preserve_index, nthreads=nthreads
         )
@@ -734,7 +732,7 @@ cdef class Table:
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
             ``Table``.
-        nthreads : int, default to system CPU count
+        nthreads : int, default None (may use up to system CPU count threads)
             If greater than 1, convert columns to Arrow in parallel using
             indicated number of threads
 
@@ -754,9 +752,6 @@ cdef class Table:
         >>> pa.Table.from_pandas(df)
         <pyarrow.lib.Table object at 0x7f05d1fb1b40>
         """
-        if nthreads is None:
-            nthreads = cpu_count()
-
         names, arrays, metadata = pdcompat.dataframe_to_arrays(
             df,
             schema=schema,

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -556,7 +556,8 @@ cdef class RecordBatch:
         return Table.from_batches([self]).to_pandas(nthreads=nthreads)
 
     @classmethod
-    def from_pandas(cls, df, Schema schema=None, bint preserve_index=True):
+    def from_pandas(cls, df, Schema schema=None, bint preserve_index=True,
+                    int nthreads=1):
         """
         Convert pandas.DataFrame to an Arrow RecordBatch
 
@@ -569,13 +570,16 @@ cdef class RecordBatch:
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
             ``RecordBatch``.
+        nthreads : int, default 1
+            If greater than 1, convert columns to Arrow in parallel using
+            indicated number of threads
 
         Returns
         -------
         pyarrow.RecordBatch
         """
         names, arrays, metadata = pdcompat.dataframe_to_arrays(
-            df, schema, preserve_index
+            df, schema, preserve_index, nthreads=nthreads
         )
         return cls.from_arrays(arrays, names, metadata)
 
@@ -714,7 +718,8 @@ cdef class Table:
         return result
 
     @classmethod
-    def from_pandas(cls, df, Schema schema=None, bint preserve_index=True):
+    def from_pandas(cls, df, Schema schema=None, bint preserve_index=True,
+                    int nthreads=1):
         """
         Convert pandas.DataFrame to an Arrow Table
 
@@ -727,6 +732,9 @@ cdef class Table:
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
             ``Table``.
+        nthreads : int, default 1
+            If greater than 1, convert columns to Arrow in parallel using
+            indicated number of threads
 
         Returns
         -------
@@ -747,7 +755,8 @@ cdef class Table:
         names, arrays, metadata = pdcompat.dataframe_to_arrays(
             df,
             schema=schema,
-            preserve_index=preserve_index
+            preserve_index=preserve_index,
+            nthreads=nthreads
         )
         return cls.from_arrays(arrays, names=names, metadata=metadata)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -557,7 +557,7 @@ cdef class RecordBatch:
 
     @classmethod
     def from_pandas(cls, df, Schema schema=None, bint preserve_index=True,
-                    int nthreads=1):
+                    nthreads=None):
         """
         Convert pandas.DataFrame to an Arrow RecordBatch
 
@@ -570,7 +570,7 @@ cdef class RecordBatch:
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
             ``RecordBatch``.
-        nthreads : int, default 1
+        nthreads : int, default to system CPU count
             If greater than 1, convert columns to Arrow in parallel using
             indicated number of threads
 
@@ -578,6 +578,8 @@ cdef class RecordBatch:
         -------
         pyarrow.RecordBatch
         """
+        if nthreads is None:
+            nthreads = cpu_count()
         names, arrays, metadata = pdcompat.dataframe_to_arrays(
             df, schema, preserve_index, nthreads=nthreads
         )
@@ -719,7 +721,7 @@ cdef class Table:
 
     @classmethod
     def from_pandas(cls, df, Schema schema=None, bint preserve_index=True,
-                    int nthreads=1):
+                    nthreads=None):
         """
         Convert pandas.DataFrame to an Arrow Table
 
@@ -732,7 +734,7 @@ cdef class Table:
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
             ``Table``.
-        nthreads : int, default 1
+        nthreads : int, default to system CPU count
             If greater than 1, convert columns to Arrow in parallel using
             indicated number of threads
 
@@ -752,6 +754,9 @@ cdef class Table:
         >>> pa.Table.from_pandas(df)
         <pyarrow.lib.Table object at 0x7f05d1fb1b40>
         """
+        if nthreads is None:
+            nthreads = cpu_count()
+
         names, arrays, metadata = pdcompat.dataframe_to_arrays(
             df,
             schema=schema,

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -72,9 +72,13 @@ class TestPandasConversion(unittest.TestCase):
     def _check_pandas_roundtrip(self, df, expected=None, nthreads=1,
                                 expected_schema=None,
                                 check_dtype=True, schema=None,
-                                check_index=False):
-        table = pa.Table.from_pandas(df,
-                                     schema=schema, preserve_index=check_index)
+                                check_index=False,
+                                as_batch=False):
+        klass = pa.RecordBatch if as_batch else pa.Table
+        table = klass.from_pandas(df, schema=schema,
+                                  preserve_index=check_index,
+                                  nthreads=nthreads)
+
         result = table.to_pandas(nthreads=nthreads)
         if expected_schema:
             assert table.schema.equals(expected_schema)
@@ -663,6 +667,7 @@ class TestPandasConversion(unittest.TestCase):
     def test_threaded_conversion(self):
         df = _alltypes_example()
         self._check_pandas_roundtrip(df, nthreads=2)
+        self._check_pandas_roundtrip(df, nthreads=2, as_batch=True)
 
     def test_category(self):
         repeats = 5

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -365,7 +365,7 @@ def test_get_record_batch_size():
 
 
 def _check_serialize_pandas_round_trip(df, nthreads=1):
-    buf = pa.serialize_pandas(df)
+    buf = pa.serialize_pandas(df, nthreads=nthreads)
     result = pa.deserialize_pandas(buf, nthreads=nthreads)
     assert_frame_equal(result, df)
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,3 +2,4 @@ pytest
 cloudpickle
 numpy>=1.10.0
 six
+futures

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,3 @@ pytest
 cloudpickle
 numpy>=1.10.0
 six
-futures

--- a/python/setup.py
+++ b/python/setup.py
@@ -381,6 +381,13 @@ class BinaryDistribution(Distribution):
     def has_ext_modules(foo):
         return True
 
+
+install_requires = ['numpy >= 1.10', 'six >= 1.0.0']
+
+if sys.version_info.major:
+    install_requires.append('futures')
+
+
 setup(
     name="pyarrow",
     packages=['pyarrow', 'pyarrow.tests'],
@@ -390,19 +397,18 @@ setup(
     distclass=BinaryDistribution,
     # Dummy extension to trigger build_ext
     ext_modules=[Extension('__dummy__', sources=[])],
-
     cmdclass={
         'clean': clean,
         'build_ext': build_ext
     },
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'plasma_store = pyarrow:_plasma_store_entry_point'
         ]
     },
     use_scm_version={"root": "..", "relative_to": __file__},
     setup_requires=['setuptools_scm', 'cython >= 0.23'],
-    install_requires=['numpy >= 1.10', 'six >= 1.0.0'],
+    install_requires=install_requires,
     tests_require=['pytest'],
     description="Python library for Apache Arrow",
     long_description=long_description,

--- a/python/setup.py
+++ b/python/setup.py
@@ -384,7 +384,7 @@ class BinaryDistribution(Distribution):
 
 install_requires = ['numpy >= 1.10', 'six >= 1.0.0']
 
-if sys.version_info.major:
+if sys.version_info.major == 2:
     install_requires.append('futures')
 
 


### PR DESCRIPTION
This results in nice speedups when column conversions do not require GIL to be held:

```python
In [5]: import numpy as np

In [6]: import pandas as pd

In [7]: import pyarrow as pa

In [8]: NROWS = 1000000

In [9]: NCOLS = 50

In [10]: arr = np.random.randn(NCOLS, NROWS).T

In [11]: arr[::5] = np.nan

In [12]: df = pd.DataFrame(arr)

In [13]: %timeit rb = pa.RecordBatch.from_pandas(df, nthreads=1)
10 loops, best of 3: 179 ms per loop

In [14]: %timeit rb = pa.RecordBatch.from_pandas(df, nthreads=4)
10 loops, best of 3: 59.7 ms per loop
```

This introduces a dependency on the `futures` Python 2.7 backport of concurrent.futures (PSF license)