### PR TITLE
ARROW-2393: [C++] Moving ARROW_CHECK_OK_[PREPEND] macros from status.h into util/logging.h since they use the logging infrastructure and shouldn't be in the public API.

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -535,7 +535,7 @@ namespace garrow {
                        std::shared_ptr<arrow::Buffer> *out) override {
       arrow::MemoryPool *pool = arrow::default_memory_pool();
       std::shared_ptr<arrow::ResizableBuffer> buffer;
-      ARROW_RETURN_NOT_OK(AllocateResizableBuffer(pool, n_bytes, &buffer));
+      RETURN_NOT_OK(AllocateResizableBuffer(pool, n_bytes, &buffer));
 
       GError *error = NULL;
       auto n_read_bytes = g_input_stream_read(input_stream_,
@@ -549,7 +549,7 @@ namespace garrow {
                                       "[gio-input-stream][read][buffer]");
       } else {
         if (n_read_bytes < n_bytes) {
-          ARROW_RETURN_NOT_OK(buffer->Resize(n_read_bytes));
+          RETURN_NOT_OK(buffer->Resize(n_read_bytes));
         }
         *out = buffer;
         return arrow::Status::OK();

--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -138,7 +138,7 @@ Status PyReadableFile::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
   PyAcquireGIL lock;
 
   PyObject* bytes_obj = NULL;
-  ARROW_RETURN_NOT_OK(file_->Read(nbytes, &bytes_obj));
+  RETURN_NOT_OK(file_->Read(nbytes, &bytes_obj));
   DCHECK(bytes_obj != NULL);
 
   *bytes_read = PyBytes_GET_SIZE(bytes_obj);
@@ -152,7 +152,7 @@ Status PyReadableFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
   PyAcquireGIL lock;
 
   OwnedRef bytes_obj;
-  ARROW_RETURN_NOT_OK(file_->Read(nbytes, bytes_obj.ref()));
+  RETURN_NOT_OK(file_->Read(nbytes, bytes_obj.ref()));
   DCHECK(bytes_obj.obj() != NULL);
 
   return PyBuffer::FromPyObject(bytes_obj.obj(), out);
@@ -177,15 +177,15 @@ Status PyReadableFile::GetSize(int64_t* size) {
 
   int64_t current_position = -1;
 
-  ARROW_RETURN_NOT_OK(file_->Tell(&current_position));
+  RETURN_NOT_OK(file_->Tell(&current_position));
 
-  ARROW_RETURN_NOT_OK(file_->Seek(0, 2));
+  RETURN_NOT_OK(file_->Seek(0, 2));
 
   int64_t file_size = -1;
-  ARROW_RETURN_NOT_OK(file_->Tell(&file_size));
+  RETURN_NOT_OK(file_->Tell(&file_size));
 
   // Restore previous file position
-  ARROW_RETURN_NOT_OK(file_->Seek(current_position, 0));
+  RETURN_NOT_OK(file_->Seek(current_position, 0));
 
   *size = file_size;
   return Status::OK();

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -59,6 +59,12 @@
     }                                \
   } while (false)
 
+// This is used by other codebases. The macros above
+// should probably have that prefix, but there is a
+// lot of code that already uses that macro and changing
+// it would be of no benefit.
+#define ARROW_RETURN_NOT_OK(s) RETURN_NOT_OK(s)
+
 namespace arrow {
 
 enum class StatusCode : char {

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -26,34 +26,11 @@
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
-// Return the given status if it is not OK.
-#define ARROW_RETURN_NOT_OK(s)           \
-  do {                                   \
-    ::arrow::Status _s = (s);            \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) { \
-      return _s;                         \
-    }                                    \
-  } while (false)
-
-// If 'to_call' returns a bad status, CHECK immediately with a logged message
-// of 'msg' followed by the status.
-#define ARROW_CHECK_OK_PREPEND(to_call, msg)                \
-  do {                                                      \
-    ::arrow::Status _s = (to_call);                         \
-    ARROW_CHECK(_s.ok()) << (msg) << ": " << _s.ToString(); \
-  } while (false)
-
-// If the status is bad, CHECK immediately, appending the status to the
-// logged message.
-#define ARROW_CHECK_OK(s) ARROW_CHECK_OK_PREPEND(s, "Bad status")
-
-namespace arrow {
-
 #ifdef ARROW_EXTRA_ERROR_CONTEXT
 
 #define RETURN_NOT_OK(s)                                                            \
   do {                                                                              \
-    Status _s = (s);                                                                \
+    ::arrow::Status _s = (s);                                                       \
     if (ARROW_PREDICT_FALSE(!_s.ok())) {                                            \
       std::stringstream ss;                                                         \
       ss << __FILE__ << ":" << __LINE__ << " code: " << #s << "\n" << _s.message(); \
@@ -65,7 +42,7 @@ namespace arrow {
 
 #define RETURN_NOT_OK(s)                 \
   do {                                   \
-    Status _s = (s);                     \
+    ::arrow::Status _s = (s);            \
     if (ARROW_PREDICT_FALSE(!_s.ok())) { \
       return _s;                         \
     }                                    \
@@ -75,12 +52,14 @@ namespace arrow {
 
 #define RETURN_NOT_OK_ELSE(s, else_) \
   do {                               \
-    Status _s = (s);                 \
+    ::arrow::Status _s = (s);        \
     if (!_s.ok()) {                  \
       else_;                         \
       return _s;                     \
     }                                \
   } while (false)
+
+namespace arrow {
 
 enum class StatusCode : char {
   OK = 0,

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -42,10 +42,10 @@ namespace arrow {
 #define ARROW_LOG(level) ARROW_LOG_INTERNAL(ARROW_##level)
 #define ARROW_IGNORE_EXPR(expr) ((void)(expr));
 
-#define ARROW_CHECK(condition)                               \
-  (condition) ? 0 : ::arrow::internal::FatalLog(ARROW_FATAL) \
-                        << __FILE__ << ":" << __LINE__       \
-                        << " Check failed: " #condition " "
+#define ARROW_CHECK(condition)                           \
+  (condition) ? 0                                        \
+              : ::arrow::internal::FatalLog(ARROW_FATAL) \
+                    << __FILE__ << ":" << __LINE__ << " Check failed: " #condition " "
 
 // If 'to_call' returns a bad status, CHECK immediately with a logged message
 // of 'msg' followed by the status.
@@ -114,8 +114,7 @@ class NullLog {
 class CerrLog {
  public:
   CerrLog(int severity)  // NOLINT(runtime/explicit)
-      : severity_(severity),
-        has_logged_(false) {}
+      : severity_(severity), has_logged_(false) {}
 
   virtual ~CerrLog() {
     if (has_logged_) {


### PR DESCRIPTION
Also removing ARROW_RETURN_NOT_OK macro. It is almost exactly the same as RETURN_NOT_OK, but RETURN_NOT_OK is declared inside an arrow namespace block and uses Status instead of ::arrow::Stat. That doesn't really matter, since the macro gets expanded where it's used and users who include Status.h and want to use RETURN_NOT_OK will get compiler errors unless they have a 'using arrow' statement