### PR TITLE
ARROW-3013: [Website] Fix download links on website for tarballs, checksums

### DIFF
--- a/site/_data/versions.yml
+++ b/site/_data/versions.yml
@@ -26,5 +26,6 @@ current:
   tarball_name: 'apache-arrow-0.10.0.tar.gz'
   mirrors-tar: 'https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz'
   java-artifacts: 'http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.arrow%22%20AND%20v%3A%220.10.0%22'
+  asc: 'https://www.apache.org/dist/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz.asc'
   sha256: 'https://www.apache.org/dist/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz.sha256'
   sha512: 'https://www.apache.org/dist/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz.sha512'

--- a/site/_data/versions.yml
+++ b/site/_data/versions.yml
@@ -26,5 +26,5 @@ current:
   tarball_name: 'apache-arrow-0.10.0.tar.gz'
   mirrors-tar: 'https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz'
   java-artifacts: 'http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.arrow%22%20AND%20v%3A%220.10.0%22'
-  asc: 'https://www.apache.org/dist/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz.asc'
+  sha256: 'https://www.apache.org/dist/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz.sha256'
   sha512: 'https://www.apache.org/dist/arrow/arrow-0.10.0/apache-arrow-0.10.0.tar.gz.sha512'

--- a/site/install.md
+++ b/site/install.md
@@ -29,7 +29,7 @@ See the [release notes][10] for more about what's new.
 ### Source release
 
 * **Source Release**: [{{site.data.versions['tarball_name']}}][6]
-* **Verification**: [asc][13], [sha256][14], [sha512][15], ([verification instructions][12])
+* **Verification**: [asc signature][13], [sha256 checksum][14], [sha512 checksum][15], ([verification instructions][12])
 * [Git tag {{site.data.versions['current'].git-tag}}][2]
 * [GPG keys for release signatures][11]
 

--- a/site/install.md
+++ b/site/install.md
@@ -29,7 +29,7 @@ See the [release notes][10] for more about what's new.
 ### Source release
 
 * **Source Release**: [{{site.data.versions['tarball_name']}}][6]
-* **Verification**: [sha512][3], [asc][7] ([verification instructions][12])
+* **Verification**: [sha256][13], [sha512][14], ([verification instructions][12])
 * [Git tag {{site.data.versions['current'].git-tag}}][2]
 * [GPG keys for release signatures][11]
 
@@ -144,13 +144,13 @@ send it to the project instead of Apache Arrow project.
 
 [1]: {{site.data.versions['current'].mirrors}}
 [2]: {{site.data.versions['current'].github-tag-link}}
-[3]: {{site.data.versions['current'].sha512}}
 [4]: {{site.data.versions['current'].java-artifacts}}
 [5]: http://conda-forge.github.io
 [6]: {{site.data.versions['current'].mirrors-tar}}
-[7]: {{site.data.versions['current'].asc}}
 [8]: https://github.com/red-data-tools/parquet-glib
 [9]: https://github.com/red-data-tools/arrow-packages
 [10]: {{site.data.versions['current'].release-notes}}
 [11]: http://www.apache.org/dist/arrow/KEYS
 [12]: https://www.apache.org/dyn/closer.cgi#verify
+[13]: {{site.data.versions['current'].sha256}}
+[14]: {{site.data.versions['current'].sha512}}

--- a/site/install.md
+++ b/site/install.md
@@ -29,7 +29,7 @@ See the [release notes][10] for more about what's new.
 ### Source release
 
 * **Source Release**: [{{site.data.versions['tarball_name']}}][6]
-* **Verification**: [sha256][13], [sha512][14], ([verification instructions][12])
+* **Verification**: [asc][13], [sha256][14], [sha512][15], ([verification instructions][12])
 * [Git tag {{site.data.versions['current'].git-tag}}][2]
 * [GPG keys for release signatures][11]
 
@@ -152,5 +152,6 @@ send it to the project instead of Apache Arrow project.
 [10]: {{site.data.versions['current'].release-notes}}
 [11]: http://www.apache.org/dist/arrow/KEYS
 [12]: https://www.apache.org/dyn/closer.cgi#verify
-[13]: {{site.data.versions['current'].sha256}}
-[14]: {{site.data.versions['current'].sha512}}
+[13]: {{site.data.versions['current'].asc}}
+[14]: {{site.data.versions['current'].sha256}}
+[15]: {{site.data.versions['current'].sha512}}


### PR DESCRIPTION
I'm not sure why the signatures are missing from:
- https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.10.0/
- https://www.apache.org/dyn/closer.cgi/arrow/arrow-0.10.0/binaries

Perhaps signatures are not supposed to be distributed with `dyn` mirroring.

The new links will point to sha256 and sha512 signatures per ASF policy, see recent change https://github.com/apache/arrow/pull/2584