### PR TITLE
ARROW-1743: [Python] Avoid non-array writeable-flag check

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -404,7 +404,7 @@ def table_to_blockmanager(options, table, memory_pool, nthreads=1):
             index_name = None if is_unnamed_index_level(name) else name
             col_pandas = col.to_pandas()
             values = col_pandas.values
-            if not values.flags.writeable:
+            if hasattr(values, 'flags') and not values.flags.writeable:
                 # ARROW-1054: in pandas 0.19.2, factorize will reject
                 # non-writeable arrays when calling MultiIndex.from_arrays
                 values = values.copy()

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -198,6 +198,13 @@ class TestPandasConversion(object):
         md = column_indexes['metadata']
         assert md['timezone'] == 'America/New_York'
 
+    def test_categorical_row_index(self):
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': [1, 2, 3]})
+        df['a'] = df.a.astype('category')
+        df = df.set_index('a')
+
+        self._check_pandas_roundtrip(df, preserve_index=True)
+
     def test_float_no_nulls(self):
         data = {}
         fields = []


### PR DESCRIPTION
This closes [ARROW-1743](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-1743).