### PR TITLE
ARROW-1723: [C++] add ARROW_STATIC to mark static libs on Windows

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -69,6 +69,14 @@ Simple release build:
 
 Detailed unit test logs will be placed in the build directory under `build/test-logs`.
 
+### Statically linking to Arrow on Windows
+
+The Arrow headers on Windows static library builds (enabled by the CMake
+option `ARROW_BUILD_STATIC`) use the preprocessor macro `ARROW_STATIC` to
+suppress dllimport/dllexport marking of symbols. Projects that statically link
+against Arrow on Windows additionally need this definition. The Unix builds do
+not use the macro.
+
 ### Building/Running benchmarks
 
 Follow the directions for simple build except run cmake

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -25,7 +25,9 @@
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
 
-#ifdef ARROW_EXPORTING
+#ifdef ARROW_STATIC
+#define ARROW_EXPORT
+#elif defined(ARROW_EXPORTING)
 #define ARROW_EXPORT __declspec(dllexport)
 #else
 #define ARROW_EXPORT __declspec(dllimport)


### PR DESCRIPTION
Add a preprocessor macro ARROW_STATIC when doing static library builds on Windows. Clients developing/building off the static library will also need to define this - please let me know how this should be documented, if this is an acceptable approach.