### PR TITLE
ARROW-2443: [Python] Allow creation of empty Dictionary indices

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -581,10 +581,6 @@ DictionaryArray::DictionaryArray(const std::shared_ptr<DataType>& type,
 Status DictionaryArray::FromArrays(const std::shared_ptr<DataType>& type,
                                    const std::shared_ptr<Array>& indices,
                                    std::shared_ptr<Array>* out) {
-  if (indices->length() == 0) {
-    return Status::Invalid("Dictionary indices must have non-zero length");
-  }
-
   DCHECK_EQ(type->id(), Type::DICTIONARY);
   const auto& dict = static_cast<const DictionaryType&>(*type);
   DCHECK_EQ(indices->type_id(), dict.index_type()->id());

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1836,6 +1836,11 @@ class TestConvertMisc(object):
         for values in arrays:
             _check_array_roundtrip(values)
 
+    def test_empty_category(self):
+        # ARROW-2443
+        df = pd.DataFrame({'cat': pd.Categorical([])})
+        _check_pandas_roundtrip(df)
+
     def test_mixed_types_fails(self):
         data = pd.DataFrame({'a': ['a', 1, 2.0]})
         with pytest.raises(pa.ArrowException):


### PR DESCRIPTION
Empty dictionaries are a valid use case if you have absolutely no data in an array. This was working pre-0.9.0 releases of Arrow.