### PR TITLE
ARROW-2507: [Rust] Don't take a reference when not needed.

### DIFF
--- a/rust/src/list.rs
+++ b/rust/src/list.rs
@@ -54,7 +54,7 @@ impl<T> List<T> {
     pub fn slice(&self, index: usize) -> &[T] {
         let start = *self.offsets.get(index) as usize;
         let end = *self.offsets.get(index + 1) as usize;
-        &self.data.slice(start, end)
+        self.data.slice(start, end)
     }
 }
 


### PR DESCRIPTION
Since this is already a reference value, we don't need to borrow it again.