### PR TITLE
ARROW-2422: Support more operators for partition filtering

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -864,12 +864,23 @@ class ParquetDataset(object):
             if p_column != f_column:
                 return True
 
-            f_value_index = self.partitions.get_index(level, p_column,
-                                                      str(f_value))
+            p_value = (self.partitions
+                       .levels[level]
+                       .dictionary[p_value_index]
+                       .as_py())
+
             if op == "=":
-                return f_value_index == p_value_index
+                return p_value == f_value
             elif op == "!=":
-                return f_value_index != p_value_index
+                return p_value != f_value
+            elif op == '<':
+                return p_value < f_value
+            elif op == '>':
+                return p_value > f_value
+            elif op == '<=':
+                return p_value <= f_value
+            elif op == '>=':
+                return p_value >= f_value
             else:
                 return True
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -867,10 +867,9 @@ class ParquetDataset(object):
 
             f_type = type(f_value)
             p_value = f_type((self.partitions
-                       .levels[level]
-                       .dictionary[p_value_index]
-                       .as_py()))
-            
+                                  .levels[level]
+                                  .dictionary[p_value_index]
+                                  .as_py()))
 
             if op == "=" or op == "==":
                 return p_value == f_value

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -859,17 +859,20 @@ class ParquetDataset(object):
 
     def _filter(self, filters):
         def filter_accepts_partition(part_key, filter, level):
+
             p_column, p_value_index = part_key
             f_column, op, f_value = filter
             if p_column != f_column:
                 return True
 
-            p_value = (self.partitions
+            f_type = type(f_value)
+            p_value = f_type((self.partitions
                        .levels[level]
                        .dictionary[p_value_index]
-                       .as_py())
+                       .as_py()))
+            
 
-            if op == "=":
+            if op == "=" or op == "==":
                 return p_value == f_value
             elif op == "!=":
                 return p_value != f_value
@@ -882,7 +885,7 @@ class ParquetDataset(object):
             elif op == '>=':
                 return p_value >= f_value
             else:
-                return True
+                raise ValueError("'%s' is not a valid operator in predicates.")
 
         def one_filter_accepts(piece, filter):
             return all(filter_accepts_partition(part_key, filter, level)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -883,7 +883,8 @@ class ParquetDataset(object):
             elif op == '>=':
                 return p_value >= f_value
             else:
-                raise ValueError("'%s' is not a valid operator in predicates.")
+                raise ValueError("'%s' is not a valid operator in predicates.",
+                                 filter[1])
 
         def one_filter_accepts(piece, filter):
             return all(filter_accepts_partition(part_key, filter, level)

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1016,15 +1016,20 @@ class TestParquetFilter:
 
         df = pd.DataFrame({
             'integer': np.array(integer_keys, dtype='i4').repeat(15),
-            'string': np.tile(np.tile(np.array(string_keys, dtype=object), 5), 2),
-            'boolean': np.tile(np.tile(np.array(boolean_keys, dtype='bool'), 5), 3),
+            'string': np.tile(np.tile(np.array(string_keys,
+                                               dtype=object
+                                               ), 5), 2),
+            'boolean': np.tile(np.tile(np.array(boolean_keys,
+                                                dtype='bool'
+                                                ), 5), 3),
         }, columns=['integer', 'string', 'boolean'])
 
         _generate_partition_directories(fs, base_path, partition_spec, df)
 
         dataset = pq.ParquetDataset(
             base_path, filesystem=fs,
-            filters=[('integer', '=', 1), ('string', '!=', 'b'), ('boolean', '==', True)]
+            filters=[('integer', '=', 1), ('string', '!=', 'b'),
+                     ('boolean', '==', True)]
         )
         table = dataset.read()
         result_df = (table.to_pandas()
@@ -1069,7 +1074,8 @@ class TestParquetFilter:
         assert result_list == [2, 3]
 
     @pytest.mark.xfail(
-        raises=TypeError, reason='We suspect loss of type information in creation of categoricals.'
+        raises=TypeError,
+        reason='Loss of type information in creation of categoricals.'
     )
     def test_cutoff_exclusive_datetime(tmpdir):
         fs = LocalFileSystem.get_instance()

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1139,8 +1139,8 @@ class TestParquetFilter:
         dataset = pq.ParquetDataset(
             base_path, filesystem=fs,
             filters=[
-                ('foo', '<=', 3),
-                ('foo', '>=', 2),
+                ('integers', '<=', 3),
+                ('integers', '>=', 2),
             ]
         )
         table = dataset.read()
@@ -1148,7 +1148,7 @@ class TestParquetFilter:
                      .sort_values(by='index')
                      .reset_index(drop=True))
 
-        result_list = [x for x in map(int, result_df['foo'].values)]
+        result_list = [int(x) for x in map(int, result_df['integers'].values)]
         assert result_list == [2, 3]
 
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1039,12 +1039,9 @@ def test_equivalency(tmpdir):
 
     df = pd.DataFrame({
         'integer': np.array(integer_keys, dtype='i4').repeat(15),
-        'string': np.tile(np.tile(np.array(string_keys,
-                                            dtype=object
-                                            ), 5), 2),
-        'boolean': np.tile(np.tile(np.array(boolean_keys,
-                                            dtype='bool'
-                                            ), 5), 3),
+        'string': np.tile(np.tile(np.array(string_keys, dtype=object), 5), 2),
+        'boolean': np.tile(np.tile(np.array(boolean_keys, dtype='bool'), 5),
+                           3),
     }, columns=['integer', 'string', 'boolean'])
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
@@ -1052,17 +1049,16 @@ def test_equivalency(tmpdir):
     dataset = pq.ParquetDataset(
         base_path, filesystem=fs,
         filters=[('integer', '=', 1), ('string', '!=', 'b'),
-                    ('boolean', '==', True)]
+                 ('boolean', '==', True)]
     )
     table = dataset.read()
-    result_df = (table.to_pandas()
-                    .reset_index(drop=True))
+    result_df = (table.to_pandas().reset_index(drop=True))
 
     assert 0 not in result_df['integer'].values
     assert 'b' not in result_df['string'].values
     assert False not in result_df['boolean'].values
 
-    @parquet 
+    @parquet
     def test_cutoff_exclusive_integer(tmpdir):
         fs = LocalFileSystem.get_instance()
         base_path = str(tmpdir)
@@ -1091,11 +1087,12 @@ def test_equivalency(tmpdir):
         )
         table = dataset.read()
         result_df = (table.to_pandas()
-                        .sort_values(by='index')
-                        .reset_index(drop=True))
+                          .sort_values(by='index')
+                          .reset_index(drop=True))
 
         result_list = [x for x in map(int, result_df['integers'].values)]
         assert result_list == [2, 3]
