### PR TITLE
Removing extraneous debug print statement from run_clang_format.py

### DIFF
--- a/cpp/build-support/run_clang_format.py
+++ b/cpp/build-support/run_clang_format.py
@@ -103,7 +103,6 @@ if __name__ == "__main__":
                 if diff:
                     # Print out the diff to stderr
                     error = True
-                    print(",".join(map(str, map(type, diff))))
                     sys.stderr.writelines(diff)
 
     sys.exit(1 if error else 0)


### PR DESCRIPTION
This was introduced in #1918 