### PR TITLE
ARROW-2423: [Python] Enable DataType, Field and plasma ObjectID equality checks against no…

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -288,7 +288,7 @@ cdef class Array:
         self.ap = sp_array.get()
         self.type = pyarrow_wrap_data_type(self.sp_array.get().type())
 
-    def __richcmp__(Array self, object other, int op):
+    def __eq__(self, other):
         raise NotImplementedError('Comparisons with pyarrow.Array are not '
                                   'implemented')
 

--- a/python/pyarrow/plasma.pyx
+++ b/python/pyarrow/plasma.pyx
@@ -139,10 +139,11 @@ cdef class ObjectID:
                              " is " + str(object_id))
         self.data = CUniqueID.from_binary(object_id)
 
-    def __richcmp__(ObjectID self, ObjectID object_id, operation):
-        if operation != 2:
-            raise ValueError("operation != 2 (only equality is supported)")
-        return self.data == object_id.data
+    def __eq__(self, other):
+        try:
+            return self.data == (<ObjectID?>other).data
+        except TypeError:
+            return False
 
     def __hash__(self):
         return hash(self.data.binary())

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -819,6 +819,19 @@ def test_object_id_size():
     plasma.ObjectID(20 * b"0")
 
 
+@pytest.mark.plasma
+def test_object_id_equality_operators():
+    import pyarrow.plasma as plasma
+
+    oid1 = plasma.ObjectID(20 * b'0')
+    oid2 = plasma.ObjectID(20 * b'0')
+    oid3 = plasma.ObjectID(19 * b'0' + b'1')
+
+    assert oid1 == oid2
+    assert oid2 != oid3
+    assert oid1 != 'foo'
+
+
 @pytest.mark.skipif(not os.path.exists("/mnt/hugepages"),
                     reason="requires hugepage support")
 def test_use_huge_pages():

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -75,9 +75,7 @@ def test_type_comparisons():
     val = pa.int32()
     assert val == pa.int32()
     assert val == 'int32'
-
-    with pytest.raises(TypeError):
-        val == 5
+    assert val != 5
 
 
 def test_type_for_alias():

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -251,3 +251,27 @@ def test_fixed_size_binary_byte_width():
 def test_decimal_byte_width():
     ty = pa.decimal128(19, 4)
     assert ty.byte_width == 16
+
+
+@pytest.mark.parametrize(('index', 'ty'), enumerate(MANY_TYPES), ids=str)
+def test_type_equality_operators(index, ty):
+    non_pyarrow = ['foo', 16, {'s', 'e', 't'}]
+
+    # could use two parametrization levels, but that'd bloat pytest's output
+    for i, other in enumerate(MANY_TYPES + non_pyarrow):
+        if i == index:
+            assert ty == other
+        else:
+            assert ty != other
+
+
+def test_field_equality_operators():
+    f1 = pa.field('a', pa.int8(), nullable=True)
+    f2 = pa.field('a', pa.int8(), nullable=True)
+    f3 = pa.field('b', pa.int8(), nullable=True)
+    f4 = pa.field('b', pa.int8(), nullable=False)
+
+    assert f1 == f2
+    assert f1 != f3
+    assert f3 != f4
+    assert f1 != 'foo'

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -133,13 +133,11 @@ cdef class DataType:
     def __repr__(self):
         return '{0.__class__.__name__}({0})'.format(self)
 
-    def __richcmp__(DataType self, object other, int op):
-        if op == cp.Py_EQ:
+    def __eq__(self, other):
+        try:
             return self.equals(other)
-        elif op == cp.Py_NE:
-            return not self.equals(other)
-        else:
-            raise TypeError('Invalid comparison')
+        except (TypeError, ValueError):
+            return False
 
     def equals(self, other):
         """
@@ -393,13 +391,11 @@ cdef class Field:
         """
         return self.field.Equals(deref(other.field))
 
-    def __richcmp__(Field self, Field other, int op):
-        if op == cp.Py_EQ:
+    def __eq__(self, other):
+        try:
             return self.equals(other)
-        elif op == cp.Py_NE:
-            return not self.equals(other)
-        else:
-            raise TypeError('Invalid comparison')
+        except TypeError:
+            return False
 
     def __reduce__(self):
         return Field, (), self.__getstate__()


### PR DESCRIPTION
…n pyarrow objects

Bumped cython version makes it possible https://github.com/apache/arrow/pull/1863