### PR TITLE
ARROW-3305: [JS] Incorrect development documentation link in javascript readme

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -194,7 +194,7 @@ Index,   origin_city
 
 # Getting involved
 
-See [develop.md](https://github.com/apache/arrow/blob/master/develop.md)
+See [DEVELOP.md](DEVELOP.md)
 
 Even if you do not plan to contribute to Apache Arrow itself or Arrow
 integrations in other projects, we'd be happy to have you involved:


### PR DESCRIPTION
Can try it out [here](https://github.com/apache/arrow/blob/fefd5ed4d5d238a9e2e31fde6d76ccf0ad0efe74/js/README.md#getting-involved)