### PR TITLE
ARROW-2138: [C++] abort on failed debug check

### DIFF
--- a/cpp/src/arrow/allocator-test.cc
+++ b/cpp/src/arrow/allocator-test.cc
@@ -51,8 +51,8 @@ TEST(stl_allocator, FreeLargeMemory) {
   uint8_t* data = alloc.allocate(100);
 
 #ifndef NDEBUG
-  EXPECT_EXIT(alloc.deallocate(data, 120), ::testing::ExitedWithCode(1),
-              ".*Check failed: \\(bytes_allocated_\\) >= \\(size\\)");
+  EXPECT_DEATH(alloc.deallocate(data, 120),
+               ".*Check failed: \\(bytes_allocated_\\) >= \\(size\\)");
 #endif
 
   alloc.deallocate(data, 100);

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -51,8 +51,8 @@ TEST(DefaultMemoryPoolDeathTest, FreeLargeMemory) {
   ASSERT_OK(pool->Allocate(100, &data));
 
 #ifndef NDEBUG
-  EXPECT_EXIT(pool->Free(data, 120), ::testing::ExitedWithCode(1),
-              ".*Check failed: \\(bytes_allocated_\\) >= \\(size\\)");
+  EXPECT_DEATH(pool->Free(data, 120),
+               ".*Check failed: \\(bytes_allocated_\\) >= \\(size\\)");
 #endif
 
   pool->Free(data, 100);

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -105,7 +105,7 @@ class CerrLog {
       std::cerr << std::endl;
     }
     if (severity_ == ARROW_FATAL) {
-      std::exit(1);
+      std::abort();
     }
   }
 
@@ -134,7 +134,7 @@ class FatalLog : public CerrLog {
     if (has_logged_) {
       std::cerr << std::endl;
     }
-    std::exit(1);
+    std::abort();
   }
 };
 


### PR DESCRIPTION
Using abort() instead of exit(1) triggers debug tools such as gdb and therefore makes debugging easier.