### PR TITLE
ARROW-2694 - [Python] ArrayValue string conversion returns the representation instead of the converted python object string

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -62,6 +62,12 @@ cdef class ArrayValue(Scalar):
         else:
             return super(Scalar, self).__repr__()
 
+    def __str__(self):
+        if hasattr(self, 'as_py'):
+            return str(self.as_py())
+        else:
+            return super(Scalar, self).__str__()
+
     def __eq__(self, other):
         if hasattr(self, 'as_py'):
             if isinstance(other, ArrayValue):

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -537,22 +537,26 @@ def test_sequence_timestamp_from_int_with_unit():
     arr_s = pa.array(data, type=s)
     assert len(arr_s) == 1
     assert arr_s.type == s
-    assert str(arr_s[0]) == "Timestamp('1970-01-01 00:00:01')"
+    assert repr(arr_s[0]) == "Timestamp('1970-01-01 00:00:01')"
+    assert str(arr_s[0]) == "1970-01-01 00:00:01"
 
     arr_ms = pa.array(data, type=ms)
     assert len(arr_ms) == 1
     assert arr_ms.type == ms
-    assert str(arr_ms[0]) == "Timestamp('1970-01-01 00:00:00.001000')"
+    assert repr(arr_ms[0]) == "Timestamp('1970-01-01 00:00:00.001000')"
+    assert str(arr_ms[0]) == "1970-01-01 00:00:00.001000"
 
     arr_us = pa.array(data, type=us)
     assert len(arr_us) == 1
     assert arr_us.type == us
-    assert str(arr_us[0]) == "Timestamp('1970-01-01 00:00:00.000001')"
+    assert repr(arr_us[0]) == "Timestamp('1970-01-01 00:00:00.000001')"
+    assert str(arr_us[0]) == "1970-01-01 00:00:00.000001"
 
     arr_ns = pa.array(data, type=ns)
     assert len(arr_ns) == 1
     assert arr_ns.type == ns
-    assert str(arr_ns[0]) == "Timestamp('1970-01-01 00:00:00.000000001')"
+    assert repr(arr_ns[0]) == "Timestamp('1970-01-01 00:00:00.000000001')"
+    assert str(arr_ns[0]) == "1970-01-01 00:00:00.000000001"
 
     with pytest.raises(pa.ArrowException):
         class CustomClass():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -37,6 +37,7 @@ class TestScalars(unittest.TestCase):
         v = arr[0]
         assert isinstance(v, pa.BooleanValue)
         assert repr(v) == "True"
+        assert str(v) == "True"
         assert v.as_py() is True
 
         assert arr[1] is pa.NA
@@ -47,6 +48,7 @@ class TestScalars(unittest.TestCase):
         v = arr[0]
         assert isinstance(v, pa.Int64Value)
         assert repr(v) == "1"
+        assert str(v) == "1"
         assert v.as_py() == 1
         assert v == 1
 
@@ -58,6 +60,7 @@ class TestScalars(unittest.TestCase):
         v = arr[0]
         assert isinstance(v, pa.DoubleValue)
         assert repr(v) == "1.5"
+        assert str(v) == "1.5"
         assert v.as_py() == 1.5
         assert v == 1.5
 
@@ -71,6 +74,7 @@ class TestScalars(unittest.TestCase):
         v = arr[0]
         assert isinstance(v, pa.HalfFloatValue)
         assert repr(v) == "1.5"
+        assert str(v) == "1.5"
         assert v.as_py() == 1.5
         assert v == 1.5
 
@@ -81,8 +85,10 @@ class TestScalars(unittest.TestCase):
 
         v = arr[0]
         assert isinstance(v, pa.StringValue)
-        assert v.as_py() == 'foo'
-        assert v == 'foo'
+        assert v.as_py() == u'foo'
+        assert repr(v) == repr(u"foo")
+        assert str(v) == str(u"foo")
+        assert v == u'foo'
         # Assert that newly created values are equal to the previously created
         # one.
         assert v == arr[0]
@@ -99,6 +105,8 @@ class TestScalars(unittest.TestCase):
         v = arr[0]
         assert isinstance(v, pa.BinaryValue)
         assert v.as_py() == b'foo'
+        assert str(v) == str(b"foo")
+        assert repr(v) == repr(b"foo")
         assert v == b'foo'
 
         assert arr[1] is pa.NA


### PR DESCRIPTION
Example:
```
# python 3.6.5
In [1]: import pyarrow as pa

In [2]: str(pa.array(['a'])[0])  # note the single quotes
Out[2]: "'a'"

In [3]: str(pa.array([1], pa.timestamp('s'))[0])
Out[3]: "Timestamp('1970-01-01 00:00:01')"
```

instead of

```
# python 3.6.5
In [1]: import pyarrow as pa

In [2]: str(pa.array(['a'])[0])
Out[2]: "a"

In [3]: str(pa.array([1], pa.timestamp('s'))[0])
Out[3]: "1970-01-01 00:00:01"
```