### PR TITLE
ARROW-1850: [C++] Use void* / const void* for buffers in file APIs

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -420,7 +420,7 @@ namespace garrow {
 
     arrow::Status Read(int64_t n_bytes,
                        int64_t *n_read_bytes,
-                       uint8_t *out) override {
+                       void *out) override {
       GError *error = NULL;
       *n_read_bytes = g_input_stream_read(input_stream_,
                                           out,
@@ -437,7 +437,7 @@ namespace garrow {
     }
 
     arrow::Status ReadAt(int64_t position, int64_t n_bytes,
-			 int64_t *n_read_bytes, uint8_t* out) override {
+			 int64_t *n_read_bytes, void* out) override {
 	return arrow::io::RandomAccessFile::ReadAt(
 	    position, n_bytes, n_read_bytes, out);
     }

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -76,7 +76,7 @@ garrow_output_stream_file_interface_init(GArrowFileInterface *iface)
   iface->get_raw = garrow_output_stream_get_raw_file_interface;
 }
 
-static std::shared_ptr<arrow::io::Writeable>
+static std::shared_ptr<arrow::io::Writable>
 garrow_output_stream_get_raw_writeable_interface(GArrowWriteable *writeable)
 {
   auto output_stream = GARROW_OUTPUT_STREAM(writeable);
@@ -325,7 +325,7 @@ namespace garrow {
       return arrow::Status::OK();
     }
 
-    arrow::Status Write(const uint8_t *data,
+    arrow::Status Write(const void *data,
                         int64_t n_bytes) override {
       GError *error = NULL;
       gsize n_written_bytes;

--- a/c_glib/arrow-glib/writeable.cpp
+++ b/c_glib/arrow-glib/writeable.cpp
@@ -88,7 +88,7 @@ garrow_writeable_flush(GArrowWriteable *writeable,
 
 G_END_DECLS
 
-std::shared_ptr<arrow::io::Writeable>
+std::shared_ptr<arrow::io::Writable>
 garrow_writeable_get_raw(GArrowWriteable *writeable)
 {
   auto *iface = GARROW_WRITEABLE_GET_IFACE(writeable);

--- a/c_glib/arrow-glib/writeable.hpp
+++ b/c_glib/arrow-glib/writeable.hpp
@@ -26,13 +26,13 @@
 /**
  * GArrowWriteableInterface:
  *
- * It wraps `arrow::io::Writeable`.
+ * It wraps `arrow::io::Writable`.
  */
 struct _GArrowWriteableInterface
 {
   GTypeInterface parent_iface;
 
-  std::shared_ptr<arrow::io::Writeable> (*get_raw)(GArrowWriteable *file);
+  std::shared_ptr<arrow::io::Writable> (*get_raw)(GArrowWriteable *file);
 };
 
-std::shared_ptr<arrow::io::Writeable> garrow_writeable_get_raw(GArrowWriteable *writeable);
+std::shared_ptr<arrow::io::Writable> garrow_writeable_get_raw(GArrowWriteable *writeable);

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -54,7 +54,7 @@ configure_file(cuda_version.h.in
   @ONLY)
 
 install(FILES
-  "${CMAKE_CURRENT_SOURCE_DIR}/cuda_version.h"
+  "${CMAKE_CURRENT_BINARY_DIR}/cuda_version.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/gpu")
 
 install(FILES

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -69,28 +69,27 @@ class CudaContext::CudaContextImpl {
     return Status::OK();
   }
 
-  Status CopyHostToDevice(uint8_t* dst, const uint8_t* src, int64_t nbytes) {
+  Status CopyHostToDevice(void* dst, const void* src, int64_t nbytes) {
     CU_RETURN_NOT_OK(cuCtxSetCurrent(context_));
-    CU_RETURN_NOT_OK(cuMemcpyHtoD(reinterpret_cast<CUdeviceptr>(dst),
-                                  reinterpret_cast<const void*>(src),
+    CU_RETURN_NOT_OK(cuMemcpyHtoD(reinterpret_cast<CUdeviceptr>(dst), src,
                                   static_cast<size_t>(nbytes)));
     return Status::OK();
   }
 
-  Status CopyDeviceToHost(uint8_t* dst, const uint8_t* src, int64_t nbytes) {
+  Status CopyDeviceToHost(void* dst, const void* src, int64_t nbytes) {
     CU_RETURN_NOT_OK(cuCtxSetCurrent(context_));
     CU_RETURN_NOT_OK(cuMemcpyDtoH(dst, reinterpret_cast<const CUdeviceptr>(src),
                                   static_cast<size_t>(nbytes)));
     return Status::OK();
   }
 
-  Status Free(uint8_t* device_ptr, int64_t nbytes) {
+  Status Free(void* device_ptr, int64_t nbytes) {
     CU_RETURN_NOT_OK(cuMemFree(reinterpret_cast<CUdeviceptr>(device_ptr)));
     bytes_allocated_ -= nbytes;
     return Status::OK();
   }
 
-  Status ExportIpcBuffer(uint8_t* data, std::unique_ptr<CudaIpcMemHandle>* handle) {
+  Status ExportIpcBuffer(void* data, std::unique_ptr<CudaIpcMemHandle>* handle) {
     CU_RETURN_NOT_OK(cuCtxSetCurrent(context_));
     CUipcMemHandle cu_handle;
     CU_RETURN_NOT_OK(cuIpcGetMemHandle(&cu_handle, reinterpret_cast<CUdeviceptr>(data)));
@@ -145,7 +144,7 @@ class CudaDeviceManager::CudaDeviceManagerImpl {
     return Status::OK();
   }
 
-  Status FreeHost(uint8_t* data, int64_t nbytes) {
+  Status FreeHost(void* data, int64_t nbytes) {
     CU_RETURN_NOT_OK(cuMemFreeHost(data));
     host_bytes_allocated_ -= nbytes;
     return Status::OK();
@@ -221,7 +220,7 @@ Status CudaDeviceManager::AllocateHost(int64_t nbytes,
   return Status::OK();
 }
 
-Status CudaDeviceManager::FreeHost(uint8_t* data, int64_t nbytes) {
+Status CudaDeviceManager::FreeHost(void* data, int64_t nbytes) {
   return impl_->FreeHost(data, nbytes);
 }
 
@@ -241,22 +240,22 @@ Status CudaContext::Allocate(int64_t nbytes, std::shared_ptr<CudaBuffer>* out) {
   return Status::OK();
 }
 
-Status CudaContext::ExportIpcBuffer(uint8_t* data,
+Status CudaContext::ExportIpcBuffer(void* data,
                                     std::unique_ptr<CudaIpcMemHandle>* handle) {
   return impl_->ExportIpcBuffer(data, handle);
 }
 
-Status CudaContext::CopyHostToDevice(uint8_t* dst, const uint8_t* src, int64_t nbytes) {
+Status CudaContext::CopyHostToDevice(void* dst, const void* src, int64_t nbytes) {
   return impl_->CopyHostToDevice(dst, src, nbytes);
 }
 
-Status CudaContext::CopyDeviceToHost(uint8_t* dst, const uint8_t* src, int64_t nbytes) {
+Status CudaContext::CopyDeviceToHost(void* dst, const void* src, int64_t nbytes) {
   return impl_->CopyDeviceToHost(dst, src, nbytes);
 }
 
 Status CudaContext::Close() { return impl_->Close(); }
 
-Status CudaContext::Free(uint8_t* device_ptr, int64_t nbytes) {
+Status CudaContext::Free(void* device_ptr, int64_t nbytes) {
   return impl_->Free(device_ptr, nbytes);
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -46,7 +46,7 @@ class ARROW_EXPORT CudaDeviceManager {
 
   Status AllocateHost(int64_t nbytes, std::shared_ptr<CudaHostBuffer>* buffer);
 
-  Status FreeHost(uint8_t* data, int64_t nbytes);
+  Status FreeHost(void* data, int64_t nbytes);
 
   int num_devices() const;
 
@@ -88,10 +88,10 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
  private:
   CudaContext();
 
-  Status ExportIpcBuffer(uint8_t* data, std::unique_ptr<CudaIpcMemHandle>* handle);
-  Status CopyHostToDevice(uint8_t* dst, const uint8_t* src, int64_t nbytes);
-  Status CopyDeviceToHost(uint8_t* dst, const uint8_t* src, int64_t nbytes);
-  Status Free(uint8_t* device_ptr, int64_t nbytes);
+  Status ExportIpcBuffer(void* data, std::unique_ptr<CudaIpcMemHandle>* handle);
+  Status CopyHostToDevice(void* dst, const void* src, int64_t nbytes);
+  Status CopyDeviceToHost(void* dst, const void* src, int64_t nbytes);
+  Status Free(void* device_ptr, int64_t nbytes);
 
   class CudaContextImpl;
   std::unique_ptr<CudaContextImpl> impl_;

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -101,11 +101,11 @@ CudaBuffer::CudaBuffer(const std::shared_ptr<CudaBuffer>& parent, const int64_t 
       is_ipc_(false) {}
 
 Status CudaBuffer::CopyToHost(const int64_t position, const int64_t nbytes,
-                              uint8_t* out) const {
+                              void* out) const {
   return context_->CopyDeviceToHost(out, data_ + position, nbytes);
 }
 
-Status CudaBuffer::CopyFromHost(const int64_t position, const uint8_t* data,
+Status CudaBuffer::CopyFromHost(const int64_t position, const void* data,
                                 int64_t nbytes) {
   DCHECK_LE(nbytes, size_ - position) << "Copy would overflow buffer";
   return context_->CopyHostToDevice(mutable_data_ + position, data, nbytes);
@@ -134,7 +134,7 @@ CudaBufferReader::CudaBufferReader(const std::shared_ptr<CudaBuffer>& buffer)
 
 CudaBufferReader::~CudaBufferReader() {}
 
-Status CudaBufferReader::Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) {
+Status CudaBufferReader::Read(int64_t nbytes, int64_t* bytes_read, void* buffer) {
   nbytes = std::min(nbytes, size_ - position_);
   *bytes_read = nbytes;
   RETURN_NOT_OK(context_->CopyDeviceToHost(buffer, data_ + position_, nbytes));
@@ -190,7 +190,7 @@ class CudaBufferWriter::CudaBufferWriterImpl {
     return Status::OK();
   }
 
-  Status Write(const uint8_t* data, int64_t nbytes) {
+  Status Write(const void* data, int64_t nbytes) {
     if (nbytes == 0) {
       return Status::OK();
     }
@@ -214,7 +214,7 @@ class CudaBufferWriter::CudaBufferWriterImpl {
     return Status::OK();
   }
 
-  Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) {
+  Status WriteAt(int64_t position, const void* data, int64_t nbytes) {
     std::lock_guard<std::mutex> guard(lock_);
     RETURN_NOT_OK(Seek(position));
     return Write(data, nbytes);
@@ -269,11 +269,11 @@ Status CudaBufferWriter::Seek(int64_t position) {
 
 Status CudaBufferWriter::Tell(int64_t* position) const { return impl_->Tell(position); }
 
-Status CudaBufferWriter::Write(const uint8_t* data, int64_t nbytes) {
+Status CudaBufferWriter::Write(const void* data, int64_t nbytes) {
   return impl_->Write(data, nbytes);
 }
 
-Status CudaBufferWriter::WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) {
+Status CudaBufferWriter::WriteAt(int64_t position, const void* data, int64_t nbytes) {
   return impl_->WriteAt(position, data, nbytes);
 }
 

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -49,14 +49,14 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   /// \brief Copy memory from GPU device to CPU host
   /// \param[out] out a pre-allocated output buffer
   /// \return Status
-  Status CopyToHost(const int64_t position, const int64_t nbytes, uint8_t* out) const;
+  Status CopyToHost(const int64_t position, const int64_t nbytes, void* out) const;
 
   /// \brief Copy memory to device at position
   /// \param[in] position start position to copy bytes
   /// \param[in] data the host data to copy
   /// \param[in] nbytes number of bytes to copy
   /// \return Status
-  Status CopyFromHost(const int64_t position, const uint8_t* data, int64_t nbytes);
+  Status CopyFromHost(const int64_t position, const void* data, int64_t nbytes);
 
   /// \brief Expose this device buffer as IPC memory which can be used in other processes
   /// \param[out] handle the exported IPC handle
@@ -130,7 +130,7 @@ class ARROW_EXPORT CudaBufferReader : public io::BufferReader {
   /// \param[in] nbytes number of bytes to read
   /// \param[out] bytes_read actual number of bytes read
   /// \param[out] buffer pre-allocated memory to write into
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
 
   /// \brief Zero-copy read from device memory
   /// \param[in] nbytes number of bytes to read
@@ -158,9 +158,9 @@ class ARROW_EXPORT CudaBufferWriter : public io::WriteableFile {
 
   Status Seek(int64_t position) override;
 
-  Status Write(const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
 
-  Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) override;
+  Status WriteAt(int64_t position, const void* data, int64_t nbytes) override;
 
   Status Tell(int64_t* position) const override;
 

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -59,7 +59,7 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   Status Tell(int64_t* position) const override;
 
   // Write bytes to the stream. Thread-safe
-  Status Write(const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
 
   int file_descriptor() const;
 
@@ -93,12 +93,12 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   Status Tell(int64_t* position) const override;
 
   // Read bytes from the file. Thread-safe
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   /// \brief Thread-safe implementation of ReadAt
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                uint8_t* out) override;
+                void* out) override;
 
   /// \brief Thread-safe implementation of ReadAt
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
@@ -141,13 +141,13 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
   Status Seek(int64_t position) override;
 
   // Required by RandomAccessFile, copies memory into out. Not thread-safe
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override;
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
 
   // Zero copy read. Not thread-safe
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                uint8_t* out) override;
+                void* out) override;
 
   /// Default implementation is thread-safe
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
@@ -155,10 +155,10 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
   bool supports_zero_copy() const override;
 
   /// Write data at the current position in the file. Thread-safe
-  Status Write(const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
 
   /// Write data at a particular position in the file. Thread-safe
-  Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) override;
+  Status WriteAt(int64_t position, const void* data, int64_t nbytes) override;
 
   // @return: the size in bytes of the memory source
   Status GetSize(int64_t* size) override;
@@ -168,7 +168,7 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
  private:
   MemoryMappedFile();
 
-  Status WriteInternal(const uint8_t* data, int64_t nbytes);
+  Status WriteInternal(const void* data, int64_t nbytes);
 
   class ARROW_NO_EXPORT MemoryMap;
   std::shared_ptr<MemoryMap> memory_map_;

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -182,12 +182,12 @@ class ARROW_EXPORT HdfsReadableFile : public RandomAccessFile {
 
   // NOTE: If you wish to read a particular range of a file in a multithreaded
   // context, you may prefer to use ReadAt to avoid locking issues
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
 
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                uint8_t* buffer) override;
+                void* buffer) override;
 
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
@@ -217,9 +217,9 @@ class ARROW_EXPORT HdfsOutputStream : public OutputStream {
 
   Status Close() override;
 
-  Status Write(const uint8_t* buffer, int64_t nbytes) override;
+  Status Write(const void* buffer, int64_t nbytes) override;
 
-  Status Write(const uint8_t* buffer, int64_t nbytes, int64_t* bytes_written);
+  Status Write(const void* buffer, int64_t nbytes, int64_t* bytes_written);
 
   Status Flush() override;
 

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -38,7 +38,7 @@ RandomAccessFile::RandomAccessFile()
     : impl_(new RandomAccessFile::RandomAccessFileImpl()) {}
 
 Status RandomAccessFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                                uint8_t* out) {
+                                void* out) {
   std::lock_guard<std::mutex> lock(impl_->lock_);
   RETURN_NOT_OK(Seek(position));
   return Read(nbytes, bytes_read, out);
@@ -51,12 +51,11 @@ Status RandomAccessFile::ReadAt(int64_t position, int64_t nbytes,
   return Read(nbytes, out);
 }
 
-Status Writeable::Write(const std::string& data) {
-  return Write(reinterpret_cast<const uint8_t*>(data.c_str()),
-               static_cast<int64_t>(data.size()));
+Status Writable::Write(const std::string& data) {
+  return Write(data.c_str(), static_cast<int64_t>(data.size()));
 }
 
-Status Writeable::Flush() { return Status::OK(); }
+Status Writable::Flush() { return Status::OK(); }
 
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -86,11 +86,11 @@ class ARROW_EXPORT Seekable {
   virtual Status Seek(int64_t position) = 0;
 };
 
-class ARROW_EXPORT Writeable {
+class ARROW_EXPORT Writable {
  public:
-  virtual ~Writeable() = default;
+  virtual ~Writable() = default;
 
-  virtual Status Write(const uint8_t* data, int64_t nbytes) = 0;
+  virtual Status Write(const void* data, int64_t nbytes) = 0;
 
   /// \brief Flush buffered bytes, if any
   virtual Status Flush();
@@ -102,13 +102,13 @@ class ARROW_EXPORT Readable {
  public:
   virtual ~Readable() = default;
 
-  virtual Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) = 0;
+  virtual Status Read(int64_t nbytes, int64_t* bytes_read, void* out) = 0;
 
   // Does not copy if not necessary
   virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) = 0;
 };
 
-class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writeable {
+class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writable {
  protected:
   OutputStream() = default;
 };
@@ -138,7 +138,7 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   /// \param[out] out The buffer to read bytes into
   /// \return Status
   virtual Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                        uint8_t* out) = 0;
+                        void* out) = 0;
 
   /// \brief Read nbytes at position, provide default implementations using Read(...), but
   /// can be overridden. Default implementation is thread-safe.
@@ -162,7 +162,7 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
 
 class ARROW_EXPORT WriteableFile : public OutputStream, public Seekable {
  public:
-  virtual Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) = 0;
+  virtual Status WriteAt(int64_t position, const void* data, int64_t nbytes) = 0;
 
  protected:
   WriteableFile() = default;

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -135,7 +135,7 @@ TEST_F(TestFileOutputStream, Close) {
   OpenFile();
 
   const char* data = "testdata";
-  ASSERT_OK(file_->Write(reinterpret_cast<const uint8_t*>(data), strlen(data)));
+  ASSERT_OK(file_->Write(data, strlen(data)));
 
   int fd = file_->file_descriptor();
   ASSERT_OK(file_->Close());
@@ -158,7 +158,7 @@ TEST_F(TestFileOutputStream, InvalidWrites) {
 
   const char* data = "";
 
-  ASSERT_RAISES(IOError, file_->Write(reinterpret_cast<const uint8_t*>(data), -1));
+  ASSERT_RAISES(IOError, file_->Write(data, -1));
 }
 
 TEST_F(TestFileOutputStream, Tell) {
@@ -170,7 +170,7 @@ TEST_F(TestFileOutputStream, Tell) {
   ASSERT_EQ(0, position);
 
   const char* data = "testdata";
-  ASSERT_OK(file_->Write(reinterpret_cast<const uint8_t*>(data), 8));
+  ASSERT_OK(file_->Write(data, 8));
   ASSERT_OK(file_->Tell(&position));
   ASSERT_EQ(8, position);
 }
@@ -179,7 +179,7 @@ TEST_F(TestFileOutputStream, TruncatesNewFile) {
   ASSERT_OK(FileOutputStream::Open(path_, &file_));
 
   const char* data = "testdata";
-  ASSERT_OK(file_->Write(reinterpret_cast<const uint8_t*>(data), strlen(data)));
+  ASSERT_OK(file_->Write(data, strlen(data)));
   ASSERT_OK(file_->Close());
 
   ASSERT_OK(FileOutputStream::Open(path_, &file_));
@@ -583,8 +583,7 @@ TEST_F(TestMemoryMappedFile, ThreadSafety) {
 
   std::shared_ptr<MemoryMappedFile> file;
   ASSERT_OK(MemoryMappedFile::Open(path, FileMode::READWRITE, &file));
-  ASSERT_OK(file->Write(reinterpret_cast<const uint8_t*>(data.c_str()),
-                        static_cast<int64_t>(data.size())));
+  ASSERT_OK(file->Write(data.c_str(), static_cast<int64_t>(data.size())));
 
   std::atomic<int> correct_count(0);
   constexpr int niter = 10000;

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -93,7 +93,7 @@ TEST(TestFixedSizeBufferWriter, Basics) {
 
   std::string data = "data123456";
   auto nbytes = static_cast<int64_t>(data.size());
-  ASSERT_OK(writer.Write(reinterpret_cast<const uint8_t*>(data.c_str()), nbytes));
+  ASSERT_OK(writer.Write(data.c_str(), nbytes));
 
   ASSERT_OK(writer.Tell(&position));
   ASSERT_EQ(nbytes, position);

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -48,7 +48,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   // Implement the OutputStream interface
   Status Close() override;
   Status Tell(int64_t* position) const override;
-  Status Write(const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
 
   /// Close the stream and return the buffer
   Status Finish(std::shared_ptr<Buffer>* result);
@@ -72,7 +72,7 @@ class ARROW_EXPORT MockOutputStream : public OutputStream {
   // Implement the OutputStream interface
   Status Close() override;
   Status Tell(int64_t* position) const override;
-  Status Write(const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
 
   int64_t GetExtentBytesWritten() const { return extent_bytes_written_; }
 
@@ -90,8 +90,8 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
   Status Close() override;
   Status Seek(int64_t position) override;
   Status Tell(int64_t* position) const override;
-  Status Write(const uint8_t* data, int64_t nbytes) override;
-  Status WriteAt(int64_t position, const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
+  Status WriteAt(int64_t position, const void* data, int64_t nbytes) override;
 
   void set_memcopy_threads(int num_threads);
   void set_memcopy_blocksize(int64_t blocksize);
@@ -111,12 +111,12 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
 
   Status Close() override;
   Status Tell(int64_t* position) const override;
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* buffer) override;
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
 
   // Zero copy read
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                uint8_t* out) override;
+                void* out) override;
 
   /// Default implementation is thread-safe
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -523,10 +523,8 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
     uint32_t buffer_size = static_cast<uint32_t>(bytes_written);
 
     // Footer: metadata length, magic bytes
-    RETURN_NOT_OK(
-        stream_->Write(reinterpret_cast<const uint8_t*>(&buffer_size), sizeof(uint32_t)));
-    return stream_->Write(reinterpret_cast<const uint8_t*>(kFeatherMagicBytes),
-                          strlen(kFeatherMagicBytes));
+    RETURN_NOT_OK(stream_->Write(&buffer_size, sizeof(uint32_t)));
+    return stream_->Write(kFeatherMagicBytes, strlen(kFeatherMagicBytes));
   }
 
   Status LoadArrayMetadata(const Array& values, ArrayMetadata* meta) {

--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -119,8 +119,7 @@ static Status ConvertArrowToJson(const std::string& arrow_path,
 
   std::string result;
   RETURN_NOT_OK(writer->Finish(&result));
-  return out_file->Write(reinterpret_cast<const uint8_t*>(result.c_str()),
-                         static_cast<int64_t>(result.size()));
+  return out_file->Write(result.c_str(), static_cast<int64_t>(result.size()));
 }
 
 static Status ValidateArrowVsJson(const std::string& arrow_path,
@@ -250,8 +249,7 @@ class TestJSONIntegration : public ::testing::Test {
     do {
       std::shared_ptr<io::FileOutputStream> out;
       RETURN_NOT_OK(io::FileOutputStream::Open(path, &out));
-      RETURN_NOT_OK(out->Write(reinterpret_cast<const uint8_t*>(data),
-                               static_cast<int64_t>(strlen(data))));
+      RETURN_NOT_OK(out->Write(data, static_cast<int64_t>(strlen(data))));
     } while (0);
     return Status::OK();
   }

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -945,8 +945,7 @@ Status WriteMessage(const Buffer& message, io::OutputStream* file,
 
   // Write the flatbuffer size prefix including padding
   int32_t flatbuffer_size = padded_message_length - 4;
-  RETURN_NOT_OK(
-      file->Write(reinterpret_cast<const uint8_t*>(&flatbuffer_size), sizeof(int32_t)));
+  RETURN_NOT_OK(file->Write(&flatbuffer_size, sizeof(int32_t)));
 
   // Write the flatbuffer
   RETURN_NOT_OK(file->Write(message.data(), message.size()));

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -687,7 +687,7 @@ class StreamBookKeeper {
   }
 
   // Write data and update position
-  Status Write(const uint8_t* data, int64_t nbytes) {
+  Status Write(const void* data, int64_t nbytes) {
     RETURN_NOT_OK(sink_->Write(data, nbytes));
     position_ += nbytes;
     return Status::OK();
@@ -776,7 +776,7 @@ class RecordBatchStreamWriter::RecordBatchStreamWriterImpl : public StreamBookKe
 
     // Write 0 EOS message
     const int32_t kEos = 0;
-    return Write(reinterpret_cast<const uint8_t*>(&kEos), sizeof(int32_t));
+    return Write(&kEos, sizeof(int32_t));
   }
 
   Status CheckStarted() {
@@ -864,8 +864,7 @@ class RecordBatchFileWriter::RecordBatchFileWriterImpl
 
   Status Start() override {
     // It is only necessary to align to 8-byte boundary at the start of the file
-    RETURN_NOT_OK(Write(reinterpret_cast<const uint8_t*>(kArrowMagicBytes),
-                        strlen(kArrowMagicBytes)));
+    RETURN_NOT_OK(Write(kArrowMagicBytes, strlen(kArrowMagicBytes)));
     RETURN_NOT_OK(Align());
 
     // We write the schema at the start of the file (and the end). This also
@@ -889,12 +888,10 @@ class RecordBatchFileWriter::RecordBatchFileWriterImpl
       return Status::Invalid("Invalid file footer");
     }
 
-    RETURN_NOT_OK(
-        Write(reinterpret_cast<const uint8_t*>(&footer_length), sizeof(int32_t)));
+    RETURN_NOT_OK(Write(&footer_length, sizeof(int32_t)));
 
     // Write magic bytes to end file
-    return Write(reinterpret_cast<const uint8_t*>(kArrowMagicBytes),
-                 strlen(kArrowMagicBytes));
+    return Write(kArrowMagicBytes, strlen(kArrowMagicBytes));
   }
 };
 

--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -76,7 +76,7 @@ class PythonFile {
     return Status::OK();
   }
 
-  Status Write(const uint8_t* data, int64_t nbytes) {
+  Status Write(const void* data, int64_t nbytes) {
     PyObject* py_data =
         PyBytes_FromStringAndSize(reinterpret_cast<const char*>(data), nbytes);
     PY_RETURN_IF_ERROR(StatusCode::IOError);
@@ -130,7 +130,7 @@ Status PyReadableFile::Tell(int64_t* position) const {
   return file_->Tell(position);
 }
 
-Status PyReadableFile::Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) {
+Status PyReadableFile::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
   PyAcquireGIL lock;
   PyObject* bytes_obj;
   ARROW_RETURN_NOT_OK(file_->Read(nbytes, &bytes_obj));
@@ -155,7 +155,7 @@ Status PyReadableFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
 }
 
 Status PyReadableFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                              uint8_t* out) {
+                              void* out) {
   std::lock_guard<std::mutex> guard(file_->lock());
   RETURN_NOT_OK(Seek(position));
   return Read(nbytes, bytes_read, out);
@@ -208,7 +208,7 @@ Status PyOutputStream::Tell(int64_t* position) const {
   return Status::OK();
 }
 
-Status PyOutputStream::Write(const uint8_t* data, int64_t nbytes) {
+Status PyOutputStream::Write(const void* data, int64_t nbytes) {
   PyAcquireGIL lock;
   position_ += nbytes;
   return file_->Write(data, nbytes);

--- a/cpp/src/arrow/python/io.h
+++ b/cpp/src/arrow/python/io.h
@@ -41,12 +41,12 @@ class ARROW_EXPORT PyReadableFile : public io::RandomAccessFile {
 
   Status Close() override;
 
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override;
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   // Thread-safe version
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                uint8_t* out) override;
+                void* out) override;
 
   // Thread-safe version
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
@@ -70,7 +70,7 @@ class ARROW_EXPORT PyOutputStream : public io::OutputStream {
 
   Status Close() override;
   Status Tell(int64_t* position) const override;
-  Status Write(const uint8_t* data, int64_t nbytes) override;
+  Status Write(const void* data, int64_t nbytes) override;
 
  private:
   std::unique_ptr<PythonFile> file_;

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -40,7 +40,7 @@ class StdoutStream : public OutputStream {
     return Status::OK();
   }
 
-  Status Write(const uint8_t* data, int64_t nbytes) override {
+  Status Write(const void* data, int64_t nbytes) override {
     pos_ += nbytes;
     std::cout.write(reinterpret_cast<const char*>(data), nbytes);
     return Status::OK();
@@ -63,7 +63,7 @@ class StdinStream : public InputStream {
     return Status::OK();
   }
 
-  Status Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out) override {
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override {
     std::cin.read(reinterpret_cast<char*>(out), nbytes);
     if (std::cin) {
       *bytes_read = nbytes;


### PR DESCRIPTION
This makes for a more convenient / less rigid API without as need for as many usages of `reinterpret_cast<const uint8_t*>`. This does not impact downstream projects (e.g. parquet-cpp is unaffected) unless they provide implementations of these virtual interfaces. 