### PR TITLE
ARROW-2946: [Packaging] Stop to use $PWD

### DIFF
--- a/dev/tasks/linux-packages/debian.ubuntu-trusty/rules
+++ b/dev/tasks/linux-packages/debian.ubuntu-trusty/rules
@@ -25,7 +25,7 @@ override_dh_auto_configure:
 	  --sourcedirectory=c_glib \
 	  --builddirectory=c_glib_build \
 	  -- \
-	  --with-arrow-cpp-build-dir=$${PWD}/cpp_build \
+	  --with-arrow-cpp-build-dir=$(CURDIR)/cpp_build \
 	  --with-arrow-cpp-build-type=$(BUILD_TYPE) \
 	  --enable-gtk-doc \
 	  --with-html-dir=\$${prefix}/share/doc/libarrow-glib-doc
@@ -35,7 +35,7 @@ override_dh_auto_build:
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build
 	env							\
-	  LD_LIBRARY_PATH=$${PWD}/cpp_build/$(BUILD_TYPE)	\
+	  LD_LIBRARY_PATH=$(CURDIR)/cpp_build/$(BUILD_TYPE)	\
 	    dh_auto_build					\
 	      --sourcedirectory=c_glib				\
 	      --builddirectory=c_glib_build

--- a/dev/tasks/linux-packages/debian/rules
+++ b/dev/tasks/linux-packages/debian/rules
@@ -37,7 +37,7 @@ override_dh_auto_configure:
 	  --sourcedirectory=c_glib \
 	  --builddirectory=c_glib_build \
 	  -- \
-	  --with-arrow-cpp-build-dir=$${PWD}/cpp_build \
+	  --with-arrow-cpp-build-dir=$(CURDIR)/cpp_build \
 	  --with-arrow-cpp-build-type=$(BUILD_TYPE) \
 	  --enable-gtk-doc \
 	  --with-html-dir=\$${prefix}/share/doc/libarrow-glib-doc
@@ -47,7 +47,7 @@ override_dh_auto_build:
 	  --sourcedirectory=cpp			\
 	  --builddirectory=cpp_build
 	env							\
-	  LD_LIBRARY_PATH=$${PWD}/cpp_build/$(BUILD_TYPE)	\
+	  LD_LIBRARY_PATH=$(CURDIR)/cpp_build/$(BUILD_TYPE)	\
 	    dh_auto_build					\
 	      --sourcedirectory=c_glib				\
 	      --builddirectory=c_glib_build


### PR DESCRIPTION
https://lintian.debian.org/tags/debian-rules-should-not-use-pwd.html