### PR TITLE
ARROW-1864: [Java] Upgrade Netty to 4.1.17

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -516,6 +516,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return Float.intBitsToFloat(getInt(index));
   }
 
+  /**
+   * Gets a 64-bit long integer at the specified absolute {@code index} in
+   * this buffer in Big Endian Byte Order.
+   */
   @Override
   public long getLongLE(int index) {
     chk(index, 8);
@@ -545,6 +549,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return v;
   }
 
+  /**
+   * Gets a 32-bit integer at the specified absolute {@code index} in
+   * this buffer in Big Endian Byte Order.
+   */
   @Override
   public int getIntLE(int index) {
     chk(index, 4);
@@ -564,12 +572,20 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return v;
   }
 
+  /**
+   * Gets a 16-bit short integer at the specified absolute {@code index} in
+   * this buffer in Big Endian Byte Order.
+   */
   @Override
   public short getShortLE(int index) {
     final short v = PlatformDependent.getShort(addr(index));
     return Short.reverseBytes(v);
   }
 
+  /**
+   * Gets an unsigned 24-bit medium integer at the specified absolute
+   * {@code index} in this buffer.
+   */
   @Override
   public int getUnsignedMedium(int index) {
     chk(index, 3);
@@ -578,6 +594,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
         (PlatformDependent.getShort(addr + 1) & 0xffff);
   }
 
