### PR TITLE
ARROW-2341: [Python] Improve pa.union() mode argument behaviour

### DIFF
--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -56,11 +56,6 @@ cdef class DictionaryType(DataType):
         const CDictionaryType* dict_type
 
 
-cdef class UnionType(DataType):
-    cdef:
-        list child_types
-
-
 cdef class TimestampType(DataType):
     cdef:
         const CTimestampType* ts_type

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -334,9 +334,9 @@ cdef class UnionValue(ArrayValue):
         cdef int8_t type_id = self.ap.raw_type_ids()[i]
         cdef shared_ptr[CArray] child = self.ap.child(type_id)
         if self.ap.mode() == _UnionMode_SPARSE:
-            return box_scalar(self.type[type_id], child, i)
+            return box_scalar(self.type[type_id].type, child, i)
         else:
-            return box_scalar(self.type[type_id], child,
+            return box_scalar(self.type[type_id].type, child,
                               self.ap.value_offset(i))
 
     def as_py(self):


### PR DESCRIPTION
Also:
- make UnionType.mode return a string ('sparse' or 'dense')
- make UnionType indexing return fields, not types (like StructType)