### PR TITLE
ARROW-2641: [C++] Avoid spurious memset() calls, improve bitmap write performance

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -318,7 +318,9 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
       APPEND_STRING PROPERTY
       COMPILE_FLAGS " -DARROW_VALGRIND")
     add_test(${TEST_NAME}
-      bash -c "cd ${EXECUTABLE_OUTPUT_PATH}; valgrind --tool=memcheck --leak-check=full --leak-check-heuristics=stdstring --error-exitcode=1 ${TEST_PATH}")
+      bash -c "cd '${CMAKE_SOURCE_DIR}'; \
+               valgrind --suppressions=valgrind.supp --tool=memcheck --gen-suppressions=all \
+                 --leak-check=full --leak-check-heuristics=stdstring --error-exitcode=1 ${TEST_PATH}")
   elseif(MSVC)
     add_test(${TEST_NAME} ${TEST_PATH})
   else()

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -210,7 +210,7 @@ class ARROW_EXPORT Array {
   /// \brief Return true if value at index is valid (not null). Does not
   /// boundscheck
   bool IsValid(int64_t i) const {
-    return null_bitmap_data_ != NULLPTR &&
+    return null_bitmap_data_ == NULLPTR ||
            BitUtil::GetBit(null_bitmap_data_, i + data_->offset);
   }
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -905,8 +905,7 @@ struct DictionaryHashHelper {};
 
 // DictionaryHashHelper implementation for primitive types
 template <typename T>
-struct DictionaryHashHelper<T,
-                            typename std::enable_if<TypeTraits<T>::is_primitive>::type> {
+struct DictionaryHashHelper<T, enable_if_has_c_type<T>> {
   using Builder = typename TypeTraits<T>::BuilderType;
   using Scalar = typename DictionaryScalar<T>::type;
 
@@ -941,8 +940,7 @@ struct DictionaryHashHelper<T,
 
 // DictionaryHashHelper implementation for StringType / BinaryType
 template <typename T>
-struct DictionaryHashHelper<
-    T, typename std::enable_if<TypeTraits<T>::is_binary_like>::type> {
+struct DictionaryHashHelper<T, enable_if_binary<T>> {
   using Builder = typename TypeTraits<T>::BuilderType;
   using Scalar = typename DictionaryScalar<T>::type;
 
@@ -978,8 +976,8 @@ struct DictionaryHashHelper<
 };
 
 // DictionaryHashHelper implementation for FixedSizeBinaryType
-template <>
-struct DictionaryHashHelper<FixedSizeBinaryType> {
+template <typename T>
+struct DictionaryHashHelper<T, enable_if_fixed_size_binary<T>> {
   using Builder = typename TypeTraits<FixedSizeBinaryType>::BuilderType;
   using Scalar = typename DictionaryScalar<FixedSizeBinaryType>::type;
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -984,10 +984,12 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
   bool is_building_delta() { return entry_id_offset_ > 0; }
 
  protected:
+  // Hash table implementation helpers
   Status DoubleTableSize();
   Scalar GetDictionaryValue(typename TypeTraits<T>::BuilderType& dictionary_builder,
                             int64_t index);
   int64_t HashValue(const Scalar& value);
+  // Check whether the dictionary entry in *slot* is equal to the given *value*
   bool SlotDifferent(hash_slot_t slot, const Scalar& value);
   Status AppendDictionary(const Scalar& value);
 
@@ -997,16 +999,20 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
   /// Size of the table. Must be a power of 2.
   int64_t hash_table_size_;
 
-  // offset for the entry ids. Used to build delta dictionaries,
-  // increased on every InternalFinish by the number of current entries
-  // in the dictionary
+  // Offset for the dictionary entries in dict_builder_.
+  // Increased on every Finish call by the number of current entries
+  // in the dictionary.
   int64_t entry_id_offset_;
 
   // Store hash_table_size_ - 1, so that j & mod_bitmask_ is equivalent to j %
   // hash_table_size_, but uses far fewer CPU cycles
   int64_t mod_bitmask_;
 
+  // This builder accumulates new dictionary entries since the last Finish call
+  // (or since the beginning if Finish hasn't been called).
+  // In other words, it contains the current delta dictionary.
   typename TypeTraits<T>::BuilderType dict_builder_;
+  // This builder stores dictionary entries encountered before the last Finish call.
   typename TypeTraits<T>::BuilderType overflow_dict_builder_;
 
   AdaptiveIntBuilder values_builder_;

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -837,6 +837,8 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   /// \return size of values buffer so far
   int64_t value_data_length() const { return byte_builder_.length(); }
 
+  int32_t byte_width() const { return byte_width_; }
+
   /// Temporary access to a value.
   ///
   /// This pointer becomes invalid on the next modifying operation.
@@ -940,7 +942,7 @@ struct DictionaryScalar<StringType> {
 
 template <>
 struct DictionaryScalar<FixedSizeBinaryType> {
-  using type = uint8_t const*;
+  using type = const uint8_t*;
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -319,7 +319,10 @@ static bool IsEqualPrimitive(const PrimitiveArray& left, const PrimitiveArray& r
     for (int64_t i = 0; i < left.length(); ++i) {
       const bool left_null = left.IsNull(i);
       const bool right_null = right.IsNull(i);
-      if (!left_null && (memcmp(left_data, right_data, byte_width) != 0 || right_null)) {
+      if (left_null != right_null) {
+        return false;
+      }
+      if (!left_null && memcmp(left_data, right_data, byte_width) != 0) {
         return false;
       }
       left_data += byte_width;

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -927,6 +927,8 @@ TYPED_TEST(TestHashKernelPrimitive, Unique) {
   auto type = TypeTraits<TypeParam>::type_singleton();
   CheckUnique<TypeParam, T>(&this->ctx_, type, {2, 1, 2, 1}, {true, false, true, true},
                             {2, 1}, {});
+  CheckUnique<TypeParam, T>(&this->ctx_, type, {2, 1, 3, 1}, {false, false, true, true},
+                            {3, 1}, {});
 }
 
 TYPED_TEST(TestHashKernelPrimitive, DictEncode) {

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -200,8 +200,8 @@ struct CastFunctor<O, I,
   void operator()(FunctionContext* ctx, const CastOptions& options,
                   const ArrayData& input, ArrayData* output) {
     auto in_data = GetValues<typename I::c_type>(input, 1);
-    internal::BitmapWriter writer(output->buffers[1]->mutable_data(), output->offset,
-                                  input.length);
+    internal::FirstTimeBitmapWriter writer(output->buffers[1]->mutable_data(),
+                                           output->offset, input.length);
 
     for (int64_t i = 0; i < input.length; ++i) {
       if (*in_data++ != 0) {

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -349,23 +349,24 @@ class HashTableKernel<Type, Action, enable_if_boolean<Type>> : public HashTable 
       internal::BitmapReader valid_reader(arr.buffers[0]->data(), arr.offset, arr.length);
       for (int64_t i = 0; i < arr.length; ++i) {
         const bool is_null = valid_reader.IsNotSet();
-        const bool value = value_reader.IsSet();
-        const int j = value ? 1 : 0;
-        hash_slot_t slot = table_[j];
         valid_reader.Next();
-        value_reader.Next();
         if (is_null) {
+          value_reader.Next();
           action->ObserveNull();
           continue;
         }
+        const bool value = value_reader.IsSet();
+        value_reader.Next();
+        const int j = value ? 1 : 0;
+        hash_slot_t slot = table_[j];
         HASH_INNER_LOOP();
       }
     } else {
       for (int64_t i = 0; i < arr.length; ++i) {
         const bool value = value_reader.IsSet();
+        value_reader.Next();
         const int j = value ? 1 : 0;
         hash_slot_t slot = table_[j];
-        value_reader.Next();
         HASH_INNER_LOOP();
       }
     }

--- a/cpp/src/arrow/compute/kernels/util-internal.h
+++ b/cpp/src/arrow/compute/kernels/util-internal.h
@@ -30,63 +30,6 @@ namespace compute {
 class FunctionContext;
 
 template <typename T>
-using is_number = std::is_base_of<Number, T>;
-
-template <typename T>
-struct has_c_type {
-  static constexpr bool value =
-      (std::is_base_of<PrimitiveCType, T>::value || std::is_base_of<DateType, T>::value ||
-       std::is_base_of<TimeType, T>::value || std::is_base_of<TimestampType, T>::value);
-};
-
-template <typename T>
-struct is_8bit_int {
-  static constexpr bool value =
-      (std::is_same<UInt8Type, T>::value || std::is_same<Int8Type, T>::value);
-};
-
-template <typename T>
-using enable_if_8bit_int = typename std::enable_if<is_8bit_int<T>::value>::type;
-
-template <typename T>
-using enable_if_primitive_ctype =
-    typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value>::type;
-
-template <typename T>
-using enable_if_date = typename std::enable_if<std::is_base_of<DateType, T>::value>::type;
-
-template <typename T>
-using enable_if_time = typename std::enable_if<std::is_base_of<TimeType, T>::value>::type;
-
-template <typename T>
-using enable_if_timestamp =
-    typename std::enable_if<std::is_base_of<TimestampType, T>::value>::type;
-
-template <typename T>
-using enable_if_has_c_type = typename std::enable_if<has_c_type<T>::value>::type;
-
-template <typename T>
-using enable_if_null = typename std::enable_if<std::is_same<NullType, T>::value>::type;
-
-template <typename T>
-using enable_if_binary =
-    typename std::enable_if<std::is_base_of<BinaryType, T>::value>::type;
-
-template <typename T>
-using enable_if_boolean =
-    typename std::enable_if<std::is_same<BooleanType, T>::value>::type;
-
-template <typename T>
-using enable_if_fixed_size_binary =
-    typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value>::type;
-
-template <typename T>
-using enable_if_list = typename std::enable_if<std::is_base_of<ListType, T>::value>::type;
-
-template <typename T>
-using enable_if_number = typename std::enable_if<is_number<T>::value>::type;
-
-template <typename T>
 inline const T* GetValues(const ArrayData& data, int i) {
   return reinterpret_cast<const T*>(data.buffers[i]->data()) + data.offset;
 }

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -621,6 +621,9 @@ INSTANTIATE_TEST_CASE_P(GenericIpcRoundTripTests, TestIpcRoundTrip, BATCH_CASES(
 INSTANTIATE_TEST_CASE_P(FileRoundTripTests, TestFileFormat, BATCH_CASES());
 INSTANTIATE_TEST_CASE_P(StreamRoundTripTests, TestStreamFormat, BATCH_CASES());
 
+// This test uses uninitialized memory
+
+#if !(defined(ARROW_VALGRIND) || defined(ADDRESS_SANITIZER))
 TEST_F(TestIpcRoundTrip, LargeRecordBatch) {
   const int64_t length = static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1;
 
@@ -649,6 +652,7 @@ TEST_F(TestIpcRoundTrip, LargeRecordBatch) {
 
   ASSERT_EQ(length, result->num_rows());
 }
+#endif
 
 void CheckBatchDictionaries(const RecordBatch& batch) {
   // Check that dictionaries that should be the same are the same

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -372,27 +372,42 @@ class ArrayWriter {
   template <typename T>
   typename std::enable_if<IsSignedInt<T>::value, void>::type WriteDataValues(
       const T& arr) {
+    static const char null_string[] = "0";
     const auto data = arr.raw_values();
-    for (int i = 0; i < arr.length(); ++i) {
-      writer_->Int64(data[i]);
+    for (int64_t i = 0; i < arr.length(); ++i) {
+      if (arr.IsValid(i)) {
+        writer_->Int64(data[i]);
+      } else {
+        writer_->RawNumber(null_string, sizeof(null_string));
+      }
     }
   }
 
   template <typename T>
   typename std::enable_if<IsUnsignedInt<T>::value, void>::type WriteDataValues(
       const T& arr) {
+    static const char null_string[] = "0";
     const auto data = arr.raw_values();
-    for (int i = 0; i < arr.length(); ++i) {
-      writer_->Uint64(data[i]);
+    for (int64_t i = 0; i < arr.length(); ++i) {
+      if (arr.IsValid(i)) {
+        writer_->Uint64(data[i]);
+      } else {
+        writer_->RawNumber(null_string, sizeof(null_string));
+      }
     }
   }
 
   template <typename T>
   typename std::enable_if<IsFloatingPoint<T>::value, void>::type WriteDataValues(
       const T& arr) {
+    static const char null_string[] = "0.";
     const auto data = arr.raw_values();
-    for (int i = 0; i < arr.length(); ++i) {
-      writer_->Double(data[i]);
+    for (int64_t i = 0; i < arr.length(); ++i) {
+      if (arr.IsValid(i)) {
+        writer_->Double(data[i]);
+      } else {
+        writer_->RawNumber(null_string, sizeof(null_string));
+      }
     }
   }
 
@@ -424,15 +439,24 @@ class ArrayWriter {
   }
 
   void WriteDataValues(const Decimal128Array& arr) {
+    static const char null_string[] = "0";
     for (int64_t i = 0; i < arr.length(); ++i) {
-      const Decimal128 value(arr.GetValue(i));
-      writer_->String(value.ToIntegerString());
+      if (arr.IsValid(i)) {
+        const Decimal128 value(arr.GetValue(i));
+        writer_->String(value.ToIntegerString());
+      } else {
+        writer_->String(null_string, sizeof(null_string));
+      }
     }
   }
 
   void WriteDataValues(const BooleanArray& arr) {
-    for (int i = 0; i < arr.length(); ++i) {
-      writer_->Bool(arr.Value(i));
+    for (int64_t i = 0; i < arr.length(); ++i) {
+      if (arr.IsValid(i)) {
+        writer_->Bool(arr.Value(i));
+      } else {
+        writer_->Bool(false);
+      }
     }
   }
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -270,7 +270,7 @@ struct TypeTraits<Decimal128Type> {
   using BuilderType = Decimal128Builder;
   constexpr static bool is_parameter_free = false;
   constexpr static bool is_binary_like = false;
-  constexpr static bool is_primitive = true;
+  constexpr static bool is_primitive = false;
 };
 
 template <>

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -34,6 +34,8 @@ struct TypeTraits<NullType> {
   using ArrayType = NullArray;
   using BuilderType = NullBuilder;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -43,6 +45,8 @@ struct TypeTraits<UInt8Type> {
   using TensorType = UInt8Tensor;
   static inline int64_t bytes_required(int64_t elements) { return elements; }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint8(); }
 };
 
@@ -53,6 +57,8 @@ struct TypeTraits<Int8Type> {
   using TensorType = Int8Tensor;
   static inline int64_t bytes_required(int64_t elements) { return elements; }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int8(); }
 };
 
@@ -66,6 +72,8 @@ struct TypeTraits<UInt16Type> {
     return elements * sizeof(uint16_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint16(); }
 };
 
@@ -79,6 +87,8 @@ struct TypeTraits<Int16Type> {
     return elements * sizeof(int16_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int16(); }
 };
 
@@ -92,6 +102,8 @@ struct TypeTraits<UInt32Type> {
     return elements * sizeof(uint32_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint32(); }
 };
 
@@ -105,6 +117,8 @@ struct TypeTraits<Int32Type> {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int32(); }
 };
 
@@ -118,6 +132,8 @@ struct TypeTraits<UInt64Type> {
     return elements * sizeof(uint64_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint64(); }
 };
 
@@ -131,6 +147,8 @@ struct TypeTraits<Int64Type> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int64(); }
 };
 
@@ -143,6 +161,8 @@ struct TypeTraits<Date64Type> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return date64(); }
 };
 
@@ -155,6 +175,8 @@ struct TypeTraits<Date32Type> {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return date32(); }
 };
 
@@ -167,6 +189,8 @@ struct TypeTraits<TimestampType> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -178,6 +202,8 @@ struct TypeTraits<Time32Type> {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -189,6 +215,8 @@ struct TypeTraits<Time64Type> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -201,6 +229,8 @@ struct TypeTraits<HalfFloatType> {
     return elements * sizeof(uint16_t);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return float16(); }
 };
 
@@ -214,6 +244,8 @@ struct TypeTraits<FloatType> {
     return static_cast<int64_t>(elements * sizeof(float));
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return float32(); }
 };
 
@@ -227,6 +259,8 @@ struct TypeTraits<DoubleType> {
     return static_cast<int64_t>(elements * sizeof(double));
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return float64(); }
 };
 
@@ -235,6 +269,8 @@ struct TypeTraits<Decimal128Type> {
   using ArrayType = Decimal128Array;
   using BuilderType = Decimal128Builder;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_binary_like = false;
+  constexpr static bool is_primitive = true;
 };
 
 template <>
@@ -246,6 +282,8 @@ struct TypeTraits<BooleanType> {
     return BitUtil::BytesForBits(elements);
   }
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = true;
+  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return boolean(); }
 };
 
@@ -254,6 +292,8 @@ struct TypeTraits<StringType> {
   using ArrayType = StringArray;
   using BuilderType = StringBuilder;
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = true;
   static inline std::shared_ptr<DataType> type_singleton() { return utf8(); }
 };
 
@@ -262,6 +302,8 @@ struct TypeTraits<BinaryType> {
   using ArrayType = BinaryArray;
   using BuilderType = BinaryBuilder;
   constexpr static bool is_parameter_free = true;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = true;
   static inline std::shared_ptr<DataType> type_singleton() { return binary(); }
 };
 
@@ -270,6 +312,8 @@ struct TypeTraits<FixedSizeBinaryType> {
   using ArrayType = FixedSizeBinaryArray;
   using BuilderType = FixedSizeBinaryBuilder;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -277,6 +321,8 @@ struct TypeTraits<ListType> {
   using ArrayType = ListArray;
   using BuilderType = ListBuilder;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -284,18 +330,24 @@ struct TypeTraits<StructType> {
   using ArrayType = StructArray;
   using BuilderType = StructBuilder;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
 struct TypeTraits<UnionType> {
   using ArrayType = UnionArray;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = false;
 };
 
 template <>
 struct TypeTraits<DictionaryType> {
   using ArrayType = DictionaryArray;
   constexpr static bool is_parameter_free = false;
+  constexpr static bool is_primitive = false;
+  constexpr static bool is_binary_like = false;
 };
 
 namespace detail {

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -26,6 +26,10 @@
 
 namespace arrow {
 
+//
+// Per-type type traits
+//
+
 template <typename T>
 struct TypeTraits {};
 
@@ -34,8 +38,6 @@ struct TypeTraits<NullType> {
   using ArrayType = NullArray;
   using BuilderType = NullBuilder;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -45,8 +47,6 @@ struct TypeTraits<UInt8Type> {
   using TensorType = UInt8Tensor;
   static inline int64_t bytes_required(int64_t elements) { return elements; }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint8(); }
 };
 
@@ -57,8 +57,6 @@ struct TypeTraits<Int8Type> {
   using TensorType = Int8Tensor;
   static inline int64_t bytes_required(int64_t elements) { return elements; }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int8(); }
 };
 
@@ -72,8 +70,6 @@ struct TypeTraits<UInt16Type> {
     return elements * sizeof(uint16_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint16(); }
 };
 
@@ -87,8 +83,6 @@ struct TypeTraits<Int16Type> {
     return elements * sizeof(int16_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int16(); }
 };
 
@@ -102,8 +96,6 @@ struct TypeTraits<UInt32Type> {
     return elements * sizeof(uint32_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint32(); }
 };
 
@@ -117,8 +109,6 @@ struct TypeTraits<Int32Type> {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int32(); }
 };
 
@@ -132,8 +122,6 @@ struct TypeTraits<UInt64Type> {
     return elements * sizeof(uint64_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return uint64(); }
 };
 
@@ -147,8 +135,6 @@ struct TypeTraits<Int64Type> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return int64(); }
 };
 
@@ -161,8 +147,6 @@ struct TypeTraits<Date64Type> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return date64(); }
 };
 
@@ -175,8 +159,6 @@ struct TypeTraits<Date32Type> {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return date32(); }
 };
 
@@ -189,8 +171,6 @@ struct TypeTraits<TimestampType> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -202,8 +182,6 @@ struct TypeTraits<Time32Type> {
     return elements * sizeof(int32_t);
   }
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -215,8 +193,6 @@ struct TypeTraits<Time64Type> {
     return elements * sizeof(int64_t);
   }
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -229,8 +205,6 @@ struct TypeTraits<HalfFloatType> {
     return elements * sizeof(uint16_t);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return float16(); }
 };
 
@@ -244,8 +218,6 @@ struct TypeTraits<FloatType> {
     return static_cast<int64_t>(elements * sizeof(float));
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return float32(); }
 };
 
@@ -259,8 +231,6 @@ struct TypeTraits<DoubleType> {
     return static_cast<int64_t>(elements * sizeof(double));
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return float64(); }
 };
 
@@ -269,8 +239,6 @@ struct TypeTraits<Decimal128Type> {
   using ArrayType = Decimal128Array;
   using BuilderType = Decimal128Builder;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_binary_like = false;
-  constexpr static bool is_primitive = false;
 };
 
 template <>
@@ -282,8 +250,6 @@ struct TypeTraits<BooleanType> {
     return BitUtil::BytesForBits(elements);
   }
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = true;
-  constexpr static bool is_binary_like = false;
   static inline std::shared_ptr<DataType> type_singleton() { return boolean(); }
 };
 
@@ -292,8 +258,6 @@ struct TypeTraits<StringType> {
   using ArrayType = StringArray;
   using BuilderType = StringBuilder;
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = true;
   static inline std::shared_ptr<DataType> type_singleton() { return utf8(); }
 };
 
@@ -302,8 +266,6 @@ struct TypeTraits<BinaryType> {
   using ArrayType = BinaryArray;
   using BuilderType = BinaryBuilder;
   constexpr static bool is_parameter_free = true;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = true;
   static inline std::shared_ptr<DataType> type_singleton() { return binary(); }
 };
 
@@ -312,8 +274,6 @@ struct TypeTraits<FixedSizeBinaryType> {
   using ArrayType = FixedSizeBinaryArray;
   using BuilderType = FixedSizeBinaryBuilder;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -321,8 +281,6 @@ struct TypeTraits<ListType> {
   using ArrayType = ListArray;
   using BuilderType = ListBuilder;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
@@ -330,25 +288,80 @@ struct TypeTraits<StructType> {
   using ArrayType = StructArray;
   using BuilderType = StructBuilder;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
 struct TypeTraits<UnionType> {
   using ArrayType = UnionArray;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = false;
 };
 
 template <>
 struct TypeTraits<DictionaryType> {
   using ArrayType = DictionaryArray;
   constexpr static bool is_parameter_free = false;
-  constexpr static bool is_primitive = false;
-  constexpr static bool is_binary_like = false;
 };
+
+//
+// Useful type predicates
+//
+
+template <typename T>
+using is_number = std::is_base_of<Number, T>;
+
+template <typename T>
+struct has_c_type {
+  static constexpr bool value =
+      (std::is_base_of<PrimitiveCType, T>::value || std::is_base_of<DateType, T>::value ||
+       std::is_base_of<TimeType, T>::value || std::is_base_of<TimestampType, T>::value);
+};
+
+template <typename T>
+struct is_8bit_int {
+  static constexpr bool value =
+      (std::is_same<UInt8Type, T>::value || std::is_same<Int8Type, T>::value);
+};
+
+template <typename T>
+using enable_if_8bit_int = typename std::enable_if<is_8bit_int<T>::value>::type;
+
+template <typename T>
+using enable_if_primitive_ctype =
+    typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value>::type;
+
+template <typename T>
+using enable_if_date = typename std::enable_if<std::is_base_of<DateType, T>::value>::type;
+
+template <typename T>
+using enable_if_time = typename std::enable_if<std::is_base_of<TimeType, T>::value>::type;
+
+template <typename T>
+using enable_if_timestamp =
+    typename std::enable_if<std::is_base_of<TimestampType, T>::value>::type;
+
+template <typename T>
+using enable_if_has_c_type = typename std::enable_if<has_c_type<T>::value>::type;
+
+template <typename T>
+using enable_if_null = typename std::enable_if<std::is_same<NullType, T>::value>::type;
+
+template <typename T>
+using enable_if_binary =
+    typename std::enable_if<std::is_base_of<BinaryType, T>::value>::type;
+
+template <typename T>
+using enable_if_boolean =
+    typename std::enable_if<std::is_same<BooleanType, T>::value>::type;
+
+template <typename T>
+using enable_if_fixed_size_binary =
+    typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value>::type;
+
+template <typename T>
+using enable_if_list = typename std::enable_if<std::is_base_of<ListType, T>::value>::type;
+
+template <typename T>
+using enable_if_number = typename std::enable_if<is_number<T>::value>::type;
 
 namespace detail {
 

--- a/cpp/src/arrow/util/bit-util-benchmark.cc
+++ b/cpp/src/arrow/util/bit-util-benchmark.cc
@@ -166,6 +166,10 @@ static void BM_BitmapWriter(benchmark::State& state) {
   BenchmarkBitmapWriter<internal::BitmapWriter>(state, state.range(0));
 }
 
+static void BM_FirstTimeBitmapWriter(benchmark::State& state) {
+  BenchmarkBitmapWriter<internal::FirstTimeBitmapWriter>(state, state.range(0));
+}
+
 static void BM_CopyBitmap(benchmark::State& state) {  // NOLINT non-const reference
   const int kBufferSize = state.range(0);
   std::shared_ptr<Buffer> buffer = CreateRandomBuffer(kBufferSize);
@@ -201,6 +205,11 @@ BENCHMARK(BM_NaiveBitmapWriter)
     ->Unit(benchmark::kMicrosecond);
 
 BENCHMARK(BM_BitmapWriter)->Args({100000})->MinTime(1.0)->Unit(benchmark::kMicrosecond);
+
+BENCHMARK(BM_FirstTimeBitmapWriter)
+    ->Args({100000})
+    ->MinTime(1.0)
+    ->Unit(benchmark::kMicrosecond);
 
 }  // namespace BitUtil
 }  // namespace arrow

--- a/cpp/src/arrow/util/hash.h
+++ b/cpp/src/arrow/util/hash.h
@@ -39,6 +39,9 @@ static constexpr double kMaxHashTableLoad = 0.5;
 
 namespace internal {
 
+// TODO this ugliness should be rewritten as an inline function with
+// a callable argument.
+
 #define DOUBLE_TABLE_SIZE(SETUP_CODE, COMPUTE_HASH)                              \
   do {                                                                           \
     int64_t new_size = hash_table_size_ * 2;                                     \

--- a/cpp/valgrind.supp
+++ b/cpp/valgrind.supp
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{
+    # Casting to/from boolean might read uninitialized data as the null bitmap isn't considered
+    <boolean_cast>
+    Memcheck:Cond
+    fun:*CastFunctor*BooleanType*
+}
+{
+    # Data can be uninitialized when its null bit is set, but we write raw buffers
+    <write_unitialized_data>
+    Memcheck:Param
+    write(buf)
+    fun:__write_nocancel
+}


### PR DESCRIPTION
Also:
* Fix ARROW-2622 and add test
* Fix various Valgrind-detected uninitialized read issues
* Add Valgrind suppressions file to silence false positives
* Add a benchmark for BooleanBuilder
* Improve speed of BooleanBuilder by 3x (from 270 to 800 MB/s here)
* Remove most implementation macros in DictionaryBuilder (replaced with a template class helper)
* Fix bug/oddity in DictionaryBuilder lookup with a delta dictionary (the non-delta dictionary could be looked up out of bounds)
* Improve implementation of boolean unique kernel
