### PR TITLE
ARROW-2195: [Plasma] Return auto-releasing buffers

### DIFF
--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -80,6 +80,35 @@ TEST_F(TestCudaBuffer, CopyFromHost) {
   AssertCudaBufferEquals(*device_buffer, host_buffer->data(), kSize);
 }
 
+TEST_F(TestCudaBuffer, FromBuffer) {
+  const int64_t kSize = 1000;
+  // Initialize device buffer with random data
+  std::shared_ptr<PoolBuffer> host_buffer;
+  std::shared_ptr<CudaBuffer> device_buffer;
+  ASSERT_OK(context_->Allocate(kSize, &device_buffer));
+  ASSERT_OK(test::MakeRandomBytePoolBuffer(kSize, default_memory_pool(), &host_buffer));
+  ASSERT_OK(device_buffer->CopyFromHost(0, host_buffer->data(), 1000));
+  // Sanity check
+  AssertCudaBufferEquals(*device_buffer, host_buffer->data(), kSize);
+
+  // Get generic Buffer from device buffer
+  std::shared_ptr<Buffer> buffer;
+  std::shared_ptr<CudaBuffer> result;
+  buffer = std::static_pointer_cast<Buffer>(device_buffer);
+  ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
+  ASSERT_EQ(result->size(), kSize);
+  AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
+  buffer = SliceBuffer(device_buffer, 0, kSize);
+  ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
+  ASSERT_EQ(result->size(), kSize);
+  AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
+  buffer = SliceBuffer(device_buffer, 3, kSize - 10);
+  buffer = SliceBuffer(buffer, 8, kSize - 20);
+  ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
+  ASSERT_EQ(result->size(), kSize - 20);
+  AssertCudaBufferEquals(*result, host_buffer->data() + 11, kSize - 20);
+}
+
 // IPC only supported on Linux
 #if defined(__linux)
 

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -97,15 +97,29 @@ TEST_F(TestCudaBuffer, FromBuffer) {
   buffer = std::static_pointer_cast<Buffer>(device_buffer);
   ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
   ASSERT_EQ(result->size(), kSize);
+  ASSERT_EQ(result->is_mutable(), true);
+  ASSERT_EQ(result->mutable_data(), buffer->mutable_data());
   AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
+
   buffer = SliceBuffer(device_buffer, 0, kSize);
   ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
   ASSERT_EQ(result->size(), kSize);
+  ASSERT_EQ(result->is_mutable(), false);
   AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
-  buffer = SliceBuffer(device_buffer, 3, kSize - 10);
-  buffer = SliceBuffer(buffer, 8, kSize - 20);
+
+  buffer = SliceMutableBuffer(device_buffer, 0, kSize);
+  ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
+  ASSERT_EQ(result->size(), kSize);
+  ASSERT_EQ(result->is_mutable(), true);
+  ASSERT_EQ(result->mutable_data(), buffer->mutable_data());
+  AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
+
+  buffer = SliceMutableBuffer(device_buffer, 3, kSize - 10);
+  buffer = SliceMutableBuffer(buffer, 8, kSize - 20);
   ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
   ASSERT_EQ(result->size(), kSize - 20);
+  ASSERT_EQ(result->is_mutable(), true);
+  ASSERT_EQ(result->mutable_data(), buffer->mutable_data());
   AssertCudaBufferEquals(*result, host_buffer->data() + 11, kSize - 20);
 }
 

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -103,6 +103,8 @@ CudaBuffer::CudaBuffer(const std::shared_ptr<CudaBuffer>& parent, const int64_t 
 Status CudaBuffer::FromBuffer(std::shared_ptr<Buffer> buffer,
                               std::shared_ptr<CudaBuffer>* out) {
   int64_t offset = 0, size = buffer->size();
+  // The original CudaBuffer may have been wrapped in another Buffer
+  // (for example through slicing).
   while (!(*out = std::dynamic_pointer_cast<CudaBuffer>(buffer))) {
     const std::shared_ptr<Buffer> parent = buffer->parent();
     if (!parent) {
@@ -111,6 +113,7 @@ Status CudaBuffer::FromBuffer(std::shared_ptr<Buffer> buffer,
     offset += buffer->data() - parent->data();
     buffer = parent;
   }
+  // Re-slice to represent the same memory area
   if (offset != 0 || (*out)->size() != size) {
     *out = std::make_shared<CudaBuffer>(*out, offset, size);
   }

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -46,6 +46,15 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
 
   ~CudaBuffer();
 
+  /// \brief Convert back generic buffer into CudaBuffer
+  /// \param[in] buffer buffer to convert
+  /// \param[out] out conversion result
+  /// \return Status
+  ///
+  /// This function returns an error if the buffer isn't backed by GPU memory
+  static Status FromBuffer(std::shared_ptr<Buffer> buffer,
+                           std::shared_ptr<CudaBuffer>* out);
+
   /// \brief Copy memory from GPU device to CPU host
   /// \param[out] out a pre-allocated output buffer
   /// \return Status
@@ -123,7 +132,7 @@ class ARROW_EXPORT CudaIpcMemHandle {
 /// able to do anything other than pointer arithmetic on the returned buffers
 class ARROW_EXPORT CudaBufferReader : public io::BufferReader {
  public:
-  explicit CudaBufferReader(const std::shared_ptr<CudaBuffer>& buffer);
+  explicit CudaBufferReader(const std::shared_ptr<Buffer>& buffer);
   ~CudaBufferReader();
 
   /// \brief Read bytes into pre-allocated host memory

--- a/cpp/src/arrow/test-util.h
+++ b/cpp/src/arrow/test-util.h
@@ -324,6 +324,14 @@ void AssertChunkedEqual(const ChunkedArray& expected, const ChunkedArray& actual
   }
 }
 
+void AssertBufferEqual(const Buffer& buffer, const std::vector<uint8_t>& expected) {
+  ASSERT_EQ(buffer.size(), expected.size());
+  const uint8_t* buffer_data = buffer.data();
+  for (size_t i = 0; i < expected.size(); ++i) {
+    ASSERT_EQ(buffer_data[i], expected[i]);
+  }
+}
+
 void PrintColumn(const Column& col, std::stringstream* ss) {
   const ChunkedArray& carr = *col.data();
   for (int i = 0; i < carr.num_chunks(); ++i) {

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -96,7 +96,7 @@
 
 // ----------------------------------------------------------------------
 // From googletest
-// XXX also in parquet-cpp
+// (also in parquet-cpp)
 
 // When you need to test the private or protected members of a class,
 // use the FRIEND_TEST macro to declare your tests as friends of the

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -94,4 +94,29 @@
 #endif
 #endif  // !defined(MANUALLY_ALIGNED_STRUCT)
 
+// ----------------------------------------------------------------------
+// From googletest
+// XXX also in parquet-cpp
+
+// When you need to test the private or protected members of a class,
+// use the FRIEND_TEST macro to declare your tests as friends of the
+// class.  For example:
+//
+// class MyClass {
+//  private:
+//   void MyMethod();
+//   FRIEND_TEST(MyClassTest, MyMethod);
+// };
+//
+// class MyClassTest : public testing::Test {
+//   // ...
+// };
+//
+// TEST_F(MyClassTest, MyMethod) {
+//   // Can call MyClass::MyMethod() here.
+// }
+
+#define FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
+
 #endif  // ARROW_UTIL_MACROS_H

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -72,6 +72,25 @@ constexpr int64_t kThreadPoolSize = 8;
 constexpr int64_t kBytesInMB = 1 << 20;
 static std::vector<std::thread> threadpool_(kThreadPoolSize);
 
+class PlasmaBuffer : public Buffer {
+ public:
+  ~PlasmaBuffer();
+
+  PlasmaBuffer(PlasmaClient* client, const ObjectID& object_id,
+               const std::shared_ptr<Buffer>& buffer)
+      : Buffer(buffer, 0, buffer->size()), client_(client), object_id_(object_id) {
+    if (buffer->is_mutable()) {
+      is_mutable_ = true;
+    }
+  }
+
+ private:
+  PlasmaClient* client_;
+  ObjectID object_id_;
+};
+
+PlasmaBuffer::~PlasmaBuffer() { (void)client_->Release(object_id_); }
+
 struct ObjectInUseEntry {
   /// A count of the number of times this client has called PlasmaClient::Create
   /// or
@@ -142,6 +161,11 @@ uint8_t* PlasmaClient::lookup_mmapped_file(int store_fd_val) {
   auto entry = mmap_table_.find(store_fd_val);
   ARROW_CHECK(entry != mmap_table_.end());
   return entry->second.pointer;
+}
+
+bool PlasmaClient::IsInUse(const ObjectID& object_id) {
+  const auto elem = objects_in_use_.find(object_id);
+  return (elem != objects_in_use_.end());
 }
 
 void PlasmaClient::increment_object_count(const ObjectID& object_id, PlasmaObject* object,
@@ -247,8 +271,12 @@ Status PlasmaClient::Create(const ObjectID& object_id, int64_t data_size,
   return Status::OK();
 }
 
-Status PlasmaClient::Get(const ObjectID* object_ids, int64_t num_objects,
-                         int64_t timeout_ms, ObjectBuffer* object_buffers) {
+Status PlasmaClient::GetBuffers(const ObjectID* object_ids, int64_t num_objects,
+                                int64_t timeout_ms,
+                                std::function<std::shared_ptr<Buffer>(
+                                    const ObjectID&, const std::shared_ptr<Buffer>&)>
+                                    wrap_buffer,
+                                ObjectBuffer* object_buffers) {
   // Fill out the info for the objects that are already in use locally.
   bool all_present = true;
   for (int i = 0; i < num_objects; ++i) {
@@ -265,31 +293,28 @@ Status PlasmaClient::Get(const ObjectID* object_ids, int64_t num_objects,
       ARROW_CHECK(object_entry->second->is_sealed)
           << "Plasma client called get on an unsealed object that it created";
       PlasmaObject* object = &object_entry->second->object;
+      std::shared_ptr<Buffer> physical_buf;
+
       if (object->device_num == 0) {
         uint8_t* data = lookup_mmapped_file(object->store_fd);
-        object_buffers[i].data =
-            std::make_shared<Buffer>(data + object->data_offset, object->data_size);
-        object_buffers[i].metadata = std::make_shared<Buffer>(
-            data + object->data_offset + object->data_size, object->metadata_size);
+        physical_buf = std::make_shared<Buffer>(
+            data + object->data_offset, object->data_size + object->metadata_size);
       } else {
 #ifdef PLASMA_GPU
-        std::shared_ptr<CudaBuffer> gpu_handle =
-            gpu_object_map.find(object_ids[i])->second->ptr;
-        object_buffers[i].data =
-            std::make_shared<CudaBuffer>(gpu_handle, 0, object->data_size);
-        object_buffers[i].metadata = std::make_shared<CudaBuffer>(
-            gpu_handle, object->data_size, object->metadata_size);
+        physical_buf = gpu_object_map.find(object_ids[i])->second->ptr;
 #else
         ARROW_LOG(FATAL) << "Arrow GPU library is not enabled.";
 #endif
       }
+      physical_buf = wrap_buffer(object_ids[i], physical_buf);
+      object_buffers[i].data = SliceBuffer(physical_buf, 0, object->data_size);
+      object_buffers[i].metadata =
+          SliceBuffer(physical_buf, object->data_size, object->metadata_size);
       object_buffers[i].data_size = object->data_size;
       object_buffers[i].metadata_size = object->metadata_size;
       object_buffers[i].device_num = object->device_num;
       // Increment the count of the number of instances of this object that this
-      // client is using. A call to PlasmaClient::Release is required to
-      // decrement this
-      // count. Cache the reference to the object.
+      // client is using. Cache the reference to the object.
       increment_object_count(object_ids[i], object, true);
     }
   }
@@ -334,44 +359,40 @@ Status PlasmaClient::Get(const ObjectID* object_ids, int64_t num_objects,
     // If we are here, the object was not currently in use, so we need to
     // process the reply from the object store.
     if (object->data_size != -1) {
+      std::shared_ptr<Buffer> physical_buf;
       if (object->device_num == 0) {
         uint8_t* data = lookup_mmapped_file(object->store_fd);
-        // Finish filling out the return values.
-        object_buffers[i].data =
-            std::make_shared<Buffer>(data + object->data_offset, object->data_size);
-        object_buffers[i].metadata = std::make_shared<Buffer>(
-            data + object->data_offset + object->data_size, object->metadata_size);
+        physical_buf = std::make_shared<Buffer>(
+            data + object->data_offset, object->data_size + object->metadata_size);
       } else {
 #ifdef PLASMA_GPU
         std::lock_guard<std::mutex> lock(gpu_mutex);
         auto handle = gpu_object_map.find(object_ids[i]);
-        std::shared_ptr<CudaBuffer> gpu_handle;
         if (handle == gpu_object_map.end()) {
           std::shared_ptr<CudaContext> context;
           RETURN_NOT_OK(manager_->GetContext(object->device_num - 1, &context));
           GpuProcessHandle* obj_handle = new GpuProcessHandle();
           RETURN_NOT_OK(context->OpenIpcBuffer(*object->ipc_handle, &obj_handle->ptr));
           gpu_object_map[object_ids[i]] = obj_handle;
-          gpu_handle = obj_handle->ptr;
+          physical_buf = obj_handle->ptr;
         } else {
           handle->second->client_count += 1;
-          gpu_handle = handle->second->ptr;
+          physical_buf = handle->second->ptr;
         }
-        object_buffers[i].data =
-            std::make_shared<CudaBuffer>(gpu_handle, 0, object->data_size);
-        object_buffers[i].metadata = std::make_shared<CudaBuffer>(
-            gpu_handle, object->data_size, object->metadata_size);
 #else
         ARROW_LOG(FATAL) << "Arrow GPU library is not enabled.";
 #endif
       }
+      // Finish filling out the return values.
+      physical_buf = wrap_buffer(object_ids[i], physical_buf);
+      object_buffers[i].data = SliceBuffer(physical_buf, 0, object->data_size);
+      object_buffers[i].metadata =
+          SliceBuffer(physical_buf, object->data_size, object->metadata_size);
       object_buffers[i].data_size = object->data_size;
       object_buffers[i].metadata_size = object->metadata_size;
       object_buffers[i].device_num = object->device_num;
       // Increment the count of the number of instances of this object that this
-      // client is using. A call to PlasmaClient::Release is required to
-      // decrement this
-      // count. Cache the reference to the object.
+      // client is using. Cache the reference to the object.
       increment_object_count(received_object_ids[i], object, true);
     } else {
       // The object was not retrieved. Make sure we already put a -1 here to
@@ -382,6 +403,22 @@ Status PlasmaClient::Get(const ObjectID* object_ids, int64_t num_objects,
     }
   }
   return Status::OK();
+}
+
+Status PlasmaClient::Get(const ObjectID* object_ids, int64_t num_objects,
+                         int64_t timeout_ms, ObjectBuffer* object_buffers) {
+  const auto wrap_buffer = [](const ObjectID& object_id,
+                              const std::shared_ptr<Buffer>& buffer) { return buffer; };
+  return GetBuffers(object_ids, num_objects, timeout_ms, wrap_buffer, object_buffers);
+}
+
+Status PlasmaClient::GetAuto(const ObjectID* object_ids, int64_t num_objects,
+                             int64_t timeout_ms, ObjectBuffer* object_buffers) {
+  const auto wrap_buffer = [=](const ObjectID& object_id,
+                               const std::shared_ptr<Buffer>& buffer) {
+    return std::make_shared<PlasmaBuffer>(this, object_id, buffer);
+  };
+  return GetBuffers(object_ids, num_objects, timeout_ms, wrap_buffer, object_buffers);
 }
 
 Status PlasmaClient::UnmapObject(const ObjectID& object_id) {

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -72,6 +72,8 @@ constexpr int64_t kThreadPoolSize = 8;
 constexpr int64_t kBytesInMB = 1 << 20;
 static std::vector<std::thread> threadpool_(kThreadPoolSize);
 
+/// A Buffer class that automatically releases the backing plasma object
+/// when it goes out of scope.
 class PlasmaBuffer : public Buffer {
  public:
   ~PlasmaBuffer();
@@ -206,7 +208,7 @@ void PlasmaClient::increment_object_count(const ObjectID& object_id, PlasmaObjec
 }
 
 Status PlasmaClient::Create(const ObjectID& object_id, int64_t data_size,
-                            uint8_t* metadata, int64_t metadata_size,
+                            const uint8_t* metadata, int64_t metadata_size,
                             std::shared_ptr<Buffer>* data, int device_num) {
   ARROW_LOG(DEBUG) << "called plasma_create on conn " << store_conn_ << " with size "
                    << data_size << " and metadata size " << metadata_size;

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -91,7 +91,7 @@ class PlasmaBuffer : public Buffer {
   ObjectID object_id_;
 };
 
-PlasmaBuffer::~PlasmaBuffer() { (void)client_->Release(object_id_); }
+PlasmaBuffer::~PlasmaBuffer() { ARROW_UNUSED(client_->Release(object_id_)); }
 
 struct ObjectInUseEntry {
   /// A count of the number of times this client has called PlasmaClient::Create

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -28,6 +28,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/status.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 #include "plasma/common.h"
 #ifdef PLASMA_GPU

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -123,8 +123,8 @@ class ARROW_EXPORT PlasmaClient {
   ///        device_num = 2 corresponds to GPU1, etc.
   /// \return The return status.
   ///
-  /// The returned object must be released once it is done with, then it
-  /// must be either sealed or aborted.
+  /// The returned object must be released once it is done with.  It must also
+  /// be either sealed or aborted.
   Status Create(const ObjectID& object_id, int64_t data_size, const uint8_t* metadata,
                 int64_t metadata_size, std::shared_ptr<Buffer>* data, int device_num = 0);
 

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -123,6 +123,7 @@ class ARROW_EXPORT PlasmaClient {
   /// \return The return status.
   Status Create(const ObjectID& object_id, int64_t data_size, uint8_t* metadata,
                 int64_t metadata_size, std::shared_ptr<Buffer>* data, int device_num = 0);
+
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the
   /// timeout
@@ -140,6 +141,10 @@ class ARROW_EXPORT PlasmaClient {
   /// \return The return status.
   Status Get(const ObjectID* object_ids, int64_t num_objects, int64_t timeout_ms,
              ObjectBuffer* object_buffers);
+
+  /// XXX
+  Status GetAuto(const ObjectID* object_ids, int64_t num_objects, int64_t timeout_ms,
+                 ObjectBuffer* object_buffers);
 
   /// Tell Plasma that the client no longer needs the object. This should be
   /// called
@@ -328,6 +333,9 @@ class ARROW_EXPORT PlasmaClient {
   int get_manager_fd() const;
 
  private:
+  FRIEND_TEST(TestPlasmaStore, GetTest);
+  FRIEND_TEST(TestPlasmaStore, GetAutoTest);
+
   /// This is a helper method for unmapping objects for which all references have
   /// gone out of scope, either by calling Release or Abort.
   ///
@@ -339,6 +347,15 @@ class ARROW_EXPORT PlasmaClient {
   Status FlushReleaseHistory();
 
   Status PerformRelease(const ObjectID& object_id);
+
+  /// Common helper for Get() and GetAuto()
+  Status GetBuffers(const ObjectID* object_ids, int64_t num_objects, int64_t timeout_ms,
+                    std::function<std::shared_ptr<Buffer>(const ObjectID&,
+                                                          const std::shared_ptr<Buffer>&)>
+                        wrap_buffer,
+                    ObjectBuffer* object_buffers);
+
+  bool IsInUse(const ObjectID& object_id);
 
   uint8_t* lookup_or_mmap(int fd, int store_fd_val, int64_t map_size);
 

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -104,4 +104,29 @@ struct PlasmaStoreInfo;
 extern const PlasmaStoreInfo* plasma_config;
 }  // namespace plasma
 
+// ----------------------------------------------------------------------
+// From googletest
+// XXX also in parquet-cpp
+
+// When you need to test the private or protected members of a class,
+// use the FRIEND_TEST macro to declare your tests as friends of the
+// class.  For example:
+//
+// class MyClass {
+//  private:
+//   void MyMethod();
+//   FRIEND_TEST(MyClassTest, MyMethod);
+// };
+//
+// class MyClassTest : public testing::Test {
+//   // ...
+// };
+//
+// TEST_F(MyClassTest, MyMethod) {
+//   // Can call MyClass::MyMethod() here.
+// }
+
+#define FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
+
 #endif  // PLASMA_COMMON_H

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -104,29 +104,4 @@ struct PlasmaStoreInfo;
 extern const PlasmaStoreInfo* plasma_config;
 }  // namespace plasma
 
-// ----------------------------------------------------------------------
-// From googletest
-// XXX also in parquet-cpp
-
-// When you need to test the private or protected members of a class,
-// use the FRIEND_TEST macro to declare your tests as friends of the
-// class.  For example:
-//
-// class MyClass {
-//  private:
-//   void MyMethod();
-//   FRIEND_TEST(MyClassTest, MyMethod);
-// };
-//
-// class MyClassTest : public testing::Test {
-//   // ...
-// };
-//
-// TEST_F(MyClassTest, MyMethod) {
-//   // Can call MyClass::MyMethod() here.
-// }
-
-#define FRIEND_TEST(test_case_name, test_name) \
-  friend class test_case_name##_##test_name##_Test
-
 #endif  // PLASMA_COMMON_H

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -68,7 +68,7 @@ class TestPlasmaStore : public ::testing::Test {
     ARROW_CHECK_OK(client_.Disconnect());
     ARROW_CHECK_OK(client2_.Disconnect());
     // Kill all plasma_store processes
-    // XXX should only kill the processes we launched
+    // TODO should only kill the processes we launched
     system("killall -9 plasma_store");
   }
 

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -155,6 +155,7 @@ TEST_F(TestPlasmaStore, GetTest) {
     EXPECT_FALSE(client_.IsInUse(object_id));
 
     ARROW_CHECK_OK(client_.Get(&object_id, 1, -1, &object_buffer));
+    ASSERT_EQ(object_buffer.device_num, 0);
     AssertObjectBufferEqual(object_buffer, {42}, {3, 5, 6, 7, 9});
     ARROW_CHECK_OK(client_.FlushReleaseHistory());
     EXPECT_TRUE(client_.IsInUse(object_id));
@@ -185,6 +186,7 @@ TEST_F(TestPlasmaStore, GetAutoTest) {
     EXPECT_FALSE(client_.IsInUse(object_id));
 
     ARROW_CHECK_OK(client_.GetAuto(&object_id, 1, -1, &object_buffer));
+    ASSERT_EQ(object_buffer.device_num, 0);
     AssertObjectBufferEqual(object_buffer, {42}, {3, 5, 6, 7, 9});
     ARROW_CHECK_OK(client_.FlushReleaseHistory());
     EXPECT_TRUE(client_.IsInUse(object_id));
@@ -403,6 +405,7 @@ TEST_F(TestPlasmaStore, GetGPUTest) {
   ARROW_CHECK_OK(client_.Seal(object_id));
 
   ARROW_CHECK_OK(client_.Get(&object_id, 1, -1, &object_buffer));
+  ASSERT_EQ(object_buffer.device_num, 1);
   // Check data
   AssertCudaRead(object_buffer.data, {4, 5, 3, 1});
   // Check metadata

--- a/python/pyarrow/plasma.pyx
+++ b/python/pyarrow/plasma.pyx
@@ -83,10 +83,8 @@ cdef extern from "plasma/client.h" nogil:
                        const uint8_t* metadata, int64_t metadata_size,
                        const shared_ptr[CBuffer]* data)
 
-        CStatus Get(const CUniqueID* object_ids, int64_t num_objects,
-                    int64_t timeout_ms, CObjectBuffer* object_buffers)
-        CStatus GetAuto(const CUniqueID* object_ids, int64_t num_objects,
-                        int64_t timeout_ms, CObjectBuffer* object_buffers)
+        CStatus Get(const c_vector[CUniqueID] object_ids, int64_t timeout_ms,
+                    c_vector[CObjectBuffer]* object_buffers)
 
         CStatus Seal(const CUniqueID& object_id)
 
@@ -119,9 +117,7 @@ cdef extern from "plasma/client.h" nogil:
 cdef extern from "plasma/client.h" nogil:
 
     cdef struct CObjectBuffer" plasma::ObjectBuffer":
-        int64_t data_size
         shared_ptr[CBuffer] data
-        int64_t metadata_size
         shared_ptr[CBuffer] metadata
 
 
@@ -241,14 +237,14 @@ cdef class PlasmaClient:
 
     cdef _get_object_buffers(self, object_ids, int64_t timeout_ms,
                              c_vector[CObjectBuffer]* result):
-        cdef c_vector[CUniqueID] ids
-        cdef ObjectID object_id
+        cdef:
+            c_vector[CUniqueID] ids
+            ObjectID object_id
+
         for object_id in object_ids:
             ids.push_back(object_id.data)
-        result[0].resize(ids.size())
         with nogil:
-            check_status(self.client.get().GetAuto(ids.data(), ids.size(),
-                         timeout_ms, result[0].data()))
+            check_status(self.client.get().Get(ids, timeout_ms, result))
 
     # XXX C++ API should instead expose some kind of CreateAuto()
     cdef _make_mutable_plasma_buffer(self, ObjectID object_id, uint8_t* data,
@@ -329,7 +325,7 @@ cdef class PlasmaClient:
         self._get_object_buffers(object_ids, timeout_ms, &object_buffers)
         result = []
         for i in range(object_buffers.size()):
-            if object_buffers[i].data_size != -1:
+            if object_buffers[i].data.get() != nullptr:
                 result.append(pyarrow_wrap_buffer(object_buffers[i].data))
             else:
                 result.append(None)
@@ -361,8 +357,10 @@ cdef class PlasmaClient:
         self._get_object_buffers(object_ids, timeout_ms, &object_buffers)
         result = []
         for i in range(object_buffers.size()):
-            # XXX what if metadata_size == -1?
-            result.append(pyarrow_wrap_buffer(object_buffers[i].metadata))
+            if object_buffers[i].metadata.get() != nullptr:
+                result.append(pyarrow_wrap_buffer(object_buffers[i].metadata))
+            else:
+                result.append(None)
         return result
 
     def put(self, object value, ObjectID object_id=None, int memcopy_threads=6,

--- a/python/pyarrow/plasma.pyx
+++ b/python/pyarrow/plasma.pyx
@@ -247,7 +247,7 @@ cdef class PlasmaClient:
             ids.push_back(object_id.data)
         result[0].resize(ids.size())
         with nogil:
-            check_status(self.client.get().Get(ids.data(), ids.size(),
+            check_status(self.client.get().GetAuto(ids.data(), ids.size(),
                          timeout_ms, result[0].data()))
 
     # XXX C++ API should instead expose some kind of CreateAuto()

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -799,15 +799,15 @@ class TestPlasmaClient(object):
         # them go out of scope.
         for _ in range(100):
             create_object(
-                self.plasma_client,
+                self.plasma_client2,
                 np.random.randint(1, DEFAULT_PLASMA_STORE_MEMORY // 20), 0)
         # Create large objects that require the full object store size, and
         # verify that they fit.
         for _ in range(2):
-            create_object(self.plasma_client, DEFAULT_PLASMA_STORE_MEMORY, 0)
+            create_object(self.plasma_client2, DEFAULT_PLASMA_STORE_MEMORY, 0)
         # Verify that an object that is too large does not fit.
         with pytest.raises(pa.lib.PlasmaStoreFull):
-            create_object(self.plasma_client, DEFAULT_PLASMA_STORE_MEMORY + 1,
+            create_object(self.plasma_client2, DEFAULT_PLASMA_STORE_MEMORY + 1,
                           0)
 
 

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -190,7 +190,6 @@ class TestPlasmaClient(object):
         plasma_store_name, self.p = self.plasma_store_ctx.__enter__()
         # Connect to Plasma.
         self.plasma_client = plasma.connect(plasma_store_name, "", 64)
-        # For the eviction test
         self.plasma_client2 = plasma.connect(plasma_store_name, "", 0)
 
     def teardown_method(self, test_method):
@@ -310,6 +309,36 @@ class TestPlasmaClient(object):
                     #     metadata_buffers[i // 2], metadata_results[i])
                 else:
                     assert results[i] is None
+
+    def test_buffer_lifetime(self):
+        # ARROW-2195
+        arr = pa.array([1, 12, 23, 3, 34], pa.int32())
+        batch = pa.RecordBatch.from_arrays([arr], ['field1'])
+
+        # Serialize RecordBatch into Plasma store
+        sink = pa.MockOutputStream()
+        writer = pa.RecordBatchStreamWriter(sink, batch.schema)
+        writer.write_batch(batch)
+        writer.close()
+
+        object_id = random_object_id()
+        data_buffer = self.plasma_client.create(object_id, sink.size())
+        stream = pa.FixedSizeBufferWriter(data_buffer)
+        writer = pa.RecordBatchStreamWriter(stream, batch.schema)
+        writer.write_batch(batch)
+        writer.close()
+        self.plasma_client.seal(object_id)
+        del data_buffer
+
+        # Unserialize RecordBatch from Plasma store
+        [data_buffer] = self.plasma_client2.get_buffers([object_id])
+        reader = pa.RecordBatchStreamReader(data_buffer)
+        read_batch = reader.read_next_batch()
+        # Lose reference to returned buffer.  The RecordBatch must still
+        # be backed by valid memory.
+        del data_buffer, reader
+
+        assert read_batch.equals(batch)
 
     def test_put_and_get(self):
         for value in [["hello", "world", 3, 1.0], None, "hello"]:


### PR DESCRIPTION
On the C++ side, add a new PlasmaClient::GetAuto() method to return buffers that release
the corresponding object on destruction.

On the Python side, return such buffers in PlasmaClient.get_buffers().