### PR TITLE
ARROW-2874: [Packaging] Pass job prefix when putting on Queue

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -466,7 +466,7 @@ def submit(ctx, task, group, job_prefix, config_path, dry_run):
                 click.echo(content)
     else:
         queue.fetch()
-        queue.put(job)
+        queue.put(job, prefix=job_prefix)
         queue.push()
         yaml.dump(job, sys.stdout)
         click.echo('Pushed job identifier is: `{}`'.format(job.branch))


### PR DESCRIPTION
To use `nightly` prefix instead of `build` for scheduled builds.