### PR TITLE
ARROW-2328: [C++] Fixed and unit tested feather writing with slice

### DIFF
--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -406,6 +406,105 @@ TEST_F(TestTableWriter, PrimitiveNullRoundTrip) {
   }
 }
 
+TEST_F(TestTableWriter, SliceRoundTrip) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeIntBatchSized(300, &batch));
+  batch = batch->Slice(100, 100);
+
+  ASSERT_OK(writer_->Append("f0", *batch->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch->column(1)));
+  Finish();
+
+  std::shared_ptr<Column> col;
+  ASSERT_OK(reader_->GetColumn(0, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(0)));
+  ASSERT_EQ("f0", col->name());
+
+  ASSERT_OK(reader_->GetColumn(1, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(1)));
+  ASSERT_EQ("f1", col->name());
+}
+
+TEST_F(TestTableWriter, SliceStringsRoundTrip) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, false));
+  batch = batch->Slice(320, 30);
+
+  ASSERT_OK(writer_->Append("f0", *batch->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch->column(1)));
+  Finish();
+
+  std::shared_ptr<Column> col;
+  ASSERT_OK(reader_->GetColumn(0, &col));
+  SCOPED_TRACE(col->data()->chunk(0)->ToString() + "\n" + batch->column(0)->ToString());
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(0)));
+  ASSERT_EQ("f0", col->name());
+
+  ASSERT_OK(reader_->GetColumn(1, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(1)));
+  ASSERT_EQ("f1", col->name());
+}
+
+TEST_F(TestTableWriter, SliceStringsWithNullsRoundTrip) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, true));
+  batch = batch->Slice(320, 30);
+
+  ASSERT_OK(writer_->Append("f0", *batch->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch->column(1)));
+  Finish();
+
+  std::shared_ptr<Column> col;
+  ASSERT_OK(reader_->GetColumn(0, &col));
+  SCOPED_TRACE(col->data()->chunk(0)->ToString() + "\n" + batch->column(0)->ToString());
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(0)));
+  ASSERT_EQ("f0", col->name());
+
+  ASSERT_OK(reader_->GetColumn(1, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(1)));
+  ASSERT_EQ("f1", col->name());
+}
+
+TEST_F(TestTableWriter, SliceAtNonEightOffsetStringsWithNullsRoundTrip) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, true));
+  batch = batch->Slice(323, 30);
+
+  ASSERT_OK(writer_->Append("f0", *batch->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch->column(1)));
+  Finish();
+
+  std::shared_ptr<Column> col;
+  ASSERT_OK(reader_->GetColumn(0, &col));
+  SCOPED_TRACE(col->data()->chunk(0)->ToString() + "\n" + batch->column(0)->ToString());
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(0)));
+  ASSERT_EQ("f0", col->name());
+
+  ASSERT_OK(reader_->GetColumn(1, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(1)));
+  ASSERT_EQ("f1", col->name());
+}
+
+TEST_F(TestTableWriter, SliceAtNonEightOffsetStringsWithNullsMultipleChunksRoundTrip) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, true));
+  batch = batch->Slice(100, 300);
+
+  ASSERT_OK(writer_->Append("f0", *batch->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch->column(1)));
+  Finish();
+
+  std::shared_ptr<Column> col;
+  ASSERT_OK(reader_->GetColumn(0, &col));
+  SCOPED_TRACE(col->data()->chunk(0)->ToString() + "\n" + batch->column(0)->ToString());
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(0)));
+  ASSERT_EQ("f0", col->name());
+
+  ASSERT_OK(reader_->GetColumn(1, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(1)));
+  ASSERT_EQ("f1", col->name());
+}
+
 }  // namespace feather
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -452,14 +452,10 @@ TEST_P(TestTableWriterSlice, SliceBooleanRoundTrip) {
   CheckSlice(batch);
 }
 
