### PR TITLE
ARROW-2470: [C++] Avoid seeking in GetFileSize

### DIFF
--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -100,6 +100,8 @@ def test_python_file_read():
     assert v == b'sample data'
     assert len(v) == 11
 
+    assert f.size() == len(data)
+
     f.close()
 
 


### PR DESCRIPTION
This makes GetFileSize thread-safe and also reduces its cost.