### PR TITLE
ARROW-2805: [Python] Use official way to find TensorFlow module

### DIFF
--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -184,11 +184,11 @@ def import_tensorflow_extension():
 
     try:
         import importlib
-    except ImportError:
+        absolute_name = importlib.util.resolve_name("tensorflow", None)
+    except (ImportError, AttributeError):
         spec = None
     else:
         import sys
-        absolute_name = importlib.util.resolve_name("tensorflow", None)
         for finder in sys.meta_path:
             spec = finder.find_spec(absolute_name, None)
             if spec is not None:

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -172,30 +172,41 @@ def import_tensorflow_extension():
     https://github.com/apache/arrow/pull/2096.
     """
     import os
-    import site
     tensorflow_loaded = False
 
     # Try to load the tensorflow extension directly
     # This is a performance optimization, tensorflow will always be
     # loaded via the "import tensorflow" statement below if this
     # doesn't succeed.
+    #
+    # This uses the official way of loading modules from
+    # https://docs.python.org/3/library/importlib.html#approximating-importlib-import-module
+
     try:
-        site_paths = site.getsitepackages() + [site.getusersitepackages()]
-    except AttributeError:
-        # Workaround for https://github.com/pypa/virtualenv/issues/228,
-        # this happends in some configurations of virtualenv
-        site_paths = [os.path.dirname(site.__file__) + '/site-packages']
-    for site_path in site_paths:
-        ext = os.path.join(site_path, "tensorflow",
+        import importlib
+    except ImportError:
+        spec = None
+    else:
+        import sys
+        absolute_name = importlib.util.resolve_name("tensorflow", None)
+        for finder in sys.meta_path:
+            spec = finder.find_spec(absolute_name, None)
+            if spec is not None:
+                break
+
+    if spec:
+        module = importlib.util.module_from_spec(spec)
+        ext = os.path.join(module.__path__,
                            "libtensorflow_framework.so")
         if os.path.exists(ext):
             import ctypes
             ctypes.CDLL(ext)
             tensorflow_loaded = True
-            break
+
 
     # If the above failed, try to load tensorflow the normal way
     # (this is more expensive)
+
     if not tensorflow_loaded:
         try:
             import tensorflow

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -204,12 +204,13 @@ def import_tensorflow_extension():
 
     if spec:
         module = importlib.util.module_from_spec(spec)
-        ext = os.path.join(module.__path__,
-                           "libtensorflow_framework.so")
-        if os.path.exists(ext):
-            import ctypes
-            ctypes.CDLL(ext)
-            tensorflow_loaded = True
+        for path in module.__path__:
+            ext = os.path.join(path, "libtensorflow_framework.so")
+            if os.path.exists(ext):
+                import ctypes
+                ctypes.CDLL(ext)
+                tensorflow_loaded = True
+                break
 
 
     # If the above failed, try to load tensorflow the normal way

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -186,11 +186,19 @@ def import_tensorflow_extension():
         import importlib
         absolute_name = importlib.util.resolve_name("tensorflow", None)
     except (ImportError, AttributeError):
+        # Sometimes, importlib is not available (e.g. Python 2)
+        # or importlib.util is not available (e.g. Python 2.7)
         spec = None
     else:
         import sys
         for finder in sys.meta_path:
-            spec = finder.find_spec(absolute_name, None)
+            try:
+                spec = finder.find_spec(absolute_name, None)
+            except AttributeError:
+                # On Travis (Python 3.5) the above produced:
+                # AttributeError: 'VendorImporter' object has no
+                # attribute 'find_spec'
+                spec = None
             if spec is not None:
                 break
 


### PR DESCRIPTION
Still trying this out, but this seems like the way to do it.

Note it will use the slow path in Python 2 but that's ok I think.