### PR TITLE
ARROW-1730, ARROW-1738: [Python] Fix wrong datetime conversion

### DIFF
--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -536,8 +536,7 @@ class DateConverter : public TypedConverterVisitor<Date64Builder, DateConverter>
 class TimestampConverter
     : public TypedConverterVisitor<Date64Builder, TimestampConverter> {
  public:
-  TimestampConverter(TimeUnit::type unit)
-      : unit_(unit) {}
+  TimestampConverter(TimeUnit::type unit) : unit_(unit) {}
 
   inline Status AppendItem(const OwnedRef& item) {
     int64_t t;
@@ -563,6 +562,7 @@ class TimestampConverter
     }
     return typed_builder_->Append(t);
   }
+
  private:
   TimeUnit::type unit_;
 };
@@ -718,7 +718,8 @@ std::shared_ptr<SeqConverter> GetConverter(const std::shared_ptr<DataType>& type
     case Type::DATE64:
       return std::make_shared<DateConverter>();
     case Type::TIMESTAMP:
-      return std::make_shared<TimestampConverter>(static_cast<TimestampType*>(&*type)->unit());
+      return std::make_shared<TimestampConverter>(
+          static_cast<TimestampType*>(&*type)->unit());
     case Type::DOUBLE:
       return std::make_shared<DoubleConverter>();
     case Type::BINARY:

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -528,6 +528,7 @@ class DateConverter : public TypedConverterVisitor<Date64Builder, DateConverter>
       t = PyDate_to_ms(pydate);
     } else {
       t = static_cast<int64_t>(PyLong_AsLongLong(item.obj()));
+      RETURN_IF_PYERROR();
     }
     return typed_builder_->Append(t);
   }
@@ -536,7 +537,7 @@ class DateConverter : public TypedConverterVisitor<Date64Builder, DateConverter>
 class TimestampConverter
     : public TypedConverterVisitor<Date64Builder, TimestampConverter> {
  public:
-  TimestampConverter(TimeUnit::type unit) : unit_(unit) {}
+  explicit TimestampConverter(TimeUnit::type unit) : unit_(unit) {}
 
   inline Status AppendItem(const OwnedRef& item) {
     int64_t t;
@@ -559,6 +560,7 @@ class TimestampConverter
       }
     } else {
       t = static_cast<int64_t>(PyLong_AsLongLong(item.obj()));
+      RETURN_IF_PYERROR();
     }
     return typed_builder_->Append(t);
   }
@@ -719,7 +721,7 @@ std::shared_ptr<SeqConverter> GetConverter(const std::shared_ptr<DataType>& type
       return std::make_shared<DateConverter>();
     case Type::TIMESTAMP:
       return std::make_shared<TimestampConverter>(
-          static_cast<TimestampType*>(&*type)->unit());
+          static_cast<const TimestampType&>(*type).unit());
     case Type::DOUBLE:
       return std::make_shared<DoubleConverter>();
     case Type::BINARY:

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -522,8 +522,14 @@ class UInt64Converter : public TypedConverterVisitor<UInt64Builder, UInt64Conver
 class DateConverter : public TypedConverterVisitor<Date64Builder, DateConverter> {
  public:
   inline Status AppendItem(const OwnedRef& item) {
-    auto pydate = reinterpret_cast<PyDateTime_Date*>(item.obj());
-    return typed_builder_->Append(PyDate_to_ms(pydate));
+    int64_t t;
+    if (PyDate_Check(item.obj())) {
+      auto pydate = reinterpret_cast<PyDateTime_Date*>(item.obj());
+      t = PyDate_to_ms(pydate);
+    } else {
+      t = static_cast<int64_t>(PyLong_AsLongLong(item.obj()));
+    }
+    return typed_builder_->Append(t);
   }
 };
 
@@ -531,8 +537,14 @@ class TimestampConverter
     : public TypedConverterVisitor<Date64Builder, TimestampConverter> {
  public:
   inline Status AppendItem(const OwnedRef& item) {
-    auto pydatetime = reinterpret_cast<PyDateTime_DateTime*>(item.obj());
-    return typed_builder_->Append(PyDateTime_to_us(pydatetime));
+    int64_t t;
+    if (PyDateTime_Check(item.obj())) {
+      auto pydatetime = reinterpret_cast<PyDateTime_DateTime*>(item.obj());
+      t = PyDateTime_to_us(pydatetime);
+    } else {
+      t = static_cast<int64_t>(PyLong_AsLongLong(item.obj()));
+    }
+    return typed_builder_->Append(t);
   }
 };
 

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -247,10 +247,24 @@ static inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
   return total_seconds * 1000;
 }
 
