### PR TITLE
ARROW-2586: [C++] Changing the type of ListBuilder's and StructBuilder's children from unique_ptr to shared_ptr so that it can support deserialization from Parquet to Arrow with arbitrary nesting

### DIFF
--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1648,8 +1648,8 @@ Status StructBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-  // ----------------------------------------------------------------------
-  // Helper functions
+// ----------------------------------------------------------------------
+// Helper functions
 
 #define BUILDER_CASE(ENUM, BuilderType)      \
   case Type::ENUM:                           \

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1273,14 +1273,15 @@ Status Decimal128Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {
 // ----------------------------------------------------------------------
 // ListBuilder
 
-ListBuilder::ListBuilder(MemoryPool* pool, std::unique_ptr<ArrayBuilder> value_builder,
+ListBuilder::ListBuilder(MemoryPool* pool,
+                         std::shared_ptr<ArrayBuilder> const& value_builder,
                          const std::shared_ptr<DataType>& type)
     : ArrayBuilder(type ? type
                         : std::static_pointer_cast<DataType>(
                               std::make_shared<ListType>(value_builder->type())),
                    pool),
       offsets_builder_(pool),
-      value_builder_(std::move(value_builder)) {}
+      value_builder_(value_builder) {}
 
 Status ListBuilder::AppendValues(const int32_t* offsets, int64_t length,
                                  const uint8_t* valid_bytes) {
@@ -1620,10 +1621,8 @@ const uint8_t* FixedSizeBinaryBuilder::GetValue(int64_t i) const {
 // Struct
 
 StructBuilder::StructBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool,
-                             std::vector<std::unique_ptr<ArrayBuilder>>&& field_builders)
-    : ArrayBuilder(type, pool) {
-  field_builders_ = std::move(field_builders);
-}
+                             std::vector<std::shared_ptr<ArrayBuilder>>&& field_builders)
+    : ArrayBuilder(type, pool), field_builders_(std::move(field_builders)) {}
 
 void StructBuilder::Reset() {
   ArrayBuilder::Reset();
@@ -1649,8 +1648,8 @@ Status StructBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-// ----------------------------------------------------------------------
-// Helper functions
+  // ----------------------------------------------------------------------
+  // Helper functions
 
 #define BUILDER_CASE(ENUM, BuilderType)      \
   case Type::ENUM:                           \
@@ -1700,7 +1699,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
 
     case Type::STRUCT: {
       const std::vector<std::shared_ptr<Field>>& fields = type->children();
-      std::vector<std::unique_ptr<ArrayBuilder>> values_builder;
+      std::vector<std::shared_ptr<ArrayBuilder>> values_builder;
 
       for (auto it : fields) {
         std::unique_ptr<ArrayBuilder> builder;

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -658,6 +658,7 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
 class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
  public:
+  using value_type = bool;
   explicit BooleanBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   explicit BooleanBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
@@ -860,7 +861,7 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
  public:
   /// Use this constructor to incrementally build the value array along with offsets and
   /// null bitmap.
-  ListBuilder(MemoryPool* pool, std::unique_ptr<ArrayBuilder> value_builder,
+  ListBuilder(MemoryPool* pool, std::shared_ptr<ArrayBuilder> const& value_builder,
               const std::shared_ptr<DataType>& type = NULLPTR);
 
   Status Init(int64_t elements) override;
@@ -891,7 +892,7 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
 
  protected:
   TypedBufferBuilder<int32_t> offsets_builder_;
-  std::unique_ptr<ArrayBuilder> value_builder_;
+  std::shared_ptr<ArrayBuilder> value_builder_;
   std::shared_ptr<Array> values_;
 
   Status AppendNextOffset();
@@ -1065,7 +1066,7 @@ using DecimalBuilder = Decimal128Builder;
 class ARROW_EXPORT StructBuilder : public ArrayBuilder {
  public:
   StructBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool,
-                std::vector<std::unique_ptr<ArrayBuilder>>&& field_builders);
+                std::vector<std::shared_ptr<ArrayBuilder>>&& field_builders);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
@@ -1101,7 +1102,7 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
   int num_fields() const { return static_cast<int>(field_builders_.size()); }
 
  protected:
-  std::vector<std::unique_ptr<ArrayBuilder>> field_builders_;
+  std::vector<std::shared_ptr<ArrayBuilder>> field_builders_;
 };
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
This allows the class that is responsible for deserializing to hold a shared_ptr to the concrete type without having to static_cast from the (List|Struct)Builder's getters.

This was needed for https://github.com/apache/parquet-cpp/pull/462.