### PR TITLE
ARROW-2909: [JS] Add convenience function for creating a table from a list of vectors

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -94,26 +94,14 @@ console.log(table.toString());
 ### Create a Table from JavaScript arrays
 
 ```es6
-const fields = [{
-        name: 'precipitation',
-        type: { name: 'floatingpoint', precision: 'SINGLE'},
-        nullable: false, children: []
-    }, {
-        name: 'date',
-        type: { name: 'date', unit: 'MILLISECOND' },
-        nullable: false, children: []
-    }];
-const rainAmounts = Array.from({length: LENGTH}, () => Number((Math.random() * 20).toFixed(1)));
-const rainDates = Array.from({length: LENGTH}, (_, i) => Date.now() - 1000 * 60 * 60 * 24 * i);
-
 const LENGTH = 2000;
-const rainfall = arrow.Table.from({
-  schema: { fields: fields },
-  batches: [{
-    count: LENGTH,
-    columns: [
-      {name: "precipitation", count: LENGTH, VALIDITY: [], DATA: rainAmounts },
-      {name: "date",          count: LENGTH, VALIDITY: [], DATA: rainDates } ] }] })
+const rainAmounts = Float32Array.from({length: LENGTH}, () => Number((Math.random() * 20).toFixed(1)));
+const rainDates = Array.from({length: LENGTH}, (_, i) => new Date(Date.now() - 1000 * 60 * 60 * 24 * i));
+
+const rainfall = arrow.Table.fromVectors(
+  [FloatVector.from(rainAmounts), DateVector.from(rainDates)],
+  ['precipitation', 'date']
+);
 ```
 
 ### Load data with `fetch`

--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -32,6 +32,8 @@ var Table = function() {};
 /** @type {?} */
 Table.from = function() {};
 /** @type {?} */
+Table.fromVectors = function() {};
+/** @type {?} */
 Table.fromAsync = function() {};
 /** @type {?} */
 Table.fromStruct = function() {};

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -238,6 +238,7 @@ try {
 // set them via string indexers to save them from the mangler
 Schema['from'] = Schema.from;
 Table['from'] = Table.from;
+Table['fromVectors'] = Table.fromVectors;
 Table['fromAsync'] = Table.fromAsync;
 Table['fromStruct'] = Table.fromStruct;
 Table['empty'] = Table.empty;

--- a/js/src/recordbatch.ts
+++ b/js/src/recordbatch.ts
@@ -25,8 +25,8 @@ import { valueToString, leftPad } from './util/pretty';
 import Long = flatbuffers.Long;
 
 export class RecordBatch<T extends StructData = StructData> extends StructVector<T> {
-    public static from<R extends StructData = StructData>(vectors: Vector[]) {
-        return new RecordBatch<R>(Schema.from(vectors),
+    public static from<R extends StructData = StructData>(vectors: Vector[], names?: string[]) {
+      return new RecordBatch<R>(Schema.from(vectors, names),
             Math.max(...vectors.map((v) => v.length)),
             vectors
         );

--- a/js/src/table.ts
+++ b/js/src/table.ts
@@ -38,6 +38,9 @@ export interface DataFrame<T extends StructData = StructData> {
 
 export class Table<T extends StructData = StructData> implements DataFrame {
     static empty<R extends StructData = StructData>() { return new Table<R>(new Schema([]), []); }
+    static fromVectors<R extends StructData = StructData>(vectors: Vector[], names?: string[]) {
+       return new Table<R>([RecordBatch.from<R>(vectors, names)])
+    }
     static from<R extends StructData = StructData>(sources?: Iterable<Uint8Array | Buffer | string> | object | string) {
         if (sources) {
             let schema: Schema | undefined;
@@ -198,6 +201,10 @@ export class Table<T extends StructData = StructData> implements DataFrame {
         return new PipeIterator(tableRowsToString(this, separator), 'utf8');
     }
 }
+
+// protect batches, batchesUnion from es2015/umd mangler
+(<any> Table.prototype).batches = Object.freeze([]);
+(<any> Table.prototype).batchesUnion = Object.freeze([]);
 
 class FilteredDataFrame<T extends StructData = StructData> implements DataFrame<T> {
     private predicate: Predicate;

--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -47,8 +47,8 @@ function generateDictionaryMap(fields: Field[]) {
 }
 
 export class Schema {
-    public static from(vectors: Vector[]) {
-        return new Schema(vectors.map((v, i) => new Field('' + i, v.type)));
+    public static from(vectors: Vector[], names?: string[]) {
+        return new Schema(vectors.map((v, i) => new Field(names ? names[i] : ('' + i), v.type)));
     }
     // @ts-ignore
     protected _bodyLength: number;


### PR DESCRIPTION
Simplifies the creation of a `Table` from JS Arrays:

```js
const LENGTH = 20000;

const idVec = Arrow.vector.IntVector.from(
  Uint32Array.from({length: LENGTH}, () => Math.round(Math.random() * 2E9))
);
const latVec = Arrow.vector.FloatVector.from(
  Float32Array.from({length: LENGTH}, () => Number((Math.random() * 180 - 90).toFixed(1)))
);
const lngVec = Arrow.vector.FloatVector.from(
  Float32Array.from({length: LENGTH}, () => Number((Math.random() * 360 - 180).toFixed(1)))
);

const table = Arrow.Table.fromVectors([idVec, latVec, lngVec], ['id', 'lat', 'lng'])

onsole.log(table.schema.fields.map((f) => f.name));
// [ 'id', 'lat', 'lng' ]

console.log(table.schema.fields.map((f) => f.type));
// [ Uint32 [Int] { TType: 2, children: undefined, isSigned: false, bitWidth: 32 },
//   Float32 [Float] { TType: 3, children: undefined, precision: 1 },
//   Float32 [Float] { TType: 3, children: undefined, precision: 1 } ]
```