### PR TITLE
ARROW-3116: [Plasma] Add "ls" to object store

### DIFF
--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -1066,9 +1066,7 @@ Status PlasmaClient::Contains(const ObjectID& object_id, bool* has_object) {
   return impl_->Contains(object_id, has_object);
 }
 
-Status PlasmaClient::List(ObjectTable* objects) {
-  return impl_->List(objects);
-}
+Status PlasmaClient::List(ObjectTable* objects) { return impl_->List(objects); }
 
 Status PlasmaClient::Abort(const ObjectID& object_id) { return impl_->Abort(object_id); }
 

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -184,6 +184,8 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
 
   Status Contains(const ObjectID& object_id, bool* has_object);
 
+  Status List(ObjectTable* objects);
+
   Status Abort(const ObjectID& object_id);
 
   Status Seal(const ObjectID& object_id);
@@ -705,6 +707,13 @@ Status PlasmaClient::Impl::Contains(const ObjectID& object_id, bool* has_object)
   return Status::OK();
 }
 
+Status PlasmaClient::Impl::List(ObjectTable* objects) {
+  RETURN_NOT_OK(SendListRequest(store_conn_));
+  std::vector<uint8_t> buffer;
+  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaListReply, &buffer));
+  return ReadListReply(buffer.data(), buffer.size(), objects);
+}
+
 static void ComputeBlockHash(const unsigned char* data, int64_t nbytes, uint64_t* hash) {
   XXH64_state_t hash_state;
   XXH64_reset(&hash_state, XXH64_DEFAULT_SEED);
@@ -1055,6 +1064,10 @@ Status PlasmaClient::Release(const ObjectID& object_id) {
 
 Status PlasmaClient::Contains(const ObjectID& object_id, bool* has_object) {
   return impl_->Contains(object_id, has_object);
+}
+
+Status PlasmaClient::List(ObjectTable* objects) {
+  return impl_->List(objects);
 }
 
 Status PlasmaClient::Abort(const ObjectID& object_id) { return impl_->Abort(object_id); }

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -151,6 +151,8 @@ class ARROW_EXPORT PlasmaClient {
   /// \return The return status.
   Status Contains(const ObjectID& object_id, bool* has_object);
 
+  Status List(ObjectTable* objects);
+
   /// Abort an unsealed object in the object store. If the abort succeeds, then
   /// it will be as if the object was never created at all. The unsealed object
   /// must have only a single reference (the one that would have been removed by

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -151,6 +151,13 @@ class ARROW_EXPORT PlasmaClient {
   /// \return The return status.
   Status Contains(const ObjectID& object_id, bool* has_object);
 
+  /// List all the objects in the object store.
+  ///
+  /// \param[out] objects ObjectTable of objects in the store. For each entry
+  ///             in the map, the following fields are available:
+  ///             - metadata_size: Size of the object metadata in bytes
+  ///             - data_size: Size of the object data in bytes
+  /// \return The return status.
   Status List(ObjectTable* objects);
 
   /// Abort an unsealed object in the object store. If the abort succeeds, then

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -153,10 +153,16 @@ class ARROW_EXPORT PlasmaClient {
 
   /// List all the objects in the object store.
   ///
+  /// This API is experimental and might change in the future.
+  ///
   /// \param[out] objects ObjectTable of objects in the store. For each entry
   ///             in the map, the following fields are available:
   ///             - metadata_size: Size of the object metadata in bytes
   ///             - data_size: Size of the object data in bytes
+  ///             - ref_count: Number of clients referencing the object buffer
+  ///             - create_time: Unix timestamp of the object creation
+  ///             - construct_duration: Object creation time in seconds
+  ///             - state: Is the object still being created or already sealed?
   /// \return The return status.
   Status List(ObjectTable* objects);
 

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -18,6 +18,8 @@
 #ifndef PLASMA_COMMON_H
 #define PLASMA_COMMON_H
 
+#include <stddef.h>
+
 #include <cstring>
 #include <memory>
 #include <string>

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -19,6 +19,7 @@
 #define PLASMA_COMMON_H
 
 #include <cstring>
+#include <memory>
 #include <string>
 // TODO(pcm): Convert getopt and sscanf in the store to use more idiomatic C++
 // and get rid of the next three lines:

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -119,6 +119,10 @@ struct ObjectTableEntry {
 #endif
   /// Number of clients currently using this object.
   int ref_count;
+  /// Unix epoch of when this object was created.
+  int64_t create_time;
+  /// How long creation of this object took.
+  int64_t construct_duration;
 
   /// The state of the object, e.g., whether it is open or sealed.
   ObjectState state;

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -84,28 +84,6 @@ struct ObjectRequest {
   ObjectLocation location;
 };
 
-// TODO(pcm): Replace this by the flatbuffers message PlasmaObjectSpec.
-struct PlasmaObject {
-#ifdef PLASMA_GPU
-  // IPC handle for Cuda.
-  std::shared_ptr<CudaIpcMemHandle> ipc_handle;
-#endif
-  /// The file descriptor of the memory mapped file in the store. It is used as
-  /// a unique identifier of the file in the client to look up the corresponding
-  /// file descriptor on the client's side.
-  int store_fd;
-  /// The offset in bytes in the memory mapped file of the data.
-  ptrdiff_t data_offset;
-  /// The offset in bytes in the memory mapped file of the metadata.
-  ptrdiff_t metadata_offset;
-  /// The size in bytes of the data.
-  int64_t data_size;
-  /// The size in bytes of the metadata.
-  int64_t metadata_size;
-  /// Device number object is on.
-  int device_num;
-};
-
 enum class ObjectState : int {
   /// Object was created but not sealed in the local Plasma Store.
   PLASMA_CREATED = 1,

--- a/cpp/src/plasma/format/common.fbs
+++ b/cpp/src/plasma/format/common.fbs
@@ -25,11 +25,14 @@ table ObjectInfo {
   data_size: long;
   // Number of bytes the metadata of this object occupies in memory.
   metadata_size: long;
+  // Number of clients using the objects.
+  ref_count: int;
   // Unix epoch of when this object was created.
   create_time: long;
   // How long creation of this object took.
   construct_duration: long;
-  // Hash of the object content.
+  // Hash of the object content. If the object is not sealed yet this is
+  // an empty string.
   digest: string;
   // Specifies if this object was deleted or added.
   is_deletion: bool;

--- a/cpp/src/plasma/format/common.fbs
+++ b/cpp/src/plasma/format/common.fbs
@@ -34,7 +34,3 @@ table ObjectInfo {
   // Specifies if this object was deleted or added.
   is_deletion: bool;
 }
-
-table ObjectList {
-  objects: [ObjectInfo];
-}

--- a/cpp/src/plasma/format/common.fbs
+++ b/cpp/src/plasma/format/common.fbs
@@ -34,3 +34,7 @@ table ObjectInfo {
   // Specifies if this object was deleted or added.
   is_deletion: bool;
 }
+
+table ObjectList {
+  objects: [ObjectInfo];
+}

--- a/cpp/src/plasma/format/plasma.fbs
+++ b/cpp/src/plasma/format/plasma.fbs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+include "common.fbs";
+
 // Plasma protocol specification
 namespace plasma.flatbuf;
 
@@ -44,6 +46,9 @@ enum MessageType:long {
   // See if the store contains an object (will be deprecated).
   PlasmaContainsRequest,
   PlasmaContainsReply,
+  // List all objects in the store.
+  PlasmaListRequest,
+  PlasmaListReply,
   // Get information for a newly connecting client.
   PlasmaConnectRequest,
   PlasmaConnectReply,
@@ -255,6 +260,13 @@ table PlasmaContainsReply {
   object_id: string;
   // 1 if the object is in the store and 0 otherwise.
   has_object: int;
+}
+
+table PlasmaListRequest {
+}
+
+table PlasmaListReply {
+  objects: [ObjectInfo];
 }
 
 // PlasmaConnect is used by a plasma client the first time it connects with the

--- a/cpp/src/plasma/plasma.h
+++ b/cpp/src/plasma/plasma.h
@@ -143,10 +143,13 @@ struct ObjectTableEntry {
   unsigned char digest[kDigestSize];
 };
 
+/// Mapping from ObjectIDs to information about the object.
+typedef std::unordered_map<ObjectID, std::unique_ptr<ObjectTableEntry>> ObjectTable;
+
 /// The plasma store information that is exposed to the eviction policy.
 struct PlasmaStoreInfo {
   /// Objects that are in the Plasma store.
-  std::unordered_map<ObjectID, std::unique_ptr<ObjectTableEntry>> objects;
+  ObjectTable objects;
   /// The amount of memory (in bytes) that we allow to be allocated in the
   /// store.
   int64_t memory_capacity;

--- a/cpp/src/plasma/plasma.h
+++ b/cpp/src/plasma/plasma.h
@@ -95,56 +95,12 @@ struct PlasmaObject {
   int device_num;
 };
 
-enum class ObjectState : int {
-  /// Object was created but not sealed in the local Plasma Store.
-  PLASMA_CREATED = 1,
-  /// Object is sealed and stored in the local Plasma Store.
-  PLASMA_SEALED
-};
-
 enum class ObjectStatus : int {
   /// The object was not found.
   OBJECT_NOT_FOUND = 0,
   /// The object was found.
   OBJECT_FOUND = 1
 };
-
-/// This type is used by the Plasma store. It is here because it is exposed to
-/// the eviction policy.
-struct ObjectTableEntry {
-  ObjectTableEntry();
-
-  ~ObjectTableEntry();
-
-  /// Memory mapped file containing the object.
-  int fd;
-  /// Device number.
-  int device_num;
-  /// Size of the underlying map.
-  int64_t map_size;
-  /// Offset from the base of the mmap.
-  ptrdiff_t offset;
-  /// Pointer to the object data. Needed to free the object.
-  uint8_t* pointer;
-  /// Size of the object in bytes.
-  int64_t data_size;
-  /// Size of the object metadata in bytes.
-  int64_t metadata_size;
-#ifdef PLASMA_GPU
-  /// IPC GPU handle to share with clients.
-  std::shared_ptr<CudaIpcMemHandle> ipc_handle;
-#endif
-  /// Number of clients currently using this object.
-  int ref_count;
-
-  /// The state of the object, e.g., whether it is open or sealed.
-  ObjectState state;
-  /// The digest of the object. Used to see if two objects are the same.
-  unsigned char digest[kDigestSize];
-};
-
-/// Mapping from ObjectIDs to information about the object.
-typedef std::unordered_map<ObjectID, std::unique_ptr<ObjectTableEntry>> ObjectTable;
 
 /// The plasma store information that is exposed to the eviction policy.
 struct PlasmaStoreInfo {

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -424,7 +424,8 @@ Status SendListReply(int sock, const ObjectTable& objects) {
   flatbuffers::FlatBufferBuilder fbb;
   std::vector<flatbuffers::Offset<fb::ObjectInfo>> object_infos;
   for (auto const& entry : objects) {
-    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size, entry.second->ref_count, 0, 0, fbb.CreateString(reinterpret_cast<char*>(entry.second->digest), kDigestSize));
+    auto digest = entry.second->state == ObjectState::PLASMA_CREATED ? fbb.CreateString("") : fbb.CreateString(reinterpret_cast<char*>(entry.second->digest), kDigestSize);
+    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size, entry.second->ref_count, 0, 0, digest);
     object_infos.push_back(info);
   }
   auto message = fb::CreatePlasmaListReply(fbb, fbb.CreateVector(object_infos));

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -432,7 +432,8 @@ Status SendListReply(int sock, const ObjectTable& objects) {
                                          kDigestSize);
     auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()),
                                      entry.second->data_size, entry.second->metadata_size,
-                                     entry.second->ref_count, 0, 0, digest);
+                                     entry.second->ref_count, entry.second->create_time,
+                                     entry.second->construct_duration, digest);
     object_infos.push_back(info);
   }
   auto message = fb::CreatePlasmaListReply(fbb, fbb.CreateVector(object_infos));
@@ -449,6 +450,8 @@ Status ReadListReply(uint8_t* data, size_t size, ObjectTable* objects) {
     entry->data_size = object->data_size();
     entry->metadata_size = object->metadata_size();
     entry->ref_count = object->ref_count();
+    entry->create_time = object->create_time();
+    entry->construct_duration = object->construct_duration();
     entry->state = object->digest()->size() == 0 ? ObjectState::PLASMA_CREATED
                                                  : ObjectState::PLASMA_SEALED;
     (*objects)[object_id] = std::move(entry);

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -427,7 +427,7 @@ Status SendListReply(int sock, const ObjectTable& objects) {
     auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size);
     object_infos.push_back(info);
   }
-  auto message = fbb.CreateVector(object_infos);
+  auto message = fb::CreatePlasmaListReply(fbb, fbb.CreateVector(object_infos));
   return PlasmaSend(sock, MessageType::PlasmaListReply, &fbb, message);
 }
 

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -410,6 +410,41 @@ Status ReadContainsReply(uint8_t* data, size_t size, ObjectID* object_id,
   return Status::OK();
 }
 
+// List messages.
+
+Status SendListRequest(int sock) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = fb::CreatePlasmaListRequest(fbb);
+  return PlasmaSend(sock, MessageType::PlasmaListRequest, &fbb, message);
+}
+
+Status ReadListRequest(uint8_t* data, size_t size) { return Status::OK(); }
+
+Status SendListReply(int sock, const ObjectTable& objects) {
+  flatbuffers::FlatBufferBuilder fbb;
+  std::vector<flatbuffers::Offset<fb::ObjectInfo>> object_infos;
+  for (auto const& entry : objects) {
+    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size);
+    object_infos.push_back(info);
+  }
+  auto message = fbb.CreateVector(object_infos);
+  return PlasmaSend(sock, MessageType::PlasmaListReply, &fbb, message);
+}
+
+Status ReadListReply(uint8_t* data, size_t size, ObjectTable* objects) {
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<fb::PlasmaListReply>(data);
+  DCHECK(VerifyFlatbuffer(message, data, size));
+  for (auto const& object : *message->objects()) {
+    ObjectID object_id = ObjectID::from_binary(object->object_id()->str());
+    auto entry = std::unique_ptr<ObjectTableEntry>(new ObjectTableEntry());
+    entry->data_size = object->data_size();
+    entry->metadata_size = object->metadata_size();
+    (*objects)[object_id] = std::move(entry);
+  }
+  return Status::OK();
+}
+
 // Connect messages.
 
 Status SendConnectRequest(int sock) {

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -424,7 +424,7 @@ Status SendListReply(int sock, const ObjectTable& objects) {
   flatbuffers::FlatBufferBuilder fbb;
   std::vector<flatbuffers::Offset<fb::ObjectInfo>> object_infos;
   for (auto const& entry : objects) {
-    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size);
+    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size, entry.second->ref_count, 0, 0, fbb.CreateString(reinterpret_cast<char*>(entry.second->digest), kDigestSize));
     object_infos.push_back(info);
   }
   auto message = fb::CreatePlasmaListReply(fbb, fbb.CreateVector(object_infos));
@@ -440,6 +440,8 @@ Status ReadListReply(uint8_t* data, size_t size, ObjectTable* objects) {
     auto entry = std::unique_ptr<ObjectTableEntry>(new ObjectTableEntry());
     entry->data_size = object->data_size();
     entry->metadata_size = object->metadata_size();
+    entry->ref_count = object->ref_count();
+    entry->state = object->digest()->size() == 0 ? ObjectState::PLASMA_CREATED : ObjectState::PLASMA_SEALED;
     (*objects)[object_id] = std::move(entry);
   }
   return Status::OK();

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -141,6 +141,16 @@ Status SendContainsReply(int sock, ObjectID object_id, bool has_object);
 Status ReadContainsReply(uint8_t* data, size_t size, ObjectID* object_id,
                          bool* has_object);
 
+/* Plasma List message functions. */
+
+Status SendListRequest(int sock);
+
+Status ReadListRequest(uint8_t* data, size_t size);
+
+Status SendListReply(int sock, const ObjectTable& objects);
+
+Status ReadListReply(uint8_t* data, size_t size, ObjectTable* objects);
+
 /* Plasma Connect message functions. */
 
 Status SendConnectRequest(int sock);

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -435,16 +435,6 @@ ObjectStatus PlasmaStore::ContainsObject(const ObjectID& object_id) {
              : ObjectStatus::OBJECT_NOT_FOUND;
 }
 
-void PlasmaStore::ListObjects() {
-  flatbuffers::FlatBufferBuilder fbb;
-  std::vector<flatbuffers::Offset<fb::ObjectInfo>> object_infos;
-  for (auto const& entry : store_info_.objects) {
-    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size);
-    object_infos.push_back(info);
-  }
-  auto list = fbb.CreateVector(object_infos);
-}
-
 // Seal an object that has been created in the hash table.
 void PlasmaStore::SealObject(const ObjectID& object_id, unsigned char digest[]) {
   ARROW_LOG(DEBUG) << "sealing object " << object_id.hex();
@@ -793,6 +783,10 @@ Status PlasmaStore::ProcessMessage(Client* client) {
       } else {
         HANDLE_SIGPIPE(SendContainsReply(client->fd, object_id, 0), client->fd);
       }
+    } break;
+    case fb::MessageType::PlasmaListRequest: {
+      RETURN_NOT_OK(ReadListRequest(input, input_size));
+      HANDLE_SIGPIPE(SendListReply(client->fd, store_info_.objects), client->fd);
     } break;
     case fb::MessageType::PlasmaSealRequest: {
       unsigned char digest[kDigestSize];

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -43,6 +43,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include <ctime>
 #include <deque>
 #include <memory>
 #include <string>
@@ -214,6 +215,8 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
   entry->offset = offset;
   entry->state = ObjectState::PLASMA_CREATED;
   entry->device_num = device_num;
+  entry->create_time = std::time(nullptr);
+  entry->construct_duration = -1;
 #ifdef PLASMA_GPU
   if (device_num != 0) {
     DCHECK_OK(gpu_handle->ExportForIpc(&entry->ipc_handle));
@@ -445,6 +448,8 @@ void PlasmaStore::SealObject(const ObjectID& object_id, unsigned char digest[]) 
   entry->state = ObjectState::PLASMA_SEALED;
   // Set the object digest.
   std::memcpy(&entry->digest[0], &digest[0], kDigestSize);
+  // Set object construction duration.
+  entry->construct_duration = std::time(nullptr) - entry->create_time;
   // Inform all subscribers that a new object has been sealed.
   ObjectInfoT info;
   info.object_id = object_id.binary();

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -435,6 +435,16 @@ ObjectStatus PlasmaStore::ContainsObject(const ObjectID& object_id) {
              : ObjectStatus::OBJECT_NOT_FOUND;
 }
 
+void PlasmaStore::ListObjects() {
+  flatbuffers::FlatBufferBuilder fbb;
+  std::vector<flatbuffers::Offset<fb::ObjectInfo>> object_infos;
+  for (auto const& entry : store_info_.objects) {
+    auto info = fb::CreateObjectInfo(fbb, fbb.CreateString(entry.first.binary()), entry.second->data_size, entry.second->metadata_size);
+    object_infos.push_back(info);
+  }
+  auto list = fbb.CreateVector(object_infos);
+}
+
 // Seal an object that has been created in the hash table.
 void PlasmaStore::SealObject(const ObjectID& object_id, unsigned char digest[]) {
   ARROW_LOG(DEBUG) << "sealing object " << object_id.hex();

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -150,8 +150,6 @@ class PlasmaStore {
   /// not
   ObjectStatus ContainsObject(const ObjectID& object_id);
 
-  void ListObjects();
-
   /// Record the fact that a particular client is no longer using an object.
   ///
   /// @param object_id The object ID of the object that is being released.

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -150,6 +150,8 @@ class PlasmaStore {
   /// not
   ObjectStatus ContainsObject(const ObjectID& object_id);
 
+  void ListObjects();
+
   /// Record the fact that a particular client is no longer using an object.
   ///
   /// @param object_id The object ID of the object that is being released.

--- a/python/doc/source/plasma.rst
+++ b/python/doc/source/plasma.rst
@@ -209,6 +209,55 @@ milliseconds). After the timeout, the interpreter will yield control back.
   b'\x01\x02\x03'
 
 
+Listing objects in the store
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The objects in the store can be listed in the following way (note that
+this functionality is currently experimental and the concrete representation
+of the object info might change in the future):
+
+.. code-block:: python
+
+  import pyarrow.plasma as plasma
+  import time
+
+  client = plasma.connect("/tmp/plasma", "", 0)
+
+  client.put("hello, world")
+  # Sleep a little so we get different creation times
+  time.sleep(2)
+  client.put("another object")
+  # Create an object that is not sealed yet
+  object_id = plasma.ObjectID.from_random()
+  client.create(object_id, 100)
+  print(client.list())
+
+  >>> {ObjectID(a111b337aa5218595c3bdc8d317aae0769adab88): {'construct_duration': 0,
+  >>>  'create_time': 1535223628,
+  >>>  'data_size': 460,
+  >>>  'metadata_size': 0,
+  >>>  'ref_count': 0,
+  >>>  'state': 'sealed'},
+  >>> ObjectID(4cba8f80c54c6d265b46c2cdfcee6e32348b12be): {'construct_duration': 0,
+  >>>  'create_time': 1535223642,
+  >>>  'data_size': 460,
+  >>>  'metadata_size': 0,
+  >>>  'ref_count': 0,
+  >>>  'state': 'sealed'},
+  >>> ObjectID(a7598230b0c26464c9d9c99ae14773ee81485428): {'construct_duration': 0,
+  >>>  'create_time': 1535223644,
+  >>>  'data_size': 460,
+  >>>  'metadata_size': 0,
+  >>>  'ref_count': 0,
+  >>>  'state': 'sealed'},
+  >>> ObjectID(e603ab0c92098ebf08f90bfcea33ff98f6476870): {'construct_duration': -1,
+  >>>  'create_time': 1535223644,
+  >>>  'data_size': 100,
+  >>>  'metadata_size': 0,
+  >>>  'ref_count': 1,
+  >>>  'state': 'created'}}
+
+
 Using Arrow and Pandas with Plasma
 ----------------------------------
 

--- a/python/doc/source/plasma.rst
+++ b/python/doc/source/plasma.rst
@@ -232,13 +232,7 @@ of the object info might change in the future):
   client.create(object_id, 100)
   print(client.list())
 
-  >>> {ObjectID(a111b337aa5218595c3bdc8d317aae0769adab88): {'construct_duration': 0,
-  >>>  'create_time': 1535223628,
-  >>>  'data_size': 460,
-  >>>  'metadata_size': 0,
-  >>>  'ref_count': 0,
-  >>>  'state': 'sealed'},
-  >>> ObjectID(4cba8f80c54c6d265b46c2cdfcee6e32348b12be): {'construct_duration': 0,
+  >>> {ObjectID(4cba8f80c54c6d265b46c2cdfcee6e32348b12be): {'construct_duration': 0,
   >>>  'create_time': 1535223642,
   >>>  'data_size': 460,
   >>>  'metadata_size': 0,

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -699,7 +699,7 @@ cdef class PlasmaClient:
            else:
                state = "sealed"
            result[object_id] = {
-               "size": deref(deref(it).second).data_size,
+               "data_size": deref(deref(it).second).data_size,
                "metadata_size": deref(deref(it).second).metadata_size,
                "ref_count": deref(deref(it).second).ref_count,
                "state": state

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -75,7 +75,7 @@ cdef extern from "plasma/common.h" nogil:
         int ref_count
         CObjectState state
 
-    ctypedef unordered_map[CUniqueID, unique_ptr[CObjectTableEntry]]
+    ctypedef unordered_map[CUniqueID, unique_ptr[CObjectTableEntry]] \
              CObjectTable" plasma::ObjectTable"
 
 

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -75,7 +75,8 @@ cdef extern from "plasma/common.h" nogil:
         int ref_count
         CObjectState state
 
-    ctypedef unordered_map[CUniqueID, unique_ptr[CObjectTableEntry]] CObjectTable" plasma::ObjectTable"
+    ctypedef unordered_map[CUniqueID, unique_ptr[CObjectTableEntry]]
+             CObjectTable" plasma::ObjectTable"
 
 
 cdef extern from "plasma/common.h":
@@ -692,7 +693,7 @@ cdef class PlasmaClient:
         result = dict()
         cdef ObjectID object_id
         cdef CObjectTableEntry entry
-        it  = objects.begin()
+        it = objects.begin()
         while it != objects.end():
             object_id = ObjectID(deref(it).first.binary())
             entry = deref(deref(it).second)

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -704,9 +704,7 @@ cdef class PlasmaClient:
 
     def list(self):
         """
-        List the objects in the store.
-
-        This API is experimental and might change in the future.
+        Experimental: List the objects in the store.
 
         Returns
         -------

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -730,7 +730,7 @@ cdef class PlasmaClient:
               Time the creation of the object took in seconds
 
             state
-              created" if the object is still being created and
+              "created" if the object is still being created and
               "sealed" if it is already sealed
         """
         cdef CObjectTable objects

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -58,6 +58,15 @@ cdef extern from "plasma/common.h" nogil:
         int type
         int location
 
+    cdef struct CObjectTableEntry" plasma::ObjectTableEntry":
+        int fd
+        int device_num
+        int64_t map_size
+        ptrdiff_t offset
+        uint8_t* pointer
+        int64_t data_size
+        int64_t metadata_size
+
 
 cdef extern from "plasma/common.h":
     cdef int64_t kDigestSize" plasma::kDigestSize"

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -703,6 +703,36 @@ cdef class PlasmaClient:
             check_status(self.client.get().Delete(ids))
 
     def list(self):
+        """
+        List the objects in the store.
+
+        This API is experimental and might change in the future.
+
+        Returns
+        -------
+        dict
+            Dictionary from ObjectIDs to an "info" dictionary describing the
+            object. The "info" dictionary has the following entries:
+
+            data_size
+              size of the object in bytes
+
+            metadata_size
+              size of the object metadata in bytes
+
+            ref_count
+              Number of clients referencing the object buffer
+
+            create_time
+              Unix timestamp of the creation of the object
+
+            construct_duration
+              Time the creation of the object took in seconds
+
+            state
+              created" if the object is still being created and
+              "sealed" if it is already sealed
+        """
         cdef CObjectTable objects
         with nogil:
             check_status(self.client.get().List(&objects))

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -73,10 +73,12 @@ cdef extern from "plasma/common.h" nogil:
         int64_t data_size
         int64_t metadata_size
         int ref_count
+        int64_t create_time
+        int64_t construct_duration
         CObjectState state
 
     ctypedef unordered_map[CUniqueID, unique_ptr[CObjectTableEntry]] \
-             CObjectTable" plasma::ObjectTable"
+        CObjectTable" plasma::ObjectTable"
 
 
 cdef extern from "plasma/common.h":
@@ -705,6 +707,8 @@ cdef class PlasmaClient:
                 "data_size": entry.data_size,
                 "metadata_size": entry.metadata_size,
                 "ref_count": entry.ref_count,
+                "create_time": entry.create_time,
+                "construct_duration": entry.construct_duration,
                 "state": state
             }
             inc(it)

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -803,22 +803,22 @@ def test_plasma_list():
 
         # Test sizes
         x, _, _ = create_object(plasma_client, 11, metadata_size=7, seal=False)
-        l = plasma_client.list()
-        assert l[x]["data_size"] == 11
-        assert l[x]["metadata_size"] == 7
+        l1 = plasma_client.list()
+        assert l1[x]["data_size"] == 11
+        assert l1[x]["metadata_size"] == 7
 
         # Test ref_count
         y = plasma_client.put(np.zeros(3))
-        l = plasma_client.list()
-        assert l[y]["ref_count"] == 0 # Ref count has already been released
+        l2 = plasma_client.list()
+        assert l2[y]["ref_count"] == 0 # Ref count has already been released
         a = plasma_client.get(y)
-        l = plasma_client.list()
-        assert l[y]["ref_count"] == 1
+        l3 = plasma_client.list()
+        assert l3[y]["ref_count"] == 1
 
         # Test state
         z, _, _ = create_object(plasma_client, 3, metadata_size=0, seal=False)
-        l = plasma_client.list()
-        assert l[z]["state"] == "created"
+        l4 = plasma_client.list()
+        assert l4[z]["state"] == "created"
         plasma_client.seal(z)
-        l = plasma_client.list()
-        assert l[z]["state"] == "sealed"
+        l5 = plasma_client.list()
+        assert l5[z]["state"] == "sealed"

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -810,10 +810,12 @@ def test_plasma_list():
         # Test ref_count
         y = plasma_client.put(np.zeros(3))
         l2 = plasma_client.list()
-        assert l2[y]["ref_count"] == 0 # Ref count has already been released
+        # Ref count has already been released
+        assert l2[y]["ref_count"] == 0
         a = plasma_client.get(y)
         l3 = plasma_client.list()
         assert l3[y]["ref_count"] == 1
+        del a
 
         # Test state
         z, _, _ = create_object(plasma_client, 3, metadata_size=0, seal=False)

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import math
 import os
 import pytest
 import random
@@ -831,4 +832,11 @@ def test_plasma_list():
         x, _, _ = create_object(plasma_client, 3, metadata_size=0, seal=False)
         t2 = time.time()
         l6 = plasma_client.list()
-        assert t1 - 1.0 <= l6[x]["create_time"] <= t2
+        assert math.floor(t1) <= l6[x]["create_time"] <= math.ceil(t2)
+        time.sleep(2.0)
+        t3 = time.time()
+        plasma_client.seal(x)
+        t4 = time.time()
+        l7 = plasma_client.list()
+        assert math.floor(t3 - t2) <= l7[x]["construct_duration"]
+        assert l7[x]["construct_duration"] <= math.ceil(t4 - t1)

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -801,18 +801,24 @@ def test_plasma_list():
             as (plasma_store_name, p):
         plasma_client = plasma.connect(plasma_store_name, "", 0)
 
+        # Test sizes
+        x, _, _ = create_object(plasma_client, 11, metadata_size=7, seal=False)
+        l = plasma_client.list()
+        assert l[x]["data_size"] == 11
+        assert l[x]["metadata_size"] == 7
+
         # Test ref_count
-        x = plasma_client.put(np.zeros(3))
+        y = plasma_client.put(np.zeros(3))
         l = plasma_client.list()
-        assert l[x]["ref_count"] == 0 # Ref count has already been released
-        a = plasma_client.get(x)
+        assert l[y]["ref_count"] == 0 # Ref count has already been released
+        a = plasma_client.get(y)
         l = plasma_client.list()
-        assert l[x]["ref_count"] == 1
+        assert l[y]["ref_count"] == 1
 
         # Test state
-        y = create_object(plasma_client, 3, metadata_size=0, seal=False)
+        z, _, _ = create_object(plasma_client, 3, metadata_size=0, seal=False)
         l = plasma_client.list()
-        assert l[y]["state"] == "created"
-        plasma_client.seal(y)
+        assert l[z]["state"] == "created"
+        plasma_client.seal(z)
         l = plasma_client.list()
-        assert l[y]["state"] == "sealed"
+        assert l[z]["state"] == "sealed"


### PR DESCRIPTION
This adds plasma_client.list to the plasma client API.

It can be used like so:

```python
  import pyarrow.plasma as plasma
  import time

  client = plasma.connect("/tmp/plasma", "", 0)

  client.put("hello, world")
  # Sleep a little so we get different creation times
  time.sleep(2)
  client.put("another object")
  # Create an object that is not sealed yet
  object_id = plasma.ObjectID.from_random()
  client.create(object_id, 100)
  print(client.list())

  >>> {ObjectID(4cba8f80c54c6d265b46c2cdfcee6e32348b12be): {'construct_duration': 0,
  >>>  'create_time': 1535223642,
  >>>  'data_size': 460,
  >>>  'metadata_size': 0,
  >>>  'ref_count': 0,
  >>>  'state': 'sealed'},
  >>> ObjectID(a7598230b0c26464c9d9c99ae14773ee81485428): {'construct_duration': 0,
  >>>  'create_time': 1535223644,
  >>>  'data_size': 460,
  >>>  'metadata_size': 0,
  >>>  'ref_count': 0,
  >>>  'state': 'sealed'},
  >>> ObjectID(e603ab0c92098ebf08f90bfcea33ff98f6476870): {'construct_duration': -1,
  >>>  'create_time': 1535223644,
  >>>  'data_size': 100,
  >>>  'metadata_size': 0,
  >>>  'ref_count': 1,
  >>>  'state': 'created'}}
```