### PR TITLE
ARROW-2427: [C++] Implement ReadAt properly

### DIFF
--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -125,9 +125,7 @@ class OSFile {
   }
 
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) {
-    std::lock_guard<std::mutex> guard(lock_);
-    RETURN_NOT_OK(Seek(position));
-    return Read(nbytes, bytes_read, out);
+    return internal::FileReadAt(fd_, reinterpret_cast<uint8_t*>(out), position, nbytes, bytes_read);
   }
 
   Status Seek(int64_t pos) {
@@ -203,6 +201,19 @@ class ReadableFile::ReadableFileImpl : public OSFile {
     return Status::OK();
   }
 
+  Status ReadBufferAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) {
+    std::shared_ptr<ResizableBuffer> buffer;
+    RETURN_NOT_OK(AllocateResizableBuffer(pool_, nbytes, &buffer));
+
+    int64_t bytes_read = 0;
+    RETURN_NOT_OK(ReadAt(position, nbytes, &bytes_read, buffer->mutable_data()));
+    if (bytes_read < nbytes) {
+      RETURN_NOT_OK(buffer->Resize(bytes_read));
+    }
+    *out = buffer;
+    return Status::OK();
+  }
+
  private:
   MemoryPool* pool_;
 };
@@ -247,9 +258,7 @@ Status ReadableFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_rea
 
 Status ReadableFile::ReadAt(int64_t position, int64_t nbytes,
                             std::shared_ptr<Buffer>* out) {
-  std::lock_guard<std::mutex> guard(impl_->lock());
-  RETURN_NOT_OK(Seek(position));
-  return impl_->ReadBuffer(nbytes, out);
+  return impl_->ReadBufferAt(position, nbytes, out);
 }
 
 Status ReadableFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
@@ -459,42 +468,38 @@ Status MemoryMappedFile::Close() {
   return Status::OK();
 }
 
-Status MemoryMappedFile::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
-  nbytes = std::max<int64_t>(
-      0, std::min(nbytes, memory_map_->size() - memory_map_->position()));
-  if (nbytes > 0) {
-    std::memcpy(out, memory_map_->head(), static_cast<size_t>(nbytes));
-  }
-  *bytes_read = nbytes;
-  memory_map_->advance(nbytes);
-  return Status::OK();
-}
-
-Status MemoryMappedFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
-  nbytes = std::max<int64_t>(
-      0, std::min(nbytes, memory_map_->size() - memory_map_->position()));
-
-  if (nbytes > 0) {
-    *out = SliceBuffer(memory_map_, memory_map_->position(), nbytes);
-  } else {
-    *out = std::make_shared<Buffer>(nullptr, 0);
-  }
-  memory_map_->advance(nbytes);
-  return Status::OK();
-}
-
 Status MemoryMappedFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                                 void* out) {
-  std::lock_guard<std::mutex> guard(memory_map_->lock());
-  RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, bytes_read, out);
+  nbytes = std::max<int64_t>(0, std::min(nbytes, memory_map_->size() - position));
+  if (nbytes > 0) {
+    std::memcpy(out, memory_map_->data() + position, static_cast<size_t>(nbytes));
+  }
+  *bytes_read = nbytes;
+  return Status::OK();
 }
 
 Status MemoryMappedFile::ReadAt(int64_t position, int64_t nbytes,
                                 std::shared_ptr<Buffer>* out) {
-  std::lock_guard<std::mutex> guard(memory_map_->lock());
-  RETURN_NOT_OK(Seek(position));
-  return Read(nbytes, out);
+  nbytes = std::max<int64_t>(0, std::min(nbytes, memory_map_->size() - position));
+
+  if (nbytes > 0) {
+    *out = SliceBuffer(memory_map_, position, nbytes);
+  } else {
+    *out = std::make_shared<Buffer>(nullptr, 0);
+  }
+  return Status::OK();
+}
+
+Status MemoryMappedFile::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
+  RETURN_NOT_OK(ReadAt(memory_map_->position(), nbytes, bytes_read, out));
+  memory_map_->advance(*bytes_read);
+  return Status::OK();
+}
+
+Status MemoryMappedFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+  RETURN_NOT_OK(ReadAt(memory_map_->position(), nbytes, out));
+  memory_map_->advance((*out)->size());
+  return Status::OK();
 }
 
 bool MemoryMappedFile::supports_zero_copy() const { return true; }

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -125,7 +125,8 @@ class OSFile {
   }
 
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) {
-    return internal::FileReadAt(fd_, reinterpret_cast<uint8_t*>(out), position, nbytes, bytes_read);
+    return internal::FileReadAt(fd_, reinterpret_cast<uint8_t*>(out), position, nbytes,
+                                bytes_read);
   }
 
   Status Seek(int64_t pos) {

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -128,7 +128,8 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   virtual bool supports_zero_copy() const = 0;
 
   /// \brief Read nbytes at position, provide default implementations using Read(...), but
-  /// can be overridden. Default implementation is thread-safe.
+  /// can be overridden. Default implementation is thread-safe.  It is unspecified
+  /// whether this method updates the file position or not.
   ///
   /// \note Child classes must explicitly call this implementation or provide their own.
   ///
@@ -141,7 +142,8 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
                         void* out) = 0;
 
   /// \brief Read nbytes at position, provide default implementations using Read(...), but
