### PR TITLE
ARROW-2291: [C++] Add additional libboost-regex-dev to build instructions in README

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -35,6 +35,7 @@ On Ubuntu/Debian you can install the requirements with:
 ```shell
 sudo apt-get install cmake \
      libboost-dev \
+     libboost-regex-dev \
      libboost-filesystem-dev \
      libboost-system-dev
 ```


### PR DESCRIPTION
libboost-regex-dev is required