### PR TITLE
ARROW-2668: [C++] Suppress -Wnull-pointer-arithmetic when compiling plasma/malloc.cc on clang

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -106,6 +106,7 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
     APPEND_STRING
     PROPERTY COMPILE_FLAGS
     " -Wno-parentheses-equality \
+-Wno-null-pointer-arithmetic \
 -Wno-shorten-64-to-32 \
 -Wno-unused-macros")
 


### PR DESCRIPTION
This generates a warning on clang-6 when using CHECKIN error level, so compiling with `-Werror` will fail without it.