### PR TITLE
ARROW-2325: [Python] Update setup.py to use Markdown project description

### DIFF
--- a/dev/release/RELEASE_MANAGEMENT.md
+++ b/dev/release/RELEASE_MANAGEMENT.md
@@ -157,9 +157,15 @@ The pip binary packages (called "wheels") are generated from the
 * Download all wheel and tar.gz files from the new BinTray package version
   ([example][4])
 
-Now, you can finally upload the wheels to PyPI using the `twine` CLI tool. You
-must be permissioned on PyPI to upload here; ask Wes McKinney or Uwe Korn if
-you need help with this.
+
+Now, you can finally upload the wheels to PyPI using the `twine` CLI tool. 
+Please make sure you use `twine>=1.11.0`. This supports the markdown 
+long description in setup.py which also requires `setuptools>=38.6.0`. 
+`setuptools` is handled in previous steps by the `.travis.yml` and 
+`appveyor.yml` build configurations. 
+
+You must be permissioned on PyPI to upload here; ask Wes McKinney or Uwe Korn 
+if you need help with this.
 
 #### Updating conda packages
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -435,11 +435,8 @@ if not os.path.exists('../.git') and os.path.exists('../java/pom.xml'):
     os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"] = version_tag.text.replace(
         "-SNAPSHOT", "a0")
 
-long_description = """Apache Arrow is a columnar in-memory analytics layer
-designed to accelerate big data. It houses a set of canonical in-memory
-representations of flat and hierarchical data along with multiple
-language-bindings for structure manipulation. It also provides IPC
-and common algorithm implementations."""
+with open('README.md') as f:
+    long_description = f.read()
 
 
 class BinaryDistribution(Distribution):

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,6 +39,8 @@ from distutils.command.clean import clean as _clean
 from distutils.util import strtobool
 from distutils import sysconfig
 
+from setuptools import setup
+
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 
@@ -494,6 +496,7 @@ setup(
     tests_require=['pytest', 'pandas'],
     description="Python library for Apache Arrow",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,8 +39,6 @@ from distutils.command.clean import clean as _clean
 from distutils.util import strtobool
 from distutils import sysconfig
 
-from setuptools import setup
-
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 


### PR DESCRIPTION
Any thoughts on the best way to make sure the `pip` upload uses `twine>=1.11.0` and `setuptools>=38.6.0`? I don't see a reference to the twine version in https://github.com/apache/arrow/blob/master/dev/release/RELEASE_MANAGEMENT.md but maybe adding a note? Or maybe it should be documented and part of the packaging discussion?