### PR TITLE
ARROW-2922: [Release] Make python command name customizable

### DIFF
--- a/dev/release/update-changelog.sh
+++ b/dev/release/update-changelog.sh
@@ -25,7 +25,7 @@ version=$1
 
 CHANGELOG=$SOURCE_DIR/../../CHANGELOG.md
 
-python $SOURCE_DIR/changelog.py $version 0 $CHANGELOG
+${PYTHON:-python} $SOURCE_DIR/changelog.py $version 0 $CHANGELOG
 
 git add $CHANGELOG
 git commit -m "[Release] Update CHANGELOG.md for $version"


### PR DESCRIPTION
We can use python3 command by "PYTHON=python3 dev/release/00-prepare.sh".

python3 is used for Python 3 on Debian GNU/Linux.