+
 
 @parquet
 @pytest.mark.xfail(
@@ -1136,14 +1133,15 @@ def test_cutoff_exclusive_datetime(tmpdir):
     )
     table = dataset.read()
     result_df = (table.to_pandas()
-                    .sort_values(by='index')
-                    .reset_index(drop=True))
+                      .sort_values(by='index')
+                      .reset_index(drop=True))
 
     expected = pd.Categorical(
         np.array([datetime.date(2018, 4, 11)], dtype='datetime64'),
         categories=np.array(date_keys, dtype='datetime64'))
 
     assert result_df['dates'].values == expected
+
 
 @parquet
 def test_inclusive_integer(tmpdir):
@@ -1174,8 +1172,8 @@ def test_inclusive_integer(tmpdir):
     )
     table = dataset.read()
     result_df = (table.to_pandas()
-                    .sort_values(by='index')
-                    .reset_index(drop=True))
+                      .sort_values(by='index')
+                      .reset_index(drop=True))
 
     result_list = [int(x) for x in map(int, result_df['integers'].values)]
     assert result_list == [2, 3]

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1013,14 +1013,12 @@ class TestParquetFilter:
             ['string', string_keys],
             ['boolean', boolean_keys]
         ]
-        N = 30
 
         df = pd.DataFrame({
-            'index': np.arange(N),
             'integer': np.array(integer_keys, dtype='i4').repeat(15),
             'string': np.tile(np.tile(np.array(string_keys, dtype=object), 5), 2),
             'boolean': np.tile(np.tile(np.array(boolean_keys, dtype='bool'), 5), 3),
-        }, columns=['index', 'integer', 'string', 'boolean'])
+        }, columns=['integer', 'string', 'boolean'])
 
         _generate_partition_directories(fs, base_path, partition_spec, df)
 
@@ -1030,7 +1028,6 @@ class TestParquetFilter:
         )
         table = dataset.read()
         result_df = (table.to_pandas()
-                     .sort_values(by='index')
                      .reset_index(drop=True))
 
         assert 0 not in result_df['integer'].values

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1003,33 +1003,37 @@ def test_read_partitioned_directory_filtered_equivalency(tmpdir):
 
     import pyarrow.parquet as pq
 
