### PR TITLE
ARROW-1841: [JS] Update text-encoding-utf-8 and tslib for node ESModules support

### DIFF
--- a/js/gulp/package-task.js
+++ b/js/gulp/package-task.js
@@ -49,6 +49,12 @@ const createMainPackageJson = (target, format) => (orig) => ({
     browser: `${mainExport}.es5.min.js`,
     [`browser:es2015`]: `${mainExport}.es2015.min.js`,
     [`@std/esm`]: { esm: `mjs` },
+    // Temporary workaround until https://github.com/Microsoft/tslib/pull/44 is merged
+    scripts: {
+        postinstall: `npm i shx && npm run tslib_mjs && npm run tslib_pkg && npm r shx`,
+        tslib_mjs: `shx cp $(node -e \"console.log(require.resolve('tslib/tslib.es6.js'))\") $(node -e \"var r=require,p=r('path');console.log(p.join(p.dirname(r.resolve('tslib')),'tslib.mjs'))\")`,
+        tslib_pkg: `node -e \"var r=require,p=r('path'),f=r('fs'),k=p.join(p.dirname(r.resolve('tslib')),'package.json'),x=JSON.parse(f.readFileSync(k));x.main='tslib';f.writeFileSync(k,JSON.stringify(x))\"`
+    }
 });
   
 const createTypeScriptPackageJson = (target, format) => (orig) => ({

--- a/js/package.json
+++ b/js/package.json
@@ -90,7 +90,7 @@
     "rxjs": "5.5.2",
     "shx": "0.2.2",
     "source-map-loader": "0.2.3",
-    "text-encoding-utf-8": "1.0.1",
+    "text-encoding-utf-8": "1.0.2",
     "trash": "4.1.0",
     "ts-jest": "21.2.1",
     "tslib": "1.8.0",

--- a/js/package.json
+++ b/js/package.json
@@ -25,7 +25,8 @@
     "lint": "npm-run-all -p lint:*",
     "lint:src": "tslint --fix --project -p tsconfig.json -c tslint.json \"src/**/*.ts\"",
     "lint:test": "tslint --fix --project -p test/tsconfig.json -c tslint.json \"test/**/*.ts\"",
-    "prepublishOnly": "echo \"Error: do 'npm run release' instead of 'npm publish'\" && exit 1"
+    "prepublishOnly": "echo \"Error: do 'npm run release' instead of 'npm publish'\" && exit 1",
+    "postinstall": "shx cp node_modules/tslib/tslib.es6.js node_modules/tslib/tslib.mjs"
   },
   "repository": {
     "type": "git",
@@ -54,7 +55,8 @@
   },
   "dependencies": {
     "flatbuffers": "trxcllnt/flatbuffers-esm",
-    "text-encoding": "0.6.4"
+    "text-encoding-utf-8": "^1.0.2",
+    "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@std/esm": "0.13.0",
@@ -90,10 +92,8 @@
     "rxjs": "5.5.2",
     "shx": "0.2.2",
     "source-map-loader": "0.2.3",
-    "text-encoding-utf-8": "1.0.2",
     "trash": "4.1.0",
     "ts-jest": "21.2.1",
-    "tslib": "1.8.0",
     "tslint": "5.8.0",
     "typescript": "2.6.1",
     "uglifyjs-webpack-plugin": "1.0.1",


### PR DESCRIPTION
Updates the `text-encoding-utf-8` dependency to version 1.0.2, [which now supports](https://github.com/arv/text-encoding-utf-8/pull/2) ESModules in node >= v8.6.0 via the `--experimental-modules` flag.

We currently support ESModules in node in the main `apache-arrow` package, but need our dependencies to also expose ESModule forms as well. I have also issued a [PR to flatbuffers](https://github.com/google/flatbuffers/pull/4504) to add ESModules support, and are using a temporary [fork of flatbuffers](https://github.com/trxcllnt/flatbuffers-esm) in my github until that PR is merged.

This PR enables the following workflow:

```js
// file - index.mjs
// run via `node --experimental-modules index.mjs`
import util from 'util';
import * as fs from 'fs';
import { Table } from 'apache-arrow';
(async () => {
  const buffer = await util.promisify(fs.readFile)('simple.arrow');
  console.log(Table.from([buffer]).toString());
/*
 foo,  bar,  baz
   1,    1,   aa
null, null, null
   3, null, null
   4,    4,  bbb
   5,    5, cccc
*/
})();
```