### PR TITLE
ARROW-3061: [JAVA] Fix BufferAllocator#getHeadroom

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
@@ -255,7 +255,9 @@ class Accountant implements AutoCloseable {
       return localHeadroom;
     }
 
-    return Math.min(localHeadroom, parent.getHeadroom());
+    // Amount of reserved memory left on top of what parent has
+    long reservedHeadroom = Math.max(0, reservation - locallyHeldMemory.get());
+    return Math.min(localHeadroom, parent.getHeadroom() + reservedHeadroom);
   }
 
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestAccountant.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestAccountant.java
@@ -80,7 +80,7 @@ public class TestAccountant {
 
     final Accountant child = new Accountant(parent, 2, Long.MAX_VALUE);
     assertEquals(2, parent.getAllocatedMemory());
-
+    assertEquals(10, child.getHeadroom());
     {
       AllocationOutcome first = child.allocateBytes(1);
       assertEquals(AllocationOutcome.SUCCESS, first);
@@ -139,7 +139,7 @@ public class TestAccountant {
     child.releaseBytes(9);
 
     assertEquals(1, child.getAllocatedMemory());
-    assertEquals(8, child.getHeadroom());
+    assertEquals(9, child.getHeadroom());
 
     // back to reservation size
     assertEquals(2, parent.getAllocatedMemory());
@@ -164,7 +164,7 @@ public class TestAccountant {
     child.releaseBytes(11);
     assertEquals(child.getAllocatedMemory(), 0);
     assertEquals(parent.getAllocatedMemory(), 2);
-    assertEquals(8, child.getHeadroom());
+    assertEquals(10, child.getHeadroom());
     assertEquals(8, parent.getHeadroom());
 
     child.close();


### PR DESCRIPTION
Buffer allocator headroom is the minimum between the parent headroom
and the memory available for the current allocator. But if the allocator
also has some reserved memory (which has been accounted for in the parent
allocator), the headroom is actually less than what is currently available.

For example if parent allocator limit is 10, and child allocator has 2 of
reserved memory, assuming that no other memory has been allocated, headroom
for the child allocator is 10, not 8.

Fix Accountant#getHeadroom to take into account reserved memory into its
calculation.