### PR TITLE
ARROW-3072: [C++] Add RETURN_NOT_OK linting rule, use ARROW_RETURN_NOT_OK in header files

### DIFF
--- a/cpp/build-support/lint_cpp_cli.py
+++ b/cpp/build-support/lint_cpp_cli.py
@@ -31,6 +31,7 @@ arguments = parser.parse_args()
 
 _STRIP_COMMENT_REGEX = re.compile('(.+)?(?=//)')
 _NULLPTR_REGEX = re.compile(r'.*\bnullptr\b.*')
+_RETURN_NOT_OK_REGEX = re.compile(r'.*\sRETURN_NOT_OK.*')
 
 
 def _strip_comments(line):
@@ -43,14 +44,24 @@ def _strip_comments(line):
 
 def lint_file(path):
     fail_rules = [
-        (lambda x: '<mutex>' in x, 'Uses <mutex>'),
-        (lambda x: re.match(_NULLPTR_REGEX, x), 'Uses nullptr')
+        # rule, error message, rule-specific exclusions list
+        (lambda x: '<mutex>' in x, 'Uses <mutex>', []),
+        (lambda x: re.match(_NULLPTR_REGEX, x), 'Uses nullptr', []),
+        (lambda x: re.match(_RETURN_NOT_OK_REGEX, x),
+         'Use ARROW_RETURN_NOT_OK in header files',
+         ['arrow/status.h',
+          'test',
+          'arrow/util/hash.h',
+          'arrow/python/util'])
     ]
 
     with open(path) as f:
         for i, line in enumerate(f):
             stripped_line = _strip_comments(line)
