### PR TITLE
ARROW-1991: [Website] Fix Docker documentation build

### DIFF
--- a/c_glib/arrow-glib/Makefile.am
+++ b/c_glib/arrow-glib/Makefile.am
@@ -16,6 +16,7 @@
 # under the License.
 
 CLEANFILES =
+DISTCLEANFILES =
 
 EXTRA_DIST =					\
 	meson.build
@@ -169,6 +170,10 @@ BUILT_SOURCES =					\
 	stamp-enums.c				\
 	stamp-enums.h
 
+DISTCLEANFILES +=				\
+	stamp-enums.c				\
+	stamp-enums.h
+
 EXTRA_DIST +=					\
 	enums.c.template			\
 	enums.h.template
@@ -214,7 +219,7 @@ INTROSPECTION_SCANNER_ARGS =
 INTROSPECTION_SCANNER_ENV =
 if USE_ARROW_BUILD_DIR
 INTROSPECTION_SCANNER_ENV +=			\
-	LD_LIBRARY_PATH=$(ARROW_LIB_DIR):$${PKG_CONFIG_PATH}
+	LD_LIBRARY_PATH=$(ARROW_LIB_DIR):$${LD_LIBRARY_PATH}
 endif
 if OS_MACOS
 INTROSPECTION_SCANNER_ENV +=			\

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -17,7 +17,7 @@
 version: '3'
 services:
   gen_apidocs:
-    build: 
+    build:
       context: gen_apidocs
     volumes:
      - ../..:/apache-arrow
@@ -29,7 +29,7 @@ services:
     volumes:
      - ../..:/apache-arrow
   dask_integration:
-    build: 
+    build:
       context: dask_integration
     volumes:
      - ../..:/apache-arrow

--- a/dev/gen_apidocs/Dockerfile
+++ b/dev/gen_apidocs/Dockerfile
@@ -14,18 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM ubuntu:14.04
-# Prerequsites for apt-add-repository
-RUN apt-get update && apt-get install -y \
-    software-properties-common python-software-properties
+FROM ubuntu:16.04
 # Basic OS dependencies
-RUN apt-add-repository -y ppa:ubuntu-toolchain-r/test && \
-    apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
         wget \
         rsync \
         git \
-        gcc-4.9 \
-        g++-4.9 \
+        gcc \
+        g++ \
         build-essential
 # This will install conda in /home/ubuntu/miniconda
 RUN wget -O /tmp/miniconda.sh \

--- a/dev/gen_apidocs/Dockerfile
+++ b/dev/gen_apidocs/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update && apt-get install -y \
         wget \
         rsync \
         git \
-        gcc \
-        g++ \
+        gcc-4.9 \
+        g++-4.9 \
         build-essential
 # This will install conda in /home/ubuntu/miniconda
 RUN wget -O /tmp/miniconda.sh \

--- a/dev/gen_apidocs/Dockerfile
+++ b/dev/gen_apidocs/Dockerfile
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 FROM ubuntu:16.04
+
 # Basic OS dependencies
 RUN apt-get update && apt-get install -y \
         wget \
@@ -22,7 +23,15 @@ RUN apt-get update && apt-get install -y \
         git \
         gcc-4.9 \
         g++-4.9 \
-        build-essential
+        build-essential \
+        software-properties-common
+
+# Java build fails with default JDK8
+RUN add-apt-repository ppa:openjdk-r/ppa &&\
+    apt-get update &&\
+    apt-get install -y openjdk-7-jdk &&\
+    update-java-alternatives -s java-1.7.0-openjdk-amd64
+
 # This will install conda in /home/ubuntu/miniconda
 RUN wget -O /tmp/miniconda.sh \
     https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
@@ -69,6 +78,7 @@ RUN /home/ubuntu/miniconda/bin/conda create -y -q -n pyarrow-dev \
         doxygen \
         maven \
         -c conda-forge
+
 ADD . /apache-arrow
 WORKDIR /apache-arrow
 CMD arrow/dev/gen_apidocs/create_documents.sh

--- a/dev/gen_apidocs/create_documents.sh
+++ b/dev/gen_apidocs/create_documents.sh
@@ -39,6 +39,20 @@ git clone --branch=asf-site \
     https://git-wip-us.apache.org/repos/asf/arrow-site.git asf-site
 popd
 
