### PR TITLE
ARROW-1657: [C++] Multithreaded Read Test Failing on Arch Linux

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -436,6 +436,17 @@ namespace garrow {
       }
     }
 
+    arrow::Status ReadAt(int64_t position, int64_t n_bytes,
+			 int64_t *n_read_bytes, uint8_t* out) {
+	return arrow::io::RandomAccessFile::ReadAt(
+	    position, n_bytes, n_read_bytes, out);
+    }
+
+    arrow::Status ReadAt(int64_t position, int64_t n_bytes,
+			 std::shared_ptr<arrow::Buffer>* out) {
+	return arrow::io::RandomAccessFile::ReadAt(position, n_bytes, out);
+    }
+
     arrow::Status Read(int64_t n_bytes,
                        std::shared_ptr<arrow::Buffer> *out) override {
       arrow::MemoryPool *pool = arrow::default_memory_pool();

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -144,8 +144,6 @@ class FixedSizeBufferWriter::FixedSizeBufferWriterImpl {
     position_ = 0;
   }
 
-  ~FixedSizeBufferWriterImpl() {}
-
   Status Close() {
     // No-op
     return Status::OK();
@@ -199,10 +197,10 @@ class FixedSizeBufferWriter::FixedSizeBufferWriterImpl {
   int64_t memcopy_threshold_;
 };
 
-FixedSizeBufferWriter::~FixedSizeBufferWriter() {}
-
 FixedSizeBufferWriter::FixedSizeBufferWriter(const std::shared_ptr<Buffer>& buffer)
     : impl_(new FixedSizeBufferWriterImpl(buffer)) {}
+
+FixedSizeBufferWriter::~FixedSizeBufferWriter() = default;
 
 Status FixedSizeBufferWriter::Close() { return impl_->Close(); }
 
@@ -242,8 +240,6 @@ BufferReader::BufferReader(const std::shared_ptr<Buffer>& buffer)
 BufferReader::BufferReader(const uint8_t* data, int64_t size)
     : buffer_(nullptr), data_(data), size_(size), position_(0) {}
 
-BufferReader::~BufferReader() {}
-
 Status BufferReader::Close() {
   // no-op
   return Status::OK();
@@ -278,14 +274,12 @@ Status BufferReader::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
 
 Status BufferReader::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                             uint8_t* out) {
-  RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, bytes_read, out);
+  return RandomAccessFile::ReadAt(position, nbytes, bytes_read, out);
 }
 
 Status BufferReader::ReadAt(int64_t position, int64_t nbytes,
                             std::shared_ptr<Buffer>* out) {
-  RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, out);
+  return RandomAccessFile::ReadAt(position, nbytes, out);
 }
 
 Status BufferReader::GetSize(int64_t* size) {

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -43,7 +43,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   static Status Create(int64_t initial_capacity, MemoryPool* pool,
                        std::shared_ptr<BufferOutputStream>* out);
 
-  ~BufferOutputStream();
+  ~BufferOutputStream() override;
 
   // Implement the OutputStream interface
   Status Close() override;
@@ -85,7 +85,7 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
  public:
   /// Input buffer must be mutable, will abort if not
   explicit FixedSizeBufferWriter(const std::shared_ptr<Buffer>& buffer);
-  ~FixedSizeBufferWriter();
+  ~FixedSizeBufferWriter() override;
 
   Status Close() override;
   Status Seek(int64_t position) override;
@@ -108,7 +108,6 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
  public:
   explicit BufferReader(const std::shared_ptr<Buffer>& buffer);
   BufferReader(const uint8_t* data, int64_t size);
-  virtual ~BufferReader();
 
   Status Close() override;
   Status Tell(int64_t* position) const override;
@@ -116,7 +115,6 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
 
   // Zero copy read
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
-
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                 uint8_t* out) override;
 

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -33,7 +33,7 @@
     if (ARROW_PREDICT_FALSE(!_s.ok())) { \
       return _s;                         \
     }                                    \
-  } while (0)
+  } while (false)
 
 // If 'to_call' returns a bad status, CHECK immediately with a logged message
 // of 'msg' followed by the status.
@@ -41,7 +41,7 @@
   do {                                                      \
     ::arrow::Status _s = (to_call);                         \
     ARROW_CHECK(_s.ok()) << (msg) << ": " << _s.ToString(); \
-  } while (0)
+  } while (false)
 
 // If the status is bad, CHECK immediately, appending the status to the
 // logged message.
@@ -69,7 +69,7 @@ namespace arrow {
     if (ARROW_PREDICT_FALSE(!_s.ok())) { \
       return _s;                         \
     }                                    \
-  } while (0)
+  } while (false)
 
 #endif  // ARROW_EXTRA_ERROR_CONTEXT
 
@@ -80,7 +80,7 @@ namespace arrow {
       else_;                         \
       return _s;                     \
     }                                \
-  } while (0)
+  } while (false)
 
 enum class StatusCode : char {
   OK = 0,


### PR DESCRIPTION
This makes `RandomAccessFile` thread-safe (and therefore `BufferReader` as well) using pimpl. JIRA is down for maintenance at the moment.