### PR TITLE
ARROW-3027: [Ruby] Stop "git tag" by "rake release"

### DIFF
--- a/ruby/red-arrow-gpu/Rakefile
+++ b/ruby/red-arrow-gpu/Rakefile
@@ -23,12 +23,10 @@ require "bundler/gem_helper"
 base_dir = File.join(File.dirname(__FILE__))
 
 helper = Bundler::GemHelper.new(base_dir)
-def helper.version_tag
-  version
-end
-
 helper.install
-spec = helper.gemspec
+
+release_task = Rake::Task["release"]
+release_task.prerequisites.replace(["build", "release:rubygem_push"])
 
 desc "Run tests"
 task :test do

--- a/ruby/red-arrow/Rakefile
+++ b/ruby/red-arrow/Rakefile
@@ -23,12 +23,10 @@ require "bundler/gem_helper"
 base_dir = File.join(__dir__)
 
 helper = Bundler::GemHelper.new(base_dir)
-def helper.version_tag
-  version
-end
-
 helper.install
-spec = helper.gemspec
+
+release_task = Rake::Task["release"]
+release_task.prerequisites.replace(["build", "release:rubygem_push"])
 
 desc "Run tests"
 task :test do


### PR DESCRIPTION
The "release" task defined by Bundler runs "git tag" but it's not
needed for us.

We can release Ruby bindings by "rake release" in ruby/red-arrow/ and ruby/red-arrow-gpu/.
It should be documented at Confluence.