### PR TITLE
ARROW-3028: [Python] Do less work to test Python documentation build

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -50,6 +50,15 @@ conda install -y -q pip \
       pandas \
       cython
 
+if [ "$ARROW_TRAVIS_PYTHON_DOCS" == "1" ] && [ "$PYTHON_VERSION" == "3.6" ]; then
+  # Build documentation depedencies
+  conda install -y -q \
+        ipython \
+        numpydoc \
+        sphinx \
+        sphinx_bootstrap_theme
+fi
+
 # ARROW-2093: PyTorch increases the size of our conda dependency stack
 # significantly, and so we have disabled these tests in Travis CI for now
 
@@ -117,7 +126,7 @@ export PYARROW_WITH_PARQUET=1
 export PYARROW_WITH_PLASMA=1
 export PYARROW_WITH_ORC=1
 
-python setup.py build_ext -q --inplace
+python setup.py develop
 
 # Basic sanity checks
 python -c "import pyarrow.parquet"
@@ -162,25 +171,12 @@ if [ "$ARROW_TRAVIS_COVERAGE" == "1" ]; then
     popd   # $TRAVIS_BUILD_DIR
 fi
 
-popd  # $ARROW_PYTHON_DIR
-
-
 if [ "$ARROW_TRAVIS_PYTHON_DOCS" == "1" ] && [ "$PYTHON_VERSION" == "3.6" ]; then
-  # Build documentation once
-  conda install -y -q \
-        ipython \
-        matplotlib \
-        numpydoc \
-        sphinx \
-        sphinx_bootstrap_theme
-
-  pushd $ARROW_PYTHON_DIR
-  # For autodoc, make sure PyArrow is installed
-  python setup.py install -q --single-version-externally-managed --record=record.text
   cd doc
   sphinx-build -q -b html -d _build/doctrees -W source _build/html
-  popd  # $ARROW_PYTHON_DIR
 fi
+
+popd  # $ARROW_PYTHON_DIR
 
 if [ "$ARROW_TRAVIS_PYTHON_BENCHMARKS" == "1" ] && [ "$PYTHON_VERSION" == "3.6" ]; then
   # Check the ASV benchmarking setup.

--- a/python/doc/source/conf.py
+++ b/python/doc/source/conf.py
@@ -66,6 +66,9 @@ extensions = [
 autodoc_default_flags = ['members', 'undoc-members', 'show-inheritance',
                          'inherited-members']
 
+# ipython directive options
+ipython_mplbackend = ''
+
 # numpydoc configuration
 napoleon_use_rtype = False
 


### PR DESCRIPTION
* matplotlib is not needed
* Build Python library once (using `setup.py develop`)