### PR TITLE
ARROW-2474: [Rust] Add windows support for memory pool abstraction

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -30,5 +30,4 @@ pub mod error;
 pub mod list;
 pub mod list_builder;
 pub mod memory;
-#[cfg(not(windows))]
 pub mod memory_pool;

--- a/rust/src/memory_pool.rs
+++ b/rust/src/memory_pool.rs
@@ -20,7 +20,7 @@ use std::cmp;
 use std::mem;
 
 use super::error::ArrowError;
-use super::error::Result;
+use super::memory::{allocate_aligned, free_aligned};
 
 const ALIGNMENT: usize = 64;
 
@@ -28,15 +28,15 @@ const ALIGNMENT: usize = 64;
 pub trait MemoryPool {
     /// Allocate memory.
     /// The implementation should ensures that allocated memory is aligned.
-    fn allocate(&self, size: usize) -> Result<*mut u8>;
+    fn allocate(&self, size: usize) -> Result<*const u8, ArrowError>;
 
     /// Reallocate memory.
     /// If the implementation doesn't support reallocating aligned memory, it allocates new memory
     /// and copied old memory to it.
-    fn reallocate(&self, old_size: usize, new_size: usize, pointer: *mut u8) -> Result<*mut u8>;
+    fn reallocate(&self, old_size: usize, new_size: usize, pointer: *const u8) -> Result<*const u8, ArrowError>;
 
     /// Free memory.
-    fn free(&self, ptr: *mut u8);
+    fn free(&self, ptr: *const u8);
 }
 
 /// Implementation of memory pool using libc api.
@@ -44,32 +44,23 @@ pub trait MemoryPool {
 struct LibcMemoryPool;
 
 impl MemoryPool for LibcMemoryPool {
-    fn allocate(&self, size: usize) -> Result<*mut u8> {
-        unsafe {
-            let mut page: *mut libc::c_void = mem::uninitialized();
-            let result = libc::posix_memalign(&mut page, ALIGNMENT, size);
-            match result {
-                0 => Ok(mem::transmute::<*mut libc::c_void, *mut u8>(page)),
-                _ => Err(ArrowError::MemoryError(
-                    "Failed to allocate memory".to_string(),
-                )),
-            }
-        }
+    fn allocate(&self, size: usize) -> Result<*const u8, ArrowError> {
+        allocate_aligned(size as i64)
     }
 
-    fn reallocate(&self, old_size: usize, new_size: usize, pointer: *mut u8) -> Result<*mut u8> {
+    fn reallocate(&self, old_size: usize, new_size: usize, pointer: *const u8) -> Result<*const u8, ArrowError> {
         unsafe {
-            let old_src = mem::transmute::<*mut u8, *mut libc::c_void>(pointer);
+            let old_src = mem::transmute::<*const u8, *mut libc::c_void>(pointer);
             let result = self.allocate(new_size)?;
-            let dst = mem::transmute::<*mut u8, *mut libc::c_void>(result);
+            let dst = mem::transmute::<*const u8, *mut libc::c_void>(result);
             libc::memcpy(dst, old_src, cmp::min(old_size, new_size));
-            libc::free(old_src);
+            free_aligned(pointer);
             Ok(result)
         }
     }
 
-    fn free(&self, ptr: *mut u8) {
-        unsafe { libc::free(mem::transmute::<*mut u8, *mut libc::c_void>(ptr)) }
+    fn free(&self, ptr: *const u8) {
+        free_aligned(ptr)
     }
 }
 

--- a/rust/src/memory_pool.rs
+++ b/rust/src/memory_pool.rs
@@ -33,7 +33,12 @@ pub trait MemoryPool {
     /// Reallocate memory.
     /// If the implementation doesn't support reallocating aligned memory, it allocates new memory
     /// and copied old memory to it.
-    fn reallocate(&self, old_size: usize, new_size: usize, pointer: *const u8) -> Result<*const u8, ArrowError>;
+    fn reallocate(
+        &self,
+        old_size: usize,
+        new_size: usize,
+        pointer: *const u8,
+    ) -> Result<*const u8, ArrowError>;
 
     /// Free memory.
     fn free(&self, ptr: *const u8);
@@ -48,7 +53,12 @@ impl MemoryPool for LibcMemoryPool {
         allocate_aligned(size as i64)
     }
 
-    fn reallocate(&self, old_size: usize, new_size: usize, pointer: *const u8) -> Result<*const u8, ArrowError> {
+    fn reallocate(
+        &self,
+        old_size: usize,
+        new_size: usize,
+        pointer: *const u8,
+    ) -> Result<*const u8, ArrowError> {
         unsafe {
             let old_src = mem::transmute::<*const u8, *mut libc::c_void>(pointer);
             let result = self.allocate(new_size)?;

--- a/rust/src/memory_pool.rs
+++ b/rust/src/memory_pool.rs
@@ -22,8 +22,6 @@ use std::mem;
 use super::error::ArrowError;
 use super::memory::{allocate_aligned, free_aligned};
 
-const ALIGNMENT: usize = 64;
-
 /// Memory pool for allocating memory. It's also responsible for tracking memory usage.
 pub trait MemoryPool {
     /// Allocate memory.
@@ -77,6 +75,7 @@ impl MemoryPool for LibcMemoryPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    const ALIGNMENT: usize = 64;
 
     #[test]
     fn test_allocate() {


### PR DESCRIPTION
@andygrove @liurenjie1024 I updated memory_pool.rs to use `*const` instead of `*mut` as this is the convention in memory.rs and it is memory.rs that is used elsewhere.

I also stuck to the memory.rs way when it came to the `Result` enum used.  I had issues getting the generic version in error.rs to work.

Feel free to submit patches to address either of these if you see fit.  Either way we can start to use the memory pool abstraction elsewhere in the code base without breaking windows.

Windows CI should be done soon.