### PR TITLE
ARROW-2462: [C++] Fix Segfault in UnpackBinaryDictionary

### DIFF
--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -790,6 +790,30 @@ TYPED_TEST(TestDictionaryCast, Basic) {
   this->CheckPass(*MakeArray(out.array()), *plain_array, plain_array->type(), options);
 }
 
+TEST_F(TestCast, DictToNonDictNoNulls) {
+  vector<std::string> dict_values = {"foo", "bar", "baz"};
+  auto ex_dict = _MakeArray<StringType, std::string>(utf8(), dict_values, {});
+  auto dict_type = dictionary(int32(), ex_dict);
+
+  // Explicitly construct with nullptr for the null_bitmap_data
+  auto c1 = std::make_shared<NumericArray<Int32Type>>(
+      3, arrow::test::GetBufferFromVector<int32_t>({1, 0, 1}));
+  auto c2 = std::make_shared<NumericArray<Int32Type>>(
+      4, arrow::test::GetBufferFromVector<int32_t>({2, 1, 0, 1}));
+
+  ArrayVector dict_arrays = {std::make_shared<DictionaryArray>(dict_type, c1),
+                             std::make_shared<DictionaryArray>(dict_type, c2)};
+  auto dict_carr = std::make_shared<ChunkedArray>(dict_arrays);
+
+  Datum cast_input(dict_carr);
+  Datum cast_output;
+  // Ensure that casting works even when the null_bitmap_data array is a nullptr
+  ASSERT_OK(Cast(&this->ctx_, cast_input,
+                 static_cast<DictionaryType&>(*dict_type).dictionary()->type(),
+                 CastOptions(), &cast_output));
+  ASSERT_EQ(Datum::CHUNKED_ARRAY, cast_output.kind());
+}
+
 /*TYPED_TEST(TestDictionaryCast, Reverse) {
   CastOptions options;
   shared_ptr<Array> plain_array =

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -529,21 +529,28 @@ void UnpackFixedSizeBinaryDictionary(FunctionContext* ctx, const Array& indices,
                                      ArrayData* output) {
   using index_c_type = typename IndexType::c_type;
 
-  internal::BitmapReader valid_bits_reader(indices.null_bitmap_data(), indices.offset(),
-                                           indices.length());
-
   const index_c_type* in = GetValues<index_c_type>(*indices.data(), 1);
-
   int32_t byte_width =
       static_cast<const FixedSizeBinaryType&>(*output->type).byte_width();
 
   uint8_t* out = output->buffers[1]->mutable_data() + byte_width * output->offset;
-  for (int64_t i = 0; i < indices.length(); ++i) {
-    if (valid_bits_reader.IsSet()) {
+
+  if (indices.null_count() != 0) {
+    internal::BitmapReader valid_bits_reader(indices.null_bitmap_data(), indices.offset(),
+                                             indices.length());
+
+    for (int64_t i = 0; i < indices.length(); ++i) {
+      if (valid_bits_reader.IsSet()) {
+        const uint8_t* value = dictionary.Value(in[i]);
+        memcpy(out + i * byte_width, value, byte_width);
+      }
+      valid_bits_reader.Next();
+    }
+  } else {
+    for (int64_t i = 0; i < indices.length(); ++i) {
       const uint8_t* value = dictionary.Value(in[i]);
       memcpy(out + i * byte_width, value, byte_width);
     }
-    valid_bits_reader.Next();
   }
 }
 
@@ -595,19 +602,27 @@ Status UnpackBinaryDictionary(FunctionContext* ctx, const Array& indices,
   RETURN_NOT_OK(MakeBuilder(ctx->memory_pool(), output->type, &builder));
   BinaryBuilder* binary_builder = static_cast<BinaryBuilder*>(builder.get());
 
-  internal::BitmapReader valid_bits_reader(indices.null_bitmap_data(), indices.offset(),
-                                           indices.length());
-
   const index_c_type* in = GetValues<index_c_type>(*indices.data(), 1);
-  for (int64_t i = 0; i < indices.length(); ++i) {
-    if (valid_bits_reader.IsSet()) {
+  if (indices.null_count() != 0) {
+    internal::BitmapReader valid_bits_reader(indices.null_bitmap_data(), indices.offset(),
+                                             indices.length());
+
+    for (int64_t i = 0; i < indices.length(); ++i) {
+      if (valid_bits_reader.IsSet()) {
+        int32_t length;
+        const uint8_t* value = dictionary.GetValue(in[i], &length);
+        RETURN_NOT_OK(binary_builder->Append(value, length));
+      } else {
+        RETURN_NOT_OK(binary_builder->AppendNull());
+      }
+      valid_bits_reader.Next();
+    }
+  } else {
+    for (int64_t i = 0; i < indices.length(); ++i) {
       int32_t length;
       const uint8_t* value = dictionary.GetValue(in[i], &length);
       RETURN_NOT_OK(binary_builder->Append(value, length));
-    } else {
-      RETURN_NOT_OK(binary_builder->AppendNull());
     }
-    valid_bits_reader.Next();
   }
 
   std::shared_ptr<Array> plain_array;


### PR DESCRIPTION
Discovered this through using pyarrow and dealing with RecordBatch Streams and parquet. The issue can be replicated as follows:

```python
import pyarrow as pa
import pyarrow.parquet as pq

# create record batch with 1 dictionary column
indices = pa.array([1,0,1,1,0])
dictionary = pa.array(['Foo', 'Bar'])
dict_array = pa.DictionaryArray.from_arrays(indices, dictionary)
rb = pa.RecordBatch.from_arrays( [ dict_array ], [ 'd0' ] )

# write out using RecordBatchStreamWriter
sink = pa.BufferOutputStream()
writer = pa.RecordBatchStreamWriter(sink, rb.schema)
writer.write_batch(rb)
writer.close()
buf = sink.get_result()

# read in and try to write parquet table
reader = pa.open_stream(buf)
tbl = reader.read_all()
pq.write_table(tbl, 'dict_table.parquet') # SEGFAULTS
```

When writing record batch streams, if there are no nulls in an array, Arrow will put a placeholder nullptr instead of putting the full bitmap of 1s, when deserializing that stream, the bitmap for the nulls isn't populated and is left to being a nullptr. When attempting to write this table via pyarrow.parquet, you end up [here](https://github.com/apache/parquet-cpp/blob/master/src/parquet/arrow/writer.cc#L963) in the parquet writer code which attempts to Cast the dictionary to a non-dictionary representation. Since the null count isn't checked before creating a BitmapReader, the BitmapReader is constructed with a nullptr for the bitmap_data, but a non-zero length which then segfaults in the constructor [here](https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/bit-util.h#L415) because `bitmap` is null. 

So a simple check of the null count before constructing the BitmapReader avoids the segfault.