### PR TITLE
ARROW-3148: [C++] Remove needless U+00A0 NO-BREAK SPACE

### DIFF
--- a/cpp/src/arrow/util/rle-encoding.h
+++ b/cpp/src/arrow/util/rle-encoding.h
@@ -71,7 +71,7 @@ namespace arrow {
 /// Examples with bit-width 1 (eg encoding booleans):
 /// ----------------------------------------
 /// 100 1s followed by 100 0s:
-/// <varint(100 << 1)> <1, padded to 1 byte>  <varint(100 << 1)> <0, padded to 1 byte>
+/// <varint(100 << 1)> <1, padded to 1 byte> <varint(100 << 1)> <0, padded to 1 byte>
 ///  - (total 4 bytes)
 //
 /// alternating 1s and 0s (200 total):


### PR DESCRIPTION
If we have NO-BREAK SPACE, we can't process this file as ASCII only
file. MSVC shows C4819 warning on code page 932.

C4819: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4819

> The file contains a character that cannot be represented in the
> current code page (number).