### PR TITLE
ARROW-1579: [Java] Adding containerized Spark Integration tests

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -33,3 +33,8 @@ services:
       context: dask_integration
     volumes:
      - ../..:/apache-arrow
+  spark_integration:
+    build: 
+      context: spark_integration
+    volumes:
+     - ../..:/apache-arrow

--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -14,35 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM ubuntu:14.04
+FROM maven:3.5.2-jdk-8-slim
 ADD . /apache-arrow
 WORKDIR /apache-arrow
 # Basic OS utilities
 RUN apt-get update && apt-get install -y \
         wget \
         git \
-        maven\
         software-properties-common
-# Setup Java
-RUN add-apt-repository ppa:openjdk-r/ppa
-RUN apt-get update && apt-get install -y openjdk-8-jdk
-update-java-alternatives -s java-1.8.0-openjdk-amd64
-ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
-ENV PATH $PATH:$JAVA_HOME/bin
-# This will install conda in /home/ubuntu/miniconda
-RUN wget -O /tmp/miniconda.sh \
-    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-    bash /tmp/miniconda.sh -b -p /home/ubuntu/miniconda && \
-    rm /tmp/miniconda.sh
-# Create Conda environment
-ENV PATH="/home/ubuntu/miniconda/bin:${PATH}"
-RUN conda create -y -q -n test-environment \
-    python=3.6
-# Install dependencies
-RUN conda install -c conda-forge \
-    numpy \
-    pandas \
-    "pytest<=3.1.1"
 
-CMD ["arrow/dev/spark_integration/spark_integration.sh"]
+# This will install conda in /home/ubuntu/miniconda
+#RUN wget -O /tmp/miniconda.sh \
+#    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+#    bash /tmp/miniconda.sh -b -p /home/ubuntu/miniconda && \
+#    rm /tmp/miniconda.sh
+# Create Conda environment
+#ENV PATH="/home/ubuntu/miniconda/bin:${PATH}"
+#RUN conda create -y -q -n test-environment \
+#    python=3.6
+# Install dependencies
+#RUN conda install -c conda-forge \
+#    numpy \
+#    pandas \
+#    "pytest<=3.1.1"
+
+CMD arrow/dev/spark_integration/spark_integration.sh
+
+# BUILD WITH: $ docker build -f arrow/dev/spark_integration/Dockerfile -t spark-arrow .
 

--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -15,28 +15,31 @@
 # limitations under the License.
 #
 FROM maven:3.5.2-jdk-8-slim
-ADD . /apache-arrow
-WORKDIR /apache-arrow
+
 # Basic OS utilities
 RUN apt-get update && apt-get install -y \
         wget \
-        git
+        git g++ cmake \
+        libjemalloc-dev libboost-dev \
+        libboost-filesystem-dev libboost-system-dev
+
 # This will install conda in /home/ubuntu/miniconda
-#RUN wget -O /tmp/miniconda.sh \
-#    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
-#    bash /tmp/miniconda.sh -b -p /home/ubuntu/miniconda && \
-#    rm /tmp/miniconda.sh
+RUN wget -O /tmp/miniconda.sh \
+    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash /tmp/miniconda.sh -b -p /home/ubuntu/miniconda && \
+    rm /tmp/miniconda.sh
+
 # Create Conda environment
-#ENV PATH="/home/ubuntu/miniconda/bin:${PATH}"
-#RUN conda create -y -q -n test-environment \
-#    python=3.6
-# Install dependencies
-#RUN conda install -c conda-forge \
-#    numpy \
-#    pandas \
-#    "pytest<=3.1.1"
+ENV PATH="/home/ubuntu/miniconda/bin:${PATH}"
+RUN conda create -y -q -n pyarrow-dev \
+    python=3.5 numpy six setuptools cython pandas pytest \
+    cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib \
+    gflags brotli jemalloc lz4-c zstd -c conda-forge
+
+ADD . /apache-arrow
+WORKDIR /apache-arrow
 
 CMD arrow/dev/spark_integration/spark_integration.sh
 
-# BUILD WITH: $ docker build -f arrow/dev/spark_integration/Dockerfile -t spark-arrow .
-
+# BUILD: $ docker build -f arrow/dev/spark_integration/Dockerfile -t spark-arrow .
+# RUN:   $ docker run -v $HOME/.m2:/root/.m2 spark-arrow

