### PR TITLE
ARROW-2133: [Python] Fix segfault on conversion of empty nested array to Pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -519,7 +519,7 @@ inline Status ConvertListsLike(PandasOptions options, const std::shared_ptr<Colu
   // TODO(ARROW-489): Currently we don't have a Python reference for single columns.
   //    Storing a reference to the whole Array would be to expensive.
 
-  OwnedRef owned_numpy_array;
+  OwnedRefNoGIL owned_numpy_array;
   RETURN_NOT_OK(
       ConvertColumnToPandas(options, flat_column, nullptr, owned_numpy_array.ref()));
 

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1351,6 +1351,10 @@ class TestPandasConversion(object):
         tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=np.int64))
         arr = pa.array([], type=pa.string())
         tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
+        arr = pa.array([], type=pa.list_(pa.int64()))
+        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
+        arr = pa.array([], type=pa.struct([pa.field('a', pa.int64())]))
+        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
 
     def test_array_from_pandas_date_with_mask(self):
         m = np.array([True, False, True])


### PR DESCRIPTION
Based on PR #1588