### PR TITLE
ARROW-3347: [Abandoned] [Rust] Implement PrimitiveArrayBuilder

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ name = "arrow"
 path = "src/lib.rs"
 
 [dependencies]
+byteorder = "1.2.6"
 bytes = "0.4"
 libc = "0.2"
 serde_json = "1.0.13"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+extern crate byteorder;
 extern crate bytes;
 extern crate libc;
 


### PR DESCRIPTION
This is a sub task of ARROW-3089.  The scope of this builder is just for types that implement the `ArrowPrimitiveType` trait, i.e. `PrimitiveArray`'s.

There are a number of follow up items that need to be addressed below.  I will create JIRA's for these once/if this PR is accepted.  I wanted to ensure that others agree with the approach and get some feedback.

The general idea here was to implement the `Write` trait for `Buffer` this allows `Buffer` to use the `WriteBytesExt` extension trait from the _byteorder_ crate which allows `Buffer` to remain untyped while allowing types that implement `ArrowPrimitiveType` to be written to a `Buffer` instance.

The `write_to_buffer` method is then implemented for each primitive type leveraging these extension methods from _byteorder_.  _byteorder_ did not have an implementation for `bool` so I had to implement it myself.

The builder itself was pretty simple and leverages these other updates.

Follow up items (JIRA's to be created upon merging this PR):
 - support for `Option<T> where T: ArrowPrimitiveType`
 - add padding up to 64 bytes, `From<Vec<T>>` does not do this at the moment and I am testing against it (**will be addressed as added in #2658**)
 - expand the `add_primitive_array_impl` macro to `u8` and `i8` (this frustrated me no end...)
 - expand capacity and copy over array when capacity is reached using `push`  (**will be addressed as added in #2658**)
 - add example to examples folder

cc @kszucs @sunchao @andygrove 