### PR TITLE
[Help needed] Implement thread pool with pthreads

### DIFF
--- a/cpp/src/arrow/util/thread-pool.h
+++ b/cpp/src/arrow/util/thread-pool.h
@@ -18,15 +18,12 @@
 #ifndef ARROW_UTIL_THREAD_POOL_H
 #define ARROW_UTIL_THREAD_POOL_H
 
-#include <condition_variable>
 #include <deque>
 #include <exception>
 #include <functional>
 #include <future>
 #include <list>
 #include <memory>
-#include <mutex>
-#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -128,6 +125,7 @@ class ARROW_EXPORT ThreadPool {
   friend ARROW_EXPORT ThreadPool* GetCpuThreadPool();
 
   struct State;
+  class Thread;
 
   ThreadPool();
 
@@ -144,7 +142,7 @@ class ARROW_EXPORT ThreadPool {
   // The worker loop is a static method so that it can keep running
   // after the ThreadPool is destroyed
   static void WorkerLoop(std::shared_ptr<State> state,
-                         std::list<std::thread>::iterator it);
+                         std::list<Thread>::iterator it);
 
   static std::shared_ptr<ThreadPool> MakeCpuThreadPool();
 


### PR DESCRIPTION
In an attempt to fix https://github.com/apache/arrow/pull/2096, I'm trying to get rid of std::thread and replace it with pthreads.

However I have a hard time getting it working. There seems to be some nondeterminism here, one of the errors is this:

```
Philipps-MacBook-Pro:build pcmoritz$ lldb -- ./debug/thread-pool-test 
(lldb) target create "./debug/thread-pool-test"
Current executable set to './debug/thread-pool-test' (x86_64).
(lldb) r
Process 5283 launched: './debug/thread-pool-test' (x86_64)
Running main() from gtest_main.cc
[==========] Running 11 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 10 tests from TestThreadPool
[ RUN      ] TestThreadPool.ConstructDestruct
Process 5283 stopped
* thread #2, stop reason = EXC_BAD_ACCESS (code=1, address=0x20)
    frame #0: 0x000000010001cc72 thread-pool-test`std::__1::function<void ()>::~function(this=0x0000000100700050) at functional:1871
   1868	function<_Rp(_ArgTypes...)>::~function()
   1869	{
   1870	    if ((void *)__f_ == &__buf_)
-> 1871	        __f_->destroy();
   1872	    else if (__f_)
   1873	        __f_->destroy_deallocate();
   1874	}
  thread #3, stop reason = EXC_BAD_ACCESS (code=1, address=0x24)
    frame #0: 0x000000010001cc72 thread-pool-test`std::__1::function<void ()>::~function(this=0x00000001007001f0) at functional:1871
   1868	function<_Rp(_ArgTypes...)>::~function()
   1869	{
   1870	    if ((void *)__f_ == &__buf_)
-> 1871	        __f_->destroy();
   1872	    else if (__f_)
   1873	        __f_->destroy_deallocate();
   1874	}
  thread #4, stop reason = EXC_BAD_ACCESS (code=1, address=0x24)
    frame #0: 0x000000010001cc72 thread-pool-test`std::__1::function<void ()>::~function(this=0x0000000100700430) at functional:1871
   1868	function<_Rp(_ArgTypes...)>::~function()
   1869	{
   1870	    if ((void *)__f_ == &__buf_)
-> 1871	        __f_->destroy();
   1872	    else if (__f_)
   1873	        __f_->destroy_deallocate();
   1874	}
Target 0: (thread-pool-test) stopped.
```

But I've also seen free corruption errors from malloc. Any help is appreciated (who is familiar with pthreads?).

@pitrou @wesm @robertnishihara 