### PR TITLE
ARROW-2864: [Plasma] Add deletion cache to delete objects later when they are not in use.

### DIFF
--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -209,6 +209,8 @@ class PlasmaStore {
   NotificationMap pending_notifications_;
 
   std::unordered_map<int, std::unique_ptr<Client>> connected_clients_;
+
+  std::unordered_set<ObjectID> deletion_cache_;
 #ifdef PLASMA_GPU
   arrow::gpu::CudaDeviceManager* manager_;
 #endif

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -216,7 +216,7 @@ TEST_F(TestPlasmaStore, DeleteObjectsTest) {
   // Objects are still used by client2_.
   result = client_.Delete(std::vector<ObjectID>{object_id1, object_id2});
   ARROW_CHECK_OK(result);
-  // The object is occupies and it should not be deleted right now.
+  // The object is used and it should not be deleted right now.
   bool has_object = false;
   ARROW_CHECK_OK(client_.Contains(object_id1, &has_object));
   ASSERT_TRUE(has_object);
@@ -226,7 +226,8 @@ TEST_F(TestPlasmaStore, DeleteObjectsTest) {
   // client2_ won't send the release request immediately because the trigger
   // condition is not reached. The release is only added to release cache.
   object_buffers.clear();
-  // After decreasing the ref count, the objects are now deleted.
+  // The reference count went to zero, but the objects are still in the release
+  // cache.
   ARROW_CHECK_OK(client_.Contains(object_id1, &has_object));
   ASSERT_TRUE(has_object);
   ARROW_CHECK_OK(client_.Contains(object_id2, &has_object));

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -222,9 +222,9 @@ TEST_F(TestPlasmaStore, DeleteObjectsTest) {
   ASSERT_TRUE(has_object);
   ARROW_CHECK_OK(client_.Contains(object_id2, &has_object));
   ASSERT_TRUE(has_object);
-  // Decrease the ref count by deleting the ObjectBuffer.
+  // Decrease the ref count by deleting the PlasmaBuffer (in ObjectBuffer).
   object_buffers.clear();
-  // The two objects will not be deleted since Get function increased the ref count.
+  // After decreasing the ref count, the objects are now deleted.
   ARROW_CHECK_OK(client_.Contains(object_id1, &has_object));
   ASSERT_FALSE(has_object);
   ARROW_CHECK_OK(client_.Contains(object_id2, &has_object));

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -648,7 +648,7 @@ cdef class PlasmaClient:
         with nogil:
             check_status(self.client.get().Disconnect())
 
-    cdef delete(self, object_ids):
+    def delete(self, object_ids):
         """
         Delete the objects with the given IDs from other object store.
 

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -664,6 +664,7 @@ cdef class PlasmaClient:
         with nogil:
             check_status(self.client.get().Delete(ids))
 
+
 def connect(store_socket_name, manager_socket_name, int release_delay,
             int num_retries=-1):
     """

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -114,6 +114,7 @@ cdef extern from "plasma/client.h" nogil:
         CStatus Transfer(const char* addr, int port,
                          const CUniqueID& object_id)
 
+        CStatus Delete(const c_vector[CUniqueID] object_ids)
 
 cdef extern from "plasma/client.h" nogil:
 
@@ -647,6 +648,21 @@ cdef class PlasmaClient:
         with nogil:
             check_status(self.client.get().Disconnect())
 
+    cdef delete(self, object_ids):
+        """
+        Delete the objects with the given IDs from other object store.
+
+        Parameters
+        ----------
+        object_ids : list
+            A list of strings used to identify the objects.
+        """
+        cdef c_vector[CUniqueID] ids
+        cdef ObjectID object_id
+        for object_id in object_ids:
+            ids.push_back(object_id.data)
+        with nogil:
+            check_status(self.client.get().Delete(ids))
 
 def connect(store_socket_name, manager_socket_name, int release_delay,
             int num_retries=-1):


### PR DESCRIPTION
1. When we send the request of deleting objects, some objects may be in use. We will put these objects into a cache. 
2. Delete call will flush the release history, so after this Delete call, there should not be release history of the to-be-deleted objects in the history cache. 
3. When Release is called, we will first handle the objects in the deletion cache without waiting. (The rest objects will waiting until the handling condition is triggered.)