### PR TITLE
ARROW-2555: [C++/Python] Allow Parquet-Arrow writer to truncate timestamps instead of failing

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -73,7 +73,6 @@ endif()
 
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
-set(CLANG_FORMAT_VERSION "6.0")
 find_package(ClangTools)
 if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
   # Generate a Clang compile_commands.json "compilation database" file for use

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
+set(CLANG_FORMAT_VERSION "6.0")
 find_package(ClangTools)
 if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
   # Generate a Clang compile_commands.json "compilation database" file for use

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1391,6 +1391,17 @@ TEST(TestArrowReadWrite, CoerceTimestampsLosePrecision) {
   ASSERT_RAISES(Invalid, WriteTable(*t4, ::arrow::default_memory_pool(), sink, 10,
                                     default_writer_properties(), coerce_millis));
 
+  // OK to lose precision if we explicitly allow it
+  auto allow_truncation =
+      (ArrowWriterProperties::Builder()
+        .coerce_timestamps(TimeUnit::MILLI)
+        ->allow_truncated_timestamps()
+        ->build());
+  ASSERT_OK_NO_THROW(WriteTable(*t3, ::arrow::default_memory_pool(), sink, 10,
+                                default_writer_properties(), allow_truncation));
+  ASSERT_OK_NO_THROW(WriteTable(*t4, ::arrow::default_memory_pool(), sink, 10,
+                                default_writer_properties(), allow_truncation));
+
   // OK to write micros to micros
   auto coerce_micros =
       (ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::MICRO)->build());

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1392,11 +1392,10 @@ TEST(TestArrowReadWrite, CoerceTimestampsLosePrecision) {
                                     default_writer_properties(), coerce_millis));
 
   // OK to lose precision if we explicitly allow it
