### PR TITLE
[C++] Update README for linting

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -262,7 +262,8 @@ You can also fix any formatting errors automatically:
     make format
 
 These commands require `clang-format-4.0` (and not any other version).
-You may found the required packages for Debian/Ubuntu on https://apt.llvm.org/.
+You may find the required packages at http://releases.llvm.org/download.html
+or use the Debian/Ubuntu APT repositories on https://apt.llvm.org/.
 
 Also, if under a Python 3 environment, you need to install a compatible
 version of `cpplint` using `pip install cpplint`.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -250,6 +250,23 @@ Logging IWYU to /tmp/arrow-cpp-iwyu.gT7XXV
 ...
 ```
 
+### Linting
+
+We require that you follow a certain coding style in the C++ code base.
+You can check your code abides by that coding style by running:
+
+    make lint
+
+You can also fix any formatting errors automatically:
+
+    make format
+
+These commands require `clang-format-4.0` (and not any other version).
+You may found the required packages for Debian/Ubuntu on https://apt.llvm.org/.
+
+Also, if under a Python 3 environment, you need to install a compatible
+version of `cpplint` using `pip install cpplint`.
+
 ## Continuous Integration
 
 Pull requests are run through travis-ci for continuous integration.  You can avoid


### PR DESCRIPTION
There are hidden gotchas when trying to run the linting Makefile targets, mention them.

See issue #1514 (I'm not sure it's required to open a JIRA entry for such a trivial issue?).