### PR TITLE
ARROW-2735: [Java] Add <relativePath> element to parent-pom to fix build failure

### DIFF
--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -17,6 +17,7 @@
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
         <version>0.10.0-SNAPSHOT</version>
+	<relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>arrow-jdbc</artifactId>


### PR DESCRIPTION
By default maven looks only one-level up for the parent-pom. Arrow JDBC
Adapter is nested by two levels causing maven to break the build. Parent POM
had to be referenced explicitly using `<relativePath>` element.