+# Make Java documentation
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+wget http://mirrors.gigenet.com/apache/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
+tar xvf apache-maven-3.5.2-bin.tar.gz
+export PATH=$(pwd)/apache-maven-3.5.2/bin:$PATH
+
+pushd arrow/java
+rm -rf target/site/apidocs/*
+mvn -Drat.skip=true install
+mvn -Drat.skip=true site
+mkdir -p ../site/asf-site/docs/java/
+rsync -r target/site/apidocs/ ../site/asf-site/docs/java/
+popd
+
 # Make Python documentation (Depends on C++ )
 # Build Arrow C++
 source activate pyarrow-dev
@@ -120,13 +134,4 @@ rm -rf html/*
 doxygen Doxyfile
 mkdir -p ../../site/asf-site/docs/cpp
 rsync -r html/ ../../site/asf-site/docs/cpp
-popd
-
-# Make Java documentation
-pushd arrow/java
-rm -rf target/site/apidocs/*
-mvn -Drat.skip=true install
-mvn -Drat.skip=true site
-mkdir -p ../site/asf-site/docs/java/
-rsync -r target/site/apidocs/ ../site/asf-site/docs/java/
 popd

--- a/dev/gen_apidocs/create_documents.sh
+++ b/dev/gen_apidocs/create_documents.sh
@@ -49,6 +49,9 @@ export PARQUET_BUILD_TOOLCHAIN=$CONDA_PREFIX
 export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:${LD_LIBRARY_PATH}
 export PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH}
 
+export CC=gcc-4.9
+export CXX=g++-4.9
+
 CPP_BUILD_DIR=$(pwd)/arrow/cpp/build_docs
 
 rm -rf $CPP_BUILD_DIR

--- a/dev/gen_apidocs/create_documents.sh
+++ b/dev/gen_apidocs/create_documents.sh
@@ -43,6 +43,7 @@ popd
 source activate pyarrow-dev
 
 export ARROW_BUILD_TOOLCHAIN=$CONDA_PREFIX
+export BOOST_ROOT=$CONDA_PREFIX
 export PARQUET_BUILD_TOOLCHAIN=$CONDA_PREFIX
 
 rm -rf arrow/cpp/build_docs

--- a/dev/gen_apidocs/create_documents.sh
+++ b/dev/gen_apidocs/create_documents.sh
@@ -67,10 +67,13 @@ popd
 # Build c_glib documentation
 pushd arrow/c_glib
 if [ -f Makefile ]; then
+    # Ensure updating to prevent auto re-configure
+    touch configure **/Makefile
     make distclean
     # Work around for 'make distclean' removes doc/reference/xml/
     git checkout doc/reference/xml
 fi
+./autogen.sh
 rm -rf build_docs
 mkdir build_docs
 pushd build_docs

--- a/dev/release/RELEASE_MANAGEMENT.md
+++ b/dev/release/RELEASE_MANAGEMENT.md
@@ -112,6 +112,15 @@ software must be built in order to create the documentation, so this
 step may take some time to run, especially the first time around as the
 Docker container will also have to be built.
 
+To upload the updated documentation to the website, navigate to `site/asf-site`
+and commit all changes:
+
+```
+pushd site/asf-site
+git add .
+git commit -m "Updated API documentation for version X.Y.Z"
+```
+
 After successfully creating the API documentation the website can be
 run locally to browse the API documentation from the top level
 `Documentation` menu. To run the website issue the command:


### PR DESCRIPTION
@kou something is failing here, I'm not sure what's different here vs. Travis CI (not sure if this is what's failing the doc build):

```
  DOC   Building HTML
../arrow-glib-docs.xml:25: warning: failed to load external entity "../xml/gtkdocentities.ent"
  %gtkdocentities;
                  ^
Entity: line 1: 
 %gtkdocentities; 
                 ^
../arrow-glib-docs.xml:29: parser error : Entity 'package_name' not defined
    <title>&package_name; Reference Manual</title>
                         ^
../arrow-glib-docs.xml:31: parser error : Entity 'package_string' not defined
      for &package_string;.
                          ^
warning: failed to load external entity "../xml/basic-array.xml"
../arrow-glib-docs.xml:43: element include: XInclude error : could not load ../xml/basic-array.xml, and no fallback was found
warning: failed to load external entity "../xml/composite-array.xml"
../arrow-glib-docs.xml:44: element include: XInclude error : could not load ../xml/composite-array.xml, and no fallback was found
../xml/array-builder.xml:25: warning: failed to load external entity "../xml/xml/gtkdocentities.ent"
  %gtkdocentities;
```