### PR TITLE
ARROW-2351 [C++] StringBuilder::append(vector<string>...) not impleme…

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -989,26 +989,26 @@ TEST_F(TestStringBuilder, TestScalarAppend) {
   }
 }
 
-
 TEST_F(TestStringBuilder, TestAppendVector) {
   vector<string> strings = {"", "bb", "a", "", "ccc"};
+  vector<uint8_t> is_null = {0, 0, 0, 1, 0};
 
   int N = static_cast<int>(strings.size());
   int reps = 1000;
 
   for (int j = 0; j < reps; ++j) {
-      ASSERT_OK(builder_->Append(strings));
+    ASSERT_OK(builder_->Append(strings, is_null.data()));
   }
   Done();
 
   ASSERT_EQ(reps * N, result_->length());
-  ASSERT_EQ(reps * 2, result_->null_count());
+  ASSERT_EQ(reps, result_->null_count());
   ASSERT_EQ(reps * 6, result_->value_data()->size());
 
   int32_t length;
   int32_t pos = 0;
   for (int i = 0; i < N * reps; ++i) {
-    if (strings[i % N].empty()) {
+    if (is_null[i % N]) {
       ASSERT_TRUE(result_->IsNull(i));
     } else {
       ASSERT_FALSE(result_->IsNull(i));

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -989,6 +989,39 @@ TEST_F(TestStringBuilder, TestScalarAppend) {
   }
 }
 
+
+TEST_F(TestStringBuilder, TestAppendVector) {
+  vector<string> strings = {"", "bb", "a", "", "ccc"};
+
+  int N = static_cast<int>(strings.size());
+  int reps = 1000;
+
+  for (int j = 0; j < reps; ++j) {
+      ASSERT_OK(builder_->Append(strings));
+  }
+  Done();
+
+  ASSERT_EQ(reps * N, result_->length());
+  ASSERT_EQ(reps * 2, result_->null_count());
+  ASSERT_EQ(reps * 6, result_->value_data()->size());
+
+  int32_t length;
+  int32_t pos = 0;
+  for (int i = 0; i < N * reps; ++i) {
+    if (strings[i % N].empty()) {
+      ASSERT_TRUE(result_->IsNull(i));
+    } else {
+      ASSERT_FALSE(result_->IsNull(i));
+      result_->GetValue(i, &length);
+      ASSERT_EQ(pos, result_->value_offset(i));
+      ASSERT_EQ(static_cast<int>(strings[i % N].size()), length);
+      ASSERT_EQ(strings[i % N], result_->GetString(i));
+
+      pos += length;
+    }
+  }
+}
+
 TEST_F(TestStringBuilder, TestZeroLength) {
   // All buffers are null
   Done();

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1404,7 +1404,6 @@ Status StringBuilder::Append(const std::vector<std::string>& values) {
                         reinterpret_cast<const uint8_t*>(str.data()), str.size());
                     this->UnsafeAppendToBitmap(true);
                   }
-
                 });
   return Status::OK();
 }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1385,6 +1385,30 @@ const uint8_t* BinaryBuilder::GetValue(int64_t i, int32_t* out_length) const {
 
 StringBuilder::StringBuilder(MemoryPool* pool) : BinaryBuilder(utf8(), pool) {}
 
+Status StringBuilder::Append(const std::vector<std::string>& values) {
+  std::size_t total_length = std::accumulate(values.begin(), values.end(),
+                                          0ULL, [](uint64_t sum, const std::string &str){
+        return sum + str.size();
+      });
+  RETURN_NOT_OK(Reserve(values.size()));
+  RETURN_NOT_OK(value_data_builder_.Reserve(total_length));
+  RETURN_NOT_OK(offsets_builder_.Reserve(values.size()));
+
+  std::for_each(values.begin(), values.end(),
+                [this](const std::string &str) {
+                  this->AppendNextOffset();
+                  if (str.empty()) {
+                    this->UnsafeAppendToBitmap(false);
+                  } else {
+                    this->value_data_builder_.Append(
+                        reinterpret_cast<const uint8_t*>(str.data()), str.size());
+                    this->UnsafeAppendToBitmap(true);
+                  }
+
+                });
+  return Status::OK();
+}
+
 // ----------------------------------------------------------------------
 // Fixed width binary
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1399,8 +1399,8 @@ Status StringBuilder::Append(const std::vector<std::string>& values,
     if (null_bytes[i]) {
       UnsafeAppendToBitmap(false);
     } else {
-      value_data_builder_.Append(reinterpret_cast<const uint8_t*>(values[i].data()),
-                                 values[i].size());
+      RETURN_NOT_OK(value_data_builder_.Append(
+          reinterpret_cast<const uint8_t*>(values[i].data()), values[i].size()));
       UnsafeAppendToBitmap(true);
     }
   }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "arrow/builder.h"
-
+#include <numeric>
 #include <algorithm>
 #include <cstdint>
 #include <cstring>

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -16,11 +16,11 @@
 // under the License.
 
 #include "arrow/builder.h"
-#include <numeric>
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <numeric>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -1385,26 +1385,25 @@ const uint8_t* BinaryBuilder::GetValue(int64_t i, int32_t* out_length) const {
 
 StringBuilder::StringBuilder(MemoryPool* pool) : BinaryBuilder(utf8(), pool) {}
 
-Status StringBuilder::Append(const std::vector<std::string>& values) {
-  std::size_t total_length = std::accumulate(values.begin(), values.end(),
-                                          0ULL, [](uint64_t sum, const std::string &str){
-        return sum + str.size();
-      });
+Status StringBuilder::Append(const std::vector<std::string>& values,
+                             uint8_t* null_bytes) {
+  std::size_t total_length = std::accumulate(
+      values.begin(), values.end(), 0ULL,
+      [](uint64_t sum, const std::string& str) { return sum + str.size(); });
   RETURN_NOT_OK(Reserve(values.size()));
   RETURN_NOT_OK(value_data_builder_.Reserve(total_length));
   RETURN_NOT_OK(offsets_builder_.Reserve(values.size()));
 
-  std::for_each(values.begin(), values.end(),
-                [this](const std::string &str) {
-                  this->AppendNextOffset();
-                  if (str.empty()) {
-                    this->UnsafeAppendToBitmap(false);
-                  } else {
-                    this->value_data_builder_.Append(
-                        reinterpret_cast<const uint8_t*>(str.data()), str.size());
-                    this->UnsafeAppendToBitmap(true);
-                  }
-                });
+  for (std::size_t i = 0; i < values.size(); ++i) {
+    RETURN_NOT_OK(AppendNextOffset());
+    if (null_bytes[i]) {
+      UnsafeAppendToBitmap(false);
+    } else {
+      value_data_builder_.Append(reinterpret_cast<const uint8_t*>(values[i].data()),
+                                 values[i].size());
+      UnsafeAppendToBitmap(true);
+    }
+  }
   return Status::OK();
 }
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -718,7 +718,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
 
   using BinaryBuilder::Append;
 
-  Status Append(const std::vector<std::string>& values, uint8_t* null_bytes);
+  Status Append(const std::vector<std::string>& values);
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -718,7 +718,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
 
   using BinaryBuilder::Append;
 
-  Status Append(const std::vector<std::string>& values);
+  Status Append(const std::vector<std::string>& values, uint8_t* null_bytes);
 };
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
changed the API from`Status Append(const std::vector<std::string>& values, uint8_t* null_bytes);` to  `Status Append(const std::vector<std::string>& values);` IMO, if string is empty, then it should be null, and vice versa.

**[update]** change the API back to original.