### PR TITLE
ARROW-2578: [Plasma] Use mersenne twister to generate random number

### DIFF
--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -28,9 +28,10 @@ using arrow::Status;
 UniqueID UniqueID::from_random() {
   UniqueID id;
   uint8_t* data = id.mutable_data();
-  std::random_device engine;
+  static thread_local std::mt19937 generator;
+  std::uniform_int_distribution<uint32_t> d(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {
-    data[i] = static_cast<uint8_t>(engine());
+    data[i] = static_cast<uint8_t>(d(generator));
   }
   return id;
 }

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -20,7 +20,6 @@
 #include <limits>
 #include <mutex>
 #include <random>
-#include <thread>
 
 #include "plasma/plasma_generated.h"
 
@@ -37,9 +36,9 @@ UniqueID UniqueID::from_random() {
   static std::mutex mutex;
   std::lock_guard<std::mutex> lock(mutex);
   static std::mt19937 generator;
-  std::uniform_int_distribution<uint32_t> d(0, std::numeric_limits<uint8_t>::max());
+  std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {
-    data[i] = static_cast<uint8_t>(d(generator));
+    data[i] = static_cast<uint8_t>(dist(generator));
   }
   return id;
 }

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -29,7 +29,12 @@ using arrow::Status;
 UniqueID UniqueID::from_random() {
   UniqueID id;
   uint8_t* data = id.mutable_data();
-  static thread_local std::mt19937 generator;
+  // NOTE(pcm): The right way to do this is to have one std::mt19937 per
+  // thread (using the thread_local keyword), but that's not supported on
+  // older versions of macOS (see https://stackoverflow.com/a/29929949)
+  static std::mutex mutex;
+  std::lock_guard<std::mutex> lock(mutex);
+  static std::mt19937 generator;
   std::uniform_int_distribution<uint32_t> d(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {
     data[i] = static_cast<uint8_t>(d(generator));

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -18,7 +18,9 @@
 #include "plasma/common.h"
 
 #include <limits>
+#include <mutex>
 #include <random>
+#include <thread>
 
 #include "plasma/plasma_generated.h"
 

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -17,6 +17,7 @@
 
 #include "plasma/common.h"
 
+#include <limits>
 #include <random>
 
 #include "plasma/plasma_generated.h"

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -51,8 +51,8 @@ class TestPlasmaStore : public ::testing::Test {
   // TODO(pcm): At the moment, stdout of the test gets mixed up with
   // stdout of the object store. Consider changing that.
   void SetUp() {
-    std::mt19937 rng;
-    rng.seed(std::random_device()());
+    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    std::mt19937 rng(seed);
     std::string store_index = std::to_string(rng());
     store_socket_name_ = "/tmp/store" + store_index;
 

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -51,7 +51,7 @@ class TestPlasmaStore : public ::testing::Test {
   // TODO(pcm): At the moment, stdout of the test gets mixed up with
   // stdout of the object store. Consider changing that.
   void SetUp() {
-    auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    uint64_t seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
     std::mt19937 rng(seed);
     std::string store_index = std::to_string(rng());
     store_socket_name_ = "/tmp/store" + store_index;

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -52,7 +52,7 @@ class TestPlasmaStore : public ::testing::Test {
   // stdout of the object store. Consider changing that.
   void SetUp() {
     uint64_t seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-    std::mt19937 rng(seed);
+    std::mt19937 rng(static_cast<uint32_t>(seed));
     std::string store_index = std::to_string(rng());
     store_socket_name_ = "/tmp/store" + store_index;
 


### PR DESCRIPTION
This gets rid of the std::random_device, which is slow and causes errors in valgrind. Instead we use the std::mt19937 Mersenne Twister.