### PR TITLE
ARROW-2464: [Python] Use a python_version marker instead of a condition

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -447,10 +447,11 @@ class BinaryDistribution(Distribution):
         return True
 
 
-install_requires = ['numpy >= 1.10', 'six >= 1.0.0']
-
-if sys.version_info.major == 2:
-    install_requires.append('futures')
+install_requires = (
+    'numpy >= 1.10',
+    'six >= 1.0.0',
+    'futures;python_version<"3.2"'
+)
 
 
 def parse_version(root):


### PR DESCRIPTION
We should let pip decide if installing futures is needed.
As such I've added a marker that limits the installation of the futures package to lower than 3.2 (when the package was first introduced).