### PR TITLE
ARROW-2683: [Python] Resource Warning (Unclosed File) when using pyarrow.parquet.read_table()

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1191,20 +1191,6 @@ def read_schema(where):
     return ParquetFile(where).schema.to_arrow_schema()
 
 
-def _ensure_file(source):
-    if is_path(source):
-        fs = _get_fs_from_path(source)
-        try:
-            return fs.open(source)
-        except IOError as e:
-            raise lib.ArrowIOError("failed to open file {}, {}"
-                                   .format(source, e))
-    elif not hasattr(source, 'seek'):
-        raise ValueError('Source does not appear file-like')
-    else:
-        return source
-
-
 def _get_fs_from_path(path):
     """
     return filesystem from path which could be an HDFS URI

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1631,6 +1631,18 @@ def test_read_non_existent_file(tmpdir):
         assert path in e.args[0]
 
 
+@parquet
+def test_read_table_doesnt_warn():
+    import pyarrow.parquet as pq
+
+    path = os.path.join(os.path.dirname(__file__), 'data', 'v0.7.1.parquet')
+
+    with pytest.warns(None) as record:
+        pq.read_table(path)
+
+    assert len(record) == 0
+
+
 def _test_write_to_dataset_with_partitions(base_path, filesystem=None):
     # ARROW-1400
     import pyarrow.parquet as pq


### PR DESCRIPTION
@pitrou has already removed [_ensure_file](https://github.com/apache/arrow/commit/f177404a25e4e79ad52ed4f9792f42595a65109e#diff-211255c3faff2b62de57e1dca9f60e13L63) which caused the `ResourceWarning`. 

However [ParquetFileReader](https://github.com/apache/parquet-cpp/blob/master/src/parquet/file_reader.cc#L227) is closed on destruction (which is triggered when `_parquet.ParquetReader` gets deallocated), it might be better to be explicit on python side.