### PR TITLE
ARROW-2559: [Plasma] delete object notification queue for a client when it disconnects with plasma

### DIFF
--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -46,6 +46,10 @@ struct Client {
 
   /// The file descriptor used to communicate with the client.
   int fd;
+
+  /// The file descriptor used to push notifications to client. This is only valid
+  /// if clients subscribes to notifiations, otherwise it's set to -1.
+  int notification_fd;
 };
 
 class PlasmaStore {


### PR DESCRIPTION
Currently the object notification queue for a client never gets freed. This change records the notification fd returned by recv_fd(), and when client disconnects, plasma closes the fd and removes its notification queue from map. 