### PR TITLE
ARROW-1047: [Java] [FollowUp] Change ArrowMagic to be non-public class

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowMagic.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowMagic.java
@@ -18,13 +18,11 @@
 
 package org.apache.arrow.vector.ipc;
 
-import org.apache.arrow.vector.ipc.WriteChannel;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-public class ArrowMagic {
+class ArrowMagic {
 
   private static final byte[] MAGIC = "ARROW1".getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
Move ArrowMagic from vector.ipc to vector.ipc.message package.