### PR TITLE
ARROW-2758: [Plasma] Use Scope enum in Plasma

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -57,7 +57,7 @@ add_custom_command(
   # flatbuffers message Message, which can be used to store deserialized
   # messages in data structures. This is currently used for ObjectInfo for
   # example.
-  COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${PLASMA_FBS_SRC} --gen-object-api
+  COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${PLASMA_FBS_SRC} --gen-object-api --scoped-enums
   DEPENDS ${PLASMA_FBS_SRC}
   COMMENT "Running flatc compiler on ${PLASMA_FBS_SRC}"
   VERBATIM)

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -366,7 +366,7 @@ Status PlasmaClient::Impl::Create(const ObjectID& object_id, int64_t data_size,
   RETURN_NOT_OK(
       SendCreateRequest(store_conn_, object_id, data_size, metadata_size, device_num));
   std::vector<uint8_t> buffer;
-  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType_PlasmaCreateReply, &buffer));
+  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaCreateReply, &buffer));
   ObjectID id;
   PlasmaObject object;
   int store_fd;
@@ -475,7 +475,7 @@ Status PlasmaClient::Impl::GetBuffers(
   // client, so we need to send a request to the plasma store.
   RETURN_NOT_OK(SendGetRequest(store_conn_, &object_ids[0], num_objects, timeout_ms));
   std::vector<uint8_t> buffer;
-  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType_PlasmaGetReply, &buffer));
+  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaGetReply, &buffer));
   std::vector<ObjectID> received_object_ids(num_objects);
   std::vector<PlasmaObject> object_data(num_objects);
   PlasmaObject* object;
@@ -677,7 +677,7 @@ Status PlasmaClient::Impl::Contains(const ObjectID& object_id, bool* has_object)
     // to see if we have the object.
     RETURN_NOT_OK(SendContainsRequest(store_conn_, object_id));
     std::vector<uint8_t> buffer;
-    RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType_PlasmaContainsReply, &buffer));
+    RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaContainsReply, &buffer));
     ObjectID object_id2;
     DCHECK_GT(buffer.size(), 0);
     RETURN_NOT_OK(
@@ -803,7 +803,7 @@ Status PlasmaClient::Impl::Abort(const ObjectID& object_id) {
 
   std::vector<uint8_t> buffer;
   ObjectID id;
-  int64_t type;
+  MessageType type;
   RETURN_NOT_OK(ReadMessage(store_conn_, &type, &buffer));
   return ReadAbortReply(buffer.data(), buffer.size(), &id);
 }
@@ -817,7 +817,7 @@ Status PlasmaClient::Impl::Delete(const ObjectID& object_id) {
     // If we don't already have a reference to the object, we can try to remove the object
     RETURN_NOT_OK(SendDeleteRequest(store_conn_, object_id));
     std::vector<uint8_t> buffer;
-    RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType_PlasmaDeleteReply, &buffer));
+    RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaDeleteReply, &buffer));
     ObjectID object_id2;
     DCHECK_GT(buffer.size(), 0);
     RETURN_NOT_OK(ReadDeleteReply(buffer.data(), buffer.size(), &object_id2));
@@ -830,7 +830,7 @@ Status PlasmaClient::Impl::Evict(int64_t num_bytes, int64_t& num_bytes_evicted) 
   RETURN_NOT_OK(SendEvictRequest(store_conn_, num_bytes));
   // Wait for a response with the number of bytes actually evicted.
   std::vector<uint8_t> buffer;
-  int64_t type;
+  MessageType type;
   RETURN_NOT_OK(ReadMessage(store_conn_, &type, &buffer));
   return ReadEvictReply(buffer.data(), buffer.size(), num_bytes_evicted);
 }
@@ -904,7 +904,7 @@ Status PlasmaClient::Impl::Connect(const std::string& store_socket_name,
   // Send a ConnectRequest to the store to get its memory capacity.
   RETURN_NOT_OK(SendConnectRequest(store_conn_));
   std::vector<uint8_t> buffer;
-  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType_PlasmaConnectReply, &buffer));
+  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaConnectReply, &buffer));
   RETURN_NOT_OK(ReadConnectReply(buffer.data(), buffer.size(), &store_capacity_));
   return Status::OK();
 }
