### PR TITLE
ARROW-2548: Clarify `List<Char>` Array example

### DIFF
--- a/format/Layout.md
+++ b/format/Layout.md
@@ -312,7 +312,7 @@ will have the following representation:
   * Length: 7,  Null count: 0
   * Null bitmap buffer: Not required
 
-    | Bytes 0-7  | Bytes 8-63  |
+    | Bytes 0-6  | Bytes 7-63  |
     |------------|-------------|
     | joemark    | unspecified |
 ```


### PR DESCRIPTION
`joemark` only spans bytes 0 through to 6, so starting from byte position 7 (not 8) the contents can be unspecified.

(or is byte 7 nulled out or something?)