### PR TITLE
ARROW-2861: [Python] Add tips about storing pandas DataFrame without index

### DIFF
--- a/python/doc/source/parquet.rst
+++ b/python/doc/source/parquet.rst
@@ -70,7 +70,9 @@ Let's look at a simple table:
                       'two': ['foo', 'bar', 'baz'],
                       'three': [True, False, True]},
                       index=list('abc'))
-   table = pa.Table.from_pandas(df)
+   table = pa.Table.from_pandas(df, preserve_index=False)
+
+We remove the dataframe index as we don't need it in the Parquet output file. If we left it in, we would end up with a column in our Parquet file called `__index_level_0__`, and it would inflate our output size.
 
 We write this to Parquet format with ``write_table``:
 


### PR DESCRIPTION
Add documentation on removing the dataframe index when building a Parquet file. I added the line

> If we left it in, we would end up with a column in our Parquet file called `__index_level_0__`

to help catch people Googling for this column name.

Should I create a JIRA for this docs patch?

Fixes #2244