### PR TITLE
ARROW-2118: [C++] Fix misleading error when memory mapping a zero-length file

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -624,16 +624,22 @@ class MemoryMappedFile::MemoryMap : public MutableBuffer {
       is_mutable_ = false;
     }
 
-    void* result = mmap(nullptr, static_cast<size_t>(file_->size()), prot_flags, map_mode,
-                        file_->fd(), 0);
-    if (result == MAP_FAILED) {
-      std::stringstream ss;
-      ss << "Memory mapping file failed, errno: " << errno;
-      return Status::IOError(ss.str());
+    size_ = file_->size();
+
+    void* result = nullptr;
+
+    // Memory mapping fails when file size is 0
+    if (size_ > 0) {
+      result =
+          mmap(nullptr, static_cast<size_t>(size_), prot_flags, map_mode, file_->fd(), 0);
+      if (result == MAP_FAILED) {
+        std::stringstream ss;
+        ss << "Memory mapping file failed, errno: " << errno;
+        return Status::IOError(ss.str());
+      }
     }
 
     data_ = mutable_data_ = reinterpret_cast<uint8_t*>(result);
-    size_ = file_->size();
 
     position_ = 0;
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -634,7 +634,7 @@ class MemoryMappedFile::MemoryMap : public MutableBuffer {
           mmap(nullptr, static_cast<size_t>(size_), prot_flags, map_mode, file_->fd(), 0);
       if (result == MAP_FAILED) {
         std::stringstream ss;
-        ss << "Memory mapping file failed, errno: " << errno;
+        ss << "Memory mapping file failed: " << std::strerror(errno);
         return Status::IOError(ss.str());
       }
     }

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -467,6 +467,16 @@ class TestMemoryMappedFile : public ::testing::Test, public MemoryMapFixture {
 
 TEST_F(TestMemoryMappedFile, InvalidUsages) {}
 
+TEST_F(TestMemoryMappedFile, ZeroSizeFlie) {
+  std::string path = "io-memory-map-zero-size";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(0, path, &result));
+
+  int64_t size = 0;
+  ASSERT_OK(result->Tell(&size));
+  ASSERT_EQ(0, size);
+}
+
 TEST_F(TestMemoryMappedFile, WriteRead) {
   const int64_t buffer_size = 1024;
   std::vector<uint8_t> buffer(buffer_size);

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -592,6 +592,14 @@ def test_memory_map_writer(tmpdir):
     assert f.read(3) == b'foo'
 
 
+def test_memory_zero_length(tmpdir):
+    path = os.path.join(str(tmpdir), guid())
+    f = open(path, 'wb')
+    f.close()
+    with pa.memory_map(path, mode='r+b') as memory_map:
+        assert memory_map.size() == 0
+
+
 def test_os_file_writer(tmpdir):
     SIZE = 4096
     arr = np.random.randint(0, 256, size=SIZE).astype('u1')


### PR DESCRIPTION
This was causing an unintuitive error to bubble up when reading a malformed, zero-length Parquet file. To improve the actual Parquet error message, we must complete PARQUET-1243