### PR TITLE
ARROW-2086: [Python] Shrink size of arrow_manylinux1_x86_64_base docker image

### DIFF
--- a/python/manylinux1/Dockerfile-x86_64
+++ b/python/manylinux1/Dockerfile-x86_64
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM quay.io/xhochy/arrow_manylinux1_x86_64_base:ARROW-2048
+FROM quay.io/xhochy/arrow_manylinux1_x86_64_base:ARROW-2086
 
 ADD arrow /arrow
 WORKDIR /arrow/cpp

--- a/python/manylinux1/Dockerfile-x86_64_base
+++ b/python/manylinux1/Dockerfile-x86_64_base
@@ -17,7 +17,7 @@
 FROM quay.io/pypa/manylinux1_x86_64:latest
 
 # Install dependencies
-RUN yum install -y flex zlib-devel
+RUN yum install -y flex zlib-devel && yum clean all
 
 ADD scripts/build_openssl.sh /
 RUN /build_openssl.sh

--- a/python/manylinux1/scripts/build_boost.sh
+++ b/python/manylinux1/scripts/build_boost.sh
@@ -23,6 +23,16 @@ wget --no-check-certificate https://dl.bintray.com/boostorg/release/${BOOST_VERS
 tar xf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz
 pushd /boost_${BOOST_VERSION_UNDERSCORE}
 ./bootstrap.sh
-./bjam cxxflags=-fPIC cflags=-fPIC --prefix=/usr --with-filesystem --with-date_time --with-system --with-regex install
+./bjam cxxflags=-fPIC cflags=-fPIC variant=release link=static --prefix=/usr --with-filesystem --with-date_time --with-system --with-regex install
 popd
 rm -rf boost_${BOOST_VERSION_UNDERSCORE}.tar.gz boost_${BOOST_VERSION_UNDERSCORE}
+# Boost always install header-only parts but they also take up quite some space.
+# We don't need them in array, so don't persist them in the docker layer.
+# phoenix 18.1 MiB
+rm -r /usr/include/boost/phoenix
+# fusion 16.7 MiB
+rm -r /usr/include/boost/fusion
+# spirit 8.2 MiB
+rm -r /usr/include/boost/spirit
+# geometry 6.0 MiB
+rm -r /usr/include/boost/geometry

--- a/python/manylinux1/scripts/build_virtualenvs.sh
+++ b/python/manylinux1/scripts/build_virtualenvs.sh
@@ -44,3 +44,11 @@ for PYTHON in ${PYTHON_VERSIONS}; do
     pip install pytest 'numpy==1.12.1' 'pandas==0.20.1'
     deactivate
 done
+
+# Remove pip cache again. It's useful during the virtualenv creation but we
+# don't want it persisted in the docker layer, ~264MiB
+rm -rf /root/.cache
+# Remove pandas' tests module as it includes a lot of data, ~27MiB per Python
+# venv, i.e. 216MiB in total
+rm -rf /opt/_internal/*/lib/*/site-packages/pandas/tests
+rm -rf /venv-test-*/lib/*/site-packages/pandas/tests


### PR DESCRIPTION
First iteration, the next step would be to go over some binaries and ensure that they get stripped or that upstream already strips them.

Image size before: 3.36G
Image size now: 2.82G

Details: https://gist.github.com/xhochy/a3db85f8509101c9762d31845ae123b1