### PR TITLE
ARROW-1720: [Python] Implement bounds check in chunk getter

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -102,6 +102,10 @@ cdef class ChunkedArray:
         pyarrow.Array
         """
         self._check_nullptr()
+
+        if i >= self.num_chunks or i < 0:
+            raise IndexError('Chunk index out of range.')
+
         return pyarrow_wrap_array(self.chunked_array.chunk(i))
 
     def iterchunks(self):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -211,6 +211,12 @@ def test_table_basics():
         for chunk in col.data.iterchunks():
             assert chunk is not None
 
+        with pytest.raises(IndexError):
+            col.data.chunk(-1)
+
+        with pytest.raises(IndexError):
+            col.data.chunk(col.data.num_chunks)
+
 
 def test_table_from_arrays_invalid_names():
     data = [


### PR DESCRIPTION
This closes [ARROW-1720](https://issues.apache.org/jira/browse/ARROW-1720).