### PR TITLE
ARROW-2529: [C++] Update mention of clang-format to 5.0 in the docs

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -320,9 +320,10 @@ You can also fix any formatting errors automatically:
 
     make format
 
-These commands require `clang-format-4.0` (and not any other version).
+These commands require `clang-format-5.0` (and not any other version).
 You may find the required packages at http://releases.llvm.org/download.html
-or use the Debian/Ubuntu APT repositories on https://apt.llvm.org/.
+or use the Debian/Ubuntu APT repositories on https://apt.llvm.org/. On macOS
+with [Homebrew][1] you can get it via `brew install llvm@5`.
 
 ## Continuous Integration
 


### PR DESCRIPTION
Also add docs on how to install on macOS via Homebrew.