### PR TITLE
ARROW-3188: [Python] Table.from_arrays segfaults if lists and schema are passed

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1180,7 +1180,7 @@ cdef class Table:
         columns.reserve(K)
 
         for i in range(K):
-            if isinstance(arrays[i], (Array, list)):
+            if isinstance(arrays[i], Array):
                 columns.push_back(
                     make_shared[CColumn](
                         c_schema.get().field(i),
@@ -1203,7 +1203,7 @@ cdef class Table:
                     )
                 )
             else:
-                raise ValueError(type(arrays[i]))
+                raise TypeError(type(arrays[i]))
 
         return pyarrow_wrap_table(CTable.Make(c_schema, columns))
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -547,6 +547,23 @@ def test_table_from_arrays_invalid_names():
         pa.Table.from_arrays(data, names=['a'])
 
 
+def test_table_from_lists_raises():
+    data = [
+        list(range(5)),
+        [-10, -5, 0, 5, 10]
+    ]
+
+    with pytest.raises(TypeError):
+        pa.Table.from_arrays(data, names=['a', 'b'])
+
+    schema = pa.schema([
+        pa.field('a', pa.uint16()),
+        pa.field('b', pa.int64())
+    ])
+    with pytest.raises(TypeError):
+        pa.Table.from_arrays(data, schema=schema)
+
+
 def test_table_pickle():
     data = [
         pa.chunked_array([[1, 2], [3, 4]], type=pa.uint32()),


### PR DESCRIPTION
I've discovered multiple issues in both `Table.from_arrays` and RecordBatch.from_arrays`. This is just a quickfix to prevent the segfault.
