### PR TITLE
ARROW-2002: [Python] check write_queue is not full and writer_thread is alive before enqueue new record when download file.

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -312,6 +312,12 @@ cdef class NativeFile:
                 pybuf = cp.PyBytes_FromStringAndSize(<const char*>buf,
                                                      bytes_read)
 
+                if writer_thread.is_alive():
+                    while write_queue.full():
+                        time.sleep(0.01)
+                else:
+                    break
+
                 write_queue.put_nowait(pybuf)
         finally:
             free(buf)


### PR DESCRIPTION
use pyarrow download file will raise queue.Full exceptions sometimes.
jira: https://issues.apache.org/jira/browse/ARROW-2002
