### PR TITLE
ARROW-1868: [Java] Cleanup usage of Types.MinorType to MinorType

### DIFF
--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -86,7 +86,7 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
 
   <#if minor.class == "Decimal">
   public void writeBigEndianBytesToDecimal(byte[] value) {
-    getWriter(Types.MinorType.DECIMAL).writeBigEndianBytesToDecimal(value);
+    getWriter(MinorType.DECIMAL).writeBigEndianBytesToDecimal(value);
   }
   </#if>
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.BigIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.BigIntHolder;
 import org.apache.arrow.vector.holders.NullableBigIntHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class BigIntVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public BigIntVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.BIGINT.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.BIGINT.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class BigIntVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.BIGINT;
+  public MinorType getMinorType() {
+    return MinorType.BIGINT;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.BitReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.BitHolder;
 import org.apache.arrow.vector.holders.NullableBitHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.OversizedAllocationException;
 import org.apache.arrow.vector.util.TransferPair;
@@ -45,8 +45,7 @@ public class BitVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public BitVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.BIT.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.BIT.getType()), allocator);
   }
 
   /**
@@ -79,8 +78,8 @@ public class BitVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.BIT;
+  public MinorType getMinorType() {
+    return MinorType.BIT;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
@@ -24,10 +24,9 @@ import org.apache.arrow.vector.complex.impl.DateDayReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.DateDayHolder;
 import org.apache.arrow.vector.holders.NullableDateDayHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
 
 /**
  * DateDayVector implements a fixed width (4 bytes) vector of
@@ -45,8 +44,7 @@ public class DateDayVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public DateDayVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.DATEDAY.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.DATEDAY.getType()), allocator);
   }
 
   /**
@@ -76,8 +74,8 @@ public class DateDayVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.DATEDAY;
+  public MinorType getMinorType() {
+    return MinorType.DATEDAY;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
@@ -24,12 +24,10 @@ import org.apache.arrow.vector.complex.impl.DateMilliReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.DateMilliHolder;
 import org.apache.arrow.vector.holders.NullableDateMilliHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.LocalDateTime;
-import org.joda.time.LocalDateTimes;
-import org.slf4j.Logger;
 
 /**
  * DateMilliVector implements a fixed width vector (8 bytes) of
@@ -47,8 +45,7 @@ public class DateMilliVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public DateMilliVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.DATEMILLI.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.DATEMILLI.getType()), allocator);
   }
 
   /**
@@ -78,8 +75,8 @@ public class DateMilliVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.DATEMILLI;
+  public MinorType getMinorType() {
+    return MinorType.DATEMILLI;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.DecimalReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.DecimalHolder;
 import org.apache.arrow.vector.holders.NullableDecimalHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.DecimalUtility;
 import org.apache.arrow.vector.util.TransferPair;
@@ -85,8 +85,8 @@ public class DecimalVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.DECIMAL;
+  public MinorType getMinorType() {
+    return MinorType.DECIMAL;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.FixedSizeBinaryReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.FixedSizeBinaryHolder;
 import org.apache.arrow.vector.holders.NullableFixedSizeBinaryHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeBinary;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
@@ -82,8 +82,8 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.FIXEDSIZEBINARY;
+  public MinorType getMinorType() {
+    return MinorType.FIXEDSIZEBINARY;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.Float4ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.Float4Holder;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class Float4Vector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public Float4Vector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.FLOAT4.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.FLOAT4.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class Float4Vector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.FLOAT4;
+  public MinorType getMinorType() {
+    return MinorType.FLOAT4;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.Float8ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.Float8Holder;
 import org.apache.arrow.vector.holders.NullableFloat8Holder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class Float8Vector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public Float8Vector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.FLOAT8.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.FLOAT8.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class Float8Vector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.FLOAT8;
+  public MinorType getMinorType() {
+    return MinorType.FLOAT8;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.IntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.IntHolder;
 import org.apache.arrow.vector.holders.NullableIntHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -45,8 +45,7 @@ public class IntVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public IntVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.INT.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.INT.getType()), allocator);
   }
 
   /**
@@ -79,8 +78,8 @@ public class IntVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.INT;
+  public MinorType getMinorType() {
+    return MinorType.INT;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.IntervalDayReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.IntervalDayHolder;
 import org.apache.arrow.vector.holders.NullableIntervalDayHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.Period;
@@ -47,8 +47,7 @@ public class IntervalDayVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public IntervalDayVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.INTERVALDAY.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.INTERVALDAY.getType()), allocator);
   }
 
   /**
@@ -78,8 +77,8 @@ public class IntervalDayVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.INTERVALDAY;
+  public MinorType getMinorType() {
+    return MinorType.INTERVALDAY;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.IntervalYearReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.IntervalYearHolder;
 import org.apache.arrow.vector.holders.NullableIntervalYearHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.Period;
@@ -44,8 +44,7 @@ public class IntervalYearVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public IntervalYearVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.INTERVALYEAR.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.INTERVALYEAR.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class IntervalYearVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.INTERVALYEAR;
+  public MinorType getMinorType() {
+    return MinorType.INTERVALYEAR;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.SmallIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.SmallIntHolder;
 import org.apache.arrow.vector.holders.NullableSmallIntHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class SmallIntVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public SmallIntVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.SMALLINT.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.SMALLINT.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class SmallIntVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.SMALLINT;
+  public MinorType getMinorType() {
+    return MinorType.SMALLINT;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -24,10 +24,9 @@ import org.apache.arrow.vector.complex.impl.TimeMicroReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeMicroHolder;
 import org.apache.arrow.vector.holders.NullableTimeMicroHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
 
 /**
  * TimeMicroVector implements a fixed width vector (8 bytes) of
@@ -46,8 +45,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public TimeMicroVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMEMICRO.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMEMICRO.getType()), allocator);
   }
 
   /**
@@ -77,8 +75,8 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMEMICRO;
+  public MinorType getMinorType() {
+    return MinorType.TIMEMICRO;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.TimeMilliReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeMilliHolder;
 import org.apache.arrow.vector.holders.NullableTimeMilliHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.LocalDateTime;
@@ -46,8 +46,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public TimeMilliVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMEMILLI.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMEMILLI.getType()), allocator);
   }
 
   /**
@@ -77,8 +76,8 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMEMILLI;
+  public MinorType getMinorType() {
+    return MinorType.TIMEMILLI;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.TimeNanoReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeNanoHolder;
 import org.apache.arrow.vector.holders.NullableTimeNanoHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public TimeNanoVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMENANO.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMENANO.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMENANO;
+  public MinorType getMinorType() {
+    return MinorType.TIMENANO;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.TimeSecReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeSecHolder;
 import org.apache.arrow.vector.holders.NullableTimeSecHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public TimeSecVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMESEC.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMESEC.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESEC;
+  public MinorType getMinorType() {
+    return MinorType.TIMESEC;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampMicroTZHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampMicroTZHolder;
 import org.apache.arrow.vector.types.TimeUnit;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -77,8 +77,8 @@ public class TimeStampMicroTZVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPMICROTZ;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPMICROTZ;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.TimeStampMicroReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampMicroHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampMicroHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.LocalDateTime;
@@ -43,8 +43,7 @@ public class TimeStampMicroVector extends TimeStampVector {
    * @param allocator allocator for memory management.
    */
   public TimeStampMicroVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMESTAMPMICRO.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMESTAMPMICRO.getType()), allocator);
   }
 
   /**
@@ -74,8 +73,8 @@ public class TimeStampMicroVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPMICRO;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPMICRO;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampMilliTZHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampMilliTZHolder;
 import org.apache.arrow.vector.types.TimeUnit;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -77,8 +77,8 @@ public class TimeStampMilliTZVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPMILLITZ;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPMILLITZ;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.TimeStampMilliReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampMilliHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampMilliHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.LocalDateTime;
@@ -43,8 +43,7 @@ public class TimeStampMilliVector extends TimeStampVector {
    * @param allocator allocator for memory management.
    */
   public TimeStampMilliVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMESTAMPMILLI.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMESTAMPMILLI.getType()), allocator);
   }
 
   /**
@@ -74,8 +73,8 @@ public class TimeStampMilliVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPMILLI;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPMILLI;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampNanoTZHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampNanoTZHolder;
 import org.apache.arrow.vector.types.TimeUnit;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -77,8 +77,8 @@ public class TimeStampNanoTZVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPNANOTZ;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPNANOTZ;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.TimeStampNanoReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampNanoHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampNanoHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.LocalDateTime;
@@ -43,8 +43,7 @@ public class TimeStampNanoVector extends TimeStampVector {
    * @param allocator allocator for memory management.
    */
   public TimeStampNanoVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMESTAMPNANO.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMESTAMPNANO.getType()), allocator);
   }
 
   /**
@@ -74,8 +73,8 @@ public class TimeStampNanoVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPNANO;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPNANO;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.TimeStampSecTZReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampSecTZHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampSecTZHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -76,8 +76,8 @@ public class TimeStampSecTZVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPSECTZ;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPSECTZ;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.TimeStampSecReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TimeStampSecHolder;
 import org.apache.arrow.vector.holders.NullableTimeStampSecHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.joda.time.LocalDateTime;
@@ -43,8 +43,7 @@ public class TimeStampSecVector extends TimeStampVector {
    * @param allocator allocator for memory management.
    */
   public TimeStampSecVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TIMESTAMPSEC.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TIMESTAMPSEC.getType()), allocator);
   }
 
   /**
@@ -74,8 +73,8 @@ public class TimeStampSecVector extends TimeStampVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TIMESTAMPSEC;
+  public MinorType getMinorType() {
+    return MinorType.TIMESTAMPSEC;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.complex.impl.TinyIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.TinyIntHolder;
 import org.apache.arrow.vector.holders.NullableTinyIntHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -44,8 +44,7 @@ public class TinyIntVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public TinyIntVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.TINYINT.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.TINYINT.getType()), allocator);
   }
 
   /**
@@ -75,8 +74,8 @@ public class TinyIntVector extends BaseFixedWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.TINYINT;
+  public MinorType getMinorType() {
+    return MinorType.TINYINT;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -23,7 +23,7 @@ import org.apache.arrow.vector.complex.impl.UInt1ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.UInt1Holder;
 import org.apache.arrow.vector.holders.NullableUInt1Holder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -37,8 +37,7 @@ public class UInt1Vector extends BaseFixedWidthVector {
   private final FieldReader reader;
 
   public UInt1Vector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.UINT1.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.UINT1.getType()), allocator);
   }
 
   public UInt1Vector(String name, FieldType fieldType, BufferAllocator allocator) {
@@ -52,8 +51,8 @@ public class UInt1Vector extends BaseFixedWidthVector {
   }
 
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.UINT1;
+  public MinorType getMinorType() {
+    return MinorType.UINT1;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -23,10 +23,9 @@ import org.apache.arrow.vector.complex.impl.UInt2ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.UInt2Holder;
 import org.apache.arrow.vector.holders.NullableUInt2Holder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
 
 /**
  * UInt2Vector implements a fixed width (2 bytes) vector of
@@ -38,8 +37,7 @@ public class UInt2Vector extends BaseFixedWidthVector {
   private final FieldReader reader;
 
   public UInt2Vector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.UINT2.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.UINT2.getType()), allocator);
   }
 
   public UInt2Vector(String name, FieldType fieldType, BufferAllocator allocator) {
@@ -53,8 +51,8 @@ public class UInt2Vector extends BaseFixedWidthVector {
   }
 
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.UINT2;
+  public MinorType getMinorType() {
+    return MinorType.UINT2;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -23,10 +23,9 @@ import org.apache.arrow.vector.complex.impl.UInt4ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.UInt4Holder;
 import org.apache.arrow.vector.holders.NullableUInt4Holder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
 
 /**
  * UInt4Vector implements a fixed width (4 bytes) vector of
@@ -38,8 +37,7 @@ public class UInt4Vector extends BaseFixedWidthVector {
   private final FieldReader reader;
 
   public UInt4Vector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.UINT4.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.UINT4.getType()), allocator);
   }
 
   public UInt4Vector(String name, FieldType fieldType, BufferAllocator allocator) {
@@ -53,8 +51,8 @@ public class UInt4Vector extends BaseFixedWidthVector {
   }
 
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.UINT4;
+  public MinorType getMinorType() {
+    return MinorType.UINT4;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -23,10 +23,9 @@ import org.apache.arrow.vector.complex.impl.UInt8ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.UInt8Holder;
 import org.apache.arrow.vector.holders.NullableUInt8Holder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
 
 /**
  * UInt8Vector implements a fixed width vector (8 bytes) of
@@ -38,8 +37,7 @@ public class UInt8Vector extends BaseFixedWidthVector {
   private final FieldReader reader;
 
   public UInt8Vector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.UINT8.getType()),
-            allocator);
+    this(name, FieldType.nullable(MinorType.UINT8.getType()), allocator);
   }
 
   public UInt8Vector(String name, FieldType fieldType, BufferAllocator allocator) {
@@ -53,8 +51,8 @@ public class UInt8Vector extends BaseFixedWidthVector {
   }
 
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.UINT8;
+  public MinorType getMinorType() {
+    return MinorType.UINT8;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -18,17 +18,14 @@
 
 package org.apache.arrow.vector;
 
-import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.impl.VarBinaryReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.VarBinaryHolder;
 import org.apache.arrow.vector.holders.NullableVarBinaryHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-
-import java.nio.ByteBuffer;
 
 /**
  * VarBinaryVector implements a variable width vector of binary
@@ -45,7 +42,7 @@ public class VarBinaryVector extends BaseVariableWidthVector {
    * @param allocator allocator for memory management.
    */
   public VarBinaryVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(Types.MinorType.VARBINARY.getType()), allocator);
