### PR TITLE
ARROW-1914: [C++] Fix build dependency for GPU support build

### DIFF
--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -32,9 +32,6 @@ set(ARROW_GPU_SRCS
   cuda_memory.cc
 )
 
-add_custom_target(arrow_gpu_sources DEPENDS ${ARROW_GPU_SRCS})
-add_dependencies(arrow_gpu_sources metadata_fbs)
-
 set(ARROW_GPU_SHARED_LINK_LIBS
   arrow_shared
   ${CUDA_LIBRARIES}
@@ -43,6 +40,7 @@ set(ARROW_GPU_SHARED_LINK_LIBS
 
 ADD_ARROW_LIB(arrow_gpu
   SOURCES ${ARROW_GPU_SRCS}
+  DEPENDENCIES metadata_fbs
   SHARED_LINK_FLAGS ""
   SHARED_LINK_LIBS ${ARROW_GPU_SHARED_LINK_LIBS}
   STATIC_LINK_LIBS ""


### PR DESCRIPTION
"make -j" may cause build error:

    [100%] Built target gflags_nothreads_static
    Install the project...
    -- Install configuration: "RELEASE"
    -- Installing: /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/build/gflags_ep-prefix/src/gflags_ep/lib/cmake/gflags/gflags-config.cmake
    -- Installing: /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/build/gflags_ep-prefix/src/gflags_ep/lib/cmake/gflags/gflags-config-version.cmake
    -- Installing: /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/build/gflags_ep-prefix/src/gflags_ep/lib/cmake/gflags/gflags-targets.cmake
    -- Installing: /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/build/gflags_ep-prefix/src/gflags_ep/lib/cmake/gflags/gflags-targets-release.cmake
    -- Installing: /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/build/gflags_ep-prefix/src/gflags_ep/bin/gflags_completions.sh
    -- Installing: /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/build/gflags_ep-prefix/src/gflags_ep/lib/pkgconfig/gflags.pc
    -- Installing: /home/kou/.cmake/packages/gflags/fb801def37c922433975cbfefb3aa08d
    [ 26%] Completed 'gflags_ep'
    [ 55%] Building C object CMakeFiles/brotlienc.dir/enc/literal_cost.c.o
    [ 26%] Built target gflags_ep
    Scanning dependencies of target arrow_gpu_objlib
    [ 26%] Building CXX object src/arrow/gpu/CMakeFiles/arrow_gpu_objlib.dir/cuda_arrow_ipc.cc.o
    [ 59%] Building C object CMakeFiles/brotlienc.dir/enc/memory.c.o
    /tmp/arrow-0.8.0.GLyu7/apache-arrow-0.8.0/cpp/src/arrow/gpu/cuda_arrow_ipc.cc:26:10: fatal error: arrow/ipc/Message_generated.h: No such file or directory
     #include "arrow/ipc/Message_generated.h"
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.
    src/arrow/gpu/CMakeFiles/arrow_gpu_objlib.dir/build.make:62: recipe for target 'src/arrow/gpu/CMakeFiles/arrow_gpu_objlib.dir/cuda_arrow_ipc.cc.o' failed
    make[2]: *** [src/arrow/gpu/CMakeFiles/arrow_gpu_objlib.dir/cuda_arrow_ipc.cc.o] Error 1
    CMakeFiles/Makefile2:2108: recipe for target 'src/arrow/gpu/CMakeFiles/arrow_gpu_objlib.dir/all' failed
    make[1]: *** [src/arrow/gpu/CMakeFiles/arrow_gpu_objlib.dir/all] Error 2
    make[1]: *** Waiting for unfinished jobs....