### PR TITLE
ARROW-2094: [C++] Install libprotobuf and set PROTOBUF_HOME when using toolchain

### DIFF
--- a/ci/travis_env_common.sh
+++ b/ci/travis_env_common.sh
@@ -47,6 +47,9 @@ if [ "$ARROW_TRAVIS_USE_TOOLCHAIN" == "1" ]; then
   export ARROW_BUILD_TOOLCHAIN=$CPP_TOOLCHAIN
   export BOOST_ROOT=$CPP_TOOLCHAIN
 
+  # Protocol buffers used by Apache ORC thirdparty build
+  export PROTOBUF_HOME=$CPP_TOOLCHAIN
+
   export PATH=$CPP_TOOLCHAIN/bin:$PATH
   export LD_LIBRARY_PATH=$CPP_TOOLCHAIN/lib:$LD_LIBRARY_PATH
   export TRAVIS_MAKE=ninja

--- a/ci/travis_install_toolchain.sh
+++ b/ci/travis_install_toolchain.sh
@@ -26,6 +26,7 @@ if [ ! -e $CPP_TOOLCHAIN ]; then
     conda create -y -q -p $CPP_TOOLCHAIN python=2.7 \
         nomkl \
         boost-cpp \
+        libprotobuf \
         rapidjson \
         flatbuffers \
         gflags \


### PR DESCRIPTION
C++-only libprotobuf is now being provided by conda-forge