### PR TITLE
ARROW-1484: [C++/Python] Implement casts between date, time, timestamp units

### DIFF
--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -71,7 +71,7 @@ namespace compute {
 
 template <typename T>
 inline const T* GetValuesAs(const ArrayData& data, int i) {
-  return reinterpret_cast<const T*>(data.buffers[1]->data()) + data.offset;
+  return reinterpret_cast<const T*>(data.buffers[i]->data()) + data.offset;
 }
 
 namespace {
@@ -316,7 +316,7 @@ inline void ShiftTime(FunctionContext* ctx, const CastOptions& options,
       }
     }
   }
-}  // namespace
+}
 
 namespace {
 

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -34,9 +34,12 @@ class FunctionContext;
 class UnaryKernel;
 
 struct CastOptions {
-  CastOptions() : allow_int_overflow(false) {}
+  CastOptions()
+      : allow_int_overflow(false),
+        allow_time_truncate(false) {}
 
   bool allow_int_overflow;
+  bool allow_time_truncate;
 };
 
 /// \since 0.7.0

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -34,9 +34,7 @@ class FunctionContext;
 class UnaryKernel;
 
 struct CastOptions {
-  CastOptions()
-      : allow_int_overflow(false),
-        allow_time_truncate(false) {}
+  CastOptions() : allow_int_overflow(false), allow_time_truncate(false) {}
 
   bool allow_int_overflow;
   bool allow_time_truncate;

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -270,6 +270,27 @@ TEST_F(TestCast, ToIntDowncastUnsafe) {
                                                     options);
 }
 
+TEST_F(TestCast, TimestampChangeUnit) {
+  auto CheckTimestampCast = [this](TimeUnit::type from_unit,
+                                   TimeUnit::type to_unit,
+                                   const std::vector<int64_t>& from_values,
+                                   const std::vector<int64_t>& to_values,
+                                   const std::vector<bool>& is_valid) {
+    CastOptions options;
+
+    CheckCase<TimestampType, int64_t, TimestampType, int64_t>(
+        timestamp(from_unit), from_values, is_valid,
+        timestamp(to_unit), to_values, options);
+  };
+
+  vector<bool> is_valid = {true, false, true, true, true};
+
+  vector<int64_t> v1 = {0, 100, 200, 1, 2};
+  vector<int64_t> e1 = {0, 100000, 200000, 1000, 2000};
+
+  CheckTimestampCast(TimeUnit::SECOND, TimeUnit::MILLI, v1, e1, is_valid);
+}
+
 TEST_F(TestCast, ToDouble) {
   CastOptions options;
   vector<bool> is_valid = {true, false, true, true, true};

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -105,6 +105,11 @@ class TestCast : public ComputeFixture, public TestBase {
       ArrayFromVector<OutType, O_TYPE>(out_type, out_values, &expected);
     }
     CheckPass(*input, *expected, out_type, options);
+
+    // Check a sliced variant
+    if (input->length() > 1) {
+      CheckPass(*input->Slice(1), *expected->Slice(1), out_type, options);
+    }
   }
 };
 

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -271,16 +271,15 @@ TEST_F(TestCast, ToIntDowncastUnsafe) {
 }
 
 TEST_F(TestCast, TimestampChangeUnit) {
-  auto CheckTimestampCast = [this](TimeUnit::type from_unit,
-                                   TimeUnit::type to_unit,
+  auto CheckTimestampCast = [this](TimeUnit::type from_unit, TimeUnit::type to_unit,
                                    const std::vector<int64_t>& from_values,
                                    const std::vector<int64_t>& to_values,
                                    const std::vector<bool>& is_valid) {
     CastOptions options;
 
     CheckCase<TimestampType, int64_t, TimestampType, int64_t>(
-        timestamp(from_unit), from_values, is_valid,
-        timestamp(to_unit), to_values, options);
+        timestamp(from_unit), from_values, is_valid, timestamp(to_unit), to_values,
+        options);
   };
 
   vector<bool> is_valid = {true, false, true, true, true};

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -278,11 +278,10 @@ TEST_F(TestCast, ToIntDowncastUnsafe) {
 TEST_F(TestCast, TimestampToTimestamp) {
   CastOptions options;
 
-  auto CheckTimestampCast = [this](const CastOptions& options,
-                                   TimeUnit::type from_unit, TimeUnit::type to_unit,
-                                   const std::vector<int64_t>& from_values,
-                                   const std::vector<int64_t>& to_values,
-                                   const std::vector<bool>& is_valid) {
+  auto CheckTimestampCast = [this](
+      const CastOptions& options, TimeUnit::type from_unit, TimeUnit::type to_unit,
+      const std::vector<int64_t>& from_values, const std::vector<int64_t>& to_values,
+      const std::vector<bool>& is_valid) {
     CheckCase<TimestampType, int64_t, TimestampType, int64_t>(
         timestamp(from_unit), from_values, is_valid, timestamp(to_unit), to_values,
         options);
@@ -318,8 +317,8 @@ TEST_F(TestCast, TimestampToTimestamp) {
   // Zero copy
   std::shared_ptr<Array> arr;
   vector<int64_t> v7 = {0, 70000, 2000, 1000, 0};
-  ArrayFromVector<TimestampType, int64_t>(timestamp(TimeUnit::SECOND), is_valid,
-                                          v7, &arr);
+  ArrayFromVector<TimestampType, int64_t>(timestamp(TimeUnit::SECOND), is_valid, v7,
+                                          &arr);
   CheckZeroCopy(*arr, timestamp(TimeUnit::SECOND));
 
   // Divide, truncate
@@ -356,10 +355,8 @@ TEST_F(TestCast, TimestampToTimestamp) {
                             timestamp(TimeUnit::SECOND), options);
 }
 
-
 TEST_F(TestCast, TimeToTime) {
   CastOptions options;
-
 
   vector<bool> is_valid = {true, false, true, true, true};
 
@@ -367,38 +364,32 @@ TEST_F(TestCast, TimeToTime) {
   vector<int32_t> v1 = {0, 100, 200, 1, 2};
   vector<int32_t> e1 = {0, 100000, 200000, 1000, 2000};
   CheckCase<Time32Type, int32_t, Time32Type, int32_t>(
-      time32(TimeUnit::SECOND), v1, is_valid,
-      time32(TimeUnit::MILLI), e1, options);
+      time32(TimeUnit::SECOND), v1, is_valid, time32(TimeUnit::MILLI), e1, options);
 
   vector<int32_t> v2 = {0, 100, 200, 1, 2};
   vector<int64_t> e2 = {0, 100000000L, 200000000L, 1000000, 2000000};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
-      time32(TimeUnit::SECOND), v2, is_valid,
-      time64(TimeUnit::MICRO), e2, options);
+      time32(TimeUnit::SECOND), v2, is_valid, time64(TimeUnit::MICRO), e2, options);
 
   vector<int32_t> v3 = {0, 100, 200, 1, 2};
   vector<int64_t> e3 = {0, 100000000000L, 200000000000L, 1000000000L, 2000000000L};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
-      time32(TimeUnit::SECOND), v3, is_valid,
-      time64(TimeUnit::NANO), e3, options);
+      time32(TimeUnit::SECOND), v3, is_valid, time64(TimeUnit::NANO), e3, options);
 
   vector<int32_t> v4 = {0, 100, 200, 1, 2};
   vector<int64_t> e4 = {0, 100000, 200000, 1000, 2000};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
-      time32(TimeUnit::MILLI), v4, is_valid,
-      time64(TimeUnit::MICRO), e4, options);
+      time32(TimeUnit::MILLI), v4, is_valid, time64(TimeUnit::MICRO), e4, options);
 
   vector<int32_t> v5 = {0, 100, 200, 1, 2};
   vector<int64_t> e5 = {0, 100000000L, 200000000L, 1000000, 2000000};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
