### PR TITLE
ARROW-2488: [C++] Add Boost 1.67 and 1.68 as recognized versions

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -137,6 +137,8 @@ if (MSVC AND ARROW_USE_STATIC_CRT)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
 set(Boost_ADDITIONAL_VERSIONS
+  "1.68.0" "1.68"
+  "1.67.0" "1.67"
   "1.66.0" "1.66"
   "1.65.0" "1.65"
   "1.64.0" "1.64"


### PR DESCRIPTION
I added 1.68 so we won't have to do this again for a little while