### PR TITLE
ARROW-1877: [Java] Fix incorrect equals method in JsonStringArrayList

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringArrayList.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringArrayList.java
@@ -19,7 +19,6 @@
 package org.apache.arrow.vector.util;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,21 +37,6 @@ public class JsonStringArrayList<E> extends ArrayList<E> {
 
   public JsonStringArrayList(int size) {
     super(size);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (!(obj instanceof List)) {
-      return false;
-    }
-    List<?> other = (List<?>) obj;
-    return this.size() == other.size() && this.containsAll(other);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringHashMap.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringHashMap.java
@@ -19,7 +19,6 @@
 package org.apache.arrow.vector.util;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,36 +33,6 @@ public class JsonStringHashMap<K, V> extends LinkedHashMap<K, V> {
 
   static {
     mapper = new ObjectMapper();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (!(obj instanceof Map)) {
-      return false;
-    }
-    Map<?, ?> other = (Map<?, ?>) obj;
-    if (this.size() != other.size()) {
-      return false;
-    }
-    for (K key : this.keySet()) {
-      if (this.get(key) == null) {
-        if (other.get(key) == null) {
-          continue;
-        } else {
-          return false;
-        }
-      }
-      if (!this.get(key).equals(other.get(key))) {
-        return false;
-      }
-    }
-    return true;
   }
 
   @Override


### PR DESCRIPTION
Currently it uses containsAll which could return wrong results.
Ex. e1: [true, true, false], e2: [true, false, false].

Remove the equals method and fallback to super class method
which has the correct implementation.