### PR TITLE
ARROW-2789: [JS] Add iterator to DataFrame

### DIFF
--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -29,7 +29,7 @@ export type NextFunc = (idx: number, batch: RecordBatch) => void;
 export type BindFunc = (batch: RecordBatch) => void;
 
 export interface DataFrame {
-    readonly length: number;
+    count(): number;
     filter(predicate: Predicate): DataFrame;
     scan(next: NextFunc, bind?: BindFunc): void;
     countBy(col: (Col|string)): CountByResult;
@@ -171,6 +171,9 @@ export class Table implements DataFrame {
         }
         return new CountByResult(vector.dictionary, IntVector.from(counts));
     }
+    public count(): number {
+        return this.length;
+    }
     public select(...columnNames: string[]) {
         return new Table(this.batches.map((batch) => batch.select(...columnNames)));
     }
@@ -218,7 +221,7 @@ class FilteredDataFrame implements DataFrame {
             }
         }
     }
-    public get length(): number {
+    public count(): number {
         // inlined version of this:
         // let sum = 0;
         // this.parent.scan((idx, columns) => {

--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -29,10 +29,11 @@ export type NextFunc = (idx: number, batch: RecordBatch) => void;
 export type BindFunc = (batch: RecordBatch) => void;
 
 export interface DataFrame {
+    readonly length: number;
     filter(predicate: Predicate): DataFrame;
     scan(next: NextFunc, bind?: BindFunc): void;
-    count(): number;
     countBy(col: (Col|string)): CountByResult;
+    [Symbol.iterator](): IterableIterator<Struct['TValue']>;
 }
 
 export class Table implements DataFrame {
@@ -143,7 +144,6 @@ export class Table implements DataFrame {
             }
         }
     }
-    public count(): number { return this.length; }
     public countBy(name: Col | string): CountByResult {
         const batches = this.batches, numBatches = batches.length;
         const count_by = typeof name === 'string' ? new Col(name) : name;
@@ -218,7 +218,7 @@ class FilteredDataFrame implements DataFrame {
             }
         }
     }
-    public count(): number {
+    public get length(): number {
         // inlined version of this:
         // let sum = 0;
         // this.parent.scan((idx, columns) => {
@@ -238,6 +238,26 @@ class FilteredDataFrame implements DataFrame {
             }
         }
         return sum;
+    }
+    public *[Symbol.iterator](): IterableIterator<Struct['TValue']> {
+        // inlined version of this:
+        // this.parent.scan((idx, columns) => {
+        //     if (this.predicate(idx, columns)) next(idx, columns);
+        // });
+        const batches = this.batches;
+        const numBatches = batches.length;
+        for (let batchIndex = -1; ++batchIndex < numBatches;) {
+            // load batches
+            const batch = batches[batchIndex];
+            // TODO: bind batches lazily
+            // If predicate doesn't match anything in the batch we don't need
+            // to bind the callback
+            const predicate = this.predicate.bind(batch);
+            // yield all indices
+            for (let index = -1, numRows = batch.length; ++index < numRows;) {
+                if (predicate(index, batch)) { yield batch.get(index) as any; }
+            }
+        }
     }
     public filter(predicate: Predicate): DataFrame {
         return new FilteredDataFrame(

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -111,8 +111,8 @@ describe(`Table`, () => {
                     }
                 });
             });
