### PR TITLE
ARROW-2812: [Ruby] Fix Arrow::Array#[] interface for Arrow::StructArray

### DIFF
--- a/ci/travis_install_osx.sh
+++ b/ci/travis_install_osx.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if [ "$ARROW_CI_C_GLIB_AFFECTED" = "1" ]; then
+if [ "$ARROW_CI_RUBY_AFFECTED" = "1" ]; then
     brew update
     brew upgrade python
     brew upgrade hg

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -46,6 +46,7 @@ module Arrow
       require "arrow/record-batch"
       require "arrow/rolling-window"
       require "arrow/slicer"
+      require "arrow/struct-array"
       require "arrow/table"
       require "arrow/table-formatter"
       require "arrow/table-list-formatter"

--- a/ruby/red-arrow/lib/arrow/struct-array.rb
+++ b/ruby/red-arrow/lib/arrow/struct-array.rb
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class StructArray
+    def [](i)
+      get_field(i)
+    end
+  end
+end

--- a/ruby/red-arrow/test/test-struct-array.rb
+++ b/ruby/red-arrow/test/test-struct-array.rb
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class StructArrayTest < Test::Unit::TestCase
+  test("#[]") do
+    type = Arrow::StructDataType.new([
+      Arrow::Field.new("field1", :boolean),
+      Arrow::Field.new("field2", :uint64),
+    ])
+    builder = Arrow::StructArrayBuilder.new(type)
+    builder.append
+    builder.get_field_builder(0).append(true)
+    builder.get_field_builder(1).append(1)
+    builder.append
+    builder.get_field_builder(0).append(false)
+    builder.get_field_builder(1).append(2)
+    array = builder.finish
+
+    assert_equal([[true, false], [1, 2]],
+                 [array[0].to_a, array[1].to_a])
+  end
+end


### PR DESCRIPTION
`Arrow::StructArray` does not have `#get_value` method, and `Arrow::Array#[]` interface depends on `#get_value` method.

And so, `StructArray` cannot access internal columns via `#[]` interface.

Error message is following.

```
NoMethodError: undefined method `get_value' for #<Arrow::StructArray:0x0000000001859ac0>
```

This patch fixes it.