### PR TITLE
ARROW-1860: [C++] Introduce ipc::PreparedMessage data structure to avoid making multiple passes over record batches

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -113,6 +113,7 @@ if (ARROW_IPC)
     ipc/message.cc
     ipc/metadata-internal.cc
     ipc/reader.cc
+    ipc/util.cc
     ipc/writer.cc
   )
   SET(ARROW_SRCS ${ARROW_SRCS}

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -22,12 +22,14 @@
 #include <string>
 #include <vector>
 
+#include "flatbuffers/flatbuffers.h"
 #include "gtest/gtest.h"
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/io/memory.h"
 #include "arrow/io/test-common.h"
+#include "arrow/ipc/Message_generated.h"
 #include "arrow/ipc/api.h"
 #include "arrow/ipc/metadata-internal.h"
 #include "arrow/ipc/test-common.h"
@@ -247,7 +249,8 @@ TEST_F(TestIpcRoundTrip, MetadataVersion) {
 }
 
 TEST_F(TestIpcRoundTrip, WriteMetadataUnaligned) {
-  ASSERT_OK(io::MemoryMapFixture::InitMemoryMap(1 << 16, "test-metadata-unaligned", &mmap_));
+  ASSERT_OK(
+      io::MemoryMapFixture::InitMemoryMap(1 << 16, "test-metadata-unaligned", &mmap_));
   ASSERT_OK(mmap_->Seek(3));
 
   std::string metadata = "some metadata";
@@ -255,15 +258,45 @@ TEST_F(TestIpcRoundTrip, WriteMetadataUnaligned) {
   // 17 bytes + 7 bytes padding
   const int64_t padded_metadata_size = 24;
 
-  Buffer metadata_buf(metadata);
+  auto metadata_buf = std::make_shared<Buffer>(metadata);
 
   int32_t out_metadata_size = 0;
-  ASSERT_OK(internal::WriteMessage(metadata_buf, mmap_.get(), &out_metadata_size));
+  ASSERT_OK(internal::WriteMessage(*metadata_buf, mmap_.get(), &out_metadata_size));
   ASSERT_EQ(padded_metadata_size, out_metadata_size);
 
   int64_t stream_position = 0;
   ASSERT_OK(mmap_->Tell(&stream_position));
   ASSERT_EQ(32, stream_position);
+
+  // Write Message object
+  flatbuffers::FlatBufferBuilder fbb;
+
+  const int64_t fake_body_size = 27;
+  auto message =
+      flatbuf::CreateMessage(fbb, internal::kCurrentMetadataVersion,
+                             flatbuf::MessageHeader_RecordBatch, 0, fake_body_size);
+  fbb.Finish(message);
+
+  auto fb = std::make_shared<Buffer>(fbb.GetBufferPointer(), fbb.GetSize());
+
+  ASSERT_OK(mmap_->Seek(3));
+  Message msg(fb, nullptr);
+
+  int64_t out_length = 0;
+  int64_t message_size = BitUtil::RoundUpToMultipleOf8(fb->size() + 4);
+  ASSERT_OK(msg.SerializeTo(mmap_.get(), &out_length));
+  ASSERT_EQ(message_size, out_length);
+
+  // Read back
+  std::unique_ptr<Message> result;
+  ASSERT_OK(mmap_->Seek(3));
+  ASSERT_OK(ReadMessage(mmap_.get(), &result));
+  ASSERT_OK(mmap_->Tell(&stream_position));
+  ASSERT_EQ(message_size + 8 + fake_body_size, stream_position);
+
+  const Buffer& result_meta = *result->metadata();
+  const Buffer& expected_meta = *fb;
+  ASSERT_TRUE(result_meta.Equals(expected_meta, expected_meta.size()));
 }
 
 TEST_P(TestIpcRoundTrip, SliceRoundTrip) {

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -28,6 +28,7 @@
 #include "arrow/ipc/Message_generated.h"
 #include "arrow/ipc/Schema_generated.h"
 #include "arrow/ipc/metadata-internal.h"
+#include "arrow/ipc/util.h"
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
 
@@ -208,6 +209,8 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
 }
 
 Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message) {
+  RETURN_NOT_OK(internal::AlignInputStream(file));
+
   int32_t message_length = 0;
   int64_t bytes_read = 0;
   RETURN_NOT_OK(file->Read(sizeof(int32_t), &bytes_read,

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -96,6 +96,8 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
                          std::vector<int64_t>* shape, std::vector<int64_t>* strides,
                          std::vector<std::string>* dim_names);
 
+int64_t GetSerializedMetadataSize(int64_t flatbuffer_size);
+
 /// Write a serialized message metadata with a length-prefix and padding to an
 /// 8-byte offset
 ///

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -710,8 +710,6 @@ Status ReadRecordBatch(const std::shared_ptr<Schema>& schema, io::InputStream* f
 
 Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
                   std::shared_ptr<Tensor>* out) {
-  // Respect alignment of Tensor messages (see WriteTensor)
-  offset = PaddedLength(offset);
   RETURN_NOT_OK(file->Seek(offset));
 
   std::unique_ptr<Message> message;

--- a/cpp/src/arrow/ipc/util.cc
+++ b/cpp/src/arrow/ipc/util.cc
@@ -15,42 +15,45 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_IPC_UTIL_H
-#define ARROW_IPC_UTIL_H
+#include "arrow/ipc/util.h"
 
 #include <cstdint>
 
-#include "arrow/array.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/status.h"
 
 namespace arrow {
 namespace ipc {
-
-// Buffers are padded to 64-byte boundaries (for SIMD)
-static constexpr int kArrowAlignment = 64;
-
-// Align on 8-byte boundaries in IPC
-static constexpr int kArrowIpcAlignment = 8;
-
-static constexpr uint8_t kPaddingBytes[kArrowAlignment] = {0};
-
-static inline int64_t PaddedLength(int64_t nbytes, int64_t alignment = kArrowAlignment) {
-  return ((nbytes + alignment - 1) / alignment) * alignment;
-}
-
 namespace internal {
 
 // Adds padding bytes if necessary to ensure all memory blocks are written on
 // 8-byte boundaries.
-Status AlignOutputStream(io::OutputStream* stream,
-                         int64_t alignment = kArrowIpcAlignment);
+Status AlignOutputStream(io::OutputStream* stream, int64_t alignment) {
+  int64_t position;
+  RETURN_NOT_OK(stream->Tell(&position));
+  int64_t remainder = PaddedLength(position, alignment) - position;
+  if (remainder > 0) {
+    return stream->Write(kPaddingBytes, remainder);
+  }
+  return Status::OK();
+}
 
-Status AlignInputStream(io::InputStream* stream, int64_t alignment = kArrowIpcAlignment);
+Status AlignInputStream(io::InputStream* stream, int64_t alignment) {
+  int64_t position;
+  RETURN_NOT_OK(stream->Tell(&position));
+  int64_t remainder = PaddedLength(position, alignment) - position;
+
+  static uint8_t kScratchBuffer[8] = {0};
+  if (remainder > 0) {
+    int64_t bytes_read = 0;
+    RETURN_NOT_OK(stream->Read(remainder, &bytes_read, kScratchBuffer));
+    if (bytes_read != remainder) {
+      return Status::IOError("Unable to align InputStream");
+    }
+  }
+  return Status::OK();
+}
 
 }  // namespace internal
-
 }  // namespace ipc
 }  // namespace arrow
-
-#endif  // ARROW_IPC_UTIL_H

--- a/cpp/src/arrow/ipc/util.cc
+++ b/cpp/src/arrow/ipc/util.cc
@@ -47,7 +47,10 @@ Status AlignInputStream(io::InputStream* stream, int64_t alignment) {
   if (remainder > 0) {
     int64_t bytes_read = 0;
     RETURN_NOT_OK(stream->Read(remainder, &bytes_read, kScratchBuffer));
-    if (bytes_read != remainder) {
+
+    // If we are not at EOS, ensure we can read the exact number of bytes to
+    // next 8-byte offset
+    if (bytes_read > 0 && bytes_read != remainder) {
       return Status::IOError("Unable to align InputStream");
     }
   }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -47,6 +47,58 @@ using internal::FileBlock;
 using internal::kArrowMagicBytes;
 
 // ----------------------------------------------------------------------
+// Writing a generic IPC message
+
+int64_t PreparedMessage::GetTotalSize() const {
+  int64_t metadata_size = internal::GetSerializedMetadataSize(this->metadata->size());
+  return metadata_size + this->total_body_length;
+}
+
+Status PreparedMessage::WriteTo(io::OutputStream* dst, int32_t* out_metadata_length,
+                                int64_t* out_body_length) const {
+  RETURN_NOT_OK(internal::WriteMessage(*this->metadata, dst, out_metadata_length));
+
+#ifndef NDEBUG
+  int64_t current_position = -1;
+  RETURN_NOT_OK(dst->Tell(&current_position));
+  DCHECK(BitUtil::IsMultipleOf8(current_position));
+#endif
+
+  // Now write the buffers
+  int64_t body_length = 0;
+  for (size_t i = 0; i < this->body_buffers.size(); ++i) {
+    const Buffer* buffer = this->body_buffers[i].get();
+    int64_t size = 0;
+    int64_t padding = 0;
+
+    // The buffer might be null if we are handling zero row lengths.
+    if (buffer) {
+      size = buffer->size();
+      padding = BitUtil::RoundUpToMultipleOf8(size) - size;
+    }
+
+    if (size > 0) {
+      RETURN_NOT_OK(dst->Write(buffer->data(), size));
+      body_length += size;
+    }
+
+    if (padding > 0) {
+      RETURN_NOT_OK(dst->Write(kPaddingBytes, padding));
+      body_length += padding;
+    }
+  }
+
+#ifndef NDEBUG
+  RETURN_NOT_OK(dst->Tell(&current_position));
+  DCHECK(BitUtil::IsMultipleOf8(current_position));
+#endif
+
+  *out_body_length = body_length;
+
+  return Status::OK();
+}
+
+// ----------------------------------------------------------------------
 // Record batch write path
 
 static inline Status GetTruncatedBitmap(int64_t offset, int64_t length,
@@ -124,20 +176,27 @@ class RecordBatchSerializer : public ArrayVisitor {
       std::shared_ptr<Buffer> bitmap;
       RETURN_NOT_OK(GetTruncatedBitmap(arr.offset(), arr.length(), arr.null_bitmap(),
                                        pool_, &bitmap));
-      buffers_.push_back(bitmap);
+      buffers_.emplace_back(std::move(bitmap));
     } else {
+      static const std::shared_ptr<Buffer> kNullBuffer =
+          std::make_shared<Buffer>(nullptr, 0);
       // Push a dummy zero-length buffer, not to be copied
-      buffers_.push_back(std::make_shared<Buffer>(nullptr, 0));
+      buffers_.push_back(kNullBuffer);
     }
     return arr.Accept(this);
   }
 
-  Status Assemble(const RecordBatch& batch, int64_t* body_length) {
-    if (field_nodes_.size() > 0) {
-      field_nodes_.clear();
-      buffer_meta_.clear();
-      buffers_.clear();
-    }
+  // Override this for writing dictionary metadata
+  virtual Status WriteMetadataMessage(int64_t num_rows, int64_t body_length,
+                                      std::shared_ptr<Buffer>* out) {
+    return WriteRecordBatchMessage(num_rows, body_length, field_nodes_, buffer_meta_,
+                                   out);
+  }
+
+  Status Prepare(const RecordBatch& batch, PreparedMessage* out) {
+    field_nodes_.clear();
+    buffer_meta_.clear();
+    buffers_.clear();
 
     // Perform depth-first traversal of the row-batch
     for (int i = 0; i < batch.num_columns(); ++i) {
@@ -166,67 +225,18 @@ class RecordBatchSerializer : public ArrayVisitor {
       offset += size + padding;
     }
 
-    *body_length = offset - buffer_start_offset_;
-    DCHECK(BitUtil::IsMultipleOf8(*body_length));
+    int64_t body_length = offset - buffer_start_offset_;
+    DCHECK(BitUtil::IsMultipleOf8(body_length));
 
-    return Status::OK();
-  }
-
-  // Override this for writing dictionary metadata
-  virtual Status WriteMetadataMessage(int64_t num_rows, int64_t body_length,
-                                      std::shared_ptr<Buffer>* out) {
-    return WriteRecordBatchMessage(num_rows, body_length, field_nodes_, buffer_meta_,
-                                   out);
-  }
-
-  Status Write(const RecordBatch& batch, io::OutputStream* dst, int32_t* metadata_length,
-               int64_t* body_length) {
-    RETURN_NOT_OK(Assemble(batch, body_length));
-
-#ifndef NDEBUG
-    int64_t start_position, current_position;
-    RETURN_NOT_OK(dst->Tell(&start_position));
-#endif
-
-    // Now that we have computed the locations of all of the buffers in shared
-    // memory, the data header can be converted to a flatbuffer and written out
+    // Now that we have computed the locations of all of the buffers in the
+    // body, the data header can be converted to a flatbuffer and written out
     //
     // Note: The memory written here is prefixed by the size of the flatbuffer
     // itself as an int32_t.
-    std::shared_ptr<Buffer> metadata_fb;
-    RETURN_NOT_OK(WriteMetadataMessage(batch.num_rows(), *body_length, &metadata_fb));
-    RETURN_NOT_OK(internal::WriteMessage(*metadata_fb, dst, metadata_length));
+    RETURN_NOT_OK(WriteMetadataMessage(batch.num_rows(), body_length, &out->metadata));
 
-#ifndef NDEBUG
-    RETURN_NOT_OK(dst->Tell(&current_position));
-    DCHECK(BitUtil::IsMultipleOf8(current_position));
-#endif
-
-    // Now write the buffers
-    for (size_t i = 0; i < buffers_.size(); ++i) {
-      const Buffer* buffer = buffers_[i].get();
-      int64_t size = 0;
-      int64_t padding = 0;
-
-      // The buffer might be null if we are handling zero row lengths.
-      if (buffer) {
-        size = buffer->size();
-        padding = BitUtil::RoundUpToMultipleOf8(size) - size;
-      }
-
-      if (size > 0) {
-        RETURN_NOT_OK(dst->Write(buffer->data(), size));
-      }
-
-      if (padding > 0) {
-        RETURN_NOT_OK(dst->Write(kPaddingBytes, padding));
-      }
-    }
-
-#ifndef NDEBUG
-    RETURN_NOT_OK(dst->Tell(&current_position));
-    DCHECK(BitUtil::IsMultipleOf8(current_position));
-#endif
+    out->body_buffers = std::move(buffers_);
+    out->total_body_length = body_length;
 
     return Status::OK();
   }
@@ -504,14 +514,14 @@ class DictionaryWriter : public RecordBatchSerializer {
                                   buffer_meta_, out);
   }
 
-  Status Write(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,
-               io::OutputStream* dst, int32_t* metadata_length, int64_t* body_length) {
+  Status Prepare(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,
+                 PreparedMessage* out) {
     dictionary_id_ = dictionary_id;
 
     // Make a dummy record batch. A bit tedious as we have to make a schema
     auto schema = arrow::schema({arrow::field("dictionary", dictionary->type())});
     auto batch = RecordBatch::Make(schema, dictionary->length(), {dictionary});
-    return RecordBatchSerializer::Write(*batch, dst, metadata_length, body_length);
+    return RecordBatchSerializer::Prepare(*batch, out);
   }
 
  private:
@@ -519,25 +529,45 @@ class DictionaryWriter : public RecordBatchSerializer {
   int64_t dictionary_id_;
 };
 
-// Adds padding bytes if necessary to ensure all memory blocks are written on
-// 64-byte boundaries.
-Status AlignStreamPosition(io::OutputStream* stream) {
-  int64_t position;
-  RETURN_NOT_OK(stream->Tell(&position));
-  int64_t remainder = PaddedLength(position) - position;
-  if (remainder > 0) {
-    return stream->Write(kPaddingBytes, remainder);
-  }
-  return Status::OK();
-}
-
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
                         io::OutputStream* dst, int32_t* metadata_length,
                         int64_t* body_length, MemoryPool* pool, int max_recursion_depth,
                         bool allow_64bit) {
+  PreparedMessage message;
   RecordBatchSerializer writer(pool, buffer_start_offset, max_recursion_depth,
                                allow_64bit);
-  return writer.Write(batch, dst, metadata_length, body_length);
+  RETURN_NOT_OK(writer.Prepare(batch, &message));
+  return message.WriteTo(dst, metadata_length, body_length);
+}
+
+Status WriteDictionary(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,
+                       int64_t buffer_start_offset, io::OutputStream* dst,
+                       int32_t* metadata_length, int64_t* body_length, MemoryPool* pool) {
+  PreparedMessage message;
+  DictionaryWriter writer(pool, buffer_start_offset, kMaxNestingDepth, false);
+  RETURN_NOT_OK(writer.Prepare(dictionary_id, dictionary, &message));
+  return message.WriteTo(dst, metadata_length, body_length);
+}
+
+Status PrepareRecordBatchMessage(const RecordBatch& batch, MemoryPool* pool,
+                                 PreparedMessage* message, int max_recursion_depth) {
+  RecordBatchSerializer writer(pool, 0, max_recursion_depth, true);
+  return writer.Prepare(batch, message);
+}
+
+Status PrepareDictionaryMessage(int64_t dictionary_id,
+                                const std::shared_ptr<Array>& dictionary,
+                                MemoryPool* pool, PreparedMessage* message,
+                                int max_recursion_depth) {
+  DictionaryWriter writer(pool, 0, kMaxNestingDepth, false);
+  return writer.Prepare(dictionary_id, dictionary, message);
+}
+
+Status GetRecordBatchSize(const RecordBatch& batch, int64_t* size) {
+  PreparedMessage message;
+  RETURN_NOT_OK(PrepareRecordBatchMessage(batch, default_memory_pool(), &message));
+  *size = message.GetTotalSize();
+  return Status::OK();
 }
 
 Status WriteRecordBatchStream(const std::vector<std::shared_ptr<RecordBatch>>& batches,
@@ -551,13 +581,6 @@ Status WriteRecordBatchStream(const std::vector<std::shared_ptr<RecordBatch>>& b
   }
   RETURN_NOT_OK(writer->Close());
   return Status::OK();
-}
-
-Status WriteLargeRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
-                             io::OutputStream* dst, int32_t* metadata_length,
-                             int64_t* body_length, MemoryPool* pool) {
-  return WriteRecordBatch(batch, buffer_start_offset, dst, metadata_length, body_length,
-                          pool, kMaxNestingDepth, true);
 }
 
 namespace {
@@ -618,8 +641,6 @@ Status GetContiguousTensor(const Tensor& tensor, MemoryPool* pool,
 
 Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadata_length,
                    int64_t* body_length) {
-  RETURN_NOT_OK(AlignStreamPosition(dst));
-
   if (tensor.is_contiguous()) {
     RETURN_NOT_OK(WriteTensorHeader(tensor, dst, metadata_length, body_length));
     auto data = tensor.data();
@@ -649,10 +670,10 @@ Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadat
   }
 }
 
-Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
-                        std::unique_ptr<Message>* out) {
-  const Tensor* tensor_to_write = &tensor;
+Status PrepareTensorMessage(const Tensor& tensor, MemoryPool* pool,
+                            PreparedMessage* out) {
   std::unique_ptr<Tensor> temp_tensor;
+  const Tensor* tensor_to_write = &tensor;
 
   if (!tensor.is_contiguous()) {
     RETURN_NOT_OK(GetContiguousTensor(tensor, pool, &temp_tensor));
@@ -660,26 +681,23 @@ Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
   }
 
   std::shared_ptr<Buffer> metadata;
-  RETURN_NOT_OK(internal::WriteTensorMessage(*tensor_to_write, 0, &metadata));
-  out->reset(new Message(metadata, tensor_to_write->data()));
+  RETURN_NOT_OK(internal::WriteTensorMessage(*tensor_to_write, 0, &out->metadata));
+  auto data = tensor_to_write->data();
+  out->body_buffers = {data};
+
+  if (data) {
+    out->total_body_length = BitUtil::RoundUpToMultipleOf8(data->size());
+  } else {
+    out->total_body_length = 0;
+  }
   return Status::OK();
 }
 
-Status WriteDictionary(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,
-                       int64_t buffer_start_offset, io::OutputStream* dst,
-                       int32_t* metadata_length, int64_t* body_length, MemoryPool* pool) {
-  DictionaryWriter writer(pool, buffer_start_offset, kMaxNestingDepth, false);
-  return writer.Write(dictionary_id, dictionary, dst, metadata_length, body_length);
-}
-
-Status GetRecordBatchSize(const RecordBatch& batch, int64_t* size) {
-  // emulates the behavior of Write without actually writing
-  int32_t metadata_length = 0;
-  int64_t body_length = 0;
-  io::MockOutputStream dst;
-  RETURN_NOT_OK(WriteRecordBatch(batch, 0, &dst, &metadata_length, &body_length,
-                                 default_memory_pool(), kMaxNestingDepth, true));
-  *size = dst.GetExtentBytesWritten();
+Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
+                        std::unique_ptr<Message>* out) {
+  PreparedMessage tensor_message;
+  RETURN_NOT_OK(PrepareTensorMessage(tensor, pool, &tensor_message));
+  out->reset(new Message(tensor_message.metadata, tensor_message.body_buffers[0]));
   return Status::OK();
 }
 


### PR DESCRIPTION
The purpose of this is to decompose a record batch into its serialized Flatbuffer metadata and sequence of buffers that form its body so that the total output size can be computed, e.g. for writing to a shared memory segment. Prior to this, one would have to call `GetRecordBatchSize`, allocate memory, then `WriteRecordBatch` which duplicates work. 

This also introduces a change to how padding is handled in unaligned streams to make the message contents deterministic. This makes record batches consistent with the way that tensors were already being written, with alignment bytes being written first to move the stream position to a multiple of 8, then beginning to write the metadata and message body.