-INSTANTIATE_TEST_CASE_P(
-    TestTableWriterSliceOffsets, TestTableWriterSlice,
-    ::testing::Values(std::make_tuple(300, 30), std::make_tuple(301, 30),
-                      std::make_tuple(302, 30), std::make_tuple(303, 30),
-                      std::make_tuple(304, 30), std::make_tuple(305, 30),
-                      std::make_tuple(306, 30), std::make_tuple(307, 30),
-                      std::make_tuple(300, 1), std::make_tuple(300, 8),
-                      std::make_tuple(1, 2)));
+INSTANTIATE_TEST_CASE_P(TestTableWriterSliceOffsets, TestTableWriterSlice,
+                        ::testing::Combine(::testing::Values(0, 1, 300, 301, 302, 303,
+                                                             304, 305, 306, 307),
+                                           ::testing::Values(0, 1, 7, 8, 30, 32, 100)));
 
 }  // namespace feather
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -505,6 +505,26 @@ TEST_F(TestTableWriter, SliceAtNonEightOffsetStringsWithNullsMultipleChunksRound
   ASSERT_EQ("f1", col->name());
 }
 
+TEST_F(TestTableWriter, SliceAtNonEightOffsetBoolean) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeBooleanBatchSized(400, &batch));
+  batch = batch->Slice(77, 37);
+
+  ASSERT_OK(writer_->Append("f0", *batch->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch->column(1)));
+  Finish();
+
+  std::shared_ptr<Column> col;
+  ASSERT_OK(reader_->GetColumn(0, &col));
+  SCOPED_TRACE(col->data()->chunk(0)->ToString() + "\n" + batch->column(0)->ToString());
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(0)));
+  ASSERT_EQ("f0", col->name());
+
+  ASSERT_OK(reader_->GetColumn(1, &col));
+  ASSERT_TRUE(col->data()->chunk(0)->Equals(batch->column(1)));
+  ASSERT_EQ("f1", col->name());
+}
+
 }  // namespace feather
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -427,7 +427,7 @@ TEST_F(TestTableWriter, SliceRoundTrip) {
 
 TEST_F(TestTableWriter, SliceStringsRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, false));
+  ASSERT_OK(MakeStringTypesRecordBatch(&batch, false));
   batch = batch->Slice(320, 30);
 
   ASSERT_OK(writer_->Append("f0", *batch->column(0)));
@@ -447,7 +447,7 @@ TEST_F(TestTableWriter, SliceStringsRoundTrip) {
 
 TEST_F(TestTableWriter, SliceStringsWithNullsRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, true));
+  ASSERT_OK(MakeStringTypesRecordBatch(&batch, true));
   batch = batch->Slice(320, 30);
 
   ASSERT_OK(writer_->Append("f0", *batch->column(0)));
@@ -467,7 +467,7 @@ TEST_F(TestTableWriter, SliceStringsWithNullsRoundTrip) {
 
 TEST_F(TestTableWriter, SliceAtNonEightOffsetStringsWithNullsRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, true));
+  ASSERT_OK(MakeStringTypesRecordBatch(&batch, true));
   batch = batch->Slice(323, 30);
 
   ASSERT_OK(writer_->Append("f0", *batch->column(0)));
