### PR TITLE
PARQUET-1398: [C++] move iv_prefix to Algorithms

### DIFF
--- a/cpp/src/parquet/parquet.thrift
+++ b/cpp/src/parquet/parquet.thrift
@@ -891,11 +891,21 @@ struct FileMetaData {
 struct AesGcmV1 {
   /** Retrieval metadata of AAD used for encryption of pages and structures **/
   1: optional binary aad_metadata
+
+  /** If file IVs are comprised of a fixed part, and variable parts
+   *  (e.g. counter), keep the fixed part here **/
+  2: optional binary iv_prefix
 }
 
 struct AesGcmCtrV1 {
   /** Retrieval metadata of AAD used for encryption of structures **/
   1: optional binary aad_metadata
+
+  /** If file IVs are comprised of a fixed part, and variable parts
+   *  (e.g. counter), keep the fixed part here **/
+  2: optional binary gcm_iv_prefix
+
+  3: optional binary ctr_iv_prefix
 }
 
 union EncryptionAlgorithm {
@@ -915,9 +925,4 @@ struct FileCryptoMetaData {
 
   /** Offset of Parquet footer (encrypted, or plaintext) **/
   4: required i64 footer_offset
-
-  /** If file IVs are comprised of a fixed part,
-   *  and variable parts (random or counter), keep the fixed
-   *  part here **/
-  5: optional binary iv_prefix
 }


### PR DESCRIPTION
this thrift update is already merged in parquet-format