### PR TITLE
ARROW-2308: [Python] Make deserialized numpy arrays 64-byte aligned.

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -207,41 +207,13 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
   return Message::ReadFrom(metadata, file, message);
 }
 
-Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message) {
-  int32_t message_length = 0;
-  int64_t bytes_read = 0;
-  RETURN_NOT_OK(file->Read(sizeof(int32_t), &bytes_read,
-                           reinterpret_cast<uint8_t*>(&message_length)));
-
-  if (bytes_read != sizeof(int32_t)) {
-    *message = nullptr;
-    return Status::OK();
-  }
-
-  if (message_length == 0) {
-    // Optional 0 EOS control message
-    *message = nullptr;
-    return Status::OK();
-  }
-
-  std::shared_ptr<Buffer> metadata;
-  RETURN_NOT_OK(file->Read(message_length, &metadata));
-  if (metadata->size() != message_length) {
-    std::stringstream ss;
-    ss << "Expected to read " << message_length << " metadata bytes, but "
-       << "only read " << metadata->size();
-    return Status::Invalid(ss.str());
-  }
-
-  return Message::ReadFrom(metadata, file, message);
-}
-
 int64_t PaddedLength(int64_t nbytes) {
   int alignment = 64;
   return ((nbytes + alignment - 1) / alignment) * alignment;
 }
 
