### PR TITLE
ARROW-2727: [Java] Fix POM file issue causing build failure in java/adapters/jdbc

### DIFF
--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -17,6 +17,7 @@
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
         <version>0.10.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>arrow-jdbc</artifactId>


### PR DESCRIPTION
It only happens when building arrow java the first time. If you have installed arrow in local before, you won't see this issue. This issue is due to the pom file issue. 