### PR TITLE
ARROW-3031: [Go] streamline Release of Arrays and Builders

### DIFF
--- a/go/arrow/array/booleanbuilder.go
+++ b/go/arrow/array/booleanbuilder.go
@@ -50,6 +50,7 @@ func (b *BooleanBuilder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }

--- a/go/arrow/array/list.go
+++ b/go/arrow/array/list.go
@@ -51,6 +51,11 @@ func (a *List) Len() int { return a.array.Len() }
 
 func (a *List) Offsets() []int32 { return a.offsets }
 
+func (a *List) Release() {
+	a.array.Release()
+	a.values.Release()
+}
+
 var (
 	_ Interface = (*List)(nil)
 )

--- a/go/arrow/array/list_test.go
+++ b/go/arrow/array/list_test.go
@@ -26,8 +26,10 @@ import (
 )
 
 func TestListArray(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
 	var (
-		pool    = memory.NewGoAllocator()
 		vs      = []int32{0, 1, 2, 3, 4, 5, 6}
 		lengths = []int{3, 0, 4}
 		isValid = []bool{true, false, true}
@@ -36,6 +38,7 @@ func TestListArray(t *testing.T) {
 
 	lb := array.NewListBuilder(pool, arrow.PrimitiveTypes.Int32)
 	defer lb.Release()
+
 	for i := 0; i < 10; i++ {
 		vb := lb.ValueBuilder().(*array.Int32Builder)
 		vb.Reserve(len(vs))
@@ -50,6 +53,8 @@ func TestListArray(t *testing.T) {
 		}
 
 		arr := lb.NewArray().(*array.List)
+		defer arr.Release()
+
 		if got, want := arr.DataType().ID(), arrow.LIST; got != want {
 			t.Fatalf("got=%v, want=%v", got, want)
 		}
@@ -79,18 +84,23 @@ func TestListArray(t *testing.T) {
 }
 
 func TestListArrayEmpty(t *testing.T) {
-	pool := memory.NewGoAllocator()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
 	lb := array.NewListBuilder(pool, arrow.PrimitiveTypes.Int32)
 	defer lb.Release()
 	arr := lb.NewArray().(*array.List)
+	defer arr.Release()
 	if got, want := arr.Len(), 0; got != want {
 		t.Fatalf("got=%d, want=%d", got, want)
 	}
 }
 
 func TestListArrayBulkAppend(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
 	var (
-		pool    = memory.NewGoAllocator()
 		vs      = []int32{0, 1, 2, 3, 4, 5, 6}
 		lengths = []int{3, 0, 4}
 		isValid = []bool{true, false, true}
@@ -108,6 +118,8 @@ func TestListArrayBulkAppend(t *testing.T) {
 	}
 
 	arr := lb.NewArray().(*array.List)
+	defer arr.Release()
+
 	if got, want := arr.DataType().ID(), arrow.LIST; got != want {
 		t.Fatalf("got=%v, want=%v", got, want)
 	}

--- a/go/arrow/array/numericbuilder.gen.go
+++ b/go/arrow/array/numericbuilder.gen.go
@@ -51,6 +51,7 @@ func (b *Int64Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -183,6 +184,7 @@ func (b *Uint64Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -315,6 +317,7 @@ func (b *Float64Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -447,6 +450,7 @@ func (b *Int32Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -579,6 +583,7 @@ func (b *Uint32Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -711,6 +716,7 @@ func (b *Float32Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -843,6 +849,7 @@ func (b *Int16Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -975,6 +982,7 @@ func (b *Uint16Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -1107,6 +1115,7 @@ func (b *Int8Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -1239,6 +1248,7 @@ func (b *Uint8Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }
@@ -1372,6 +1382,7 @@ func (b *TimestampBuilder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }

--- a/go/arrow/array/numericbuilder.gen.go.tmpl
+++ b/go/arrow/array/numericbuilder.gen.go.tmpl
@@ -57,6 +57,7 @@ func (b *{{.Name}}Builder) Release() {
 		if b.data != nil {
 			b.data.Release()
 			b.data = nil
+			b.rawData = nil
 		}
 	}
 }

--- a/go/arrow/array/struct_test.go
+++ b/go/arrow/array/struct_test.go
@@ -26,10 +26,12 @@ import (
 )
 
 func TestStructArray(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
 	var (
-		pool = memory.NewGoAllocator()
-		f1s  = []byte{'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'}
-		f2s  = []int32{1, 2, 3, 4}
+		f1s = []byte{'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'}
+		f2s = []int32{1, 2, 3, 4}
 
 		f1Lengths = []int{3, 0, 3, 4}
 		f1Offsets = []int32{0, 3, 3, 6, 10}
@@ -129,7 +131,9 @@ func TestStructArray(t *testing.T) {
 }
 
 func TestStructArrayEmpty(t *testing.T) {
-	pool := memory.NewGoAllocator()
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
 	sb := array.NewStructBuilder(pool, arrow.StructOf())
 	defer sb.Release()
 
@@ -149,10 +153,12 @@ func TestStructArrayEmpty(t *testing.T) {
 }
 
 func TestStructArrayBulkAppend(t *testing.T) {
+	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer pool.AssertSize(t, 0)
+
 	var (
-		pool = memory.NewGoAllocator()
-		f1s  = []byte{'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'}
-		f2s  = []int32{1, 2, 3, 4}
+		f1s = []byte{'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'}
+		f2s = []int32{1, 2, 3, 4}
 
 		f1Lengths = []int{3, 0, 3, 4}
 		f1Offsets = []int32{0, 3, 3, 6, 10}

--- a/go/arrow/example_test.go
+++ b/go/arrow/example_test.go
@@ -32,6 +32,7 @@ func Example_minimal() {
 
 	// Create an int64 array builder.
 	builder := array.NewInt64Builder(pool)
+	defer builder.Release()
 
 	builder.Append(1)
 	builder.Append(2)
@@ -44,6 +45,7 @@ func Example_minimal() {
 
 	// Finish building the int64 array and reset the builder.
 	ints := builder.NewInt64Array()
+	defer ints.Release()
 
 	// Enumerate the values.
 	for i, v := range ints.Int64Values() {
@@ -81,6 +83,7 @@ func Example_fromMemory() {
 
 	// Create a boolean array and lazily determine NullN using UnknownNullCount
 	bools := array.NewBoolean(16, data, nullBitmap, array.UnknownNullCount)
+	defer bools.Release()
 
 	// Show the null count
 	fmt.Printf("NullN()  = %d\n", bools.NullN())
@@ -155,6 +158,8 @@ func Example_listArray() {
 	vb.Append(9)
 
 	arr := lb.NewArray().(*array.List)
+	defer arr.Release()
+
 	fmt.Printf("NullN()   = %d\n", arr.NullN())
 	fmt.Printf("Len()     = %d\n", arr.Len())
 	fmt.Printf("Offsets() = %v\n", arr.Offsets())
@@ -162,6 +167,7 @@ func Example_listArray() {
 	offsets := arr.Offsets()[1:]
 
 	varr := arr.ListValues().(*array.Int64)
+
 	pos := 0
 	for i := 0; i < arr.Len(); i++ {
 		if !arr.IsValid(i) {
@@ -197,6 +203,7 @@ func Example_listArray() {
 //  [{‘joe’, 1}, {null, 2}, null, {‘mark’, 4}]
 func Example_structArray() {
 	pool := memory.NewGoAllocator()
+
 	dtype := arrow.StructOf([]arrow.Field{
 		{Name: "f1", Type: arrow.ListOf(arrow.PrimitiveTypes.Uint8)},
 		{Name: "f2", Type: arrow.PrimitiveTypes.Int32},


### PR DESCRIPTION
This CL makes sure all resources are correctly released in List and
Struct tests, as well as in the top-level package examples.

needs https://github.com/apache/arrow/pull/2411