### PR TITLE
ARROW-2822: [C++] Remove the unneeded const qualifier and clarify the comments

### DIFF
--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -252,7 +252,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   ARROW_DEPRECATED("Use Finish instead")
   std::shared_ptr<Buffer> data() const { return data_; }
 
-  const value_type GetValue(int64_t index) const {
+  value_type GetValue(int64_t index) const {
     return reinterpret_cast<const value_type*>(data_->data())[index];
   }
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -253,7 +253,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   std::shared_ptr<Buffer> data() const { return data_; }
 
   value_type GetValue(int64_t index) const {
-    return reinterpret_cast<const value_type*>(data_->data())[index];
+    return reinterpret_cast<value_type*>(data_->data())[index];
   }
 
   /// \brief Append a sequence of elements in one shot

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -253,7 +253,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   std::shared_ptr<Buffer> data() const { return data_; }
 
   value_type GetValue(int64_t index) const {
-    return reinterpret_cast<value_type*>(data_->data())[index];
+    return reinterpret_cast<const value_type*>(data_->data())[index];
   }
 
   /// \brief Append a sequence of elements in one shot

--- a/cpp/src/arrow/util/lazy-benchmark.cc
+++ b/cpp/src/arrow/util/lazy-benchmark.cc
@@ -35,7 +35,7 @@ std::vector<T> generate_junk(int64_t size) {
   return v;
 }
 
-// baseline
+// Baseline
 void BM_for_loop(benchmark::State& state) {
   auto source = generate_junk(kSize);
   std::vector<int> target(kSize);
@@ -47,7 +47,7 @@ void BM_for_loop(benchmark::State& state) {
 
 BENCHMARK(BM_for_loop)->Repetitions(3)->Unit(benchmark::kMillisecond);
 
-// for comparison: pure copy without any changes
+// For comparison: pure copy without any changes
 void BM_std_copy(benchmark::State& state) {
   auto source = generate_junk(kSize);
   std::vector<int> target(kSize);
@@ -59,7 +59,7 @@ void BM_std_copy(benchmark::State& state) {
 
 BENCHMARK(BM_std_copy)->Repetitions(3)->Unit(benchmark::kMillisecond);
 
-// for comparison: pure copy without any changes
+// For comparison: pure copy with type convesion.
 void BM_std_copy_converting(benchmark::State& state) {
   auto source = generate_junk<int32_t>(kSize);
   // bigger type to avoid warnings
@@ -72,7 +72,7 @@ void BM_std_copy_converting(benchmark::State& state) {
 
 BENCHMARK(BM_std_copy_converting)->Repetitions(3)->Unit(benchmark::kMillisecond);
 
-// std::copy with a lazy iterator
+// std::copy with a lazy range as a source
 void BM_lazy_copy(benchmark::State& state) {
   auto source = generate_junk(kSize);
   std::vector<int> target(kSize);
@@ -86,8 +86,8 @@ void BM_lazy_copy(benchmark::State& state) {
 
 BENCHMARK(BM_lazy_copy)->Repetitions(3)->Unit(benchmark::kMillisecond);
 
-// std::copy with a lazy iterator which does static cast
-// should be the same performance as std::copy with differtly typed iterators
+// std::copy with a lazy range which does static cast.
+// Should be the same performance as std::copy with differtly typed iterators
 void BM_lazy_copy_converting(benchmark::State& state) {
   auto source = generate_junk<int64_t>(kSize);
   std::vector<int32_t> target(kSize);
@@ -102,7 +102,7 @@ void BM_lazy_copy_converting(benchmark::State& state) {
 
 BENCHMARK(BM_lazy_copy_converting)->Repetitions(3)->Unit(benchmark::kMillisecond);
 
-// for loop with a post-increment of a lazy operator
+// For loop with a post-increment of a lazy operator
 void BM_lazy_postinc(benchmark::State& state) {
   auto source = generate_junk(kSize);
   std::vector<int> target(kSize);


### PR DESCRIPTION
Few changes we discussed in the PR #2239.