### PR TITLE
ARROW-2991: [CI] Remove some AppVeyor build configurations

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,14 +49,14 @@ environment:
       CONFIGURATION: "Release"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       BOOST_ROOT: C:\Libraries\boost_1_64_0
-    - JOB: "Build_Debug"
-      GENERATOR: Ninja
-      CONFIGURATION: "Debug"
-    - JOB: "Static_Crt_Build"
-      GENERATOR: Ninja
     - JOB: "Toolchain"
       GENERATOR: Visual Studio 14 2015 Win64
       CONFIGURATION: "Release"
+    - JOB: "Static_Crt_Build"
+      GENERATOR: Ninja
+    - JOB: "Build_Debug"
+      GENERATOR: Ninja
+      CONFIGURATION: "Debug"
     - JOB: "Cmake_Script_Tests"
       GENERATOR: Ninja
       CONFIGURATION: "Release"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,21 +52,15 @@ environment:
     - JOB: "Build_Debug"
       GENERATOR: Ninja
       CONFIGURATION: "Debug"
-    - JOB: "Build"
-      GENERATOR: Ninja
-      CONFIGURATION: "Release"
     - JOB: "Static_Crt_Build"
       GENERATOR: Ninja
     - JOB: "Toolchain"
       GENERATOR: Visual Studio 14 2015 Win64
       CONFIGURATION: "Release"
     - JOB: "Cmake_Script_Tests"
-      GENERATOR: NMake Makefiles
+      GENERATOR: Ninja
       CONFIGURATION: "Release"
       BUILD_SCRIPT: "CMake_Build_Script"
-    - JOB: "Build"
-      GENERATOR: NMake Makefiles
-      CONFIGURATION: "Release"
     - JOB: "Rust_Stable"
       RUST_VERSION: stable
       TARGET: x86_64-pc-windows-msvc

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -30,7 +30,6 @@ conda config --add channels https://repo.continuum.io/pkgs/free
 conda config --add channels conda-forge
 conda info -a
 
-if "%GENERATOR%"=="NMake Makefiles" set need_vcvarsall=1
 if "%GENERATOR%"=="Ninja" set need_vcvarsall=1
 
 if defined need_vcvarsall (


### PR DESCRIPTION
Remove two build configurations:
- Release build with Ninja and VS2015 (we already have a Release build with
  Ninja and VS2017, and a Debug build with Ninja and VS2015)
- Release build with NMake (we don't care much about NMake enough to add
  10+ minutes of build time)