### PR TITLE
ARROW-2450: [Python] Test for Parquet roundtrip of null lists

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -136,6 +136,6 @@ if [ "$ARROW_TRAVIS_PYTHON_BENCHMARKS" == "1" ] && [ "$PYTHON_VERSION" == "3.6" 
   # Generate machine information (mandatory)
   asv machine --yes
   # Run benchmarks on the changeset being tested
-  asv run --no-pull --show-stderr --quick ${TRAVIS_COMMIT}^!
+  asv run --no-pull --show-stderr --quick HEAD^!
   popd
 fi

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -221,6 +221,8 @@ cdef class ColumnChunkMetaData:
     property statistics:
 
         def __get__(self):
+            if not self.metadata.is_stats_set():
+                return None
             statistics = RowGroupStatistics()
             statistics.init(self.metadata.statistics())
             return statistics


### PR DESCRIPTION
Actual fix is in PARQUET-1268.
Also fix a crash when a column doesn't have any statistics.