### PR TITLE
ARROW-2580: [GLib] Fix abs functions for Decimal128

### DIFF
--- a/c_glib/arrow-glib/decimal.cpp
+++ b/c_glib/arrow-glib/decimal.cpp
@@ -176,17 +176,15 @@ garrow_decimal128_to_string(GArrowDecimal128 *decimal)
  * garrow_decimal128_abs:
  * @decimal: A #GArrowDecimal128.
  *
- * Returns: (transfer full): The absolute value of the decimal.
+ * Computes the absolute value of the @decimal destructively.
  *
  * Since: 0.10.0
  */
-GArrowDecimal128 *
+void
 garrow_decimal128_abs(GArrowDecimal128 *decimal)
 {
   auto arrow_decimal = garrow_decimal128_get_raw(decimal);
-  auto arrow_sub_decimal =
-    std::make_shared<arrow::Decimal128>(arrow_decimal->Abs());
-  return garrow_decimal128_new_raw(&arrow_sub_decimal);
+  arrow_decimal->Abs();
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/decimal.h
+++ b/c_glib/arrow-glib/decimal.h
@@ -40,6 +40,6 @@ GArrowDecimal128 *garrow_decimal128_new_integer(const gint64 data);
 gchar *garrow_decimal128_to_string_scale(GArrowDecimal128 *decimal,
                                          gint32 scale);
 gchar *garrow_decimal128_to_string(GArrowDecimal128 *decimal);
-GArrowDecimal128 *garrow_decimal128_abs(GArrowDecimal128 *decimal);
+void garrow_decimal128_abs(GArrowDecimal128 *decimal);
 
 G_END_DECLS

--- a/c_glib/test/test-decimal.rb
+++ b/c_glib/test/test-decimal.rb
@@ -33,6 +33,7 @@ class TestDecimal128 < Test::Unit::TestCase
     absolute_value = "23049223942343532412"
     negative_value = "-23049223942343532412"
     decimal = Arrow::Decimal128.new(negative_value)
-    assert_equal(absolute_value, decimal.abs.to_s)
+    decimal.abs
+    assert_equal(absolute_value, decimal.to_s)
   end
 end


### PR DESCRIPTION
I fixed about https://github.com/apache/arrow/pull/2037#issuecomment-388665809.