### PR TITLE
ARROW-3279: [C++] Allow linking Arrow tests dynamically on Windows

### DIFF
--- a/ci/cpp-python-msvc-build.bat
+++ b/ci/cpp-python-msvc-build.bat
@@ -18,12 +18,18 @@
 @echo on
 
 if "%JOB%" == "Static_Crt_Build" (
+  @rem Since we link the CRT statically, we should also disable building
+  @rem the Arrow shared library to link the tests statically, otherwise
+  @rem the Arrow DLL and the tests end up using a different instance of
+  @rem the CRT, which wreaks havoc.
+
   mkdir cpp\build-debug
   pushd cpp\build-debug
 
   cmake -G "%GENERATOR%" ^
         -DARROW_USE_STATIC_CRT=ON ^
         -DARROW_BOOST_USE_SHARED=OFF ^
+        -DARROW_BUILD_SHARED=OFF ^
         -DCMAKE_BUILD_TYPE=Debug ^
         -DARROW_CXXFLAGS="/MP" ^
         ..  || exit /B
@@ -38,6 +44,7 @@ if "%JOB%" == "Static_Crt_Build" (
   cmake -G "%GENERATOR%" ^
         -DARROW_USE_STATIC_CRT=ON ^
         -DARROW_BOOST_USE_SHARED=OFF ^
+        -DARROW_BUILD_SHARED=OFF ^
         -DCMAKE_BUILD_TYPE=Release ^
         -DARROW_CXXFLAGS="/WX /MP" ^
         ..  || exit /B
@@ -50,6 +57,10 @@ if "%JOB%" == "Static_Crt_Build" (
   exit /B 0
 )
 
+@rem In the configurations below we disable building the Arrow static library
+@rem to save some time.  Unfortunately this will still build the Parquet static
+@rem library because of PARQUET-1420 (Thrift-generated symbols not exported in DLL).
+
 if "%JOB%" == "Build_Debug" (
   mkdir cpp\build-debug
   pushd cpp\build-debug
@@ -57,6 +68,7 @@ if "%JOB%" == "Build_Debug" (
   cmake -G "%GENERATOR%" ^
         -DARROW_BOOST_USE_SHARED=OFF ^
         -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+        -DARROW_BUILD_STATIC=OFF ^
         -DARROW_CXXFLAGS="/MP" ^
         ..  || exit /B
 
@@ -111,6 +123,7 @@ cmake -G "%GENERATOR%" ^
       -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
       -DARROW_BOOST_USE_SHARED=OFF ^
       -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+      -DARROW_BUILD_STATIC=OFF ^
       -DARROW_CXXFLAGS="/WX /MP" ^
       -DARROW_PARQUET=ON ^
       -DARROW_PYTHON=ON ^

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -295,7 +295,9 @@ Always OFF if building binaries"
 endif()
 
 if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
-  set(ARROW_BUILD_STATIC ON)
+  if (NOT MSVC AND NOT ARROW_BUILD_STATIC)
+    message(FATAL_ERROR "ARROW_BUILD_TESTS needs ARROW_BUILD_STATIC")
+  endif ()
   set(ARROW_WITH_BROTLI ON)
   set(ARROW_WITH_LZ4 ON)
   set(ARROW_WITH_SNAPPY ON)
@@ -674,11 +676,22 @@ if (NOT MSVC)
     ${CMAKE_DL_LIBS})
 endif()
 
-set(ARROW_MIN_TEST_LIBS
-  arrow_static
-  ${ARROW_STATIC_LINK_LIBS}
-  gtest_main
-  gtest)
+if (ARROW_BUILD_STATIC)
+  set(ARROW_MIN_TEST_LIBS
+    arrow_static
+    ${ARROW_STATIC_LINK_LIBS}
+    gtest_main
+    gtest)
+else ()
+  set(ARROW_MIN_TEST_LIBS
+    arrow_shared
+    ${ARROW_LINK_LIBS}
+    ${BOOST_SYSTEM_LIBRARY}
+    ${BOOST_FILESYSTEM_LIBRARY}
+    ${BOOST_REGEX_LIBRARY}
+    gtest_main
+    gtest)
+endif()
 
 if(NOT MSVC)
   set(ARROW_MIN_TEST_LIBS

--- a/cpp/src/arrow/compute/kernels/util-internal.h
+++ b/cpp/src/arrow/compute/kernels/util-internal.h
@@ -23,6 +23,7 @@
 
 #include "arrow/compute/kernel.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace compute {
@@ -49,18 +50,23 @@ static inline void CopyData(const ArrayData& input, ArrayData* output) {
 
 namespace detail {
 
+ARROW_EXPORT
 Status InvokeUnaryArrayKernel(FunctionContext* ctx, UnaryKernel* kernel,
                               const Datum& value, std::vector<Datum>* outputs);
 
+ARROW_EXPORT
 Status InvokeBinaryArrayKernel(FunctionContext* ctx, BinaryKernel* kernel,
                                const Datum& left, const Datum& right,
                                std::vector<Datum>* outputs);
+ARROW_EXPORT
 Status InvokeBinaryArrayKernel(FunctionContext* ctx, BinaryKernel* kernel,
                                const Datum& left, const Datum& right, Datum* output);
 
+ARROW_EXPORT
 Datum WrapArraysLike(const Datum& value,
                      const std::vector<std::shared_ptr<Array>>& arrays);
 
+ARROW_EXPORT
 Datum WrapDatumsLike(const Datum& value, const std::vector<Datum>& datums);
 
 }  // namespace detail

--- a/cpp/src/arrow/io/mman.h
+++ b/cpp/src/arrow/io/mman.h
@@ -15,10 +15,11 @@
 
 #endif
 
+#include "arrow/util/windows_compatibility.h"
+
 #include <errno.h>
 #include <io.h>
 #include <sys/types.h>
-#include <windows.h>
 
 #define PROT_NONE 0
 #define PROT_READ 1

--- a/cpp/src/arrow/ipc/json-internal.h
+++ b/cpp/src/arrow/ipc/json-internal.h
@@ -95,21 +95,25 @@ namespace ipc {
 namespace internal {
 namespace json {
 
-Status WriteSchema(const Schema& schema, RjWriter* writer);
-Status WriteRecordBatch(const RecordBatch& batch, RjWriter* writer);
-Status WriteArray(const std::string& name, const Array& array, RjWriter* writer);
+ARROW_EXPORT Status WriteSchema(const Schema& schema, RjWriter* writer);
+ARROW_EXPORT Status WriteRecordBatch(const RecordBatch& batch, RjWriter* writer);
+ARROW_EXPORT Status WriteArray(const std::string& name, const Array& array,
+                               RjWriter* writer);
 
-Status ReadSchema(const rj::Value& json_obj, MemoryPool* pool,
-                  std::shared_ptr<Schema>* schema);
+ARROW_EXPORT Status ReadSchema(const rj::Value& json_obj, MemoryPool* pool,
+                               std::shared_ptr<Schema>* schema);
 
-Status ReadRecordBatch(const rj::Value& json_obj, const std::shared_ptr<Schema>& schema,
-                       MemoryPool* pool, std::shared_ptr<RecordBatch>* batch);
+ARROW_EXPORT Status ReadRecordBatch(const rj::Value& json_obj,
+                                    const std::shared_ptr<Schema>& schema,
+                                    MemoryPool* pool,
+                                    std::shared_ptr<RecordBatch>* batch);
 
-Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
-                 const std::shared_ptr<DataType>& type, std::shared_ptr<Array>* array);
+ARROW_EXPORT Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
+                              const std::shared_ptr<DataType>& type,
+                              std::shared_ptr<Array>* array);
 
-Status ReadArray(MemoryPool* pool, const rj::Value& json_obj, const Schema& schema,
-                 std::shared_ptr<Array>* array);
+ARROW_EXPORT Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
+                              const Schema& schema, std::shared_ptr<Array>* array);
 
 }  // namespace json
 }  // namespace internal

--- a/cpp/src/arrow/ipc/json.h
+++ b/cpp/src/arrow/ipc/json.h
@@ -41,7 +41,7 @@ namespace json {
 /// \brief Write the JSON representation of an Arrow record batch file or stream
 ///
 /// This is used for integration testing
-class JsonWriter {
+class ARROW_EXPORT JsonWriter {
  public:
   ~JsonWriter();
 
@@ -74,7 +74,7 @@ class JsonWriter {
 /// \brief Read the JSON representation of an Arrow record batch file or stream
 ///
 /// This is used for integration testing
-class JsonReader {
+class ARROW_EXPORT JsonReader {
  public:
   ~JsonReader();
 

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -146,7 +146,7 @@ if (ARROW_BUILD_TESTS)
 
   set(ARROW_PYTHON_MIN_TEST_LIBS
     arrow_python_test_main
-    arrow_python_static
+    arrow_python_shared
     arrow_shared)
 
   set(ARROW_PYTHON_TEST_LINK_LIBS ${ARROW_PYTHON_MIN_TEST_LIBS})

--- a/cpp/src/arrow/python/decimal.h
+++ b/cpp/src/arrow/python/decimal.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "arrow/type.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 
@@ -37,18 +38,21 @@ class OwnedRef;
 namespace internal {
 
 // \brief Import the Python Decimal type
+ARROW_EXPORT
 Status ImportDecimalType(OwnedRef* decimal_type);
 
 // \brief Convert a Python Decimal object to a C++ string
 // \param[in] python_decimal A Python decimal.Decimal instance
 // \param[out] The string representation of the Python Decimal instance
 // \return The status of the operation
+ARROW_EXPORT
 Status PythonDecimalToString(PyObject* python_decimal, std::string* out);
 
 // \brief Convert a C++ std::string to a Python Decimal instance
 // \param[in] decimal_constructor The decimal type object
 // \param[in] decimal_string A decimal string
 // \return An instance of decimal.Decimal
+ARROW_EXPORT
 PyObject* DecimalFromString(PyObject* decimal_constructor,
                             const std::string& decimal_string);
 
@@ -57,18 +61,21 @@ PyObject* DecimalFromString(PyObject* decimal_constructor,
 // \param[in] arrow_type An instance of arrow::DecimalType
 // \param[out] out A pointer to a Decimal128
 // \return The status of the operation
+ARROW_EXPORT
 Status DecimalFromPythonDecimal(PyObject* python_decimal, const DecimalType& arrow_type,
                                 Decimal128* out);
 
 // \brief Check whether obj is an instance of Decimal
+ARROW_EXPORT
 bool PyDecimal_Check(PyObject* obj);
 
 // \brief Check whether obj is nan. This function will abort the program if the argument
 // is not a Decimal instance
+ARROW_EXPORT
 bool PyDecimal_ISNAN(PyObject* obj);
 
 // \brief Helper class to track and update the precision and scale of a decimal
-class DecimalMetadata {
+class ARROW_EXPORT DecimalMetadata {
  public:
   DecimalMetadata();
   DecimalMetadata(int32_t precision, int32_t scale);

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -53,6 +53,7 @@ namespace internal {
 // \brief Import a Python module
 // \param[in] module_name The name of the module
 // \param[out] ref The OwnedRef containing the module PyObject*
+ARROW_EXPORT
 Status ImportModule(const std::string& module_name, OwnedRef* ref);
 
 // \brief Import an object from a Python module
@@ -60,6 +61,7 @@ Status ImportModule(const std::string& module_name, OwnedRef* ref);
 // \param[in] name The name of the object to import
 // \param[out] ref The OwnedRef containing the \c name attribute of the Python module \c
 // module
+ARROW_EXPORT
 Status ImportFromModule(const OwnedRef& module, const std::string& name, OwnedRef* ref);
 
 // \brief Check whether obj is an integer, independent of Python versions.
@@ -72,9 +74,11 @@ inline bool IsPyInteger(PyObject* obj) {
 }
 
 // \brief Use pandas missing value semantics to check if a value is null
+ARROW_EXPORT
 bool PandasObjectIsNull(PyObject* obj);
 
 // \brief Check whether obj is a floating-point NaN
+ARROW_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);
 
 inline bool IsPyBinary(PyObject* obj) {
@@ -89,15 +93,19 @@ template <typename Int>
 Status CIntFromPython(PyObject* obj, Int* out, const std::string& overflow_message = "");
 
 // \brief Convert a Python unicode string to a std::string
+ARROW_EXPORT
 Status PyUnicode_AsStdString(PyObject* obj, std::string* out);
 
 // \brief Convert a Python bytes object to a std::string
+ARROW_EXPORT
 std::string PyBytes_AsStdString(PyObject* obj);
 
 // \brief Call str() on the given object and return the result as a std::string
+ARROW_EXPORT
 Status PyObject_StdStringStr(PyObject* obj, std::string* out);
 
 // \brief Return the repr() of the given object (always succeeds)
+ARROW_EXPORT
 std::string PyObject_StdStringRepr(PyObject* obj);
 
 // \brief Cast the given size to int32_t, with error checking
@@ -113,9 +121,12 @@ inline Status CastSize(Py_ssize_t size, int32_t* out,
 
 // \brief Print the Python object's __str__ form along with the passed error
 // message
+ARROW_EXPORT
 Status InvalidValue(PyObject* obj, const std::string& why);
 
+ARROW_EXPORT
 Status IntegerScalarToDoubleSafe(PyObject* obj, double* result);
+ARROW_EXPORT
 Status IntegerScalarToFloat32Safe(PyObject* obj, float* result);
 
 }  // namespace internal

--- a/cpp/src/arrow/table_builder.h
+++ b/cpp/src/arrow/table_builder.h
@@ -38,7 +38,7 @@ class Schema;
 /// \class RecordBatchBuilder
 /// \brief Helper class for creating record batches iteratively given a known
 /// schema
-class RecordBatchBuilder {
+class ARROW_EXPORT RecordBatchBuilder {
  public:
   /// \brief Create an initialize a RecordBatchBuilder
   /// \param[in] schema The schema for the record batch
@@ -93,6 +93,8 @@ class RecordBatchBuilder {
   std::shared_ptr<Schema> schema() const { return schema_; }
 
  private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(RecordBatchBuilder);
+
   RecordBatchBuilder(const std::shared_ptr<Schema>& schema, MemoryPool* pool,
                      int64_t initial_capacity);
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -403,19 +403,6 @@ class ARROW_EXPORT ListType : public NestedType {
   std::string name() const override { return "list"; }
 };
 
-namespace meta {
-
-/// Additional ListType class that can be instantiated with only compile-time arguments.
-template <typename T>
-class ARROW_EXPORT ListType : public ::arrow::ListType {
- public:
-  using ValueType = T;
-
-  ListType() : ::arrow::ListType(std::make_shared<T>()) {}
-};
-
-}  // namespace meta
-
 // BinaryType type is represents lists of 1-byte values.
 class ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
  public:

--- a/cpp/src/arrow/util/cpu-info.cc
+++ b/cpp/src/arrow/util/cpu-info.cc
@@ -32,9 +32,9 @@
 
 #ifdef _WIN32
 #include <intrin.h>
-#include <windows.h>
 #include <array>
 #include <bitset>
+#include "arrow/util/windows_compatibility.h"
 
 #endif
 

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -34,7 +34,7 @@ namespace arrow {
 namespace io {
 
 // Output stream that just writes to stdout.
-class StdoutStream : public OutputStream {
+class ARROW_EXPORT StdoutStream : public OutputStream {
  public:
   StdoutStream() : pos_(0) { set_mode(FileMode::WRITE); }
   ~StdoutStream() override {}
@@ -57,7 +57,7 @@ class StdoutStream : public OutputStream {
 };
 
 // Output stream that just writes to stderr.
-class StderrStream : public OutputStream {
+class ARROW_EXPORT StderrStream : public OutputStream {
  public:
   StderrStream() : pos_(0) { set_mode(FileMode::WRITE); }
   ~StderrStream() override {}
@@ -80,7 +80,7 @@ class StderrStream : public OutputStream {
 };
 
 // Input stream that just reads from stdin.
-class StdinStream : public InputStream {
+class ARROW_EXPORT StdinStream : public InputStream {
  public:
   StdinStream() : pos_(0) { set_mode(FileMode::READ); }
   ~StdinStream() override {}
@@ -143,35 +143,55 @@ struct PlatformFilename {
 };
 #endif
 
+ARROW_EXPORT
 Status FileNameFromString(const std::string& file_name, PlatformFilename* out);
 
+ARROW_EXPORT
 Status FileOpenReadable(const PlatformFilename& file_name, int* fd);
+ARROW_EXPORT
 Status FileOpenWritable(const PlatformFilename& file_name, bool write_only, bool truncate,
                         bool append, int* fd);
 
+ARROW_EXPORT
 Status FileRead(int fd, uint8_t* buffer, const int64_t nbytes, int64_t* bytes_read);
+ARROW_EXPORT
 Status FileReadAt(int fd, uint8_t* buffer, int64_t position, int64_t nbytes,
                   int64_t* bytes_read);
+ARROW_EXPORT
 Status FileWrite(int fd, const uint8_t* buffer, const int64_t nbytes);
+ARROW_EXPORT
 Status FileTruncate(int fd, const int64_t size);
 
+ARROW_EXPORT
 Status FileTell(int fd, int64_t* pos);
+ARROW_EXPORT
 Status FileSeek(int fd, int64_t pos);
+ARROW_EXPORT
 Status FileSeek(int fd, int64_t pos, int whence);
+ARROW_EXPORT
 Status FileGetSize(int fd, int64_t* size);
 
+ARROW_EXPORT
 Status FileClose(int fd);
 
+ARROW_EXPORT
 Status CreatePipe(int fd[2]);
 
+ARROW_EXPORT
 Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
                       void** new_addr);
 
+ARROW_EXPORT
 Status GetEnvVar(const char* name, std::string* out);
+ARROW_EXPORT
 Status GetEnvVar(const std::string& name, std::string* out);
+ARROW_EXPORT
 Status SetEnvVar(const char* name, const char* value);
+ARROW_EXPORT
 Status SetEnvVar(const std::string& name, const std::string& value);
+ARROW_EXPORT
 Status DelEnvVar(const char* name);
+ARROW_EXPORT
 Status DelEnvVar(const std::string& name);
 
 }  // namespace internal

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -22,6 +22,8 @@
 #include <memory>
 #include <string>
 
+#include "arrow/util/visibility.h"
+
 namespace arrow {
 
 enum class ArrowLogLevel : int {
@@ -106,7 +108,7 @@ enum class ArrowLogLevel : int {
 // In logging.cc, we can choose different log libs using different macros.
 
 // This is also a null log which does not output anything.
-class ArrowLogBase {
+class ARROW_EXPORT ArrowLogBase {
  public:
   virtual ~ArrowLogBase() {}
 
@@ -124,7 +126,7 @@ class ArrowLogBase {
   virtual std::ostream& Stream() { return std::cerr; }
 };
 
-class ArrowLog : public ArrowLogBase {
+class ARROW_EXPORT ArrowLog : public ArrowLogBase {
  public:
   ArrowLog(const char* file_name, int line_number, ArrowLogLevel severity);
 
@@ -169,7 +171,7 @@ class ArrowLog : public ArrowLogBase {
 
 // This class make ARROW_CHECK compilation pass to change the << operator to void.
 // This class is copied from glog.
-class Voidify {
+class ARROW_EXPORT Voidify {
  public:
   Voidify() {}
   // This has to be an operator with a precedence lower than << but

--- a/cpp/src/arrow/util/windows_compatibility.h
+++ b/cpp/src/arrow/util/windows_compatibility.h
@@ -24,6 +24,8 @@
 #define NOMINMAX
 #endif
 
+#define WIN32_LEAN_AND_MEAN
+
 #include <winsock2.h>
 #include <windows.h>
 

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -91,23 +91,6 @@ set(PARQUET_TEST_LINK_LIBS
   parquet_static
   thriftstatic)
 
-set(PARQUET_TEST_SHARED_LINK_LIBS
-  ${PARQUET_MIN_TEST_LIBS}
-  parquet_shared)
-
-#############################################################
-# Benchmark linking
-
-if (PARQUET_BUILD_STATIC)
-  set(PARQUET_BENCHMARK_LINK_LIBS
-    parquet_benchmark_main
-    parquet_static)
-else()
-  set(PARQUET_BENCHMARK_LINK_LIBS
-    parquet_benchmark_main
-    parquet_shared)
-endif()
-
 ############################################################
 # Generated Thrift sources
 
@@ -161,8 +144,8 @@ set(PARQUET_SRCS
   util/memory.cc
 )
 
-# # Ensure that thrift compilation is done before using its generated headers
-# # in parquet code.
+# Ensure that thrift compilation is done before using its generated headers
+# in parquet code.
 add_custom_target(parquet-thrift-deps ALL
   DEPENDS ${THRIFT_OUTPUT_FILES})
 set(PARQUET_DEPENDENCIES ${PARQUET_DEPENDENCIES} parquet-thrift-deps)
@@ -189,7 +172,16 @@ if(NOT APPLE AND NOT MSVC)
   set(SHARED_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/parquet/symbols.map")
 endif()
 
+# Because of PARQUET-1420 (Thrift-generated symbols not exported in DLL),
+# parquet tests must be linked against the static parquet lib.
+if (NO_TESTS)
+  set(PARQUET_LIB_OPTIONS)
+else ()
+  set(PARQUET_LIB_OPTIONS "BUILD_STATIC")
+endif()
+
 ADD_ARROW_LIB(parquet
+  ${PARQUET_LIB_OPTIONS}
   SOURCES ${PARQUET_SRCS}
   OUTPUTS PARQUET_LIBRARIES
   DEPENDENCIES ${PARQUET_DEPENDENCIES}
@@ -275,6 +267,9 @@ ADD_PARQUET_TEST(public-api-test)
 ADD_PARQUET_TEST(types-test)
 ADD_PARQUET_TEST(reader-test)
 ADD_PARQUET_TEST(schema-test)
+
+#############################################################
+# Benchmark linking
 
 set(PARQUET_BENCHMARK_LINK_LIBRARIES
   arrow_benchmark_main

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -26,6 +26,7 @@
 #include "parquet/hasher.h"
 #include "parquet/types.h"
 #include "parquet/util/memory.h"
+#include "parquet/util/visibility.h"
 
 namespace parquet {
 class OutputStream;
@@ -33,7 +34,7 @@ class OutputStream;
 // A Bloom filter is a compact structure to indicate whether an item is not in a set or
 // probably in a set. The Bloom filter usually consists of a bit set that represents a
 // set of elements, a hash strategy and a Bloom filter algorithm.
-class BloomFilter {
+class PARQUET_EXPORT BloomFilter {
  public:
   // Maximum Bloom filter size, it sets to HDFS default block size 128MB
   // This value will be reconsidered when implementing Bloom filter producer.
@@ -117,7 +118,7 @@ class BloomFilter {
 //
 // This implementation sets 8 bits in each tiny Bloom filter. Each tiny Bloom
 // filter is 32 bytes to take advantage of 32-byte SIMD instructions.
-class BlockSplitBloomFilter : public BloomFilter {
+class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
  public:
   /// The constructor of BlockSplitBloomFilter. It uses murmur3_x64_128 as hash function.
   BlockSplitBloomFilter();

--- a/cpp/src/parquet/murmur3.h
+++ b/cpp/src/parquet/murmur3.h
@@ -26,13 +26,14 @@
 
 #include "parquet/hasher.h"
 #include "parquet/types.h"
+#include "parquet/util/visibility.h"
 
 namespace parquet {
 
 /// Source:
 /// https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
 /// (Modified to adapt to coding conventions and to inherit the Hasher abstract class)
-class MurmurHash3 : public Hasher {
+class PARQUET_EXPORT MurmurHash3 : public Hasher {
  public:
   MurmurHash3() : seed_(DEFAULT_SEED) {}
   uint64_t Hash(int32_t value) const override;

--- a/cpp/src/parquet/schema-internal.h
+++ b/cpp/src/parquet/schema-internal.h
@@ -26,11 +26,15 @@
 #include <vector>
 
 #include "parquet/schema.h"
-#include "parquet/thrift.h"
 #include "parquet/types.h"
 #include "parquet/util/macros.h"
 
 namespace parquet {
+
+namespace format {
+class SchemaElement;
+}
+
 namespace schema {
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
This helps reduce build times because we don't have to build both the static and shared library.