### PR TITLE
ARROW-1555 [Python] Implement Dask exists function

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -135,7 +135,7 @@ class FileSystem(object):
         """
         raise NotImplementedError
 
-    def isfilestore(self):
+    def _isfilestore(self):
         """
         Returns True if this FileSystem is a unix-style file store with directories.
         """
@@ -215,8 +215,8 @@ class LocalFileSystem(FileSystem):
     def isfile(self, path):
         return os.path.isfile(path)
 
-    @implements(FileSystem.isfilestore)
-    def isfilestore(self):
+    @implements(FileSystem._isfilestore)
+    def _isfilestore(self):
         return True
 
     @implements(FileSystem.exists)
@@ -257,8 +257,8 @@ class DaskFileSystem(FileSystem):
     def isfile(self, path):
         raise NotImplementedError("Unsupported file system API")
 
-    @implements(FileSystem.isfilestore)
-    def isfilestore(self):
+    @implements(FileSystem._isfilestore)
+    def _isfilestore(self):
         """
         Object Stores like S3 and GCSFS are based on key lookups, not true file-paths
         """

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -251,6 +251,10 @@ class DaskFileSystem(FileSystem):
     def delete(self, path, recursive=False):
         return self.fs.rm(path, recursive=recursive)
 
+    @implements(FileSystem.exists)
+    def exists(self, path):
+        return os.path.exists(path)
+
     @implements(FileSystem.mkdir)
     def mkdir(self, path):
         return self.fs.mkdir(path)

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -253,7 +253,7 @@ class DaskFileSystem(FileSystem):
 
     @implements(FileSystem.exists)
     def exists(self, path):
-        return os.path.exists(path)
+        return self.fs.exists(path)
 
     @implements(FileSystem.mkdir)
     def mkdir(self, path):

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -137,7 +137,8 @@ class FileSystem(object):
 
     def _isfilestore(self):
         """
-        Returns True if this FileSystem is a unix-style file store with directories.
+        Returns True if this FileSystem is a unix-style file store with
+        directories.
         """
         raise NotImplementedError
 
@@ -260,7 +261,8 @@ class DaskFileSystem(FileSystem):
     @implements(FileSystem._isfilestore)
     def _isfilestore(self):
         """
-        Object Stores like S3 and GCSFS are based on key lookups, not true file-paths
+        Object Stores like S3 and GCSFS are based on key lookups, not true
+        file-paths
         """
         return False
 

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -135,6 +135,12 @@ class FileSystem(object):
         """
         raise NotImplementedError
 
+    def isfilestore(self):
+        """
+        Returns True if this FileSystem is a unix-style file store with directories.
+        """
+        raise NotImplementedError
+
     def read_parquet(self, path, columns=None, metadata=None, schema=None,
                      nthreads=1, use_pandas_metadata=False):
         """
@@ -209,6 +215,10 @@ class LocalFileSystem(FileSystem):
     def isfile(self, path):
         return os.path.isfile(path)
 
+    @implements(FileSystem.isfilestore)
+    def isfilestore(self):
+        return True
+
     @implements(FileSystem.exists)
     def exists(self, path):
         return os.path.exists(path)
@@ -246,6 +256,13 @@ class DaskFileSystem(FileSystem):
     @implements(FileSystem.isfile)
     def isfile(self, path):
         raise NotImplementedError("Unsupported file system API")
+
+    @implements(FileSystem.isfilestore)
+    def isfilestore(self):
+        """
+        Object Stores like S3 and GCSFS are based on key lookups, not true file-paths
+        """
+        return False
 
     @implements(FileSystem.delete)
     def delete(self, path, recursive=False):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -985,7 +985,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     else:
         fs = _ensure_filesystem(filesystem)
 
-    if not fs.exists(root_path) and fs.isfilestore():
+    if fs.isfilestore() and not fs.exists(root_path):
         fs.mkdir(root_path)
 
     if partition_cols is not None and len(partition_cols) > 0:
@@ -1004,7 +1004,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             subtable = Table.from_pandas(subgroup,
                                          preserve_index=preserve_index)
             prefix = "/".join([root_path, subdir])
-            if not fs.exists(prefix) and fs.isfilestore():
+            if fs.isfilestore() and not fs.exists(prefix):
                 fs.mkdir(prefix)
             outfile = compat.guid() + ".parquet"
             full_path = "/".join([prefix, outfile])

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -985,7 +985,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     else:
         fs = _ensure_filesystem(filesystem)
 
-    if not fs.exists(root_path):
+    if not fs.exists(root_path) and fs.isfilestore():
         fs.mkdir(root_path)
 
     if partition_cols is not None and len(partition_cols) > 0:
@@ -1004,7 +1004,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             subtable = Table.from_pandas(subgroup,
                                          preserve_index=preserve_index)
             prefix = "/".join([root_path, subdir])
-            if not fs.exists(prefix):
+            if not fs.exists(prefix) and fs.isfilestore():
                 fs.mkdir(prefix)
             outfile = compat.guid() + ".parquet"
             full_path = "/".join([prefix, outfile])

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -985,7 +985,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     else:
         fs = _ensure_filesystem(filesystem)
 
-    if fs.isfilestore() and not fs.exists(root_path):
+    if fs._isfilestore() and not fs.exists(root_path):
         fs.mkdir(root_path)
 
     if partition_cols is not None and len(partition_cols) > 0:
@@ -1004,7 +1004,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
             subtable = Table.from_pandas(subgroup,
                                          preserve_index=preserve_index)
             prefix = "/".join([root_path, subdir])
-            if fs.isfilestore() and not fs.exists(prefix):
+            if fs._isfilestore() and not fs.exists(prefix):
                 fs.mkdir(prefix)
             outfile = compat.guid() + ".parquet"
             full_path = "/".join([prefix, outfile])

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -978,6 +978,7 @@ def _generate_partition_directories(fs, base_dir, partition_spec, df):
                 part_table = pa.Table.from_pandas(filtered_df)
                 with fs.open(file_path, 'wb') as f:
                     _write_table(part_table, f)
+                assert fs.exists(file_path)
             else:
                 _visit_level(level_dir, level + 1, this_part_keys)
 


### PR DESCRIPTION
Hi Maintainers,

This is a tiny patch to add the `exists` implementation for the Dask filesystem closing [ARROW-1555](https://issues.apache.org/jira/browse/ARROW-1555).

I ran into an issue attempting to use the new `S3FSWrapper` with `s3fs` to upload a parquet file to S3. The following pseudo-code raises a `NotImplemented` error because the parquet implementation makes a call to check if the directory exists on the fs first. Because there is no implementation for `DaskFilesystem`, it defaults to the base classes' `exists` which raises a `NotImplemented` error.

```
import pandas as pd
import pyarrow as pa
import pyarrow.parquet as pq

df = pd.DataFrame(<some_data>)
pa_table = pa.Table.from_pandas(df)
dst_path = s3://<bucket>/<path>.parq.snappy
s3_fs = pa.filesystem.S3FSWrapper(fs=s3fs.S3FileSystem())
pq.write_to_dataset(pa_table, dst_path, filesystem=s3_fs)
```