### PR TITLE
ARROW-2911: [Python] Parquet binary statistics that end in '\0' truncate last byte

### DIFF
--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -135,6 +135,7 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
         int num_columns()
 
     cdef c_string FormatStatValue(ParquetType parquet_type, const char* val)
+    cdef c_string FormatStatValue(ParquetType parquet_type, c_string val)
 
 
 cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -134,7 +134,6 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
         c_bool Equals(const SchemaDescriptor& other)
         int num_columns()
 
-    cdef c_string FormatStatValue(ParquetType parquet_type, const char* val)
     cdef c_string FormatStatValue(ParquetType parquet_type, c_string val)
 
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -99,7 +99,7 @@ cdef class RowGroupStatistics:
         raw_physical_type = self.statistics.get().physical_type()
         encode_min = self.statistics.get().EncodeMin()
 
-        min_value = FormatStatValue(raw_physical_type, encode_min.c_str())
+        min_value = FormatStatValue(raw_physical_type, encode_min)
         return self._cast_statistic(min_value)
 
     @property
@@ -107,7 +107,7 @@ cdef class RowGroupStatistics:
         raw_physical_type = self.statistics.get().physical_type()
         encode_max = self.statistics.get().EncodeMax()
 
-        max_value = FormatStatValue(raw_physical_type, encode_max.c_str())
+        max_value = FormatStatValue(raw_physical_type, encode_max)
         return self._cast_statistic(max_value)
 
     @property

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -630,6 +630,10 @@ def test_parquet_metadata_api():
             [True, False, False, True, True], pa.bool_(),
             'BOOLEAN', False, True, 0, 5, 0
         ),
+        (
+            [b'\x00', b'b', b'12', None, b'aaa'], pa.binary(),
+            'BYTE_ARRAY', b'\x00', b'b', 1, 4, 0
+        ),
     ]
 )
 def test_parquet_column_statistics_api(data, type, physical_type, min_value,


### PR DESCRIPTION
Depends on https://github.com/apache/parquet-cpp/pull/479

Merge once parquet-cpp 1.5.0 is released.