### PR TITLE
ARROW-3341: [R] Support for logical vector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -261,10 +261,10 @@ matrix:
         fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_linux.sh
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh --only-library
-    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib
-    - export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib/pkgconfig
     - $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
     - $TRAVIS_BUILD_DIR/ci/travis_lint.sh
+    - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib
+    - export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib/pkgconfig
     - pushd ${TRAVIS_BUILD_DIR}/r
 
 

--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -4,3 +4,5 @@
 src/.clang-format
 LICENSE.md
 ^data-raw$
+lint.sh
+

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -40,9 +40,7 @@ template <int RTYPE, typename Type, typename ArrayType>
 std::shared_ptr<arrow::Array> SimpleArray(SEXP x) {
   Rcpp::Vector<RTYPE> vec(x);
   std::vector<std::shared_ptr<arrow::Buffer>> buffers{
-    nullptr,
-    std::make_shared<SimpleRBuffer<RTYPE>>(vec)
-  };
+      nullptr, std::make_shared<SimpleRBuffer<RTYPE>>(vec)};
 
   int null_count = 0;
   if (RTYPE != RAWSXP) {
@@ -85,19 +83,20 @@ std::shared_ptr<arrow::Array> SimpleArray(SEXP x) {
   return std::make_shared<ArrayType>(data);
 }
 
-std::shared_ptr<arrow::Array> MakeBooleanArray(Rcpp::Vector<LGLSXP, Rcpp::NoProtectStorage> vec) {
+std::shared_ptr<arrow::Array> MakeBooleanArray(
+    Rcpp::Vector<LGLSXP, Rcpp::NoProtectStorage> vec) {
   R_xlen_t n = vec.size();
 
   // allocate a buffer for the data
   std::shared_ptr<arrow::Buffer> data_bitmap;
-  R_ERROR_NOT_OK(arrow::AllocateBuffer(ceil(n/8), &data_bitmap));
+  R_ERROR_NOT_OK(arrow::AllocateBuffer(ceil(n / 8), &data_bitmap));
   auto data_bitmap_data = data_bitmap->mutable_data();
   arrow::internal::FirstTimeBitmapWriter bitmap_writer(data_bitmap_data, 0, n);
   R_xlen_t null_count = 0;
 
   // loop until the first no null
   R_xlen_t i = 0;
-  for(; i < n; i++, bitmap_writer.Next()) {
+  for (; i < n; i++, bitmap_writer.Next()) {
     if (vec[i] == 0) {
       bitmap_writer.Clear();
     } else if (vec[i] == NA_LOGICAL) {
@@ -111,7 +110,7 @@ std::shared_ptr<arrow::Array> MakeBooleanArray(Rcpp::Vector<LGLSXP, Rcpp::NoProt
   if (i < n) {
     // there has been a null before the end, so we need
     // to collect that information in a null bitmap
-    R_ERROR_NOT_OK(arrow::AllocateBuffer(ceil(n/8), &null_bitmap));
+    R_ERROR_NOT_OK(arrow::AllocateBuffer(ceil(n / 8), &null_bitmap));
     auto null_bitmap_data = null_bitmap->mutable_data();
     arrow::internal::FirstTimeBitmapWriter null_bitmap_writer(null_bitmap_data, 0, n);
 
@@ -121,7 +120,7 @@ std::shared_ptr<arrow::Array> MakeBooleanArray(Rcpp::Vector<LGLSXP, Rcpp::NoProt
     }
 
     // finish both bitmaps
-    for(; i < n; i++, bitmap_writer.Next(), null_bitmap_writer.Next()) {
+    for (; i < n; i++, bitmap_writer.Next(), null_bitmap_writer.Next()) {
       if (vec[i] == 0) {
         bitmap_writer.Clear();
         null_bitmap_writer.Set();
@@ -137,15 +136,14 @@ std::shared_ptr<arrow::Array> MakeBooleanArray(Rcpp::Vector<LGLSXP, Rcpp::NoProt
   }
   bitmap_writer.Finish();
 
-  auto data = ArrayData::Make(
-    std::make_shared<BooleanType>(), n, {std::move(null_bitmap), std::move(data_bitmap) }, null_count, 0 /*offset*/
+  auto data = ArrayData::Make(std::make_shared<BooleanType>(), n,
+                              {std::move(null_bitmap), std::move(data_bitmap)},
+                              null_count, 0 /*offset*/
   );
 
   // return the right Array class
   return std::make_shared<BooleanArray>(data);
-
 }
-
 
 }  // namespace r
 }  // namespace arrow
@@ -153,20 +151,23 @@ std::shared_ptr<arrow::Array> MakeBooleanArray(Rcpp::Vector<LGLSXP, Rcpp::NoProt
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Array> Array__from_vector(SEXP x) {
   switch (TYPEOF(x)) {
-  case LGLSXP:
-    return arrow::r::MakeBooleanArray(x);
-  case INTSXP:
-    if (Rf_isFactor(x)) {
+    case LGLSXP:
+      return arrow::r::MakeBooleanArray(x);
+    case INTSXP:
+      if (Rf_isFactor(x)) {
+        break;
+      }
+      return arrow::r::SimpleArray<INTSXP, arrow::Int32Type,
+                                   arrow::NumericArray<arrow::Int32Type>>(x);
+    case REALSXP:
+      // TODO: Dates, ...
+      return arrow::r::SimpleArray<REALSXP, arrow::DoubleType,
+                                   arrow::NumericArray<arrow::DoubleType>>(x);
+    case RAWSXP:
+      return arrow::r::SimpleArray<RAWSXP, arrow::Int8Type,
+                                   arrow::NumericArray<arrow::Int8Type>>(x);
+    default:
       break;
-    }
-    return arrow::r::SimpleArray<INTSXP, arrow::Int32Type, arrow::NumericArray<arrow::Int32Type>>(x);
-  case REALSXP:
-    // TODO: Dates, ...
-    return arrow::r::SimpleArray<REALSXP, arrow::DoubleType, arrow::NumericArray<arrow::DoubleType>>(x);
-  case RAWSXP:
-    return arrow::r::SimpleArray<RAWSXP, arrow::Int8Type, arrow::NumericArray<arrow::Int8Type>>(x);
-  default:
-    break;
   }
 
   stop("not handled");
@@ -202,14 +203,16 @@ inline SEXP BooleanArray_to_Vector(const std::shared_ptr<arrow::Array>& array) {
   LogicalVector vec(n);
 
   // process the data
-  arrow::internal::BitmapReader data_reader(array->data()->buffers[1]->data(), array->offset(), n);
+  arrow::internal::BitmapReader data_reader(array->data()->buffers[1]->data(),
+                                            array->offset(), n);
   for (size_t i = 0; i < n; i++, data_reader.Next()) {
     vec[i] = data_reader.IsSet();
   }
 
   // then the null bitmap if needed
   if (array->null_count()) {
-    arrow::internal::BitmapReader null_reader(array->null_bitmap()->data(), array->offset(), n);
+    arrow::internal::BitmapReader null_reader(array->null_bitmap()->data(),
+                                              array->offset(), n);
     for (size_t i = 0; i < n; i++, null_reader.Next()) {
       if (null_reader.IsNotSet()) {
         vec[i] = LogicalVector::get_na();
@@ -223,17 +226,17 @@ inline SEXP BooleanArray_to_Vector(const std::shared_ptr<arrow::Array>& array) {
 // [[Rcpp::export]]
 SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array) {
   switch (array->type_id()) {
-  case Type::BOOL:
-    return BooleanArray_to_Vector(array);
-  case Type::INT8:
-    return simple_Array_to_Vector<RAWSXP>(array);
-  case Type::INT32:
-    return simple_Array_to_Vector<INTSXP>(array);
-  case Type::DOUBLE:
-    return simple_Array_to_Vector<REALSXP>(array);
-  default:
-    break;
-}
+    case Type::BOOL:
+      return BooleanArray_to_Vector(array);
+    case Type::INT8:
+      return simple_Array_to_Vector<RAWSXP>(array);
+    case Type::INT32:
+      return simple_Array_to_Vector<INTSXP>(array);
+    case Type::DOUBLE:
+      return simple_Array_to_Vector<REALSXP>(array);
+    default:
+      break;
+  }
 
   stop(tfm::format("cannot handle Array of type %d", array->type_id()));
   return R_NilValue;

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -64,3 +64,16 @@ test_that("Array supports NA", {
   expect_equal(Array__Mask(x_int), c(rep(TRUE, 10), FALSE))
   expect_equal(Array__Mask(x_dbl), c(rep(TRUE, 10), FALSE))
 })
+
+test_that("Array supports logical vectors (ARROW-3341)", {
+  # with NA
+  x <- sample(c(TRUE, FALSE, NA), 1000, replace = TRUE)
+  arr_lgl <- array(x)
+  expect_identical(x, arr_lgl$as_vector())
+
+  # without NA
+  x <- sample(c(TRUE, FALSE), 1000, replace = TRUE)
+  arr_lgl <- array(x)
+  expect_identical(x, arr_lgl$as_vector())
+})
+

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -18,19 +18,22 @@
 context("arrow::RecordBatch")
 
 test_that("RecordBatch", {
-  tbl <- tibble::tibble(int = 1:10, dbl = as.numeric(1:10))
+  tbl <- tibble::tibble(
+    int = 1:10, dbl = as.numeric(1:10),
+    lgl = sample(c(TRUE, FALSE, NA), 10, replace = TRUE)
+  )
   batch <- record_batch(tbl)
 
   expect_true(batch == batch)
   expect_equal(
     batch$schema(),
-    schema(int = int32(), dbl = float64())
+    schema(int = int32(), dbl = float64(), lgl = boolean())
   )
-  expect_equal(batch$num_columns(), 2L)
+  expect_equal(batch$num_columns(), 3L)
   expect_equal(batch$num_rows(), 10L)
   expect_equal(batch$column_name(0), "int")
   expect_equal(batch$column_name(1), "dbl")
-  expect_equal(names(batch), c("int", "dbl"))
+  expect_equal(names(batch), c("int", "dbl", "lgl"))
 
   col_int <- batch$column(0)
   expect_true(inherits(col_int, 'arrow::Array'))
@@ -42,10 +45,15 @@ test_that("RecordBatch", {
   expect_equal(col_dbl$as_vector(), tbl$dbl)
   expect_equal(col_dbl$type(), float64())
 
+  col_lgl <- batch$column(2)
+  expect_true(inherits(col_dbl, 'arrow::Array'))
+  expect_equal(col_lgl$as_vector(), tbl$lgl)
+  expect_equal(col_lgl$type(), boolean())
+
   batch2 <- batch$RemoveColumn(0)
   expect_equal(
     batch2$schema(),
-    schema(dbl = float64())
+    schema(dbl = float64(), lgl = boolean())
   )
   expect_equal(batch2$column(0), batch$column(1))
 

--- a/r/tests/testthat/test-chunkedarray.R
+++ b/r/tests/testthat/test-chunkedarray.R
@@ -75,3 +75,28 @@ test_that("ChunkedArray handles NA", {
   expect_equal(Array__Mask(chunks[[2]]), !is.na(data[[2]]))
   expect_equal(Array__Mask(chunks[[3]]), !is.na(data[[3]]))
 })
+
+test_that("ChunkedArray supports logical vectors (ARROW-3341)", {
+  # with NA
+  data <- purrr::rerun(3, sample(c(TRUE, FALSE, NA), 100, replace = TRUE))
+  arr_lgl <- chunked_array(!!!data)
+  expect_equal(arr_lgl$length(), 300L)
+  expect_equal(arr_lgl$null_count(), sum(unlist(map(data, is.na))))
+
+  chunks <- arr_lgl$chunks()
+  expect_identical(data[[1]], chunks[[1]]$as_vector())
+  expect_identical(data[[2]], chunks[[2]]$as_vector())
+  expect_identical(data[[3]], chunks[[3]]$as_vector())
+
+  # without NA
+  data <- purrr::rerun(3, sample(c(TRUE, FALSE), 100, replace = TRUE))
+  arr_lgl <- chunked_array(!!!data)
+  expect_equal(arr_lgl$length(), 300L)
+  expect_equal(arr_lgl$null_count(), sum(unlist(map(data, is.na))))
+
+  chunks <- arr_lgl$chunks()
+  expect_identical(data[[1]], chunks[[1]]$as_vector())
+  expect_identical(data[[2]], chunks[[2]]$as_vector())
+  expect_identical(data[[3]], chunks[[3]]$as_vector())
+})
+


### PR DESCRIPTION
As opposed to the other arrays, this needs special handling of buffers because R stores logical vectors as `int`. 