### PR TITLE
ARROW-2901: [Java] Build is failing on Java9

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -368,6 +368,7 @@
           <version>2.20</version>
           <configuration>
             <enableAssertions>true</enableAssertions>
+            <childDelegation>true</childDelegation>
             <forkCount>${forkCount}</forkCount>
             <reuseForks>true</reuseForks>
             <systemPropertyVariables>


### PR DESCRIPTION
This solves issue of building Arrow JDBC Adapter.
This is related to an issue with Surefire and Java9 [link](https://issues.apache.org/jira/browse/SUREFIRE-1265)