### PR TITLE
ARROW-2305: [Python] Bump Cython requirement to 0.27+

### DIFF
--- a/ci/msvc-build.bat
+++ b/ci/msvc-build.bat
@@ -68,10 +68,8 @@ if "%JOB%" == "Build_Debug" (
   exit /B 0
 )
 
-@rem Note: avoid Cython 0.28.0 due to https://github.com/cython/cython/issues/2148
 conda create -n arrow -q -y python=%PYTHON% ^
-      six pytest setuptools numpy pandas ^
-      cython=0.27.3 ^
+      six pytest setuptools numpy pandas cython ^
       thrift-cpp=0.11.0
 
 call activate arrow

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -36,13 +36,12 @@ source activate $CONDA_ENV_DIR
 python --version
 which python
 
-# Note: avoid Cython 0.28.0 due to https://github.com/cython/cython/issues/2148
 conda install -y -q pip \
       nomkl \
       cloudpickle \
       numpy=1.13.1 \
       pandas \
-      cython=0.27.3
+      cython
 
 # ARROW-2093: PyTorch increases the size of our conda dependency stack
 # significantly, and so we have disabled these tests in Travis CI for now

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -104,7 +104,7 @@ setup_miniconda() {
         numpy \
         pandas \
         six \
-        cython=0.27.3 -c conda-forge
+        cython -c conda-forge
   source activate arrow-test
 }
 

--- a/python/manylinux1/scripts/build_virtualenvs.sh
+++ b/python/manylinux1/scripts/build_virtualenvs.sh
@@ -34,7 +34,7 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
 
     echo "=== (${PYTHON}, ${U_WIDTH}) Installing build dependencies ==="
     $PIP install "numpy==1.10.4"
-    $PIP install "cython==0.27.3"
+    $PIP install "cython==0.28.1"
     $PIP install "pandas==0.20.3"
     $PIP install "virtualenv==15.1.0"
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,8 +42,8 @@ from distutils import sysconfig
 # Check if we're running 64-bit Python
 is_64_bit = sys.maxsize > 2**32
 
-if Cython.__version__ < '0.19.1':
-    raise Exception('Please upgrade to Cython 0.19.1 or newer')
+if Cython.__version__ < '0.27':
+    raise Exception('Please upgrade to Cython 0.27 or newer')
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -491,7 +491,7 @@ setup(
         ]
     },
     use_scm_version={"root": "..", "relative_to": __file__, "parse": parse_version},
-    setup_requires=['setuptools_scm', 'cython >= 0.23'] + setup_requires,
+    setup_requires=['setuptools_scm', 'cython >= 0.27'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas'],
     description="Python library for Apache Arrow",


### PR DESCRIPTION
Starting with Cython 0.27, it's possible to implement comparisons using `__eq__` and friends instead of `__richcmp__`: http://docs.cython.org/en/latest/src/changes.html#id16