### PR TITLE
ARROW-2603: [Python] Allow date and datetime subclassing

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -724,7 +724,7 @@ Status NumPyConverter::ConvertDates() {
     obj = objects[i];
     if ((have_mask && mask_values[i]) || internal::PandasObjectIsNull(obj)) {
       RETURN_NOT_OK(builder.AppendNull());
-    } else if (PyDate_CheckExact(obj)) {
+    } else if (PyDate_Check(obj)) {
       RETURN_NOT_OK(builder.Append(UnboxDate<ArrowType>::Unbox(obj)));
     } else {
       std::stringstream ss;
@@ -1071,11 +1071,11 @@ Status NumPyConverter::ConvertObjectsInfer() {
       return ConvertBooleans();
     } else if (PyObject_is_integer(obj)) {
       return ConvertObjectIntegers();
-    } else if (PyDate_CheckExact(obj)) {
+    } else if (PyDateTime_Check(obj)) {
+      return ConvertDateTimes();
+    } else if (PyDate_Check(obj)) {
       // We could choose Date32 or Date64
       return ConvertDates<Date32Type>();
-    } else if (PyDateTime_CheckExact(obj)) {
-      return ConvertDateTimes();
     } else if (PyTime_Check(obj)) {
       return ConvertTimes();
     } else if (PyObject_IsInstance(obj, decimal_type_.obj()) == 1) {

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -522,7 +522,7 @@ Status Append(PyObject* context, PyObject* elem, SequenceBuilder* builder,
                                  subdicts, blobs_out));
   } else if (elem == Py_None) {
     RETURN_NOT_OK(builder->AppendNone());
-  } else if (PyDateTime_CheckExact(elem)) {
+  } else if (PyDateTime_Check(elem)) {
     PyDateTime_DateTime* datetime = reinterpret_cast<PyDateTime_DateTime*>(elem);
     RETURN_NOT_OK(builder->AppendDate64(PyDateTime_to_us(datetime)));
   } else if (is_buffer(elem)) {

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -489,7 +489,7 @@ def test_datetime_subclassing():
     assert arr_date.type == date_type
     assert arr_date[0].as_py() == datetime.date(2007, 7, 13)
 
-    class MyDatetime(datetime):
+    class MyDatetime(datetime.datetime):
         pass
 
     data = [

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -477,6 +477,55 @@ def test_sequence_timestamp_with_unit():
                                                   23, 34, 123456)
 
 
+def test_datetime_subclassing():
+    class MyDate(datetime.date):
+        pass
+    data = [
+        MyDate(2007, 7, 13),
+    ]
+    date_type = pa.date32()
+    arr_date = pa.array(data, type=date_type)
+    assert len(arr_date) == 1
+    assert arr_date.type == date_type
+    assert arr_date[0].as_py() == datetime.date(2007, 7, 13)
+
+    class MyDatetime(datetime):
+        pass
+
+    data = [
+        MyDatetime(2007, 7, 13, 1, 23, 34, 123456),
+    ]
+
+    s = pa.timestamp('s')
+    ms = pa.timestamp('ms')
+    us = pa.timestamp('us')
+    ns = pa.timestamp('ns')
+
+    arr_s = pa.array(data, type=s)
+    assert len(arr_s) == 1
+    assert arr_s.type == s
+    assert arr_s[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                 23, 34, 0)
+
+    arr_ms = pa.array(data, type=ms)
+    assert len(arr_ms) == 1
+    assert arr_ms.type == ms
+    assert arr_ms[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                  23, 34, 123000)
+
+    arr_us = pa.array(data, type=us)
+    assert len(arr_us) == 1
+    assert arr_us.type == us
+    assert arr_us[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                  23, 34, 123456)
+
+    arr_ns = pa.array(data, type=ns)
+    assert len(arr_ns) == 1
+    assert arr_ns.type == ns
+    assert arr_ns[0].as_py() == datetime.datetime(2007, 7, 13, 1,
+                                                  23, 34, 123456)
+
+
 def test_sequence_timestamp_from_int_with_unit():
     data = [1]
 

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -19,7 +19,6 @@ import decimal
 import json
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
-from distutils.version import LooseVersion
 
 import numpy as np
 import numpy.testing as npt
@@ -811,14 +810,12 @@ class TestConvertDateTimeLikeTypes(object):
         })
         tm.assert_frame_equal(expected_df, result)
 
-    @pytest.mark.xfail(
-        LooseVersion(pd.__version__) >= "0.23.0",
-        reason="https://github.com/pandas-dev/pandas/issues/21142",
-    )
     def test_python_datetime_subclass(self):
 
         class MyDatetime(datetime):
             pass
