### PR TITLE
ARROW-2223: [JS] compile src/bin as es5-cjs to all output targets

### DIFF
--- a/js/gulp/arrow-task.js
+++ b/js/gulp/arrow-task.js
@@ -31,10 +31,10 @@ const arrowTask = ((cache) => memoizeTask(cache, function copyMain(target, forma
     const dtsGlob = `${targetDir(`es2015`, `cjs`)}/**/*.ts`;
     const cjsGlob = `${targetDir(`es2015`, `cjs`)}/**/*.js`;
     const esmGlob = `${targetDir(`es2015`, `esm`)}/**/*.js`;
-    const es5UmdGlob = `${targetDir(`es5`, `umd`)}/**/*.js`;
-    const es5UmdMaps = `${targetDir(`es5`, `umd`)}/**/*.map`;
-    const es2015UmdGlob = `${targetDir(`es2015`, `umd`)}/**/*.js`;
-    const es2015UmdMaps = `${targetDir(`es2015`, `umd`)}/**/*.map`;
+    const es5UmdGlob = `${targetDir(`es5`, `umd`)}/*.js`;
+    const es5UmdMaps = `${targetDir(`es5`, `umd`)}/*.map`;
+    const es2015UmdGlob = `${targetDir(`es2015`, `umd`)}/*.js`;
+    const es2015UmdMaps = `${targetDir(`es2015`, `umd`)}/*.map`;
     const ch_ext = (ext) => gulpRename((p) => { p.extname = ext; });
     const append = (ap) => gulpRename((p) => { p.basename += ap; });
     return Observable.forkJoin(

--- a/js/gulp/closure-task.js
+++ b/js/gulp/closure-task.js
@@ -27,6 +27,7 @@ const gulp = require('gulp');
 const path = require('path');
 const sourcemaps = require('gulp-sourcemaps');
 const { memoizeTask } = require('./memoize-task');
+const { compileBinFiles } = require('./typescript-task');
 const ASTBuilders = require('ast-types').builders;
 const transformAST = require('gulp-transform-js-ast');
 const { Observable, ReplaySubject } = require('rxjs');
@@ -55,7 +56,10 @@ const closureTask = ((cache) => memoizeTask(cache, function closure(target, form
         // rename the sourcemaps from *.js.map files to *.min.js.map
         sourcemaps.write(`.`, { mapFile: (mapPath) => mapPath.replace(`.js.map`, `.${target}.min.js.map`) }),
         gulp.dest(out)
-    ).publish(new ReplaySubject()).refCount();
+    )
+    .merge(compileBinFiles(target, format))
+    .takeLast(1)
+    .publish(new ReplaySubject()).refCount();
 }))({});
 
 const createClosureArgs = (entry, externs) => ({

--- a/js/gulp/uglify-task.js
+++ b/js/gulp/uglify-task.js
@@ -27,6 +27,7 @@ const {
 const path = require('path');
 const webpack = require(`webpack`);
 const { memoizeTask } = require('./memoize-task');
+const { compileBinFiles } = require('./typescript-task');
 const { Observable, ReplaySubject } = require('rxjs');
 const UglifyJSPlugin = require(`uglifyjs-webpack-plugin`);
 const esmRequire = require(`@std/esm`)(module, { cjs: true, esm: `js`, warnings: false });
@@ -73,6 +74,7 @@ const uglifyTask = ((cache, commonConfig) => memoizeTask(cache, function uglifyJ
     const compilers = webpack(webpackConfigs);
     return Observable
             .bindNodeCallback(compilers.run.bind(compilers))()
+            .merge(compileBinFiles(target, format)).takeLast(1)
             .multicast(new ReplaySubject()).refCount();
 }))({}, {
     resolve: { mainFields: [`module`, `main`] },

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -58,15 +58,15 @@ knownTargets.forEach((target) =>
     )
 );
 
-// The main "apache-arrow" module builds the es5/cjs, es5/umd,
-// es2015/esm, es2015/umd, and ts targets, then copies and
-// renames the compiled output into the apache-arrow folder
+// The main "apache-arrow" module builds the es5/umd, es2015/cjs,
+// es2015/esm, and es2015/umd targets, then copies and renames the
+// compiled output into the apache-arrow folder
 gulp.task(`build:${npmPkgName}`,
     gulp.series(
         cleanTask(npmPkgName),
         gulp.parallel(
-            `build:${taskName(`es5`, `cjs`)}`,
             `build:${taskName(`es5`, `umd`)}`,
+            `build:${taskName(`es2015`, `cjs`)}`,
             `build:${taskName(`es2015`, `esm`)}`,
             `build:${taskName(`es2015`, `umd`)}`
         ),

--- a/js/src/bin/arrow2csv.ts
+++ b/js/src/bin/arrow2csv.ts
@@ -84,12 +84,10 @@ if (!files.length) {
 }
 
 files.forEach((source) => {
-    debugger;
     let table: Arrow.Table, input = fs.readFileSync(source);
     try {
         table = Arrow.Table.from(input);
     } catch (e) {
-        debugger;
         table = Arrow.Table.from(parse(input + ''));
     }
     if (argv.schema && argv.schema.length) {

--- a/js/tsconfig/tsconfig.base.json
+++ b/js/tsconfig/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["../node_modules"],
+  "exclude": ["../node_modules", "../src/bin/*.ts"],
   "include": ["../src/**/*.ts"],
   "compileOnSave": false,
   "compilerOptions": {

--- a/js/tsconfig/tsconfig.bin.cjs.json
+++ b/js/tsconfig/tsconfig.bin.cjs.json
@@ -1,0 +1,12 @@
+//Compiler configuaration to build the ES5 CommonJS bin files
+{
+    "extends": "./tsconfig.base.json",
+    "exclude": ["../node_modules"],
+    "include": ["../src/bin/*.ts"],
+      "compilerOptions": {
+      "target": "ES5",
+      "module": "commonjs",
+      "declaration": false
+    }
+  }
+  


### PR DESCRIPTION
This ensures the `bin` files are uniformly es5/commonjs for all target modules. Now this works:
```sh
npm i @apache-arrow/esnext-esm
npx arrow2csv -f some-file.arrow
```

Resolves https://issues.apache.org/jira/browse/ARROW-2223