### PR TITLE
ARROW-2322: [Java] Document dev environment requirements for publishing Java release artifacts

### DIFF
--- a/dev/release/README
+++ b/dev/release/README
@@ -2,7 +2,9 @@ requirements:
 - being a committer to be able to push to dist and maven repository
 - a gpg key to sign the artifacts
 - use java 7. check your JAVA_HOME environment variable (at least for now. See ARROW-930)
-- have the build requirements for cpp and c_glibg installed (see their README)
+- Maven configured to publish artifacts to Apache repositories (see
+  http://www.apache.org/dev/publishing-maven-artifacts.html)
+- have the build requirements for cpp and c_glib installed (see their README)
 
 to release, run the following (replace 0.1.0 with version to release):
 

--- a/dev/release/RELEASE_MANAGEMENT.md
+++ b/dev/release/RELEASE_MANAGEMENT.md
@@ -180,7 +180,10 @@ same time because they are interdependent.
 
 ### Updating Java Maven artifacts in Maven central
 
-See instructions at end of https://github.com/apache/arrow/blob/master/dev/release/README
+See instructions at end of
+https://github.com/apache/arrow/blob/master/dev/release/README. You must set up
+Maven to be able to publish to Apache's repositories. Read more at
+http://www.apache.org/dev/publishing-maven-artifacts.html.
 
 [1]: https://github.com/apache/arrow/blob/master/dev/release/README
 [2]: https://github.com/apache/arrow-dist


### PR DESCRIPTION
This is a one-time setup, but may be a stumbling block for new release managers (it was for me after a clean install)