### PR TITLE
ARROW-3131: [Go] add Go1.11 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,7 +263,7 @@ matrix:
     go_import_path: github.com/apache/arrow
     os: linux
     go:
-    - 1.10.x
+    - 1.11.x
     before_script:
     - if [ $ARROW_CI_GO_AFFECTED != "1" ]; then exit; fi
     script:


### PR DESCRIPTION
needs #2486 