### PR TITLE
ARROW-2159: [JS] Support custom predicates

### DIFF
--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -70,6 +70,7 @@ CountByResult.prototype.asJSON;
 
 var col = function () {};
 var lit = function () {};
+var custom = function () {};
 
 var Value = function() {};
 /** @type {?} */

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -168,6 +168,7 @@ export namespace view {
 export namespace predicate {
     export import col = predicate_.col;
     export import lit = predicate_.lit;
+    export import custom = predicate_.custom;
 
     export import Or = predicate_.Or;
     export import Col = predicate_.Col;

--- a/js/src/predicate.ts
+++ b/js/src/predicate.ts
@@ -222,5 +222,17 @@ export class GTeq extends ComparisonPredicate {
     }
 }
 
+export class CustomPredicate {
+    constructor(private next: PredicateFunc, private bind_: (batch: RecordBatch) => void) {}
+
+    bind(batch: RecordBatch) {
+        this.bind_(batch);
+        return this.next;
+    }
+}
+
 export function lit(v: any): Value<any> { return new Literal(v); }
 export function col(n: string): Col<any> { return new Col(n); }
+export function custom(next: PredicateFunc, bind: (batch: RecordBatch) => void) {
+    return new CustomPredicate(next, bind);
+}

--- a/js/src/predicate.ts
+++ b/js/src/predicate.ts
@@ -222,8 +222,10 @@ export class GTeq extends ComparisonPredicate {
     }
 }
 
-export class CustomPredicate {
-    constructor(private next: PredicateFunc, private bind_: (batch: RecordBatch) => void) {}
+export class CustomPredicate extends Predicate {
+    constructor(private next: PredicateFunc, private bind_: (batch: RecordBatch) => void) {
+        super();
+    }
 
     bind(batch: RecordBatch) {
         this.bind_(batch);


### PR DESCRIPTION
Adds support for defining a custom predicate with callback functions, like so:
```js
table.filter(predicate.custom(
    (idx) => {...},
    (batch) => {...}
));
```