### PR TITLE
ARROW-3234: [C++] Fix libprotobuf shared library link order

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -637,18 +637,12 @@ if (ARROW_WITH_GRPC)
 endif()
 
 if (ARROW_ORC)
-  if (ARROW_PROTOBUF_USE_SHARED)
-    SET(ARROW_LINK_LIBS
-      protobuf
-      ${ARROW_LINK_LIBS})
-  else()
-    SET(ARROW_STATIC_LINK_LIBS
-      protobuf
-      ${ARROW_STATIC_LINK_LIBS})
-  endif()
   SET(ARROW_STATIC_LINK_LIBS
-    orc
-    ${ARROW_STATIC_LINK_LIBS})
+    ${ARROW_STATIC_LINK_LIBS}
+    orc)
+  set_target_properties(orc
+    PROPERTIES INTERFACE_LINK_LIBRARIES
+    protobuf)
 endif()
 
 if (ARROW_STATIC_LINK_LIBS)


### PR DESCRIPTION
We need to link libprotobuf shared library after liborc.

We should use "-lorc -lprotobuf" instead of "-lprotobuf -lorc".

If we use libprotobuf as static library, we can control link order by
ARROW_STATIC_LINK_LIBS. But we can't control link order when we use
libprotobuf as shared library by variables.

We need to tell CMake link order.