-  auto allow_truncation =
-      (ArrowWriterProperties::Builder()
-        .coerce_timestamps(TimeUnit::MILLI)
-        ->allow_truncated_timestamps()
-        ->build());
+  auto allow_truncation = (ArrowWriterProperties::Builder()
+                               .coerce_timestamps(TimeUnit::MILLI)
+                               ->allow_truncated_timestamps()
+                               ->build());
   ASSERT_OK_NO_THROW(WriteTable(*t3, ::arrow::default_memory_pool(), sink, 10,
                                 default_writer_properties(), allow_truncation));
   ASSERT_OK_NO_THROW(WriteTable(*t4, ::arrow::default_memory_pool(), sink, 10,

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -366,9 +366,9 @@ class ArrowColumnWriter {
   Status WriteTimestamps(const Array& data, int64_t num_levels, const int16_t* def_levels,
                          const int16_t* rep_levels);
 
-  Status WriteTimestampsCoerce(const bool truncated_timestamps_allowed,
-                               const Array& data, int64_t num_levels,
-                               const int16_t* def_levels, const int16_t* rep_levels);
+  Status WriteTimestampsCoerce(const bool truncated_timestamps_allowed, const Array& data,
+                               int64_t num_levels, const int16_t* def_levels,
+                               const int16_t* rep_levels);
 
   template <typename ParquetType, typename ArrowType>
   Status WriteNonNullableBatch(const ArrowType& type, int64_t num_values,
@@ -655,8 +655,7 @@ Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncated_timestamps_
 
   auto DivideBy = [&](const int64_t factor) {
     for (int64_t i = 0; i < array.length(); i++) {
-      if (!truncated_timestamps_allowed && !data.IsNull(i) &&
-          (values[i] % factor != 0)) {
+      if (!truncated_timestamps_allowed && !data.IsNull(i) && (values[i] % factor != 0)) {
         std::stringstream ss;
         ss << "Casting from " << type.ToString() << " to " << target_type->ToString()
            << " would lose data: " << values[i];

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -627,9 +627,8 @@ Status ArrowColumnWriter::WriteTimestamps(const Array& values, int64_t num_level
     // Casting is required. This covers several cases
     // * Nanoseconds -> cast to microseconds
     // * coerce_timestamps_enabled_, cast all timestamps to requested unit
-    return WriteTimestampsCoerce(
-        ctx_->properties->truncated_timestamps_allowed(),
-        values, num_levels, def_levels, rep_levels);
+    return WriteTimestampsCoerce(ctx_->properties->truncated_timestamps_allowed(), values,
+                                 num_levels, def_levels, rep_levels);
   } else {
     // No casting of timestamps is required, take the fast path
     return TypedWriteBatch<Int64Type, ::arrow::TimestampType>(values, num_levels,
@@ -656,8 +655,8 @@ Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncating_timestamps
 
   auto DivideBy = [&](const int64_t factor) {
     for (int64_t i = 0; i < array.length(); i++) {
-      if (!truncating_timestamps_allowed &&
-          !data.IsNull(i) && (values[i] % factor != 0)) {
+      if (!truncating_timestamps_allowed && !data.IsNull(i) &&
+          (values[i] % factor != 0)) {
         std::stringstream ss;
         ss << "Casting from " << type.ToString() << " to " << target_type->ToString()
            << " would lose data: " << values[i];

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -366,7 +366,8 @@ class ArrowColumnWriter {
   Status WriteTimestamps(const Array& data, int64_t num_levels, const int16_t* def_levels,
                          const int16_t* rep_levels);
 
-  Status WriteTimestampsCoerce(const Array& data, int64_t num_levels,
+  Status WriteTimestampsCoerce(const bool truncating_timestamps_allowed,
+                               const Array& data, int64_t num_levels,
                                const int16_t* def_levels, const int16_t* rep_levels);
 
   template <typename ParquetType, typename ArrowType>
@@ -626,7 +627,9 @@ Status ArrowColumnWriter::WriteTimestamps(const Array& values, int64_t num_level
     // Casting is required. This covers several cases
     // * Nanoseconds -> cast to microseconds
     // * coerce_timestamps_enabled_, cast all timestamps to requested unit
-    return WriteTimestampsCoerce(values, num_levels, def_levels, rep_levels);
+    return WriteTimestampsCoerce(
+        ctx_->properties->truncated_timestamps_allowed(),
+        values, num_levels, def_levels, rep_levels);
   } else {
     // No casting of timestamps is required, take the fast path
     return TypedWriteBatch<Int64Type, ::arrow::TimestampType>(values, num_levels,
@@ -634,7 +637,8 @@ Status ArrowColumnWriter::WriteTimestamps(const Array& values, int64_t num_level
   }
 }
 
-Status ArrowColumnWriter::WriteTimestampsCoerce(const Array& array, int64_t num_levels,
+Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncating_timestamps_allowed,
+                                                const Array& array, int64_t num_levels,
                                                 const int16_t* def_levels,
                                                 const int16_t* rep_levels) {
   int64_t* buffer;
@@ -652,7 +656,8 @@ Status ArrowColumnWriter::WriteTimestampsCoerce(const Array& array, int64_t num_
 
   auto DivideBy = [&](const int64_t factor) {
     for (int64_t i = 0; i < array.length(); i++) {
-      if (!data.IsNull(i) && (values[i] % factor != 0)) {
+      if (!truncating_timestamps_allowed &&
+          !data.IsNull(i) && (values[i] % factor != 0)) {
         std::stringstream ss;
         ss << "Casting from " << type.ToString() << " to " << target_type->ToString()
            << " would lose data: " << values[i];

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -366,7 +366,7 @@ class ArrowColumnWriter {
   Status WriteTimestamps(const Array& data, int64_t num_levels, const int16_t* def_levels,
                          const int16_t* rep_levels);
 
-  Status WriteTimestampsCoerce(const bool truncating_timestamps_allowed,
+  Status WriteTimestampsCoerce(const bool truncated_timestamps_allowed,
                                const Array& data, int64_t num_levels,
                                const int16_t* def_levels, const int16_t* rep_levels);
 
@@ -636,7 +636,7 @@ Status ArrowColumnWriter::WriteTimestamps(const Array& values, int64_t num_level
   }
 }
 
-Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncating_timestamps_allowed,
+Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncated_timestamps_allowed,
                                                 const Array& array, int64_t num_levels,
                                                 const int16_t* def_levels,
                                                 const int16_t* rep_levels) {
@@ -655,7 +655,7 @@ Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncating_timestamps
 
   auto DivideBy = [&](const int64_t factor) {
     for (int64_t i = 0; i < array.length(); i++) {
-      if (!truncating_timestamps_allowed && !data.IsNull(i) &&
+      if (!truncated_timestamps_allowed && !data.IsNull(i) &&
           (values[i] % factor != 0)) {
         std::stringstream ss;
         ss << "Casting from " << type.ToString() << " to " << target_type->ToString()

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -45,9 +45,9 @@ class PARQUET_EXPORT ArrowWriterProperties {
   class Builder {
    public:
     Builder()
-      : write_nanos_as_int96_(false),
-        coerce_timestamps_enabled_(false),
-        truncated_timestamps_allowed_(false) {}
+        : write_nanos_as_int96_(false),
+          coerce_timestamps_enabled_(false),
+          truncated_timestamps_allowed_(false) {}
     virtual ~Builder() {}
 
     Builder* disable_deprecated_int96_timestamps() {
@@ -77,11 +77,8 @@ class PARQUET_EXPORT ArrowWriterProperties {
     }
 
     std::shared_ptr<ArrowWriterProperties> build() {
-      return std::shared_ptr<ArrowWriterProperties>(
-        new ArrowWriterProperties(
-          write_nanos_as_int96_,
-          coerce_timestamps_enabled_,
-          coerce_timestamps_unit_,
+      return std::shared_ptr<ArrowWriterProperties>(new ArrowWriterProperties(
+          write_nanos_as_int96_, coerce_timestamps_enabled_, coerce_timestamps_unit_,
           truncated_timestamps_allowed_));
     }
 

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -44,7 +44,10 @@ class PARQUET_EXPORT ArrowWriterProperties {
  public:
   class Builder {
    public:
-    Builder() : write_nanos_as_int96_(false), coerce_timestamps_enabled_(false) {}
+    Builder()
+      : write_nanos_as_int96_(false),
+        coerce_timestamps_enabled_(false),
+        truncated_timestamps_allowed_(false) {}
     virtual ~Builder() {}
 
     Builder* disable_deprecated_int96_timestamps() {
@@ -63,9 +66,23 @@ class PARQUET_EXPORT ArrowWriterProperties {
       return this;
     }
 
+    Builder* allow_truncated_timestamps() {
+      truncated_timestamps_allowed_ = true;
+      return this;
+    }
+
+    Builder* disallow_truncated_timestamps() {
+      truncated_timestamps_allowed_ = false;
+      return this;
+    }
+
     std::shared_ptr<ArrowWriterProperties> build() {
-      return std::shared_ptr<ArrowWriterProperties>(new ArrowWriterProperties(
-          write_nanos_as_int96_, coerce_timestamps_enabled_, coerce_timestamps_unit_));
+      return std::shared_ptr<ArrowWriterProperties>(
+        new ArrowWriterProperties(
+          write_nanos_as_int96_,
+          coerce_timestamps_enabled_,
+          coerce_timestamps_unit_,
+          truncated_timestamps_allowed_));
     }
 
    private:
@@ -73,6 +90,7 @@ class PARQUET_EXPORT ArrowWriterProperties {
 
     bool coerce_timestamps_enabled_;
     ::arrow::TimeUnit::type coerce_timestamps_unit_;
+    bool truncated_timestamps_allowed_;
   };
 
   bool support_deprecated_int96_timestamps() const { return write_nanos_as_int96_; }
@@ -82,17 +100,22 @@ class PARQUET_EXPORT ArrowWriterProperties {
     return coerce_timestamps_unit_;
   }
 
+  bool truncated_timestamps_allowed() const { return truncated_timestamps_allowed_; }
+
  private:
   explicit ArrowWriterProperties(bool write_nanos_as_int96,
                                  bool coerce_timestamps_enabled,
-                                 ::arrow::TimeUnit::type coerce_timestamps_unit)
+                                 ::arrow::TimeUnit::type coerce_timestamps_unit,
+                                 bool truncated_timestamps_allowed)
       : write_nanos_as_int96_(write_nanos_as_int96),
         coerce_timestamps_enabled_(coerce_timestamps_enabled),
-        coerce_timestamps_unit_(coerce_timestamps_unit) {}
+        coerce_timestamps_unit_(coerce_timestamps_unit),
+        truncated_timestamps_allowed_(truncated_timestamps_allowed) {}
 
   const bool write_nanos_as_int96_;
   const bool coerce_timestamps_enabled_;
   const ::arrow::TimeUnit::type coerce_timestamps_unit_;
+  const bool truncated_timestamps_allowed_;
 };
 
 std::shared_ptr<ArrowWriterProperties> PARQUET_EXPORT default_arrow_writer_properties();

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -323,5 +323,7 @@ cdef extern from "parquet/arrow/writer.h" namespace "parquet::arrow" nogil:
             Builder* disable_deprecated_int96_timestamps()
             Builder* enable_deprecated_int96_timestamps()
             Builder* coerce_timestamps(TimeUnit unit)
+            Builder* allow_truncated_timestamps()
+            Builder* disallow_truncated_timestamps()
             shared_ptr[ArrowWriterProperties] build()
         c_bool support_deprecated_int96_timestamps()

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -874,7 +874,8 @@ cdef class ParquetWriter:
             raise ValueError('Invalid value for coerce_timestamps: {0}'
                              .format(self.coerce_timestamps))
 
-    cdef void _set_allow_truncated_timestamps(self, ArrowWriterProperties.Builder* props):
+    cdef void _set_allow_truncated_timestamps(
+            self, ArrowWriterProperties.Builder* props):
         if self.allow_truncated_timestamps:
             props.allow_truncated_timestamps()
         else:

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -804,6 +804,7 @@ cdef class ParquetWriter:
         object use_dictionary
         object use_deprecated_int96_timestamps
         object coerce_timestamps
+        object allow_truncated_timestamps
         object compression
         object version
         int row_group_size
@@ -812,7 +813,8 @@ cdef class ParquetWriter:
                   compression=None, version=None,
                   MemoryPool memory_pool=None,
                   use_deprecated_int96_timestamps=False,
-                  coerce_timestamps=None):
+                  coerce_timestamps=None,
+                  allow_truncated_timestamps=False):
         cdef:
             shared_ptr[WriterProperties] properties
             c_string c_where
@@ -835,6 +837,7 @@ cdef class ParquetWriter:
         self.version = version
         self.use_deprecated_int96_timestamps = use_deprecated_int96_timestamps
         self.coerce_timestamps = coerce_timestamps
+        self.allow_truncated_timestamps = allow_truncated_timestamps
 
         cdef WriterProperties.Builder properties_builder
         self._set_version(&properties_builder)
@@ -845,6 +848,7 @@ cdef class ParquetWriter:
         cdef ArrowWriterProperties.Builder arrow_properties_builder
         self._set_int96_support(&arrow_properties_builder)
         self._set_coerce_timestamps(&arrow_properties_builder)
+        self._set_allow_truncated_timestamps(&arrow_properties_builder)
         arrow_properties = arrow_properties_builder.build()
 
         pool = maybe_unbox_memory_pool(memory_pool)
@@ -869,6 +873,12 @@ cdef class ParquetWriter:
         elif self.coerce_timestamps is not None:
             raise ValueError('Invalid value for coerce_timestamps: {0}'
                              .format(self.coerce_timestamps))
+
+    cdef void _set_allow_truncated_timestamps(self, ArrowWriterProperties.Builder* props):
+        if self.allow_truncated_timestamps:
+            props.allow_truncated_timestamps()
+        else:
+            props.disallow_truncated_timestamps()
 
     cdef void _set_version(self, WriterProperties.Builder* props):
         if self.version is not None:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -246,6 +246,10 @@ use_deprecated_int96_timestamps : boolean, default None
 coerce_timestamps : string, default None
     Cast timestamps a particular resolution.
     Valid values: {None, 'ms', 'us'}
+allow_truncated_timestamps : boolean, default False
+    Allow loss of data when coercing timestamps to a particular
+    resolution. E.g. if microsecond or nanosecond data is lost when coercing to
+    'ms', do not raise an exception
 compression : str or dict
     Specify the compression codec, either on a general basis or per-column.
     Valid values: {'NONE', 'SNAPPY', 'GZIP', 'LZO', 'BROTLI', 'LZ4', 'ZSTD'}
@@ -1049,6 +1053,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 use_dictionary=True, compression='snappy',
                 use_deprecated_int96_timestamps=None,
                 coerce_timestamps=None,
+                allow_truncated_timestamps=False,
                 flavor=None, **kwargs):
     row_group_size = kwargs.pop('chunk_size', row_group_size)
     use_int96 = use_deprecated_int96_timestamps
@@ -1059,6 +1064,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 flavor=flavor,
                 use_dictionary=use_dictionary,
                 coerce_timestamps=coerce_timestamps,
+                allow_truncated_timestamps=allow_truncated_timestamps,
                 compression=compression,
                 use_deprecated_int96_timestamps=use_int96,
                 **kwargs) as writer:

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -767,15 +767,14 @@ def test_coerce_timestamps(tempdir):
                      coerce_timestamps='unknown')
 
 
-    _write_table(arrow_table, filename, version="2.0", coerce_timestamps='ms')
-
-
 def test_coerce_timestamps_truncated(tempdir):
     """
     ARROW-2555: Test that we can truncate timestamps when coercing if explicitly allowed.
     """
-    dt_us = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1, second=1, microsecond=1)
-    dt_ms = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1, second=1)
+    dt_us = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1,
+                              second=1, microsecond=1)
+    dt_ms = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1,
+                              second=1)
 
     fields_us = [pa.field('datetime64', pa.timestamp('us'))]
     arrays_us = {'datetime64': [dt_us, dt_ms]}
@@ -786,7 +785,8 @@ def test_coerce_timestamps_truncated(tempdir):
     filename = tempdir / 'pandas_truncated.parquet'
     table_us = pa.Table.from_pandas(df_us, schema=schema_us)
 
-    _write_table(table_us, filename, version="2.0", coerce_timestamps='ms', allow_truncated_timestamps=True)
+    _write_table(table_us, filename, version="2.0", coerce_timestamps='ms',
+                 allow_truncated_timestamps=True)
     table_ms = _read_table(filename)
     df_ms = table_ms.to_pandas()
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -767,6 +767,34 @@ def test_coerce_timestamps(tempdir):
                      coerce_timestamps='unknown')
 
 
+    _write_table(arrow_table, filename, version="2.0", coerce_timestamps='ms')
+
+
+def test_coerce_timestamps_truncated(tempdir):
+    """
+    ARROW-2555: Test that we can truncate timestamps when coercing if explicitly allowed.
+    """
+    dt_us = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1, second=1, microsecond=1)
+    dt_ms = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1, second=1)
+
+    fields_us = [pa.field('datetime64', pa.timestamp('us'))]
+    arrays_us = {'datetime64': [dt_us, dt_ms]}
+
+    df_us = pd.DataFrame(arrays_us)
+    schema_us = pa.schema(fields_us)
+
+    filename = tempdir / 'pandas_truncated.parquet'
+    table_us = pa.Table.from_pandas(df_us, schema=schema_us)
+
+    _write_table(table_us, filename, version="2.0", coerce_timestamps='ms', allow_truncated_timestamps=True)
+    table_ms = _read_table(filename)
+    df_ms = table_ms.to_pandas()
+
+    arrays_expected = {'datetime64': [dt_ms, dt_ms]}
+    df_expected = pd.DataFrame(arrays_expected)
+    tm.assert_frame_equal(df_expected, df_ms)
+
+
 def test_column_of_lists(tempdir):
     df, schema = dataframe_with_lists()
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -769,7 +769,8 @@ def test_coerce_timestamps(tempdir):
 
 def test_coerce_timestamps_truncated(tempdir):
     """
-    ARROW-2555: Test that we can truncate timestamps when coercing if explicitly allowed.
+    ARROW-2555: Test that we can truncate timestamps when coercing if
+    explicitly allowed.
     """
     dt_us = datetime.datetime(year=2017, month=1, day=1, hour=1, minute=1,
                               second=1, microsecond=1)


### PR DESCRIPTION
Plumbs an option `allow_truncated_timestamps` through ParquetWriter and the like.  If this option is set, it allows timestamps to be coerced from us to ms without complaining or crashing.