### PR TITLE
ARROW-530: [C++/Python] Provide subpools for better memory allocation …

### DIFF
--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -95,21 +95,21 @@ TEST(LoggingMemoryPool, Logging) {
 TEST(ProxyMemoryPool, Logging) {
   MemoryPool* pool = default_memory_pool();
 
-  ProxyMemoryPool pp = ProxyMemoryPool(pool);
+  ProxyMemoryPool* pp = new ProxyMemoryPool(pool);
 
   uint8_t* data;
   ASSERT_OK(pool->Allocate(100, &data));
 
   uint8_t* data2;
-  ASSERT_OK(pp.Allocate(300, &data2));
+  ASSERT_OK(pp->Allocate(300, &data2));
 
   ASSERT_EQ(400, pool->bytes_allocated());
-  ASSERT_EQ(300, pp.bytes_allocated());
+  ASSERT_EQ(300, pp->bytes_allocated());
 
   pool->Free(data, 100);
-  pp.Free(data2, 300);
+  pp->Free(data2, 300);
 
   ASSERT_EQ(0, pool->bytes_allocated());
-  ASSERT_EQ(0, pp.bytes_allocated());
+  ASSERT_EQ(0, pp->bytes_allocated());
 }
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -95,21 +95,21 @@ TEST(LoggingMemoryPool, Logging) {
 TEST(ProxyMemoryPool, Logging) {
   MemoryPool* pool = default_memory_pool();
 
-  ProxyMemoryPool* pp = new ProxyMemoryPool(pool);
+  ProxyMemoryPool pp(pool);
 
   uint8_t* data;
   ASSERT_OK(pool->Allocate(100, &data));
 
   uint8_t* data2;
-  ASSERT_OK(pp->Allocate(300, &data2));
+  ASSERT_OK(pp.Allocate(300, &data2));
 
   ASSERT_EQ(400, pool->bytes_allocated());
-  ASSERT_EQ(300, pp->bytes_allocated());
+  ASSERT_EQ(300, pp.bytes_allocated());
 
   pool->Free(data, 100);
-  pp->Free(data2, 300);
+  pp.Free(data2, 300);
 
   ASSERT_EQ(0, pool->bytes_allocated());
-  ASSERT_EQ(0, pp->bytes_allocated());
+  ASSERT_EQ(0, pp.bytes_allocated());
 }
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -92,24 +92,24 @@ TEST(LoggingMemoryPool, Logging) {
   ASSERT_EQ(200, pool->max_memory());
 }
 
-TEST(ProxyMemoryPool, ProxyMemoryPool) {
+TEST(ProxyMemoryPool, Logging) {
   MemoryPool* pool = default_memory_pool();
 
-  ProxyMemoryPool pp(pool);
+  ProxyMemoryPool pp = ProxyMemoryPool(pool);
 
   uint8_t* data;
   ASSERT_OK(pool->Allocate(100, &data));
 
   uint8_t* data2;
-  ASSERT_OK(pp->Allocate(300, &data2));
+  ASSERT_OK(pp.Allocate(300, &data2));
 
-  ASSERT_EQ(100, pool->bytes_allocated());
-  ASSERT_EQ(300, pp->proxy_bytes_allocated());
+  ASSERT_EQ(400, pool->bytes_allocated());
+  ASSERT_EQ(300, pp.proxy_bytes_allocated());
 
   pool->Free(data, 100);
-  pp->Free(data2, 300);
+  pp.Free(data2, 300);
 
   ASSERT_EQ(0, pool->bytes_allocated());
-  ASSERT_EQ(0, pp->proxy_bytes_allocated());
+  ASSERT_EQ(0, pp.proxy_bytes_allocated());
 }
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -91,4 +91,25 @@ TEST(LoggingMemoryPool, Logging) {
 
   ASSERT_EQ(200, pool->max_memory());
 }
+
+TEST(ProxyMemoryPool, ProxyMemoryPool) {
+  MemoryPool* pool = default_memory_pool();
+
+  ProxyMemoryPool pp(pool);
+
+  uint8_t* data;
+  ASSERT_OK(pool->Allocate(100, &data));
+
+  uint8_t* data2;
+  ASSERT_OK(pp->Allocate(300, &data2));
+
+  ASSERT_EQ(100, pool->bytes_allocated());
+  ASSERT_EQ(300, pp->proxy_bytes_allocated());
+
+  pool->Free(data, 100);
+  pp->Free(data2, 300);
+
+  ASSERT_EQ(0, pool->bytes_allocated());
+  ASSERT_EQ(0, pp->proxy_bytes_allocated());
+}
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -104,12 +104,12 @@ TEST(ProxyMemoryPool, Logging) {
   ASSERT_OK(pp.Allocate(300, &data2));
 
   ASSERT_EQ(400, pool->bytes_allocated());
-  ASSERT_EQ(300, pp.proxy_bytes_allocated());
+  ASSERT_EQ(300, pp.bytes_allocated());
 
   pool->Free(data, 100);
   pp.Free(data2, 300);
 
   ASSERT_EQ(0, pool->bytes_allocated());
-  ASSERT_EQ(0, pp.proxy_bytes_allocated());
+  ASSERT_EQ(0, pp.bytes_allocated());
 }
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -206,28 +206,23 @@ ProxyMemoryPool::ProxyMemoryPool(MemoryPool* pool) : pool_(pool) {}
 
 Status ProxyMemoryPool::Allocate(int64_t size, uint8_t** out) {
   Status s = pool_->Allocate(size, out);
-  proxy_bytes_allocated_ += size;
+  bytes_allocated_ += size;
   return s;
 }
 
 Status ProxyMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
   Status s = pool_->Reallocate(old_size, new_size, ptr);
-  proxy_bytes_allocated_ += new_size - old_size;
+  bytes_allocated_ += new_size - old_size;
   return s;
 }
 
 void ProxyMemoryPool::Free(uint8_t* buffer, int64_t size) {
   pool_->Free(buffer, size);
-  proxy_bytes_allocated_ -= size;
+  bytes_allocated_ -= size;
 }
 
 int64_t ProxyMemoryPool::bytes_allocated() const {
-  int64_t nb_bytes = pool_->bytes_allocated();
-  return nb_bytes;
-}
-
-int64_t ProxyMemoryPool::proxy_bytes_allocated() {
-  int64_t nb_bytes = proxy_bytes_allocated_;
+  int64_t nb_bytes = bytes_allocated_;
   return nb_bytes;
 }
 

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -207,39 +207,31 @@ ProxyMemoryPool::ProxyMemoryPool(MemoryPool* pool) : pool_(pool), proxy_bytes_al
 Status ProxyMemoryPool::Allocate(int64_t size, uint8_t** out) {
   proxy_bytes_allocated_ += size;
   Status s = pool_->Allocate(size, out);
-  std::cout << "Allocate: size = " << size << std::endl;
   return s;
 }
 
 Status ProxyMemoryPool::Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) {
   Status s = pool_->Reallocate(old_size, new_size, ptr);
   proxy_bytes_allocated_ += new_size - old_size;
-  std::cout << "Reallocate: old_size = " << old_size << " - new_size = " << new_size
-            << " - proxy_allocated - " << proxy_bytes_allocated_ << std::endl;
   return s;
 }
 
 void ProxyMemoryPool::Free(uint8_t* buffer, int64_t size) {
   pool_->Free(buffer, size);
   proxy_bytes_allocated_ -= size;
-  std::cout << "Free: size = " << size << std::endl;
 }
 
 int64_t ProxyMemoryPool::bytes_allocated() const {
   int64_t nb_bytes = pool_->bytes_allocated();
-  std::cout << "bytes_allocated: " << nb_bytes << std::endl;
   return nb_bytes;
 }
 
 int64_t ProxyMemoryPool::proxy_bytes_allocated() const {
-  int64_t nb_bytes = proxy_bytes_allocated_;
-  std::cout << "bytes_allocated: " << nb_bytes << std::endl;
-  return nb_bytes;
+  return proxy_bytes_allocated_;
 }
 
 int64_t ProxyMemoryPool::max_memory() const {
   int64_t mem = pool_->max_memory();
-  std::cout << "max_memory: " << mem << std::endl;
   return mem;
 }
 }  // namespace arrow

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -202,11 +202,11 @@ int64_t LoggingMemoryPool::max_memory() const {
   return mem;
 }
 
