### PR TITLE
ARROW-2813: [CI] [Followup] Disable gcov output in Travis-CI logs

### DIFF
--- a/ci/travis_upload_cpp_coverage.sh
+++ b/ci/travis_upload_cpp_coverage.sh
@@ -25,7 +25,7 @@ pushd $TRAVIS_BUILD_DIR
 
 # Display C++ coverage summary
 lcov --list $ARROW_CPP_COVERAGE_FILE
-# Upload report to CodeCov
-bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+# Upload report to CodeCov, disabling gcov discovery to save time and avoid warnings
+bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"
 
 popd


### PR DESCRIPTION
We don't actually need codecov's gcov discovery, since we gather coverage ourselves using `lcov` in the CI scripts. This suppresses hundreds of lines of logs in Travis-CI's output.