### PR TITLE
ARROW-2894: [Glib] Adjust tests to format refactor

### DIFF
--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -107,7 +107,7 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_to_s
-    assert_equal("[true, false, true]",
+    assert_equal("[\n  true,\n  false,\n  true\n]",
                  build_boolean_array([true, false, true]).to_s)
   end
 end

--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -107,7 +107,12 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_to_s
-    assert_equal("[\n  true,\n  false,\n  true\n]",
-                 build_boolean_array([true, false, true]).to_s)
+    assert_equal(<<-CONTENT.chomp, build_boolean_array([true, false, true]).to_s)
+[
+  true,
+  false,
+  true
+]
+    CONTENT
   end
 end

--- a/c_glib/test/test-dictionary-array.rb
+++ b/c_glib/test/test-dictionary-array.rb
@@ -33,9 +33,20 @@ class TestDictionaryArray < Test::Unit::TestCase
       dictionary_array = Arrow::DictionaryArray.new(@data_type, indices)
       assert_equal(<<-STRING.chomp, dictionary_array.to_s)
 
--- is_valid: all not null
--- dictionary: ["C", "C++", "Ruby"]
--- indices: [0, 2, 2, 1, 0]
+-- dictionary:
+  [
+    "C",
+    "C++",
+    "Ruby"
+  ]
+-- indices:
+  [
+    0,
+    2,
+    2,
+    1,
+    0
+  ]
       STRING
     end
   end

--- a/c_glib/test/test-dictionary-encode.rb
+++ b/c_glib/test/test-dictionary-encode.rb
@@ -23,9 +23,22 @@ class TestDictionaryEncode < Test::Unit::TestCase
     array = build_int32_array([1, 3, 1, -1, -3, -1])
     assert_equal(<<-STRING.chomp, array.dictionary_encode.to_s)
 
--- is_valid: all not null
--- dictionary: [1, 3, -1, -3]
--- indices: [0, 1, 0, 2, 3, 2]
+-- dictionary:
+  [
+    1,
+    3,
+    -1,
+    -3
+  ]
+-- indices:
+  [
+    0,
+    1,
+    0,
+    2,
+    3,
+    2
+  ]
     STRING
   end
 
@@ -33,9 +46,17 @@ class TestDictionaryEncode < Test::Unit::TestCase
     array = build_string_array(["Ruby", "Python", "Ruby"])
     assert_equal(<<-STRING.chomp, array.dictionary_encode.to_s)
 
--- is_valid: all not null
--- dictionary: ["Ruby", "Python"]
--- indices: [0, 1, 0]
+-- dictionary:
+  [
+    "Ruby",
+    "Python"
+  ]
+-- indices:
+  [
+    0,
+    1,
+    0
+  ]
     STRING
   end
 end

--- a/c_glib/test/test-orc-file-reader.rb
+++ b/c_glib/test/test-orc-file-reader.rb
@@ -60,19 +60,19 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
           column.data.chunks.collect(&:to_s),
         ]
       end
