### PR TITLE
DOC: Fix a tiny typo in parquet documentation

### DIFF
--- a/python/doc/source/parquet.rst
+++ b/python/doc/source/parquet.rst
@@ -101,7 +101,7 @@ We need not use a string to specify the origin of the file. It can be any of:
 * A Python file object
 
 In general, a Python file object will have the worst read performance, while a
-string file path or an instance of :class:`~.NativeFIle` (especially memory
+string file path or an instance of :class:`~.NativeFile` (especially memory
 maps) will perform the best.
 
 Finer-grained Reading and Writing


### PR DESCRIPTION
I ran across this little typo in the docs and it was easier to submit a PR than to make an account on Jira to report it. 😄 