### PR TITLE
ARROW-2526: [GLib] Update .gitignore

### DIFF
--- a/c_glib/.gitignore
+++ b/c_glib/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 Makefile
 Makefile.in
 .deps/
@@ -27,12 +44,10 @@ Makefile.in
 /doc/reference/*.signals
 /doc/reference/*.types
 /doc/reference/gtk-doc.make
+/doc/reference/entities.xml
 /doc/reference/*.stamp
 /doc/reference/html/
-/doc/reference/xml/*
-!/doc/reference/xml/Makefile.am
-!/doc/reference/xml/meson.build
-!/doc/reference/xml/gtkdocentities.ent.in
+/doc/reference/xml/
 /doc/reference/tmpl/
 /libtool
 /m4/
@@ -45,8 +60,3 @@ Makefile.in
 /example/build
 /example/read-batch
 /example/read-stream
-!/example/go/Makefile
-/example/go/read-batch
-/example/go/read-stream
-/example/go/write-batch
-/example/go/write-stream


### PR DESCRIPTION
We should have done this when we updated document build configuration
for Meson and removed Go examples.