### PR TITLE
ARROW-2525: [GLib] Add garrow_struct_array_flatten()

### DIFF
--- a/c_glib/.gitignore
+++ b/c_glib/.gitignore
@@ -40,6 +40,7 @@ Makefile.in
 /arrow-glib/enums.c
 /arrow-glib/enums.h
 /arrow-glib/stamp-*
+/arrow-glib/version.h
 /arrow-glib/*.pc
 /arrow-gpu-glib/*.pc
 /example/build

--- a/c_glib/arrow-glib/Makefile.am
+++ b/c_glib/arrow-glib/Makefile.am
@@ -82,7 +82,8 @@ libarrow_glib_la_headers +=			\
 	compute.h
 
 libarrow_glib_la_generated_headers =		\
-	enums.h
+	enums.h					\
+	version.h
 
 libarrow_glib_la_generated_sources =		\
 	enums.c					\
@@ -166,6 +167,7 @@ libarrow_glib_la_SOURCES =			\
 	$(libarrow_glib_la_cpp_headers)
 
 BUILT_SOURCES =					\
+	$(libarrow_glib_la_genearted_headers)	\
 	$(libarrow_glib_la_genearted_sources)	\
 	stamp-enums.c				\
 	stamp-enums.h

--- a/c_glib/arrow-glib/arrow-glib.h
+++ b/c_glib/arrow-glib/arrow-glib.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <arrow-glib/gobject-type.h>
+#include <arrow-glib/version.h>
 
 #include <arrow-glib/array.h>
 #include <arrow-glib/array-builder.h>

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <arrow-glib/version.h>
+
 #include <arrow-glib/basic-array.h>
 #include <arrow-glib/data-type.h>
 
@@ -127,7 +129,12 @@ GArrowStructArray *garrow_struct_array_new(GArrowDataType *data_type,
 
 GArrowArray *garrow_struct_array_get_field(GArrowStructArray *array,
                                            gint i);
+
+GARROW_DEPRECATED_IN_0_10_FOR(garrow_struct_array_flatten)
 GList *garrow_struct_array_get_fields(GArrowStructArray *array);
+
+GARROW_AVAILABLE_IN_0_10
+GList *garrow_struct_array_flatten(GArrowStructArray *array, GError **error);
 
 
 #define GARROW_TYPE_DICTIONARY_ARRAY (garrow_dictionary_array_get_type())

--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -142,6 +142,16 @@ cpp_headers += files(
 )
 
 
+version_h_conf = configuration_data()
+version_h_conf.set('GARROW_VERSION_MAJOR', version_major)
+version_h_conf.set('GARROW_VERSION_MINOR', version_minor)
+version_h_conf.set('GARROW_VERSION_MICRO', version_micro)
+version_h_conf.set('GARROW_VERSION_TAG', version_tag)
+version_h = configure_file(input: 'version.h.in',
+                           output: 'version.h',
+                           configuration: version_h_conf)
+c_headers += version_h
+
 enums = gnome.mkenums('enums',
                       sources: c_headers,
                       identifier_prefix: 'GArrow',

--- a/c_glib/arrow-glib/version.h.in
+++ b/c_glib/arrow-glib/version.h.in
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <glib.h>
+
+/**
+ * SECTION: version
+ * @section_id: version-macros
+ * @title: Version related macros
+ * @include: arrow-glib/arrow-glib.h
+ *
+ * Apache Arrow GLib provides macros that can be used by C pre-processor.
+ * They are useful to check version related things at compile time.
+ */
+
+/**
+ * GARROW_VERSION_MAJOR:
+ *
+ * The major version.
+ *
+ * Since: 0.10.0
+ */
+#define GARROW_VERSION_MAJOR (@GARROW_VERSION_MAJOR@)
+
+/**
+ * GARROW_VERSION_MINOR:
+ *
+ * The minor version.
+ *
+ * Since: 0.10.0
+ */
+#define GARROW_VERSION_MINOR (@GARROW_VERSION_MINOR@)
+
+/**
+ * GARROW_VERSION_MICRO:
+ *
+ * The micro version.
+ *
+ * Since: 0.10.0
+ */
+#define GARROW_VERSION_MICRO (@GARROW_VERSION_MICRO@)
+
+/**
+ * GARROW_VERSION_TAG:
+ *
+ * The version tag. Normally, it's an empty string. It's "SNAPSHOT"
+ * for snapshot version.
+ *
+ * Since: 0.10.0
+ */
+#define GARROW_VERSION_TAG   "@GARROW_VERSION_TAG@"
+
+/**
+ * GARROW_VERSION_CHECK:
+ * @major: A major version to check for.
+ * @minor: A minor version to check for.
+ * @micro: A micro version to check for.
+ *
+ * You can use this macro in C pre-processor.
+ *
+ * Returns: %TRUE if the compile time Apache Arrow GLib version is the
+ *   same as or newer than the passed version, %FALSE otherwise.
+ *
+ * Since: 0.10.0
+ */
+#define GARROW_VERSION_CHECK(major, minor, micro)       \
+  (GARROW_MAJOR_VERSION > (major) ||                    \
+   (GARROW_MAJOR_VERSION == (major) &&                  \
+    GARROW_MINOR_VERSION > (minor)) ||                  \
+   (GARROW_MAJOR_VERSION == (major) &&                  \
+    GARROW_MINOR_VERSION == (minor) &&                  \
+    GARROW_MICRO_VERSION >= (micro)))
+
+/**
+ * GARROW_DISABLE_DEPRECATION_WARNINGS:
+ *
+ * If this macro is defined, no deprecated warnings are produced.
+ *
+ * You must define this macro before including the
+ * arrow-glib/arrow-glib.h header.
+ *
+ * Since: 0.10.0
+ */
+
+#ifdef GARROW_DISABLE_DEPRECATION_WARNINGS
+#  define GARROW_DEPRECATED
+#  define GARROW_DEPRECATED_FOR(function)
+#  define GARROW_UNAVAILABLE(major, minor)
+#else
+#  define GARROW_DEPRECATED G_DEPRECATED
+#  define GARROW_DEPRECATED_FOR(function) G_DEPRECATED_FOR(function)
+#  define GARROW_UNAVAILABLE(major, minor) G_UNAVAILABLE(major, minor)
+#endif
+
+/**
+ * GARROW_VERSION_0_10:
+ *
+ * You can use this macro value for compile time API version check.
+ *
+ * Since: 0.10.0
+ */
+#define GARROW_VERSION_0_10 G_ENCODE_VERSION(0, 10)
+
+/**
+ * GARROW_VERSION_MIN_REQUIRED:
+ *
+ * You can use this macro for compile time API version check.
+ *
+ * This macro value must be one of the predefined version macros such
+ * as %GARROW_VERSION_0_10.
+ *
+ * If you use any functions that is defined by newer version than
+ * %GARROW_VERSION_MIN_REQUIRED, deprecated warnings are produced at
+ * compile time.
+ *
+ * You must define this macro before including the
+ * arrow-glib/arrow-glib.h header.
+ *
+ * Since: 0.10.0
+ */
+#ifndef GARROW_VERSION_MIN_REQUIRED
+#  define GARROW_VERSION_MIN_REQUIRED                           \
+  G_ENCODE_VERSION(GARROW_VERSION_MAJOR, GARROW_VERSION_MINOR)
+#endif
+
+/**
+ * GARROW_VERSION_MAX_ALLOWED:
+ *
+ * You can use this macro for compile time API version check.
+ *
+ * This macro value must be one of the predefined version macros such
+ * as %GARROW_VERSION_0_10.
+ *
+ * If you use any functions that is defined by newer version than
+ * %GARROW_VERSION_MAX_ALLOWED, deprecated warnings are produced at
+ * compile time.
+ *
+ * You must define this macro before including the
+ * arrow-glib/arrow-glib.h header.
+ *
+ * Since: 0.10.0
+ */
+#ifndef GARROW_VERSION_MAX_ALLOWED
+#  define GARROW_VERSION_MAX_ALLOWED            \
+  G_ENCODE_VERSION(GARROW_VERSION_MAJOR, GARROW_VERSION_MINOR)
+#endif
+
+
+#define GARROW_AVAILABLE_IN_ALL
+
+#if GARROW_VERSION_MIN_REQUIRED >= GARROW_VERSION_0_10
+#  define GARROW_DEPRECATED_IN_0_10               GARROW_DEPRECATED
+#  define GARROW_DEPRECATED_IN_0_10_FOR(function) GARROW_DEPRECATED_FOR(function)
+#else
+#  define GARROW_DEPRECATED_IN_0_10
+#  define GARROW_DEPRECATED_IN_0_10_FOR(function)
+#endif
+
+#if GARROW_VERSION_MAX_ALLOWED < GARROW_VERSION_0_10
+#  define GARROW_AVAILABLE_IN_0_10 GARROW_UNAVAILABLE(0, 10)
+#else
+#  define GARROW_AVAILABLE_IN_0_10
+#endif

