### PR TITLE
ARROW-2986: [C++] Use /EHsc flag for exception handling on MSVC, disable C4772 compiler warning in arrow/util/logging.h

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -53,7 +53,9 @@ if (MSVC)
     string(REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
     # Set desired warning level (e.g. set /W4 for more warnings)
-    set(CXX_COMMON_FLAGS "/W3")
+    #
+    # ARROW-2986: Without /EHsc we get C4530 warning
+    set(CXX_COMMON_FLAGS "/W3 /EHsc")
   endif()
 
   if (ARROW_USE_STATIC_CRT)

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -114,7 +114,7 @@ class NullLog {
 // Do not warn about destructor aborting
 #if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable:4722)
+#pragma warning(disable : 4722)
 #endif
 
 class CerrLog {

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -111,6 +111,12 @@ class NullLog {
   }
 };
 
+// Do not warn about destructor aborting
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4722)
+#endif
+
 class CerrLog {
  public:
   CerrLog(int severity)  // NOLINT(runtime/explicit)
@@ -153,6 +159,10 @@ class FatalLog : public CerrLog {
     std::abort();
   }
 };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 }  // namespace internal
 


### PR DESCRIPTION
I'm not sure when these warnings appeared (things used to build cleanly for me), but these changes fix them. 

As an aside, I don't think that libarrow should have any code that throws exceptions or includes `<exception>` in its public API. I opened ARROW-3017 about addressing that