+  /**
+   * Gets an unsigned 24-bit medium integer at the specified absolute {@code index} in
+   * this buffer in Big Endian Byte Order.
+   */
   @Override
   public int getUnsignedMediumLE(int index) {
     chk(index, 3);
@@ -593,6 +613,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
+  /**
+   * Sets the specified 16-bit short integer at the specified absolute {@code index}
+   * in this buffer with Big Endian byte order.
+   */
   @Override
   public ByteBuf setShortLE(int index, int value) {
     chk(index, 2);
@@ -600,6 +624,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
+  /**
+   * Sets the specified 24-bit medium integer at the specified absolute
+   * {@code index} in this buffer.
+   */
   @Override
   public ByteBuf setMedium(int index, int value) {
     chk(index, 3);
@@ -609,6 +637,11 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
+
+  /**
+   * Sets the specified 24-bit medium integer at the specified absolute {@code index}
+   * in this buffer with Big Endian byte order.
+   */
   @Override
   public ByteBuf setMediumLE(int index, int value) {
     chk(index, 3);
@@ -625,6 +658,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
+  /**
+   * Sets the specified 32-bit integer at the specified absolute {@code index}
+   * in this buffer with Big Endian byte order.
+   */
   @Override
   public ByteBuf setIntLE(int index, int value) {
     chk(index, 4);
@@ -639,6 +676,10 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
+  /**
+   * Sets the specified 64-bit long integer at the specified absolute {@code index}
+   * in this buffer with Big Endian byte order.
+   */
   @Override
   public ByteBuf setLongLE(int index, long value) {
     chk(index, 8);
@@ -754,6 +795,7 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return getShort(index);
   }
 
+  /** @see  {@link #getShortLE(int)} */
   @Override
   protected short _getShortLE(int index) {
     return getShortLE(index);
@@ -764,16 +806,19 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return getInt(index);
   }
 
+  /** @see  {@link #getIntLE(int)} */
   @Override
   protected int _getIntLE(int index) {
     return getIntLE(index);
   }
 
+  /** @see  {@link #getUnsignedMedium(int)} */
   @Override
   protected int _getUnsignedMedium(int index) {
     return getUnsignedMedium(index);
   }
 
+  /** @see  {@link #getUnsignedMediumLE(int)} */
   @Override
   protected int _getUnsignedMediumLE(int index) {
     return getUnsignedMediumLE(index);
@@ -784,6 +829,7 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return getLong(index);
   }
 
+  /** @see  {@link #getLongLE(int)} */
   @Override
   protected long _getLongLE(int index) {
     return getLongLE(index);
@@ -799,6 +845,7 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     setShort(index, value);
   }
 
+  /** @see  {@link #setShortLE(int, int)} */
   @Override
   protected void _setShortLE(int index, int value) {
     setShortLE(index, value);
@@ -809,6 +856,7 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     setMedium(index, value);
   }
 
+  /** @see  {@link #setMediumLE(int, int)} */
   @Override
   protected void _setMediumLE(int index, int value) {
     setMediumLE(index, value);
@@ -819,6 +867,7 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     setInt(index, value);
   }
 
+  /** @see  {@link #setIntLE(int, int)} */
   @Override
   protected void _setIntLE(int index, int value) {
     setIntLE(index, value);
@@ -829,6 +878,7 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     setLong(index, value);
   }
 
+  /** @see  {@link #setLongLE(int, long)} */
   @Override
   public void _setLongLE(int index, long value) {
     setLongLE(index, value);

--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -512,10 +512,30 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   @Override
+  public float getFloat(int index) {
+    return Float.intBitsToFloat(getInt(index));
+  }
+
+  @Override
   public long getLongLE(int index) {
     chk(index, 8);
     final long v = PlatformDependent.getLong(addr(index));
     return Long.reverseBytes(v);
+  }
+
+  @Override
+  public double getDouble(int index) {
+    return Double.longBitsToDouble(getLong(index));
+  }
+
+  @Override
+  public char getChar(int index) {
+    return (char) getShort(index);
+  }
+
+  @Override
+  public long getUnsignedInt(int index) {
+    return getInt(index) & 0xFFFFFFFFL;
   }
 
   @Override
@@ -530,6 +550,11 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
     chk(index, 4);
     final int v = PlatformDependent.getInt(addr(index));
     return Integer.reverseBytes(v);
+  }
+
+  @Override
+  public int getUnsignedShort(int index) {
+    return getShort(index) & 0xFFFF;
   }
 
   @Override
@@ -622,6 +647,27 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
   }
 
   @Override
+  public ArrowBuf setChar(int index, int value) {
+    chk(index, 2);
+    PlatformDependent.putShort(addr(index), (short) value);
+    return this;
+  }
+
+  @Override
+  public ArrowBuf setFloat(int index, float value) {
+    chk(index, 4);
+    PlatformDependent.putInt(addr(index), Float.floatToRawIntBits(value));
+    return this;
+  }
+
+  @Override
+  public ArrowBuf setDouble(int index, double value) {
+    chk(index, 8);
+    PlatformDependent.putLong(addr(index), Double.doubleToRawLongBits(value));
+    return this;
+  }
+
+  @Override
   public ArrowBuf writeShort(int value) {
     ensure(2);
     PlatformDependent.putShort(addr(writerIndex), (short) value);
@@ -641,6 +687,30 @@ public final class ArrowBuf extends AbstractByteBuf implements AutoCloseable {
   public ArrowBuf writeLong(long value) {
     ensure(8);
     PlatformDependent.putLong(addr(writerIndex), value);
+    writerIndex += 8;
+    return this;
+  }
+
+  @Override
+  public ArrowBuf writeChar(int value) {
+    ensure(2);
+    PlatformDependent.putShort(addr(writerIndex), (short) value);
+    writerIndex += 2;
+    return this;
+  }
+
+  @Override
+  public ArrowBuf writeFloat(float value) {
+    ensure(4);
+    PlatformDependent.putInt(addr(writerIndex), Float.floatToRawIntBits(value));
+    writerIndex += 4;
+    return this;
+  }
+
+  @Override
+  public ArrowBuf writeDouble(double value) {
+    ensure(8);
+    PlatformDependent.putLong(addr(writerIndex), Double.doubleToRawLongBits(value));
     writerIndex += 8;
     return this;
   }

--- a/java/memory/src/main/java/io/netty/buffer/MutableWrappedByteBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/MutableWrappedByteBuf.java
@@ -23,8 +23,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
+
+import io.netty.util.ByteProcessor;
 
 /**
  * This is basically a complete copy of DuplicatedByteBuf. We copy because we want to override
@@ -129,6 +132,16 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  public short getShortLE(int index) {
+    return buffer.getShortLE(index);
+  }
+
+  @Override
+  protected short _getShortLE(int index) {
+    return buffer.getShortLE(index);
+  }
+
+  @Override
   public int getUnsignedMedium(int index) {
     return _getUnsignedMedium(index);
   }
@@ -136,6 +149,16 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected int _getUnsignedMedium(int index) {
     return buffer.getUnsignedMedium(index);
+  }
+
+  @Override
+  public int getUnsignedMediumLE(int index) {
+    return buffer.getUnsignedMediumLE(index);
+  }
+
+  @Override
+  protected int _getUnsignedMediumLE(int index) {
+    return buffer.getUnsignedMediumLE(index);
   }
 
   @Override
@@ -149,6 +172,16 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  public int getIntLE(int index) {
+    return buffer.getIntLE(index);
+  }
+
+  @Override
+  protected int _getIntLE(int index) {
+    return buffer.getIntLE(index);
+  }
+
+  @Override
   public long getLong(int index) {
     return _getLong(index);
   }
@@ -156,6 +189,16 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected long _getLong(int index) {
     return buffer.getLong(index);
+  }
+
+  @Override
+  public long getLongLE(int index) {
+    return buffer.getLongLE(index);
+  }
+
+  @Override
+  protected long _getLongLE(int index) {
+    return buffer.getLongLE(index);
   }
 
   @Override
@@ -207,6 +250,17 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  public ByteBuf setShortLE(int index, int value) {
+    buffer.setShortLE(index, value);
+    return this;
+  }
+
+  @Override
+  protected void _setShortLE(int index, int value) {
+    buffer.setShortLE(index, value);
+  }
+
+  @Override
   public ByteBuf setMedium(int index, int value) {
     _setMedium(index, value);
     return this;
@@ -215,6 +269,17 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected void _setMedium(int index, int value) {
     buffer.setMedium(index, value);
+  }
+
+  @Override
+  public ByteBuf setMediumLE(int index, int value) {
+    buffer.setMediumLE(index, value);
+    return this;
+  }
+
+  @Override
+  protected void _setMediumLE(int index, int value) {
+    buffer.setMediumLE(index, value);
   }
 
   @Override
@@ -229,6 +294,17 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
+  public ByteBuf setIntLE(int index, int value) {
+    buffer.setIntLE(index, value);
+    return this;
+  }
+
+  @Override
+  protected void _setIntLE(int index, int value) {
+    buffer.setIntLE(index, value);
+  }
+
+  @Override
   public ByteBuf setLong(int index, long value) {
     _setLong(index, value);
     return this;
@@ -237,6 +313,17 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   @Override
   protected void _setLong(int index, long value) {
     buffer.setLong(index, value);
+  }
+
+  @Override
+  public ByteBuf setLongLE(int index, long value) {
+    buffer.setLongLE(index, value);
+    return this;
+  }
+
+  @Override
+  protected void _setLongLE(int index, long value) {
+    buffer.setLongLE(index, value);
   }
 
   @Override
@@ -255,6 +342,12 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   public ByteBuf setBytes(int index, ByteBuffer src) {
     buffer.setBytes(index, src);
     return this;
+  }
+
+  @Override
+  public int setBytes(int index, FileChannel in, long position, int length)
+      throws IOException {
+    return buffer.setBytes(index, in, position, length);
   }
 
   @Override
@@ -282,6 +375,13 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
     return buffer.setBytes(index, in, length);
   }
 
+
+  @Override
+  public int getBytes(int index, FileChannel out, long position, int length)
+      throws IOException {
+    return buffer.getBytes(index, out, position, length);
+  }
+
   @Override
   public int nioBufferCount() {
     return buffer.nioBufferCount();
@@ -298,18 +398,30 @@ abstract class MutableWrappedByteBuf extends AbstractByteBuf {
   }
 
   @Override
-  public int forEachByte(int index, int length, ByteBufProcessor processor) {
+  public int forEachByte(int index, int length, ByteProcessor processor) {
     return buffer.forEachByte(index, length, processor);
   }
 
   @Override
-  public int forEachByteDesc(int index, int length, ByteBufProcessor processor) {
+  public int forEachByteDesc(int index, int length, ByteProcessor processor) {
     return buffer.forEachByteDesc(index, length, processor);
   }
 
   @Override
   public final int refCnt() {
     return unwrap().refCnt();
+  }
+
+  @Override
+  public final ByteBuf touch() {
+    unwrap().touch();
+    return this;
+  }
+
+  @Override
+  public final ByteBuf touch(Object hint) {
+    unwrap().touch(hint);
+    return this;
   }
 
   @Override

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
@@ -147,6 +147,12 @@ public class ArrowByteBufAllocator implements ByteBufAllocator {
     throw new UnsupportedOperationException("Allocator doesn't support heap-based memory.");
   }
 
+  /**
+   * This method was copied from AbstractByteBufAllocator. Netty 4.1.x moved this method from
+   * AbstractByteBuf to AbstractByteBufAllocator. However, as ArrowByteBufAllocator doesn't extend
+   * AbstractByteBufAllocator, it doesn't get the implementation automatically and we have to copy
+   * the codes.
+   */
   @Override
   public int calculateNewCapacity(int minNewCapacity, int maxCapacity) {
     if (minNewCapacity < 0) {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,7 +32,7 @@
     <dep.junit.version>4.11</dep.junit.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava.version>18.0</dep.guava.version>
-    <dep.netty.version>4.0.49.Final</dep.netty.version>
+    <dep.netty.version>4.1.17.Final</dep.netty.version>
     <dep.jackson.version>2.7.9</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <fbs.version>1.2.0-3f79e055</fbs.version>

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
@@ -134,9 +134,9 @@ public class MapWithOrdinal<K, V> implements Map<K, V> {
 
     @Override
     public Collection<V> values() {
-      return Lists.newArrayList(Iterables.transform(secondary.entries(), new Function<IntObjectMap.Entry<V>, V>() {
+      return Lists.newArrayList(Iterables.transform(secondary.entries(), new Function<IntObjectMap.PrimitiveEntry<V>, V>() {
         @Override
-        public V apply(IntObjectMap.Entry<V> entry) {
+        public V apply(IntObjectMap.PrimitiveEntry<V> entry) {
           return Preconditions.checkNotNull(entry).value();
         }
       }));


### PR DESCRIPTION
Upgrade Netty to 4.1.17 since the Netty community will deprecate 4.0.x soon. This PR includes the following changes:
- Bump Netty version.
- Implement new ByteBuf APIs added in Netty 4.1.x: a bunch of get/setXXXLE methods. They are the opposite of get/setXXX method regarding byte order. E.g., as ArrowBuf is little endian, `setInt` will put an `int` to the buffer in little endian byte order, while `setIntLE` will put `int` in big byte endian order. The method naming seems confusing anyway, and I opened a Netty issue: https://github.com/netty/netty/issues/7465. The user can call these new methods to get or set multi-byte integers in big endian byte order.
- Make ArrowByteBufAllocator overwrite AbstractByteBufAllocator.