### PR TITLE
ARROW-2907: [GitHub] Improve the first paragraph of "How to contribute patches"

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,8 @@ to end up in JIRA, either before or after completing a pull request.
 ## How to contribute patches
 
 We prefer to receive contributions in the form of GitHub pull requests. Please
-send pull requests against the [github.com/apache/arrow][4] repository.
+send pull requests against the [github.com/apache/arrow][4] repository following
+the procedure below.
 
 If you are looking for some ideas on what to contribute, check out the [JIRA
 issues][3] for the Apache Arrow project. Comment on the issue and/or contact


### PR DESCRIPTION
In previous version, it is unclear that contributors need to follow
the procedure "To contribute a patch". In this version, it clearly
indicate that contributors need to follow the procedure described
later in the section.