### PR TITLE
ARROW-2701: [C++] Make MemoryMappedFile resizable redux

### DIFF
--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -195,19 +195,26 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
   // Required by RandomAccessFile, copies memory into out. Not thread-safe
   Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
 
-  // Zero copy read. Not thread-safe
+  // Zero copy read, moves position pointer. Not thread-safe
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
+  // Zero-copy read, leaves position unchanged. Acquires a reader lock
+  // for the duration of slice creation (typically very short). Is thread-safe.
+  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+
+  // Raw copy of the memory at specified position. Thread-safe, but
+  // locks out other readers for the duration of memcpy. Prefer the
+  // zero copy method
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                 void* out) override;
-
-  /// Default implementation is thread-safe
-  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   bool supports_zero_copy() const override;
 
   /// Write data at the current position in the file. Thread-safe
   Status Write(const void* data, int64_t nbytes) override;
+
+  /// Set the size of the map to new_size.
+  Status Resize(int64_t new_size);
 
   /// Write data at a particular position in the file. Thread-safe
   Status WriteAt(int64_t position, const void* data, int64_t nbytes) override;

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -614,6 +614,199 @@ TEST_F(TestMemoryMappedFile, WriteRead) {
   }
 }
 
+TEST_F(TestMemoryMappedFile, WriteResizeRead) {
+  const int64_t buffer_size = 1024;
+  const int reps = 5;
+  std::vector<std::vector<uint8_t>> buffers(reps);
+  for (auto& b : buffers) {
+    b.resize(buffer_size);
+    test::random_bytes(buffer_size, 0, b.data());
+  }
+
+  std::string path = "io-memory-map-write-read-test";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(buffer_size, path, &result));
+
+  int64_t position = 0;
+  std::shared_ptr<Buffer> out_buffer;
+  for (int i = 0; i < reps; ++i) {
+    if (i != 0) {
+      ASSERT_OK(result->Resize(buffer_size * (i + 1)));
+    }
+    ASSERT_OK(result->Write(buffers[i].data(), buffer_size));
+    ASSERT_OK(result->ReadAt(position, buffer_size, &out_buffer));
+
+    ASSERT_EQ(out_buffer->size(), buffer_size);
+    ASSERT_EQ(0, memcmp(out_buffer->data(), buffers[i].data(), buffer_size));
+    out_buffer.reset();
+
+    position += buffer_size;
+  }
+}
+
+TEST_F(TestMemoryMappedFile, ResizeRaisesOnExported) {
+  const int64_t buffer_size = 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  test::random_bytes(buffer_size, 0, buffer.data());
+
+  std::string path = "io-memory-map-write-read-test";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(buffer_size, path, &result));
+
+  std::shared_ptr<Buffer> out_buffer1, out_buffer2;
+  ASSERT_OK(result->Write(buffer.data(), buffer_size));
+  ASSERT_OK(result->ReadAt(0, buffer_size, &out_buffer1));
+  ASSERT_OK(result->ReadAt(0, buffer_size, &out_buffer2));
+  ASSERT_EQ(0, memcmp(out_buffer1->data(), buffer.data(), buffer_size));
+  ASSERT_EQ(0, memcmp(out_buffer2->data(), buffer.data(), buffer_size));
+
+  // attempt resize
+  ASSERT_RAISES(IOError, result->Resize(2 * buffer_size));
+
+  out_buffer1.reset();
+
+  ASSERT_RAISES(IOError, result->Resize(2 * buffer_size));
+
+  out_buffer2.reset();
+
+  ASSERT_OK(result->Resize(2 * buffer_size));
+
+  int64_t map_size;
+  ASSERT_OK(result->GetSize(&map_size));
+  ASSERT_EQ(map_size, 2 * buffer_size);
+
+  int64_t file_size;
+  ASSERT_OK(internal::FileGetSize(result->file_descriptor(), &file_size));
+  ASSERT_EQ(file_size, buffer_size * 2);
+}
+
+TEST_F(TestMemoryMappedFile, WriteReadZeroInitSize) {
+  const int64_t buffer_size = 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  test::random_bytes(buffer_size, 0, buffer.data());
+
+  std::string path = "io-memory-map-write-read-test";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(0, path, &result));
+
+  std::shared_ptr<Buffer> out_buffer;
+  ASSERT_OK(result->Resize(buffer_size));
+  ASSERT_OK(result->Write(buffer.data(), buffer_size));
+  ASSERT_OK(result->ReadAt(0, buffer_size, &out_buffer));
+  ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size));
+
+  int64_t map_size;
+  ASSERT_OK(result->GetSize(&map_size));
+  ASSERT_EQ(map_size, buffer_size);
+}
+
+TEST_F(TestMemoryMappedFile, WriteThenShrink) {
+  const int64_t buffer_size = 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  test::random_bytes(buffer_size, 0, buffer.data());
+
+  std::string path = "io-memory-map-write-read-test";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(buffer_size * 2, path, &result));
+
+  std::shared_ptr<Buffer> out_buffer;
+  ASSERT_OK(result->Resize(buffer_size));
+  ASSERT_OK(result->Write(buffer.data(), buffer_size));
+  ASSERT_OK(result->Resize(buffer_size / 2));
+
+  ASSERT_OK(result->ReadAt(0, buffer_size / 2, &out_buffer));
+  ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size / 2));
+
+  int64_t map_size;
+  ASSERT_OK(result->GetSize(&map_size));
+  ASSERT_EQ(map_size, buffer_size / 2);
+
+  int64_t file_size;
+  ASSERT_OK(internal::FileGetSize(result->file_descriptor(), &file_size));
+  ASSERT_EQ(file_size, buffer_size / 2);
+}
+
+TEST_F(TestMemoryMappedFile, WriteThenShrinkToHalfThenWrite) {
+  const int64_t buffer_size = 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  test::random_bytes(buffer_size, 0, buffer.data());
+
+  std::string path = "io-memory-map-write-read-test";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(buffer_size, path, &result));
+
+  std::shared_ptr<Buffer> out_buffer;
+  ASSERT_OK(result->Write(buffer.data(), buffer_size));
+  ASSERT_OK(result->Resize(buffer_size / 2));
+
+  int64_t position;
+  ASSERT_OK(result->Tell(&position));
+  ASSERT_EQ(position, buffer_size / 2);
+
+  ASSERT_OK(result->ReadAt(0, buffer_size / 2, &out_buffer));
+  ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size / 2));
+  out_buffer.reset();
+
+  // should resume writing directly at the seam
+  ASSERT_OK(result->Resize(buffer_size));
+  ASSERT_OK(result->Write(buffer.data() + buffer_size / 2, buffer_size / 2));
+
+  ASSERT_OK(result->ReadAt(0, buffer_size, &out_buffer));
+  ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size));
+
+  int64_t map_size;
+  ASSERT_OK(result->GetSize(&map_size));
+  ASSERT_EQ(map_size, buffer_size);
+
+  int64_t file_size;
+  ASSERT_OK(internal::FileGetSize(result->file_descriptor(), &file_size));
+  ASSERT_EQ(file_size, buffer_size);
+}
+
+TEST_F(TestMemoryMappedFile, ResizeToZeroThanWrite) {
+  const int64_t buffer_size = 1024;
+  std::vector<uint8_t> buffer(buffer_size);
+  test::random_bytes(buffer_size, 0, buffer.data());
+
+  std::string path = "io-memory-map-write-read-test";
+  std::shared_ptr<MemoryMappedFile> result;
+  ASSERT_OK(InitMemoryMap(buffer_size, path, &result));
+
+  std::shared_ptr<Buffer> out_buffer;
+  // just a sanity check that writing works ook
+  ASSERT_OK(result->Write(buffer.data(), buffer_size));
+  ASSERT_OK(result->ReadAt(0, buffer_size, &out_buffer));
+  ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size));
+  out_buffer.reset();
+
+  ASSERT_OK(result->Resize(0));
+  int64_t mapped_size;
+  ASSERT_OK(result->GetSize(&mapped_size));
+  ASSERT_EQ(mapped_size, 0);
+
+  int64_t position;
+  ASSERT_OK(result->Tell(&position));
+  ASSERT_EQ(position, 0);
+
+  int64_t file_size;
+  ASSERT_OK(internal::FileGetSize(result->file_descriptor(), &file_size));
+  ASSERT_EQ(file_size, 0);
+
+  // provision a vector to the buffer size in case ReadAt decides
+  // to read even though it shouldn't
+  std::vector<uint8_t> should_remain_empty(buffer_size);
+  int64_t bytes_read;
+  ASSERT_OK(result->ReadAt(0, 1, &bytes_read,
+                           reinterpret_cast<void*>(should_remain_empty.data())));
+  ASSERT_EQ(bytes_read, 0);
+
+  // just a sanity check that writing works ook
+  ASSERT_OK(result->Resize(buffer_size));
+  ASSERT_OK(result->Write(buffer.data(), buffer_size));
+  ASSERT_OK(result->ReadAt(0, buffer_size, &out_buffer));
+  ASSERT_EQ(0, memcmp(out_buffer->data(), buffer.data(), buffer_size));
+}
+
 TEST_F(TestMemoryMappedFile, WriteAt) {
   const int64_t buffer_size = 1024;
   std::vector<uint8_t> buffer(buffer_size);

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -164,6 +164,9 @@ Status FileClose(int fd);
 
 Status CreatePipe(int fd[2]);
 
+Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
+                      void** new_addr);
+
 Status GetEnvVar(const char* name, std::string* out);
 Status GetEnvVar(const std::string& name, std::string* out);
 Status SetEnvVar(const char* name, const char* value);

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -661,6 +661,8 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         CStatus Open(const c_string& path, FileMode mode,
                      shared_ptr[CMemoryMappedFile]* file)
 
