### PR TITLE
ARROW-1828: [C++] Hash kernel specialization for BooleanType

### DIFF
--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -844,23 +844,21 @@ TEST_F(TestHashKernel, UniqueTimeTimestamp) {
 }
 
 TEST_F(TestHashKernel, UniqueBoolean) {
-  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(),
-    {true, true, false, true},
-    {true, false, true, true}, {true, false}, {});
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {true, true, false, true},
+                                 {true, false, true, true}, {true, false}, {});
 
-  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(),
-    {false, true, false, true},
-    {true, false, true, true}, {false, true}, {});
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {false, true, false, true},
+                                 {true, false, true, true}, {false, true}, {});
 }
 
 TEST_F(TestHashKernel, DictEncodeBoolean) {
-  CheckDictEncode<BooleanType, bool>(&this->ctx_, boolean(),
-    {true, true, false, true, false},
-    {true, false, true, true, true}, {true, false}, {}, {0, 0, 1, 0, 1});
+  CheckDictEncode<BooleanType, bool>(
+      &this->ctx_, boolean(), {true, true, false, true, false},
+      {true, false, true, true, true}, {true, false}, {}, {0, 0, 1, 0, 1});
 
-  CheckDictEncode<BooleanType, bool>(&this->ctx_, boolean(),
-    {false, true, false, true, false},
-    {true, false, true, true, true}, {false, true}, {}, {0, 0, 0, 1, 0});
+  CheckDictEncode<BooleanType, bool>(
+      &this->ctx_, boolean(), {false, true, false, true, false},
+      {true, false, true, true, true}, {false, true}, {}, {0, 0, 0, 1, 0});
 }
 
 TEST_F(TestHashKernel, UniqueBinary) {

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -851,11 +851,11 @@ TEST_F(TestHashKernel, UniqueBoolean) {
                                  {true, false, true, true}, {false, true}, {});
 
   // No nulls
-  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {true, true, false, true},
-                                 {}, {true, false}, {});
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {true, true, false, true}, {},
+                                 {true, false}, {});
 
-  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {false, true, false, true},
-                                 {}, {false, true}, {});
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {false, true, false, true}, {},
+                                 {false, true}, {});
 }
 
 TEST_F(TestHashKernel, DictEncodeBoolean) {
@@ -868,13 +868,13 @@ TEST_F(TestHashKernel, DictEncodeBoolean) {
       {true, false, true, true, true}, {false, true}, {}, {0, 0, 0, 1, 0});
 
   // No nulls
-  CheckDictEncode<BooleanType, bool>(
-      &this->ctx_, boolean(), {true, true, false, true, false},
-      {}, {true, false}, {}, {0, 0, 1, 0, 1});
+  CheckDictEncode<BooleanType, bool>(&this->ctx_, boolean(),
+                                     {true, true, false, true, false}, {}, {true, false},
+                                     {}, {0, 0, 1, 0, 1});
 
-  CheckDictEncode<BooleanType, bool>(
-      &this->ctx_, boolean(), {false, true, false, true, false},
-      {}, {false, true}, {}, {0, 1, 0, 1, 0});
+  CheckDictEncode<BooleanType, bool>(&this->ctx_, boolean(),
+                                     {false, true, false, true, false}, {}, {false, true},
+                                     {}, {0, 1, 0, 1, 0});
 }
 
 TEST_F(TestHashKernel, UniqueBinary) {

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -843,6 +843,26 @@ TEST_F(TestHashKernel, UniqueTimeTimestamp) {
                                       {});
 }
 
+TEST_F(TestHashKernel, UniqueBoolean) {
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(),
+    {true, true, false, true},
+    {true, false, true, true}, {true, false}, {});
+
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(),
+    {false, true, false, true},
+    {true, false, true, true}, {false, true}, {});
+}
+
+TEST_F(TestHashKernel, DictEncodeBoolean) {
+  CheckDictEncode<BooleanType, bool>(&this->ctx_, boolean(),
+    {true, true, false, true, false},
+    {true, false, true, true, true}, {true, false}, {}, {0, 0, 1, 0, 1});
+
+  CheckDictEncode<BooleanType, bool>(&this->ctx_, boolean(),
+    {false, true, false, true, false},
+    {true, false, true, true, true}, {false, true}, {}, {0, 0, 0, 1, 0});
+}
+
 TEST_F(TestHashKernel, UniqueBinary) {
   CheckUnique<BinaryType, std::string>(&this->ctx_, binary(),
                                        {"test", "", "test2", "test"},

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -849,6 +849,13 @@ TEST_F(TestHashKernel, UniqueBoolean) {
 
   CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {false, true, false, true},
                                  {true, false, true, true}, {false, true}, {});
+
+  // No nulls
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {true, true, false, true},
+                                 {}, {true, false}, {});
+
+  CheckUnique<BooleanType, bool>(&this->ctx_, boolean(), {false, true, false, true},
+                                 {}, {false, true}, {});
 }
 
 TEST_F(TestHashKernel, DictEncodeBoolean) {
@@ -859,6 +866,15 @@ TEST_F(TestHashKernel, DictEncodeBoolean) {
   CheckDictEncode<BooleanType, bool>(
       &this->ctx_, boolean(), {false, true, false, true, false},
       {true, false, true, true, true}, {false, true}, {}, {0, 0, 0, 1, 0});
+
+  // No nulls
+  CheckDictEncode<BooleanType, bool>(
+      &this->ctx_, boolean(), {true, true, false, true, false},
+      {}, {true, false}, {}, {0, 0, 1, 0, 1});
+
+  CheckDictEncode<BooleanType, bool>(
+      &this->ctx_, boolean(), {false, true, false, true, false},
+      {}, {false, true}, {}, {0, 1, 0, 1, 0});
 }
 
 TEST_F(TestHashKernel, UniqueBinary) {

--- a/cpp/src/arrow/compute/kernels/util-internal.h
+++ b/cpp/src/arrow/compute/kernels/util-internal.h
@@ -60,6 +60,10 @@ using enable_if_binary =
     typename std::enable_if<std::is_base_of<BinaryType, T>::value>::type;
 
 template <typename T>
+using enable_if_boolean =
+    typename std::enable_if<std::is_same<BooleanType, T>::value>::type;
+
+template <typename T>
 using enable_if_fixed_size_binary =
     typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value>::type;
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -210,7 +210,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int bit_width()
 
     cdef cppclass CDecimal128Type \
-            " arrow::Decimal128Type"\(CFixedSizeBinaryType):
+            " arrow::Decimal128Type"(CFixedSizeBinaryType):
         CDecimal128Type(int precision, int scale)
         int precision()
         int scale()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -209,7 +209,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int byte_width()
         int bit_width()
 
-    cdef cppclass CDecimal128Type" arrow::Decimal128Type"(CFixedSizeBinaryType):
+    cdef cppclass CDecimal128Type \
+            " arrow::Decimal128Type"\(CFixedSizeBinaryType):
         CDecimal128Type(int precision, int scale)
         int precision()
         int scale()


### PR DESCRIPTION
This is a bit tedious because we want to preserve the order in which the unique values were observed. 