### PR TITLE
ARROW-2151: [Python] Fix conversion from np.uint64 scalars

### DIFF
--- a/cpp/src/arrow/python/builtin_convert.cc
+++ b/cpp/src/arrow/python/builtin_convert.cc
@@ -538,8 +538,8 @@ class UInt64Converter : public TypedConverterVisitor<UInt64Builder, UInt64Conver
  public:
   // Append a non-missing item
   Status AppendItem(PyObject* obj) {
-    const auto val = static_cast<int64_t>(PyLong_AsUnsignedLongLong(obj));
-    RETURN_IF_PYERROR();
+    uint64_t val;
+    RETURN_NOT_OK(internal::UInt64FromPythonInt(obj, &val));
     return typed_builder_->Append(val);
   }
 };

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -176,6 +176,23 @@ bool IsPyInteger(PyObject* obj) {
 #endif
 }
 
+Status UInt64FromPythonInt(PyObject* obj, uint64_t* out) {
+  OwnedRef ref;
+  // PyLong_AsUnsignedLongLong() doesn't handle conversion from non-ints
+  // (e.g. np.uint64), so do it ourselves
+  if (!PyLong_Check(obj)) {
+    ref.reset(PyNumber_Long(obj));
+    RETURN_IF_PYERROR();
+    obj = ref.obj();
+  }
+  auto result = static_cast<uint64_t>(PyLong_AsUnsignedLongLong(obj));
+  if (result == static_cast<uint64_t>(-1)) {
+    RETURN_IF_PYERROR();
+  }
+  *out = static_cast<uint64_t>(result);
+  return Status::OK();
+}
+
 }  // namespace internal
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -57,6 +57,8 @@ Status DecimalFromPythonDecimal(PyObject* python_decimal, const DecimalType& arr
                                 Decimal128* out);
 bool IsPyInteger(PyObject* obj);
 
+Status UInt64FromPythonInt(PyObject* obj, uint64_t* out);
+
 }  // namespace internal
 }  // namespace py
 }  // namespace arrow

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1328,6 +1328,15 @@ class TestListTypes(object):
 
         tm.assert_frame_equal(result, df)
 
+    def test_array_from_nested_arrays(self):
+        df, schema = dataframe_with_arrays()
+        for field in schema:
+            arr = df[field.name].values
+            expected = pa.array(list(arr), type=field.type)
+            result = pa.array(arr)
+            assert result.type == field.type  # == list<scalar>
+            assert result.equals(expected)
+
 
 class TestConvertStructTypes(object):
     """


### PR DESCRIPTION
Also add tests for ARROW-1345, ARROW-2008.