### PR TITLE
ARROW-2054: [C++] Fix compilation warnings

### DIFF
--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -866,7 +866,7 @@ static Status GetField(const rj::Value& obj, const DictionaryMemo* dictionary_me
   if (dictionary_memo != nullptr && it_dictionary != json_field.MemberEnd()) {
     // Field is dictionary encoded. We must have already
     RETURN_NOT_OBJECT("dictionary", it_dictionary, json_field);
-    int64_t dictionary_id;
+    int64_t dictionary_id = -1;
     bool is_ordered;
     std::shared_ptr<DataType> index_type;
     RETURN_NOT_OK(ParseDictionary(it_dictionary->value.GetObject(), &dictionary_id,
@@ -1346,7 +1346,7 @@ static Status ReadDictionaries(const rj::Value& doc, const DictionaryTypeMap& id
 
   for (const rj::Value& val : dictionary_array) {
     DCHECK(val.IsObject());
-    int64_t dictionary_id;
+    int64_t dictionary_id = -1;
     std::shared_ptr<Array> dictionary;
     RETURN_NOT_OK(
         ReadDictionary(val.GetObject(), id_to_field, pool, &dictionary_id, &dictionary));

--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -590,6 +590,8 @@ class TimestampConverter
         case TimeUnit::NANO:
           t = PyDateTime_to_ns(pydatetime);
           break;
+        default:
+          return Status::UnknownError("Invalid time unit");
       }
     } else if (PyArray_CheckAnyScalarExact(item.obj())) {
       // numpy.datetime64

--- a/cpp/src/plasma/fling.cc
+++ b/cpp/src/plasma/fling.cc
@@ -43,7 +43,7 @@ int send_fd(int conn, int fd) {
   header->cmsg_level = SOL_SOCKET;
   header->cmsg_type = SCM_RIGHTS;
   header->cmsg_len = CMSG_LEN(sizeof(int));
-  *reinterpret_cast<int*>(CMSG_DATA(header)) = fd;
+  memcpy(CMSG_DATA(header), reinterpret_cast<void*>(&fd), sizeof(int));
 
   // Send file descriptor.
   ssize_t r = sendmsg(conn, &msg, 0);


### PR DESCRIPTION
One of them is a pointer aliasing offense (thus a real bug), the other ones could merely be ignored.