### PR TITLE
ARROW-2327: [JS] Table.fromStruct missing from externs

### DIFF
--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -34,6 +34,8 @@ Table.from = function() {};
 /** @type {?} */
 Table.fromAsync = function() {};
 /** @type {?} */
+Table.fromStruct = function() {};
+/** @type {?} */
 Table.empty = function() {};
 /** @type {?} */
 Table.prototype.schema;

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -221,6 +221,7 @@ try {
 Schema['from'] = Schema.from;
 Table['from'] = Table.from;
 Table['fromAsync'] = Table.fromAsync;
+Table['fromStruct'] = Table.fromStruct;
 Table['empty'] = Table.empty;
 Vector['create'] = Vector.create;
 RecordBatch['from'] = RecordBatch.from;

--- a/js/test/Arrow.ts
+++ b/js/test/Arrow.ts
@@ -43,8 +43,8 @@ import { read, readAsync } from '../src/Arrow';
 export { read, readAsync };
 import { View,  VectorLike } from '../src/Arrow';
 export { View,  VectorLike };
-import { Table, Field, Schema, RecordBatch, Type } from '../src/Arrow';
-export { Table, Field, Schema, RecordBatch, Type };
+import { Table, Field, Schema, RecordBatch, Type, vector } from '../src/Arrow';
+export { Table, Field, Schema, RecordBatch, Type, vector };
 
 import { TypedArray, TypedArrayConstructor, IntBitWidth, TimeBitWidth } from '../src/Arrow';
 export { TypedArray, TypedArrayConstructor, IntBitWidth, TimeBitWidth };


### PR DESCRIPTION
Add `Table.fromStruct` to unit tests, and add it to externs to make the test pass