### PR TITLE
ARROW-2974: [Python] Replace usages of "source activate" with "conda activate" in CI scripts

### DIFF
--- a/ci/travis_before_script_c_glib.sh
+++ b/ci/travis_before_script_c_glib.sh
@@ -22,7 +22,12 @@ set -ex
 source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
 source $TRAVIS_BUILD_DIR/ci/travis_install_conda.sh
-pip install meson
+
+conda create -n meson -y -q python=3.6
+conda activate meson
+
+# ARROW-3186: meson 0.47.2 issues
+pip install meson==0.47.1
 
 if [ $TRAVIS_OS_NAME = "osx" ]; then
   export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/libffi/lib/pkgconfig

--- a/ci/travis_env_common.sh
+++ b/ci/travis_env_common.sh
@@ -20,7 +20,6 @@
 # hide nodejs experimental-feature warnings
 export NODE_NO_WARNINGS=1
 export MINICONDA=$HOME/miniconda
-export PATH="$MINICONDA/bin:$PATH"
 export CONDA_PKGS_DIRS=$HOME/.conda_packages
 
 export ARROW_CPP_DIR=$TRAVIS_BUILD_DIR/cpp

--- a/ci/travis_install_conda.sh
+++ b/ci/travis_install_conda.sh
@@ -29,10 +29,13 @@ function download_miniconda() {
   wget --no-verbose -O miniconda.sh $MINICONDA_URL
 }
 
+export MINICONDA=$HOME/miniconda
+export CONDA_PKGS_DIRS=$HOME/.conda_packages
 
-if (! which conda > /dev/null ); then
-
-  source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
+# If miniconda is installed already, run the activation script
+if [ -d "$MINICONDA" ]; then
+  source $MINICONDA/etc/profile.d/conda.sh
+else
   mkdir -p $CONDA_PKGS_DIRS
 
   CONDA_RETRIES=5
@@ -53,7 +56,7 @@ if (! which conda > /dev/null ); then
   fi
 
   bash miniconda.sh -b -p $MINICONDA
-  export PATH="$MINICONDA/bin:$PATH"
+  source $MINICONDA/etc/profile.d/conda.sh
 
   conda update -y -q conda
   conda config --set auto_update_conda false

--- a/ci/travis_script_integration.sh
+++ b/ci/travis_script_integration.sh
@@ -44,7 +44,7 @@ pushd $ARROW_INTEGRATION_DIR
 
 CONDA_ENV_NAME=arrow-integration-test
 conda create -y -q -n $CONDA_ENV_NAME python=3.5
-source activate $CONDA_ENV_NAME
+conda activate $CONDA_ENV_NAME
 
 # faster builds, please
 conda install -y nomkl

--- a/ci/travis_script_manylinux.sh
+++ b/ci/travis_script_manylinux.sh
@@ -37,7 +37,7 @@ PYTHON_VERSION=3.6
 CONDA_ENV_DIR=$TRAVIS_BUILD_DIR/pyarrow-test-$PYTHON_VERSION
 
 conda create -y -q -p $CONDA_ENV_DIR python=$PYTHON_VERSION
-source activate $CONDA_ENV_DIR
+conda activate $CONDA_ENV_DIR
 
 pip install -q tensorflow
 pip install "dist/`ls dist/ | grep cp36`"

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -33,7 +33,7 @@ PYTHON_VERSION=$1
 CONDA_ENV_DIR=$TRAVIS_BUILD_DIR/pyarrow-test-$PYTHON_VERSION
 
 conda create -y -q -p $CONDA_ENV_DIR python=$PYTHON_VERSION cmake curl
-source activate $CONDA_ENV_DIR
+conda activate $CONDA_ENV_DIR
 
 python --version
 which python
