### PR TITLE
ARROW-1838: [C++] Conform kernel API to use Datum for input and output

### DIFF
--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -697,7 +697,7 @@ TEST_F(TestCast, PreallocatedMemory) {
   out_data->buffers.push_back(out_values);
 
   Datum out(out_data);
-  ASSERT_OK(kernel->Call(&this->ctx_, *arr->data(), &out));
+  ASSERT_OK(kernel->Call(&this->ctx_, Datum(arr), &out));
 
   // Buffer address unchanged
   ASSERT_EQ(out_values.get(), out_data->buffers[1].get());

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -131,7 +131,7 @@ struct ARROW_EXPORT Datum {
 /// \brief An array-valued function of a single input argument
 class ARROW_EXPORT UnaryKernel : public OpKernel {
  public:
-  virtual Status Call(FunctionContext* ctx, const ArrayData& input, Datum* out) = 0;
+  virtual Status Call(FunctionContext* ctx, const Datum& input, Datum* out) = 0;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -658,8 +658,9 @@ class HashKernelImpl : public HashKernel {
   explicit HashKernelImpl(std::unique_ptr<HashTable> hasher)
       : hasher_(std::move(hasher)) {}
 
-  Status Call(FunctionContext* ctx, const ArrayData& input, Datum* out) override {
-    RETURN_NOT_OK(Append(ctx, input));
+  Status Call(FunctionContext* ctx, const Datum& input, Datum* out) override {
+    DCHECK_EQ(Datum::ARRAY, input.kind());
+    RETURN_NOT_OK(Append(ctx, *input.array()));
     return Flush(out);
   }
 

--- a/cpp/src/arrow/compute/kernels/util-internal.cc
+++ b/cpp/src/arrow/compute/kernels/util-internal.cc
@@ -34,13 +34,13 @@ Status InvokeUnaryArrayKernel(FunctionContext* ctx, UnaryKernel* kernel,
                               const Datum& value, std::vector<Datum>* outputs) {
   if (value.kind() == Datum::ARRAY) {
     Datum output;
-    RETURN_NOT_OK(kernel->Call(ctx, *value.array(), &output));
+    RETURN_NOT_OK(kernel->Call(ctx, value, &output));
     outputs->push_back(output);
   } else if (value.kind() == Datum::CHUNKED_ARRAY) {
     const ChunkedArray& array = *value.chunked_array();
     for (int i = 0; i < array.num_chunks(); i++) {
       Datum output;
-      RETURN_NOT_OK(kernel->Call(ctx, *(array.chunk(i)->data()), &output));
+      RETURN_NOT_OK(kernel->Call(ctx, Datum(array.chunk(i)), &output));
       outputs->push_back(output);
     }
   } else {


### PR DESCRIPTION
We could also add helper methods that do automatic boxing into a `Datum` at a later time if it helps with code complexity. 