### PR TITLE
ARROW-2749: [GLib] Rename *garrow_decimal128_array_get_value to *garrow_decimal128_array_format_value

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -2139,17 +2139,20 @@ garrow_decimal128_array_class_init(GArrowDecimal128ArrayClass *klass)
 }
 
 /**
- * garrow_decimal128_array_get_value:
+ * garrow_decimal128_array_format_value:
  * @array: A #GArrowDecimal128Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The formatted i-th value.
+ *
+ * The returned string should be freed with g_free() when no longer
+ * needed.
  *
  * Since: 0.10.0
  */
 gchar *
-garrow_decimal128_array_get_value(GArrowDecimal128Array *array,
-                                  gint64 i)
+garrow_decimal128_array_format_value(GArrowDecimal128Array *array,
+                                     gint64 i)
 {
   auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
   auto arrow_decimal128_array =

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -654,7 +654,7 @@ struct _GArrowDecimal128ArrayClass
   GArrowFixedSizeBinaryArrayClass parent_class;
 };
 
-gchar *garrow_decimal128_array_get_value(GArrowDecimal128Array *array,
-                                         gint64 i);
+gchar *garrow_decimal128_array_format_value(GArrowDecimal128Array *array,
+                                            gint64 i);
 
 G_END_DECLS

--- a/c_glib/test/test-decimal-array.rb
+++ b/c_glib/test/test-decimal-array.rb
@@ -22,6 +22,6 @@ class TestDecimalArray < Test::Unit::TestCase
     decimal = Arrow::Decimal128.new("23423445")
     builder.append(decimal)
     array = builder.finish
-    assert_equal("234234.45", array.get_value(0))
+    assert_equal("234234.45", array.format_value(0))
   end
 end


### PR DESCRIPTION
Because the current `get_value` function returns the formatted value.