### PR TITLE
ARROW-2994: [Python] Only include Python and NumPy include directories for libarrow_python targets

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -715,12 +715,5 @@ endif()
 add_subdirectory(src/arrow)
 
 if(ARROW_PYTHON)
-  find_package(PythonLibsNew REQUIRED)
-  find_package(NumPy REQUIRED)
-
-  include_directories(SYSTEM
-    ${NUMPY_INCLUDE_DIRS}
-    ${PYTHON_INCLUDE_DIRS})
-
   add_subdirectory(src/arrow/python)
 endif()

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -101,6 +101,10 @@ function(ADD_ARROW_LIB LIB_NAME)
   if(MSVC)
     set(LIB_DEPS ${ARG_SOURCES})
     set(EXTRA_DEPS ${ARG_DEPENDENCIES})
+
+    if (ARG_EXTRA_INCLUDES)
+      set(LIB_INCLUDES ${ARG_EXTRA_INCLUDES})
+    endif()
   else()
     add_library(${LIB_NAME}_objlib OBJECT
       ${ARG_SOURCES})
@@ -110,21 +114,28 @@ function(ADD_ARROW_LIB LIB_NAME)
       add_dependencies(${LIB_NAME}_objlib ${ARG_DEPENDENCIES})
     endif()
     set(LIB_DEPS $<TARGET_OBJECTS:${LIB_NAME}_objlib>)
+    set(LIB_INCLUDES)
     set(EXTRA_DEPS)
+
+    if (ARG_EXTRA_INCLUDES)
+      target_include_directories(${LIB_NAME}_objlib SYSTEM PUBLIC
+        ${ARG_EXTRA_INCLUDES}
+        )
+    endif()
   endif()
 
   set(RUNTIME_INSTALL_DIR bin)
-
-  if (ARG_EXTRA_INCLUDES)
-    target_include_directories(${LIB_NAME}_objlib SYSTEM PUBLIC
-      ${ARG_EXTRA_INCLUDES}
-      )
-  endif()
 
   if (ARROW_BUILD_SHARED)
     add_library(${LIB_NAME}_shared SHARED ${LIB_DEPS})
     if (EXTRA_DEPS)
       add_dependencies(${LIB_NAME}_shared ${EXTRA_DEPS})
+    endif()
+
+    if (LIB_INCLUDES)
+      target_include_directories(${LIB_NAME}_shared SYSTEM PUBLIC
+        ${ARG_EXTRA_INCLUDES}
+        )
     endif()
 
     if(APPLE)
@@ -182,6 +193,12 @@ function(ADD_ARROW_LIB LIB_NAME)
     add_library(${LIB_NAME}_static STATIC ${LIB_DEPS})
     if(EXTRA_DEPS)
       add_dependencies(${LIB_NAME}_static ${EXTRA_DEPS})
+    endif()
+
+    if (LIB_INCLUDES)
+      target_include_directories(${LIB_NAME}_static SYSTEM PUBLIC
+        ${ARG_EXTRA_INCLUDES}
+        )
     endif()
 
     if (MSVC)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -92,7 +92,7 @@ endfunction()
 function(ADD_ARROW_LIB LIB_NAME)
   set(options)
   set(one_value_args SHARED_LINK_FLAGS)
-  set(multi_value_args SOURCES STATIC_LINK_LIBS STATIC_PRIVATE_LINK_LIBS SHARED_LINK_LIBS SHARED_PRIVATE_LINK_LIBS DEPENDENCIES)
+  set(multi_value_args SOURCES STATIC_LINK_LIBS STATIC_PRIVATE_LINK_LIBS SHARED_LINK_LIBS SHARED_PRIVATE_LINK_LIBS EXTRA_INCLUDES DEPENDENCIES)
   cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -115,8 +115,20 @@ function(ADD_ARROW_LIB LIB_NAME)
 
   set(RUNTIME_INSTALL_DIR bin)
 
+  if (ARG_EXTRA_INCLUDES)
+    target_include_directories(${LIB_NAME}_objlib PUBLIC BEFORE
+      ${ARG_EXTRA_INCLUDES}
+      )
+  endif()
+
+  # if (ARG_EXTRA_INCLUDES)
+  #   get_property(object_include_dirs TARGET ${LIB_NAME}_objlib
+  #     PROPERTY INCLUDE_DIRECTORIES)
+  # endif()
+
   if (ARROW_BUILD_SHARED)
     add_library(${LIB_NAME}_shared SHARED ${LIB_DEPS})
+    # target_include_directories(${LIB_NAME}_shared PUBLIC ${object_include_dirs})
     if (EXTRA_DEPS)
       add_dependencies(${LIB_NAME}_shared ${EXTRA_DEPS})
     endif()
