### PR TITLE
ARROW-3136: [C++] Clean up public API

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -50,6 +50,9 @@
 namespace liborc = orc;
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace adapters {
 namespace orc {
 

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -42,6 +42,8 @@ namespace arrow {
 using std::string;
 using std::vector;
 
+using internal::checked_cast;
+
 namespace {
 // used to prevent compiler optimizing away side-effect-less statements
 volatile int throw_away = 0;

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -40,7 +40,10 @@
 
 namespace arrow {
 
+using internal::BitmapAnd;
 using internal::checked_cast;
+using internal::CopyBitmap;
+using internal::CountSetBits;
 
 std::shared_ptr<ArrayData> ArrayData::Make(const std::shared_ptr<DataType>& type,
                                            int64_t length,

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -40,6 +40,8 @@
 
 namespace arrow {
 
+using internal::checked_cast;
+
 std::shared_ptr<ArrayData> ArrayData::Make(const std::shared_ptr<DataType>& type,
                                            int64_t length,
                                            std::vector<std::shared_ptr<Buffer>>&& buffers,

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -584,7 +584,8 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
  protected:
   inline void SetData(const std::shared_ptr<ArrayData>& data) {
     this->PrimitiveArray::SetData(data);
-    byte_width_ = checked_cast<const FixedSizeBinaryType&>(*type()).byte_width();
+    byte_width_ =
+        internal::checked_cast<const FixedSizeBinaryType&>(*type()).byte_width();
   }
 
   int32_t byte_width_;
@@ -694,7 +695,9 @@ class ARROW_EXPORT UnionArray : public Array {
   const type_id_t* raw_type_ids() const { return raw_type_ids_ + data_->offset; }
   const int32_t* raw_value_offsets() const { return raw_value_offsets_ + data_->offset; }
 
-  UnionMode::type mode() const { return checked_cast<const UnionType&>(*type()).mode(); }
+  UnionMode::type mode() const {
+    return internal::checked_cast<const UnionType&>(*type()).mode();
+  }
 
   // Return the given field as an individual array.
   // For sparse unions, the returned array has its offset, length and null

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -317,6 +317,7 @@ static inline std::ostream& operator<<(std::ostream& os, const Array& x) {
   return os;
 }
 
+/// Base class for non-nested arrays
 class ARROW_EXPORT FlatArray : public Array {
  protected:
   using Array::Array;
@@ -338,7 +339,7 @@ class ARROW_EXPORT NullArray : public FlatArray {
   }
 };
 
-/// Base class for fixed-size logical types
+/// Base class for arrays of fixed-size logical types
 class ARROW_EXPORT PrimitiveArray : public FlatArray {
  public:
   PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t length,
@@ -394,6 +395,7 @@ class ARROW_EXPORT NumericArray : public PrimitiveArray {
   using PrimitiveArray::PrimitiveArray;
 };
 
+/// Concrete Array class for boolean data
 class ARROW_EXPORT BooleanArray : public PrimitiveArray {
  public:
   using TypeClass = BooleanType;
@@ -416,6 +418,7 @@ class ARROW_EXPORT BooleanArray : public PrimitiveArray {
 // ----------------------------------------------------------------------
 // ListArray
 
+/// Concrete Array class for list data
 class ARROW_EXPORT ListArray : public Array {
  public:
   using TypeClass = ListType;
@@ -473,6 +476,7 @@ class ARROW_EXPORT ListArray : public Array {
 // ----------------------------------------------------------------------
 // Binary and String
 
+/// Concrete Array class for variable-size binary data
 class ARROW_EXPORT BinaryArray : public FlatArray {
  public:
   using TypeClass = BinaryType;
@@ -540,6 +544,7 @@ class ARROW_EXPORT BinaryArray : public FlatArray {
   const uint8_t* raw_data_;
 };
 
+/// Concrete Array class for variable-size string (utf-8) data
 class ARROW_EXPORT StringArray : public BinaryArray {
  public:
   using TypeClass = StringType;
@@ -563,6 +568,7 @@ class ARROW_EXPORT StringArray : public BinaryArray {
 // ----------------------------------------------------------------------
 // Fixed width binary
 
+/// Concrete Array class for fixed-size binary data
 class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
  public:
   using TypeClass = FixedSizeBinaryType;
@@ -593,6 +599,8 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
 
 // ----------------------------------------------------------------------
 // Decimal128Array
+
+/// Concrete Array class for 128-bit decimal data
 class ARROW_EXPORT Decimal128Array : public FixedSizeBinaryArray {
  public:
   using TypeClass = Decimal128Type;
@@ -611,6 +619,7 @@ using DecimalArray = Decimal128Array;
 // ----------------------------------------------------------------------
 // Struct
 
+/// Concrete Array class for struct data
 class ARROW_EXPORT StructArray : public Array {
  public:
   using TypeClass = StructType;
@@ -641,6 +650,7 @@ class ARROW_EXPORT StructArray : public Array {
 // ----------------------------------------------------------------------
 // Union
 
+/// Concrete Array class for union data
 class ARROW_EXPORT UnionArray : public Array {
  public:
   using TypeClass = UnionType;
@@ -721,21 +731,23 @@ class ARROW_EXPORT UnionArray : public Array {
 // ----------------------------------------------------------------------
 // DictionaryArray (categorical and dictionary-encoded in memory)
 
-// A dictionary array contains an array of non-negative integers (the
-// "dictionary indices") along with a data type containing a "dictionary"
-// corresponding to the distinct values represented in the data.
-//
-// For example, the array
-//
-//   ["foo", "bar", "foo", "bar", "foo", "bar"]
-//
-// with dictionary ["bar", "foo"], would have dictionary array representation
-//
-//   indices: [1, 0, 1, 0, 1, 0]
-//   dictionary: ["bar", "foo"]
-//
-// The indices in principle may have any integer type (signed or unsigned),
-// though presently data in IPC exchanges must be signed int32.
+/// \brief Concrete Array class for dictionary data
+///
+/// A dictionary array contains an array of non-negative integers (the
+/// "dictionary indices") along with a data type containing a "dictionary"
+/// corresponding to the distinct values represented in the data.
+///
+/// For example, the array
+///
+///   ["foo", "bar", "foo", "bar", "foo", "bar"]
+///
+/// with dictionary ["bar", "foo"], would have dictionary array representation
+///
+///   indices: [1, 0, 1, 0, 1, 0]
+///   dictionary: ["bar", "foo"]
+///
+/// The indices in principle may have any integer type (signed or unsigned),
+/// though presently data in IPC exchanges must be signed int32.
 class ARROW_EXPORT DictionaryArray : public Array {
  public:
   using TypeClass = DictionaryType;

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -47,6 +47,7 @@
 namespace arrow {
 
 using internal::AdaptiveIntBuilderBase;
+using internal::checked_cast;
 
 namespace {
 

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -310,7 +310,7 @@ class ARROW_EXPORT PrimitiveBuilder : public ArrayBuilder {
   template <typename ValuesIter, typename ValidIter>
   typename std::enable_if<!std::is_pointer<ValidIter>::value, Status>::type AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
-    static_assert(!is_null_pointer<ValidIter>::value,
+    static_assert(!internal::is_null_pointer<ValidIter>::value,
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
                   "version instead");
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
@@ -727,7 +727,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   template <typename ValuesIter, typename ValidIter>
   typename std::enable_if<!std::is_pointer<ValidIter>::value, Status>::type AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
-    static_assert(!is_null_pointer<ValidIter>::value,
+    static_assert(!internal::is_null_pointer<ValidIter>::value,
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
                   "version instead");
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -35,6 +35,7 @@
 
 namespace arrow {
 
+using internal::BitmapEquals;
 using internal::checked_cast;
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -35,6 +35,8 @@
 
 namespace arrow {
 
+using internal::checked_cast;
+
 // ----------------------------------------------------------------------
 // Public method implementations
 

--- a/cpp/src/arrow/compute/context.cc
+++ b/cpp/src/arrow/compute/context.cc
@@ -26,7 +26,7 @@ namespace arrow {
 namespace compute {
 
 FunctionContext::FunctionContext(MemoryPool* pool)
-    : pool_(pool), cpu_info_(CpuInfo::GetInstance()) {}
+    : pool_(pool), cpu_info_(internal::CpuInfo::GetInstance()) {}
 
 MemoryPool* FunctionContext::memory_pool() const { return pool_; }
 

--- a/cpp/src/arrow/compute/context.h
+++ b/cpp/src/arrow/compute/context.h
@@ -27,7 +27,9 @@
 
 namespace arrow {
 
+namespace internal {
 class CpuInfo;
+}  // namespace internal
 
 namespace compute {
 
@@ -63,12 +65,12 @@ class ARROW_EXPORT FunctionContext {
   /// \brief Return the current status of the context
   const Status& status() const { return status_; }
 
-  CpuInfo* cpu_info() const { return cpu_info_; }
+  internal::CpuInfo* cpu_info() const { return cpu_info_; }
 
  private:
   Status status_;
   MemoryPool* pool_;
-  CpuInfo* cpu_info_;
+  internal::CpuInfo* cpu_info_;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/boolean.cc
+++ b/cpp/src/arrow/compute/kernels/boolean.cc
@@ -24,6 +24,14 @@
 #include <vector>
 
 namespace arrow {
+
+using internal::BitmapAnd;
+using internal::BitmapOr;
+using internal::BitmapXor;
+using internal::CopyBitmap;
+using internal::CountSetBits;
+using internal::InvertBitmap;
+
 namespace compute {
 
 class InvertKernel : public UnaryKernel {

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -73,6 +73,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::CopyBitmap;
 
 namespace compute {
 

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -71,6 +71,9 @@
 #endif  // ARROW_EXTRA_ERROR_CONTEXT
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace compute {
 
 constexpr int64_t kMillisecondsInDay = 86400000;

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -35,6 +35,9 @@
 #include "arrow/util/hash.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace compute {
 
 // TODO(wesm): Enable top-level dispatch to SSE4 hashing if it is enabled

--- a/cpp/src/arrow/flight/flight-benchmark.cc
+++ b/cpp/src/arrow/flight/flight-benchmark.cc
@@ -43,9 +43,11 @@ DEFINE_int32(records_per_batch, 4096, "Total records per batch within stream");
 
 namespace perf = arrow::flight::perf;
 
-using ThreadPool = ::arrow::internal::ThreadPool;
-
 namespace arrow {
+
+using internal::StopWatch;
+using internal::ThreadPool;
+
 namespace flight {
 
 struct PerformanceStats {

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -32,6 +32,9 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace io {
 
 class TestBufferOutputStream : public ::testing::Test {

--- a/cpp/src/arrow/io/io-readahead-test.cc
+++ b/cpp/src/arrow/io/io-readahead-test.cc
@@ -33,6 +33,9 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace io {
 namespace internal {
 

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -34,6 +34,9 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 namespace feather {
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -43,6 +43,9 @@
 #include "arrow/visitor.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 namespace feather {
 

--- a/cpp/src/arrow/ipc/ipc-read-write-test.cc
+++ b/cpp/src/arrow/ipc/ipc-read-write-test.cc
@@ -42,6 +42,9 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 
 using BatchVector = std::vector<std::shared_ptr<RecordBatch>>;

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -40,6 +40,9 @@
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 namespace internal {
 namespace json {

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -46,6 +46,7 @@
 namespace arrow {
 
 namespace flatbuf = org::apache::arrow::flatbuf;
+using internal::checked_cast;
 
 namespace ipc {
 namespace internal {

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -42,6 +42,9 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 
 using internal::FileBlock;

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -44,6 +44,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::CopyBitmap;
 
 namespace ipc {
 

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -35,6 +35,8 @@
 
 namespace arrow {
 
+using internal::checked_cast;
+
 class PrettyPrinter {
  public:
   PrettyPrinter(int indent, int indent_size, int window, std::ostream* sink)

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -58,6 +58,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::ParallelFor;
 
 namespace py {
 

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -56,6 +56,9 @@
 #include "arrow/python/util/datetime.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 using internal::kNanosecondsInDay;

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -45,6 +45,9 @@
 #include "arrow/python/util/datetime.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 Status CallDeserializeCallback(PyObject* context, PyObject* value,

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -33,6 +33,9 @@
 #include <arrow/api.h>
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 #define GET_PRIMITIVE_TYPE(NAME, FACTORY) \

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -59,6 +59,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::CopyBitmap;
 
 namespace py {
 

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -57,6 +57,9 @@
 #include "arrow/python/util/datetime.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 using internal::NumPyTypeSize;

--- a/cpp/src/arrow/python/python-test.cc
+++ b/cpp/src/arrow/python/python-test.cc
@@ -33,6 +33,9 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 TEST(PyBuffer, InvalidInputObject) {

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -47,6 +47,9 @@
 #include "arrow/python/util/datetime.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -50,6 +50,9 @@
 constexpr int32_t kMaxRecursionDepth = 100;
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace py {
 
 /// A Sequence is a heterogeneous collections of elements. It can contain

--- a/cpp/src/arrow/table_builder-test.cc
+++ b/cpp/src/arrow/table_builder-test.cc
@@ -33,6 +33,8 @@
 
 namespace arrow {
 
+using internal::checked_cast;
+
 class TestRecordBatchBuilder : public TestBase {
  public:
 };

--- a/cpp/src/arrow/table_builder.h
+++ b/cpp/src/arrow/table_builder.h
@@ -66,7 +66,7 @@ class ARROW_EXPORT RecordBatchBuilder {
   /// \return pointer to template type
   template <typename T>
   T* GetFieldAs(int i) {
-    return checked_cast<T*>(raw_field_builders_[i]);
+    return internal::checked_cast<T*>(raw_field_builders_[i]);
   }
 
   /// \brief Finish current batch and optionally reset

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -32,6 +32,8 @@
 
 namespace arrow {
 
+using internal::checked_cast;
+
 static void ComputeRowMajorStrides(const FixedWidthType& type,
                                    const std::vector<int64_t>& shape,
                                    std::vector<int64_t>* strides) {

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -34,6 +34,8 @@ using std::vector;
 
 namespace arrow {
 
+using internal::checked_cast;
+
 TEST(TestField, Basics) {
   Field f0("f0", int32());
   Field f0_nn("f0", int32(), false);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -34,6 +34,8 @@
 
 namespace arrow {
 
+using internal::checked_cast;
+
 bool Field::HasMetadata() const {
   return (metadata_ != nullptr) && (metadata_->size() > 0);
 }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -38,10 +38,8 @@ namespace arrow {
 
 /// \brief Main data type enumeration
 ///
-/// Data types in this library are all *logical*. They can be expressed as
-/// either a primitive physical type (bytes or bits of some fixed size), a
-/// nested type consisting of other data types, or another data type (e.g. a
-/// timestamp encoded as an int64)
+/// This enumeration provides a quick way to interrogate the category
+/// of a DataType instance.
 struct Type {
   enum type {
     /// A NULL type having no physical storage
@@ -134,6 +132,15 @@ struct Type {
   };
 };
 
+/// \brief Base class for all data types
+///
+/// Data types in this library are all *logical*. They can be expressed as
+/// either a primitive physical type (bytes or bits of some fixed size), a
+/// nested type consisting of other data types, or another data type (e.g. a
+/// timestamp encoded as an int64).
+///
+/// Simple datatypes may be entirely described by their Type id, but
+/// complex datatypes are usually parametric.
 class ARROW_EXPORT DataType {
  public:
   explicit DataType(Type::type id) : id_(id) {}
@@ -178,6 +185,7 @@ inline std::ostream& operator<<(std::ostream& os, const DataType& type) {
   return os;
 }
 
+/// \brief Base class for all fixed-width data types
 class ARROW_EXPORT FixedWidthType : public DataType {
  public:
   using DataType::DataType;
@@ -185,22 +193,26 @@ class ARROW_EXPORT FixedWidthType : public DataType {
   virtual int bit_width() const = 0;
 };
 
+/// \brief Base class for all data types representing primitive values
 class ARROW_EXPORT PrimitiveCType : public FixedWidthType {
  public:
   using FixedWidthType::FixedWidthType;
 };
 
+/// \brief Base class for all numeric data types
 class ARROW_EXPORT Number : public PrimitiveCType {
  public:
   using PrimitiveCType::PrimitiveCType;
 };
 
+/// \brief Base class for all integral data types
 class ARROW_EXPORT Integer : public Number {
  public:
   using Number::Number;
   virtual bool is_signed() const = 0;
 };
 
+/// \brief Base class for all floating-point data types
 class ARROW_EXPORT FloatingPoint : public Number {
  public:
   using Number::Number;
@@ -208,8 +220,7 @@ class ARROW_EXPORT FloatingPoint : public Number {
   virtual Precision precision() const = 0;
 };
 
-/// \class ParametricType
-/// \brief A superclass for types having additional metadata
+/// \brief Base class for all parametric data types
 class ParametricType {};
 
 class ARROW_EXPORT NestedType : public DataType, public ParametricType {
@@ -219,8 +230,13 @@ class ARROW_EXPORT NestedType : public DataType, public ParametricType {
 
 class NoExtraMeta {};
 
-// A field is a piece of metadata that includes (for now) a name and a data
-// type
+/// \brief The combination of a field name and data type, with optional metadata
+///
+/// Fields are used to describe the individual constituents of a
+/// nested DataType or a Schema.
+///
+/// A field's metadata is represented by a KeyValueMetadata instance,
+/// which holds arbitrary key-value pairs.
 class ARROW_EXPORT Field {
  public:
   Field(const std::string& name, const std::shared_ptr<DataType>& type,
@@ -287,6 +303,7 @@ class IntegerTypeImpl : public detail::CTypeImpl<DERIVED, Integer, TYPE_ID, C_TY
 
 }  // namespace detail
 
+/// Concrete type class for always-null data
 class ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
  public:
   static constexpr Type::type type_id = Type::NA;
@@ -299,6 +316,7 @@ class ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
   std::string name() const override { return "null"; }
 };
 
+/// Concrete type class for boolean data
 class ARROW_EXPORT BooleanType : public FixedWidthType, public NoExtraMeta {
  public:
   static constexpr Type::type type_id = Type::BOOL;
@@ -312,54 +330,63 @@ class ARROW_EXPORT BooleanType : public FixedWidthType, public NoExtraMeta {
   std::string name() const override { return "bool"; }
 };
 
+/// Concrete type class for unsigned 8-bit integer data
 class ARROW_EXPORT UInt8Type
     : public detail::IntegerTypeImpl<UInt8Type, Type::UINT8, uint8_t> {
  public:
   std::string name() const override { return "uint8"; }
 };
 
+/// Concrete type class for signed 8-bit integer data
 class ARROW_EXPORT Int8Type
     : public detail::IntegerTypeImpl<Int8Type, Type::INT8, int8_t> {
  public:
   std::string name() const override { return "int8"; }
 };
 
+/// Concrete type class for unsigned 16-bit integer data
 class ARROW_EXPORT UInt16Type
     : public detail::IntegerTypeImpl<UInt16Type, Type::UINT16, uint16_t> {
  public:
   std::string name() const override { return "uint16"; }
 };
 
+/// Concrete type class for signed 16-bit integer data
 class ARROW_EXPORT Int16Type
     : public detail::IntegerTypeImpl<Int16Type, Type::INT16, int16_t> {
  public:
   std::string name() const override { return "int16"; }
 };
 
+/// Concrete type class for unsigned 32-bit integer data
 class ARROW_EXPORT UInt32Type
     : public detail::IntegerTypeImpl<UInt32Type, Type::UINT32, uint32_t> {
  public:
   std::string name() const override { return "uint32"; }
 };
 
+/// Concrete type class for signed 32-bit integer data
 class ARROW_EXPORT Int32Type
     : public detail::IntegerTypeImpl<Int32Type, Type::INT32, int32_t> {
  public:
   std::string name() const override { return "int32"; }
 };
 
+/// Concrete type class for unsigned 64-bit integer data
 class ARROW_EXPORT UInt64Type
     : public detail::IntegerTypeImpl<UInt64Type, Type::UINT64, uint64_t> {
  public:
   std::string name() const override { return "uint64"; }
 };
 
+/// Concrete type class for signed 64-bit integer data
 class ARROW_EXPORT Int64Type
     : public detail::IntegerTypeImpl<Int64Type, Type::INT64, int64_t> {
  public:
   std::string name() const override { return "int64"; }
 };
 
+/// Concrete type class for 16-bit floating-point data
 class ARROW_EXPORT HalfFloatType
     : public detail::CTypeImpl<HalfFloatType, FloatingPoint, Type::HALF_FLOAT, uint16_t> {
  public:
@@ -367,6 +394,7 @@ class ARROW_EXPORT HalfFloatType
   std::string name() const override { return "halffloat"; }
 };
 
+/// Concrete type class for 32-bit floating-point data (C "float")
 class ARROW_EXPORT FloatType
     : public detail::CTypeImpl<FloatType, FloatingPoint, Type::FLOAT, float> {
  public:
@@ -374,6 +402,7 @@ class ARROW_EXPORT FloatType
   std::string name() const override { return "float"; }
 };
 
+/// Concrete type class for 64-bit floating-point data (C "double")
 class ARROW_EXPORT DoubleType
     : public detail::CTypeImpl<DoubleType, FloatingPoint, Type::DOUBLE, double> {
  public:
@@ -381,6 +410,11 @@ class ARROW_EXPORT DoubleType
   std::string name() const override { return "double"; }
 };
 
+/// \brief Concrete type class for list data
+///
+/// List data is nested data where each value is a variable number of
+/// child items.  Lists can be recursively nested, for example
+/// list(list(int32)).
 class ARROW_EXPORT ListType : public NestedType {
  public:
   static constexpr Type::type type_id = Type::LIST;
@@ -403,7 +437,7 @@ class ARROW_EXPORT ListType : public NestedType {
   std::string name() const override { return "list"; }
 };
 
-// BinaryType type is represents lists of 1-byte values.
+/// \brief Concrete type class for variable-size binary data
 class ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
  public:
   static constexpr Type::type type_id = Type::BINARY;
@@ -419,7 +453,7 @@ class ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
   explicit BinaryType(Type::type logical_type) : DataType(logical_type) {}
 };
 
-// BinaryType type is represents lists of 1-byte values.
+/// \brief Concrete type class for fixed-size binary data
 class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public ParametricType {
  public:
   static constexpr Type::type type_id = Type::FIXED_SIZE_BINARY;
@@ -440,7 +474,7 @@ class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public Parametri
   int32_t byte_width_;
 };
 
-// UTF-8 encoded strings
+/// \brief Concrete type class for variable-size string data, utf8-encoded
 class ARROW_EXPORT StringType : public BinaryType {
  public:
   static constexpr Type::type type_id = Type::STRING;
@@ -452,6 +486,7 @@ class ARROW_EXPORT StringType : public BinaryType {
   std::string name() const override { return "utf8"; }
 };
 
+/// \brief Concrete type class for struct data
 class ARROW_EXPORT StructType : public NestedType {
  public:
   static constexpr Type::type type_id = Type::STRUCT;
@@ -476,6 +511,7 @@ class ARROW_EXPORT StructType : public NestedType {
   mutable std::unordered_map<std::string, int> name_to_index_;
 };
 
+/// \brief Base type class for (fixed-size) decimal data
 class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
  public:
   explicit DecimalType(int32_t byte_width, int32_t precision, int32_t scale)
@@ -491,6 +527,7 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
   int32_t scale_;
 };
 
+/// \brief Concrete type class for 128-bit decimal data
 class ARROW_EXPORT Decimal128Type : public DecimalType {
  public:
   static constexpr Type::type type_id = Type::DECIMAL;
@@ -507,6 +544,7 @@ struct UnionMode {
   enum type { SPARSE, DENSE };
 };
 
+/// \brief Concrete type class for union data
 class ARROW_EXPORT UnionType : public NestedType {
  public:
   static constexpr Type::type type_id = Type::UNION;
@@ -537,6 +575,7 @@ class ARROW_EXPORT UnionType : public NestedType {
 
 enum class DateUnit : char { DAY = 0, MILLI = 1 };
 
+/// \brief Base type class for date data
 class ARROW_EXPORT DateType : public FixedWidthType {
  public:
   DateUnit unit() const { return unit_; }
@@ -546,7 +585,7 @@ class ARROW_EXPORT DateType : public FixedWidthType {
   DateUnit unit_;
 };
 
-/// Date as int32_t days since UNIX epoch
+/// Concrete type class for 32-bit date data (as number of days since UNIX epoch)
 class ARROW_EXPORT Date32Type : public DateType {
  public:
   static constexpr Type::type type_id = Type::DATE32;
@@ -563,7 +602,7 @@ class ARROW_EXPORT Date32Type : public DateType {
   std::string name() const override { return "date32"; }
 };
 
-/// Date as int64_t milliseconds since UNIX epoch
+/// Concrete type class for 64-bit date data (as number of milliseconds since UNIX epoch)
 class ARROW_EXPORT Date64Type : public DateType {
  public:
   static constexpr Type::type type_id = Type::DATE64;
@@ -602,6 +641,7 @@ static inline std::ostream& operator<<(std::ostream& os, TimeUnit::type unit) {
   return os;
 }
 
+/// Base type class for time data
 class ARROW_EXPORT TimeType : public FixedWidthType, public ParametricType {
  public:
   TimeUnit::type unit() const { return unit_; }
@@ -693,6 +733,7 @@ class ARROW_EXPORT IntervalType : public FixedWidthType {
 // ----------------------------------------------------------------------
 // DictionaryType (for categorical or dictionary-encoded data)
 
+/// Concrete type class for dictionary data
 class ARROW_EXPORT DictionaryType : public FixedWidthType {
  public:
   static constexpr Type::type type_id = Type::DICTIONARY;
@@ -789,55 +830,58 @@ class ARROW_EXPORT Schema {
 };
 
 // ----------------------------------------------------------------------
-// Factory functions
+// Parametric factory functions
+// Other factory functions are in type_fwd.h
 
-/// \brief Make an instance of FixedSizeBinaryType
+/// \brief Create a FixedSizeBinaryType instance
 ARROW_EXPORT
 std::shared_ptr<DataType> fixed_size_binary(int32_t byte_width);
 
-/// \brief Make an instance of DecimalType
+/// \brief Create a Decimal128Type instance
 ARROW_EXPORT
 std::shared_ptr<DataType> decimal(int32_t precision, int32_t scale);
 
-/// \brief Make an instance of ListType
+/// \brief Create a ListType instance from its child Field type
 ARROW_EXPORT
 std::shared_ptr<DataType> list(const std::shared_ptr<Field>& value_type);
 
-/// \brief Make an instance of ListType
+/// \brief Create a ListType instance from its child DataType
 ARROW_EXPORT
 std::shared_ptr<DataType> list(const std::shared_ptr<DataType>& value_type);
 
-/// \brief Make an instance of TimestampType
+/// \brief Create a TimestampType instance from its unit
 ARROW_EXPORT
 std::shared_ptr<DataType> timestamp(TimeUnit::type unit);
 
-/// \brief Make an instance of TimestampType
+/// \brief Create a TimestampType instance from its unit and timezone
 ARROW_EXPORT
 std::shared_ptr<DataType> timestamp(TimeUnit::type unit, const std::string& timezone);
 
-/// \brief Create an instance of 32-bit time type
+/// \brief Create a 32-bit time type instance
+///
 /// Unit can be either SECOND or MILLI
 std::shared_ptr<DataType> ARROW_EXPORT time32(TimeUnit::type unit);
 
-/// \brief Create an instance of 64-bit time type
+/// \brief Create a 64-bit time type instance
+///
 /// Unit can be either MICRO or NANO
 std::shared_ptr<DataType> ARROW_EXPORT time64(TimeUnit::type unit);
 
-/// \brief Create an instance of Struct type
+/// \brief Create a StructType instance
 std::shared_ptr<DataType> ARROW_EXPORT
 struct_(const std::vector<std::shared_ptr<Field>>& fields);
 
-/// \brief Create an instance of Union type
+/// \brief Create a UnionType instance
 std::shared_ptr<DataType> ARROW_EXPORT
 union_(const std::vector<std::shared_ptr<Field>>& child_fields,
        const std::vector<uint8_t>& type_codes, UnionMode::type mode = UnionMode::SPARSE);
 
-/// \brief Create and instance of Union type
+/// \brief Create a UnionType instance
 std::shared_ptr<DataType> ARROW_EXPORT
 union_(const std::vector<std::shared_ptr<Array>>& children,
        UnionMode::type mode = UnionMode::SPARSE);
 
-/// \brief Create an instance of Dictionary type
+/// \brief Create a DictionaryType instance
 std::shared_ptr<DataType> ARROW_EXPORT
 dictionary(const std::shared_ptr<DataType>& index_type,
            const std::shared_ptr<Array>& values, bool ordered = false);

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -274,7 +274,7 @@ class ARROW_EXPORT CTypeImpl : public BASE {
   int bit_width() const override { return static_cast<int>(sizeof(C_TYPE) * CHAR_BIT); }
 
   Status Accept(TypeVisitor* visitor) const override {
-    return visitor->Visit(checked_cast<const DERIVED&>(*this));
+    return visitor->Visit(internal::checked_cast<const DERIVED&>(*this));
   }
 
   std::string ToString() const override { return this->name(); }

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -135,26 +135,42 @@ using IntervalArray = NumericArray<IntervalType>;
 
 // ----------------------------------------------------------------------
 // (parameter-free) Factory functions
+// Other factory functions are in type.h
 
+/// \brief Return a NullType instance
 std::shared_ptr<DataType> ARROW_EXPORT null();
+/// \brief Return a BooleanType instance
 std::shared_ptr<DataType> ARROW_EXPORT boolean();
+/// \brief Return a Int8Type instance
 std::shared_ptr<DataType> ARROW_EXPORT int8();
+/// \brief Return a Int16Type instance
 std::shared_ptr<DataType> ARROW_EXPORT int16();
+/// \brief Return a Int32Type instance
 std::shared_ptr<DataType> ARROW_EXPORT int32();
+/// \brief Return a Int64Type instance
 std::shared_ptr<DataType> ARROW_EXPORT int64();
+/// \brief Return a UInt8Type instance
 std::shared_ptr<DataType> ARROW_EXPORT uint8();
+/// \brief Return a UInt16Type instance
 std::shared_ptr<DataType> ARROW_EXPORT uint16();
+/// \brief Return a UInt32Type instance
 std::shared_ptr<DataType> ARROW_EXPORT uint32();
+/// \brief Return a UInt64Type instance
 std::shared_ptr<DataType> ARROW_EXPORT uint64();
+/// \brief Return a HalfFloatType instance
 std::shared_ptr<DataType> ARROW_EXPORT float16();
+/// \brief Return a FloatType instance
 std::shared_ptr<DataType> ARROW_EXPORT float32();
+/// \brief Return a DoubleType instance
 std::shared_ptr<DataType> ARROW_EXPORT float64();
+/// \brief Return a StringType instance
 std::shared_ptr<DataType> ARROW_EXPORT utf8();
+/// \brief Return a BinaryType instance
 std::shared_ptr<DataType> ARROW_EXPORT binary();
-
+/// \brief Return a Date32Type instance
 std::shared_ptr<DataType> ARROW_EXPORT date32();
+/// \brief Return a Date64Type instance
 std::shared_ptr<DataType> ARROW_EXPORT date64();
-std::shared_ptr<DataType> ARROW_EXPORT decimal_type(int precision, int scale);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/util/bit-stream-utils.h
+++ b/cpp/src/arrow/util/bit-stream-utils.h
@@ -30,6 +30,7 @@
 #include "arrow/util/macros.h"
 
 namespace arrow {
+namespace BitUtil {
 
 /// Utility class to write bit/byte streams.  This class can write data to either be
 /// bit packed or byte aligned (and a single stream that has a mix of both).
@@ -403,6 +404,7 @@ inline bool BitReader::GetZigZagVlqInt(int32_t* v) {
   return true;
 }
 
+}  // namespace BitUtil
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_BIT_STREAM_UTILS_H

--- a/cpp/src/arrow/util/bit-util-benchmark.cc
+++ b/cpp/src/arrow/util/bit-util-benchmark.cc
@@ -26,6 +26,9 @@
 #include "arrow/util/bit-util.h"
 
 namespace arrow {
+
+using internal::CopyBitmap;
+
 namespace BitUtil {
 
 // A naive bitmap reader implementation, meant as a baseline against

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -39,6 +39,13 @@
 
 namespace arrow {
 
+using internal::BitmapAnd;
+using internal::BitmapOr;
+using internal::BitmapXor;
+using internal::CopyBitmap;
+using internal::CountSetBits;
+using internal::InvertBitmap;
+
 template <class BitmapWriter>
 void WriteVectorToWriter(BitmapWriter& writer, const std::vector<int> values) {
   for (const auto& value : values) {

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -738,9 +738,9 @@ TEST(BitUtil, RoundUpToPowerOf2) {
 }
 
 static void TestZigZag(int32_t v) {
-  uint8_t buffer[BitReader::MAX_VLQ_BYTE_LEN];
-  BitWriter writer(buffer, sizeof(buffer));
-  BitReader reader(buffer, sizeof(buffer));
+  uint8_t buffer[BitUtil::BitReader::MAX_VLQ_BYTE_LEN];
+  BitUtil::BitWriter writer(buffer, sizeof(buffer));
+  BitUtil::BitReader reader(buffer, sizeof(buffer));
   writer.PutZigZagVlqInt(v);
   int32_t result;
   EXPECT_TRUE(reader.GetZigZagVlqInt(&result));

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -35,9 +35,7 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
-
 namespace BitUtil {
-
 namespace {
 
 void FillBitsFromBytes(const std::vector<uint8_t>& bytes, uint8_t* bits) {
@@ -65,6 +63,8 @@ Status BytesToBits(const std::vector<uint8_t>& bytes, MemoryPool* pool,
 }
 
 }  // namespace BitUtil
+
+namespace internal {
 
 int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length) {
   constexpr int64_t pop_len = sizeof(uint64_t) * 8;
@@ -333,4 +333,5 @@ Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
       pool, left, left_offset, right, right_offset, length, out_offset, out_buffer);
 }
 
+}  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -246,26 +246,26 @@ static inline void ByteSwap(void* dst, const void* src, int len) {
 
 // Convert to little/big endian format from the machine's native endian format.
 #if ARROW_LITTLE_ENDIAN
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T ToBigEndian(T value) {
   return ByteSwap(value);
 }
 
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T ToLittleEndian(T value) {
   return value;
 }
 #else
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T ToBigEndian(T value) {
   return value;
 }
 
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T ToLittleEndian(T value) {
   return ByteSwap(value);
 }
@@ -273,26 +273,26 @@ static inline T ToLittleEndian(T value) {
 
 // Convert from big/little endian format to the machine's native endian format.
 #if ARROW_LITTLE_ENDIAN
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T FromBigEndian(T value) {
   return ByteSwap(value);
 }
 
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T FromLittleEndian(T value) {
   return value;
 }
 #else
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T FromBigEndian(T value) {
   return value;
 }
 
-template <typename T, typename = EnableIfIsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                                 int16_t, uint16_t>>
+template <typename T, typename = internal::EnableIfIsOneOf<T, int64_t, uint64_t, int32_t,
+                                                           uint32_t, int16_t, uint16_t>>
 static inline T FromLittleEndian(T value) {
   return ByteSwap(value);
 }

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -552,8 +552,6 @@ void GenerateBitsUnrolled(uint8_t* bitmap, int64_t start_offset, int64_t length,
   }
 }
 
-}  // namespace internal
-
 // ----------------------------------------------------------------------
 // Bitmap utilities
 
@@ -636,6 +634,7 @@ Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 
+}  // namespace internal
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_BIT_UTIL_H

--- a/cpp/src/arrow/util/checked-cast-test.cc
+++ b/cpp/src/arrow/util/checked-cast-test.cc
@@ -22,6 +22,7 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
+namespace internal {
 
 class Foo {
  public:
@@ -68,4 +69,5 @@ TEST(CheckedCast, TestInvalidSubclassCast) {
 #endif
 }
 
+}  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/checked_cast.h
+++ b/cpp/src/arrow/util/checked_cast.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 namespace arrow {
+namespace internal {
 
 template <typename OutputType, typename InputType>
 inline OutputType checked_cast(InputType&& value) {
@@ -37,6 +38,7 @@ inline OutputType checked_cast(InputType&& value) {
 #endif
 }
 
+}  // namespace internal
 }  // namespace arrow
 
 #endif  // ARROW_CAST_H

--- a/cpp/src/arrow/util/compression-test.cc
+++ b/cpp/src/arrow/util/compression-test.cc
@@ -29,6 +29,7 @@ using std::string;
 using std::vector;
 
 namespace arrow {
+namespace util {
 
 template <Compression::type CODEC>
 void CheckCodecRoundtrip(const vector<uint8_t>& data) {
@@ -88,4 +89,5 @@ TEST(TestCompressors, ZSTD) { CheckCodec<Compression::ZSTD>(); }
 
 TEST(TestCompressors, Lz4) { CheckCodec<Compression::LZ4>(); }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -42,6 +42,7 @@
 #include "arrow/status.h"
 
 namespace arrow {
+namespace util {
 
 Codec::~Codec() {}
 
@@ -92,4 +93,5 @@ Status Codec::Create(Compression::type codec_type, std::unique_ptr<Codec>* resul
   return Status::OK();
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -30,6 +30,8 @@ struct Compression {
   enum type { UNCOMPRESSED, SNAPPY, GZIP, BROTLI, ZSTD, LZ4, LZO };
 };
 
+namespace util {
+
 class ARROW_EXPORT Codec {
  public:
   virtual ~Codec();
@@ -48,6 +50,7 @@ class ARROW_EXPORT Codec {
   virtual const char* name() const = 0;
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -28,6 +28,7 @@
 #include "arrow/util/macros.h"
 
 namespace arrow {
+namespace util {
 
 // ----------------------------------------------------------------------
 // Brotli implementation
@@ -61,4 +62,5 @@ Status BrotliCodec::Compress(int64_t input_len, const uint8_t* input,
   return Status::OK();
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression_brotli.h
+++ b/cpp/src/arrow/util/compression_brotli.h
@@ -25,6 +25,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 // Brotli codec.
 class ARROW_EXPORT BrotliCodec : public Codec {
@@ -40,6 +41,7 @@ class ARROW_EXPORT BrotliCodec : public Codec {
   const char* name() const override { return "brotli"; }
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_COMPRESSION_BROTLI_H

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -25,6 +25,7 @@
 #include "arrow/util/macros.h"
 
 namespace arrow {
+namespace util {
 
 // ----------------------------------------------------------------------
 // Lz4 implementation
@@ -57,4 +58,5 @@ Status Lz4Codec::Compress(int64_t input_len, const uint8_t* input,
   return Status::OK();
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression_lz4.h
+++ b/cpp/src/arrow/util/compression_lz4.h
@@ -25,6 +25,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 // Lz4 codec.
 class ARROW_EXPORT Lz4Codec : public Codec {
@@ -40,6 +41,7 @@ class ARROW_EXPORT Lz4Codec : public Codec {
   const char* name() const override { return "lz4"; }
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_COMPRESSION_LZ4_H

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -28,6 +28,7 @@
 using std::size_t;
 
 namespace arrow {
+namespace util {
 
 // ----------------------------------------------------------------------
 // Snappy implementation
@@ -59,4 +60,5 @@ Status SnappyCodec::Compress(int64_t input_len, const uint8_t* input,
   return Status::OK();
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression_snappy.h
+++ b/cpp/src/arrow/util/compression_snappy.h
@@ -25,6 +25,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 class ARROW_EXPORT SnappyCodec : public Codec {
  public:
@@ -39,6 +40,7 @@ class ARROW_EXPORT SnappyCodec : public Codec {
   const char* name() const override { return "snappy"; }
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_COMPRESSION_SNAPPY_H

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -30,6 +30,7 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
+namespace util {
 
 // ----------------------------------------------------------------------
 // gzip implementation
@@ -249,4 +250,5 @@ Status GZipCodec::Compress(int64_t input_length, const uint8_t* input,
 
 const char* GZipCodec::name() const { return "gzip"; }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression_zlib.h
+++ b/cpp/src/arrow/util/compression_zlib.h
@@ -26,6 +26,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 // GZip codec.
 class ARROW_EXPORT GZipCodec : public Codec {
@@ -56,6 +57,7 @@ class ARROW_EXPORT GZipCodec : public Codec {
   std::unique_ptr<GZipCodecImpl> impl_;
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_COMPRESSION_ZLIB_H

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -28,6 +28,7 @@
 using std::size_t;
 
 namespace arrow {
+namespace util {
 
 // ----------------------------------------------------------------------
 // ZSTD implementation
@@ -59,4 +60,5 @@ Status ZSTDCodec::Compress(int64_t input_len, const uint8_t* input,
   return Status::OK();
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/compression_zstd.h
+++ b/cpp/src/arrow/util/compression_zstd.h
@@ -25,6 +25,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 // ZSTD codec.
 class ARROW_EXPORT ZSTDCodec : public Codec {
@@ -40,6 +41,7 @@ class ARROW_EXPORT ZSTDCodec : public Codec {
   const char* name() const override { return "zstd"; }
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_COMPRESSION_ZSTD_H

--- a/cpp/src/arrow/util/cpu-info.cc
+++ b/cpp/src/arrow/util/cpu-info.cc
@@ -55,6 +55,7 @@ using boost::algorithm::trim;
 using std::max;
 
 namespace arrow {
+namespace internal {
 
 static struct {
   std::string name;
@@ -319,4 +320,5 @@ void CpuInfo::SetDefaultCacheSize() {
 #endif
 }
 
+}  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/cpu-info.h
+++ b/cpp/src/arrow/util/cpu-info.h
@@ -27,6 +27,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace internal {
 
 /// CpuInfo is an interface to query for cpu information at runtime.  The caller can
 /// ask for the sizes of the caches and what hardware features are supported.
@@ -94,6 +95,7 @@ class ARROW_EXPORT CpuInfo {
   std::string model_name_;
 };
 
+}  // namespace internal
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_CPU_INFO_H

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -138,7 +138,7 @@ class ARROW_EXPORT Decimal128 {
   Status Rescale(int32_t original_scale, int32_t new_scale, Decimal128* out) const;
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
   Status ToInteger(T* out) const {
     constexpr auto min_value = std::numeric_limits<T>::min();
     constexpr auto max_value = std::numeric_limits<T>::max();

--- a/cpp/src/arrow/util/logging-test.cc
+++ b/cpp/src/arrow/util/logging-test.cc
@@ -26,6 +26,7 @@
 // https://github.com/ray-project/ray/blob/master/src/ray/util/logging_test.cc.
 
 namespace arrow {
+namespace util {
 
 int64_t current_time_ms() {
   std::chrono::milliseconds ms_since_epoch =
@@ -101,6 +102,7 @@ TEST(LogPerfTest, PerfTest) {
   ArrowLog::ShutDownArrowLog();
 }
 
+}  // namespace util
 }  // namespace arrow
 
 int main(int argc, char** argv) {

--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -28,6 +28,7 @@
 #endif
 
 namespace arrow {
+namespace util {
 
 // This code is adapted from
 // https://github.com/ray-project/ray/blob/master/src/ray/util/logging.cc.
@@ -78,7 +79,7 @@ class CerrLog {
 #ifdef ARROW_USE_GLOG
 typedef google::LogMessage LoggingProvider;
 #else
-typedef arrow::CerrLog LoggingProvider;
+typedef CerrLog LoggingProvider;
 #endif
 
 ArrowLogLevel ArrowLog::severity_threshold_ = ArrowLogLevel::ARROW_INFO;
@@ -186,4 +187,5 @@ ArrowLog::~ArrowLog() {
   }
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -25,6 +25,7 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 enum class ArrowLogLevel : int {
   ARROW_DEBUG = -1,
@@ -34,16 +35,16 @@ enum class ArrowLogLevel : int {
   ARROW_FATAL = 3
 };
 
-#define ARROW_LOG_INTERNAL(level) ::arrow::ArrowLog(__FILE__, __LINE__, level)
-#define ARROW_LOG(level) ARROW_LOG_INTERNAL(::arrow::ArrowLogLevel::ARROW_##level)
+#define ARROW_LOG_INTERNAL(level) ::arrow::util::ArrowLog(__FILE__, __LINE__, level)
+#define ARROW_LOG(level) ARROW_LOG_INTERNAL(::arrow::util::ArrowLogLevel::ARROW_##level)
 #define ARROW_IGNORE_EXPR(expr) ((void)(expr))
 
 #define ARROW_CHECK(condition)                                                         \
-  (condition)                                                                          \
-      ? ARROW_IGNORE_EXPR(0)                                                           \
-      : ::arrow::Voidify() &                                                           \
-            ::arrow::ArrowLog(__FILE__, __LINE__, ::arrow::ArrowLogLevel::ARROW_FATAL) \
-                << " Check failed: " #condition " "
+  (condition) ? ARROW_IGNORE_EXPR(0)                                                   \
+              : ::arrow::util::Voidify() &                                             \
+                    ::arrow::util::ArrowLog(__FILE__, __LINE__,                        \
+                                            ::arrow::util::ArrowLogLevel::ARROW_FATAL) \
+                        << " Check failed: " #condition " "
 
 // If 'to_call' returns a bad status, CHECK immediately with a logged message
 // of 'msg' followed by the status.
@@ -58,35 +59,35 @@ enum class ArrowLogLevel : int {
 #define ARROW_CHECK_OK(s) ARROW_CHECK_OK_PREPEND(s, "Bad status")
 
 #ifdef NDEBUG
-#define ARROW_DFATAL arrow::ArrowLogLevel::ARROW_WARNING
+#define ARROW_DFATAL ::arrow::util::ArrowLogLevel::ARROW_WARNING
 
 #define DCHECK(condition)       \
   ARROW_IGNORE_EXPR(condition); \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_OK(status)    \
   ARROW_IGNORE_EXPR(status); \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_EQ(val1, val2) \
   ARROW_IGNORE_EXPR(val1);    \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_NE(val1, val2) \
   ARROW_IGNORE_EXPR(val1);    \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_LE(val1, val2) \
   ARROW_IGNORE_EXPR(val1);    \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_LT(val1, val2) \
   ARROW_IGNORE_EXPR(val1);    \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_GE(val1, val2) \
   ARROW_IGNORE_EXPR(val1);    \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 #define DCHECK_GT(val1, val2) \
   ARROW_IGNORE_EXPR(val1);    \
-  while (false) ::arrow::ArrowLogBase()
+  while (false) ::arrow::util::ArrowLogBase()
 
 #else
-#define ARROW_DFATAL arrow::ArrowLogLevel::ARROW_FATAL
+#define ARROW_DFATAL ::arrow::util::ArrowLogLevel::ARROW_FATAL
 
 #define DCHECK(condition) ARROW_CHECK(condition)
 #define DCHECK_OK(status) (ARROW_CHECK((status).ok()) << (status).message())
@@ -179,6 +180,7 @@ class ARROW_EXPORT Voidify {
   void operator&(ArrowLogBase&) {}
 };
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_LOGGING_H

--- a/cpp/src/arrow/util/parallel.h
+++ b/cpp/src/arrow/util/parallel.h
@@ -27,6 +27,7 @@
 #include "arrow/util/thread-pool.h"
 
 namespace arrow {
+namespace internal {
 
 // A parallelizer that takes a `Status(int)` function and calls it with
 // arguments between 0 and `num_tasks - 1`, on an arbitrary number of threads.
@@ -88,6 +89,7 @@ Status ParallelFor(int nthreads, int num_tasks, FUNCTION&& func) {
   return Status::OK();
 }
 
+}  // namespace internal
 }  // namespace arrow
 
 #endif

--- a/cpp/src/arrow/util/rle-encoding-test.cc
+++ b/cpp/src/arrow/util/rle-encoding-test.cc
@@ -33,6 +33,7 @@
 using std::vector;
 
 namespace arrow {
+namespace util {
 
 const int MAX_WIDTH = 32;
 
@@ -465,4 +466,5 @@ TEST(BitRle, Overflow) {
   }
 }
 
+}  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/rle-encoding-test.cc
+++ b/cpp/src/arrow/util/rle-encoding-test.cc
@@ -40,7 +40,7 @@ TEST(BitArray, TestBool) {
   const int len = 8;
   uint8_t buffer[len];
 
-  BitWriter writer(buffer, len);
+  BitUtil::BitWriter writer(buffer, len);
 
   // Write alternating 0's and 1's
   for (int i = 0; i < 8; ++i) {
@@ -73,7 +73,7 @@ TEST(BitArray, TestBool) {
   EXPECT_EQ((int)buffer[1], BOOST_BINARY(1 1 0 0 1 1 0 0));
 
   // Use the reader and validate
-  BitReader reader(buffer, len);
+  BitUtil::BitReader reader(buffer, len);
   for (int i = 0; i < 8; ++i) {
     bool val = false;
     bool result = reader.GetValue(1, &val);
@@ -106,7 +106,7 @@ void TestBitArrayValues(int bit_width, int num_vals) {
   const uint64_t mod = bit_width == 64 ? 1 : 1LL << bit_width;
 
   std::vector<uint8_t> buffer(len);
-  BitWriter writer(buffer.data(), len);
+  BitUtil::BitWriter writer(buffer.data(), len);
   for (int i = 0; i < num_vals; ++i) {
     bool result = writer.PutValue(i % mod, bit_width);
     EXPECT_TRUE(result);
@@ -114,7 +114,7 @@ void TestBitArrayValues(int bit_width, int num_vals) {
   writer.Flush();
   EXPECT_EQ(writer.bytes_written(), len);
 
-  BitReader reader(buffer.data(), len);
+  BitUtil::BitReader reader(buffer.data(), len);
   for (int i = 0; i < num_vals; ++i) {
     int64_t val = 0;
     bool result = reader.GetValue(bit_width, &val);
@@ -140,7 +140,7 @@ TEST(BitArray, TestMixed) {
   uint8_t buffer[len];
   bool parity = true;
 
-  BitWriter writer(buffer, len);
+  BitUtil::BitWriter writer(buffer, len);
   for (int i = 0; i < len; ++i) {
     bool result;
     if (i % 2 == 0) {
@@ -154,7 +154,7 @@ TEST(BitArray, TestMixed) {
   writer.Flush();
 
   parity = true;
-  BitReader reader(buffer, len);
+  BitUtil::BitReader reader(buffer, len);
   for (int i = 0; i < len; ++i) {
     bool result;
     if (i % 2 == 0) {

--- a/cpp/src/arrow/util/rle-encoding.h
+++ b/cpp/src/arrow/util/rle-encoding.h
@@ -126,7 +126,7 @@ class RleDecoder {
                              int64_t valid_bits_offset);
 
  protected:
-  BitReader bit_reader_;
+  BitUtil::BitReader bit_reader_;
   /// Number of bits needed to encode the value. Must be between 0 and 64.
   int bit_width_;
   uint64_t current_value_;
@@ -172,8 +172,8 @@ class RleEncoder {
         1 +
         static_cast<int>(BitUtil::BytesForBits(MAX_VALUES_PER_LITERAL_RUN * bit_width));
     /// Up to MAX_VLQ_BYTE_LEN indicator and a single 'bit_width' value.
-    int max_repeated_run_size =
-        BitReader::MAX_VLQ_BYTE_LEN + static_cast<int>(BitUtil::BytesForBits(bit_width));
+    int max_repeated_run_size = BitUtil::BitReader::MAX_VLQ_BYTE_LEN +
+                                static_cast<int>(BitUtil::BytesForBits(bit_width));
     return std::max(max_literal_run_size, max_repeated_run_size);
   }
 
@@ -241,7 +241,7 @@ class RleEncoder {
   const int bit_width_;
 
   /// Underlying buffer.
-  BitWriter bit_writer_;
+  BitUtil::BitWriter bit_writer_;
 
   /// If true, the buffer is full and subsequent Put()'s will fail.
   bool buffer_full_;

--- a/cpp/src/arrow/util/rle-encoding.h
+++ b/cpp/src/arrow/util/rle-encoding.h
@@ -29,6 +29,7 @@
 #include "arrow/util/macros.h"
 
 namespace arrow {
+namespace util {
 
 /// Utility classes to do run length encoding (RLE) for fixed bit width values.  If runs
 /// are sufficiently long, RLE is used, otherwise, the values are just bit-packed
@@ -596,6 +597,7 @@ inline void RleEncoder::Clear() {
   bit_writer_.Clear();
 }
 
+}  // namespace util
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_RLE_ENCODING_H

--- a/cpp/src/arrow/util/stopwatch.h
+++ b/cpp/src/arrow/util/stopwatch.h
@@ -26,6 +26,7 @@
 #include <iostream>
 
 namespace arrow {
+namespace internal {
 
 uint64_t CurrentTime() {
   timespec time;
@@ -46,4 +47,5 @@ class StopWatch {
   uint64_t start_;
 };
 
+}  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/thread-pool.h
+++ b/cpp/src/arrow/util/thread-pool.h
@@ -37,13 +37,21 @@
 
 namespace arrow {
 
-// Get the number of worker threads used by the process-global thread pool
-// for CPU-bound tasks.  This is an idealized number, the actual number
-// may lag a bit.
+/// \brief Get the capacity of the global thread pool
+///
+/// Return the number of worker threads in the thread pool to which
+/// Arrow dispatches various CPU-bound tasks.  This is an ideal number,
+/// not necessarily the exact number of threads at a given point in time.
+///
+/// You can change this number using SetCpuThreadPoolCapacity().
 ARROW_EXPORT int GetCpuThreadPoolCapacity();
 
-// Set the number of worker threads used by the process-global thread pool
-// for CPU-bound tasks.
+/// \brief Set the capacity of the global thread pool
+///
+/// Set the number of worker threads int the thread pool to which
+/// Arrow dispatches various CPU-bound tasks.
+///
+/// The current number is returned by GetCpuThreadPoolCapacity().
 ARROW_EXPORT Status SetCpuThreadPoolCapacity(int threads);
 
 namespace internal {

--- a/cpp/src/arrow/util/type_traits.h
+++ b/cpp/src/arrow/util/type_traits.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 namespace arrow {
+namespace internal {
 
 /// \brief Metafunction to allow checking if a type matches any of another set of types
 template <typename...>
@@ -41,6 +42,7 @@ template <typename T>
 struct is_null_pointer : std::is_same<std::nullptr_t, typename std::remove_cv<T>::type> {
 };
 
+}  // namespace internal
 }  // namespace arrow
 
 #endif  // ARROW_UTIL_TYPE_TRAITS_H

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -30,7 +30,7 @@ namespace arrow {
 
 #define TYPE_VISIT_INLINE(TYPE_CLASS) \
   case TYPE_CLASS::type_id:           \
-    return visitor->Visit(checked_cast<const TYPE_CLASS&>(type));
+    return visitor->Visit(internal::checked_cast<const TYPE_CLASS&>(type));
 
 template <typename VISITOR>
 inline Status VisitTypeInline(const DataType& type, VISITOR* visitor) {
@@ -69,10 +69,11 @@ inline Status VisitTypeInline(const DataType& type, VISITOR* visitor) {
 
 #undef TYPE_VISIT_INLINE
 
-#define ARRAY_VISIT_INLINE(TYPE_CLASS) \
-  case TYPE_CLASS::type_id:            \
-    return visitor->Visit(             \
-        checked_cast<const typename TypeTraits<TYPE_CLASS>::ArrayType&>(array));
+#define ARRAY_VISIT_INLINE(TYPE_CLASS)                                             \
+  case TYPE_CLASS::type_id:                                                        \
+    return visitor->Visit(                                                         \
+        internal::checked_cast<const typename TypeTraits<TYPE_CLASS>::ArrayType&>( \
+            array));
 
 template <typename VISITOR>
 inline Status VisitArrayInline(const Array& array, VISITOR* visitor) {

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -52,7 +52,8 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
       num_bytes = *reinterpret_cast<const int32_t*>(data);
       const uint8_t* decoder_data = data + sizeof(int32_t);
       if (!rle_decoder_) {
-        rle_decoder_.reset(new ::arrow::RleDecoder(decoder_data, num_bytes, bit_width_));
+        rle_decoder_.reset(
+            new ::arrow::util::RleDecoder(decoder_data, num_bytes, bit_width_));
       } else {
         rle_decoder_->Reset(decoder_data, num_bytes, bit_width_);
       }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -123,7 +123,7 @@ class SerializedPageReader : public PageReader {
   std::shared_ptr<Page> current_page_;
 
   // Compression codec to use.
-  std::unique_ptr<::arrow::Codec> decompressor_;
+  std::unique_ptr<::arrow::util::Codec> decompressor_;
   std::shared_ptr<ResizableBuffer> decompression_buffer_;
 
   // Maximum allowed page size

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -62,7 +62,7 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
       num_bytes =
           static_cast<int32_t>(BitUtil::BytesForBits(num_buffered_values * bit_width_));
       if (!bit_packed_decoder_) {
-        bit_packed_decoder_.reset(new ::arrow::BitReader(data, num_bytes));
+        bit_packed_decoder_.reset(new ::arrow::BitUtil::BitReader(data, num_bytes));
       } else {
         bit_packed_decoder_->Reset(data, num_bytes);
       }

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -48,7 +48,9 @@ namespace BitUtil {
 class BitReader;
 }  // namespace BitUtil
 
+namespace util {
 class RleDecoder;
+}  // namespace util
 
 }  // namespace arrow
 
@@ -79,7 +81,7 @@ class PARQUET_EXPORT LevelDecoder {
   int bit_width_;
   int num_values_remaining_;
   Encoding::type encoding_;
-  std::unique_ptr<::arrow::RleDecoder> rle_decoder_;
+  std::unique_ptr<::arrow::util::RleDecoder> rle_decoder_;
   std::unique_ptr<::arrow::BitUtil::BitReader> bit_packed_decoder_;
 };
 

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -44,7 +44,10 @@
 
 namespace arrow {
 
+namespace BitUtil {
 class BitReader;
+}  // namespace BitUtil
+
 class RleDecoder;
 
 }  // namespace arrow
@@ -77,7 +80,7 @@ class PARQUET_EXPORT LevelDecoder {
   int num_values_remaining_;
   Encoding::type encoding_;
   std::unique_ptr<::arrow::RleDecoder> rle_decoder_;
-  std::unique_ptr<::arrow::BitReader> bit_packed_decoder_;
+  std::unique_ptr<::arrow::BitUtil::BitReader> bit_packed_decoder_;
 };
 
 // Abstract page iterator interface. This way, we can feed column pages to the

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -35,7 +35,7 @@
 namespace parquet {
 
 using BitWriter = ::arrow::BitUtil::BitWriter;
-using RleEncoder = ::arrow::RleEncoder;
+using RleEncoder = ::arrow::util::RleEncoder;
 
 LevelEncoder::LevelEncoder() {}
 LevelEncoder::~LevelEncoder() {}

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -271,7 +271,7 @@ class SerializedPageWriter : public PageWriter {
   int64_t total_compressed_size_;
 
   // Compression codec to use.
-  std::unique_ptr<::arrow::Codec> compressor_;
+  std::unique_ptr<::arrow::util::Codec> compressor_;
 };
 
 // This implementation of the PageWriter writes to the final sink on Close .

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -34,7 +34,7 @@
 
 namespace parquet {
 
-using BitWriter = ::arrow::BitWriter;
+using BitWriter = ::arrow::BitUtil::BitWriter;
 using RleEncoder = ::arrow::RleEncoder;
 
 LevelEncoder::LevelEncoder() {}

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -38,7 +38,9 @@ namespace BitUtil {
 class BitWriter;
 }  // namespace BitUtil
 
+namespace util {
 class RleEncoder;
+}  // namespace util
 
 }  // namespace arrow
 
@@ -70,7 +72,7 @@ class PARQUET_EXPORT LevelEncoder {
   int bit_width_;
   int rle_length_;
   Encoding::type encoding_;
-  std::unique_ptr<::arrow::RleEncoder> rle_encoder_;
+  std::unique_ptr<::arrow::util::RleEncoder> rle_encoder_;
   std::unique_ptr<::arrow::BitUtil::BitWriter> bit_packed_encoder_;
 };
 

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -34,7 +34,10 @@
 
 namespace arrow {
 
+namespace BitUtil {
 class BitWriter;
+}  // namespace BitUtil
+
 class RleEncoder;
 
 }  // namespace arrow
@@ -68,7 +71,7 @@ class PARQUET_EXPORT LevelEncoder {
   int rle_length_;
   Encoding::type encoding_;
   std::unique_ptr<::arrow::RleEncoder> rle_encoder_;
-  std::unique_ptr<::arrow::BitWriter> bit_packed_encoder_;
+  std::unique_ptr<::arrow::BitUtil::BitWriter> bit_packed_encoder_;
 };
 
 class PageWriter {

--- a/cpp/src/parquet/encoding-internal.h
+++ b/cpp/src/parquet/encoding-internal.h
@@ -468,7 +468,7 @@ class DictEncoder : public Encoder<DType> {
         dict_encoded_size_(0),
         type_length_(desc->type_length()) {
     hash_slots_.Assign(hash_table_size_, HASH_SLOT_EMPTY);
-    cpu_info_ = ::arrow::CpuInfo::GetInstance();
+    cpu_info_ = ::arrow::internal::CpuInfo::GetInstance();
   }
 
   ~DictEncoder() override { DCHECK(buffered_indices_.empty()); }
@@ -580,7 +580,7 @@ class DictEncoder : public Encoder<DType> {
   // For ByteArray / FixedLenByteArray data. Not owned
   ChunkedAllocator* pool_;
 
-  ::arrow::CpuInfo* cpu_info_;
+  ::arrow::internal::CpuInfo* cpu_info_;
 
   /// Size of the table. Must be a power of 2.
   int hash_table_size_;

--- a/cpp/src/parquet/encoding-internal.h
+++ b/cpp/src/parquet/encoding-internal.h
@@ -341,7 +341,7 @@ class DictionaryDecoder : public Decoder<Type> {
     uint8_t bit_width = *data;
     ++data;
     --len;
-    idx_decoder_ = ::arrow::RleDecoder(data, len, bit_width);
+    idx_decoder_ = ::arrow::util::RleDecoder(data, len, bit_width);
   }
 
   int Decode(T* buffer, int max_values) override {
@@ -376,7 +376,7 @@ class DictionaryDecoder : public Decoder<Type> {
   // pointers).
   std::shared_ptr<ResizableBuffer> byte_array_data_;
 
-  ::arrow::RleDecoder idx_decoder_;
+  ::arrow::util::RleDecoder idx_decoder_;
 };
 
 template <typename Type>
@@ -487,9 +487,9 @@ class DictEncoder : public Encoder<DType> {
     // an extra "RleEncoder::MinBufferSize" bytes. These extra bytes won't be used
     // but not reserving them would cause the encoder to fail.
     return 1 +
-           ::arrow::RleEncoder::MaxBufferSize(
+           ::arrow::util::RleEncoder::MaxBufferSize(
                bit_width(), static_cast<int>(buffered_indices_.size())) +
-           ::arrow::RleEncoder::MinBufferSize(bit_width());
+           ::arrow::util::RleEncoder::MinBufferSize(bit_width());
   }
 
   /// The minimum bit width required to encode the currently buffered indices.
@@ -791,7 +791,7 @@ inline int DictEncoder<DType>::WriteIndices(uint8_t* buffer, int buffer_len) {
   ++buffer;
   --buffer_len;
 
-  ::arrow::RleEncoder encoder(buffer, buffer_len, bit_width());
+  ::arrow::util::RleEncoder encoder(buffer, buffer_len, bit_width());
   for (int index : buffered_indices_) {
     if (!encoder.Put(index)) return -1;
   }

--- a/cpp/src/parquet/encoding-internal.h
+++ b/cpp/src/parquet/encoding-internal.h
@@ -143,7 +143,7 @@ class PlainDecoder<BooleanType> : public Decoder<BooleanType> {
 
   virtual void SetData(int num_values, const uint8_t* data, int len) {
     num_values_ = num_values;
-    bit_reader_ = ::arrow::BitReader(data, len);
+    bit_reader_ = BitUtil::BitReader(data, len);
   }
 
   // Two flavors of bool decoding
@@ -175,7 +175,7 @@ class PlainDecoder<BooleanType> : public Decoder<BooleanType> {
   }
 
  private:
-  ::arrow::BitReader bit_reader_;
+  BitUtil::BitReader bit_reader_;
 };
 
 // ----------------------------------------------------------------------
@@ -210,7 +210,7 @@ class PlainEncoder<BooleanType> : public Encoder<BooleanType> {
         bits_available_(kInMemoryDefaultCapacity * 8),
         bits_buffer_(AllocateBuffer(pool, kInMemoryDefaultCapacity)),
         values_sink_(new InMemoryOutputStream(pool)) {
-    bit_writer_.reset(new ::arrow::BitWriter(bits_buffer_->mutable_data(),
+    bit_writer_.reset(new BitUtil::BitWriter(bits_buffer_->mutable_data(),
                                              static_cast<int>(bits_buffer_->size())));
   }
 
@@ -274,7 +274,7 @@ class PlainEncoder<BooleanType> : public Encoder<BooleanType> {
 
  protected:
   int bits_available_;
-  std::unique_ptr<::arrow::BitWriter> bit_writer_;
+  std::unique_ptr<BitUtil::BitWriter> bit_writer_;
   std::shared_ptr<ResizableBuffer> bits_buffer_;
   std::unique_ptr<InMemoryOutputStream> values_sink_;
 };
@@ -819,7 +819,7 @@ class DeltaBitPackDecoder : public Decoder<DType> {
 
   virtual void SetData(int num_values, const uint8_t* data, int len) {
     num_values_ = num_values;
-    decoder_ = ::arrow::BitReader(data, len);
+    decoder_ = BitUtil::BitReader(data, len);
     values_current_block_ = 0;
     values_current_mini_block_ = 0;
   }
@@ -885,7 +885,7 @@ class DeltaBitPackDecoder : public Decoder<DType> {
   }
 
   ::arrow::MemoryPool* pool_;
-  ::arrow::BitReader decoder_;
+  BitUtil::BitReader decoder_;
   int32_t values_current_block_;
   int32_t num_mini_blocks_;
   uint64_t values_per_mini_block_;

--- a/cpp/src/parquet/file-deserialize-test.cc
+++ b/cpp/src/parquet/file-deserialize-test.cc
@@ -196,7 +196,7 @@ TEST_F(TestPageSerde, Compression) {
     test::random_bytes(page_size, 0, &faux_data[i]);
   }
   for (auto codec_type : codec_types) {
-    std::unique_ptr<::arrow::Codec> codec = GetCodecFromArrow(codec_type);
+    auto codec = GetCodecFromArrow(codec_type);
 
     std::vector<uint8_t> buffer;
     for (int i = 0; i < num_pages; ++i) {

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -41,12 +41,6 @@
 
 using std::string;
 
-namespace arrow {
-
-class Codec;
-
-}  // namespace arrow
-
 namespace parquet {
 
 // PARQUET-978: Minimize footer reads by reading 64 KB from the end of the file

--- a/cpp/src/parquet/util/memory.cc
+++ b/cpp/src/parquet/util/memory.cc
@@ -32,31 +32,32 @@
 #include "parquet/types.h"
 
 using arrow::MemoryPool;
+using arrow::util::Codec;
 
 namespace parquet {
 
-std::unique_ptr<::arrow::Codec> GetCodecFromArrow(Compression::type codec) {
-  std::unique_ptr<::arrow::Codec> result;
+std::unique_ptr<Codec> GetCodecFromArrow(Compression::type codec) {
+  std::unique_ptr<Codec> result;
   switch (codec) {
     case Compression::UNCOMPRESSED:
       break;
     case Compression::SNAPPY:
-      PARQUET_THROW_NOT_OK(::arrow::Codec::Create(::arrow::Compression::SNAPPY, &result));
+      PARQUET_THROW_NOT_OK(Codec::Create(::arrow::Compression::SNAPPY, &result));
       break;
     case Compression::GZIP:
-      PARQUET_THROW_NOT_OK(::arrow::Codec::Create(::arrow::Compression::GZIP, &result));
+      PARQUET_THROW_NOT_OK(Codec::Create(::arrow::Compression::GZIP, &result));
       break;
     case Compression::LZO:
-      PARQUET_THROW_NOT_OK(::arrow::Codec::Create(::arrow::Compression::LZO, &result));
+      PARQUET_THROW_NOT_OK(Codec::Create(::arrow::Compression::LZO, &result));
       break;
     case Compression::BROTLI:
-      PARQUET_THROW_NOT_OK(::arrow::Codec::Create(::arrow::Compression::BROTLI, &result));
+      PARQUET_THROW_NOT_OK(Codec::Create(::arrow::Compression::BROTLI, &result));
       break;
     case Compression::LZ4:
-      PARQUET_THROW_NOT_OK(::arrow::Codec::Create(::arrow::Compression::LZ4, &result));
+      PARQUET_THROW_NOT_OK(Codec::Create(::arrow::Compression::LZ4, &result));
       break;
     case Compression::ZSTD:
-      PARQUET_THROW_NOT_OK(::arrow::Codec::Create(::arrow::Compression::ZSTD, &result));
+      PARQUET_THROW_NOT_OK(Codec::Create(::arrow::Compression::ZSTD, &result));
       break;
     default:
       break;

--- a/cpp/src/parquet/util/memory.h
+++ b/cpp/src/parquet/util/memory.h
@@ -37,15 +37,17 @@
 #include "parquet/util/visibility.h"
 
 namespace arrow {
+namespace util {
 
 class Codec;
 
+}  // namespace util
 }  // namespace arrow
 
 namespace parquet {
 
 PARQUET_EXPORT
-std::unique_ptr<::arrow::Codec> GetCodecFromArrow(Compression::type codec);
+std::unique_ptr<::arrow::util::Codec> GetCodecFromArrow(Compression::type codec);
 
 static constexpr int64_t kInMemoryDefaultCapacity = 1024;
 

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -66,6 +66,9 @@ using arrow::gpu::CudaContext;
 using arrow::gpu::CudaDeviceManager;
 #endif
 
+using arrow::util::ArrowLog;
+using arrow::util::ArrowLogLevel;
+
 namespace fb = plasma::flatbuf;
 
 namespace plasma {
@@ -895,8 +898,8 @@ void StartServer(char* socket_name, int64_t system_memory, std::string plasma_di
 }  // namespace plasma
 
 int main(int argc, char* argv[]) {
-  arrow::ArrowLog::StartArrowLog(argv[0], arrow::ArrowLogLevel::ARROW_INFO);
-  arrow::ArrowLog::InstallFailureSignalHandler();
+  ArrowLog::StartArrowLog(argv[0], ArrowLogLevel::ARROW_INFO);
+  ArrowLog::InstallFailureSignalHandler();
   char* socket_name = nullptr;
   // Directory where plasma memory mapped files are stored.
   std::string plasma_directory;
@@ -986,6 +989,6 @@ int main(int argc, char* argv[]) {
   plasma::g_runner->Shutdown();
   plasma::g_runner = nullptr;
 
-  arrow::ArrowLog::ShutDownArrowLog();
+  ArrowLog::ShutDownArrowLog();
   return 0;
 }

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1080,7 +1080,7 @@ cdef extern from 'arrow/util/compression.h' namespace 'arrow' nogil:
         CompressionType_ZSTD" arrow::Compression::ZSTD"
         CompressionType_LZ4" arrow::Compression::LZ4"
 
-    cdef cppclass CCodec" arrow::Codec":
+    cdef cppclass CCodec" arrow::util::Codec":
         @staticmethod
         CStatus Create(CompressionType codec, unique_ptr[CCodec]* out)
 

--- a/python/pyarrow/tensorflow/plasma_op.cc
+++ b/python/pyarrow/tensorflow/plasma_op.cc
@@ -60,7 +60,8 @@ static tf::mutex d2h_stream_mu;
 // parallelization.
 
 int64_t get_byte_width(const arrow::DataType& dtype) {
-  return arrow::checked_cast<const arrow::FixedWidthType&>(dtype).bit_width() / CHAR_BIT;
+  return arrow::internal::checked_cast<const arrow::FixedWidthType&>(dtype)
+      .bit_width() / CHAR_BIT;
 }
 
 // Put:  tf.Tensor -> plasma.


### PR DESCRIPTION
Move some exported functions and classes into `arrow::util` and `arrow::internal` namespaces.
Also add and improve some docstrings for public API members.
