### PR TITLE
ARROW-3212: [C++] Make IPC metadata deterministic, regardless of current stream position. Clean up stream / tensor alignment logic

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -178,6 +178,35 @@ garrow_input_stream_class_init(GArrowInputStreamClass *klass)
 }
 
 
+/**
+ * garrow_input_stream_read_tensor:
+ * @input_stream: A #GArrowInputStream.
+ * @position: The read start position.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (transfer full) (nullable):
+ *   #GArrowTensor on success, %NULL on error.
+ *
+ * Since: 0.4.0
+ */
+GArrowTensor *
+garrow_input_stream_read_tensor(GArrowInputStream *input_stream,
+                                gint64 position,
+                                GError **error)
+{
+  auto arrow_input_stream =
+    garrow_input_stream_get_raw(input_stream);
+
+  std::shared_ptr<arrow::Tensor> arrow_tensor;
+  auto status = arrow::ipc::ReadTensor(arrow_input_stream.get(),
+                                       &arrow_tensor);
+  if (garrow_error_check(error, status, "[input-stream][read-tensor]")) {
+    return garrow_tensor_new_raw(&arrow_tensor);
+  } else {
+    return NULL;
+  }
+}
+
 G_DEFINE_TYPE(GArrowSeekableInputStream,                \
               garrow_seekable_input_stream,             \
               GARROW_TYPE_INPUT_STREAM);
@@ -257,37 +286,6 @@ garrow_seekable_input_stream_read_at(GArrowSeekableInputStream *input_stream,
     return NULL;
   }
 }
