### PR TITLE
ARROW-641: [C++] Do not build io-hdfs-test if ARROW_HDFS is off

### DIFF
--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -19,9 +19,11 @@
 # arrow_io : Arrow IO interfaces
 
 ADD_ARROW_TEST(io-file-test)
-if (NOT ARROW_BOOST_HEADER_ONLY)
+
+if (ARROW_HDFS AND NOT ARROW_BOOST_HEADER_ONLY)
   ADD_ARROW_TEST(io-hdfs-test NO_VALGRIND)
 endif()
+
 ADD_ARROW_TEST(io-memory-test)
 
 ADD_ARROW_BENCHMARK(io-memory-benchmark)


### PR DESCRIPTION
Initially I was looking to see if we could gracefully skip the tests if we have the requisite libraries available but are unable to connect to a running HDFS cluster, but I think this would mask errors that we want to see. So this just makes it so that developers who don't want to see the test failure can skip building the unit test executable