### PR TITLE
ARROW-1689: [Python] Implement zero-copy conversions for DictionaryArray

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -958,13 +958,13 @@ class CategoricalBlock : public PandasBlock {
     using T = typename TRAITS::T;
     constexpr int npy_type = TRAITS::npy_type;
 
-
     const ChunkedArray& data = *col->data().get();
 
     // Sniff the first chunk
     const std::shared_ptr<Array> arr_first = data.chunk(0);
     const auto& dict_arr_first = static_cast<const DictionaryArray&>(*arr_first);
-    const auto& indices_first = static_cast<const PrimitiveArray&>(*dict_arr_first.indices());
+    const auto& indices_first =
+        static_cast<const PrimitiveArray&>(*dict_arr_first.indices());
 
     if (data.num_chunks() == 1 && indices_first.null_count() == 0) {
       RETURN_NOT_OK(AllocateNDArrayFromIndices<T>(npy_type, indices_first));
@@ -973,8 +973,7 @@ class CategoricalBlock : public PandasBlock {
       ss << "Needed to copy " << data.num_chunks() << " chunks with "
          << indices_first.null_count() << " indices nulls, but zero_copy_only was True";
       return Status::Invalid(ss.str());
-    }
-    else {
+    } else {
       RETURN_NOT_OK(AllocateNDArray(npy_type, 1));
 
       // No relative placement offset because a single column
@@ -1075,9 +1074,8 @@ class CategoricalBlock : public PandasBlock {
       return Status::OK();
     }
 
-    PyObject* block_arr = PyArray_NewFromDescr(&PyArray_Type, descr, 1, block_dims, nullptr, data,
-                                               NPY_ARRAY_CARRAY,
-                                               nullptr);
+    PyObject* block_arr = PyArray_NewFromDescr(&PyArray_Type, descr, 1, block_dims,
+                                               nullptr, data, NPY_ARRAY_CARRAY, nullptr);
 
     npy_intp placement_dims[1] = {num_columns_};
     PyObject* placement_arr = PyArray_SimpleNew(1, placement_dims, NPY_INT64);

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -968,6 +968,11 @@ class CategoricalBlock : public PandasBlock {
 
     if (data.num_chunks() == 1 && indices_first.null_count() == 0) {
       RETURN_NOT_OK(AllocateNDArrayFromIndices<T>(npy_type, indices_first));
+    } else if (options_.zero_copy_only) {
+      std::stringstream ss;
+      ss << "Needed to copy " << data.num_chunks() << " chunks with "
+         << indices_first.null_count() << " indices nulls, but zero_copy_only was True";
+      return Status::Invalid(ss.str());
     }
     else {
       RETURN_NOT_OK(AllocateNDArray(npy_type, 1));

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -217,6 +217,19 @@ class TestPandasConversion(object):
         result = pa.array([0, 1, 2]).to_pandas(zero_copy_only=True)
         npt.assert_array_equal(result, [0, 1, 2])
 
+    def test_zero_copy_dictionaries(self):
+        arr = pa.DictionaryArray.from_arrays(
+            np.array([0, 0]),
+            np.array(['A']))
+
+        result = arr.to_pandas(zero_copy_only=True)
+        values = pd.Categorical(['A', 'A'])
+
+        tm.assert_series_equal(
+            pd.Series(result),
+            pd.Series(values),
+           check_names=False)
+
     def test_zero_copy_failure_on_object_types(self):
         with pytest.raises(pa.ArrowException):
             pa.array(['A', 'B', 'C']).to_pandas(zero_copy_only=True)

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -225,10 +225,8 @@ class TestPandasConversion(object):
         result = arr.to_pandas(zero_copy_only=True)
         values = pd.Categorical(['A', 'A'])
 
-        tm.assert_series_equal(
-            pd.Series(result),
-            pd.Series(values),
-           check_names=False)
+        tm.assert_series_equal(pd.Series(result), pd.Series(values),
+                               check_names=False)
 
     def test_zero_copy_failure_on_object_types(self):
         with pytest.raises(pa.ArrowException):
@@ -257,14 +255,6 @@ class TestPandasConversion(object):
 
         with pytest.raises(pa.ArrowException):
             pa.array(arr).to_pandas(zero_copy_only=True)
-
-    def test_zero_copy_dictionaries(self):
-        arr = pa.DictionaryArray.from_arrays(
-            np.array([0, 0]),
-            np.array(['A']))
-
-        with pytest.raises(pa.ArrowException):
-            arr.to_pandas(zero_copy_only=True)
 
     def test_float_nulls(self):
         num_values = 100

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -220,10 +220,10 @@ class TestPandasConversion(object):
     def test_zero_copy_dictionaries(self):
         arr = pa.DictionaryArray.from_arrays(
             np.array([0, 0]),
-            np.array(['A']))
+            np.array([5]))
 
         result = arr.to_pandas(zero_copy_only=True)
-        values = pd.Categorical(['A', 'A'])
+        values = pd.Categorical([5, 5])
 
         tm.assert_series_equal(pd.Series(result), pd.Series(values),
                                check_names=False)


### PR DESCRIPTION
This PR closes [ARROW-1689](https://issues.apache.org/jira/browse/ARROW-1689).
I want to add the zero-copy option after https://github.com/apache/arrow/pull/1233 merged.