### PR TITLE
ARROW-2053: [C++] fix build instruction is incomplete

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -59,6 +59,7 @@ Simple debug build:
     cd debug
     cmake ..
     make unittest
+    sudo make install
 
 Simple release build:
 
@@ -68,6 +69,7 @@ Simple release build:
     cd release
     cmake .. -DCMAKE_BUILD_TYPE=Release
     make unittest
+    sudo make install
 
 Detailed unit test logs will be placed in the build directory under `build/test-logs`.
 


### PR DESCRIPTION
I did the following [c_glib](https://github.com/apache/arrow/tree/master/c_glib)  instruction
```
cd c_glib
brew install -y gobject-introspection
./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH
```

I got the following result
```
checking for arrow arrow-compute... no
configure: error: Package requirements (arrow arrow-compute) were not met:
No package 'arrow' found
No package 'arrow-compute' found
Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.
Alternatively, you may set the environment variables ARROW_CFLAGS
and ARROW_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```
 
I need the following information to succeed 

`sudo make install`