### PR TITLE
ARROW-3000: [C++] Add option to label test groups then only build those unit tests

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -81,6 +81,7 @@ fi
 cmake -GNinja \
       $CMAKE_COMMON_FLAGS \
       -DARROW_BUILD_TESTS=on \
+      -DARROW_TEST_INCLUDE_LABELS=python \
       -DARROW_BUILD_UTILITIES=off \
       -DARROW_PLASMA=on \
       -DARROW_TENSORFLOW=on \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -119,6 +119,10 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
     "Build the Arrow googletest unit tests"
     ON)
 
+  set(ARROW_TEST_INCLUDE_LABELS "" CACHE STRING
+    "Only build unit tests having the indicated label or labels. \
+Pass multiple labels by dividing with semicolons")
+
   option(ARROW_BUILD_BENCHMARKS
     "Build the Arrow micro benchmarks"
     OFF)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -308,10 +308,22 @@ endfunction()
 function(ADD_ARROW_TEST REL_TEST_NAME)
   set(options NO_VALGRIND)
   set(single_value_args)
-  set(multi_value_args STATIC_LINK_LIBS EXTRA_INCLUDES)
+  set(multi_value_args STATIC_LINK_LIBS EXTRA_LINK_LIBS EXTRA_INCLUDES LABELS)
   cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if (ARROW_TEST_INCLUDE_LABELS)
+    set(_SKIP_TEST TRUE)
+    foreach (_INCLUDED_LABEL ${ARG_LABELS})
+      if ("${ARG_LABELS}" MATCHES "${_INCLUDED_LABEL}")
+        set(_SKIP_TEST FALSE)
+      endif()
+    endforeach()
+    if (_SKIP_TEST)
+      return()
+    endif()
   endif()
 
   if(NO_TESTS OR NOT ARROW_BUILD_STATIC)
@@ -330,6 +342,11 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
     else()
       target_link_libraries(${TEST_NAME} ${ARROW_TEST_LINK_LIBS})
     endif()
+
+    if (ARG_EXTRA_LINK_LIBS)
+      target_link_libraries(${TEST_NAME} ${ARG_EXTRA_LINK_LIBS})
+    endif()
+
     if (ARG_EXTRA_INCLUDES)
       target_include_directories(${TEST_NAME} SYSTEM PUBLIC
         ${ARG_EXTRA_INCLUDES}
@@ -355,7 +372,16 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
     add_test(${TEST_NAME}
       ${BUILD_SUPPORT_DIR}/run-test.sh ${CMAKE_BINARY_DIR} test ${TEST_PATH})
   endif()
-  set_tests_properties(${TEST_NAME} PROPERTIES LABELS "unittest")
+
+  set_property(TEST ${TEST_NAME}
+    APPEND PROPERTY
+    LABELS "unitest")
+
+  if (ARG_LABELS)
+    set_property(TEST ${TEST_NAME}
+      APPEND PROPERTY
+      LABELS ${ARG_LABELS})
+  endif()
 endfunction()
 
 # A wrapper for add_dependencies() that is compatible with NO_TESTS.

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -314,7 +314,7 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  if (ARROW_TEST_INCLUDE_LABELS)
+  if (NOT "${ARROW_TEST_INCLUDE_LABELS}" STREQUAL "")
     set(_SKIP_TEST TRUE)
     foreach (_INCLUDED_LABEL ${ARG_LABELS})
       if ("${ARG_LABELS}" MATCHES "${_INCLUDED_LABEL}")
@@ -375,7 +375,7 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
 
   set_property(TEST ${TEST_NAME}
     APPEND PROPERTY
-    LABELS "unitest")
+    LABELS "unittest")
 
   if (ARG_LABELS)
     set_property(TEST ${TEST_NAME}

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -23,12 +23,11 @@ ADD_ARROW_TEST(ipc-read-write-test)
 ADD_ARROW_TEST(ipc-json-test)
 
 if (NOT ARROW_BOOST_HEADER_ONLY)
-  ADD_ARROW_TEST(json-integration-test)
+  ADD_ARROW_TEST(json-integration-test
+    EXTRA_LINK_LIBS gflags)
 
-  if (ARROW_BUILD_TESTS)
-    target_link_libraries(json-integration-test
-      gflags)
-
+  # Test is being built
+  if (TARGET json-integration-test)
     if (UNIX)
       if (APPLE)
         set_target_properties(json-integration-test

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -139,8 +139,8 @@ if (ARROW_BUILD_TESTS)
 
   ADD_ARROW_TEST(python-test
     STATIC_LINK_LIBS "${ARROW_PYTHON_TEST_LINK_LIBS}"
+    EXTRA_LINK_LIBS ${PYTHON_LIBRARIES}
     EXTRA_INCLUDES "${ARROW_PYTHON_INCLUDES}"
+    LABELS "python"
     NO_VALGRIND)
-  target_link_libraries(python-test
-    ${PYTHON_LIBRARIES})
 endif()

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -196,7 +196,7 @@ endif()
 # Unit tests
 #######################################
 
-ADD_ARROW_TEST(test/serialization_tests)
-ARROW_TEST_LINK_LIBRARIES(test/serialization_tests plasma_static ${PLASMA_LINK_LIBS})
-ADD_ARROW_TEST(test/client_tests)
-ARROW_TEST_LINK_LIBRARIES(test/client_tests plasma_static ${PLASMA_LINK_LIBS})
+ADD_ARROW_TEST(test/serialization_tests
+  EXTRA_LINK_LIBS plasma_static ${PLASMA_LINK_LIBS})
+ADD_ARROW_TEST(test/client_tests
+  EXTRA_LINK_LIBS plasma_static ${PLASMA_LINK_LIBS})


### PR DESCRIPTION
This should help make our groups of unit tests more modular and easier to build only the relevant ones for a particular test cycle