### PR TITLE
ARROW-2044: [JS] Typings should be a regular dependency

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -52,6 +52,8 @@
     "npm-release.sh"
   ],
   "dependencies": {
+    "@types/flatbuffers": "1.6.5",
+    "@types/node": "9.3.0",
     "@types/text-encoding-utf-8": "1.0.1",
     "command-line-args": "5.0.1",
     "command-line-usage": "4.1.0",
@@ -62,10 +64,8 @@
   },
   "devDependencies": {
     "@std/esm": "0.19.7",
-    "@types/flatbuffers": "1.6.5",
     "@types/glob": "5.0.35",
     "@types/jest": "22.1.0",
-    "@types/node": "9.3.0",
     "ast-types": "0.10.1",
     "benchmark": "2.1.4",
     "coveralls": "3.0.0",


### PR DESCRIPTION
Made @types/{flatbuffers,node} regular dependencies so they will be included with release packages