### PR TITLE
ARROW-3111: [Java] Adding logback config file to allow running tests with different log level

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -34,8 +34,8 @@ mvn install
 
 ## Test Logging Configuration
 
-When running tests, Arrow Java uses the LOGBack logger with SLF4J. By default,
-LOGBack has a log level set to DEBUG. Besides setting this level
+When running tests, Arrow Java uses the Logback logger with SLF4J. By default,
+Logback has a log level set to DEBUG. Besides setting this level
 programmatically, it can also be configured with a file named either
 "logback.xml" or "logback-test.xml" residing in the classpath. The file
 location can also be specified in the Maven command line with the following
@@ -48,6 +48,6 @@ root directory:
 mvn -Dlogback.configurationFile=file:`pwd`/dev/logback.xml
 ```
 
-See [LOGBack Configuration][1] for more details.
+See [Logback Configuration][1] for more details.
 
 [1]: https://logback.qos.ch/manual/configuration.html

--- a/java/README.md
+++ b/java/README.md
@@ -31,3 +31,23 @@ install:
 cd java
 mvn install
 ```
+
+## Test Logging Configuration
+
+When running tests, Arrow Java uses the LOGBack logger with SLF4J. By default,
+LOGBack has a log level set to DEBUG. Besides setting this level
+programmatically, it can also be configured with a file named either
+"logback.xml" or "logback-test.xml" residing in the classpath. The file
+location can also be specified in the Maven command line with the following
+option `-Dlogback.configurationFile=file:<absolute-file-path>`. A sample
+logback.xml file is available in `java/dev` with a log level of ERROR. Arrow
+Java can be built with this file using the following command run in the project
+root directory:
+
+```bash
+mvn -Dlogback.configurationFile=file:`pwd`/dev/logback.xml
+```
+
+See [LOGBack Configuration][1] for more details.
+
+[1]: https://logback.qos.ch/manual/configuration.html

--- a/java/dev/logback.xml
+++ b/java/dev/logback.xml
@@ -1,0 +1,29 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+
+<!-- This can be used when running tests with Maven by specifying the following option:
+$ mvn -Dlogback.configurationFile=file:${ARROW_HOME}/java/dev/logback.xml
+-->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/java/dev/logback.xml
+++ b/java/dev/logback.xml
@@ -10,7 +10,7 @@
   language governing permissions and limitations under the License. -->
 
 <!-- This can be used when running tests with Maven by specifying the following option:
-$ mvn -Dlogback.configurationFile=file:${ARROW_HOME}/java/dev/logback.xml
+$ mvn -Dlogback.configurationFile=file:${ARROW_HOME}/java/dev/logback.xml test
 -->
 
 <configuration>


### PR DESCRIPTION
Java uses the logback logger when running test, which has a default level of DEBUG. To change the level, an XML config file is needed. This adds a config file with level of ERROR. This config file is not used automatically and it's location needs to be specified. One way to specify this via command line is: `mvn -Dlogback.configurationFile=file:${ARROW_HOME}/java/dev/logback.xml`.