### PR TITLE
ARROW-2401 Support filters on Hive partitioned Parquet files

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -864,7 +864,7 @@ class ParquetDataset(object):
             if p_column != f_column:
                 return True
 
-            f_value_index = self.partitions.get_index(level, p_column, f_value)
+            f_value_index = self.partitions.get_index(level, p_column, str(f_value))
             if op == "=":
                 return f_value_index == p_value_index
             elif op == "!=":

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -712,9 +712,9 @@ class ParquetDataset(object):
     validate_schema : boolean, default True
         Check that individual file schemas are all the same / compatible
     filters : List[Tuple] or None (default)
-        List of filters to apply, like ``[('x', '=', 0), ...]``. This implements
-        partition-level (hive) filtering only, i.e., to prevent the loading
-        of some files of the dataset.
+        List of filters to apply, like ``[('x', '=', 0), ...]``. This
+        implements partition-level (hive) filtering only, i.e., to prevent the
+        loading of some files of the dataset.
     """
     def __init__(self, path_or_paths, filesystem=None, schema=None,
                  metadata=None, split_row_groups=False, validate_schema=True,
@@ -864,7 +864,8 @@ class ParquetDataset(object):
             if p_column != f_column:
                 return True
 
-            f_value_index = self.partitions.get_index(level, p_column, str(f_value))
+            f_value_index = self.partitions.get_index(level, p_column,
+                                                      str(f_value))
             if op == "=":
                 return f_value_index == p_value_index
             elif op == "!=":

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -21,7 +21,6 @@ import inspect
 import json
 import re
 import six
-import itertools
 from six.moves.urllib.parse import urlparse
 # pathlib might not be available in Python 2
 try:
@@ -714,7 +713,8 @@ class ParquetDataset(object):
         Check that individual file schemas are all the same / compatible
     """
     def __init__(self, path_or_paths, filesystem=None, schema=None,
-                 metadata=None, split_row_groups=False, validate_schema=True, filters=None):
+                 metadata=None, split_row_groups=False, validate_schema=True,
+                 filters=None):
         if filesystem is None:
             a_path = path_or_paths
             if isinstance(a_path, list):
@@ -873,7 +873,7 @@ class ParquetDataset(object):
                        for level, part_key in enumerate(piece.partition_keys))
 
         def all_filters_accept(piece):
-            return all(one_filter_accepts(piece,f) for f in filters)
+            return all(one_filter_accepts(piece, f) for f in filters)
 
         self.pieces = [p for p in self.pieces if all_filters_accept(p)]
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -711,6 +711,10 @@ class ParquetDataset(object):
         Divide files into pieces for each row group in the file
     validate_schema : boolean, default True
         Check that individual file schemas are all the same / compatible
+    filters : List[Tuple] or None (default)
+        List of filters to apply, like ``[('x', '=', 0), ...]``. This implements
+        partition-level (hive) filtering only, i.e., to prevent the loading
+        of some files of the dataset.
     """
     def __init__(self, path_or_paths, filesystem=None, schema=None,
                  metadata=None, split_row_groups=False, validate_schema=True,

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1022,7 +1022,7 @@ def test_read_partitioned_directory_filtered(tmpdir):
 
     dataset = pq.ParquetDataset(
         base_path, filesystem=fs,
-        filters=[('foo', '=', '1'), ('bar', '!=', 'b')]
+        filters=[('foo', '=', 1), ('bar', '!=', 'b')]
     )
     table = dataset.read()
     result_df = (table.to_pandas()

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1020,7 +1020,10 @@ def test_read_partitioned_directory_filtered(tmpdir):
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
 
-    dataset = pq.ParquetDataset(base_path, filesystem=fs, filters=[('foo', '=', '1'), ('bar', '!=', 'b')])
+    dataset = pq.ParquetDataset(
+        base_path, filesystem=fs,
+        filters=[('foo', '=', '1'), ('bar', '!=', 'b')]
+    )
     table = dataset.read()
     result_df = (table.to_pandas()
                  .sort_values(by='index')
@@ -1028,7 +1031,6 @@ def test_read_partitioned_directory_filtered(tmpdir):
 
     assert 0 not in result_df['foo'].values
     assert 'b' not in result_df['bar'].values
-
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
This PR enables filtering based on a Hive partitioned directory structure of Parquet files. Only `=` and `!=` are supported as filters. 