### PR TITLE
ARROW-1906: [Python] Do not override user-supplied type in pyarrow.array when converting DatetimeTZ pandas data

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -369,7 +369,8 @@ def get_datetimetz_type(values, dtype, type_):
     if values.dtype.type != np.datetime64:
         return values, type_
 
-    if isinstance(dtype, DatetimeTZDtype):
+    if isinstance(dtype, DatetimeTZDtype) and type_ is None:
+        # If no user type passed, construct a tz-aware timestamp type
         tz = dtype.tz
         unit = dtype.unit
         type_ = pa.timestamp(unit, tz)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -331,7 +331,11 @@ def test_cast_timestamp_unit():
     s_nyc = s.dt.tz_localize('tzlocal()').dt.tz_convert('America/New_York')
 
     us_with_tz = pa.timestamp('us', tz='America/New_York')
+
     arr = pa.Array.from_pandas(s_nyc, type=us_with_tz)
+
+    # ARROW-1906
+    assert arr.type == us_with_tz
 
     arr2 = pa.Array.from_pandas(s, type=pa.timestamp('us'))
 


### PR DESCRIPTION
cc @BryanCutler 