### PR TITLE
ARROW-2564: [C++] Replace deprecated method in documentation

### DIFF
--- a/cpp/apidoc/tutorials/row_wise_conversion.md
+++ b/cpp/apidoc/tutorials/row_wise_conversion.md
@@ -108,7 +108,7 @@ std::vector<std::shared_ptr<arrow::Field>> schema_vector = {
 auto schema = std::make_shared<arrow::Schema>(schema_vector);
 
 std::shared_ptr<arrow::Table> table = arrow::Table::Make(schema,
-                                                         {id_array, cost_array, cost_components_array});
+    {id_array, cost_array, cost_components_array});
 ```
 
 The final `table` variable is the one we then can pass on to other functions

--- a/cpp/apidoc/tutorials/row_wise_conversion.md
+++ b/cpp/apidoc/tutorials/row_wise_conversion.md
@@ -107,9 +107,8 @@ std::vector<std::shared_ptr<arrow::Field>> schema_vector = {
 };
 auto schema = std::make_shared<arrow::Schema>(schema_vector);
 
-std::shared_ptr<arrow::Table> table;
-ARROW_RETURN_NOT_OK(MakeTable(schema,
-    {id_array, cost_array, cost_components_array}, &table));
+std::shared_ptr<arrow::Table> table = arrow::Table::Make(schema,
+                                                         {id_array, cost_array, cost_components_array});
 ```
 
 The final `table` variable is the one we then can pass on to other functions


### PR DESCRIPTION
Tutorial update to keep working code.
https://issues.apache.org/jira/browse/ARROW-2564