@@ -174,6 +186,7 @@ function(ADD_ARROW_LIB LIB_NAME)
 
   if (ARROW_BUILD_STATIC)
     add_library(${LIB_NAME}_static STATIC ${LIB_DEPS})
+    # target_include_directories(${LIB_NAME}_static PUBLIC ${object_include_dirs})
     if(EXTRA_DEPS)
       add_dependencies(${LIB_NAME}_static ${EXTRA_DEPS})
     endif()

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -116,19 +116,13 @@ function(ADD_ARROW_LIB LIB_NAME)
   set(RUNTIME_INSTALL_DIR bin)
 
   if (ARG_EXTRA_INCLUDES)
-    target_include_directories(${LIB_NAME}_objlib PUBLIC BEFORE
+    target_include_directories(${LIB_NAME}_objlib SYSTEM PUBLIC
       ${ARG_EXTRA_INCLUDES}
       )
   endif()
 
-  # if (ARG_EXTRA_INCLUDES)
-  #   get_property(object_include_dirs TARGET ${LIB_NAME}_objlib
-  #     PROPERTY INCLUDE_DIRECTORIES)
-  # endif()
-
   if (ARROW_BUILD_SHARED)
     add_library(${LIB_NAME}_shared SHARED ${LIB_DEPS})
-    # target_include_directories(${LIB_NAME}_shared PUBLIC ${object_include_dirs})
     if (EXTRA_DEPS)
       add_dependencies(${LIB_NAME}_shared ${EXTRA_DEPS})
     endif()
@@ -186,7 +180,6 @@ function(ADD_ARROW_LIB LIB_NAME)
 
   if (ARROW_BUILD_STATIC)
     add_library(${LIB_NAME}_static STATIC ${LIB_DEPS})
-    # target_include_directories(${LIB_NAME}_static PUBLIC ${object_include_dirs})
     if(EXTRA_DEPS)
       add_dependencies(${LIB_NAME}_static ${EXTRA_DEPS})
     endif()
@@ -298,7 +291,7 @@ endfunction()
 function(ADD_ARROW_TEST REL_TEST_NAME)
   set(options NO_VALGRIND)
   set(single_value_args)
-  set(multi_value_args STATIC_LINK_LIBS)
+  set(multi_value_args STATIC_LINK_LIBS EXTRA_INCLUDES)
   cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -319,6 +312,11 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
       target_link_libraries(${TEST_NAME} ${ARG_STATIC_LINK_LIBS})
     else()
       target_link_libraries(${TEST_NAME} ${ARROW_TEST_LINK_LIBS})
+    endif()
+    if (ARG_EXTRA_INCLUDES)
+      target_include_directories(${TEST_NAME} SYSTEM PUBLIC
+        ${ARG_EXTRA_INCLUDES}
+        )
     endif()
     add_dependencies(unittest ${TEST_NAME})
   else()

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -116,6 +116,8 @@ if (ARROW_BUILD_TESTS)
 
   target_link_libraries(arrow_python_test_main
     gtest)
+  target_include_directories(arrow_python_test_main SYSTEM PUBLIC
+    ${ARROW_PYTHON_INCLUDES})
 
   if (APPLE)
 	target_link_libraries(arrow_python_test_main
@@ -137,6 +139,7 @@ if (ARROW_BUILD_TESTS)
 
   ADD_ARROW_TEST(python-test
     STATIC_LINK_LIBS "${ARROW_PYTHON_TEST_LINK_LIBS}"
+    EXTRA_INCLUDES "${ARROW_PYTHON_INCLUDES}"
     NO_VALGRIND)
   target_link_libraries(python-test
     ${PYTHON_LIBRARIES})

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -19,6 +19,9 @@
 # arrow_python
 #######################################
 
+find_package(PythonLibsNew REQUIRED)
+find_package(NumPy REQUIRED)
+
 set(ARROW_PYTHON_SRCS
   arrow_to_pandas.cc
   arrow_to_python.cc
@@ -55,11 +58,16 @@ if (MSVC)
     )
 endif()
 
+set(ARROW_PYTHON_INCLUDES
+  ${NUMPY_INCLUDE_DIRS}
+  ${PYTHON_INCLUDE_DIRS})
+
 ADD_ARROW_LIB(arrow_python
   SOURCES ${ARROW_PYTHON_SRCS}
   SHARED_LINK_FLAGS ""
   SHARED_LINK_LIBS ${ARROW_PYTHON_SHARED_LINK_LIBS}
   STATIC_LINK_LIBS "${PYTHON_OTHER_LIBS}"
+  EXTRA_INCLUDES "${ARROW_PYTHON_INCLUDES}"
 )
 
 if ("${COMPILER_FAMILY}" STREQUAL "clang")


### PR DESCRIPTION
This should enable CMake to reuse artifacts when switching between Python versions