### PR TITLE
ARROW-2896: [GLib] Add missing exports

### DIFF
--- a/c_glib/test/run-test.sh
+++ b/c_glib/test/run-test.sh
@@ -33,6 +33,7 @@ for module in ${modules}; do
     fi
   fi
 done
+export LD_LIBRARY_PATH
 
 if [ -f "Makefile" -a "${NO_MAKE}" != "yes" ]; then
   make -j8 > /dev/null || exit $?
@@ -49,5 +50,6 @@ for module in ${modules}; do
     GI_TYPELIB_PATH="${module_typelib_dir}:${GI_TYPELIB_PATH}"
   fi
 done
+export GI_TYPELIB_PATH
 
 ${GDB} ruby ${test_dir}/run-test.rb "$@"


### PR DESCRIPTION
If we don't call export, c_glib/test/run-test.rb can't use
LD_LIBRARY_PATH and GI_TYPELIB_PATH variables.

See also https://github.com/apache/arrow/pull/2303#issuecomment-406934428