### PR TITLE
ARROW-1683: [Python] Restore TimestampType to pyarrow namespace

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -37,7 +37,8 @@ from pyarrow.lib import (null, bool_,
                          float16, float32, float64,
                          binary, string, decimal,
                          list_, struct, dictionary, field,
-                         type_for_alias, DataType, NAType,
+                         type_for_alias,
+                         DataType, NAType,
                          Field,
                          Schema,
                          schema,
@@ -66,6 +67,9 @@ from pyarrow.lib import (null, bool_,
                          BinaryValue, StringValue, FixedSizeBinaryValue,
                          DecimalValue,
                          Date32Value, Date64Value, TimestampValue)
+
+# ARROW-1683: Remove after 0.8.0?
+from pyarrow.lib import TimestampType
 
 from pyarrow.lib import (HdfsFile, NativeFile, PythonFile,
                          FixedSizeBufferWriter,

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -132,3 +132,8 @@ def test_is_temporal_date_time_timestamp():
         assert not types.is_time(case)
 
     assert not types.is_temporal(pa.int32())
+
+
+def test_timestamp_type():
+    # See ARROW-1683
+    assert isinstance(pa.timestamp('ns'), pa.TimestampType)


### PR DESCRIPTION
This is being used in PySpark. After 0.8.0 we should migrate Spark to use the `pyarrow.types` APIs and then remove this from the top level namespace again

cc @BryanCutler 