### PR TITLE
ARROW-1869: [JAVA] Fix LowCostIdentityHashMap name

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -76,7 +76,7 @@ public class AllocationManager {
   private final UnsafeDirectLittleEndian underlying;
   // ARROW-1627 Trying to minimize memory overhead caused by previously used IdentityHashMap
   // see JIRA for details
-  private final LowCostIdentityHasMap<BaseAllocator, BufferLedger> map = new LowCostIdentityHasMap<>();
+  private final LowCostIdentityHashMap<BaseAllocator, BufferLedger> map = new LowCostIdentityHashMap<>();
   private final ReadWriteLock lock = new ReentrantReadWriteLock();
   private final AutoCloseableLock readLock = new AutoCloseableLock(lock.readLock());
   private final AutoCloseableLock writeLock = new AutoCloseableLock(lock.writeLock());

--- a/java/memory/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
@@ -28,7 +28,7 @@ import com.google.common.base.Preconditions;
  * that provides "getKey" method
  * @param <V>
  */
-public class LowCostIdentityHasMap<K, V extends ValueWithKeyIncluded<K>> {
+public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
 
   /*
    * The internal data structure to hold values.
@@ -52,7 +52,7 @@ public class LowCostIdentityHasMap<K, V extends ValueWithKeyIncluded<K>> {
   /**
    * Creates an Map with default expected maximum size.
    */
-  public LowCostIdentityHasMap() {
+  public LowCostIdentityHashMap() {
     this(DEFAULT_MIN_SIZE);
   }
 
@@ -63,7 +63,7 @@ public class LowCostIdentityHasMap<K, V extends ValueWithKeyIncluded<K>> {
    *            The estimated maximum number of entries that will be put in
    *            this map.
    */
-  public LowCostIdentityHasMap(int maxSize) {
+  public LowCostIdentityHashMap(int maxSize) {
     if (maxSize >= 0) {
       this.size = 0;
       threshold = getThreshold(maxSize);
@@ -96,7 +96,7 @@ public class LowCostIdentityHasMap<K, V extends ValueWithKeyIncluded<K>> {
   private Object[] newElementArray(int s) {
     return new Object[s];
   }
-  
+
   /**
    * Removes all elements from this map, leaving it empty.
    *

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestLowCostIdentityHashMap.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestLowCostIdentityHashMap.java
@@ -27,11 +27,11 @@ import org.junit.Test;
 /**
  * To test simplified implementation of IdentityHashMap
  */
-public class TestLowCostIdentityHasMap {
+public class TestLowCostIdentityHashMap {
 
   @Test
   public void testIdentityHashMap() throws Exception {
-    LowCostIdentityHasMap<String, StringWithKey> hashMap = new LowCostIdentityHasMap<>();
+    LowCostIdentityHashMap<String, StringWithKey> hashMap = new LowCostIdentityHashMap<>();
 
     StringWithKey obj1 = new StringWithKey("s1key", "s1value");
     StringWithKey obj2 = new StringWithKey("s2key", "s2value");
@@ -88,7 +88,7 @@ public class TestLowCostIdentityHasMap {
 
   @Test
   public void testLargeMap() throws Exception {
-    LowCostIdentityHasMap<String, StringWithKey> hashMap = new LowCostIdentityHasMap<>();
+    LowCostIdentityHashMap<String, StringWithKey> hashMap = new LowCostIdentityHashMap<>();
 
     String [] keys = new String[200];
     for (int i = 0; i < 200; i++) {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/ARROW-1869

This PR fixes spelling error in class name for `LowCostIdentityHashMap`.
Follow-up for https://github.com/apache/arrow/pull/1150.