### PR TITLE
ARROW-1964: [Python] Expose StringBuilder to Python

### DIFF
--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import six
+from pyarrow.compat import tobytes
+
+cdef class StringBuilder:
+    cdef:
+        unique_ptr[CStringBuilder] builder
+
+    def __cinit__(self, MemoryPool memory_pool=None):
+        cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+        self.builder.reset(new CStringBuilder(pool))
+
+    def append(self, value):
+        if value is None or value is np.nan:
+            self.builder.get().AppendNull()
+        elif isinstance(value, (six.string_types, six.binary_type)):
+            self.builder.get().Append(tobytes(value))
+        else:
+            raise TypeError('StringBuilder only accepts string objects')
+
+    def append_values(self, values):
+        for value in values:
+            self.append(value)
+
+    def length(self):
+        return self.builder.get().length()
+
+    def null_count(self):
+        return self.builder.get().null_count()
+
+    def finish(self):
+        return pyarrow_wrap_array(self._finish())
+
+    cdef shared_ptr[CArray] _finish(self) nogil:
+        cdef shared_ptr[CArray] out
+        self.builder.get().Finish(&out)
+        return out

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -19,6 +19,7 @@
 
 from pyarrow.includes.common cimport *
 
+
 cdef extern from "arrow/util/key_value_metadata.h" namespace "arrow" nogil:
     cdef cppclass CKeyValueMetadata" arrow::KeyValueMetadata":
         CKeyValueMetadata()
@@ -530,6 +531,24 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     CStatus ConcatenateTables(const vector[shared_ptr[CTable]]& tables,
                               shared_ptr[CTable]* result)
+
+    cdef extern from "arrow/builder.h" namespace "arrow" nogil:
+
+        cdef cppclass CArrayBuilder" arrow::ArrayBuilder":
+            CArrayBuilder(shared_ptr[CDataType], CMemoryPool* pool)
+
+        cdef cppclass CBinaryBuilder" arrow::BinaryBuilder"(CArrayBuilder):
+            CArrayBuilder(shared_ptr[CDataType], CMemoryPool* pool)
+
+        cdef cppclass CStringBuilder" arrow::StringBuilder"(CBinaryBuilder):
+            CStringBuilder(CMemoryPool* pool)
+
+            int64_t length()
+            int64_t null_count()
+
+            CStatus Append(const c_string& value)
+            CStatus AppendNull()
+            CStatus Finish(shared_ptr[CArray]* out)
 
 
 cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -106,6 +106,9 @@ include "scalar.pxi"
 # Array types
 include "array.pxi"
 
+# Builders
+include "builder.pxi"
+
 # Column, Table, Record Batch
 include "table.pxi"
 

--- a/python/pyarrow/tests/test_builder.py
+++ b/python/pyarrow/tests/test_builder.py
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+import pyarrow as pa
+from pyarrow.lib import StringBuilder
+import numpy as np
+import pandas as pd
+
+
+@pytest.fixture
+def sbuilder():
+    return StringBuilder()
+
+
+def test_string_builder_append_string(sbuilder):
+    sbuilder.append(b'jsaafakjh')
+    assert (sbuilder.length() == 1)
+    sbuilder.append('jsaafakjh')
+    assert (sbuilder.length() == 2)
+    arr = sbuilder.finish()
+    assert (sbuilder.length() == 0)
+    assert (isinstance(arr, pa.Array))
+    assert (arr.null_count == 0)
+    assert (arr.type == 'str')
+    assert(len(arr.to_pylist()) == 2)
+
+
+def test_string_builder_append_none(sbuilder):
+    sbuilder.append(None)
+    assert (sbuilder.null_count() == 1)
+    for i in range(10):
+        sbuilder.append(None)
+    assert (sbuilder.null_count() == 11)
+    arr = sbuilder.finish()
+    assert (arr.null_count == 11)
+
+
+def test_string_builder_append_nan(sbuilder):
+    sbuilder.append(np.nan)
+    sbuilder.append(np.nan)
+    assert (sbuilder.null_count() == 2)
+    arr = sbuilder.finish()
+    assert (arr.null_count == 2)
+
+
+def test_string_builder_append_both(sbuilder):
+    sbuilder.append(np.nan)
+    sbuilder.append(None)
+    sbuilder.append("Some text")
+    sbuilder.append("Some text")
+    sbuilder.append(np.nan)
+    sbuilder.append(None)
+    assert (sbuilder.null_count() == 4)
+    arr = sbuilder.finish()
+    assert (arr.null_count == 4)
+    expected = [None, None, "Some text", "Some text", None, None]
+    assert (arr.to_pylist() == expected)
+
+
+def test_string_builder_append_pylist(sbuilder):
+    sbuilder.append_values([np.nan, None, "text", None, "other text"])
+    assert (sbuilder.null_count() == 3)
+    arr = sbuilder.finish()
+    assert (arr.null_count == 3)
+    expected = [None, None, "text", None, "other text"]
+    assert (arr.to_pylist() == expected)
+
+
+def test_string_builder_append_series(sbuilder):
+    sbuilder.append_values(
+        pd.Series([np.nan, None, "text", None, "other text"])
+    )
+    assert (sbuilder.null_count() == 3)
+    arr = sbuilder.finish()
+    assert (arr.null_count == 3)
+    expected = [None, None, "text", None, "other text"]
+    assert (arr.to_pylist() == expected)
+
+
+def test_string_builder_append_numpy(sbuilder):
+    sbuilder.append_values(
+        np.asarray([np.nan, None, "text", None, "other text"])
+    )
+    assert (sbuilder.null_count() == 3)
+    arr = sbuilder.finish()
+    assert (arr.null_count == 3)
+    expected = [None, None, "text", None, "other text"]
+    assert (arr.to_pylist() == expected)
+
+
+def test_string_builder_append_after_finish(sbuilder):
+    sbuilder.append_values([np.nan, None, "text", None, "other text"])
+    assert (sbuilder.null_count() == 3)
+    arr = sbuilder.finish()
+    sbuilder.append("No effect")
+    assert (arr.null_count == 3)
+    expected = [None, None, "text", None, "other text"]
+    assert (arr.to_pylist() == expected)


### PR DESCRIPTION
* Partial implementation of ARROW-1964
* Only implements StringBuilder not the other builders, notably the DictionaryBuilder mentioned in issue 1964