### PR TITLE
ARROW-2385: [Rust] implement to_json for DataType and Field

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,3 +36,4 @@ path = "src/lib.rs"
 [dependencies]
 bytes = "0.4"
 libc = "0.2"
+serde_json = "1.0.13"

--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -145,4 +145,59 @@ mod tests {
         let v: Vec<i32> = it.map(|n| n + 1).collect();
         assert_eq!(vec![2, 3, 4, 5, 6], v);
     }
+
+    #[test]
+    fn test_buffer_eq() {
+        let a = Buffer::from(vec![1, 2, 3, 4, 5]);
+        let b = Buffer::from(vec![5, 4, 3, 2, 1]);
+        let c = a.iter()
+            .zip(b.iter())
+            .map(|(a, b)| a == b)
+            .collect::<Vec<bool>>();
+        assert_eq!(c, vec![false, false, true, false, false]);
+    }
+
+    #[test]
+    fn test_buffer_lt() {
+        let a = Buffer::from(vec![1, 2, 3, 4, 5]);
+        let b = Buffer::from(vec![5, 4, 3, 2, 1]);
+        let c = a.iter()
+            .zip(b.iter())
+            .map(|(a, b)| a < b)
+            .collect::<Vec<bool>>();
+        assert_eq!(c, vec![true, true, false, false, false]);
+    }
+
+    #[test]
+    fn test_buffer_gt() {
+        let a = Buffer::from(vec![1, 2, 3, 4, 5]);
+        let b = Buffer::from(vec![5, 4, 3, 2, 1]);
+        let c = a.iter()
+            .zip(b.iter())
+            .map(|(a, b)| a > b)
+            .collect::<Vec<bool>>();
+        assert_eq!(c, vec![false, false, false, true, true]);
+    }
+
+    #[test]
+    fn test_buffer_add() {
+        let a = Buffer::from(vec![1, 2, 3, 4, 5]);
+        let b = Buffer::from(vec![5, 4, 3, 2, 1]);
+        let c = a.iter()
+            .zip(b.iter())
+            .map(|(a, b)| a + b)
+            .collect::<Vec<i32>>();
+        assert_eq!(c, vec![6, 6, 6, 6, 6]);
+    }
+
+    #[test]
+    fn test_buffer_multiply() {
+        let a = Buffer::from(vec![1, 2, 3, 4, 5]);
+        let b = Buffer::from(vec![5, 4, 3, 2, 1]);
+        let c = a.iter()
+            .zip(b.iter())
+            .map(|(a, b)| a * b)
+            .collect::<Vec<i32>>();
+        assert_eq!(c, vec![5, 8, 9, 8, 5]);
+    }
 }

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -57,8 +57,8 @@ impl DataType {
                     ))),
                 },
                 Some(s) if s == "int" => match map.get("isSigned") {
-                    Some(Value::Bool(true)) => match map.get("bitWidth") {
-                        Some(Value::Number(n)) => match n.as_u64() {
+                    Some(&Value::Bool(true)) => match map.get("bitWidth") {
+                        Some(&Value::Number(ref n)) => match n.as_u64() {
                             Some(8) => Ok(DataType::Int8),
                             Some(16) => Ok(DataType::Int16),
                             Some(32) => Ok(DataType::Int32),
@@ -71,8 +71,8 @@ impl DataType {
                             "int bitWidth missing or invalid"
                         ))),
                     },
-                    Some(Value::Bool(false)) => match map.get("bitWidth") {
-                        Some(Value::Number(n)) => match n.as_u64() {
+                    Some(&Value::Bool(false)) => match map.get("bitWidth") {
+                        Some(&Value::Number(ref n)) => match n.as_u64() {
                             Some(8) => Ok(DataType::UInt8),
                             Some(16) => Ok(DataType::UInt16),
                             Some(32) => Ok(DataType::UInt32),
@@ -94,7 +94,7 @@ impl DataType {
                     other
                 ))),
                 None => match map.get("fields") {
-                    Some(Value::Array(fields_array)) => {
+                    Some(&Value::Array(ref fields_array)) => {
                         let fields = fields_array
                             .iter()
                             .map(|f| Field::from(f))
@@ -153,7 +153,7 @@ impl Field {
         match json {
             &Value::Object(ref map) => {
                 let name = match map.get("name") {
-                    Some(Value::String(name)) => name.to_string(),
+                    Some(&Value::String(ref name)) => name.to_string(),
                     _ => {
                         return Err(ArrowError::ParseError(format!(
                             "Field missing 'name' attribute"
@@ -161,7 +161,7 @@ impl Field {
                     }
                 };
                 let nullable = match map.get("nullable") {
-                    Some(Value::Bool(b)) => *b,
+                    Some(&Value::Bool(b)) => b,
                     _ => {
                         return Err(ArrowError::ParseError(format!(
                             "Field missing 'nullable' attribute"

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -162,10 +162,6 @@ impl Field {
             "nullable": self.nullable,
             "type": self.data_type.to_json(),
         })
-
-        //        let mut map = Map::new();
-        //        map.insert("name".to_string(), Value::String(self.name.clone()));
-        //        Value::from(map)
     }
 
     pub fn to_string(&self) -> String {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,6 +18,9 @@
 extern crate bytes;
 extern crate libc;
 
+#[macro_use]
+extern crate serde_json;
+
 pub mod array;
 pub mod bitmap;
 pub mod buffer;


### PR DESCRIPTION
Note that this PR also moves some tests for comparing arrays from Array to Buffer<T> and removes some redundant code that was implemented before it was possible to get a type-safe Iterator from Buffer<T>. 

This change was made in this PR because the serde_json crate's macros pretty much forced me to address this now.