### PR TITLE
ARROW-1676: [C++] Only pad null bitmap up to a factor of 8 bytes in Feather format

### DIFF
--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -554,7 +554,7 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
     if (values.null_count() > 0) {
       // We assume there is one bit for each value in values.nulls, aligned on a
       // byte boundary, and we write this much data into the stream
-      int64_t null_bitmap_size = BitUtil::BytesForBits(values.length());
+      int64_t null_bitmap_size = GetOutputLength(BitUtil::BytesForBits(values.length()));
       if (values.null_bitmap()) {
         RETURN_NOT_OK(WritePadded(stream_.get(), values.null_bitmap()->data(),
                                   null_bitmap_size, &bytes_written));

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -554,12 +554,12 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
     if (values.null_count() > 0) {
       // We assume there is one bit for each value in values.nulls, aligned on a
       // byte boundary, and we write this much data into the stream
+      int64_t null_bitmap_size = BitUtil::BytesForBits(values.length());
       if (values.null_bitmap()) {
         RETURN_NOT_OK(WritePadded(stream_.get(), values.null_bitmap()->data(),
-                                  values.null_bitmap()->size(), &bytes_written));
+                                  null_bitmap_size, &bytes_written));
       } else {
-        RETURN_NOT_OK(WritePaddedBlank(
-            stream_.get(), BitUtil::BytesForBits(values.length()), &bytes_written));
+        RETURN_NOT_OK(WritePaddedBlank(stream_.get(), null_bitmap_size, &bytes_written));
       }
       meta->total_bytes += bytes_written;
     }

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -266,6 +266,8 @@ class TestFeatherReader(unittest.TestCase):
         expected = pd.DataFrame({'arr': values.to_pandas()})
         assert_frame_equal(result, expected)
 
+        self._check_pandas_roundtrip(expected, null_counts=[1])
+
     def test_boolean_object_nulls(self):
         repeats = 100
         arr = np.array([False, None, True] * repeats, dtype=object)

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -251,22 +251,23 @@ class TestFeatherReader(unittest.TestCase):
 
     def test_buffer_bounds_error(self):
         # ARROW-1676
-        values = pa.array([None] + list(range(128)), type=pa.float64())
-
         path = random_path()
         self.test_files.append(path)
 
-        writer = FeatherWriter()
-        writer.open(path)
+        for i in range(16, 256):
+            values = pa.array([None] + list(range(i)), type=pa.float64())
 
-        writer.write_array('arr', values)
-        writer.close()
+            writer = FeatherWriter()
+            writer.open(path)
 
-        result = read_feather(path)
-        expected = pd.DataFrame({'arr': values.to_pandas()})
-        assert_frame_equal(result, expected)
+            writer.write_array('arr', values)
+            writer.close()
 
-        self._check_pandas_roundtrip(expected, null_counts=[1])
+            result = read_feather(path)
+            expected = pd.DataFrame({'arr': values.to_pandas()})
+            assert_frame_equal(result, expected)
+
+            self._check_pandas_roundtrip(expected, null_counts=[1])
 
     def test_boolean_object_nulls(self):
         repeats = 100

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -249,6 +249,23 @@ class TestFeatherReader(unittest.TestCase):
         result = read_feather(path)
         assert_frame_equal(result, ex_frame)
 
+    def test_buffer_bounds_error(self):
+        # ARROW-1676
+        values = pa.array([None] + list(range(128)), type=pa.float64())
+
+        path = random_path()
+        self.test_files.append(path)
+
+        writer = FeatherWriter()
+        writer.open(path)
+
+        writer.write_array('arr', values)
+        writer.close()
+
+        result = read_feather(path)
+        expected = pd.DataFrame({'arr': values.to_pandas()})
+        assert_frame_equal(result, expected)
+
     def test_boolean_object_nulls(self):
         repeats = 100
         arr = np.array([False, None, True] * repeats, dtype=object)


### PR DESCRIPTION
cc @rvernica 

Due to Arrow's buffer padding, the validity bitmap may be larger than the Feather format expects it to be. This can result in off-by-one errors when reading files.

It's disappointing that this correctness issue has existed for so long. I am looking to determine if this might have affected users of the Python API