### PR TITLE
ARROW-2307: [Python] Allow reading record batch streams with zero record batches

### DIFF
--- a/ci/msvc-build.bat
+++ b/ci/msvc-build.bat
@@ -69,7 +69,8 @@ if "%JOB%" == "Build_Debug" (
 )
 
 conda create -n arrow -q -y python=%PYTHON% ^
-      six pytest setuptools numpy pandas cython ^
+      six pytest setuptools numpy pandas ^
+      cython=0.27.3 ^
       thrift-cpp=0.11.0
 
 call activate arrow

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -41,7 +41,7 @@ conda install -y -q pip \
       cloudpickle \
       numpy=1.13.1 \
       pandas \
-      cython
+      cython=0.27.3
 
 # ARROW-2093: PyTorch increases the size of our conda dependency stack
 # significantly, and so we have disabled these tests in Travis CI for now

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -374,6 +374,17 @@ TEST_F(TestTable, FromRecordBatches) {
   ASSERT_RAISES(Invalid, Table::FromRecordBatches({batch1, batch2}, &result));
 }
 
+TEST_F(TestTable, FromRecordBatchesZeroLength) {
+  // ARROW-2307
+  MakeExample1(10);
+
+  std::shared_ptr<Table> result;
+  ASSERT_OK(Table::FromRecordBatches(schema_, {}, &result));
+
+  ASSERT_EQ(0, result->num_rows());
+  ASSERT_TRUE(result->schema()->Equals(*schema_));
+}
+
 TEST_F(TestTable, ConcatenateTables) {
   const int64_t length = 10;
 

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -297,14 +297,9 @@ std::shared_ptr<Table> Table::Make(const std::shared_ptr<Schema>& schema,
   return std::make_shared<SimpleTable>(schema, arrays, num_rows);
 }
 
-Status Table::FromRecordBatches(const std::vector<std::shared_ptr<RecordBatch>>& batches,
+Status Table::FromRecordBatches(const std::shared_ptr<Schema>& schema,
+                                const std::vector<std::shared_ptr<RecordBatch>>& batches,
                                 std::shared_ptr<Table>* table) {
-  if (batches.size() == 0) {
-    return Status::Invalid("Must pass at least one record batch");
-  }
-
-  std::shared_ptr<Schema> schema = batches[0]->schema();
-
   const int nbatches = static_cast<int>(batches.size());
   const int ncolumns = static_cast<int>(schema->num_fields());
 
@@ -330,6 +325,15 @@ Status Table::FromRecordBatches(const std::vector<std::shared_ptr<RecordBatch>>&
 
   *table = Table::Make(schema, columns);
   return Status::OK();
+}
+
+Status Table::FromRecordBatches(const std::vector<std::shared_ptr<RecordBatch>>& batches,
+                                std::shared_ptr<Table>* table) {
+  if (batches.size() == 0) {
+    return Status::Invalid("Must pass at least one record batch");
+  }
+
+  return FromRecordBatches(batches[0]->schema(), batches, table);
 }
 
 Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -169,9 +169,25 @@ class ARROW_EXPORT Table {
                                      const std::vector<std::shared_ptr<Array>>& arrays,
                                      int64_t num_rows = -1);
 
-  // Construct table from RecordBatch, but only if all of the batch schemas are
-  // equal. Returns Status::Invalid if there is some problem
+  /// \brief Construct table from RecordBatches, using schema supplied by the first
+  /// RecordBatch.
+  ///
+  /// \param[in] batches
+  /// \param[out] table
+  /// \return Status Returns Status::Invalid if there is some problem
   static Status FromRecordBatches(
+      const std::vector<std::shared_ptr<RecordBatch>>& batches,
+      std::shared_ptr<Table>* table);
+
+  /// Construct table from RecordBatches, using supplied schema. There may be
+  /// zero record batches
+  ///
+  /// \param[in] schema
+  /// \param[in] batches
+  /// \param[out] table
+  /// \return Status
+  static Status FromRecordBatches(
+      const std::shared_ptr<Schema>& schema,
       const std::vector<std::shared_ptr<RecordBatch>>& batches,
       std::shared_ptr<Table>* table);
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -172,8 +172,8 @@ class ARROW_EXPORT Table {
   /// \brief Construct table from RecordBatches, using schema supplied by the first
   /// RecordBatch.
   ///
-  /// \param[in] batches
-  /// \param[out] table
+  /// \param[in] batches a std::vector of record batches
+  /// \param[out] table the returned table
   /// \return Status Returns Status::Invalid if there is some problem
   static Status FromRecordBatches(
       const std::vector<std::shared_ptr<RecordBatch>>& batches,
@@ -182,9 +182,9 @@ class ARROW_EXPORT Table {
   /// Construct table from RecordBatches, using supplied schema. There may be
   /// zero record batches
   ///
-  /// \param[in] schema
-  /// \param[in] batches
-  /// \param[out] table
+  /// \param[in] schema the arrow::Schema for each batch
+  /// \param[in] batches a std::vector of record batches
+  /// \param[out] table the returned table
   /// \return Status
   static Status FromRecordBatches(
       const std::shared_ptr<Schema>& schema,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -456,6 +456,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         @staticmethod
         CStatus FromRecordBatches(
+            const shared_ptr[CSchema]& schema,
             const vector[shared_ptr[CRecordBatch]]& batches,
             shared_ptr[CTable]* table)
 

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -304,7 +304,8 @@ cdef class _RecordBatchReader:
                     break
                 batches.push_back(batch)
 
-            check_status(CTable.FromRecordBatches(batches, &table))
+            check_status(CTable.FromRecordBatches(self.schema.sp_schema,
+                                                  batches, &table))
 
         return pyarrow_wrap_table(table)
 
@@ -386,7 +387,8 @@ cdef class _RecordBatchFileReader:
         with nogil:
             for i in range(nbatches):
                 check_status(self.reader.get().ReadRecordBatch(i, &batches[i]))
-            check_status(CTable.FromRecordBatches(batches, &table))
+            check_status(CTable.FromRecordBatches(self.schema.sp_schema,
+                                                  batches, &table))
 
         return pyarrow_wrap_table(table)
 


### PR DESCRIPTION
This is a pretty rough edge case -- it would be good to get this fix into 0.9.0.