### PR TITLE
[Python] [Doc] Fix a typo in doc/source/ipc.rst

### DIFF
--- a/python/doc/source/ipc.rst
+++ b/python/doc/source/ipc.rst
@@ -270,7 +270,7 @@ Component-based Serialization
 For serializing Python objects containing some number of NumPy arrays, Arrow
 buffers, or other data types, it may be desirable to transport their serialized
 representation without having to produce an intermediate copy using the
-``to_buffer`` method. To motivate this, support we have a list of NumPy arrays:
+``to_buffer`` method. To motivate this, suppose we have a list of NumPy arrays:
 
 .. ipython:: python
 


### PR DESCRIPTION
Close #2493 