### PR TITLE
ARROW-2929: [C++] ARROW-2826 Breaks parquet-cpp 1.4.0 builds

### DIFF
--- a/dev/tasks/conda-recipes/appveyor.yml
+++ b/dev/tasks/conda-recipes/appveyor.yml
@@ -66,7 +66,8 @@ artifacts:
 deploy:
   release: {{ task.tag }}
   provider: GitHub
-  auth_token: "%CROSSBOW_GITHUB_TOKEN%"
+  auth_token:
+    secure: "%CROSSBOW_GITHUB_TOKEN%"
   artifact: /.*\.tar\.bz2/
   draft: false
   prerelease: false

--- a/dev/tasks/conda-recipes/appveyor.yml
+++ b/dev/tasks/conda-recipes/appveyor.yml
@@ -66,8 +66,7 @@ artifacts:
 deploy:
   release: {{ task.tag }}
   provider: GitHub
-  auth_token:
-    secure: "%CROSSBOW_GITHUB_TOKEN%"
+  auth_token: "%CROSSBOW_GITHUB_TOKEN%"
   artifact: /.*\.tar\.bz2/
   draft: false
   prerelease: false

--- a/dev/tasks/conda-recipes/parquet-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/parquet-cpp/meta.yaml
@@ -15,9 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{% set version = "1.4.0" %}
-{% set commit = "b62c22e52d37fa9580d85c5a2a2d73bd8e268364" %}
-{% set sha256sum = "2fa5704fc1164f68508e3050d30a6436dd56434e1a592d8ddf4afd68f62a7c01" %}
+{% set version = "1.4.0.post0" %}
+{% set commit = "master" %}
 
 # NOTE(wesm): When updating the build, please remember also to update the
 # pinned Arrow version. We are letting parquet-cpp build its own Apache Arrow
@@ -30,12 +29,11 @@ package:
   version: {{ version }}
 
 source:
-  fn: apache-parquet-cpp-{{ version }}.tar.gz
+  fn: {{ commit }}.tar.gz
   url: https://github.com/apache/parquet-cpp/archive/{{ commit }}.tar.gz
-  sha256: {{ sha256sum }}
 
 build:
-  number: 2
+  number: 0
   skip: true  # [win32]
   skip: true  # [win and py<35]
 

--- a/dev/tasks/conda-recipes/pyarrow/meta.yaml
+++ b/dev/tasks/conda-recipes/pyarrow/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - numpy 1.12.*   # [win and py>=36]
     - six
     - arrow-cpp {{ ARROW_VERSION }}
-    - parquet-cpp 1.4.0
+    - parquet-cpp 1.4.0.post0
 
   run:
     - python
@@ -51,7 +51,7 @@ requirements:
     - pandas
     - six
     - arrow-cpp {{ ARROW_VERSION }}
-    - parquet-cpp 1.4.0
+    - parquet-cpp 1.4.0.post0
     - futures  # [py27]
 
 test:

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -49,7 +49,8 @@ artifacts:
 deploy:
   release: {{ task.tag }}
   provider: GitHub
-  auth_token: "%CROSSBOW_GITHUB_TOKEN%"
+  auth_token:
+    secure: "%CROSSBOW_GITHUB_TOKEN%"
   artifact: /.*\.whl/
   draft: false
   prerelease: false

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -28,7 +28,7 @@ environment:
   ARROW_SRC: C:\apache-arrow
   PYARROW_VERSION: {{ arrow.version }}
   PYARROW_REF: {{ arrow.head }}
-  PARQUET_CPP_REF: apache-parquet-cpp-1.4.0
+  PARQUET_CPP_REF: master
 
 init:
   - set MINICONDA=C:\Miniconda35-x64

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -47,8 +47,7 @@ artifacts:
 deploy:
   release: {{ task.tag }}
   provider: GitHub
-  auth_token:
-    secure: "%CROSSBOW_GITHUB_TOKEN%"
+  auth_token: "%CROSSBOW_GITHUB_TOKEN%"
   artifact: /.*\.whl/
   draft: false
   prerelease: false

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -23,8 +23,6 @@ environment:
   NUMPY: "{{ numpy_version }}"
   PYTHON: "{{ python_version }}"
   MSVC_DEFAULT_OPTIONS: ON
-  BOOST_ROOT: C:\Libraries\boost_1_63_0
-  BOOST_LIBRARYDIR: C:\Libraries\boost_1_63_0\lib64-msvc-14.0
   ARROW_SRC: C:\apache-arrow
   PYARROW_VERSION: {{ arrow.version }}
   PYARROW_REF: {{ arrow.head }}


### PR DESCRIPTION
This uses parquet-cpp master when building windows wheels and conda
packages on all platforms