### PR TITLE
ARROW-1852: [C++] Make retrieval of Plasma manager fd a const operation

### DIFF
--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -617,7 +617,7 @@ Status PlasmaClient::Fetch(int num_object_ids, const ObjectID* object_ids) {
   return SendFetchRequest(manager_conn_, object_ids, num_object_ids);
 }
 
-int PlasmaClient::get_manager_fd() { return manager_conn_; }
+int PlasmaClient::get_manager_fd() const { return manager_conn_; }
 
 Status PlasmaClient::Info(const ObjectID& object_id, int* object_status) {
   ARROW_CHECK(manager_conn_ >= 0);

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -313,7 +313,7 @@ class ARROW_EXPORT PlasmaClient {
   ///
   /// \return The file descriptor for the manager connection. If there is no
   ///         connection to the manager, this is -1.
-  int get_manager_fd();
+  int get_manager_fd() const;
 
  private:
   /// This is a helper method for unmapping objects for which all references have


### PR DESCRIPTION
This small patch makes it possible to retrieve the manager fd in a `const` context. For example:

```cpp
class handle {
public:
  bool connected() const {
    return client_.get_manager_fd() != -1;
  }
private:
  plasma::PlasmaClient client_;
};
```

Without this patch, it's impossible to implement the above function.

An alternative would be to simply provide such a utility function as part of `PlasmaClient`, but this changes the API. Let me know what you prefer.