### PR TITLE
ARROW-2696: [JAVA] enhance AllocationListener with an onFailedAllocation() call

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -21,8 +21,8 @@ package org.apache.arrow.memory;
 /**
  * An allocation listener being notified for allocation/deallocation
  * <p>
- * It is expected to be called from multiple threads and as such,
- * provider should take care of making the implementation thread-safe
+ * It might be called from multiple threads if the allocator hierarchy shares a listener, in which
+ * case, the provider should take care of making the implementation thread-safe.
  */
 public interface AllocationListener {
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -30,6 +30,11 @@ public interface AllocationListener {
     @Override
     public void onAllocation(long size) {
     }
+
+    @Override
+    public boolean onFailedAllocation(long size, Accountant.AllocationOutcome outcome) {
+      return false;
+    }
   };
 
   /**
@@ -38,5 +43,16 @@ public interface AllocationListener {
    * @param size the buffer size being allocated
    */
   void onAllocation(long size);
+
+  /**
+   * Called whenever an allocation failed, giving the caller a chance to create some space in the allocator
+   * (either by freeing some resource, or by changing the limit), and, if successful, allowing the allocator
+   * to retry the allocation.
+   *
+   * @param size     the buffer size that was being allocated
+   * @param outcome  the outcome of the failed allocation. Carries information of what failed
+   * @return true, if the allocation can be retried; false if the allocation should fail
+   */
+  boolean onFailedAllocation(long size, Accountant.AllocationOutcome outcome);
 
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -72,7 +72,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     this(parentAllocator.listener, parentAllocator, name, initReservation, maxAllocation);
   }
 
-  private BaseAllocator(
+  protected BaseAllocator(
       final AllocationListener listener,
       final BaseAllocator parentAllocator,
       final String name,
@@ -333,21 +333,31 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       final String name,
       final long initReservation,
       final long maxAllocation) {
+    return newChildAllocator(name, this.listener, initReservation, maxAllocation);
+  }
+
+  @Override
+  public BufferAllocator newChildAllocator(
+      final String name,
+      final AllocationListener listener,
+      final long initReservation,
+      final long maxAllocation) {
     assertOpen();
 
-    final ChildAllocator childAllocator = new ChildAllocator(this, name, initReservation,
-        maxAllocation);
+    final ChildAllocator childAllocator = new ChildAllocator(listener,this, name, initReservation,
+                                                             maxAllocation);
 
     if (DEBUG) {
       synchronized (DEBUG_LOCK) {
         childAllocators.put(childAllocator, childAllocator);
         historicalLog.recordEvent("allocator[%s] created new child allocator[%s]", name,
-            childAllocator.name);
+                                  childAllocator.name);
       }
     }
 
     return childAllocator;
   }
