### PR TITLE
ARROW-2031: [Python] HadoopFileSystem is pickleable

### DIFF
--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -31,9 +31,19 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
     def __init__(self, host="default", port=0, user=None, kerb_ticket=None,
                  driver='libhdfs'):
+        self._connect(host, port, user, kerb_ticket, driver)
+
+    def _connect(self, host, port, user, kerb_ticket, driver):
         if driver == 'libhdfs':
             _maybe_set_hadoop_classpath()
+        super(HadoopFileSystem, self)._connect(host, port, user, kerb_ticket,
+                                               driver)
 
+    def __getstate__(self):
+        return (self.host, self.port, self.user, self.kerb_ticket, self.driver)
+
+    def __setstate__(self, state):
+        host, port, user, kerb_ticket, driver = state
         self._connect(host, port, user, kerb_ticket, driver)
 
     @implements(FileSystem.isdir)

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -31,20 +31,14 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
     def __init__(self, host="default", port=0, user=None, kerb_ticket=None,
                  driver='libhdfs'):
-        self._connect(host, port, user, kerb_ticket, driver)
-
-    def _connect(self, host, port, user, kerb_ticket, driver):
         if driver == 'libhdfs':
             _maybe_set_hadoop_classpath()
-        super(HadoopFileSystem, self)._connect(host, port, user, kerb_ticket,
-                                               driver)
 
-    def __getstate__(self):
-        return (self.host, self.port, self.user, self.kerb_ticket, self.driver)
-
-    def __setstate__(self, state):
-        host, port, user, kerb_ticket, driver = state
         self._connect(host, port, user, kerb_ticket, driver)
+
+    def __reduce__(self):
+        return (HadoopFileSystem, (self.host, self.port, self.user,
+                                   self.kerb_ticket, self.driver))
 
     @implements(FileSystem.isdir)
     def isdir(self, path):

--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -18,6 +18,8 @@
 # ----------------------------------------------------------------------
 # HDFS IO implementation
 
+cimport cython
+
 _HDFS_PATH_RE = re.compile('hdfs://(.*):(\d+)(.*)')
 
 try:
@@ -53,35 +55,48 @@ def strip_hdfs_abspath(path):
         return path
 
 
+@cython.auto_pickle(False)
 cdef class HadoopFileSystem:
     cdef:
         shared_ptr[CHadoopFileSystem] client
 
     cdef readonly:
         bint is_open
-
-    def __cinit__(self):
-        pass
+        str host
+        str user
+        str kerb_ticket
+        str driver
+        int port
 
     def _connect(self, host, port, user, kerb_ticket, driver):
         cdef HdfsConnectionConfig conf
 
         if host is not None:
             conf.host = tobytes(host)
+        self.host = host
+
         conf.port = port
+        self.port = port
+
         if user is not None:
             conf.user = tobytes(user)
+        self.user = user
+
         if kerb_ticket is not None:
             conf.kerb_ticket = tobytes(kerb_ticket)
+        self.kerb_ticket = kerb_ticket
 
         if driver == 'libhdfs':
             with nogil:
                 check_status(HaveLibHdfs())
             conf.driver = HdfsDriver_LIBHDFS
-        else:
+        elif driver == 'libhdfs3':
             with nogil:
                 check_status(HaveLibHdfs3())
             conf.driver = HdfsDriver_LIBHDFS3
+        else:
+            raise ValueError("unknown driver: %r" % driver)
+        self.driver = driver
 
         with nogil:
             check_status(CHadoopFileSystem.Connect(&conf, &self.client))

--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -18,8 +18,6 @@
 # ----------------------------------------------------------------------
 # HDFS IO implementation
 
-cimport cython
-
 _HDFS_PATH_RE = re.compile('hdfs://(.*):(\d+)(.*)')
 
 try:
@@ -55,7 +53,6 @@ def strip_hdfs_abspath(path):
         return path
 
 
-@cython.auto_pickle(False)
 cdef class HadoopFileSystem:
     cdef:
         shared_ptr[CHadoopFileSystem] client


### PR DESCRIPTION
Adds support for pickling `HadoopFileSystem`

A few additional small fixes:
- Adds a check that `driver` is one of {'libhdfs3', 'libhdfs'}
- A few small tweaks to the hdfs tests to make them easier to run locally.