### PR TITLE
ARROW-2275: [C++] Guard against bad use of Buffer.mutable_data()

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -70,6 +70,14 @@ Status Buffer::FromString(const std::string& data, std::shared_ptr<Buffer>* out)
   return FromString(data, default_memory_pool(), out);
 }
 
+#ifndef NDEBUG
+// DCHECK macros aren't allowed in public include files
+uint8_t* Buffer::mutable_data() {
+  DCHECK(is_mutable());
+  return mutable_data_;
+}
+#endif
+
 PoolBuffer::PoolBuffer(MemoryPool* pool) : ResizableBuffer(nullptr, 0) {
   if (pool == nullptr) {
     pool = default_memory_pool();

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -54,7 +54,11 @@ class ARROW_EXPORT Buffer {
   ///
   /// \note The passed memory must be kept alive through some other means
   Buffer(const uint8_t* data, int64_t size)
-      : is_mutable_(false), data_(data), size_(size), capacity_(size) {}
+      : is_mutable_(false),
+        data_(data),
+        mutable_data_(NULLPTR),
+        size_(size),
+        capacity_(size) {}
 
   /// \brief Construct from std::string without copying memory
   ///
@@ -113,7 +117,11 @@ class ARROW_EXPORT Buffer {
 
   int64_t capacity() const { return capacity_; }
   const uint8_t* data() const { return data_; }
+#ifdef NDEBUG
   uint8_t* mutable_data() { return mutable_data_; }
+#else
+  uint8_t* mutable_data();
+#endif
 
   int64_t size() const { return size_; }
 

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -71,7 +71,7 @@ class ARROW_EXPORT Tensor {
   std::shared_ptr<Buffer> data() const { return data_; }
 
   const uint8_t* raw_data() const { return data_->data(); }
-  uint8_t* raw_data() { return data_->mutable_data(); }
+  uint8_t* raw_mutable_data() { return data_->mutable_data(); }
 
   const std::vector<int64_t>& shape() const { return shape_; }
   const std::vector<int64_t>& strides() const { return strides_; }


### PR DESCRIPTION
Also disambiguate the Tensor API on this front.