### PR TITLE
ARROW-1623: [C++] Add convenience method to construct Buffer from a string that owns its memory

### DIFF
--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -52,6 +52,22 @@ TEST(TestBuffer, FromStdString) {
   ASSERT_EQ(static_cast<int64_t>(val.size()), buf.size());
 }
 
+TEST(TestBuffer, FromStdStringWithMemory) {
+  std::string* val = new std::string("hello, world");
+  std::shared_ptr<Buffer> buf;
+  std::string expected("hello, world");
+
+  ASSERT_OK(Buffer::FromString(*val, default_memory_pool(), &buf));
+
+  ASSERT_EQ(0, memcmp(buf->data(), val->c_str(), val->size()));
+  ASSERT_EQ(static_cast<int64_t>(val->size()), buf->size());
+
+  delete val;
+
+  ASSERT_EQ(0, memcmp(buf->data(), expected.c_str(), expected.size()));
+  ASSERT_EQ(static_cast<int64_t>(expected.size()), buf->size());
+}
+
 TEST(TestBuffer, Resize) {
   PoolBuffer buf;
 

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -53,17 +53,18 @@ TEST(TestBuffer, FromStdString) {
 }
 
 TEST(TestBuffer, FromStdStringWithMemory) {
-  std::string* val = new std::string("hello, world");
+  std::string expected = "hello, world";
   std::shared_ptr<Buffer> buf;
-  std::string expected("hello, world");
 
-  ASSERT_OK(Buffer::FromString(*val, default_memory_pool(), &buf));
+  {
+    std::string temp = "hello, world";
+    ASSERT_OK(Buffer::FromString(temp, &buf));
+    ASSERT_EQ(0, memcmp(buf->data(), temp.c_str(), temp.size()));
+    ASSERT_EQ(static_cast<int64_t>(temp.size()), buf->size());
+  }
 
-  ASSERT_EQ(0, memcmp(buf->data(), val->c_str(), val->size()));
-  ASSERT_EQ(static_cast<int64_t>(val->size()), buf->size());
-
-  delete val;
-
+  // Now temp goes out of scope and we check if created buffer
+  // is still valid to make sure it actually owns its space
   ASSERT_EQ(0, memcmp(buf->data(), expected.c_str(), expected.size()));
   ASSERT_EQ(static_cast<int64_t>(expected.size()), buf->size());
 }

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -60,13 +60,15 @@ bool Buffer::Equals(const Buffer& other) const {
 
 Status Buffer::FromString(const std::string& data, MemoryPool* pool,
                           std::shared_ptr<Buffer>* out) {
-  auto str = reinterpret_cast<const uint8_t*>(data.c_str());
   auto size = static_cast<int64_t>(data.size());
-
   RETURN_NOT_OK(AllocateBuffer(pool, size, out));
-  std::memcpy((*out)->mutable_data(), str, size);
-
+  std::copy(data.c_str(), data.c_str() + size, (*out)->mutable_data());
   return Status::OK();
+}
+
+Status Buffer::FromString(const std::string& data,
+                          std::shared_ptr<Buffer>* out) {
+  return FromString(data, default_memory_pool(), out);
 }
 
 PoolBuffer::PoolBuffer(MemoryPool* pool) : ResizableBuffer(nullptr, 0) {

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -58,6 +58,17 @@ bool Buffer::Equals(const Buffer& other) const {
                              !memcmp(data_, other.data_, static_cast<size_t>(size_))));
 }
 
+Status Buffer::FromString(const std::string& data, MemoryPool* pool,
+                          std::shared_ptr<Buffer>* out) {
+  auto str = reinterpret_cast<const uint8_t*>(data.c_str());
+  auto size = static_cast<int64_t>(data.size());
+
+  RETURN_NOT_OK(AllocateBuffer(pool, size, out));
+  std::memcpy((*out)->mutable_data(), str, size);
+
+  return Status::OK();
+}
+
 PoolBuffer::PoolBuffer(MemoryPool* pool) : ResizableBuffer(nullptr, 0) {
   if (pool == nullptr) {
     pool = default_memory_pool();

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -66,8 +66,7 @@ Status Buffer::FromString(const std::string& data, MemoryPool* pool,
   return Status::OK();
 }
 
-Status Buffer::FromString(const std::string& data,
-                          std::shared_ptr<Buffer>* out) {
+Status Buffer::FromString(const std::string& data, std::shared_ptr<Buffer>* out) {
   return FromString(data, default_memory_pool(), out);
 }
 

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -101,10 +101,15 @@ class ARROW_EXPORT Buffer {
   ///
   /// \param[in] data a std::string object
   /// \param[in] pool a memory pool
-  /// \param[out] the created buffer
+  /// \param[out] out the created buffer
   ///
   /// \return Status message
   static Status FromString(const std::string& data, MemoryPool* pool,
+                           std::shared_ptr<Buffer>* out);
+
+  /// \brief Construct a new buffer that owns its memory from a std::string
+  /// using the default memory pool
+  static Status FromString(const std::string& data,
                            std::shared_ptr<Buffer>* out);
 
   int64_t capacity() const { return capacity_; }

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -97,6 +97,16 @@ class ARROW_EXPORT Buffer {
   Status Copy(const int64_t start, const int64_t nbytes,
               std::shared_ptr<Buffer>* out) const;
 
+  /// \brief Construct a new buffer that owns its memory from a std::string
+  ///
+  /// \param[in] data a std::string object
+  /// \param[in] pool a memory pool
+  /// \param[out] the created buffer
+  ///
+  /// \return Status message
+  static Status FromString(const std::string& data, MemoryPool* pool,
+                           std::shared_ptr<Buffer>* out);
+
   int64_t capacity() const { return capacity_; }
   const uint8_t* data() const { return data_; }
   uint8_t* mutable_data() { return mutable_data_; }

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -109,8 +109,7 @@ class ARROW_EXPORT Buffer {
 
   /// \brief Construct a new buffer that owns its memory from a std::string
   /// using the default memory pool
-  static Status FromString(const std::string& data,
-                           std::shared_ptr<Buffer>* out);
+  static Status FromString(const std::string& data, std::shared_ptr<Buffer>* out);
 
   int64_t capacity() const { return capacity_; }
   const uint8_t* data() const { return data_; }


### PR DESCRIPTION
Add static member function Buffer::FromString to create a new buffer that owns its memory from given std::string. The memory is allocated from a given memory pool or the default one if not specified.