### PR TITLE
ARROW-2121: [Python] Handle object arrays directly in pandas serializer.

### DIFF
--- a/python/README-benchmarks.md
+++ b/python/README-benchmarks.md
@@ -41,8 +41,6 @@ First you have to install ASV's development version:
 pip install git+https://github.com/airspeed-velocity/asv.git
 ```
 
-<!--- TODO remove the above once https://github.com/airspeed-velocity/asv/pull/611 is merged -->
-
 Then you need to set up a few environment variables:
 
 ```shell

--- a/python/benchmarks/convert_pandas.py
+++ b/python/benchmarks/convert_pandas.py
@@ -48,3 +48,23 @@ class PandasConversionsFromArrow(PandasConversionsBase):
 
     def time_to_series(self, n, dtype):
         self.arrow_data.to_pandas()
+
+
+class ZeroCopyPandasRead(object):
+
+    def setup(self):
+        # Transpose to make column-major
+        values = np.random.randn(10, 100000)
+
+        df = pd.DataFrame(values.T)
+        ctx = pa.default_serialization_context()
+
+        self.serialized = ctx.serialize(df)
+        self.as_buffer = self.serialized.to_buffer()
+        self.as_components = self.serialized.to_components()
+
+    def time_deserialize_from_buffer(self):
+        pa.deserialize(self.as_buffer)
+
+    def time_deserialize_from_components(self):
+        pa.deserialize_components(self.as_components)

--- a/python/doc/source/ipc.rst
+++ b/python/doc/source/ipc.rst
@@ -317,9 +317,8 @@ An object can be reconstructed from its component-based representation using
 Serializing pandas Objects
 --------------------------
 
-We provide a serialization context that has optimized handling of pandas
-objects like ``DataFrame`` and ``Series``. This can be created with
-``pyarrow.pandas_serialization_context()``. Combined with component-based
+The default serialization context has optimized handling of pandas
+objects like ``DataFrame`` and ``Series``. Combined with component-based
 serialization above, this enables zero-copy transport of pandas DataFrame
 objects not containing any Python objects:
 
@@ -327,7 +326,7 @@ objects not containing any Python objects:
 
    import pandas as pd
    df = pd.DataFrame({'a': [1, 2, 3, 4, 5]})
-   context = pa.pandas_serialization_context()
+   context = pa.default_serialization_context()
    serialized_df = context.serialize(df)
    df_components = serialized_df.to_components()
    original_df = context.deserialize_components(df_components)

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -125,7 +125,6 @@ from pyarrow.ipc import (Message, MessageReader,
 localfs = LocalFileSystem.get_instance()
 
 from pyarrow.serialization import (default_serialization_context,
-                                   pandas_serialization_context,
                                    register_default_serialization_handlers,
                                    register_torch_serialization_handlers)
 

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -434,7 +434,8 @@ def dataframe_to_serialized_dict(frame):
         # subclass of _int.ObjectBlock.
         if type(block) == _int.ObjectBlock:
             block_data['object'] = None
-            block_data['block'] = builtin_pickle.dumps(values)
+            block_data['block'] = builtin_pickle.dumps(
+                values, protocol=builtin_pickle.HIGHEST_PROTOCOL)
 
         blocks.append(block_data)
 

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -23,12 +23,11 @@ import re
 import pandas.core.internals as _int
 import numpy as np
 import pandas as pd
-import pickle
 
 import six
 
 import pyarrow as pa
-from pyarrow.compat import PY2, zip_longest  # noqa
+from pyarrow.compat import builtin_pickle, PY2, zip_longest  # noqa
 
 
 def infer_dtype(column):
@@ -433,7 +432,7 @@ def dataframe_to_serialized_dict(frame):
         # If we are dealing with an object array, pickle it instead.
         if isinstance(block, _int.ObjectBlock):
             block_data['object'] = None
-            block_data['block'] = pickle.dumps(values)
+            block_data['block'] = builtin_pickle.dumps(values)
 
         blocks.append(block_data)
 
@@ -470,8 +469,8 @@ def _reconstruct_block(item):
                                 klass=_int.DatetimeTZBlock,
                                 dtype=dtype)
     elif 'object' in item:
-        block = _int.make_block(pickle.loads(block_arr), placement=placement,
-                                klass=_int.ObjectBlock)
+        block = _int.make_block(builtin_pickle.loads(block_arr),
+                                placement=placement, klass=_int.ObjectBlock)
     else:
         block = _int.make_block(block_arr, placement=placement)
 

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -429,8 +429,10 @@ def dataframe_to_serialized_dict(frame):
             block=values
         )
 
