### PR TITLE
ARROW-1679: [GLib] Add garrow_record_batch_reader_read_next()

### DIFF
--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -168,13 +168,13 @@ garrow_record_batch_reader_get_schema(GArrowRecordBatchReader *reader)
  * Since: 0.4.0
  *
  * Deprecated: 0.5.0:
- *   Use garrow_record_batch_reader_read_next_record_batch() instead.
+ *   Use garrow_record_batch_reader_read_next() instead.
  */
 GArrowRecordBatch *
 garrow_record_batch_reader_get_next_record_batch(GArrowRecordBatchReader *reader,
                                                  GError **error)
 {
-  return garrow_record_batch_reader_read_next_record_batch(reader, error);
+  return garrow_record_batch_reader_read_next(reader, error);
 }
 
 /**
@@ -186,10 +186,30 @@ garrow_record_batch_reader_get_next_record_batch(GArrowRecordBatchReader *reader
  *   The next record batch in the stream or %NULL on end of stream.
  *
  * Since: 0.5.0
+ *
+ * Deprecated: 0.8.0:
+ *   Use garrow_record_batch_reader_read_next() instead.
  */
 GArrowRecordBatch *
 garrow_record_batch_reader_read_next_record_batch(GArrowRecordBatchReader *reader,
                                                   GError **error)
+{
+  return garrow_record_batch_reader_read_next(reader, error);
+}
+
+/**
+ * garrow_record_batch_reader_read_next:
+ * @reader: A #GArrowRecordBatchReader.
+ * @error: (nullable): Return locatipcn for a #GError or %NULL.
+ *
+ * Returns: (nullable) (transfer full):
+ *   The next record batch in the stream or %NULL on end of stream.
+ *
+ * Since: 0.8.0
+ */
+GArrowRecordBatch *
+garrow_record_batch_reader_read_next(GArrowRecordBatchReader *reader,
+                                     GError **error)
 {
   auto arrow_reader = garrow_record_batch_reader_get_raw(reader);
   std::shared_ptr<arrow::RecordBatch> arrow_record_batch;
@@ -197,7 +217,7 @@ garrow_record_batch_reader_read_next_record_batch(GArrowRecordBatchReader *reade
 
   if (garrow_error_check(error,
                          status,
-                         "[record-batch-reader][read-next-record-batch]")) {
+                         "[record-batch-reader][read-next]")) {
     if (arrow_record_batch == nullptr) {
       return NULL;
     } else {

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -77,12 +77,18 @@ GType garrow_record_batch_reader_get_type(void) G_GNUC_CONST;
 GArrowSchema *garrow_record_batch_reader_get_schema(
   GArrowRecordBatchReader *reader);
 #ifndef GARROW_DISABLE_DEPRECATED
-G_GNUC_DEPRECATED_FOR(garrow_record_batch_reader_read_next_record_batch)
+G_GNUC_DEPRECATED_FOR(garrow_record_batch_reader_read_next)
 GArrowRecordBatch *garrow_record_batch_reader_get_next_record_batch(
   GArrowRecordBatchReader *reader,
   GError **error);
 #endif
+#ifndef GARROW_DISABLE_DEPRECATED
+G_GNUC_DEPRECATED_FOR(garrow_record_batch_reader_read_next)
 GArrowRecordBatch *garrow_record_batch_reader_read_next_record_batch(
+  GArrowRecordBatchReader *reader,
+  GError **error);
+#endif
+GArrowRecordBatch *garrow_record_batch_reader_read_next(
   GArrowRecordBatchReader *reader,
   GError **error);
 

--- a/c_glib/example/go/read-stream.go
+++ b/c_glib/example/go/read-stream.go
@@ -87,9 +87,9 @@ func main() {
 		log.Fatalf("Failed to parse data: %v", err)
 	}
 	for i := 0; true; i++ {
-		recordBatch, err := reader.ReadNextRecordBatch()
+		recordBatch, err := reader.ReadNext()
 		if err != nil {
-			log.Fatalf("Failed to read next record batch: %v", err)
+			log.Fatalf("Failed to read the next record batch: %v", err)
 		}
 		if recordBatch == nil {
 			break

--- a/c_glib/example/lua/read-stream.lua
+++ b/c_glib/example/lua/read-stream.lua
@@ -25,7 +25,7 @@ local reader = Arrow.RecordBatchStreamReader.new(input)
 
 local i = 0
 while true do
-   local record_batch = reader:read_next_record_batch()
+   local record_batch = reader:read_next()
    if not record_batch then
       break
    end

--- a/c_glib/example/read-stream.c
+++ b/c_glib/example/read-stream.c
@@ -117,10 +117,9 @@ main(int argc, char **argv)
     while (TRUE) {
       GArrowRecordBatch *record_batch;
 
-      record_batch =
-        garrow_record_batch_reader_read_next_record_batch(reader, &error);
+      record_batch = garrow_record_batch_reader_read_next(reader, &error);
       if (error) {
-        g_print("failed to get record batch: %s\n", error->message);
+        g_print("failed to read the next record batch: %s\n", error->message);
         g_error_free(error);
         g_object_unref(reader);
         g_object_unref(input);

--- a/c_glib/test/test-array-builder.rb
+++ b/c_glib/test/test-array-builder.rb
@@ -17,6 +17,7 @@
 
 module ArrayBuilderAppendValuesTests
   def test_empty
+    require_gi(1, 42, 0)
     builder = create_builder
     builder.append_values([])
     assert_equal(build_array([]),
@@ -24,6 +25,7 @@ module ArrayBuilderAppendValuesTests
   end
 
   def test_values_only
+    require_gi(1, 42, 0)
     builder = create_builder
     builder.append_values(sample_values)
     assert_equal(build_array(sample_values),

--- a/c_glib/test/test-stream-writer.rb
+++ b/c_glib/test/test-stream-writer.rb
@@ -44,8 +44,8 @@ class TestStreamWriter < Test::Unit::TestCase
       assert_equal(["enabled"],
                    stream_reader.schema.fields.collect(&:name))
       assert_equal(true,
-                   stream_reader.read_next_record_batch.get_column(0).get_value(0))
-      assert_nil(stream_reader.read_next_record_batch)
+                   stream_reader.read_next.get_column(0).get_value(0))
+      assert_nil(stream_reader.read_next)
     ensure
       input.close
     end


### PR DESCRIPTION
garrow_record_batch_reader_read_next_record_batch() is deprecated.
It's for following C++ API change.