### PR TITLE
ARROW-1522: [Python] Zero copy buffer deserialization

### DIFF
--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -105,7 +105,8 @@ Status DeserializeArray(const Array& array, int64_t offset, PyObject* base,
   return Status::OK();
 }
 
-Status GetValue(PyObject* context, const UnionArray& parent, const Array& arr, int64_t index, int32_t type,
+Status GetValue(PyObject* context, const UnionArray& parent, const Array& arr,
+                int64_t index, int32_t type,
                 PyObject* base, const SerializedPyObject& blobs,
                 PyObject** result) {
   switch (arr.type()->id()) {
@@ -272,7 +273,8 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
 
   for (int i = 0; i < num_buffers; ++i) {
     int64_t size;
-    RETURN_NOT_OK(src->ReadAt(offset, sizeof(int64_t), &bytes_read, reinterpret_cast<uint8_t*>(&size)));
+    RETURN_NOT_OK(src->ReadAt(offset, sizeof(int64_t), &bytes_read,
+                              reinterpret_cast<uint8_t*>(&size)));
     RETURN_NOT_OK(src->Tell(&offset));
     std::shared_ptr<Buffer> buffer;
     RETURN_NOT_OK(src->ReadAt(offset, size, &buffer));

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -276,6 +276,7 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
   for (int i = 0; i < num_buffers; ++i) {
     int64_t size;
     RETURN_NOT_OK(src->ReadAt(offset, sizeof(int64_t), &bytes_read, reinterpret_cast<uint8_t*>(&size)));
+    RETURN_NOT_OK(src->Tell(&offset));
     std::shared_ptr<Buffer> buffer;
     RETURN_NOT_OK(src->ReadAt(offset, size, &buffer));
     out->buffers.push_back(buffer);

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -33,6 +33,7 @@
 #include "arrow/python/helpers.h"
 #include "arrow/python/numpy_convert.h"
 #include "arrow/python/python_to_arrow.h"
+#include "arrow/python/pyarrow.h"
 #include "arrow/python/util/datetime.h"
 #include "arrow/table.h"
 #include "arrow/util/logging.h"
@@ -45,22 +46,22 @@ Status CallDeserializeCallback(PyObject* context, PyObject* value,
 
 Status DeserializeTuple(PyObject* context, const Array& array, int64_t start_idx,
                         int64_t stop_idx, PyObject* base,
-                        const std::vector<std::shared_ptr<Tensor>>& tensors,
+                        const SerializedPyObject& blobs,
                         PyObject** out);
 
 Status DeserializeList(PyObject* context, const Array& array, int64_t start_idx,
                        int64_t stop_idx, PyObject* base,
-                       const std::vector<std::shared_ptr<Tensor>>& tensors,
+                       const SerializedPyObject& blobs,
                        PyObject** out);
 
 Status DeserializeSet(PyObject* context, const Array& array, int64_t start_idx,
                       int64_t stop_idx, PyObject* base,
-                      const std::vector<std::shared_ptr<Tensor>>& tensors,
+                      const SerializedPyObject& blobs,
                       PyObject** out);
 
 Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
                        int64_t stop_idx, PyObject* base,
-                       const std::vector<std::shared_ptr<Tensor>>& tensors,
+                       const SerializedPyObject& blobs,
                        PyObject** out) {
   const auto& data = static_cast<const StructArray&>(array);
   ScopedRef keys, vals;
@@ -70,9 +71,9 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
   DCHECK_EQ(2, data.num_fields());
 
   RETURN_NOT_OK(DeserializeList(context, *data.field(0), start_idx, stop_idx, base,
-                                tensors, keys.ref()));
+                                blobs, keys.ref()));
   RETURN_NOT_OK(DeserializeList(context, *data.field(1), start_idx, stop_idx, base,
-                                tensors, vals.ref()));
+                                blobs, vals.ref()));
   for (int64_t i = start_idx; i < stop_idx; ++i) {
     // PyDict_SetItem behaves differently from PyList_SetItem and PyTuple_SetItem.
     // The latter two steal references whereas PyDict_SetItem does not. So we need
@@ -91,10 +92,10 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
 }
 
 Status DeserializeArray(const Array& array, int64_t offset, PyObject* base,
-                        const std::vector<std::shared_ptr<arrow::Tensor>>& tensors,
+                        const SerializedPyObject& blobs,
                         PyObject** out) {
   int32_t index = static_cast<const Int32Array&>(array).Value(offset);
-  RETURN_NOT_OK(py::TensorToNdarray(*tensors[index], base, out));
+  RETURN_NOT_OK(py::TensorToNdarray(*blobs.tensors[index], base, out));
   // Mark the array as immutable
   ScopedRef flags(PyObject_GetAttrString(*out, "flags"));
   DCHECK(flags.get() != NULL) << "Could not mark Numpy array immutable";
@@ -105,7 +106,7 @@ Status DeserializeArray(const Array& array, int64_t offset, PyObject* base,
 }
 
 Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type,
-                PyObject* base, const std::vector<std::shared_ptr<Tensor>>& tensors,
+                PyObject* base, const SerializedPyObject& blobs,
                 PyObject** result) {
   switch (arr.type()->id()) {
     case Type::BOOL:
@@ -151,16 +152,16 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
       const auto& l = static_cast<const ListArray&>(*s.field(0));
       if (s.type()->child(0)->name() == "list") {
         return DeserializeList(context, *l.values(), l.value_offset(index),
-                               l.value_offset(index + 1), base, tensors, result);
+                               l.value_offset(index + 1), base, blobs, result);
       } else if (s.type()->child(0)->name() == "tuple") {
         return DeserializeTuple(context, *l.values(), l.value_offset(index),
-                                l.value_offset(index + 1), base, tensors, result);
+                                l.value_offset(index + 1), base, blobs, result);
       } else if (s.type()->child(0)->name() == "dict") {
         return DeserializeDict(context, *l.values(), l.value_offset(index),
-                               l.value_offset(index + 1), base, tensors, result);
+                               l.value_offset(index + 1), base, blobs, result);
       } else if (s.type()->child(0)->name() == "set") {
         return DeserializeSet(context, *l.values(), l.value_offset(index),
-                              l.value_offset(index + 1), base, tensors, result);
+                              l.value_offset(index + 1), base, blobs, result);
       } else {
         DCHECK(false) << "unexpected StructArray type " << s.type()->child(0)->name();
       }
