### PR TITLE
ARROW-1711: [Python] Fix flake8 calls to lint the right directories

### DIFF
--- a/ci/travis_lint.sh
+++ b/ci/travis_lint.sh
@@ -31,10 +31,10 @@ popd
 # Fail fast on style checks
 sudo pip install flake8
 
-PYARROW_DIR=$TRAVIS_BUILD_DIR/python
+PYARROW_DIR=$TRAVIS_BUILD_DIR/python/pyarrow
 
-flake8 --count $PYTHON_DIR/pyarrow
+flake8 --count $PYARROW_DIR
 
 # Check Cython files with some checks turned off
 flake8 --count --config=$PYTHON_DIR/.flake8.cython \
-       $PYTHON_DIR/pyarrow
+       $PYARROW_DIR

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -47,7 +47,7 @@ cdef _is_array_like(obj):
     try:
         import pandas
         return isinstance(obj, (np.ndarray, pd.Series, pd.Index, Categorical))
-    except:
+    except ImportError:
         return isinstance(obj, np.ndarray)
 
 

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -116,7 +116,7 @@ def write_feather(df, dest):
     writer = FeatherWriter(dest)
     try:
         writer.write(df)
-    except:
+    except Exception:
         # Try to make sure the resource is closed
         import gc
         writer = None

--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -32,7 +32,7 @@ def have_libhdfs():
         with nogil:
             check_status(HaveLibHdfs())
         return True
-    except:
+    except Exception:
         return False
 
 
@@ -41,7 +41,7 @@ def have_libhdfs3():
         with nogil:
             check_status(HaveLibHdfs3())
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -915,7 +915,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,
             **kwargs)
         writer.write_table(table, row_group_size=row_group_size)
-    except:
+    except Exception:
         if writer is not None:
             writer.close()
         if isinstance(where, six.string_types):

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -20,9 +20,9 @@ import sys
 
 import numpy as np
 
-import pyarrow as pa
 from pyarrow import serialize_pandas, deserialize_pandas
 from pyarrow.lib import _default_serialization_context
+
 
 def register_default_serialization_handlers(serialization_context):
 
@@ -43,34 +43,27 @@ def register_default_serialization_handlers(serialization_context):
             custom_serializer=lambda obj: str(obj),
             custom_deserializer=lambda data: long(data))  # noqa: F821
 
-
     def _serialize_ordered_dict(obj):
         return list(obj.keys()), list(obj.values())
 
-
     def _deserialize_ordered_dict(data):
         return OrderedDict(zip(data[0], data[1]))
-
 
     serialization_context.register_type(
         OrderedDict, "OrderedDict",
         custom_serializer=_serialize_ordered_dict,
         custom_deserializer=_deserialize_ordered_dict)
 
-
     def _serialize_default_dict(obj):
         return list(obj.keys()), list(obj.values()), obj.default_factory
 
-
     def _deserialize_default_dict(data):
         return defaultdict(data[2], zip(data[0], data[1]))
-
 
     serialization_context.register_type(
         defaultdict, "defaultdict",
         custom_serializer=_serialize_default_dict,
         custom_deserializer=_deserialize_default_dict)
-
 
     serialization_context.register_type(
         type(lambda: 0), "function",
@@ -78,22 +71,19 @@ def register_default_serialization_handlers(serialization_context):
 
     # ----------------------------------------------------------------------
     # Set up serialization for numpy with dtype object (primitive types are
-    # handled efficiently with Arrow's Tensor facilities, see python_to_arrow.cc)
-
+    # handled efficiently with Arrow's Tensor facilities, see
+    # python_to_arrow.cc)
 
     def _serialize_numpy_array(obj):
         return obj.tolist(), obj.dtype.str
 
-
     def _deserialize_numpy_array(data):
         return np.array(data[0], dtype=np.dtype(data[1]))
-
 
     serialization_context.register_type(
         np.ndarray, 'np.array',
         custom_serializer=_serialize_numpy_array,
         custom_deserializer=_deserialize_numpy_array)
-
 
     # ----------------------------------------------------------------------
     # Set up serialization for pandas Series and DataFrame

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -289,7 +289,7 @@ class TestFeatherReader(unittest.TestCase):
         path = random_path()
         try:
             write_feather(df, path)
-        except:
+        except Exception:
             pass
 
         assert not os.path.exists(path)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -62,7 +62,7 @@ def assert_equal(obj1, obj2):
             # Workaround to make comparison of OrderedDicts work on Python 2.7
             if obj1 == obj2:
                 return
-        except:
+        except Exception:
             pass
         if obj1.__dict__ == {}:
             print("WARNING: Empty dict in ", obj1)
@@ -374,24 +374,24 @@ def test_arrow_limits(self):
         # Test that objects that are too large for Arrow throw a Python
         # exception. These tests give out of memory errors on Travis and need
         # to be run on a machine with lots of RAM.
-        l = 2 ** 29 * [1.0]
-        serialization_roundtrip(l, mmap)
-        del l
-        l = 2 ** 29 * ["s"]
-        serialization_roundtrip(l, mmap)
-        del l
-        l = 2 ** 29 * [["1"], 2, 3, [{"s": 4}]]
-        serialization_roundtrip(l, mmap)
-        del l
-        l = 2 ** 29 * [{"s": 1}] + 2 ** 29 * [1.0]
-        serialization_roundtrip(l, mmap)
-        del l
-        l = np.zeros(2 ** 25)
-        serialization_roundtrip(l, mmap)
-        del l
-        l = [np.zeros(2 ** 18) for _ in range(2 ** 7)]
-        serialization_roundtrip(l, mmap)
-        del l
+        x = 2 ** 29 * [1.0]
+        serialization_roundtrip(x, mmap)
+        del x
+        x = 2 ** 29 * ["s"]
+        serialization_roundtrip(x, mmap)
+        del x
+        x = 2 ** 29 * [["1"], 2, 3, [{"s": 4}]]
+        serialization_roundtrip(x, mmap)
+        del x
+        x = 2 ** 29 * [{"s": 1}] + 2 ** 29 * [1.0]
+        serialization_roundtrip(x, mmap)
+        del x
+        x = np.zeros(2 ** 25)
+        serialization_roundtrip(x, mmap)
+        del x
+        x = [np.zeros(2 ** 18) for _ in range(2 ** 7)]
+        serialization_roundtrip(x, mmap)
+        del x
 
 
 def test_serialization_callback_error():

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -300,6 +300,7 @@ def test_datetime_serialization(large_memory_map):
         for d in data:
             serialization_roundtrip(d, mmap)
 
+
 def test_torch_serialization(large_memory_map):
     pytest.importorskip("torch")
     import torch
@@ -310,6 +311,7 @@ def test_torch_serialization(large_memory_map):
                   "uint8", "int16", "int32", "int64"]:
             obj = torch.from_numpy(np.random.randn(1000).astype(t))
             serialization_roundtrip(obj, mmap)
+
 
 def test_numpy_immutable(large_memory_map):
     with pa.memory_map(large_memory_map, mode="r+") as mmap:
@@ -341,6 +343,7 @@ def test_serialization_callback_numpy():
         custom_deserializer=deserialize_dummy_class)
 
     pa.serialize(DummyClass())
+
 
 def test_buffer_serialization():
 


### PR DESCRIPTION
This got messed up during one of the patches in which these files were refactored. Once the build fails, I will fix the lint errors