+    this(name, FieldType.nullable(MinorType.VARBINARY.getType()), allocator);
   }
 
   /**
@@ -75,8 +72,8 @@ public class VarBinaryVector extends BaseVariableWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.VARBINARY;
+  public MinorType getMinorType() {
+    return MinorType.VARBINARY;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -18,18 +18,15 @@
 
 package org.apache.arrow.vector;
 
-import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.impl.VarCharReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.VarCharHolder;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.Text;
 import org.apache.arrow.vector.util.TransferPair;
-
-import java.nio.ByteBuffer;
 
 /**
  * VarCharVector implements a variable width vector of VARCHAR
@@ -46,7 +43,7 @@ public class VarCharVector extends BaseVariableWidthVector {
    * @param allocator allocator for memory management.
    */
   public VarCharVector(String name, BufferAllocator allocator) {
-    this(name, FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()), allocator);
+    this(name, FieldType.nullable(MinorType.VARCHAR.getType()), allocator);
   }
 
   /**
@@ -76,8 +73,8 @@ public class VarCharVector extends BaseVariableWidthVector {
    * @return {@link org.apache.arrow.vector.types.Types.MinorType}
    */
   @Override
-  public Types.MinorType getMinorType() {
-    return Types.MinorType.VARCHAR;
+  public MinorType getMinorType() {
+    return MinorType.VARCHAR;
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.BufferLayout.BufferType;
 import org.apache.arrow.vector.TypeLayout;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -170,8 +170,8 @@ public class JsonFileWriter implements AutoCloseable {
         generator.writeArrayFieldStart(bufferType.getName());
         final int bufferValueCount = (bufferType.equals(OFFSET)) ? valueCount + 1 : valueCount;
         for (int i = 0; i < bufferValueCount; i++) {
-          if (bufferType.equals(DATA) && (vector.getMinorType() == Types.MinorType.VARCHAR ||
-                  vector.getMinorType() == Types.MinorType.VARBINARY)) {
+          if (bufferType.equals(DATA) && (vector.getMinorType() == MinorType.VARCHAR ||
+                  vector.getMinorType() == MinorType.VARBINARY)) {
             writeValueToGenerator(bufferType, vectorBuffer, vectorBuffers.get(v-1), vector, i);
           } else {
             writeValueToGenerator(bufferType, vectorBuffer, null, vector, i);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -20,7 +20,7 @@ package org.apache.arrow.vector;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.Types.MinorType;
 import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Before;
@@ -70,8 +70,8 @@ public class TestCopyFrom {
 
   @Test /* NullableVarChar */
   public void testCopyFromWithNulls() {
-    try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, Types.MinorType.VARCHAR, allocator);
-         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, Types.MinorType.VARCHAR, allocator)) {
+    try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator);
+         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
 
       vector.allocateNew();
       int capacity = vector.getValueCapacity();
@@ -130,8 +130,8 @@ public class TestCopyFrom {
 
   @Test /* NullableVarChar */
   public void testCopyFromWithNulls1() {
-    try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, Types.MinorType.VARCHAR, allocator);
-         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, Types.MinorType.VARCHAR, allocator)) {
+    try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator);
+         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
 
       vector.allocateNew();
       int capacity = vector.getValueCapacity();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
@@ -26,7 +26,6 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.impl.UnionFixedSizeListReader;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
 import org.apache.arrow.vector.complex.reader.FieldReader;
-import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -224,7 +223,7 @@ public class TestFixedSizeListVector {
       String emptyListStr = listVector.getField().toString();
       Assert.assertTrue(emptyListStr.contains(ListVector.DATA_VECTOR_NAME));
 
-      listVector.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
+      listVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
       String emptyVectorStr = listVector.getField().toString();
       Assert.assertTrue(emptyVectorStr.contains(ListVector.DATA_VECTOR_NAME));
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -27,7 +27,6 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.complex.reader.FieldReader;
-import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
@@ -759,7 +758,7 @@ public class TestListVector {
       String emptyListStr = listVector.getField().toString();
       assertTrue(emptyListStr.contains(ListVector.DATA_VECTOR_NAME));
 
-      listVector.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
+      listVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
       String emptyVectorStr = listVector.getField().toString();
       assertTrue(emptyVectorStr.contains(ListVector.DATA_VECTOR_NAME));
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -30,7 +30,6 @@ import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.holders.NullableIntHolder;
 import org.apache.arrow.vector.holders.NullableUInt4Holder;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
-import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.After;
@@ -65,9 +64,9 @@ public class TestUnionVector {
       unionVector.allocateNew();
 
       // write some data
-      unionVector.setType(0, Types.MinorType.UINT4);
+      unionVector.setType(0, MinorType.UINT4);
       unionVector.setSafe(0, uInt4Holder);
-      unionVector.setType(2, Types.MinorType.UINT4);
+      unionVector.setType(2, MinorType.UINT4);
       unionVector.setSafe(2, uInt4Holder);
       unionVector.setValueCount(4);
 


### PR DESCRIPTION
Cleanup usage specifying Types.MinorType to just MinorType in vector classes and tests, and removed unused imports.