### PR TITLE
ARROW-2029: [Python] NativeFile.tell errors after close

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -91,19 +91,19 @@ cdef class NativeFile:
         self._assert_writeable()
         file[0] = <shared_ptr[OutputStream]> self.wr_file
 
+    def _assert_open(self):
+        if not self.is_open:
+            raise ValueError("I/O operation on closed file")
+
     def _assert_readable(self):
+        self._assert_open()
         if not self.is_readable:
             raise IOError("only valid on readonly files")
 
-        if not self.is_open:
-            raise IOError("file not open")
-
     def _assert_writeable(self):
+        self._assert_open()
         if not self.is_writeable:
             raise IOError("only valid on writeable files")
-
-        if not self.is_open:
-            raise IOError("file not open")
 
     def size(self):
         """
@@ -120,6 +120,7 @@ cdef class NativeFile:
         Return current stream position
         """
         cdef int64_t position
+        self._assert_open()
         with nogil:
             if self.is_readable:
                 check_status(self.rd_file.get().Tell(&position))


### PR DESCRIPTION
Previously checking if the file was closed was subclass specific, and wasn't caught in the hdfs backed file, leading to program crashes.

This adds a check in `NativeFile.tell` for the file being open, and a test on a few subclasses of `NativeFile` to assure the error is raised.

Note that since most python file-like objects raise a `ValueError` for operations after close, I changed the type of the existing error for these cases. This could be changed back, but an error should at least be thrown.