### PR TITLE
ARROW-2432: [Python] Fix Pandas decimal type conversion with None values

### DIFF
--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -184,14 +184,15 @@ Status DecimalMetadata::Update(int32_t suggested_precision, int32_t suggested_sc
 }
 
 Status DecimalMetadata::Update(PyObject* object) {
-  DCHECK(PyDecimal_Check(object)) << "Object is not a Python Decimal";
+  bool is_decimal = PyDecimal_Check(object);
+  DCHECK(is_decimal) << "Object is not a Python Decimal";
 
-  if (ARROW_PREDICT_FALSE(PyDecimal_ISNAN(object))) {
+  if (ARROW_PREDICT_FALSE(!is_decimal || PyDecimal_ISNAN(object))) {
     return Status::OK();
   }
 
-  int32_t precision;
-  int32_t scale;
+  int32_t precision = 0;
+  int32_t scale = 0;
   RETURN_NOT_OK(InferDecimalPrecisionAndScale(object, &precision, &scale));
   return Update(precision, scale);
 }

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -743,7 +743,9 @@ Status NumPyConverter::ConvertDecimals() {
 
   if (type_ == NULLPTR) {
     for (PyObject* object : objects) {
-      RETURN_NOT_OK(max_decimal_metadata.Update(object));
+      if (!internal::PandasObjectIsNull(object)) {
+        RETURN_NOT_OK(max_decimal_metadata.Update(object));
+      }
     }
 
     type_ =

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -758,22 +758,19 @@ Status NumPyConverter::ConvertDecimals() {
   for (PyObject* object : objects) {
     const int is_decimal = PyObject_IsInstance(object, decimal_type_.obj());
 
-    if (ARROW_PREDICT_FALSE(is_decimal == 0)) {
+    if (ARROW_PREDICT_FALSE(is_decimal == 1)) {
+      Decimal128 value;
+      RETURN_NOT_OK(internal::DecimalFromPythonDecimal(object, decimal_type, &value));
+      RETURN_NOT_OK(builder.Append(value));
+    } else if (ARROW_PREDICT_FALSE(is_decimal == 0 && internal::PandasObjectIsNull(object))) {
+      RETURN_NOT_OK(builder.AppendNull());
+    } else {
+      // PyObject_IsInstance could error and set an exception
+      RETURN_IF_PYERROR();
       std::stringstream ss;
       ss << "Error converting from Python objects to Decimal: ";
       RETURN_NOT_OK(InvalidConversion(object, "decimal.Decimal", &ss));
       return Status::Invalid(ss.str());
-    } else if (ARROW_PREDICT_FALSE(is_decimal == -1)) {
-      DCHECK_NE(PyErr_Occurred(), nullptr);
-      RETURN_IF_PYERROR();
-    }
-
-    if (internal::PandasObjectIsNull(object)) {
-      RETURN_NOT_OK(builder.AppendNull());
-    } else {
-      Decimal128 value;
-      RETURN_NOT_OK(internal::DecimalFromPythonDecimal(object, decimal_type, &value));
-      RETURN_NOT_OK(builder.Append(value));
     }
   }
   return PushBuilderResult(&builder);

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -758,11 +758,11 @@ Status NumPyConverter::ConvertDecimals() {
   for (PyObject* object : objects) {
     const int is_decimal = PyObject_IsInstance(object, decimal_type_.obj());
 
-    if (ARROW_PREDICT_FALSE(is_decimal == 1)) {
+    if (is_decimal == 1) {
       Decimal128 value;
       RETURN_NOT_OK(internal::DecimalFromPythonDecimal(object, decimal_type, &value));
       RETURN_NOT_OK(builder.Append(value));
-    } else if (ARROW_PREDICT_FALSE(is_decimal == 0 && internal::PandasObjectIsNull(object))) {
+    } else if (is_decimal == 0 && internal::PandasObjectIsNull(object)) {
       RETURN_NOT_OK(builder.AppendNull());
     } else {
       // PyObject_IsInstance could error and set an exception

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1163,7 +1163,7 @@ class TestConvertStringLikeTypes(object):
         # Explicitly set type
         _check_series_roundtrip(s, type_=pa.binary())
         # Infer type from bytearrays
-        _check_series_roundtrip(s)
+        _check_series_roundtrip(s, expected_pa_type=pa.binary())
 
     def test_table_empty_str(self):
         values = ['', '', '', '', '']

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1326,6 +1326,22 @@ class TestConvertDecimalTypes(object):
         expected = [decimal.Decimal('0.01000'), decimal.Decimal('0.00100')]
         assert array.to_pylist() == expected
 
+    def test_decimal_with_None_explicit_type(self):
+        data = [
+            decimal.Decimal('3.14'),
+            None,
+        ]
+        series = pd.Series(data)
+        _check_series_roundtrip(series, type_=pa.decimal128(12, 5))
+
+    def test_decimal_with_None_infer_type(self):
+        data = [
+            decimal.Decimal('3.14'),
+            None,
+        ]
+        series = pd.Series(data)
+        _check_series_roundtrip(series)
+
 
 class TestListTypes(object):
     """

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -80,8 +80,14 @@ def _check_pandas_roundtrip(df, expected=None, nthreads=1,
                                             else False))
 
 
-def _check_series_roundtrip(s, type_=None):
+def _check_series_roundtrip(s, type_=None, expected_pa_type=None):
     arr = pa.array(s, from_pandas=True, type=type_)
+
+    if type_ is not None and expected_pa_type is None:
+        expected_pa_type = type_
+
+    if expected_pa_type is not None:
+        assert arr.type == expected_pa_type
 
     result = pd.Series(arr.to_pandas(), name=s.name)
     if patypes.is_timestamp(arr.type) and arr.type.tz is not None:
@@ -1149,19 +1155,14 @@ class TestConvertStringLikeTypes(object):
 
     def test_variable_size_bytes(self):
         s = pd.Series([b'123', b'', b'a', None])
-        arr = pa.Array.from_pandas(s, type=pa.binary())
-        assert arr.type == pa.binary()
         _check_series_roundtrip(s, type_=pa.binary())
 
     def test_binary_from_bytearray(self):
-        s = pd.Series([bytearray(b'123'), bytearray(b''), bytearray(b'a')])
+        s = pd.Series([bytearray(b'123'), bytearray(b''), bytearray(b'a'), None])
         # Explicitly set type
-        arr = pa.Array.from_pandas(s, type=pa.binary())
-        assert arr.type == pa.binary()
-        # Infer type from bytearrays
-        arr = pa.Array.from_pandas(s)
-        assert arr.type == pa.binary()
         _check_series_roundtrip(s, type_=pa.binary())
+        # Infer type from bytearrays
+        _check_series_roundtrip(s)
 
     def test_table_empty_str(self):
         values = ['', '', '', '', '']
@@ -1327,20 +1328,16 @@ class TestConvertDecimalTypes(object):
         assert array.to_pylist() == expected
 
     def test_decimal_with_None_explicit_type(self):
-        data = [
-            decimal.Decimal('3.14'),
-            None,
-        ]
-        series = pd.Series(data)
+        series = pd.Series([decimal.Decimal('3.14'), None])
+        _check_series_roundtrip(series, type_=pa.decimal128(12, 5))
+
+        # Test that having all None values still produces decimal array
+        series = pd.Series([None] * 2)
         _check_series_roundtrip(series, type_=pa.decimal128(12, 5))
 
     def test_decimal_with_None_infer_type(self):
-        data = [
-            decimal.Decimal('3.14'),
-            None,
-        ]
-        series = pd.Series(data)
-        _check_series_roundtrip(series)
+        series = pd.Series([decimal.Decimal('3.14'), None])
+        _check_series_roundtrip(series, expected_pa_type=pa.decimal128(3, 2))
 
 
 class TestListTypes(object):

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1158,7 +1158,8 @@ class TestConvertStringLikeTypes(object):
         _check_series_roundtrip(s, type_=pa.binary())
 
     def test_binary_from_bytearray(self):
-        s = pd.Series([bytearray(b'123'), bytearray(b''), bytearray(b'a'), None])
+        s = pd.Series([bytearray(b'123'), bytearray(b''), bytearray(b'a'),
+                       None])
         # Explicitly set type
         _check_series_roundtrip(s, type_=pa.binary())
         # Infer type from bytearrays


### PR DESCRIPTION
This fixes conversion of Pandas decimal types to Arrow with None values. Previously, if the type was specified, an error would occur when checking if the object was Decimal. If the type was not specified, a segmentation fault would occur when attempting to find the max precision and scale.

Added new tests which include None values for both the above cases.