### PR TITLE
ARROW-2996: [C++] Fix typo in cpp/.clang-tidy

### DIFF
--- a/cpp/.clang-tidy
+++ b/cpp/.clang-tidy
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-.*,modernize-.*,readablity-.*'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-*,modernize-*,readability-*'
 HeaderFilterRegex: 'arrow/.*'
 AnalyzeTemporaryDtors: true
 CheckOptions:


### PR DESCRIPTION
There was a typo in the list of checks for clang-tidy. To my knowledge, none of the google/modernize/readablity[sic] checks were being run.