### PR TITLE
ARROW-3007: [Packaging] Remove needless dependencies

### DIFF
--- a/dev/tasks/linux-packages/debian/control
+++ b/dev/tasks/linux-packages/debian/control
@@ -33,8 +33,7 @@ Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends:
   ${misc:Depends},
-  ${shlibs:Depends},
-  libjemalloc1
+  ${shlibs:Depends}
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides library files.
@@ -62,9 +61,7 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},
-  libarrow10 (= ${binary:Version}),
-  libnvidia-fatbinaryloader,
-  libcuda1
+  libarrow10 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides library files for GPU support.


### PR DESCRIPTION
Dependencies should be computed by ${shlibs:Depends}. Because package name may
be different between distributions. For example, libcuda1 doesn't
exist on Ubuntu 18.04.