### PR TITLE
ARROW-2411: [C++] Add StringBuilder::Append(const char **values)

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1023,7 +1023,7 @@ TEST_F(TestStringBuilder, TestAppendVector) {
 }
 
 TEST_F(TestStringBuilder, TestAppendCStringsWithValidBytes) {
-  const char* strings[] = {nullptr, "", "a", nullptr, "ccc"};
+  const char* strings[] = {nullptr, "aaa", nullptr, "ignored", ""};
   vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
 
   int N = static_cast<int>(sizeof(strings) / sizeof(strings[0]));
@@ -1035,24 +1035,19 @@ TEST_F(TestStringBuilder, TestAppendCStringsWithValidBytes) {
   Done();
 
   ASSERT_EQ(reps * N, result_->length());
-  ASSERT_EQ(reps, result_->null_count());
-  ASSERT_EQ(reps * 4, result_->value_data()->size());
+  ASSERT_EQ(reps * 3, result_->null_count());
+  ASSERT_EQ(reps * 3, result_->value_data()->size());
 
   int32_t length;
   int32_t pos = 0;
   for (int i = 0; i < N * reps; ++i) {
-    if (valid_bytes[i % N]) {
+    auto string = strings[i % N];
+    if (string && valid_bytes[i % N]) {
       ASSERT_FALSE(result_->IsNull(i));
       result_->GetValue(i, &length);
       ASSERT_EQ(pos, result_->value_offset(i));
-      auto string = strings[i % N];
-      if (string) {
-        ASSERT_EQ(static_cast<int32_t>(strlen(strings[i % N])), length);
-        ASSERT_EQ(strings[i % N], result_->GetString(i));
-      } else {
-        ASSERT_EQ(0, length);
-        ASSERT_EQ("", result_->GetString(i));
-      }
+      ASSERT_EQ(static_cast<int32_t>(strlen(string)), length);
+      ASSERT_EQ(strings[i % N], result_->GetString(i));
 
       pos += length;
     } else {

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1036,7 +1036,7 @@ TEST_F(TestStringBuilder, TestAppendCStringsWithValidBytes) {
 
   ASSERT_EQ(reps * N, result_->length());
   ASSERT_EQ(reps, result_->null_count());
-  ASSERT_EQ(reps * 6, result_->value_data()->size());
+  ASSERT_EQ(reps * 4, result_->value_data()->size());
 
   int32_t length;
   int32_t pos = 0;

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1022,6 +1022,39 @@ TEST_F(TestStringBuilder, TestAppendVector) {
   }
 }
 
+TEST_F(TestStringBuilder, TestAppendCStrings) {
+  const char* strings[] = {"", "bb", "a", nullptr, "ccc"};
+  vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
+
+  int N = static_cast<int>(sizeof(strings) / sizeof(strings[0]));
+  int reps = 1000;
+
+  for (int j = 0; j < reps; ++j) {
+    ASSERT_OK(builder_->Append(strings, N, valid_bytes.data()));
+  }
+  Done();
+
+  ASSERT_EQ(reps * N, result_->length());
+  ASSERT_EQ(reps, result_->null_count());
+  ASSERT_EQ(reps * 6, result_->value_data()->size());
+
+  int32_t length;
+  int32_t pos = 0;
+  for (int i = 0; i < N * reps; ++i) {
+    if (valid_bytes[i % N]) {
+      ASSERT_FALSE(result_->IsNull(i));
+      result_->GetValue(i, &length);
+      ASSERT_EQ(pos, result_->value_offset(i));
+      ASSERT_EQ(static_cast<int32_t>(strlen(strings[i % N])), length);
+      ASSERT_EQ(strings[i % N], result_->GetString(i));
+
+      pos += length;
+    } else {
+      ASSERT_TRUE(result_->IsNull(i));
+    }
+  }
+}
+
 TEST_F(TestStringBuilder, TestZeroLength) {
   // All buffers are null
   Done();

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1413,8 +1413,7 @@ Status StringBuilder::Append(const std::vector<std::string>& values,
   return Status::OK();
 }
 
-Status StringBuilder::Append(const char** values,
-                             int64_t length,
+Status StringBuilder::Append(const char** values, int64_t length,
                              const uint8_t* valid_bytes) {
   std::size_t total_length = 0;
   std::vector<std::size_t> value_lengths(length);

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1418,11 +1418,14 @@ Status StringBuilder::Append(const char** values,
                              const uint8_t* valid_bytes) {
   std::size_t total_length = 0;
   std::vector<std::size_t> value_lengths(length);
+  bool have_null_value = false;
   for (int64_t i = 0; i < length; ++i) {
     if (values[i]) {
       auto value_length = strlen(values[i]);
       value_lengths[i] = value_length;
       total_length += value_length;
+    } else {
+      have_null_value = true;
     }
   }
   RETURN_NOT_OK(Reserve(length));
@@ -1437,14 +1440,28 @@ Status StringBuilder::Append(const char** values,
             reinterpret_cast<const uint8_t*>(values[i]), value_lengths[i]));
       }
     }
+    UnsafeAppendToBitmap(valid_bytes, length);
   } else {
-    for (int64_t i = 0; i < length; ++i) {
-      RETURN_NOT_OK(AppendNextOffset());
-      RETURN_NOT_OK(value_data_builder_.Append(
-          reinterpret_cast<const uint8_t*>(values[i]), value_lengths[i]));
+    if (have_null_value) {
+      std::vector<uint8_t> valid_vector(length, 0);
+      for (int64_t i = 0; i < length; ++i) {
+        RETURN_NOT_OK(AppendNextOffset());
+        if (values[i]) {
+          RETURN_NOT_OK(value_data_builder_.Append(
+              reinterpret_cast<const uint8_t*>(values[i]), value_lengths[i]));
+          valid_vector[i] = 1;
+        }
+      }
+      UnsafeAppendToBitmap(valid_vector.data(), length);
+    } else {
+      for (int64_t i = 0; i < length; ++i) {
+        RETURN_NOT_OK(AppendNextOffset());
+        RETURN_NOT_OK(value_data_builder_.Append(
+            reinterpret_cast<const uint8_t*>(values[i]), value_lengths[i]));
+      }
+      UnsafeAppendToBitmap(nullptr, length);
     }
   }
-  UnsafeAppendToBitmap(valid_bytes, length);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -721,8 +721,8 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status Append(const std::vector<std::string>& values,
                 const uint8_t* valid_bytes = NULLPTR);
 
-  /// \brief Append a sequence of C strings in one shot
-  /// \param[in] values a contiguous C array of C strings
+  /// \brief Append a sequence of nul-terminated char * in one shot
+  /// \param[in] values a contiguous C array of nul-terminated char *
   /// \param[in] length the number of values to append
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -720,6 +720,16 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
 
   Status Append(const std::vector<std::string>& values,
                 const uint8_t* valid_bytes = NULLPTR);
+
+  /// \brief Append a sequence of C strings in one shot
+  /// \param[in] values a contiguous C array of C strings
+  /// \param[in] length the number of values to append
+  /// \param[in] valid_bytes an optional sequence of bytes where non-zero
+  /// indicates a valid (non-null) value
+  /// \return Status
+  Status Append(const char** values,
+                int64_t length,
+                const uint8_t* valid_bytes = NULLPTR);
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -727,8 +727,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value
   /// \return Status
-  Status Append(const char** values,
-                int64_t length,
+  Status Append(const char** values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 };
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -721,7 +721,10 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status Append(const std::vector<std::string>& values,
                 const uint8_t* valid_bytes = NULLPTR);
 
-  /// \brief Append a sequence of nul-terminated char * in one shot
+  /// \brief Append a sequence of nul-terminated char * in one shot.
+  ///        If values has NULL, the value is processed as a null value
+  ///        even when valid_bytes of the value is 1.
+  ///
   /// \param[in] values a contiguous C array of nul-terminated char *
   /// \param[in] length the number of values to append
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -721,9 +721,9 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status Append(const std::vector<std::string>& values,
                 const uint8_t* valid_bytes = NULLPTR);
 
-  /// \brief Append a sequence of nul-terminated char * in one shot.
-  ///        If values has NULL, the value is processed as a null value
-  ///        even when valid_bytes of the value is 1.
+  /// \brief Append a sequence of nul-terminated strings in one shot.
+  ///        If one of the values is NULL, it is processed as a null
+  ///        value even if the corresponding valid_bytes entry is 1.
   ///
   /// \param[in] values a contiguous C array of nul-terminated char *
   /// \param[in] length the number of values to append


### PR DESCRIPTION
This implementation uses not NULL-terminated C strings and the length of values instead of NULL-terminated C strings. Because other builder uses the interface such as `PrimitiveBuilder::Append()`.