### PR TITLE
ARROW-3034: [Packaging] Resolve symbolic link in tar.gz

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -107,7 +107,7 @@ rm -rf ${tag}/c_glib
 mv tmp-c_glib ${tag}/c_glib
 
 # Create new tarball from modified source directory
-tar czf ${tarball} ${tag}
+tar czhf ${tarball} ${tag}
 rm -rf ${tag}
 
 ${SOURCE_DIR}/run-rat.sh ${tarball}


### PR DESCRIPTION
Because bsdtar on MSYS2 can't extract tar.gz that includes symlink.