### PR TITLE
ARROW-2468: [Rust] Builder::slice_mut() should take mut self.

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -65,7 +65,7 @@ impl<T> Builder<T> {
     }
 
     /// Get the internal byte-aligned memory buffer as a mutable slice
-    pub fn slice_mut(&self, start: usize, end: usize) -> &mut [T] {
+    pub fn slice_mut(&mut self, start: usize, end: usize) -> &mut [T] {
         assert!(start <= end);
         assert!(start < self.capacity as usize);
         assert!(end <= self.capacity as usize);


### PR DESCRIPTION
Since `Builder::slice_mut()` is returning a mutable reference to
data that it owns, it should take `&mut self`.