### PR TITLE
ARROW-2377: [GLib] Support old GObject Introspection

### DIFF
--- a/c_glib/test/test-list-array.rb
+++ b/c_glib/test/test-list-array.rb
@@ -21,7 +21,8 @@ class TestListArray < Test::Unit::TestCase
   def test_new
     value_offsets = Arrow::Buffer.new([0, 2, 5, 5].pack("l*"))
     data = Arrow::Buffer.new([1, 2, 3, 4, 5].pack("c*"))
-    values = Arrow::Int8Array.new(5, data, nil, 0)
+    nulls = Arrow::Buffer.new([0b11111].pack("C*"))
+    values = Arrow::Int8Array.new(5, data, nulls, 0)
     assert_equal(build_list_array(Arrow::Int8DataType.new,
                                   [[1, 2], [3, 4, 5], nil]),
                  Arrow::ListArray.new(3,

--- a/c_glib/test/test-struct-array.rb
+++ b/c_glib/test/test-struct-array.rb
@@ -37,9 +37,10 @@ class TestStructArray < Test::Unit::TestCase
     struct_array1 = build_struct_array(fields, structs)
 
     data_type = Arrow::StructDataType.new(fields)
+    nulls = Arrow::Buffer.new([0b11].pack("C*"))
     children = [
-      Arrow::Int8Array.new(2, Arrow::Buffer.new([-29, 2].pack("C*")), nil, 0),
-      Arrow::BooleanArray.new(2, Arrow::Buffer.new([0b01].pack("C*")), nil, 0),
+      Arrow::Int8Array.new(2, Arrow::Buffer.new([-29, 2].pack("C*")), nulls, 0),
+      Arrow::BooleanArray.new(2, Arrow::Buffer.new([0b01].pack("C*")), nulls, 0),
     ]
     assert_equal(struct_array1,
                  Arrow::StructArray.new(data_type,


### PR DESCRIPTION
Old GObject Introspection doesn't support "(nullable)" annotation.