### PR TITLE
ARROW-3257: [C++] Stop to use IMPORTED_LINK_INTERFACE_LIBRARIES

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -640,9 +640,6 @@ if (ARROW_ORC)
   SET(ARROW_STATIC_LINK_LIBS
     ${ARROW_STATIC_LINK_LIBS}
     orc)
-  set_target_properties(orc
-    PROPERTIES INTERFACE_LINK_LIBRARIES
-    protobuf)
 endif()
 
 if (ARROW_STATIC_LINK_LIBS)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -33,6 +33,10 @@ function(ADD_THIRDPARTY_LIB LIB_NAME)
     add_library(${AUG_LIB_NAME} STATIC IMPORTED)
     set_target_properties(${AUG_LIB_NAME}
       PROPERTIES IMPORTED_LOCATION "${ARG_STATIC_LIB}")
+    if(ARG_DEPS)
+      set_target_properties(${AUG_LIB_NAME}
+        PROPERTIES INTERFACE_LINK_LIBRARIES "${ARG_DEPS}")
+    endif()
     message("Added static library dependency ${LIB_NAME}: ${ARG_STATIC_LIB}")
 
     SET(AUG_LIB_NAME "${LIB_NAME}_shared")
@@ -48,7 +52,7 @@ function(ADD_THIRDPARTY_LIB LIB_NAME)
     endif()
     if(ARG_DEPS)
       set_target_properties(${AUG_LIB_NAME}
-        PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES "${ARG_DEPS}")
+        PROPERTIES INTERFACE_LINK_LIBRARIES "${ARG_DEPS}")
     endif()
     message("Added shared library dependency ${LIB_NAME}: ${ARG_SHARED_LIB}")
   elseif(ARG_STATIC_LIB)
@@ -61,8 +65,10 @@ function(ADD_THIRDPARTY_LIB LIB_NAME)
       PROPERTIES IMPORTED_LOCATION "${ARG_STATIC_LIB}")
     if(ARG_DEPS)
       set_target_properties(${AUG_LIB_NAME}
-        PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES "${ARG_DEPS}")
+        PROPERTIES INTERFACE_LINK_LIBRARIES "${ARG_DEPS}")
     endif()
+    set_target_properties(${LIB_NAME}
+      PROPERTIES INTERFACE_LINK_LIBRARIES "${AUG_LIB_NAME}")
     message("Added static library dependency ${LIB_NAME}: ${ARG_STATIC_LIB}")
   elseif(ARG_SHARED_LIB)
     add_library(${LIB_NAME} SHARED IMPORTED)
@@ -84,8 +90,10 @@ function(ADD_THIRDPARTY_LIB LIB_NAME)
     message("Added shared library dependency ${LIB_NAME}: ${ARG_SHARED_LIB}")
     if(ARG_DEPS)
       set_target_properties(${AUG_LIB_NAME}
-        PROPERTIES IMPORTED_LINK_INTERFACE_LIBRARIES "${ARG_DEPS}")
+        PROPERTIES INTERFACE_LINK_LIBRARIES "${ARG_DEPS}")
     endif()
+    set_target_properties(${LIB_NAME}
+      PROPERTIES INTERFACE_LINK_LIBRARIES "${AUG_LIB_NAME}")
   else()
     message(FATAL_ERROR "No static or shared library provided for ${LIB_NAME}")
   endif()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -516,7 +516,7 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   if(MSVC)
     set_target_properties(gflags
       PROPERTIES
-      IMPORTED_LINK_INTERFACE_LIBRARIES "shlwapi.lib")
+      INTERFACE_LINK_LIBRARIES "shlwapi.lib")
   endif()
 
   if(GFLAGS_VENDORED)
@@ -1137,7 +1137,8 @@ if (ARROW_ORC)
 
   include_directories(SYSTEM ${ORC_INCLUDE_DIR})
   ADD_THIRDPARTY_LIB(orc
-    STATIC_LIB ${ORC_STATIC_LIB})
+    STATIC_LIB ${ORC_STATIC_LIB}
+    DEPS protobuf)
 
   if (ORC_VENDORED)
     add_dependencies(orc orc_ep)


### PR DESCRIPTION
Because it's deprecated in CMake 3.2 that is the minimum required
version:

https://cmake.org/cmake/help/v3.2/prop_tgt/IMPORTED_LINK_INTERFACE_LIBRARIES.html

The document says that we should use INTERFACE_LINK_LIBRARIES:

https://cmake.org/cmake/help/v3.2/prop_tgt/INTERFACE_LINK_LIBRARIES.html