-            test(`count() returns the correct length`, () => {
-                expect(table.count()).toEqual(values.length);
+            test(`length getter returns the correct length`, () => {
+                expect(table.length).toEqual(values.length);
             });
             test(`getColumnIndex`, () => {
                 expect(table.getColumnIndex('i32')).toEqual(I32);
@@ -191,8 +191,8 @@ describe(`Table`, () => {
             for (let this_test of filter_tests) {
                 const { name, filtered, expected } = this_test;
                 describe(name, () => {
-                    test(`count() returns the correct length`, () => {
-                        expect(filtered.count()).toEqual(expected.length);
+                    test(`length getter returns the correct length`, () => {
+                        expect(filtered.length).toEqual(expected.length);
                     });
                     describe(`scan()`, () => {
                         test(`iterates over expected values`, () => {
@@ -266,26 +266,26 @@ describe(`Table`, () => {
                 })].join('\n') + '\n';
                 expect(selected.toString()).toEqual(expected);
             });
-            test(`table.filter(..).count() on always false predicates returns 0`, () => {
-                expect(table.filter(col('i32').ge(100)).count()).toEqual(0);
-                expect(table.filter(col('dictionary').eq('z')).count()).toEqual(0);
+            test(`table.filter(..).length on always false predicates returns 0`, () => {
+                expect(table.filter(col('i32').ge(100)).length).toEqual(0);
+                expect(table.filter(col('dictionary').eq('z')).length).toEqual(0);
             });
             describe(`lit-lit comparison`, () => {
-                test(`always-false count() returns 0`, () => {
-                    expect(table.filter(lit('abc').eq('def')).count()).toEqual(0);
-                    expect(table.filter(lit(0).ge(1)).count()).toEqual(0);
+                test(`always-false length returns 0`, () => {
+                    expect(table.filter(lit('abc').eq('def')).length).toEqual(0);
+                    expect(table.filter(lit(0).ge(1)).length).toEqual(0);
                 });
-                test(`always-true count() returns length`, () => {
-                    expect(table.filter(lit('abc').eq('abc')).count()).toEqual(table.length);
-                    expect(table.filter(lit(-100).le(0)).count()).toEqual(table.length);
+                test(`always-true length is the same as table length`, () => {
+                    expect(table.filter(lit('abc').eq('abc')).length).toEqual(table.length);
+                    expect(table.filter(lit(-100).le(0)).length).toEqual(table.length);
                 });
             });
             describe(`col-col comparison`, () => {
-                test(`always-false count() returns 0`, () => {
-                    expect(table.filter(col('dictionary').eq(col('i32'))).count()).toEqual(0);
+                test(`always-false length returns 0`, () => {
+                    expect(table.filter(col('dictionary').eq(col('i32'))).length).toEqual(0);
                 });
-                test(`always-true count() returns length`, () => {
-                    expect(table.filter(col('dictionary').eq(col('dictionary'))).count()).toEqual(table.length);
+                test(`always-true length is the same as table length`, () => {
+                    expect(table.filter(col('dictionary').eq(col('dictionary'))).length).toEqual(table.length);
                 });
             });
         });

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -111,8 +111,8 @@ describe(`Table`, () => {
                     }
                 });
             });
-            test(`length getter returns the correct length`, () => {
-                expect(table.length).toEqual(values.length);
+            test(`count() returns the correct length`, () => {
+                expect(table.count()).toEqual(values.length);
             });
             test(`getColumnIndex`, () => {
                 expect(table.getColumnIndex('i32')).toEqual(I32);
@@ -191,8 +191,8 @@ describe(`Table`, () => {
             for (let this_test of filter_tests) {
                 const { name, filtered, expected } = this_test;
                 describe(name, () => {
-                    test(`length getter returns the correct length`, () => {
-                        expect(filtered.length).toEqual(expected.length);
+                    test(`count() returns the correct length`, () => {
+                        expect(filtered.count()).toEqual(expected.length);
                     });
                     describe(`scan()`, () => {
                         test(`iterates over expected values`, () => {
@@ -266,26 +266,26 @@ describe(`Table`, () => {
                 })].join('\n') + '\n';
                 expect(selected.toString()).toEqual(expected);
             });
-            test(`table.filter(..).length on always false predicates returns 0`, () => {
-                expect(table.filter(col('i32').ge(100)).length).toEqual(0);
-                expect(table.filter(col('dictionary').eq('z')).length).toEqual(0);
+            test(`table.filter(..).count() on always false predicates returns 0`, () => {
+                expect(table.filter(col('i32').ge(100)).count()).toEqual(0);
+                expect(table.filter(col('dictionary').eq('z')).count()).toEqual(0);
             });
             describe(`lit-lit comparison`, () => {
-                test(`always-false length returns 0`, () => {
-                    expect(table.filter(lit('abc').eq('def')).length).toEqual(0);
-                    expect(table.filter(lit(0).ge(1)).length).toEqual(0);
+                test(`always-false count() returns 0`, () => {
+                    expect(table.filter(lit('abc').eq('def')).count()).toEqual(0);
+                    expect(table.filter(lit(0).ge(1)).count()).toEqual(0);
                 });
-                test(`always-true length is the same as table length`, () => {
-                    expect(table.filter(lit('abc').eq('abc')).length).toEqual(table.length);
-                    expect(table.filter(lit(-100).le(0)).length).toEqual(table.length);
+                test(`always-true count() returns length`, () => {
+                    expect(table.filter(lit('abc').eq('abc')).count()).toEqual(table.length);
+                    expect(table.filter(lit(-100).le(0)).count()).toEqual(table.length);
                 });
             });
             describe(`col-col comparison`, () => {
-                test(`always-false length returns 0`, () => {
-                    expect(table.filter(col('dictionary').eq(col('i32'))).length).toEqual(0);
+                test(`always-false count() returns 0`, () => {
+                    expect(table.filter(col('dictionary').eq(col('i32'))).count()).toEqual(0);
                 });
-                test(`always-true length is the same as table length`, () => {
-                    expect(table.filter(col('dictionary').eq(col('dictionary'))).length).toEqual(table.length);
+                test(`always-true count() returns length`, () => {
+                    expect(table.filter(col('dictionary').eq(col('dictionary'))).count()).toEqual(table.length);
                 });
             });
         });


### PR DESCRIPTION
Add an iterator to `FilteredDataFrame` and the `DataFrame` interface