-      assert_equal([
-                     ["boolean1: bool", ["[false, true]"]],
-                     ["byte1: int8", ["[1, 100]"]],
-                     ["short1: int16", ["[1024, 2048]"]],
-                     ["int1: int32", ["[65536, 65536]"]],
+      expected = [
+                     ["boolean1: bool", ["[\n  false,\n  true\n]"]],
+                     ["byte1: int8", ["[\n  1,\n  100\n]"]],
+                     ["short1: int16", ["[\n  1024,\n  2048\n]"]],
+                     ["int1: int32", ["[\n  65536,\n  65536\n]"]],
                      [
                        "long1: int64",
-                       ["[9223372036854775807, 9223372036854775807]"],
+                       ["[\n  9223372036854775807,\n  9223372036854775807\n]"],
                      ],
-                     ["float1: float", ["[1, 2]"]],
-                     ["double1: double", ["[-15, -5]"]],
-                     ["bytes1: binary", ["[0001020304, ]"]],
-                     ["string1: string", ["[\"hi\", \"bye\"]"]],
+                     ["float1: float", ["[\n  1,\n  2\n]"]],
+                     ["double1: double", ["[\n  -15,\n  -5\n]"]],
+                     ["bytes1: binary", ["[\n  0001020304,\n  \n]"]],
+                     ["string1: string", ["[\n  \"hi\",\n  \"bye\"\n]"]],
                      [
                        "middle: " +
                        "struct<list: " +
@@ -80,14 +80,32 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
                        [
                          <<-STRUCT.chomp
 
--- is_valid: all not null
--- child 0 type: list<item: struct<int1: int32, string1: string>> values: 
-  -- is_valid: all not null
-  -- value_offsets: [0, 2, 4]
-  -- values: 
-    -- is_valid: all not null
-    -- child 0 type: int32 values: [1, 2, 1, 2]
-    -- child 1 type: string values: ["bye", "sigh", "bye", "sigh"]
+-- is_valid:
+all not null
+-- child 0 type: list<item: struct<int1: int32, string1: string>> values:   [
+
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        1,
+        2
+      ]
+    -- child 1 type: string values:       [
+        "bye",
+        "sigh"
+      ],
+
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        1,
+        2
+      ]
+    -- child 1 type: string values:       [
+        "bye",
+        "sigh"
+      ]
+  ]
                           STRUCT
                        ]
                      ],
@@ -95,13 +113,32 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
                        "list: list<item: struct<int1: int32, string1: string>>",
                        [
                          <<-LIST.chomp
+[
 
--- is_valid: all not null
--- value_offsets: [0, 2, 5]
--- values: 
-  -- is_valid: all not null
-  -- child 0 type: int32 values: [3, 4, 100000000, -100000, 1234]
-  -- child 1 type: string values: ["good", "bad", "cat", "in", "hat"]
+  -- is_valid:
+all not null
+  -- child 0 type: int32 values:     [
+      3,
+      4
+    ]
+  -- child 1 type: string values:     [
+      "good",
+      "bad"
+    ],
+
+  -- is_valid:
+all not null
+  -- child 0 type: int32 values:     [
+      100000000,
+      -100000,
+      1234
+    ]
+  -- child 1 type: string values:     [
+      "cat",
+      "in",
+      "hat"
+    ]
+]
                          LIST
                        ]
                      ],
@@ -111,21 +148,42 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
                        "struct<int1: int32, string1: string>>>",
                        [
                          <<-MAP.chomp
+[
 
--- is_valid: all not null
--- value_offsets: [0, 0, 2]
--- values: 
-  -- is_valid: all not null
-  -- child 0 type: string values: ["chani", "mauddib"]
+  -- is_valid:
+all not null
+  -- child 0 type: string values:     []
   -- child 1 type: struct<int1: int32, string1: string> values: 
-    -- is_valid: all not null
-    -- child 0 type: int32 values: [5, 1]
-    -- child 1 type: string values: ["chani", "mauddib"]
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       []
+    -- child 1 type: string values:       [],
+
+  -- is_valid:
+all not null
+  -- child 0 type: string values:     [
+      "chani",
+      "mauddib"
+    ]
+  -- child 1 type: struct<int1: int32, string1: string> values: 
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        5,
+        1
+      ]
+    -- child 1 type: string values:       [
+        "chani",
+        "mauddib"
+      ]
+]
                          MAP
                        ],
                      ],
-                   ],
-                   dump)
+                   ]
+      expected.zip(dump).each do |ex, actual|
+        assert_equal(ex, actual)
+      end
     end
 
     test("select fields") do
@@ -139,8 +197,8 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
         ]
       end
       assert_equal([
-                     ["boolean1: bool", ["[false, true]"]],
-                     ["short1: int16", ["[1024, 2048]"]],
+                     ["boolean1: bool", ["[\n  false,\n  true\n]"]],
+                     ["short1: int16", ["[\n  1024,\n  2048\n]"]],
                    ],
                    dump)
     end
@@ -155,45 +213,82 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
           record_batch.get_column(i).to_s,
         ]
       end
