### PR TITLE
ARROW-3175: [Java] Switch to official flatbuffers Java artifact and com.github.icexelloss for flatc executable artifact

### DIFF
--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -28,8 +28,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.vlkan</groupId>
-      <artifactId>flatbuffers</artifactId>
+      <groupId>com.google.flatbuffers</groupId>
+      <artifactId>flatbuffers-java</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <flatc.download.skip>false</flatc.download.skip>
-    <flatc.executable>${project.build.directory}/flatc-${os.detected.classifier}-${flatc.version}.exe</flatc.executable>
+    <flatc.executable>${project.build.directory}/flatc-${os.detected.classifier}-${dep.flatc.version}.exe</flatc.executable>
     <flatc.generated.files>${project.build.directory}/generated-sources/flatc</flatc.generated.files>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
   </properties>
@@ -62,7 +62,7 @@
               <artifactItem>
                 <groupId>com.github.icexelloss</groupId>
                 <artifactId>flatc-${os.detected.classifier}</artifactId>
-                <version>${flatc.version}</version>
+                <version>${dep.flatc.version}</version>
                 <type>exe</type>
                 <overWrite>true</overWrite>
                 <outputDirectory>${project.build.directory}</outputDirectory>
@@ -88,7 +88,7 @@
             <executable>chmod</executable>
             <arguments>
               <argument>+x</argument>
-              <argument>${project.build.directory}/flatc-${os.detected.classifier}-${flatc.version}.exe</argument>
+              <argument>${project.build.directory}/flatc-${os.detected.classifier}-${dep.flatc.version}.exe</argument>
             </arguments>
             <skip>${flatc.download.skip}</skip>
           </configuration>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -60,7 +60,7 @@
           <configuration>
             <artifactItems>
               <artifactItem>
-                <groupId>com.vlkan</groupId>
+                <groupId>com.github.icexelloss</groupId>
                 <artifactId>flatc-${os.detected.classifier}</artifactId>
                 <version>${flatc.version}</version>
                 <type>exe</type>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -24,15 +24,15 @@
 
   <properties>
     <flatc.download.skip>false</flatc.download.skip>
-    <flatc.executable>${project.build.directory}/flatc-${os.detected.classifier}-${fbs.version}.exe</flatc.executable>
+    <flatc.executable>${project.build.directory}/flatc-${os.detected.classifier}-${flatc.version}.exe</flatc.executable>
     <flatc.generated.files>${project.build.directory}/generated-sources/flatc</flatc.generated.files>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>com.vlkan</groupId>
-      <artifactId>flatbuffers</artifactId>
+      <groupId>com.google.flatbuffers</groupId>
+      <artifactId>flatbuffers-java</artifactId>
     </dependency>
   </dependencies>
 
@@ -62,7 +62,7 @@
               <artifactItem>
                 <groupId>com.vlkan</groupId>
                 <artifactId>flatc-${os.detected.classifier}</artifactId>
-                <version>${fbs.version}</version>
+                <version>${flatc.version}</version>
                 <type>exe</type>
                 <overWrite>true</overWrite>
                 <outputDirectory>${project.build.directory}</outputDirectory>
@@ -88,7 +88,7 @@
             <executable>chmod</executable>
             <arguments>
               <argument>+x</argument>
-              <argument>${project.build.directory}/flatc-${os.detected.classifier}-${fbs.version}.exe</argument>
+              <argument>${project.build.directory}/flatc-${os.detected.classifier}-${flatc.version}.exe</argument>
             </arguments>
             <skip>${flatc.download.skip}</skip>
           </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <dep.jackson.version>2.7.9</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <fbs.version>1.9.0</fbs.version>
-    <flatc.version>1.2.0-3f79e055</flatc.version>
+    <flatc.version>1.9.0</flatc.version>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
   </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,8 +35,8 @@
     <dep.netty.version>4.1.22.Final</dep.netty.version>
     <dep.jackson.version>2.7.9</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
-    <fbs.version>1.9.0</fbs.version>
-    <flatc.version>1.9.0</flatc.version>
+    <dep.fbs.version>1.9.0</dep.fbs.version>
+    <dep.flatc.version>1.9.0</dep.flatc.version>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
   </properties>
@@ -483,7 +483,7 @@
       <dependency>
         <groupId>com.google.flatbuffers</groupId>
         <artifactId>flatbuffers-java</artifactId>
-        <version>${fbs.version}</version>
+        <version>${dep.fbs.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,7 +35,8 @@
     <dep.netty.version>4.1.22.Final</dep.netty.version>
     <dep.jackson.version>2.7.9</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
-    <fbs.version>1.2.0-3f79e055</fbs.version>
+    <fbs.version>1.9.0</fbs.version>
+    <flatc.version>1.2.0-3f79e055</flatc.version>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
   </properties>
@@ -480,8 +481,8 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.vlkan</groupId>
-        <artifactId>flatbuffers</artifactId>
+        <groupId>com.google.flatbuffers</groupId>
+        <artifactId>flatbuffers-java</artifactId>
         <version>${fbs.version}</version>
       </dependency>
       <dependency>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -67,8 +67,8 @@
       <artifactId>netty-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.vlkan</groupId>
-      <artifactId>flatbuffers</artifactId>
+      <groupId>com.google.flatbuffers</groupId>
+      <artifactId>flatbuffers-java</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The existing flatbuffer we use from com.vlkan is quite old and since flatbuffer now publishes official maven artifact, we should those.

One caveats is that the flatc we use is not available in the official release, so we are using one provided by com.github.icexelloss.