### PR TITLE
ARROW-1503: [Python] Add default serialization context, callbacks for pandas.Series/DataFrame

### DIFF
--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -187,3 +187,50 @@ def deserialize_pandas(buf, nthreads=None):
     reader = pa.RecordBatchStreamReader(buffer_reader)
     table = reader.read_all()
     return table.to_pandas(nthreads=nthreads)
+
+
+# ----------------------------------------------------------------------
+# Set up default serialization context
+
+def _serialize_pandas_series(s):
+    import pandas as pd
+    # TODO: serializing Series without extra copy
+    serialized = serialize_pandas(pd.DataFrame({s.name: s}))
+    return {
+        'type': 'Series',
+        'data': serialized.to_pybytes()
+    }
+
+
+def _serialize_pandas_dataframe(df):
+    return {
+        'type': 'DataFrame',
+        'data': serialize_pandas(df).to_pybytes()
+    }
+
+
+def _deserialize_callback_pandas(data):
+    deserialized = deserialize_pandas(data['data'])
+    type_ = data['type']
+    if type_ == 'Series':
+        return deserialized[deserialized.columns[0]]
+    elif type_ == 'DataFrame':
+        return deserialized
+    else:
+        raise ValueError(type_)
+
+
+try:
+    import pandas as pd
+    lib._default_serialization_context.register_type(
+        pd.Series, 'pandas.Series',
+        custom_serializer=_serialize_pandas_series,
+        custom_deserializer=_deserialize_callback_pandas)
+
+    lib._default_serialization_context.register_type(
+        pd.DataFrame, 'pandas.DataFrame',
+        custom_serializer=_serialize_pandas_dataframe,
+        custom_deserializer=_deserialize_callback_pandas)
+except ImportError:
+    # no pandas
+    pass

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -526,3 +526,15 @@ def _add_any_metadata(table, pandas_metadata):
         return pa.Table.from_arrays(columns)
     else:
         return table
+
+
+_default_serialization_context.register_type(
+    pd.Series, 'pandas.Series',
+    custom_serializer=_serialize_series,
+    custom_deserializer=_deserialize_series)
+
+
+_default_serialization_context.register_type(
+    pd.DataFrame, 'pandas.DataFrame',
+    custom_serializer=_serialize_dataframe,
+    custom_deserializer=_deserialize_dataframe)

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -526,15 +526,3 @@ def _add_any_metadata(table, pandas_metadata):
         return pa.Table.from_arrays(columns)
     else:
         return table
-
-
-_default_serialization_context.register_type(
-    pd.Series, 'pandas.Series',
-    custom_serializer=_serialize_series,
-    custom_deserializer=_deserialize_series)
-
-
-_default_serialization_context.register_type(
-    pd.DataFrame, 'pandas.DataFrame',
-    custom_serializer=_serialize_dataframe,
-    custom_deserializer=_deserialize_dataframe)

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -137,6 +137,10 @@ cdef class SerializationContext:
                     obj.__dict__.update(serialized_obj)
         return obj
 
+
+_default_serialization_context = SerializationContext()
+
+
 cdef class SerializedPyObject:
     """
     Arrow-serialized representation of Python object
@@ -174,6 +178,9 @@ cdef class SerializedPyObject:
         """
         cdef PyObject* result
 
+        if context is None:
+            context = _default_serialization_context
+
         with nogil:
             check_status(DeserializeObject(context, self.data,
                                            <PyObject*> self.base, &result))
@@ -210,6 +217,10 @@ def serialize(object value, SerializationContext context=None):
     """
     cdef SerializedPyObject serialized = SerializedPyObject()
     wrapped_value = [value]
+
+    if context is None:
+        context = _default_serialization_context
+
     with nogil:
         check_status(SerializeObject(context, wrapped_value, &serialized.data))
     return serialized

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -209,7 +209,8 @@ def serialize(object value, SerializationContext context=None):
     value: object
         Python object for the sequence that is to be serialized.
     context : SerializationContext
-        Custom serialization and deserialization context
+        Custom serialization and deserialization context, uses a default
+        context with some standard type handlers if not specified
 
     Returns
     -------
@@ -236,7 +237,8 @@ def serialize_to(object value, sink, SerializationContext context=None):
     sink: NativeFile or file-like
         File the sequence will be written to.
     context : SerializationContext
-        Custom serialization and deserialization context
+        Custom serialization and deserialization context, uses a default
+        context with some standard type handlers if not specified
     """
     serialized = serialize(value, context)
     serialized.write_to(sink)

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -22,7 +22,8 @@ import threading
 
 import numpy as np
 
-from pandas.util.testing import assert_frame_equal
+from pandas.util.testing import (assert_frame_equal,
+                                 assert_series_equal)
 import pandas as pd
 
 from pyarrow.compat import unittest
@@ -427,6 +428,20 @@ def test_serialize_pandas_no_preserve_index():
     buf = pa.serialize_pandas(df, preserve_index=True)
     result = pa.deserialize_pandas(buf)
     assert_frame_equal(result, df)
+
+
+def test_serialize_with_pandas_objects():
+    df = pd.DataFrame({'a': [1, 2, 3]}, index=[1, 2, 3])
+
+    data = {
+        'a_series': df['a'],
+        'a_frame': df
+    }
+
+    serialized = pa.serialize(data).to_buffer()
+    deserialized = pa.deserialize(serialized)
+    assert_frame_equal(deserialized['a_frame'], df)
+    assert_series_equal(deserialized['a_series'], df['a'])
 
 
 def test_schema_batch_serialize_methods():


### PR DESCRIPTION
The performance is a bit slower than it could be because we do not have native handling of pyarrow.Buffer (per ARROW-1522). That would allow us to skip the `to_pybytes` copy portion