-      assert_equal([
-                     ["boolean1: bool", "[false, true]"],
-                     ["byte1: int8", "[1, 100]"],
-                     ["short1: int16", "[1024, 2048]"],
-                     ["int1: int32", "[65536, 65536]"],
+      expected = [
+                     ["boolean1: bool", "[\n  false,\n  true\n]"],
+                     ["byte1: int8", "[\n  1,\n  100\n]"],
+                     ["short1: int16", "[\n  1024,\n  2048\n]"],
+                     ["int1: int32", "[\n  65536,\n  65536\n]"],
                      [
                        "long1: int64",
-                       "[9223372036854775807, 9223372036854775807]",
+                       "[\n  9223372036854775807,\n  9223372036854775807\n]",
                      ],
-                     ["float1: float", "[1, 2]"],
-                     ["double1: double", "[-15, -5]"],
-                     ["bytes1: binary", "[0001020304, ]"],
-                     ["string1: string", "[\"hi\", \"bye\"]"],
+                     ["float1: float", "[\n  1,\n  2\n]"],
+                     ["double1: double", "[\n  -15,\n  -5\n]"],
+                     ["bytes1: binary", "[\n  0001020304,\n  \n]"],
+                     ["string1: string", "[\n  \"hi\",\n  \"bye\"\n]"],
                      [
                        "middle: " +
                        "struct<list: " +
                        "list<item: struct<int1: int32, string1: string>>>",
                        <<-STRUCT.chomp
 
--- is_valid: all not null
--- child 0 type: list<item: struct<int1: int32, string1: string>> values: 
-  -- is_valid: all not null
-  -- value_offsets: [0, 2, 4]
-  -- values: 
-    -- is_valid: all not null
-    -- child 0 type: int32 values: [1, 2, 1, 2]
-    -- child 1 type: string values: ["bye", "sigh", "bye", "sigh"]
+-- is_valid:
+all not null
+-- child 0 type: list<item: struct<int1: int32, string1: string>> values:   [
+
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        1,
+        2
+      ]
+    -- child 1 type: string values:       [
+        "bye",
+        "sigh"
+      ],
+
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        1,
+        2
+      ]
+    -- child 1 type: string values:       [
+        "bye",
+        "sigh"
+      ]
+  ]
                         STRUCT
                      ],
                      [
                        "list: list<item: struct<int1: int32, string1: string>>",
                        <<-LIST.chomp
+[
 
--- is_valid: all not null
--- value_offsets: [0, 2, 5]
--- values: 
-  -- is_valid: all not null
-  -- child 0 type: int32 values: [3, 4, 100000000, -100000, 1234]
-  -- child 1 type: string values: ["good", "bad", "cat", "in", "hat"]
+  -- is_valid:
+all not null
+  -- child 0 type: int32 values:     [
+      3,
+      4
+    ]
+  -- child 1 type: string values:     [
+      "good",
+      "bad"
+    ],
+
+  -- is_valid:
+all not null
+  -- child 0 type: int32 values:     [
+      100000000,
+      -100000,
+      1234
+    ]
+  -- child 1 type: string values:     [
+      "cat",
+      "in",
+      "hat"
+    ]
+]
                        LIST
                      ],
                      [
@@ -201,20 +296,41 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
                        "struct<key: string, value: " +
                        "struct<int1: int32, string1: string>>>",
                        <<-MAP.chomp
+[
 
--- is_valid: all not null
--- value_offsets: [0, 0, 2]
--- values: 
-  -- is_valid: all not null
-  -- child 0 type: string values: ["chani", "mauddib"]
+  -- is_valid:
+all not null
+  -- child 0 type: string values:     []
   -- child 1 type: struct<int1: int32, string1: string> values: 
-    -- is_valid: all not null
-    -- child 0 type: int32 values: [5, 1]
-    -- child 1 type: string values: ["chani", "mauddib"]
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       []
+    -- child 1 type: string values:       [],
+
+  -- is_valid:
+all not null
+  -- child 0 type: string values:     [
+      "chani",
+      "mauddib"
+    ]
+  -- child 1 type: struct<int1: int32, string1: string> values: 
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        5,
+        1
+      ]
+    -- child 1 type: string values:       [
+        "chani",
+        "mauddib"
+      ]
+]
                        MAP
                      ],
-                   ],
-                   dump)
+                   ]
+      expected.zip(dump).each do |ex, actual|
+        assert_equal(ex, actual)
+      end
     end
 
     test("select fields") do