--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -19,7 +19,9 @@ AC_PREREQ(2.65)
 
 m4_define([arrow_glib_version],
            m4_esyscmd(grep "^  <version>" "$(dirname $0)/../java/pom.xml" | \
-                        sed -e 's/\(^  <version>\|<\/version>$\)//g' | \
+                        sed -E \
+                            -e 's/(^  <version>)//g' \
+                            -e 's/(<\/version>$)//g' | \
                         tr -d '\n'))
 AC_INIT([arrow-glib],
         arrow_glib_version,
@@ -33,6 +35,27 @@ AC_CONFIG_HEADERS([config.h])
 
 AM_INIT_AUTOMAKE([1.13 foreign])
 AM_SILENT_RULES([yes])
+
+GARROW_VERSION_MAJOR=$(echo "arrow_glib_version" | \
+                         sed -E -e 's/^([[0-9]]+)\..+$/\1/' | \
+                         tr -d '\n')
+GARROW_VERSION_MINOR=$(echo "arrow_glib_version" | \
+                         sed -E -e 's/^[[0-9]]+\.([[0-9]]+)\..+$/\1/' | \
+                         tr -d '\n')
+GARROW_VERSION_MICRO=$(echo "arrow_glib_version" | \
+                         sed -E -e 's/^[[0-9]]+\.[[0-9]]+\.([[0-9]]+).*$/\1/' | \
+                         tr -d '\n')
+if echo "arrow_glib_version" | grep -- "-" > /dev/null; then
+  GARROW_VERSION_TAG=$(echo "arrow_glib_version" | \
+                         sed -E -e 's/^[[0-9]]+\.[[0-9]]+\.[[0-9]]+-(.+)$/\1/' | \
+                         tr -d '\n')
+else
+  GARROW_VERSION_TAG=
+fi
+AC_SUBST(GARROW_VERSION_MAJOR)
+AC_SUBST(GARROW_VERSION_MINOR)
+AC_SUBST(GARROW_VERSION_MICRO)
+AC_SUBST(GARROW_VERSION_TAG)
 
 AC_CANONICAL_HOST
 AC_MSG_CHECKING([for macOS])
@@ -139,6 +162,7 @@ AC_CONFIG_FILES([
   Makefile
   arrow-glib/Makefile
   arrow-glib/arrow-glib.pc
+  arrow-glib/version.h
   arrow-gpu-glib/Makefile
   arrow-gpu-glib/arrow-gpu-glib.pc
   doc/Makefile

--- a/c_glib/doc/reference/Makefile.am
+++ b/c_glib/doc/reference/Makefile.am
@@ -30,7 +30,8 @@ MKDB_OPTIONS =					\
 	--source-suffixes="c,cpp,h"
 
 HFILE_GLOB =					\
-	$(top_srcdir)/arrow-glib/*.h
+	$(top_srcdir)/arrow-glib/*.h		\
+	$(top_builddir)/arrow-glib/*.h
 
 IGNORE_HFILES =
 

--- a/c_glib/doc/reference/arrow-glib-docs.xml
+++ b/c_glib/doc/reference/arrow-glib-docs.xml
@@ -136,6 +136,14 @@
   </part>
   -->
 
+  <part id="misc">
+    <title>Misc</title>
+    <chapter id="version">
+      <title>Version</title>
+      <xi:include href="xml/version.xml"></xi:include>
+    </chapter>
+  </part>
+
   <chapter id="object-tree">
     <title>Object Hierarchy</title>
     <xi:include href="xml/tree_index.sgml"/>
@@ -147,6 +155,14 @@
   <index id="deprecated-api-index" role="deprecated">
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
+  </index>
+  <index id="api-index-0-10-0" role="0.10.0">
+    <title>Index of new symbols in 0.10.0</title>
+    <xi:include href="xml/api-index-0.10.0.xml"><xi:fallback /></xi:include>
+  </index>
+  <index id="api-index-0-9-0" role="0.9.0">
+    <title>Index of new symbols in 0.9.0</title>
+    <xi:include href="xml/api-index-0.9.0.xml"><xi:fallback /></xi:include>
   </index>
   <index id="api-index-0-8-0" role="0.8.0">
     <title>Index of new symbols in 0.8.0</title>

--- a/c_glib/test/test-struct-array.rb
+++ b/c_glib/test/test-struct-array.rb
@@ -50,7 +50,7 @@ class TestStructArray < Test::Unit::TestCase
                                         -1))
   end
 
-  def test_fields
+  def test_flatten
     fields = [
       Arrow::Field.new("score", Arrow::Int8DataType.new),
       Arrow::Field.new("enabled", Arrow::BooleanDataType.new),
@@ -74,7 +74,7 @@ class TestStructArray < Test::Unit::TestCase
           array.get_field(1).get_value(i),
         ]
       else
-        array.fields.collect do |field|
+        array.flatten.collect do |field|
           field.get_value(i)
         end
       end


### PR DESCRIPTION
garrow_struct_array_get_fields() is deprecated.

Version related macros are also added for deprecating
garrow_struct_array_get_fields().