### PR TITLE
ARROW-1958: [Python] Error in pandas conversion for datetimetz row index

### DIFF
--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -254,6 +254,16 @@ class TestPandasConversion(object):
         md = column_indexes['metadata']
         assert md['timezone'] == 'America/New_York'
 
+    def test_datetimetz_row_index(self):
+        df = pd.DataFrame({
+            'a': pd.date_range(
+                start='2017-01-01', periods=3, tz='America/New_York'
+            )
+        })
+        df = df.set_index('a')
+
+        _check_pandas_roundtrip(df, preserve_index=True)
+
     def test_categorical_row_index(self):
         df = pd.DataFrame({'a': [1, 2, 3], 'b': [1, 2, 3]})
         df['a'] = df.a.astype('category')


### PR DESCRIPTION
Fix conversion of datetimetz row index for non-UTC time zones in to_pandas.