### PR TITLE
ARROW-2838: [Python] Speed up PandasObjectIsNull

### DIFF
--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -74,7 +74,7 @@ inline bool IsPyInteger(PyObject* obj) {
 // \brief Use pandas missing value semantics to check if a value is null
 bool PandasObjectIsNull(PyObject* obj);
 
-// \brief Check whether obj is nan
+// \brief Check whether obj is a floating-point NaN
 bool PyFloat_IsNaN(PyObject* obj);
 
 inline bool IsPyBinary(PyObject* obj) {


### PR DESCRIPTION
Results for microbenchmarks.PandasObjectIsNull.time_PandasObjectIsNull:

* before:

```
               ========= =============
                  type
               --------- -------------
                  int     1.35±0.02ms
                 float    1.54±0.02ms
                 object     1.25±0ms
                decimal    20.8±0.5ms
               ========= =============
```

* after:

```
               ========= ============
                  type
               --------- ------------
                  int      811±10μs
                 float     1.54±0ms
                 object    1.37±0ms
                decimal   22.0±0.7ms
               ========= ============
```