### PR TITLE
ARROW-2500: [Java] IPC Writers/readers are not always setting validity bits correctly

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -140,9 +140,11 @@ public class BitVectorHelper {
     }
     int count = 0;
     final int sizeInBytes = getValidityBufferSize(valueCount);
+    // If value count is not a multiple of 8, then calculate number of used bits in the last byte
     final int remainder = valueCount % 8;
 
-    for (int i = 0; i < sizeInBytes - 1; i++) {
+    final int sizeInBytesMinus1 = sizeInBytes - 1;
+    for (int i = 0; i < sizeInBytesMinus1; i++) {
       byte byteValue = validityBuffer.getByte(i);
       count += Integer.bitCount(byteValue & 0xFF);
     }
@@ -151,7 +153,7 @@ public class BitVectorHelper {
     byte byteValue = validityBuffer.getByte(sizeInBytes - 1);
     if (remainder != 0) {
       // making the remaining bits all 1s if it is not fully filled
-      byte mask = (byte)(0xFF << remainder);
+      byte mask = (byte) (0xFF << remainder);
       byteValue = (byte) (byteValue | mask);
     }
     count += Integer.bitCount(byteValue & 0xFF);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -142,16 +142,20 @@ public class BitVectorHelper {
     final int sizeInBytes = getValidityBufferSize(valueCount);
     final int remainder = valueCount % 8;
 
-    for (int i = 0; i < sizeInBytes; i++) {
+    for (int i = 0; i < sizeInBytes - 1; i++) {
       byte byteValue = validityBuffer.getByte(i);
-      // handling with the last byte
-      if (i == sizeInBytes - 1 && remainder != 0) {
-        // making the remaining bits all 1s if it is not fully filled
-        byte mask = (byte)(0xFF << remainder);
-        byteValue = (byte) (byteValue | mask);
-      }
       count += Integer.bitCount(byteValue & 0xFF);
     }
+
+    // handling with the last byte
+    byte byteValue = validityBuffer.getByte(sizeInBytes - 1);
+    if (remainder != 0) {
+      // making the remaining bits all 1s if it is not fully filled
+      byte mask = (byte)(0xFF << remainder);
+      byteValue = (byte) (byteValue | mask);
+    }
+    count += Integer.bitCount(byteValue & 0xFF);
+
     return 8 * sizeInBytes - count;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -140,12 +140,13 @@ public class BitVectorHelper {
     }
     int count = 0;
     final int sizeInBytes = getValidityBufferSize(valueCount);
-    int remainder = valueCount % 8;
+    final int remainder = valueCount % 8;
 
     for (int i = 0; i < sizeInBytes; i++) {
       byte byteValue = validityBuffer.getByte(i);
+      // handling with the last byte
       if (i == sizeInBytes - 1 && remainder != 0) {
-        // making the remaining bits all 1s
+        // making the remaining bits all 1s if it is not fully filled
         byte mask = (byte)(0xFF << remainder);
         byteValue = (byte) (byteValue | mask);
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import io.netty.buffer.ArrowBuf;
+import io.netty.buffer.PooledByteBufAllocatorL;
+
+public class TestBitVectorHelper {
+    @Test
+    public void testGetNullCount() throws Exception {
+        ArrowBuf validityBuffer = new ArrowBuf(
+                null, null, new PooledByteBufAllocatorL().empty,
+                null, null, 0, 3, true);
+        validityBuffer.setByte(0, 22);
+
+        int count =  BitVectorHelper.getNullCount(validityBuffer, 3);
+        assertEquals(count, 1);
+    }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -28,12 +28,43 @@ import io.netty.buffer.PooledByteBufAllocatorL;
 public class TestBitVectorHelper {
     @Test
     public void testGetNullCount() throws Exception {
+        // test case 1, 1 null value for 0b110
         ArrowBuf validityBuffer = new ArrowBuf(
                 null, null, new PooledByteBufAllocatorL().empty,
                 null, null, 0, 3, true);
-        validityBuffer.setByte(0, 22);
+        // we set validity buffer to be 0b10110, but only have 3 items with 1st item is null
+        validityBuffer.setByte(0, 0b10110);
 
+        // we will only consider 0b110 here, since we only 3 items and only one is null
         int count =  BitVectorHelper.getNullCount(validityBuffer, 3);
         assertEquals(count, 1);
+
+        // test case 2, no null value for 0xFF
+        validityBuffer = new ArrowBuf(
+                null, null, new PooledByteBufAllocatorL().empty,
+                null, null, 0, 8, true);
+        validityBuffer.setByte(0, 0xFF);
+
+        count =  BitVectorHelper.getNullCount(validityBuffer, 8);
+        assertEquals(count, 0);
+
+        // test case 3, 1 null value for 0x7F
+        validityBuffer = new ArrowBuf(
+                null, null, new PooledByteBufAllocatorL().empty,
+                null, null, 0, 8, true);
+        validityBuffer.setByte(0, 0x7F);
+
+        count =  BitVectorHelper.getNullCount(validityBuffer, 8);
+        assertEquals(count, 1);
+
+        // test case 4, validity buffer has multiple bytes, 11 items
+        validityBuffer = new ArrowBuf(
+                null, null, new PooledByteBufAllocatorL().empty,
+                null, null, 0, 11, true);
+        validityBuffer.setByte(0, 0b10101010);
+        validityBuffer.setByte(1, 0b01010101);
+
+        count =  BitVectorHelper.getNullCount(validityBuffer, 11);
+        assertEquals(count, 5);
     }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -36,7 +36,7 @@ public class TestBitVectorHelper {
         validityBuffer.setByte(0, 0b10110);
 
         // we will only consider 0b110 here, since we only 3 items and only one is null
-        int count =  BitVectorHelper.getNullCount(validityBuffer, 3);
+        int count = BitVectorHelper.getNullCount(validityBuffer, 3);
         assertEquals(count, 1);
 
         // test case 2, no null value for 0xFF
@@ -45,7 +45,7 @@ public class TestBitVectorHelper {
                 null, null, 0, 8, true);
         validityBuffer.setByte(0, 0xFF);
 
-        count =  BitVectorHelper.getNullCount(validityBuffer, 8);
+        count = BitVectorHelper.getNullCount(validityBuffer, 8);
         assertEquals(count, 0);
 
         // test case 3, 1 null value for 0x7F
@@ -54,7 +54,7 @@ public class TestBitVectorHelper {
                 null, null, 0, 8, true);
         validityBuffer.setByte(0, 0x7F);
 
-        count =  BitVectorHelper.getNullCount(validityBuffer, 8);
+        count = BitVectorHelper.getNullCount(validityBuffer, 8);
         assertEquals(count, 1);
 
         // test case 4, validity buffer has multiple bytes, 11 items
@@ -64,7 +64,7 @@ public class TestBitVectorHelper {
         validityBuffer.setByte(0, 0b10101010);
         validityBuffer.setByte(1, 0b01010101);
 
-        count =  BitVectorHelper.getNullCount(validityBuffer, 11);
+        count = BitVectorHelper.getNullCount(validityBuffer, 11);
         assertEquals(count, 5);
     }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
@@ -18,8 +18,6 @@
 
 package org.apache.arrow.vector.ipc;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -36,6 +34,7 @@ import java.util.Map;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
@@ -718,7 +717,7 @@ public class TestArrowFile extends BaseFileTest {
       Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
       try (FileOutputStream fileOutputStream = new FileOutputStream(file);
            VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList((FieldVector) vector), vector.getValueCount());
-           ArrowFileWriter writer = new ArrowFileWriter(root, new MapDictionaryProvider(), fileOutputStream.getChannel());) {
+           ArrowFileWriter writer = new ArrowFileWriter(root, null, fileOutputStream.getChannel());) {
         writeBatchData(writer, vector, root);
       }
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
@@ -19,7 +19,6 @@
 package org.apache.arrow.vector.ipc;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -747,18 +746,18 @@ public class TestArrowFile extends BaseFileTest {
       reader.loadNextBatch();
 
       assertEquals(read.getValueCount(), 5);
-      assertNull(read.getObject(0));
-      assertEquals(read.getObject(1), Integer.valueOf(1));
-      assertEquals(read.getObject(2), Integer.valueOf(2));
-      assertNull(read.getObject(3));
-      assertEquals(read.getObject(4), Integer.valueOf(1));
+      assertEquals(read.isNull(0), true);
+      assertEquals(read.get(1), 1);
+      assertEquals(read.get(2), 2);
+      assertEquals(read.isNull(3), true);
+      assertEquals(read.get(4), 1);
 
       reader.loadNextBatch();
 
       assertEquals(read.getValueCount(), 3);
-      assertNull(read.getObject(0));
-      assertEquals(read.getObject(1), Integer.valueOf(1));
-      assertEquals(read.getObject(2), Integer.valueOf(2));
+      assertEquals(read.isNull(0), true);
+      assertEquals(read.get(1), 1);
+      assertEquals(read.get(2), 2);
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
@@ -719,45 +719,14 @@ public class TestArrowFile extends BaseFileTest {
       try (FileOutputStream fileOutputStream = new FileOutputStream(file);
            VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList((FieldVector) vector), vector.getValueCount());
            ArrowFileWriter writer = new ArrowFileWriter(root, new MapDictionaryProvider(), fileOutputStream.getChannel());) {
-        writer.start();
-
-        vector.setNull(0);
-        vector.setSafe(1, 1);
-        vector.setSafe(2, 2);
-        vector.setNull(3);
-        vector.setSafe(4, 1);
-        vector.setValueCount(5);
-        root.setRowCount(5);
-        writer.writeBatch();
-
-        vector.setNull(0);
-        vector.setSafe(1, 1);
-        vector.setSafe(2, 2);
-        vector.setValueCount(3);
-        root.setRowCount(3);
-        writer.writeBatch();
+        writeBatchData(writer, vector, root);
       }
     }
 
     try (FileInputStream fileInputStream = new FileInputStream(file);
          ArrowFileReader reader = new ArrowFileReader(fileInputStream.getChannel(), allocator);) {
-      IntVector read = (IntVector) reader.getVectorSchemaRoot().getFieldVectors().get(0);
-
-      reader.loadNextBatch();
-
-      assertEquals(read.getValueCount(), 5);
-      assertEquals(read.isNull(0), true);
-      assertEquals(read.get(1), 1);
-      assertEquals(read.get(2), 2);
-      assertEquals(read.isNull(3), true);
-      assertEquals(read.get(4), 1);
-
-      reader.loadNextBatch();
-
-      assertEquals(read.getValueCount(), 3);
-      assertEquals(read.isNull(0), true);
-      assertEquals(read.get(1), 1);
-      assertEquals(read.get(2), 2);
+      IntVector vector = (IntVector) reader.getVectorSchemaRoot().getFieldVectors().get(0);
+      validateBatchData(reader, vector);
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -105,8 +105,8 @@ public class TestArrowStream extends BaseFileTest {
 
     try (IntVector vector = new IntVector("foo", allocator);) {
       Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
-      try (VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList((FieldVector) vector), vector.getValueCount());
-           ArrowStreamWriter writer = new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(os));) {
+      try (VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList(vector), vector.getValueCount());
+           ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(os));) {
         writeBatchData(writer, vector, root);
       }
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -101,53 +101,21 @@ public class TestArrowStream extends BaseFileTest {
 
   @Test
   public void testReadWriteMultipleBatches() throws IOException {
-
     ByteArrayOutputStream os = new ByteArrayOutputStream();
 
     try (IntVector vector = new IntVector("foo", allocator);) {
       Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
       try (VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList((FieldVector) vector), vector.getValueCount());
            ArrowStreamWriter writer = new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(os));) {
-        writer.start();
-
-        vector.setNull(0);
-        vector.setSafe(1, 1);
-        vector.setSafe(2, 2);
-        vector.setNull(3);
-        vector.setSafe(4, 1);
-        vector.setValueCount(5);
-        root.setRowCount(5);
-        writer.writeBatch();
-
-        vector.setNull(0);
-        vector.setSafe(1, 1);
-        vector.setSafe(2, 2);
-        vector.setValueCount(3);
-        root.setRowCount(3);
-        writer.writeBatch();
+        writeBatchData(writer, vector, root);
       }
     }
 
     ByteArrayInputStream in = new ByteArrayInputStream(os.toByteArray());
 
     try (ArrowStreamReader reader = new ArrowStreamReader(in, allocator);) {
-      IntVector read = (IntVector) reader.getVectorSchemaRoot().getFieldVectors().get(0);
-
-      reader.loadNextBatch();
-
-      assertEquals(read.getValueCount(), 5);
-      assertEquals(read.isNull(0), true);
-      assertEquals(read.get(1), 1);
-      assertEquals(read.get(2), 2);
-      assertEquals(read.isNull(3), true);
-      assertEquals(read.get(4), 1);
-
-      reader.loadNextBatch();
-
-      assertEquals(read.getValueCount(), 3);
-      assertEquals(read.isNull(0), true);
-      assertEquals(read.get(1), 1);
-      assertEquals(read.get(2), 2);
+      IntVector vector = (IntVector) reader.getVectorSchemaRoot().getFieldVectors().get(0);
+      validateBatchData(reader, vector);
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector.ipc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -137,18 +136,18 @@ public class TestArrowStream extends BaseFileTest {
       reader.loadNextBatch();
 
       assertEquals(read.getValueCount(), 5);
-      assertNull(read.getObject(0));
-      assertEquals(read.getObject(1), Integer.valueOf(1));
-      assertEquals(read.getObject(2), Integer.valueOf(2));
-      assertNull(read.getObject(3));
-      assertEquals(read.getObject(4), Integer.valueOf(1));
+      assertEquals(read.isNull(0), true);
+      assertEquals(read.get(1), 1);
+      assertEquals(read.get(2), 2);
+      assertEquals(read.isNull(3), true);
+      assertEquals(read.get(4), 1);
 
       reader.loadNextBatch();
 
       assertEquals(read.getValueCount(), 3);
-      assertNull(read.getObject(0));
-      assertEquals(read.getObject(1), Integer.valueOf(1));
-      assertEquals(read.getObject(2), Integer.valueOf(2));
+      assertEquals(read.isNull(0), true);
+      assertEquals(read.get(1), 1);
+      assertEquals(read.get(2), 2);
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -20,20 +20,20 @@ package org.apache.arrow.vector.ipc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.channels.Channels;
+import java.util.Collections;
 
-import io.netty.buffer.ArrowBuf;
-import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.ipc.ArrowStreamReader;
-import org.apache.arrow.vector.ipc.ArrowStreamWriter;
-import org.apache.arrow.vector.ipc.BaseFileTest;
-import org.apache.arrow.vector.ipc.MessageSerializerTest;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Test;
@@ -97,6 +97,58 @@ public class TestArrowStream extends BaseFileTest {
         assertFalse(reader.loadNextBatch());
         assertEquals(0, reader.getVectorSchemaRoot().getRowCount());
       }
+    }
+  }
+
+  @Test
+  public void testReadWriteMultipleBatches() throws IOException {
+
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+    try (IntVector vector = new IntVector("foo", allocator);) {
+      Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
+      try (VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList((FieldVector) vector), vector.getValueCount());
+           ArrowStreamWriter writer = new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(os));) {
+        writer.start();
+
+        vector.setNull(0);
+        vector.setSafe(1, 1);
+        vector.setSafe(2, 2);
+        vector.setNull(3);
+        vector.setSafe(4, 1);
+        vector.setValueCount(5);
+        root.setRowCount(5);
+        writer.writeBatch();
+
+        vector.setNull(0);
+        vector.setSafe(1, 1);
+        vector.setSafe(2, 2);
+        vector.setValueCount(3);
+        root.setRowCount(3);
+        writer.writeBatch();
+      }
+    }
+
+    ByteArrayInputStream in = new ByteArrayInputStream(os.toByteArray());
+
+    try (ArrowStreamReader reader = new ArrowStreamReader(in, allocator);) {
+      IntVector read = (IntVector) reader.getVectorSchemaRoot().getFieldVectors().get(0);
+
+      reader.loadNextBatch();
+
+      assertEquals(read.getValueCount(), 5);
+      assertNull(read.getObject(0));
+      assertEquals(read.getObject(1), Integer.valueOf(1));
+      assertEquals(read.getObject(2), Integer.valueOf(2));
+      assertNull(read.getObject(3));
+      assertEquals(read.getObject(4), Integer.valueOf(1));
+
+      reader.loadNextBatch();
+
+      assertEquals(read.getValueCount(), 3);
+      assertNull(read.getObject(0));
+      assertEquals(read.getObject(1), Integer.valueOf(1));
+      assertEquals(read.getObject(2), Integer.valueOf(2));
     }
   }
 }


### PR DESCRIPTION
Fix the issue of getNullCount() does not return the correct result in certain cases. 

For example, validityBuffer is 0b10110, while valueCount=3, the null count should be 1, but currently it returns 0.

Fix approach:
1. Based on the valueCount, modify the last byte by mask the remaining bits to be all 1's.
0b10110 will become 0b11111110
2. Count how many 1 in the byte by using bitCount()
3. Use 8 * sizeInBytes - count to get the total 0's

Test: 
Added 2 tests to the existing test classes;
Created 1 new file to purposely test BitVectorHelper.java, since it has some public static method and we may add more testes in the future.