### PR TITLE
ARROW-3073,3074: [JS] Add DateVector.from and fix DateVector.indexOf

### DIFF
--- a/js/src/Arrow.externs.js
+++ b/js/src/Arrow.externs.js
@@ -195,6 +195,12 @@ Uint64.add = function() {};
 /** @type {?} */
 Uint64.multiply = function() {};
 /** @type {?} */
+Uint64.from = function() {};
+/** @type {?} */
+Uint64.fromNumber = function() {};
+/** @type {?} */
+Uint64.fromString = function() {};
+/** @type {?} */
 Uint64.prototype.times;
 /** @type {?} */
 Uint64.prototype.plus
@@ -204,6 +210,10 @@ var Int64 = function() {};
 Int64.add = function() {};
 /** @type {?} */
 Int64.multiply = function() {};
+/** @type {?} */
+Int64.from = function() {};
+/** @type {?} */
+Int64.fromNumber = function() {};
 /** @type {?} */
 Int64.fromString = function() {};
 /** @type {?} */
@@ -220,6 +230,10 @@ var Int128 = function() {};
 Int128.add = function() {};
 /** @type {?} */
 Int128.multiply = function() {};
+/** @type {?} */
+Int128.from = function() {};
+/** @type {?} */
+Int128.fromNumber = function() {};
 /** @type {?} */
 Int128.fromString = function() {};
 /** @type {?} */
@@ -538,6 +552,8 @@ var FloatVector = function() {};
 FloatVector.from = function() {};
 
 var DateVector = function() {};
+/** @type {?} */
+DateVector.from = function() {};
 /** @type {?} */
 DateVector.prototype.asEpochMilliseconds;
 var DecimalVector = function() {};

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -246,14 +246,24 @@ RecordBatch['from'] = RecordBatch.from;
 
 util_int_.Uint64['add'] = util_int_.Uint64.add;
 util_int_.Uint64['multiply'] = util_int_.Uint64.multiply;
+util_int_.Uint64['from'] = util_int_.Uint64.from;
+util_int_.Uint64['fromNumber'] = util_int_.Uint64.fromNumber;
+util_int_.Uint64['fromString'] = util_int_.Uint64.fromString;
+util_int_.Uint64['convertArray'] = util_int_.Uint64.convertArray;
 
 util_int_.Int64['add'] = util_int_.Int64.add;
 util_int_.Int64['multiply'] = util_int_.Int64.multiply;
+util_int_.Int64['from'] = util_int_.Int64.from;
+util_int_.Int64['fromNumber'] = util_int_.Int64.fromNumber;
 util_int_.Int64['fromString'] = util_int_.Int64.fromString;
+util_int_.Int64['convertArray'] = util_int_.Int64.convertArray;
 
 util_int_.Int128['add'] = util_int_.Int128.add;
 util_int_.Int128['multiply'] = util_int_.Int128.multiply;
+util_int_.Int128['from'] = util_int_.Int128.from;
+util_int_.Int128['fromNumber'] = util_int_.Int128.fromNumber;
 util_int_.Int128['fromString'] = util_int_.Int128.fromString;
+util_int_.Int128['convertArray'] = util_int_.Int128.convertArray;
 
 data_.ChunkedData['computeOffsets'] = data_.ChunkedData.computeOffsets;
 
@@ -301,6 +311,7 @@ type_.DataType['isMap'] = type_.DataType.isMap;
 type_.DataType['isDictionary'] = type_.DataType.isDictionary;
 
 vector_.BoolVector['from'] = vector_.BoolVector.from;
+vector_.DateVector['from'] = vector_.DateVector.from;
 vector_.IntVector['from'] = vector_.IntVector.from;
 vector_.FloatVector['from'] = vector_.FloatVector.from;
 

--- a/js/src/util/int.ts
+++ b/js/src/util/int.ts
@@ -118,6 +118,51 @@ export class Uint64 extends BaseInt64 {
         return this;
     }
 
