### PR TITLE
ARROW-3199: [Plasma] File descriptor send and receive retries

### DIFF
--- a/cpp/src/plasma/fling.cc
+++ b/cpp/src/plasma/fling.cc
@@ -69,6 +69,7 @@ int send_fd(int conn, int fd) {
       }
     } else if (r == 0) {
       ARROW_LOG(INFO) << "Encountered unexpected EOF";
+      return 0;
     } else {
       ARROW_CHECK(r > 0);
       return static_cast<int>(r);

--- a/cpp/src/plasma/fling.cc
+++ b/cpp/src/plasma/fling.cc
@@ -16,6 +16,8 @@
 
 #include <string.h>
 
+#include "arrow/util/logging.h"
+
 void init_msg(struct msghdr* msg, struct iovec* iov, char* buf, size_t buf_len) {
   iov->iov_base = buf;
   iov->iov_len = 1;
@@ -53,13 +55,13 @@ int send_fd(int conn, int fd) {
         continue;
       } else {
         ARROW_LOG(INFO) << "Error in send_fd (errno = " << errno << ")";
-        return -1;
+        return static_cast<int>(r);
       }
     } else if (r == 0) {
       ARROW_LOG(INFO) << "Encountered unexpected EOF";
     } else {
       ARROW_CHECK(r > 0);
-      break;
+      return static_cast<int>(r);
     }
   }
 }

--- a/cpp/src/plasma/fling.cc
+++ b/cpp/src/plasma/fling.cc
@@ -73,8 +73,8 @@ int recv_fd(int conn) {
   init_msg(&msg, &iov, buf, sizeof(buf));
 
   while (true) {
-    int error = recvmsg(conn, &msg, 0);
-    if (error == -1) {
+    ssize_t r = recvmsg(conn, &msg, 0);
+    if (r == -1) {
       if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
         continue;
       } else {

--- a/cpp/src/plasma/fling.cc
+++ b/cpp/src/plasma/fling.cc
@@ -54,7 +54,8 @@ int send_fd(int conn, int fd) {
       if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
         continue;
       } else if (errno == EMSGSIZE) {
-        ARROW_LOG(WARNING) << "Failed to send file descriptor with errno = EMSGSIZE, retrying.";
+        ARROW_LOG(WARNING) << "Failed to send file descriptor"
+                           << " (errno = EMSGSIZE), retrying.";
         // If we failed to send the file descriptor, loop until we have sent it
         // successfully. TODO(rkn): This is problematic for two reasons. First
         // of all, sending the file descriptor should just succeed without any


### PR DESCRIPTION
An additional piece of eyes would be appreciated for this. It seems to solve our issue reported in the JIRA, but I'm not sure what the semantics of partial reads/writes is here (in particular, how are partial read/writes handled for ancillary data like file descriptors?).

found by cc @stephanie-wang 