### PR TITLE
ARROW-2611: [Python] Fix Python 2 integer serialization

### DIFF
--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -112,9 +112,15 @@ Status GetValue(PyObject* context, const UnionArray& parent, const Array& arr,
     case Type::BOOL:
       *result = PyBool_FromLong(checked_cast<const BooleanArray&>(arr).Value(index));
       return Status::OK();
-    case Type::INT64:
-      *result = PyLong_FromSsize_t(checked_cast<const Int64Array&>(arr).Value(index));
+    case Type::INT64: {
+      const std::string& child_name = parent.type()->child(type)->name();
+      if (child_name == "py2_int") {
+        *result = PyInt_FromSsize_t(checked_cast<const Int64Array&>(arr).Value(index));
+      } else {
+        *result = PyLong_FromSsize_t(checked_cast<const Int64Array&>(arr).Value(index));
+      }
       return Status::OK();
+    }
     case Type::BINARY: {
       int32_t nchars;
       const uint8_t* str = checked_cast<const BinaryArray&>(arr).GetValue(index, &nchars);

--- a/cpp/src/arrow/python/arrow_to_python.cc
+++ b/cpp/src/arrow/python/arrow_to_python.cc
@@ -113,12 +113,14 @@ Status GetValue(PyObject* context, const UnionArray& parent, const Array& arr,
       *result = PyBool_FromLong(checked_cast<const BooleanArray&>(arr).Value(index));
       return Status::OK();
     case Type::INT64: {
+#if PY_MAJOR_VERSION < 3
       const std::string& child_name = parent.type()->child(type)->name();
       if (child_name == "py2_int") {
         *result = PyInt_FromSsize_t(checked_cast<const Int64Array&>(arr).Value(index));
-      } else {
-        *result = PyLong_FromSsize_t(checked_cast<const Int64Array&>(arr).Value(index));
+        return Status::OK();
       }
+#endif
+      *result = PyLong_FromSsize_t(checked_cast<const Int64Array&>(arr).Value(index));
       return Status::OK();
     }
     case Type::BINARY: {

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -100,8 +100,8 @@ def assert_equal(obj1, obj2):
         for i in range(len(obj1)):
             assert_equal(obj1[i], obj2[i])
     else:
-        assert obj1 == obj2, ("Objects {} and {} are different."
-                              .format(obj1, obj2))
+        assert type(obj1) == type(obj2) and obj1 == obj2, \
+                "Objects {} and {} are different.".format(obj1, obj2)
 
 
 PRIMITIVE_OBJECTS = [


### PR DESCRIPTION
Fixes an issue where serialization turns integers into longs in Python 2.

```python
In [1]: import pyarrow as pa

In [2]: value = 1

In [3]: type(value)
Out[3]: int

In [4]: serialized = pa.serialize(value)

In [5]: deserialized = serialized.deserialize()

In [6]: type(deserialized)
Out[6]: long
```