### PR TITLE
ARROW-2261: [GLib] Improve memory management for GArrowBuffer data

### DIFF
--- a/c_glib/arrow-glib/buffer.h
+++ b/c_glib/arrow-glib/buffer.h
@@ -36,6 +36,7 @@ struct _GArrowBufferClass
 
 GArrowBuffer  *garrow_buffer_new          (const guint8 *data,
                                            gint64 size);
+GArrowBuffer  *garrow_buffer_new_bytes    (GBytes *data);
 gboolean       garrow_buffer_equal        (GArrowBuffer *buffer,
                                            GArrowBuffer *other_buffer);
 gboolean       garrow_buffer_equal_n_bytes(GArrowBuffer *buffer,
@@ -70,6 +71,7 @@ struct _GArrowMutableBufferClass
 
 GArrowMutableBuffer *garrow_mutable_buffer_new  (guint8 *data,
                                                  gint64 size);
+GArrowMutableBuffer *garrow_mutable_buffer_new_bytes(GBytes *data);
 GArrowMutableBuffer *garrow_mutable_buffer_slice(GArrowMutableBuffer *buffer,
                                                  gint64 offset,
                                                  gint64 size);

--- a/c_glib/arrow-glib/buffer.hpp
+++ b/c_glib/arrow-glib/buffer.hpp
@@ -24,7 +24,11 @@
 #include <arrow-glib/buffer.h>
 
 GArrowBuffer *garrow_buffer_new_raw(std::shared_ptr<arrow::Buffer> *arrow_buffer);
+GArrowBuffer *garrow_buffer_new_raw_bytes(std::shared_ptr<arrow::Buffer> *arrow_buffer,
+                                          GBytes *data);
 std::shared_ptr<arrow::Buffer> garrow_buffer_get_raw(GArrowBuffer *buffer);
 
 GArrowMutableBuffer *garrow_mutable_buffer_new_raw(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer);
+GArrowMutableBuffer *garrow_mutable_buffer_new_raw_bytes(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer,
+                                                         GBytes *data);
 GArrowPoolBuffer *garrow_pool_buffer_new_raw(std::shared_ptr<arrow::PoolBuffer> *arrow_buffer);

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -282,16 +282,79 @@ garrow_seekable_input_stream_read_tensor(GArrowSeekableInputStream *input_stream
                                        arrow_random_access_file.get(),
                                        &arrow_tensor);
   if (garrow_error_check(error, status, "[seekable-input-stream][read-tensor]")) {
-    return garrow_tensor_new_raw(&arrow_tensor, nullptr);
+    return garrow_tensor_new_raw(&arrow_tensor);
   } else {
     return NULL;
   }
 }
 
 
