### PR TITLE
ARROW-2170: [Python] construct_metadata fails on reading files where no index was preserved

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -197,8 +197,11 @@ def construct_metadata(df, column_names, index_levels, index_column_names,
     -------
     dict
     """
-    df_types = types[:-len(index_levels)]
-    index_types = types[-len(index_levels):]
+    # Use ntypes instead of Python shorthand notation [:-len(x)] as [:-0]
+    # behaves differently to what we want.
+    ntypes = len(types)
+    df_types = types[:ntypes - len(index_levels)]
+    index_types = types[ntypes - len(index_levels):]
 
     column_metadata = [
         get_column_metadata(

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -215,6 +215,9 @@ def test_pandas_parquet_2_0_rountrip_read_pandas_no_index_written(tmpdir):
     arrow_table = pa.Table.from_pandas(df, preserve_index=False)
     js = json.loads(arrow_table.schema.metadata[b'pandas'].decode('utf8'))
     assert not js['index_columns']
+    # ARROW-2170
+    # While index_columns should be empty, columns needs to be filled still.
+    assert js['columns']
 
     _write_table(arrow_table, filename.strpath, version="2.0",
                  coerce_timestamps='ms')


### PR DESCRIPTION
cc @cpcloud 

The result was that we only persisted empty Pandas metadata for these files.