### PR TITLE
ARROW-2424: [Rust] Fix build - add missing import

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -18,6 +18,7 @@
 use libc;
 use std::mem;
 use std::ptr;
+use std::slice;
 
 use super::buffer::*;
 use super::memory::*;


### PR DESCRIPTION
@pitrou recent merges broke the build somehow - this fixes it