### PR TITLE
ARROW-1935: [Website] Remove link to nightly builds. Fix signature / checksum links, add verification instructions

### DIFF
--- a/site/install.md
+++ b/site/install.md
@@ -29,8 +29,9 @@ See the [release notes][10] for more about what's new.
 ### Source release
 
 * **Source Release**: [apache-arrow-0.8.0.tar.gz][6]
-* **Verification**: [sha512][3], [asc][7]
+* **Verification**: [sha512][3], [asc][7] ([verification instructions][12])
 * [Git tag 1d689e5][2]
+* [PGP keys for release signatures][11]
 
 ### Java Packages
 
@@ -144,26 +145,15 @@ These repositories are managed at
 [red-data-tools/arrow-packages][9]. If you have any feedback, please
 send it to the project instead of Apache Arrow project.
 
-### Nightly Development Builds
-
-To assist with development and debugging, some nightly builds are
-available. These builds are not releases and not necessarily produced on ASF
-infrastructure. They are to be used strictly for development.
-
-* **conda packages** for C++ and Python (Linux only)
-
-```
-conda install arrow-cpp -c twosigma
-conda install pyarrow -c twosigma
-```
-
 [1]: https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.8.0/
 [2]: https://github.com/apache/arrow/releases/tag/apache-arrow-0.8.0
-[3]: https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.8.0/apache-arrow-0.8.0.tar.gz.sha512
+[3]: https://www.apache.org/dist/arrow/arrow-0.8.0/apache-arrow-0.8.0.tar.gz.sha512
 [4]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.arrow%22%20AND%20v%3A%220.8.0%22
 [5]: http://conda-forge.github.io
 [6]: https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.8.0/apache-arrow-0.8.0.tar.gz
-[7]: https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.8.0/apache-arrow-0.8.0.tar.gz.asc
+[7]: https://www.apache.org/dist/arrow/arrow-0.8.0/apache-arrow-0.8.0.tar.gz.asc
 [8]: https://github.com/red-data-tools/parquet-glib
 [9]: https://github.com/red-data-tools/arrow-packages
 [10]: http://arrow.apache.org/release/0.8.0.html
+[11]: http://www.apache.org/dist/arrow/KEYS
+[12]: https://www.apache.org/dyn/closer.cgi#verify


### PR DESCRIPTION
Website fixes per ASF policies and feedback in ARROW-1935, ARROW-1936