### PR TITLE
ARROW-2326: [Python] Use @loader_path/ as rpath instead of @loader_path when bundling C++ libraries in wheels on macOS

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -457,15 +457,20 @@ foreach(module ${CYTHON_EXTENSIONS})
       # root of the pyarrow/ package so that libarrow/libarrow_python are able
       # to be loaded properly
       if(APPLE)
-        set(module_install_rpath "@loader_path")
+        set(module_install_rpath "@loader_path/")
       else()
         set(module_install_rpath "\$ORIGIN")
       endif()
-      list(LENGTH directories i)
-      while(${i} GREATER 0)
-        set(module_install_rpath "${module_install_rpath}/..")
-        math(EXPR i "${i} - 1" )
-      endwhile(${i} GREATER 0)
+
+      # XXX(wesm): ARROW-2326 this logic is only needed when we have Cython
+      # modules in interior directories. Since all of our C extensions and
+      # bundled libraries are in the same place, we can skip this part
+
+      # list(LENGTH directories i)
+      # while(${i} GREATER 0)
+      #   set(module_install_rpath "${module_install_rpath}/..")
+      #   math(EXPR i "${i} - 1" )
+      # endwhile(${i} GREATER 0)
 
       set_target_properties(${module_name} PROPERTIES
         INSTALL_RPATH ${module_install_rpath})


### PR DESCRIPTION
See discussion in JIRA. I will try to build the wheel with crossbow and see if this resolves the issue