### PR TITLE
ARROW-2596: [GLib] Use the default directory of GTK-Doc

### DIFF
--- a/c_glib/.gitignore
+++ b/c_glib/.gitignore
@@ -43,7 +43,6 @@ Makefile.in
 /doc/reference/*.prerequisites
 /doc/reference/*.signals
 /doc/reference/*.types
-/doc/reference/gtk-doc.make
 /doc/reference/entities.xml
 /doc/reference/*.stamp
 /doc/reference/html/
@@ -61,3 +60,4 @@ Makefile.in
 /example/build
 /example/read-batch
 /example/read-stream
+/gtk-doc.make

--- a/c_glib/autogen.sh
+++ b/c_glib/autogen.sh
@@ -22,5 +22,5 @@ set -e
 
 mkdir -p m4
 
-gtkdocize --copy --docdir doc/reference
+gtkdocize --copy
 autoreconf --install

--- a/c_glib/doc/reference/Makefile.am
+++ b/c_glib/doc/reference/Makefile.am
@@ -61,7 +61,7 @@ GTKDOC_LIBS +=							\
 	$(top_builddir)/arrow-gpu-glib/libarrow-gpu-glib.la
 endif
 
-include $(srcdir)/gtk-doc.make
+include $(top_srcdir)/gtk-doc.make
 
 CLEANFILES +=					\
 	$(DOC_MODULE)-decl-list.txt		\


### PR DESCRIPTION
We don't need to customize it.