### PR TITLE
ARROW-3018: [Plasma] Remove Mersenne twister

### DIFF
--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -17,10 +17,10 @@
 
 #include "plasma/common.h"
 
-#include <chrono>
 #include <limits>
 #include <mutex>
 #include <random>
+#include <vector>
 
 #include "plasma/plasma_generated.h"
 

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -20,7 +20,6 @@
 #include <limits>
 #include <mutex>
 #include <random>
-#include <vector>
 
 #include "plasma/plasma_generated.h"
 

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -31,7 +31,7 @@ namespace plasma {
 using arrow::Status;
 
 std::mt19937 RandomlySeededMersenneTwister() {
-  // We use the "/dev/urandom" argument here. Without it,
+  // We use the "/dev/urandom" argument here. Without it, the libstdc++
   // std::random_device gets randomness using a special CPU instruction
   // (RDRND) which crashes the valgrind shipped with Ubuntu 16.04.
   std::random_device urandom("/dev/urandom");

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -17,6 +17,7 @@
 
 #include "plasma/common.h"
 
+#include <chrono>
 #include <limits>
 #include <mutex>
 #include <random>
@@ -29,6 +30,12 @@ namespace plasma {
 
 using arrow::Status;
 
+std::mt19937 RandomlySeededMersenneTwister() {
+  auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  std::mt19937 seeded_engine(seed);
+  return seeded_engine;
+}
+
 UniqueID UniqueID::from_random() {
   UniqueID id;
   uint8_t* data = id.mutable_data();
@@ -37,7 +44,7 @@ UniqueID UniqueID::from_random() {
   // older versions of macOS (see https://stackoverflow.com/a/29929949)
   static std::mutex mutex;
   std::lock_guard<std::mutex> lock(mutex);
-  static std::mt19937 generator;
+  static std::mt19937 generator = RandomlySeededMersenneTwister();
   std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint8_t>::max());
   for (int i = 0; i < kUniqueIDSize; i++) {
     data[i] = static_cast<uint8_t>(dist(generator));

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -36,7 +36,7 @@ std::mt19937 RandomlySeededMersenneTwister() {
   // (RDRND) which crashes the valgrind shipped with Ubuntu 16.04.
   std::random_device urandom("/dev/urandom");
   std::vector<std::mt19937::result_type> seeds;
-  for (int i = 0; i < std::mt19937::state_size; ++i) {
+  for (size_t i = 0; i < std::mt19937::state_size; ++i) {
     seeds.push_back(urandom());
   }
   std::seed_seq seq(seeds.begin(), seeds.end());

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -31,7 +31,8 @@ namespace plasma {
 using arrow::Status;
 
 std::mt19937 RandomlySeededMersenneTwister() {
-  auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+  auto seed = static_cast<std::mt19937::result_type>(
+      std::chrono::high_resolution_clock::now().time_since_epoch().count());
   std::mt19937 seeded_engine(seed);
   return seeded_engine;
 }

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -18,8 +18,6 @@
 #include "plasma/common.h"
 
 #include <limits>
-#include <mutex>
-#include <random>
 
 #include "plasma/plasma_generated.h"
 

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -46,6 +46,7 @@ class ARROW_EXPORT UniqueID {
   std::string binary() const;
   std::string hex() const;
   size_t hash() const;
+  static int64_t size() { return kUniqueIDSize; }
 
  private:
   uint8_t id_[kUniqueIDSize];

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -39,7 +39,6 @@ constexpr int64_t kUniqueIDSize = 20;
 
 class ARROW_EXPORT UniqueID {
  public:
-  static UniqueID from_random();
   static UniqueID from_binary(const std::string& binary);
   bool operator==(const UniqueID& rhs) const;
   const uint8_t* data() const;

--- a/cpp/src/plasma/test-common.h
+++ b/cpp/src/plasma/test-common.h
@@ -27,7 +27,7 @@ namespace plasma {
 
 ObjectID random_object_id() {
   ObjectID result;
-  arrow::test::random_bytes(kUniqueIDSize, 0, result.mutable_data());
+  arrow::random_bytes(kUniqueIDSize, 0, result.mutable_data());
   return result;
 }
 

--- a/cpp/src/plasma/test-common.h
+++ b/cpp/src/plasma/test-common.h
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PLASMA_TEST_COMMON_H
+#define PLASMA_TEST_COMMON_H
+
+#include "arrow/test-util.h"
+#include "gtest/gtest.h"
+
+#include "plasma/common.h"
+
+namespace plasma {
+
+ObjectID random_object_id() {
+  ObjectID result;
+  arrow::test::random_bytes(kUniqueIDSize, 0, result.mutable_data());
+  return result;
+}
+
+}  // namespace plasma
+
+#endif // PLASMA_TEST_COMMON_H

--- a/cpp/src/plasma/test-common.h
+++ b/cpp/src/plasma/test-common.h
@@ -33,4 +33,4 @@ ObjectID random_object_id() {
 
 }  // namespace plasma
 
-#endif // PLASMA_TEST_COMMON_H
+#endif  // PLASMA_TEST_COMMON_H

--- a/cpp/src/plasma/test-common.h
+++ b/cpp/src/plasma/test-common.h
@@ -26,8 +26,9 @@
 namespace plasma {
 
 ObjectID random_object_id() {
+  static uint32_t random_seed = 0;
   ObjectID result;
-  arrow::random_bytes(kUniqueIDSize, 0, result.mutable_data());
+  arrow::random_bytes(kUniqueIDSize, random_seed++, result.mutable_data());
   return result;
 }
 

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -26,7 +26,7 @@
 #include <random>
 #include <thread>
 
-#include "plasma/test/test_common.h"
+#include "plasma/test-common.h"
 
 #include "plasma/client.h"
 #include "plasma/common.h"

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -26,14 +26,12 @@
 #include <random>
 #include <thread>
 
-#include "arrow/test-util.h"
+#include "plasma/test/test_common.h"
 
 #include "plasma/client.h"
 #include "plasma/common.h"
 #include "plasma/plasma.h"
 #include "plasma/protocol.h"
-
-#include "gtest/gtest.h"
 
 namespace plasma {
 
@@ -105,7 +103,7 @@ TEST_F(TestPlasmaStore, NewSubscriberTest) {
   ARROW_CHECK_OK(local_client.Connect(store_socket_name_, ""));
   ARROW_CHECK_OK(local_client2.Connect(store_socket_name_, ""));
 
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
 
   // Test for the object being in local Plasma store.
   // First create object.
@@ -122,7 +120,7 @@ TEST_F(TestPlasmaStore, NewSubscriberTest) {
   ARROW_CHECK_OK(local_client2.Subscribe(&fd));
   ASSERT_GT(fd, 0);
 
-  ObjectID object_id2 = ObjectID::from_random();
+  ObjectID object_id2 = random_object_id();
   int64_t data_size2 = 0;
   int64_t metadata_size2 = 0;
   ARROW_CHECK_OK(
@@ -146,7 +144,7 @@ TEST_F(TestPlasmaStore, NewSubscriberTest) {
 }
 
 TEST_F(TestPlasmaStore, SealErrorsTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
 
   Status result = client_.Seal(object_id);
   ASSERT_TRUE(result.IsPlasmaObjectNonexistent());
@@ -161,7 +159,7 @@ TEST_F(TestPlasmaStore, SealErrorsTest) {
 }
 
 TEST_F(TestPlasmaStore, DeleteTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
 
   // Test for deleting non-existance object.
   Status result = client_.Delete(object_id);
@@ -191,8 +189,8 @@ TEST_F(TestPlasmaStore, DeleteTest) {
 }
 
 TEST_F(TestPlasmaStore, DeleteObjectsTest) {
-  ObjectID object_id1 = ObjectID::from_random();
-  ObjectID object_id2 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
+  ObjectID object_id2 = random_object_id();
 
   // Test for deleting non-existance object.
   Status result = client_.Delete(std::vector<ObjectID>{object_id1, object_id2});
@@ -241,7 +239,7 @@ TEST_F(TestPlasmaStore, DeleteObjectsTest) {
 }
 
 TEST_F(TestPlasmaStore, ContainsTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
 
   // Test for object non-existence.
   bool has_object;
@@ -262,7 +260,7 @@ TEST_F(TestPlasmaStore, ContainsTest) {
 TEST_F(TestPlasmaStore, GetTest) {
   std::vector<ObjectBuffer> object_buffers;
 
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
 
   // Test for object non-existence.
   ARROW_CHECK_OK(client_.Get({object_id}, 0, &object_buffers));
@@ -299,7 +297,7 @@ TEST_F(TestPlasmaStore, GetTest) {
 
 TEST_F(TestPlasmaStore, LegacyGetTest) {
   // Test for old non-releasing Get() variant
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
   {
     ObjectBuffer object_buffer;
 
@@ -327,8 +325,8 @@ TEST_F(TestPlasmaStore, LegacyGetTest) {
 }
 
 TEST_F(TestPlasmaStore, MultipleGetTest) {
-  ObjectID object_id1 = ObjectID::from_random();
-  ObjectID object_id2 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
+  ObjectID object_id2 = random_object_id();
   std::vector<ObjectID> object_ids = {object_id1, object_id2};
   std::vector<ObjectBuffer> object_buffers;
 
@@ -350,7 +348,7 @@ TEST_F(TestPlasmaStore, MultipleGetTest) {
 }
 
 TEST_F(TestPlasmaStore, AbortTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
   std::vector<ObjectBuffer> object_buffers;
 
   // Test for object non-existence.
@@ -396,7 +394,7 @@ TEST_F(TestPlasmaStore, AbortTest) {
 }
 
 TEST_F(TestPlasmaStore, MultipleClientTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
   std::vector<ObjectBuffer> object_buffers;
 
   // Test for object non-existence on the first client.
@@ -420,7 +418,7 @@ TEST_F(TestPlasmaStore, MultipleClientTest) {
 
   // Test that one client disconnecting does not interfere with the other.
   // First create object on the second client.
-  object_id = ObjectID::from_random();
+  object_id = random_object_id();
   ARROW_CHECK_OK(client2_.Create(object_id, data_size, metadata, metadata_size, &data));
   // Disconnect the first client.
   ARROW_CHECK_OK(client_.Disconnect());
@@ -437,7 +435,7 @@ TEST_F(TestPlasmaStore, ManyObjectTest) {
   // and leave the last third unsealed.
   std::vector<ObjectID> object_ids;
   for (int i = 0; i < 100; i++) {
-    ObjectID object_id = ObjectID::from_random();
+    ObjectID object_id = random_object_id();
     object_ids.push_back(object_id);
 
     // Test for object non-existence on the first client.
@@ -521,7 +519,7 @@ void AssertCudaRead(const std::shared_ptr<Buffer>& buffer,
 }  // namespace
 
 TEST_F(TestPlasmaStore, GetGPUTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
   std::vector<ObjectBuffer> object_buffers;
 
   // Test for object non-existence.
@@ -555,7 +553,7 @@ TEST_F(TestPlasmaStore, GetGPUTest) {
 }
 
 TEST_F(TestPlasmaStore, MultipleClientGPUTest) {
-  ObjectID object_id = ObjectID::from_random();
+  ObjectID object_id = random_object_id();
   std::vector<ObjectBuffer> object_buffers;
 
   // Test for object non-existence on the first client.
@@ -579,7 +577,7 @@ TEST_F(TestPlasmaStore, MultipleClientGPUTest) {
 
   // Test that one client disconnecting does not interfere with the other.
   // First create object on the second client.
-  object_id = ObjectID::from_random();
+  object_id = random_object_id();
   ARROW_CHECK_OK(
       client2_.Create(object_id, data_size, metadata, metadata_size, &data, 1));
   // Disconnect the first client.

--- a/cpp/src/plasma/test/serialization_tests.cc
+++ b/cpp/src/plasma/test/serialization_tests.cc
@@ -18,7 +18,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "plasma/test/test_common.h"
+#include "plasma/test-common.h"
 
 #include "plasma/common.h"
 #include "plasma/io.h"

--- a/cpp/src/plasma/test/serialization_tests.cc
+++ b/cpp/src/plasma/test/serialization_tests.cc
@@ -18,12 +18,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "plasma/test/test_common.h"
+
 #include "plasma/common.h"
 #include "plasma/io.h"
 #include "plasma/plasma.h"
 #include "plasma/protocol.h"
-
-#include "gtest/gtest.h"
 
 namespace fb = plasma::flatbuf;
 
@@ -76,7 +76,7 @@ PlasmaObject random_plasma_object(void) {
 
 TEST(PlasmaSerialization, CreateRequest) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   int64_t data_size1 = 42;
   int64_t metadata_size1 = 11;
   int device_num1 = 0;
@@ -99,7 +99,7 @@ TEST(PlasmaSerialization, CreateRequest) {
 
 TEST(PlasmaSerialization, CreateReply) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   PlasmaObject object1 = random_plasma_object();
   int64_t mmap_size1 = 1000000;
   ARROW_CHECK_OK(SendCreateReply(fd, object_id1, &object1, PlasmaError::OK, mmap_size1));
@@ -120,7 +120,7 @@ TEST(PlasmaSerialization, CreateReply) {
 
 TEST(PlasmaSerialization, SealRequest) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   unsigned char digest1[kDigestSize];
   memset(&digest1[0], 7, kDigestSize);
   ARROW_CHECK_OK(SendSealRequest(fd, object_id1, &digest1[0]));
@@ -135,7 +135,7 @@ TEST(PlasmaSerialization, SealRequest) {
 
 TEST(PlasmaSerialization, SealReply) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   ARROW_CHECK_OK(SendSealReply(fd, object_id1, PlasmaError::ObjectExists));
   std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaSealReply);
   ObjectID object_id2;
@@ -148,8 +148,8 @@ TEST(PlasmaSerialization, SealReply) {
 TEST(PlasmaSerialization, GetRequest) {
   int fd = create_temp_file();
   ObjectID object_ids[2];
-  object_ids[0] = ObjectID::from_random();
-  object_ids[1] = ObjectID::from_random();
+  object_ids[0] = random_object_id();
+  object_ids[1] = random_object_id();
   int64_t timeout_ms = 1234;
   ARROW_CHECK_OK(SendGetRequest(fd, object_ids, 2, timeout_ms));
   std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaGetRequest);
@@ -166,8 +166,8 @@ TEST(PlasmaSerialization, GetRequest) {
 TEST(PlasmaSerialization, GetReply) {
   int fd = create_temp_file();
   ObjectID object_ids[2];
-  object_ids[0] = ObjectID::from_random();
-  object_ids[1] = ObjectID::from_random();
+  object_ids[0] = random_object_id();
+  object_ids[1] = random_object_id();
   std::unordered_map<ObjectID, PlasmaObject> plasma_objects;
   plasma_objects[object_ids[0]] = random_plasma_object();
   plasma_objects[object_ids[1]] = random_plasma_object();
@@ -200,7 +200,7 @@ TEST(PlasmaSerialization, GetReply) {
 
 TEST(PlasmaSerialization, ReleaseRequest) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   ARROW_CHECK_OK(SendReleaseRequest(fd, object_id1));
   std::vector<uint8_t> data =
       read_message_from_file(fd, MessageType::PlasmaReleaseRequest);
@@ -212,7 +212,7 @@ TEST(PlasmaSerialization, ReleaseRequest) {
 
 TEST(PlasmaSerialization, ReleaseReply) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   ARROW_CHECK_OK(SendReleaseReply(fd, object_id1, PlasmaError::ObjectExists));
   std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaReleaseReply);
   ObjectID object_id2;
@@ -224,7 +224,7 @@ TEST(PlasmaSerialization, ReleaseReply) {
 
 TEST(PlasmaSerialization, DeleteRequest) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   ARROW_CHECK_OK(SendDeleteRequest(fd, std::vector<ObjectID>{object_id1}));
   std::vector<uint8_t> data =
       read_message_from_file(fd, MessageType::PlasmaDeleteRequest);
@@ -237,7 +237,7 @@ TEST(PlasmaSerialization, DeleteRequest) {
 
 TEST(PlasmaSerialization, DeleteReply) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   PlasmaError error1 = PlasmaError::ObjectExists;
   ARROW_CHECK_OK(SendDeleteReply(fd, std::vector<ObjectID>{object_id1},
                                  std::vector<PlasmaError>{error1}));
@@ -257,8 +257,8 @@ TEST(PlasmaSerialization, StatusRequest) {
   int fd = create_temp_file();
   constexpr int64_t num_objects = 2;
   ObjectID object_ids[num_objects];
-  object_ids[0] = ObjectID::from_random();
-  object_ids[1] = ObjectID::from_random();
+  object_ids[0] = random_object_id();
+  object_ids[1] = random_object_id();
   ARROW_CHECK_OK(SendStatusRequest(fd, object_ids, num_objects));
   std::vector<uint8_t> data =
       read_message_from_file(fd, MessageType::PlasmaStatusRequest);
@@ -273,8 +273,8 @@ TEST(PlasmaSerialization, StatusRequest) {
 TEST(PlasmaSerialization, StatusReply) {
   int fd = create_temp_file();
   ObjectID object_ids[2];
-  object_ids[0] = ObjectID::from_random();
-  object_ids[1] = ObjectID::from_random();
+  object_ids[0] = random_object_id();
+  object_ids[1] = random_object_id();
   int object_statuses[2] = {42, 43};
   ARROW_CHECK_OK(SendStatusReply(fd, object_ids, object_statuses, 2));
   std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaStatusReply);
@@ -316,8 +316,8 @@ TEST(PlasmaSerialization, EvictReply) {
 TEST(PlasmaSerialization, FetchRequest) {
   int fd = create_temp_file();
   ObjectID object_ids[2];
-  object_ids[0] = ObjectID::from_random();
-  object_ids[1] = ObjectID::from_random();
+  object_ids[0] = random_object_id();
+  object_ids[1] = random_object_id();
   ARROW_CHECK_OK(SendFetchRequest(fd, object_ids, 2));
   std::vector<uint8_t> data = read_message_from_file(fd, MessageType::PlasmaFetchRequest);
   std::vector<ObjectID> object_ids_read;
@@ -331,9 +331,9 @@ TEST(PlasmaSerialization, WaitRequest) {
   int fd = create_temp_file();
   const int num_objects_in = 2;
   ObjectRequest object_requests_in[num_objects_in] = {
-      ObjectRequest({ObjectID::from_random(), ObjectRequestType::PLASMA_QUERY_ANYWHERE,
+      ObjectRequest({random_object_id(), ObjectRequestType::PLASMA_QUERY_ANYWHERE,
                      ObjectLocation::Local}),
-      ObjectRequest({ObjectID::from_random(), ObjectRequestType::PLASMA_QUERY_LOCAL,
+      ObjectRequest({random_object_id(), ObjectRequestType::PLASMA_QUERY_LOCAL,
                      ObjectLocation::Local})};
   const int num_ready_objects_in = 1;
   int64_t timeout_ms = 1000;
@@ -365,10 +365,10 @@ TEST(PlasmaSerialization, WaitReply) {
   const int num_objects_in = 2;
   /* Create a map with two ObjectRequests in it. */
   ObjectRequestMap objects_in(num_objects_in);
-  ObjectID id1 = ObjectID::from_random();
+  ObjectID id1 = random_object_id();
   objects_in[id1] =
       ObjectRequest({id1, ObjectRequestType::PLASMA_QUERY_LOCAL, ObjectLocation::Local});
-  ObjectID id2 = ObjectID::from_random();
+  ObjectID id2 = random_object_id();
   objects_in[id2] = ObjectRequest(
       {id2, ObjectRequestType::PLASMA_QUERY_LOCAL, ObjectLocation::Nonexistent});
 
@@ -393,7 +393,7 @@ TEST(PlasmaSerialization, WaitReply) {
 
 TEST(PlasmaSerialization, DataRequest) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   const char* address1 = "address1";
   int port1 = 12345;
   ARROW_CHECK_OK(SendDataRequest(fd, object_id1, address1, port1));
@@ -413,7 +413,7 @@ TEST(PlasmaSerialization, DataRequest) {
 
 TEST(PlasmaSerialization, DataReply) {
   int fd = create_temp_file();
-  ObjectID object_id1 = ObjectID::from_random();
+  ObjectID object_id1 = random_object_id();
   int64_t object_size1 = 146;
   int64_t metadata_size1 = 198;
   ARROW_CHECK_OK(SendDataReply(fd, object_id1, object_size1, metadata_size1));

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -44,9 +44,6 @@ cdef extern from "plasma/common.h" nogil:
         @staticmethod
         CUniqueID from_binary(const c_string& binary)
 
-        @staticmethod
-        CUniqueID from_random()
-
         c_bool operator==(const CUniqueID& rhs) const
 
         c_string hex() const
@@ -166,11 +163,6 @@ cdef class ObjectID:
             Binary representation of the ObjectID.
         """
         return self.data.binary()
-
-    @staticmethod
-    def from_random():
-        cdef CUniqueID data = CUniqueID.from_random()
-        return ObjectID(data.binary())
 
 
 cdef class ObjectNotAvailable:

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -170,7 +170,8 @@ cdef class ObjectID:
 
     @staticmethod
     def from_random():
-        random_id = bytes(random.getrandbits(8) for i in range(20))
+        size = 20
+        random_id = random.getrandbits(8 * size).to_bytes(size, "little")
         return ObjectID(random_id)
 
 

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -170,8 +170,7 @@ cdef class ObjectID:
 
     @staticmethod
     def from_random():
-        size = 20
-        random_id = random.getrandbits(8 * size).to_bytes(size, "little")
+        random_id = bytes(bytearray(random.getrandbits(8) for _ in range(20)))
         return ObjectID(random_id)
 
 

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -28,6 +28,7 @@ from cpython.pycapsule cimport *
 
 import collections
 import pyarrow
+import random
 
 from pyarrow.lib cimport Buffer, NativeFile, check_status, pyarrow_wrap_buffer
 from pyarrow.includes.libarrow cimport (CBuffer, CMutableBuffer,
@@ -43,6 +44,9 @@ cdef extern from "plasma/common.h" nogil:
 
         @staticmethod
         CUniqueID from_binary(const c_string& binary)
+
+        @staticmethod
+        CUniqueID from_random()
 
         c_bool operator==(const CUniqueID& rhs) const
 
@@ -163,6 +167,11 @@ cdef class ObjectID:
             Binary representation of the ObjectID.
         """
         return self.data.binary()
+
+    @staticmethod
+    def from_random():
+        random_id = bytes(random.getrandbits(8) for i in range(20))
+        return ObjectID(random_id)
 
 
 cdef class ObjectNotAvailable:

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -279,7 +279,7 @@ class TestPlasmaClient(object):
             result = self.plasma_client.get(object_id)
             assert result == value
 
-            object_id = pa.plasma.ObjectID.from_random()
+            object_id = random_object_id()
             [result] = self.plasma_client.get([object_id], timeout_ms=0)
             assert result == pa.plasma.ObjectNotAvailable
 
@@ -791,11 +791,3 @@ def test_plasma_client_sharing():
         del plasma_client
         assert (buf == np.zeros(3)).all()
         del buf  # This segfaulted pre ARROW-2448.
-
-
-@pytest.mark.plasma
-def test_object_id_randomness():
-    cmd = "from pyarrow import plasma; print(plasma.ObjectID.from_random())"
-    first_object_id = subprocess.check_output(["python", "-c", cmd])
-    second_object_id = subprocess.check_output(["python", "-c", cmd])
-    assert first_object_id != second_object_id

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -23,7 +23,6 @@ import os
 import pytest
 import random
 import signal
-import subprocess
 import sys
 
 import numpy as np

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -23,6 +23,7 @@ import os
 import pytest
 import random
 import signal
+import subprocess
 import sys
 
 import numpy as np
@@ -790,3 +791,11 @@ def test_plasma_client_sharing():
         del plasma_client
         assert (buf == np.zeros(3)).all()
         del buf  # This segfaulted pre ARROW-2448.
+
+
+@pytest.mark.plasma
+def test_object_id_randomness():
+    cmd = "from pyarrow import plasma; print(plasma.ObjectID.from_random())"
+    first_object_id = subprocess.check_output(["python", "-c", cmd])
+    second_object_id = subprocess.check_output(["python", "-c", cmd])
+    assert first_object_id != second_object_id


### PR DESCRIPTION
This removes the C++ random ObjectID generator. Having a global random number generator is not a good idea and with an existing random number generator, it is very easy to write code like:

```
std::string random_string = // Create random string of length ObjectID::size()
auto object_id = ObjectID::from_binary(random_string);
```