### PR TITLE
ARROW-2834: [GLib] Remove "enable_" prefix from Meson options

### DIFF
--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -55,7 +55,7 @@ if arrow_gpu_dependency.found()
 endif
 subdir('example')
 
-if get_option('enable_gtk_doc')
+if get_option('gtk_doc')
   subdir('doc/reference')
 endif
 

--- a/c_glib/meson_options.txt
+++ b/c_glib/meson_options.txt
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('enable_gtk_doc',
+option('gtk_doc',
        type: 'boolean',
        value: false,
        description: 'Build document by GTK-Doc')

--- a/ci/travis_before_script_c_glib.sh
+++ b/ci/travis_before_script_c_glib.sh
@@ -79,7 +79,7 @@ rm -rf build
 
 # Build with Meson
 MESON_OPTIONS="--prefix=$ARROW_C_GLIB_INSTALL_MESON"
-MESON_OPTIONS="$MESON_OPTIONS -Denable_gtk_doc=true"
+MESON_OPTIONS="$MESON_OPTIONS -Dgtk_doc=true"
 mkdir -p build
 env \
   CFLAGS="-DARROW_NO_DEPRECATED_API" \


### PR DESCRIPTION
Because GNOME uses this policy.

https://wiki.gnome.org/Initiatives/GnomeGoals/MesonPorting

> Drop the enable from --enable-foo boolean options; Meson has boolean
> values, so -Denable-foo=true would read as redundant, and
> -Denable-foo=false would read as contradictory. Use -Dfoo=true or
> -Dfoo=false instead