### PR TITLE
ARROW-2739: [GLib] Use G_DECLARE_DERIVABLE_TYPE 

### DIFF
--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -1311,47 +1311,16 @@ GArrowArrayBuilder *garrow_struct_array_builder_get_field_builder(GArrowStructAr
 GList *garrow_struct_array_builder_get_field_builders(GArrowStructArrayBuilder *builder);
 
 
-#define GARROW_TYPE_DECIMAL128_ARRAY_BUILDER        \
-  (garrow_decimal128_array_builder_get_type())
-#define GARROW_DECIMAL128_ARRAY_BUILDER(obj)                        \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                \
-                              GARROW_TYPE_DECIMAL128_ARRAY_BUILDER, \
-                              GArrowDecimal128ArrayBuilder))
-#define GARROW_DECIMAL128_ARRAY_BUILDER_CLASS(klass)                \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                                 \
-                           GARROW_TYPE_DECIMAL128_ARRAY_BUILDER,    \
-                           GArrowDecimal128ArrayBuilderClass))
-#define GARROW_IS_DECIMAL128_ARRAY_BUILDER(obj)                             \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj),                                        \
-                              GARROW_TYPE_DECIMAL128_ARRAY_BUILDER))
-#define GARROW_IS_DECIMAL128_ARRAY_BUILDER_CLASS(klass)             \
-  (G_TYPE_CHECK_CLASS_TYPE((klass),                                 \
-                           GARROW_TYPE_DECIMAL128_ARRAY_BUILDER))
-#define GARROW_DECIMAL128_ARRAY_BUILDER_GET_CLASS(obj)              \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                                 \
-                             GARROW_TYPE_DECIMAL128_ARRAY_BUILDER,  \
-                             GArrowDecimal128ArrayBuilderClass))
-
-typedef struct _GArrowDecimal128ArrayBuilder         GArrowDecimal128ArrayBuilder;
-typedef struct _GArrowDecimal128ArrayBuilderClass    GArrowDecimal128ArrayBuilderClass;
-
-/**
- * GArrowDecimal128ArrayBuilder:
- *
- * It wraps `arrow::Decimal128Builder`.
- */
-struct _GArrowDecimal128ArrayBuilder
-{
-  /*< private >*/
-  GArrowArrayBuilder parent_instance;
-};
-
+#define GARROW_TYPE_DECIMAL128_ARRAY_BUILDER (garrow_decimal128_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowDecimal128ArrayBuilder,
+                         garrow_decimal128_array_builder,
+                         GARROW,
+                         DECIMAL128_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
 struct _GArrowDecimal128ArrayBuilderClass
 {
   GArrowArrayBuilderClass parent_class;
 };
-
-GType garrow_decimal128_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowDecimal128ArrayBuilder *garrow_decimal128_array_builder_new(GArrowDecimalDataType *data_type);
 

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -650,47 +650,17 @@ GArrowTime64DataType *garrow_time64_data_type_new      (GArrowTimeUnit unit,
                                                         GError **error);
 
 
-#define GARROW_TYPE_DECIMAL_DATA_TYPE            \
-  (garrow_decimal_data_type_get_type())
-#define GARROW_DECIMAL_DATA_TYPE(obj)                            \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                             \
-                              GARROW_TYPE_DECIMAL_DATA_TYPE,     \
-                              GArrowDecimalDataType))
-#define GARROW_DECIMAL_DATA_TYPE_CLASS(klass)                    \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                              \
-                           GARROW_TYPE_DECIMAL_DATA_TYPE,        \
-                           GArrowDecimalDataTypeClass))
-#define GARROW_IS_DECIMAL_DATA_TYPE(obj)                         \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj),                             \
-                            GARROW_TYPE_DECIMAL_DATA_TYPE))
-#define GARROW_IS_DECIMAL_DATA_TYPE_CLASS(klass)                 \
-  (G_TYPE_CHECK_CLASS_TYPE((klass),                              \
-                           GARROW_TYPE_DECIMAL_DATA_TYPE))
-#define GARROW_DECIMAL_DATA_TYPE_GET_CLASS(obj),                 \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                              \
-                             GARROW_TYPE_DECIMAL_DATA_TYPE,      \
-                             GArrowDecimalDataTypeClass))
-
-typedef struct _GArrowDecimalDataType       GArrowDecimalDataType;
-typedef struct _GArrowDecimalDataTypeClass  GArrowDecimalDataTypeClass;
-
-/**
- * GArrowDecimalType:
- *
- * It wraps `arrow::DecimalType`.
- */
-struct _GArrowDecimalDataType
-{
-  /*< private >*/
-  GArrowDataType parent_instance;
-};
-
+#define GARROW_TYPE_DECIMAL_DATA_TYPE (garrow_decimal_data_type_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowDecimalDataType,
+                         garrow_decimal_data_type,
+                         GARROW,
+                         DECIMAL_DATA_TYPE,
+                         GArrowDataType)
 struct _GArrowDecimalDataTypeClass
 {
   GArrowDataTypeClass parent_class;
 };
 
-GType                   garrow_decimal_data_type_get_type (void) G_GNUC_CONST;
 GArrowDecimalDataType   *garrow_decimal_data_type_new     (gint32 precision,
                                                            gint32 scale);
 


### PR DESCRIPTION
Because we can use gobject macro for class definition.
