### PR TITLE
ARROW-1686: [Docs] rsync contents of apidocs directory into site java directory

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -110,33 +110,3 @@ Studio 2015):
 ```
 dev/release/verify-release-candidate.bat apache-arrow-0.7.0.tar.gz
 ```
-
-## Creating API documentation
-
-The generation of API documentation for `C++`, `C Glib`, `Python` 
-and `Java` has been Dockerized. To generate the API documentation
-run the following command:
-
-```shell
-bash dev/gen_apidocs.sh
-```
-
-This script assumes that the `parquet-cpp` Git repository 
-https://github.com/apache/parquet-cpp has been cloned
-besides the Arrow repository and a `dist` directory can be created
-at the same level by the current user. Please note that most of the
-software must be built in order to create the documentation, so this
-step may take some time to run, especially the first time around as the
-Docker container will also have to be built.
-
-After successfully creating the API documentation the website can be
-run locally to browse the API documentation from the top level
-`Documentation` menu. To run the website issue the command:
-
-```shell
-bash dev/run_site.sh
-```
-
-The local URL for the website running inside the docker container
-will be shown as `Server address:` in the output of the command.
-To stop the server press `Ctrl-C` in that window.

--- a/dev/gen_apidocs/create_documents.sh
+++ b/dev/gen_apidocs/create_documents.sh
@@ -106,5 +106,5 @@ rm -rf target/site/apidocs/*
 mvn -Drat.skip=true install
 mvn -Drat.skip=true site
 mkdir -p ../site/asf-site/docs/java/
-rsync -r target/site/apidocs ../site/asf-site/docs/java/
+rsync -r target/site/apidocs/ ../site/asf-site/docs/java/
 popd

--- a/dev/release/README
+++ b/dev/release/README
@@ -1,7 +1,7 @@
 requirements:
 - being a committer to be able to push to dist and maven repository
 - a gpg key to sign the artifacts
-- use java 7. check your JAVA_HOME environment variable (at least for now. See ARROW-930) 
+- use java 7. check your JAVA_HOME environment variable (at least for now. See ARROW-930)
 - have the build requirements for cpp and c_glibg installed (see their README)
 
 to release, run the following (replace 0.1.0 with version to release):
@@ -28,7 +28,7 @@ mvn versions:set -DnewVersion=0.1-SNAPSHOT
 git reset --hard
 - setup gpg agent
 eval $(gpg-agent --daemon --allow-preset-passphrase)
-gpg --use-agent -s LICENSE.txt 
+gpg --use-agent -s LICENSE.txt
 - delete tag localy
 git tag -d apache-arrow-0.1.0
 

--- a/dev/release/RELEASE_MANAGEMENT.md
+++ b/dev/release/RELEASE_MANAGEMENT.md
@@ -96,9 +96,33 @@ from your apache.org e-mail address to be accepted.
 
 ### Updating website with new API documentation
 
-Currently, this is manual, but is in the process of being automated (see
-ARROW-905). See instructions in
-https://github.com/apache/arrow/blob/master/site/README.md
+The API documentation for `C++`, `C Glib`, `Python` and `Java` can be generated
+via a Docker-based setup. To generate the API documentation run the following
+command:
+
+```shell
+bash dev/gen_apidocs.sh
+```
+
+This script assumes that the `parquet-cpp` Git repository
+https://github.com/apache/parquet-cpp has been cloned
+besides the Arrow repository and a `dist` directory can be created
+at the same level by the current user. Please note that most of the
+software must be built in order to create the documentation, so this
+step may take some time to run, especially the first time around as the
+Docker container will also have to be built.
+
+After successfully creating the API documentation the website can be
+run locally to browse the API documentation from the top level
+`Documentation` menu. To run the website issue the command:
+
+```shell
+bash dev/run_site.sh
+```
+
+The local URL for the website running inside the docker container
+will be shown as `Server address:` in the output of the command.
+To stop the server press `Ctrl-C` in that window.
 
 ### Updating C++ and Python packages
 


### PR DESCRIPTION
Omitting the trailing slash results in a `java/apidocs` subdirectory being created