### PR TITLE
ARROW-3287: [C++] Suppress "redeclared without dllimport attribute" warning from MinGW

### DIFF
--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -110,7 +110,7 @@ class ARROW_EXPORT Status {
   Status& operator=(const Status& s);
 
   // Move the specified status.
-  Status(Status&& s) noexcept;
+  inline Status(Status&& s) noexcept;
   Status& operator=(Status&& s) noexcept;
 
   // AND the statuses.


### PR DESCRIPTION
This fixes the following warning from MinGW:

    ../apache-arrow-0.11.0/c_glib/../cpp/src/arrow/status.h:265:8: warning: 'arrow::Status::Status(arrow::Status&&)' redeclared without dllimport attribute after being referenced with dll linkage
     inline Status::Status(Status&& s) noexcept : state_(s.state_) { s.state_ = NULL; }
            ^~~~~~