### PR TITLE
ARROW-2311: [Python/C++] Fix struct array slicing

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -353,7 +353,13 @@ StructArray::StructArray(const std::shared_ptr<DataType>& type, int64_t length,
 
 std::shared_ptr<Array> StructArray::field(int i) const {
   if (!boxed_fields_[i]) {
-    boxed_fields_[i] = MakeArray(data_->child_data[i]);
+    std::shared_ptr<ArrayData> field_data;
+    if (data_->offset != 0 || data_->child_data[i]->length != data_->length) {
+      field_data = SliceData(*data_->child_data[i].get(), data_->offset, data_->length);
+    } else {
+      field_data = data_->child_data[i];
+    }
+    boxed_fields_[i] = MakeArray(field_data);
   }
   DCHECK(boxed_fields_[i]);
   return boxed_fields_[i];

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -149,6 +149,8 @@ struct ARROW_EXPORT ArrayData {
   std::shared_ptr<DataType> type;
   int64_t length;
   int64_t null_count;
+  // The logical start point into the physical buffers (in values, not bytes).
+  // Note that, for child data, this must be *added* to the child data's own offset.
   int64_t offset;
   std::vector<std::shared_ptr<Buffer>> buffers;
   std::vector<std::shared_ptr<ArrayData>> child_data;
@@ -599,7 +601,8 @@ class ARROW_EXPORT StructArray : public Array {
               int64_t offset = 0);
 
   // Return a shared pointer in case the requestor desires to share ownership
-  // with this array.
+  // with this array.  The returned array has its offset, length and null
+  // count adjusted.
   std::shared_ptr<Array> field(int pos) const;
 
  private:

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -136,11 +136,7 @@ class RangeEqualsVisitor {
       for (int j = 0; j < left.num_fields(); ++j) {
         // TODO: really we should be comparing stretches of non-null data rather
         // than looking at one value at a time.
-        const int64_t left_abs_index = i + left.offset();
-        const int64_t right_abs_index = o_i + right.offset();
-
-        equal_fields = left.field(j)->RangeEquals(left_abs_index, left_abs_index + 1,
-                                                  right_abs_index, right.field(j));
+        equal_fields = left.field(j)->RangeEquals(i, i + 1, o_i, right.field(j));
         if (!equal_fields) {
           return false;
         }
@@ -467,9 +463,9 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
       return Status::OK();
     }
 
-    result_ =
-        left.values()->RangeEquals(left.value_offset(0), left.value_offset(left.length()),
-                                   right.value_offset(0), right.values());
+    result_ = left.values()->RangeEquals(
+        left.value_offset(0), left.value_offset(left.length()) - left.value_offset(0),
+        right.value_offset(0), right.values());
     return Status::OK();
   }
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -376,10 +376,6 @@ class RecordBatchSerializer : public ArrayVisitor {
     --max_recursion_depth_;
     for (int i = 0; i < array.num_fields(); ++i) {
       std::shared_ptr<Array> field = array.field(i);
-      if (array.offset() != 0 || array.length() < field->length()) {
-        // If offset is non-zero, slice the child array
-        field = field->Slice(array.offset(), array.length());
-      }
       RETURN_NOT_OK(VisitArray(*field));
     }
     ++max_recursion_depth_;

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -233,7 +233,8 @@ class ArrayPrinter : public PrettyPrinter {
     Newline();
     Write("-- values: ");
     auto values =
-        array.values()->Slice(array.value_offset(0), array.value_offset(array.length()));
+        array.values()->Slice(array.value_offset(0),
+                              array.value_offset(array.length()) - array.value_offset(0));
     RETURN_NOT_OK(PrettyPrint(*values, indent_ + 2, sink_));
 
     return Status::OK();
@@ -264,7 +265,7 @@ class ArrayPrinter : public PrettyPrinter {
     for (int i = 0; i < array.num_fields(); ++i) {
       children.emplace_back(array.field(i));
     }
-    return PrintChildren(children, array.offset(), array.length());
+    return PrintChildren(children, 0, array.length());
   }
 
   Status Visit(const UnionArray& array) {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -388,7 +388,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
                      int64_t offset=0)
 
         shared_ptr[CArray] field(int pos)
-        const vector[shared_ptr[CArray]] fields()
 
     CStatus ValidateArray(const CArray& array)
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -342,6 +342,7 @@ cdef class UnionValue(ArrayValue):
     def as_py(self):
         return self.getitem(self.index).as_py()
 
+
 cdef class FixedSizeBinaryValue(ArrayValue):
 
     def as_py(self):
@@ -358,20 +359,23 @@ cdef class FixedSizeBinaryValue(ArrayValue):
 
 
 cdef class StructValue(ArrayValue):
+
     def as_py(self):
         cdef:
             CStructArray* ap
             vector[shared_ptr[CField]] child_fields = self.type.type.children()
+
         ap = <CStructArray*> self.sp_array.get()
-        wrapped_arrays = (pyarrow_wrap_array(ap.field(i))
-                          for i in range(ap.num_fields()))
-        child_names = (child.get().name() for child in child_fields)
+        wrapped_arrays = [pyarrow_wrap_array(ap.field(i))
+                          for i in range(ap.num_fields())]
+        child_names = [child.get().name() for child in child_fields]
         # Return the struct as a dict
         return {
             frombytes(name): child_array[self.index].as_py()
             for name, child_array in
             zip(child_names, wrapped_arrays)
         }
+
 
 cdef dict _scalar_classes = {
     _Type_BOOL: BooleanValue,

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -145,6 +145,15 @@ def test_array_slice():
             assert arr[start:stop].to_pylist() == arr.to_pylist()[start:stop]
 
 
+def test_struct_array_slice():
+    # ARROW-2311: slicing nested arrays needs special care
+    ty = pa.struct([pa.field('a', pa.int8()),
+                    pa.field('b', pa.float32())])
+    arr = pa.array([(1, 2.5), (3, 4.5), (5, 6.5)], type=ty)
+    assert arr[1:].to_pylist() == [{'a': 3, 'b': 4.5},
+                                   {'a': 5, 'b': 6.5}]
+
+
 def test_array_factory_invalid_type():
     arr = np.array([datetime.timedelta(1), datetime.timedelta(2)])
     with pytest.raises(ValueError):


### PR DESCRIPTION
`StructArray::field()` would not adjust the offset if the struct array was sliced, requiring error-prone fixup code in the caller.