### PR TITLE
ARROW-2455: [C++] Initialize the atomic bytes_allocated_ properly

### DIFF
--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -40,7 +40,7 @@ struct CudaDevice {
 
 class CudaContext::CudaContextImpl {
  public:
-  CudaContextImpl(): bytes_allocated_(0) {}
+  CudaContextImpl() : bytes_allocated_(0) {}
 
   Status Init(const CudaDevice& device) {
     device_ = device;

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -40,7 +40,7 @@ struct CudaDevice {
 
 class CudaContext::CudaContextImpl {
  public:
-  CudaContextImpl() {}
+  CudaContextImpl(): bytes_allocated_(0) {}
 
   Status Init(const CudaDevice& device) {
     device_ = device;


### PR DESCRIPTION
The atomic counter `bytes_allocated_` in `CudaContextImpl` isn't initialized, leading to failure of cuda-test on windows.