### PR TITLE
ARROW-2816: [Python] Make NativeFile BufferedIOBase-compliant

### DIFF
--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -59,6 +59,9 @@ Status PyBuffer::Init(PyObject* obj) {
     size_ = py_buf_.len;
     capacity_ = py_buf_.len;
     is_mutable_ = !py_buf_.readonly;
+    if (is_mutable_) {
+      mutable_data_ = reinterpret_cast<uint8_t*>(py_buf_.buf);
+    }
     return Status::OK();
   } else {
     return Status(StatusCode::PythonError, "");

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -588,6 +588,8 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         FileMode mode()
 
     cdef cppclass Readable:
+        # put overload under a different name to avoid cython bug with multiple
+        # layers of inheritance
         CStatus ReadB" Read"(int64_t nbytes, shared_ptr[CBuffer]* out)
         CStatus Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out)
 
@@ -609,7 +611,8 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         CStatus ReadAt(int64_t position, int64_t nbytes,
                        int64_t* bytes_read, uint8_t* buffer)
         CStatus ReadAt(int64_t position, int64_t nbytes,
-                       int64_t* bytes_read, shared_ptr[CBuffer]* out)
+                       shared_ptr[CBuffer]* out)
+        c_bool supports_zero_copy()
 
     cdef cppclass WriteableFile(OutputStream, Seekable):
         CStatus WriteAt(int64_t position, const uint8_t* data,

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -19,7 +19,6 @@
 # arrow::ipc
 
 from libc.stdlib cimport malloc, free
-from libc.string cimport memchr
 from pyarrow.compat import frombytes, tobytes, encode_file_path
 from io import BufferedIOBase, UnsupportedOperation
 
@@ -290,11 +289,13 @@ cdef class NativeFile:
         cdef:
             int64_t bytes_read
             uint8_t* buf
+            Buffer py_buf
+            int64_t buf_len
 
         self._assert_readable()
 
-        cdef Buffer py_buf = py_buffer(b)
-        cdef int64_t buf_len = py_buf.size
+        py_buf = py_buffer(b)
+        buf_len = py_buf.size
 
         buf = py_buf.buffer.get().mutable_data()
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -19,7 +19,9 @@
 # arrow::ipc
 
 from libc.stdlib cimport malloc, free
+from libc.string cimport memchr
 from pyarrow.compat import frombytes, tobytes, encode_file_path
+from io import BufferedIOBase, UnsupportedOperation
 
 import re
 import six
@@ -99,6 +101,13 @@ cdef class NativeFile:
     def seekable(self):
         self._assert_open()
         return self.is_readable
+
+    def isatty(self):
+        self._assert_open()
+        return False
+
+    def fileno(self):
+        raise UnsupportedOperation()
 
     def close(self):
         if not self.closed:
@@ -262,6 +271,70 @@ cdef class NativeFile:
         Alias for read, needed to match the IOBase interface."""
         return self.read(nbytes=None)
 
+    def readall(self):
+        return self.read()
+
+    def readinto(self, b):
+        """
+        Read into the supplied buffer
+
+        Parameters
+        -----------
+        b: any python object supporting buffer interface
+
+        Returns
+        --------
+        number of bytes written
+        """
+
+        cdef:
+            int64_t bytes_read
+            uint8_t* buf
+
+        self._assert_readable()
+
+        cdef Buffer py_buf = py_buffer(b)
+        cdef int64_t buf_len = py_buf.size
+
+        buf = py_buf.buffer.get().mutable_data()
+
+        with nogil:
+            check_status(self.rd_file.get().Read(buf_len, &bytes_read, buf))
+
+        return bytes_read
+
+    def readline(self, size=None):
+        """Read and return a line of bytes from the file.
+
+        If size is specified, read at most size bytes.
+
+        Line terminator is always b"\\n".
+        """
+
+        raise UnsupportedOperation()
+
+    def readlines(self, hint=None):
+        """
+        Read lines of the file
+
+        Parameters
+        -----------
+
+        hint: int maximum number of bytes read until we stop
+        """
+
+        raise UnsupportedOperation()
+
+    def __iter__(self):
+        self._assert_readable()
+        return self
+
+    def __next__(self):
+        line = self.readline()
+        if not line:
+            raise StopIteration
+        return line
+
     def read_buffer(self, nbytes=None):
         cdef:
             int64_t c_nbytes
@@ -278,6 +351,15 @@ cdef class NativeFile:
             check_status(self.rd_file.get().ReadB(c_nbytes, &output))
 
         return pyarrow_wrap_buffer(output)
+
+    def truncate(self):
+        raise UnsupportedOperation()
+
+    def writelines(self, lines):
+        self._assert_writable()
+
+        for line in lines:
+            self.write(line)
 
     def download(self, stream_or_path, buffer_size=None):
         """
@@ -414,6 +496,7 @@ cdef class NativeFile:
         if exc_info is not None:
             raise exc_info[0], exc_info[1], exc_info[2]
 
+BufferedIOBase.register(NativeFile)
 
 # ----------------------------------------------------------------------
 # Python file-like objects
@@ -448,6 +531,15 @@ cdef class PythonFile(NativeFile):
             raise ValueError('Invalid file mode: {0}'.format(mode))
 
         self.closed = False
+
+    def truncate(self, pos=None):
+        self.handle.truncate(pos)
+
+    def readline(self, size=None):
+        return self.handle.readline(size)
+
+    def readlines(self, hint=None):
+        return self.handle.readlines(hint)
 
 
 cdef class MemoryMappedFile(NativeFile):
@@ -504,6 +596,10 @@ cdef class MemoryMappedFile(NativeFile):
         self.wr_file = <shared_ptr[OutputStream]> handle
         self.rd_file = <shared_ptr[RandomAccessFile]> handle
         self.closed = False
+
+    def fileno(self):
+        self._assert_open()
+        return self.handle.get().file_descriptor()
 
 
 def memory_map(path, mode='r'):
@@ -578,6 +674,10 @@ cdef class OSFile(NativeFile):
         with nogil:
             check_status(FileOutputStream.Open(path, &self.wr_file))
         self.is_writable = True
+
+    def fileno(self):
+        self._assert_open()
+        return self.handle.file_descriptor()
 
 
 cdef class FixedSizeBufferWriter(NativeFile):

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from io import BytesIO, TextIOWrapper
+from io import (BytesIO, TextIOWrapper, BufferedIOBase, IOBase)
 import gc
 import os
 import pickle
@@ -105,6 +105,47 @@ def test_python_file_read():
     f.close()
 
 
+def test_python_file_readall():
+    data = b'some sample data'
+
+    buf = BytesIO(data)
+    with pa.PythonFile(buf, mode='r') as f:
+        assert f.readall() == data
+
+
+def test_python_file_readinto():
+    length = 10
+    data = b'some sample data longer than 10'
+    dst_buf = bytearray(length)
+    src_buf = BytesIO(data)
+
+    with pa.PythonFile(src_buf, mode='r') as f:
+        assert f.readinto(dst_buf) == 10
+
+        assert dst_buf[:length] == data[:length]
+        assert len(dst_buf) == length
+
+
+def test_python_file_correct_abc():
+    with pa.PythonFile(BytesIO(b''), mode='r') as f:
+        assert isinstance(f, BufferedIOBase)
+        assert isinstance(f, IOBase)
+
+
+def test_python_file_iterable():
+    data = b'''line1
+    line2
+    line3
+    '''
+
+    buf = BytesIO(data)
+    buf2 = BytesIO(data)
+
+    with pa.PythonFile(buf, mode='r') as f:
+        for read, expected in zip(f, buf2):
+            assert read == expected
+
+
 def test_python_file_large_seeks():
     def factory(filename):
         return pa.PythonFile(open(filename, 'rb'))
@@ -178,6 +219,26 @@ def test_python_file_implicit_mode(tmpdir):
     assert not pf.seekable()
     pf.write(b'foobar\n')
     assert bio.getvalue() == b'foobar\n'
+
+
+def test_python_file_writelines(tmpdir):
+    lines = [b'line1\n', b'line2\n' b'line3']
+    path = os.path.join(str(tmpdir), 'foo.txt')
+    with open(path, 'wb') as f:
+        try:
+            f = pa.PythonFile(f, mode='w')
+            assert f.writable()
+            f.writelines(lines)
+        finally:
+            f.close()
+
+    with open(path, 'rb') as f:
+        try:
+            f = pa.PythonFile(f, mode='r')
+            assert f.readable()
+            assert f.read() == b''.join(lines)
+        finally:
+            f.close()
 
 
 def test_python_file_closing():
@@ -577,6 +638,8 @@ def test_mock_output_stream():
 def sample_disk_data(request, tmpdir):
     SIZE = 4096
     arr = np.random.randint(0, 256, size=SIZE).astype('u1')
+    # add up to 32 newlines
+    arr[np.random.randint(0, SIZE, 32)] = ord(b'\n')
     data = arr.tobytes()[:SIZE]
 
     path = os.path.join(str(tmpdir), guid())
@@ -586,6 +649,7 @@ def sample_disk_data(request, tmpdir):
 
     def teardown():
         _try_delete(path)
+
     request.addfinalizer(teardown)
     return path, data
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -638,8 +638,6 @@ def test_mock_output_stream():
 def sample_disk_data(request, tmpdir):
     SIZE = 4096
     arr = np.random.randint(0, 256, size=SIZE).astype('u1')
-    # add up to 32 newlines
-    arr[np.random.randint(0, SIZE, 32)] = ord(b'\n')
     data = arr.tobytes()[:SIZE]
 
     path = os.path.join(str(tmpdir), guid())


### PR DESCRIPTION
See [JIRA](https://issues.apache.org/jira/browse/ARROW-2816). 

This PR adds implements some of the missing methods from BufferedIOBase and registers NativeFile (and so all it's descendants) with BufferedIOBase ABC.