### PR TITLE
ARROW-2005: [Python] Fix incorrect flake8 config path to Cython lint config

### DIFF
--- a/ci/travis_lint.sh
+++ b/ci/travis_lint.sh
@@ -35,10 +35,10 @@ popd
 # Fail fast on style checks
 sudo pip install flake8
 
-PYARROW_DIR=$TRAVIS_BUILD_DIR/python/pyarrow
+PYTHON_DIR=$TRAVIS_BUILD_DIR/python
 
-flake8 --count $PYARROW_DIR
+flake8 --count $PYTHON_DIR/pyarrow
 
 # Check Cython files with some checks turned off
 flake8 --count --config=$PYTHON_DIR/.flake8.cython \
-       $PYARROW_DIR
+       $PYTHON_DIR/pyarrow

--- a/python/pyarrow/_orc.pxd
+++ b/python/pyarrow/_orc.pxd
@@ -29,9 +29,10 @@ from pyarrow.includes.libarrow cimport (CArray, CSchema, CStatus,
                                         TimeUnit)
 
 
-cdef extern from "arrow/adapters/orc/adapter.h" namespace "arrow::adapters::orc" nogil:
-    cdef cppclass ORCFileReader:
+cdef extern from "arrow/adapters/orc/adapter.h" \
+        namespace "arrow::adapters::orc" nogil:
 
+    cdef cppclass ORCFileReader:
         @staticmethod
         CStatus Open(const shared_ptr[RandomAccessFile]& file,
                      CMemoryPool* pool,
@@ -40,7 +41,8 @@ cdef extern from "arrow/adapters/orc/adapter.h" namespace "arrow::adapters::orc"
         CStatus ReadSchema(shared_ptr[CSchema]* out)
 
         CStatus ReadStripe(int64_t stripe, shared_ptr[CRecordBatch]* out)
-        CStatus ReadStripe(int64_t stripe, std_vector[int], shared_ptr[CRecordBatch]* out)
+        CStatus ReadStripe(int64_t stripe, std_vector[int],
+                           shared_ptr[CRecordBatch]* out)
 
         CStatus Read(shared_ptr[CTable]* out)
         CStatus Read(std_vector[int], shared_ptr[CTable]* out)

--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -50,7 +50,7 @@ cdef class ORCReader:
         get_reader(source, &rd_handle)
         with nogil:
             check_status(ORCFileReader.Open(rd_handle, self.allocator,
-                                             &self.reader))
+                                            &self.reader))
 
     def schema(self):
         """
@@ -69,10 +69,10 @@ cdef class ORCReader:
         return pyarrow_wrap_schema(sp_arrow_schema)
 
     def nrows(self):
-        return deref(self.reader).NumberOfRows();
+        return deref(self.reader).NumberOfRows()
 
     def nstripes(self):
-        return deref(self.reader).NumberOfStripes();
+        return deref(self.reader).NumberOfStripes()
 
     def read_stripe(self, n, include_indices=None):
         cdef:
@@ -85,11 +85,13 @@ cdef class ORCReader:
 
         if include_indices is None:
             with nogil:
-                check_status(deref(self.reader).ReadStripe(stripe, &sp_record_batch))
+                (check_status(deref(self.reader)
+                              .ReadStripe(stripe, &sp_record_batch)))
         else:
             indices = include_indices
             with nogil:
-                check_status(deref(self.reader).ReadStripe(stripe, indices, &sp_record_batch))
+                (check_status(deref(self.reader)
+                              .ReadStripe(stripe, indices, &sp_record_batch)))
 
         batch = RecordBatch()
         batch.init(sp_record_batch)

--- a/python/pyarrow/plasma.pyx
+++ b/python/pyarrow/plasma.pyx
@@ -248,8 +248,8 @@ cdef class PlasmaClient:
             check_status(self.client.get().Get(ids.data(), ids.size(),
                          timeout_ms, result[0].data()))
 
-    cdef _make_plasma_buffer(self, ObjectID object_id, shared_ptr[CBuffer] buffer,
-                             int64_t size):
+    cdef _make_plasma_buffer(self, ObjectID object_id,
+                             shared_ptr[CBuffer] buffer, int64_t size):
         result = PlasmaBuffer(object_id, self)
         result.init(buffer)
         return result
@@ -302,7 +302,9 @@ cdef class PlasmaClient:
             check_status(self.client.get().Create(object_id.data, data_size,
                                                   <uint8_t*>(metadata.data()),
                                                   metadata.size(), &data))
-        return self._make_mutable_plasma_buffer(object_id, data.get().mutable_data(), data_size)
+        return self._make_mutable_plasma_buffer(object_id,
+                                                data.get().mutable_data(),
+                                                data_size)
 
     def get_buffers(self, object_ids, timeout_ms=-1):
         """


### PR DESCRIPTION
This was silently passing even though the config file was not found. This first build should fail, then I will fix the flakes