### PR TITLE
ARROW-2465: [Plasma/GPU] Preserve plasma_store rpath

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -147,6 +147,7 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/plasma")
 
 # Plasma store
+set_target_properties(plasma_store PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 install(TARGETS plasma_store DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # pkg-config support


### PR DESCRIPTION
This allows it to find libarrow_gpu.so when installed