### PR TITLE
ARROW-3006: [GLib] Fix a bug that .gir/.typelib for GPU aren't installed

### DIFF
--- a/c_glib/arrow-gpu-glib/Makefile.am
+++ b/c_glib/arrow-gpu-glib/Makefile.am
@@ -90,7 +90,6 @@ ArrowGPU_1_0_gir_INCLUDES =			\
 	Arrow-1.0
 ArrowGPU_1_0_gir_CFLAGS =			\
 	$(AM_CPPFLAGS)
-ArrowGPU_1_0_gir_LDFLAGS =
 ArrowGPU_1_0_gir_LIBS =
 ArrowGPU_1_0_gir_FILES =			\
 	$(libarrow_gpu_glib_la_sources)
@@ -114,7 +113,6 @@ ArrowGPU_1_0_gir_LIBS +=				\
 	libarrow-gpu-glib.la
 endif
 
-					\
 INTROSPECTION_GIRS += ArrowGPU-1.0.gir
 
 girdir = $(datadir)/gir-1.0


### PR DESCRIPTION
00aed053fd77e5c5e17d83e36d85a82a1b738fa0 introduced this bug.