+    static from(val: number|string, out_buffer = new Uint32Array(2)): Uint64 {
+        if (typeof(val) === 'number') {
+            return Uint64.fromNumber(val as number, out_buffer);
+        } else {
+            return Uint64.fromString(val as string, out_buffer);
+        }
+    }
+
+    static fromNumber(num: number, out_buffer = new Uint32Array(2)): Uint64 {
+        // Always parse numbers as strings - pulling out high and low bits
+        // directly seems to lose precision sometimes
+        // For example:
+        //     > -4613034156400212000 >>> 0
+        //     721782784
+        // The correct lower 32-bits are 721782752
+        return Uint64.fromString(num.toString(), out_buffer);
+    }
+
+    static fromString(str: string, out_buffer = new Uint32Array(2)): Uint64 {
+        const length = str.length;
+
+        let out = new Uint64(out_buffer);
+        for (let posn = 0; posn < length;) {
+            const group = kInt32DecimalDigits < length - posn ?
+                          kInt32DecimalDigits : length - posn;
+            const chunk = new Uint64(new Uint32Array([parseInt(str.substr(posn, group), 10), 0]));
+            const multiple = new Uint64(new Uint32Array([kPowersOfTen[group], 0]));
+
+            out.times(multiple);
+            out.plus(chunk);
+
+            posn += group;
+        }
+
+        return out;
+    }
+
+    static convertArray(values: (string|number)[]): Uint32Array {
+        const data = new Uint32Array(values.length * 2);
+        for (let i = -1, n = values.length; ++i < n;) {
+            Uint64.from(values[i], new Uint32Array(data.buffer, data.byteOffset + 2 * i * 4, 2));
+        }
+        return data;
+    }
+
     static multiply(left: Uint64, right: Uint64): Uint64 {
         let rtrn = new Uint64(new Uint32Array(left.buffer));
         return rtrn.times(right);
@@ -156,6 +201,24 @@ export class Int64 extends BaseInt64 {
             (this_high === other_high && this.buffer[0] < other.buffer[0]);
     }
 
+    static from(val: number|string, out_buffer = new Uint32Array(2)) {
+        if (typeof(val) === 'number') {
+            return Int64.fromNumber(val as number, out_buffer);
+        } else {
+            return Int64.fromString(val as string, out_buffer);
+        }
+    }
+
+    static fromNumber(num: number, out_buffer = new Uint32Array(2)): Int64 {
+        // Always parse numbers as strings - pulling out high and low bits
+        // directly seems to lose precision sometimes
+        // For example:
+        //     > -4613034156400212000 >>> 0
+        //     721782784
+        // The correct lower 32-bits are 721782752
+        return Int64.fromString(num.toString(), out_buffer);
+    }
+
     static fromString(str: string, out_buffer = new Uint32Array(2)): Int64 {
         // TODO: Assert that out_buffer is 0 and length = 2
         const negate = str.startsWith('-');
@@ -173,8 +236,15 @@ export class Int64 extends BaseInt64 {
 
             posn += group;
         }
-
         return negate ? out.negate() : out;
+    }
+
+    static convertArray(values: (string|number)[]): Uint32Array {
+        const data = new Uint32Array(values.length * 2);
+        for (let i = -1, n = values.length; ++i < n;) {
+            Int64.from(values[i], new Uint32Array(data.buffer, data.byteOffset + 2 * i * 4, 2));
+        }
+        return data;
     }
 
     static multiply(left: Int64, right: Int64): Int64 {
@@ -297,6 +367,24 @@ export class Int128 {
         return rtrn.plus(right);
     }
 
+    static from(val: number|string, out_buffer = new Uint32Array(4)) {
+        if (typeof(val) === 'number') {
+            return Int128.fromNumber(val as number, out_buffer);
+        } else {
+            return Int128.fromString(val as string, out_buffer);
+        }
+    }
+
+    static fromNumber(num: number, out_buffer = new Uint32Array(4)): Int128 {
+        // Always parse numbers as strings - pulling out high and low bits
+        // directly seems to lose precision sometimes
+        // For example:
+        //     > -4613034156400212000 >>> 0
+        //     721782784
+        // The correct lower 32-bits are 721782752
+        return Int128.fromString(num.toString(), out_buffer);
+    }
+
     static fromString(str: string, out_buffer = new Uint32Array(4)): Int128 {
         // TODO: Assert that out_buffer is 0 and length = 4
         const negate = str.startsWith('-');
@@ -316,5 +404,14 @@ export class Int128 {
         }
 
         return negate ? out.negate() : out;
+    }
+
+    static convertArray(values: (string|number)[]): Uint32Array {
+        // TODO: Distinguish between string and number at compile-time
+        const data = new Uint32Array(values.length * 4);
+        for (let i = -1, n = values.length; ++i < n;) {
+            Int128.from(values[i], new Uint32Array(data.buffer, data.byteOffset + 4 * 4 * i, 4));
+        }
+        return data;
     }
 }

--- a/js/src/util/int.ts
+++ b/js/src/util/int.ts
@@ -118,12 +118,11 @@ export class Uint64 extends BaseInt64 {
         return this;
     }
 
-    static from(val: number|string, out_buffer = new Uint32Array(2)): Uint64 {
-        if (typeof(val) === 'number') {
-            return Uint64.fromNumber(val as number, out_buffer);
-        } else {
-            return Uint64.fromString(val as string, out_buffer);
-        }
+    static from(val: any, out_buffer = new Uint32Array(2)): Uint64 {
+        return Uint64.fromString(
+            typeof(val) === 'string' ? val : val.toString(),
+            out_buffer
+        );
     }
 
     static fromNumber(num: number, out_buffer = new Uint32Array(2)): Uint64 {
@@ -201,12 +200,11 @@ export class Int64 extends BaseInt64 {
             (this_high === other_high && this.buffer[0] < other.buffer[0]);
     }
 
-    static from(val: number|string, out_buffer = new Uint32Array(2)) {
-        if (typeof(val) === 'number') {
-            return Int64.fromNumber(val as number, out_buffer);
-        } else {
-            return Int64.fromString(val as string, out_buffer);
-        }
+    static from(val: any, out_buffer = new Uint32Array(2)): Int64 {
+        return Int64.fromString(
+            typeof(val) === 'string' ? val : val.toString(),
+            out_buffer
+        );
     }
 
     static fromNumber(num: number, out_buffer = new Uint32Array(2)): Int64 {
@@ -367,12 +365,11 @@ export class Int128 {
         return rtrn.plus(right);
     }
 
-    static from(val: number|string, out_buffer = new Uint32Array(4)) {
-        if (typeof(val) === 'number') {
-            return Int128.fromNumber(val as number, out_buffer);
-        } else {
-            return Int128.fromString(val as string, out_buffer);
-        }
+    static from(val: any, out_buffer = new Uint32Array(4)): Int128 {
+        return Int128.fromString(
+            typeof(val) === 'string' ? val : val.toString(),
+            out_buffer
+        );
     }
 
     static fromNumber(num: number, out_buffer = new Uint32Array(4)): Int128 {

--- a/js/src/vector.ts
+++ b/js/src/vector.ts
@@ -19,6 +19,7 @@ import { Data, ChunkedData, FlatData, BoolData, FlatListData, NestedData, Dictio
 import { VisitorNode, TypeVisitor, VectorVisitor } from './visitor';
 import { DataType, ListType, FlatType, NestedType, FlatListType, TimeUnit } from './type';
 import { IterableArrayLike, Precision, DateUnit, IntervalUnit, UnionMode } from './type';
+import * as IntUtil from './util/int';
 
 export interface VectorLike { length: number; nullCount: number; }
 
@@ -259,6 +260,10 @@ export class FloatVector<T extends Float = Float<any>> extends FlatVector<T> {
 }
 
 export class DateVector extends FlatVector<Date_> {
+    static from(data: Date[]): DateVector {
+        const converted = IntUtil.Int64.convertArray(data.map((d) => d.getTime()));
+        return new DateVector(new FlatData(new Date_(DateUnit.MILLISECOND), data.length, null, converted))
+    }
     static defaultView<T extends Date_>(data: Data<T>) {
         return data.type.unit === DateUnit.DAY ? new DateDayView(data) : new DateMillisecondView(data, 2);
     }

--- a/js/src/vector/flat.ts
+++ b/js/src/vector/flat.ts
@@ -183,6 +183,15 @@ export class DateDayView extends PrimitiveView<Date_> {
 
 export class DateMillisecondView extends FixedSizeView<Date_> {
     public toArray() { return [...this]; }
+    public indexOf(search: Date) {
+        let index = 0;
+        for (let value of this) {
+            if (value.getTime() === search.getTime()) { return index; }
+            ++index;
+        }
+
+        return -1;
+    }
     protected getValue(values: Int32Array, index: number, size: number): Date {
         return epochMillisecondsLongToDate(values, index * size);
     }

--- a/js/src/vector/flat.ts
+++ b/js/src/vector/flat.ts
@@ -183,15 +183,6 @@ export class DateDayView extends PrimitiveView<Date_> {
 
 export class DateMillisecondView extends FixedSizeView<Date_> {
     public toArray() { return [...this]; }
-    public indexOf(search: Date) {
-        let index = 0;
-        for (let value of this) {
-            if (value.getTime() === search.getTime()) { return index; }
-            ++index;
-        }
-
-        return -1;
-    }
     protected getValue(values: Int32Array, index: number, size: number): Date {
         return epochMillisecondsLongToDate(values, index * size);
     }

--- a/js/test/unit/int-tests.ts
+++ b/js/test/unit/int-tests.ts
@@ -63,6 +63,15 @@ describe(`Uint64`, () => {
         let b = new Uint64(new Uint32Array([568, 32]));
         expect(a.lessThan(b)).toBeTruthy();
     });
+    test(`fromString parses string`, () => {
+        expect(Uint64.fromString('6789123456789')).toEqual(new Int64(new Uint32Array([0xb74abf15, 0x62c])));
+    });
+    test(`fromString parses big (full unsigned 64-bit) string`, () => {
+        expect(Uint64.fromString('18364758544493064720')).toEqual(new Uint64(new Uint32Array([0x76543210, 0xfedcba98])));
+    });
+    test(`fromNumber converts 53-ish bit number`, () => {
+        expect(Uint64.fromNumber(8086463330923024)).toEqual(new Uint64(new Uint32Array([0x76543210, 0x001cba98])));
+    });
 });
 
 describe(`Int64`, () => {
@@ -150,6 +159,10 @@ describe(`Int64`, () => {
     test(`fromString parses negative string`, () => {
         expect(Int64.fromString('-6789123456789')).toEqual(new Int64(new Uint32Array([0x48b540eb, 0xfffff9d3])));
     });
+    test(`fromNumber converts 53-ish bit number`, () => {
+        expect(Int64.fromNumber(8086463330923024)).toEqual(new Int64(new Uint32Array([0x76543210, 0x001cba98])));
+        expect(Int64.fromNumber(-8086463330923024)).toEqual(new Int64(new Uint32Array([0x89abcdf0, 0xffe34567])));
+    });
 });
 
 describe(`Int128`, () => {
@@ -221,4 +234,9 @@ describe(`Int128`, () => {
                                                 0x0ffdccec,
                                                 0xf6b64f09])));
     });
+    test(`fromNumber converts 53-ish bit number`, () => {
+        expect(Int128.fromNumber(8086463330923024)).toEqual(new Int128(new Uint32Array([0x76543210, 0x001cba98, 0, 0])));
+        expect(Int128.fromNumber(-8086463330923024)).toEqual(new Int128(new Uint32Array([0x89abcdf0, 0xffe34567, 0xffffffff, 0xffffffff])));
+    });
 });
+

--- a/js/test/unit/int-tests.ts
+++ b/js/test/unit/int-tests.ts
@@ -239,4 +239,3 @@ describe(`Int128`, () => {
         expect(Int128.fromNumber(-8086463330923024)).toEqual(new Int128(new Uint32Array([0x89abcdf0, 0xffe34567, 0xffffffff, 0xffffffff])));
     });
 });
-

--- a/js/test/unit/vector-tests.ts
+++ b/js/test/unit/vector-tests.ts
@@ -31,6 +31,8 @@ const {
     Uint8, Uint16, Uint32, Uint64,
 } = Arrow.type;
 
+const { DateUnit } = Arrow.enum_;
+
 const FixedSizeVectors = {
     Int64Vector: [IntVector, Int64] as [typeof IntVector, typeof Int64],
     Uint64Vector: [IntVector, Uint64] as [typeof IntVector, typeof Uint64],
@@ -318,18 +320,31 @@ describe(`Utf8Vector`, () => {
 });
 
 describe(`DateVector`, () => {
-    const values = [
-        new Date(1989, 5, 22, 1, 2, 3),
-        new Date(1988, 3, 25, 4, 5, 6),
-        new Date(1987, 2, 24, 7, 8, 9),
-        new Date(2018, 4, 12, 17, 30, 0)
-    ];
     const extras = [
         new Date(2000, 0, 1),
         new Date(1991, 5, 28, 12, 11, 10)
     ];
-    const vector = DateVector.from(values);
-    basicVectorTests(vector, values, extras);
+    describe(`unit = MILLISECOND`, () => {
+        const values = [
+            new Date(1989, 5, 22, 1, 2, 3),
+            new Date(1988, 3, 25, 4, 5, 6),
+            new Date(1987, 2, 24, 7, 8, 9),
+            new Date(2018, 4, 12, 17, 30, 0)
+        ];
+        const vector = DateVector.from(values);
+        basicVectorTests(vector, values, extras);
+    });
+    describe(`unit = DAY`, () => {
+        // Use UTC to ensure that dates are always at midnight
+        const values = [
+            new Date(Date.UTC(1989, 5, 22)),
+            new Date(Date.UTC(1988, 3, 25)),
+            new Date(Date.UTC(1987, 2, 24)),
+            new Date(Date.UTC(2018, 4, 12))
+        ];
+        const vector = DateVector.from(values, DateUnit.DAY);
+        basicVectorTests(vector, values, extras);
+    });
 });
 
 describe(`DictionaryVector`, () => {

--- a/js/test/unit/vector-tests.ts
+++ b/js/test/unit/vector-tests.ts
@@ -23,7 +23,7 @@ const utf8Encoder = new TextEncoder('utf-8');
 
 const { packBools } = Arrow.util;
 const { BoolData, FlatData, FlatListData, DictionaryData } = Arrow.data;
-const { Vector, IntVector, FloatVector, BoolVector, Utf8Vector, DictionaryVector } = Arrow.vector;
+const { Vector, IntVector, FloatVector, BoolVector, Utf8Vector, DateVector, DictionaryVector } = Arrow.vector;
 const {
     Dictionary, Utf8, Bool,
     Float16, Float32, Float64,
@@ -315,6 +315,21 @@ describe(`Utf8Vector`, () => {
     describe(`sliced`, () => {
         basicVectorTests(vector.slice(1,3), values.slice(1,3), ['foo', 'abc']);
     });
+});
+
+describe(`DateVector`, () => {
+    const values = [
+        new Date(1989, 5, 22, 1, 2, 3),
+        new Date(1988, 3, 25, 4, 5, 6),
+        new Date(1987, 2, 24, 7, 8, 9),
+        new Date(2018, 4, 12, 17, 30, 0)
+    ];
+    const extras = [
+        new Date(2000, 0, 1),
+        new Date(1991, 5, 28, 12, 11, 10)
+    ];
+    const vector = DateVector.from(values);
+    basicVectorTests(vector, values, extras);
 });
 
 describe(`DictionaryVector`, () => {


### PR DESCRIPTION
- Add a `DateVector.from` static method for creating a `DateVector` from a JS `Date[]`. Relies on `Arrow.util.Int64.fromNumber`. ([ARROW-3073](https://issues.apache.org/jira/browse/ARROW-3073))
- Add a specialized implementation of `indexOf` for `DateVector` since the base implementation (in `FixedSizeView`) throws an error. ([ARROW-3074](https://issues.apache.org/jira/browse/ARROW-3074))