### PR TITLE
ARROW-1909: [C++] Enables building with benchmarks on windows

### DIFF
--- a/cpp/src/arrow/compute/compute-benchmark.cc
+++ b/cpp/src/arrow/compute/compute-benchmark.cc
@@ -191,7 +191,7 @@ static void BM_UniqueString100bytes(benchmark::State& state) {
 BENCHMARK(BM_BuildDictionary)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_BuildStringDictionary)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
 
-constexpr int64_t kHashBenchmarkLength = 1 << 24;
+constexpr int kHashBenchmarkLength = 1 << 24;
 
 #define ADD_HASH_ARGS(WHAT)                        \
   WHAT->Args({kHashBenchmarkLength, 50})           \

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -57,6 +57,11 @@ if (ARROW_BUILD_BENCHMARKS)
     target_link_libraries(arrow_benchmark_main
       benchmark
     )
+  elseif(MSVC)
+    target_link_libraries(arrow_benchmark_main
+      benchmark
+      Shlwapi.lib
+  )
   else()
 	  target_link_libraries(arrow_benchmark_main
       benchmark


### PR DESCRIPTION
These changes were necessary to compile on Windows with "-DARROW_BUILD_BENCHMARKS=ON".  I added Shwlapi based on https://github.com/google/benchmark/issues/202.