### PR TITLE
ARROW-2544: [CI] Run the C++ tests with two jobs

### DIFF
--- a/ci/travis_script_cpp.sh
+++ b/ci/travis_script_cpp.sh
@@ -23,6 +23,6 @@ source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
 pushd $CPP_BUILD_DIR
 
-ctest -VV -L unittest
+ctest -j2 -VV -L unittest
 
 popd

--- a/ci/travis_script_cpp.sh
+++ b/ci/travis_script_cpp.sh
@@ -23,6 +23,6 @@ source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
 pushd $CPP_BUILD_DIR
 
-ctest -j2 -VV -L unittest
+ctest -j2 --output-on-failure -L unittest
 
 popd


### PR DESCRIPTION
Travis-CI provides workers with two cores. We should use them.
This should make testing our C++ implementation faster.