### PR TITLE
ARROW-764: [C++] Improves performance of CopyBitmap and adds benchmarks

### DIFF
--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -63,10 +63,10 @@ if (ARROW_BUILD_BENCHMARKS)
       Shlwapi.lib
   )
   else()
-	  target_link_libraries(arrow_benchmark_main
+    target_link_libraries(arrow_benchmark_main
       benchmark
       pthread
-	  )
+    )
   endif()
 
   # TODO(wesm): Some benchmarks include gtest.h
@@ -79,5 +79,7 @@ ADD_ARROW_TEST(decimal-test)
 ADD_ARROW_TEST(key-value-metadata-test)
 ADD_ARROW_TEST(rle-encoding-test)
 ADD_ARROW_TEST(stl-util-test)
+
+ADD_ARROW_BENCHMARK(bit-util-benchmark)
 
 add_subdirectory(variant)

--- a/cpp/src/arrow/util/bit-util-benchmark.cc
+++ b/cpp/src/arrow/util/bit-util-benchmark.cc
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include <vector>
+
+#include "arrow/buffer.h"
+#include "arrow/builder.h"
+#include "arrow/memory_pool.h"
+#include "arrow/test-util.h"
+#include "arrow/util/bit-util.h"
+
+namespace arrow {
+namespace BitUtil {
+
+static void BM_CopyBitmap(benchmark::State& state) {  // NOLINT non-const reference
+  const int kBufferSize = state.range(0);
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_OK(AllocateBuffer(default_memory_pool(), kBufferSize, &buffer));
+  memset(buffer->mutable_data(), 0, kBufferSize);
+  test::random_bytes(kBufferSize, 0, buffer->mutable_data());
+
+  const int num_bits = kBufferSize * 8;
+  const uint8_t* src = buffer->data();
+
+  std::shared_ptr<Buffer> copy;
+  while (state.KeepRunning()) {
+    ABORT_NOT_OK(CopyBitmap(default_memory_pool(), src, state.range(1), num_bits, &copy));
+  }
+  state.SetBytesProcessed(state.iterations() * kBufferSize * sizeof(int8_t));
+}
+
+BENCHMARK(BM_CopyBitmap)
+    ->Args({100000, 0})
+    ->Args({1000000, 0})
+    ->Args({100000, 4})
+    ->Args({1000000, 4})
+    ->MinTime(1.0)
+    ->Unit(benchmark::kMicrosecond);
+
+}  // namespace BitUtil
+}  // namespace arrow

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -165,19 +165,20 @@ TEST(BitUtilTests, TestCopyBitmap) {
   memset(buffer->mutable_data(), 0, kBufferSize);
   test::random_bytes(kBufferSize, 0, buffer->mutable_data());
 
-  const int num_bits = kBufferSize * 8;
-
   const uint8_t* src = buffer->data();
 
+  std::vector<int64_t> lengths = {kBufferSize * 8 - 4, kBufferSize * 8};
   std::vector<int64_t> offsets = {0, 12, 16, 32, 37, 63, 64, 128};
-  for (int64_t offset : offsets) {
-    const int64_t copy_length = num_bits - offset;
+  for (int64_t num_bits : lengths) {
+    for (int64_t offset : offsets) {
+      const int64_t copy_length = num_bits - offset;
 
-    std::shared_ptr<Buffer> copy;
-    ASSERT_OK(CopyBitmap(default_memory_pool(), src, offset, copy_length, &copy));
+      std::shared_ptr<Buffer> copy;
+      ASSERT_OK(CopyBitmap(default_memory_pool(), src, offset, copy_length, &copy));
 
-    for (int64_t i = 0; i < copy_length; ++i) {
-      ASSERT_EQ(BitUtil::GetBit(src, i + offset), BitUtil::GetBit(copy->data(), i));
+      for (int64_t i = 0; i < copy_length; ++i) {
+        ASSERT_EQ(BitUtil::GetBit(src, i + offset), BitUtil::GetBit(copy->data(), i));
+      }
     }
   }
 }

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -139,13 +139,10 @@ static inline void SetArrayBit(uint8_t* bits, int i, bool is_set) {
 }
 
 static inline void SetBitTo(uint8_t* bits, int64_t i, bool bit_is_set) {
-  // TODO: speed up. See https://graphics.stanford.edu/~seander/bithacks.html
+  // https://graphics.stanford.edu/~seander/bithacks.html
   // "Conditionally set or clear bits without branching"
-  if (bit_is_set) {
-    SetBit(bits, i);
-  } else {
-    ClearBit(bits, i);
-  }
+  bits[i / 8] ^= static_cast<uint8_t>(-static_cast<uint8_t>(bit_is_set) ^ bits[i / 8]) &
+                 kBitmask[i % 8];
 }
 
 // Returns the minimum number of bits needed to represent the value of 'x'


### PR DESCRIPTION
I took a swing at improving the CopyBitmap performance (benchmarks below).  I'm a C/C++ novice, so I thought I'd get some feedback before I went too much further.

**Starting Point**
```
Run on (4 X 2208 MHz CPU s)
12/13/17 21:15:18
Benchmark                                        Time           CPU Iterations
------------------------------------------------------------------------------
BM_CopyBitmap/97.6563k/0/min_time:1.000       4779 us       4758 us        289   20.0445MB/s
BM_CopyBitmap/976.563k/0/min_time:1.000      47740 us      47476 us         26   20.0875MB/s
BM_CopyBitmap/97.6563k/4/min_time:1.000       4858 us       4866 us        289   19.5991MB/s
BM_CopyBitmap/976.563k/4/min_time:1.000      48117 us      47953 us         29   19.8879MB/s
```

**Using stanford bithacks for SetBitTo**
```
Run on (4 X 2208 MHz CPU s)
12/13/17 21:22:05
Benchmark                                        Time           CPU Iterations
------------------------------------------------------------------------------
BM_CopyBitmap/97.6563k/0/min_time:1.000       1647 us       1649 us        815   57.8415MB/s
BM_CopyBitmap/976.563k/0/min_time:1.000      16368 us      16397 us         81   58.1629MB/s
BM_CopyBitmap/97.6563k/4/min_time:1.000       1599 us       1610 us        815   59.2186MB/s
BM_CopyBitmap/976.563k/4/min_time:1.000      16026 us      16011 us         81   59.5644MB/s
```

**memcpy + shifting**
*This solution provides varying performance depending on whether or not the bit offset is a multiple of 8*
```
Run on (4 X 2208 MHz CPU s)
12/13/17 21:23:44
Benchmark                                        Time           CPU Iterations
------------------------------------------------------------------------------
BM_CopyBitmap/97.6563k/0/min_time:1.000          5 us          5 us     280000   18.9651GB/s
BM_CopyBitmap/976.563k/0/min_time:1.000         62 us         61 us      22400   15.1721GB/s
BM_CopyBitmap/97.6563k/4/min_time:1.000        171 us        170 us       6892   560.872MB/s
BM_CopyBitmap/976.563k/4/min_time:1.000       1639 us       1639 us        896   581.782MB/s
```