### PR TITLE
ARROW-2546: [CI] Intermittent npm failures

### DIFF
--- a/ci/travis_before_script_js.sh
+++ b/ci/travis_before_script_js.sh
@@ -22,6 +22,9 @@ set -ex
 
 source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
+# Install npm 5.8 if we don't already have it
+dpkg --compare-versions `npm -v` ge 5.8 || npm i -g npm@^5.8
+
 pushd $ARROW_JS_DIR
 
 npm install


### PR DESCRIPTION
Upgrade CI npm version beyond 5.7.1 to avoid EINTEGRITY errors, as suggested here: https://github.com/npm/npm/issues/16861#issuecomment-371256089