### PR TITLE
ARROW-2725: [Java] make Accountant.AllocationOutcome publicly visible

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
@@ -170,7 +170,7 @@ class Accountant implements AutoCloseable {
     }
 
     final AllocationOutcome finalOutcome = beyondLimit ? AllocationOutcome.FAILED_LOCAL :
-        parentOutcome.ok ? AllocationOutcome.SUCCESS : AllocationOutcome.FAILED_PARENT;
+        parentOutcome.isOk() ? AllocationOutcome.SUCCESS : AllocationOutcome.FAILED_PARENT;
 
     if (updatePeak) {
       updatePeak();
@@ -258,39 +258,4 @@ class Accountant implements AutoCloseable {
     return Math.min(localHeadroom, parent.getHeadroom());
   }
 
-  /**
-   * Describes the type of outcome that occurred when trying to account for allocation of memory.
-   */
-  public static enum AllocationOutcome {
-
-    /**
-     * Allocation succeeded.
-     */
-    SUCCESS(true),
-
-    /**
-     * Allocation succeeded but only because the allocator was forced to move beyond a limit.
-     */
-    FORCED_SUCCESS(true),
-
-    /**
-     * Allocation failed because the local allocator's limits were exceeded.
-     */
-    FAILED_LOCAL(false),
-
-    /**
-     * Allocation failed because a parent allocator's limits were exceeded.
-     */
-    FAILED_PARENT(false);
-
-    private final boolean ok;
-
-    AllocationOutcome(boolean ok) {
-      this.ok = ok;
-    }
-
-    public boolean isOk() {
-      return ok;
-    }
-  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -32,7 +32,7 @@ public interface AllocationListener {
     }
 
     @Override
-    public boolean onFailedAllocation(long size, Accountant.AllocationOutcome outcome) {
+    public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
       return false;
     }
   };
@@ -53,6 +53,6 @@ public interface AllocationListener {
    * @param outcome  the outcome of the failed allocation. Carries information of what failed
    * @return true, if the allocation can be retried; false if the allocation should fail
    */
-  boolean onFailedAllocation(long size, Accountant.AllocationOutcome outcome);
+  boolean onFailedAllocation(long size, AllocationOutcome outcome);
 
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcome.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcome.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory;
+
+/**
+ * Describes the type of outcome that occurred when trying to account for allocation of memory.
+ */
+public enum AllocationOutcome {
+
+  /**
+   * Allocation succeeded.
+   */
+  SUCCESS(true),
+
+  /**
+   * Allocation succeeded but only because the allocator was forced to move beyond a limit.
+   */
+  FORCED_SUCCESS(true),
+
+  /**
+   * Allocation failed because the local allocator's limits were exceeded.
+   */
+  FAILED_LOCAL(false),
+
+  /**
+   * Allocation failed because a parent allocator's limits were exceeded.
+   */
+  FAILED_PARENT(false);
+
+  private final boolean ok;
+
+  AllocationOutcome(boolean ok) {
+    this.ok = ok;
+  }
+
+  public boolean isOk() {
+    return ok;
+  }
+}

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestAccountant.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestAccountant.java
@@ -20,7 +20,6 @@ package org.apache.arrow.memory;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.arrow.memory.Accountant.AllocationOutcome;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -247,7 +247,7 @@ public class TestBaseAllocator {
     }
 
     @Override
-    public boolean onFailedAllocation(long size,  Accountant.AllocationOutcome outcome) {
+    public boolean onFailedAllocation(long size,  AllocationOutcome outcome) {
       if (expandOnFail) {
         expandAlloc.setLimit(expandLimit);
         return true;


### PR DESCRIPTION
Made Accountant.AllocationOutcome publicly visible, as it's now referred to in the AllocationListener