### PR TITLE
ARROW-2645: [Java] Refactor ArrowWriter to remove all ArrowFileWriter specifc logic

### DIFF
--- a/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
+++ b/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
@@ -112,7 +112,6 @@ public class EchoServerTest {
         writer.writeBatch();
       }
       writer.end();
-      assertTrue(writer.getRecordBlocks().isEmpty());
 
       assertEquals(new Schema(asList(field)), reader.getVectorSchemaRoot().getSchema());
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -38,6 +38,7 @@ public class ArrowFileWriter extends ArrowWriter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArrowFileWriter.class);
 
+  // All ArrowBlocks written are saved in these lists to be passed to ArrowFooter in endInternal.
   private final List<ArrowBlock> dictionaryBlocks = new ArrayList<>();
   private final List<ArrowBlock> recordBlocks = new ArrayList<>();
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -20,19 +20,26 @@ package org.apache.arrow.vector.ipc;
 
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
 import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.message.ArrowBlock;
+import org.apache.arrow.vector.ipc.message.ArrowDictionaryBatch;
 import org.apache.arrow.vector.ipc.message.ArrowFooter;
-import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ArrowFileWriter extends ArrowWriter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArrowFileWriter.class);
+
+  private final List<ArrowBlock> dictionaryBlocks = new ArrayList<>();
+  private final List<ArrowBlock> recordBlocks = new ArrayList<>();
 
   public ArrowFileWriter(VectorSchemaRoot root, DictionaryProvider provider, WritableByteChannel out) {
     super(root, provider, out);
@@ -44,12 +51,23 @@ public class ArrowFileWriter extends ArrowWriter {
   }
 
   @Override
-  protected void endInternal(WriteChannel out,
-                             Schema schema,
-                             List<ArrowBlock> dictionaries,
-                             List<ArrowBlock> records) throws IOException {
+  protected ArrowBlock writeDictionaryBatch(ArrowDictionaryBatch batch) throws IOException {
+    ArrowBlock block = super.writeDictionaryBatch(batch);
+    dictionaryBlocks.add(block);
+    return block;
+  }
+
+  @Override
+  protected ArrowBlock writeRecordBatch(ArrowRecordBatch batch) throws IOException {
+    ArrowBlock block = super.writeRecordBatch(batch);
+    recordBlocks.add(block);
+    return block;
+  }
+
+  @Override
+  protected void endInternal(WriteChannel out) throws IOException {
     long footerStart = out.getCurrentPosition();
-    out.write(new ArrowFooter(schema, dictionaries, records), false);
+    out.write(new ArrowFooter(schema, dictionaryBlocks, recordBlocks), false);
     int footerLength = (int) (out.getCurrentPosition() - footerStart);
     if (footerLength <= 0) {
       throw new InvalidArrowFileException("invalid footer");
@@ -58,5 +76,15 @@ public class ArrowFileWriter extends ArrowWriter {
     LOGGER.debug(String.format("Footer starts at %d, length: %d", footerStart, footerLength));
     ArrowMagic.writeMagic(out, false);
     LOGGER.debug(String.format("magic written, now at %d", out.getCurrentPosition()));
+  }
+
+  @VisibleForTesting
+  public List<ArrowBlock> getRecordBlocks() {
+    return recordBlocks;
+  }
+
+  @VisibleForTesting
+  public List<ArrowBlock> getDictionaryBlocks() {
+    return dictionaryBlocks;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
@@ -20,18 +20,11 @@ package org.apache.arrow.vector.ipc;
 
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
-import org.apache.arrow.vector.ipc.message.ArrowBlock;
-import org.apache.arrow.vector.ipc.ArrowWriter;
-import org.apache.arrow.vector.ipc.WriteChannel;
-import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
-import org.apache.arrow.vector.ipc.message.MessageSerializer;
-import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
-import java.util.List;
 
 public class ArrowStreamWriter extends ArrowWriter {
 
@@ -48,17 +41,7 @@ public class ArrowStreamWriter extends ArrowWriter {
   }
 
   @Override
-  protected void endInternal(WriteChannel out,
-                             Schema schema,
-                             List<ArrowBlock> dictionaries,
-                             List<ArrowBlock> records) throws IOException {
+  protected void endInternal(WriteChannel out) throws IOException {
     out.writeIntLittleEndian(0);
-  }
-
-  @Override
-  protected void writeRecordBatch(ArrowRecordBatch batch) throws IOException {
-    ArrowBlock block = MessageSerializer.serialize(out, batch);
-    LOGGER.debug(String.format("RecordBatch at %d, metadata: %d, body: %d",
-        block.getOffset(), block.getMetadataLength(), block.getBodyLength()));
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -82,8 +82,6 @@ public class TestArrowStream extends BaseFileTest {
         }
         writer.end();
         bytesWritten = writer.bytesWritten();
-
-        assertTrue(writer.getRecordBlocks().isEmpty());
       }
 
       ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
@@ -110,8 +108,6 @@ public class TestArrowStream extends BaseFileTest {
       try (VectorSchemaRoot root = new VectorSchemaRoot(schema, Collections.singletonList(vector), vector.getValueCount());
            ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(os));) {
         writeBatchData(writer, vector, root);
-
-        assertTrue(writer.getRecordBlocks().isEmpty());
       }
     }
 


### PR DESCRIPTION
Related to #2079 , the DictionaryBatch `ArrowBlock`s were being accumulated in the base class and used by `ArrowFileWriter` but not `ArrowStreamWriter`.  This refactors the `ArrowWriter` to move Lists of ArrowBlocks from the base class to only `ArrowFileWriter`. 

Moved tests counting ArrowBlocks written from ArrowStreamWriter tests to ArrowFileWriter.