--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -19,9 +19,11 @@ FROM maven:3.5.2-jdk-8-slim
 # Basic OS utilities
 RUN apt-get update && apt-get install -y \
         wget \
-        git g++ cmake \
-        libjemalloc-dev libboost-dev \
-        libboost-filesystem-dev libboost-system-dev
+        git build-essential \
+        software-properties-common
+
+#RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test \
+#        && apt-get update && apt-get install -y gcc-4.9 g++-4.9
 
 # This will install conda in /home/ubuntu/miniconda
 RUN wget -O /tmp/miniconda.sh \
@@ -29,12 +31,38 @@ RUN wget -O /tmp/miniconda.sh \
     bash /tmp/miniconda.sh -b -p /home/ubuntu/miniconda && \
     rm /tmp/miniconda.sh
 
+# Python dependencies
+RUN apt-get install -y \
+        pkg-config
+
 # Create Conda environment
 ENV PATH="/home/ubuntu/miniconda/bin:${PATH}"
 RUN conda create -y -q -n pyarrow-dev \
-    python=3.5 numpy six setuptools cython pandas pytest \
-    cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib \
-    gflags brotli jemalloc lz4-c zstd -c conda-forge
+        # Python
+        python=2.7 \
+        numpy \
+        pandas \
+        pytest \
+        cython \
+        ipython \
+        matplotlib \
+        six \
+        setuptools \
+        setuptools_scm \
+        # C++
+        boost-cpp \
+        cmake \
+        flatbuffers \
+        rapidjson \
+        thrift-cpp \
+        snappy \
+        zlib \
+        gflags \
+        brotli \
+        jemalloc \
+        lz4-c \
+        zstd \
+        -c conda-forge
 
 ADD . /apache-arrow
 WORKDIR /apache-arrow

--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -20,9 +20,7 @@ WORKDIR /apache-arrow
 # Basic OS utilities
 RUN apt-get update && apt-get install -y \
         wget \
-        git \
-        software-properties-common
-
+        git
 # This will install conda in /home/ubuntu/miniconda
 #RUN wget -O /tmp/miniconda.sh \
 #    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \

--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM ubuntu:14.04
+ADD . /apache-arrow
+WORKDIR /apache-arrow
+# Basic OS utilities
+RUN apt-get update && apt-get install -y \
+        wget \
+        git \
+        maven\
+        software-properties-common
+# Setup Java
+RUN add-apt-repository ppa:openjdk-r/ppa
+RUN apt-get update && apt-get install -y openjdk-8-jdk
+update-java-alternatives -s java-1.8.0-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+ENV PATH $PATH:$JAVA_HOME/bin
+# This will install conda in /home/ubuntu/miniconda
+RUN wget -O /tmp/miniconda.sh \
+    https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash /tmp/miniconda.sh -b -p /home/ubuntu/miniconda && \
+    rm /tmp/miniconda.sh
+# Create Conda environment
+ENV PATH="/home/ubuntu/miniconda/bin:${PATH}"
+RUN conda create -y -q -n test-environment \
+    python=3.6
+# Install dependencies
+RUN conda install -c conda-forge \
+    numpy \
+    pandas \
+    "pytest<=3.1.1"
+
+CMD ["arrow/dev/spark_integration/spark_integration.sh"]
+

--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -22,9 +22,6 @@ RUN apt-get update && apt-get install -y \
         git build-essential \
         software-properties-common
 
-#RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test \
-#        && apt-get update && apt-get install -y gcc-4.9 g++-4.9
-
 # This will install conda in /home/ubuntu/miniconda
 RUN wget -O /tmp/miniconda.sh \
     https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \

--- a/dev/spark_integration/spark_integration.sh
+++ b/dev/spark_integration/spark_integration.sh
@@ -20,14 +20,36 @@
 cd /apache-arrow
 
 export ARROW_BUILD_TYPE=release
-export ARROW_HOME=$(pwd)/dist
-export PARQUET_HOME=$(pwd)/dist
+export ARROW_HOME=$(pwd)/arrow
 CONDA_BASE=/home/ubuntu/miniconda
