### PR TITLE
ARROW-2569: [C++] Improve thread pool size heuristic

### DIFF
--- a/cpp/src/arrow/util/io-util.cc
+++ b/cpp/src/arrow/util/io-util.cc
@@ -29,6 +29,7 @@
 #include <sstream>
 
 #include <fcntl.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>  // IWYU pragma: keep
@@ -426,6 +427,76 @@ Status FileTruncate(int fd, const int64_t size) {
   }
   return Status::OK();
 }
+
+//
+// Environment variables
+//
+
+Status GetEnvVar(const char* name, std::string* out) {
+#ifdef _WIN32
+  // On Windows, getenv() reads an early copy of the process' environment
+  // which doesn't get updated when SetEnvironmentVariable() is called.
+  constexpr int32_t bufsize = 2000;
+  char c_str[bufsize];
+  auto res = GetEnvironmentVariableA(name, c_str, bufsize);
+  if (res >= bufsize) {
+    return Status::CapacityError("environment variable value too long");
+  } else if (res == 0) {
+    return Status::KeyError("environment variable undefined");
+  }
+  *out = std::string(c_str);
+  return Status::OK();
+#else
+  char* c_str = getenv(name);
+  if (c_str == nullptr) {
+    return Status::KeyError("environment variable undefined");
+  }
+  *out = std::string(c_str);
+  return Status::OK();
+#endif
+}
+
+Status GetEnvVar(const std::string& name, std::string* out) {
+  return GetEnvVar(name.c_str(), out);
+}
+
+Status SetEnvVar(const char* name, const char* value) {
+#ifdef _WIN32
+  if (SetEnvironmentVariableA(name, value)) {
+    return Status::OK();
+  } else {
+    return Status::Invalid("failed setting environment variable");
+  }
+#else
+  if (setenv(name, value, 1) == 0) {
+    return Status::OK();
+  } else {
+    return Status::Invalid("failed setting environment variable");
+  }
+#endif
+}
+
+Status SetEnvVar(const std::string& name, const std::string& value) {
+  return SetEnvVar(name.c_str(), value.c_str());
+}
+
+Status DelEnvVar(const char* name) {
+#ifdef _WIN32
+  if (SetEnvironmentVariableA(name, nullptr)) {
+    return Status::OK();
+  } else {
+    return Status::Invalid("failed deleting environment variable");
+  }
+#else
+  if (unsetenv(name) == 0) {
+    return Status::OK();
+  } else {
+    return Status::Invalid("failed deleting environment variable");
+  }
+#endif
+}
+
+Status DelEnvVar(const std::string& name) { return DelEnvVar(name.c_str()); }
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -163,6 +163,13 @@ Status FileClose(int fd);
 
 Status CreatePipe(int fd[2]);
 
+Status GetEnvVar(const char* name, std::string* out);
+Status GetEnvVar(const std::string& name, std::string* out);
+Status SetEnvVar(const char* name, const char* value);
+Status SetEnvVar(const std::string& name, const std::string& value);
+Status DelEnvVar(const char* name);
+Status DelEnvVar(const std::string& name);
+
 }  // namespace internal
 }  // namespace arrow
 

--- a/cpp/src/arrow/util/thread-pool-test.cc
+++ b/cpp/src/arrow/util/thread-pool-test.cc
@@ -21,6 +21,12 @@
 #include <thread>
 #include <vector>
 
+#include <stdlib.h>
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#endif
+
 #include "arrow/test-util.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/thread-pool.h"
@@ -269,6 +275,60 @@ TEST_F(TestThreadPool, Submit) {
     auto fut = pool->Submit(sleep_for, 0.001);
     fut.get();
   }
+}
+
+#ifdef _WIN32
+static int setenv(const char* envname, const char* envval, int overwrite) {
+  DCHECK_NE(overwrite, 0);
+  return SetEnvironmentVariableA(envname, envval) ? 0 : -1;
+}
+
+static int unsetenv(const char* envname) {
+  return SetEnvironmentVariableA(envname, nullptr) ? 0 : -1;
+}
+#endif
+
+TEST(TestGlobalThreadPool, Capacity) {
+  // Sanity check
+  auto pool = CPUThreadPool();
+  size_t capacity = pool->GetCapacity();
+  DCHECK_GT(capacity, 0);
+
+  // Exercise default capacity heuristic
+  unsetenv("OMP_NUM_THREADS");
+  unsetenv("OMP_THREAD_LIMIT");
+  size_t hw_capacity = std::thread::hardware_concurrency();
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), hw_capacity);
+  setenv("OMP_NUM_THREADS", "13", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), 13);
+  setenv("OMP_NUM_THREADS", "7,5,13", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), 7);
+  unsetenv("OMP_NUM_THREADS");
+
+  setenv("OMP_THREAD_LIMIT", "1", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), 1);
+  setenv("OMP_THREAD_LIMIT", "999", 1);
+  if (hw_capacity <= 999) {
+    ASSERT_EQ(ThreadPool::DefaultCapacity(), hw_capacity);
+  }
+  setenv("OMP_NUM_THREADS", "6,5,13", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), 6);
+  setenv("OMP_THREAD_LIMIT", "2", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), 2);
+
+  // Invalid env values
+  setenv("OMP_NUM_THREADS", "0", 1);
+  setenv("OMP_THREAD_LIMIT", "0", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), hw_capacity);
+  setenv("OMP_NUM_THREADS", "zzz", 1);
+  setenv("OMP_THREAD_LIMIT", "x", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), hw_capacity);
+  setenv("OMP_THREAD_LIMIT", "-1", 1);
+  setenv("OMP_NUM_THREADS", "155555555555555558878888888888888888999878787", 1);
+  ASSERT_EQ(ThreadPool::DefaultCapacity(), hw_capacity);
+
+  unsetenv("OMP_NUM_THREADS");
+  unsetenv("OMP_THREAD_LIMIT");
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/thread-pool.h
+++ b/cpp/src/arrow/util/thread-pool.h
@@ -72,6 +72,10 @@ class ThreadPool {
   // thread count is fully adjusted.
   Status SetCapacity(size_t threads);
 
+  // Heuristic for the default capacity of a thread pool for CPU-bound tasks.
+  // This is exposed as a static method to help with testing.
+  static size_t DefaultCapacity();
+
   // Shutdown the pool.  Once the pool starts shutting down, new tasks
   // cannot be submitted anymore.
   // If "wait" is true, shutdown waits for all pending tasks to be finished.
@@ -109,6 +113,7 @@ class ThreadPool {
 
  protected:
   FRIEND_TEST(TestThreadPool, SetCapacity);
+  FRIEND_TEST(TestGlobalThreadPool, Capacity);
 
   ThreadPool();
 


### PR DESCRIPTION
The heuristic goes this way:
- if the OMP_NUM_THREADS environment variable exists, it defines the baseline
  number of available threads
- otherwise, the baseline is the value returned by std::thread::harware_concurrency()
- the OMP_THREAD_LIMIT environment variable, if it exists, defined the upper bound
  for the final value, i.e. we return min(baseline, limit), otherwise we just
  return the baseline.

This is the heuristic used by other packages such as the GNU "nproc" utility.