### PR TITLE
ARROW-2601: [Python] Prevent user from calling *MemoryPool constructors directly

### DIFF
--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -193,6 +193,18 @@ def test_python_file_closing():
 
 
 # ----------------------------------------------------------------------
+# MemoryPool
+
+
+def test_memory_pool_cannot_use_ctor():
+    with pytest.raises(TypeError):
+        pa.MemoryPool()
+
+    with pytest.raises(TypeError):
+        pa.ProxyMemoryPool()
+
+
+# ----------------------------------------------------------------------
 # Buffers
 
 


### PR DESCRIPTION
Note I opened ARROW-2808 as a follow up since unit testing around use of various memory pools is rather thin at the moment