### PR TITLE
ARROW-1671: [C++] Deprecate arrow::MakeArray that returns Status, refactor existing code to new variant

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -144,12 +144,24 @@ struct ARROW_EXPORT ArrayData {
   std::vector<std::shared_ptr<ArrayData>> child_data;
 };
 
+#ifndef ARROW_NO_DEPRECATED_API
+
 /// \brief Create a strongly-typed Array instance from generic ArrayData
 /// \param[in] data the array contents
 /// \param[out] out the resulting Array instance
 /// \return Status
+///
+/// \note Deprecated since 0.8.0
 ARROW_EXPORT
 Status MakeArray(const std::shared_ptr<ArrayData>& data, std::shared_ptr<Array>* out);
+
+#endif
+
+/// \brief Create a strongly-typed Array instance from generic ArrayData
+/// \param[in] data the array contents
+/// \return the resulting Array instance
+ARROW_EXPORT
+std::shared_ptr<Array> MakeArray(const std::shared_ptr<ArrayData>& data);
 
 // ----------------------------------------------------------------------
 // User array accessor types

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -102,7 +102,8 @@ Status ArrayBuilder::Advance(int64_t elements) {
 Status ArrayBuilder::Finish(std::shared_ptr<Array>* out) {
   std::shared_ptr<ArrayData> internal_data;
   RETURN_NOT_OK(FinishInternal(&internal_data));
-  return MakeArray(internal_data, out);
+  *out = MakeArray(internal_data);
+  return Status::OK();
 }
 
 Status ArrayBuilder::Reserve(int64_t elements) {

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -717,7 +717,8 @@ Status Cast(FunctionContext* ctx, const Array& array,
   auto out_data = std::make_shared<ArrayData>(out_type, array.length());
 
   RETURN_NOT_OK(func->Call(ctx, array, out_data.get()));
-  return MakeArray(out_data, out);
+  *out = MakeArray(out_data);
+  return Status::OK();
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -369,8 +369,8 @@ TEST_F(TestCast, PreallocatedMemory) {
   // Buffer address unchanged
   ASSERT_EQ(out_values.get(), out_data->buffers[1].get());
 
-  std::shared_ptr<Array> result, expected;
-  ASSERT_OK(MakeArray(out_data, &result));
+  std::shared_ptr<Array> result = MakeArray(out_data);
+  std::shared_ptr<Array> expected;
   ArrayFromVector<Int64Type, int64_t>(int64(), is_valid, e1, &expected);
 
   AssertArraysEqual(*expected, *result);

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -371,7 +371,8 @@ class TableReader::TableReaderImpl {
 
     auto arr_data =
         std::make_shared<ArrayData>(type, meta->length(), buffers, meta->null_count());
-    return MakeArray(arr_data, out);
+    *out = MakeArray(arr_data);
+    return Status::OK();
   }
 
   bool HasDescription() const { return metadata_->HasDescription(); }
@@ -490,7 +491,8 @@ static Status SanitizeUnsupportedTypes(const Array& values, std::shared_ptr<Arra
                                          values.null_bitmap(), values.null_count());
     return Status::OK();
   } else {
-    return MakeArray(values.data(), out);
+    *out = MakeArray(values.data());
+    return Status::OK();
   }
 }
 

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -364,9 +364,7 @@ class NumPyConverter {
   }
 
   Status PushArray(const std::shared_ptr<ArrayData>& data) {
-    std::shared_ptr<Array> result;
-    RETURN_NOT_OK(MakeArray(data, &result));
-    out_arrays_.emplace_back(std::move(result));
+    out_arrays_.emplace_back(MakeArray(data));
     return Status::OK();
   }
 
@@ -495,8 +493,8 @@ static Status CastBuffer(const std::shared_ptr<Buffer>& input, const int64_t len
   std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, input};
   auto tmp_data = std::make_shared<ArrayData>(in_type, length, buffers, 0);
 
-  std::shared_ptr<Array> tmp_array, casted_array;
-  RETURN_NOT_OK(MakeArray(tmp_data, &tmp_array));
+  std::shared_ptr<Array> tmp_array = MakeArray(tmp_data);
+  std::shared_ptr<Array> casted_array;
 
   compute::FunctionContext context(pool);
   compute::CastOptions cast_options;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -192,7 +192,7 @@ RecordBatch::RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows
 
 std::shared_ptr<Array> RecordBatch::column(int i) const {
   if (!boxed_columns_[i]) {
-    DCHECK(MakeArray(columns_[i], &boxed_columns_[i]).ok());
+    boxed_columns_[i] = MakeArray(columns_[i]);
   }
   DCHECK(boxed_columns_[i]);
   return boxed_columns_[i];


### PR DESCRIPTION
We should be very strict to not return Status from functions that cannot fail