### PR TITLE
ARROW-2349: [Python] Opt in to bundling Boost shared libraries separately

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -78,7 +78,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     OFF)
   option(PYARROW_BUNDLE_BOOST
     "Bundle the Boost libraries when we bundle Arrow C++"
-    ON)
+    OFF)
   set(PYARROW_CXXFLAGS "" CACHE STRING
     "Compiler flags to append when compiling Arrow")
 endif()

--- a/python/setup.py
+++ b/python/setup.py
@@ -136,7 +136,7 @@ class build_ext(_build_ext):
         # Default is True but this only is actually bundled when
         # we also bundle arrow-cpp.
         self.bundle_boost = strtobool(
-            os.environ.get('PYARROW_BUNDLE_BOOST', '1'))
+            os.environ.get('PYARROW_BUNDLE_BOOST', '0'))
 
     CYTHON_MODULE_NAMES = [
         'lib',
@@ -195,15 +195,15 @@ class build_ext(_build_ext):
 
             if self.bundle_arrow_cpp:
                 cmake_options.append('-DPYARROW_BUNDLE_ARROW_CPP=ON')
-                cmake_options.append('-DPYARROW_BUNDLE_BOOST=ON')
                 # ARROW-1090: work around CMake rough edges
                 if 'ARROW_HOME' in os.environ and sys.platform != 'win32':
                     pkg_config = pjoin(os.environ['ARROW_HOME'], 'lib',
                                        'pkgconfig')
                     os.environ['PKG_CONFIG_PATH'] = pkg_config
                     del os.environ['ARROW_HOME']
-            else:
-                cmake_options.append('-DPYARROW_BUNDLE_BOOST=OFF')
+
+            if self.bundle_boost:
+                cmake_options.append('-DPYARROW_BUNDLE_BOOST=ON')
 
             cmake_options.append('-DCMAKE_BUILD_TYPE={0}'
                                  .format(self.build_type.lower()))


### PR DESCRIPTION
In the scenario that the following are true, this prevents issues in the following case:

* Arrow libraries built with static Boost linking, and we pass `--with-static-boost` to setup.py
* Arrow libraries being bundled `--bundle-arrow-cpp`
* Boost libraries cannot be found when building pyarrow

Right now if `--bundle-arrow-cpp` is passed, then `-DPYARROW_BUNDLE_BOOST=ON` is passed to CMake.

Related to issues in https://github.com/apache/arrow-dist/pull/23