### PR TITLE
ARROW-2644: [Python] Fix prototype declaration in Parquet binding

### DIFF
--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -198,7 +198,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         ParquetCompression compression() const
         const vector[ParquetEncoding]& encodings() const
 
-        bint has_dictionary_page() const
+        int64_t has_dictionary_page() const
         int64_t dictionary_page_offset() const
         int64_t data_page_offset() const
         int64_t index_page_offset() const


### PR DESCRIPTION
This would cause a compilation error on Windows (downcast error).