### PR TITLE
ARROW-2705: [JS] CombinationPredicates should take list of predicates

### DIFF
--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -74,6 +74,8 @@ CountByResult.prototype.asJSON;
 
 var col = function () {};
 var lit = function () {};
+var and = function () {};
+var or = function () {};
 var custom = function () {};
 
 var Value = function() {};

--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -97,7 +97,7 @@ var Col = function() {};
 Col.prototype.bind;
 var CombinationPredicate = function () {};
 /** @type {?} */
-CombinationPredicate.prototype.predicates;
+CombinationPredicate.prototype.children;
 var Or = function() {};
 var And = function() {};
 var Not = function() {};

--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -95,6 +95,9 @@ Value.prototype.ne;
 var Col = function() {};
 /** @type {?} */
 Col.prototype.bind;
+var CombinationPredicate = function () {};
+/** @type {?} */
+CombinationPredicate.prototype.predicates;
 var Or = function() {};
 var And = function() {};
 var Not = function() {};

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -177,6 +177,8 @@ export namespace view {
 export namespace predicate {
     export import col = predicate_.col;
     export import lit = predicate_.lit;
+    export import and = predicate_.and;
+    export import or = predicate_.or;
     export import custom = predicate_.custom;
 
     export import Or = predicate_.Or;

--- a/js/src/predicate.ts
+++ b/js/src/predicate.ts
@@ -77,10 +77,9 @@ export class Col<T= any> extends Value<T> {
 
 export abstract class Predicate {
     abstract bind(batch: RecordBatch): PredicateFunc;
-    and(expr: Predicate): Predicate { return new And(this, expr); }
-    or(expr: Predicate): Predicate { return new Or(this, expr); }
+    and(...expr: Predicate[]): And { return new And(this, ...expr); }
+    or(...expr: Predicate[]): And { return new Or(this, ...expr); }
     not(): Predicate { return new Not(this); }
-    ands(): Predicate[] { return [this]; }
 }
 
 export abstract class ComparisonPredicate<T= any> extends Predicate {
@@ -112,25 +111,38 @@ export abstract class ComparisonPredicate<T= any> extends Predicate {
 }
 
 export abstract class CombinationPredicate extends Predicate {
-    constructor(public readonly left: Predicate, public readonly right: Predicate) {
+    readonly predicates: Predicate[]
+    constructor(...predicates: Predicate[]) {
         super();
+        this.predicates = predicates;
     }
 }
 
 export class And extends CombinationPredicate {
-    bind(batch: RecordBatch) {
-        const left = this.left.bind(batch);
-        const right = this.right.bind(batch);
-        return (idx: number, batch: RecordBatch) => left(idx, batch) && right(idx, batch);
+    constructor(...predicates: Predicate[]) {
+        // Flatten any Ands
+        predicates = predicates.reduce((accum: Predicate[], p: Predicate): Predicate[] => {
+            return accum.concat(p instanceof And ? p.predicates : p)
+        }, [])
+        super(...predicates);
     }
-    ands(): Predicate[] { return this.left.ands().concat(this.right.ands()); }
+    bind(batch: RecordBatch) {
+        const bound = this.predicates.map((p) => p.bind(batch));
+        return (idx: number, batch: RecordBatch) => bound.every((p) => p(idx, batch));
+    }
 }
 
 export class Or extends CombinationPredicate {
+    constructor(...predicates: Predicate[]) {
+        // Flatten any Ors
+        predicates = predicates.reduce((accum: Predicate[], p: Predicate): Predicate[] => {
+            return accum.concat(p instanceof Or ? p.predicates : p)
+        }, [])
+        super(...predicates);
+    }
     bind(batch: RecordBatch) {
-        const left = this.left.bind(batch);
-        const right = this.right.bind(batch);
-        return (idx: number, batch: RecordBatch) => left(idx, batch) || right(idx, batch);
+        const bound = this.predicates.map((p) => p.bind(batch));
+        return (idx: number, batch: RecordBatch) => bound.some((p) => p(idx, batch));
     }
 }
 
@@ -256,6 +268,8 @@ export class CustomPredicate extends Predicate {
 
 export function lit(v: any): Value<any> { return new Literal(v); }
 export function col(n: string): Col<any> { return new Col(n); }
+export function and(...p: Predicate[]): Predicate { return new And(...p); }
+export function or(...p: Predicate[]): Predicate { return new Or(...p); }
 export function custom(next: PredicateFunc, bind: (batch: RecordBatch) => void) {
     return new CustomPredicate(next, bind);
 }

--- a/js/src/predicate.ts
+++ b/js/src/predicate.ts
@@ -78,7 +78,7 @@ export class Col<T= any> extends Value<T> {
 export abstract class Predicate {
     abstract bind(batch: RecordBatch): PredicateFunc;
     and(...expr: Predicate[]): And { return new And(this, ...expr); }
-    or(...expr: Predicate[]): And { return new Or(this, ...expr); }
+    or(...expr: Predicate[]): Or { return new Or(this, ...expr); }
     not(): Predicate { return new Not(this); }
 }
 
@@ -270,8 +270,8 @@ export class CustomPredicate extends Predicate {
 
 export function lit(v: any): Value<any> { return new Literal(v); }
 export function col(n: string): Col<any> { return new Col(n); }
-export function and(...p: Predicate[]): Predicate { return new And(...p); }
-export function or(...p: Predicate[]): Predicate { return new Or(...p); }
+export function and(...p: Predicate[]): And { return new And(...p); }
+export function or(...p: Predicate[]): Or { return new Or(...p); }
 export function custom(next: PredicateFunc, bind: (batch: RecordBatch) => void) {
     return new CustomPredicate(next, bind);
 }

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -19,7 +19,7 @@ import Arrow, { vector, RecordBatch } from '../Arrow';
 
 const { predicate, Table } = Arrow;
 
-const { col, lit, custom } = predicate;
+const { col, lit, custom, and, or, And, Or } = predicate;
 
 const F32 = 0, I32 = 1, DICT = 2;
 const test_data = [
@@ -297,6 +297,24 @@ describe(`Table`, () => {
             });
         });
     }
+});
+
+describe(`Predicate`, () => {
+    const p1 = col('a').gt(100);
+    const p2 = col('a').lt(1000);
+    const p3 = col('b').eq('foo');
+    const p4 = col('c').eq('bar');
+    const expected = [p1, p2, p3, p4]
+    test(`and flattens children`, () => {
+        expect(and(p1, p2, p3, p4).predicates).toEqual(expected);
+        expect(and(p1.and(p2), new And(p3, p4)).predicates).toEqual(expected);
+        expect(and(p1.and(p2, p3, p4)).predicates).toEqual(expected);
+    });
+    test(`or flattens children`, () => {
+        expect(or(p1, p2, p3, p4).predicates).toEqual(expected);
+        expect(or(p1.or(p2), new Or(p3, p4)).predicates).toEqual(expected);
+        expect(or(p1.or(p2, p3, p4)).predicates).toEqual(expected);
+    });
 });
 
 function leftPad(str: string, fill: string, n: number) {

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -306,14 +306,14 @@ describe(`Predicate`, () => {
     const p4 = col('c').eq('bar');
     const expected = [p1, p2, p3, p4]
     test(`and flattens children`, () => {
-        expect(and(p1, p2, p3, p4).predicates).toEqual(expected);
-        expect(and(p1.and(p2), new And(p3, p4)).predicates).toEqual(expected);
-        expect(and(p1.and(p2, p3, p4)).predicates).toEqual(expected);
+        expect(and(p1, p2, p3, p4).children).toEqual(expected);
+        expect(and(p1.and(p2), new And(p3, p4)).children).toEqual(expected);
+        expect(and(p1.and(p2, p3, p4)).children).toEqual(expected);
     });
     test(`or flattens children`, () => {
-        expect(or(p1, p2, p3, p4).predicates).toEqual(expected);
-        expect(or(p1.or(p2), new Or(p3, p4)).predicates).toEqual(expected);
-        expect(or(p1.or(p2, p3, p4)).predicates).toEqual(expected);
+        expect(or(p1, p2, p3, p4).children).toEqual(expected);
+        expect(or(p1.or(p2), new Or(p3, p4)).children).toEqual(expected);
+        expect(or(p1.or(p2, p3, p4)).children).toEqual(expected);
     });
 });
 


### PR DESCRIPTION
`CombinationPredicate` now stores a list of child predicates rather than just a left and right
Also adds `and`, `or` functions for easier creation of combination predicates with
several children