### PR TITLE
ARROW-2868: [Packaging] Fix Apache Arrow ORC GLib related problems

### DIFF
--- a/c_glib/arrow-glib/Makefile.am
+++ b/c_glib/arrow-glib/Makefile.am
@@ -234,7 +234,7 @@ pkgconfig_DATA =				\
 
 if HAVE_ARROW_ORC
 pkgconfig_DATA +=				\
-	arrow-glib-orc.pc
+	arrow-orc-glib.pc
 endif
 
 if HAVE_INTROSPECTION

--- a/c_glib/arrow-glib/arrow-orc-glib.pc.in
+++ b/c_glib/arrow-glib/arrow-orc-glib.pc.in
@@ -20,7 +20,7 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: Apache Arrow GLib ORC
+Name: Apache Arrow ORC GLib
 Description: ORC modules for Apache Arrow GLib
 Version: @VERSION@
 Requires: arrow-glib

--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -216,7 +216,7 @@ pkgconfig.generate(filebase: meson.project_name(),
                    requires: ['gio-2.0', 'arrow'],
                    libraries: [libarrow_glib])
 if arrow_orc_dependency.found()
-  pkgconfig.generate(filebase: meson.project_name(),
+  pkgconfig.generate(filebase: 'arrow-orc-glib',
                      name: 'Apache Arrow GLib ORC',
                      description: 'ORC modules for Apache Arrow GLib',
                      version: version,

--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -177,7 +177,7 @@ AC_CONFIG_FILES([
   Makefile
   arrow-glib/Makefile
   arrow-glib/arrow-glib.pc
-  arrow-glib/arrow-glib-orc.pc
+  arrow-glib/arrow-orc-glib.pc
   arrow-glib/version.h
   arrow-gpu-glib/Makefile
   arrow-gpu-glib/arrow-gpu-glib.pc

--- a/dev/tasks/linux-packages/debian/libarrow-glib-dev.install
+++ b/dev/tasks/linux-packages/debian/libarrow-glib-dev.install
@@ -2,6 +2,6 @@ usr/include/arrow-glib/
 usr/lib/*/libarrow-glib.a
 usr/lib/*/libarrow-glib.so
 usr/lib/*/pkgconfig/arrow-glib.pc
-usr/lib/*/pkgconfig/arrow-glib-orc.pc
+usr/lib/*/pkgconfig/arrow-orc-glib.pc
 usr/share/gir-1.0/Arrow-1.0.gir
 usr/share/arrow-glib/example/

--- a/dev/tasks/linux-packages/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/yum/arrow.spec.in
@@ -60,7 +60,6 @@ mkdir cpp/build
 cd cpp/build
 %cmake3 .. \
   -DCMAKE_BUILD_TYPE=$build_type \
-  -DARROW_ORC=ON \
 %if %{use_python}
   -DARROW_PYTHON=ON \
   -DPythonInterp_FIND_VERSION=ON \
@@ -205,6 +204,7 @@ Libraries and header files for Apache Arrow GLib.
 %{_libdir}/libarrow-glib.a
 %{_libdir}/libarrow-glib.so
 %{_libdir}/pkgconfig/arrow-glib.pc
+%{_libdir}/pkgconfig/arrow-orc-glib.pc
 %{_libdir}/girepository-1.0/*.typelib
 %{_datadir}/arrow-glib/example/
 


### PR DESCRIPTION
* .pc file name was wrong: `arrow-glib-orc.pc` -> `arrow-orc-glib.pc`
  * We use `arrow-XXX-glib.pc` rule such as `arrow-gpu-glib.pc`.
* .spec didn't include `arrow-orc-glib.pc`.
* .spec included duplicated `-DARROW_ORC=ON`
  * https://github.com/apache/arrow-dist/commit/6580a6b7f7fd3d2e5f06b68fe606767db72faf9e was backported.