### PR TITLE
ARROW-2419: [Site] Hard-code timezone

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -18,6 +18,7 @@ permalink: /blog/:year/:month/:day/:title/
 repository: https://github.com/apache/arrow
 destination: build
 excerpt_separator: ""
+timezone: America/New_York
 
 kramdown:
   input: GFM


### PR DESCRIPTION
This avoids generating blog posts with different local times and dates depending on where the committer generating the Website is located.