-      time32(TimeUnit::MILLI), v5, is_valid,
-      time64(TimeUnit::NANO), e5, options);
+      time32(TimeUnit::MILLI), v5, is_valid, time64(TimeUnit::NANO), e5, options);
 
   vector<int64_t> v6 = {0, 100, 200, 1, 2};
   vector<int64_t> e6 = {0, 100000, 200000, 1000, 2000};
   CheckCase<Time64Type, int64_t, Time64Type, int64_t>(
-      time64(TimeUnit::MICRO), v6, is_valid,
-      time64(TimeUnit::NANO), e6, options);
+      time64(TimeUnit::MICRO), v6, is_valid, time64(TimeUnit::NANO), e6, options);
 
   // Zero copy
   std::shared_ptr<Array> arr;
@@ -412,47 +403,76 @@ TEST_F(TestCast, TimeToTime) {
 
   options.allow_time_truncate = true;
   CheckCase<Time32Type, int32_t, Time32Type, int32_t>(
-      time32(TimeUnit::MILLI), v8, is_valid,
-      time32(TimeUnit::SECOND), e8, options);
+      time32(TimeUnit::MILLI), v8, is_valid, time32(TimeUnit::SECOND), e8, options);
   CheckCase<Time64Type, int32_t, Time32Type, int32_t>(
-      time64(TimeUnit::MICRO), v8, is_valid,
-      time32(TimeUnit::MILLI), e8, options);
+      time64(TimeUnit::MICRO), v8, is_valid, time32(TimeUnit::MILLI), e8, options);
   CheckCase<Time64Type, int32_t, Time64Type, int32_t>(
-      time64(TimeUnit::NANO), v8, is_valid,
-      time64(TimeUnit::MICRO), e8, options);
+      time64(TimeUnit::NANO), v8, is_valid, time64(TimeUnit::MICRO), e8, options);
 
   vector<int64_t> v9 = {0, 100123000, 200456000, 1123000, 2456000};
   vector<int32_t> e9 = {0, 100, 200, 1, 2};
   CheckCase<Time64Type, int64_t, Time32Type, int32_t>(
-      time64(TimeUnit::MICRO), v9, is_valid,
-      time32(TimeUnit::SECOND), e9, options);
+      time64(TimeUnit::MICRO), v9, is_valid, time32(TimeUnit::SECOND), e9, options);
   CheckCase<Time64Type, int64_t, Time32Type, int32_t>(
-      time64(TimeUnit::NANO), v9, is_valid,
-      time32(TimeUnit::MILLI), e9, options);
+      time64(TimeUnit::NANO), v9, is_valid, time32(TimeUnit::MILLI), e9, options);
 
   vector<int64_t> v10 = {0, 100123000000L, 200456000000L, 1123000000L, 2456000000};
   vector<int32_t> e10 = {0, 100, 200, 1, 2};
   CheckCase<Time64Type, int64_t, Time32Type, int32_t>(
-      time64(TimeUnit::NANO), v10, is_valid,
-      time32(TimeUnit::SECOND), e10, options);
+      time64(TimeUnit::NANO), v10, is_valid, time32(TimeUnit::SECOND), e10, options);
 
   // Disallow truncate, failures
 
   options.allow_time_truncate = false;
