### PR TITLE
ARROW-3190: [C++] Rename Writeable references to Writable, add backwards compatibility, deprecations

### DIFF
--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -154,7 +154,7 @@ class ARROW_EXPORT CudaBufferReader : public io::BufferReader {
 
 /// \class CudaBufferWriter
 /// \brief File interface for writing to CUDA buffers, with optional buffering
-class ARROW_EXPORT CudaBufferWriter : public io::WriteableFile {
+class ARROW_EXPORT CudaBufferWriter : public io::WritableFile {
  public:
   explicit CudaBufferWriter(const std::shared_ptr<CudaBuffer>& buffer);
   ~CudaBufferWriter() override;

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -62,12 +62,12 @@ class OSFile {
 
   // Note: only one of the Open* methods below may be called on a given instance
 
-  Status OpenWriteable(const std::string& path, bool truncate, bool append,
-                       bool write_only) {
+  Status OpenWritable(const std::string& path, bool truncate, bool append,
+                      bool write_only) {
     RETURN_NOT_OK(SetFileName(path));
 
     RETURN_NOT_OK(
-        internal::FileOpenWriteable(file_name_, write_only, truncate, append, &fd_));
+        internal::FileOpenWritable(file_name_, write_only, truncate, append, &fd_));
     is_open_ = true;
     mode_ = write_only ? FileMode::WRITE : FileMode::READWRITE;
 
@@ -79,9 +79,9 @@ class OSFile {
     return Status::OK();
   }
 
-  // This is different from OpenWriteable(string, ...) in that it doesn't
+  // This is different from OpenWritable(string, ...) in that it doesn't
   // truncate nor mandate a seekable file
-  Status OpenWriteable(int fd) {
+  Status OpenWritable(int fd) {
     if (!internal::FileGetSize(fd, &size_).ok()) {
       // Non-seekable file
       size_ = -1;
@@ -290,9 +290,9 @@ class FileOutputStream::FileOutputStreamImpl : public OSFile {
  public:
   Status Open(const std::string& path, bool append) {
     const bool truncate = !append;
-    return OpenWriteable(path, truncate, append, true /* write_only */);
+    return OpenWritable(path, truncate, append, true /* write_only */);
   }
-  Status Open(int fd) { return OpenWriteable(fd); }
+  Status Open(int fd) { return OpenWritable(fd); }
 };
 
 FileOutputStream::FileOutputStream() { impl_.reset(new FileOutputStreamImpl()); }
@@ -371,7 +371,7 @@ class MemoryMappedFile::MemoryMap : public MutableBuffer {
       constexpr bool append = false;
       constexpr bool truncate = false;
       constexpr bool write_only = false;
-      RETURN_NOT_OK(file_->OpenWriteable(path, truncate, append, write_only));
+      RETURN_NOT_OK(file_->OpenWritable(path, truncate, append, write_only));
 
       is_mutable_ = true;
     } else {

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -173,7 +173,7 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
 // supporting zero copy reads. The same class is used for both reading and
 // writing.
 //
-// If opening a file in a writeable mode, it is not truncated first as with
+// If opening a file in a writable mode, it is not truncated first as with
 // FileOutputStream
 class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
  public:

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -229,7 +229,7 @@ Status HdfsReadableFile::Tell(int64_t* position) const { return impl_->Tell(posi
 // ----------------------------------------------------------------------
 // File writing
 
-// Private implementation for writeable-only files
+// Private implementation for writable-only files
 class HdfsOutputStream::HdfsOutputStreamImpl : public HdfsAnyFileImpl {
  public:
   HdfsOutputStreamImpl() {}
@@ -475,9 +475,9 @@ class HadoopFileSystem::HadoopFileSystemImpl {
     return Status::OK();
   }
 
-  Status OpenWriteable(const std::string& path, bool append, int32_t buffer_size,
-                       int16_t replication, int64_t default_block_size,
-                       std::shared_ptr<HdfsOutputStream>* file) {
+  Status OpenWritable(const std::string& path, bool append, int32_t buffer_size,
+                      int16_t replication, int64_t default_block_size,
+                      std::shared_ptr<HdfsOutputStream>* file) {
     int flags = O_WRONLY;
     if (append) flags |= O_APPEND;
 
@@ -594,17 +594,17 @@ Status HadoopFileSystem::OpenReadable(const std::string& path,
   return OpenReadable(path, kDefaultHdfsBufferSize, file);
 }
 
-Status HadoopFileSystem::OpenWriteable(const std::string& path, bool append,
-                                       int32_t buffer_size, int16_t replication,
-                                       int64_t default_block_size,
-                                       std::shared_ptr<HdfsOutputStream>* file) {
-  return impl_->OpenWriteable(path, append, buffer_size, replication, default_block_size,
-                              file);
+Status HadoopFileSystem::OpenWritable(const std::string& path, bool append,
+                                      int32_t buffer_size, int16_t replication,
+                                      int64_t default_block_size,
+                                      std::shared_ptr<HdfsOutputStream>* file) {
+  return impl_->OpenWritable(path, append, buffer_size, replication, default_block_size,
+                             file);
 }
 
-Status HadoopFileSystem::OpenWriteable(const std::string& path, bool append,
-                                       std::shared_ptr<HdfsOutputStream>* file) {
-  return OpenWriteable(path, append, 0, 0, 0, file);
+Status HadoopFileSystem::OpenWritable(const std::string& path, bool append,
+                                      std::shared_ptr<HdfsOutputStream>* file) {
+  return OpenWritable(path, append, 0, 0, 0, file);
 }
 
 Status HadoopFileSystem::Chmod(const std::string& path, int mode) {
@@ -618,6 +618,20 @@ Status HadoopFileSystem::Chown(const std::string& path, const char* owner,
 
 Status HadoopFileSystem::Rename(const std::string& src, const std::string& dst) {
   return impl_->Rename(src, dst);
+}
+
+// Deprecated in 0.11
+
+Status HadoopFileSystem::OpenWriteable(const std::string& path, bool append,
+                                       int32_t buffer_size, int16_t replication,
+                                       int64_t default_block_size,
+                                       std::shared_ptr<HdfsOutputStream>* file) {
+  return OpenWritable(path, append, buffer_size, replication, default_block_size, file);
+}
+
+Status HadoopFileSystem::OpenWriteable(const std::string& path, bool append,
+                                       std::shared_ptr<HdfsOutputStream>* file) {
+  return OpenWritable(path, append, 0, 0, 0, file);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -156,10 +156,19 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
   // @param buffer_size, 0 for default
   // @param replication, 0 for default
   // @param default_block_size, 0 for default
+  Status OpenWritable(const std::string& path, bool append, int32_t buffer_size,
+                      int16_t replication, int64_t default_block_size,
+                      std::shared_ptr<HdfsOutputStream>* file);
+
+  Status OpenWritable(const std::string& path, bool append,
+                      std::shared_ptr<HdfsOutputStream>* file);
+
+  ARROW_DEPRECATED("Use OpenWritable")
   Status OpenWriteable(const std::string& path, bool append, int32_t buffer_size,
                        int16_t replication, int64_t default_block_size,
                        std::shared_ptr<HdfsOutputStream>* file);
 
+  ARROW_DEPRECATED("Use OpenWritable")
   Status OpenWriteable(const std::string& path, bool append,
                        std::shared_ptr<HdfsOutputStream>* file);
 
@@ -212,7 +221,7 @@ class ARROW_EXPORT HdfsReadableFile : public RandomAccessFile {
 };
 
 // Naming this file OutputStream because it does not support seeking (like the
-// WriteableFile interface)
+// WritableFile interface)
 class ARROW_EXPORT HdfsOutputStream : public OutputStream {
  public:
   ~HdfsOutputStream() override;

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -162,16 +162,18 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   std::unique_ptr<RandomAccessFileImpl> impl_;
 };
 
-class ARROW_EXPORT WriteableFile : public OutputStream, public Seekable {
+class ARROW_EXPORT WritableFile : public OutputStream, public Seekable {
  public:
   virtual Status WriteAt(int64_t position, const void* data, int64_t nbytes) = 0;
 
  protected:
-  WriteableFile() = default;
+  WritableFile() = default;
 };
 
-class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile,
-                                            public WriteableFile {
+// TOOD(wesm): remove this after 0.11
+using WriteableFile = WritableFile;
+
+class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile, public WritableFile {
  protected:
   ReadWriteFileInterface() { RandomAccessFile::set_mode(FileMode::READWRITE); }
 };

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -170,7 +170,7 @@ class ARROW_EXPORT WritableFile : public OutputStream, public Seekable {
   WritableFile() = default;
 };
 
-// TOOD(wesm): remove this after 0.11
+// TODO(wesm): remove this after 0.11
 using WriteableFile = WritableFile;
 
 class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile, public WritableFile {

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -73,13 +73,13 @@ class TestFileOutputStream : public FileTestFixture {
     internal::PlatformFilename file_name;
     ASSERT_OK(internal::FileNameFromString(path_, &file_name));
     int fd_file, fd_stream;
-    ASSERT_OK(internal::FileOpenWriteable(file_name, true /* write_only */,
-                                          false /* truncate */, false /* append */,
-                                          &fd_file));
+    ASSERT_OK(internal::FileOpenWritable(file_name, true /* write_only */,
+                                         false /* truncate */, false /* append */,
+                                         &fd_file));
     ASSERT_OK(FileOutputStream::Open(fd_file, &file_));
-    ASSERT_OK(internal::FileOpenWriteable(file_name, true /* write_only */,
-                                          false /* truncate */, false /* append */,
-                                          &fd_stream));
+    ASSERT_OK(internal::FileOpenWritable(file_name, true /* write_only */,
+                                         false /* truncate */, false /* append */,
+                                         &fd_stream));
     ASSERT_OK(FileOutputStream::Open(fd_stream, &stream_));
   }
 
@@ -169,8 +169,8 @@ TEST_F(TestFileOutputStream, FromFileDescriptor) {
   // Re-open at end of file
   internal::PlatformFilename file_name;
   ASSERT_OK(internal::FileNameFromString(path_, &file_name));
-  ASSERT_OK(internal::FileOpenWriteable(file_name, true /* write_only */,
-                                        false /* truncate */, false /* append */, &fd));
+  ASSERT_OK(internal::FileOpenWritable(file_name, true /* write_only */,
+                                       false /* truncate */, false /* append */, &fd));
   ASSERT_OK(internal::FileSeek(fd, 0, SEEK_END));
   ASSERT_OK(FileOutputStream::Open(fd, &stream_));
 

--- a/cpp/src/arrow/io/io-hdfs-test.cc
+++ b/cpp/src/arrow/io/io-hdfs-test.cc
@@ -68,8 +68,8 @@ class TestHadoopFileSystem : public ::testing::Test {
                         bool append = false, int buffer_size = 0, int16_t replication = 0,
                         int default_block_size = 0) {
     std::shared_ptr<HdfsOutputStream> file;
-    RETURN_NOT_OK(client_->OpenWriteable(path, append, buffer_size, replication,
-                                         default_block_size, &file));
+    RETURN_NOT_OK(client_->OpenWritable(path, append, buffer_size, replication,
+                                        default_block_size, &file));
 
     RETURN_NOT_OK(file->Write(buffer, size));
     RETURN_NOT_OK(file->Close());

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -81,7 +81,7 @@ class ARROW_EXPORT MockOutputStream : public OutputStream {
 };
 
 /// \brief Enables random writes into a fixed-size mutable buffer
-class ARROW_EXPORT FixedSizeBufferWriter : public WriteableFile {
+class ARROW_EXPORT FixedSizeBufferWriter : public WritableFile {
  public:
   /// Input buffer must be mutable, will abort if not
   explicit FixedSizeBufferWriter(const std::shared_ptr<Buffer>& buffer);

--- a/cpp/src/arrow/util/io-util.cc
+++ b/cpp/src/arrow/util/io-util.cc
@@ -154,8 +154,8 @@ Status FileOpenReadable(const PlatformFilename& file_name, int* fd) {
   return CheckFileOpResult(ret, errno_actual, file_name, "open local");
 }
 
-Status FileOpenWriteable(const PlatformFilename& file_name, bool write_only,
-                         bool truncate, bool append, int* fd) {
+Status FileOpenWritable(const PlatformFilename& file_name, bool write_only, bool truncate,
+                        bool append, int* fd) {
   int ret, errno_actual;
 
 #if defined(_MSC_VER)

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -146,8 +146,8 @@ struct PlatformFilename {
 Status FileNameFromString(const std::string& file_name, PlatformFilename* out);
 
 Status FileOpenReadable(const PlatformFilename& file_name, int* fd);
-Status FileOpenWriteable(const PlatformFilename& file_name, bool write_only,
-                         bool truncate, bool append, int* fd);
+Status FileOpenWritable(const PlatformFilename& file_name, bool write_only, bool truncate,
+                        bool append, int* fd);
 
 Status FileRead(int fd, uint8_t* buffer, const int64_t nbytes, int64_t* bytes_read);
 Status FileReadAt(int fd, uint8_t* buffer, int64_t position, int64_t nbytes,

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -528,7 +528,7 @@ cdef class BufferWriter(NativeFile):
 
     def seek(self, int64_t position, int whence=0):
         # TODO: remove this method after NativeFile.seek supports
-        # writeable files.
+        # writable files.
         cdef int64_t offset
 
         with nogil:

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -601,10 +601,10 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
     cdef cppclass Seekable:
         CStatus Seek(int64_t position)
 
-    cdef cppclass Writeable:
+    cdef cppclass Writable:
         CStatus Write(const uint8_t* data, int64_t nbytes)
 
-    cdef cppclass OutputStream(FileInterface, Writeable):
+    cdef cppclass OutputStream(FileInterface, Writable):
         pass
 
     cdef cppclass InputStream(FileInterface, Readable):
@@ -619,12 +619,12 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
                        shared_ptr[CBuffer]* out)
         c_bool supports_zero_copy()
 
-    cdef cppclass WriteableFile(OutputStream, Seekable):
+    cdef cppclass WritableFile(OutputStream, Seekable):
         CStatus WriteAt(int64_t position, const uint8_t* data,
                         int64_t nbytes)
 
     cdef cppclass ReadWriteFileInterface(RandomAccessFile,
-                                         WriteableFile):
+                                         WritableFile):
         pass
 
     cdef cppclass FileSystem:
@@ -727,10 +727,10 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         CStatus OpenReadable(const c_string& path,
                              shared_ptr[HdfsReadableFile]* handle)
 
-        CStatus OpenWriteable(const c_string& path, c_bool append,
-                              int32_t buffer_size, int16_t replication,
-                              int64_t default_block_size,
-                              shared_ptr[HdfsOutputStream]* handle)
+        CStatus OpenWritable(const c_string& path, c_bool append,
+                             int32_t buffer_size, int16_t replication,
+                             int64_t default_block_size,
+                             shared_ptr[HdfsOutputStream]* handle)
 
     cdef cppclass CBufferReader \
             " arrow::io::BufferReader"(RandomAccessFile):
@@ -747,7 +747,7 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
         int64_t GetExtentBytesWritten()
 
     cdef cppclass CFixedSizeBufferWriter \
-            " arrow::io::FixedSizeBufferWriter"(WriteableFile):
+            " arrow::io::FixedSizeBufferWriter"(WritableFile):
         CFixedSizeBufferWriter(const shared_ptr[CBuffer]& buffer)
 
         void set_memcopy_threads(int num_threads)

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -74,7 +74,7 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::gpu" nogil:
         CStatus Read(int64_t nbytes, shared_ptr[CBuffer]* out)
 
     cdef cppclass \
-            CCudaBufferWriter" arrow::gpu::CudaBufferWriter"(WriteableFile):
+            CCudaBufferWriter" arrow::gpu::CudaBufferWriter"(WritableFile):
         CCudaBufferWriter(const shared_ptr[CCudaBuffer]& buffer)
         CStatus Close()
         CStatus Flush()

--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -420,9 +420,9 @@ cdef class HadoopFileSystem:
             with nogil:
                 check_status(
                     self.client.get()
-                    .OpenWriteable(c_path, append, c_buffer_size,
-                                   c_replication, c_default_block_size,
-                                   &wr_handle))
+                    .OpenWritable(c_path, append, c_buffer_size,
+                                  c_replication, c_default_block_size,
+                                  &wr_handle))
 
             out.wr_file = <shared_ptr[OutputStream]> wr_handle
             out.is_writable = True


### PR DESCRIPTION
"Writable" is the correct spelling. Seems this issue also occurred with the Python buffer protocol, where "writeable" exists now for backwards compatibility