@@ -168,7 +169,15 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
     // We use an Int32Builder here to distinguish the tensor indices from
     // the Type::INT64 above (see tensor_indices_ in SequenceBuilder).
     case Type::INT32: {
-      return DeserializeArray(arr, index, base, tensors, result);
+      return DeserializeArray(arr, index, base, blobs, result);
+    }
+    // We use an UInt32Builder here to distinguish the buffer indices from
+    // tensor indices and the Type::INT64 above (see tensor_indices_ in
+    // SequenceBuilder).
+    case Type::UINT32: {
+      int32_t ref = static_cast<const UInt32Array&>(arr).Value(index);
+      *result = wrap_buffer(blobs.buffers[ref]);
+      return Status::OK();
     }
     default:
       DCHECK(false) << "union tag " << type << " not recognized";
@@ -190,7 +199,7 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
       uint8_t type = type_ids[i];                                                  \
       PyObject* value;                                                             \
       RETURN_NOT_OK(GetValue(context, *data.UnsafeChild(type), offset, type, base, \
-                             tensors, &value));                                    \
+                             blobs, &value));                                      \
       SET_ITEM_FN(result.get(), i - start_idx, value);                             \
     }                                                                              \
   }                                                                                \
@@ -199,21 +208,21 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int32_t type
 
 Status DeserializeList(PyObject* context, const Array& array, int64_t start_idx,
                        int64_t stop_idx, PyObject* base,
-                       const std::vector<std::shared_ptr<Tensor>>& tensors,
+                       const SerializedPyObject& blobs,
                        PyObject** out) {
   DESERIALIZE_SEQUENCE(PyList_New, PyList_SET_ITEM);
 }
 
 Status DeserializeTuple(PyObject* context, const Array& array, int64_t start_idx,
                         int64_t stop_idx, PyObject* base,
-                        const std::vector<std::shared_ptr<Tensor>>& tensors,
+                        const SerializedPyObject& blobs,
                         PyObject** out) {
   DESERIALIZE_SEQUENCE(PyTuple_New, PyTuple_SET_ITEM);
 }
 
 Status DeserializeSet(PyObject* context, const Array& array, int64_t start_idx,
                       int64_t stop_idx, PyObject* base,
-                      const std::vector<std::shared_ptr<Tensor>>& tensors,
+                      const SerializedPyObject& blobs,
                       PyObject** out) {
   const auto& data = static_cast<const UnionArray&>(array);
   ScopedRef result(PySet_New(nullptr));
@@ -230,7 +239,7 @@ Status DeserializeSet(PyObject* context, const Array& array, int64_t start_idx,
       int8_t type = type_ids[i];
       PyObject* value;
       RETURN_NOT_OK(GetValue(context, *data.UnsafeChild(type), offset, type, base,
-                             tensors, &value));
+                             blobs, &value));
       if (PySet_Add(result.get(), value) < 0) {
         RETURN_IF_PYERROR();
       }
