### PR TITLE
ARROW-3285: [GLib] Add arrow_cpp_build_type and arrow_cpp_build_dir options

### DIFF
--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -57,7 +57,7 @@ sources += files(
   'compute.cpp',
 )
 
-if arrow_orc_dependency.found()
+if have_arrow_orc
   sources += files(
     'orc-file-reader.cpp',
   )
@@ -108,7 +108,7 @@ c_headers += files(
   'compute.h',
 )
 
-if arrow_orc_dependency.found()
+if have_arrow_orc
   c_headers += files(
     'orc-file-reader.h',
   )
@@ -156,7 +156,7 @@ cpp_headers += files(
   'compute.hpp',
 )
 
-if arrow_orc_dependency.found()
+if have_arrow_orc
   cpp_headers += files(
     'orc-file-reader.hpp',
   )
@@ -189,7 +189,7 @@ install_headers(headers, subdir: meson.project_name())
 
 
 dependencies = [
-  dependency('arrow'),
+  arrow,
   dependency('gobject-2.0'),
   dependency('gio-2.0'),
 ]
@@ -197,17 +197,13 @@ libarrow_glib = library('arrow-glib',
                         sources: sources + enums,
                         install: true,
                         dependencies: dependencies,
-                        include_directories: [
-                          root_inc,
-                        ],
-                       soversion: so_version,
-                       version: library_version)
-libarrow_glib_dependency = declare_dependency(link_with: libarrow_glib,
-                                              include_directories: [
-                                                root_inc,
-                                              ],
-                                              dependencies: dependencies,
-                                              sources: enums_header)
+                        include_directories: base_include_directories,
+                        soversion: so_version,
+                        version: library_version)
+arrow_glib = declare_dependency(link_with: libarrow_glib,
+                                include_directories: base_include_directories,
+                                dependencies: dependencies,
+                                sources: enums_header)
 
 pkgconfig.generate(filebase: meson.project_name(),
                    name: 'Apache Arrow GLib',
@@ -215,7 +211,7 @@ pkgconfig.generate(filebase: meson.project_name(),
                    version: version,
                    requires: ['gio-2.0', 'arrow'],
                    libraries: [libarrow_glib])
-if arrow_orc_dependency.found()
+if have_arrow_orc
   pkgconfig.generate(filebase: 'arrow-orc-glib',
                      name: 'Apache Arrow GLib ORC',
                      description: 'ORC modules for Apache Arrow GLib',
@@ -238,4 +234,3 @@ arrow_glib_gir = gnome.generate_gir(libarrow_glib,
                                     extra_args: [
                                       '--warn-all',
                                     ])
-arrow_glib_gir_dependency = declare_dependency(sources: arrow_glib_gir)

--- a/c_glib/arrow-gpu-glib/meson.build
+++ b/c_glib/arrow-gpu-glib/meson.build
@@ -36,23 +36,19 @@ install_headers(headers, subdir: 'arrow-gpu-glib')
 
 
 dependencies = [
-  arrow_gpu_dependency,
-  libarrow_glib_dependency,
+  arrow_gpu,
+  arrow_glib,
 ]
 libarrow_gpu_glib = library('arrow-gpu-glib',
                             sources: sources,
                             install: true,
                             dependencies: dependencies,
-                            include_directories: [
-                              root_inc,
-                            ],
+                            include_directories: base_include_directories,
                             soversion: so_version,
                             version: library_version)
-libarrow_gpu_glib_dependency = declare_dependency(link_with: libarrow_gpu_glib,
-                                                  include_directories: [
-                                                    root_inc,
-                                                  ],
-                                                  dependencies: dependencies)
+arrow_gpu_glib = declare_dependency(link_with: libarrow_gpu_glib,
+                                    include_directories: base_include_directories,
+                                    dependencies: dependencies)
 
 pkgconfig.generate(filebase: 'arrow-gpu-glib',
                    name: 'Apache Arrow GPU GLib',
@@ -62,7 +58,7 @@ pkgconfig.generate(filebase: 'arrow-gpu-glib',
                    libraries: [libarrow_gpu_glib])
 
 gnome.generate_gir(libarrow_gpu_glib,
-                   dependencies: arrow_glib_gir_dependency,
+                   dependencies: declare_dependency(sources: arrow_glib_gir),
                    sources: sources + c_headers,
                    namespace: 'ArrowGPU',
                    nsversion: api_version,

--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -111,9 +111,9 @@ GTK_DOC_CHECK([1.18-2])
 
 AC_ARG_WITH(arrow-cpp-build-type,
   [AS_HELP_STRING([--with-arrow-cpp-build-type=TYPE],
-                  [-DCMAKE_BUILD_TYPE option value for Arrow C++ (default=Release)])],
+                  [-DCMAKE_BUILD_TYPE option value for Arrow C++ (default=release)])],
   [GARROW_ARROW_CPP_BUILD_TYPE="$withval"],
-  [GARROW_ARROW_CPP_BUILD_TYPE="Release"])
+  [GARROW_ARROW_CPP_BUILD_TYPE="release"])
 
 AC_ARG_WITH(arrow-cpp-build-dir,
   [AS_HELP_STRING([--with-arrow-cpp-build-dir=PATH],

--- a/c_glib/doc/reference/meson.build
+++ b/c_glib/doc/reference/meson.build
@@ -48,19 +48,19 @@ source_directories = [
   join_paths(meson.build_root(), 'arrow-glib'),
 ]
 dependencies = [
-  libarrow_glib_dependency,
+  arrow_glib,
 ]
-if arrow_gpu_dependency.found()
+if arrow_gpu.found()
   source_directories += [
     join_paths(meson.source_root(), 'arrow-gpu-glib'),
     join_paths(meson.build_root(), 'arrow-gpu-glib'),
   ]
   dependencies += [
-    libarrow_gpu_glib_dependency,
+    arrow_gpu_glib,
   ]
 endif
 ignore_headers = []
-if not arrow_orc_dependency.found()
+if not have_arrow_orc
   ignore_headers += [
     join_paths(meson.source_root(), 'arrow-glib', 'orc-file-reader.h'),
   ]

--- a/c_glib/example/meson.build
+++ b/c_glib/example/meson.build
@@ -18,8 +18,8 @@
 # under the License.
 
 executable('build', 'build.c',
-	   dependencies: [libarrow_glib_dependency])
+	   dependencies: [arrow_glib])
 executable('read-batch', 'read-batch.c',
-	   dependencies: [libarrow_glib_dependency])
+	   dependencies: [arrow_glib])
 executable('read-stream', 'read-stream.c',
-	   dependencies: [libarrow_glib_dependency])
+	   dependencies: [arrow_glib])

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -47,13 +47,51 @@ data_dir = join_paths(prefix, get_option('datadir'))
 gnome = import('gnome')
 pkgconfig = import('pkgconfig')
 
-root_inc = include_directories('.')
+base_include_directories = [
+  include_directories('.')
+]
 
-arrow_orc_dependency = dependency('arrow-orc', required: false)
+arrow_cpp_build_dir = get_option('arrow_cpp_build_dir')
+arrow_cpp_build_type = get_option('arrow_cpp_build_type')
+if arrow_cpp_build_dir == ''
+  arrow_cpp_build_lib_dir = ''
+else
+  arrow_cpp_build_lib_dir = join_paths(arrow_cpp_build_dir,
+                                       arrow_cpp_build_type.to_lower())
+endif
+
+if arrow_cpp_build_lib_dir == ''
+  arrow = dependency('arrow')
+  have_arrow_orc = dependency('arrow-orc', required: false).found()
+  arrow_gpu = dependency('arrow-gpu', required: false)
+else
+  base_include_directories += [
+    include_directories(join_paths(arrow_cpp_build_dir, 'src')),
+    include_directories('../cpp/src'),
+  ]
+  cpp_compiler = meson.get_compiler('cpp')
+  arrow = cpp_compiler.find_library('arrow',
+                                    dirs: [arrow_cpp_build_lib_dir])
+  arrow_orc_code = '''
+#include <arrow/adapters/orc/adapter.h>
+
+int
+main(void)
+{
+  arrow::adapters::orc::ORCFileReader::Open(nullptr, nullptr, nullptr);
+  return 0;
+}
+  '''
+  have_arrow_orc = cpp_compiler.links(arrow_orc_code,
+                                      include_directories: base_include_directories,
+                                      dependencies: [arrow])
+  arrow_gpu = cpp_compiler.find_library('arrow_gpu',
+                                        dirs: [arrow_cpp_build_lib_dir],
+                                        required: false)
+endif
 
 subdir('arrow-glib')
-arrow_gpu_dependency = dependency('arrow-gpu', required: false)
-if arrow_gpu_dependency.found()
+if arrow_gpu.found()
   subdir('arrow-gpu-glib')
 endif
 subdir('example')

--- a/c_glib/meson_options.txt
+++ b/c_glib/meson_options.txt
@@ -22,3 +22,12 @@ option('gtk_doc',
        value: false,
        description: 'Build document by GTK-Doc')
 
+option('arrow_cpp_build_type',
+       type: 'string',
+       value: 'release',
+       description: '-DCMAKE_BUILD_TYPE option value for Arrow C++')
+
+option('arrow_cpp_build_dir',
+       type: 'string',
+       value: '',
+       description: 'Use this option to build with not installed Arrow C++')


### PR DESCRIPTION
It's for building Arrow GLib without installing Arrow C++. GNU Autotools build system already has these options.