### PR TITLE
ARROW-3069: [Release] Stop using SHA1 checksums per ASF policy

### DIFF
--- a/dev/release/js-source-release.sh
+++ b/dev/release/js-source-release.sh
@@ -118,7 +118,6 @@ ${SOURCE_DIR}/run-rat.sh ${tarball}
 
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
-sha1sum $tarball > ${tarball}.sha1
 sha256sum $tarball > ${tarball}.sha256
 sha512sum $tarball > ${tarball}.sha512
 

--- a/dev/release/js-verify-release-candidate.sh
+++ b/dev/release/js-verify-release-candidate.sh
@@ -54,14 +54,14 @@ fetch_archive() {
   local dist_name=$1
   download_rc_file ${dist_name}.tar.gz
   download_rc_file ${dist_name}.tar.gz.asc
-  download_rc_file ${dist_name}.tar.gz.sha1
+  download_rc_file ${dist_name}.tar.gz.sha256
   download_rc_file ${dist_name}.tar.gz.sha512
   gpg --verify ${dist_name}.tar.gz.asc ${dist_name}.tar.gz
   if [ "$(uname)" == "Darwin" ]; then
-    shasum -a 1 ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha1
+    shasum -a 256 ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha256
     shasum -a 512 ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha512
   else
-    sha1sum ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha1
+    sha256sum ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha256
     sha512sum ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha512
   fi
 }

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -74,11 +74,11 @@ fetch_archive() {
   local dist_name=$1
   download_rc_file ${dist_name}.tar.gz
   download_rc_file ${dist_name}.tar.gz.asc
-  download_rc_file ${dist_name}.tar.gz.sha1
   download_rc_file ${dist_name}.tar.gz.sha256
+  download_rc_file ${dist_name}.tar.gz.sha512
   gpg --verify ${dist_name}.tar.gz.asc ${dist_name}.tar.gz
-  shasum -a 1 -c ${dist_name}.tar.gz.sha1
   shasum -a 256 -c ${dist_name}.tar.gz.sha256
+  shasum -a 512 -c ${dist_name}.tar.gz.sha512
 }
 
 verify_binary_artifacts() {
@@ -106,8 +106,8 @@ verify_binary_artifacts() {
     # basename of the artifact
     pushd $(dirname $artifact)
     base_artifact=$(basename $artifact)
-    shasum -a 1 -c $base_artifact.sha1 || exit 1
     shasum -a 256 -c $base_artifact.sha256 || exit 1
+    shasum -a 512 -c $base_artifact.sha512 || exit 1
     popd
   done
 }

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -700,7 +700,7 @@ def hashbytes(bytes, algoname):
               type=click.Path(file_okay=False, dir_okay=True),
               help='Directory to download the build artifacts')
 @click.option('-a', '--algorithm',
-              default=['sha1', 'sha256'],
+              default=['sha256', 'sha512'],
               show_default=True,
               type=click.Choice(sorted(hashlib.algorithms_guaranteed)),
               multiple=True,


### PR DESCRIPTION
Not tested yet.