### PR TITLE
ARROW-1821: [INTEGRATION] Add integration test case for when Field has zero null count and optional validity buffer

### DIFF
--- a/integration/data/simple.json
+++ b/integration/data/simple.json
@@ -61,6 +61,54 @@
           "DATA": ["aa", "", "", "bbb", "cccc"]
         }
       ]
+    },
+    {
+      "count": 5,
+      "columns": [
+        {
+          "name": "foo",
+          "count": 5,
+          "VALIDITY": [1, 1, 1, 1, 1],
+          "DATA": [1, 2, 3, 4, 5]
+        },
+        {
+          "name": "bar",
+          "count": 5,
+          "VALIDITY": [1, 1, 1, 1, 1],
+          "DATA": [1.0, 2.0, 3.0, 4.0, 5.0]
+        },
+        {
+          "name": "baz",
+          "count": 5,
+          "VALIDITY": [1, 1, 1, 1, 1],
+          "OFFSET": [0, 2, 3, 4, 7, 11],
+          "DATA": ["aa", "b", "c", "ddd", "eeee"]
+        }
+      ]
+    },
+    {
+      "count": 5,
+      "columns": [
+        {
+          "name": "foo",
+          "count": 5,
+          "VALIDITY": [0, 0, 0, 0, 0],
+          "DATA": [1, 2, 3, 4, 5]
+        },
+        {
+          "name": "bar",
+          "count": 5,
+          "VALIDITY": [0, 0, 0, 0, 0],
+          "DATA": [1.0, 2.0, 3.0, 4.0, 5.0]
+        },
+        {
+          "name": "baz",
+          "count": 5,
+          "VALIDITY": [0, 0, 0, 0, 0],
+          "OFFSET": [0, 0, 0, 0, 0, 0],
+          "DATA": ["", "", "", "", ""]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Currently when a Field has null count = 0, C++ will omit the validity buffer as it is optional in this case.  Testing for #1316 was failing because Java was not handling this properly.  This PR adds an explicit test to ensure this is being tested and easier to locate possible issues. 