### PR TITLE
ARROW-2047: [Python] Use sys.executable instead of one in the search path.

### DIFF
--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -554,7 +554,7 @@ def test_deserialize_buffer_in_different_process():
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
     python_file = os.path.join(dir_path, 'deserialize_buffer.py')
-    subprocess.check_call(['python', python_file, f.name])
+    subprocess.check_call([sys.executable, python_file, f.name])
 
 
 def test_set_pickle():


### PR DESCRIPTION
* It currently relies on the behavior of `subprocess.check_call()` that searches for the executable in the search path. Because of it, the test run needs a valid search path setup.
