### PR TITLE
ARROW-1799: [Plasma C++] Make unittest does not create plasma store executable

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -199,4 +199,5 @@ endif()
 ADD_ARROW_TEST(test/serialization_tests
   EXTRA_LINK_LIBS plasma_static ${PLASMA_LINK_LIBS})
 ADD_ARROW_TEST(test/client_tests
-  EXTRA_LINK_LIBS plasma_static ${PLASMA_LINK_LIBS})
+  EXTRA_LINK_LIBS plasma_static ${PLASMA_LINK_LIBS}
+  EXTRA_DEPENDENCIES plasma_store)


### PR DESCRIPTION
Depends on PR https://github.com/apache/arrow/pull/2439

Author: Lukasz Bartnik <l.bartnik@gmail.com>