### PR TITLE
ARROW-2371: [GLib] Update "Requires" in .pc on GNU Autotools build

### DIFF
--- a/c_glib/arrow-glib/arrow-glib.pc.in
+++ b/c_glib/arrow-glib/arrow-glib.pc.in
@@ -25,4 +25,4 @@ Description: C API for Apache Arrow based on GLib
 Version: @VERSION@
 Libs: -L${libdir} -larrow-glib
 Cflags: -I${includedir}
-Requires: gobject-2.0 arrow
+Requires: gio-2.0 arrow


### PR DESCRIPTION
We use GIO for input stream and output stream.