### PR TITLE
ARROW-2944: [Format] Synchronize some metadata changes to columnar format Markdown documents

### DIFF
--- a/format/IPC.md
+++ b/format/IPC.md
@@ -138,10 +138,6 @@ struct FieldNode {
 }
 
 struct Buffer {
-  /// The shared memory page id where this buffer is located. Currently this is
-  /// not used
-  page: int;
-
   /// The relative offset into the shared memory page where the bytes for this
   /// buffer starts
   offset: long;

--- a/format/Metadata.md
+++ b/format/Metadata.md
@@ -51,15 +51,13 @@ table Field {
   name: string;
   nullable: bool;
   type: Type;
-  // present only if the field is dictionary encoded
-  // will point to a dictionary provided by a DictionaryBatch message
-  dictionary: long;
+
+  // Present only if the field is dictionary encoded
+  dictionary: DictionaryEncoding;
+
   // children apply only to Nested data types like Struct, List and Union
   children: [Field];
-  /// layout of buffers produced for this type (as derived from the Type)
-  /// does not include children
-  /// each recordbatch will return instances of those Buffers.
-  layout: [ VectorLayout ];
+
   // User-defined metadata
   custom_metadata: [ KeyValue ];
 }
@@ -76,18 +74,9 @@ Field:
   "nullable" : false,
   "type" : /* Type */,
   "children" : [ /* Field */ ],
-  "typeLayout" : {
-    "vectors" : [ /* VectorLayout */ ]
-  }
 }
 ```
-VectorLayout:
-```
-{
-  "type" : "DATA|OFFSET|VALIDITY|TYPE",
-  "typeBitWidth" : /* int */
-}
-```
+
 Type:
 ```
 {
@@ -95,6 +84,7 @@ Type:
   // fields as defined in the Flatbuffer depending on the type name
 }
 ```
+
 Union:
 ```
 {


### PR DESCRIPTION
These changes were made in 0.8 but the Markdown documents were not updated