+static inline int64_t PyDateTime_to_s(PyDateTime_DateTime* pydatetime) {
+  return PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime)) / 1000LL;
+}
+
+static inline int64_t PyDateTime_to_ms(PyDateTime_DateTime* pydatetime) {
+  int64_t date_ms = PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime));
+  int ms = PyDateTime_DATE_GET_MICROSECOND(pydatetime) / 1000;
+  return date_ms + ms;
+}
+
 static inline int64_t PyDateTime_to_us(PyDateTime_DateTime* pydatetime) {
   int64_t ms = PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime));
   int us = PyDateTime_DATE_GET_MICROSECOND(pydatetime);
   return ms * 1000 + us;
+}
+
+static inline int64_t PyDateTime_to_ns(PyDateTime_DateTime* pydatetime) {
+  return PyDateTime_to_us(pydatetime) * 1000;
 }
 
 static inline int32_t PyDate_to_days(PyDateTime_Date* pydate) {

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -197,6 +197,68 @@ class TestConvertSequence(unittest.TestCase):
         assert arr[3].as_py() == datetime.datetime(2010, 8, 13, 5,
                                                    46, 57, 437699)
 
+    def test_timestamp_with_unit(self):
+        data = [
+            datetime.datetime(2007, 7, 13, 1, 23, 34, 123456),
+        ]
+
+        s = pa.timestamp('s')
+        ms = pa.timestamp('ms')
+        us = pa.timestamp('us')
+        ns = pa.timestamp('ns')
+
+        arr_s = pa.array(data, type=s)
+        assert len(arr_s) == 1
+        assert arr_s.type == s
+        assert arr_s[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                     23, 34, 0)
+
+        arr_ms = pa.array(data, type=ms)
+        assert len(arr_ms) == 1
+        assert arr_ms.type == ms
+        assert arr_ms[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                      23, 34, 123000)
+
+        arr_us = pa.array(data, type=us)
+        assert len(arr_us) == 1
+        assert arr_us.type == us
+        assert arr_us[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                      23, 34, 123456)
+
+        arr_ns = pa.array(data, type=ns)
+        assert len(arr_ns) == 1
+        assert arr_ns.type == ns
+        assert arr_ns[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                      23, 34, 123456)
+
+    def test_timestamp_from_int_with_unit(self):
+        data = [1]
+
+        s = pa.timestamp('s')
+        ms = pa.timestamp('ms')
+        us = pa.timestamp('us')
+        ns = pa.timestamp('ns')
+
+        arr_s = pa.array(data, type=s)
+        assert len(arr_s) == 1
+        assert arr_s.type == s
+        assert str(arr_s[0]) == "Timestamp('1970-01-01 00:00:01')"
+
+        arr_ms = pa.array(data, type=ms)
+        assert len(arr_ms) == 1
+        assert arr_ms.type == ms
+        assert str(arr_ms[0]) == "Timestamp('1970-01-01 00:00:00.001000')"
+
+        arr_us = pa.array(data, type=us)
+        assert len(arr_us) == 1
+        assert arr_us.type == us
+        assert str(arr_us[0]) == "Timestamp('1970-01-01 00:00:00.000001')"
+
+        arr_ns = pa.array(data, type=ns)
+        assert len(arr_ns) == 1
+        assert arr_ns.type == ns
+        assert str(arr_ns[0]) == "Timestamp('1970-01-01 00:00:00.000000001')"
+
     def test_mixed_nesting_levels(self):
         pa.array([1, 2, None])
         pa.array([[1], [2], None])

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -259,6 +259,13 @@ class TestConvertSequence(unittest.TestCase):
         assert arr_ns.type == ns
         assert str(arr_ns[0]) == "Timestamp('1970-01-01 00:00:00.000000001')"
 
+        with pytest.raises(pa.ArrowException):
+            class CustomClass():
+                pass
+            pa.array([1, CustomClass()], type=ns)
+            pa.array([1, CustomClass()], type=pa.date32())
+            pa.array([1, CustomClass()], type=pa.date64())
+
     def test_mixed_nesting_levels(self):
         pa.array([1, 2, None])
         pa.array([[1], [2], None])


### PR DESCRIPTION
This closes [ARROW-1730](https://issues.apache.org/jira/browse/ARROW-1730) and [ARROW-1738](https://issues.apache.org/jira/browse/ARROW-1738).