-        # If we are dealing with an object array, pickle it instead.
-        if isinstance(block, _int.ObjectBlock):
+        # If we are dealing with an object array, pickle it instead. Note that
+        # we do not use isinstance here because _int.CategoricalBlock is a
+        # subclass of _int.ObjectBlock.
+        if type(block) == _int.ObjectBlock:
             block_data['object'] = None
             block_data['block'] = builtin_pickle.dumps(values)
 

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -22,8 +22,7 @@ import sys
 import numpy as np
 
 from pyarrow.compat import builtin_pickle
-from pyarrow.lib import (SerializationContext, _default_serialization_context,
-                         frombuffer)
+from pyarrow.lib import SerializationContext, _default_serialization_context
 
 try:
     import cloudpickle
@@ -42,23 +41,6 @@ def _serialize_numpy_array_list(obj):
 
 def _deserialize_numpy_array_list(data):
     return np.array(data[0], dtype=np.dtype(data[1]))
-
-
-def _pickle_to_buffer(x):
-    pickled = builtin_pickle.dumps(x, protocol=builtin_pickle.HIGHEST_PROTOCOL)
-    return frombuffer(pickled)
-
-
-def _load_pickle_from_buffer(data):
-    as_memoryview = memoryview(data)
-    if six.PY2:
-        return builtin_pickle.loads(as_memoryview.tobytes())
-    else:
-        return builtin_pickle.loads(as_memoryview)
-
-
-_serialize_numpy_array_pickle = _pickle_to_buffer
-_deserialize_numpy_array_pickle = _load_pickle_from_buffer
 
 
 # ----------------------------------------------------------------------
@@ -190,11 +172,3 @@ def default_serialization_context():
 
 
 register_default_serialization_handlers(_default_serialization_context)
-
-
-def pandas_serialization_context():
-    context = default_serialization_context()
-    context.register_type(np.ndarray, 'np.array',
-                          custom_serializer=_serialize_numpy_array_pickle,
-                          custom_deserializer=_deserialize_numpy_array_pickle)
-    return context

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -22,7 +22,8 @@ import sys
 import numpy as np
 
 from pyarrow.compat import builtin_pickle
-from pyarrow.lib import SerializationContext, _default_serialization_context
+from pyarrow.lib import (SerializationContext, _default_serialization_context,
+                         frombuffer)
 
 try:
     import cloudpickle
@@ -41,6 +42,19 @@ def _serialize_numpy_array_list(obj):
 
 def _deserialize_numpy_array_list(data):
     return np.array(data[0], dtype=np.dtype(data[1]))
+
+
+def _pickle_to_buffer(x):
+    pickled = builtin_pickle.dumps(x, protocol=builtin_pickle.HIGHEST_PROTOCOL)
+    return frombuffer(pickled)
+
+
+def _load_pickle_from_buffer(data):
+    as_memoryview = memoryview(data)
+    if six.PY2:
+        return builtin_pickle.loads(as_memoryview.tobytes())
+    else:
+        return builtin_pickle.loads(as_memoryview)
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1613,7 +1613,7 @@ def _fully_loaded_dataframe_example():
 
 
 def _check_serialize_components_roundtrip(df):
-    ctx = pa.pandas_serialization_context()
+    ctx = pa.default_serialization_context()
 
     components = ctx.serialize(df).to_components()
     deserialized = ctx.deserialize_components(components)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -284,8 +284,6 @@ def test_clone():
 def test_primitive_serialization(large_buffer):
     for obj in PRIMITIVE_OBJECTS:
         serialization_roundtrip(obj, large_buffer)
-        serialization_roundtrip(obj, large_buffer,
-                                pa.pandas_serialization_context())
 
 
 def test_serialize_to_buffer():


### PR DESCRIPTION
The goal here is to get the best of both the `pandas_serialization_context` (speed at serializing pandas dataframes containing strings and other objects) and the `default_serialization_context` (correctly serializing a large class of numpy object arrays).

This PR sort of messes up the function `pa.pandas_compat.dataframe_to_serialized_dict`. Is that function just a helper function for implementing the custom pandas serializers? Or is it intended to be used in other places.

TODO in this PR (assuming you think this approach is reasonable):

- [x] remove `pandas_serialization_context`
- [x] make sure this code path is tested
- [x] double check performance/behavior

cc @wesm @pcmoritz @devin-petersohn 