### PR TITLE
ARROW-2174: [JS] export arrow format and schema enums

### DIFF
--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -252,6 +252,67 @@ Type.DenseUnion = function() {};
 /** @type {?} */
 Type.SparseUnion = function() {};
 
+var DateUnit = function() {};
+/** @type {?} */
+DateUnit.DAY = function() {};
+/** @type {?} */
+DateUnit.MILLISECOND = function() {};
+var TimeUnit = function() {};
+/** @type {?} */
+TimeUnit.SECOND = function() {};
+/** @type {?} */
+TimeUnit.MILLISECOND = function() {};
+/** @type {?} */
+TimeUnit.MICROSECOND = function() {};
+/** @type {?} */
+TimeUnit.NANOSECOND = function() {};
+var Precision = function() {};
+/** @type {?} */
+Precision.HALF = function() {};
+/** @type {?} */
+Precision.SINGLE = function() {};
+/** @type {?} */
+Precision.DOUBLE = function() {};
+var UnionMode = function() {};
+/** @type {?} */
+UnionMode.Sparse = function() {};
+/** @type {?} */
+UnionMode.Dense = function() {};
+var VectorType = function() {};
+/** @type {?} */
+VectorType.OFFSET = function() {};
+/** @type {?} */
+VectorType.DATA = function() {};
+/** @type {?} */
+VectorType.VALIDITY = function() {};
+/** @type {?} */
+VectorType.TYPE = function() {};
+var IntervalUnit = function() {};
+/** @type {?} */
+IntervalUnit.YEAR_MONTH = function() {};
+/** @type {?} */
+IntervalUnit.DAY_TIME = function() {};
+var MessageHeader = function() {};
+/** @type {?} */
+MessageHeader.NONE = function() {};
+/** @type {?} */
+MessageHeader.Schema = function() {};
+/** @type {?} */
+MessageHeader.DictionaryBatch = function() {};
+/** @type {?} */
+MessageHeader.RecordBatch = function() {};
+/** @type {?} */
+MessageHeader.Tensor = function() {};
+var MetadataVersion = function() {};
+/** @type {?} */
+MetadataVersion.V1 = function() {};
+/** @type {?} */
+MetadataVersion.V2 = function() {};
+/** @type {?} */
+MetadataVersion.V3 = function() {};
+/** @type {?} */
+MetadataVersion.V4 = function() {};
+
 var DataType = function() {};
 /** @type {?} */
 DataType.isNull = function() {};
@@ -643,38 +704,38 @@ VectorVisitor.prototype.visit;
 /** @type {?} */
 VectorVisitor.prototype.visitMany;
 /** @type {?} */
-VectorVisitor.prototype.visitNullVector;
+VectorVisitor.prototype.visitNull;
 /** @type {?} */
-VectorVisitor.prototype.visitBoolVector;
+VectorVisitor.prototype.visitBool;
 /** @type {?} */
-VectorVisitor.prototype.visitIntVector;
+VectorVisitor.prototype.visitInt;
 /** @type {?} */
-VectorVisitor.prototype.visitFloatVector;
+VectorVisitor.prototype.visitFloat;
 /** @type {?} */
-VectorVisitor.prototype.visitUtf8Vector;
+VectorVisitor.prototype.visitUtf8;
 /** @type {?} */
-VectorVisitor.prototype.visitBinaryVector;
+VectorVisitor.prototype.visitBinary;
 /** @type {?} */
-VectorVisitor.prototype.visitFixedSizeBinaryVector;
+VectorVisitor.prototype.visitFixedSizeBinary;
 /** @type {?} */
-VectorVisitor.prototype.visitDateVector;
+VectorVisitor.prototype.visitDate;
 /** @type {?} */
-VectorVisitor.prototype.visitTimestampVector;
+VectorVisitor.prototype.visitTimestamp;
 /** @type {?} */
-VectorVisitor.prototype.visitTimeVector;
+VectorVisitor.prototype.visitTime;
 /** @type {?} */
-VectorVisitor.prototype.visitDecimalVector;
+VectorVisitor.prototype.visitDecimal;
 /** @type {?} */
-VectorVisitor.prototype.visitListVector;
+VectorVisitor.prototype.visitList;
 /** @type {?} */
-VectorVisitor.prototype.visitStructVector;
+VectorVisitor.prototype.visitStruct;
 /** @type {?} */
-VectorVisitor.prototype.visitUnionVector;
+VectorVisitor.prototype.visitUnion;
 /** @type {?} */
-VectorVisitor.prototype.visitDictionaryVector;
+VectorVisitor.prototype.visitDictionary;
 /** @type {?} */
