### PR TITLE
ARROW-2600: [Python] Add additional LocalFileSystem filesystem methods

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -17,6 +17,7 @@
 
 from os.path import join as pjoin
 import os
+import sys
 import posixpath
 
 from pyarrow.util import implements
@@ -182,6 +183,12 @@ class FileSystem(object):
         """
         raise NotImplementedError
 
+    def head(self, files, line_count=10):
+        """
+        Take a file or list of files and print out the first n lines of the
+        file.
+        """
+
     @property
     def pathsep(self):
         return '/'
@@ -230,6 +237,29 @@ class LocalFileSystem(FileSystem):
         Open file for reading or writing
         """
         return open(path, mode=mode)
+
+    def _head_stdout(self, file_name, line_count):
+        with open(file_name, mode='r') as f:
+            for i, line in enumerate(f):
+                if i > line_count:
+                    break
+                else:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+
+    @implements(FileSystem.head)
+    def head(self, files, line_count=10):
+        """
+        Take a file or list of files and print out the first n lines of the
+        file.
+        """
+        if isinstance(files, str):
+            self._head_stdout(files, line_count - 1)
+        else:
+            for file in files:
+                print("==> %s <==" % file)
+                self._head_stdout(file, line_count - 1)
+                print()
 
     @property
     def pathsep(self):

--- a/python/pyarrow/tests/test_localfilesystem.py
+++ b/python/pyarrow/tests/test_localfilesystem.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pyarrow as pa
+import pytest
+import os
+
+
+@pytest.fixture(scope="module")
+def head_files():
+    with open("test_apache_license.txt", "w+") as license:
+        license.write("""# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+""")
+
+    with open("test_setup.py", "w+") as license:
+        license.write("""import contextlib
+import glob
+import os
+import os.path as osp
+import re
+import shlex
+import shutil
+import sys
+
+from Cython.Distutils import build_ext as _build_ext
+import Cython
+
+
+import pkg_resources
+from setuptools import setup, Extension, Distribution
+
+from os.path import join as pjoin
+
+""")
+    yield
+    os.remove("test_apache_license.txt")
+    os.remove("test_setup.py")
+
+
+def test_lfs_single_file_head(head_files, capsys):
+    head = """# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+"""
+    pa.LocalFileSystem().head("test_apache_license.txt", 4)
+    captured = capsys.readouterr()
+    assert captured.out == head
+
+
+def test_lfs_file_list_head(head_files, capsys):
+    files = ["test_apache_license.txt", "test_setup.py"]
+    head = """==> test_apache_license.txt <==
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+
+==> test_setup.py <==
+import contextlib
+import glob
+import os
+import os.path as osp
+import re
+import shlex
+import shutil
+import sys
+
+from Cython.Distutils import build_ext as _build_ext
+
+"""
+
+    pa.LocalFileSystem().head(files)
+    captured = capsys.readouterr()
+    assert captured.out == head


### PR DESCRIPTION
When starting to dig into ticket 1360 I noticed some of the methods could be added for the LocalFileSystem. I wanted to get this one reviewed first, but also ask:

I have the hdfs docker image linked in ticket 1360. What I'm not sure of is how pytest and the current CI will spin up an HDFS image, and should I create files on HDFS for something like the cat method to use similar to how I did in this PR or is there a different/better way to handle test for this?

For 1319 do we know how much can be implemented in Python? I see a couple tickets tagged C++/Python so I didn't know if once I got into this ticket if there are certain pieces that are known to require C++ interaction or if should all be available to do in Python?

Lastly I styled this off cat in Ubuntu 16.04 (I doubt there is much if any difference across versions and flavors), but I was wondering how we want to implement the methods if we are worried about extra flags the terminal supports, things like printing the file name if it's a list of files and not printing with an individual file or just implementing the core functionality of printing the file lines? That's just one example, but I figured I would check as I move on to the other filesystem commands.