### PR TITLE
ARROW-2402: [C++] Avoid spurious copies with FixedSizeBinaryBuilder

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1412,9 +1412,9 @@ TEST_F(TestFWBinaryArray, ZeroSize) {
   auto type = fixed_size_binary(0);
   FixedSizeBinaryBuilder builder(type);
 
-  ASSERT_OK(builder.Append(nullptr));
-  ASSERT_OK(builder.Append(nullptr));
-  ASSERT_OK(builder.Append(nullptr));
+  ASSERT_OK(builder.Append(""));
+  ASSERT_OK(builder.Append(std::string()));
+  ASSERT_OK(builder.Append(static_cast<const uint8_t*>(nullptr)));
   ASSERT_OK(builder.AppendNull());
   ASSERT_OK(builder.AppendNull());
   ASSERT_OK(builder.AppendNull());

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -131,6 +131,25 @@ static void BM_BuildBinaryArray(benchmark::State& state) {  // NOLINT non-const 
   state.SetBytesProcessed(state.iterations() * iterations * value.size());
 }
 
+static void BM_BuildFixedSizeBinaryArray(
+    benchmark::State& state) {  // NOLINT non-const reference
+  const int64_t iterations = 1 << 20;
+  const int width = 10;
+
+  auto type = fixed_size_binary(width);
+  const char value[width + 1] = "1234567890";
+
+  while (state.KeepRunning()) {
+    FixedSizeBinaryBuilder builder(type);
+    for (int64_t i = 0; i < iterations; i++) {
+      ABORT_NOT_OK(builder.Append(value));
+    }
+    std::shared_ptr<Array> out;
+    ABORT_NOT_OK(builder.Finish(&out));
+  }
+  state.SetBytesProcessed(state.iterations() * iterations * width);
+}
+
 BENCHMARK(BM_BuildPrimitiveArrayNoNulls)->Repetitions(3)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_BuildVectorNoNulls)->Repetitions(3)->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_BuildAdaptiveIntNoNulls)->Repetitions(3)->Unit(benchmark::kMicrosecond);
@@ -140,5 +159,6 @@ BENCHMARK(BM_BuildAdaptiveIntNoNullsScalarAppend)
 BENCHMARK(BM_BuildAdaptiveUIntNoNulls)->Repetitions(3)->Unit(benchmark::kMicrosecond);
 
 BENCHMARK(BM_BuildBinaryArray)->Repetitions(3)->Unit(benchmark::kMicrosecond);
+BENCHMARK(BM_BuildFixedSizeBinaryArray)->Repetitions(3)->Unit(benchmark::kMicrosecond);
 
 }  // namespace arrow

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1422,12 +1422,6 @@ FixedSizeBinaryBuilder::FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& 
       byte_width_(static_cast<const FixedSizeBinaryType&>(*type).byte_width()),
       byte_builder_(pool) {}
 
-Status FixedSizeBinaryBuilder::Append(const uint8_t* value) {
-  RETURN_NOT_OK(Reserve(1));
-  UnsafeAppendToBitmap(true);
-  return byte_builder_.Append(value, byte_width_);
-}
-
 Status FixedSizeBinaryBuilder::Append(const uint8_t* data, int64_t length,
                                       const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -730,7 +730,14 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& type,
                          MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
-  Status Append(const uint8_t* value);
+  Status Append(const uint8_t* value) {
+    RETURN_NOT_OK(Reserve(1));
+    UnsafeAppendToBitmap(true);
+    return byte_builder_.Append(value, byte_width_);
+  }
+  Status Append(const char* value) {
+    return Append(reinterpret_cast<const uint8_t*>(value));
+  }
 
   template <size_t NBYTES>
   Status Append(const std::array<uint8_t, NBYTES>& value) {


### PR DESCRIPTION
The lack of a FixedSizeBinaryBuilder::Append() overload for "const char*" implied a temporary conversion to std::string.