### PR TITLE
ARROW-3012: [Python] Fix setuptools_scm usage

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -11,3 +11,4 @@ global-exclude *~
 global-exclude \#*
 global-exclude .git*
 global-exclude .DS_Store
+prune .asv

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -27,8 +27,18 @@ except DistributionNotFound:
     # Package is not installed, parse git tag at runtime
     try:
         import setuptools_scm
+        # Code duplicated from setup.py to avoid a dependency on each other
+        def parse_git(root, **kwargs):
+            """
+            Parse function for setuptools_scm that ignores tags for non-C++
+            subprojects, e.g. apache-arrow-js-XXX tags.
+            """
+            from setuptools_scm.git import parse
+            kwargs['describe_command'] = \
+                "git describe --dirty --tags --long --match 'apache-arrow-[0-9].*'"
+            return parse(root, **kwargs)
         __version__ = setuptools_scm.get_version('../',
-                                                 tag_regex='^apache-arrow-([\.0-9]+)$')
+                                                 parse=parse_git)
     except ImportError:
         __version__ = None
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -24,31 +24,16 @@ from pkg_resources import get_distribution, DistributionNotFound
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
-   # package is not installed
+    # Package is not installed, parse git tag at runtime
     try:
-        # This code is duplicated from setup.py to avoid a dependency on each
-        # other.
-        def parse_version(root):
-            from setuptools_scm import version_from_scm
-            import setuptools_scm.git
-            describe = (setuptools_scm.git.DEFAULT_DESCRIBE +
-                        " --match 'apache-arrow-[0-9]*'")
-            # Strip catchall from the commandline
-            describe = describe.replace("--match *.*", "")
-            version = setuptools_scm.git.parse(root, describe)
-            if not version:
-                return version_from_scm(root)
-            else:
-                return version
-
         import setuptools_scm
-        __version__ = setuptools_scm.get_version('../', parse=parse_version)
-    except (ImportError, LookupError):
+        __version__ = setuptools_scm.get_version('../',
+                                                 tag_regex='^apache-arrow-([\.0-9]+)$')
+    except ImportError:
         __version__ = None
 
 
 import pyarrow.compat as compat
-
 
 # Workaround for https://issues.apache.org/jira/browse/ARROW-2657
 # and https://issues.apache.org/jira/browse/ARROW-2920

--- a/python/setup.py
+++ b/python/setup.py
@@ -457,18 +457,42 @@ def _move_shared_libs_unix(build_prefix, build_lib, lib_name):
             os.symlink(lib_filename, link_name)
 
 
-# In the case of a git-archive, we don't have any version information
-# from the SCM to infer a version. The only source is the java/pom.xml.
-#
-# Note that this is only the case for git-archives. sdist tarballs have
-# all relevant information (but not the Java sources).
-if not os.path.exists('../.git') and os.path.exists('../java/pom.xml'):
-    import xml.etree.ElementTree as ET
-    tree = ET.parse('../java/pom.xml')
-    version_tag = list(tree.getroot().findall(
-        '{http://maven.apache.org/POM/4.0.0}version'))[0]
-    os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"] = version_tag.text.replace(
-        "-SNAPSHOT", "a0")
+# If the event of not running from a git clone (e.g. from a git archive
+# or a Python sdist), see if we can set the version number ourselves
+if (not os.path.exists('../.git')
+        and not os.environ.get('SETUPTOOLS_SCM_PRETEND_VERSION')):
+    if os.path.exists('PKG-INFO'):
+        # We're probably in a Python sdist, setuptools_scm will handle fine
+        pass
+    elif os.path.exists('../java/pom.xml'):
+        # We're probably in a git archive
+        import xml.etree.ElementTree as ET
+        tree = ET.parse('../java/pom.xml')
+        version_tag = list(tree.getroot().findall(
+            '{http://maven.apache.org/POM/4.0.0}version'))[0]
+        use_setuptools_scm = False
+        os.environ['SETUPTOOLS_SCM_PRETEND_VERSION'] = \
+            version_tag.text.replace("-SNAPSHOT", "a0")
+    else:
+        raise RuntimeError("""\
+            No reliable source available to get Arrow version.
+
+            This is either because you copied the python/ directory yourself
+            outside of a git clone or source archive, or because you ran
+            `pip install` on the python/ directory.
+
+            * Recommended workaround: first run `python sdist`, then
+              `pip install` the resulting source distribution.
+
+            * If you're looking for an editable (in-place) install,
+              `python setup.py develop` should work fine in place of
+              `pip install -e .`.
+
+            * If you really want to `pip install` the python/ directory,
+              set the SETUPTOOLS_SCM_PRETEND_VERSION environment variable
+              to force the Arrow version to the given value.
+            """)
+
 
 with open('README.md') as f:
     long_description = f.read()
@@ -486,25 +510,12 @@ install_requires = (
 )
 
 
-def parse_version(root):
-    from setuptools_scm import version_from_scm
-    import setuptools_scm.git
-    describe = (setuptools_scm.git.DEFAULT_DESCRIBE +
-                " --match 'apache-arrow-[0-9]*'")
-    # Strip catchall from the commandline
-    describe = describe.replace("--match *.*", "")
-    version = setuptools_scm.git.parse(root, describe)
-    if not version:
-        return version_from_scm(root)
-    else:
-        return version
-
-
 # Only include pytest-runner in setup_requires if we're invoking tests
 if {'pytest', 'test', 'ptr'}.intersection(sys.argv):
     setup_requires = ['pytest-runner']
 else:
     setup_requires = []
+
 
 setup(
     name="pyarrow",
@@ -524,8 +535,9 @@ setup(
             'plasma_store = pyarrow:_plasma_store_entry_point'
         ]
     },
-    use_scm_version={"root": "..", "relative_to": __file__,
-                     "parse": parse_version},
+    use_scm_version={"root": "..",
+                     "relative_to": __file__,
+                     "tag_regex": '^apache-arrow-([\.0-9]+)$'},
     setup_requires=['setuptools_scm', 'cython >= 0.27'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas'],

--- a/python/setup.py
+++ b/python/setup.py
@@ -494,6 +494,17 @@ if (not os.path.exists('../.git')
             """)
 
 
+def parse_git(root, **kwargs):
+    """
+    Parse function for setuptools_scm that ignores tags for non-C++
+    subprojects, e.g. apache-arrow-js-XXX tags.
+    """
+    from setuptools_scm.git import parse
+    kwargs['describe_command'] = \
+        "git describe --dirty --tags --long --match 'apache-arrow-[0-9].*'"
+    return parse(root, **kwargs)
+
+
 with open('README.md') as f:
     long_description = f.read()
 
@@ -537,7 +548,7 @@ setup(
     },
     use_scm_version={"root": "..",
                      "relative_to": __file__,
-                     "tag_regex": '^apache-arrow-([\.0-9]+)$'},
+                     "parse": parse_git},
     setup_requires=['setuptools_scm', 'cython >= 0.27'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas'],


### PR DESCRIPTION
We were using a deprecated / unofficial API together with hand-written version parsing.
We can just pass a custom git tag regex instead.

Also, harden the fallback in setup.py when we're not in a git clone (typically when running `pip install`, as pip always copies the project directory before acting on it).
Include a clear error message when not able to infer the Arrow version, to let people
know how to workaround the issue.

pip-installing source distributions should now work fine (and get the right version
number).