@@ -227,8 +343,8 @@ map: list<item: struct<key: string, value: struct<int1: int32, string1: string>>
         ]
       end
       assert_equal([
-                     ["boolean1: bool", "[false, true]"],
-                     ["short1: int16", "[1024, 2048]"],
+                     ["boolean1: bool", "[\n  false,\n  true\n]"],
+                     ["short1: int16", "[\n  1024,\n  2048\n]"],
                    ],
                    dump)
     end

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -131,8 +131,20 @@ class TestTable < Test::Unit::TestCase
 
     def test_to_s
       assert_equal(<<-PRETTY_PRINT, @record_batch.to_s)
-visible: [true, false, true, false, true]
-valid: [false, true, false, true, false]
+visible:   [
+    true,
+    false,
+    true,
+    false,
+    true
+  ]
+valid:   [
+    false,
+    true,
+    false,
+    true,
+    false
+  ]
       PRETTY_PRINT
     end
 

--- a/ruby/red-arrow/test/run-test.rb
+++ b/ruby/red-arrow/test/run-test.rb
@@ -32,4 +32,6 @@ $LOAD_PATH.unshift(lib_dir.to_s)
 
 require_relative "helper"
 
+ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] ||= "10000"
+
 exit(Test::Unit::AutoRunner.run(true, test_dir.to_s))

--- a/ruby/red-arrow/test/test-orc.rb
+++ b/ruby/red-arrow/test/test-orc.rb
@@ -23,6 +23,10 @@ class ORCTest < Test::Unit::TestCase
     @orc_path = fixture_path("TestOrcFile.test1.orc")
   end
 
+  def pp_values(values)
+    "[\n  " + values.collect(&:inspect).join(",\n  ") + "\n]"
+  end
+
   sub_test_case("load") do
     test("default") do
       table = Arrow::Table.load(@orc_path)
@@ -33,18 +37,18 @@ class ORCTest < Test::Unit::TestCase
         ]
       end
       assert_equal([
-                     ["boolean1: bool", ["[false, true]"]],
-                     ["byte1: int8", ["[1, 100]"]],
-                     ["short1: int16", ["[1024, 2048]"]],
-                     ["int1: int32", ["[65536, 65536]"]],
+                     ["boolean1: bool", [pp_values([false, true])]],
+                     ["byte1: int8", [pp_values([1, 100])]],
+                     ["short1: int16", [pp_values([1024, 2048])]],
+                     ["int1: int32", [pp_values([65536, 65536])]],
                      [
                        "long1: int64",
-                       ["[9223372036854775807, 9223372036854775807]"],
+                       [pp_values([9223372036854775807, 9223372036854775807])],
                      ],
-                     ["float1: float", ["[1, 2]"]],
-                     ["double1: double", ["[-15, -5]"]],
-                     ["bytes1: binary", ["[0001020304, ]"]],
-                     ["string1: string", ["[\"hi\", \"bye\"]"]],
+                     ["float1: float", [pp_values([1, 2])]],
+                     ["double1: double", [pp_values([-15, -5])]],
+                     ["bytes1: binary", ["[\n  0001020304,\n  \n]"]],
+                     ["string1: string", [pp_values(["hi", "bye"])]],
                      [
                        "middle: " +
                        "struct<list: " +
@@ -52,14 +56,32 @@ class ORCTest < Test::Unit::TestCase
                        [
                          <<-STRUCT.chomp
 
--- is_valid: all not null
--- child 0 type: list<item: struct<int1: int32, string1: string>> values: 
-  -- is_valid: all not null
-  -- value_offsets: [0, 2, 4]
-  -- values: 
-    -- is_valid: all not null
-    -- child 0 type: int32 values: [1, 2, 1, 2]
-    -- child 1 type: string values: ["bye", "sigh", "bye", "sigh"]
+-- is_valid:
+all not null
+-- child 0 type: list<item: struct<int1: int32, string1: string>> values:   [
+
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        1,
+        2
+      ]
+    -- child 1 type: string values:       [
+        "bye",
+        "sigh"
+      ],
+
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        1,
+        2
+      ]
+    -- child 1 type: string values:       [
+        "bye",
+        "sigh"
+      ]
+  ]
                           STRUCT
                        ]
                      ],
