### PR TITLE
ARROW-2666: [Python] Add __array__ method to Array, ChunkedArray, Column

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -652,6 +652,11 @@ cdef class Array:
                                               self, &out))
         return wrap_array_output(out)
 
+    def __array__(self, dtype=None):
+        if dtype is None:
+            return self.to_pandas()
+        return self.to_pandas().astype(dtype)
+
     def to_numpy(self):
         """
         EXPERIMENTAL: Construct a NumPy view of this array. Only supports

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -147,11 +147,12 @@ cdef class ChunkedArray:
                   c_bool zero_copy_only=False,
                   c_bool integer_object_nulls=False):
         """
-        Convert the arrow::Column to a pandas.Series
+        Convert the arrow::ChunkedArray to an array object suitable for use
+        in pandas
 
-        Returns
-        -------
-        pandas.Series
+        See also
+        --------
+        Column.to_pandas
         """
         cdef:
             PyObject* out
@@ -170,6 +171,11 @@ cdef class ChunkedArray:
                 self, &out))
 
         return wrap_array_output(out)
+
+    def __array__(self, dtype=None):
+        if dtype is None:
+            return self.to_pandas()
+        return self.to_pandas().astype(dtype)
 
     def dictionary_encode(self):
         """
@@ -516,6 +522,9 @@ cdef class Column:
                           .dt.tz_convert(tz))
 
         return result
+
+    def __array__(self, dtype=None):
+        return self.data.__array__(dtype=dtype)
 
     def equals(self, Column other):
         """

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -156,6 +156,35 @@ def test_to_pandas_zero_copy():
         np_arr.sum()
 
 
+def test_asarray():
+    arr = pa.array(range(4))
+
+    # The iterator interface gives back an array of Int64Value's
+    np_arr = np.asarray([_ for _ in arr])
+    assert np_arr.tolist() == [0, 1, 2, 3]
+    assert np_arr.dtype == np.dtype('O')
+    assert type(np_arr[0]) == pa.lib.Int64Value
+
+    # Using np.asarray gives back an array with 'int64' dtype
+    np_arr = np.asarray(arr)
+    assert np_arr.tolist() == [0, 1, 2, 3]
+    assert np_arr.dtype == np.dtype('int64')
+
+    # An optional type can be specified when calling np.asarray
+    np_arr = np.asarray(arr, dtype='str')
+    assert np_arr.tolist() == ['0', '1', '2', '3']
+
+    # If PyArrow array has null values, numpy type will be changed as needed
+    # to support nulls.
+    arr = pa.array([0, 1, 2, None])
+    assert arr.type == pa.int64()
+    np_arr = np.asarray(arr)
+    elements = np_arr.tolist()
+    assert elements[:3] == [0., 1., 2.]
+    assert np.isnan(elements[3])
+    assert np_arr.dtype == np.dtype('float64')
+
+
 def test_array_getitem():
     arr = pa.array(range(10, 15))
     lst = arr.to_pylist()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -165,7 +165,7 @@ def test_asarray():
     assert np_arr.dtype == np.dtype('O')
     assert type(np_arr[0]) == pa.lib.Int64Value
 
-    # Using np.asarray gives back an array with 'int64' dtype
+    # Calling with the arrow array gives back an array with 'int64' dtype
     np_arr = np.asarray(arr)
     assert np_arr.tolist() == [0, 1, 2, 3]
     assert np_arr.dtype == np.dtype('int64')


### PR DESCRIPTION
Implement `__array__` method on `pyarrow.Array`, `pyarrow.ChunkedArray` and `pyarrow.Column` so that the `to_pandas()` method is used when calling `numpy.asarray` on an instance of these classes. 

Currently `numpy.asarray` falls back to using the iterator interface so we get numpy object arrays of the underlying pyarrow scalar value type.