### PR TITLE
ARROW-2396: [Rust] Unify Rust Errors

### DIFF
--- a/rust/src/array.rs
+++ b/rust/src/array.rs
@@ -42,7 +42,7 @@ pub enum ArrayData {
 }
 
 macro_rules! arraydata_from_primitive {
-    ($DT:ty, $AT:ident) => {
+    ($DT: ty, $AT: ident) => {
         impl From<Vec<$DT>> for ArrayData {
             fn from(v: Vec<$DT>) -> Self {
                 ArrayData::$AT(Buffer::from(v))
@@ -91,7 +91,7 @@ impl Array {
 }
 
 macro_rules! array_from_primitive {
-    ($DT:ty) => {
+    ($DT: ty) => {
         impl From<Vec<$DT>> for Array {
             fn from(v: Vec<$DT>) -> Self {
                 Array {
@@ -117,7 +117,7 @@ array_from_primitive!(i32);
 array_from_primitive!(i64);
 
 macro_rules! array_from_optional_primitive {
-    ($DT:ty, $DEFAULT:expr) => {
+    ($DT: ty, $DEFAULT: expr) => {
         impl From<Vec<Option<$DT>>> for Array {
             fn from(v: Vec<Option<$DT>>) -> Self {
                 let mut null_count = 0;

--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -92,7 +92,7 @@ where
 }
 
 macro_rules! array_from_primitive {
-    ($DT:ty) => {
+    ($DT: ty) => {
         impl From<Vec<$DT>> for Buffer<$DT> {
             fn from(v: Vec<$DT>) -> Self {
                 // allocate aligned memory buffer

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -17,11 +17,7 @@
 
 use serde_json;
 use serde_json::Value;
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum ArrowError {
-    ParseError(String),
-}
+use super::error::ArrowError;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum DataType {

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -15,17 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::convert::*;
-
-#[derive(Debug, Clone)]
-pub struct Error {
-    msg: String,
-}
-
-impl From<&'static str> for Error where {
-    fn from(msg: &'static str) -> Self {
-        Error {
-            msg: String::from(msg),
-        }
-    }
+#[derive(Debug, Clone, PartialEq)]
+pub enum ArrowError {
+    MemoryError(String),
+    ParseError(String),
 }

--- a/rust/src/memory.rs
+++ b/rust/src/memory.rs
@@ -18,17 +18,19 @@
 use libc;
 use std::mem;
 
-use super::error::Error;
+use super::error::ArrowError;
 
 const ALIGNMENT: usize = 64;
 
-pub fn allocate_aligned(size: i64) -> Result<*const u8, Error> {
+pub fn allocate_aligned(size: i64) -> Result<*const u8, ArrowError> {
     unsafe {
         let mut page: *mut libc::c_void = mem::uninitialized();
         let result = libc::posix_memalign(&mut page, ALIGNMENT, size as usize);
         match result {
             0 => Ok(mem::transmute::<*mut libc::c_void, *const u8>(page)),
-            _ => Err(Error::from("Failed to allocate memory")),
+            _ => Err(ArrowError::MemoryError(format!(
+                "Failed to allocate memory"
+            ))),
         }
     }
 }


### PR DESCRIPTION
Currently there are two Error items - one Enum and one Struct. This unifies them under a single ArrowError Enum.

Let me know any feedback

