### PR TITLE
ARROW-2359: [C++] do not use static shared_ptr in TYPE_FACTORY to make it thread safe

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -369,8 +369,7 @@ ACCEPT_VISITOR(DictionaryType);
 
 #define TYPE_FACTORY(NAME, KLASS)                                        \
   std::shared_ptr<DataType> NAME() {                                     \
-    static std::shared_ptr<DataType> result = std::make_shared<KLASS>(); \
-    return result;                                                       \
+    return std::make_shared<KLASS>();                                    \
   }
 
 TYPE_FACTORY(null, NullType);


### PR DESCRIPTION
ARROW-2359: [C++] do not use static shared_ptr in TYPE_FACTORY to make it thread safe