### PR TITLE
ARROW-2551: [Plasma] notification code improvement

### DIFF
--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -861,10 +861,7 @@ Status PlasmaClient::Impl::Subscribe(int* fd) {
   int flags = fcntl(sock[1], F_GETFL, 0);
   ARROW_CHECK(fcntl(sock[1], F_SETFL, flags | O_NONBLOCK) == 0);
   // Tell the Plasma store about the subscription.
-  RETURN_NOT_OK(SendSubscribeRequest(store_conn_));
-  // Send the file descriptor that the Plasma store should use to push
-  // notifications about sealed objects to this client.
-  ARROW_CHECK(send_fd(store_conn_, sock[1]) >= 0);
+  RETURN_NOT_OK(SendSubscribeRequest(store_conn_, sock[1]));
   close(sock[1]);
   // Return the file descriptor that the client should use to read notifications
   // about sealed objects.

--- a/cpp/src/plasma/format/plasma.fbs
+++ b/cpp/src/plasma/format/plasma.fbs
@@ -312,6 +312,8 @@ table PlasmaWaitReply {
 }
 
 table PlasmaSubscribeRequest {
+  // The file descriptor used by client to receive object notifications.
+  notification_fd: int;
 }
 
 table PlasmaDataRequest {

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -574,10 +574,18 @@ Status ReadWaitReply(uint8_t* data, size_t size, ObjectRequest object_requests[]
 
 // Subscribe messages.
 
-Status SendSubscribeRequest(int sock) {
+Status SendSubscribeRequest(int sock, int notification_fd) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = CreatePlasmaSubscribeRequest(fbb);
+  auto message = CreatePlasmaSubscribeRequest(fbb, notification_fd);
   return PlasmaSend(sock, MessageType_PlasmaSubscribeRequest, &fbb, message);
+}
+
+Status ReadSubscribeRequest(uint8_t* data, size_t size, int* notification_fd) {
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<PlasmaSubscribeRequest>(data);
+  DCHECK(verify_flatbuffer(message, data, size));
+  *notification_fd = message->notification_fd();
+  return Status::OK();
 }
 
 // Data messages.

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -179,7 +179,9 @@ Status ReadWaitReply(uint8_t* data, size_t size, ObjectRequest object_requests[]
 
 /* Plasma Subscribe message functions. */
 
-Status SendSubscribeRequest(int sock);
+Status SendSubscribeRequest(int sock, int notification_fd);
+
+Status ReadSubscribeRequest(uint8_t* data, size_t size, int* notification_fd);
 
 /* Data messages. */
 

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -145,7 +145,8 @@ class PlasmaStore {
   /// Subscribe a file descriptor to updates about new sealed objects.
   ///
   /// @param client The client making this request.
-  void subscribe_to_updates(Client* client);
+  /// @param notification_fd The file descriptor used by client to receive notifications.
+  void subscribe_to_updates(Client* client, int notification_fd);
 
   /// Connect a new client to the PlasmaStore.
   ///
@@ -162,7 +163,16 @@ class PlasmaStore {
   Status process_message(Client* client);
 
  private:
+  /// Push an object notification to all subscribers.
+  ///
+  /// @param object_notification The object notification to be pushed.
   void push_notification(ObjectInfoT* object_notification);
+
+  /// Push an object notification to one subscribers.
+  ///
+  /// @param object_notification The object notification to be pushed.
+  /// @param client_fd The client file descriptor to which the notification is sent.
+  void push_notification(ObjectInfoT* object_notification, int client_fd);
 
   void add_client_to_object_clients(ObjectTableEntry* entry, Client* client);
 


### PR DESCRIPTION
 When a client subscribes to plasma store, the store pushes notifications of existing objects to ALL subscribers - while in this case it just needs to push to the new subscriber. 