### PR TITLE
ARROW-2595: [Plasma] Use map.find instead of operator[] to avoid producing garbage data

### DIFF
--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -297,11 +297,14 @@ void PlasmaStore::return_from_get(GetRequest* get_req) {
   // tables if it is present there. It should only be present there if the get
   // request timed out.
   for (ObjectID& object_id : get_req->object_ids) {
-    auto& get_requests = object_get_requests_[object_id];
-    // Erase get_req from the vector.
-    auto it = std::find(get_requests.begin(), get_requests.end(), get_req);
-    if (it != get_requests.end()) {
-      get_requests.erase(it);
+    auto object_request_iter = object_get_requests_.find(object_id);
+    if (object_request_iter != object_get_requests_.end()) {
+      auto& get_requests = object_request_iter->second;
+      // Erase get_req from the vector.
+      auto it = std::find(get_requests.begin(), get_requests.end(), get_req);
+      if (it != get_requests.end()) {
+        get_requests.erase(it);
+      }
     }
   }
   // Remove the get request.


### PR DESCRIPTION
- Problem
  * Using object_get_requests_[object_id] will produce a lot of garbage data in PlasmaStore::return_from_get. During the measurement process, we found that there was a lot of memory growth in this point.

- Solution
  * Use iterator instead of operator []