### PR TITLE
ARROW-1926: [GLib] Add garrow_timestamp_data_type_get_unit()

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -805,6 +805,24 @@ garrow_timestamp_data_type_new(GArrowTimeUnit unit)
   return data_type;
 }
 
+/**
+ * garrow_timestamp_data_type_get_unit:
+ * @timestamp_data_type: The #GArrowTimestampDataType.
+ *
+ * Returns: The unit of the timestamp data type.
+ *
+ * Since: 0.8.0
+ */
+GArrowTimeUnit
+garrow_timestamp_data_type_get_unit(GArrowTimestampDataType *timestamp_data_type)
+{
+  const auto arrow_data_type =
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(timestamp_data_type));
+  const auto arrow_timestamp_data_type =
+    std::static_pointer_cast<arrow::TimestampType>(arrow_data_type);
+  return garrow_time_unit_from_raw(arrow_timestamp_data_type->unit());
+}
+
 
 G_DEFINE_TYPE(GArrowTimeDataType,               \
               garrow_time_data_type,            \

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -774,6 +774,8 @@ struct _GArrowTimestampDataTypeClass
 
 GType                 garrow_timestamp_data_type_get_type (void) G_GNUC_CONST;
 GArrowTimestampDataType *garrow_timestamp_data_type_new   (GArrowTimeUnit unit);
+GArrowTimeUnit
+garrow_timestamp_data_type_get_unit (GArrowTimestampDataType *timestamp_data_type);
 
 
 #define GARROW_TYPE_TIME_DATA_TYPE              \

--- a/c_glib/test/test-timestamp-data-type.rb
+++ b/c_glib/test/test-timestamp-data-type.rb
@@ -29,6 +29,10 @@ class TestTimestampDataType < Test::Unit::TestCase
     def test_to_s
       assert_equal("timestamp[s]", @data_type.to_s)
     end
+
+    def test_unit
+      assert_equal(Arrow::TimeUnit::SECOND, @data_type.unit)
+    end
   end
 
   sub_test_case("millisecond") do
@@ -38,6 +42,10 @@ class TestTimestampDataType < Test::Unit::TestCase
 
     def test_to_s
       assert_equal("timestamp[ms]", @data_type.to_s)
+    end
+
+    def test_unit
+      assert_equal(Arrow::TimeUnit::MILLI, @data_type.unit)
     end
   end
 
@@ -49,6 +57,10 @@ class TestTimestampDataType < Test::Unit::TestCase
     def test_to_s
       assert_equal("timestamp[us]", @data_type.to_s)
     end
+
+    def test_unit
+      assert_equal(Arrow::TimeUnit::MICRO, @data_type.unit)
+    end
   end
 
   sub_test_case("nano") do
@@ -58,6 +70,10 @@ class TestTimestampDataType < Test::Unit::TestCase
 
     def test_to_s
       assert_equal("timestamp[ns]", @data_type.to_s)
+    end
+
+    def test_unit
+      assert_equal(Arrow::TimeUnit::NANO, @data_type.unit)
     end
   end
 end


### PR DESCRIPTION
This is not a 0.8.0 broker.

If 0.8.0 RC2 is dropped, I hope that 0.8.0 includes this.
If RC2 has no problem, I hope that 0.9.0 includes this. 