### PR TITLE
ARROW-2049: [Python] Try searching for the Cython executable according to sysconfig

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -158,7 +158,7 @@ class build_ext(_build_ext):
         static_lib_option = ''
 
         scripts_dir = get_scripts_dir()
-        cython_executable = os.path.join(scripts_dir, 'cython')
+        cython_executable = os.path.join(scripts_dir, 'cython%s' % sysconfig.get_config_var('EXE'))
         if not os.path.exists(cython_executable):
             cython_executable = None
 


### PR DESCRIPTION
* setup.py doesn't even try to detect the right cython executable specially when it is used in virtualenv. Instead it always tries to use the one found in the search path.
