### PR TITLE
ARROW-1737: [GLib] Use G_DECLARE_DERIVABLE_TYPE

### DIFF
--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -25,11 +25,15 @@
 G_BEGIN_DECLS
 
 #define GARROW_TYPE_ARRAY_BUILDER (garrow_array_builder_get_type())
-GARROW_DECLARE_TYPE(GArrowArrayBuilder,
-                    garrow_array_builder,
-                    GARROW,
-                    ARRAY_BUILDER,
-                    GObject)
+G_DECLARE_DERIVABLE_TYPE(GArrowArrayBuilder,
+                         garrow_array_builder,
+                         GARROW,
+                         ARRAY_BUILDER,
+                         GObject)
+struct _GArrowArrayBuilderClass
+{
+  GObjectClass parent_class;
+};
 
 GArrowArray        *garrow_array_builder_finish   (GArrowArrayBuilder *builder,
                                                    GError **error);
@@ -156,11 +160,15 @@ gboolean garrow_int_array_builder_append_nulls(GArrowIntArrayBuilder *builder,
 
 
 #define GARROW_TYPE_UINT_ARRAY_BUILDER (garrow_uint_array_builder_get_type())
-GARROW_DECLARE_TYPE(GArrowUIntArrayBuilder,
-                    garrow_uint_array_builder,
-                    GARROW,
-                    UINT_ARRAY_BUILDER,
-                    GArrowArrayBuilder)
+G_DECLARE_DERIVABLE_TYPE(GArrowUIntArrayBuilder,
+                         garrow_uint_array_builder,
+                         GARROW,
+                         UINT_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
+struct _GArrowUIntArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
 
 GArrowUIntArrayBuilder *garrow_uint_array_builder_new(void);
 

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -24,11 +24,15 @@
 G_BEGIN_DECLS
 
 #define GARROW_TYPE_CAST_OPTIONS (garrow_cast_options_get_type())
-GARROW_DECLARE_TYPE(GArrowCastOptions,
-                    garrow_cast_options,
-                    GARROW,
-                    CAST_OPTIONS,
-                    GObject)
+G_DECLARE_DERIVABLE_TYPE(GArrowCastOptions,
+                         garrow_cast_options,
+                         GARROW,
+                         CAST_OPTIONS,
+                         GObject)
+struct _GArrowCastOptionsClass
+{
+  GObjectClass parent_class;
+};
 
 GArrowCastOptions *garrow_cast_options_new(void);
 

--- a/c_glib/arrow-glib/gobject-type.h
+++ b/c_glib/arrow-glib/gobject-type.h
@@ -21,38 +21,18 @@
 
 #include <glib-object.h>
 
-#ifdef G_DECLARE_DERIVABLE_TYPE
-#  define GARROW_DECLARE_TYPE(ObjectName,       \
-                              object_name,      \
-                              MODULE_NAME,      \
-                              OBJECT_NAME,      \
-                              ParentName)       \
-  G_DECLARE_DERIVABLE_TYPE(ObjectName,          \
-                           object_name,         \
-                           MODULE_NAME,         \
-                           OBJECT_NAME,         \
-                           ParentName)          \
-  struct _ ## ObjectName ## Class               \
-  {                                             \
-    ParentName ## Class parent_class;           \
-  };
-#else
-#  define GARROW_DECLARE_TYPE(ObjectName,                               \
-                              object_name,                              \
-                              MODULE_NAME,                              \
-                              OBJECT_NAME,                              \
-                              ParentName)                               \
+#ifndef G_DECLARE_DERIVABLE_TYPE
+#  define G_DECLARE_DERIVABLE_TYPE(ObjectName,                          \
+                                   object_name,                         \
+                                   MODULE_NAME,                         \
+                                   OBJECT_NAME,                         \
+                                   ParentName)                          \
   typedef struct _ ## ObjectName ObjectName;                            \
   typedef struct _ ## ObjectName ## Class ObjectName ## Class;          \
                                                                         \
   struct _ ## ObjectName                                                \
   {                                                                     \
     ParentName parent_instance;                                         \
-  };                                                                    \
-                                                                        \
-  struct _ ## ObjectName ## Class                                       \
-  {                                                                     \
-    ParentName ## Class parent_class;                                   \
   };                                                                    \
                                                                         \
   GType object_name ## _get_type(void) G_GNUC_CONST;                    \

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -31,11 +31,15 @@
 G_BEGIN_DECLS
 
 #define GARROW_TYPE_RECORD_BATCH_READER (garrow_record_batch_reader_get_type())
-GARROW_DECLARE_TYPE(GArrowRecordBatchReader,
-                    garrow_record_batch_reader,
-                    GARROW,
-                    RECORD_BATCH_READER,
-                    GObject)
+G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchReader,
+                         garrow_record_batch_reader,
+                         GARROW,
+                         RECORD_BATCH_READER,
+                         GObject)
+struct _GArrowRecordBatchReaderClass
+{
+  GObjectClass parent_class;
+};
 
 GArrowSchema *garrow_record_batch_reader_get_schema(
   GArrowRecordBatchReader *reader);
@@ -57,11 +61,15 @@ GArrowRecordBatch *garrow_record_batch_reader_read_next(
 
 
 #define GARROW_TYPE_TABLE_BATCH_READER (garrow_table_batch_reader_get_type())
-GARROW_DECLARE_TYPE(GArrowTableBatchReader,
-                    garrow_table_batch_reader,
-                    GARROW,
-                    TABLE_BATCH_READER,
-                    GArrowRecordBatchReader)
+G_DECLARE_DERIVABLE_TYPE(GArrowTableBatchReader,
+                         garrow_table_batch_reader,
+                         GARROW,
+                         TABLE_BATCH_READER,
+                         GArrowRecordBatchReader)
+struct _GArrowTableBatchReaderClass
+{
+  GArrowRecordBatchReaderClass parent_class;
+};
 
 GArrowTableBatchReader *garrow_table_batch_reader_new(GArrowTable *table);
 


### PR DESCRIPTION
Because GTK-Doc scans G_DECLARE_DERIVABLE_TYPE to find class definition.