### PR TITLE
ARROW-2089: [GLib] Rename to GARROW_TYPE_BOOLEAN for consistency

### DIFF
--- a/c_glib/arrow-glib/type.cpp
+++ b/c_glib/arrow-glib/type.cpp
@@ -39,7 +39,7 @@ garrow_type_from_raw(arrow::Type::type type)
   case arrow::Type::type::NA:
     return GARROW_TYPE_NA;
   case arrow::Type::type::BOOL:
-    return GARROW_TYPE_BOOL;
+    return GARROW_TYPE_BOOLEAN;
   case arrow::Type::type::UINT8:
     return GARROW_TYPE_UINT8;
   case arrow::Type::type::INT8:

--- a/c_glib/arrow-glib/type.h
+++ b/c_glib/arrow-glib/type.h
@@ -26,7 +26,7 @@ G_BEGIN_DECLS
 /**
  * GArrowType:
  * @GARROW_TYPE_NA: A degenerate NULL type represented as 0 bytes/bits.
- * @GARROW_TYPE_BOOL: A boolean value represented as 1 bit.
+ * @GARROW_TYPE_BOOLEAN: A boolean value represented as 1 bit.
  * @GARROW_TYPE_UINT8: Little-endian 8bit unsigned integer.
  * @GARROW_TYPE_INT8: Little-endian 8bit signed integer.
  * @GARROW_TYPE_UINT16: Little-endian 16bit unsigned integer.
@@ -58,7 +58,7 @@ G_BEGIN_DECLS
  */
 typedef enum {
   GARROW_TYPE_NA,
-  GARROW_TYPE_BOOL,
+  GARROW_TYPE_BOOLEAN,
   GARROW_TYPE_UINT8,
   GARROW_TYPE_INT8,
   GARROW_TYPE_UINT16,

--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -92,7 +92,7 @@ class TestArray < Test::Unit::TestCase
   def test_value_type
     builder = Arrow::BooleanArrayBuilder.new
     array = builder.finish
-    assert_equal(Arrow::Type::BOOL, array.value_type)
+    assert_equal(Arrow::Type::BOOLEAN, array.value_type)
   end
 
   def test_slice

--- a/c_glib/test/test-boolean-data-type.rb
+++ b/c_glib/test/test-boolean-data-type.rb
@@ -18,7 +18,7 @@
 class TestBooleanDataType < Test::Unit::TestCase
   def test_type
     data_type = Arrow::BooleanDataType.new
-    assert_equal(Arrow::Type::BOOL, data_type.id)
+    assert_equal(Arrow::Type::BOOLEAN, data_type.id)
   end
 
   def test_to_s

--- a/c_glib/test/test-chunked-array.rb
+++ b/c_glib/test/test-chunked-array.rb
@@ -45,7 +45,7 @@ class TestChunkedArray < Test::Unit::TestCase
       build_boolean_array([true, false]),
       build_boolean_array([true]),
     ]
-    assert_equal(Arrow::Type::BOOL,
+    assert_equal(Arrow::Type::BOOLEAN,
                  Arrow::ChunkedArray.new(chunks).value_type)
   end
 


### PR DESCRIPTION
Array name and data type name use "boolean" not "bool".
GArrowType only uses "bool".