### PR TITLE
ARROW-1652 [JS - WIP] Add optional batch hint to Vector.get

### DIFF
--- a/js/src/vector/dictionary.ts
+++ b/js/src/vector/dictionary.ts
@@ -26,14 +26,17 @@ export class DictionaryVector<T> extends Vector<T> {
         this.data = dictionary;
         this.length = index && index.length || 0;
     }
-    index(index: number) {
-        return this.keys.get(index);
+    index(index: number, batch?: number) {
+        return this.keys.get(index, batch);
     }
     value(index: number) {
         return this.data.get(index);
     }
-    get(index: number) {
-        return this.value(this.index(index));
+    get(index: number, batch?: number) {
+        return this.value(this.index(index, batch));
+    }
+    *batches() {
+        return this.keys.batches();
     }
     concat(vector: DictionaryVector<T>) {
         return DictionaryVector.from(this,

--- a/js/src/vector/struct.ts
+++ b/js/src/vector/struct.ts
@@ -26,8 +26,8 @@ export class StructVector extends Vector<any[]> {
         this.length = Math.max(0, ...vectors.map((v) => v.length));
         validity && (this.validity = BitVector.from(validity));
     }
-    get(index: number) {
-        return this.validity.get(index) ? this.vectors.map((v) => v.get(index)) : null;
+    get(index: number, batch?: number) {
+        return this.validity.get(index, batch) ? this.vectors.map((v) => v.get(index, batch)) : null;
     }
     concat(vector: StructVector) {
         return StructVector.from(this,

--- a/js/src/vector/vector.ts
+++ b/js/src/vector/vector.ts
@@ -59,9 +59,10 @@ export class Vector<T> implements Iterable<T> {
     public type: string;
     public length: number;
     public stride: number;
+    public *batches() {}
     public props: Map<PropertyKey, any>;
     protected validity: Vector<boolean>;
-    get(index: number): T { return null; }
+    get(index: number, batch?: number): T { return null; }
     concat(vector: Vector<T>) { return vector; }
     slice<R = T>(start?: number, end?: number, batch?: number) {
         const { stride } = this;


### PR DESCRIPTION
Added an optional `batch` to `Vector.get`, as well as a `*batches` iterator. The most significant changes are in `ListVector` and `IndexVector`, because I removed the `returnWithBatchIndex` argument and made some tweaks to the way offset vectors are handled (Rather than subtracting `batch` when accessing data, use `length - 1` to reduce `index while iterating).