-    foo_keys = [0, 1]
-    bar_keys = ['a', 'b', 'c']
+    integer_keys = [0, 1]
+    string_keys = ['a', 'b', 'c']
+    boolean_keys = [True, False]
     partition_spec = [
-        ['foo', foo_keys],
-        ['bar', bar_keys]
+        ['integer', integer_keys],
+        ['string', string_keys],
+        ['boolean', boolean_keys]
     ]
     N = 30
 
     df = pd.DataFrame({
         'index': np.arange(N),
-        'foo': np.array(foo_keys, dtype='i4').repeat(15),
-        'bar': np.tile(np.tile(np.array(bar_keys, dtype=object), 5), 2),
-    }, columns=['index', 'foo', 'bar'])
+        'integer': np.array(integer_keys, dtype='i4').repeat(15),
+        'string': np.tile(np.tile(np.array(string_keys, dtype=object), 5), 2),
+        'boolean': np.tile(np.tile(np.array(boolean_keys, dtype='bool'), 5), 3),
+    }, columns=['index', 'integer', 'string', 'boolean'])
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
 
     dataset = pq.ParquetDataset(
         base_path, filesystem=fs,
-        filters=[('foo', '=', 1), ('bar', '!=', 'b')]
+        filters=[('integer', '=', 1), ('string', '!=', 'b'), ('boolean', '==', True)]
     )
     table = dataset.read()
     result_df = (table.to_pandas()
                  .sort_values(by='index')
                  .reset_index(drop=True))
 
-    assert 0 not in result_df['foo'].values
-    assert 'b' not in result_df['bar'].values
+    assert 0 not in result_df['integer'].values
+    assert 'b' not in result_df['string'].values
+    assert False not in result_df['boolean'].values
 
 
 @parquet
@@ -1039,24 +1043,35 @@ def test_read_partitioned_directory_filtered_cutoff_exclusive(tmpdir):
 
     import pyarrow.parquet as pq
 
-    foo_keys = [0, 1, 2, 3, 4]
+    integer_keys = [0, 1, 2, 3, 4]
+    date_keys = [
+        datetime.date(2018, 4, 9),
+        datetime.date(2018, 4, 10),
+        datetime.date(2018, 4, 11),
+        datetime.date(2018, 4, 12),
+        datetime.date(2018, 4, 13)
+    ]
     partition_spec = [
-        ['foo', foo_keys]
+        ['integers', integer_keys],
+        ['dates', date_keys]
     ]
     N = 5
 
     df = pd.DataFrame({
         'index': np.arange(N),
-        'foo': np.array(foo_keys, dtype='i4'),
-    }, columns=['index', 'foo'])
+        'integers': np.array(integer_keys, dtype='i4'),
+        'dates': np.array(date_keys, dtype='datetime64'),
+    }, columns=['index', 'integers', 'dates'])
 
     _generate_partition_directories(fs, base_path, partition_spec, df)
 
     dataset = pq.ParquetDataset(
         base_path, filesystem=fs,
         filters=[
-            ('foo', '<', 4),
-            ('foo', '>', 1),
+            # ('integers', '<', 4),
+            # ('integers', '>', 1),
+            ('dates', '<', "2018-04-12"),
+            ('dates', '>', "2018-04-10")
         ]
     )
     table = dataset.read()
@@ -1064,8 +1079,10 @@ def test_read_partitioned_directory_filtered_cutoff_exclusive(tmpdir):
                  .sort_values(by='index')
                  .reset_index(drop=True))
 
-    result_list = [x for x in map(int, result_df['foo'].values)]
+    result_list = [x for x in map(int, result_df['integers'].values)]
     assert result_list == [2, 3]
+
+    assert result_df['dates'].dates == [datetime.date(2018, 4, 11)]
 
 
 @parquet

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -997,128 +997,159 @@ def test_read_partitioned_directory(tmpdir):
 
 
 @parquet
-def test_read_partitioned_directory_filtered_equivalency(tmpdir):
-    fs = LocalFileSystem.get_instance()
-    base_path = str(tmpdir)
+class TestParquetFilter:
 
-    import pyarrow.parquet as pq
+    def test_equivalency(tmpdir):
+        fs = LocalFileSystem.get_instance()
+        base_path = str(tmpdir)
 
-    integer_keys = [0, 1]
-    string_keys = ['a', 'b', 'c']
-    boolean_keys = [True, False]
-    partition_spec = [
-        ['integer', integer_keys],
-        ['string', string_keys],
-        ['boolean', boolean_keys]
-    ]
-    N = 30
+        import pyarrow.parquet as pq
 
