### PR TITLE
ARROW-1706: [Python] Coerce array inputs to StructArray.from_arrays. Flip order of arguments

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -828,8 +828,9 @@ cdef class DictionaryArray(Array):
 
 
 cdef class StructArray(Array):
+
     @staticmethod
-    def from_arrays(field_names, arrays):
+    def from_arrays(arrays, names=None):
         cdef:
             Array array
             shared_ptr[CArray] c_array
@@ -838,6 +839,8 @@ cdef class StructArray(Array):
             ssize_t num_arrays
             ssize_t length
             ssize_t i
+
+        arrays = [asarray(x) for x in arrays]
 
         num_arrays = len(arrays)
         if num_arrays == 0:
@@ -855,7 +858,7 @@ cdef class StructArray(Array):
         cdef DataType struct_type = struct([
             field(name, array.type)
             for name, array in
-            zip(field_names, arrays)
+            zip(names, arrays)
         ])
 
         c_result.reset(new CStructArray(struct_type.sp_type, length, c_arrays))

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -831,6 +831,20 @@ cdef class StructArray(Array):
 
     @staticmethod
     def from_arrays(arrays, names=None):
+        """
+        Construct StructArray from collection of arrays representing each field
+        in the struct
+
+        Parameters
+        ----------
+        arrays : sequence of Array
+        names : List[str]
+            Field names
+
+        Returns
+        -------
+        result : StructArray
+        """
         cdef:
             Array array
             shared_ptr[CArray] c_array
@@ -839,6 +853,9 @@ cdef class StructArray(Array):
             ssize_t num_arrays
             ssize_t length
             ssize_t i
+
+        if names is None:
+            raise ValueError('Names are currently required')
 
         arrays = [asarray(x) for x in arrays]
 

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -493,8 +493,8 @@ def test_structarray():
     strs = pa.array([u'a', None, u'c'], type=pa.string())
     bools = pa.array([True, False, None], type=pa.bool_())
     arr = pa.StructArray.from_arrays(
-        ['ints', 'strs', 'bools'],
-        [ints, strs, bools])
+        [ints, strs, bools],
+        ['ints', 'strs', 'bools'])
 
     expected = [
         {'ints': None, 'strs': u'a', 'bools': True},

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -538,7 +538,8 @@ def test_structarray_from_arrays_coerce():
     bools = [True, False, None]
     ints_nonnull = [1, 2, 3]
 
-    result = pa.StructArray.from_arrays([ints, strs, bools, ints_nonnull],
+    arrays = [ints, strs, bools, ints_nonnull]
+    result = pa.StructArray.from_arrays(arrays,
                                         ['ints', 'strs', 'bools',
                                          'int_nonnull'])
     expected = pa.StructArray.from_arrays(
@@ -547,5 +548,8 @@ def test_structarray_from_arrays_coerce():
          pa.array(bools),
          pa.array(ints_nonnull, type='int64')],
         ['ints', 'strs', 'bools', 'int_nonnull'])
+
+    with pytest.raises(ValueError):
+        pa.StructArray.from_arrays(arrays)
 
     assert result.equals(expected)

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -529,3 +529,23 @@ def test_struct_from_dicts():
                 {'a': None, 'b': None, 'c': None},
                 {'a': None, 'b': 'bar', 'c': None}]
     assert arr.to_pylist() == expected
+
+
+def test_structarray_from_arrays_coerce():
+    # ARROW-1706
+    ints = [None, 2, 3]
+    strs = [u'a', None, u'c']
+    bools = [True, False, None]
+    ints_nonnull = [1, 2, 3]
+
+    result = pa.StructArray.from_arrays([ints, strs, bools, ints_nonnull],
+                                        ['ints', 'strs', 'bools',
+                                         'int_nonnull'])
+    expected = pa.StructArray.from_arrays(
+        [pa.array(ints, type='int64'),
+         pa.array(strs, type='utf8'),
+         pa.array(bools),
+         pa.array(ints_nonnull, type='int64')],
+        ['ints', 'strs', 'bools', 'int_nonnull'])
+
+    assert result.equals(expected)

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1153,8 +1153,8 @@ class TestPandasConversion(object):
         strs = pa.array([u'a', None, u'c'], type=pa.string())
         bools = pa.array([True, False, None], type=pa.bool_())
         arr = pa.StructArray.from_arrays(
-            ['ints', 'strs', 'bools'],
-            [ints, strs, bools])
+            [ints, strs, bools],
+            ['ints', 'strs', 'bools'])
 
         expected = pd.Series([
             {'ints': None, 'strs': u'a', 'bools': True},


### PR DESCRIPTION
I flipped the argument order to be more consistent with the same methods in RecordBatch, Table. The StructArray method doesn't seem to be widely used so I'm not sure there's the need to go through a deprecation cycle