### PR TITLE
ARROW-1754: [Python] alternative fix for duplicate index/column name that preserves index name if available

### DIFF
--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -191,8 +191,9 @@ class TestPandasConversion(object):
         assert idx0['field_name'] == idx0_name
         assert idx0['name'] is None
 
-        assert foo_name == '__index_level_1__'
-        assert foo['name'] == 'foo'
+        assert foo_name == 'foo'
+        assert foo['field_name'] == foo_name
+        assert foo['name'] == foo_name
 
     def test_categorical_column_index(self):
         df = pd.DataFrame(


### PR DESCRIPTION
Related to the discussion about the pandas metadata specification in https://github.com/pandas-dev/pandas/pull/18201, and an alternative to https://github.com/apache/arrow/pull/1271.

I don't open this PR because it should necessarily be merged, I just want to show that it is not that difficult to both fix [ARROW-1754](https://issues.apache.org/jira/browse/ARROW-1754) and preserve index names as field names when possible (as this was mentioned in https://github.com/pandas-dev/pandas/pull/18201 as the reason to make this change to not preserve index names). 
The diff is partly a revert of https://github.com/apache/arrow/pull/1271, but then adapted to the current codebase.

Main reasons I prefer to preserve index names: 1) usability in pyarrow itself (if you would want to work with pyarrow Tables created from pandas) and 2) when interchanging parquet files with other people / other non-pandas systems, then it would be much nicer to not have `__index_level_n__` column names if possible.
