### PR TITLE
ARROW-1713: [Python] Fix incorrect pd.Series.index serialization

### DIFF
--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -100,7 +100,8 @@ try:
 
     def _serialize_pandas_series(obj):
         # TODO: serializing Series without extra copy
-        return serialize_pandas(pd.DataFrame({obj.name: obj})).to_pybytes()
+        return serialize_pandas(pd.DataFrame({obj.name: obj},
+                                             index=obj.index)).to_pybytes()
 
     def _deserialize_pandas_series(data):
         deserialized = deserialize_pandas(data)

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -433,15 +433,22 @@ def test_serialize_pandas_no_preserve_index():
 def test_serialize_with_pandas_objects():
     df = pd.DataFrame({'a': [1, 2, 3]}, index=[1, 2, 3])
 
+    s = pd.Series([1, 2, 3, 4])
+    s.index = pd.RangeIndex(start=0, stop=8, step=2)
+    # FIXME: No named Series name will be serialized u'None'.
+    s.name = 'discrete'
+
     data = {
         'a_series': df['a'],
-        'a_frame': df
+        'a_frame': df,
+        'discrete_idx_series': s
     }
 
     serialized = pa.serialize(data).to_buffer()
     deserialized = pa.deserialize(serialized)
     assert_frame_equal(deserialized['a_frame'], df)
     assert_series_equal(deserialized['a_series'], df['a'])
+    assert_series_equal(deserialized['discrete_idx_series'], s)
 
 
 def test_schema_batch_serialize_methods():


### PR DESCRIPTION
This closes [ARROW-1713](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-1713).