### PR TITLE
ARROW-2820: [Python] Check that array lengths in RecordBatch.from_arrays are all the same

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -818,6 +818,9 @@ cdef class RecordBatch:
 
         c_arrays.reserve(len(arrays))
         for arr in arrays:
+            if len(arr) != num_rows:
+                raise ValueError('Arrays were not all the same length: '
+                                 '{0} vs {1}'.format(len(arr), num_rows))
             c_arrays.push_back(arr.sp_array)
 
         return pyarrow_wrap_batch(

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -170,6 +170,15 @@ def test_recordbatch_basics():
         batch[2]
 
 
+def test_recordbatch_from_arrays_validate_lengths():
+    # ARROW-2820
+    data = [pa.array([1]), pa.array(["tokyo", "like", "happy"]),
+            pa.array(["derek"])]
+
+    with pytest.raises(ValueError):
+        pa.RecordBatch.from_arrays(data, ['id', 'tags', 'name'])
+
+
 def test_recordbatch_no_fields():
     batch = pa.RecordBatch.from_arrays([], [])
 


### PR DESCRIPTION
Failing to validate could cause a segfault