+        CStatus Resize(int64_t size)
+
         int file_descriptor()
 
     # ----------------------------------------------------------------------

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -548,6 +548,7 @@ cdef class MemoryMappedFile(NativeFile):
     Supports 'r', 'r+w', 'w' modes
     """
     cdef:
+        shared_ptr[CMemoryMappedFile] handle
         object path
 
     @staticmethod
@@ -566,6 +567,7 @@ cdef class MemoryMappedFile(NativeFile):
         result.is_writable = True
         result.wr_file = <shared_ptr[OutputStream]> handle
         result.rd_file = <shared_ptr[RandomAccessFile]> handle
+        result.handle = handle
         result.closed = False
 
         return result
@@ -596,7 +598,18 @@ cdef class MemoryMappedFile(NativeFile):
 
         self.wr_file = <shared_ptr[OutputStream]> handle
         self.rd_file = <shared_ptr[RandomAccessFile]> handle
+        self.handle = handle
         self.closed = False
+
+    def resize(self, new_size):
+        """
+        Resize the map and underlying file.
+
+        Parameters
+        ----------
+        new_size : new size in bytes
+        """
+        check_status(self.handle.get().Resize(new_size))
 
     def fileno(self):
         self._assert_open()

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -759,6 +759,26 @@ def test_memory_map_writer(tmpdir):
     assert f.read(3) == b'foo'
 
 
+def test_memory_map_resize(tmpdir):
+    SIZE = 4096
+    arr = np.random.randint(0, 256, size=SIZE).astype(np.uint8)
+    data1 = arr.tobytes()[:(SIZE // 2)]
+    data2 = arr.tobytes()[(SIZE // 2):]
+
+    path = os.path.join(str(tmpdir), guid())
+
+    mmap = pa.create_memory_map(path, SIZE / 2)
+    mmap.write(data1)
+
+    mmap.resize(SIZE)
+    mmap.write(data2)
+
+    mmap.close()
+
+    with open(path, 'rb') as f:
+        assert f.read() == arr.tobytes()
+
+
 def test_memory_zero_length(tmpdir):
     path = os.path.join(str(tmpdir), guid())
     f = open(path, 'wb')


### PR DESCRIPTION
This is an adjusted version of the [previous PR](https://github.com/apache/arrow/pull/2134).

The following problems were addressed:

* `MemoryMap` doesn't differentiate between `size_` and `capacity_` or `Resize` and `Reserve`. I still keep them, so I can inherit from `ResizableBuffer` to show the intent, but it might as well be changed back to `MutableBuffer` with a generic `Resize` method with a cleaner signature

* Before resizing, I acquire the `resize_lock` and check the `use_count` of the `MemoryMap`. If there are active slices, meaning readers holding a reference to this map, the resizing fails. 

* For this to work, the readers have to acquire the same lock, or else they can change the `use_count` while we aren't looking. This means, that the readers can't create slices concurrently, which may not be as bad, since slicing doesn't block that long, but it's not nice. It's worse for the `memcpy`ing `ReadAt`. A `shared_mutex` would solve this problem.

* I removed any automatic resizing

* 1ba892 fixes a bug, where you could write past the end using `WriteAt`. I can open a separate PR for it

As I said, I'm not very happy with the implementation, but it works and seems safe to me. 