### PR TITLE
ARROW-1643: [Python] Accept hdfs:// prefixes in parquet.read_table and attempt to connect to HDFS

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -311,8 +311,6 @@ schema : arrow Schema
     def __del__(self):
         if getattr(self, 'is_open', False):
             self.close()
-        if self.file_handle is not None:
-            self.file_handle.close()
 
     def __enter__(self):
         return self
@@ -332,6 +330,8 @@ schema : arrow Schema
         if self.is_open:
             self.writer.close()
             self.is_open = False
+        if self.file_handle is not None:
+            self.file_handle.close()
 
 
 def _get_pandas_index_columns(keyvalues):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1139,7 +1139,7 @@ def _ensure_file(source):
         fs = _get_fs_from_path(source)
         try:
             return fs.open(source)
-        except FileNotFoundError as e:
+        except IOError as e:
             raise lib.ArrowIOError("failed to open file {}, {}"
                                    .format(source, e))
     elif not hasattr(source, 'seek'):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1163,9 +1163,6 @@ def _get_fs_from_path(path):
     if _has_pathlib and isinstance(path, pathlib.Path):
         path = str(path)
     parsed_uri = urlparse(path)
-    if parsed_uri.scheme not in ['', 'file', 'hdfs']:
-        raise ValueError("Invalid file URI scheme {}".format(
-            parsed_uri.scheme))
     if parsed_uri.scheme == 'hdfs':
         netloc_split = parsed_uri.netloc.split(':')
         host = netloc_split[0]

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -395,6 +395,7 @@ class TestLibHdfs3(HdfsTestCases, unittest.TestCase):
         if not pa.have_libhdfs3():
             pytest.skip('No libhdfs3 available on system')
 
+
 def _get_hdfs_uri(path):
     host = os.environ.get('ARROW_HDFS_TEST_HOST', 'localhost')
     try:

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -272,19 +272,11 @@ class HdfsTestCases(object):
 
         assert result == data
 
-    @test_parquet.parquet
-    def test_read_multiple_parquet_files(self):
+    def _write_multiple_hdfs_pq_files(self, tmpdir):
         import pyarrow.parquet as pq
-
         nfiles = 10
         size = 5
-
-        tmpdir = pjoin(self.tmp_path, 'multi-parquet-' + guid())
-
-        self.hdfs.mkdir(tmpdir)
-
         test_data = []
-        paths = []
         for i in range(nfiles):
             df = test_parquet._test_dataframe(size, seed=i)
 
@@ -300,10 +292,35 @@ class HdfsTestCases(object):
                 pq.write_table(table, f)
 
             test_data.append(table)
-            paths.append(path)
 
-        result = self.hdfs.read_parquet(tmpdir)
         expected = pa.concat_tables(test_data)
+        return expected
+
+    @test_parquet.parquet
+    def test_read_multiple_parquet_files(self):
+
+        tmpdir = pjoin(self.tmp_path, 'multi-parquet-' + guid())
+
+        self.hdfs.mkdir(tmpdir)
+
+        expected = self._write_multiple_hdfs_pq_files(tmpdir)
+        result = self.hdfs.read_parquet(tmpdir)
+
+        pdt.assert_frame_equal(result.to_pandas()
+                               .sort_values(by='index').reset_index(drop=True),
+                               expected.to_pandas())
+
+    @test_parquet.parquet
+    def test_read_multiple_parquet_files_with_uri(self):
+        import pyarrow.parquet as pq
+
+        tmpdir = pjoin(self.tmp_path, 'multi-parquet-uri-' + guid())
+
+        self.hdfs.mkdir(tmpdir)
+
+        expected = self._write_multiple_hdfs_pq_files(tmpdir)
+        path = _get_hdfs_uri(tmpdir)
+        result = pq.read_table(path)
 
         pdt.assert_frame_equal(result.to_pandas()
                                .sort_values(by='index').reset_index(drop=True),
@@ -315,14 +332,7 @@ class HdfsTestCases(object):
 
         tmpdir = pjoin(self.tmp_path, 'uri-parquet-' + guid())
         self.hdfs.mkdir(tmpdir)
-        host = os.environ.get('ARROW_HDFS_TEST_HOST', 'localhost')
-        try:
-            port = int(os.environ.get('ARROW_HDFS_TEST_PORT', 0))
-        except ValueError:
-            raise ValueError('Env variable ARROW_HDFS_TEST_PORT was not '
-                             'an integer')
-        path = "hdfs://{}:{}{}".format(host, port,
-                                       pjoin(tmpdir, 'test.parquet'))
+        path = _get_hdfs_uri(pjoin(tmpdir, 'test.parquet'))
 
         size = 5
         df = test_parquet._test_dataframe(size, seed=0)
@@ -384,3 +394,14 @@ class TestLibHdfs3(HdfsTestCases, unittest.TestCase):
     def check_driver(cls):
         if not pa.have_libhdfs3():
             pytest.skip('No libhdfs3 available on system')
+
+def _get_hdfs_uri(path):
+    host = os.environ.get('ARROW_HDFS_TEST_HOST', 'localhost')
+    try:
+        port = int(os.environ.get('ARROW_HDFS_TEST_PORT', 0))
+    except ValueError:
+        raise ValueError('Env variable ARROW_HDFS_TEST_PORT was not '
+                         'an integer')
+    uri = "hdfs://{}:{}{}".format(host, port, path)
+
+    return uri

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -322,7 +322,7 @@ class HdfsTestCases(object):
             raise ValueError('Env variable ARROW_HDFS_TEST_PORT was not '
                              'an integer')
         path = "hdfs://{}:{}{}".format(host, port,
-                                        pjoin(tmpdir, 'test.parquet'))
+                                       pjoin(tmpdir, 'test.parquet'))
 
         size = 5
         df = test_parquet._test_dataframe(size, seed=0)


### PR DESCRIPTION
This patch enables pq.read_table, pq.write_table, and pq.ParquetFile to accept HDFS URI and connect to HDFS.