@@ -942,7 +942,7 @@ Status PlasmaClient::Impl::Info(const ObjectID& object_id, int* object_status) {
 
   RETURN_NOT_OK(SendStatusRequest(manager_conn_, &object_id, 1));
   std::vector<uint8_t> buffer;
-  RETURN_NOT_OK(PlasmaReceive(manager_conn_, MessageType_PlasmaStatusReply, &buffer));
+  RETURN_NOT_OK(PlasmaReceive(manager_conn_, MessageType::PlasmaStatusReply, &buffer));
   ObjectID id;
   RETURN_NOT_OK(ReadStatusReply(buffer.data(), buffer.size(), &id, object_status, 1));
   ARROW_CHECK(object_id == id);
@@ -965,25 +965,25 @@ Status PlasmaClient::Impl::Wait(int64_t num_object_requests,
   RETURN_NOT_OK(SendWaitRequest(manager_conn_, object_requests, num_object_requests,
                                 num_ready_objects, timeout_ms));
   std::vector<uint8_t> buffer;
-  RETURN_NOT_OK(PlasmaReceive(manager_conn_, MessageType_PlasmaWaitReply, &buffer));
+  RETURN_NOT_OK(PlasmaReceive(manager_conn_, MessageType::PlasmaWaitReply, &buffer));
   RETURN_NOT_OK(
       ReadWaitReply(buffer.data(), buffer.size(), object_requests, &num_ready_objects));
 
   *num_objects_ready = 0;
   for (int i = 0; i < num_object_requests; ++i) {
     int type = object_requests[i].type;
-    int status = object_requests[i].status;
+    ObjectStatus status = object_requests[i].status;
     switch (type) {
       case PLASMA_QUERY_LOCAL:
-        if (status == ObjectStatus_Local) {
+        if (status == ObjectStatus::Local) {
           *num_objects_ready += 1;
         }
         break;
       case PLASMA_QUERY_ANYWHERE:
-        if (status == ObjectStatus_Local || status == ObjectStatus_Remote) {
+        if (status == ObjectStatus::Local || status == ObjectStatus::Remote) {
           *num_objects_ready += 1;
         } else {
-          ARROW_CHECK(status == ObjectStatus_Nonexistent);
+          ARROW_CHECK(status == ObjectStatus::Nonexistent);
         }
         break;
       default:

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -958,8 +958,8 @@ Status PlasmaClient::Impl::Wait(int64_t num_object_requests,
   ARROW_CHECK(num_ready_objects <= num_object_requests);
 
   for (int i = 0; i < num_object_requests; ++i) {
-    ARROW_CHECK(object_requests[i].type == PLASMA_QUERY_LOCAL ||
-                object_requests[i].type == PLASMA_QUERY_ANYWHERE);
+    ARROW_CHECK(object_requests[i].type == ObjectRequestType::PLASMA_QUERY_LOCAL ||
+                object_requests[i].type == ObjectRequestType::PLASMA_QUERY_ANYWHERE);
   }
 
   RETURN_NOT_OK(SendWaitRequest(manager_conn_, object_requests, num_object_requests,
@@ -971,15 +971,15 @@ Status PlasmaClient::Impl::Wait(int64_t num_object_requests,
 
   *num_objects_ready = 0;
   for (int i = 0; i < num_object_requests; ++i) {
-    int type = object_requests[i].type;
+    ObjectRequestType type = object_requests[i].type;
     ObjectStatus status = object_requests[i].status;
     switch (type) {
-      case PLASMA_QUERY_LOCAL:
+      case ObjectRequestType::PLASMA_QUERY_LOCAL:
         if (status == ObjectStatus::Local) {
           *num_objects_ready += 1;
         }
         break;
-      case PLASMA_QUERY_ANYWHERE:
+      case ObjectRequestType::PLASMA_QUERY_ANYWHERE:
         if (status == ObjectStatus::Local || status == ObjectStatus::Remote) {
           *num_objects_ready += 1;
         } else {

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -259,15 +259,15 @@ class ARROW_EXPORT PlasmaClient {
   ///        "type" field.
   ///        - A PLASMA_QUERY_LOCAL request is satisfied when object_id becomes
   ///          available in the local Plasma Store. In this case, this function
-  ///          sets the "status" field to ObjectStatus_Local. Note, if the
+  ///          sets the "status" field to ObjectStatus::Local. Note, if the
   ///          status
-  ///          is not ObjectStatus_Local, it will be ObjectStatus_Nonexistent,
+  ///          is not ObjectStatus::Local, it will be ObjectStatus::Nonexistent,
   ///          but it may exist elsewhere in the system.
   ///        - A PLASMA_QUERY_ANYWHERE request is satisfied when object_id
   ///        becomes
   ///          available either at the local Plasma Store or on a remote Plasma
   ///          Store. In this case, the functions sets the "status" field to
-  ///          ObjectStatus_Local or ObjectStatus_Remote.
+  ///          ObjectStatus::Local or ObjectStatus::Remote.
   /// \param num_ready_objects The number of requests in object_requests array
   /// that
   ///        must be satisfied before the function returns, unless it timeouts.

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -78,24 +78,24 @@ bool UniqueID::operator==(const UniqueID& rhs) const {
   return std::memcmp(data(), rhs.data(), kUniqueIDSize) == 0;
 }
 
-Status plasma_error_status(int plasma_error) {
+Status plasma_error_status(PlasmaError plasma_error) {
   switch (plasma_error) {
-    case PlasmaError_OK:
+    case PlasmaError::OK:
       return Status::OK();
-    case PlasmaError_ObjectExists:
+    case PlasmaError::ObjectExists:
       return Status::PlasmaObjectExists("object already exists in the plasma store");
-    case PlasmaError_ObjectNonexistent:
+    case PlasmaError::ObjectNonexistent:
       return Status::PlasmaObjectNonexistent("object does not exist in the plasma store");
-    case PlasmaError_OutOfMemory:
+    case PlasmaError::OutOfMemory:
       return Status::PlasmaStoreFull("object does not fit in the plasma store");
     default:
-      ARROW_LOG(FATAL) << "unknown plasma error code " << plasma_error;
+      ARROW_LOG(FATAL) << "unknown plasma error code " << static_cast<int>(plasma_error);
   }
   return Status::OK();
 }
 
-ARROW_EXPORT int ObjectStatusLocal = ObjectStatus_Local;
-ARROW_EXPORT int ObjectStatusRemote = ObjectStatus_Remote;
+ARROW_EXPORT ObjectStatus ObjectStatusLocal = ObjectStatus::Local;
+ARROW_EXPORT ObjectStatus ObjectStatusRemote = ObjectStatus::Remote;
 
 const PlasmaStoreInfo* plasma_config;
 

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -31,6 +31,10 @@
 #include "arrow/status.h"
 #include "arrow/util/logging.h"
 
+// Forward declaration outside the namespace, which is defined in plasma_generated.h.
+enum class PlasmaError : int32_t;
+enum class ObjectStatus : int32_t;
+
 namespace plasma {
 
 constexpr int64_t kUniqueIDSize = 20;
@@ -54,7 +58,7 @@ static_assert(std::is_pod<UniqueID>::value, "UniqueID must be plain old data");
 
 typedef UniqueID ObjectID;
 
-arrow::Status plasma_error_status(int plasma_error);
+arrow::Status plasma_error_status(PlasmaError plasma_error);
 
 /// Size of object hash digests.
 constexpr int64_t kDigestSize = sizeof(uint64_t);
@@ -76,7 +80,7 @@ struct ObjectRequest {
   ///  - ObjectStatus_Nonexistent: object does not exist in the system.
   ///  - PLASMA_CLIENT_IN_TRANSFER, if the object is currently being scheduled
   ///    for being transferred or it is transferring.
-  int status;
+  ObjectStatus status;
 };
 
 enum ObjectRequestType {
@@ -86,8 +90,8 @@ enum ObjectRequestType {
   PLASMA_QUERY_ANYWHERE
 };
 
-extern int ObjectStatusLocal;
-extern int ObjectStatusRemote;
+extern ObjectStatus ObjectStatusLocal;
+extern ObjectStatus ObjectStatusRemote;
 
 /// Globally accessible reference to plasma store configuration.
 /// TODO(pcm): This can be avoided with some refactoring of existing code

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -63,6 +63,13 @@ arrow::Status plasma_error_status(PlasmaError plasma_error);
 /// Size of object hash digests.
 constexpr int64_t kDigestSize = sizeof(uint64_t);
 
+enum class ObjectRequestType : int {
+  /// Query for object in the local plasma store.
+  PLASMA_QUERY_LOCAL = 1,
+  /// Query for object in the local plasma store or in a remote plasma store.
+  PLASMA_QUERY_ANYWHERE
+};
+
 /// Object request data structure. Used for Wait.
 struct ObjectRequest {
   /// The ID of the requested object. If ID_NIL request any object.
@@ -72,7 +79,7 @@ struct ObjectRequest {
   ///    local Plasma Store.
   ///  - PLASMA_QUERY_ANYWHERE: return if or when the object is available in
   ///    the system (i.e., either in the local or a remote Plasma Store).
-  int type;
+  ObjectRequestType type;
   /// Object status. Same as the status returned by plasma_status() function
   /// call. This is filled in by plasma_wait_for_objects1():
   ///  - ObjectStatus_Local: object is ready at the local Plasma Store.
@@ -81,13 +88,6 @@ struct ObjectRequest {
   ///  - PLASMA_CLIENT_IN_TRANSFER, if the object is currently being scheduled
   ///    for being transferred or it is transferring.
   ObjectStatus status;
-};
-
-enum ObjectRequestType {
-  /// Query for object in the local plasma store.
-  PLASMA_QUERY_LOCAL = 1,
-  /// Query for object in the local plasma store or in a remote plasma store.
-  PLASMA_QUERY_ANYWHERE
 };
 
 extern ObjectStatus ObjectStatusLocal;

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -82,9 +82,9 @@ struct ObjectRequest {
   ObjectRequestType type;
   /// Object status. Same as the status returned by plasma_status() function
   /// call. This is filled in by plasma_wait_for_objects1():
-  ///  - ObjectStatus_Local: object is ready at the local Plasma Store.
-  ///  - ObjectStatus_Remote: object is ready at a remote Plasma Store.
-  ///  - ObjectStatus_Nonexistent: object does not exist in the system.
+  ///  - ObjectStatus::Local: object is ready at the local Plasma Store.
+  ///  - ObjectStatus::Remote: object is ready at a remote Plasma Store.
+  ///  - ObjectStatus::Nonexistent: object does not exist in the system.
   ///  - PLASMA_CLIENT_IN_TRANSFER, if the object is currently being scheduled
   ///    for being transferred or it is transferring.
   ObjectStatus status;

--- a/cpp/src/plasma/format/plasma.fbs
+++ b/cpp/src/plasma/format/plasma.fbs
@@ -17,7 +17,7 @@
 
 // Plasma protocol specification
 
-enum MessageType:int {
+enum MessageType:int64 {
   // Message that gets send when a client hangs up.
   PlasmaDisconnectClient = 0,
   // Create a new object.
@@ -301,7 +301,7 @@ table ObjectReply {
   // ID of the object.
   object_id: string;
   // The object status. This specifies where the object is stored.
-  status: int;
+  status: ObjectStatus;
 }
 
 table PlasmaWaitReply {

--- a/cpp/src/plasma/format/plasma.fbs
+++ b/cpp/src/plasma/format/plasma.fbs
@@ -17,7 +17,7 @@
 
 // Plasma protocol specification
 
-enum MessageType:int64 {
+enum MessageType:long {
   // Message that gets send when a client hangs up.
   PlasmaDisconnectClient = 0,
   // Create a new object.

--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -59,7 +59,7 @@ Status WriteBytes(int fd, uint8_t* cursor, size_t length) {
   return Status::OK();
 }
 
-Status WriteMessage(int fd, int64_t type, int64_t length, uint8_t* bytes) {
+Status WriteMessage(int fd, MessageType type, int64_t length, uint8_t* bytes) {
   int64_t version = kPlasmaProtocolVersion;
   RETURN_NOT_OK(WriteBytes(fd, reinterpret_cast<uint8_t*>(&version), sizeof(version)));
   RETURN_NOT_OK(WriteBytes(fd, reinterpret_cast<uint8_t*>(&type), sizeof(type)));
@@ -90,24 +90,24 @@ Status ReadBytes(int fd, uint8_t* cursor, size_t length) {
   return Status::OK();
 }
 
-Status ReadMessage(int fd, int64_t* type, std::vector<uint8_t>* buffer) {
+Status ReadMessage(int fd, MessageType* type, std::vector<uint8_t>* buffer) {
   int64_t version;
   RETURN_NOT_OK_ELSE(ReadBytes(fd, reinterpret_cast<uint8_t*>(&version), sizeof(version)),
-                     *type = MessageType_PlasmaDisconnectClient);
+                     *type = MessageType::PlasmaDisconnectClient);
   ARROW_CHECK(version == kPlasmaProtocolVersion) << "version = " << version;
   RETURN_NOT_OK_ELSE(ReadBytes(fd, reinterpret_cast<uint8_t*>(type), sizeof(*type)),
-                     *type = MessageType_PlasmaDisconnectClient);
+                     *type = MessageType::PlasmaDisconnectClient);
   int64_t length_temp;
   RETURN_NOT_OK_ELSE(
       ReadBytes(fd, reinterpret_cast<uint8_t*>(&length_temp), sizeof(length_temp)),
-      *type = MessageType_PlasmaDisconnectClient);
+      *type = MessageType::PlasmaDisconnectClient);
   // The length must be read as an int64_t, but it should be used as a size_t.
   size_t length = static_cast<size_t>(length_temp);
   if (length > buffer->size()) {
     buffer->resize(length);
   }
   RETURN_NOT_OK_ELSE(ReadBytes(fd, buffer->data(), length),
-                     *type = MessageType_PlasmaDisconnectClient);
+                     *type = MessageType::PlasmaDisconnectClient);
   return Status::OK();
 }
 

--- a/cpp/src/plasma/io.h
+++ b/cpp/src/plasma/io.h
@@ -30,6 +30,9 @@
 #include "arrow/status.h"
 #include "plasma/compat.h"
 
+// Forward declaration outside the namespace, which is defined in plasma_generated.h.
+enum class MessageType : int64_t;
+
 namespace plasma {
 
 // TODO(pcm): Replace our own custom message header (message type,
@@ -41,11 +44,11 @@ using arrow::Status;
 
 Status WriteBytes(int fd, uint8_t* cursor, size_t length);
 
-Status WriteMessage(int fd, int64_t type, int64_t length, uint8_t* bytes);
+Status WriteMessage(int fd, MessageType type, int64_t length, uint8_t* bytes);
 
 Status ReadBytes(int fd, uint8_t* cursor, size_t length);
 
-Status ReadMessage(int fd, int64_t* type, std::vector<uint8_t>* buffer);
+Status ReadMessage(int fd, MessageType* type, std::vector<uint8_t>* buffer);
 
 int bind_ipc_sock(const std::string& pathname, bool shall_listen);
 

--- a/cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc
+++ b/cpp/src/plasma/lib/java/org_apache_arrow_plasma_PlasmaClientJNI.cc
@@ -252,7 +252,7 @@ JNIEXPORT jobjectArray JNICALL Java_org_apache_arrow_plasma_PlasmaClientJNI_wait
     jbyteArray_to_object_id(
         env, reinterpret_cast<jbyteArray>(env->GetObjectArrayElement(object_ids, i)),
         &oreqs[i].object_id);
-    oreqs[i].type = plasma::PLASMA_QUERY_ANYWHERE;
+    oreqs[i].type = plasma::ObjectRequestType::PLASMA_QUERY_ANYWHERE;
   }
 
   int num_return_objects;

--- a/cpp/src/plasma/plasma.h
+++ b/cpp/src/plasma/plasma.h
@@ -95,14 +95,14 @@ struct PlasmaObject {
   int device_num;
 };
 
-enum object_state {
+enum class object_state : int {
   /// Object was created but not sealed in the local Plasma Store.
   PLASMA_CREATED = 1,
   /// Object is sealed and stored in the local Plasma Store.
   PLASMA_SEALED
 };
 
-enum object_status {
+enum class object_status : int {
   /// The object was not found.
   OBJECT_NOT_FOUND = 0,
   /// The object was found.

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -38,7 +38,7 @@ bool verify_flatbuffer(T* object, uint8_t* data, size_t size) {
 
 /* Plasma receive message. */
 
-Status PlasmaReceive(int sock, int64_t message_type, std::vector<uint8_t>* buffer);
+Status PlasmaReceive(int sock, MessageType message_type, std::vector<uint8_t>* buffer);
 
 /* Plasma Create message functions. */
 
@@ -48,7 +48,7 @@ Status SendCreateRequest(int sock, ObjectID object_id, int64_t data_size,
 Status ReadCreateRequest(uint8_t* data, size_t size, ObjectID* object_id,
                          int64_t* data_size, int64_t* metadata_size, int* device_num);
 
-Status SendCreateReply(int sock, ObjectID object_id, PlasmaObject* object, int error,
+Status SendCreateReply(int sock, ObjectID object_id, PlasmaObject* object, PlasmaError error,
                        int64_t mmap_size);
 
 Status ReadCreateReply(uint8_t* data, size_t size, ObjectID* object_id,
@@ -69,7 +69,7 @@ Status SendSealRequest(int sock, ObjectID object_id, unsigned char* digest);
 Status ReadSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
                        unsigned char* digest);
 
-Status SendSealReply(int sock, ObjectID object_id, int error);
+Status SendSealReply(int sock, ObjectID object_id, PlasmaError error);
 
 Status ReadSealReply(uint8_t* data, size_t size, ObjectID* object_id);
 
@@ -96,7 +96,7 @@ Status SendReleaseRequest(int sock, ObjectID object_id);
 
 Status ReadReleaseRequest(uint8_t* data, size_t size, ObjectID* object_id);
 
-Status SendReleaseReply(int sock, ObjectID object_id, int error);
+Status SendReleaseReply(int sock, ObjectID object_id, PlasmaError error);
 
 Status ReadReleaseReply(uint8_t* data, size_t size, ObjectID* object_id);
 
@@ -106,7 +106,7 @@ Status SendDeleteRequest(int sock, ObjectID object_id);
 
 Status ReadDeleteRequest(uint8_t* data, size_t size, ObjectID* object_id);
 
-Status SendDeleteReply(int sock, ObjectID object_id, int error);
+Status SendDeleteReply(int sock, ObjectID object_id, PlasmaError error);
 
 Status ReadDeleteReply(uint8_t* data, size_t size, ObjectID* object_id);
 

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -48,8 +48,8 @@ Status SendCreateRequest(int sock, ObjectID object_id, int64_t data_size,
 Status ReadCreateRequest(uint8_t* data, size_t size, ObjectID* object_id,
                          int64_t* data_size, int64_t* metadata_size, int* device_num);
 
-Status SendCreateReply(int sock, ObjectID object_id, PlasmaObject* object, PlasmaError error,
-                       int64_t mmap_size);
+Status SendCreateReply(int sock, ObjectID object_id, PlasmaObject* object,
+                       PlasmaError error, int64_t mmap_size);
 
 Status ReadCreateReply(uint8_t* data, size_t size, ObjectID* object_id,
                        PlasmaObject* object, int* store_fd, int64_t* mmap_size);

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -83,14 +83,14 @@ class PlasmaStore {
   /// @param client The client that created the object.
   /// @param result The object that has been created.
   /// @return One of the following error codes:
-  ///  - PlasmaError_OK, if the object was created successfully.
-  ///  - PlasmaError_ObjectExists, if an object with this ID is already
+  ///  - PlasmaError::OK, if the object was created successfully.
+  ///  - PlasmaError::ObjectExists, if an object with this ID is already
   ///    present in the store. In this case, the client should not call
   ///    plasma_release.
-  ///  - PlasmaError_OutOfMemory, if the store is out of memory and
+  ///  - PlasmaError::OutOfMemory, if the store is out of memory and
   ///    cannot create the object. In this case, the client should not call
   ///    plasma_release.
-  int create_object(const ObjectID& object_id, int64_t data_size, int64_t metadata_size,
+  PlasmaError create_object(const ObjectID& object_id, int64_t data_size, int64_t metadata_size,
                     int device_num, Client* client, PlasmaObject* result);
 
   /// Abort a created but unsealed object. If the client is not the
@@ -106,10 +106,10 @@ class PlasmaStore {
   ///
   /// @param object_id Object ID of the object to be deleted.
   /// @return One of the following error codes:
-  ///  - PlasmaError_OK, if the object was delete successfully.
-  ///  - PlasmaError_ObjectNonexistent, if ths object isn't existed.
-  ///  - PlasmaError_ObjectInUse, if the object is in use.
-  int delete_object(ObjectID& object_id);
+  ///  - PlasmaError::OK, if the object was delete successfully.
+  ///  - PlasmaError::ObjectNonexistent, if ths object isn't existed.
+  ///  - PlasmaError::ObjectInUse, if the object is in use.
+  PlasmaError delete_object(ObjectID& object_id);
 
   /// Delete objects that have been created in the hash table. This should only
   /// be called on objects that are returned by the eviction policy to evict.

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -90,8 +90,9 @@ class PlasmaStore {
   ///  - PlasmaError::OutOfMemory, if the store is out of memory and
   ///    cannot create the object. In this case, the client should not call
   ///    plasma_release.
-  PlasmaError create_object(const ObjectID& object_id, int64_t data_size, int64_t metadata_size,
-                    int device_num, Client* client, PlasmaObject* result);
+  PlasmaError create_object(const ObjectID& object_id, int64_t data_size,
+                            int64_t metadata_size, int device_num, Client* client,
+                            PlasmaObject* result);
 
   /// Abort a created but unsealed object. If the client is not the
   /// creator, then the abort will fail.
@@ -144,7 +145,7 @@ class PlasmaStore {
   /// @param object_id Object ID that will be checked.
   /// @return OBJECT_FOUND if the object is in the store, OBJECT_NOT_FOUND if
   /// not
-  int contains_object(const ObjectID& object_id);
+  object_status contains_object(const ObjectID& object_id);
 
   /// Record the fact that a particular client is no longer using an object.
   ///

--- a/cpp/src/plasma/test/serialization_tests.cc
+++ b/cpp/src/plasma/test/serialization_tests.cc
@@ -48,10 +48,10 @@ int create_temp_file(void) {
  * @return Pointer to the content of the message. Needs to be freed by the
  * caller.
  */
-std::vector<uint8_t> read_message_from_file(int fd, int message_type) {
+std::vector<uint8_t> read_message_from_file(int fd, MessageType message_type) {
   /* Go to the beginning of the file. */
   lseek(fd, 0, SEEK_SET);
-  int64_t type;
+  MessageType type;
   std::vector<uint8_t> data;
   ARROW_CHECK_OK(ReadMessage(fd, &type, &data));
   ARROW_CHECK(type == message_type);
@@ -80,7 +80,7 @@ TEST(PlasmaSerialization, CreateRequest) {
   int device_num1 = 0;
   ARROW_CHECK_OK(
       SendCreateRequest(fd, object_id1, data_size1, metadata_size1, device_num1));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaCreateRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaCreateRequest);
   ObjectID object_id2;
   int64_t data_size2;
   int64_t metadata_size2;
@@ -99,8 +99,8 @@ TEST(PlasmaSerialization, CreateReply) {
   ObjectID object_id1 = ObjectID::from_random();
   PlasmaObject object1 = random_plasma_object();
   int64_t mmap_size1 = 1000000;
-  ARROW_CHECK_OK(SendCreateReply(fd, object_id1, &object1, 0, mmap_size1));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaCreateReply);
+  ARROW_CHECK_OK(SendCreateReply(fd, object_id1, &object1, PlasmaError::OK, mmap_size1));
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaCreateReply);
   ObjectID object_id2;
   PlasmaObject object2;
   memset(&object2, 0, sizeof(object2));
@@ -121,7 +121,7 @@ TEST(PlasmaSerialization, SealRequest) {
   unsigned char digest1[kDigestSize];
   memset(&digest1[0], 7, kDigestSize);
   ARROW_CHECK_OK(SendSealRequest(fd, object_id1, &digest1[0]));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaSealRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaSealRequest);
   ObjectID object_id2;
   unsigned char digest2[kDigestSize];
   ARROW_CHECK_OK(ReadSealRequest(data.data(), data.size(), &object_id2, &digest2[0]));
@@ -133,8 +133,8 @@ TEST(PlasmaSerialization, SealRequest) {
 TEST(PlasmaSerialization, SealReply) {
   int fd = create_temp_file();
   ObjectID object_id1 = ObjectID::from_random();
-  ARROW_CHECK_OK(SendSealReply(fd, object_id1, PlasmaError_ObjectExists));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaSealReply);
+  ARROW_CHECK_OK(SendSealReply(fd, object_id1, PlasmaError::ObjectExists));
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaSealReply);
   ObjectID object_id2;
   Status s = ReadSealReply(data.data(), data.size(), &object_id2);
   ASSERT_EQ(object_id1, object_id2);
@@ -149,7 +149,7 @@ TEST(PlasmaSerialization, GetRequest) {
   object_ids[1] = ObjectID::from_random();
   int64_t timeout_ms = 1234;
   ARROW_CHECK_OK(SendGetRequest(fd, object_ids, 2, timeout_ms));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaGetRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaGetRequest);
   std::vector<ObjectID> object_ids_return;
   int64_t timeout_ms_return;
   ARROW_CHECK_OK(
@@ -172,7 +172,7 @@ TEST(PlasmaSerialization, GetReply) {
   std::vector<int64_t> mmap_sizes = {100, 200, 300};
   ARROW_CHECK_OK(SendGetReply(fd, object_ids, plasma_objects, 2, store_fds, mmap_sizes));
 
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaGetReply);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaGetReply);
   ObjectID object_ids_return[2];
   PlasmaObject plasma_objects_return[2];
   std::vector<int> store_fds_return;
@@ -200,7 +200,7 @@ TEST(PlasmaSerialization, ReleaseRequest) {
   ObjectID object_id1 = ObjectID::from_random();
   ARROW_CHECK_OK(SendReleaseRequest(fd, object_id1));
   std::vector<uint8_t> data =
-      read_message_from_file(fd, MessageType_PlasmaReleaseRequest);
+      read_message_from_file(fd, MessageType::PlasmaReleaseRequest);
   ObjectID object_id2;
   ARROW_CHECK_OK(ReadReleaseRequest(data.data(), data.size(), &object_id2));
   ASSERT_EQ(object_id1, object_id2);
@@ -210,8 +210,8 @@ TEST(PlasmaSerialization, ReleaseRequest) {
 TEST(PlasmaSerialization, ReleaseReply) {
   int fd = create_temp_file();
   ObjectID object_id1 = ObjectID::from_random();
-  ARROW_CHECK_OK(SendReleaseReply(fd, object_id1, PlasmaError_ObjectExists));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaReleaseReply);
+  ARROW_CHECK_OK(SendReleaseReply(fd, object_id1, PlasmaError::ObjectExists));
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaReleaseReply);
   ObjectID object_id2;
   Status s = ReadReleaseReply(data.data(), data.size(), &object_id2);
   ASSERT_EQ(object_id1, object_id2);
@@ -223,7 +223,7 @@ TEST(PlasmaSerialization, DeleteRequest) {
   int fd = create_temp_file();
   ObjectID object_id1 = ObjectID::from_random();
   ARROW_CHECK_OK(SendDeleteRequest(fd, object_id1));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaDeleteRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaDeleteRequest);
   ObjectID object_id2;
   ARROW_CHECK_OK(ReadDeleteRequest(data.data(), data.size(), &object_id2));
   ASSERT_EQ(object_id1, object_id2);
@@ -233,9 +233,9 @@ TEST(PlasmaSerialization, DeleteRequest) {
 TEST(PlasmaSerialization, DeleteReply) {
   int fd = create_temp_file();
   ObjectID object_id1 = ObjectID::from_random();
-  int error1 = PlasmaError_ObjectExists;
+  PlasmaError error1 = PlasmaError::ObjectExists;
   ARROW_CHECK_OK(SendDeleteReply(fd, object_id1, error1));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaDeleteReply);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaDeleteReply);
   ObjectID object_id2;
   Status s = ReadDeleteReply(data.data(), data.size(), &object_id2);
   ASSERT_EQ(object_id1, object_id2);
@@ -250,7 +250,7 @@ TEST(PlasmaSerialization, StatusRequest) {
   object_ids[0] = ObjectID::from_random();
   object_ids[1] = ObjectID::from_random();
   ARROW_CHECK_OK(SendStatusRequest(fd, object_ids, num_objects));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaStatusRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaStatusRequest);
   ObjectID object_ids_read[num_objects];
   ARROW_CHECK_OK(
       ReadStatusRequest(data.data(), data.size(), object_ids_read, num_objects));
@@ -266,7 +266,7 @@ TEST(PlasmaSerialization, StatusReply) {
   object_ids[1] = ObjectID::from_random();
   int object_statuses[2] = {42, 43};
   ARROW_CHECK_OK(SendStatusReply(fd, object_ids, object_statuses, 2));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaStatusReply);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaStatusReply);
   int64_t num_objects = ReadStatusReply_num_objects(data.data(), data.size());
 
   std::vector<ObjectID> object_ids_read(num_objects);
@@ -284,7 +284,7 @@ TEST(PlasmaSerialization, EvictRequest) {
   int fd = create_temp_file();
   int64_t num_bytes = 111;
   ARROW_CHECK_OK(SendEvictRequest(fd, num_bytes));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaEvictRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaEvictRequest);
   int64_t num_bytes_received;
   ARROW_CHECK_OK(ReadEvictRequest(data.data(), data.size(), &num_bytes_received));
   ASSERT_EQ(num_bytes, num_bytes_received);
@@ -295,7 +295,7 @@ TEST(PlasmaSerialization, EvictReply) {
   int fd = create_temp_file();
   int64_t num_bytes = 111;
   ARROW_CHECK_OK(SendEvictReply(fd, num_bytes));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaEvictReply);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaEvictReply);
   int64_t num_bytes_received;
   ARROW_CHECK_OK(ReadEvictReply(data.data(), data.size(), num_bytes_received));
   ASSERT_EQ(num_bytes, num_bytes_received);
@@ -308,7 +308,7 @@ TEST(PlasmaSerialization, FetchRequest) {
   object_ids[0] = ObjectID::from_random();
   object_ids[1] = ObjectID::from_random();
   ARROW_CHECK_OK(SendFetchRequest(fd, object_ids, 2));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaFetchRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaFetchRequest);
   std::vector<ObjectID> object_ids_read;
   ARROW_CHECK_OK(ReadFetchRequest(data.data(), data.size(), object_ids_read));
   ASSERT_EQ(object_ids[0], object_ids_read[0]);
@@ -320,15 +320,15 @@ TEST(PlasmaSerialization, WaitRequest) {
   int fd = create_temp_file();
   const int num_objects_in = 2;
   ObjectRequest object_requests_in[num_objects_in] = {
-      ObjectRequest({ObjectID::from_random(), PLASMA_QUERY_ANYWHERE, 0}),
-      ObjectRequest({ObjectID::from_random(), PLASMA_QUERY_LOCAL, 0})};
+      ObjectRequest({ObjectID::from_random(), PLASMA_QUERY_ANYWHERE, ObjectStatus::Local}),
+      ObjectRequest({ObjectID::from_random(), PLASMA_QUERY_LOCAL, ObjectStatus::Local})};
   const int num_ready_objects_in = 1;
   int64_t timeout_ms = 1000;
 
   ARROW_CHECK_OK(SendWaitRequest(fd, &object_requests_in[0], num_objects_in,
                                  num_ready_objects_in, timeout_ms));
   /* Read message back. */
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaWaitRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaWaitRequest);
   int num_ready_objects_out;
   int64_t timeout_ms_read;
   ObjectRequestMap object_requests_out;
@@ -353,13 +353,13 @@ TEST(PlasmaSerialization, WaitReply) {
   /* Create a map with two ObjectRequests in it. */
   ObjectRequestMap objects_in(num_objects_in);
   ObjectID id1 = ObjectID::from_random();
-  objects_in[id1] = ObjectRequest({id1, 0, ObjectStatus_Local});
+  objects_in[id1] = ObjectRequest({id1, 0, ObjectStatus::Local});
   ObjectID id2 = ObjectID::from_random();
-  objects_in[id2] = ObjectRequest({id2, 0, ObjectStatus_Nonexistent});
+  objects_in[id2] = ObjectRequest({id2, 0, ObjectStatus::Nonexistent});
 
   ARROW_CHECK_OK(SendWaitReply(fd, objects_in, num_objects_in));
   /* Read message back. */
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaWaitReply);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaWaitReply);
   ObjectRequest objects_out[2];
   int num_objects_out;
   ARROW_CHECK_OK(
@@ -383,7 +383,7 @@ TEST(PlasmaSerialization, DataRequest) {
   int port1 = 12345;
   ARROW_CHECK_OK(SendDataRequest(fd, object_id1, address1, port1));
   /* Reading message back. */
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaDataRequest);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaDataRequest);
   ObjectID object_id2;
   char* address2;
   int port2;
@@ -403,7 +403,7 @@ TEST(PlasmaSerialization, DataReply) {
   int64_t metadata_size1 = 198;
   ARROW_CHECK_OK(SendDataReply(fd, object_id1, object_size1, metadata_size1));
   /* Reading message back. */
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType_PlasmaDataReply);
+  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaDataReply);
   ObjectID object_id2;
   int64_t object_size2;
   int64_t metadata_size2;

--- a/cpp/src/plasma/test/serialization_tests.cc
+++ b/cpp/src/plasma/test/serialization_tests.cc
@@ -80,7 +80,8 @@ TEST(PlasmaSerialization, CreateRequest) {
   int device_num1 = 0;
   ARROW_CHECK_OK(
       SendCreateRequest(fd, object_id1, data_size1, metadata_size1, device_num1));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaCreateRequest);
+  std::vector<uint8_t> data =
+      read_message_from_file(fd, MessageType::PlasmaCreateRequest);
   ObjectID object_id2;
   int64_t data_size2;
   int64_t metadata_size2;
@@ -223,7 +224,8 @@ TEST(PlasmaSerialization, DeleteRequest) {
   int fd = create_temp_file();
   ObjectID object_id1 = ObjectID::from_random();
   ARROW_CHECK_OK(SendDeleteRequest(fd, object_id1));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaDeleteRequest);
+  std::vector<uint8_t> data =
+      read_message_from_file(fd, MessageType::PlasmaDeleteRequest);
   ObjectID object_id2;
   ARROW_CHECK_OK(ReadDeleteRequest(data.data(), data.size(), &object_id2));
   ASSERT_EQ(object_id1, object_id2);
@@ -250,7 +252,8 @@ TEST(PlasmaSerialization, StatusRequest) {
   object_ids[0] = ObjectID::from_random();
   object_ids[1] = ObjectID::from_random();
   ARROW_CHECK_OK(SendStatusRequest(fd, object_ids, num_objects));
-  std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaStatusRequest);
+  std::vector<uint8_t> data =
+      read_message_from_file(fd, MessageType::PlasmaStatusRequest);
   ObjectID object_ids_read[num_objects];
   ARROW_CHECK_OK(
       ReadStatusRequest(data.data(), data.size(), object_ids_read, num_objects));
@@ -320,8 +323,10 @@ TEST(PlasmaSerialization, WaitRequest) {
   int fd = create_temp_file();
   const int num_objects_in = 2;
   ObjectRequest object_requests_in[num_objects_in] = {
-      ObjectRequest({ObjectID::from_random(), PLASMA_QUERY_ANYWHERE, ObjectStatus::Local}),
-      ObjectRequest({ObjectID::from_random(), PLASMA_QUERY_LOCAL, ObjectStatus::Local})};
+      ObjectRequest({ObjectID::from_random(), ObjectRequestType::PLASMA_QUERY_ANYWHERE,
+                     ObjectStatus::Local}),
+      ObjectRequest({ObjectID::from_random(), ObjectRequestType::PLASMA_QUERY_LOCAL,
+                     ObjectStatus::Local})};
   const int num_ready_objects_in = 1;
   int64_t timeout_ms = 1000;
 
@@ -353,9 +358,11 @@ TEST(PlasmaSerialization, WaitReply) {
   /* Create a map with two ObjectRequests in it. */
   ObjectRequestMap objects_in(num_objects_in);
   ObjectID id1 = ObjectID::from_random();
-  objects_in[id1] = ObjectRequest({id1, 0, ObjectStatus::Local});
+  objects_in[id1] =
+      ObjectRequest({id1, ObjectRequestType::PLASMA_QUERY_LOCAL, ObjectStatus::Local});
   ObjectID id2 = ObjectID::from_random();
-  objects_in[id2] = ObjectRequest({id2, 0, ObjectStatus::Nonexistent});
+  objects_in[id2] = ObjectRequest(
+      {id2, ObjectRequestType::PLASMA_QUERY_LOCAL, ObjectStatus::Nonexistent});
 
   ARROW_CHECK_OK(SendWaitReply(fd, objects_in, num_objects_in));
   /* Read message back. */

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -63,8 +63,8 @@ cdef extern from "plasma/common.h":
     cdef int64_t kDigestSize" plasma::kDigestSize"
 
     cdef enum ObjectRequestType:
-        PLASMA_QUERY_LOCAL"plasma::PLASMA_QUERY_LOCAL",
-        PLASMA_QUERY_ANYWHERE"plasma::PLASMA_QUERY_ANYWHERE"
+        PLASMA_QUERY_LOCAL"plasma::ObjectRequestType::PLASMA_QUERY_LOCAL",
+        PLASMA_QUERY_ANYWHERE"plasma::ObjectRequestType::PLASMA_QUERY_ANYWHERE"
 
     cdef int ObjectStatusLocal"plasma::ObjectStatusLocal"
     cdef int ObjectStatusRemote"plasma::ObjectStatusRemote"


### PR DESCRIPTION
In this PR there are following changes:
1. add option "--scoped-enum" to Flat Buffer Compiler.
2. change the old-styled c++ enum to c++11 style. 

This change will unify the enum style in both Plasma and Ray. See Ray [Issue2121](https://github.com/ray-project/ray/issues/2121) and Ray [PR2194](https://github.com/ray-project/ray/pull/2194).