### PR TITLE
ARROW-3336: [JS] Fix IPC writer serializing sliced arrays

### DIFF
--- a/js/src/vector/nested.ts
+++ b/js/src/vector/nested.ts
@@ -33,7 +33,7 @@ export abstract class NestedView<T extends NestedType> implements View<T> {
         this._children = children || new Array(this.numChildren);
     }
     public clone(data: Data<T>): this {
-        return new (<any> this.constructor)(data, this._children) as this;
+        return new (<any> this.constructor)(data, new Array(this.numChildren)) as this;
     }
     public isValid(): boolean {
         return true;

--- a/js/test/integration/validate-tests.ts
+++ b/js/test/integration/validate-tests.ts
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import '../jest-extensions';
+
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -58,62 +60,6 @@ const jsonAndArrowPaths = toArray(zip(
     resolvePathArgs(process.env.ARROW_PATHS!)
 ))
 .filter(([p1, p2]) => p1 !== undefined && p2 !== undefined) as [string, string][];
-
-expect.extend({
-    toEqualVector([v1, format1, columnName]: [any, string, string], [v2, format2]: [any, string]) {
-
-        const format = (x: any, y: any, msg= ' ') => `${
-            this.utils.printExpected(x)}${
-                msg}${
-            this.utils.printReceived(y)
-        }`;
-
-        let getFailures = new Array<string>();
-        let propsFailures = new Array<string>();
-        let iteratorFailures = new Array<string>();
-        let allFailures = [
-            { title: 'get', failures: getFailures },
-            { title: 'props', failures: propsFailures },
-            { title: 'iterator', failures: iteratorFailures }
-        ];
-
-        let props = [
-            // 'name', 'nullable', 'metadata',
-            'type', 'length', 'nullCount'
-        ];
-
-        for (let i = -1, n = props.length; ++i < n;) {
-            const prop = props[i];
-            if (`${v1[prop]}` !== `${v2[prop]}`) {
-                propsFailures.push(`${prop}: ${format(v1[prop], v2[prop], ' !== ')}`);
-            }
-        }
-
-        for (let i = -1, n = v1.length; ++i < n;) {
-            let x1 = v1.get(i), x2 = v2.get(i);
-            if (this.utils.stringify(x1) !== this.utils.stringify(x2)) {
-                getFailures.push(`${i}: ${format(x1, x2, ' !== ')}`);
-            }
-        }
-
-        let i = -1;
-        for (let [x1, x2] of zip(v1, v2)) {
-            ++i;
-            if (this.utils.stringify(x1) !== this.utils.stringify(x2)) {
-                iteratorFailures.push(`${i}: ${format(x1, x2, ' !== ')}`);
-            }
-        }
-
-        return {
-            pass: allFailures.every(({ failures }) => failures.length === 0),
-            message: () => [
-                `${columnName}: (${format(format1, format2, ' !== ')})\n`,
-                ...allFailures.map(({ failures, title }) =>
-                    !failures.length ? `` : [`${title}:`, ...failures].join(`\n`))
-            ].join('\n')
-        };
-    }
-});
 
 describe(`Integration`, () => {
     for (const [jsonFilePath, arrowFilePath] of jsonAndArrowPaths) {

--- a/js/test/jest-extensions.ts
+++ b/js/test/jest-extensions.ts
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { zip } from 'ix/iterable/zip';
+
+expect.extend({
+    toEqualVector([v1, format1, columnName]: [any, string, string], [v2, format2]: [any, string]) {
+
+        const format = (x: any, y: any, msg= ' ') => `${
+            this.utils.printExpected(x)}${
+                msg}${
+            this.utils.printReceived(y)
+        }`;
+
+        let getFailures = new Array<string>();
+        let propsFailures = new Array<string>();
+        let iteratorFailures = new Array<string>();
+        let allFailures = [
+            { title: 'get', failures: getFailures },
+            { title: 'props', failures: propsFailures },
+            { title: 'iterator', failures: iteratorFailures }
+        ];
+
+        let props = [
+            // 'name', 'nullable', 'metadata',
+            'type', 'length', 'nullCount'
+        ];
+
+        for (let i = -1, n = props.length; ++i < n;) {
+            const prop = props[i];
+            if (`${v1[prop]}` !== `${v2[prop]}`) {
+                propsFailures.push(`${prop}: ${format(v1[prop], v2[prop], ' !== ')}`);
+            }
+        }
+
+        for (let i = -1, n = v1.length; ++i < n;) {
+            let x1 = v1.get(i), x2 = v2.get(i);
+            if (this.utils.stringify(x1) !== this.utils.stringify(x2)) {
+                getFailures.push(`${i}: ${format(x1, x2, ' !== ')}`);
+            }
+        }
+
+        let i = -1;
+        for (let [x1, x2] of zip(v1, v2)) {
+            ++i;
+            if (this.utils.stringify(x1) !== this.utils.stringify(x2)) {
+                iteratorFailures.push(`${i}: ${format(x1, x2, ' !== ')}`);
+            }
+        }
+
+        return {
+            pass: allFailures.every(({ failures }) => failures.length === 0),
+            message: () => [
+                `${columnName}: (${format(format1, format2, ' !== ')})\n`,
+                ...allFailures.map(({ failures, title }) =>
+                    !failures.length ? `` : [`${title}:`, ...failures].join(`\n`))
+            ].join('\n')
+        };
+    }
+});

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -321,7 +321,7 @@ function leftPad(str: string, fill: string, n: number) {
     return (new Array(n + 1).join(fill) + str).slice(-1 * n);
 }
 
-function getSingleRecordBatchTable() {
+export function getSingleRecordBatchTable() {
     return Table.from({
         'schema': {
             'fields': [

--- a/js/test/unit/writer-tests.ts
+++ b/js/test/unit/writer-tests.ts
@@ -17,8 +17,9 @@
 
 import '../jest-extensions';
 
-import { Table, RecordBatch } from '../Arrow';
+import Arrow from '../Arrow';
 import { getSingleRecordBatchTable } from './table-tests';
+const { Table, RecordBatch } = Arrow;
 
 describe('Table.serialize()', () => {
     test(`Serializes sliced RecordBatches`, () => {

--- a/js/test/unit/writer-tests.ts
+++ b/js/test/unit/writer-tests.ts
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import '../jest-extensions';
+
+import { Table, RecordBatch } from '../Arrow';
+import { getSingleRecordBatchTable } from './table-tests';
+
+describe('Table.serialize()', () => {
+    test(`Serializes sliced RecordBatches`, () => {
+
+        const table = getSingleRecordBatchTable();
+        const batch = table.batches[0], half = batch.length / 2 | 0;
+
+        // First compare what happens when slicing from the batch level
+        let [batch1, batch2] = [batch.slice(0, half), batch.slice(half)];
+
+        compareBatchAndTable(table,    0, batch1, Table.from(new Table(batch1).serialize()));
+        compareBatchAndTable(table, half, batch2, Table.from(new Table(batch2).serialize()));
+
+        // Then compare what happens when creating a RecordBatch by slicing each child individually
+        batch1 = new RecordBatch(batch1.schema, batch1.length, batch1.schema.fields.map((_, i) => {
+            return batch.getChildAt(i)!.slice(0, half);
+        }));
+
+        batch2 = new RecordBatch(batch2.schema, batch2.length, batch2.schema.fields.map((_, i) => {
+            return batch.getChildAt(i)!.slice(half);
+        }));
+
+        compareBatchAndTable(table,    0, batch1, Table.from(new Table(batch1).serialize()));
+        compareBatchAndTable(table, half, batch2, Table.from(new Table(batch2).serialize()));
+    });
+});
+
+function compareBatchAndTable(source: Table, offset: number, batch: RecordBatch, table: Table) {
+    expect(batch.length).toEqual(table.length);
+    expect(table.numCols).toEqual(source.numCols);
+    expect(batch.numCols).toEqual(source.numCols);
+    for (let i = -1, n = source.numCols; ++i < n;) {
+        const v0 = source.getColumnAt(i)!.slice(offset, offset + batch.length);
+        const v1 = batch.getChildAt(i);
+        const v2 = table.getColumnAt(i);
+        const name = source.schema.fields[i].name;
+        (expect([v1, `batch`, name]) as any).toEqualVector([v0, `source`]);
+        (expect([v2, `table`, name]) as any).toEqualVector([v0, `source`]);
+    }
+}


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARROW-3336. Realized too late I branched from the https://github.com/apache/arrow/pull/2616, so that's why there's some extra commits at the front.

Check out the relevant tests here: https://github.com/trxcllnt/arrow/blob/860f61046fca0081dbe0ce986a97408ed5934e22/js/test/unit/writer-tests.ts#L26. This test covers the primitive, nested, and dictionary vectors, but it'd be worth adding more (for example, Unions).