+
 
   @Override
   public AllocationReservation newReservation() {

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -350,7 +350,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       final long maxAllocation) {
     assertOpen();
 
-    final ChildAllocator childAllocator = new ChildAllocator(listener,this, name, initReservation,
+    final ChildAllocator childAllocator = new ChildAllocator(listener, this, name, initReservation,
         maxAllocation);
 
     if (DEBUG) {

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -56,28 +56,21 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   private final HistoricalLog historicalLog;
   private volatile boolean isClosed = false; // the allocator has been closed
 
+  /**
+   * Initialize an allocator
+   * @param parentAllocator   parent allocator. null if defining a root allocator
+   * @param listener          listener callback. Must be non-null -- use {@link AllocationListener#NOOP} if no listener
+   *                          desired
+   * @param name              name of this allocator
+   * @param initReservation   initial reservation. Cannot be modified after construction
+   * @param maxAllocation     limit. Allocations past the limit fail. Can be modified after construction
+   */
   protected BaseAllocator(
-      final AllocationListener listener,
-      final String name,
-      final long initReservation,
-      final long maxAllocation) throws OutOfMemoryException {
-    this(listener, null, name, initReservation, maxAllocation);
-  }
-
-  protected BaseAllocator(
-      final BaseAllocator parentAllocator,
-      final String name,
-      final long initReservation,
-      final long maxAllocation) throws OutOfMemoryException {
-    this(parentAllocator.listener, parentAllocator, name, initReservation, maxAllocation);
-  }
-
-  protected BaseAllocator(
-      final AllocationListener listener,
-      final BaseAllocator parentAllocator,
-      final String name,
-      final long initReservation,
-      final long maxAllocation) throws OutOfMemoryException {
+          final BaseAllocator parentAllocator,
+          final AllocationListener listener,
+          final String name,
+          final long initReservation,
+          final long maxAllocation) throws OutOfMemoryException {
     super(parentAllocator, initReservation, maxAllocation);
 
     this.listener = listener;

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -275,6 +275,10 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         nextPowerOfTwo(initialRequestSize)
         : initialRequestSize;
     AllocationOutcome outcome = this.allocateBytes(actualRequestSize);
+    if (!outcome.isOk() && listener.onFailedAllocation(actualRequestSize, outcome)) {
+      // Second try, in case the listener can do something about it
+      outcome = this.allocateBytes(actualRequestSize);
+    }
     if (!outcome.isOk()) {
       throw new OutOfMemoryException(createErrorMsg(this, actualRequestSize, initialRequestSize));
     }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -69,6 +69,17 @@ public interface BufferAllocator extends AutoCloseable {
   public BufferAllocator newChildAllocator(String name, long initReservation, long maxAllocation);
 
   /**
+   * Create a new child allocator.
+   *
+   * @param name            the name of the allocator.
+   * @param listener        allocation listener for the newly created child
+   * @param initReservation the initial space reservation (obtained from this allocator)
+   * @param maxAllocation   maximum amount of space the new allocator can allocate
+   * @return the new allocator, or null if it can't be created
+   */
+  public BufferAllocator newChildAllocator(String name, AllocationListener listener, long initReservation, long maxAllocation);
+
+  /**
    * Close and release all buffers generated from this buffer pool.
    *
    * <p>When assertions are on, complains if there are any outstanding buffers; to avoid

--- a/java/memory/src/main/java/org/apache/arrow/memory/ChildAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ChildAllocator.java
@@ -47,7 +47,7 @@ class ChildAllocator extends BaseAllocator {
       String name,
       long initReservation,
       long maxAllocation) {
-    super(listener, parentAllocator, name, initReservation, maxAllocation);
+    super(parentAllocator, listener, name, initReservation, maxAllocation);
   }
 
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/ChildAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ChildAllocator.java
@@ -32,6 +32,7 @@ class ChildAllocator extends BaseAllocator {
   /**
    * Constructor.
    *
+   * @param listener        Allocation listener to be used in this child
    * @param parentAllocator parent allocator -- the one creating this child
    * @param name            the name of this child allocator
    * @param initReservation initial amount of space to reserve (obtained from the parent)
@@ -41,11 +42,12 @@ class ChildAllocator extends BaseAllocator {
    *                        allocation policy in force, even less memory may be available
    */
   ChildAllocator(
+      AllocationListener listener,
       BaseAllocator parentAllocator,
       String name,
       long initReservation,
       long maxAllocation) {
-    super(parentAllocator, name, initReservation, maxAllocation);
+    super(listener, parentAllocator, name, initReservation, maxAllocation);
   }
 
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
@@ -31,7 +31,7 @@ public class RootAllocator extends BaseAllocator {
   }
 
   public RootAllocator(final AllocationListener listener, final long limit) {
-    super(listener, "ROOT", 0, limit);
+    super(null, listener, "ROOT", 0, limit);
   }
 
   /**

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -223,21 +223,42 @@ public class TestBaseAllocator {
   }
 
   // Allocation listener
-  // The only thing it does is it counts the number of times it has been invoked, and how much memory allocation it
-  // has seen
+  // It counts the number of times it has been invoked, and how much memory allocation it has seen
+  // When set to 'expand on fail', it attempts to expand the associated allocator's limit
   static class TestAllocationListener implements AllocationListener {
     private int numCalls;
     private long totalMem;
+    private boolean expandOnFail;
+    BufferAllocator expandAlloc;
+    long expandLimit;
 
     TestAllocationListener() {
       this.numCalls = 0;
       this.totalMem = 0;
+      this.expandOnFail = false;
+      this.expandAlloc = null;
+      this.expandLimit = 0;
     }
 
     @Override
     public void onAllocation(long size) {
       numCalls++;
       totalMem += size;
+    }
+
+    @Override
+    public boolean onFailedAllocation(long size,  Accountant.AllocationOutcome outcome) {
+      if (expandOnFail) {
+        expandAlloc.setLimit(expandLimit);
+        return true;
+      }
+      return false;
+    }
+
+    void setExpandOnFail(BufferAllocator expandAlloc, long expandLimit) {
+      this.expandOnFail = true;
+      this.expandAlloc = expandAlloc;
+      this.expandLimit = expandLimit;
     }
 
     int getNumCalls() {
@@ -288,7 +309,35 @@ public class TestBaseAllocator {
     }
   }
 
-  private static void allocateAndFree(final BufferAllocator allocator) {
+  @Test
+  public void testRootAllocator_listenerAllocationFail() throws Exception {
+    TestAllocationListener l1 = new TestAllocationListener();
+    assertEquals(0, l1.getNumCalls());
+    assertEquals(0, l1.getTotalMem());
+    // Test attempts to allocate too much from a child whose limit is set to half of the max allocation
+    // The listener's callback triggers, expanding the child allocator's limit, so then the allocation succeeds
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
+      try (final BufferAllocator c1 = rootAllocator.newChildAllocator("c1", l1,0, MAX_ALLOCATION / 2)) {
+        try {
+          c1.buffer(MAX_ALLOCATION);
+          fail("allocated memory beyond max allowed");
+        } catch (OutOfMemoryException e) {
+          // expected
+        }
+        assertEquals(0, l1.getNumCalls());
+        assertEquals(0, l1.getTotalMem());
+
+        l1.setExpandOnFail(c1, MAX_ALLOCATION);
+        ArrowBuf arrowBuf = c1.buffer(MAX_ALLOCATION);
+        assertNotNull("allocation failed", arrowBuf);
+        assertEquals(1, l1.getNumCalls());
+        assertEquals(MAX_ALLOCATION, l1.getTotalMem());
+        arrowBuf.release();
+      }
+    }
+  }
+
+    private static void allocateAndFree(final BufferAllocator allocator) {
     final ArrowBuf arrowBuf = allocator.buffer(512);
     assertNotNull("allocation failed", arrowBuf);
     arrowBuf.release();

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -225,7 +225,7 @@ public class TestBaseAllocator {
   // Allocation listener
   // It counts the number of times it has been invoked, and how much memory allocation it has seen
   // When set to 'expand on fail', it attempts to expand the associated allocator's limit
-  static class TestAllocationListener implements AllocationListener {
+  private static final class TestAllocationListener implements AllocationListener {
     private int numCalls;
     private long totalMem;
     private boolean expandOnFail;


### PR DESCRIPTION
On allocation failures, before throwing an out of memory exception, the base allocator makes a listener callback, giving the user code a change to correct its memory usage -- perhaps flush some state; perhaps clear out some caches; or perhaps trade-off some limits. 

The AllocationListener has a new method added:
  boolean onFailedAllocation(long size,  Accountant.AllocationOutcome outcome)
with the semantics: return 'true' if the allocation can be retried (presumably after the code altered the state in some way), or 'false' if not. 

If the listener asks for a retry, the allocator retries exactly once. 