### PR TITLE
ARROW-3256,3304: [JS] fix file footer inconsistency, yield all messages from the stream reader

### DIFF
--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -30,6 +30,7 @@ import { Schema, Field, Type } from './type';
 import { Table, DataFrame, NextFunc, BindFunc, CountByResult } from './table';
 import { fromReadableStream } from './ipc/reader/node';
 import { read, readAsync, readStream } from './ipc/reader/arrow';
+import { readBuffersAsync, readRecordBatchesAsync } from './ipc/reader/arrow';
 import { serializeFile, serializeStream } from './ipc/writer/binary';
 
 export import View = vector_.View;
@@ -41,6 +42,7 @@ export import TypedArrayConstructor = type_.TypedArrayConstructor;
 
 export { fromReadableStream };
 export { read, readAsync, readStream };
+export { readBuffersAsync, readRecordBatchesAsync };
 export { serializeFile, serializeStream };
 export { Table, DataFrame, NextFunc, BindFunc, CountByResult };
 export { Field, Schema, RecordBatch, Vector, Type };

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -215,6 +215,8 @@ try {
         Arrow['readAsync'] = readAsync;
         Arrow['readStream'] = readStream;
         Arrow['fromReadableStream'] = fromReadableStream;
+        Arrow['readBuffersAsync'] = readBuffersAsync;
+        Arrow['readRecordBatchesAsync'] = readRecordBatchesAsync;
 
         Arrow['serializeFile'] = serializeFile;
         Arrow['serializeStream'] = serializeStream;

--- a/js/src/ipc/metadata.ts
+++ b/js/src/ipc/metadata.ts
@@ -17,7 +17,6 @@
 
 /* tslint:disable:class-name */
 
-import { align } from '../util/bit';
 import { Schema, Long, MessageHeader, MetadataVersion } from '../type';
 
 export class Footer {
@@ -53,7 +52,7 @@ export class RecordBatchMetadata extends Message {
     public buffers: BufferMetadata[];
     constructor(version: MetadataVersion, length: Long | number, nodes: FieldMetadata[], buffers: BufferMetadata[], bodyLength?: Long | number) {
         if (bodyLength === void(0)) {
-            bodyLength = buffers.reduce((s, b) => align(s + b.length + (b.offset - s), 8), 0);
+            bodyLength = buffers.reduce((bodyLength, buffer) => bodyLength + buffer.length, 0);
         }
         super(version, bodyLength, MessageHeader.RecordBatch);
         this.nodes = nodes;

--- a/js/src/ipc/reader/binary.ts
+++ b/js/src/ipc/reader/binary.ts
@@ -39,7 +39,7 @@ import {
 
 import ByteBuffer = flatbuffers.ByteBuffer;
 
-type MessageReader = (bb: ByteBuffer) => IterableIterator<RecordBatchMetadata | DictionaryBatch>;
+type MessageReader = (bb: ByteBuffer) => IterableIterator<Message>;
 
 export function* readBuffers<T extends Uint8Array | Buffer | string>(sources: Iterable<T> | Uint8Array | Buffer | string) {
     let schema: Schema | null = null;
@@ -56,8 +56,8 @@ export function* readBuffers<T extends Uint8Array | Buffer | string>(sources: It
                     schema, message,
                     loader: new BinaryDataLoader(
                         bb,
-                        arrayIterator(message.nodes),
-                        arrayIterator(message.buffers),
+                        arrayIterator((message as any).nodes || []),
+                        arrayIterator((message as any).buffers || []),
                         dictionaries
                     )
                 };
@@ -78,8 +78,8 @@ export async function* readBuffersAsync<T extends Uint8Array | Buffer | string>(
                     schema, message,
                     loader: new BinaryDataLoader(
                         bb,
-                        arrayIterator(message.nodes),
-                        arrayIterator(message.buffers),
+                        arrayIterator((message as any).nodes || []),
+                        arrayIterator((message as any).buffers || []),
                         dictionaries
                     )
                 };
@@ -148,7 +148,7 @@ function* readStreamMessages(bb: ByteBuffer) {
         } else if (Message.isDictionaryBatch(message)) {
             yield message;
         } else {
-            continue;
+            yield message;
         }
         // position the buffer after the body to read the next message
         bb.setPosition(bb.position() + message.bodyLength);

--- a/js/src/ipc/reader/node.ts
+++ b/js/src/ipc/reader/node.ts
@@ -29,6 +29,10 @@ export async function* fromReadableStream(stream: NodeJS.ReadableStream) {
 
     for await (let chunk of (stream as any as AsyncIterable<Uint8Array | Buffer | string>)) {
 
+        if (chunk == null) {
+            continue;
+        }
+
         const grown = new Uint8Array(bytes.byteLength + chunk.length);
 
         if (typeof chunk !== 'string') {
@@ -54,7 +58,7 @@ export async function* fromReadableStream(stream: NodeJS.ReadableStream) {
             messageLength = new DataView(bytes.buffer).getInt32(0, true);
         }
 
-        while (messageLength < bytes.byteLength) {
+        while (messageLength > 0 && messageLength <= bytes.byteLength) {
             if (!message) {
                 (bb = new ByteBuffer(bytes)).setPosition(4);
                 if (message = _Message.getRootAsMessage(bb)) {

--- a/js/src/util/node.ts
+++ b/js/src/util/node.ts
@@ -88,6 +88,6 @@ function wait(stream: NodeJS.WritableStream, done: boolean, write: (x?: any) => 
         stream['once']('error', write);
         stream['once']('drain', write);
     } else if (!(!p || stream === p.stdout) && !(stream as any)['isTTY']) {
-        stream['end'](<any> null);
+        stream['end']();
     }
 }


### PR DESCRIPTION
Yield all messages from the stream reader to support reading multiple tables from the same source stream. This is something a stream-reader refactor should support out of the box, but this PR adds this ability to master until that refactor is done. I added [an integration test](https://github.com/trxcllnt/arrow/blob/6c58f4aea84c7eebdd807f67d066d93d9348b110/js/test/integration/validate-tests.ts#L195) that shows what such a reader would look like today.