### PR TITLE
ARROW-2390: [C++/Python] Map Python exceptions to Arrow status codes

### DIFF
--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -98,6 +98,23 @@ Status CheckPyError(StatusCode code) {
 
     std::string message;
     RETURN_NOT_OK(internal::PyObject_StdStringStr(exc_value, &message));
+
+    if (code == StatusCode::UnknownError) {
+      // Try to match the Python exception type with an appropriate Status code
+      if (PyErr_GivenExceptionMatches(exc_type, PyExc_MemoryError)) {
+        code = StatusCode::OutOfMemory;
+      } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_KeyError)) {
+        code = StatusCode::KeyError;
+      } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_TypeError)) {
+        code = StatusCode::TypeError;
+      } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_ValueError)) {
+        code = StatusCode::Invalid;
+      } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_EnvironmentError)) {
+        code = StatusCode::IOError;
+      } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_NotImplementedError)) {
+        code = StatusCode::NotImplemented;
+      }
+    }
     return Status(code, message);
   }
   return Status::OK();

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -471,7 +471,7 @@ def test_sequence_timestamp_from_int_with_unit():
     assert arr_ns.type == ns
     assert str(arr_ns[0]) == "Timestamp('1970-01-01 00:00:00.000000001')"
 
-    with pytest.raises(pa.ArrowTypeError):
+    with pytest.raises(pa.ArrowException):
         class CustomClass():
             pass
         pa.array([1, CustomClass()], type=ns)

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -316,7 +316,7 @@ def test_sequence_utf8_to_unicode():
 
     # test a non-utf8 unicode string
     val = (u'mañana').encode('utf-16-le')
-    with pytest.raises(pa.ArrowException):
+    with pytest.raises(pa.ArrowInvalid):
         pa.array([val], type=pa.string())
 
 
@@ -471,7 +471,7 @@ def test_sequence_timestamp_from_int_with_unit():
     assert arr_ns.type == ns
     assert str(arr_ns[0]) == "Timestamp('1970-01-01 00:00:00.000000001')"
 
-    with pytest.raises(pa.ArrowException):
+    with pytest.raises(pa.ArrowTypeError):
         class CustomClass():
             pass
         pa.array([1, CustomClass()], type=ns)
@@ -496,7 +496,7 @@ def test_sequence_mixed_nesting_levels():
 
 def test_sequence_mixed_types_fails():
     data = ['a', 1, 2.0]
-    with pytest.raises(pa.ArrowException):
+    with pytest.raises(pa.ArrowTypeError):
         pa.array(data)
 
 

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -592,7 +592,7 @@ def test_serialize_to_components_invalid_cases():
         'data': [buf]
     }
 
-    with pytest.raises(pa.ArrowException):
+    with pytest.raises(pa.ArrowInvalid):
         pa.deserialize_components(components)
 
     components = {
@@ -601,7 +601,7 @@ def test_serialize_to_components_invalid_cases():
         'data': [buf, buf]
     }
 
-    with pytest.raises(pa.ArrowException):
+    with pytest.raises(pa.ArrowInvalid):
         pa.deserialize_components(components)
 
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -234,7 +234,7 @@ def test_recordbatchlist_schema_equals():
     batch1 = pa.RecordBatch.from_pandas(data1)
     batch2 = pa.RecordBatch.from_pandas(data2)
 
-    with pytest.raises(pa.ArrowException):
+    with pytest.raises(pa.ArrowInvalid):
         pa.Table.from_batches([batch1, batch2])
 
 


### PR DESCRIPTION
Instead of always returning an "unknown error" status code when a Python exception is raised, we can easily discriminate and return e.g. a TypeError status code when a Python TypeError is raised, etc.