### PR TITLE
ARROW-2998: [C++] Add unique_ptr versions of Allocate[Resizable]Buffer

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -199,7 +199,6 @@ Status AllocateResizableBuffer(const int64_t size,
   return AllocateResizableBuffer(default_memory_pool(), size, out);
 }
 
-
 Status AllocateEmptyBitmap(MemoryPool* pool, int64_t length,
                            std::shared_ptr<Buffer>* out) {
   RETURN_NOT_OK(AllocateBuffer(pool, BitUtil::BytesForBits(length), out));

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -155,7 +155,20 @@ Status AllocateBuffer(MemoryPool* pool, const int64_t size,
   return Status::OK();
 }
 
+Status AllocateBuffer(MemoryPool* pool, const int64_t size,
+                      std::unique_ptr<Buffer>* out) {
+  auto buffer = std::unique_ptr<PoolBuffer>(new PoolBuffer(pool));
+  RETURN_NOT_OK(buffer->Resize(size));
+  buffer->ZeroPadding();
+  *out = std::move(buffer);
+  return Status::OK();
+}
+
 Status AllocateBuffer(const int64_t size, std::shared_ptr<Buffer>* out) {
+  return AllocateBuffer(default_memory_pool(), size, out);
+}
+
+Status AllocateBuffer(const int64_t size, std::unique_ptr<Buffer>* out) {
   return AllocateBuffer(default_memory_pool(), size, out);
 }
 
@@ -168,10 +181,25 @@ Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
   return Status::OK();
 }
 
+Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
+                               std::unique_ptr<ResizableBuffer>* out) {
+  auto buffer = std::unique_ptr<PoolBuffer>(new PoolBuffer(pool));
+  RETURN_NOT_OK(buffer->Resize(size));
+  buffer->ZeroPadding();
+  *out = std::move(buffer);
+  return Status::OK();
+}
+
 Status AllocateResizableBuffer(const int64_t size,
                                std::shared_ptr<ResizableBuffer>* out) {
   return AllocateResizableBuffer(default_memory_pool(), size, out);
 }
+
+Status AllocateResizableBuffer(const int64_t size,
+                               std::unique_ptr<ResizableBuffer>* out) {
+  return AllocateResizableBuffer(default_memory_pool(), size, out);
+}
+
 
 Status AllocateEmptyBitmap(MemoryPool* pool, int64_t length,
                            std::shared_ptr<Buffer>* out) {

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -18,6 +18,7 @@
 #include "arrow/buffer.h"
 
 #include <cstdint>
+#include <utility>
 
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -231,6 +231,16 @@ class ARROW_EXPORT ResizableBuffer : public MutableBuffer {
 ARROW_EXPORT
 Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::shared_ptr<Buffer>* out);
 
+/// \brief Allocate a fixed size mutable buffer from a memory pool, zero its padding.
+///
+/// \param[in] pool a memory pool
+/// \param[in] size size of buffer to allocate
+/// \param[out] out the allocated buffer (contains padding)
+///
+/// \return Status message
+ARROW_EXPORT
+Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::unique_ptr<Buffer>* out);
+
 /// \brief Allocate a fixed-size mutable buffer from the default memory pool
 ///
 /// \param[in] size size of buffer to allocate
@@ -239,6 +249,15 @@ Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::shared_ptr<Buff
 /// \return Status message
 ARROW_EXPORT
 Status AllocateBuffer(const int64_t size, std::shared_ptr<Buffer>* out);
+
+/// \brief Allocate a fixed-size mutable buffer from the default memory pool
+///
+/// \param[in] size size of buffer to allocate
+/// \param[out] out the allocated buffer (contains padding)
+///
+/// \return Status message
+ARROW_EXPORT
+Status AllocateBuffer(const int64_t size, std::unique_ptr<Buffer>* out);
 
 /// \brief Allocate a resizeable buffer from a memory pool, zero its padding.
 ///
@@ -251,6 +270,17 @@ ARROW_EXPORT
 Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
                                std::shared_ptr<ResizableBuffer>* out);
 
+/// \brief Allocate a resizeable buffer from a memory pool, zero its padding.
+///
+/// \param[in] pool a memory pool
+/// \param[in] size size of buffer to allocate
+/// \param[out] out the allocated buffer
+///
+/// \return Status message
+ARROW_EXPORT
+Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
+                               std::unique_ptr<ResizableBuffer>* out);
+
 /// \brief Allocate a resizeable buffer from the default memory pool
 ///
 /// \param[in] size size of buffer to allocate
@@ -259,6 +289,16 @@ Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
 /// \return Status message
 ARROW_EXPORT
 Status AllocateResizableBuffer(const int64_t size, std::shared_ptr<ResizableBuffer>* out);
+
+
+/// \brief Allocate a resizeable buffer from the default memory pool
+///
+/// \param[in] size size of buffer to allocate
+/// \param[out] out the allocated buffer
+///
+/// \return Status message
+ARROW_EXPORT
+Status AllocateResizableBuffer(const int64_t size, std::unique_ptr<ResizableBuffer>* out);
 
 /// \brief Allocate a zero-initialized bitmap buffer from a memory pool
 ///

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -290,7 +290,6 @@ Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
 ARROW_EXPORT
 Status AllocateResizableBuffer(const int64_t size, std::shared_ptr<ResizableBuffer>* out);
 
-
 /// \brief Allocate a resizeable buffer from the default memory pool
 ///
 /// \param[in] size size of buffer to allocate


### PR DESCRIPTION
This could be improved in a couple of ways:

1. Remove duplication. I didn't do this yet because ther already is duplication in buffer.cc and I wanted some feedback before proceeding.

2. Add tests. I didn't do this yet because the testing of the existing `shared_ptr` `AllocateBuffer` functions is quite slim, so I wanted some feedback before proceeding.