### PR TITLE
ARROW-1886: [C++/Python] Flatten struct columns in table 

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -139,6 +139,38 @@ std::shared_ptr<ChunkedArray> ChunkedArray::Slice(int64_t offset) const {
   return Slice(offset, length_);
 }
 
+Status ChunkedArray::Flatten(MemoryPool* pool,
+                             std::vector<std::shared_ptr<ChunkedArray>>* out) const {
+  std::vector<std::shared_ptr<ChunkedArray>> flattened;
+  if (type()->id() != Type::STRUCT) {
+    // Emulate non-existent copy constructor
+    flattened.emplace_back(std::make_shared<ChunkedArray>(chunks_));
+    *out = flattened;
+    return Status::OK();
+  }
+  std::vector<ArrayVector> flattened_chunks;
+  for (const auto& chunk : chunks_) {
+    ArrayVector res;
+    RETURN_NOT_OK(dynamic_cast<const StructArray&>(*chunk).Flatten(pool, &res));
+    if (!flattened_chunks.size()) {
+      // First chunk
+      for (const auto& array : res) {
+        flattened_chunks.push_back({array});
+      }
+    } else {
+      DCHECK_EQ(flattened_chunks.size(), res.size());
+      for (size_t i = 0; i < res.size(); ++i) {
+        flattened_chunks[i].push_back(res[i]);
+      }
+    }
+  }
+  for (const auto& vec : flattened_chunks) {
+    flattened.emplace_back(std::make_shared<ChunkedArray>(vec));
+  }
+  *out = flattened;
+  return Status::OK();
+}
+
 Column::Column(const std::shared_ptr<Field>& field, const ArrayVector& chunks)
     : field_(field) {
   data_ = std::make_shared<ChunkedArray>(chunks, field->type());
@@ -159,6 +191,20 @@ Column::Column(const std::string& name, const std::shared_ptr<Array>& data)
 Column::Column(const std::shared_ptr<Field>& field,
                const std::shared_ptr<ChunkedArray>& data)
     : field_(field), data_(data) {}
+
+Status Column::Flatten(MemoryPool* pool,
+                       std::vector<std::shared_ptr<Column>>* out) const {
+  std::vector<std::shared_ptr<Column>> flattened;
+  std::vector<std::shared_ptr<Field>> flattened_fields = field_->Flatten();
+  std::vector<std::shared_ptr<ChunkedArray>> flattened_data;
+  RETURN_NOT_OK(data_->Flatten(pool, &flattened_data));
+  DCHECK_EQ(flattened_fields.size(), flattened_data.size());
+  for (size_t i = 0; i < flattened_fields.size(); ++i) {
+    flattened.push_back(std::make_shared<Column>(flattened_fields[i], flattened_data[i]));
+  }
+  *out = flattened;
+  return Status::OK();
+}
 
 bool Column::Equals(const Column& other) const {
   if (!field_->Equals(other.field())) {
@@ -268,12 +314,28 @@ class SimpleTable : public Table {
     return Table::Make(new_schema, columns_);
   }
 
+  Status Flatten(MemoryPool* pool, std::shared_ptr<Table>* out) const override {
+    std::vector<std::shared_ptr<Field>> flattened_fields;
+    std::vector<std::shared_ptr<Column>> flattened_columns;
+    for (const auto& column : columns_) {
+      std::vector<std::shared_ptr<Column>> new_columns;
+      RETURN_NOT_OK(column->Flatten(pool, &new_columns));
+      for (const auto& new_col : new_columns) {
+        flattened_fields.push_back(new_col->field());
+        flattened_columns.push_back(new_col);
+      }
+    }
+    auto flattened_schema =
+        std::make_shared<Schema>(flattened_fields, schema_->metadata());
+    *out = Table::Make(flattened_schema, flattened_columns);
+    return Status::OK();
+  }
+
   Status Validate() const override {
+    // Make sure columns and schema are consistent
     if (static_cast<int>(columns_.size()) != schema_->num_fields()) {
       return Status::Invalid("Number of columns did not match schema");
     }
-
-    // Make sure columns are all the same length
     for (int i = 0; i < num_columns(); ++i) {
       const Column* col = columns_[i].get();
       if (col == nullptr) {
@@ -281,6 +343,17 @@ class SimpleTable : public Table {
         ss << "Column " << i << " was null";
         return Status::Invalid(ss.str());
       }
+      if (!col->field()->Equals(*schema_->field(i))) {
+        std::stringstream ss;
+        ss << "Column field " << i << " named " << col->name()
+           << " is inconsistent with schema";
+        return Status::Invalid(ss.str());
+      }
+    }
+
+    // Make sure columns are all the same length
+    for (int i = 0; i < num_columns(); ++i) {
+      const Column* col = columns_[i].get();
       if (col->length() != num_rows_) {
         std::stringstream ss;
         ss << "Column " << i << " named " << col->name() << " expected length "

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -144,7 +144,7 @@ Status ChunkedArray::Flatten(MemoryPool* pool,
   std::vector<std::shared_ptr<ChunkedArray>> flattened;
   if (type()->id() != Type::STRUCT) {
     // Emulate non-existent copy constructor
-    flattened.emplace_back(std::make_shared<ChunkedArray>(chunks_));
+    flattened.emplace_back(std::make_shared<ChunkedArray>(chunks_, type_));
     *out = flattened;
     return Status::OK();
   }

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -69,6 +69,13 @@ class ARROW_EXPORT ChunkedArray {
   /// \brief Slice from offset until end of the chunked array
   std::shared_ptr<ChunkedArray> Slice(int64_t offset) const;
 
+  /// \brief Flatten this chunked array as a vector of chunked arrays, one
+  /// for each struct field
+  ///
+  /// \param[in] pool The pool for buffer allocations, if any
+  /// \param[out] out The resulting vector of arrays
+  Status Flatten(MemoryPool* pool, std::vector<std::shared_ptr<ChunkedArray>>* out) const;
+
   std::shared_ptr<DataType> type() const { return type_; }
 
   bool Equals(const ChunkedArray& other) const;
@@ -132,6 +139,12 @@ class ARROW_EXPORT Column {
   std::shared_ptr<Column> Slice(int64_t offset) const {
     return std::make_shared<Column>(field_, data_->Slice(offset));
   }
+
+  /// \brief Flatten this column as a vector of columns
+  ///
+  /// \param[in] pool The pool for buffer allocations, if any
+  /// \param[out] out The resulting vector of arrays
+  Status Flatten(MemoryPool* pool, std::vector<std::shared_ptr<Column>>* out) const;
 
   bool Equals(const Column& other) const;
   bool Equals(const std::shared_ptr<Column>& other) const;
@@ -214,6 +227,13 @@ class ARROW_EXPORT Table {
   /// \return new Table
   virtual std::shared_ptr<Table> ReplaceSchemaMetadata(
       const std::shared_ptr<const KeyValueMetadata>& metadata) const = 0;
+
+  /// \brief Flatten the table, producing a new Table.  Any column with a
+  /// struct type will be flattened into multiple columns
+  ///
+  /// \param[in] pool The pool for buffer allocations, if any
+  /// \param[out] out The returned table
+  virtual Status Flatten(MemoryPool* pool, std::shared_ptr<Table>* out) const = 0;
 
   /// \brief Perform any checks to validate the input arguments
   virtual Status Validate() const = 0;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -42,6 +42,21 @@ std::shared_ptr<Field> Field::RemoveMetadata() const {
   return std::make_shared<Field>(name_, type_, nullable_);
 }
 
+std::vector<std::shared_ptr<Field>> Field::Flatten() const {
+  std::vector<std::shared_ptr<Field>> flattened;
+  if (type_->id() == Type::STRUCT) {
+    for (const auto& child : type_->children()) {
+      auto flattened_child = std::make_shared<Field>(*child);
+      flattened.push_back(flattened_child);
+      flattened_child->name_.insert(0, name() + ".");
+      flattened_child->nullable_ |= nullable_;
+    }
+  } else {
+    flattened.push_back(std::make_shared<Field>(*this));
+  }
+  return flattened;
+}
+
 bool Field::Equals(const Field& other) const {
   if (this == &other) {
     return true;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -236,6 +236,8 @@ class ARROW_EXPORT Field {
       const std::shared_ptr<const KeyValueMetadata>& metadata) const;
   std::shared_ptr<Field> RemoveMetadata() const;
 
+  std::vector<std::shared_ptr<Field>> Flatten() const;
+
   bool Equals(const Field& other) const;
   bool Equals(const std::shared_ptr<Field>& other) const;
 

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -22,6 +22,7 @@
 #include <initializer_list>
 #include <limits>
 #include <memory>
+#include <valarray>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -92,7 +93,7 @@ void ASSERT_READER_VALUES(internal::BitmapReader& reader, std::vector<int> value
 // Assert equal contents of a memory area and a vector of bytes
 void ASSERT_BYTES_EQ(const uint8_t* left, const std::vector<uint8_t>& right) {
   auto left_array = std::vector<uint8_t>(left, left + right.size());
-  ASSERT_EQ(std::vector<uint8_t>(std::begin(left_array), std::end(left_array)), right);
+  ASSERT_EQ(left_array, right);
 }
 
 TEST(BitUtilTests, TestIsMultipleOf64) {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -258,6 +258,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CField] AddMetadata(
             const shared_ptr[CKeyValueMetadata]& metadata)
         shared_ptr[CField] RemoveMetadata()
+        vector[shared_ptr[CField]] Flatten()
 
     cdef cppclass CStructType" arrow::StructType"(CDataType):
         CStructType(const vector[shared_ptr[CField]]& fields)
@@ -437,6 +438,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         c_bool Equals(const CColumn& other)
 
+        CStatus Flatten(CMemoryPool* pool, vector[shared_ptr[CColumn]]* out)
+
         shared_ptr[CField] field()
 
         int64_t length()
@@ -494,6 +497,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CStatus AddColumn(int i, const shared_ptr[CColumn]& column,
                           shared_ptr[CTable]* out)
         CStatus RemoveColumn(int i, shared_ptr[CTable]* out)
+
+        CStatus Flatten(CMemoryPool* pool, shared_ptr[CTable]* out)
+
+        CStatus Validate()
 
         shared_ptr[CTable] ReplaceSchemaMetadata(
             const shared_ptr[CKeyValueMetadata]& metadata)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -97,6 +97,17 @@ def test_column_to_pandas():
     assert series.iloc[0] == -10
 
 
+def test_column_flatten():
+    ty = pa.struct([pa.field('x', pa.int16()),
+                    pa.field('y', pa.float32())])
+    a = pa.array([(1, 2.5), (3, 4.5), (5, 6.5)], type=ty)
+    col = pa.Column.from_array('foo', a)
+    x, y = col.flatten()
+    assert x == pa.column('foo.x', pa.array([1, 3, 5], type=pa.int16()))
+    assert y == pa.column('foo.y', pa.array([2.5, 4.5, 6.5],
+                                            type=pa.float32()))
+
+
 def test_recordbatch_basics():
     data = [
         pa.array(range(5)),
@@ -269,6 +280,7 @@ def test_table_basics():
         pa.array([-10, -5, 0, 5, 10])
     ]
     table = pa.Table.from_arrays(data, names=('a', 'b'))
+    table._validate()
     assert len(table) == 5
     assert table.num_rows == 5
     assert table.num_columns == 2
@@ -367,6 +379,7 @@ def test_table_remove_column():
     table = pa.Table.from_arrays(data, names=('a', 'b', 'c'))
 
     t2 = table.remove_column(0)
+    t2._validate()
     expected = pa.Table.from_arrays(data[1:], names=('b', 'c'))
     assert t2.equals(expected)
 
@@ -379,10 +392,32 @@ def test_table_remove_column_empty():
     table = pa.Table.from_arrays(data, names=['a'])
 
     t2 = table.remove_column(0)
+    t2._validate()
     assert len(t2) == len(table)
 
     t3 = t2.add_column(0, table[0])
+    t3._validate()
     assert t3.equals(table)
+
+
+def test_table_flatten():
+    ty1 = pa.struct([pa.field('x', pa.int16()),
+                     pa.field('y', pa.float32())])
+    ty2 = pa.struct([pa.field('nest', ty1)])
+    a = pa.array([(1, 2.5), (3, 4.5)], type=ty1)
+    b = pa.array([((11, 12.5),), ((13, 14.5),)], type=ty2)
+    c = pa.array([False, True], type=pa.bool_())
+
+    table = pa.Table.from_arrays([a, b, c], names=['a', 'b', 'c'])
+    t2 = table.flatten()
+    t2._validate()
+    expected = pa.Table.from_arrays([
+        pa.array([1, 3], type=pa.int16()),
+        pa.array([2.5, 4.5], type=pa.float32()),
+        pa.array([(11, 12.5), (13, 14.5)], type=ty1),
+        c],
+        names=['a.x', 'a.y', 'b.nest', 'c'])
+    assert t2.equals(expected)
 
 
 def test_concat_tables():
@@ -401,6 +436,7 @@ def test_concat_tables():
                               names=('a', 'b'))
 
     result = pa.concat_tables([t1, t2])
+    result._validate()
     assert len(result) == 10
 
     expected = pa.Table.from_arrays([pa.array(x + y)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -106,6 +106,12 @@ def test_column_flatten():
     assert x == pa.column('foo.x', pa.array([1, 3, 5], type=pa.int16()))
     assert y == pa.column('foo.y', pa.array([2.5, 4.5, 6.5],
                                             type=pa.float32()))
+    # Empty column
+    a = pa.array([], type=ty)
+    col = pa.Column.from_array('foo', a)
+    x, y = col.flatten()
+    assert x == pa.column('foo.x', pa.array([], type=pa.int16()))
+    assert y == pa.column('foo.y', pa.array([], type=pa.float32()))
 
 
 def test_recordbatch_basics():

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -487,6 +487,20 @@ cdef class Field:
             new_field = self.field.RemoveMetadata()
         return pyarrow_wrap_field(new_field)
 
+    def flatten(self):
+        """
+        Flatten this field.  If a struct field, individual child fields
+        will be returned with their names prefixed by the parent's name.
+
+        Returns
+        -------
+        fields : List[pyarrow.Field]
+        """
+        cdef vector[shared_ptr[CField]] flattened
+        with nogil:
+            flattened = self.field.Flatten()
+        return [pyarrow_wrap_field(f) for f in flattened]
+
 
 cdef class Schema:
 


### PR DESCRIPTION
Add C++ and Python APIs to flatten struct fields and struct columns.

Based on PR #1755.