### PR TITLE
ARROW-2675: Fix build error with clang-10 (Apple Clang / LLVM)

### DIFF
--- a/cpp/cmake_modules/CompilerInfo.cmake
+++ b/cpp/cmake_modules/CompilerInfo.cmake
@@ -78,6 +78,11 @@ elseif("${COMPILER_VERSION_FULL}" MATCHES ".*clang-9")
   set(COMPILER_FAMILY "clang")
   set(COMPILER_VERSION "4.0.0svn")
 
+# clang on Mac OS X, XCode 9.
+elseif("${COMPILER_VERSION_FULL}" MATCHES ".*clang-10")
+  set(COMPILER_FAMILY "clang")
+  set(COMPILER_VERSION "4.1.0svn")
+
 # gcc
 elseif("${COMPILER_VERSION_FULL_LOWER}" MATCHES ".*gcc[ -]version.*")
   set(COMPILER_FAMILY "gcc")


### PR DESCRIPTION
As mac os X has been updated to the version 10.13.5, XCode has been updated to XCode 9.4 and Command Line Tools have been updated to the version 10.0, the clang version has also been updated to clang-10 (Apple Clang / LLVM) correspondingly. However, Arrow can only be built under clang-9, as shown in the file 
https://github.com/apache/arrow/blob/b1d1633c90d20d3cbcbcee9a29c3f057164bb53c/cpp/cmake_modules/CompilerInfo.cmake#L77

So, it's time to update Arrow to support clang-10.