### PR TITLE
ARROW-2064: [GLib] Add common build problems link to the install section

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -53,6 +53,8 @@ recommended that you use packages.
 Note that the packages are "unofficial". "Official" packages will be
 released in the future.
 
+If you find problems when installing please see [common build problems](https://github.com/apache/arrow/blob/master/c_glib/README.md#common-build-problems).
+
 ### Package
 
 See [install document](../site/install.md) for details.


### PR DESCRIPTION
I think I should add "Add common build problems" link to the install section. I could not find the the link when installing.

