### PR TITLE
ARROW-1454: [Python] Also match ArrowNotImplementedError in unsupported type conversions from pandas

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -367,8 +367,11 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None):
     def convert_column(col, ty):
         try:
             return pa.array(col, from_pandas=True, type=ty)
-        except (pa.ArrowInvalid, pa.ArrowTypeError) as e:
-            e.args += ("Conversion failed for column %s" % col.name,)
+        except (pa.ArrowInvalid,
+                pa.ArrowNotImplementedError,
+                pa.ArrowTypeError) as e:
+            e.args += ("Conversion failed for column {0!s} with type {1!s}"
+                       .format(col.name, col.dtype),)
             raise e
 
     if nthreads == 1:

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -2084,3 +2084,19 @@ def _pytime_to_micros(pytime):
             pytime.minute * 60000000 +
             pytime.second * 1000000 +
             pytime.microsecond)
+
+
+def test_convert_unsupported_type_error_message():
+    # ARROW-1454
+
+    df = pd.DataFrame({
+        't1': pd.date_range('2000-01-01', periods=20),
+        't2': pd.date_range('2000-05-01', periods=20)
+    })
+
+    # timedelta64 as yet unsupported
+    df['diff'] = df.t2 - df.t1
+
+    expected_msg = 'Conversion failed for column diff with type timedelta64'
+    with pytest.raises(pa.ArrowNotImplementedError, match=expected_msg):
+        pa.Table.from_pandas(df)


### PR DESCRIPTION
Unsupported conversions were bubbling up to pandas users in an unfriendly way. Now we have:

```
In [1]: paste
import pandas as pd
import numpy as np
import pyarrow as pa

df = pd.DataFrame({
    't1': pd.date_range('2000-01-01', periods=20),
    't2': pd.date_range('2000-05-01', periods=20)
})
df['diff'] = df.t2 - df.t1
pa.Table.from_pandas(df)

## -- End pasted text --
<SNIP>
~/code/arrow/python/pyarrow/error.pxi in pyarrow.lib.check_status()
     87             raise ArrowKeyError(message)
     88         elif status.IsNotImplemented():
---> 89             raise ArrowNotImplementedError(message)
     90         elif status.IsTypeError():
     91             raise ArrowTypeError(message)

ArrowNotImplementedError: ('Unsupported numpy type 22\n', 'Conversion failed for column diff with type timedelta64[ns]')
```