### PR TITLE
ARROW-2632: [Java] ArrowStreamWriter accumulates ArrowBlock but does not use them

### DIFF
--- a/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
+++ b/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
@@ -112,6 +112,7 @@ public class EchoServerTest {
         writer.writeBatch();
       }
       writer.end();
+      assertTrue(writer.getRecordBlocks().isEmpty());
 
       assertEquals(new Schema(asList(field)), reader.getVectorSchemaRoot().getSchema());
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
@@ -57,6 +57,8 @@ public class ArrowStreamWriter extends ArrowWriter {
 
   @Override
   protected void writeRecordBatch(ArrowRecordBatch batch) throws IOException {
-    MessageSerializer.serialize(out, batch);
+    ArrowBlock block = MessageSerializer.serialize(out, batch);
+    LOGGER.debug(String.format("RecordBatch at %d, metadata: %d, body: %d",
+        block.getOffset(), block.getMetadataLength(), block.getBodyLength()));
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
@@ -23,6 +23,8 @@ import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.message.ArrowBlock;
 import org.apache.arrow.vector.ipc.ArrowWriter;
 import org.apache.arrow.vector.ipc.WriteChannel;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.io.IOException;
@@ -51,5 +53,10 @@ public class ArrowStreamWriter extends ArrowWriter {
                              List<ArrowBlock> dictionaries,
                              List<ArrowBlock> records) throws IOException {
     out.writeIntLittleEndian(0);
+  }
+
+  @Override
+  protected void writeRecordBatch(ArrowRecordBatch batch) throws IOException {
+    MessageSerializer.serialize(out, batch);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
@@ -44,7 +45,7 @@ import com.google.common.collect.ImmutableList;
 
 public abstract class ArrowWriter implements AutoCloseable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ArrowWriter.class);
+  protected static final Logger LOGGER = LoggerFactory.getLogger(ArrowWriter.class);
 
   // schema with fields in message format, not memory format
   private final Schema schema;
@@ -163,5 +164,10 @@ public abstract class ArrowWriter implements AutoCloseable {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @VisibleForTesting
+  public List<ArrowBlock> getRecordBlocks() {
+    return recordBlocks;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -48,7 +48,7 @@ public abstract class ArrowWriter implements AutoCloseable {
 
   // schema with fields in message format, not memory format
   private final Schema schema;
-  private final WriteChannel out;
+  protected final WriteChannel out;
 
   private final VectorUnloader unloader;
   private final List<ArrowDictionaryBatch> dictionaries;

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -82,6 +82,8 @@ public class TestArrowStream extends BaseFileTest {
         }
         writer.end();
         bytesWritten = writer.bytesWritten();
+
+        assertTrue(writer.getRecordBlocks().isEmpty());
       }
 
       ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
@@ -108,6 +110,8 @@ public class TestArrowStream extends BaseFileTest {
       try (VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList(vector), vector.getValueCount());
            ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(os));) {
         writeBatchData(writer, vector, root);
+
+        assertTrue(writer.getRecordBlocks().isEmpty());
       }
     }
 


### PR DESCRIPTION
ArrowStreamWriter inherits from ArrowWriter the behavior of accumulating an ArrowBlock for each ArrowRecordBatch that is written. But this data is never used in the context of ArrowStreamWriter. writeRecordBatch can be overridden in ArrowStreamWriter to avoid adding the memory overhead.