@@ -244,9 +253,12 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
   int64_t offset;
   int64_t bytes_read;
   int32_t num_tensors;
+  int32_t num_buffers;
   // Read number of tensors
   RETURN_NOT_OK(
       src->Read(sizeof(int32_t), &bytes_read, reinterpret_cast<uint8_t*>(&num_tensors)));
+  RETURN_NOT_OK(
+      src->Read(sizeof(int32_t), &bytes_read, reinterpret_cast<uint8_t*>(&num_buffers)));
 
   std::shared_ptr<RecordBatchReader> reader;
   RETURN_NOT_OK(ipc::RecordBatchStreamReader::Open(src, &reader));
@@ -260,6 +272,16 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
     out->tensors.push_back(tensor);
     RETURN_NOT_OK(src->Tell(&offset));
   }
+
+  for (int i = 0; i < num_buffers; ++i) {
+    int64_t size;
+    RETURN_NOT_OK(src->ReadAt(offset, sizeof(int64_t), &bytes_read, reinterpret_cast<uint8_t*>(&size)));
+    std::shared_ptr<Buffer> buffer;
+    RETURN_NOT_OK(src->ReadAt(offset, size, &buffer));
+    out->buffers.push_back(buffer);
+    RETURN_NOT_OK(src->Tell(&offset));
+  }
+
   return Status::OK();
 }
 
@@ -268,7 +290,7 @@ Status DeserializeObject(PyObject* context, const SerializedPyObject& obj, PyObj
   PyAcquireGIL lock;
   PyDateTime_IMPORT;
   return DeserializeList(context, *obj.batch->column(0), 0, obj.batch->num_rows(), base,
-                         obj.tensors, out);
+                         obj, out);
 }
 
 }  // namespace py

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <numpy/arrayobject.h>

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -193,7 +193,7 @@ class SequenceBuilder {
   }
 
   template <typename BuilderType>
