### PR TITLE
ARROW-2871: [Python] Raise when calling to_numpy() on boolean array

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -606,12 +606,19 @@ cdef class Array:
 
     def to_numpy(self):
         """
-        Construct a NumPy view of this array
+        EXPERIMENTAL: Construct a NumPy view of this array. Only supports
+        primitive arrays with the same memory layout as NumPy (i.e. integers,
+        floating point) without any nulls.
+
+        Returns
+        -------
+        arr : numpy.ndarray
+
         """
         if self.null_count:
             raise NotImplementedError('NumPy array view is only supported '
                                       'for arrays without nulls.')
-        if not is_primitive(self.type.id):
+        if not is_primitive(self.type.id) or self.type.id == _Type_BOOL:
             raise NotImplementedError('NumPy array view is only supported '
                                       'for primitive types.')
         buflist = self.buffers()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -108,6 +108,19 @@ def test_to_numpy_zero_copy():
     np.testing.assert_array_equal(np_arr, expected)
 
 
+def test_to_numpy_unsupported_types():
+    # ARROW-2871: Some primitive types are not yet supported in to_numpy
+    bool_arr = pa.array([True, False, True])
+
+    with pytest.raises(NotImplementedError):
+        bool_arr.to_numpy()
+
+    null_arr = pa.array([None, None, None])
+
+    with pytest.raises(NotImplementedError):
+        null_arr.to_numpy()
+
+
 def test_to_pandas_zero_copy():
     import gc
 


### PR DESCRIPTION
Also marks that `to_numpy` API is experimental, since we need to figure out what to do about nulls (ARROW-2870)