### PR TITLE
ARROW-2914: [Integration] Add WindowPandasUDFTests to Spark integration script

### DIFF
--- a/dev/spark_integration/spark_integration.sh
+++ b/dev/spark_integration/spark_integration.sh
@@ -85,7 +85,7 @@ echo "Testing Spark: $SPARK_SCALA_TESTS"
 build/mvn -Dtest=none -DwildcardSuites="$SPARK_SCALA_TESTS" test
 
 # Run pyarrow related Python tests only
-SPARK_PYTHON_TESTS="ArrowTests PandasUDFTests ScalarPandasUDFTests GroupedMapPandasUDFTests GroupedAggPandasUDFTests"
+SPARK_PYTHON_TESTS="ArrowTests PandasUDFTests ScalarPandasUDFTests GroupedMapPandasUDFTests GroupedAggPandasUDFTests WindowPandasUDFTests"
 echo "Testing PySpark: $SPARK_PYTHON_TESTS"
 SPARK_TESTING=1 bin/pyspark pyspark.sql.tests $SPARK_PYTHON_TESTS
 popd


### PR DESCRIPTION
New pandas_udf tests were added for windowing, adding them to the list of Spark Python tests to run.