### PR TITLE
ARROW-1948: [Java] Load ListVector validity buffer with BitVectorHelper to handle all non-null

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -124,7 +124,7 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     ArrowBuf offBuffer = ownBuffers.get(1);
 
     validityBuffer.release();
-    validityBuffer = bitBuffer.retain(allocator);
+    validityBuffer = BitVectorHelper.loadValidityBuffer(fieldNode, bitBuffer, allocator);
     offsetBuffer.release();
     offsetBuffer = offBuffer.retain(allocator);
 


### PR DESCRIPTION
Need to properly set the ListVector validity buffer for the case when the field has all non-nulls.  This is done already in `BitVectorHelper.loadValidityBuffer`, so just need to build the buffer with a call to that function.