### PR TITLE
ARROW-3017: [C++] Don't throw exception in arrow/util/thread-pool.h

### DIFF
--- a/cpp/src/arrow/util/thread-pool.h
+++ b/cpp/src/arrow/util/thread-pool.h
@@ -25,6 +25,7 @@
 #include <exception>
 #include <functional>
 #include <future>
+#include <iostream>
 #include <list>
 #include <memory>
 #include <type_traits>
@@ -117,7 +118,8 @@ class ARROW_EXPORT ThreadPool {
     Status st = SpawnReal(detail::packaged_task_wrapper<Result>(std::move(task)));
     if (!st.ok()) {
       // This happens when Submit() is called after Shutdown()
-      throw std::runtime_error(st.ToString());
+      std::cerr << st.ToString() << std::endl;
+      std::abort();
     }
     return fut;
   }


### PR DESCRIPTION
Simple patch for resolving https://issues.apache.org/jira/browse/ARROW-3017