### PR TITLE
ARROW-2442: [C++] Disambiguate builder Append() overloads

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -435,7 +435,7 @@ class ORCFileReader::Impl {
     if (batch->hasNulls) {
       valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
     }
-    RETURN_NOT_OK(builder->Append(length, valid_bytes));
+    RETURN_NOT_OK(builder->AppendValues(length, valid_bytes));
 
     for (int i = 0; i < builder->num_fields(); i++) {
       RETURN_NOT_OK(AppendBatch(type->getSubtype(i), batch->fields[i], offset, length,
@@ -482,7 +482,7 @@ class ORCFileReader::Impl {
       int64_t start = batch->offsets[i];
       int64_t list_length = batch->offsets[i + 1] - start;
       if (list_length && (!has_nulls || batch->notNull[i])) {
-        RETURN_NOT_OK(struct_builder->Append(list_length, nullptr));
+        RETURN_NOT_OK(struct_builder->AppendValues(list_length, nullptr));
         RETURN_NOT_OK(AppendBatch(keytype, keys, start, list_length,
                                   struct_builder->field_builder(0)));
         RETURN_NOT_OK(AppendBatch(valtype, vals, start, list_length,
@@ -506,7 +506,7 @@ class ORCFileReader::Impl {
       valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
     }
     const elem_type* source = batch->data.data() + offset;
-    RETURN_NOT_OK(builder->Append(source, length, valid_bytes));
+    RETURN_NOT_OK(builder->AppendValues(source, length, valid_bytes));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -725,8 +725,8 @@ TEST(TestBooleanBuilder, TestStdBoolVectorAppend) {
       chunk_values.push_back(values[i]);
       chunk_is_valid.push_back(is_valid[i]);
     }
-    ASSERT_OK(builder.Append(chunk_values, chunk_is_valid));
-    ASSERT_OK(builder_nn.Append(chunk_values));
+    ASSERT_OK(builder.AppendValues(chunk_values, chunk_is_valid));
+    ASSERT_OK(builder_nn.AppendValues(chunk_values));
   }
 
   std::shared_ptr<Array> result, result_nn;
@@ -1031,7 +1031,7 @@ TEST_F(TestStringBuilder, TestAppendCStringsWithValidBytes) {
   int reps = 1000;
 
   for (int j = 0; j < reps; ++j) {
-    ASSERT_OK(builder_->Append(strings, N, valid_bytes.data()));
+    ASSERT_OK(builder_->AppendValues(strings, N, valid_bytes.data()));
   }
   Done();
 
@@ -2397,7 +2397,7 @@ TEST(TestDecimalDictionaryBuilder, Basic) {
   auto dtype = arrow::dictionary(int8(), decimal_array);
 
   Int8Builder int_builder;
-  ASSERT_OK(int_builder.Append({0, 0, 1, 0}));
+  ASSERT_OK(int_builder.AppendValues({0, 0, 1, 0}));
   std::shared_ptr<Array> int_array;
   ASSERT_OK(int_builder.Finish(&int_array));
 
@@ -3031,7 +3031,7 @@ TEST_F(TestStructBuilder, BulkAppend) {
   ASSERT_OK(char_vb->Resize(list_values.size()));
   ASSERT_OK(int_vb->Resize(int_values.size()));
 
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
 
   ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
                                   list_is_valid.data()));

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -592,7 +592,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {
   this->Check(this->builder_nn_, false);
 }
 
-TYPED_TEST(TestPrimitiveBuilder, TestAppendVector) {
+TYPED_TEST(TestPrimitiveBuilder, TestAppendValues) {
   DECL_T();
 
   int64_t size = 10000;
@@ -604,8 +604,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVector) {
   // first slug
   int64_t K = 1000;
 
-  ASSERT_OK(this->builder_->Append(draws.data(), K, valid_bytes.data()));
-  ASSERT_OK(this->builder_nn_->Append(draws.data(), K));
+  ASSERT_OK(this->builder_->AppendValues(draws.data(), K, valid_bytes.data()));
+  ASSERT_OK(this->builder_nn_->AppendValues(draws.data(), K));
 
   ASSERT_EQ(1000, this->builder_->length());
   ASSERT_EQ(1024, this->builder_->capacity());
@@ -614,8 +614,9 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVector) {
   ASSERT_EQ(1024, this->builder_nn_->capacity());
 
   // Append the next 9000
-  ASSERT_OK(this->builder_->Append(draws.data() + K, size - K, valid_bytes.data() + K));
-  ASSERT_OK(this->builder_nn_->Append(draws.data() + K, size - K));
+  ASSERT_OK(
+      this->builder_->AppendValues(draws.data() + K, size - K, valid_bytes.data() + K));
+  ASSERT_OK(this->builder_nn_->AppendValues(draws.data() + K, size - K));
 
   ASSERT_EQ(size, this->builder_->length());
   ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
@@ -624,7 +625,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVector) {
   this->Check(this->builder_nn_, false);
 }
 
-TYPED_TEST(TestPrimitiveBuilder, TestAppendVectorStdBool) {
+TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesStdBool) {
   // ARROW-1383
   DECL_T();
 
@@ -641,8 +642,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVectorStdBool) {
   for (int64_t i = 0; i < K; ++i) {
     is_valid.push_back(this->valid_bytes_[i] != 0);
   }
-  ASSERT_OK(this->builder_->Append(draws.data(), K, is_valid));
-  ASSERT_OK(this->builder_nn_->Append(draws.data(), K));
+  ASSERT_OK(this->builder_->AppendValues(draws.data(), K, is_valid));
+  ASSERT_OK(this->builder_nn_->AppendValues(draws.data(), K));
 
   ASSERT_EQ(1000, this->builder_->length());
   ASSERT_EQ(1024, this->builder_->capacity());
@@ -657,8 +658,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendVectorStdBool) {
     is_valid.push_back(this->valid_bytes_[i] != 0);
   }
 
-  ASSERT_OK(this->builder_->Append(partial_draws, is_valid));
-  ASSERT_OK(this->builder_nn_->Append(partial_draws));
+  ASSERT_OK(this->builder_->AppendValues(partial_draws, is_valid));
+  ASSERT_OK(this->builder_nn_->AppendValues(partial_draws));
 
   ASSERT_EQ(size, this->builder_->length());
   ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
@@ -997,7 +998,7 @@ TEST_F(TestStringBuilder, TestAppendVector) {
   int reps = 1000;
 
   for (int j = 0; j < reps; ++j) {
-    ASSERT_OK(builder_->Append(strings, valid_bytes.data()));
+    ASSERT_OK(builder_->AppendValues(strings, valid_bytes.data()));
   }
   Done();
 
@@ -1063,7 +1064,7 @@ TEST_F(TestStringBuilder, TestAppendCStringsWithoutValidBytes) {
   int reps = 1000;
 
   for (int j = 0; j < reps; ++j) {
-    ASSERT_OK(builder_->Append(strings, N));
+    ASSERT_OK(builder_->AppendValues(strings, N));
   }
   Done();
 
@@ -1427,8 +1428,9 @@ TEST_F(TestFWBinaryArray, Builder) {
 
   const uint8_t* raw_is_valid = is_valid.data();
 
-  ASSERT_OK(builder_->Append(raw_data, 50, raw_is_valid));
-  ASSERT_OK(builder_->Append(raw_data + 50 * byte_width, length - 50, raw_is_valid + 50));
+  ASSERT_OK(builder_->AppendValues(raw_data, 50, raw_is_valid));
+  ASSERT_OK(
+      builder_->AppendValues(raw_data + 50 * byte_width, length - 50, raw_is_valid + 50));
   ASSERT_OK(builder_->Finish(&result));
   CheckResult(*result);
 
@@ -1659,10 +1661,10 @@ TEST_F(TestAdaptiveIntBuilder, TestInt64) {
   ASSERT_TRUE(expected_->Equals(result_));
 }
 
-TEST_F(TestAdaptiveIntBuilder, TestAppendVector) {
+TEST_F(TestAdaptiveIntBuilder, TestAppendValues) {
   std::vector<int64_t> expected_values(
       {0, static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1});
-  ASSERT_OK(builder_->Append(expected_values.data(), expected_values.size()));
+  ASSERT_OK(builder_->AppendValues(expected_values.data(), expected_values.size()));
   Done();
 
   ArrayFromVector<Int64Type, int64_t>(expected_values, &expected_);
@@ -1754,10 +1756,10 @@ TEST_F(TestAdaptiveUIntBuilder, TestUInt64) {
   ASSERT_TRUE(expected_->Equals(result_));
 }
 
-TEST_F(TestAdaptiveUIntBuilder, TestAppendVector) {
+TEST_F(TestAdaptiveUIntBuilder, TestAppendValues) {
   std::vector<uint64_t> expected_values(
       {0, static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1});
-  ASSERT_OK(builder_->Append(expected_values.data(), expected_values.size()));
+  ASSERT_OK(builder_->AppendValues(expected_values.data(), expected_values.size()));
   Done();
 
   ArrayFromVector<UInt64Type, uint64_t>(expected_values, &expected_);
@@ -2497,17 +2499,17 @@ TEST_F(TestListArray, Equality) {
   vector<int32_t> unequal_values = {1, 2, 2, 2, 3, 4, 5};
 
   // setup two equal arrays
-  ASSERT_OK(builder_->Append(equal_offsets.data(), equal_offsets.size()));
-  ASSERT_OK(vb->Append(equal_values.data(), equal_values.size()));
+  ASSERT_OK(builder_->AppendValues(equal_offsets.data(), equal_offsets.size()));
+  ASSERT_OK(vb->AppendValues(equal_values.data(), equal_values.size()));
 
   ASSERT_OK(builder_->Finish(&array));
-  ASSERT_OK(builder_->Append(equal_offsets.data(), equal_offsets.size()));
-  ASSERT_OK(vb->Append(equal_values.data(), equal_values.size()));
+  ASSERT_OK(builder_->AppendValues(equal_offsets.data(), equal_offsets.size()));
+  ASSERT_OK(vb->AppendValues(equal_values.data(), equal_values.size()));
 
   ASSERT_OK(builder_->Finish(&equal_array));
   // now an unequal one
-  ASSERT_OK(builder_->Append(unequal_offsets.data(), unequal_offsets.size()));
-  ASSERT_OK(vb->Append(unequal_values.data(), unequal_values.size()));
+  ASSERT_OK(builder_->AppendValues(unequal_offsets.data(), unequal_offsets.size()));
+  ASSERT_OK(vb->AppendValues(unequal_values.data(), unequal_values.size()));
 
   ASSERT_OK(builder_->Finish(&unequal_array));
 
@@ -2678,7 +2680,7 @@ TEST_F(TestListArray, BulkAppend) {
   Int32Builder* vb = static_cast<Int32Builder*>(builder_->value_builder());
   ASSERT_OK(vb->Reserve(values.size()));
 
-  ASSERT_OK(builder_->Append(offsets.data(), offsets.size(), is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(offsets.data(), offsets.size(), is_valid.data()));
   for (int32_t value : values) {
     ASSERT_OK(vb->Append(value));
   }
@@ -2696,8 +2698,8 @@ TEST_F(TestListArray, BulkAppendInvalid) {
   Int32Builder* vb = static_cast<Int32Builder*>(builder_->value_builder());
   ASSERT_OK(vb->Reserve(values.size()));
 
-  ASSERT_OK(builder_->Append(offsets.data(), offsets.size(), is_valid.data()));
-  ASSERT_OK(builder_->Append(offsets.data(), offsets.size(), is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(offsets.data(), offsets.size(), is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(offsets.data(), offsets.size(), is_valid.data()));
   for (int32_t value : values) {
     ASSERT_OK(vb->Append(value));
   }
@@ -3031,8 +3033,8 @@ TEST_F(TestStructBuilder, BulkAppend) {
 
   ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
 
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3061,10 +3063,10 @@ TEST_F(TestStructBuilder, BulkAppendInvalid) {
   ASSERT_OK(char_vb->Reserve(list_values.size()));
   ASSERT_OK(int_vb->Reserve(int_values.size()));
 
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
 
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3103,9 +3105,9 @@ TEST_F(TestStructBuilder, TestEquality) {
   ASSERT_OK(int_vb->Reserve(int_values.size()));
 
   // setup two equal arrays, one of which takes an unequal bitmap
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3119,9 +3121,9 @@ TEST_F(TestStructBuilder, TestEquality) {
   ASSERT_OK(char_vb->Resize(list_values.size()));
   ASSERT_OK(int_vb->Resize(int_values.size()));
 
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3136,10 +3138,10 @@ TEST_F(TestStructBuilder, TestEquality) {
   ASSERT_OK(int_vb->Resize(int_values.size()));
 
   // setup an unequal one with the unequal bitmap
-  ASSERT_OK(
-      builder_->Append(unequal_struct_is_valid.size(), unequal_struct_is_valid.data()));
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(unequal_struct_is_valid.size(),
+                                   unequal_struct_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3154,9 +3156,10 @@ TEST_F(TestStructBuilder, TestEquality) {
   ASSERT_OK(int_vb->Resize(int_values.size()));
 
   // setup an unequal one with unequal offsets
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
-  ASSERT_OK(list_vb->Append(unequal_list_offsets.data(), unequal_list_offsets.size(),
-                            unequal_list_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(unequal_list_offsets.data(),
+                                  unequal_list_offsets.size(),
+                                  unequal_list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3171,9 +3174,9 @@ TEST_F(TestStructBuilder, TestEquality) {
   ASSERT_OK(int_vb->Resize(int_values.size()));
 
   // setup anunequal one with unequal values
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : unequal_list_values) {
     char_vb->UnsafeAppend(value);
   }
@@ -3230,9 +3233,9 @@ TEST_F(TestStructBuilder, TestSlice) {
   ASSERT_OK(char_vb->Reserve(list_values.size()));
   ASSERT_OK(int_vb->Reserve(int_values.size()));
 
-  ASSERT_OK(builder_->Append(struct_is_valid.size(), struct_is_valid.data()));
-  ASSERT_OK(
-      list_vb->Append(list_offsets.data(), list_offsets.size(), list_is_valid.data()));
+  ASSERT_OK(builder_->AppendValues(struct_is_valid.size(), struct_is_valid.data()));
+  ASSERT_OK(list_vb->AppendValues(list_offsets.data(), list_offsets.size(),
+                                  list_is_valid.data()));
   for (int8_t value : list_values) {
     char_vb->UnsafeAppend(value);
   }

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -33,7 +33,7 @@ static void BM_BuildPrimitiveArrayNoNulls(
     Int64Builder builder;
     for (int i = 0; i < kFinalSize; i++) {
       // Build up an array of 512 MiB in size
-      ABORT_NOT_OK(builder.Append(data.data(), data.size(), nullptr));
+      ABORT_NOT_OK(builder.AppendValues(data.data(), data.size(), nullptr));
     }
     std::shared_ptr<Array> out;
     ABORT_NOT_OK(builder.Finish(&out));
@@ -69,7 +69,7 @@ static void BM_BuildAdaptiveIntNoNulls(
     AdaptiveIntBuilder builder;
     for (int64_t i = 0; i < size; i += chunk_size) {
       // Build up an array of 512 MiB in size
-      ABORT_NOT_OK(builder.Append(data.data() + i, chunk_size, nullptr));
+      ABORT_NOT_OK(builder.AppendValues(data.data() + i, chunk_size, nullptr));
     }
     std::shared_ptr<Array> out;
     ABORT_NOT_OK(builder.Finish(&out));
@@ -107,7 +107,7 @@ static void BM_BuildAdaptiveUIntNoNulls(
     AdaptiveUIntBuilder builder;
     for (int64_t i = 0; i < size; i += chunk_size) {
       // Build up an array of 512 MiB in size
-      ABORT_NOT_OK(builder.Append(data.data() + i, chunk_size, nullptr));
+      ABORT_NOT_OK(builder.AppendValues(data.data() + i, chunk_size, nullptr));
     }
     std::shared_ptr<Array> out;
     ABORT_NOT_OK(builder.Finish(&out));

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1056,7 +1056,7 @@ typename DictionaryBuilder<T>::Scalar DictionaryBuilder<T>::GetDictionaryValue(
 template <typename T>
 Status DictionaryBuilder<T>::FinishInternal(std::shared_ptr<ArrayData>* out) {
   entry_id_offset_ += dict_builder_.length();
-  RETURN_NOT_OK(overflow_dict_builder_.Append(
+  RETURN_NOT_OK(overflow_dict_builder_.AppendValues(
       reinterpret_cast<const DictionaryBuilder<T>::Scalar*>(dict_builder_.data()->data()),
       dict_builder_.length(), nullptr));
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -265,8 +265,8 @@ Status PrimitiveBuilder<T>::Resize(int64_t capacity) {
 }
 
 template <typename T>
-Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
-                                   const uint8_t* valid_bytes) {
+Status PrimitiveBuilder<T>::AppendValues(const value_type* values, int64_t length,
+                                         const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
 
   if (length > 0) {
@@ -282,7 +282,13 @@ Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
 
 template <typename T>
 Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
-                                   const std::vector<bool>& is_valid) {
+                                   const uint8_t* valid_bytes) {
+  return AppendValues(values, length, valid_bytes);
+}
+
+template <typename T>
+Status PrimitiveBuilder<T>::AppendValues(const value_type* values, int64_t length,
+                                         const std::vector<bool>& is_valid) {
   RETURN_NOT_OK(Reserve(length));
   DCHECK_EQ(length, static_cast<int64_t>(is_valid.size()));
 
@@ -298,14 +304,31 @@ Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
 }
 
 template <typename T>
+Status PrimitiveBuilder<T>::Append(const value_type* values, int64_t length,
+                                   const std::vector<bool>& is_valid) {
+  return AppendValues(values, length, is_valid);
+}
+
+template <typename T>
+Status PrimitiveBuilder<T>::AppendValues(const std::vector<value_type>& values,
+                                         const std::vector<bool>& is_valid) {
+  return AppendValues(values.data(), static_cast<int64_t>(values.size()), is_valid);
+}
+
+template <typename T>
 Status PrimitiveBuilder<T>::Append(const std::vector<value_type>& values,
                                    const std::vector<bool>& is_valid) {
-  return Append(values.data(), static_cast<int64_t>(values.size()), is_valid);
+  return AppendValues(values, is_valid);
+}
+
+template <typename T>
+Status PrimitiveBuilder<T>::AppendValues(const std::vector<value_type>& values) {
+  return AppendValues(values.data(), static_cast<int64_t>(values.size()));
 }
 
 template <typename T>
 Status PrimitiveBuilder<T>::Append(const std::vector<value_type>& values) {
-  return Append(values.data(), static_cast<int64_t>(values.size()));
+  return AppendValues(values);
 }
 
 template <typename T>
@@ -411,8 +434,8 @@ Status AdaptiveIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-Status AdaptiveIntBuilder::Append(const int64_t* values, int64_t length,
-                                  const uint8_t* valid_bytes) {
+Status AdaptiveIntBuilder::AppendValues(const int64_t* values, int64_t length,
+                                        const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
 
   if (length > 0) {
@@ -466,6 +489,11 @@ Status AdaptiveIntBuilder::Append(const int64_t* values, int64_t length,
   ArrayBuilder::UnsafeAppendToBitmap(valid_bytes, length);
 
   return Status::OK();
+}
+
+Status AdaptiveIntBuilder::Append(const int64_t* values, int64_t length,
+                                  const uint8_t* valid_bytes) {
+  return AppendValues(values, length, valid_bytes);
 }
 
 template <typename new_type, typename old_type>
@@ -567,8 +595,8 @@ Status AdaptiveUIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-Status AdaptiveUIntBuilder::Append(const uint64_t* values, int64_t length,
-                                   const uint8_t* valid_bytes) {
+Status AdaptiveUIntBuilder::AppendValues(const uint64_t* values, int64_t length,
+                                         const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
 
   if (length > 0) {
@@ -622,6 +650,11 @@ Status AdaptiveUIntBuilder::Append(const uint64_t* values, int64_t length,
   ArrayBuilder::UnsafeAppendToBitmap(valid_bytes, length);
 
   return Status::OK();
+}
+
+Status AdaptiveUIntBuilder::Append(const uint64_t* values, int64_t length,
+                                   const uint8_t* valid_bytes) {
+  return AppendValues(values, length, valid_bytes);
 }
 
 template <typename new_type, typename old_type>
@@ -744,8 +777,8 @@ Status BooleanBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
-                              const uint8_t* valid_bytes) {
+Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
+                                    const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
 
   for (int64_t i = 0; i < length; ++i) {
@@ -758,7 +791,12 @@ Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
 }
 
 Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
-                              const std::vector<bool>& is_valid) {
+                              const uint8_t* valid_bytes) {
+  return AppendValues(values, length, valid_bytes);
+}
+
+Status BooleanBuilder::AppendValues(const uint8_t* values, int64_t length,
+                                    const std::vector<bool>& is_valid) {
   RETURN_NOT_OK(Reserve(length));
   DCHECK_EQ(length, static_cast<int64_t>(is_valid.size()));
 
@@ -771,17 +809,31 @@ Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
   return Status::OK();
 }
 
+Status BooleanBuilder::Append(const uint8_t* values, int64_t length,
+                              const std::vector<bool>& is_valid) {
+  return AppendValues(values, length, is_valid);
+}
+
+Status BooleanBuilder::AppendValues(const std::vector<uint8_t>& values,
+                                    const std::vector<bool>& is_valid) {
+  return AppendValues(values.data(), static_cast<int64_t>(values.size()), is_valid);
+}
+
 Status BooleanBuilder::Append(const std::vector<uint8_t>& values,
                               const std::vector<bool>& is_valid) {
-  return Append(values.data(), static_cast<int64_t>(values.size()), is_valid);
+  return AppendValues(values, is_valid);
+}
+
+Status BooleanBuilder::AppendValues(const std::vector<uint8_t>& values) {
+  return AppendValues(values.data(), static_cast<int64_t>(values.size()));
 }
 
 Status BooleanBuilder::Append(const std::vector<uint8_t>& values) {
-  return Append(values.data(), static_cast<int64_t>(values.size()));
+  return AppendValues(values);
 }
 
-Status BooleanBuilder::Append(const std::vector<bool>& values,
-                              const std::vector<bool>& is_valid) {
+Status BooleanBuilder::AppendValues(const std::vector<bool>& values,
+                                    const std::vector<bool>& is_valid) {
   const int64_t length = static_cast<int64_t>(values.size());
   RETURN_NOT_OK(Reserve(length));
   DCHECK_EQ(length, static_cast<int64_t>(is_valid.size()));
@@ -795,7 +847,12 @@ Status BooleanBuilder::Append(const std::vector<bool>& values,
   return Status::OK();
 }
 
-Status BooleanBuilder::Append(const std::vector<bool>& values) {
+Status BooleanBuilder::Append(const std::vector<bool>& values,
+                              const std::vector<bool>& is_valid) {
+  return AppendValues(values, is_valid);
+}
+
+Status BooleanBuilder::AppendValues(const std::vector<bool>& values) {
   const int64_t length = static_cast<int64_t>(values.size());
   RETURN_NOT_OK(Reserve(length));
 
@@ -805,6 +862,10 @@ Status BooleanBuilder::Append(const std::vector<bool>& values) {
 
   ArrayBuilder::UnsafeSetNotNull(length);
   return Status::OK();
+}
+
+Status BooleanBuilder::Append(const std::vector<bool>& values) {
+  return AppendValues(values);
 }
 
 // ----------------------------------------------------------------------
@@ -1226,12 +1287,17 @@ ListBuilder::ListBuilder(MemoryPool* pool, std::unique_ptr<ArrayBuilder> value_b
       offsets_builder_(pool),
       value_builder_(std::move(value_builder)) {}
 
-Status ListBuilder::Append(const int32_t* offsets, int64_t length,
-                           const uint8_t* valid_bytes) {
+Status ListBuilder::AppendValues(const int32_t* offsets, int64_t length,
+                                 const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
   UnsafeAppendToBitmap(valid_bytes, length);
   offsets_builder_.UnsafeAppend(offsets, length);
   return Status::OK();
+}
+
+Status ListBuilder::Append(const int32_t* offsets, int64_t length,
+                           const uint8_t* valid_bytes) {
+  return AppendValues(offsets, length, valid_bytes);
 }
 
 Status ListBuilder::AppendNextOffset() {
@@ -1385,8 +1451,8 @@ const uint8_t* BinaryBuilder::GetValue(int64_t i, int32_t* out_length) const {
 
 StringBuilder::StringBuilder(MemoryPool* pool) : BinaryBuilder(utf8(), pool) {}
 
-Status StringBuilder::Append(const std::vector<std::string>& values,
-                             const uint8_t* valid_bytes) {
+Status StringBuilder::AppendValues(const std::vector<std::string>& values,
+                                   const uint8_t* valid_bytes) {
   std::size_t total_length = std::accumulate(
       values.begin(), values.end(), 0ULL,
       [](uint64_t sum, const std::string& str) { return sum + str.size(); });
@@ -1413,8 +1479,13 @@ Status StringBuilder::Append(const std::vector<std::string>& values,
   return Status::OK();
 }
 
-Status StringBuilder::Append(const char** values, int64_t length,
+Status StringBuilder::Append(const std::vector<std::string>& values,
                              const uint8_t* valid_bytes) {
+  return AppendValues(values, valid_bytes);
+}
+
+Status StringBuilder::AppendValues(const char** values, int64_t length,
+                                   const uint8_t* valid_bytes) {
   std::size_t total_length = 0;
   std::vector<std::size_t> value_lengths(length);
   bool have_null_value = false;
@@ -1471,6 +1542,11 @@ Status StringBuilder::Append(const char** values, int64_t length,
   return Status::OK();
 }
 
+Status StringBuilder::Append(const char** values, int64_t length,
+                             const uint8_t* valid_bytes) {
+  return AppendValues(values, length, valid_bytes);
+}
+
 // ----------------------------------------------------------------------
 // Fixed width binary
 
@@ -1480,11 +1556,16 @@ FixedSizeBinaryBuilder::FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& 
       byte_width_(static_cast<const FixedSizeBinaryType&>(*type).byte_width()),
       byte_builder_(pool) {}
 
-Status FixedSizeBinaryBuilder::Append(const uint8_t* data, int64_t length,
-                                      const uint8_t* valid_bytes) {
+Status FixedSizeBinaryBuilder::AppendValues(const uint8_t* data, int64_t length,
+                                            const uint8_t* valid_bytes) {
   RETURN_NOT_OK(Reserve(length));
   UnsafeAppendToBitmap(valid_bytes, length);
   return byte_builder_.Append(data, length * byte_width_);
+}
+
+Status FixedSizeBinaryBuilder::Append(const uint8_t* data, int64_t length,
+                                      const uint8_t* valid_bytes) {
+  return AppendValues(data, length, valid_bytes);
 }
 
 Status FixedSizeBinaryBuilder::Append(const std::string& value) {

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -217,6 +217,9 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value
   /// \return Status
+  Status AppendValues(const value_type* values, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const value_type* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -226,6 +229,9 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null
   /// (0). Equal in length to values
   /// \return Status
+  Status AppendValues(const value_type* values, int64_t length,
+                      const std::vector<bool>& is_valid);
+  /// \deprecated Use AppendValues instead.
   Status Append(const value_type* values, int64_t length,
                 const std::vector<bool>& is_valid);
 
@@ -234,11 +240,16 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null
   /// (0). Equal in length to values
   /// \return Status
+  Status AppendValues(const std::vector<value_type>& values,
+                      const std::vector<bool>& is_valid);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<value_type>& values, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values a std::vector of values
   /// \return Status
+  Status AppendValues(const std::vector<value_type>& values);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<value_type>& values);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
@@ -267,6 +278,7 @@ class ARROW_EXPORT NumericBuilder : public PrimitiveBuilder<T> {
       : PrimitiveBuilder<T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
   using PrimitiveBuilder<T>::Append;
+  using PrimitiveBuilder<T>::AppendValues;
   using PrimitiveBuilder<T>::Init;
   using PrimitiveBuilder<T>::Resize;
   using PrimitiveBuilder<T>::Reserve;
@@ -433,6 +445,9 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value
   /// \return Status
+  Status AppendValues(const uint64_t* values, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const uint64_t* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -495,6 +510,9 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value
   /// \return Status
+  Status AppendValues(const int64_t* values, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const int64_t* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -560,6 +578,9 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value
   /// \return Status
+  Status AppendValues(const uint8_t* values, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const uint8_t* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -569,6 +590,9 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null
   /// (0). Equal in length to values
   /// \return Status
+  Status AppendValues(const uint8_t* values, int64_t length,
+                      const std::vector<bool>& is_valid);
+  /// \deprecated Use AppendValues instead.
   Status Append(const uint8_t* values, int64_t length, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
@@ -576,11 +600,16 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null
   /// (0). Equal in length to values
   /// \return Status
+  Status AppendValues(const std::vector<uint8_t>& values,
+                      const std::vector<bool>& is_valid);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<uint8_t>& values, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values a std::vector of bytes
   /// \return Status
+  Status AppendValues(const std::vector<uint8_t>& values);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<uint8_t>& values);
 
   /// \brief Append a sequence of elements in one shot
@@ -588,11 +617,15 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \param[in] is_valid an std::vector<bool> indicating valid (1) or null
   /// (0). Equal in length to values
   /// \return Status
+  Status AppendValues(const std::vector<bool>& values, const std::vector<bool>& is_valid);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<bool>& values, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values an std::vector<bool> indicating true (1) or false
   /// \return Status
+  Status AppendValues(const std::vector<bool>& values);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<bool>& values);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
@@ -638,6 +671,9 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
   ///
   /// If passed, valid_bytes is of equal length to values, and any zero byte
   /// will be considered as a null for that slot
+  Status AppendValues(const int32_t* offsets, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const int32_t* offsets, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -718,6 +754,15 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
 
   using BinaryBuilder::Append;
 
+  /// \brief Append a sequence of strings in one shot.
+  ///
+  /// \param[in] values a vector of strings
+  /// \param[in] valid_bytes an optional sequence of bytes where non-zero
+  /// indicates a valid (non-null) value
+  /// \return Status
+  Status AppendValues(const std::vector<std::string>& values,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const std::vector<std::string>& values,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -730,6 +775,9 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   /// \param[in] valid_bytes an optional sequence of bytes where non-zero
   /// indicates a valid (non-null) value
   /// \return Status
+  Status AppendValues(const char** values, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const char** values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 };
@@ -758,6 +806,9 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
     return byte_builder_.Append(value);
   }
 
+  Status AppendValues(const uint8_t* data, int64_t length,
+                      const uint8_t* valid_bytes = NULLPTR);
+  /// \deprecated Use AppendValues instead.
   Status Append(const uint8_t* data, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
   Status Append(const std::string& value);
@@ -786,6 +837,7 @@ class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
                              MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   using FixedSizeBinaryBuilder::Append;
+  using FixedSizeBinaryBuilder::AppendValues;
 
   Status Append(const Decimal128& val);
 
@@ -813,10 +865,14 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
   /// will be considered as a null for that field, but users must using app-
   /// end methods or advance methods of the child builders' independently to
   /// insert data.
-  Status Append(int64_t length, const uint8_t* valid_bytes) {
+  Status AppendValues(int64_t length, const uint8_t* valid_bytes) {
     RETURN_NOT_OK(Reserve(length));
     UnsafeAppendToBitmap(valid_bytes, length);
     return Status::OK();
+  }
+  /// \deprecated Use AppendValues instead.
+  Status Append(int64_t length, const uint8_t* valid_bytes) {
+    return AppendValues(length, valid_bytes);
   }
 
   /// Append an element to the Struct. All child-builders' Append method must

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -220,6 +220,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   Status AppendValues(const value_type* values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const value_type* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -232,6 +233,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   Status AppendValues(const value_type* values, int64_t length,
                       const std::vector<bool>& is_valid);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const value_type* values, int64_t length,
                 const std::vector<bool>& is_valid);
 
@@ -243,6 +245,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   Status AppendValues(const std::vector<value_type>& values,
                       const std::vector<bool>& is_valid);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<value_type>& values, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
@@ -250,6 +253,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   /// \return Status
   Status AppendValues(const std::vector<value_type>& values);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<value_type>& values);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
@@ -448,6 +452,7 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
   Status AppendValues(const uint64_t* values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const uint64_t* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -513,6 +518,7 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
   Status AppendValues(const int64_t* values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const int64_t* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -581,6 +587,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   Status AppendValues(const uint8_t* values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const uint8_t* values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -593,6 +600,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   Status AppendValues(const uint8_t* values, int64_t length,
                       const std::vector<bool>& is_valid);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const uint8_t* values, int64_t length, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
@@ -603,6 +611,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   Status AppendValues(const std::vector<uint8_t>& values,
                       const std::vector<bool>& is_valid);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<uint8_t>& values, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
@@ -610,6 +619,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \return Status
   Status AppendValues(const std::vector<uint8_t>& values);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<uint8_t>& values);
 
   /// \brief Append a sequence of elements in one shot
@@ -619,6 +629,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \return Status
   Status AppendValues(const std::vector<bool>& values, const std::vector<bool>& is_valid);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<bool>& values, const std::vector<bool>& is_valid);
 
   /// \brief Append a sequence of elements in one shot
@@ -626,6 +637,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   /// \return Status
   Status AppendValues(const std::vector<bool>& values);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<bool>& values);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
@@ -674,6 +686,7 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
   Status AppendValues(const int32_t* offsets, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const int32_t* offsets, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -763,6 +776,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status AppendValues(const std::vector<std::string>& values,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const std::vector<std::string>& values,
                 const uint8_t* valid_bytes = NULLPTR);
 
@@ -778,6 +792,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status AppendValues(const char** values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const char** values, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
 };
@@ -809,6 +824,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   Status AppendValues(const uint8_t* data, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(const uint8_t* data, int64_t length,
                 const uint8_t* valid_bytes = NULLPTR);
   Status Append(const std::string& value);
@@ -871,6 +887,7 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
     return Status::OK();
   }
   /// \deprecated Use AppendValues instead.
+  ARROW_DEPRECATED("Use AppendValues instead")
   Status Append(int64_t length, const uint8_t* valid_bytes) {
     return AppendValues(length, valid_bytes);
   }

--- a/cpp/src/arrow/ipc/test-common.h
+++ b/cpp/src/arrow/ipc/test-common.h
@@ -103,11 +103,12 @@ Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool
   if (include_nulls) {
     std::shared_ptr<PoolBuffer> valid_bytes;
     RETURN_NOT_OK(test::MakeRandomBytePoolBuffer(length, pool, &valid_bytes));
-    RETURN_NOT_OK(builder.Append(reinterpret_cast<const int32_t*>(data->data()), length,
-                                 valid_bytes->data()));
+    RETURN_NOT_OK(builder.AppendValues(reinterpret_cast<const int32_t*>(data->data()),
+                                       length, valid_bytes->data()));
     return builder.Finish(out);
   }
-  RETURN_NOT_OK(builder.Append(reinterpret_cast<const int32_t*>(data->data()), length));
+  RETURN_NOT_OK(
+      builder.AppendValues(reinterpret_cast<const int32_t*>(data->data()), length));
   return builder.Finish(out);
 }
 

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -223,7 +223,7 @@ class SequenceBuilder {
       DCHECK(data->length() == offsets.back());
       std::shared_ptr<Array> offset_array;
       Int32Builder builder(::arrow::int32(), pool_);
-      RETURN_NOT_OK(builder.Append(offsets.data(), offsets.size()));
+      RETURN_NOT_OK(builder.AppendValues(offsets.data(), offsets.size()));
       RETURN_NOT_OK(builder.Finish(&offset_array));
       std::shared_ptr<Array> list_array;
       RETURN_NOT_OK(ListArray::FromArrays(*offset_array, *data, pool_, &list_array));

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -73,6 +73,23 @@
 
 // ----------------------------------------------------------------------
 
+// clang-format off
+// [[deprecated]] is only available in C++14, use this for the time being
+// This macro takes an optional deprecation message
+#if __cplusplus <= 201103L
+# ifdef __GNUC__
+#  define ARROW_DEPRECATED(...) __attribute__((deprecated(__VA_ARGS__)))
+# elif defined(_MSC_VER)
+#  define ARROW_DEPRECATED(...) __declspec(deprecated(__VA_ARGS__))
+# else
+#  define ARROW_DEPRECATED(...)
+# endif
+#else
+#  define ARROW_DEPRECATED(...) [[deprecated(__VA_ARGS__)]]
+#endif
+
+// ----------------------------------------------------------------------
+
 // macros to disable padding
 // these macros are portable across different compilers and platforms
 //[https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h#L1355]

--- a/cpp/src/arrow/util/variant.h
+++ b/cpp/src/arrow/util/variant.h
@@ -39,22 +39,9 @@
 #include <functional>
 #include <limits>
 
+#include <arrow/util/macros.h>
 #include <arrow/util/variant/recursive_wrapper.h>
 #include <arrow/util/variant/variant_visitor.h>
-
-// clang-format off
-// [[deprecated]] is only available in C++14, use this for the time being
-#if __cplusplus <= 201103L
-# ifdef __GNUC__
-#  define ARROW_VARIANT_DEPRECATED __attribute__((deprecated))
-# elif defined(_MSC_VER)
-#  define ARROW_VARIANT_DEPRECATED __declspec(deprecated)
-# else
-#  define ARROW_VARIANT_DEPRECATED
-# endif
-#else
-#  define ARROW_VARIANT_DEPRECATED [[deprecated]]
-#endif
 
 
 #ifdef _MSC_VER
@@ -867,7 +854,8 @@ public:
 
     // This function is deprecated because it returns an internal index field.
     // Use which() instead.
-    ARROW_VARIANT_DEPRECATED VARIANT_INLINE type_index_t get_type_index() const
+    ARROW_DEPRECATED("Use which() instead")
+    VARIANT_INLINE type_index_t get_type_index() const
     {
         return type_index;
     }


### PR DESCRIPTION
Vector-style Append() methods are renamed AppendValues().
The original methods are marked deprecated.