@@ -67,13 +89,32 @@ class ORCTest < Test::Unit::TestCase
                        "list: list<item: struct<int1: int32, string1: string>>",
                        [
                          <<-LIST.chomp
+[
 
--- is_valid: all not null
--- value_offsets: [0, 2, 5]
--- values: 
-  -- is_valid: all not null
-  -- child 0 type: int32 values: [3, 4, 100000000, -100000, 1234]
-  -- child 1 type: string values: ["good", "bad", "cat", "in", "hat"]
+  -- is_valid:
+all not null
+  -- child 0 type: int32 values:     [
+      3,
+      4
+    ]
+  -- child 1 type: string values:     [
+      "good",
+      "bad"
+    ],
+
+  -- is_valid:
+all not null
+  -- child 0 type: int32 values:     [
+      100000000,
+      -100000,
+      1234
+    ]
+  -- child 1 type: string values:     [
+      "cat",
+      "in",
+      "hat"
+    ]
+]
                          LIST
                        ]
                      ],
@@ -83,16 +124,35 @@ class ORCTest < Test::Unit::TestCase
                        "struct<int1: int32, string1: string>>>",
                        [
                          <<-MAP.chomp
+[
 
--- is_valid: all not null
--- value_offsets: [0, 0, 2]
--- values: 
-  -- is_valid: all not null
-  -- child 0 type: string values: ["chani", "mauddib"]
+  -- is_valid:
+all not null
+  -- child 0 type: string values:     []
   -- child 1 type: struct<int1: int32, string1: string> values: 
-    -- is_valid: all not null
-    -- child 0 type: int32 values: [5, 1]
-    -- child 1 type: string values: ["chani", "mauddib"]
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       []
+    -- child 1 type: string values:       [],
+
+  -- is_valid:
+all not null
+  -- child 0 type: string values:     [
+      "chani",
+      "mauddib"
+    ]
+  -- child 1 type: struct<int1: int32, string1: string> values: 
+    -- is_valid:
+all not null
+    -- child 0 type: int32 values:       [
+        5,
+        1
+      ]
+    -- child 1 type: string values:       [
+        "chani",
+        "mauddib"
+      ]
+]
                          MAP
                        ],
                      ],
@@ -109,8 +169,8 @@ class ORCTest < Test::Unit::TestCase
         ]
       end
       assert_equal([
-                     ["boolean1: bool", ["[false, true]"]],
-                     ["short1: int16", ["[1024, 2048]"]],
+                     ["boolean1: bool", [pp_values([false, true])]],
+                     ["short1: int16", [pp_values([1024, 2048])]],
                    ],
                    dump)
     end

--- a/ruby/red-arrow/test/test-rolling-window.rb
+++ b/ruby/red-arrow/test/test-rolling-window.rb
@@ -27,7 +27,14 @@ class RollingWindowTest < Test::Unit::TestCase
 
   test("#lag") do
     assert_equal(<<-ARRAY.chomp, @table.window.lag(:number).to_s)
-[null, -3, null, null, 2, -3]
+[
+  null,
+  -3,
+  null,
+  null,
+  2,
+  -3
+]
     ARRAY
   end
 end


### PR DESCRIPTION
cc @kou 

I I adjusted the tests to pass. Sadly I had to realise that some of the outputs still don't look pretty. I will change this in a follow-up PR.

There were some issues for me to build Glib in the same environment as the conda one described in https://arrow.apache.org/docs/python/development.html#developing-on-linux-and-macos.

- my configure command was 
```
./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$CONDA_PREFIX/lib/pkgconfig/:$PKG_CONFIG_PATH --prefix=`pwd`/dist
```
- I had to run `cp $CONDA_PREFIX/lib/libarrow* arrow-glib/.libs/` as otherwise the GISCAN step would not suceed. Even setting `LD_LIBRARY_PATH` did not help
- To run the tests I also needed to add `GI.prepend_typelib_path('dist/lib/girepository-1.0/')` to `c_glib/test/run-test.rb`. Otherwise `GI.load("Arrow")` did not find the necessary definitions.