-Status ReadMessageAligned(io::RandomAccessFile* file, std::unique_ptr<Message>* message) {
+Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message,
+                   bool aligned) {
   int32_t message_length = 0;
   int64_t bytes_read = 0;
   RETURN_NOT_OK(file->Read(sizeof(int32_t), &bytes_read,
@@ -267,10 +239,16 @@ Status ReadMessageAligned(io::RandomAccessFile* file, std::unique_ptr<Message>* 
     return Status::Invalid(ss.str());
   }
 
-  int64_t offset;
-  RETURN_NOT_OK(file->Tell(&offset));
-  offset = PaddedLength(offset);
-  RETURN_NOT_OK(file->Seek(offset));
+  // If requested, align the file before reading the message.
+  if (aligned) {
+    io::RandomAccessFile* seekable_file =
+        reinterpret_cast<io::RandomAccessFile*>(file);
+    int64_t offset;
+    RETURN_NOT_OK(seekable_file->Tell(&offset));
+    offset = PaddedLength(offset);
+    RETURN_NOT_OK(seekable_file->Seek(offset));
+    file = reinterpret_cast<io::InputStream*>(seekable_file);
+  }
 
   return Message::ReadFrom(metadata, file, message);
 }

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -28,6 +28,7 @@
 #include "arrow/ipc/Message_generated.h"
 #include "arrow/ipc/Schema_generated.h"
 #include "arrow/ipc/metadata-internal.h"
+#include "arrow/ipc/util.h"
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
 
@@ -205,11 +206,6 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
 
   auto metadata = SliceBuffer(buffer, 4, buffer->size() - 4);
   return Message::ReadFrom(metadata, file, message);
-}
-
-int64_t PaddedLength(int64_t nbytes) {
-  int alignment = 64;
-  return ((nbytes + alignment - 1) / alignment) * alignment;
 }
 
 Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message,

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -237,13 +237,12 @@ Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message,
 
   // If requested, align the file before reading the message.
   if (aligned) {
-    io::RandomAccessFile* seekable_file =
-        reinterpret_cast<io::RandomAccessFile*>(file);
     int64_t offset;
-    RETURN_NOT_OK(seekable_file->Tell(&offset));
-    offset = PaddedLength(offset);
-    RETURN_NOT_OK(seekable_file->Seek(offset));
-    file = reinterpret_cast<io::InputStream*>(seekable_file);
+    RETURN_NOT_OK(file->Tell(&offset));
+    int64_t aligned_offset = PaddedLength(offset);
+    int64_t num_extra_bytes = aligned_offset - offset;
+    std::shared_ptr<Buffer> dummy_buffer;
+    RETURN_NOT_OK(file->Read(num_extra_bytes, &dummy_buffer));
   }
 
   return Message::ReadFrom(metadata, file, message);

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -184,6 +184,9 @@ Status ReadMessage(const int64_t offset, const int32_t metadata_length,
 ARROW_EXPORT
 Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message);
 
+ARROW_EXPORT
+Status ReadMessageAligned(io::RandomAccessFile* file, std::unique_ptr<Message>* message);
+
 }  // namespace ipc
 }  // namespace arrow
 

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -182,10 +182,8 @@ Status ReadMessage(const int64_t offset, const int32_t metadata_length,
 /// there are not enough bytes available or the message length is 0 (e.g. EOS
 /// in a stream)
 ARROW_EXPORT
-Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message);
-
-ARROW_EXPORT
-Status ReadMessageAligned(io::RandomAccessFile* file, std::unique_ptr<Message>* message);
+Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message,
+                   bool aligned = false);
 
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -685,16 +685,7 @@ Status RecordBatchFileReader::ReadRecordBatch(int i,
 
 static Status ReadContiguousPayload(io::InputStream* file,
                                     std::unique_ptr<Message>* message) {
-  RETURN_NOT_OK(ReadMessage(file, message));
-  if (*message == nullptr) {
-    return Status::Invalid("Unable to read metadata at offset");
-  }
-  return Status::OK();
-}
-
-static Status ReadContiguousPayloadAligned(io::RandomAccessFile* file,
-                                    std::unique_ptr<Message>* message) {
-  RETURN_NOT_OK(ReadMessageAligned(file, message));
+  RETURN_NOT_OK(ReadMessage(file, message, true));
   if (*message == nullptr) {
     return Status::Invalid("Unable to read metadata at offset");
   }
@@ -724,7 +715,7 @@ Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
   RETURN_NOT_OK(file->Seek(offset));
 
   std::unique_ptr<Message> message;
-  RETURN_NOT_OK(ReadContiguousPayloadAligned(file, &message));
+  RETURN_NOT_OK(ReadContiguousPayload(file, &message));
   return ReadTensor(*message, out);
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -684,8 +684,9 @@ Status RecordBatchFileReader::ReadRecordBatch(int i,
 }
 
 static Status ReadContiguousPayload(io::InputStream* file,
-                                    std::unique_ptr<Message>* message) {
-  RETURN_NOT_OK(ReadMessage(file, message, true));
+                                    std::unique_ptr<Message>* message,
+                                    bool aligned = false) {
+  RETURN_NOT_OK(ReadMessage(file, message, aligned));
   if (*message == nullptr) {
     return Status::Invalid("Unable to read metadata at offset");
   }
@@ -715,7 +716,7 @@ Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
   RETURN_NOT_OK(file->Seek(offset));
 
   std::unique_ptr<Message> message;
-  RETURN_NOT_OK(ReadContiguousPayload(file, &message));
+  RETURN_NOT_OK(ReadContiguousPayload(file, &message, true));
   return ReadTensor(*message, out);
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -692,6 +692,15 @@ static Status ReadContiguousPayload(io::InputStream* file,
   return Status::OK();
 }
 
+static Status ReadContiguousPayloadAligned(io::RandomAccessFile* file,
+                                    std::unique_ptr<Message>* message) {
+  RETURN_NOT_OK(ReadMessageAligned(file, message));
+  if (*message == nullptr) {
+    return Status::Invalid("Unable to read metadata at offset");
+  }
+  return Status::OK();
+}
+
 Status ReadSchema(io::InputStream* stream, std::shared_ptr<Schema>* out) {
   std::shared_ptr<RecordBatchReader> reader;
   RETURN_NOT_OK(RecordBatchStreamReader::Open(stream, &reader));
@@ -715,7 +724,7 @@ Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
   RETURN_NOT_OK(file->Seek(offset));
 
   std::unique_ptr<Message> message;
-  RETURN_NOT_OK(ReadContiguousPayload(file, &message));
+  RETURN_NOT_OK(ReadContiguousPayloadAligned(file, &message));
   return ReadTensor(*message, out);
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -716,7 +716,7 @@ Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
   RETURN_NOT_OK(file->Seek(offset));
 
   std::unique_ptr<Message> message;
-  RETURN_NOT_OK(ReadContiguousPayload(file, &message, true));
+  RETURN_NOT_OK(ReadContiguousPayload(file, &message, true /* aligned */));
   return ReadTensor(*message, out);
 }
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -618,6 +618,9 @@ Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadat
 
   if (tensor.is_contiguous()) {
     RETURN_NOT_OK(WriteTensorHeader(tensor, dst, metadata_length, body_length));
+    // It's important to align the stream position again so that the tensor data
+    // is aligned.
+    RETURN_NOT_OK(AlignStreamPosition(dst));
     auto data = tensor.data();
     if (data) {
       *body_length = data->size();
@@ -630,6 +633,9 @@ Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadat
     Tensor dummy(tensor.type(), tensor.data(), tensor.shape());
     const auto& type = static_cast<const FixedWidthType&>(*tensor.type());
     RETURN_NOT_OK(WriteTensorHeader(dummy, dst, metadata_length, body_length));
+    // It's important to align the stream position again so that the tensor data
+    // is aligned.
+    RETURN_NOT_OK(AlignStreamPosition(dst));
 
     const int elem_size = type.bit_width() / 8;
 

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -289,6 +289,9 @@ Status TensorToNdarray(const std::shared_ptr<Tensor>& tensor, PyObject* base,
     array_flags |= NPY_ARRAY_WRITEABLE;
   }
 
+  int64_t alignment = 64;
+  mutable_data = reinterpret_cast<void*>(((reinterpret_cast<int64_t>(mutable_data) + alignment - 1) / alignment) * alignment);
+
   PyObject* result =
       PyArray_NewFromDescr(&PyArray_Type, dtype, ndim, npy_shape.data(),
                            npy_strides.data(), mutable_data, array_flags, nullptr);

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -289,9 +289,6 @@ Status TensorToNdarray(const std::shared_ptr<Tensor>& tensor, PyObject* base,
     array_flags |= NPY_ARRAY_WRITEABLE;
   }
 
-  int64_t alignment = 64;
-  mutable_data = reinterpret_cast<void*>(((reinterpret_cast<int64_t>(mutable_data) + alignment - 1) / alignment) * alignment);
-
   PyObject* result =
       PyArray_NewFromDescr(&PyArray_Type, dtype, ndim, npy_shape.data(),
                            npy_strides.data(), mutable_data, array_flags, nullptr);

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -691,3 +691,20 @@ def test_path_objects(tmpdir):
     pa.serialize_to(obj, p)
     res = pa.deserialize_from(p, None)
     assert res == obj
+
+
+def test_tensor_alignment():
+    # Deserialized numpy arrays should be 64-byte aligned.
+    x = np.random.normal(size=(10, 20, 30))
+    y = pa.deserialize(pa.serialize(x).to_buffer())
+    assert y.ctypes.data % 64 == 0
+
+    xs = [np.random.normal(size=i) for i in range(100)]
+    ys = pa.deserialize(pa.serialize(xs).to_buffer())
+    for y in ys:
+        assert y.ctypes.data % 64 == 0
+
+    xs = [np.random.normal(size=i * (1,)) for i in range(20)]
+    ys = pa.deserialize(pa.serialize(xs).to_buffer())
+    for y in ys:
+        assert y.ctypes.data % 64 == 0

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -708,3 +708,9 @@ def test_tensor_alignment():
     ys = pa.deserialize(pa.serialize(xs).to_buffer())
     for y in ys:
         assert y.ctypes.data % 64 == 0
+
+    xs = [np.random.normal(size=i * (5,)) for i in range(1, 8)]
+    xs = [xs[i][(i + 1) * (slice(1, 3),)] for i in range(len(xs))]
+    ys = pa.deserialize(pa.serialize(xs).to_buffer())
+    for y in ys:
+        assert y.ctypes.data % 64 == 0


### PR DESCRIPTION
I'm not too sure about the relation to https://issues.apache.org/jira/browse/ARROW-1860, but I thought I'd open this for comment.

This aligns numpy arrays to 64-byte boundaries.

cc @pcmoritz @wesm @yaroslavvb