### PR TITLE
ARROW-2370: [GLib] Fix include path in .pc on Meson build

### DIFF
--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -184,8 +184,7 @@ pkgconfig.generate(filebase: meson.project_name(),
                    description: 'C API for Apache Arrow based on GLib',
                    version: version,
                    requires: ['gio-2.0', 'arrow'],
-                   libraries: [libarrow_glib],
-                   subdirs: ['arrow-glib'])
+                   libraries: [libarrow_glib])
 
 arrow_glib_gir = gnome.generate_gir(libarrow_glib,
                                     sources: sources + c_headers + enums,

--- a/c_glib/arrow-gpu-glib/meson.build
+++ b/c_glib/arrow-gpu-glib/meson.build
@@ -59,8 +59,7 @@ pkgconfig.generate(filebase: 'arrow-gpu-glib',
                    description: 'C API for Apache Arrow GPU based on GLib',
                    version: version,
                    requires: ['arrow-glib', 'arrow-gpu'],
-                   libraries: [libarrow_gpu_glib],
-                   subdirs: ['arrow-gpu-glib'])
+                   libraries: [libarrow_gpu_glib])
 
 gnome.generate_gir(libarrow_gpu_glib,
                    dependencies: arrow_glib_gir_dependency,


### PR DESCRIPTION
`-I${includedir}` is correct. `-I${includedir}/arrow-glib` is wrong.