### PR TITLE
ARROW-2787: [Python] Fix Cython usage instructions

### DIFF
--- a/python/doc/source/extending.rst
+++ b/python/doc/source/extending.rst
@@ -339,7 +339,10 @@ To build this module, you will need a slightly customized ``setup.py`` file
         ext.include_dirs.append(np.get_include())
         ext.include_dirs.append(pa.get_include())
         ext.libraries.extend(pa.get_libraries())
-        ext.library_dirs.append(pa.get_library_dirs())
+        ext.library_dirs.extend(pa.get_library_dirs())
+        # Try uncommenting the following line on Linux if you otherwise
+        # get weird linker errors or runtime crashes
+        #ext.define_macros.append(("_GLIBCXX_USE_CXX11_ABI", "0"))
 
     setup(
         ext_modules=ext_modules,


### PR DESCRIPTION
It is necessary to compile a C++ Cython extension with the same ABI as that used to compile Arrow, otherwise mysterious failures may ensue.