### PR TITLE
ARROW-2827: [C++] Stop to use -jN in sub make

### DIFF
--- a/cpp/build-support/build-lz4-lib.sh
+++ b/cpp/build-support/build-lz4-lib.sh
@@ -18,4 +18,8 @@
 # under the License.
 #
 export CFLAGS="${CFLAGS} -O3 -fPIC"
-make -j4
+if [ -z "$MAKELEVEL" ]; then
+  make -j4
+else
+  make
+fi

--- a/cpp/build-support/build-zstd-lib.sh
+++ b/cpp/build-support/build-zstd-lib.sh
@@ -18,4 +18,8 @@
 # under the License.
 #
 export CFLAGS="${CFLAGS} -O3 -fPIC"
-make -j4
+if [ -z "$MAKELEVEL" ]; then
+  make -j4
+else
+  make
+fi


### PR DESCRIPTION
It may break parallel build in some cases such as building deb
packages case.