### PR TITLE
ARROW-1911: [JS] Add Graphistry to Arrow JS proof points

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Arrow is a set of technologies that enable big-data systems to process and move 
 Initial implementations include:
 
  - [The Arrow Format](https://github.com/apache/arrow/tree/master/format)
- - [Java implementation](https://github.com/apache/arrow/tree/master/java)
  - [C++ implementation](https://github.com/apache/arrow/tree/master/cpp)
+ - [Java implementation](https://github.com/apache/arrow/tree/master/java)
+ - [JavaScript implementation](https://github.com/apache/arrow/tree/master/js)
  - [Python interface to C++ libraries](https://github.com/apache/arrow/tree/master/python)
- - [JavaScript reader and writer](https://github.com/apache/arrow/tree/master/js)
 
 Arrow is an [Apache Software Foundation](www.apache.org) project. Learn more at
 [arrow.apache.org](http://arrow.apache.org).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Initial implementations include:
  - [Java implementation](https://github.com/apache/arrow/tree/master/java)
  - [C++ implementation](https://github.com/apache/arrow/tree/master/cpp)
  - [Python interface to C++ libraries](https://github.com/apache/arrow/tree/master/python)
+ - [JavaScript reader and writer](https://github.com/apache/arrow/tree/master/js)
 
 Arrow is an [Apache Software Foundation](www.apache.org) project. Learn more at
 [arrow.apache.org](http://arrow.apache.org).

--- a/js/DEVELOP.md
+++ b/js/DEVELOP.md
@@ -17,6 +17,30 @@
   under the License.
 -->
 
+# Getting Involved
+Even if you do not plan to contribute to Apache Arrow itself or Arrow
+integrations in other projects, we'd be happy to have you involved:
+
+* Join the mailing list: send an email to
+  [dev-subscribe@arrow.apache.org][1]. Share your ideas and use cases for the
+  project.
+* [Follow our activity on JIRA][3]
+* [Learn the format][2]
+* Contribute code to one of the reference implementations
+
+We prefer to receive contributions in the form of GitHub pull requests. Please send pull requests against the [github.com/apache/arrow][4] repository.
+
+If you are looking for some ideas on what to contribute, check out the [JIRA
+issues][3] for the Apache Arrow project. Comment on the issue and/or contact
+[dev@arrow.apache.org](http://mail-archives.apache.org/mod_mbox/arrow-dev/)
+with your questions and ideas.
+
+If you’d like to report a bug but don’t have time to fix it, you can still post
+it on JIRA, or email the mailing list
+[dev@arrow.apache.org](http://mail-archives.apache.org/mod_mbox/arrow-dev/)
+
+
+
 # The npm scripts
 
 * `npm run clean` - cleans targets

--- a/js/README.md
+++ b/js/README.md
@@ -22,7 +22,7 @@
 [![Build Status](https://travis-ci.org/apache/arrow.svg?branch=master)](https://travis-ci.org/apache/arrow)
 [![Coverage Status](https://coveralls.io/repos/github/apache/arrow/badge.svg)](https://coveralls.io/github/apache/arrow)
 
-Arrow is a set of technologies that enable big-data systems to process and transfer data quickly.
+Arrow is a set of technologies that enable big data systems to process and transfer data quickly.
 
 ## install [apache-arrow from npm](https://www.npmjs.com/package/apache-arrow)
 
@@ -32,7 +32,7 @@ Arrow is a set of technologies that enable big-data systems to process and trans
 
 # Powering Columnar In-Memory Analytics
 
-Apache Arrow is a columnar memory layout specification for encoding vectors and table-like containers of flat and nested data. The Arrow spec aligns columnar data in memory to minimize cache misses and take advantage of the latest SIMD (Single input multiple data) and GPU operations on modern processors.
+[Apache Arrow](https://github.com/apache/arrow) is a columnar memory layout specification for encoding vectors and table-like containers of flat and nested data. The Arrow spec aligns columnar data in memory to minimize cache misses and take advantage of the latest SIMD (Single input multiple data) and GPU operations on modern processors.
 
 Apache Arrow is the emerging standard for large in-memory columnar data ([Spark](https://spark.apache.org/), [Pandas](http://wesmckinney.com/blog/pandas-and-apache-arrow/), [Drill](https://drill.apache.org/), [Graphistry](https://www.graphistry.com), ...). By standardizing on a common binary interchange format, big data systems can reduce the costs and friction associated with cross-system communication.
 
@@ -197,26 +197,24 @@ The JS community is a diverse group with a varied list of target environments an
 
 If you think we missed a compilation target and it's a blocker for adoption, please open an issue.
 
-# Community
+# People
 
 Full list of broader Apache Arrow [committers](https://arrow.apache.org/committers/) and [projects & organizations](https://github.com/apache/arrow/blob/master/site/powered_by.md).
 
-## Committers
+* Brian Hulette, CCRi,  _contributor_
+* Paul Taylor, Graphistry, Inc.,  _committer_
 
-* Brian Hulette, CCRI
-* Paul Taylor, Graphistry, Inc.
+# Powered By Apache Arrow in JS 
 
 ## Open Source Projects
 
 * [Apache Arrow](https://arrow.apache.org) -- Parent project for Powering Columnar In-Memory Analytics, including affiliated open source projects
 * [rxjs-mapd](https://github.com/graphistry/rxjs-mapd) -- A MapD Core node-driver that returns query results as Arrow columns
 
-
-
 ## Companies & Organizations
 
 * [CCRi](http://www.ccri.com/) -- Commonwealth Computer Research Inc, or CCRi, is a Central Virginia based data science and software engineering company
-* [GoAI](http://gpuopenanalytics.com/) -- Open GPU-Accelerated Analytics Initiative for Arrow-powered analytics across GPU tools and vendors
+* [GOAI](http://gpuopenanalytics.com/) -- GPU Open Analytics Initiative standardizes on Arrow as part of creating common data frameworks that enable developers and statistical researchers to accelerate data science on GPUs
 * [Graphistry, Inc.](https://www.graphistry.com/) - Supercharged Visual Investigation Platform used by teams for security, anti-fraud, and related investigations. The Graphistry team uses Arrow in its NodeJS GPU backend and client libraries, and is an early contributing member to GOAI and Arrow\[JS\] focused on bringing these technologies to the enterprise.
 
 # License

--- a/js/README.md
+++ b/js/README.md
@@ -36,12 +36,6 @@ Apache Arrow is a columnar memory layout specification for encoding vectors and 
 
 Apache Arrow is the emerging standard for large in-memory columnar data ([Spark](https://spark.apache.org/), [Pandas](http://wesmckinney.com/blog/pandas-and-apache-arrow/), [Drill](https://drill.apache.org/), [Graphistry](https://www.graphistry.com), ...). By standardizing on a common binary interchange format, big data systems can reduce the costs and friction associated with cross-system communication.
 
-# Related Projects
-
-* [Graphistry](https://www.graphistry.com) -- Supercharged visual investigations for security, anti-fraud, and other enterprise-scale event data problems that includes Arrow JS for the GPU backend
-* [GoAI](http://gpuopenanalytics.com/) -- Open GPU-Accelerated Analytics Initiative for Arrow-powered analytics across GPU tools and vendors
-* [rxjs-mapd](https://github.com/graphistry/rxjs-mapd) -- A MapD Core node-driver that returns query results as Arrow columns
-
 # Usage
 
 ## Get a table from an Arrow file on disk
@@ -202,6 +196,28 @@ npm install @apache-arrow/esnext-umd # standalone esNext/UMD package
 The JS community is a diverse group with a varied list of target environments and tool chains. Publishing multiple packages accommodates projects of all stripes.
 
 If you think we missed a compilation target and it's a blocker for adoption, please open an issue.
+
+# Community
+
+Full list of broader Apache Arrow [committers](https://arrow.apache.org/committers/) and [projects & organizations](https://github.com/apache/arrow/blob/master/site/powered_by.md).
+
+## Committers
+
+* Brian Hulette, CCRI
+* Paul Taylor, Graphistry, Inc.
+
+## Open Source Projects
+
+* [Apache Arrow](https://arrow.apache.org) -- Parent project for Powering Columnar In-Memory Analytics, including affiliated open source projects
+* [rxjs-mapd](https://github.com/graphistry/rxjs-mapd) -- A MapD Core node-driver that returns query results as Arrow columns
+
+
+
+## Companies & Organizations
+
+* [CCRi](http://www.ccri.com/) -- Commonwealth Computer Research Inc, or CCRi, is a Central Virginia based data science and software engineering company
+* [GoAI](http://gpuopenanalytics.com/) -- Open GPU-Accelerated Analytics Initiative for Arrow-powered analytics across GPU tools and vendors
+* [Graphistry, Inc.](https://www.graphistry.com/) - Supercharged Visual Investigation Platform used by teams for security, anti-fraud, and related investigations. The Graphistry team uses Arrow in its NodeJS GPU backend and client libraries, and is an early contributing member to GOAI and Arrow\[JS\] focused on bringing these technologies to the enterprise.
 
 # License
 

--- a/js/README.md
+++ b/js/README.md
@@ -199,13 +199,15 @@ If you think we missed a compilation target and it's a blocker for adoption, ple
 
 # People
 
-Full list of broader Apache Arrow [committers](https://arrow.apache.org/committers/) and [projects & organizations](https://github.com/apache/arrow/blob/master/site/powered_by.md).
+Full list of broader Apache Arrow [committers](https://arrow.apache.org/committers/).
 
 * Brian Hulette, CCRi,  _contributor_
 * Paul Taylor, Graphistry, Inc.,  _committer_
 
 # Powered By Apache Arrow in JS 
 
+Full list of broader Apache Arrow [projects & organizations](https://github.com/apache/arrow/blob/master/site/powered_by.md).
+ 
 ## Open Source Projects
 
 * [Apache Arrow](https://arrow.apache.org) -- Parent project for Powering Columnar In-Memory Analytics, including affiliated open source projects

--- a/js/README.md
+++ b/js/README.md
@@ -217,7 +217,7 @@ Full list of broader Apache Arrow [projects & organizations](https://github.com/
 
 * [CCRi](http://www.ccri.com/) -- Commonwealth Computer Research Inc, or CCRi, is a Central Virginia based data science and software engineering company
 * [GOAI](http://gpuopenanalytics.com/) -- GPU Open Analytics Initiative standardizes on Arrow as part of creating common data frameworks that enable developers and statistical researchers to accelerate data science on GPUs
-* [Graphistry, Inc.](https://www.graphistry.com/) - Supercharged Visual Investigation Platform used by teams for security, anti-fraud, and related investigations. The Graphistry team uses Arrow in its NodeJS GPU backend and client libraries, and is an early contributing member to GOAI and Arrow\[JS\] focused on bringing these technologies to the enterprise.
+* [Graphistry, Inc.](https://www.graphistry.com/) - An end-to-end GPU accelerated visual investigation platform used by teams for security, anti-fraud, and related investigations. Graphistry uses Arrow in its NodeJS GPU backend and client libraries, and is an early contributing member to GOAI and Arrow\[JS\] working to bring these technologies to the enterprise.
 
 # License
 

--- a/js/README.md
+++ b/js/README.md
@@ -34,11 +34,12 @@ Arrow is a set of technologies that enable big-data systems to process and trans
 
 Apache Arrow is a columnar memory layout specification for encoding vectors and table-like containers of flat and nested data. The Arrow spec aligns columnar data in memory to minimize cache misses and take advantage of the latest SIMD (Single input multiple data) and GPU operations on modern processors.
 
-Apache Arrow is the emerging standard for large in-memory columnar data ([Spark](https://spark.apache.org/), [Pandas](http://wesmckinney.com/blog/pandas-and-apache-arrow/), [Drill](https://drill.apache.org/), ...). By standardizing on a common binary interchange format, big data systems can reduce the costs and friction associated with cross-system communication.
+Apache Arrow is the emerging standard for large in-memory columnar data ([Spark](https://spark.apache.org/), [Pandas](http://wesmckinney.com/blog/pandas-and-apache-arrow/), [Drill](https://drill.apache.org/), [Graphistry](https://www.graphistry.com), ...). By standardizing on a common binary interchange format, big data systems can reduce the costs and friction associated with cross-system communication.
 
 # Related Projects
 
-* [GoAI](http://gpuopenanalytics.com/) -- Arrow-powered GPU analytics
+* [Graphistry](https://www.graphistry.com) -- Supercharged visual investigations for security, anti-fraud, and other enterprise-scale event data problems that includes Arrow JS for the GPU backend
+* [GoAI](http://gpuopenanalytics.com/) -- Open GPU-Accelerated Analytics Initiative for Arrow-powered analytics across GPU tools and vendors
 * [rxjs-mapd](https://github.com/graphistry/rxjs-mapd) -- A MapD Core node-driver that returns query results as Arrow columns
 
 # Usage

--- a/site/powered_by.md
+++ b/site/powered_by.md
@@ -103,6 +103,13 @@ short description of your use case.
   Dremio reads data from any source (RDBMS, HDFS, S3, NoSQL) into Arrow
   buffers, and provides fast SQL access via ODBC, JDBC, and REST for BI,
   Python, R, and more (all backed by Apache Arrow).
+* **[GOAI][19]:** Open GPU-Accelerated Analytics Initiative for Arrow-powered 
+  analytics across GPU tools and vendors  
+* **[Graphistry][18]:** Supercharged Visual Investigation Platform used by
+  teams for security, anti-fraud, and related investigations. The Graphistry
+  team uses Arrow in its NodeJS GPU backend and client libraries, and is an
+  early contributing member to GOAI and Arrow\[JS\] focused on bringing these 
+  technologies to the enterprise.  
 * **[Quilt Data][13]:** Quilt is a data package manager, designed to make
   managing data as easy as managing code. It supports Parquet format via
   pyarrow for data access.
@@ -124,3 +131,5 @@ short description of your use case.
 [15]: https://github.com/dask/dask
 [16]: https://red-data-tools.github.io/
 [17]: https://github.com/red-data-tools/red-arrow/
+[18]: https://www.graphistry.com
+[19]: http://gpuopenanalytics.com


### PR DESCRIPTION
Realized Graphistry's use wasn't listed, which matters as we're the most enterprise-y user right now.

Also made the GOAI reference more clear.