### PR TITLE
ARROW-1904: [C++] Deprecate PrimitiveArray::raw_values

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -139,10 +139,14 @@ PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t le
   SetData(ArrayData::Make(type, length, {null_bitmap, data}, null_count, offset));
 }
 
+#ifndef ARROW_NO_DEPRECATED_API
+
 const uint8_t* PrimitiveArray::raw_values() const {
   return raw_values_ +
          offset() * static_cast<const FixedWidthType&>(*type()).bit_width() / CHAR_BIT;
 }
+
+#endif
 
 template <typename T>
 NumericArray<T>::NumericArray(const std::shared_ptr<ArrayData>& data)

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -573,9 +573,7 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
 
   int32_t byte_width() const { return byte_width_; }
 
-  const uint8_t* raw_values() const {
-    return raw_values_ + data_->offset * byte_width_;
-  }
+  const uint8_t* raw_values() const { return raw_values_ + data_->offset * byte_width_; }
 
  protected:
   inline void SetData(const std::shared_ptr<ArrayData>& data) {

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -334,8 +334,14 @@ class ARROW_EXPORT PrimitiveArray : public FlatArray {
   /// Does not account for any slice offset
   std::shared_ptr<Buffer> values() const { return data_->buffers[1]; }
 
+#ifndef ARROW_NO_DEPRECATED_API
+
   /// \brief Return pointer to start of raw data
+  ///
+  /// \note Deprecated since 0.8.0
   const uint8_t* raw_values() const;
+
+#endif
 
  protected:
   PrimitiveArray() {}
@@ -566,6 +572,10 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
   const uint8_t* Value(int64_t i) const { return GetValue(i); }
 
   int32_t byte_width() const { return byte_width_; }
+
+  const uint8_t* raw_values() const {
+    return raw_values_ + data_->offset * byte_width_;
+  }
 
  protected:
   inline void SetData(const std::shared_ptr<ArrayData>& data) {

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -312,8 +312,16 @@ static bool IsEqualPrimitive(const PrimitiveArray& left, const PrimitiveArray& r
   const auto& size_meta = dynamic_cast<const FixedWidthType&>(*left.type());
   const int byte_width = size_meta.bit_width() / CHAR_BIT;
 
-  const uint8_t* left_data = left.values() ? left.raw_values() : nullptr;
-  const uint8_t* right_data = right.values() ? right.raw_values() : nullptr;
+  const uint8_t* left_data = nullptr;
+  const uint8_t* right_data = nullptr;
+
+  if (left.values()) {
+    left_data = left.values()->data() + left.offset() * byte_width;
+  }
+
+  if (right.values()) {
+    right_data = right.values()->data() + right.offset() * byte_width;
+  }
 
   if (left.null_count() > 0) {
     for (int64_t i = 0; i < left.length(); ++i) {


### PR DESCRIPTION
I was mistaken about this method's handling of the offset parameter, but it doesn't work correctly for boolean data (also a subclass of `PrimitiveArray`), so I think it's better to remove this method altogether