### PR TITLE
ARROW-2010: [C++] Do not suppress shorten-64-to-32 warnings from clang, fix warnings in ORC adapter

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -100,7 +100,7 @@ if ("${UPPERCASE_BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
 -Wno-cast-align -Wno-vla-extension -Wno-shift-sign-overflow \
 -Wno-used-but-marked-unused -Wno-missing-variable-declarations \
 -Wno-gnu-zero-variadic-macro-arguments -Wconversion -Wno-sign-conversion \
--Wno-disabled-macro-expansion -Wno-shorten-64-to-32")
+-Wno-disabled-macro-expansion")
 
     # Version numbers where warnings are introduced
     if ("${COMPILER_VERSION}" VERSION_GREATER "3.3")

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -105,6 +105,8 @@ Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
     return Status::OK();
   }
   liborc::TypeKind kind = type->getKind();
+  const int subtype_count = static_cast<int>(type->getSubtypeCount());
+
   switch (kind) {
     case liborc::BOOLEAN:
       *out = boolean();
@@ -135,7 +137,7 @@ Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
       *out = binary();
       break;
     case liborc::CHAR:
-      *out = fixed_size_binary(type->getMaximumLength());
+      *out = fixed_size_binary(static_cast<int>(type->getMaximumLength()));
       break;
     case liborc::TIMESTAMP:
       *out = timestamp(TimeUnit::NANO);
@@ -144,16 +146,18 @@ Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
       *out = date32();
       break;
     case liborc::DECIMAL: {
-      if (type->getPrecision() == 0) {
+      const int precision = static_cast<int>(type->getPrecision());
+      const int scale = static_cast<int>(type->getScale());
+      if (precision == 0) {
         // In HIVE 0.11/0.12 precision is set as 0, but means max precision
         *out = decimal(38, 6);
       } else {
-        *out = decimal(type->getPrecision(), type->getScale());
+        *out = decimal(precision, scale);
       }
       break;
     }
     case liborc::LIST: {
-      if (type->getSubtypeCount() != 1) {
+      if (subtype_count != 1) {
         return Status::Invalid("Invalid Orc List type");
       }
       std::shared_ptr<DataType> elemtype;
@@ -162,7 +166,7 @@ Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
       break;
     }
     case liborc::MAP: {
-      if (type->getSubtypeCount() != 2) {
+      if (subtype_count != 2) {
         return Status::Invalid("Invalid Orc Map type");
       }
       std::shared_ptr<DataType> keytype;
@@ -173,9 +177,8 @@ Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
       break;
     }
     case liborc::STRUCT: {
-      int size = type->getSubtypeCount();
       std::vector<std::shared_ptr<Field>> fields;
-      for (int child = 0; child < size; ++child) {
+      for (int child = 0; child < subtype_count; ++child) {
         std::shared_ptr<DataType> elemtype;
         RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
         std::string name = type->getFieldName(child);
@@ -185,10 +188,9 @@ Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
       break;
     }
     case liborc::UNION: {
-      int size = type->getSubtypeCount();
       std::vector<std::shared_ptr<Field>> fields;
       std::vector<uint8_t> type_codes;
-      for (int child = 0; child < size; ++child) {
+      for (int child = 0; child < subtype_count; ++child) {
         std::shared_ptr<DataType> elemtype;
         RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
         fields.push_back(field("_union_" + std::to_string(child), elemtype));
@@ -259,7 +261,7 @@ class ORCFileReader::Impl {
           "Only ORC files with a top-level struct "
           "can be handled");
     }
-    int size = type.getSubtypeCount();
+    int size = static_cast<int>(type.getSubtypeCount());
     std::vector<std::shared_ptr<Field>> fields;
     for (int child = 0; child < size; ++child) {
       std::shared_ptr<DataType> elemtype;
@@ -449,7 +451,7 @@ class ORCFileReader::Impl {
     const liborc::Type* elemtype = type->getSubtype(0);
 
     const bool has_nulls = batch->hasNulls;
-    for (int i = offset; i < length + offset; i++) {
+    for (int64_t i = offset; i < length + offset; i++) {
       if (!has_nulls || batch->notNull[i]) {
         int64_t start = batch->offsets[i];
         int64_t end = batch->offsets[i + 1];
@@ -474,7 +476,7 @@ class ORCFileReader::Impl {
     const liborc::Type* valtype = type->getSubtype(1);
 
     const bool has_nulls = batch->hasNulls;
-    for (int i = offset; i < length + offset; i++) {
+    for (int64_t i = offset; i < length + offset; i++) {
       RETURN_NOT_OK(list_builder->Append());
       int64_t start = batch->offsets[i];
       int64_t list_length = batch->offsets[i + 1] - start;
@@ -516,7 +518,7 @@ class ORCFileReader::Impl {
     if (length == 0) {
       return Status::OK();
     }
-    int start = builder->length();
+    int64_t start = builder->length();
 
     const uint8_t* valid_bytes = nullptr;
     if (batch->hasNulls) {
@@ -540,7 +542,7 @@ class ORCFileReader::Impl {
     if (length == 0) {
       return Status::OK();
     }
-    int start = builder->length();
+    int64_t start = builder->length();
 
     const uint8_t* valid_bytes = nullptr;
     if (batch->hasNulls) {
@@ -551,7 +553,7 @@ class ORCFileReader::Impl {
     const int64_t* source = batch->data.data() + offset;
     uint8_t* target = reinterpret_cast<uint8_t*>(builder->data()->mutable_data());
 
-    for (int i = 0; i < length; i++) {
+    for (int64_t i = 0; i < length; i++) {
       if (source[i]) {
         BitUtil::SetBit(target, start + i);
       } else {
@@ -569,7 +571,7 @@ class ORCFileReader::Impl {
     if (length == 0) {
       return Status::OK();
     }
-    int start = builder->length();
+    int64_t start = builder->length();
 
     const uint8_t* valid_bytes = nullptr;
     if (batch->hasNulls) {
@@ -581,7 +583,7 @@ class ORCFileReader::Impl {
     const int64_t* nanos = batch->nanoseconds.data() + offset;
     int64_t* target = reinterpret_cast<int64_t*>(builder->data()->mutable_data());
 
-    for (int i = 0; i < length; i++) {
+    for (int64_t i = 0; i < length; i++) {
       // TODO: boundscheck this, as ORC supports higher resolution timestamps
       // than arrow for nanosecond resolution
       target[start + i] = seconds[i] * kOneSecondNanos + nanos[i];
@@ -596,9 +598,10 @@ class ORCFileReader::Impl {
     auto batch = static_cast<liborc::StringVectorBatch*>(cbatch);
 
     const bool has_nulls = batch->hasNulls;
-    for (int i = offset; i < length + offset; i++) {
+    for (int64_t i = offset; i < length + offset; i++) {
       if (!has_nulls || batch->notNull[i]) {
-        RETURN_NOT_OK(builder->Append(batch->data[i], batch->length[i]));
+        RETURN_NOT_OK(
+            builder->Append(batch->data[i], static_cast<int32_t>(batch->length[i])));
       } else {
         RETURN_NOT_OK(builder->AppendNull());
       }
@@ -612,7 +615,7 @@ class ORCFileReader::Impl {
     auto batch = static_cast<liborc::StringVectorBatch*>(cbatch);
 
     const bool has_nulls = batch->hasNulls;
-    for (int i = offset; i < length + offset; i++) {
+    for (int64_t i = offset; i < length + offset; i++) {
       if (!has_nulls || batch->notNull[i]) {
         RETURN_NOT_OK(builder->Append(batch->data[i]));
       } else {
@@ -629,7 +632,7 @@ class ORCFileReader::Impl {
     const bool has_nulls = cbatch->hasNulls;
     if (type->getPrecision() == 0 || type->getPrecision() > 18) {
       auto batch = static_cast<liborc::Decimal128VectorBatch*>(cbatch);
-      for (int i = offset; i < length + offset; i++) {
+      for (int64_t i = offset; i < length + offset; i++) {
         if (!has_nulls || batch->notNull[i]) {
           RETURN_NOT_OK(builder->Append(
               Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
@@ -639,7 +642,7 @@ class ORCFileReader::Impl {
       }
     } else {
       auto batch = static_cast<liborc::Decimal64VectorBatch*>(cbatch);
-      for (int i = offset; i < length + offset; i++) {
+      for (int64_t i = offset; i < length + offset; i++) {
         if (!has_nulls || batch->notNull[i]) {
           RETURN_NOT_OK(builder->Append(Decimal128(batch->values[i])));
         } else {

--- a/cpp/src/plasma/fling.cc
+++ b/cpp/src/plasma/fling.cc
@@ -23,7 +23,7 @@ void init_msg(struct msghdr* msg, struct iovec* iov, char* buf, size_t buf_len) 
   msg->msg_iov = iov;
   msg->msg_iovlen = 1;
   msg->msg_control = buf;
-  msg->msg_controllen = buf_len;
+  msg->msg_controllen = static_cast<socklen_t>(buf_len);
   msg->msg_name = NULL;
   msg->msg_namelen = 0;
 }


### PR DESCRIPTION
These are warnings we want to see to prevent silent truncation of values without an explicit cast. 

See also bug ARROW-2032 that I encountered while working on this