### PR TITLE
ARROW-3226: [Plasma] Fix small memory crash

### DIFF
--- a/cpp/src/plasma/eviction_policy.cc
+++ b/cpp/src/plasma/eviction_policy.cc
@@ -72,7 +72,8 @@ void EvictionPolicy::ObjectCreated(const ObjectID& object_id) {
   memory_used_ += size;
   ARROW_CHECK(memory_used_ <= store_info_->memory_capacity);
 }
-bool EvictionPolicy::IsCapableOf(int64_t need_size) {
+
+bool EvictionPolicy::AbleToAdd(int64_t need_size) {
   return memory_used_ + need_size <= store_info_->memory_capacity;
 }
 

--- a/cpp/src/plasma/eviction_policy.cc
+++ b/cpp/src/plasma/eviction_policy.cc
@@ -72,6 +72,9 @@ void EvictionPolicy::ObjectCreated(const ObjectID& object_id) {
   memory_used_ += size;
   ARROW_CHECK(memory_used_ <= store_info_->memory_capacity);
 }
+bool EvictionPolicy::IsCapableOf(int64_t need_size) {
+  return memory_used_ + need_size <= store_info_->memory_capacity;
+}
 
 bool EvictionPolicy::RequireSpace(int64_t size, std::vector<ObjectID>* objects_to_evict) {
   // Check if there is enough space to create the object.

--- a/cpp/src/plasma/eviction_policy.h
+++ b/cpp/src/plasma/eviction_policy.h
@@ -124,7 +124,12 @@ class EvictionPolicy {
   ///
   /// @param object_id The ID of the object that is now being used.
   void RemoveObject(const ObjectID& object_id);
-  bool IsCapableOf(int64_t need_size);
+
+  /// To check whether we can add an object of a specific size.
+  ///
+  /// @param size The object size to check.
+  bool AbleToAdd(int64_t size);
+
  private:
   /// The amount of memory (in bytes) currently being used.
   int64_t memory_used_;

--- a/cpp/src/plasma/eviction_policy.h
+++ b/cpp/src/plasma/eviction_policy.h
@@ -124,7 +124,7 @@ class EvictionPolicy {
   ///
   /// @param object_id The ID of the object that is now being used.
   void RemoveObject(const ObjectID& object_id);
-
+  bool IsCapableOf(int64_t need_size);
  private:
   /// The amount of memory (in bytes) currently being used.
   int64_t memory_used_;

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -179,7 +179,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
         pointer =
             reinterpret_cast<uint8_t*>(dlmemalign(kBlockSize, data_size + metadata_size));
       }
-      if (pointer == nullptr || !eviction_policy_.IsCapableOf(data_size + metadata_size)) {
+      if (pointer == nullptr || !eviction_policy_.AbleToAdd(data_size + metadata_size)) {
         ARROW_LOG(WARNING) << "dlmemalign returned with nullptr.";
         // Tell the eviction policy how much space we need to create this object.
         std::vector<ObjectID> objects_to_evict;

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -180,14 +180,11 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
             reinterpret_cast<uint8_t*>(dlmemalign(kBlockSize, data_size + metadata_size));
       }
       if (pointer == nullptr || !eviction_policy_.AbleToAdd(data_size + metadata_size)) {
-        ARROW_LOG(WARNING) << "dlmemalign returned with nullptr.";
         // Tell the eviction policy how much space we need to create this object.
         std::vector<ObjectID> objects_to_evict;
         bool success =
             eviction_policy_.RequireSpace(data_size + metadata_size, &objects_to_evict);
         DeleteObjects(objects_to_evict);
-        ARROW_LOG(WARNING) << "Calling Delete Objects.";
-
         // Return an error to the client if not enough space could be freed to
         // create the object.
         if (!success) {
@@ -222,8 +219,6 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
   entry->device_num = device_num;
   entry->create_time = std::time(nullptr);
   entry->construct_duration = -1;
-
-  ARROW_LOG(WARNING) << "Created the entry.";
 #ifdef PLASMA_GPU
   if (device_num != 0) {
     DCHECK_OK(gpu_handle->ExportForIpc(&entry->ipc_handle));
@@ -237,7 +232,6 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
   result->data_size = data_size;
   result->metadata_size = metadata_size;
   result->device_num = device_num;
-  ARROW_LOG(WARNING) << "Put object to store_info_ and call ObjectCreated.";
   // Notify the eviction policy that this object was created. This must be done
   // immediately before the call to AddToClientObjectIds so that the
   // eviction policy does not have an opportunity to evict the object.

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -47,7 +47,7 @@ void AssertObjectBufferEqual(const ObjectBuffer& object_buffer,
   arrow::AssertBufferEqual(*object_buffer.data, data);
 }
 
-template<unsigned int M>
+template <unsigned int M>
 class TestPlasmaStoreBase : public ::testing::Test {
  public:
   // TODO(pcm): At the moment, stdout of the test gets mixed up with
@@ -61,8 +61,8 @@ class TestPlasmaStoreBase : public ::testing::Test {
     std::string plasma_directory =
         test_executable.substr(0, test_executable.find_last_of("/"));
     std::ostringstream ostream;
-    ostream << plasma_directory << "/plasma_store_server -m " << M
-            << " -s " << store_socket_name_ + " 1> /dev/null 2> /dev/null &";
+    ostream << plasma_directory << "/plasma_store_server -m " << M << " -s "
+            << store_socket_name_ + " 1> /dev/null 2> /dev/null &";
     std::string plasma_command = ostream.str();
     system(plasma_command.c_str());
     ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));
@@ -491,9 +491,9 @@ TEST_F(TestPlasmaStore, ManyObjectTest) {
   }
 }
 
-using SmallMemoryTestPlasmaStore = TestPlasmaStoreBase<1000>;
+using TestSmallMemoryPlasmaStore = TestPlasmaStoreBase<1000>;
 
-TEST_F(SmallMemoryTestPlasmaStore, SmallMemoryTest) {
+TEST_F(TestSmallMemoryPlasmaStore, SmallMemoryTest) {
   // Create many objects on the first client. Seal one third, abort one third,
   // and leave the last third unsealed.
   std::vector<ObjectID> object_ids;


### PR DESCRIPTION
Plasma Store will do the eviction when the memory allocation fails. When specified a smaller store limit, the memory allocation will succeed but Plasma Store will crash when limit memory reached.
Call stack:
```
F0912 23:55:49.693681 2961466240 eviction_policy.cc:73]  Check failed: memory_used_ <= store_info_->memory_capacity
*** Check failure stack trace: ***
    @        0x1087d0aca  google::LogMessage::Fail()
    @        0x1087ce8ee  google::LogMessage::SendToLog()
    @        0x1087cf76f  google::LogMessage::Flush()
    @        0x1087cf5a9  google::LogMessage::~LogMessage()
    @        0x1087cf865  google::LogMessage::~LogMessage()
    @        0x1087e8ef5  arrow::ArrowLog::~ArrowLog()
    @        0x1087aef8e  plasma::EvictionPolicy::ObjectCreated()
    @        0x1087a21e8  plasma::PlasmaStore::CreateObject()
    @        0x1087a6e8c  plasma::PlasmaStore::ProcessMessage()
    @        0x1087abc1c  std::__1::__function::__func<>::operator()()
    @        0x1087af81e  plasma::EventLoop::FileEventCallback()
    @        0x1087c8eb1  aeProcessEvents
    @        0x1087c919b  aeMain
    @        0x1087a8508  plasma::PlasmaStoreRunner::Start()
    @        0x1087a81fa  plasma::StartServer()
    @        0x1087a8d9c  main
```