### PR TITLE
ARROW-1817: [Java] Configure JsonReader to read floating point NaN values

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -69,6 +69,8 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
     this.allocator = allocator;
     MappingJsonFactory jsonFactory = new MappingJsonFactory();
     this.parser = jsonFactory.createParser(inputFile);
+    // Allow for reading "NaN" for floating point values
+    this.parser.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -69,7 +69,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
     this.allocator = allocator;
     MappingJsonFactory jsonFactory = new MappingJsonFactory();
     this.parser = jsonFactory.createParser(inputFile);
-    // Allow for reading "NaN" for floating point values
+    // Allow reading NaN for floating point values
     this.parser.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -84,6 +84,8 @@ public class JsonFileWriter implements AutoCloseable {
       prettyPrinter.indentArraysWith(NopIndenter.instance);
       this.generator.setPrettyPrinter(prettyPrinter);
     }
+    // Allow writing of floating point NaN values not as strings
+    this.generator.configure(JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS, false);
   }
 
   public void start(Schema schema, DictionaryProvider provider) throws IOException {

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -47,6 +47,7 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
 import org.apache.arrow.vector.complex.writer.BigIntWriter;
 import org.apache.arrow.vector.complex.writer.DateMilliWriter;
+import org.apache.arrow.vector.complex.writer.Float4Writer;
 import org.apache.arrow.vector.complex.writer.IntWriter;
 import org.apache.arrow.vector.complex.writer.TimeMilliWriter;
 import org.apache.arrow.vector.complex.writer.TimeStampMilliTZWriter;
@@ -95,10 +96,28 @@ public class BaseFileTest {
     DateTimeZone.setDefault(defaultTimezone);
   }
 
+  protected void writeData(int count, MapVector parent) {
+    ComplexWriter writer = new ComplexWriterImpl("root", parent);
+    MapWriter rootWriter = writer.rootAsMap();
+    IntWriter intWriter = rootWriter.integer("int");
+    BigIntWriter bigIntWriter = rootWriter.bigInt("bigInt");
+    Float4Writer float4Writer = rootWriter.float4("float");
+    for (int i = 0; i < count; i++) {
+      intWriter.setPosition(i);
+      intWriter.writeInt(i);
+      bigIntWriter.setPosition(i);
+      bigIntWriter.writeBigInt(i);
+      float4Writer.setPosition(i);
+      float4Writer.writeFloat4(i == 0 ? Float.NaN : i);
+    }
+    writer.setValueCount(count);
+  }
+
   protected void validateContent(int count, VectorSchemaRoot root) {
     for (int i = 0; i < count; i++) {
       Assert.assertEquals(i, root.getVector("int").getObject(i));
       Assert.assertEquals(Long.valueOf(i), root.getVector("bigInt").getObject(i));
+      Assert.assertEquals(i == 0 ? Float.NaN : i, root.getVector("float").getObject(i));
     }
   }
 
@@ -452,20 +471,6 @@ public class BaseFileTest {
       genValue = new BigDecimal(BigInteger.valueOf(i * 1111111111111111L), type.getScale());
       Assert.assertEquals(genValue, readValue);
     }
-  }
-
-  protected void writeData(int count, MapVector parent) {
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    MapWriter rootWriter = writer.rootAsMap();
-    IntWriter intWriter = rootWriter.integer("int");
-    BigIntWriter bigIntWriter = rootWriter.bigInt("bigInt");
-    for (int i = 0; i < count; i++) {
-      intWriter.setPosition(i);
-      intWriter.writeInt(i);
-      bigIntWriter.setPosition(i);
-      bigIntWriter.writeBigInt(i);
-    }
-    writer.setValueCount(count);
   }
 
   public void validateUnionData(int count, VectorSchemaRoot root) {


### PR DESCRIPTION
The last upgrade of the Jackson JSON library changed behavior to no longer allow reading of "NaN" values  by default.  This change configures the JSON generator and parser to allow for NaN values (unquoted) alongside standard floating point numbers.  A test was added for JSON writing/reading and modified the test for Arrow file and stream .