@@ -487,7 +487,7 @@ TEST_F(TestTableWriter, SliceAtNonEightOffsetStringsWithNullsRoundTrip) {
 
 TEST_F(TestTableWriter, SliceAtNonEightOffsetStringsWithNullsMultipleChunksRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(MakeStringTypesRecordBatchWithNulls(&batch, true));
+  ASSERT_OK(MakeStringTypesRecordBatch(&batch, true));
   batch = batch->Slice(100, 300);
 
   ASSERT_OK(writer_->Append("f0", *batch->column(0)));

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -79,19 +79,19 @@ static Status WritePaddedWithOffset(io::OutputStream* stream, const uint8_t* dat
                                     int64_t bit_offset, const int64_t length,
                                     int64_t* bytes_written) {
   data = data + bit_offset / 8;
-  uint8_t bit_shift = bit_offset % 8;
+  uint8_t bit_shift = static_cast<uint8_t>(bit_offset % 8);
   if (bit_offset == 0) {
     RETURN_NOT_OK(stream->Write(data, length));
   } else {
     constexpr int64_t buffersize = 256;
     uint8_t buffer[buffersize];
-    const uint8_t lshift = uint8_t(8) - bit_shift;
+    const uint8_t lshift = static_cast<uint8_t>(8 - bit_shift);
     const uint8_t* buffer_end = buffer + buffersize;
     uint8_t* buffer_it = buffer;
 
     for (const uint8_t* end = data + length; data != end;) {
-      uint8_t r = *data++ >> bit_shift;
-      uint8_t l = *data << lshift;
+      uint8_t r = static_cast<uint8_t>(*data++ >> bit_shift);
+      uint8_t l = static_cast<uint8_t>(*data << lshift);
       uint8_t value = l | r;
       *buffer_it++ = value;
       if (buffer_it == buffer_end) {

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -591,8 +591,7 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
 
     // Write the null bitmask
     if (values.null_count() > 0) {
-      // We assume there is one bit for each value in values.nulls, aligned on a
-      // byte boundary, and we write this much data into the stream
+      // We assume there is one bit for each value in values.nulls, starting at the zero offset.
       int64_t null_bitmap_size = GetOutputLength(BitUtil::BytesForBits(values.length()));
       if (values.null_bitmap()) {
         auto null_bitmap = values.null_bitmap();

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -79,18 +79,18 @@ static Status WritePaddedWithOffset(io::OutputStream* stream, const uint8_t* dat
                                     int64_t bit_offset, const int64_t length,
                                     int64_t* bytes_written) {
   data = data + bit_offset / 8;
-  bit_offset = bit_offset % 8;
+  uint8_t bit_shift = bit_offset % 8;
   if (bit_offset == 0) {
     RETURN_NOT_OK(stream->Write(data, length));
   } else {
     constexpr int64_t buffersize = 256;
     uint8_t buffer[buffersize];
-    const uint8_t lshift = 8 - bit_offset;
+    const uint8_t lshift = uint8_t(8) - bit_shift;
     const uint8_t* buffer_end = buffer + buffersize;
     uint8_t* buffer_it = buffer;
 
     for (const uint8_t* end = data + length; data != end;) {
-      uint8_t r = *data++ >> bit_offset;
+      uint8_t r = *data++ >> bit_shift;
       uint8_t l = *data << lshift;
       uint8_t value = l | r;
       *buffer_it++ = value;

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -101,7 +101,6 @@ static Status WritePaddedWithOffset(io::OutputStream* stream, const uint8_t* dat
     }
     if (buffer_it != buffer) {
       RETURN_NOT_OK(stream->Write(buffer, buffer_it - buffer));
-      buffer_it = buffer;
     }
   }
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -591,7 +591,8 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
 
     // Write the null bitmask
     if (values.null_count() > 0) {
-      // We assume there is one bit for each value in values.nulls, starting at the zero offset.
+      // We assume there is one bit for each value in values.nulls,
+      // starting at the zero offset.
       int64_t null_bitmap_size = GetOutputLength(BitUtil::BytesForBits(values.length()));
       if (values.null_bitmap()) {
         auto null_bitmap = values.null_bitmap();

--- a/cpp/src/arrow/ipc/ipc-json-test.cc
+++ b/cpp/src/arrow/ipc/ipc-json-test.cc
@@ -375,7 +375,7 @@ TEST(TestJsonFileReadWrite, MinimalFormatExample) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatch, &MakeStruct, &MakeUnion, &MakeDates,   \
+                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion, &MakeDates,   \
                     &MakeTimestamps, &MakeTimes, &MakeFWBinary, &MakeDecimal,           \
                     &MakeDictionary);
 

--- a/cpp/src/arrow/ipc/ipc-json-test.cc
+++ b/cpp/src/arrow/ipc/ipc-json-test.cc
@@ -375,9 +375,9 @@ TEST(TestJsonFileReadWrite, MinimalFormatExample) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion, &MakeDates,   \
-                    &MakeTimestamps, &MakeTimes, &MakeFWBinary, &MakeDecimal,           \
-                    &MakeDictionary);
+                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,
+                    &MakeDates, &MakeTimestamps, &MakeTimes, &MakeFWBinary,
+                    &MakeDecimal, &MakeDictionary);
 
 class TestJsonRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*> {
  public:

--- a/cpp/src/arrow/ipc/ipc-json-test.cc
+++ b/cpp/src/arrow/ipc/ipc-json-test.cc
@@ -375,7 +375,7 @@ TEST(TestJsonFileReadWrite, MinimalFormatExample) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,   \
+                    &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion,      \
                     &MakeDates, &MakeTimestamps, &MakeTimes, &MakeFWBinary,             \
                     &MakeDecimal, &MakeDictionary);
 

--- a/cpp/src/arrow/ipc/ipc-json-test.cc
+++ b/cpp/src/arrow/ipc/ipc-json-test.cc
@@ -375,8 +375,8 @@ TEST(TestJsonFileReadWrite, MinimalFormatExample) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,
-                    &MakeDates, &MakeTimestamps, &MakeTimes, &MakeFWBinary,
+                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,   \
+                    &MakeDates, &MakeTimestamps, &MakeTimes, &MakeFWBinary,             \
                     &MakeDecimal, &MakeDictionary);
 
 class TestJsonRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*> {

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -119,7 +119,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,               \
+                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,   \
                     &MakeDictionary, &MakeDates, &MakeTimestamps, &MakeTimes,           \
                     &MakeFWBinary, &MakeNull, &MakeDecimal, &MakeBooleanBatch);
 

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -119,7 +119,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatch, &MakeStruct, &MakeUnion,               \
+                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,               \
                     &MakeDictionary, &MakeDates, &MakeTimestamps, &MakeTimes,           \
                     &MakeFWBinary, &MakeNull, &MakeDecimal, &MakeBooleanBatch);
 

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -119,7 +119,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
 #define BATCH_CASES()                                                                   \
   ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch, \
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                  \
-                    &MakeStringTypesRecordBatchWithoutNulls, &MakeStruct, &MakeUnion,   \
+                    &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion,      \
                     &MakeDictionary, &MakeDates, &MakeTimestamps, &MakeTimes,           \
                     &MakeFWBinary, &MakeNull, &MakeDecimal, &MakeBooleanBatch);
 

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -232,8 +232,8 @@ Status MakeRandomBinaryArray(int64_t length, bool include_nulls, MemoryPool* poo
   return builder.Finish(out);
 }
 
-Status MakeStringTypesRecordBatchWithNulls(std::shared_ptr<RecordBatch>* out,
-                                           bool with_nulls = true) {
+Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch> *out,
+                                  bool with_nulls = true) {
   const int64_t length = 500;
   auto string_type = utf8();
   auto binary_type = binary();
@@ -258,8 +258,8 @@ Status MakeStringTypesRecordBatchWithNulls(std::shared_ptr<RecordBatch>* out,
   return Status::OK();
 }
 
-Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch>* out) {
-  return MakeStringTypesRecordBatchWithNulls(out, true);
+Status MakeStringTypesRecordBatchWithoutNulls(std::shared_ptr<RecordBatch> *out) {
+  return MakeStringTypesRecordBatch(out, true);
 }
 
 Status MakeNullRecordBatch(std::shared_ptr<RecordBatch>* out) {

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -258,7 +258,7 @@ Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch>* out,
   return Status::OK();
 }
 
-Status MakeStringTypesRecordBatchWithoutNulls(std::shared_ptr<RecordBatch>* out) {
+Status MakeStringTypesRecordBatchWithNulls(std::shared_ptr<RecordBatch>* out) {
   return MakeStringTypesRecordBatch(out, true);
 }
 

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -232,7 +232,7 @@ Status MakeRandomBinaryArray(int64_t length, bool include_nulls, MemoryPool* poo
   return builder.Finish(out);
 }
 
-Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch> *out,
+Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch>* out,
                                   bool with_nulls = true) {
   const int64_t length = 500;
   auto string_type = utf8();
@@ -258,7 +258,7 @@ Status MakeStringTypesRecordBatch(std::shared_ptr<RecordBatch> *out,
   return Status::OK();
 }
 
-Status MakeStringTypesRecordBatchWithoutNulls(std::shared_ptr<RecordBatch> *out) {
+Status MakeStringTypesRecordBatchWithoutNulls(std::shared_ptr<RecordBatch>* out) {
   return MakeStringTypesRecordBatch(out, true);
 }
 


### PR DESCRIPTION
When writing a slice of a table to feather, both the scalar data and the null bitmap were written out wrongly, i.e. from the beginning of the original table instead of from the offset.
- scalar data is written from the offset
- null bitmap is written from the offset.

I messed up my original pull request https://github.com/apache/arrow/pull/1766, hence this replaces it. Hope that helps.