### PR TITLE
ARROW-2451: [Python] Handle non-object arrays more efficiently in custom serializer.

### DIFF
--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -315,8 +315,11 @@ def test_default_dict_serialization(large_buffer):
 
 def test_numpy_serialization(large_buffer):
     for t in ["bool", "int8", "uint8", "int16", "uint16", "int32",
-              "uint32", "float16", "float32", "float64"]:
+              "uint32", "float16", "float32", "float64", "<U1", "<U2", "<U3",
+              "<U4", "|S1", "|S2", "|S3", "|S4", "|O"]:
         obj = np.random.randint(0, 10, size=(100, 100)).astype(t)
+        serialization_roundtrip(obj, large_buffer)
+        obj = obj[1:99, 10:90]
         serialization_roundtrip(obj, large_buffer)
 
 


### PR DESCRIPTION
**Before this PR**

```python
import numpy as np
import pyarrow as pa

x = np.array(10 ** 8 * [True, False])
%time serialized_obj = pa.serialize(x).to_buffer()  # 10.4s
%time new_x = pa.deserialize(serialized_obj)  # 8.94s

x = np.array([str(i) for i in range(10 ** 7)])
%time serialized_obj = pa.serialize(x).to_buffer()  # 2.24s
%time new_x = pa.deserialize(serialized_obj)  # 2.03s
```

**After this PR**

```python
import numpy as np
import pyarrow as pa

x = np.array(10 ** 8 * [True, False])
%time serialized_obj = pa.serialize(x).to_buffer()  # 117ms
%time new_x = pa.deserialize(serialized_obj)  # 265us

x = np.array([str(i) for i in range(10 ** 7)])
%time serialized_obj = pa.serialize(x).to_buffer()  # 174ms
%time new_x = pa.deserialize(serialized_obj)  # 13.2ms
```

cc @devin-petersohn @mitar @pcmoritz 