### PR TITLE
ARROW-2604: [Java] Add convenience method to VarCharVector to set Text

### DIFF
--- a/java/vector/src/main/codegen/templates/ComplexWriters.java
+++ b/java/vector/src/main/codegen/templates/ComplexWriters.java
@@ -115,12 +115,15 @@ public class ${eName}WriterImpl extends AbstractFieldWriter {
     vector.setValueCount(idx()+1);
   }
 
-  <#if minor.class == "Decimal">
+  <#if minor.class == "Decimal" ||
+       minor.class == "VarChar">
   public void write${minor.class}(${friendlyType} value) {
     vector.setSafe(idx(), value);
     vector.setValueCount(idx()+1);
   }
+  </#if>
 
+  <#if minor.class == "Decimal">
   public void writeBigEndianBytesToDecimal(byte[] value) {
     vector.setBigEndianSafe(idx(), value);
     vector.setValueCount(idx()+1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -265,6 +265,29 @@ public class VarCharVector extends BaseVariableWidthVector {
     lastSet = index;
   }
 
+  /**
+   * Set the variable length element at the specified index to the
+   * content in supplied Text
+   *
+   * @param index   position of the element to set
+   * @param text    Text object with data
+   */
+  public void set(int index, Text text) {
+    set(index, text.getBytes(), 0, text.getLength());
+  }
+
+  /**
+   * Same as {@link #set(int, NullableVarCharHolder)} except that it handles the
+   * case where index and length of new element are beyond the existing
+   * capacity of the vector.
+   *
+   * @param index   position of the element to set.
+   * @param text    Text object with data
+   */
+  public void setSafe(int index, Text text) {
+    setSafe(index, text.getBytes(), 0, text.getLength());
+  }
+
 
   /******************************************************************
    *                                                                *

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -42,6 +42,7 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.util.Text;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.After;
 import org.junit.Before;
@@ -885,6 +886,10 @@ public class TestValueVector {
       vector.setSafe(5, STR3ByteBuffer, 1, STR3.length - 1);
       vector.setSafe(6, STR3ByteBuffer, 2, STR3.length - 2);
 
+      // Set with convenience function
+      Text txt = new Text("foo");
+      vector.setSafe(7, txt);
+
       // Check the sample strings.
       assertArrayEquals(STR1, vector.get(0));
       assertArrayEquals(STR2, vector.get(1));
@@ -894,10 +899,13 @@ public class TestValueVector {
       assertArrayEquals(Arrays.copyOfRange(STR3, 1, STR3.length), vector.get(5));
       assertArrayEquals(Arrays.copyOfRange(STR3, 2, STR3.length), vector.get(6));
 
+      // Check returning a Text object
+      assertEquals(txt, vector.getObject(7));
+
       // Ensure null value throws.
       boolean b = false;
       try {
-        vector.get(7);
+        vector.get(8);
       } catch (IllegalStateException e) {
         b = true;
       } finally {


### PR DESCRIPTION
This adds a convenience method to easily set values in `VarCharVector` using the friendly type `Text`.  This allows the user to set values without having to think about the correct encoding.  Text objects can be constructed from a String using the constructor `Text(String string)`.

Extended existing test to set/get a `VarCharVector` using `Text` objects.