-VectorVisitor.prototype.visitIntervalVector;
+VectorVisitor.prototype.visitInterval;
 /** @type {?} */
-VectorVisitor.prototype.visitFixedSizeListVector;
+VectorVisitor.prototype.visitFixedSizeList;
 /** @type {?} */
-VectorVisitor.prototype.visitMapVector;
+VectorVisitor.prototype.visitMap;

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -59,6 +59,18 @@ export namespace data {
     export import ChunkedData = data_.ChunkedData;
 }
 
+export namespace enum_ {
+    export import Type = type_.ArrowType;
+    export import DateUnit = type_.DateUnit;
+    export import TimeUnit = type_.TimeUnit;
+    export import Precision = type_.Precision;
+    export import UnionMode = type_.UnionMode;
+    export import VectorType = type_.VectorType;
+    export import IntervalUnit = type_.IntervalUnit;
+    export import MessageHeader = type_.MessageHeader;
+    export import MetadataVersion = type_.MetadataVersion;
+}
+
 export namespace type {
     export import Schema = type_.Schema;
     export import Field = type_.Field;
@@ -179,6 +191,7 @@ try {
         Arrow['type'] = type;
         Arrow['util'] = util;
         Arrow['view'] = view;
+        Arrow['enum_'] = enum_;
         Arrow['vector'] = vector;
         Arrow['visitor'] = visitor;
         Arrow['predicate'] = predicate;

--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -146,52 +146,31 @@ export abstract class DataType<TType extends Type = any> implements Partial<Visi
     // @ts-ignore
     public [Symbol.toStringTag]: string;
 
-    static            isNull (x: DataType): x is Null            { return x.TType === Type.Null;            }
-    static             isInt (x: DataType): x is Int             { return x.TType === Type.Int;             }
-    static           isFloat (x: DataType): x is Float           { return x.TType === Type.Float;           }
-    static          isBinary (x: DataType): x is Binary          { return x.TType === Type.Binary;          }
-    static            isUtf8 (x: DataType): x is Utf8            { return x.TType === Type.Utf8;            }
-    static            isBool (x: DataType): x is Bool            { return x.TType === Type.Bool;            }
-    static         isDecimal (x: DataType): x is Decimal         { return x.TType === Type.Decimal;         }
-    static            isDate (x: DataType): x is Date_           { return x.TType === Type.Date;            }
-    static            isTime (x: DataType): x is Time            { return x.TType === Type.Time;            }
-    static       isTimestamp (x: DataType): x is Timestamp       { return x.TType === Type.Timestamp;       }
-    static        isInterval (x: DataType): x is Interval        { return x.TType === Type.Interval;        }
-    static            isList (x: DataType): x is List            { return x.TType === Type.List;            }
-    static          isStruct (x: DataType): x is Struct          { return x.TType === Type.Struct;          }
-    static           isUnion (x: DataType): x is Union           { return x.TType === Type.Union;           }
-    static      isDenseUnion (x: DataType): x is DenseUnion      { return x.TType === Type.DenseUnion;      }
-    static     isSparseUnion (x: DataType): x is SparseUnion     { return x.TType === Type.SparseUnion;     }
-    static isFixedSizeBinary (x: DataType): x is FixedSizeBinary { return x.TType === Type.FixedSizeBinary; }
-    static   isFixedSizeList (x: DataType): x is FixedSizeList   { return x.TType === Type.FixedSizeList;   }
-    static             isMap (x: DataType): x is Map_            { return x.TType === Type.Map;             }
-    static      isDictionary (x: DataType): x is Dictionary      { return x.TType === Type.Dictionary;      }
+    static            isNull (x: any): x is Null            { return x && x.TType === Type.Null;            }
+    static             isInt (x: any): x is Int             { return x && x.TType === Type.Int;             }
+    static           isFloat (x: any): x is Float           { return x && x.TType === Type.Float;           }
+    static          isBinary (x: any): x is Binary          { return x && x.TType === Type.Binary;          }
+    static            isUtf8 (x: any): x is Utf8            { return x && x.TType === Type.Utf8;            }
+    static            isBool (x: any): x is Bool            { return x && x.TType === Type.Bool;            }
+    static         isDecimal (x: any): x is Decimal         { return x && x.TType === Type.Decimal;         }
+    static            isDate (x: any): x is Date_           { return x && x.TType === Type.Date;            }
+    static            isTime (x: any): x is Time            { return x && x.TType === Type.Time;            }
+    static       isTimestamp (x: any): x is Timestamp       { return x && x.TType === Type.Timestamp;       }
+    static        isInterval (x: any): x is Interval        { return x && x.TType === Type.Interval;        }
+    static            isList (x: any): x is List            { return x && x.TType === Type.List;            }
+    static          isStruct (x: any): x is Struct          { return x && x.TType === Type.Struct;          }
+    static           isUnion (x: any): x is Union           { return x && x.TType === Type.Union;           }
+    static      isDenseUnion (x: any): x is DenseUnion      { return x && x.TType === Type.DenseUnion;      }
+    static     isSparseUnion (x: any): x is SparseUnion     { return x && x.TType === Type.SparseUnion;     }
+    static isFixedSizeBinary (x: any): x is FixedSizeBinary { return x && x.TType === Type.FixedSizeBinary; }
+    static   isFixedSizeList (x: any): x is FixedSizeList   { return x && x.TType === Type.FixedSizeList;   }
+    static             isMap (x: any): x is Map_            { return x && x.TType === Type.Map;             }
+    static      isDictionary (x: any): x is Dictionary      { return x && x.TType === Type.Dictionary;      }
 
     constructor(public readonly TType: TType,
                 public readonly children?: Field[]) {}
-
-    acceptTypeVisitor(visitor: TypeVisitor): any {
-        switch (this.TType) {
-            case Type.Null:            return DataType.isNull(this)            && visitor.visitNull(this)            || null;
-            case Type.Int:             return DataType.isInt(this)             && visitor.visitInt(this)             || null;
-            case Type.Float:           return DataType.isFloat(this)           && visitor.visitFloat(this)           || null;
-            case Type.Binary:          return DataType.isBinary(this)          && visitor.visitBinary(this)          || null;
-            case Type.Utf8:            return DataType.isUtf8(this)            && visitor.visitUtf8(this)            || null;
-            case Type.Bool:            return DataType.isBool(this)            && visitor.visitBool(this)            || null;
-            case Type.Decimal:         return DataType.isDecimal(this)         && visitor.visitDecimal(this)         || null;
-            case Type.Date:            return DataType.isDate(this)            && visitor.visitDate(this)            || null;
-            case Type.Time:            return DataType.isTime(this)            && visitor.visitTime(this)            || null;
-            case Type.Timestamp:       return DataType.isTimestamp(this)       && visitor.visitTimestamp(this)       || null;
-            case Type.Interval:        return DataType.isInterval(this)        && visitor.visitInterval(this)        || null;
-            case Type.List:            return DataType.isList(this)            && visitor.visitList(this)            || null;
-            case Type.Struct:          return DataType.isStruct(this)          && visitor.visitStruct(this)          || null;
-            case Type.Union:           return DataType.isUnion(this)           && visitor.visitUnion(this)           || null;
-            case Type.FixedSizeBinary: return DataType.isFixedSizeBinary(this) && visitor.visitFixedSizeBinary(this) || null;
-            case Type.FixedSizeList:   return DataType.isFixedSizeList(this)   && visitor.visitFixedSizeList(this)   || null;
-            case Type.Map:             return DataType.isMap(this)             && visitor.visitMap(this)             || null;
-            case Type.Dictionary:      return DataType.isDictionary(this)      && visitor.visitDictionary(this)      || null;
-            default: return null;
-        }
+    public acceptTypeVisitor(visitor: TypeVisitor): any {
+        return TypeVisitor.visitTypeInline(visitor, this);
     }
     protected static [Symbol.toStringTag] = ((proto: DataType) => {
         (<any> proto).ArrayType = Array;
@@ -205,9 +184,6 @@ export class Null extends DataType<Type.Null> {
         super(Type.Null);
     }
     public toString() { return `Null`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitNull(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Null) => {
         return proto[Symbol.toStringTag] = 'Null';
     })(Null.prototype);
@@ -221,7 +197,7 @@ export class Int<TValueType = any, TArrayType extends IntArray = IntArray> exten
     }
     public get ArrayType(): TypedArrayConstructor<TArrayType> {
         switch (this.bitWidth) {
-            case  8: return (this.isSigned ? Int8Array : Uint8Array) as any;
+            case  8: return (this.isSigned ?  Int8Array :  Uint8Array) as any;
             case 16: return (this.isSigned ? Int16Array : Uint16Array) as any;
             case 32: return (this.isSigned ? Int32Array : Uint32Array) as any;
             case 64: return (this.isSigned ? Int32Array : Uint32Array) as any;
@@ -229,7 +205,6 @@ export class Int<TValueType = any, TArrayType extends IntArray = IntArray> exten
         throw new Error(`Unrecognized ${this[Symbol.toStringTag]} type`);
     }
     public toString() { return `${this.isSigned ? `I` : `Ui`}nt${this.bitWidth}`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any { return visitor.visitInt(this); }
     protected static [Symbol.toStringTag] = ((proto: Int) => {
         return proto[Symbol.toStringTag] = 'Int';
     })(Int.prototype);
@@ -259,7 +234,6 @@ export class Float<TArrayType extends FloatArray = FloatArray> extends DataType<
         throw new Error(`Unrecognized ${this[Symbol.toStringTag]} type`);
     }
     public toString() { return `Float${(this.precision << 5) || 16}`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any { return visitor.visitFloat(this); }
     protected static [Symbol.toStringTag] = ((proto: Float) => {
         return proto[Symbol.toStringTag] = 'Float';
     })(Float.prototype);
@@ -275,9 +249,6 @@ export class Binary extends DataType<Type.Binary> {
         super(Type.Binary);
     }
     public toString() { return `Binary`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitBinary(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Binary) => {
         (<any> proto).ArrayType = Uint8Array;
         return proto[Symbol.toStringTag] = 'Binary';
@@ -290,9 +261,6 @@ export class Utf8 extends DataType<Type.Utf8> {
         super(Type.Utf8);
     }
     public toString() { return `Utf8`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitUtf8(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Utf8) => {
         (<any> proto).ArrayType = Uint8Array;
         return proto[Symbol.toStringTag] = 'Utf8';
@@ -305,9 +273,6 @@ export class Bool extends DataType<Type.Bool> {
         super(Type.Bool);
     }
     public toString() { return `Bool`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitBool(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Bool) => {
         (<any> proto).ArrayType = Uint8Array;
         return proto[Symbol.toStringTag] = 'Bool';
@@ -321,9 +286,6 @@ export class Decimal extends DataType<Type.Decimal> {
         super(Type.Decimal);
     }
     public toString() { return `Decimal[${this.precision}e${this.scale > 0 ? `+` : ``}${this.scale}]`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitDecimal(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Decimal) => {
         (<any> proto).ArrayType = Uint32Array;
         return proto[Symbol.toStringTag] = 'Decimal';
@@ -337,9 +299,6 @@ export class Date_ extends DataType<Type.Date> {
         super(Type.Date);
     }
     public toString() { return `Date${(this.unit + 1) * 32}<${DateUnit[this.unit]}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitDate(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Date_) => {
         (<any> proto).ArrayType = Int32Array;
         return proto[Symbol.toStringTag] = 'Date';
@@ -353,9 +312,6 @@ export class Time extends DataType<Type.Time> {
         super(Type.Time);
     }
     public toString() { return `Time${this.bitWidth}<${TimeUnit[this.unit]}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitTime(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Time) => {
         (<any> proto).ArrayType = Uint32Array;
         return proto[Symbol.toStringTag] = 'Time';
@@ -368,9 +324,6 @@ export class Timestamp extends DataType<Type.Timestamp> {
         super(Type.Timestamp);
     }
     public toString() { return `Timestamp<${TimeUnit[this.unit]}${this.timezone ? `, ${this.timezone}` : ``}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitTimestamp(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Timestamp) => {
         (<any> proto).ArrayType = Int32Array;
         return proto[Symbol.toStringTag] = 'Timestamp';
@@ -383,9 +336,6 @@ export class Interval extends DataType<Type.Interval> {
         super(Type.Interval);
     }
     public toString() { return `Interval<${IntervalUnit[this.unit]}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitInterval(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Interval) => {
         (<any> proto).ArrayType = Int32Array;
         return proto[Symbol.toStringTag] = 'Interval';
@@ -401,9 +351,6 @@ export class List<T extends DataType = any> extends DataType<Type.List> {
     public get ArrayType() { return this.valueType.ArrayType; }
     public get valueType() { return this.children[0].type as T; }
     public get valueField() { return this.children[0] as Field<T>; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitList(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: List) => {
         return proto[Symbol.toStringTag] = 'List';
     })(List.prototype);
@@ -415,9 +362,6 @@ export class Struct extends DataType<Type.Struct> {
         super(Type.Struct, children);
     }
     public toString() { return `Struct<${this.children.map((f) => f.type).join(`, `)}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitStruct(this);
-    }
     protected static [Symbol.toStringTag] = ((proto: Struct) => {
         return proto[Symbol.toStringTag] = 'Struct';
     })(Struct.prototype);
@@ -431,7 +375,6 @@ export class Union<TType extends Type = any> extends DataType<TType> {
         super(<TType> (mode === UnionMode.Sparse ? Type.SparseUnion : Type.DenseUnion), children);
     }
     public toString() { return `${this[Symbol.toStringTag]}<${this.typeIds.map((x) => Type[x]).join(` | `)}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any { return visitor.visitUnion(this); }
     protected static [Symbol.toStringTag] = ((proto: Union) => {
         (<any> proto).ArrayType = Int8Array;
         return proto[Symbol.toStringTag] = 'Union';
@@ -462,7 +405,6 @@ export class FixedSizeBinary extends DataType<Type.FixedSizeBinary> {
         super(Type.FixedSizeBinary);
     }
     public toString() { return `FixedSizeBinary[${this.byteWidth}]`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any { return visitor.visitFixedSizeBinary(this); }
     protected static [Symbol.toStringTag] = ((proto: FixedSizeBinary) => {
         (<any> proto).ArrayType = Uint8Array;
         return proto[Symbol.toStringTag] = 'FixedSizeBinary';
@@ -479,7 +421,6 @@ export class FixedSizeList<T extends DataType = any> extends DataType<Type.Fixed
     public get valueType() { return this.children[0].type as T; }
     public get valueField() { return this.children[0] as Field<T>; }
     public toString() { return `FixedSizeList[${this.listSize}]<${this.valueType}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any { return visitor.visitFixedSizeList(this); }
     protected static [Symbol.toStringTag] = ((proto: FixedSizeList) => {
         return proto[Symbol.toStringTag] = 'FixedSizeList';
     })(FixedSizeList.prototype);
@@ -493,7 +434,6 @@ export class Map_ extends DataType<Type.Map> {
         super(Type.Map, children);
     }
     public toString() { return `Map<${this.children.join(`, `)}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any { return visitor.visitMap(this); }
     protected static [Symbol.toStringTag] = ((proto: Map_) => {
         return proto[Symbol.toStringTag] = 'Map_';
     })(Map_.prototype);
@@ -513,10 +453,7 @@ export class Dictionary<T extends DataType> extends DataType<Type.Dictionary> {
         this.id = id == null ? DictionaryBatch.getId() : typeof id === 'number' ? id : id.low;
     }
     public get ArrayType() { return this.dictionary.ArrayType; }
-    public toString() { return `Dictionary<${this.dictionary}, ${this.indicies}>`; }
-    public acceptTypeVisitor(visitor: TypeVisitor): any {
-        return visitor.visitDictionary(this);
-    }
+    public toString() { return `Dictionary<${this.indicies}, ${this.dictionary}>`; }
     protected static [Symbol.toStringTag] = ((proto: Dictionary) => {
         return proto[Symbol.toStringTag] = 'Dictionary';
     })(Dictionary.prototype);

--- a/js/src/visitor.ts
+++ b/js/src/visitor.ts
@@ -24,131 +24,106 @@ import { Bool, Null, Int, Float, Date_, Time, Interval, Timestamp } from './type
 export interface VisitorNode {
     acceptTypeVisitor(visitor: TypeVisitor): any;
     acceptVectorVisitor(visitor: VectorVisitor): any;
-    // acceptMessageVisitor(visitor: MessageVisitor): any;
 }
 
 export abstract class TypeVisitor {
-    visit(node: Partial<VisitorNode>): any {
-        return node.acceptTypeVisitor!(this);
+    visit(type: Partial<VisitorNode>): any {
+        return type.acceptTypeVisitor && type.acceptTypeVisitor(this) || null;
     }
-    visitMany(nodes: Partial<VisitorNode>[]): any[] {
-        return nodes.map((node) => this.visit(node));
+    visitMany(types: Partial<VisitorNode>[]): any[] {
+        return types.map((type) => this.visit(type));
     }
-    abstract visitNull(node: Null): any;
-    abstract visitBool(node: Bool): any;
-    abstract visitInt(node: Int): any;
-    abstract visitFloat(node: Float): any;
-    abstract visitUtf8(node: Utf8): any;
-    abstract visitBinary(node: Binary): any;
-    abstract visitFixedSizeBinary(node: FixedSizeBinary): any;
-    abstract visitDate(node: Date_): any;
-    abstract visitTimestamp(node: Timestamp): any;
-    abstract visitTime(node: Time): any;
-    abstract visitDecimal(node: Decimal): any;
-    abstract visitList(node: List): any;
-    abstract visitStruct(node: Struct): any;
-    abstract visitUnion(node: Union<any>): any;
-    abstract visitDictionary(node: Dictionary): any;
-    abstract visitInterval(node: Interval): any;
-    abstract visitFixedSizeList(node: FixedSizeList): any;
-    abstract visitMap(node: Map_): any;
+    abstract visitNull?(type: Null): any;
+    abstract visitBool?(type: Bool): any;
+    abstract visitInt?(type: Int): any;
+    abstract visitFloat?(type: Float): any;
+    abstract visitUtf8?(type: Utf8): any;
+    abstract visitBinary?(type: Binary): any;
+    abstract visitFixedSizeBinary?(type: FixedSizeBinary): any;
+    abstract visitDate?(type: Date_): any;
+    abstract visitTimestamp?(type: Timestamp): any;
+    abstract visitTime?(type: Time): any;
+    abstract visitDecimal?(type: Decimal): any;
+    abstract visitList?(type: List): any;
+    abstract visitStruct?(type: Struct): any;
+    abstract visitUnion?(type: Union<any>): any;
+    abstract visitDictionary?(type: Dictionary): any;
+    abstract visitInterval?(type: Interval): any;
+    abstract visitFixedSizeList?(type: FixedSizeList): any;
+    abstract visitMap?(type: Map_): any;
 
     static visitTypeInline<T extends DataType>(visitor: TypeVisitor, type: T): any {
         switch (type.TType) {
-            case Type.Null:            return visitor.visitNull(type            as any as Null);
-            case Type.Int:             return visitor.visitInt(type             as any as Int);
-            case Type.Float:           return visitor.visitFloat(type           as any as Float);
-            case Type.Binary:          return visitor.visitBinary(type          as any as Binary);
-            case Type.Utf8:            return visitor.visitUtf8(type            as any as Utf8);
-            case Type.Bool:            return visitor.visitBool(type            as any as Bool);
-            case Type.Decimal:         return visitor.visitDecimal(type         as any as Decimal);
-            case Type.Date:            return visitor.visitDate(type            as any as Date_);
-            case Type.Time:            return visitor.visitTime(type            as any as Time);
-            case Type.Timestamp:       return visitor.visitTimestamp(type       as any as Timestamp);
-            case Type.Interval:        return visitor.visitInterval(type        as any as Interval);
-            case Type.List:            return visitor.visitList(type            as any as List<T>);
-            case Type.Struct:          return visitor.visitStruct(type          as any as Struct);
-            case Type.Union:           return visitor.visitUnion(type           as any as Union);
-            case Type.FixedSizeBinary: return visitor.visitFixedSizeBinary(type as any as FixedSizeBinary);
-            case Type.FixedSizeList:   return visitor.visitFixedSizeList(type   as any as FixedSizeList);
-            case Type.Map:             return visitor.visitMap(type             as any as Map_);
-            case Type.Dictionary:      return visitor.visitDictionary(type      as any as Dictionary);
+            case Type.Null:            return visitor.visitNull            && visitor.visitNull(type            as any as Null);
+            case Type.Int:             return visitor.visitInt             && visitor.visitInt(type             as any as Int);
+            case Type.Float:           return visitor.visitFloat           && visitor.visitFloat(type           as any as Float);
+            case Type.Binary:          return visitor.visitBinary          && visitor.visitBinary(type          as any as Binary);
+            case Type.Utf8:            return visitor.visitUtf8            && visitor.visitUtf8(type            as any as Utf8);
+            case Type.Bool:            return visitor.visitBool            && visitor.visitBool(type            as any as Bool);
+            case Type.Decimal:         return visitor.visitDecimal         && visitor.visitDecimal(type         as any as Decimal);
+            case Type.Date:            return visitor.visitDate            && visitor.visitDate(type            as any as Date_);
+            case Type.Time:            return visitor.visitTime            && visitor.visitTime(type            as any as Time);
+            case Type.Timestamp:       return visitor.visitTimestamp       && visitor.visitTimestamp(type       as any as Timestamp);
+            case Type.Interval:        return visitor.visitInterval        && visitor.visitInterval(type        as any as Interval);
+            case Type.List:            return visitor.visitList            && visitor.visitList(type            as any as List<T>);
+            case Type.Struct:          return visitor.visitStruct          && visitor.visitStruct(type          as any as Struct);
+            case Type.Union:           return visitor.visitUnion           && visitor.visitUnion(type           as any as Union);
+            case Type.FixedSizeBinary: return visitor.visitFixedSizeBinary && visitor.visitFixedSizeBinary(type as any as FixedSizeBinary);
+            case Type.FixedSizeList:   return visitor.visitFixedSizeList   && visitor.visitFixedSizeList(type   as any as FixedSizeList);
+            case Type.Map:             return visitor.visitMap             && visitor.visitMap(type             as any as Map_);
+            case Type.Dictionary:      return visitor.visitDictionary      && visitor.visitDictionary(type      as any as Dictionary);
             default: return null;
         }
     }
 }
 
 export abstract class VectorVisitor {
-    visit(node: Partial<VisitorNode>): any {
-        return node.acceptVectorVisitor!(this);
+    visit(vector: Partial<VisitorNode>): any {
+        return vector.acceptVectorVisitor && vector.acceptVectorVisitor(this) || null;
     }
-    visitMany(nodes: Partial<VisitorNode>[]): any[] {
-        return nodes.map((node) => this.visit(node));
+    visitMany(vectors: Partial<VisitorNode>[]): any[] {
+        return vectors.map((vector) => this.visit(vector));
     }
-    abstract visitNullVector(node: Vector<Null>): any;
-    abstract visitBoolVector(node: Vector<Bool>): any;
-    abstract visitIntVector(node: Vector<Int>): any;
-    abstract visitFloatVector(node: Vector<Float>): any;
-    abstract visitUtf8Vector(node: Vector<Utf8>): any;
-    abstract visitBinaryVector(node: Vector<Binary>): any;
-    abstract visitFixedSizeBinaryVector(node: Vector<FixedSizeBinary>): any;
-    abstract visitDateVector(node: Vector<Date_>): any;
-    abstract visitTimestampVector(node: Vector<Timestamp>): any;
-    abstract visitTimeVector(node: Vector<Time>): any;
-    abstract visitDecimalVector(node: Vector<Decimal>): any;
-    abstract visitListVector(node: Vector<List>): any;
-    abstract visitStructVector(node: Vector<Struct>): any;
-    abstract visitUnionVector(node: Vector<Union<any>>): any;
-    abstract visitDictionaryVector(node: Vector<Dictionary>): any;
-    abstract visitIntervalVector(node: Vector<Interval>): any;
-    abstract visitFixedSizeListVector(node: Vector<FixedSizeList>): any;
-    abstract visitMapVector(node: Vector<Map_>): any;
+    abstract visitNull?(vector: Vector<Null>): any;
+    abstract visitBool?(vector: Vector<Bool>): any;
+    abstract visitInt?(vector: Vector<Int>): any;
+    abstract visitFloat?(vector: Vector<Float>): any;
+    abstract visitUtf8?(vector: Vector<Utf8>): any;
+    abstract visitBinary?(vector: Vector<Binary>): any;
+    abstract visitFixedSizeBinary?(vector: Vector<FixedSizeBinary>): any;
+    abstract visitDate?(vector: Vector<Date_>): any;
+    abstract visitTimestamp?(vector: Vector<Timestamp>): any;
+    abstract visitTime?(vector: Vector<Time>): any;
+    abstract visitDecimal?(vector: Vector<Decimal>): any;
+    abstract visitList?(vector: Vector<List>): any;
+    abstract visitStruct?(vector: Vector<Struct>): any;
+    abstract visitUnion?(vector: Vector<Union<any>>): any;
+    abstract visitDictionary?(vector: Vector<Dictionary>): any;
+    abstract visitInterval?(vector: Vector<Interval>): any;
+    abstract visitFixedSizeList?(vector: Vector<FixedSizeList>): any;
+    abstract visitMap?(vector: Vector<Map_>): any;
 
     static visitTypeInline<T extends DataType>(visitor: VectorVisitor, type: T, vector: Vector<T>): any {
         switch (type.TType) {
-            case Type.Null:            return visitor.visitNullVector(vector            as any as Vector<Null>);
-            case Type.Int:             return visitor.visitIntVector(vector             as any as Vector<Int>);
-            case Type.Float:           return visitor.visitFloatVector(vector           as any as Vector<Float>);
-            case Type.Binary:          return visitor.visitBinaryVector(vector          as any as Vector<Binary>);
-            case Type.Utf8:            return visitor.visitUtf8Vector(vector            as any as Vector<Utf8>);
-            case Type.Bool:            return visitor.visitBoolVector(vector            as any as Vector<Bool>);
-            case Type.Decimal:         return visitor.visitDecimalVector(vector         as any as Vector<Decimal>);
-            case Type.Date:            return visitor.visitDateVector(vector            as any as Vector<Date_>);
-            case Type.Time:            return visitor.visitTimeVector(vector            as any as Vector<Time>);
-            case Type.Timestamp:       return visitor.visitTimestampVector(vector       as any as Vector<Timestamp>);
-            case Type.Interval:        return visitor.visitIntervalVector(vector        as any as Vector<Interval>);
-            case Type.List:            return visitor.visitListVector(vector            as any as Vector<List<T>>);
-            case Type.Struct:          return visitor.visitStructVector(vector          as any as Vector<Struct>);
-            case Type.Union:           return visitor.visitUnionVector(vector           as any as Vector<Union>);
-            case Type.FixedSizeBinary: return visitor.visitFixedSizeBinaryVector(vector as any as Vector<FixedSizeBinary>);
-            case Type.FixedSizeList:   return visitor.visitFixedSizeListVector(vector   as any as Vector<FixedSizeList>);
-            case Type.Map:             return visitor.visitMapVector(vector             as any as Vector<Map_>);
-            case Type.Dictionary:      return visitor.visitDictionaryVector(vector      as any as Vector<Dictionary>);
+            case Type.Null:            return visitor.visitNull            && visitor.visitNull(vector            as any as Vector<Null>);
+            case Type.Int:             return visitor.visitInt             && visitor.visitInt(vector             as any as Vector<Int>);
+            case Type.Float:           return visitor.visitFloat           && visitor.visitFloat(vector           as any as Vector<Float>);
+            case Type.Binary:          return visitor.visitBinary          && visitor.visitBinary(vector          as any as Vector<Binary>);
+            case Type.Utf8:            return visitor.visitUtf8            && visitor.visitUtf8(vector            as any as Vector<Utf8>);
+            case Type.Bool:            return visitor.visitBool            && visitor.visitBool(vector            as any as Vector<Bool>);
+            case Type.Decimal:         return visitor.visitDecimal         && visitor.visitDecimal(vector         as any as Vector<Decimal>);
+            case Type.Date:            return visitor.visitDate            && visitor.visitDate(vector            as any as Vector<Date_>);
+            case Type.Time:            return visitor.visitTime            && visitor.visitTime(vector            as any as Vector<Time>);
+            case Type.Timestamp:       return visitor.visitTimestamp       && visitor.visitTimestamp(vector       as any as Vector<Timestamp>);
+            case Type.Interval:        return visitor.visitInterval        && visitor.visitInterval(vector        as any as Vector<Interval>);
+            case Type.List:            return visitor.visitList            && visitor.visitList(vector            as any as Vector<List<T>>);
+            case Type.Struct:          return visitor.visitStruct          && visitor.visitStruct(vector          as any as Vector<Struct>);
+            case Type.Union:           return visitor.visitUnion           && visitor.visitUnion(vector           as any as Vector<Union>);
+            case Type.FixedSizeBinary: return visitor.visitFixedSizeBinary && visitor.visitFixedSizeBinary(vector as any as Vector<FixedSizeBinary>);
+            case Type.FixedSizeList:   return visitor.visitFixedSizeList   && visitor.visitFixedSizeList(vector   as any as Vector<FixedSizeList>);
+            case Type.Map:             return visitor.visitMap             && visitor.visitMap(vector             as any as Vector<Map_>);
+            case Type.Dictionary:      return visitor.visitDictionary      && visitor.visitDictionary(vector      as any as Vector<Dictionary>);
             default: return null;
         }
     }
 }
-
-// import { Footer, Block } from './ipc/message';
-// import { Field, FieldNode, Buffer } from './ipc/message';
-// import { Message, Schema, RecordBatch, DictionaryBatch } from './ipc/message';
-
-// export abstract class MessageVisitor {
-//     visit(node: VisitorNode): any {
-//         return node.acceptMessageVisitor(this);
-//     }
-//     visitMany(nodes: VisitorNode[]): any[] {
-//         return nodes.map((node) => this.visit(node));
-//     }
-//     abstract visitFooter(node: Footer): any;
-//     abstract visitBlock(node: Block): any;
-//     abstract visitMessage(node: Message): any;
-//     abstract visitSchema(node: Schema): any;
-//     abstract visitField<T extends DataType>(node: Field<T>): any;
-//     abstract visitBuffer(node: Buffer): any;
-//     abstract visitFieldNode(node: FieldNode): any;
-//     abstract visitDataType<T extends Type>(node: DataType<T>): any;
-//     abstract visitDictionary(node: Dictionary): any;
-//     abstract visitRecordBatch(node: RecordBatch): any;
-//     abstract visitDictionaryBatch(node: DictionaryBatch): any;
-// }

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -436,7 +436,7 @@ describe(`Table`, () => {
             });
             test(`table.toString()`, () => {
                 let selected = table.select('i32', 'dictionary');
-                let headers  = [`"row_id"`, `"i32: Int32"`, `"dictionary: Dictionary<Utf8, Int8>"`];
+                let headers  = [`"row_id"`, `"i32: Int32"`, `"dictionary: Dictionary<Int8, Utf8>"`];
                 let expected = [headers.join(' | '), ...values.map((row, idx) => {
                     return [`${idx}`, `${row[I32]}`, `"${row[DICT]}"`].map((str, col) => {
                                 return leftPad(str, ' ', headers[col].length);


### PR DESCRIPTION
A bit of cleanup before we finalize the 0.3 JS release. Adds exports for some of the Arrow format and schema enums, refactors the VectorVisitor method names, and adds support for partial visitors by always using `visitTypeInline` in the DataType's `acceptTypeVisitor` impl.