### PR TITLE
ARROW-2884: [Packaging] Support RC

### DIFF
--- a/dev/tasks/linux-packages/Rakefile
+++ b/dev/tasks/linux-packages/Rakefile
@@ -41,15 +41,25 @@ class ApacheArrowPackageTask < PackageTask
 
   def define_archive_task
     file @archive_name do
-      if /\A\d+\.\d+\.\d+\z/ =~ @version
-        download_archive
+      case @version
+      when /\A\d+\.\d+\.\d+-rc\d+\z/
+        download_rc_archive
+      when /\A\d+\.\d+\.\d+\z/
+        download_released_archive
       else
         build_archive
       end
     end
   end
 
-  def download_archive
+  def download_rc_archive
+    base_url = "https://dist.apache.org/repos/dist/dev/arrow"
+    archive_name_no_rc = @archive_name.gsub(/-rc\d+(\.tar\.gz)\z/, "\\1")
+    url = "#{base_url}/#{@package}-#{@version}/#{archive_name_no_rc}"
+    download(url, @archive_name)
+  end
+
+  def download_released_archive
     mirror_base_url = "https://www.apache.org/dyn/closer.cgi/arrow"
     mirror_list_url = "#{mirror_base_url}/arrow-#{@version}/#{@archive_name}"
     open(mirror_list_url) do |response|

--- a/dev/tasks/linux-packages/apt/build.sh
+++ b/dev/tasks/linux-packages/apt/build.sh
@@ -48,6 +48,12 @@ run cp /host/tmp/${PACKAGE}-${VERSION}.tar.gz \
   build/${PACKAGE}_${VERSION}.orig.tar.gz
 run cd build
 run tar xfz ${PACKAGE}_${VERSION}.orig.tar.gz
+case "${VERSION}" in
+  *~rc*)
+    mv ${PACKAGE}-$(echo $VERSION | sed -r -e 's/~rc[0-9]+//') \
+       ${PACKAGE}-${VERSION}
+    ;;
+esac
 run cd ${PACKAGE}-${VERSION}/
 if [ -d "/host/tmp/${specific_debian_dir}" ]; then
   run cp -rp "/host/tmp/${specific_debian_dir}" debian

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require "English"
 require "open-uri"
 require "time"
 
@@ -31,6 +32,19 @@ class PackageTask
     @full_archive_name = File.expand_path(@archive_name)
 
     @rpm_package = @package
+    case @version
+    when /-(rc\d+)\z/
+      base_version = $PREMATCH
+      rc = $1
+      @deb_upstream_version = "#{base_version}~#{rc}"
+      @rpm_version = base_version
+      @rpm_release = "0.#{rc}"
+    else
+      @deb_upstream_version = @version
+      @rpm_version = @version
+      @rpm_release = "1"
+    end
+    @deb_release = "1"
   end
 
   def define
@@ -61,12 +75,15 @@ class PackageTask
     end
   end
 
-  def download(url, download_dir)
-    base_name = url.split("/").last
-    absolute_output_path = File.join(download_dir, base_name)
+  def download(url, output_path)
+    if File.directory?(output_path)
+      base_name = url.split("/").last
+      output_path = File.join(output_path, base_name)
+    end
+    absolute_output_path = File.expand_path(output_path)
 
     unless File.exist?(absolute_output_path)
-      mkdir_p(download_dir)
+      mkdir_p(File.dirname(absolute_output_path))
       rake_output_message "Downloading... #{url}"
       open(url) do |downloaded_file|
         File.open(absolute_output_path, "wb") do |output_file|
@@ -122,14 +139,17 @@ class PackageTask
         tmp_dir = "#{yum_dir}/tmp"
         rm_rf(tmp_dir)
         mkdir_p(tmp_dir)
-        cp(@archive_name, tmp_dir)
+        rpm_archive_name = "#{@package}-#{@rpm_version}.tar.gz"
+        cp(@archive_name,
+           File.join(tmp_dir, rpm_archive_name))
 
         env_sh = "#{yum_dir}/env.sh"
         File.open(env_sh, "w") do |file|
           file.puts(<<-ENV)
