### PR TITLE
[Rust] Update README to link to Rust library

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Major components of the project include:
  - [Java libraries](https://github.com/apache/arrow/tree/master/java)
  - [JavaScript libraries](https://github.com/apache/arrow/tree/master/js)
  - [Python bindings to C++](https://github.com/apache/arrow/tree/master/python)
+ - [Rust libraries](https://github.com/apache/arrow/tree/master/rust)
 
 Arrow is an [Apache Software Foundation](https://www.apache.org) project. Learn more at
 [arrow.apache.org](https://arrow.apache.org).

--- a/rust/README.md
+++ b/rust/README.md
@@ -25,8 +25,6 @@ This is a starting point for a native Rust implementation of Arrow.
 
 The current code demonstrates arrays of primitive types and structs.
 
-Contiguous memory buffers are used but they are not aligned at 8-byte boundaries yet.
-
 ## Example
 
 ```rust


### PR DESCRIPTION
Also removes an out-of-date comment in the Rust README.