### PR TITLE
Refactor code

### DIFF
--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -636,6 +636,9 @@ void PlasmaStore::subscribe_to_updates(Client* client) {
     return;
   }
 
+  // Add this fd to global map, which is needed for this client to receive notifications.
+  pending_notifications_[fd];
+
   // Push notifications to the new subscriber about existing objects.
   for (const auto& entry : store_info_.objects) {
     push_notification(&entry.second->info);

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -623,6 +623,15 @@ void PlasmaStore::push_notification(ObjectInfoT* object_info) {
   }
 }
 
+void PlasmaStore::push_notification(ObjectInfoT* object_info, int client_fd) {
+  auto it = pending_notifications_.find(client_fd);
+  if (it != pending_notifications_.end()) {
+    auto notification = create_object_info_buffer(object_info);
+    it->second.object_notifications.emplace_back(std::move(notification));
+    send_notifications(it->first);
+  }
+}
+
 // Subscribe to notifications about sealed objects.
 void PlasmaStore::subscribe_to_updates(Client* client) {
   ARROW_LOG(DEBUG) << "subscribing to updates on fd " << client->fd;
@@ -639,11 +648,12 @@ void PlasmaStore::subscribe_to_updates(Client* client) {
   // Add this fd to global map, which is needed for this client to receive notifications.
   pending_notifications_[fd];
 
-  // Push notifications to the new subscriber about existing objects.
+  // Push notifications to the new subscriber about existing sealed objects.
   for (const auto& entry : store_info_.objects) {
-    push_notification(&entry.second->info);
+    if (entry.second->state == PLASMA_SEALED) {
+      push_notification(&entry.second->info, fd);
+    }
   }
-  send_notifications(fd);
 }
 
 Status PlasmaStore::process_message(Client* client) {

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -104,7 +104,7 @@ GetRequest::GetRequest(Client* client, const std::vector<ObjectID>& object_ids)
   num_objects_to_wait_for = unique_ids.size();
 }
 
-Client::Client(int fd) : fd(fd) {}
+Client::Client(int fd) : fd(fd), notification_fd(boost::none) {}
 
 PlasmaStore::PlasmaStore(EventLoop* loop, int64_t system_memory, std::string directory,
                          bool hugepages_enabled)
@@ -548,10 +548,18 @@ void PlasmaStore::disconnect_client(int client_fd) {
     abort_object(entry, client);
   }
 
-  // Note, the store may still attempt to send a message to the disconnected
-  // client (for example, when an object ID that the client was waiting for
-  // is ready). In these cases, the attempt to send the message will fail, but
-  // the store should just ignore the failure.
+  if (client->notification_fd) {
+    // This client has subscribed for notifications.
+    auto notify_fd = client->notification_fd.get();
+    loop_->RemoveFileEvent(notify_fd);
+    // Close socket.
+    close(notify_fd);
+    // Remove notification queue for this fd from global map.
+    pending_notifications_.erase(notify_fd);
+    // Reset fd.
+    client->notification_fd = boost::none;
+  }
+
   connected_clients_.erase(it);
 }
 
