### PR TITLE
ARROW-2593: [Python] TypeError: data type "mixed-integer" not understood

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -648,6 +648,7 @@ _pandas_logical_type_map = {
     'string': np.str_,
     'empty': np.object_,
     'mixed': np.object_,
+    'mixed-integer': np.object_
 }
 
 

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1818,7 +1818,7 @@ class TestConvertMisc(object):
         (np.object, pa.binary()),
         (np.object, pa.binary(10)),
         (np.object, pa.list_(pa.int64())),
-        ]
+    ]
 
     def test_all_none_objects(self):
         df = pd.DataFrame({'a': [None, None, None]})
@@ -1984,6 +1984,11 @@ class TestConvertMisc(object):
         assert arr.to_pylist() == [42, -43]
         arr = pa.array(data['y'], type=pa.int16())
         assert arr.to_pylist() == [-1, 2]
+
+    def test_mixed_integer_columns(self):
+        df = pd.DataFrame({'foo': [], 123: []})
+        expected_df = pd.DataFrame({'foo': [], '123': []})
+        _check_pandas_roundtrip(df, expected=expected_df, preserve_index=True)
 
 
 def _fully_loaded_dataframe_example():

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -1986,8 +1986,9 @@ class TestConvertMisc(object):
         assert arr.to_pylist() == [-1, 2]
 
     def test_mixed_integer_columns(self):
-        df = pd.DataFrame({'foo': [], 123: []})
-        expected_df = pd.DataFrame({'foo': [], '123': []})
+        row = [[], []]
+        df = pd.DataFrame(data=[row], columns=['foo', 123])
+        expected_df = pd.DataFrame(data=[row], columns=['foo', '123'])
         _check_pandas_roundtrip(df, expected=expected_df, preserve_index=True)
 
 


### PR DESCRIPTION
Both `name` and `field_name` is [enforced](https://github.com/apache/arrow/blob/master/python/pyarrow/pandas_compat.py#L167) to be a string, but that way we lose the type of it (an integer in this case). 
Could We use one of it to preserve the original type of the column name?