### PR TITLE
ARROW-2571: [C++] Lz4Codec doesn't properly handle empty data

### DIFF
--- a/cpp/src/arrow/util/compression-test.cc
+++ b/cpp/src/arrow/util/compression-test.cc
@@ -69,7 +69,7 @@ void CheckCodecRoundtrip(const vector<uint8_t>& data) {
 
 template <Compression::type CODEC>
 void CheckCodec() {
-  int sizes[] = {10000, 100000};
+  int sizes[] = {0, 10000, 100000};
   for (int data_size : sizes) {
     vector<uint8_t> data(data_size);
     test::random_bytes(data_size, 1234, data.data());

--- a/cpp/src/arrow/util/compression-test.cc
+++ b/cpp/src/arrow/util/compression-test.cc
@@ -38,31 +38,32 @@ void CheckCodecRoundtrip(const vector<uint8_t>& data) {
   ASSERT_OK(Codec::Create(CODEC, &c1));
   ASSERT_OK(Codec::Create(CODEC, &c2));
 
-  int max_compressed_len = static_cast<int>(c1->MaxCompressedLen(data.size(), &data[0]));
+  int max_compressed_len =
+      static_cast<int>(c1->MaxCompressedLen(data.size(), data.data()));
   std::vector<uint8_t> compressed(max_compressed_len);
   std::vector<uint8_t> decompressed(data.size());
 
   // compress with c1
   int64_t actual_size;
-  ASSERT_OK(c1->Compress(data.size(), &data[0], max_compressed_len, &compressed[0],
+  ASSERT_OK(c1->Compress(data.size(), data.data(), max_compressed_len, compressed.data(),
                          &actual_size));
   compressed.resize(actual_size);
 
   // decompress with c2
-  ASSERT_OK(c2->Decompress(compressed.size(), &compressed[0], decompressed.size(),
-                           &decompressed[0]));
+  ASSERT_OK(c2->Decompress(compressed.size(), compressed.data(), decompressed.size(),
+                           decompressed.data()));
 
   ASSERT_EQ(data, decompressed);
 
   // compress with c2
   int64_t actual_size2;
-  ASSERT_OK(c2->Compress(data.size(), &data[0], max_compressed_len, &compressed[0],
+  ASSERT_OK(c2->Compress(data.size(), data.data(), max_compressed_len, compressed.data(),
                          &actual_size2));
   ASSERT_EQ(actual_size2, actual_size);
 
   // decompress with c1
-  ASSERT_OK(c1->Decompress(compressed.size(), &compressed[0], decompressed.size(),
-                           &decompressed[0]));
+  ASSERT_OK(c1->Decompress(compressed.size(), compressed.data(), decompressed.size(),
+                           decompressed.data()));
 
   ASSERT_EQ(data, decompressed);
 }

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -34,7 +34,7 @@ Status Lz4Codec::Decompress(int64_t input_len, const uint8_t* input, int64_t out
   int64_t decompressed_size = LZ4_decompress_safe(
       reinterpret_cast<const char*>(input), reinterpret_cast<char*>(output_buffer),
       static_cast<int>(input_len), static_cast<int>(output_len));
-  if (decompressed_size < 1) {
+  if (decompressed_size < 0) {
     return Status::IOError("Corrupt Lz4 compressed data.");
   }
   return Status::OK();
@@ -51,7 +51,7 @@ Status Lz4Codec::Compress(int64_t input_len, const uint8_t* input,
   *output_length = LZ4_compress_default(
       reinterpret_cast<const char*>(input), reinterpret_cast<char*>(output_buffer),
       static_cast<int>(input_len), static_cast<int>(output_buffer_len));
-  if (*output_length < 1) {
+  if (*output_length == 0) {
     return Status::IOError("Lz4 compression failure.");
   }
   return Status::OK();


### PR DESCRIPTION
From the lz4 manual [1]:

int LZ4_compress_default(const char* src, char* dst, int srcSize, int
      dstCapacity);
return : the number of bytes written into buffer 'dst' (necessarily <= dstCapacity)
         or 0 if compression fails

int LZ4_decompress_safe (const char* src, char* dst, int compressedSize,
      int dstCapacity);
return : the number of bytes decompressed into destination buffer (necessarily <= dstCapacity)
         If destination buffer is not large enough, decoding will stop and output an error code (negative value).
         If the source stream is detected malformed, the function will stop decoding and return a negative result.
         This function is protected against malicious data packets.

Fixes: 83a4405ea0 ('ARROW-599: [C++] Lz4 compression codec support')

[1] https://github.com/lz4/lz4/blob/bf6fd938e522150e2a30bee978102769a51f4b3e/doc/lz4_manual.html#L64