### PR TITLE
ARROW-2576: [GLib] Add abs functions for Decimal128

### DIFF
--- a/c_glib/arrow-glib/decimal.cpp
+++ b/c_glib/arrow-glib/decimal.cpp
@@ -172,6 +172,23 @@ garrow_decimal128_to_string(GArrowDecimal128 *decimal)
   return g_strndup(string.data(), string.size());
 }
 
+/**
+ * garrow_decimal128_abs:
+ * @decimal: A #GArrowDecimal128.
+ *
+ * Returns: (transfer full): The absolute value of the decimal.
+ *
+ * Since: 0.10.0
+ */
+GArrowDecimal128 *
+garrow_decimal128_abs(GArrowDecimal128 *decimal)
+{
+  auto arrow_decimal = garrow_decimal128_get_raw(decimal);
+  auto arrow_sub_decimal =
+    std::make_shared<arrow::Decimal128>(arrow_decimal->Abs());
+  return garrow_decimal128_new_raw(&arrow_sub_decimal);
+}
+
 G_END_DECLS
 
 GArrowDecimal128 *

--- a/c_glib/arrow-glib/decimal.h
+++ b/c_glib/arrow-glib/decimal.h
@@ -40,5 +40,6 @@ GArrowDecimal128 *garrow_decimal128_new_integer(const gint64 data);
 gchar *garrow_decimal128_to_string_scale(GArrowDecimal128 *decimal,
                                          gint32 scale);
 gchar *garrow_decimal128_to_string(GArrowDecimal128 *decimal);
+GArrowDecimal128 *garrow_decimal128_abs(GArrowDecimal128 *decimal);
 
 G_END_DECLS

--- a/c_glib/test/test-decimal.rb
+++ b/c_glib/test/test-decimal.rb
@@ -28,4 +28,11 @@ class TestDecimal128 < Test::Unit::TestCase
     decimal = Arrow::Decimal128.new(string_data)
     assert_equal(string_data, decimal.to_s)
   end
+
+  def test_abs
+    absolute_value = "23049223942343532412"
+    negative_value = "-23049223942343532412"
+    decimal = Arrow::Decimal128.new(negative_value)
+    assert_equal(absolute_value, decimal.abs.to_s)
+  end
 end


### PR DESCRIPTION
Add garrow_decimal128_abs().