### PR TITLE
ARROW-2921: [Release] Update .deb/.rpm changelogs in preparation

### DIFF
--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -31,6 +31,16 @@ if [ "$#" -eq 2 ]; then
   # Update changelog
   $SOURCE_DIR/update-changelog.sh $version
 
+  echo "Updating .deb/.rpm changelogs for $version"
+  cd $SOURCE_DIR/../tasks/linux-packages
+  rake \
+    version:update \
+    ARROW_RELEASE_TIME="$(date +%Y-%m-%dT%H:%M:%S%z)" \
+    ARROW_VERSION=${version}
+  git add debian*/changelog yum/*.spec.in
+  git commit -m "[Release] Update .deb/.rpm changelogs for $version"
+  cd -
+
   echo "prepare release ${version} on tag ${tag} then reset to version ${nextVersionSNAPSHOT}"
 
   cd "${SOURCE_DIR}/../../java"


### PR DESCRIPTION
NOTE: We need to add more changelog entries for packaging RC because we should use earlier version for RC packages than no-RC packages.

For example, no-RC package should use "0.10.0-1" and RC package should use "0.10.0~rc1-1" (.deb) and "010.0-0.rc1" (.rpm).

It means that we should run `(cd dev/tasks/linux-packages && rake version:update)` for building RC packages. But we don't need to run the command for building no-RC packages.