### PR TITLE
ARROW-2122: [Python] Pyarrow fails to serialize dataframe with timestamp.

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -128,7 +128,7 @@ def get_extension_dtype_info(column):
         }
         physical_dtype = str(cats.codes.dtype)
     elif hasattr(dtype, 'tz'):
-        metadata = {'timezone': str(dtype.tz)}
+        metadata = {'timezone': pa.lib.tzinfo_to_string(dtype.tz)}
         physical_dtype = 'datetime64[ns]'
     else:
         metadata = None
@@ -418,7 +418,7 @@ def dataframe_to_serialized_dict(frame):
         block_data = {}
 
         if isinstance(block, _int.DatetimeTZBlock):
-            block_data['timezone'] = values.tz.zone
+            block_data['timezone'] = pa.lib.tzinfo_to_string(values.tz)
             values = values.values
         elif isinstance(block, _int.CategoricalBlock):
             block_data.update(dictionary=values.categories,
@@ -482,6 +482,7 @@ def _reconstruct_block(item):
 
 def _make_datetimetz(tz):
     from pyarrow.compat import DatetimeTZDtype
+    tz = pa.lib.string_to_tzinfo(tz)
     return DatetimeTZDtype('ns', tz=tz)
 
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -235,8 +235,7 @@ cdef class TimestampValue(ArrayValue):
         value = self.value
 
         if not dtype.timezone().empty():
-            import pytz
-            tzinfo = pytz.timezone(frombytes(dtype.timezone()))
+            tzinfo = string_to_tzinfo(frombytes(dtype.timezone()))
         else:
             tzinfo = None
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -300,9 +300,11 @@ cdef class Column:
         result = pd.Series(values, name=self.name)
 
         if isinstance(self.type, TimestampType):
-            if self.type.tz is not None:
+            tz = self.type.tz
+            if tz is not None:
+                tz = string_to_tzinfo(tz)
                 result = (result.dt.tz_localize('utc')
-                          .dt.tz_convert(self.type.tz))
+                          .dt.tz_convert(tz))
 
         return result
 

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -26,6 +26,7 @@ import decimal
 import itertools
 import numpy as np
 import six
+import pytz
 
 
 int_type_pairs = [
@@ -649,3 +650,14 @@ def test_decimal_array_with_none_and_nan():
 
     array = pa.array(values, type=pa.decimal128(10, 4))
     assert array.to_pylist() == [decimal.Decimal('1.2340'), None, None, None]
+
+
+@pytest.mark.parametrize('tz,name', [
+    (pytz.FixedOffset(90), '+01:30'),
+    (pytz.FixedOffset(-90), '-01:30'),
+    (pytz.utc, 'UTC'),
+    (pytz.timezone('America/New_York'), 'America/New_York')
+])
+def test_timezone_string(tz, name):
+    assert pa.lib.tzinfo_to_string(tz) == name
+    assert pa.lib.string_to_tzinfo(name) == tz

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1001,6 +1001,17 @@ class TestConvertDateTimeLikeTypes(object):
         assert pa.Array.from_pandas(expected).equals(result)
 
 
+def test_fixed_offset_timezone():
+    df = pd.DataFrame({
+        'a': [
+            pd.Timestamp('2012-11-11 00:00:00+01:00'),
+            pd.NaT
+            ]
+        })
+    _check_pandas_roundtrip(df)
+    _check_serialize_components_roundtrip(df)
+
+
 class TestConvertStringLikeTypes(object):
     """
     Conversion tests for string and binary types.

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1000,16 +1000,15 @@ class TestConvertDateTimeLikeTypes(object):
         expected = pd.Series([None, date(1991, 1, 1), None])
         assert pa.Array.from_pandas(expected).equals(result)
 
-
-def test_fixed_offset_timezone():
-    df = pd.DataFrame({
-        'a': [
-            pd.Timestamp('2012-11-11 00:00:00+01:00'),
-            pd.NaT
-            ]
-        })
-    _check_pandas_roundtrip(df)
-    _check_serialize_components_roundtrip(df)
+    def test_fixed_offset_timezone(self):
+        df = pd.DataFrame({
+            'a': [
+                pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                pd.NaT
+                ]
+             })
+        _check_pandas_roundtrip(df)
+        _check_serialize_components_roundtrip(df)
 
 
 class TestConvertStringLikeTypes(object):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -847,6 +847,25 @@ cdef timeunit_to_string(TimeUnit unit):
         return 'ns'
 
 
+FIXED_OFFSET_PREFIX = '+'
+
+
+def tzinfo_to_string(tz):
+    if tz.zone is None:
+        return '{}{:d}'.format(FIXED_OFFSET_PREFIX, tz._minutes)
+    else:
+        return tz.zone
+
+
+def string_to_tzinfo(tz):
+    import pytz
+    if tz.startswith(FIXED_OFFSET_PREFIX):
+        minutes = int(tz[len(FIXED_OFFSET_PREFIX):])
+        return pytz.FixedOffset(minutes)
+    else:
+        return pytz.timezone(tz)
+
+
 def timestamp(unit, tz=None):
     """
     Create instance of timestamp type with resolution and optional time zone
@@ -894,7 +913,7 @@ def timestamp(unit, tz=None):
         _timestamp_type_cache[unit_code] = out
     else:
         if not isinstance(tz, six.string_types):
-            tz = tz.zone
+            tz = tzinfo_to_string(tz)
 
         c_timezone = tobytes(tz)
         out.init(ctimestamp(unit_code, c_timezone))

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -849,7 +849,7 @@ cdef timeunit_to_string(TimeUnit unit):
         return 'ns'
 
 
-_FIXED_OFFSET_RE = re.compile(r'([+-])(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])')
+_FIXED_OFFSET_RE = re.compile(r'([+-])(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$')
 
 
 def tzinfo_to_string(tz):


### PR DESCRIPTION
Fixes [ARROW-2122](https://issues.apache.org/jira/browse/ARROW-2122).