### PR TITLE
ARROW-3029: [Python] Generate version file when building

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -15,13 +15,11 @@ Testing/
 # Generated sources
 *.c
 *.cpp
-pyarrow/version.py
 pyarrow/*_api.h
+pyarrow/_generated_version.py
 
 # Bundled headers
 pyarrow/include
-
-# Python files
 
 # setup.py working directory
 build

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -20,10 +20,9 @@
 import os as _os
 import sys as _sys
 
-from pkg_resources import get_distribution, DistributionNotFound
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from ._generated_version import version as __version__
+except ImportError:
     # Package is not installed, parse git tag at runtime
     try:
         import setuptools_scm

--- a/python/setup.py
+++ b/python/setup.py
@@ -546,9 +546,11 @@ setup(
             'plasma_store = pyarrow:_plasma_store_entry_point'
         ]
     },
-    use_scm_version={"root": "..",
-                     "relative_to": __file__,
-                     "parse": parse_git},
+    use_scm_version={"root": os.path.dirname(setup_dir),
+                     "parse": parse_git,
+                     "write_to": os.path.join(setup_dir,
+                                              "pyarrow/_generated_version.py"),
+                     },
     setup_requires=['setuptools_scm', 'cython >= 0.27'] + setup_requires,
     install_requires=install_requires,
     tests_require=['pytest', 'pandas'],


### PR DESCRIPTION
Remove the reliance on pkg_resources to find out the version of an install PyArrow.
Here, this makes `import pyarrow` around 200 ms. faster.