### PR TITLE
ARROW-3240: [GLib] Add build instructions using meson

### DIFF
--- a/c_glib/.gitignore
+++ b/c_glib/.gitignore
@@ -61,3 +61,4 @@ Makefile.in
 /example/read-batch
 /example/read-stream
 /gtk-doc.make
+/build/

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -75,7 +75,7 @@ Arrow GLib. See Arrow C++ document about how to install Arrow C++.
 
 If you use macOS with [Homebrew](https://brew.sh/), you must install required packages and set `PKG_CONFIG_PATH` before build Arrow GLib:
 
-If you use GNU Autotools, you can build and install Arrow GLib after by the followings:
+If you use GNU Autotools, you can build and install Arrow GLib by the followings:
 
 macOS:
 
@@ -96,7 +96,7 @@ Others:
 % sudo make install
 ```
 
-If you use Meson, you can build and install Arrow GLib after by the followings:
+If you use Meson, you can build and install Arrow GLib by the followings:
 
 macOS:
 
@@ -147,7 +147,7 @@ On macOS with [Homebrew](https://brew.sh/):
 % brew bundle
 ```
 
-If you use GNU Autotools, you can build and install Arrow GLib after by the followings:
+If you use GNU Autotools, you can build and install Arrow GLib by the followings:
 
 ```console
 % cd c_glib
@@ -163,7 +163,7 @@ You need to set `PKG_CONFIG_PATH` to `configure` On macOS:
 % ./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH --enable-gtk-doc
 ```
 
-If you use Meson, you can build and install Arrow GLib after by the followings:
+If you use Meson, you can build and install Arrow GLib by the followings:
 
 ```console
 % cd c_glib
@@ -173,7 +173,7 @@ If you use Meson, you can build and install Arrow GLib after by the followings:
 % (cd build && sudo ninja install)
 ```
 
-You need to set `PKG_CONFIG_PATH` to `meson` On macOS:
+You need to set `PKG_CONFIG_PATH` on macOS:
 
 ```console
 % PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH meson build -Dgtk_doc=true

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -104,8 +104,8 @@ macOS:
 % cd c_glib
 % brew bundle
 % PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH meson build --buildtype=release
-% (cd build && ninja)
-% (cd build && sudo ninja install)
+% ninja -C build
+% sudo ninja -C build install
 ```
 
 Others:
@@ -113,8 +113,8 @@ Others:
 ```console
 % cd c_glib
 % meson build --buildtype=release
-% (cd build && ninja)
-% (cd build && sudo ninja install)
+% ninja -C build
+% sudo ninja -C build install
 ```
 
 ### How to build by developers
@@ -166,8 +166,8 @@ If you use Meson, you can build and install Arrow GLib by the followings:
 ```console
 % cd c_glib
 % meson build -Dgtk_doc=true
-% (cd build && ninja)
-% (cd build && sudo ninja install)
+% ninja -C build
+% sudo ninja -C build install
 ```
 
 You need to set `PKG_CONFIG_PATH` on macOS:

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -53,7 +53,7 @@ recommended that you use packages.
 Note that the packages are "unofficial". "Official" packages will be
 released in the future.
 
-If you find problems when installing please see [common build problems](https://github.com/apache/arrow/blob/master/c_glib/README.md#common-build-problems).
+We support two build systems, GNU Autotools and Meson. If you find problems when installing please see [common build problems](https://github.com/apache/arrow/blob/master/c_glib/README.md#common-build-problems).
 
 ### Package
 
@@ -73,9 +73,11 @@ GLib (replace the version number in the following commands with the one you use)
 You need to build and install Arrow C++ before you build and install
 Arrow GLib. See Arrow C++ document about how to install Arrow C++.
 
-You can build and install Arrow GLib after you install Arrow C++.
-
 If you use macOS with [Homebrew](https://brew.sh/), you must install required packages and set `PKG_CONFIG_PATH` before build Arrow GLib:
+
+If you use GNU Autotools, you can build and install Arrow GLib after by the followings:
+
+macOS:
 
 ```console
 % cd c_glib
@@ -94,6 +96,29 @@ Others:
 % sudo make install
 ```
 
+If you use Meson, you can build and install Arrow GLib after by the followings:
+
+macOS:
+
+```console
+% cd c_glib
+% brew bundle
+% mkdir -p build
+% PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH meson build --buildtype=release
+% (cd build && ninja)
+% (cd build && sudo ninja install)
+```
+
+Others:
+
+```console
+% cd c_glib
+% mkdir -p build
+% meson build --buildtype=release
+% (cd build && ninja)
+% (cd build && sudo ninja install)
+```
+
 ### How to build by developers
 
 You need to install Arrow C++ before you install Arrow GLib. See Arrow
@@ -106,13 +131,14 @@ to build Arrow GLib. You can install them by the followings:
 On Debian GNU/Linux or Ubuntu:
 
 ```console
-% sudo apt install -y -V gtk-doc-tools autoconf-archive libgirepository1.0-dev
+% sudo apt install -y -V gtk-doc-tools autoconf-archive libgirepository1.0-dev meson ninja-build
 ```
 
 On CentOS 7 or later:
 
 ```console
 % sudo yum install -y gtk-doc gobject-introspection-devel
+% sudo pip install -y meson ninja
 ```
 
 On macOS with [Homebrew](https://brew.sh/):
@@ -121,7 +147,7 @@ On macOS with [Homebrew](https://brew.sh/):
 % brew bundle
 ```
 
-Now, you can build Arrow GLib:
+If you use GNU Autotools, you can build and install Arrow GLib after by the followings:
 
 ```console
 % cd c_glib
@@ -135,6 +161,22 @@ You need to set `PKG_CONFIG_PATH` to `configure` On macOS:
 
 ```console
 % ./configure PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH --enable-gtk-doc
+```
+
+If you use Meson, you can build and install Arrow GLib after by the followings:
+
+```console
+% cd c_glib
+% mkdir -p build
+% meson build -Dgtk_doc=true
+% (cd build && ninja)
+% (cd build && sudo ninja install)
+```
+
+You need to set `PKG_CONFIG_PATH` to `meson` On macOS:
+
+```console
+% PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH meson build -Dgtk_doc=true
 ```
 
 ## Usage

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -103,7 +103,6 @@ macOS:
 ```console
 % cd c_glib
 % brew bundle
-% mkdir -p build
 % PKG_CONFIG_PATH=$(brew --prefix libffi)/lib/pkgconfig:$PKG_CONFIG_PATH meson build --buildtype=release
 % (cd build && ninja)
 % (cd build && sudo ninja install)
@@ -113,7 +112,6 @@ Others:
 
 ```console
 % cd c_glib
-% mkdir -p build
 % meson build --buildtype=release
 % (cd build && ninja)
 % (cd build && sudo ninja install)
@@ -167,7 +165,6 @@ If you use Meson, you can build and install Arrow GLib by the followings:
 
 ```console
 % cd c_glib
-% mkdir -p build
 % meson build -Dgtk_doc=true
 % (cd build && ninja)
 % (cd build && sudo ninja install)


### PR DESCRIPTION
Because we support two build systems, GNU Autotools and Meson.