### PR TITLE
ARROW-2269: [Python] Fixing paths for libs when building bdist

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -259,9 +259,9 @@ class build_ext(_build_ext):
                 if self.with_parquet and not self.with_static_parquet:
                     move_shared_libs(build_prefix, build_lib, "parquet")
                 if not self.with_static_boost:
-                    move_shared_libs(build_prefix, build_lib, "arrow_boost_filesystem")
-                    move_shared_libs(build_prefix, build_lib, "arrow_boost_system")
-                    move_shared_libs(build_prefix, build_lib, "arrow_boost_regex")
+                    move_shared_libs(build_prefix, build_lib, "boost_filesystem")
+                    move_shared_libs(build_prefix, build_lib, "boost_system")
+                    move_shared_libs(build_prefix, build_lib, "boost_regex")
 
             print('Bundling includes: ' + pjoin(build_prefix, 'include'))
             if os.path.exists(pjoin(build_lib, 'pyarrow', 'include')):


### PR DESCRIPTION
Not sure why this is needed for me and why it was not discovered before. Let's see what CI says.