### PR TITLE
ARROW-2917: [Python] Use detach() to avoid PyTorch gradient errors

### DIFF
--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -136,7 +136,7 @@ def register_torch_serialization_handlers(serialization_context):
         import torch
 
         def _serialize_torch_tensor(obj):
-            return obj.numpy()
+            return obj.detach().numpy()
 
         def _deserialize_torch_tensor(data):
             return torch.from_numpy(data)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -364,6 +364,10 @@ def test_torch_serialization(large_buffer):
         serialization_roundtrip(obj, large_buffer,
                                 context=serialization_context)
 
+    tensor_requiring_grad = torch.randn(10, 10, requires_grad=True)
+    serialization_roundtrip(tensor_requiring_grad, large_buffer,
+                            context=serialization_context)
+
 
 def test_numpy_immutable(large_buffer):
     obj = np.zeros([10])


### PR DESCRIPTION
`detach()` doesn't copy data unless it has to and will give a RuntimeError if the detached data needs to have its gradient calculated.