### PR TITLE
ARROW-1992: [C++/Python] Fix segfault when string to categorical empty string array

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -406,12 +406,18 @@ class HashTableKernel<Type, Action, enable_if_binary<Type>> : public HashTable {
   }
 
   Status Append(const ArrayData& arr) override {
+    constexpr uint8_t empty_value = 0;
     if (!initialized_) {
       RETURN_NOT_OK(Init());
     }
 
     const int32_t* offsets = GetValues<int32_t>(arr, 1);
-    const uint8_t* data = GetValues<uint8_t>(arr, 2);
+    const uint8_t* data;
+    if (arr.buffers[2].get() == nullptr) {
+      data = &empty_value;
+    } else {
+      data = GetValues<uint8_t>(arr, 2);
+    }
 
     auto action = static_cast<Action*>(this);
     RETURN_NOT_OK(action->Reserve(arr.length));

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1237,6 +1237,21 @@ class TestPandasConversion(object):
         assert data_column['numpy_type'] == 'object'
         assert data_column['metadata'] == {'precision': 26, 'scale': 11}
 
+    def test_table_empty_str(self):
+        values = ['', '', '', '', '']
+        df = pd.DataFrame({'strings': values})
+        field = pa.field('strings', pa.string())
+        schema = pa.schema([field])
+        table = pa.Table.from_pandas(df, schema=schema)
+
+        result1 = table.to_pandas(strings_to_categorical=False)
+        expected1 = pd.DataFrame({'strings': values})
+        tm.assert_frame_equal(result1, expected1, check_dtype=True)
+
+        result2 = table.to_pandas(strings_to_categorical=True)
+        expected2 = pd.DataFrame({'strings': pd.Categorical(values)})
+        tm.assert_frame_equal(result2, expected2, check_dtype=True)
+
     def test_table_str_to_categorical_without_na(self):
         values = ['a', 'a', 'b', 'b', 'c']
         df = pd.DataFrame({'strings': values})


### PR DESCRIPTION
This closes [ARROW-1992](https://issues.apache.org/jira/browse/ARROW-1992).