### PR TITLE
ARROW-2509: Build for node 9.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,7 @@ matrix:
     - if [ $ARROW_CI_INTEGRATION_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_linux.sh
     - $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
-    - nvm install node
+    - nvm install 9.8
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_js.sh
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh
     script:
@@ -141,7 +141,8 @@ matrix:
   # NodeJS
   - language: node_js
     os: linux
-    node_js: node
+    node_js:
+    - '9.8'
     before_script:
     - if [ $ARROW_CI_JS_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_linux.sh


### PR DESCRIPTION
This pins the node version and gets us a green build again. We probably need to update some dependencies to get the code working on node 10 (I can reproduce the crash locally)