### PR TITLE
[C++] Fix a typo in cpplint

### DIFF
--- a/cpp/build-support/cpplint.py
+++ b/cpp/build-support/cpplint.py
@@ -6381,13 +6381,13 @@ def ParseArguments(args):
       try:
         _valid_extensions = set(val.split(','))
       except ValueError:
-          PrintUsage('Extensions must be comma seperated list.')
+          PrintUsage('Extensions must be comma separated list.')
     elif opt == '--headers':
       global _header_extensions
       try:
           _header_extensions = set(val.split(','))
       except ValueError:
-        PrintUsage('Extensions must be comma seperated list.')
+        PrintUsage('Extensions must be comma separated list.')
     elif opt == '--recursive':
       recursive = True
     elif opt == '--quiet':


### PR DESCRIPTION
s/seperated/separated
This PR imports google/styleguide#348.