### PR TITLE
ARROW-2830: [deb] Enable parallel build again

### DIFF
--- a/dev/tasks/linux-packages/debian/rules
+++ b/dev/tasks/linux-packages/debian/rules
@@ -11,7 +11,7 @@ export DEB_BUILD_MAINT_OPTIONS=reproducible=-timeless
 BUILD_TYPE=release
 
 %:
-	dh $@ --with gir,autoreconf --no-parallel
+	dh $@ --with gir,autoreconf
 
 override_dh_autoreconf:
 	dh_autoreconf \


### PR DESCRIPTION
7a413fe029d0295b6eef8069331e1fda44195e42 was a broker of this.