+            # see https://github.com/pandas-dev/pandas/issues/21142
+            nanosecond = 0.0
 
         date_array = [MyDatetime(2000, 1, 1, 1, 1, 1)]
         df = pd.DataFrame({"datetime": pd.Series(date_array, dtype=object)})
@@ -828,7 +825,8 @@ class TestConvertDateTimeLikeTypes(object):
 
         result = table.to_pandas()
         expected_df = pd.DataFrame({"datetime": date_array})
-
+        # https://github.com/pandas-dev/pandas/issues/21142
+        expected_df["datetime"] = pd.to_datetime(expected_df["datetime"])
         tm.assert_frame_equal(expected_df, result)
 
     def test_python_date_subclass(self):

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -814,6 +814,38 @@ class TestConvertDateTimeLikeTypes(object):
         })
         tm.assert_frame_equal(expected_df, result)
 
+    def test_python_datetime_subclass(self):
+
+        class MyDatetime(datetime):
+            pass
+
+        date_array = [MyDatetime(2000, 1, 1)]
+        df = pd.DataFrame({"datetime": pd.Series(date_array, dtype=object)})
+
+        table = pa.Table.from_pandas(df)
+        assert isinstance(table[0].data.chunk(0), pa.TimestampArray)
+
+        result = table.to_pandas()
+        expected_df = pd.DataFrame({"datetime": date_array})
+        tm.assert_frame_equal(expected_df, result)
+
+    def test_python_date_subclass(self):
+
+        class MyDate(date):
+            pass
+
+        date_array = [MyDate(2000, 1, 1)]
+        df = pd.DataFrame({"date": pd.Series(date_array, dtype=object)})
+
+        table = pa.Table.from_pandas(df)
+        assert isinstance(table[0].data.chunk(0), pa.Date32Array)
+
+        result = table.to_pandas()
+        expected_df = pd.DataFrame(
+            {"date": np.array(["2000-01-01"], dtype="datetime64[ns]")}
+        )
+        tm.assert_frame_equal(expected_df, result)
+
     def test_datetime64_to_date32(self):
         # ARROW-1718
         arr = pa.array([date(2017, 10, 23), None])

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -813,7 +813,6 @@ class TestConvertDateTimeLikeTypes(object):
     def test_python_datetime_subclass(self):
 
         class MyDatetime(datetime):
-            pass
             # see https://github.com/pandas-dev/pandas/issues/21142
             nanosecond = 0.0
 
@@ -825,8 +824,10 @@ class TestConvertDateTimeLikeTypes(object):
 
         result = table.to_pandas()
         expected_df = pd.DataFrame({"datetime": date_array})
+
         # https://github.com/pandas-dev/pandas/issues/21142
         expected_df["datetime"] = pd.to_datetime(expected_df["datetime"])
+
         tm.assert_frame_equal(expected_df, result)
 
     def test_python_date_subclass(self):

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -15,24 +15,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from collections import OrderedDict
-
-from datetime import date, datetime, time, timedelta
 import decimal
 import json
-
-import pytest
+from collections import OrderedDict
+from datetime import date, datetime, time, timedelta
+from distutils.version import LooseVersion
 
 import numpy as np
 import numpy.testing as npt
-
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
 
-from pyarrow.compat import PY2
 import pyarrow as pa
 import pyarrow.types as patypes
+from pyarrow.compat import PY2
 
 from .pandas_examples import dataframe_with_arrays, dataframe_with_lists
 
@@ -814,12 +811,16 @@ class TestConvertDateTimeLikeTypes(object):
         })
         tm.assert_frame_equal(expected_df, result)
 
+    @pytest.mark.xfail(
+        LooseVersion(pd.__version__) >= "0.23.0",
+        reason="https://github.com/pandas-dev/pandas/issues/21142",
+    )
     def test_python_datetime_subclass(self):
 
         class MyDatetime(datetime):
             pass
 
-        date_array = [MyDatetime(2000, 1, 1)]
+        date_array = [MyDatetime(2000, 1, 1, 1, 1, 1)]
         df = pd.DataFrame({"datetime": pd.Series(date_array, dtype=object)})
 
         table = pa.Table.from_pandas(df)
@@ -827,6 +828,7 @@ class TestConvertDateTimeLikeTypes(object):
 
         result = table.to_pandas()
         expected_df = pd.DataFrame({"datetime": date_array})
+
         tm.assert_frame_equal(expected_df, result)
 
     def test_python_date_subclass(self):


### PR DESCRIPTION
When converting a pandas dataframe holding subclasses of date/datetime objects, arrow raises an ArrowInvalid exception

```
import pandas as pd
import pyarrow as pa
import datetime

classMyDate(datetime.date):
    pass

date_array = [MyDate(2000, 1, 1)]
df = pd.DataFrame({"date": pd.Series(date_array, dtype=object)})

table = pa.Table.from_pandas(df)
```