### PR TITLE
ARROW-2545: [Python] Link against required system libraries

### DIFF
--- a/cpp/cmake_modules/FindPythonLibsNew.cmake
+++ b/cpp/cmake_modules/FindPythonLibsNew.cmake
@@ -9,6 +9,8 @@
 #  PYTHON_INCLUDE_DIRS        - path to where Python.h is found
 #  PYTHON_SITE_PACKAGES       - path to installation site-packages
 #  PYTHON_IS_DEBUG            - whether the Python interpreter is a debug build
+#  PYTHON_OTHER_LIBS          - third-party libraries (as link flags) needed
+#                               for linking with Python
 #
 #  PYTHON_INCLUDE_PATH        - path to where Python.h is found (deprecated)
 #
@@ -87,11 +89,11 @@ print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
 print(s.get_config_var('LIBPL'));
+print(s.get_config_var('LIBS') or '');
 "
     RESULT_VARIABLE _PYTHON_SUCCESS
     OUTPUT_VARIABLE _PYTHON_VALUES
-    ERROR_VARIABLE _PYTHON_ERROR_VALUE
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    ERROR_VARIABLE _PYTHON_ERROR_VALUE)
 
 if(NOT _PYTHON_SUCCESS MATCHES 0)
     if(PythonLibsNew_FIND_REQUIRED)
@@ -114,6 +116,7 @@ list(GET _PYTHON_VALUES 5 PYTHON_IS_DEBUG)
 list(GET _PYTHON_VALUES 6 PYTHON_SIZEOF_VOID_P)
 list(GET _PYTHON_VALUES 7 PYTHON_LIBRARY_SUFFIX)
 list(GET _PYTHON_VALUES 8 PYTHON_LIBRARY_PATH)
+list(GET _PYTHON_VALUES 9 PYTHON_OTHER_LIBS)
 
 # Make sure the Python has the same pointer-size as the chosen compiler
 # Skip the check on OS X, it doesn't consistently have CMAKE_SIZEOF_VOID_P defined

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -19,34 +19,6 @@
 # arrow_python
 #######################################
 
-if (ARROW_BUILD_TESTS)
-  add_library(arrow_python_test_main STATIC
-	util/test_main.cc)
-
-  target_link_libraries(arrow_python_test_main
-    gtest)
-
-  if (APPLE)
-	target_link_libraries(arrow_python_test_main
-      ${CMAKE_DL_LIBS})
-	set_target_properties(arrow_python_test_main
-      PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
-  elseif(NOT MSVC)
-	target_link_libraries(arrow_python_test_main
-      pthread
-      ${CMAKE_DL_LIBS})
-  endif()
-endif()
-
-set(ARROW_PYTHON_MIN_TEST_LIBS
-  arrow_python_test_main
-  arrow_python_static
-  arrow_shared)
-
-set(ARROW_PYTHON_TEST_LINK_LIBS ${ARROW_PYTHON_MIN_TEST_LIBS})
-
-# ----------------------------------------------------------------------
-
 set(ARROW_PYTHON_SRCS
   arrow_to_pandas.cc
   arrow_to_python.cc
@@ -73,6 +45,7 @@ endif()
 
 set(ARROW_PYTHON_SHARED_LINK_LIBS
   arrow_shared
+  ${PYTHON_OTHER_LIBS}
 )
 
 if (MSVC)
@@ -86,7 +59,7 @@ ADD_ARROW_LIB(arrow_python
   SOURCES ${ARROW_PYTHON_SRCS}
   SHARED_LINK_FLAGS ""
   SHARED_LINK_LIBS ${ARROW_PYTHON_SHARED_LINK_LIBS}
-  STATIC_LINK_LIBS ""
+  STATIC_LINK_LIBS "${PYTHON_OTHER_LIBS}"
 )
 
 if ("${COMPILER_FAMILY}" STREQUAL "clang")
@@ -127,7 +100,33 @@ install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-python.pc"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
+# ----------------------------------------------------------------------
+
 if (ARROW_BUILD_TESTS)
+  add_library(arrow_python_test_main STATIC
+	util/test_main.cc)
+
+  target_link_libraries(arrow_python_test_main
+    gtest)
+
+  if (APPLE)
+	target_link_libraries(arrow_python_test_main
+      ${CMAKE_DL_LIBS})
+	set_target_properties(arrow_python_test_main
+      PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  elseif(NOT MSVC)
+	target_link_libraries(arrow_python_test_main
+      pthread
+      ${CMAKE_DL_LIBS})
+  endif()
+
+  set(ARROW_PYTHON_MIN_TEST_LIBS
+    arrow_python_test_main
+    arrow_python_static
+    arrow_shared)
+
+  set(ARROW_PYTHON_TEST_LINK_LIBS ${ARROW_PYTHON_MIN_TEST_LIBS})
+
   ADD_ARROW_TEST(python-test
     STATIC_LINK_LIBS "${ARROW_PYTHON_TEST_LINK_LIBS}"
     NO_VALGRIND)


### PR DESCRIPTION
Python can require system libraries such as "libutil".  When linking dynamically against libpythonXX.so, this is not a problem since those libraries are automatically depended on.  When linking statically
against libpythonXX.a (this is the case when Python itself is statically linked and therefore does not provide a .so), you need to specify those libraries explicitly.