### PR TITLE
ARROW-3281: [Java] Make sure that WritableByteChannel in WriteChannel writes

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -73,7 +73,9 @@ public class WriteChannel implements AutoCloseable {
   public long write(ByteBuffer buffer) throws IOException {
     long length = buffer.remaining();
     LOGGER.debug("Writing buffer with size: " + length);
-    out.write(buffer);
+    while(buffer.remaining() > 0) {
+      out.write(buffer);
+    }
     currentPosition += length;
     return length;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -35,9 +35,9 @@ import io.netty.buffer.ArrowBuf;
  * Wrapper around a WritableByteChannel that maintains the position as well adding
  * some common serialization utilities.
  *
- * All write methods in this class follows full write semantics, i.e., write calls
+ * All write methods in this class follow full write semantics, i.e., write calls
  * only return after requested data has been fully written. Note this is different
- * from java WritableByteChannel interface where partial write is allow
+ * from java WritableByteChannel interface where partial write is allowed
  */
 public class WriteChannel implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(WriteChannel.class);
@@ -77,7 +77,7 @@ public class WriteChannel implements AutoCloseable {
   public long write(ByteBuffer buffer) throws IOException {
     long length = buffer.remaining();
     LOGGER.debug("Writing buffer with size: " + length);
-    while(buffer.hasRemaining()) {
+    while (buffer.hasRemaining()) {
       out.write(buffer);
     }
     currentPosition += length;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -73,7 +73,7 @@ public class WriteChannel implements AutoCloseable {
   public long write(ByteBuffer buffer) throws IOException {
     long length = buffer.remaining();
     LOGGER.debug("Writing buffer with size: " + length);
-    while(buffer.remaining() > 0) {
+    while(buffer.hasRemaining()) {
       out.write(buffer);
     }
     currentPosition += length;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -34,6 +34,10 @@ import io.netty.buffer.ArrowBuf;
 /**
  * Wrapper around a WritableByteChannel that maintains the position as well adding
  * some common serialization utilities.
+ *
+ * All write methods in this class follows full write semantics, i.e., write calls
+ * only return after requested data has been fully written. Note this is different
+ * from java WritableByteChannel interface where partial write is allow
  */
 public class WriteChannel implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(WriteChannel.class);


### PR DESCRIPTION
out complete bytes

Author: Animesh Trivedi <atrivedi@apache.org>

Loop around the write call to make sure that all remaining
bytes in a ByteBuffer is consumed by the write call.