### PR TITLE
ARROW-2527: [GLib] Enable GPU document

### DIFF
--- a/c_glib/doc/reference/arrow-glib-docs.xml
+++ b/c_glib/doc/reference/arrow-glib-docs.xml
@@ -126,15 +126,13 @@
     </chapter>
   </part>
 
-  <!-- TODO
   <part id="gpu">
     <title>GPU</title>
     <chapter id="cuda">
       <title>CUDA</title>
-      <xi:include href="xml/cuda.xml"/>
+      <xi:include href="xml/cuda.xml"><xi:fallback /></xi:include>
     </chapter>
   </part>
-  -->
 
   <chapter id="object-tree">
     <title>Object Hierarchy</title>


### PR DESCRIPTION
If the built Apache Arrow doesn't support GPU, it just generates empty
section.