### PR TITLE
ARROW-2437: [C++] Add ReadMessage without aligned argument.

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -248,6 +248,9 @@ Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message,
   return Message::ReadFrom(metadata, file, message);
 }
 
+Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message) {
+  return ReadMessage(file, message, false /* aligned */);
+}
 // ----------------------------------------------------------------------
 // Implement InputStream message reader
 

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -183,7 +183,14 @@ Status ReadMessage(const int64_t offset, const int32_t metadata_length,
 /// in a stream)
 ARROW_EXPORT
 Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message,
-                   bool aligned = false);
+                   bool aligned);
+
+/// \brief Read encapulated RPC message (metadata and body) from InputStream.
+///
+/// This is a version of ReadMessage that does not have the aligned argument
+/// for backwards compatibility.
+ARROW_EXPORT
+Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message);
 
 }  // namespace ipc
 }  // namespace arrow


### PR DESCRIPTION
cc @xhochy 