### PR TITLE
ARROW-2742: [Python] Allow Table.from_batches to use iterator of record batches

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1058,12 +1058,12 @@ cdef class Table:
     @staticmethod
     def from_batches(batches, Schema schema=None):
         """
-        Construct a Table from a list of Arrow RecordBatches
+        Construct a Table from an iterator of Arrow RecordBatches
 
         Parameters
         ----------
-        batches: list of RecordBatch
-            RecordBatch list to be converted, all schemas must be equal
+        batches: iterator of RecordBatch
+            Iterator of RecordBatch to be converted, all schemas must be equal
         schema : Schema, default None
             If not passed, will be inferred from the first RecordBatch
 
@@ -1081,7 +1081,7 @@ cdef class Table:
             c_batches.push_back(batch.sp_batch)
 
         if schema is None:
-            if len(batches) == 0:
+            if c_batches.size() == 0:
                 raise ValueError('Must pass schema, or at least '
                                  'one RecordBatch')
             c_schema = c_batches[0].get().schema()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1058,12 +1058,12 @@ cdef class Table:
     @staticmethod
     def from_batches(batches, Schema schema=None):
         """
-        Construct a Table from an iterator of Arrow RecordBatches
+        Construct a Table from a sequence or iterator of Arrow RecordBatches
 
         Parameters
         ----------
-        batches: iterator of RecordBatch
-            Iterator of RecordBatch to be converted, all schemas must be equal
+        batches: sequence or iterator of RecordBatch
+            Sequence of RecordBatch to be converted, all schemas must be equal
         schema : Schema, default None
             If not passed, will be inferred from the first RecordBatch
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -302,6 +302,9 @@ def test_table_to_batches():
     assert_frame_equal(pa.Table.from_batches(batches).to_pandas(),
                        expected_df)
 
+    table_from_iter = pa.Table.from_batches(iter([batch1, batch2, batch1]))
+    assert table.equals(table_from_iter)
+
 
 def test_table_basics():
     data = [


### PR DESCRIPTION
This changes `pyarrow.Table.from_batches` from requiring a list of RecordBatches to being able to accept an iterator by checking the resulting vector size instead of the Python list len.  Added a test that using an iterator of RecordBatches creates the expected Table.