-
-/**
- * garrow_seekable_input_stream_read_tensor:
- * @input_stream: A #GArrowSeekableInputStream.
- * @position: The read start position.
- * @error: (nullable): Return location for a #GError or %NULL.
- *
- * Returns: (transfer full) (nullable):
- *   #GArrowTensor on success, %NULL on error.
- *
- * Since: 0.4.0
- */
-GArrowTensor *
-garrow_seekable_input_stream_read_tensor(GArrowSeekableInputStream *input_stream,
-                                         gint64 position,
-                                         GError **error)
-{
-  auto arrow_random_access_file =
-    garrow_seekable_input_stream_get_raw(input_stream);
-
-  std::shared_ptr<arrow::Tensor> arrow_tensor;
-  auto status = arrow::ipc::ReadTensor(position,
-                                       arrow_random_access_file.get(),
-                                       &arrow_tensor);
-  if (garrow_error_check(error, status, "[seekable-input-stream][read-tensor]")) {
-    return garrow_tensor_new_raw(&arrow_tensor);
-  } else {
-    return NULL;
-  }
-}
-
 
 typedef struct GArrowBufferInputStreamPrivate_ {
   GArrowBuffer *buffer;

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -186,14 +186,13 @@ garrow_input_stream_class_init(GArrowInputStreamClass *klass)
  * Returns: (transfer full) (nullable):
  *   #GArrowTensor on success, %NULL on error.
  *
- * Since: 0.4.0
+ * Since: 0.11.0
  */
 GArrowTensor *
 garrow_input_stream_read_tensor(GArrowInputStream *input_stream,
                                 GError **error)
 {
-  auto arrow_input_stream =
-    garrow_input_stream_get_raw(input_stream);
+  auto arrow_input_stream = garrow_input_stream_get_raw(input_stream);
 
   std::shared_ptr<arrow::Tensor> arrow_tensor;
   auto status = arrow::ipc::ReadTensor(arrow_input_stream.get(),
@@ -284,6 +283,7 @@ garrow_seekable_input_stream_read_at(GArrowSeekableInputStream *input_stream,
     return NULL;
   }
 }
+
 
 typedef struct GArrowBufferInputStreamPrivate_ {
   GArrowBuffer *buffer;

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -181,7 +181,6 @@ garrow_input_stream_class_init(GArrowInputStreamClass *klass)
 /**
  * garrow_input_stream_read_tensor:
  * @input_stream: A #GArrowInputStream.
- * @position: The read start position.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: (transfer full) (nullable):
@@ -191,7 +190,6 @@ garrow_input_stream_class_init(GArrowInputStreamClass *klass)
  */
 GArrowTensor *
 garrow_input_stream_read_tensor(GArrowInputStream *input_stream,
-                                gint64 position,
                                 GError **error)
 {
   auto arrow_input_stream =

--- a/c_glib/arrow-glib/input-stream.h
+++ b/c_glib/arrow-glib/input-stream.h
@@ -37,6 +37,10 @@ struct _GArrowInputStreamClass
   GObjectClass parent_class;
 };
 
+GArrowTensor *garrow_input_stream_read_tensor(GArrowInputStream *input_stream,
+                                              gint64 position,
+                                              GError **error);
+
 #define GARROW_TYPE_SEEKABLE_INPUT_STREAM       \
   (garrow_seekable_input_stream_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowSeekableInputStream,
@@ -56,9 +60,6 @@ GArrowBuffer *garrow_seekable_input_stream_read_at(GArrowSeekableInputStream *in
                                                    gint64 position,
                                                    gint64 n_bytes,
                                                    GError **error);
-GArrowTensor *garrow_seekable_input_stream_read_tensor(GArrowSeekableInputStream *input_stream,
-                                                       gint64 position,
-                                                       GError **error);
 
 
 #define GARROW_TYPE_BUFFER_INPUT_STREAM         \

--- a/c_glib/arrow-glib/input-stream.h
+++ b/c_glib/arrow-glib/input-stream.h
@@ -38,7 +38,6 @@ struct _GArrowInputStreamClass
 };
 
 GArrowTensor *garrow_input_stream_read_tensor(GArrowInputStream *input_stream,
-                                              gint64 position,
                                               GError **error);
 
 #define GARROW_TYPE_SEEKABLE_INPUT_STREAM       \

--- a/c_glib/test/test-tensor.rb
+++ b/c_glib/test/test-tensor.rb
@@ -120,7 +120,6 @@ class TestTensor < Test::Unit::TestCase
     output = Arrow::BufferOutputStream.new(buffer)
     output.write_tensor(@tensor)
     input = Arrow::BufferInputStream.new(buffer)
-    assert_equal(@tensor,
-                 input.read_tensor(0))
+    assert_equal(@tensor, input.read_tensor())
   end
 end

--- a/c_glib/test/test-tensor.rb
+++ b/c_glib/test/test-tensor.rb
@@ -120,6 +120,6 @@ class TestTensor < Test::Unit::TestCase
     output = Arrow::BufferOutputStream.new(buffer)
     output.write_tensor(@tensor)
     input = Arrow::BufferInputStream.new(buffer)
-    assert_equal(@tensor, input.read_tensor())
+    assert_equal(@tensor, input.read_tensor)
   end
 end

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -179,7 +179,7 @@ if ("${COMPILER_FAMILY}" STREQUAL "msvc")
 endif()
 
 if ("${COMPILER_FAMILY}" STREQUAL "gcc" AND
-    "${COMPILER_VERSION}" VERSION_GREATER "7.0")
+    "${COMPILER_VERSION}" VERSION_GREATER "6.0")
   # Without this, gcc >= 7 warns related to changes in C++17
   set(CXX_ONLY_FLAGS "${CXX_ONLY_FLAGS} -Wno-noexcept-type")
 endif()

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -178,7 +178,8 @@ if ("${COMPILER_FAMILY}" STREQUAL "msvc")
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /wd4800")
 endif()
 
-if ("${COMPILER_FAMILY}" STREQUAL "gcc")
+if ("${COMPILER_FAMILY}" STREQUAL "gcc" AND
+    "${COMPILER_VERSION}" VERSION_GREATER "7.0")
   # Without this, gcc >= 7 warns related to changes in C++17
   set(CXX_ONLY_FLAGS "${CXX_ONLY_FLAGS} -Wno-noexcept-type")
 endif()

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -144,7 +144,7 @@ class ARROW_EXPORT Buffer {
   static std::shared_ptr<Buffer> Wrap(const std::vector<T>& data) {
     return std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(data.data()),
                                     static_cast<int64_t>(sizeof(T) * data.size()));
-  }  // namespace arrow
+  }
 
   /// \brief Copy buffer contents into a new std::string
   /// \return std::string

--- a/cpp/src/arrow/flight/flight-benchmark.cc
+++ b/cpp/src/arrow/flight/flight-benchmark.cc
@@ -156,7 +156,8 @@ Status RunPerformanceTest(const int port) {
 
   // Elapsed time in seconds
   uint64_t elapsed_nanos = timer.Stop();
-  double time_elapsed = elapsed_nanos / static_cast<double>(1000000000LL);
+  double time_elapsed =
+      static_cast<double>(elapsed_nanos) / static_cast<double>(1000000000);
 
   constexpr double kMegabyte = static_cast<double>(1 << 20);
 
@@ -167,8 +168,9 @@ Status RunPerformanceTest(const int port) {
 
   std::cout << "Bytes read: " << stats.total_bytes << std::endl;
   std::cout << "Nanos: " << elapsed_nanos << std::endl;
-  std::cout << "Speed: " << (stats.total_bytes / time_elapsed / kMegabyte) << " MB/s"
-            << std::endl;
+  std::cout << "Speed: "
+            << (static_cast<double>(stats.total_bytes) / kMegabyte / time_elapsed)
+            << " MB/s" << std::endl;
   return Status::OK();
 }
 

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -146,7 +146,7 @@ class SerializationTraits<IpcPayload> {
       pb_stream.WriteRawMaybeAliased(buffer->data(), static_cast<int>(buffer->size()));
 
       // Write padding if not multiple of 8
-      const int remainder = buffer->size() % 8;
+      const int remainder = static_cast<int>(buffer->size() % 8);
       if (remainder) {
         pb_stream.WriteRawMaybeAliased(kPaddingBytes, 8 - remainder);
       }

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -28,6 +28,11 @@ namespace io {
 
 FileInterface::~FileInterface() = default;
 
+Status InputStream::Advance(int64_t nbytes) {
+  std::shared_ptr<Buffer> temp;
+  return Read(nbytes, &temp);
+}
+
 struct RandomAccessFile::RandomAccessFileImpl {
   std::mutex lock_;
 };

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -115,6 +115,9 @@ class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writable 
 
 class ARROW_EXPORT InputStream : virtual public FileInterface, public Readable {
  public:
+  /// \brief Advance or skip stream indicated number of bytes
+  /// \param[in] nbytes the number to move forward
+  /// \return Status
   Status Advance(int64_t nbytes);
 
  protected:

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -114,6 +114,9 @@ class ARROW_EXPORT OutputStream : virtual public FileInterface, public Writable 
 };
 
 class ARROW_EXPORT InputStream : virtual public FileInterface, public Readable {
+ public:
+  Status Advance(int64_t nbytes);
+
  protected:
   InputStream() = default;
 };

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -51,6 +51,10 @@ Status BufferOutputStream::Create(int64_t initial_capacity, MemoryPool* pool,
   return Status::OK();
 }
 
+Status BufferOutputStream::Create(std::shared_ptr<BufferOutputStream>* out) {
+  return Create(1024, default_memory_pool(), out);
+}
+
 BufferOutputStream::~BufferOutputStream() {
   // This can fail, better to explicitly call close
   if (buffer_) {

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -51,10 +51,6 @@ Status BufferOutputStream::Create(int64_t initial_capacity, MemoryPool* pool,
   return Status::OK();
 }
 
-Status BufferOutputStream::Create(std::shared_ptr<BufferOutputStream>* out) {
-  return Create(1024, default_memory_pool(), out);
-}
-
 BufferOutputStream::~BufferOutputStream() {
   // This can fail, better to explicitly call close
   if (buffer_) {

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -40,6 +40,17 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
  public:
   explicit BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer);
 
+  /// \brief Create in-memory output stream with a default capacity of 1K using
+  /// the default memory pool
+  /// \param[out] out the created stream
+  static Status Create(std::shared_ptr<BufferOutputStream>* out);
+
+  /// \brief Create in-memory output stream with indicated capacity using a
+  /// memory pool
+  /// \param[in] initial_capacity the initial allocated internal capacity of
+  /// the OutputStream
+  /// \param[in,out] pool a MemoryPool to use for allocations
+  /// \param[out] out the created stream
   static Status Create(int64_t initial_capacity, MemoryPool* pool,
                        std::shared_ptr<BufferOutputStream>* out);
 

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -40,11 +40,6 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
  public:
   explicit BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer);
 
-  /// \brief Create in-memory output stream with a default capacity of 1K using
-  /// the default memory pool
-  /// \param[out] out the created stream
-  static Status Create(std::shared_ptr<BufferOutputStream>* out);
-
   /// \brief Create in-memory output stream with indicated capacity using a
   /// memory pool
   /// \param[in] initial_capacity the initial allocated internal capacity of

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -826,6 +826,7 @@ TEST_F(TestTensorRoundTrip, BasicRoundtrip) {
   std::vector<int64_t> shape_2 = {1, 1};
   std::vector<int64_t> strides_2 = {8, 8};
   Tensor t0_not_multiple_64(int64(), data, shape_2, strides_2, dim_names);
+  CheckTensorRoundTrip(t0_not_multiple_64);
 }
 
 TEST_F(TestTensorRoundTrip, NonContiguous) {

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -200,6 +200,8 @@ Status Message::SerializeTo(io::OutputStream* stream, int32_t alignment,
     RETURN_NOT_OK(stream->Write(body_buffer->data(), body_buffer->size()));
     *output_length += body_buffer->size();
 
+    DCHECK_GE(this->body_length(), body_buffer->size());
+
     int64_t remainder = this->body_length() - body_buffer->size();
     RETURN_NOT_OK(WritePadding(stream, remainder));
     *output_length += remainder;

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -258,6 +258,16 @@ Status AlignStream(io::OutputStream* stream, int64_t alignment) {
   return Status::OK();
 }
 
+Status CheckAligned(io::FileInterface* stream, int64_t alignment) {
+  int64_t current_position;
+  ARROW_RETURN_NOT_OK(stream->Tell(&current_position));
+  if (current_position % alignment != 0) {
+    return Status::Invalid("Stream is not aligned");
+  } else {
+    return Status::OK();
+  }
+}
+
 Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message) {
   int32_t message_length = 0;
   int64_t bytes_read = 0;

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -245,10 +245,7 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
 Status AlignStream(io::InputStream* stream, int64_t alignment) {
   int64_t position = -1;
   RETURN_NOT_OK(stream->Tell(&position));
-  int64_t aligned_position = PaddedLength(position, alignment);
-  int64_t num_extra_bytes = aligned_position - position;
-  std::shared_ptr<Buffer> dummy_buffer;
-  return stream->Read(num_extra_bytes, &dummy_buffer);
+  return stream->Advance(PaddedLength(position, alignment) - position);
 }
 
 Status AlignStream(io::OutputStream* stream, int64_t alignment) {

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -34,6 +34,7 @@ class Buffer;
 
 namespace io {
 
+class FileInterface;
 class InputStream;
 class OutputStream;
 class RandomAccessFile;
@@ -212,6 +213,11 @@ Status AlignStream(io::InputStream* stream, int64_t alignment = 8);
 /// \return Status
 ARROW_EXPORT
 Status AlignStream(io::OutputStream* stream, int64_t alignment = 8);
+
+/// \brief Return error Status if file position is not a multiple of the
+/// indicated alignment
+ARROW_EXPORT
+Status CheckAligned(io::FileInterface* stream, int64_t alignment = 8);
 
 /// \brief Read encapsulated RPC message (metadata and body) from InputStream
 ///

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -140,9 +140,11 @@ class ARROW_EXPORT Message {
   /// \brief Write length-prefixed metadata and body to output stream
   ///
   /// \param[in] file output stream to write to
+  /// \param[in] body_alignment
   /// \param[out] output_length the number of bytes written
   /// \return Status
-  Status SerializeTo(io::OutputStream* file, int64_t* output_length) const;
+  Status SerializeTo(io::OutputStream* file, int64_t body_alignment,
+                     int64_t* output_length) const;
 
  private:
   // Hide serialization details from user API
@@ -192,19 +194,29 @@ ARROW_EXPORT
 Status ReadMessage(const int64_t offset, const int32_t metadata_length,
                    io::RandomAccessFile* file, std::unique_ptr<Message>* message);
 
+/// \brief Advance stream to an 8-byte offset if its position is not a multiple
+/// of 8 already
+/// \param[in] stream an input stream
+/// \param[in] alignment the byte multiple for the metadata prefix, usually 8
+/// or 64, to ensure the body starts on a multiple of that alignment
+/// \return Status
+ARROW_EXPORT
+Status AlignStream(io::InputStream* stream, int64_t alignment = 8);
+
+/// \brief Advance stream to an 8-byte offset if its position is not a multiple
+/// of 8 already
+/// \param[in] stream an output stream
+/// \param[in] alignment the byte multiple for the metadata prefix, usually 8
+/// or 64, to ensure the body starts on a multiple of that alignment
+/// \return Status
+ARROW_EXPORT
+Status AlignStream(io::OutputStream* stream, int64_t alignment = 8);
+
 /// \brief Read encapsulated RPC message (metadata and body) from InputStream
 ///
 /// Read length-prefixed message with as-yet unknown length. Returns null if
 /// there are not enough bytes available or the message length is 0 (e.g. EOS
 /// in a stream)
-ARROW_EXPORT
-Status ReadMessage(io::InputStream* stream, bool aligned,
-                   std::unique_ptr<Message>* message);
-
-/// \brief Read encapsulated RPC message (metadata and body) from InputStream.
-///
-/// This is a version of ReadMessage that does not have the aligned argument
-/// for backwards compatibility.
 ARROW_EXPORT
 Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message);
 

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -140,10 +140,11 @@ class ARROW_EXPORT Message {
   /// \brief Write length-prefixed metadata and body to output stream
   ///
   /// \param[in] file output stream to write to
-  /// \param[in] body_alignment
+  /// \param[in] alignment byte alignment for metadata and body, usually 8
+  /// or 64
   /// \param[out] output_length the number of bytes written
   /// \return Status
-  Status SerializeTo(io::OutputStream* file, int64_t body_alignment,
+  Status SerializeTo(io::OutputStream* file, int64_t alignment,
                      int64_t* output_length) const;
 
  private:

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -141,12 +141,17 @@ class ARROW_EXPORT Message {
   /// \brief Write length-prefixed metadata and body to output stream
   ///
   /// \param[in] file output stream to write to
-  /// \param[in] alignment byte alignment for metadata and body, usually 8
-  /// or 64
+  /// \param[in] alignment byte alignment for metadata, usually 8 or
+  /// 64. Whether the body is padded depends on the metadata; if the body
+  /// buffer is smaller than the size indicated in the metadata, then extra
+  /// padding bytes will be written
   /// \param[out] output_length the number of bytes written
   /// \return Status
-  Status SerializeTo(io::OutputStream* file, int64_t alignment,
+  Status SerializeTo(io::OutputStream* file, int32_t alignment,
                      int64_t* output_length) const;
+
+  /// \brief Return true if the Message metadata passes Flatbuffer validation
+  bool Verify() const;
 
  private:
   // Hide serialization details from user API
@@ -203,7 +208,7 @@ Status ReadMessage(const int64_t offset, const int32_t metadata_length,
 /// or 64, to ensure the body starts on a multiple of that alignment
 /// \return Status
 ARROW_EXPORT
-Status AlignStream(io::InputStream* stream, int64_t alignment = 8);
+Status AlignStream(io::InputStream* stream, int32_t alignment = 8);
 
 /// \brief Advance stream to an 8-byte offset if its position is not a multiple
 /// of 8 already
@@ -212,12 +217,12 @@ Status AlignStream(io::InputStream* stream, int64_t alignment = 8);
 /// or 64, to ensure the body starts on a multiple of that alignment
 /// \return Status
 ARROW_EXPORT
-Status AlignStream(io::OutputStream* stream, int64_t alignment = 8);
+Status AlignStream(io::OutputStream* stream, int32_t alignment = 8);
 
 /// \brief Return error Status if file position is not a multiple of the
 /// indicated alignment
 ARROW_EXPORT
-Status CheckAligned(io::FileInterface* stream, int64_t alignment = 8);
+Status CheckAligned(io::FileInterface* stream, int32_t alignment = 8);
 
 /// \brief Read encapsulated RPC message (metadata and body) from InputStream
 ///

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -682,18 +682,6 @@ static Status SchemaToFlatbuffer(FBB& fbb, const Schema& schema,
   return Status::OK();
 }
 
-Status WriteFlatbufferBuilder(FBB& fbb, std::shared_ptr<Buffer>* out) {
-  int32_t size = fbb.GetSize();
-
-  std::shared_ptr<Buffer> result;
-  RETURN_NOT_OK(AllocateBuffer(default_memory_pool(), size, &result));
-
-  uint8_t* dst = result->mutable_data();
-  memcpy(dst, fbb.GetBufferPointer(), size);
-  *out = result;
-  return Status::OK();
-}
-
 static Status WriteFBMessage(FBB& fbb, flatbuf::MessageHeader header_type,
                              flatbuffers::Offset<void> header, int64_t body_length,
                              std::shared_ptr<Buffer>* out) {

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -780,7 +780,7 @@ Status WriteTensorMessage(const Tensor& tensor, int64_t buffer_start_offset,
   auto fb_shape = fbb.CreateVector(dims);
   auto fb_strides = fbb.CreateVector(tensor.strides());
 
-  int64_t body_length = PaddedLength(tensor.size() * elem_size, kTensorAlignment);
+  int64_t body_length = tensor.size() * elem_size;
   flatbuf::Buffer buffer(buffer_start_offset, body_length);
 
   TensorOffset fb_tensor =

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -682,7 +682,7 @@ static Status SchemaToFlatbuffer(FBB& fbb, const Schema& schema,
   return Status::OK();
 }
 
-static Status WriteFlatbufferBuilder(FBB& fbb, std::shared_ptr<Buffer>* out) {
+Status WriteFlatbufferBuilder(FBB& fbb, std::shared_ptr<Buffer>* out) {
   int32_t size = fbb.GetSize();
 
   std::shared_ptr<Buffer> result;
@@ -957,7 +957,7 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
 // ----------------------------------------------------------------------
 // Implement message writing
 
-Status WriteMessage(const Buffer& message, int64_t alignment, io::OutputStream* file,
+Status WriteMessage(const Buffer& message, int32_t alignment, io::OutputStream* file,
                     int32_t* message_length) {
   // ARROW-3212: We do not make assumptions that the output stream is aligned
   int32_t padded_message_length = static_cast<int32_t>(message.size()) + 4;

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -776,6 +776,9 @@ Status WriteTensorMessage(const Tensor& tensor, int64_t buffer_start_offset,
 
   FBB fbb;
 
+  const auto& type = checked_cast<const FixedWidthType&>(*tensor.type());
+  const int elem_size = type.bit_width() / 8;
+
   flatbuf::Type fb_type_type;
   Offset fb_type;
   RETURN_NOT_OK(TensorTypeToFlatbuffer(fbb, *tensor.type(), &fb_type_type, &fb_type));
@@ -788,7 +791,8 @@ Status WriteTensorMessage(const Tensor& tensor, int64_t buffer_start_offset,
 
   auto fb_shape = fbb.CreateVector(dims);
   auto fb_strides = fbb.CreateVector(tensor.strides());
-  int64_t body_length = tensor.data()->size();
+
+  int64_t body_length = PaddedLength(tensor.size() * elem_size, kTensorAlignment);
   flatbuf::Buffer buffer(buffer_start_offset, body_length);
 
   TensorOffset fb_tensor =

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -109,7 +109,7 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
 /// \param[out] message_length the total size of the payload written including
 /// padding
 /// \return Status
-Status WriteMessage(const Buffer& message, int64_t alignment, io::OutputStream* file,
+Status WriteMessage(const Buffer& message, int32_t alignment, io::OutputStream* file,
                     int32_t* message_length);
 
 // Serialize arrow::Schema as a Flatbuffer
@@ -138,6 +138,9 @@ Status WriteDictionaryMessage(const int64_t id, const int64_t length,
                               const int64_t body_length,
                               const std::vector<FieldMetadata>& nodes,
                               const std::vector<BufferMetadata>& buffers,
+                              std::shared_ptr<Buffer>* out);
+
+Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
                               std::shared_ptr<Buffer>* out);
 
 }  // namespace internal

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/buffer.h"
 #include "arrow/ipc/Schema_generated.h"
 #include "arrow/ipc/dictionary.h"
 #include "arrow/ipc/message.h"
@@ -140,8 +141,19 @@ Status WriteDictionaryMessage(const int64_t id, const int64_t length,
                               const std::vector<BufferMetadata>& buffers,
                               std::shared_ptr<Buffer>* out);
 
-Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
-                              std::shared_ptr<Buffer>* out);
+
+static inline Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
+                                            std::shared_ptr<Buffer>* out) {
+  int32_t size = fbb.GetSize();
+
+  std::shared_ptr<Buffer> result;
+  RETURN_NOT_OK(AllocateBuffer(default_memory_pool(), size, &result));
+
+  uint8_t* dst = result->mutable_data();
+  memcpy(dst, fbb.GetBufferPointer(), size);
+  *out = result;
+  return Status::OK();
+}
 
 }  // namespace internal
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -105,7 +105,7 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
 /// \param[in] message a buffer containing the metadata to write
 /// \param[in] alignment the size multiple of the total message size including
 /// length prefix, metadata, and padding. Usually 8 or 64
-/// \param[in,ou] file the OutputStream to write to
+/// \param[in,out] file the OutputStream to write to
 /// \param[out] message_length the total size of the payload written including
 /// padding
 /// \return Status

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -97,10 +97,19 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
                          std::vector<std::string>* dim_names);
 
 /// Write a serialized message metadata with a length-prefix and padding to an
-/// 8-byte offset
+/// 8-byte offset. Does not make assumptions about whether the stream is
+/// aligned already
 ///
 /// <message_size: int32><message: const void*><padding>
-Status WriteMessage(const Buffer& message, io::OutputStream* file,
+///
+/// \param[in] message a buffer containing the metadata to write
+/// \param[in] alignment the size multiple of the total message size including
+/// length prefix, metadata, and padding. Usually 8 or 64
+/// \param[in,ou] file the OutputStream to write to
+/// \param[out] message_length the total size of the payload written including
+/// padding
+/// \return Status
+Status WriteMessage(const Buffer& message, int64_t alignment, io::OutputStream* file,
                     int32_t* message_length);
 
 // Serialize arrow::Schema as a Flatbuffer

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -141,7 +141,6 @@ Status WriteDictionaryMessage(const int64_t id, const int64_t length,
                               const std::vector<BufferMetadata>& buffers,
                               std::shared_ptr<Buffer>* out);
 
-
 static inline Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
                                             std::shared_ptr<Buffer>* out) {
   int32_t size = fbb.GetSize();

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -695,18 +695,13 @@ Status RecordBatchFileReader::ReadRecordBatch(int i,
   return impl_->ReadRecordBatch(i, batch);
 }
 
-static Status ReadContiguousPayload(io::InputStream* file, bool aligned,
+static Status ReadContiguousPayload(io::InputStream* file,
                                     std::unique_ptr<Message>* message) {
-  RETURN_NOT_OK(ReadMessage(file, aligned, message));
+  RETURN_NOT_OK(ReadMessage(file, message));
   if (*message == nullptr) {
     return Status::Invalid("Unable to read metadata at offset");
   }
   return Status::OK();
-}
-
-static Status ReadContiguousPayload(io::InputStream* file,
-                                    std::unique_ptr<Message>* message) {
-  return ReadContiguousPayload(file, false /* aligned */, message);
 }
 
 Status ReadSchema(io::InputStream* stream, std::shared_ptr<Schema>* out) {
@@ -727,12 +722,8 @@ Status ReadRecordBatch(const std::shared_ptr<Schema>& schema, io::InputStream* f
 
 Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
                   std::shared_ptr<Tensor>* out) {
-  // Respect alignment of Tensor messages (see WriteTensor)
-  offset = PaddedLength(offset);
-  RETURN_NOT_OK(file->Seek(offset));
-
   std::unique_ptr<Message> message;
-  RETURN_NOT_OK(ReadContiguousPayload(file, true /* aligned */, &message));
+  RETURN_NOT_OK(ReadContiguousPayload(file, &message));
   return ReadTensor(*message, out);
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -720,8 +720,7 @@ Status ReadRecordBatch(const std::shared_ptr<Schema>& schema, io::InputStream* f
                          out);
 }
 
-Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
-                  std::shared_ptr<Tensor>* out) {
+Status ReadTensor(io::InputStream* file, std::shared_ptr<Tensor>* out) {
   std::unique_ptr<Message> message;
   RETURN_NOT_OK(ReadContiguousPayload(file, &message));
   return ReadTensor(*message, out);

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -219,15 +219,13 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
                        int max_recursion_depth, io::RandomAccessFile* file,
                        std::shared_ptr<RecordBatch>* out);
 
-/// \brief EXPERIMENTAL: Read arrow::Tensor as encapsulated IPC message in file
+/// \brief Read arrow::Tensor as encapsulated IPC message in file
 ///
-/// \param[in] offset the file location of the start of the message
-/// \param[in] file the file where the batch is located
+/// \param[in] file an InputStream pointed at the start of the message
 /// \param[out] out the read tensor
 /// \return Status
 ARROW_EXPORT
-Status ReadTensor(int64_t offset, io::RandomAccessFile* file,
-                  std::shared_ptr<Tensor>* out);
+Status ReadTensor(io::InputStream* file, std::shared_ptr<Tensor>* out);
 
 /// \brief EXPERIMENTAL: Read arrow::Tensor from IPC message
 ///

--- a/cpp/src/arrow/ipc/util.h
+++ b/cpp/src/arrow/ipc/util.h
@@ -28,17 +28,17 @@ namespace arrow {
 namespace ipc {
 
 // Buffers are padded to 64-byte boundaries (for SIMD)
-static constexpr int kArrowAlignment = 64;
+static constexpr int32_t kArrowAlignment = 64;
 
 // Tensors are padded to 64-byte boundaries
-static constexpr int kTensorAlignment = 64;
+static constexpr int32_t kTensorAlignment = 64;
 
 // Align on 8-byte boundaries in IPC
-static constexpr int kArrowIpcAlignment = 8;
+static constexpr int32_t kArrowIpcAlignment = 8;
 
 static constexpr uint8_t kPaddingBytes[kArrowAlignment] = {0};
 
-static inline int64_t PaddedLength(int64_t nbytes, int64_t alignment = kArrowAlignment) {
+static inline int64_t PaddedLength(int64_t nbytes, int32_t alignment = kArrowAlignment) {
   return ((nbytes + alignment - 1) / alignment) * alignment;
 }
 

--- a/cpp/src/arrow/ipc/util.h
+++ b/cpp/src/arrow/ipc/util.h
@@ -30,6 +30,9 @@ namespace ipc {
 // Buffers are padded to 64-byte boundaries (for SIMD)
 static constexpr int kArrowAlignment = 64;
 
+// Tensors are padded to 64-byte boundaries
+static constexpr int kTensorAlignment = 64;
+
 // Align on 8-byte boundaries in IPC
 static constexpr int kArrowIpcAlignment = 8;
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -746,7 +746,7 @@ class StreamBookKeeper {
     return Status::OK();
   }
 
-  Status Align(int64_t alignment = kArrowIpcAlignment) {
+  Status Align(int32_t alignment = kArrowIpcAlignment) {
     // Adds padding bytes if necessary to ensure all memory blocks are written on
     // 8-byte (or other alignment) boundaries.
     int64_t remainder = PaddedLength(position_, alignment) - position_;

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -647,12 +647,6 @@ Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadat
                                          scratch_space->mutable_data(), dst));
   }
 
-  // Write padding bytes after body, if any, for alignment
-  const int64_t remainder = *body_length % kTensorAlignment;
-  if (remainder != 0) {
-    RETURN_NOT_OK(dst->Write(kPaddingBytes, kTensorAlignment - remainder));
-    *body_length += kTensorAlignment - remainder;
-  }
   return Status::OK();
 }
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -482,7 +482,8 @@ class DictionaryWriter : public RecordBatchSerializer {
 
 Status WriteIpcPayload(const IpcPayload& payload, io::OutputStream* dst,
                        int32_t* metadata_length) {
-  RETURN_NOT_OK(internal::WriteMessage(*payload.metadata, 8, dst, metadata_length));
+  RETURN_NOT_OK(internal::WriteMessage(*payload.metadata, kArrowIpcAlignment, dst,
+                                       metadata_length));
 
 #ifndef NDEBUG
   RETURN_NOT_OK(CheckAligned(dst));

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -256,11 +256,14 @@ ARROW_EXPORT
 Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
                         std::unique_ptr<Message>* out);
 
-/// \brief EXPERIMENTAL: Write arrow::Tensor as a contiguous message
+/// \brief Write arrow::Tensor as a contiguous message. The metadata and body
+/// are written assuming 64-byte alignment. It is the user's responsibility to
+/// ensure that the OutputStream has been aligned to a 64-byte multiple before
+/// writing the message.
 ///
 /// \param[in] tensor the Tensor to write
 /// \param[in] dst the OutputStream to write to
-/// \param[out] metadata_length the actual metadata length
+/// \param[out] metadata_length the actual metadata length, including padding
 /// \param[out] body_length the acutal message body length
 /// \return Status
 ///

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -32,6 +32,7 @@
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
 #include "arrow/ipc/reader.h"
+#include "arrow/ipc/util.h"
 #include "arrow/table.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
@@ -272,6 +273,11 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
   for (int i = 0; i < num_tensors; ++i) {
     std::shared_ptr<Tensor> tensor;
     RETURN_NOT_OK(ipc::ReadTensor(src, &tensor));
+
+#ifndef NDEBUG
+    RETURN_NOT_OK(ipc::CheckAligned(src, ipc::kTensorAlignment));
+#endif
+
     out->tensors.push_back(tensor);
   }
 

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -267,8 +267,10 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
   RETURN_NOT_OK(src->Tell(&offset));
   offset += 4;  // Skip the end-of-stream message
   for (int i = 0; i < num_tensors; ++i) {
+    RETURN_NOT_OK(ipc::AlignStream(src, 64));
+
     std::shared_ptr<Tensor> tensor;
-    RETURN_NOT_OK(ipc::ReadTensor(offset, src, &tensor));
+    RETURN_NOT_OK(ipc::ReadTensor(src, &tensor));
     out->tensors.push_back(tensor);
     RETURN_NOT_OK(src->Tell(&offset));
   }

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -268,16 +268,12 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
   RETURN_NOT_OK(src->Advance(4));
 
   /// Align stream so tensor bodies are 64-byte aligned
-  RETURN_NOT_OK(ipc::AlignStream(src, 64));
+  RETURN_NOT_OK(ipc::AlignStream(src, ipc::kTensorAlignment));
 
   for (int i = 0; i < num_tensors; ++i) {
     std::shared_ptr<Tensor> tensor;
     RETURN_NOT_OK(ipc::ReadTensor(src, &tensor));
-
-#ifndef NDEBUG
-    RETURN_NOT_OK(ipc::CheckAligned(src, ipc::kTensorAlignment));
-#endif
-
+    RETURN_NOT_OK(ipc::AlignStream(src, ipc::kTensorAlignment));
     out->tensors.push_back(tensor);
   }
 

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -760,6 +760,9 @@ Status SerializedPyObject::WriteTo(io::OutputStream* dst) {
       dst->Write(reinterpret_cast<const uint8_t*>(&num_buffers), sizeof(int32_t)));
   RETURN_NOT_OK(ipc::WriteRecordBatchStream({this->batch}, dst));
 
+  // Align stream to 64-byte offset so tensor bodies are 64-byte aligned
+  RETURN_NOT_OK(ipc::AlignStream(dst, 64));
+
   int32_t metadata_length;
   int64_t body_length;
   for (const auto& tensor : this->tensors) {

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -32,6 +32,7 @@
 #include "arrow/builder.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
+#include "arrow/ipc/util.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/memory_pool.h"
 #include "arrow/record_batch.h"
@@ -767,6 +768,9 @@ Status SerializedPyObject::WriteTo(io::OutputStream* dst) {
   int64_t body_length;
   for (const auto& tensor : this->tensors) {
     RETURN_NOT_OK(ipc::WriteTensor(*tensor, dst, &metadata_length, &body_length));
+#ifndef NDEBUG
+    RETURN_NOT_OK(ipc::CheckAligned(dst, ipc::kTensorAlignment));
+#endif
   }
 
   for (const auto& buffer : this->buffers) {

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -768,9 +768,7 @@ Status SerializedPyObject::WriteTo(io::OutputStream* dst) {
   int64_t body_length;
   for (const auto& tensor : this->tensors) {
     RETURN_NOT_OK(ipc::WriteTensor(*tensor, dst, &metadata_length, &body_length));
-#ifndef NDEBUG
-    RETURN_NOT_OK(ipc::CheckAligned(dst, ipc::kTensorAlignment));
-#endif
+    RETURN_NOT_OK(ipc::AlignStream(dst, 64));
   }
 
   for (const auto& buffer : this->buffers) {

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -762,13 +762,13 @@ Status SerializedPyObject::WriteTo(io::OutputStream* dst) {
   RETURN_NOT_OK(ipc::WriteRecordBatchStream({this->batch}, dst));
 
   // Align stream to 64-byte offset so tensor bodies are 64-byte aligned
-  RETURN_NOT_OK(ipc::AlignStream(dst, 64));
+  RETURN_NOT_OK(ipc::AlignStream(dst, ipc::kTensorAlignment));
 
   int32_t metadata_length;
   int64_t body_length;
   for (const auto& tensor : this->tensors) {
     RETURN_NOT_OK(ipc::WriteTensor(*tensor, dst, &metadata_length, &body_length));
-    RETURN_NOT_OK(ipc::AlignStream(dst, 64));
+    RETURN_NOT_OK(ipc::AlignStream(dst, ipc::kTensorAlignment));
   }
 
   for (const auto& buffer : this->buffers) {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -780,7 +780,8 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MetadataVersion metadata_version()
         MessageType type()
 
-        CStatus SerializeTo(OutputStream* stream, int64_t* output_length)
+        CStatus SerializeTo(OutputStream* stream, int64_t alignment,
+                            int64_t* output_length)
 
     c_string FormatMessageType(MessageType type)
 
@@ -848,8 +849,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
                         int32_t* metadata_length,
                         int64_t* body_length)
 
-    CStatus ReadTensor(int64_t offset, RandomAccessFile* file,
-                       shared_ptr[CTensor]* out)
+    CStatus ReadTensor(InputStream* stream, shared_ptr[CTensor]* out)
 
     CStatus ReadRecordBatch(const CMessage& message,
                             const shared_ptr[CSchema]& schema,
@@ -867,6 +867,9 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     CStatus ReadRecordBatch(const shared_ptr[CSchema]& schema,
                             InputStream* stream,
                             shared_ptr[CRecordBatch]* out)
+
+    CStatus AlignStream(InputStream* stream, int64_t alignment)
+    CStatus AlignStream(OutputStream* stream, int64_t alignment)
 
     cdef cppclass CFeatherWriter" arrow::ipc::feather::TableWriter":
         @staticmethod

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -780,7 +780,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MetadataVersion metadata_version()
         MessageType type()
 
-        CStatus SerializeTo(OutputStream* stream, int64_t alignment,
+        CStatus SerializeTo(OutputStream* stream, int32_t alignment,
                             int64_t* output_length)
 
     c_string FormatMessageType(MessageType type)

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -78,7 +78,7 @@ cdef class Message:
         cdef:
             BufferOutputStream stream = BufferOutputStream(memory_pool)
             int64_t output_length = 0
-            int64_t c_alignment = alignment
+            int32_t c_alignment = alignment
 
         with nogil:
             check_status(self.message.get()

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -60,12 +60,14 @@ cdef class Message:
             result = self.message.get().Equals(deref(other.message.get()))
         return result
 
-    def serialize(self, memory_pool=None):
+    def serialize(self, alignment=8, memory_pool=None):
         """
         Write message as encapsulated IPC message
 
         Parameters
         ----------
+        alignment : int, default 8
+            Byte alignment for metadata and body
         memory_pool : MemoryPool, default None
             Uses default memory pool if not specified
 
@@ -76,10 +78,11 @@ cdef class Message:
         cdef:
             BufferOutputStream stream = BufferOutputStream(memory_pool)
             int64_t output_length = 0
+            int64_t c_alignment = alignment
 
         with nogil:
             check_status(self.message.get()
-                         .SerializeTo(stream.wr_file.get(),
+                         .SerializeTo(stream.wr_file.get(), c_alignment,
                                       &output_length))
         return stream.getvalue()
 
@@ -440,10 +443,10 @@ def write_tensor(Tensor tensor, NativeFile dest):
 
 
 def read_tensor(NativeFile source):
-    """
-    Read pyarrow.Tensor from pyarrow.NativeFile object from current
+    """Read pyarrow.Tensor from pyarrow.NativeFile object from current
     position. If the file source supports zero copy (e.g. a memory map), then
-    this operation does not allocate any memory
+    this operation does not allocate any memory. This function not assume that
+    the stream is aligned
 
     Parameters
     ----------
@@ -452,16 +455,14 @@ def read_tensor(NativeFile source):
     Returns
     -------
     tensor : Tensor
+
     """
     cdef:
         shared_ptr[CTensor] sp_tensor
 
     source._assert_readable()
-
-    cdef int64_t offset = source.tell()
     with nogil:
-        check_status(ReadTensor(offset, source.rd_file.get(), &sp_tensor))
-
+        check_status(ReadTensor(source.rd_file.get(), &sp_tensor))
     return pyarrow_wrap_tensor(sp_tensor)
 
 

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -63,6 +63,13 @@ except ImportError:
     pass
 
 
+try:
+    import tensorflow  # noqa
+    defaults['tensorflow'] = True
+except ImportError:
+    pass
+
+
 def pytest_configure(config):
     pass
 

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -640,6 +640,18 @@ def test_serialize_to_components_invalid_cases():
         pa.deserialize_components(components)
 
 
+def test_serialize_read_concatenated_records():
+    # ARROW-1996 -- see stream alignment work in ARROW-2840, ARROW-3212
+    f = pa.BufferOutputStream()
+    pa.serialize_to(12, f)
+    pa.serialize_to(23, f)
+    buf = f.getvalue()
+
+    f = pa.BufferReader(buf)
+    pa.read_serialized(f).deserialize()
+    pa.read_serialized(f).deserialize()
+
+
 @pytest.mark.skipif(os.name == 'nt', reason="deserialize_regex not pickleable")
 def test_deserialize_in_different_process():
     from multiprocessing import Process, Queue


### PR DESCRIPTION
The detail of whether an `InputStream` or `OutputStream` is aligned to 8- or 64-byte boundary had contaminated a number of IPC functions, causing generated metadata (plus padding, if any) to be non-deterministic. This introduces a new `ipc::AlignStream` function and the desired use is to align the stream at the highest level possible. I've implemented the changes in the Python tensor serialization code paths. I removed various cruft where alignment issues leaked into the API

This also resolves ARROW-2840, ARROW-2027, ARROW-2776, ARROW-1996