### PR TITLE
ARROW-1867: [Java] Add missing methods to BitVector from legacy vector class

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -198,4 +198,18 @@ public class BitVectorHelper {
 
     return newBuffer;
   }
+
+  /**
+   * Set the byte of the given index in the data buffer by applying a bit mask to
+   * the current byte at that index.
+   *
+   * @param data
+   * @param byteIndex
+   * @param bitMask
+   */
+  static void setBitMaskedByte(ArrowBuf data, int byteIndex, byte bitMask) {
+    byte currentByte = data.getByte(byteIndex);
+    currentByte |= bitMask;
+    data.setByte(byteIndex, currentByte);
+  }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVector.java
@@ -232,7 +232,7 @@ public class TestBitVector {
 
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
-          vector.set(i, 1);
+          vector.setToOne(i);
         }
       }
 
@@ -246,12 +246,12 @@ public class TestBitVector {
       }
 
       /* trigger first realloc */
-      vector.setSafe(valueCapacity, 1);
+      vector.setSafeToOne(valueCapacity);
       assertEquals(valueCapacity * 2, vector.getValueCapacity());
 
       for (int i = valueCapacity; i < valueCapacity*2; i++) {
         if ((i & 1) == 1) {
-          vector.set(i, 1);
+          vector.setToOne(i);
         }
       }
 
@@ -265,12 +265,12 @@ public class TestBitVector {
       }
 
       /* trigger second realloc */
-      vector.setSafe(valueCapacity*2, 1);
+      vector.setSafeToOne(valueCapacity*2);
       assertEquals(valueCapacity * 4, vector.getValueCapacity());
 
       for (int i = valueCapacity*2; i < valueCapacity*4; i++) {
         if ((i & 1) == 1) {
-          vector.set(i, 1);
+          vector.setToOne(i);
         }
       }
 
@@ -291,7 +291,7 @@ public class TestBitVector {
       assertEquals(valueCapacity * 4, toVector.getValueCapacity());
 
       /* realloc the toVector */
-      toVector.setSafe(valueCapacity * 4, 1);
+      toVector.setSafeToOne(valueCapacity * 4);
 
       for (int i = 0; i < toVector.getValueCapacity(); i++) {
         if (i <= valueCapacity * 4) {
@@ -505,9 +505,7 @@ public class TestBitVector {
     try (BitVector bitVector = new BitVector("bits", allocator)) {
       bitVector.reset();
       bitVector.allocateNew(length);
-      for (int i = start; i < start + count; i++) {
-        bitVector.set(i, 1);
-      }
+      bitVector.setRangeToOne(start, count);
       for (int i = 0; i < start; i++) {
         Assert.assertTrue(desc + i, bitVector.isNull(i));
       }


### PR DESCRIPTION
After the ValueVector refactor, the BitVector class was missing the methods setToOne and setRangeToOne from the legacy vector class.  This PR adds them back and restores the BItVector tests to use these APIs.