### PR TITLE
ARROW-2225: [JS] support tables split across buffers

### DIFF
--- a/js/src/ipc/reader/binary.ts
+++ b/js/src/ipc/reader/binary.ts
@@ -49,7 +49,7 @@ export function* readBuffers<T extends Uint8Array | Buffer | string>(sources: It
     }
     for (const source of sources) {
         const bb = toByteBuffer(source);
-        if ((!schema && ({ schema, readMessages } = readSchema(bb))) && schema && readMessages) {
+        if ((!schema && ({ schema, readMessages } = readSchema(bb)) || true) && schema && readMessages) {
             for (const message of readMessages(bb)) {
                 yield {
                     schema, message,
@@ -71,7 +71,7 @@ export async function* readBuffersAsync<T extends Uint8Array | Buffer | string>(
     let readMessages: MessageReader | null = null;
     for await (const source of sources) {
         const bb = toByteBuffer(source);
-        if ((!schema && ({ schema, readMessages } = readSchema(bb))) && schema && readMessages) {
+        if ((!schema && ({ schema, readMessages } = readSchema(bb)) || true) && schema && readMessages) {
             for (const message of readMessages(bb)) {
                 yield {
                     schema, message,


### PR DESCRIPTION
@TheNeuralBit somewhere along the way we lost this. Resolves https://issues.apache.org/jira/browse/ARROW-2225