### PR TITLE
ARROW-2273: [Python] Raise NotImplementedError when pandas Sparse types serializing

### DIFF
--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -81,13 +81,31 @@ def _register_custom_pandas_handlers(context):
 
     import pyarrow.pandas_compat as pdcompat
 
+    sparse_type_error_msg = (
+        '{0} serialization is not supported.\n'
+        'Note that {0} is planned to be deprecated '
+        'in pandas future releases.\n'
+        'See https://github.com/pandas-dev/pandas/issues/19239 '
+        'for more information.'
+    )
+
     def _serialize_pandas_dataframe(obj):
+        if isinstance(obj, pd.SparseDataFrame):
+            raise NotImplementedError(
+                sparse_type_error_msg.format('SparseDataFrame')
+            )
+
         return pdcompat.dataframe_to_serialized_dict(obj)
 
     def _deserialize_pandas_dataframe(data):
         return pdcompat.serialized_dict_to_dataframe(data)
 
     def _serialize_pandas_series(obj):
+        if isinstance(obj, pd.SparseSeries):
+            raise NotImplementedError(
+                sparse_type_error_msg.format('SparseSeries')
+            )
+
         return _serialize_pandas_dataframe(pd.DataFrame({obj.name: obj}))
 
     def _deserialize_pandas_series(data):


### PR DESCRIPTION
This fixes [ARROW-2273](https://issues.apache.org/jira/browse/ARROW-2273).

`pandas` Sparse types are planned to be deprecated in pandas future releases (https://github.com/pandas-dev/pandas/issues/19239).
`SparseDataFrame` and `SparseSeries` are naive implementation and have many bugs. IMO, this is not the right time to support these in `pyarrow`.