### PR TITLE
ARROW-2466: [C++] Fix "append" flag to FileOutputStream

### DIFF
--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -44,7 +44,7 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   /// \param[out] out a base interface OutputStream instance
   ///
   /// When opening a new file, any existing file with the indicated path is
-  /// truncated to 0 bytes, deleting any existing memory
+  /// truncated to 0 bytes, deleting any existing data
   static Status Open(const std::string& path, std::shared_ptr<OutputStream>* out);
 
   /// \brief Open a local file for writing
@@ -68,7 +68,7 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
   /// \param[out] file a FileOutputStream instance
   ///
   /// When opening a new file, any existing file with the indicated path is
-  /// truncated to 0 bytes, deleting any existing memory
+  /// truncated to 0 bytes, deleting any existing data
   static Status Open(const std::string& path, std::shared_ptr<FileOutputStream>* file);
 
   /// \brief Open a local file for writing

--- a/cpp/src/arrow/util/io-util.cc
+++ b/cpp/src/arrow/util/io-util.cc
@@ -149,7 +149,7 @@ Status FileOpenReadable(const PlatformFilename& file_name, int* fd) {
 }
 
 Status FileOpenWriteable(const PlatformFilename& file_name, bool write_only,
-                         bool truncate, int* fd) {
+                         bool truncate, bool append, int* fd) {
   int ret, errno_actual;
 
 #if defined(_MSC_VER)
@@ -161,6 +161,9 @@ Status FileOpenWriteable(const PlatformFilename& file_name, bool write_only,
 
   if (truncate) {
     oflag |= _O_TRUNC;
+  }
+  if (append) {
+    oflag |= _O_APPEND;
   }
 
   if (write_only) {
@@ -177,6 +180,9 @@ Status FileOpenWriteable(const PlatformFilename& file_name, bool write_only,
 
   if (truncate) {
     oflag |= O_TRUNC;
+  }
+  if (append) {
+    oflag |= O_APPEND;
   }
 
   if (write_only) {

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -146,7 +146,7 @@ Status FileNameFromString(const std::string& file_name, PlatformFilename* out);
 
 Status FileOpenReadable(const PlatformFilename& file_name, int* fd);
 Status FileOpenWriteable(const PlatformFilename& file_name, bool write_only,
-                         bool truncate, int* fd);
+                         bool truncate, bool append, int* fd);
 
 Status FileRead(int fd, uint8_t* buffer, const int64_t nbytes, int64_t* bytes_read);
 Status FileReadAt(int fd, uint8_t* buffer, int64_t position, int64_t nbytes,


### PR DESCRIPTION
The "append" flag only meant "don't truncate", and would write at the start of the file.