### PR TITLE
ARROW-2503: [Python] Prevent trailing space character for string statistics

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -587,7 +587,7 @@ def test_parquet_metadata_api():
         ([-1.1, 2.2, 2.3, None, 4.4], np.float64, -1.1, 4.4, 1, 4),
         (
             [u'', u'b', unichar(1000), None, u'aaa'],
-            str, b' ', (unichar(1000) + u' ').encode('utf-8'), 1, 4
+            str, b'', unichar(1000).encode('utf-8'), 1, 4
         ),
         ([True, False, False, True, True], np.bool, False, True, 0, 5),
     ]


### PR DESCRIPTION
The trailing space is added in `parquet-cpp.` `pyarrow` calls the function `FormatStatValue` which adds the trailing space (https://github.com/apache/parquet-cpp/blob/master/src/parquet/types.cc#L52).

https://issues.apache.org/jira/browse/PARQUET-1283 is about fixing this behavior. Once the corresponding PR is merged into `parquet-cpp` and `pyarrow` is synced, the `test_parquet.py:test_parquet_column_statistics_api` will break for `str`. This PR fixes that breakage.