@@ -635,6 +643,11 @@ void PlasmaStore::push_notification(ObjectInfoT* object_info, int client_fd) {
 // Subscribe to notifications about sealed objects.
 void PlasmaStore::subscribe_to_updates(Client* client) {
   ARROW_LOG(DEBUG) << "subscribing to updates on fd " << client->fd;
+  if (client->notification_fd) {
+    // This client has already subscribed. Return.
+    return;
+  }
+
   // TODO(rkn): The store could block here if the client doesn't send a file
   // descriptor.
   int fd = recv_fd(client->fd);
@@ -647,6 +660,7 @@ void PlasmaStore::subscribe_to_updates(Client* client) {
 
   // Add this fd to global map, which is needed for this client to receive notifications.
   pending_notifications_[fd];
+  client->notification_fd = fd;
 
   // Push notifications to the new subscriber about existing sealed objects.
   for (const auto& entry : store_info_.objects) {

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -164,6 +164,8 @@ class PlasmaStore {
  private:
   void push_notification(ObjectInfoT* object_notification);
 
+  void push_notification(ObjectInfoT* object_notification, int client_fd);
+
   void add_client_to_object_clients(ObjectTableEntry* entry, Client* client);
 
   void return_from_get(GetRequest* get_req);

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -18,6 +18,7 @@
 #ifndef PLASMA_STORE_H
 #define PLASMA_STORE_H
 
+#include <boost/optional.hpp>
 #include <deque>
 #include <memory>
 #include <string>
@@ -46,6 +47,10 @@ struct Client {
 
   /// The file descriptor used to communicate with the client.
   int fd;
+
+  /// The file descriptor used to push notifications to client. This is only valid
+  /// if client subscribes to plasma store.
+  boost::optional<int> notification_fd;
 };
 
 class PlasmaStore {

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -52,15 +52,15 @@ class TestPlasmaStore : public ::testing::Test {
     std::mt19937 rng;
     rng.seed(std::random_device()());
     std::string store_index = std::to_string(rng());
+    store_socket_name_ = "/tmp/store" + store_index;
 
     std::string plasma_directory =
         test_executable.substr(0, test_executable.find_last_of("/"));
-    std::string plasma_command = plasma_directory +
-                                 "/plasma_store -m 1000000000 -s /tmp/store" +
-                                 store_index + " 1> /dev/null 2> /dev/null &";
+    std::string plasma_command = plasma_directory + "/plasma_store -m 1000000000 -s " +
+                                 store_socket_name_ + " 1> /dev/null 2> /dev/null &";
     system(plasma_command.c_str());
-    ARROW_CHECK_OK(client_.Connect("/tmp/store" + store_index, ""));
-    ARROW_CHECK_OK(client2_.Connect("/tmp/store" + store_index, ""));
+    ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));
+    ARROW_CHECK_OK(client2_.Connect(store_socket_name_, ""));
   }
   virtual void TearDown() {
     ARROW_CHECK_OK(client_.Disconnect());
@@ -83,10 +83,59 @@ class TestPlasmaStore : public ::testing::Test {
     ARROW_CHECK_OK(client.Release(object_id));
   }
 
+  const std::string& GetStoreSocketName() const { return store_socket_name_; }
+
  protected:
   PlasmaClient client_;
   PlasmaClient client2_;
+  std::string store_socket_name_;
 };
+
+TEST_F(TestPlasmaStore, NewSubscriberTest) {
+  PlasmaClient local_client, local_client2;
+
+  ARROW_CHECK_OK(local_client.Connect(store_socket_name_, ""));
+  ARROW_CHECK_OK(local_client2.Connect(store_socket_name_, ""));
+
+  ObjectID object_id = ObjectID::from_random();
+
+  // Test for the object being in local Plasma store.
+  // First create object.
+  int64_t data_size = 100;
+  uint8_t metadata[] = {5};
+  int64_t metadata_size = sizeof(metadata);
+  std::shared_ptr<Buffer> data;
+  ARROW_CHECK_OK(
+      local_client.Create(object_id, data_size, metadata, metadata_size, &data));
+  ARROW_CHECK_OK(local_client.Seal(object_id));
+
+  // Test that new subscriber client2 can receive notifications about existing objects.
+  int fd = -1;
+  ARROW_CHECK_OK(local_client2.Subscribe(&fd));
+  ASSERT_GT(fd, 0);
+
+  ObjectID object_id2 = ObjectID::from_random();
+  int64_t data_size2 = 0;
+  int64_t metadata_size2 = 0;
+  ARROW_CHECK_OK(
+      local_client2.GetNotification(fd, &object_id2, &data_size2, &metadata_size2));
+  ASSERT_EQ(object_id, object_id2);
+  ASSERT_EQ(data_size, data_size2);
+  ASSERT_EQ(metadata_size, metadata_size2);
+
+  // Delete the object.
+  ARROW_CHECK_OK(local_client.Release(object_id));
+  ARROW_CHECK_OK(local_client.Delete(object_id));
+
+  ARROW_CHECK_OK(
+      local_client2.GetNotification(fd, &object_id2, &data_size2, &metadata_size2));
+  ASSERT_EQ(object_id, object_id2);
+  ASSERT_EQ(-1, data_size2);
+  ASSERT_EQ(-1, metadata_size2);
+
+  ARROW_CHECK_OK(local_client2.Disconnect());
+  ARROW_CHECK_OK(local_client.Disconnect());
+}
 
 TEST_F(TestPlasmaStore, SealErrorsTest) {
   ObjectID object_id = ObjectID::from_random();


### PR DESCRIPTION
This change targets to improve a few places in current plasma notification code:
1. When a client subscribes to Plasma, the store pushes notifications about existing objects to ALL subscribers, while it should only push to the new subscriber.
2. And in the above scenario, it should only push "sealed" objects to the new subscriber, while currently it pushes all objects regardless of the state.
3. When a client disconnects, it will no longer be able to receive notifications, thus the NotificationQueue for the client should be removed from global map.
