### PR TITLE
ARROW-2575: [Python] Exclude hidden files when reading Parquet dataset

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -642,7 +642,8 @@ class ParquetManifest(object):
 
     def _should_silently_exclude(self, file_name):
         return (file_name.endswith('.crc') or
-                file_name in EXCLUDED_PARQUET_PATHS)
+                file_name in EXCLUDED_PARQUET_PATHS or
+                file_name.startswith('.'))
 
     def _visit_directories(self, level, directories, part_keys):
         for path in directories:


### PR DESCRIPTION
On Unix systems hidden files are listed because os.walk does not care about hidden files. This especially creates a problem in macOS where .DS_Store files are created automatically.