### PR TITLE
ARROW-2304: [C++] Fix HDFS MultipleClients unit test

### DIFF
--- a/cpp/src/arrow/io/io-hdfs-test.cc
+++ b/cpp/src/arrow/io/io-hdfs-test.cc
@@ -181,6 +181,8 @@ TYPED_TEST(TestHadoopFileSystem, ConnectsAgain) {
 TYPED_TEST(TestHadoopFileSystem, MultipleClients) {
   SKIP_IF_NO_DRIVER();
 
+  ASSERT_OK(this->MakeScratchDir());
+
   std::shared_ptr<HadoopFileSystem> client1;
   std::shared_ptr<HadoopFileSystem> client2;
   ASSERT_OK(HadoopFileSystem::Connect(&this->conf_, &client1));
@@ -189,7 +191,7 @@ TYPED_TEST(TestHadoopFileSystem, MultipleClients) {
 
   // client2 continues to function after equivalent client1 has shutdown
   std::vector<HdfsPathInfo> listing;
-  EXPECT_OK(client2->ListDirectory(this->scratch_dir_, &listing));
+  ASSERT_OK(client2->ListDirectory(this->scratch_dir_, &listing));
   ASSERT_OK(client2->Disconnect());
 }
 


### PR DESCRIPTION
This test was failing because the `scratch_dir_` directory did not exist