### PR TITLE
ARROW-2137: [Python] Don't print paths that are ignored when reading Parquet files

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -594,7 +594,7 @@ class ParquetManifest(object):
             elif path.endswith('_metadata'):
                 self.metadata_path = full_path
             elif self._should_silently_exclude(path):
-                print('Ignoring path: {0}'.format(full_path))
+                continue
             else:
                 filtered_files.append(full_path)
 


### PR DESCRIPTION
_should_silently_exclude should silently exclude, not print stuff