-G_DEFINE_TYPE(GArrowBufferInputStream,                       \
-              garrow_buffer_input_stream,                     \
-              GARROW_TYPE_SEEKABLE_INPUT_STREAM);
+typedef struct GArrowBufferInputStreamPrivate_ {
+  GArrowBuffer *buffer;
+} GArrowBufferInputStreamPrivate;
+
+enum {
+  PROP_0_,
+  PROP_BUFFER
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowBufferInputStream,                     \
+                           garrow_buffer_input_stream,                  \
+                           GARROW_TYPE_SEEKABLE_INPUT_STREAM);
+
+#define GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(obj)                     \
+  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                                   \
+                               GARROW_TYPE_BUFFER_INPUT_STREAM,         \
+                               GArrowBufferInputStreamPrivate))
+
+static void
+garrow_buffer_input_stream_dispose(GObject *object)
+{
+  auto priv = GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(object);
+
+  if (priv->buffer) {
+    g_object_unref(priv->buffer);
+    priv->buffer = nullptr;
+  }
+
+  G_OBJECT_CLASS(garrow_buffer_input_stream_parent_class)->dispose(object);
+}
+
+static void
+garrow_buffer_input_stream_set_property(GObject *object,
+                                        guint prop_id,
+                                        const GValue *value,
+                                        GParamSpec *pspec)
+{
+  auto priv = GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_BUFFER:
+    priv->buffer = GARROW_BUFFER(g_value_dup_object(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_buffer_input_stream_get_property(GObject *object,
+                                        guint prop_id,
+                                        GValue *value,
+                                        GParamSpec *pspec)
+{
+  auto priv = GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_BUFFER:
+    g_value_set_object(value, priv->buffer);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
 
 static void
 garrow_buffer_input_stream_init(GArrowBufferInputStream *object)
@@ -301,6 +364,21 @@ garrow_buffer_input_stream_init(GArrowBufferInputStream *object)
 static void
 garrow_buffer_input_stream_class_init(GArrowBufferInputStreamClass *klass)
 {
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose      = garrow_buffer_input_stream_dispose;
+  gobject_class->set_property = garrow_buffer_input_stream_set_property;
+  gobject_class->get_property = garrow_buffer_input_stream_get_property;
+
+  spec = g_param_spec_object("buffer",
+                             "Buffer",
+                             "The data",
+                             GARROW_TYPE_BUFFER,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_BUFFER, spec);
 }
 
 /**
@@ -315,18 +393,24 @@ garrow_buffer_input_stream_new(GArrowBuffer *buffer)
   auto arrow_buffer = garrow_buffer_get_raw(buffer);
   auto arrow_buffer_reader =
     std::make_shared<arrow::io::BufferReader>(arrow_buffer);
-  return garrow_buffer_input_stream_new_raw(&arrow_buffer_reader);
+  return garrow_buffer_input_stream_new_raw_buffer(&arrow_buffer_reader, buffer);
 }
 
 /**
  * garrow_buffer_input_stream_get_buffer:
  * @input_stream: A #GArrowBufferInputStream.
  *
- * Returns: (transfer full): The data of the array as #GArrowBuffer.
+ * Returns: (transfer full): The data of the stream as #GArrowBuffer.
  */
 GArrowBuffer *
 garrow_buffer_input_stream_get_buffer(GArrowBufferInputStream *input_stream)
 {
+  auto priv = GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(input_stream);
+  if (priv->buffer) {
+    g_object_ref(priv->buffer);
+    return priv->buffer;
+  }
+
   auto arrow_buffer_reader = garrow_buffer_input_stream_get_raw(input_stream);
   auto arrow_buffer = arrow_buffer_reader->buffer();
   return garrow_buffer_new_raw(&arrow_buffer);
@@ -627,9 +711,17 @@ garrow_seekable_input_stream_get_raw(GArrowSeekableInputStream *seekable_input_s
 GArrowBufferInputStream *
 garrow_buffer_input_stream_new_raw(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader)
 {
+  return garrow_buffer_input_stream_new_raw_buffer(arrow_buffer_reader, nullptr);
+}
+
+GArrowBufferInputStream *
+garrow_buffer_input_stream_new_raw_buffer(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader,
+                                          GArrowBuffer *buffer)
+{
   auto buffer_input_stream =
     GARROW_BUFFER_INPUT_STREAM(g_object_new(GARROW_TYPE_BUFFER_INPUT_STREAM,
                                             "input-stream", arrow_buffer_reader,
+                                            "buffer", buffer,
                                             NULL));
   return buffer_input_stream;
 }

--- a/c_glib/arrow-glib/input-stream.hpp
+++ b/c_glib/arrow-glib/input-stream.hpp
@@ -31,6 +31,8 @@ std::shared_ptr<arrow::io::InputStream> garrow_input_stream_get_raw(GArrowInputS
 std::shared_ptr<arrow::io::RandomAccessFile> garrow_seekable_input_stream_get_raw(GArrowSeekableInputStream *input_stream);
 
 GArrowBufferInputStream *garrow_buffer_input_stream_new_raw(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader);
+GArrowBufferInputStream *garrow_buffer_input_stream_new_raw_buffer(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader,
+                                                                   GArrowBuffer *buffer);
 std::shared_ptr<arrow::io::BufferReader> garrow_buffer_input_stream_get_raw(GArrowBufferInputStream *input_stream);
 
 GArrowMemoryMappedInputStream *garrow_memory_mapped_input_stream_new_raw(std::shared_ptr<arrow::io::MemoryMappedFile> *arrow_memory_mapped_file);

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -198,7 +198,7 @@ garrow_tensor_new(GArrowDataType *data_type,
                                     arrow_shape,
                                     arrow_strides,
                                     arrow_dimension_names);
-  auto tensor = garrow_tensor_new_raw(&arrow_tensor, data);
+  auto tensor = garrow_tensor_new_raw_buffer(&arrow_tensor, data);
   return tensor;
 }
 
@@ -436,8 +436,14 @@ garrow_tensor_is_column_major(GArrowTensor *tensor)
 G_END_DECLS
 
 GArrowTensor *
-garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor,
-                      GArrowBuffer *buffer)
+garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor)
+{
+  return garrow_tensor_new_raw_buffer(arrow_tensor, nullptr);
+}
+
+GArrowTensor *
+garrow_tensor_new_raw_buffer(std::shared_ptr<arrow::Tensor> *arrow_tensor,
+                             GArrowBuffer *buffer)
 {
   auto tensor = GARROW_TENSOR(g_object_new(GARROW_TYPE_TENSOR,
                                            "tensor", arrow_tensor,

--- a/c_glib/arrow-glib/tensor.hpp
+++ b/c_glib/arrow-glib/tensor.hpp
@@ -23,6 +23,7 @@
 
 #include <arrow-glib/tensor.h>
 
-GArrowTensor *garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor,
-                                    GArrowBuffer *buffer);
+GArrowTensor *garrow_tensor_new_raw(std::shared_ptr<arrow::Tensor> *arrow_tensor);
+GArrowTensor *garrow_tensor_new_raw_buffer(std::shared_ptr<arrow::Tensor> *arrow_tensor,
+                                           GArrowBuffer *buffer);
 std::shared_ptr<arrow::Tensor> garrow_tensor_get_raw(GArrowTensor *tensor);

--- a/c_glib/test/test-buffer.rb
+++ b/c_glib/test/test-buffer.rb
@@ -23,6 +23,16 @@ class TestBuffer < Test::Unit::TestCase
     @buffer = Arrow::Buffer.new(@data)
   end
 
+  def test_new_bytes
+    bytes_data = GLib::Bytes.new(@data)
+    buffer = Arrow::Buffer.new(bytes_data)
+    if GLib.check_binding_version?(3, 2, 2)
+      assert_equal(bytes_data.pointer, buffer.data.pointer)
+    else
+      assert_equal(@data, buffer.data.to_s)
+    end
+  end
+
   def test_equal
     assert_equal(@buffer,
                  Arrow::Buffer.new(@data.dup))

--- a/c_glib/test/test-mutable-buffer.rb
+++ b/c_glib/test/test-mutable-buffer.rb
@@ -21,6 +21,16 @@ class TestMutableBuffer < Test::Unit::TestCase
     @buffer = Arrow::MutableBuffer.new(@data)
   end
 
+  def test_new_bytes
+    bytes_data = GLib::Bytes.new(@data)
+    buffer = Arrow::MutableBuffer.new(bytes_data)
+    if GLib.check_binding_version?(3, 2, 2)
+      assert_equal(bytes_data.pointer, buffer.mutable_data.pointer)
+    else
+      assert_equal(@data, buffer.mutable_data.to_s)
+    end
+  end
+
   def test_mutable?
     assert do
       @buffer.mutable?


### PR DESCRIPTION
This change introduces GBytes constructors to GArrowBuffer and
GArrowMutableBuffer. GBytes has reference count feature. It means that
we can share the same memory safely.

We can't share the same memory safely with the current raw guint8
constructor.