-    df = pd.DataFrame({
-        'index': np.arange(N),
-        'integer': np.array(integer_keys, dtype='i4').repeat(15),
-        'string': np.tile(np.tile(np.array(string_keys, dtype=object), 5), 2),
-        'boolean': np.tile(np.tile(np.array(boolean_keys, dtype='bool'), 5), 3),
-    }, columns=['index', 'integer', 'string', 'boolean'])
-
-    _generate_partition_directories(fs, base_path, partition_spec, df)
-
-    dataset = pq.ParquetDataset(
-        base_path, filesystem=fs,
-        filters=[('integer', '=', 1), ('string', '!=', 'b'), ('boolean', '==', True)]
-    )
-    table = dataset.read()
-    result_df = (table.to_pandas()
-                 .sort_values(by='index')
-                 .reset_index(drop=True))
-
-    assert 0 not in result_df['integer'].values
-    assert 'b' not in result_df['string'].values
-    assert False not in result_df['boolean'].values
-
-
-@parquet
-def test_read_partitioned_directory_filtered_cutoff_exclusive(tmpdir):
-    fs = LocalFileSystem.get_instance()
-    base_path = str(tmpdir)
-
-    import pyarrow.parquet as pq
-
-    integer_keys = [0, 1, 2, 3, 4]
-    date_keys = [
-        datetime.date(2018, 4, 9),
-        datetime.date(2018, 4, 10),
-        datetime.date(2018, 4, 11),
-        datetime.date(2018, 4, 12),
-        datetime.date(2018, 4, 13)
-    ]
-    partition_spec = [
-        ['integers', integer_keys],
-        ['dates', date_keys]
-    ]
-    N = 5
-
-    df = pd.DataFrame({
-        'index': np.arange(N),
-        'integers': np.array(integer_keys, dtype='i4'),
-        'dates': np.array(date_keys, dtype='datetime64'),
-    }, columns=['index', 'integers', 'dates'])
-
-    _generate_partition_directories(fs, base_path, partition_spec, df)
-
-    dataset = pq.ParquetDataset(
-        base_path, filesystem=fs,
-        filters=[
-            # ('integers', '<', 4),
-            # ('integers', '>', 1),
-            ('dates', '<', "2018-04-12"),
-            ('dates', '>', "2018-04-10")
+        integer_keys = [0, 1]
+        string_keys = ['a', 'b', 'c']
+        boolean_keys = [True, False]
+        partition_spec = [
+            ['integer', integer_keys],
+            ['string', string_keys],
+            ['boolean', boolean_keys]
         ]
-    )
-    table = dataset.read()
-    result_df = (table.to_pandas()
-                 .sort_values(by='index')
-                 .reset_index(drop=True))
+        N = 30
 
-    result_list = [x for x in map(int, result_df['integers'].values)]
-    assert result_list == [2, 3]
+        df = pd.DataFrame({
+            'index': np.arange(N),
+            'integer': np.array(integer_keys, dtype='i4').repeat(15),
+            'string': np.tile(np.tile(np.array(string_keys, dtype=object), 5), 2),
+            'boolean': np.tile(np.tile(np.array(boolean_keys, dtype='bool'), 5), 3),
+        }, columns=['index', 'integer', 'string', 'boolean'])
 
-    assert result_df['dates'].dates == [datetime.date(2018, 4, 11)]
+        _generate_partition_directories(fs, base_path, partition_spec, df)
 
+        dataset = pq.ParquetDataset(
+            base_path, filesystem=fs,
+            filters=[('integer', '=', 1), ('string', '!=', 'b'), ('boolean', '==', True)]
+        )
+        table = dataset.read()
+        result_df = (table.to_pandas()
+                     .sort_values(by='index')
+                     .reset_index(drop=True))
 
-@parquet
-def test_read_partitioned_directory_filtered_cutoff_inclusive(tmpdir):
-    fs = LocalFileSystem.get_instance()
-    base_path = str(tmpdir)
+        assert 0 not in result_df['integer'].values
+        assert 'b' not in result_df['string'].values
+        assert False not in result_df['boolean'].values
 
-    import pyarrow.parquet as pq
+    def test_cutoff_exclusive_integer(tmpdir):
+        fs = LocalFileSystem.get_instance()
+        base_path = str(tmpdir)
 
-    foo_keys = [0, 1, 2, 3, 4]
-    partition_spec = [
-        ['foo', foo_keys]
-    ]
-    N = 5
+        import pyarrow.parquet as pq
 
-    df = pd.DataFrame({
-        'index': np.arange(N),
-        'foo': np.array(foo_keys, dtype='i4'),
-    }, columns=['index', 'foo'])
-
-    _generate_partition_directories(fs, base_path, partition_spec, df)
-
-    dataset = pq.ParquetDataset(
-        base_path, filesystem=fs,
-        filters=[
-            ('foo', '<=', 3),
-            ('foo', '>=', 2),
+        integer_keys = [0, 1, 2, 3, 4]
+        partition_spec = [
+            ['integers', integer_keys],
         ]
-    )
-    table = dataset.read()
-    result_df = (table.to_pandas()
-                 .sort_values(by='index')
-                 .reset_index(drop=True))
+        N = 5
 
-    result_list = [x for x in map(int, result_df['foo'].values)]
-    assert result_list == [2, 3]
+        df = pd.DataFrame({
+            'index': np.arange(N),
+            'integers': np.array(integer_keys, dtype='i4'),
+        }, columns=['index', 'integers'])
+
+        _generate_partition_directories(fs, base_path, partition_spec, df)
+
+        dataset = pq.ParquetDataset(
+            base_path, filesystem=fs,
+            filters=[
+                ('integers', '<', 4),
+                ('integers', '>', 1),
+            ]
+        )
+        table = dataset.read()
+        result_df = (table.to_pandas()
+                     .sort_values(by='index')
+                     .reset_index(drop=True))
+
+        result_list = [x for x in map(int, result_df['integers'].values)]
+        assert result_list == [2, 3]
+
+    @pytest.mark.xfail(
+        raises=TypeError, reason='We suspect loss of type information in creation of categoricals.'
+    )
+    def test_cutoff_exclusive_datetime(tmpdir):
+        fs = LocalFileSystem.get_instance()
+        base_path = str(tmpdir)
+
+        import pyarrow.parquet as pq
+
+        date_keys = [
+            datetime.date(2018, 4, 9),
+            datetime.date(2018, 4, 10),
+            datetime.date(2018, 4, 11),
+            datetime.date(2018, 4, 12),
+            datetime.date(2018, 4, 13)
+        ]
+        partition_spec = [
+            ['dates', date_keys]
+        ]
+        N = 5
+
+        df = pd.DataFrame({
+            'index': np.arange(N),
+            'dates': np.array(date_keys, dtype='datetime64'),
+        }, columns=['index', 'dates'])
+
+        _generate_partition_directories(fs, base_path, partition_spec, df)
+
+        dataset = pq.ParquetDataset(
+            base_path, filesystem=fs,
+            filters=[
+                ('dates', '<', "2018-04-12"),
+                ('dates', '>', "2018-04-10")
+            ]
+        )
+        table = dataset.read()
+        result_df = (table.to_pandas()
+                     .sort_values(by='index')
+                     .reset_index(drop=True))
+
+        expected = pd.Categorical(
+            np.array([datetime.date(2018, 4, 11)], dtype='datetime64'),
+            categories=np.array(date_keys, dtype='datetime64'))
+
+        assert result_df['dates'].values == expected
+
+    def test_inclusive_integer(tmpdir):
+        fs = LocalFileSystem.get_instance()
+        base_path = str(tmpdir)
+
+        import pyarrow.parquet as pq
+
+        integer_keys = [0, 1, 2, 3, 4]
+        partition_spec = [
+            ['integers', integer_keys],
+        ]
+        N = 5
+
+        df = pd.DataFrame({
+            'index': np.arange(N),
+            'integers': np.array(integer_keys, dtype='i4'),
+        }, columns=['index', 'integers'])
+
+        _generate_partition_directories(fs, base_path, partition_spec, df)
+
+        dataset = pq.ParquetDataset(
+            base_path, filesystem=fs,
+            filters=[
+                ('foo', '<=', 3),
+                ('foo', '>=', 2),
+            ]
+        )
+        table = dataset.read()
+        result_df = (table.to_pandas()
+                     .sort_values(by='index')
+                     .reset_index(drop=True))
+
+        result_list = [x for x in map(int, result_df['foo'].values)]
+        assert result_list == [2, 3]
 
 
 @pytest.yield_fixture


### PR DESCRIPTION
This extends the functionality of https://github.com/apache/arrow/pull/1840, by adding support for '<', '>', '<=', '>=' comparison operators in filters.