### PR TITLE
ARROW-2313: [C++] Add -NDEBUG flag to arrow.pc

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -236,4 +236,10 @@ else()
   message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif ()
 
+if ("${CMAKE_CXX_FLAGS}" MATCHES "-DNDEBUG")
+  set(ARROW_DEFINITION_FLAGS "-DNDEBUG")
+else()
+  set(ARROW_DEFINITION_FLAGS "")
+endif()
+
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")

--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -25,4 +25,4 @@ Name: Apache Arrow
 Description: Arrow is a set of technologies that enable big-data systems to process and move data fast.
 Version: @ARROW_VERSION@
 Libs: -L${libdir} -larrow
-Cflags: -I${includedir}
+Cflags: -I${includedir} @ARROW_DEFINITION_FLAGS@


### PR DESCRIPTION
Arrow C++ users should use the same -NDEBUG flag as Arrow C++ itself.