### PR TITLE
ARROW-2141: [Python] Support variable length binary conversion from Pandas

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -1396,8 +1396,8 @@ inline Status NumPyConverter::ConvertTypedLists<NPY_OBJECT, BinaryType>(
       RETURN_NOT_OK(CheckFlatNumpyArray(numpy_array, NPY_OBJECT));
 
       int64_t offset = 0;
-      RETURN_NOT_OK(AppendObjectBinaries(numpy_array, nullptr, 0, value_builder,
-                                         &offset));
+      RETURN_NOT_OK(
+          AppendObjectBinaries(numpy_array, nullptr, 0, value_builder, &offset));
       if (offset < PyArray_SIZE(numpy_array)) {
         return Status::Invalid("Array cell value exceeded 2GB");
       }

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -223,13 +223,15 @@ static Status AppendObjectBinaries(PyArrayObject* arr, PyArrayObject* mask,
       continue;
     } else if (PyBytes_Check(obj)) {
       const int32_t length = static_cast<int32_t>(PyBytes_GET_SIZE(obj));
-      if (ARROW_PREDICT_FALSE(builder->value_data_length() + length > kBinaryMemoryLimit)) {
+      if (ARROW_PREDICT_FALSE(builder->value_data_length() + length >
+                              kBinaryMemoryLimit)) {
         break;
       }
       RETURN_NOT_OK(builder->Append(PyBytes_AS_STRING(obj), length));
     } else if (PyByteArray_Check(obj)) {
       const int32_t length = static_cast<int32_t>(PyByteArray_GET_SIZE(obj));
-      if (ARROW_PREDICT_FALSE(builder->value_data_length() + length > kBinaryMemoryLimit)) {
+      if (ARROW_PREDICT_FALSE(builder->value_data_length() + length >
+                              kBinaryMemoryLimit)) {
         break;
       }
       RETURN_NOT_OK(builder->Append(PyByteArray_AS_STRING(obj), length));

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -1178,7 +1178,7 @@ Status NumPyConverter::ConvertObjects() {
       case Type::STRING:
         return ConvertObjectStrings();
       case Type::BINARY:
-	return ConvertObjectBytes();
+        return ConvertObjectBytes();
       case Type::FIXED_SIZE_BINARY:
         return ConvertObjectFixedWidthBytes(type_);
       case Type::BOOL:
@@ -1386,7 +1386,8 @@ inline Status NumPyConverter::ConvertTypedLists<NPY_OBJECT, BinaryType>(
       RETURN_NOT_OK(CheckFlatNumpyArray(numpy_array, NPY_OBJECT));
 
       int64_t offset = 0;
-      RETURN_NOT_OK(AppendObjectBinaries(numpy_array, nullptr, 0, value_builder, &offset));
+      RETURN_NOT_OK(AppendObjectBinaries(numpy_array, nullptr, 0, value_builder,
+                                         &offset));
       if (offset < PyArray_SIZE(numpy_array)) {
         return Status::Invalid("Array cell value exceeded 2GB");
       }

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1105,6 +1105,16 @@ class TestConvertStringLikeTypes(object):
         assert arr.type == pa.binary()
         _check_series_roundtrip(s, type_=pa.binary())
 
+    def test_binary_from_bytearray(self):
+        s = pd.Series([bytearray(b'123'), bytearray(b''), bytearray(b'a')])
+        # Explicitly set type
+        arr = pa.Array.from_pandas(s, type=pa.binary())
+        assert arr.type == pa.binary()
+        # Infer type from bytearrays
+        arr = pa.Array.from_pandas(s)
+        assert arr.type == pa.binary()
+        _check_series_roundtrip(s, type_=pa.binary())
+
     def test_table_empty_str(self):
         values = ['', '', '', '', '']
         df = pd.DataFrame({'strings': values})

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1099,6 +1099,12 @@ class TestConvertStringLikeTypes(object):
         with pytest.raises(pa.ArrowInvalid):
             pa.Table.from_pandas(df, schema=schema)
 
+    def test_variable_size_bytes(self):
+        s = pd.Series([b'123', b'', b'a', None])
+        arr = pa.Array.from_pandas(s, type=pa.binary())
+        assert arr.type == pa.binary()
+        _check_series_roundtrip(s, type_=pa.binary())
+
     def test_table_empty_str(self):
         values = ['', '', '', '', '']
         df = pd.DataFrame({'strings': values})
@@ -1693,7 +1699,7 @@ class TestConvertMisc(object):
         # XXX unsupported
         # (np.dtype([('a', 'i2')]), pa.struct([pa.field('a', pa.int16())])),
         (np.object, pa.string()),
-        # (np.object, pa.binary()),  # XXX unsupported
+        (np.object, pa.binary()),
         (np.object, pa.binary(10)),
         (np.object, pa.list_(pa.int64())),
         ]


### PR DESCRIPTION
Currently, when performing `from_pandas` conversion with binary data and the user specifies the type as variable length binary `pa.binary()` then the type is inferred and a cast from binary to binary is attempted.  The casting then fails because the cast kernel does not support binary types.  This PR checks if the user specifies a variable length binary type in conversion, and then copies data to a BinaryArray instead of trying to infer the type and then casting.