### PR TITLE
Fix link to CHANGELOG

### DIFF
--- a/site/_posts/2017-12-19-0.8.0-release.md
+++ b/site/_posts/2017-12-19-0.8.0-release.md
@@ -173,8 +173,7 @@ implementations and bindings to more languages.
 
 [1]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20ARROW%20AND%20status%20in%20(Resolved%2C%20Closed)%20AND%20fixVersion%20%3D%200.8.0
 [2]: https://arrow.apache.org/install
-[3]: https://arrow.apache.org/release/0.7.0.html
-[3]: https://github.com/kou
+[3]: https://arrow.apache.org/release/0.8.0.html
 [4]: https://github.com/trxcllnt
 [5]: https://github.com/cpcloud
 [6]: https://github.com/apache/parquet-cpp


### PR DESCRIPTION
The last link identifier `[3]` was defined twice.
The first link `[3]` was pointing to the wrong changelog version