### PR TITLE
ARROW-2551: [Plasma] Improve notification logic

### DIFF
--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -655,7 +655,7 @@ void PlasmaStore::push_notification(ObjectInfoT* object_info, int client_fd) {
   if (it != pending_notifications_.end()) {
     auto notification = create_object_info_buffer(object_info);
     it->second.object_notifications.emplace_back(std::move(notification));
-    send_notifications(it->first);
+    send_notifications(it);
   }
 }
 

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -18,6 +18,7 @@
 #ifndef PLASMA_STORE_H
 #define PLASMA_STORE_H
 
+#include <boost/optional.hpp>
 #include <deque>
 #include <memory>
 #include <string>
@@ -50,6 +51,10 @@ struct Client {
 
   /// Object ids that are used by this client.
   std::unordered_set<ObjectID> object_ids;
+
+  /// The file descriptor used to push notifications to client. This is only valid
+  /// if client subscribes to plasma store.
+  boost::optional<int> notification_fd;
 };
 
 class PlasmaStore {

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -170,6 +170,8 @@ class PlasmaStore {
  private:
   void push_notification(ObjectInfoT* object_notification);
 
+  void push_notification(ObjectInfoT* object_notification, int client_fd);
+
   void add_to_client_object_ids(ObjectTableEntry* entry, Client* client);
 
   void return_from_get(GetRequest* get_req);

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -18,7 +18,6 @@
 #ifndef PLASMA_STORE_H
 #define PLASMA_STORE_H
 
-#include <boost/optional.hpp>
 #include <deque>
 #include <memory>
 #include <string>
@@ -53,8 +52,8 @@ struct Client {
   std::unordered_set<ObjectID> object_ids;
 
   /// The file descriptor used to push notifications to client. This is only valid
-  /// if client subscribes to plasma store.
-  boost::optional<int> notification_fd;
+  /// if client subscribes to plasma store. -1 indicates invalid.
+  int notification_fd;
 };
 
 class PlasmaStore {


### PR DESCRIPTION
This change targets to improve a few places in current plasma notification code:
1. When a client subscribes to Plasma, the store pushes notifications about existing objects to ALL subscribers, while it should only push to the new subscriber.
2. And in the above scenario, it should only push "sealed" objects to the new subscriber, while currently it pushes all objects regardless of the state.
3. When a client disconnects, it will no longer be able to receive notifications, thus the NotificationQueue for the client should be removed from global map.