-  CheckFails<Time32Type>(time32(TimeUnit::MILLI), v8, is_valid,
-                         time32(TimeUnit::SECOND), options);
-  CheckFails<Time64Type>(time64(TimeUnit::MICRO), v8, is_valid,
-                         time32(TimeUnit::MILLI), options);
-  CheckFails<Time64Type>(time64(TimeUnit::NANO), v8, is_valid,
-                         time64(TimeUnit::MICRO), options);
-  CheckFails<Time64Type>(time64(TimeUnit::MICRO), v9, is_valid,
-                         time32(TimeUnit::SECOND), options);
-  CheckFails<Time64Type>(time64(TimeUnit::NANO), v9, is_valid,
-                         time32(TimeUnit::MILLI), options);
-  CheckFails<Time64Type>(time64(TimeUnit::NANO), v10, is_valid,
-                         time32(TimeUnit::SECOND), options);
+  CheckFails<Time32Type>(time32(TimeUnit::MILLI), v8, is_valid, time32(TimeUnit::SECOND),
+                         options);
+  CheckFails<Time64Type>(time64(TimeUnit::MICRO), v8, is_valid, time32(TimeUnit::MILLI),
+                         options);
+  CheckFails<Time64Type>(time64(TimeUnit::NANO), v8, is_valid, time64(TimeUnit::MICRO),
+                         options);
+  CheckFails<Time64Type>(time64(TimeUnit::MICRO), v9, is_valid, time32(TimeUnit::SECOND),
+                         options);
+  CheckFails<Time64Type>(time64(TimeUnit::NANO), v9, is_valid, time32(TimeUnit::MILLI),
+                         options);
+  CheckFails<Time64Type>(time64(TimeUnit::NANO), v10, is_valid, time32(TimeUnit::SECOND),
+                         options);
 }
 
