### PR TITLE
ARROW-2743: [Java] Change CI script to remove project artifacts before building

### DIFF
--- a/ci/travis_script_java.sh
+++ b/ci/travis_script_java.sh
@@ -24,6 +24,6 @@ JAVA_DIR=${TRAVIS_BUILD_DIR}/java
 pushd $JAVA_DIR
 
 export MAVEN_OPTS="$MAVEN_OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
-mvn -B install
+mvn -B install build-helper:remove-project-artifact -Dbuildhelper.failOnError=false
 
 popd

--- a/ci/travis_script_java.sh
+++ b/ci/travis_script_java.sh
@@ -23,6 +23,12 @@ JAVA_DIR=${TRAVIS_BUILD_DIR}/java
 
 pushd $JAVA_DIR
 
+echo "finding arrow in repo"
+find /home/travis/.m2/repository/org/apache/arrow/
+echo "finding all in repo"
+find /home/travis/.m2/repository/
+echo "done"
+
 export MAVEN_OPTS="$MAVEN_OPTS -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
 mvn -B install build-helper:remove-project-artifact -Dbuildhelper.failOnError=false
 

--- a/ci/travis_script_java.sh
+++ b/ci/travis_script_java.sh
@@ -23,8 +23,6 @@ JAVA_DIR=${TRAVIS_BUILD_DIR}/java
 
 pushd $JAVA_DIR
 
-echo "finding arrow in repo"
-find /home/travis/.m2/repository/org/apache/arrow/
 echo "finding all in repo"
 find /home/travis/.m2/repository/
 echo "done"

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -17,6 +17,7 @@
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
         <version>0.10.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>arrow-jdbc</artifactId>

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -17,7 +17,6 @@
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-java-root</artifactId>
         <version>0.10.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>arrow-jdbc</artifactId>


### PR DESCRIPTION
This adds a command to the Java CI script to remove project artifacts, of the current version, from the local Maven repo prior to building.  This is to catch a potential issue where the build might use parent poms from the local repo instead of in the current project. 

The history of this issue is ARROW-1780 added a child pom 2 levels deep that used the arrow-java-root as parent but did not specify the parent path.  The build was able to pass because it found the parent pom in the local repo, but should have been using the one from the project.  Bug ARROW-2727 was reported because when trying a clean build without the parent pom in the repo, the build will fail.  This was resolved by specifying the correct parent relative path.