-            for rule, why in fail_rules:
+            for rule, why, rule_exclusions in fail_rules:
+                if any([True for excl in rule_exclusions if excl in path]):
+                    continue
+
                 if rule(stripped_line):
                     raise Exception('File {0} failed C++/CLI lint check: {1}\n'
                                     'Line {2}: {3}'

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -345,9 +345,9 @@ class ARROW_EXPORT BufferBuilder {
     int64_t old_capacity = capacity_;
 
     if (buffer_ == NULLPTR) {
-      RETURN_NOT_OK(AllocateResizableBuffer(pool_, elements, &buffer_));
+      ARROW_RETURN_NOT_OK(AllocateResizableBuffer(pool_, elements, &buffer_));
     } else {
-      RETURN_NOT_OK(buffer_->Resize(elements, shrink_to_fit));
+      ARROW_RETURN_NOT_OK(buffer_->Resize(elements, shrink_to_fit));
     }
     capacity_ = buffer_->capacity();
     data_ = buffer_->mutable_data();
@@ -367,7 +367,7 @@ class ARROW_EXPORT BufferBuilder {
   Status Append(const void* data, int64_t length) {
     if (capacity_ < length + size_) {
       int64_t new_capacity = BitUtil::NextPower2(length + size_);
-      RETURN_NOT_OK(Resize(new_capacity));
+      ARROW_RETURN_NOT_OK(Resize(new_capacity));
     }
     UnsafeAppend(data, length);
     return Status::OK();
@@ -378,7 +378,7 @@ class ARROW_EXPORT BufferBuilder {
     constexpr auto nbytes = static_cast<int64_t>(NBYTES);
     if (capacity_ < nbytes + size_) {
       int64_t new_capacity = BitUtil::NextPower2(nbytes + size_);
-      RETURN_NOT_OK(Resize(new_capacity));
+      ARROW_RETURN_NOT_OK(Resize(new_capacity));
     }
 
     std::copy(data.cbegin(), data.cend(), data_ + size_);
@@ -390,7 +390,7 @@ class ARROW_EXPORT BufferBuilder {
   Status Advance(const int64_t length) {
     if (capacity_ < length + size_) {
       int64_t new_capacity = BitUtil::NextPower2(length + size_);
-      RETURN_NOT_OK(Resize(new_capacity));
+      ARROW_RETURN_NOT_OK(Resize(new_capacity));
     }
     memset(data_ + size_, 0, static_cast<size_t>(length));
     size_ += length;
@@ -404,7 +404,7 @@ class ARROW_EXPORT BufferBuilder {
   }
 
   Status Finish(std::shared_ptr<Buffer>* out, bool shrink_to_fit = true) {
-    RETURN_NOT_OK(Resize(size_, shrink_to_fit));
+    ARROW_RETURN_NOT_OK(Resize(size_, shrink_to_fit));
     *out = buffer_;
     Reset();
     return Status::OK();

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -235,7 +235,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   /// The memory at the corresponding data slot is set to 0 to prevent uninitialized
   /// memory access
   Status AppendNulls(const uint8_t* valid_bytes, int64_t length) {
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
     memset(raw_data_ + length_, 0,
            static_cast<size_t>(TypeTraits<Type>::bytes_required(length)));
     UnsafeAppendToBitmap(valid_bytes, length);
@@ -243,7 +243,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   }
 
   Status AppendNull() {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     memset(raw_data_ + length_, 0, sizeof(value_type));
     UnsafeAppendToBitmap(false);
     return Status::OK();
@@ -292,7 +292,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   template <typename ValuesIter>
   Status AppendValues(ValuesIter values_begin, ValuesIter values_end) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
 
     std::copy(values_begin, values_end, raw_data_ + length_);
 
@@ -314,7 +314,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
                   "version instead");
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
 
     std::copy(values_begin, values_end, raw_data_ + length_);
 
@@ -333,7 +333,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   typename std::enable_if<std::is_pointer<ValidIter>::value, Status>::type AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
 
     std::copy(values_begin, values_end, raw_data_ + length_);
 
@@ -376,7 +376,7 @@ class ARROW_EXPORT NumericBuilder : public PrimitiveBuilder<T> {
 
   /// Append a single scalar and increase the size if necessary.
   Status Append(const value_type val) {
-    RETURN_NOT_OK(ArrayBuilder::Reserve(1));
+    ARROW_RETURN_NOT_OK(ArrayBuilder::Reserve(1));
     UnsafeAppend(val);
     return Status::OK();
   }
@@ -426,14 +426,14 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
 
   /// Write nulls as uint8_t* (0 value indicates null) into pre-allocated memory
   Status AppendNulls(const uint8_t* valid_bytes, int64_t length) {
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
     memset(data_->mutable_data() + length_ * int_size_, 0, int_size_ * length);
     UnsafeAppendToBitmap(valid_bytes, length);
     return Status::OK();
   }
 
   Status AppendNull() {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     memset(data_->mutable_data() + length_ * int_size_, 0, int_size_);
     UnsafeAppendToBitmap(false);
     return Status::OK();
@@ -501,12 +501,12 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
   /// Scalar append
   Status Append(const uint64_t val) {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     BitUtil::SetBit(null_bitmap_data_, length_);
 
     uint8_t new_int_size = internal::ExpandedUIntSize(val, int_size_);
     if (new_int_size != int_size_) {
-      RETURN_NOT_OK(ExpandIntSize(new_int_size));
+      ARROW_RETURN_NOT_OK(ExpandIntSize(new_int_size));
     }
 
     switch (int_size_) {
@@ -564,12 +564,12 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
   /// Scalar append
   Status Append(const int64_t val) {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     BitUtil::SetBit(null_bitmap_data_, length_);
 
     uint8_t new_int_size = internal::ExpandedIntSize(val, int_size_);
     if (new_int_size != int_size_) {
-      RETURN_NOT_OK(ExpandIntSize(new_int_size));
+      ARROW_RETURN_NOT_OK(ExpandIntSize(new_int_size));
     }
 
     switch (int_size_) {
@@ -629,14 +629,14 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
 
   /// Write nulls as uint8_t* (0 value indicates null) into pre-allocated memory
   Status AppendNulls(const uint8_t* valid_bytes, int64_t length) {
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
     UnsafeAppendToBitmap(valid_bytes, length);
 
     return Status::OK();
   }
 
   Status AppendNull() {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     UnsafeAppendToBitmap(false);
 
     return Status::OK();
@@ -644,7 +644,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
 
   /// Scalar append
   Status Append(const bool val) {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     BitUtil::SetBit(null_bitmap_data_, length_);
     if (val) {
       BitUtil::SetBit(raw_data_, length_);
@@ -708,7 +708,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   template <typename ValuesIter>
   Status AppendValues(ValuesIter values_begin, ValuesIter values_end) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
     auto iter = values_begin;
     internal::GenerateBitsUnrolled(raw_data_, length_, length,
                                    [&iter]() -> bool { return *(iter++); });
@@ -731,7 +731,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
                   "version instead");
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
 
     auto iter = values_begin;
     internal::GenerateBitsUnrolled(raw_data_, length_, length,
@@ -752,7 +752,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   typename std::enable_if<std::is_pointer<ValidIter>::value, Status>::type AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
 
     auto iter = values_begin;
     internal::GenerateBitsUnrolled(raw_data_, length_, length,
@@ -919,7 +919,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
                          MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
 
   Status Append(const uint8_t* value) {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     UnsafeAppendToBitmap(true);
     return byte_builder_.Append(value, byte_width_);
   }
@@ -929,7 +929,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
 
   template <size_t NBYTES>
   Status Append(const std::array<uint8_t, NBYTES>& value) {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     UnsafeAppendToBitmap(true);
     return byte_builder_.Append(value);
   }
@@ -994,7 +994,7 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
   /// end methods or advance methods of the child builders' independently to
   /// insert data.
   Status AppendValues(int64_t length, const uint8_t* valid_bytes) {
-    RETURN_NOT_OK(Reserve(length));
+    ARROW_RETURN_NOT_OK(Reserve(length));
     UnsafeAppendToBitmap(valid_bytes, length);
     return Status::OK();
   }
@@ -1002,7 +1002,7 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
   /// Append an element to the Struct. All child-builders' Append method must
   /// be called independently to maintain data-structure consistency.
   Status Append(bool is_valid = true) {
-    RETURN_NOT_OK(Reserve(1));
+    ARROW_RETURN_NOT_OK(Reserve(1));
     UnsafeAppendToBitmap(is_valid);
     return Status::OK();
   }

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -50,9 +50,9 @@ inline Status CheckPyError(StatusCode code = StatusCode::UnknownError) {
 ARROW_EXPORT Status PassPyError();
 
 // TODO(wesm): We can just let errors pass through. To be explored later
-#define RETURN_IF_PYERROR() RETURN_NOT_OK(CheckPyError());
+#define RETURN_IF_PYERROR() ARROW_RETURN_NOT_OK(CheckPyError());
 
-#define PY_RETURN_IF_ERROR(CODE) RETURN_NOT_OK(CheckPyError(CODE));
+#define PY_RETURN_IF_ERROR(CODE) ARROW_RETURN_NOT_OK(CheckPyError(CODE));
 
 class ARROW_EXPORT PyAcquireGIL {
  public:
@@ -186,7 +186,7 @@ struct PyBytesView {
       *is_utf8 = true;
       return FromUnicode(obj);
     } else {
-      RETURN_NOT_OK(FromBinary(obj, "a string or bytes object"));
+      ARROW_RETURN_NOT_OK(FromBinary(obj, "a string or bytes object"));
       if (check_utf8) {
         // Check the bytes are utf8 utf-8
         OwnedRef decoded(PyUnicode_FromStringAndSize(bytes, size));

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -29,7 +29,7 @@
 
 #ifdef ARROW_EXTRA_ERROR_CONTEXT
 
-#define RETURN_NOT_OK(s)                                                            \
+#define ARROW_RETURN_NOT_OK(s)                                                      \
   do {                                                                              \
     ::arrow::Status _s = (s);                                                       \
     if (ARROW_PREDICT_FALSE(!_s.ok())) {                                            \
@@ -41,7 +41,7 @@
 
 #else
 
-#define RETURN_NOT_OK(s)                 \
+#define ARROW_RETURN_NOT_OK(s)           \
   do {                                   \
     ::arrow::Status _s = (s);            \
     if (ARROW_PREDICT_FALSE(!_s.ok())) { \
@@ -60,11 +60,10 @@
     }                                \
   } while (false)
 
-// This is used by other codebases. The macros above
-// should probably have that prefix, but there is a
-// lot of code that already uses that macro and changing
-// it would be of no benefit.
-#define ARROW_RETURN_NOT_OK(s) RETURN_NOT_OK(s)
+// This is an internal-use macro and should not be used in public headers.
+#ifndef RETURN_NOT_OK
+#define RETURN_NOT_OK(s) ARROW_RETURN_NOT_OK(s)
+#endif
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -105,10 +105,10 @@ class StdinStream : public InputStream {
 
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override {
     std::shared_ptr<ResizableBuffer> buffer;
-    RETURN_NOT_OK(AllocateResizableBuffer(nbytes, &buffer));
+    ARROW_RETURN_NOT_OK(AllocateResizableBuffer(nbytes, &buffer));
     int64_t bytes_read;
-    RETURN_NOT_OK(Read(nbytes, &bytes_read, buffer->mutable_data()));
-    RETURN_NOT_OK(buffer->Resize(bytes_read, false));
+    ARROW_RETURN_NOT_OK(Read(nbytes, &bytes_read, buffer->mutable_data()));
+    ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read, false));
     buffer->ZeroPadding();
     *out = buffer;
     return Status::OK();


### PR DESCRIPTION
This also checks whether `RETURN_NOT_OK` is defined in case another codebase exposes such a define in its headers and is included first