### PR TITLE
ARROW-2502: [Rust] Restore Windows Compatibility

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -123,7 +123,7 @@ impl<T> Builder<T> {
             );
             self.capacity = new_capacity;
             self.data = mem::transmute::<*const u8, *mut T>(new_buffer);
-            libc::free(mem::transmute::<*mut T, *mut libc::c_void>(old_buffer));
+            free_aligned(mem::transmute::<*mut T, *const u8>(old_buffer));
         }
     }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,4 +30,5 @@ pub mod error;
 pub mod list;
 pub mod list_builder;
 pub mod memory;
+#[cfg(not(windows))]
 pub mod memory_pool;


### PR DESCRIPTION
This PR restores the windows compatibility for the current master.  The memory pool abstraction is not used anywhere else within the code base and so is not included in windows builds.

Next I plan to add [CI](https://issues.apache.org/jira/browse/ARROW-2436?filter=12343557&jql=project%20%3D%20ARROW%20AND%20component%20%3D%20Rust%20AND%20status%20%3D%20Open) for windows.  Followed by [ARROW-2474](https://issues.apache.org/jira/browse/ARROW-2474?filter=12343557&jql=project%20%3D%20ARROW%20AND%20component%20%3D%20Rust%20AND%20status%20%3D%20Open), which I will add windows compatibility to the memory pool abstraction, allowing it to be used throughout the code base.