-  /// can be overridden. Default implementation is thread-safe.
+  /// can be overridden. Default implementation is thread-safe.  It is unspecified
+  /// whether this method updates the file position or not.
   ///
   /// \note Child classes must explicitly call this implementation or provide their own.
   ///

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -113,13 +113,11 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
   Status Close() override;
   Status Tell(int64_t* position) const override;
   Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
-
   // Zero copy read
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                 void* out) override;
-
-  /// Default implementation is thread-safe
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   Status GetSize(int64_t* size) override;

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -283,7 +283,7 @@ class TableReader::TableReaderImpl {
     }
 
     std::shared_ptr<Buffer> buffer;
-    RETURN_NOT_OK(source->Read(magic_size, &buffer));
+    RETURN_NOT_OK(source->ReadAt(0, magic_size, &buffer));
 
     if (memcmp(buffer->data(), kFeatherMagicBytes, magic_size)) {
       return Status::Invalid("Not a feather file");

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -157,6 +157,24 @@ Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStrea
   return Message::Open(metadata, body, out);
 }
 
+Status Message::ReadFrom(const int64_t offset, const std::shared_ptr<Buffer>& metadata,
+                         io::RandomAccessFile* file, std::unique_ptr<Message>* out) {
+  auto fb_message = flatbuf::GetMessage(metadata->data());
+
+  int64_t body_length = fb_message->bodyLength();
+
+  std::shared_ptr<Buffer> body;
+  RETURN_NOT_OK(file->ReadAt(offset, body_length, &body));
+  if (body->size() < body_length) {
+    std::stringstream ss;
+    ss << "Expected to be able to read " << body_length << " bytes for message body, got "
+       << body->size();
+    return Status::IOError(ss.str());
+  }
+
+  return Message::Open(metadata, body, out);
+}
+
 Status Message::SerializeTo(io::OutputStream* file, int64_t* output_length) const {
   int32_t metadata_length = 0;
   RETURN_NOT_OK(internal::WriteMessage(*metadata(), file, &metadata_length));
@@ -210,7 +228,7 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
   }
 
   auto metadata = SliceBuffer(buffer, 4, buffer->size() - 4);
-  return Message::ReadFrom(metadata, file, message);
+  return Message::ReadFrom(offset + metadata_length, metadata, file, message);
 }
 
 Status ReadMessage(io::InputStream* file, bool aligned,

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -97,6 +97,18 @@ class ARROW_EXPORT Message {
   static Status ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStream* stream,
                          std::unique_ptr<Message>* out);
 
+  /// \brief Read message body from position in file, and create Message given
+  /// the Flatbuffer metadata
+  /// \param[in] offset the position in the file where the message body starts.
+  /// \param[in] metadata containing a serialized Message flatbuffer
+  /// \param[in] file the seekable file interface to read from
+  /// \param[out] out the created Message
+  /// \return Status
+  ///
+  /// \note If file supports zero-copy, this is zero-copy
+  static Status ReadFrom(const int64_t offset, const std::shared_ptr<Buffer>& metadata,
+                         io::RandomAccessFile* file, std::unique_ptr<Message>* out);
+
   /// \brief Return true if message type and contents are equal
   ///
   /// \param other another message

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -268,11 +268,11 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
     int64_t size;
     RETURN_NOT_OK(src->ReadAt(offset, sizeof(int64_t), &bytes_read,
                               reinterpret_cast<uint8_t*>(&size)));
-    RETURN_NOT_OK(src->Tell(&offset));
+    offset += sizeof(int64_t);
     std::shared_ptr<Buffer> buffer;
     RETURN_NOT_OK(src->ReadAt(offset, size, &buffer));
     out->buffers.push_back(buffer);
-    RETURN_NOT_OK(src->Tell(&offset));
+    offset += size;
   }
 
   return Status::OK();


### PR DESCRIPTION
Allow for concurrent I/O by avoiding locking and seeking.

**Caveat**: this changes `ReadAt` to not advance the file pointer (under POSIX). Since `ReadAt` is meant for multithreaded I/O, relying on the file pointer doesn't make sense. Unfortunately, some IO in Arrow mixes calls to `ReadAt()` and file pointer-dependent operations (see diff).