+TEST_F(TestCast, DateToDate) {
+  CastOptions options;
+
+  vector<bool> is_valid = {true, false, true, true, true};
+
+  constexpr int64_t F = 86400000;
+
+  // Multiply promotion
+  vector<int32_t> v1 = {0, 100, 200, 1, 2};
+  vector<int64_t> e1 = {0, 100 * F, 200 * F, F, 2 * F};
+  CheckCase<Date32Type, int32_t, Date64Type, int64_t>(date32(), v1, is_valid, date64(),
+                                                      e1, options);
+
+  // Zero copy
+  std::shared_ptr<Array> arr;
+  vector<int32_t> v2 = {0, 70000, 2000, 1000, 0};
+  vector<int64_t> v3 = {0, 70000, 2000, 1000, 0};
+  ArrayFromVector<Date32Type, int32_t>(date32(), is_valid, v2, &arr);
+  CheckZeroCopy(*arr, date32());
+
+  ArrayFromVector<Date64Type, int64_t>(date64(), is_valid, v3, &arr);
+  CheckZeroCopy(*arr, date64());
+
+  // Divide, truncate
+  vector<int64_t> v8 = {0, 100 * F + 123, 200 * F + 456, F + 123, 2 * F + 456};
+  vector<int32_t> e8 = {0, 100, 200, 1, 2};
+
+  options.allow_time_truncate = true;
+  CheckCase<Date64Type, int64_t, Date32Type, int32_t>(date64(), v8, is_valid, date32(),
+                                                      e8, options);
+
+  // Disallow truncate, failures
+  options.allow_time_truncate = false;
+  CheckFails<Date64Type>(date64(), v8, is_valid, date32(), options);
+}
 
 TEST_F(TestCast, ToDouble) {
   CastOptions options;

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -68,7 +68,7 @@ class TestCast : public ComputeFixture, public TestBase {
                  const std::shared_ptr<DataType>& out_type, const CastOptions& options) {
     std::shared_ptr<Array> result;
     ASSERT_OK(Cast(&ctx_, input, out_type, options, &result));
-    AssertArraysEqual(expected, *result);
+    ASSERT_ARRAYS_EQUAL(expected, *result);
   }
 
   template <typename InType, typename I_TYPE>
@@ -360,7 +360,7 @@ TEST_F(TestCast, FromNull) {
   ASSERT_EQ(length, result->null_count());
 
   // OK to look at bitmaps
-  AssertArraysEqual(*result, *result);
+  ASSERT_ARRAYS_EQUAL(*result, *result);
 }
 
 TEST_F(TestCast, PreallocatedMemory) {
@@ -398,7 +398,7 @@ TEST_F(TestCast, PreallocatedMemory) {
   std::shared_ptr<Array> expected;
   ArrayFromVector<Int64Type, int64_t>(int64(), is_valid, e1, &expected);
 
-  AssertArraysEqual(*expected, *result);
+  ASSERT_ARRAYS_EQUAL(*expected, *result);
 }
 
 template <typename TestType>

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -275,13 +275,14 @@ TEST_F(TestCast, ToIntDowncastUnsafe) {
                                                     options);
 }
 
-TEST_F(TestCast, TimestampChangeUnit) {
-  auto CheckTimestampCast = [this](TimeUnit::type from_unit, TimeUnit::type to_unit,
+TEST_F(TestCast, TimestampToTimestamp) {
+  CastOptions options;
+
+  auto CheckTimestampCast = [this](const CastOptions& options,
+                                   TimeUnit::type from_unit, TimeUnit::type to_unit,
                                    const std::vector<int64_t>& from_values,
                                    const std::vector<int64_t>& to_values,
                                    const std::vector<bool>& is_valid) {
-    CastOptions options;
-
     CheckCase<TimestampType, int64_t, TimestampType, int64_t>(
         timestamp(from_unit), from_values, is_valid, timestamp(to_unit), to_values,
         options);
@@ -289,11 +290,72 @@ TEST_F(TestCast, TimestampChangeUnit) {
 
   vector<bool> is_valid = {true, false, true, true, true};
 
+  // Multiply promotions
   vector<int64_t> v1 = {0, 100, 200, 1, 2};
   vector<int64_t> e1 = {0, 100000, 200000, 1000, 2000};
+  CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::MILLI, v1, e1, is_valid);
 
-  CheckTimestampCast(TimeUnit::SECOND, TimeUnit::MILLI, v1, e1, is_valid);
+  vector<int64_t> v2 = {0, 100, 200, 1, 2};
+  vector<int64_t> e2 = {0, 100000000L, 200000000L, 1000000, 2000000};
+  CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::MICRO, v2, e2, is_valid);
+
+  vector<int64_t> v3 = {0, 100, 200, 1, 2};
+  vector<int64_t> e3 = {0, 100000000000L, 200000000000L, 1000000000L, 2000000000L};
+  CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::NANO, v3, e3, is_valid);
+
+  vector<int64_t> v4 = {0, 100, 200, 1, 2};
+  vector<int64_t> e4 = {0, 100000, 200000, 1000, 2000};
+  CheckTimestampCast(options, TimeUnit::MILLI, TimeUnit::MICRO, v4, e4, is_valid);
+
+  vector<int64_t> v5 = {0, 100, 200, 1, 2};
+  vector<int64_t> e5 = {0, 100000000L, 200000000L, 1000000, 2000000};
+  CheckTimestampCast(options, TimeUnit::MILLI, TimeUnit::NANO, v5, e5, is_valid);
+
+  vector<int64_t> v6 = {0, 100, 200, 1, 2};
+  vector<int64_t> e6 = {0, 100000, 200000, 1000, 2000};
+  CheckTimestampCast(options, TimeUnit::MICRO, TimeUnit::NANO, v6, e6, is_valid);
+
+  // Zero copy
+  std::shared_ptr<Array> arr;
+  vector<int64_t> v7 = {0, 70000, 2000, 1000, 0};
+  ArrayFromVector<TimestampType, int64_t>(timestamp(TimeUnit::SECOND), is_valid,
+                                          v7, &arr);
+  CheckZeroCopy(*arr, timestamp(TimeUnit::SECOND));
+
+  // Divide, truncate
+  vector<int64_t> v8 = {0, 100123, 200456, 1123, 2456};
+  vector<int64_t> e8 = {0, 100, 200, 1, 2};
+
+  options.allow_time_truncate = true;
+  CheckTimestampCast(options, TimeUnit::MILLI, TimeUnit::SECOND, v8, e8, is_valid);
+  CheckTimestampCast(options, TimeUnit::MICRO, TimeUnit::MILLI, v8, e8, is_valid);
+  CheckTimestampCast(options, TimeUnit::NANO, TimeUnit::MICRO, v8, e8, is_valid);
+
+  vector<int64_t> v9 = {0, 100123000, 200456000, 1123000, 2456000};
+  vector<int64_t> e9 = {0, 100, 200, 1, 2};
+  CheckTimestampCast(options, TimeUnit::MICRO, TimeUnit::SECOND, v9, e9, is_valid);
+  CheckTimestampCast(options, TimeUnit::NANO, TimeUnit::MILLI, v9, e9, is_valid);
+
+  vector<int64_t> v10 = {0, 100123000000L, 200456000000L, 1123000000L, 2456000000};
+  vector<int64_t> e10 = {0, 100, 200, 1, 2};
+  CheckTimestampCast(options, TimeUnit::NANO, TimeUnit::SECOND, v10, e10, is_valid);
+
+  // Disallow truncate, failures
+  options.allow_time_truncate = false;
+  CheckFails<TimestampType>(timestamp(TimeUnit::MILLI), v8, is_valid,
+                            timestamp(TimeUnit::SECOND), options);
+  CheckFails<TimestampType>(timestamp(TimeUnit::MICRO), v8, is_valid,
+                            timestamp(TimeUnit::MILLI), options);
+  CheckFails<TimestampType>(timestamp(TimeUnit::MILLI), v8, is_valid,
+                            timestamp(TimeUnit::SECOND), options);
+  CheckFails<TimestampType>(timestamp(TimeUnit::MICRO), v9, is_valid,
+                            timestamp(TimeUnit::SECOND), options);
+  CheckFails<TimestampType>(timestamp(TimeUnit::NANO), v9, is_valid,
+                            timestamp(TimeUnit::MILLI), options);
+  CheckFails<TimestampType>(timestamp(TimeUnit::NANO), v10, is_valid,
+                            timestamp(TimeUnit::SECOND), options);
 }
+
 
 TEST_F(TestCast, ToDouble) {
   CastOptions options;

--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -281,15 +281,20 @@ Status MakeArray(const std::vector<uint8_t>& valid_bytes, const std::vector<T>& 
   return builder->Finish(out);
 }
 
-void AssertArraysEqual(const Array& expected, const Array& actual) {
-  if (!actual.Equals(expected)) {
-    std::stringstream pp_result;
-    std::stringstream pp_expected;
+#define ASSERT_ARRAYS_EQUAL(LEFT, RIGHT)                                               \
+  do {                                                                                 \
+    if (!(LEFT).Equals((RIGHT))) {                                                     \
+      std::stringstream pp_result;                                                     \
+      std::stringstream pp_expected;                                                   \
+                                                                                       \
+      EXPECT_OK(PrettyPrint(RIGHT, 0, &pp_result));                                    \
+      EXPECT_OK(PrettyPrint(LEFT, 0, &pp_expected));                                   \
+      FAIL() << "Got: \n" << pp_result.str() << "\nExpected: \n" << pp_expected.str(); \
+    }                                                                                  \
+  } while (false)
 
-    EXPECT_OK(PrettyPrint(actual, 0, &pp_result));
-    EXPECT_OK(PrettyPrint(expected, 0, &pp_expected));
-    FAIL() << "Got: \n" << pp_result.str() << "\nExpected: \n" << pp_expected.str();
-  }
+void AssertArraysEqual(const Array& expected, const Array& actual) {
+  ASSERT_ARRAYS_EQUAL(expected, actual);
 }
 
 #define ASSERT_BATCHES_EQUAL(LEFT, RIGHT)    \

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -228,7 +228,11 @@ class ARROW_EXPORT FloatingPoint : public Number {
   virtual Precision precision() const = 0;
 };
 
-class ARROW_EXPORT NestedType : public DataType {
+/// \class ParametricType
+/// \brief A superclass for types having additional metadata
+class ParametricType {};
+
+class ARROW_EXPORT NestedType : public DataType, public ParametricType {
  public:
   using DataType::DataType;
 };
@@ -444,7 +448,7 @@ class ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
 };
 
 // BinaryType type is represents lists of 1-byte values.
-class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType {
+class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public ParametricType {
  public:
   static constexpr Type::type type_id = Type::FIXED_SIZE_BINARY;
 
@@ -611,7 +615,7 @@ static inline std::ostream& operator<<(std::ostream& os, TimeUnit::type unit) {
   return os;
 }
 
-class ARROW_EXPORT TimeType : public FixedWidthType {
+class ARROW_EXPORT TimeType : public FixedWidthType, public ParametricType {
  public:
   TimeUnit::type unit() const { return unit_; }
 
@@ -650,7 +654,7 @@ class ARROW_EXPORT Time64Type : public TimeType {
   std::string name() const override { return "time64"; }
 };
 
-class ARROW_EXPORT TimestampType : public FixedWidthType {
+class ARROW_EXPORT TimestampType : public FixedWidthType, public ParametricType {
  public:
   using Unit = TimeUnit;
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -260,8 +260,8 @@ cdef class Array:
 
         type = _ensure_type(target_type)
 
-        if not safe:
-            options.allow_int_overflow = 1
+        options.allow_int_overflow = not safe
+        options.allow_time_truncate = not safe
 
         with nogil:
             check_status(Cast(_context(), self.ap[0], type.sp_type,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -747,6 +747,7 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CCastOptions" arrow::compute::CastOptions":
         c_bool allow_int_overflow
+        c_bool allow_time_truncate
 
     CStatus Cast(CFunctionContext* context, const CArray& array,
                  const shared_ptr[CDataType]& to_type,

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -304,6 +304,17 @@ def test_cast_timestamp_unit():
     assert arr[0].as_py() == s_nyc[0]
     assert arr2[0].as_py() == s[0]
 
+    # Disallow truncation
+    arr = pa.array([123123], type='int64').cast(pa.timestamp('ms'))
+    expected = pa.array([123], type='int64').cast(pa.timestamp('s'))
+
+    target = pa.timestamp('s')
+    with pytest.raises(ValueError):
+        arr.cast(target)
+
+    result = arr.cast(target, safe=False)
+    assert result.equals(expected)
+
 
 def test_cast_signed_to_unsigned():
     safe_cases = [

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -290,6 +290,21 @@ def test_cast_integers_unsafe():
         _check_cast_case(case, safe=False)
 
 
+def test_cast_timestamp_unit():
+    # ARROW-1680
+    val = datetime.datetime.now()
+    s = pd.Series([val])
+    s_nyc = s.dt.tz_localize('tzlocal()').dt.tz_convert('America/New_York')
+
+    us_with_tz = pa.timestamp('us', tz='America/New_York')
+    arr = pa.Array.from_pandas(s_nyc, type=us_with_tz)
+
+    arr2 = pa.Array.from_pandas(s, type=pa.timestamp('us'))
+
+    assert arr[0].as_py() == s_nyc[0]
+    assert arr2[0].as_py() == s[0]
+
+
 def test_cast_signed_to_unsigned():
     safe_cases = [
         (np.array([0, 1, 2, 3], dtype='i1'), pa.uint8(),


### PR DESCRIPTION
Several JIRAs here that made sense to tackle together:

* ARROW-1680
* ARROW-1482
* ARROW-1484
* ARROW-1524

This also fixes bugs relating to ignoring the offset in sliced arrays in some of the cast kernel implementations.

cc @BryanCutler @xhochy @cpcloud 