### PR TITLE
ARROW-2513: [Python] DictionaryType should give access to index type and dictionary array

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -210,6 +210,11 @@ def test_types_picklable():
         assert pickle.loads(data) == ty
 
 
+def test_dictionary_type():
+    ty = pa.dictionary(pa.int32(), pa.array(['a', 'b', 'c']))
+    assert ty.index_type == pa.int32()
+
+
 def test_fields_hashable():
     in_dict = {}
     fields = [pa.field('a', pa.int64()),

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -213,6 +213,7 @@ def test_types_picklable():
 def test_dictionary_type():
     ty = pa.dictionary(pa.int32(), pa.array(['a', 'b', 'c']))
     assert ty.index_type == pa.int32()
+    assert ty.dictionary.to_pylist() == ['a', 'b', 'c']
 
 
 def test_fields_hashable():

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -189,6 +189,11 @@ cdef class DictionaryType(DataType):
         def __get__(self):
             return pyarrow_wrap_data_type(self.dict_type.index_type())
 
+    property dictionary:
+
+        def __get__(self):
+            return pyarrow_wrap_array(self.dict_type.dictionary())
+
 
 cdef class ListType(DataType):
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -184,6 +184,11 @@ cdef class DictionaryType(DataType):
         def __get__(self):
             return self.dict_type.ordered()
 
+    property index_type:
+
+        def __get__(self):
+            return pyarrow_wrap_data_type(self.dict_type.index_type())
+
 
 cdef class ListType(DataType):
 


### PR DESCRIPTION
Implement missing Python properties for DictionaryType