### PR TITLE
ARROW-3357: [Rust] Add a mutable buffer implementation

### DIFF
--- a/rust/src/array.rs
+++ b/rust/src/array.rs
@@ -181,9 +181,11 @@ macro_rules! def_primitive_array {
                     let m = self.value(i as i64);
                     match n {
                         None => n = Some(m),
-                        Some(nn) => if cmp(m, nn) {
-                            n = Some(m)
-                        },
+                        Some(nn) => {
+                            if cmp(m, nn) {
+                                n = Some(m)
+                            }
+                        }
                     }
                 }
                 n

--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -418,7 +418,8 @@ mod tests {
         let buffer_copy = thread::spawn(move || {
             // access buffer in another thread.
             buffer.clone()
-        }).join();
+        })
+        .join();
 
         assert!(buffer_copy.is_ok());
         assert_eq!(buffer2, buffer_copy.ok().unwrap());

--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -418,8 +418,7 @@ mod tests {
         let buffer_copy = thread::spawn(move || {
             // access buffer in another thread.
             buffer.clone()
-        })
-        .join();
+        }).join();
 
         assert!(buffer_copy.is_ok());
         assert_eq!(buffer2, buffer_copy.ok().unwrap());


### PR DESCRIPTION
Currently we only have a immutable buffer implementation (`Buffer`). To implement various array builders, it's better to also have a mutable version of this so that we can keep appending data to a buffer. This PR adds a `MutableBuffer` struct which is growable and can be mutated. A mutable buffer can also be consumed and converted into a immutable buffer.