### PR TITLE
ARROW-1661: [Python] Build Python 3.7 in manylinux container

### DIFF
--- a/python/manylinux1/Dockerfile-x86_64
+++ b/python/manylinux1/Dockerfile-x86_64
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FROM quay.io/wesm/arrow_manylinux1_x86_64_base:ARROW-1968
+FROM quay.io/xhochy/arrow_manylinux1_x86_64_base:latest
 
 ADD arrow /arrow
 WORKDIR /arrow/cpp

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -26,7 +26,7 @@
 # * Copyright (c) 2013-2016, Matt Terry and Matthew Brett (BSD 2-clause)
 
 # Build different python versions with various unicode widths
-PYTHON_VERSIONS="${PYTHON_VERSIONS:-2.7,16 2.7,32 3.5,16 3.6,16}"
+PYTHON_VERSIONS="${PYTHON_VERSIONS:-2.7,16 2.7,32 3.5,16 3.6,16 3.7,16}"
 
 source /multibuild/manylinux_utils.sh
 
@@ -58,10 +58,11 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
     PIP="${CPYTHON_PATH}/bin/pip"
     PATH="$PATH:${CPYTHON_PATH}"
 
-    # TensorFlow is not supported for Python 2.7 with unicode width 16
-    if [ $PYTHON != "2.7" ] || [ $U_WIDTH = "32" ]
-    then
-      $PIP install --ignore-installed --upgrade tensorflow
+    # TensorFlow is not supported for Python 2.7 with unicode width 16 or with Python 3.7
+    if [ $PYTHON != "2.7" ] || [ $U_WIDTH = "32" ]; then
+      if [ $PYTHON != "3.7" ]; then
+        $PIP install --ignore-installed --upgrade tensorflow
+      fi
     fi
 
     echo "=== (${PYTHON}) Building Arrow C++ libraries ==="

--- a/python/setup.py
+++ b/python/setup.py
@@ -515,9 +515,10 @@ class BinaryDistribution(Distribution):
 
 
 install_requires = (
-    'numpy >= 1.10',
+    'numpy >= 1.10; python_version < "3.7"',
+    'numpy >= 1.14; python_version >= "3.7"',
     'six >= 1.0.0',
-    'futures;python_version<"3.2"'
+    'futures; python_version < "3.2"'
 )
 
 
@@ -561,7 +562,8 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         ],
     license='Apache License, Version 2.0',
     maintainer="Apache Arrow Developers",

--- a/python/setup.py
+++ b/python/setup.py
@@ -515,6 +515,9 @@ class BinaryDistribution(Distribution):
 
 
 install_requires = (
+    # Use the minimal possible NumPy version. 1.10 works for all supported
+    # Python versions except 3.7. For Python 3.7, NumPy 1.14 is the minimal
+    # working version.
     'numpy >= 1.10; python_version < "3.7"',
     'numpy >= 1.14; python_version >= "3.7"',
     'six >= 1.0.0',


### PR DESCRIPTION
All dependencies have now released Python 3.7 compatible version, so use them.

For conda-forge, this might take a bit more time but once they have rebuilt all packages, we can automatically provide a 3.7 package there. See also https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/10