-ProxyMemoryPool::ProxyMemoryPool(MemoryPool* pool) : pool_(pool), proxy_bytes_allocated_(0) {}
+ProxyMemoryPool::ProxyMemoryPool(MemoryPool* pool) : pool_(pool) {}
 
 Status ProxyMemoryPool::Allocate(int64_t size, uint8_t** out) {
-  proxy_bytes_allocated_ += size;
   Status s = pool_->Allocate(size, out);
+  proxy_bytes_allocated_ += size;
   return s;
 }
 
@@ -226,8 +226,9 @@ int64_t ProxyMemoryPool::bytes_allocated() const {
   return nb_bytes;
 }
 
-int64_t ProxyMemoryPool::proxy_bytes_allocated() const {
-  return proxy_bytes_allocated_;
+int64_t ProxyMemoryPool::proxy_bytes_allocated() {
+  int64_t nb_bytes = proxy_bytes_allocated_;
+  return nb_bytes;
 }
 
 int64_t ProxyMemoryPool::max_memory() const {

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -19,8 +19,8 @@
 #define ARROW_MEMORY_POOL_H
 
 #include <atomic>
-#include <mutex>
 #include <cstdint>
+#include <mutex>
 
 #include "arrow/util/visibility.h"
 

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -89,7 +89,7 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
 
 /// Derived class for memory allocation.
 ///
-/// Tracks the number of bytes and maximum mmeory allocated through its direct
+/// Tracks the number of bytes and maximum memory allocated through its direct
 /// calls. Actual allocation is delegated to MemoryPool class.
 class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
  public:

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -88,8 +88,8 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
 
 class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
  public:
-  explicit ProxyMemoryPool (MemoryPool* pool);
-  ~ProxyMemoryPool () override = default;
+  explicit ProxyMemoryPool(MemoryPool* pool);
+  ~ProxyMemoryPool() override = default;
 
   Status Allocate(int64_t size, uint8_t** out) override;
   Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -100,11 +100,11 @@ class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
 
   int64_t max_memory() const override;
 
-  int64_t proxy_bytes_allocated_;
-  int64_t proxy_bytes_allocated() const;
+  int64_t proxy_bytes_allocated();
 
  private:
   MemoryPool* pool_;
+  int64_t proxy_bytes_allocated_ = 0;
 };
 
 ARROW_EXPORT MemoryPool* default_memory_pool();

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -100,11 +100,9 @@ class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
 
   int64_t max_memory() const override;
 
-  int64_t proxy_bytes_allocated();
-
  private:
   MemoryPool* pool_;
-  int64_t proxy_bytes_allocated_ = 0;
+  int64_t bytes_allocated_ = 0;
 };
 
 ARROW_EXPORT MemoryPool* default_memory_pool();

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -86,6 +86,27 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
   MemoryPool* pool_;
 };
 
