### PR TITLE
ARROW-2184: [C++]  Add static constructor for FileOutputStream returning shared_ptr to OutputStream

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -555,6 +555,17 @@ FileOutputStream::~FileOutputStream() {
 }
 
 Status FileOutputStream::Open(const std::string& path,
+                              std::shared_ptr<OutputStream>* file) {
+  return Open(path, false, file);
+}
+
+Status FileOutputStream::Open(const std::string& path, bool append,
+                              std::shared_ptr<OutputStream>* out) {
+  *out = std::shared_ptr<FileOutputStream>(new FileOutputStream());
+  return std::static_pointer_cast<FileOutputStream>(*out)->impl_->Open(path, append);
+}
+
+Status FileOutputStream::Open(const std::string& path,
                               std::shared_ptr<FileOutputStream>* file) {
   return Open(path, false, file);
 }

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -41,6 +41,21 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
 
   /// \brief Open a local file for writing, truncating any existing file
   /// \param[in] path with UTF8 encoding
+  /// \param[out] out a base interface OutputStream instance
+  ///
+  /// When opening a new file, any existing file with the indicated path is
+  /// truncated to 0 bytes, deleting any existing memory
+  static Status Open(const std::string& path, std::shared_ptr<OutputStream>* out);
+
+  /// \brief Open a local file for writing
+  /// \param[in] path with UTF8 encoding
+  /// \param[in] append append to existing file, otherwise truncate to 0 bytes
+  /// \param[out] out a base interface OutputStream instance
+  static Status Open(const std::string& path, bool append,
+                     std::shared_ptr<OutputStream>* out);
+
+  /// \brief Open a local file for writing, truncating any existing file
+  /// \param[in] path with UTF8 encoding
   /// \param[out] file a FileOutputStream instance
   ///
   /// When opening a new file, any existing file with the indicated path is

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -821,7 +821,6 @@ cdef class ParquetWriter:
                   use_deprecated_int96_timestamps=False,
                   coerce_timestamps=None):
         cdef:
-            shared_ptr[FileOutputStream] filestream
             shared_ptr[WriterProperties] properties
             c_string c_where
             CMemoryPool* pool
@@ -830,8 +829,7 @@ cdef class ParquetWriter:
             c_where = tobytes(where)
             with nogil:
                 check_status(FileOutputStream.Open(c_where,
-                                                   &filestream))
-            self.sink = <shared_ptr[OutputStream]> filestream
+                                                   &self.sink))
             self.own_sink = True
         else:
             get_writer(where, &self.sink)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -539,7 +539,7 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
 
     cdef cppclass FileOutputStream(OutputStream):
         @staticmethod
-        CStatus Open(const c_string& path, shared_ptr[FileOutputStream]* file)
+        CStatus Open(const c_string& path, shared_ptr[OutputStream]* file)
 
         int file_descriptor()
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -550,12 +550,9 @@ cdef class OSFile(NativeFile):
         self.rd_file = <shared_ptr[RandomAccessFile]> handle
 
     cdef _open_writable(self, c_string path):
-        cdef shared_ptr[FileOutputStream] handle
-
         with nogil:
-            check_status(FileOutputStream.Open(path, &handle))
+            check_status(FileOutputStream.Open(path, &self.wr_file))
         self.is_writable = True
-        self.wr_file = <shared_ptr[OutputStream]> handle
 
 
 cdef class FixedSizeBufferWriter(NativeFile):


### PR DESCRIPTION
Add constructors to return pointers to the base interface