### PR TITLE
ARROW-1757: [C++] Add DictionaryArray::FromArrays alternate ctor that can check or sanitized "untrusted" indices

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -2384,6 +2384,37 @@ TEST(TestDictionary, Validate) {
   // ASSERT_OK(ValidateArray(*arr3));
 }
 
+TEST(TestDictionary, FromArray) {
+  std::shared_ptr<Array> dict;
+  vector<string> dict_values = {"foo", "bar", "baz"};
+  ArrayFromVector<StringType, string>(dict_values, &dict);
+  std::shared_ptr<DataType> dict_type = dictionary(int16(), dict);
+
+  std::shared_ptr<Array> indices1;
+  vector<int16_t> indices_values1 = {1, 2, 0, 0, 2, 0};
+  ArrayFromVector<Int16Type, int16_t>(indices_values1, &indices1);
+
+  std::shared_ptr<Array> indices2;
+  vector<int16_t> indices_values2 = {1, 2, 0, 3, 2, 0};
+  ArrayFromVector<Int16Type, int16_t>(indices_values2, &indices2);
+
+  std::shared_ptr<Array> indices3;
+  vector<bool> is_valid3 = {true, true, false, true, true, true};
+  vector<int16_t> indices_values3 = {1, 2, -1, 0, 2, 0};
+  ArrayFromVector<Int16Type, int16_t>(is_valid3, indices_values3, &indices3);
+
+  std::shared_ptr<Array> indices4;
+  vector<bool> is_valid4 = {true, true, false, true, true, true};
+  vector<int16_t> indices_values4 = {1, 2, 1, 3, 2, 0};
+  ArrayFromVector<Int16Type, int16_t>(is_valid4, indices_values4, &indices4);
+
+  std::shared_ptr<Array> arr1, arr2, arr3, arr4;
+  ASSERT_OK(DictionaryArray::FromArrays(dict_type, indices1, &arr1));
+  ASSERT_RAISES(Invalid, DictionaryArray::FromArrays(dict_type, indices2, &arr2));
+  ASSERT_OK(DictionaryArray::FromArrays(dict_type, indices3, &arr3));
+  ASSERT_RAISES(Invalid, DictionaryArray::FromArrays(dict_type, indices4, &arr4));
+}
+
 // ----------------------------------------------------------------------
 // Struct tests
 

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -494,7 +494,7 @@ DictionaryArray::DictionaryArray(const std::shared_ptr<DataType>& type,
 
 Status DictionaryArray::FromArrays(const std::shared_ptr<DataType>& type,
                                    const std::shared_ptr<Array>& indices,
-                                   std::shared_ptr<Array>* out) { 
+                                   std::shared_ptr<Array>* out) {
   if (indices->length() == 0) {
     return Status::Invalid("Dictionary indices must have non-zero length");
   }
@@ -526,12 +526,11 @@ Status DictionaryArray::FromArrays(const std::shared_ptr<DataType>& type,
     return Status::NotImplemented(ss.str());
   }
 
-  if(!is_valid) {
+  if (!is_valid) {
     return Status::Invalid("Invalid dictionary indices");
   }
 
-  std::shared_ptr<DictionaryArray> internal = std::make_shared<DictionaryArray>(type, indices);
-  *out = internal;
+  *out = std::make_shared<DictionaryArray>(type, indices);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -726,6 +726,13 @@ class ARROW_EXPORT DictionaryArray : public Array {
   DictionaryArray(const std::shared_ptr<DataType>& type,
                   const std::shared_ptr<Array>& indices);
 
+  /// \brief Construct DictionaryArray from dictonary data type and indices array
+  ///
+  /// This function does the validation of the indices and input type
+  ///
+  /// \param[in] type a data type containing a dictionary
+  /// \param[in] indices an array of non-negative integers as dictionary indices
+  /// \param[out] out the resulting DictionaryArray instance
   static Status FromArrays(const std::shared_ptr<DataType>& type,
                            const std::shared_ptr<Array>& indices,
                            std::shared_ptr<Array>* out);
@@ -738,6 +745,10 @@ class ARROW_EXPORT DictionaryArray : public Array {
  private:
   void SetData(const std::shared_ptr<ArrayData>& data);
 
+  /// \brief Check if all indices are within valid range
+  ///
+  /// \param[in] indices dictionary indices
+  /// \param[in] range valid range of indices (0 <= index < range)
   template <typename ArrowType>
     static bool SanityCheck(const std::shared_ptr<Array>& indices, const int64_t range) {
     using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
@@ -746,11 +757,11 @@ class ARROW_EXPORT DictionaryArray : public Array {
     const int64_t size = sizeof(data) / sizeof(data[0]);
 
     for (int64_t idx = 0; idx < size; ++idx) {
-      if (!array->IsNull(idx)){
-	if (data[idx] < 0 || data[idx] >= range) {
+      if (!array->IsNull(idx)) {
+        if (data[idx] < 0 || data[idx] >= range) {
 	  return false;
-	}
-      } 
+        }
+      }
     }
     return true;
   }

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -782,38 +782,6 @@ ARROW_EXTERN_TEMPLATE NumericArray<TimestampType>;
 ARROW_EXPORT
 Status ValidateArray(const Array& array);
 
-/// \brief Perform validation check to determine if all indices are within
-/// valid range (0 <= index < upper_bound)
-///
-/// \param[in] indices array of indices
-/// \param[in] upper_bound upper bound of valid range for indices
-/// \return Status
-template <typename ArrowType>
-Status ValidateArray(const std::shared_ptr<Array>& indices, const int64_t upper_bound) {
-  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
-  const auto& array = static_cast<const ArrayType&>(*indices);
-  const typename ArrowType::c_type* data = array.raw_values();
-  const int64_t size = array.length();
-
-  if (array.null_count() == 0) {
-    for (int64_t idx = 0; idx < size; ++idx) {
-      if (data[idx] < 0 || data[idx] >= upper_bound) {
-        return Status::Invalid("Dictionary has out-of-bound index [0, dict.length)");
-      }
-    }
-  } else {
-    for (int64_t idx = 0; idx < size; ++idx) {
-      if (!array.IsNull(idx)) {
-        if (data[idx] < 0 || data[idx] >= upper_bound) {
-          return Status::Invalid("Dictionary has out-of-bound index [0, dict.length)");
-        }
-      }
-    }
-  }
-
-  return Status::OK();
-}
-
 }  // namespace arrow
 
 #endif  // ARROW_ARRAY_H


### PR DESCRIPTION
Add static member function DictionaryArray::FromArrays to create DictionaryArray from a given type and an indices array. This method calls DictionaryArray::SanityCheck to check if all indices are within valid range.