### PR TITLE
ARROW-2771: [JS] Add row proxy object accessor

### DIFF
--- a/js/src/ipc/writer/binary.ts
+++ b/js/src/ipc/writer/binary.ts
@@ -82,7 +82,7 @@ export function* serializeFile(table: Table) {
     // Then yield the footer metadata (not aligned)
     ({ metadataLength, buffer } = serializeFooter(new Footer(dictionaryBatches, recordBatches, table.schema)));
     yield buffer;
-    
+
     // Last, yield the footer length + terminating magic arrow string (aligned)
     buffer = new Uint8Array(magicAndPadding);
     new DataView(buffer.buffer).setInt32(0, metadataLength, platformIsLittleEndian);

--- a/js/src/util/node.ts
+++ b/js/src/util/node.ts
@@ -21,10 +21,10 @@ export class PipeIterator<T> implements IterableIterator<T> {
         let write = (err?: any) => {
             stream['removeListener']('error', write);
             stream['removeListener']('drain', write);
-            if (err) return this.throw(err);
+            if (err) { return this.throw(err); }
             if (stream['writable']) {
                 do {
-                    if ((res = this.next()).done) break;
+                    if ((res = this.next()).done) { break; }
                 } while (emit(stream, encoding, res.value));
             }
             return wait(stream, res && res.done, write);
@@ -56,10 +56,10 @@ export class AsyncPipeIterator<T> implements AsyncIterableIterator<T> {
         let write = async (err?: any) => {
             stream['removeListener']('error', write);
             stream['removeListener']('drain', write);
-            if (err) return this.throw(err);
+            if (err) { return this.throw(err); }
             if (stream['writable']) {
                 do {
-                    if ((res = await this.next()).done) break;
+                    if ((res = await this.next()).done) { break; }
                 } while (emit(stream, encoding, res.value));
             }
             return wait(stream, res && res.done, write);

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -86,13 +86,20 @@ describe(`Table`, () => {
             });
             test(`gets expected values`, () => {
                 for (let i = -1; ++i < values.length;) {
-                    expect(table.get(i).toArray()).toEqual(values[i]);
+                    const row = table.get(i);
+                    const expected = values[i];
+                    expect(row.f32).toEqual(expected[F32]);
+                    expect(row.i32).toEqual(expected[I32]);
+                    expect(row.dictionary).toEqual(expected[DICT]);
                 }
             });
             test(`iterates expected values`, () => {
                 let i = 0;
                 for (let row of table) {
-                    expect(row.toArray()).toEqual(values[i++]);
+                    const expected = values[i++];
+                    expect(row.f32).toEqual(expected[F32]);
+                    expect(row.i32).toEqual(expected[I32]);
+                    expect(row.dictionary).toEqual(expected[DICT]);
                 }
             });
             describe(`scan()`, () => {
@@ -252,8 +259,8 @@ describe(`Table`, () => {
                 let idx = 0, expected_row;
                 for (let row of selected) {
                     expected_row = values[idx++];
-                    expect(row.get(0)).toEqual(expected_row[F32]);
-                    expect(row.get(1)).toEqual(expected_row[DICT]);
+                    expect(row.f32).toEqual(expected_row[F32]);
+                    expect(row.dictionary).toEqual(expected_row[DICT]);
                 }
             });
             test(`table.toString()`, () => {


### PR DESCRIPTION
Creates a custom `RowProxy` class based on the schema whenever a new `Table` is constructed, and yields instances of it in `get` and the iterator.

Now you could use the following code to compute the mean of the `score` column for all rows where `name === target`.

``` javascript
let sum = 0, count = 0;
for (let row of table) {
    if (row.name === target) {
        sum += row.score;
        count += 1;
    }
}
return sum/count;
```