-  Status AddElement(const int8_t tag, BuilderType* out, const std::string& name="") {
+  Status AddElement(const int8_t tag, BuilderType* out, const std::string& name = "") {
     if (tag != -1) {
       fields_[tag] = ::arrow::field(name, out->type());
       RETURN_NOT_OK(out->Finish(&children_[tag]));
@@ -553,7 +553,8 @@ Status SerializeArray(PyObject* context, PyArrayObject* array, SequenceBuilder* 
     case NPY_HALF:
     case NPY_FLOAT:
     case NPY_DOUBLE: {
-      RETURN_NOT_OK(builder->AppendTensor(static_cast<int32_t>(blobs_out->tensors.size())));
+      RETURN_NOT_OK(builder->AppendTensor(
+            static_cast<int32_t>(blobs_out->tensors.size())));
       std::shared_ptr<Tensor> tensor;
       RETURN_NOT_OK(NdarrayToTensor(default_memory_pool(),
                                     reinterpret_cast<PyObject*>(array), &tensor));

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -719,7 +719,9 @@ Status SerializeObject(PyObject* context, PyObject* sequence, SerializedPyObject
 
 Status WriteSerializedObject(const SerializedPyObject& obj, io::OutputStream* dst) {
   int32_t num_tensors = static_cast<int32_t>(obj.tensors.size());
+  int32_t num_buffers = static_cast<int32_t>(obj.buffers.size());
   RETURN_NOT_OK(dst->Write(reinterpret_cast<uint8_t*>(&num_tensors), sizeof(int32_t)));
+  RETURN_NOT_OK(dst->Write(reinterpret_cast<uint8_t*>(&num_buffers), sizeof(int32_t)));
   RETURN_NOT_OK(ipc::WriteRecordBatchStream({obj.batch}, dst));
 
   int32_t metadata_length;

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -63,7 +63,7 @@ class SequenceBuilder {
         doubles_(::arrow::float64(), pool),
         date64s_(::arrow::date64(), pool),
         tensor_indices_(::arrow::int32(), pool),
-        buffer_indices_(::arrow::uint32(), pool),
+        buffer_indices_(::arrow::int32(), pool),
         list_offsets_({0}),
         tuple_offsets_({0}),
         dict_offsets_({0}),

--- a/cpp/src/arrow/python/python_to_arrow.h
+++ b/cpp/src/arrow/python/python_to_arrow.h
@@ -24,6 +24,8 @@
 #include <vector>
 
 #include "arrow/status.h"
+#include "arrow/python/common.h"
+#include "arrow/python/pyarrow.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -42,6 +44,7 @@ namespace py {
 struct ARROW_EXPORT SerializedPyObject {
   std::shared_ptr<RecordBatch> batch;
   std::vector<std::shared_ptr<Tensor>> tensors;
+  std::vector<std::shared_ptr<Buffer>> buffers;
 };
 
 /// \brief Serialize Python sequence as a RecordBatch plus

--- a/cpp/src/arrow/python/python_to_arrow.h
+++ b/cpp/src/arrow/python/python_to_arrow.h
@@ -23,9 +23,9 @@
 #include <memory>
 #include <vector>
 
-#include "arrow/status.h"
 #include "arrow/python/common.h"
 #include "arrow/python/pyarrow.h"
+#include "arrow/status.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -102,15 +102,14 @@ def register_default_serialization_handlers(serialization_context):
         import pandas as pd
 
         def _serialize_pandas_series(obj):
-            # TODO: serializing Series without extra copy
-            return serialize_pandas(pd.DataFrame({obj.name: obj})).to_pybytes()
+            return serialize_pandas(pd.DataFrame({obj.name: obj}))
 
         def _deserialize_pandas_series(data):
             deserialized = deserialize_pandas(data)
             return deserialized[deserialized.columns[0]]
 
         def _serialize_pandas_dataframe(obj):
-            return serialize_pandas(obj).to_pybytes()
+            return serialize_pandas(obj)
 
         def _deserialize_pandas_dataframe(data):
             return deserialize_pandas(data)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -336,6 +336,25 @@ def test_serialization_callback_numpy():
 
     pa.serialize(DummyClass())
 
+def test_buffer_serialization():
+
+    class BufferClass(object):
+        pass
+
+    def serialize_buffer_class(obj):
+        return pa.frombuffer(b"hello")
+
+    def deserialize_buffer_class(serialized_obj):
+        return serialized_obj
+
+    pa._default_serialization_context.register_type(
+        BufferClass, "BufferClass", pickle=False,
+        custom_serializer=serialize_buffer_class,
+        custom_deserializer=deserialize_buffer_class)
+
+    b = pa.serialize(BufferClass()).to_buffer()
+    assert pa.deserialize(b).to_pybytes() == b"hello"
+
 
 @pytest.mark.skip(reason="extensive memory requirements")
 def test_arrow_limits(self):


### PR DESCRIPTION
This PR makes it possible to add serialization handlers that allow to deserialize python objects using zero copy. If the serialization handler returns an arrow buffer, it will be appended to the serialized objects and the object can be reconstructed from there without copying the buffer.

TODO before merge:

- [x] Add pandas zero copy buffer read
- [x] See if fixing the TODO about union tags makes the code cleaner