### PR TITLE
ARROW-2222: handle untrusted inputs

### DIFF
--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -257,6 +257,9 @@ Status BufferReader::Tell(int64_t* position) const {
 bool BufferReader::supports_zero_copy() const { return true; }
 
 Status BufferReader::Read(int64_t nbytes, int64_t* bytes_read, void* buffer) {
+  if (nbytes < 0) {
+    return Status::IOError("Cannot read a negative number of bytes from BufferReader.");
+  }
   *bytes_read = std::min(nbytes, size_ - position_);
   if (*bytes_read) {
     memcpy(buffer, data_ + position_, *bytes_read);
@@ -266,6 +269,9 @@ Status BufferReader::Read(int64_t nbytes, int64_t* bytes_read, void* buffer) {
 }
 
 Status BufferReader::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+  if (nbytes < 0) {
+    return Status::IOError("Cannot read a negative number of bytes from BufferReader.");
+  }
   int64_t size = std::min(nbytes, size_ - position_);
 
   if (size > 0 && buffer_ != nullptr) {

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -137,7 +137,7 @@ bool Message::Equals(const Message& other) const {
 Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStream* stream,
                          std::unique_ptr<Message>* out) {
   auto data = metadata->data();
-  flatbuffers::Verifier verifier(data, metadata->size());
+  flatbuffers::Verifier verifier(data, metadata->size(), 128);
   if (!flatbuf::VerifyMessageBuffer(verifier)) {
     return Status::IOError("Invalid flatbuffers message.");
   }

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -136,7 +136,12 @@ bool Message::Equals(const Message& other) const {
 
 Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStream* stream,
                          std::unique_ptr<Message>* out) {
-  auto fb_message = flatbuf::GetMessage(metadata->data());
+  auto data = metadata->data();
+  flatbuffers::Verifier verifier(data, metadata->size());
+  if (!flatbuf::VerifyMessageBuffer(verifier)) {
+    return Status::IOError("Invalid flatbuffers message.");
+  }
+  auto fb_message = flatbuf::GetMessage(data);
 
   int64_t body_length = fb_message->bodyLength();
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -328,6 +328,9 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
   if (message->header_type() != flatbuf::MessageHeader_RecordBatch) {
     DCHECK_EQ(message->header_type(), flatbuf::MessageHeader_RecordBatch);
   }
+  if (message->header() == nullptr) {
+    return Status::IOError("Header-pointer of flatbuffer-encoded Message is null.");
+  }
   auto batch = reinterpret_cast<const flatbuf::RecordBatch*>(message->header());
   return ReadRecordBatch(batch, schema, max_recursion_depth, file, out);
 }
@@ -426,6 +429,9 @@ class RecordBatchStreamReader::RecordBatchStreamReaderImpl {
     RETURN_NOT_OK(
         ReadMessageAndValidate(message_reader_.get(), Message::SCHEMA, false, &message));
 
+    if (message->header() == nullptr) {
+      return Status::IOError("Header-pointer of flatbuffer-encoded Message is null.");
+    }
     RETURN_NOT_OK(internal::GetDictionaryTypes(message->header(), &dictionary_types_));
 
     // TODO(wesm): In future, we may want to reconcile the ids in the stream with


### PR DESCRIPTION
This is a proof of concept of handling untrusted inputs. The error messages aren't filled yet and tests aren't there, but this is everything the fuzzer found after running over an hour. It basically includes the following parts:

## Flatbuffer validation
This may be the only thing that could be optional and where we should test the performance impact. It's a single, simple change in `Message::ReadFrom`.

## nullptr validation
It seems, that even when we validate the flatbuffer, nullptrs are still legit in many places and we just ignore them. I've added a bunch of checks. We may want to introduce a simple macro for that, that includes error message generation and the return w/ an `IOError`.

## Integer handling in `BufferReader`
The `nbytes` argument can be negative since it's a signed integer. I've seen at least one case where the fuzzer tried to produce a negative body size of a message that led to a negative `nbytes` argument, a subsequent negative `position_` and a out of bounds read. I think we should catch the negative body length somewhere else and produce a proper error message, but I'm not sure if that's the only way of provoking "negative reads". For robustness, the checks should be there. If someone is to worried about performance, we should rather implement a template-based, header-based, function-inlined interface that reads exactly the number of bytes that are required for certain types.