### PR TITLE
ARROW-3026: [Python] [Plasma] Only run Plasma unit tests with valgrind under Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,10 +82,8 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
     # Only run Plasma tests with valgrind in one of the Python builds because
     # they are slow
-    - export ARROW_TRAVIS_PLASMA_VALGRIND=0
-    - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 2.7
-    - export ARROW_TRAVIS_PLASMA_VALGRIND=1
-    - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
+    - TRAVIS_PLASMA_VALGRIND=0 $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 2.7
+    - TRAVIS_PLASMA_VALGRIND=1 $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
     - $TRAVIS_BUILD_DIR/ci/travis_upload_cpp_coverage.sh
   # [OS X] C++ & Python w/ XCode 6.4
   - compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,11 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_build_parquet_cpp.sh
     # Build Arrow Java to test the pyarrow<->JVM in-process bridge
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
+    # Only run Plasma tests with valgrind in one of the Python builds because
+    # they are slow
+    - export ARROW_TRAVIS_PLASMA_VALGRIND=0
     - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 2.7
+    - export ARROW_TRAVIS_PLASMA_VALGRIND=1
     - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
     - $TRAVIS_BUILD_DIR/ci/travis_upload_cpp_coverage.sh
   # [OS X] C++ & Python w/ XCode 6.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,10 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh
     # Only run Plasma tests with valgrind in one of the Python builds because
     # they are slow
-    - TRAVIS_PLASMA_VALGRIND=0 $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 2.7
-    - TRAVIS_PLASMA_VALGRIND=1 $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
+    - export PLASMA_VALGRIND=0
+    - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 2.7
+    - export PLASMA_VALGRIND=1
+    - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
     - $TRAVIS_BUILD_DIR/ci/travis_upload_cpp_coverage.sh
   # [OS X] C++ & Python w/ XCode 6.4
   - compiler: clang

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -124,9 +124,7 @@ python -c "import pyarrow.parquet"
 python -c "import pyarrow.plasma"
 python -c "import pyarrow.orc"
 
-if [ "$TRAVIS_PLASMA_VALGRIND" == "1" ]; then
-  export PLASMA_VALGRIND=1
-fi
+echo "PLASMA_VALGRIND: $PLASMA_VALGRIND"
 
 # Set up huge pages for plasma test
 if [ $TRAVIS_OS_NAME == "linux" ]; then

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -124,7 +124,7 @@ python -c "import pyarrow.parquet"
 python -c "import pyarrow.plasma"
 python -c "import pyarrow.orc"
 
-if [ "$ARROW_TRAVIS_PLASMA_VALGRIND" == "1" ]; then
+if [ "$TRAVIS_PLASMA_VALGRIND" == "1" ]; then
   export PLASMA_VALGRIND=1
 fi
 

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -124,7 +124,7 @@ python -c "import pyarrow.parquet"
 python -c "import pyarrow.plasma"
 python -c "import pyarrow.orc"
 
-if [ "$ARROW_TRAVIS_VALGRIND" == "1" ]; then
+if [ "$ARROW_TRAVIS_PLASMA_VALGRIND" == "1" ]; then
   export PLASMA_VALGRIND=1
 fi
 


### PR DESCRIPTION
These tests are time consuming, and memory leaks are likely to be present in both builds if there are any.

cc @pcmoritz @robertnishihara @pitrou