### PR TITLE
ARROW-1675: [Python] Use RecordBatch.from_pandas in Feather write path

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -662,7 +662,6 @@ cdef _as_type(type):
     return type_for_alias(type)
 
 
-
 cdef set PRIMITIVE_TYPES = set([
     _Type_NA, _Type_BOOL,
     _Type_UINT8, _Type_INT8,


### PR DESCRIPTION
This also makes Feather writes more robust to columns having a mix of unicode and bytes (these gets coerced to binary)

Also resolves ARROW-1672