+class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
+ public:
+  explicit ProxyMemoryPool (MemoryPool* pool);
+  ~ProxyMemoryPool () override = default;
+
+  Status Allocate(int64_t size, uint8_t** out) override;
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override;
+
+  void Free(uint8_t* buffer, int64_t size) override;
+
+  int64_t bytes_allocated() const override;
+
+  int64_t max_memory() const override;
+
+  int64_t proxy_bytes_allocated_;
+  int64_t proxy_bytes_allocated() const;
+
+ private:
+  MemoryPool* pool_;
+};
+
 ARROW_EXPORT MemoryPool* default_memory_pool();
 
 #ifdef ARROW_NO_DEFAULT_MEMORY_POOL

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -90,7 +90,7 @@ from pyarrow.lib import TimestampType
 from pyarrow.lib import (Buffer, ResizableBuffer, foreign_buffer, py_buffer,
                          compress, decompress, allocate_buffer)
 
-from pyarrow.lib import (MemoryPool, total_allocated_bytes,
+from pyarrow.lib import (MemoryPool, ProxyMemoryPool, total_allocated_bytes,
                          set_memory_pool, default_memory_pool,
                          log_memory_allocations)
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -194,7 +194,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass CProxyMemoryPool" arrow::ProxyMemoryPool"(CMemoryPool):
         CProxyMemoryPool(CMemoryPool*)
-        int64_t bytes_allocated()
 
     cdef cppclass CBuffer" arrow::Buffer":
         CBuffer(const uint8_t* data, int64_t size)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -192,6 +192,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CLoggingMemoryPool" arrow::LoggingMemoryPool"(CMemoryPool):
         CLoggingMemoryPool(CMemoryPool*)
 
+    cdef cppclass CProxyMemoryPool" arrow::ProxyMemoryPool"(CMemoryPool):
+        CProxyMemoryPool(CMemoryPool*)
+        int64_t proxy_bytes_allocated()
+
     cdef cppclass CBuffer" arrow::Buffer":
         CBuffer(const uint8_t* data, int64_t size)
         const uint8_t* data()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -194,7 +194,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass CProxyMemoryPool" arrow::ProxyMemoryPool"(CMemoryPool):
         CProxyMemoryPool(CMemoryPool*)
-        int64_t proxy_bytes_allocated()
+        int64_t bytes_allocated()
 
     cdef cppclass CBuffer" arrow::Buffer":
         CBuffer(const uint8_t* data, int64_t size)

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -45,6 +45,10 @@ cdef class LoggingMemoryPool(MemoryPool):
 
 
 cdef class ProxyMemoryPool(MemoryPool):
+    """
+    Derived MemoryPool class that tracks the number of bytes and
+    maximum memory allocated through its direct calls.
+    """
     cdef:
         unique_ptr[CProxyMemoryPool] proxy_pool
 

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -67,8 +67,6 @@ def set_memory_pool(MemoryPool pool):
 cdef MemoryPool _default_memory_pool = default_memory_pool()
 cdef LoggingMemoryPool _logging_memory_pool = (
     LoggingMemoryPool(_default_memory_pool))
-cdef ProxyMemoryPool _proxy_memory_pool = (
-    ProxyMemoryPool(_default_memory_pool))
 
 
 def log_memory_allocations(enable=True):

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -44,6 +44,18 @@ cdef class LoggingMemoryPool(MemoryPool):
         self.init(self.logging_pool.get())
 
 
+cdef class ProxyMemoryPool(MemoryPool):
+    cdef:
+        unique_ptr[CProxyMemoryPool] proxy_pool
+
+    def __cinit__(self, MemoryPool pool):
+        self.proxy_pool.reset(new CProxyMemoryPool(pool.pool))
+        self.init(self.proxy_pool.get())
+
+    def proxy_bytes_allocated(self):
+        return self.proxy_pool.get().proxy_bytes_allocated()
+
+
 def default_memory_pool():
     cdef:
         MemoryPool pool = MemoryPool()
@@ -58,6 +70,8 @@ def set_memory_pool(MemoryPool pool):
 cdef MemoryPool _default_memory_pool = default_memory_pool()
 cdef LoggingMemoryPool _logging_memory_pool = (
     LoggingMemoryPool(_default_memory_pool))
+cdef ProxyMemoryPool _proxy_memory_pool = (
+    ProxyMemoryPool(_default_memory_pool))
 
 
 def log_memory_allocations(enable=True):

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -52,9 +52,6 @@ cdef class ProxyMemoryPool(MemoryPool):
         self.proxy_pool.reset(new CProxyMemoryPool(pool.pool))
         self.init(self.proxy_pool.get())
 
-    def proxy_bytes_allocated(self):
-        return self.proxy_pool.get().proxy_bytes_allocated()
-
 
 def default_memory_pool():
     cdef:


### PR DESCRIPTION
…tracking

Currently we can only track the amount of bytes allocated by the main memory pool or the alternative jemalloc implementation. To better understand certain situation, we should provide a MemoryPool proxy implementation that tracks only the amount of memory that was made through its direct calls but delegates the actual allocation to an underlying pool.

Authors: Rok Mihevc <rok@mihevc.org> and Alex Hagerman <alex@unexpectedeof.net>

Usage example:
---------------------
import pyarrow as pa

def report(pool, proxy_pool):
    print("Total: ", pa.total_allocated_bytes())
    print("Default pool: ", pool.bytes_allocated())
    print("Proxy allocated: ", proxy_pool.proxy_bytes_allocated())

pool = pa.default_memory_pool()
proxy_pool = pa.ProxyMemoryPool(pool)

report(pool, proxy_pool)
a1 = pa.array([0]*1000, memory_pool=pool)
report(pool, proxy_pool)
a2 = pa.array([0]*1, memory_pool=proxy_pool)
report(pool, proxy_pool)
a3 = pa.array([0]*1000, memory_pool=proxy_pool)
report(pool, proxy_pool)
a3 = pa.array([0]*1000, memory_pool=proxy_pool)
report(pool, proxy_pool)

Result:
---------------------
Total:  0
Default pool:  0
bytes_allocated: 0
Proxy allocated:  0
Total:  8128
Default pool:  8128
bytes_allocated: 0
Proxy allocated:  0
Allocate: size = 64
Allocate: size = 256
Reallocate: old_size = 256 - new_size = 64 - proxy_allocated - 128
Total:  8256
Default pool:  8256
bytes_allocated: 128
Proxy allocated:  128
Allocate: size = 128
Allocate: size = 8192
Reallocate: old_size = 8192 - new_size = 8000 - proxy_allocated - 8256
Total:  16384
Default pool:  16384
bytes_allocated: 8256
Proxy allocated:  8256
Allocate: size = 128
Allocate: size = 8192
Reallocate: old_size = 8192 - new_size = 8000 - proxy_allocated - 16384
Free: size = 128
Free: size = 8000
Total:  16384
Default pool:  16384
bytes_allocated: 8256
Proxy allocated:  8256