### PR TITLE
ARROW-2032: [C++] ORC ep installs on each call to ninja build

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -926,8 +926,7 @@ if (ARROW_ORC)
                       -DZLIB_HOME=${ZLIB_HOME})
 
   ExternalProject_Add(orc_ep
-    GIT_REPOSITORY "https://github.com/apache/orc"
-    GIT_TAG ${ORC_VERSION}
+    URL "https://github.com/apache/orc/archive/${ORC_VERSION}.tar.gz"
     BUILD_BYPRODUCTS ${ORC_STATIC_LIB}
     CMAKE_ARGS ${ORC_CMAKE_ARGS})
 


### PR DESCRIPTION
ExternalProject_add using git is sadly always triggering something.
Using HTTP archives instead don't need to check if they are at the
correct revision.