-export LD_LIBRARY_PATH=$(pwd)/dist/lib:${CONDA_BASE}/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${CONDA_BASE}/lib:${LD_LIBRARY_PATH}
+export PYTHONPATH=${ARROW_HOME}/python:${PYTHONPATH}
 export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
 
-# Allow for --user Python installation inside Docker
-#export HOME=$(pwd)
+# Activate our pyarrow-dev conda env
+source activate pyarrow-dev
+
+# Build arrow-cpp and install
+pushd arrow/cpp
+rm -rf build/*
+mkdir -p build
+cd build/
+cmake -DARROW_PYTHON=on -DARROW_HDFS=on -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$ARROW_HOME ..
+make -j4
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
+make install
+popd
+
+# Build pyarrow and install inplace
+pushd arrow/python
+python setup.py clean
+python setup.py build_ext --build-type=release --inplace
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
+popd
 
 # Install Arrow to local maven repo and get the version
 pushd arrow/java
@@ -37,31 +59,48 @@ ARROW_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -De
 echo "Using Arrow version $ARROW_VERSION"
 popd
 
-# Get the Spark master branch from github
-export GIT_COMMITTER_NAME="Nobody"
-export GIT_COMMITTER_EMAIL="nobody@nowhere.com"
-rm -rf spark
-git clone https://github.com/apache/spark.git
+# Build Spark with Arrow
+SPARK_REPO=https://github.com/apache/spark.git
+SPARK_BRANCH=master
+
+# Get the Spark repo if not in image already
+if [ ! -d "$(pwd)/spark" ]; then
+    export GIT_COMMITTER_NAME="Nobody"
+    export GIT_COMMITTER_EMAIL="nobody@nowhere.com"
+    git clone "$SPARK_REPO"
+fi
+
+pushd spark
+
+# Make sure branch has no modifications
+git checkout "$SPARK_BRANCH"
+git reset --hard HEAD
 
 # Update Spark pom with the Arrow version just installed and build Spark, need package phase for pyspark
-pushd spark
 sed -i -e "s/\(.*<arrow.version>\).*\(<\/arrow.version>\)/\1$ARROW_VERSION\2/g" ./pom.xml
 echo "Building Spark with Arrow $ARROW_VERSION"
-build/mvn -DskipTests clean package
+#build/mvn -DskipTests clean package
+build/mvn -DskipTests package
 
 # Run Arrow related Scala tests only, NOTE: -Dtest=_NonExist_ is to enable surefire test discovery without running any tests so that Scalatest can run
 SPARK_SCALA_TESTS="org.apache.spark.sql.execution.arrow,org.apache.spark.sql.execution.vectorized.ColumnarBatchSuite,org.apache.spark.sql.execution.vectorized.ArrowColumnVectorSuite"
-echo "Testing Spark $SPARK_SCALA_TESTS"
+echo "Testing Spark: $SPARK_SCALA_TESTS"
 # TODO: should be able to only build spark-sql tests with adding "-pl sql/core" but not currently working
 build/mvn -Dtest=none -DwildcardSuites="$SPARK_SCALA_TESTS" test
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
 
 # Run pyarrow related Python tests only
-#SPARK_TESTING=1 bin/pyspark pyspark.sql.tests ArrowTests GroupbyApplyTests VectorizedUDFTests
+SPARK_PYTHON_TESTS="ArrowTests PandasUDFTests ScalarPandasUDF GroupbyApplyPandasUDFTests GroupbyAggPandasUDFTests"
+echo "Testing PySpark: $SPARK_PYTHON_TESTS"
+SPARK_TESTING=1 bin/pyspark pyspark.sql.tests $SPARK_PYTHON_TESTS 
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
 popd
 
 # Clean up
 echo "Cleaning up.."
-#rm -rf spark .local
-rm -rf spark
-
+source deactivate
 

--- a/dev/spark_integration/spark_integration.sh
+++ b/dev/spark_integration/spark_integration.sh
@@ -47,18 +47,20 @@ git clone https://github.com/apache/spark.git
 pushd spark
 sed -i -e "s/\(.*<arrow.version>\).*\(<\/arrow.version>\)/\1$ARROW_VERSION\2/g" ./pom.xml
 echo "Building Spark with Arrow $ARROW_VERSION"
-mvn -DskipTests clean package
+build/mvn -DskipTests clean package
 
 # Run Arrow related Scala tests only, NOTE: -Dtest=_NonExist_ is to enable surefire test discovery without running any tests so that Scalatest can run
 SPARK_SCALA_TESTS="org.apache.spark.sql.execution.arrow,org.apache.spark.sql.execution.vectorized.ColumnarBatchSuite,org.apache.spark.sql.execution.vectorized.ArrowColumnVectorSuite"
 echo "Testing Spark $SPARK_SCALA_TESTS"
-mvn -Dtest=_NonExist_ -DwildcardSuites="'$SPARK_SCALA_TESTS'" test -pl sql/core
+# TODO: should be able to only build spark-sql tests with adding "-pl sql/core" but not currently working
+build/mvn -Dtest=none -DwildcardSuites="$SPARK_SCALA_TESTS" test
 
 # Run pyarrow related Python tests only
 #SPARK_TESTING=1 bin/pyspark pyspark.sql.tests ArrowTests GroupbyApplyTests VectorizedUDFTests
 popd
 
 # Clean up
+echo "Cleaning up.."
 #rm -rf spark .local
 rm -rf spark
 

--- a/dev/spark_integration/spark_integration.sh
+++ b/dev/spark_integration/spark_integration.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set up environment and working directory
+cd /apache-arrow
+
+export ARROW_BUILD_TYPE=release
+export ARROW_HOME=$(pwd)/dist
+export PARQUET_HOME=$(pwd)/dist
+CONDA_BASE=/home/ubuntu/miniconda
+export LD_LIBRARY_PATH=$(pwd)/dist/lib:${CONDA_BASE}/lib:${LD_LIBRARY_PATH}
+
+# Allow for --user Python installation inside Docker
+export HOME=$(pwd)
+
+# Clean up and get the Spark master branch from github
+#rm -rf spark .local
+#rm -rf spark
+export GIT_COMMITTER_NAME="Nobody"
+export GIT_COMMITTER_EMAIL="nobody@nowhere.com"
+git clone https://github.com/apache/spark.git
+
+# Install Arrow to local maven repo (in container?) and get the version
+pushd arrow/java
+mvn clean install -DskipTests -Drat.skip=true -Dmaven.repo.local=/apache-arrow/.m2/repository
+ARROW_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }'`
+popd
+
+# Update Spark pom with the Arrow version just installed and build Spark
+pushd spark
+sed -i -e "s/\(.*<arrow.version>\).*\(<\/arrow.version>\)/\1$ARROW_VERSION\2/g" ./pom.xml
+build/mvn clean package -DskipTests -Dmaven.repo.local=/apache-arrow/.m2/repository
+
+# Run Arrow related Scala tests
+build/mvn test -Dtest=ArrowConvertersSuite,ArrowUtilsSuite -Dmaven.repo.local=/apache-arrow/.m2/repository
+popd
+
+

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -24,7 +24,7 @@ except DistributionNotFound:
    # package is not installed
     try:
         import setuptools_scm
-        __version__ = setuptools_scm.get_version('../')
+        __version__ = setuptools_scm.get_version(root='../../', relative_to=__file__)
     except (ImportError, LookupError):
         __version__ = None
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -24,7 +24,7 @@ except DistributionNotFound:
    # package is not installed
     try:
         import setuptools_scm
-        __version__ = setuptools_scm.get_version(root='../../', relative_to=__file__)
+        __version__ = setuptools_scm.get_version('../')
     except (ImportError, LookupError):
         __version__ = None
 


### PR DESCRIPTION
This adds configuration files for running containerized integration tests with Spark for Java and Python.  The image is based off of maven with openJDK-8 and will include a copy of Arrow when built on the parent directory to ARROW_HOME.  Running the container will do the following: 

1) Install Arrow Java artifacts to m2 repo in container 
2) Checkout current Spark master branch
3) Update Spark POM to use the installed version of Arrow and package
4) Run Arrow related Java/Scala Spark tests
5) Run pyarrow related Python Spark tests

Successful completion of the running container will indicate that there are no breaking changes between current Spark code and the Arrow code 