### PR TITLE
ARROW-2561: [C++] Fix double free in cuda-test under code coverage

### DIFF
--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -43,7 +43,7 @@ ADD_ARROW_LIB(arrow_gpu
   DEPENDENCIES metadata_fbs
   SHARED_LINK_FLAGS ""
   SHARED_LINK_LIBS ${ARROW_GPU_SHARED_LINK_LIBS}
-  STATIC_LINK_LIBS ""
+  STATIC_LINK_LIBS ${ARROW_GPU_SHARED_LINK_LIBS}
 )
 
 # CUDA build version
@@ -72,7 +72,7 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 set(ARROW_GPU_TEST_LINK_LIBS
-  arrow_gpu_shared
+  arrow_gpu_static
   ${ARROW_TEST_LINK_LIBS})
 
 if (ARROW_BUILD_TESTS)

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -33,7 +33,6 @@ set(ARROW_GPU_SRCS
 )
 
 set(ARROW_GPU_SHARED_LINK_LIBS
-  arrow_shared
   ${CUDA_LIBRARIES}
   ${CUDA_CUDA_LIBRARY}
 )
@@ -42,7 +41,8 @@ ADD_ARROW_LIB(arrow_gpu
   SOURCES ${ARROW_GPU_SRCS}
   DEPENDENCIES metadata_fbs
   SHARED_LINK_FLAGS ""
-  SHARED_LINK_LIBS ${ARROW_GPU_SHARED_LINK_LIBS}
+  SHARED_LINK_LIBS arrow_shared ${ARROW_GPU_SHARED_LINK_LIBS}
+  # Static arrow_gpu must also link against CUDA shared libs
   STATIC_LINK_LIBS ${ARROW_GPU_SHARED_LINK_LIBS}
 )
 
@@ -72,6 +72,7 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 set(ARROW_GPU_TEST_LINK_LIBS
+  # ARROW-2561: Must link statically against arrow and arrow_gpu to avoid double free
   arrow_gpu_static
   ${ARROW_TEST_LINK_LIBS})
 


### PR DESCRIPTION
As far as I can understand, the problem is due to both shared and static linking with libarrow.  Some static std::string in libarrow.so would be destroyed twice at shutdown.  Linking entirely statically seems to fix the issue.