### PR TITLE
ARROW-2129: [Python] Handle conversion of empty tables to Pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -280,6 +280,9 @@ class PandasBlock {
 
 template <typename T>
 inline const T* GetPrimitiveValues(const Array& arr) {
+  if (arr.length() == 0) {
+    return nullptr;
+  }
   const auto& prim_arr = static_cast<const PrimitiveArray&>(arr);
   const T* raw_values = reinterpret_cast<const T*>(prim_arr.values()->data());
   return raw_values + arr.offset();
@@ -304,9 +307,11 @@ inline void ConvertIntegerNoNullsSameType(PandasOptions options, const ChunkedAr
                                           T* out_values) {
   for (int c = 0; c < data.num_chunks(); c++) {
     const auto& arr = *data.chunk(c);
-    const T* in_values = GetPrimitiveValues<T>(arr);
-    memcpy(out_values, in_values, sizeof(T) * arr.length());
-    out_values += arr.length();
+    if (arr.length() > 0) {
+      const T* in_values = GetPrimitiveValues<T>(arr);
+      memcpy(out_values, in_values, sizeof(T) * arr.length());
+      out_values += arr.length();
+    }
   }
 }
 

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1322,6 +1322,12 @@ class TestPandasConversion(object):
         _check_pandas_roundtrip(df2, preserve_index=True)
         _check_pandas_roundtrip(df2, as_batch=True, preserve_index=True)
 
+    def test_convert_empty_table(self):
+        arr = pa.array([], type=pa.int64())
+        npt.assert_array_equal(arr.to_pandas(), np.array([]))
+        arr = pa.array([], type=pa.string())
+        npt.assert_array_equal(arr.to_pandas(), np.array([]))
+
     def test_array_from_pandas_date_with_mask(self):
         m = np.array([True, False, True])
         data = pd.Series([

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1324,9 +1324,9 @@ class TestPandasConversion(object):
 
     def test_convert_empty_table(self):
         arr = pa.array([], type=pa.int64())
-        npt.assert_array_equal(arr.to_pandas(), np.array([]))
+        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=np.int64))
         arr = pa.array([], type=pa.string())
-        npt.assert_array_equal(arr.to_pandas(), np.array([]))
+        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
 
     def test_array_from_pandas_date_with_mask(self):
         m = np.array([True, False, True])


### PR DESCRIPTION
Opened https://issues.apache.org/jira/browse/ARROW-2133 to handle the nested case. 