@@ -186,7 +186,7 @@ if [ "$ARROW_TRAVIS_PYTHON_BENCHMARKS" == "1" ] && [ "$PYTHON_VERSION" == "3.6" 
   # (see https://github.com/airspeed-velocity/asv/issues/449)
   source deactivate
   conda create -y -q -n pyarrow_asv python=$PYTHON_VERSION
-  source activate pyarrow_asv
+  conda activate pyarrow_asv
   pip install -q git+https://github.com/pitrou/asv.git@customize_commands
 
   export PYARROW_WITH_PARQUET=1

--- a/dev/container/script/env.sh
+++ b/dev/container/script/env.sh
@@ -17,7 +17,7 @@
 #
 
 # See also https://arrow.apache.org/docs/python/development.html#build-and-test
-source activate pyarrow-dev
+conda activate pyarrow-dev
 export ARROW_BUILD_TYPE=release
 export ARROW_BUILD_TOOLCHAIN=$CONDA_PREFIX
 export PARQUET_BUILD_TOOLCHAIN=$CONDA_PREFIX

--- a/dev/dask_integration/dask_integration.sh
+++ b/dev/dask_integration/dask_integration.sh
@@ -19,7 +19,7 @@
 # Set up environment and working directory
 cd /apache-arrow
 
-source activate pyarrow-dev
+conda activate pyarrow-dev
 
 # install pytables from defaults for now
 conda install -y pytables

--- a/dev/gen_apidocs/create_documents.sh
+++ b/dev/gen_apidocs/create_documents.sh
@@ -48,7 +48,7 @@ popd
 
 # Make Python documentation (Depends on C++ )
 # Build Arrow C++
-source activate pyarrow-dev
+conda activate pyarrow-dev
 export ARROW_BUILD_TOOLCHAIN=$CONDA_PREFIX
 export PARQUET_BUILD_TOOLCHAIN=$CONDA_PREFIX
 export LD_LIBRARY_PATH=$(pwd)/apidocs-dist/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}

--- a/dev/hdfs_integration/hdfs_integration.sh
+++ b/dev/hdfs_integration/hdfs_integration.sh
@@ -23,7 +23,7 @@ set -e
 # and contains both arrow and parquet-cpp
 
 # Activate conda environment
-source activate pyarrow-dev
+conda activate pyarrow-dev
 
 # Arrow build variables
 export ARROW_BUILD_TYPE=debug

--- a/dev/hiveserver2/hiveserver2.sh
+++ b/dev/hiveserver2/hiveserver2.sh
@@ -23,7 +23,7 @@ set -e
 # and contains both arrow and parquet-cpp
 
 # Activate conda environment
-source activate pyarrow-dev
+conda activate pyarrow-dev
 
 # Arrow build variables
 export ARROW_BUILD_TYPE=debug

--- a/dev/iwyu/run_iwyu.sh
+++ b/dev/iwyu/run_iwyu.sh
@@ -56,7 +56,7 @@ popd
 # Add iwyu and iwyu_tool.py to path
 export PATH=$IWYU_BUILD_DIR/iwyu-build:$PATH
 
-source activate pyarrow-dev
+conda activate pyarrow-dev
 
 cmake -GNinja -DARROW_PYTHON=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -143,7 +143,7 @@ setup_miniconda() {
         pandas \
         six \
         cython -c conda-forge
-  source activate arrow-test
+  conda activate arrow-test
 }
 
 # Build and test C++

--- a/dev/spark_integration/spark_integration.sh
+++ b/dev/spark_integration/spark_integration.sh
@@ -23,7 +23,7 @@ set -e
 cd /apache-arrow
 
 # Activate our pyarrow-dev conda env
-source activate pyarrow-dev
+conda activate pyarrow-dev
 
 export ARROW_HOME=$(pwd)/arrow
 export ARROW_BUILD_TYPE=release

--- a/integration/README.md
+++ b/integration/README.md
@@ -44,7 +44,7 @@ bash miniconda.sh -b -p miniconda
 export PATH=`pwd`/miniconda/bin:$PATH
 
 conda create -n arrow-integration python=3.6 nomkl numpy six
-source activate arrow-integration
+conda activate arrow-integration
 ```
 
 If you are on macOS, instead use the URL:

--- a/python/asv-build.sh
+++ b/python/asv-build.sh
@@ -21,7 +21,7 @@ set -e
 
 # ASV doesn't activate its conda environment for us
 if [ -z "$ASV_ENV_DIR" ]; then exit 1; fi
-source activate $ASV_ENV_DIR
+conda activate $ASV_ENV_DIR
 echo "== Conda Prefix for benchmarks: " $CONDA_PREFIX " =="
 
 # Build Arrow C++ libraries

--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -84,7 +84,7 @@ from conda-forge:
          python=3.6 numpy six setuptools cython pandas pytest \
          cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib \
          gflags brotli jemalloc lz4-c zstd -c conda-forge
-   source activate pyarrow-dev
+   conda activate pyarrow-dev
 
 We need to set some environment variables to let Arrow's build system know
 about our build toolchain:

--- a/python/testing/functions.sh
+++ b/python/testing/functions.sh
@@ -32,7 +32,7 @@ bootstrap_python_env() {
   CONDA_ENV_DIR=$BUILD_DIR/pyarrow-test-$PYTHON_VERSION
 
   conda create -y -q -p $CONDA_ENV_DIR python=$PYTHON_VERSION cmake curl
-  source activate $CONDA_ENV_DIR
+  conda activate $CONDA_ENV_DIR
 
   python --version
   which python


### PR DESCRIPTION
Also includes temporary pin to meson 0.47.1 in the glib build per ARROW-3186