### PR TITLE
ARROW-2926: [Python] Do not attempt to write tables with invalid schemas in ParquetWriter.write_table

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -327,6 +327,13 @@ schema : arrow Schema
         if self.schema_changed:
             table = _sanitize_table(table, self.schema, self.flavor)
         assert self.is_open
+
+        if not table.schema.equals(self.schema):
+            msg = ('Table schema does not match schema used to create file: '
+                   '\ntable:\n{0!s} vs. \nfile:\n{1!s}'.format(table.schema,
+                                                               self.schema))
+            raise ValueError(msg)
+
         self.writer.write_table(table, row_group_size=row_group_size)
 
     def close(self):


### PR DESCRIPTION
To be honest, `parquet::arrow::FileWriter` should probably also validate. I will open a corresponding issue "upstream"