-SOURCE_ARCHIVE=#{@archive_name}
+SOURCE_ARCHIVE=#{rpm_archive_name}
 PACKAGE=#{@rpm_package}
-VERSION=#{@version}
+VERSION=#{@rpm_version}
+RELEASE=#{@rpm_release}
           ENV
         end
 
@@ -143,7 +163,9 @@ VERSION=#{@version}
           when "PACKAGE"
             @rpm_package
           when "VERSION"
-            @version
+            @rpm_version
+          when "RELEASE"
+            @rpm_release
           else
             matched
           end
@@ -189,7 +211,9 @@ VERSION=#{@version}
         tmp_dir = "#{apt_dir}/tmp"
         rm_rf(tmp_dir)
         mkdir_p(tmp_dir)
-        cp(@archive_name, tmp_dir)
+        deb_archive_name = "#{@package}-#{@deb_upstream_version}.tar.gz"
+        cp(@archive_name,
+           File.join(tmp_dir, deb_archive_name))
         Dir.glob("debian*") do |debian_dir|
           cp_r(debian_dir, "#{tmp_dir}/#{debian_dir}")
         end
@@ -198,7 +222,7 @@ VERSION=#{@version}
         File.open(env_sh, "w") do |file|
           file.puts(<<-ENV)
 PACKAGE=#{@package}
-VERSION=#{@version}
+VERSION=#{@deb_upstream_version}
           ENV
         end
 
@@ -247,10 +271,6 @@ VERSION=#{@version}
     end
   end
 
-  def package_version
-    "#{@version}-1"
-  end
-
   def package_changelog_message
     "New upstream release."
   end
@@ -279,7 +299,7 @@ VERSION=#{@version}
     Dir.glob("debian*") do |debian_dir|
       update_content("#{debian_dir}/changelog") do |content|
         <<-CHANGELOG.rstrip
-#{@package} (#{package_version}) unstable; urgency=low
+#{@package} (#{@deb_upstream_version}-#{@deb_release}) unstable; urgency=low
 
   * New upstream release.
 
@@ -296,7 +316,7 @@ VERSION=#{@version}
     update_content("yum/#{@rpm_package}.spec.in") do |content|
       content = content.sub(/^(%changelog\n)/, <<-CHANGELOG)
 %changelog
-* #{release_time} #{packager_name} <#{packager_email}> - #{package_version}
+* #{release_time} #{packager_name} <#{packager_email}> - #{@rpm_version}-#{@rpm_release}
 - #{package_changelog_message}
 
       CHANGELOG

--- a/dev/tasks/linux-packages/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/yum/arrow.spec.in
@@ -24,13 +24,13 @@
 
 Name:		@PACKAGE@
 Version:	@VERSION@
-Release:	1%{?dist}
+Release:	@RELEASE@%{?dist}
 Summary:	Apache Arrow is a data processing library for analysis
 
 Group:		Development/Libraries
 License:	Apache-2.0
 URL:		https://arrow.apache.org/
-Source0:	https://dist.apache.org/repos/dist/release/arrow/arrow-%{version}/apache-@PACKAGE@-%{version}.tar.gz
+Source0:	https://dist.apache.org/repos/dist/release/@PACKAGE@/@PACKAGE@-%{version}/apache-@PACKAGE@-%{version}.tar.gz
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 BuildRequires:	pkgconfig


### PR DESCRIPTION
.deb should use "X.Y.Z\~rcN" for deb version. "X.Y.Z" sorts earlier than "X.Y.Z\~rcN".

.rpm should use revision for rcN such as "0.rcN". Revision is "1" or larger for released versions.

See also:

  * https://fedoraproject.org/wiki/Packaging:Versioning#Prerelease_versions
  * https://fedoraproject.org/wiki/Package_Versioning_Examples