### PR TITLE
ARROW-2251: [GLib] Keep GArrowBuffer alive while GArrowTensor for the buffer is live

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -282,7 +282,7 @@ garrow_seekable_input_stream_read_tensor(GArrowSeekableInputStream *input_stream
                                        arrow_random_access_file.get(),
                                        &arrow_tensor);
   if (garrow_error_check(error, status, "[seekable-input-stream][read-tensor]")) {
-    return garrow_tensor_new_raw(&arrow_tensor);
+    return garrow_tensor_new_raw(&arrow_tensor, nullptr);
   } else {
     return NULL;
   }

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -40,17 +40,32 @@ G_BEGIN_DECLS
 
 typedef struct GArrowTensorPrivate_ {
   std::shared_ptr<arrow::Tensor> tensor;
+  GArrowBuffer *buffer;
 } GArrowTensorPrivate;
 
 enum {
   PROP_0,
-  PROP_TENSOR
+  PROP_TENSOR,
+  PROP_BUFFER
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowTensor, garrow_tensor, G_TYPE_OBJECT)
 
 #define GARROW_TENSOR_GET_PRIVATE(obj)                                   \
   (G_TYPE_INSTANCE_GET_PRIVATE((obj), GARROW_TYPE_TENSOR, GArrowTensorPrivate))
+
+static void
+garrow_tensor_dispose(GObject *object)
+{
+  auto priv = GARROW_TENSOR_GET_PRIVATE(object);
+
+  if (priv->buffer) {
+    g_object_unref(priv->buffer);
+    priv->buffer = nullptr;
+  }
+
+  G_OBJECT_CLASS(garrow_tensor_parent_class)->dispose(object);
+}
 
 static void
 garrow_tensor_finalize(GObject *object)
@@ -64,9 +79,9 @@ garrow_tensor_finalize(GObject *object)
 
 static void
 garrow_tensor_set_property(GObject *object,
-                          guint prop_id,
-                          const GValue *value,
-                          GParamSpec *pspec)
+                           guint prop_id,
+                           const GValue *value,
+                           GParamSpec *pspec)
 {
   auto priv = GARROW_TENSOR_GET_PRIVATE(object);
 
@@ -74,6 +89,9 @@ garrow_tensor_set_property(GObject *object,
   case PROP_TENSOR:
     priv->tensor =
       *static_cast<std::shared_ptr<arrow::Tensor> *>(g_value_get_pointer(value));
+    break;
+  case PROP_BUFFER:
+    priv->buffer = GARROW_BUFFER(g_value_dup_object(value));
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -83,11 +101,16 @@ garrow_tensor_set_property(GObject *object,
 
 static void
 garrow_tensor_get_property(GObject *object,
-                          guint prop_id,
-                          GValue *value,
-                          GParamSpec *pspec)
+                           guint prop_id,
+                           GValue *value,
+                           GParamSpec *pspec)
 {
+  auto priv = GARROW_TENSOR_GET_PRIVATE(object);
+
   switch (prop_id) {
+  case PROP_BUFFER:
+    g_value_set_object(value, priv->buffer);
+    break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     break;
@@ -106,6 +129,7 @@ garrow_tensor_class_init(GArrowTensorClass *klass)
 
   auto gobject_class = G_OBJECT_CLASS(klass);
 
+  gobject_class->dispose      = garrow_tensor_dispose;
   gobject_class->finalize     = garrow_tensor_finalize;
   gobject_class->set_property = garrow_tensor_set_property;
   gobject_class->get_property = garrow_tensor_get_property;
@@ -116,6 +140,14 @@ garrow_tensor_class_init(GArrowTensorClass *klass)
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_TENSOR, spec);
+
+  spec = g_param_spec_object("buffer",
+                             "Buffer",
+                             "The data",
+                             GARROW_TYPE_BUFFER,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_BUFFER, spec);
 }
 
 /**
@@ -166,7 +198,7 @@ garrow_tensor_new(GArrowDataType *data_type,
                                     arrow_shape,
                                     arrow_strides,
                                     arrow_dimension_names);
-  auto tensor = garrow_tensor_new_raw(&arrow_tensor);
+  auto tensor = garrow_tensor_new_raw(&arrow_tensor, data);
   return tensor;
 }
 
@@ -231,6 +263,12 @@ garrow_tensor_get_value_type(GArrowTensor *tensor)
 GArrowBuffer *
 garrow_tensor_get_buffer(GArrowTensor *tensor)
 {
+  auto priv = GARROW_TENSOR_GET_PRIVATE(tensor);
+  if (priv->buffer) {
+    g_object_ref(priv->buffer);
+    return priv->buffer;
+  }
+
   auto arrow_tensor = garrow_tensor_get_raw(tensor);
   auto arrow_buffer = arrow_tensor->data();
   return garrow_buffer_new_raw(&arrow_buffer);
@@ -398,10 +436,12 @@ garrow_tensor_is_column_major(GArrowTensor *tensor)
 G_END_DECLS
 
 GArrowTensor *
-garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor)
+garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor,
+                      GArrowBuffer *buffer)
 {
   auto tensor = GARROW_TENSOR(g_object_new(GARROW_TYPE_TENSOR,
                                            "tensor", arrow_tensor,
+                                           "buffer", buffer,
                                            NULL));
   return tensor;
 }

--- a/c_glib/arrow-glib/tensor.hpp
+++ b/c_glib/arrow-glib/tensor.hpp
@@ -23,5 +23,6 @@
 
 #include <arrow-glib/tensor.h>
 
-GArrowTensor *garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor);
+GArrowTensor *garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor,
+                                    GArrowBuffer *buffer);
 std::shared_ptr<arrow::Tensor> garrow_tensor_get_raw(GArrowTensor *tensor);


### PR DESCRIPTION
It prevents GC-related crash.