### PR TITLE
ARROW-2131: [Python] Prepend module path to PYTHONPATH when spawning subprocess

### DIFF
--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -580,6 +580,21 @@ def test_deserialize_in_different_process():
     p.join()
 
 
+def _get_modified_env_with_pythonpath():
+    # Prepend pyarrow root directory to PYTHONPATH
+    env = os.environ.copy()
+    existing_pythonpath = env.get('PYTHONPATH', '')
+    if sys.platform == 'win32':
+        sep = ';'
+    else:
+        sep = ':'
+
+    module_path, _ = os.path.split(pa.__path__[0])
+
+    env['PYTHONPATH'] =  sep.join((module_path, existing_pythonpath))
+    return env
+
+
 def test_deserialize_buffer_in_different_process():
     import tempfile
     import subprocess
@@ -589,9 +604,12 @@ def test_deserialize_buffer_in_different_process():
     f.write(b.to_pybytes())
     f.close()
 
+    subprocess_env = _get_modified_env_with_pythonpath()
+
     dir_path = os.path.dirname(os.path.realpath(__file__))
     python_file = os.path.join(dir_path, 'deserialize_buffer.py')
-    subprocess.check_call([sys.executable, python_file, f.name])
+    subprocess.check_call([sys.executable, python_file, f.name],
+                          env=subprocess_env)
 
 
 def test_set_pickle():

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -589,9 +589,10 @@ def _get_modified_env_with_pythonpath():
     else:
         sep = ':'
 
-    module_path, _ = os.path.split(pa.__path__[0])
+    module_path = os.path.abspath(
+        os.path.dirname(os.path.dirname(pa.__file__)))
 
-    env['PYTHONPATH'] =  sep.join((module_path, existing_pythonpath))
+    env['PYTHONPATH'] = sep.join((module_path, existing_pythonpath))
     return env
 
 


### PR DESCRIPTION
This enables this test to pass in an in-place build without running `setup.py develop`