### PR TITLE
ARROW-3369: [Packaging] Wheel builds are failing due to wheel 0.32 release

### DIFF
--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -99,7 +99,6 @@ function build_wheel {
     # build will also work with newer NumPy versions.
     export ARROW_HOME=`pwd`/arrow-dist
     export PARQUET_HOME=`pwd`/arrow-dist
-    pip install "cython==0.27.3" "numpy==${NP_TEST_DEP}"
 
     pushd cpp
     mkdir build

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -99,6 +99,9 @@ function build_wheel {
     # build will also work with newer NumPy versions.
     export ARROW_HOME=`pwd`/arrow-dist
     export PARQUET_HOME=`pwd`/arrow-dist
+    if [ -n "$BUILD_DEPENDS" ]; then
+        pip install $(pip_opts) $BUILD_DEPENDS
+    fi
 
     pushd cpp
     mkdir build

--- a/dev/tasks/python-wheels/travis.linux.yml
+++ b/dev/tasks/python-wheels/travis.linux.yml
@@ -28,9 +28,6 @@ env:
   global:
     - PLAT=x86_64
     - TRAVIS_TAG={{ task.tag }}
-    - BUILD_REF={{ arrow.head }}
-    - PYTHON_VERSION={{ python_version }}
-    - PYARROW_VERSION={{ arrow.version }}
 
 before_script:
   - docker pull quay.io/xhochy/arrow_manylinux1_x86_64_base:latest
@@ -42,8 +39,9 @@ script:
 
   - pushd arrow/python/manylinux1
   - docker run --shm-size=2g
-      -e SETUPTOOLS_SCM_PRETEND_VERSION=$PYARROW_VERSION
-      -e PYTHON_VERSIONS=$PYTHON_VERSION
+      -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.version }}
+      -e PYTHON_VERSIONS={{ python_version }}
+      -e WHEEL_VERSION={{ wheel_version }}
       -v $PWD:/io
       -v $PWD/../../:/arrow
       quay.io/xhochy/arrow_manylinux1_x86_64_base:latest /io/build_arrow.sh

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -25,10 +25,12 @@ env:
   global:
     - PLAT=x86_64
     - TRAVIS_TAG={{ task.tag }}
-    - PYARROW_VERSION={{ arrow.version }}
-    - MB_PYTHON_VERSION={{ python_version }}
     - MACOSX_DEPLOYMENT_TARGET="10.9"
+    - PYARROW_VERSION={{ arrow.version }}
     - PYARROW_BUILD_VERBOSE=1
+    - MB_PYTHON_VERSION={{ python_version }}
+    - BUILD_DEPENDS="wheel=={{ wheel_version }} numpy=={{ numpy_version }} cython==0.27.3 six"
+    - TEST_DEPENDS="numpy=={{ numpy_version }} pandas=={{ pandas_version }} six"
 
 before_install:
   - git clone https://github.com/matthew-brett/multibuild # TODO pin it
@@ -48,9 +50,6 @@ before_install:
   - before_install
 
 install:
-  - BUILD_DEPENDS="wheel=={{ wheel_version }} numpy=={{ numpy_version }} cython==0.27.3 six"
-  - TEST_DEPENDS="numpy=={{ numpy_version }} pandas=={{ pandas_version }} six"
-
   - mkdir -p dist
 
   # multibuild's default clean_code function

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -25,13 +25,9 @@ env:
   global:
     - PLAT=x86_64
     - TRAVIS_TAG={{ task.tag }}
-    - BUILD_REF={{ arrow.head }}
     - PYARROW_VERSION={{ arrow.version }}
-    - MACOSX_DEPLOYMENT_TARGET="10.9"
     - MB_PYTHON_VERSION={{ python_version }}
-    - NP_BUILD_DEP="{{ numpy_build_version }}"
-    - NP_TEST_DEP="{{ numpy_test_version }}"
-    - PANDAS_DEP="{{ pandas_version }}"
+    - MACOSX_DEPLOYMENT_TARGET="10.9"
     - PYARROW_BUILD_VERBOSE=1
 
 before_install:
@@ -52,13 +48,13 @@ before_install:
   - before_install
 
 install:
-  - BUILD_DEPENDS="numpy==$NP_BUILD_DEP six cython"
-  - TEST_DEPENDS="numpy==$NP_TEST_DEP six pandas==$PANDAS_DEP"
+  - BUILD_DEPENDS="wheel=={{ wheel_version }} numpy=={{ numpy_version }} cython==0.27.3 six"
+  - TEST_DEPENDS="numpy=={{ numpy_version }} pandas=={{ pandas_version }} six"
 
   - mkdir -p dist
 
   # multibuild's default clean_code function
-  - clean_code arrow $BUILD_REF
+  - clean_code arrow {{ arrow.head }}
 
   # the following functions are defined in osx-build.sh
   - build_wheel arrow

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -34,6 +34,8 @@ env:
 
 before_install:
   - git clone https://github.com/matthew-brett/multibuild # TODO pin it
+  - git -C multibuild checkout 4e7a9396e9a50731bb83fc0d16bb98fb0c4032d7
+
   - git clone -b {{ arrow.branch }} {{ arrow.remote }} arrow
   - git -C arrow checkout {{ arrow.head }}
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -139,6 +139,7 @@ tasks:
     platform: linux
     template: python-wheels/travis.linux.yml
     params:
+      wheel_version: 0.31.1
       python_version: 2.7,16
     artifacts:
       - pyarrow-{version}-cp27-cp27m-manylinux1_x86_64.whl
@@ -147,6 +148,7 @@ tasks:
     platform: linux
     template: python-wheels/travis.linux.yml
     params:
+      wheel_version: 0.31.1
       python_version: 2.7,32
     artifacts:
       - pyarrow-{version}-cp27-cp27mu-manylinux1_x86_64.whl
@@ -155,6 +157,7 @@ tasks:
     platform: linux
     template: python-wheels/travis.linux.yml
     params:
+      wheel_version: 0.31.1
       python_version: 3.5,16
     artifacts:
       - pyarrow-{version}-cp35-cp35m-manylinux1_x86_64.whl
@@ -163,6 +166,7 @@ tasks:
     platform: linux
     template: python-wheels/travis.linux.yml
     params:
+      wheel_version: 0.31.1
       python_version: 3.6,16
     artifacts:
       - pyarrow-{version}-cp36-cp36m-manylinux1_x86_64.whl
@@ -173,10 +177,10 @@ tasks:
     platform: osx
     template: python-wheels/travis.osx.yml
     params:
-      numpy_build_version: 1.10.4
-      numpy_test_version: 1.14.0
+      numpy_version: 1.14
       pandas_version: 0.23.0
       python_version: 2.7
+      wheel_version: 0.31.1
     artifacts:
       - pyarrow-{version}-cp27-cp27m-macosx_10_6_intel.whl
 
@@ -184,10 +188,10 @@ tasks:
     platform: osx
     template: python-wheels/travis.osx.yml
     params:
-      numpy_build_version: 1.10.4
-      numpy_test_version: 1.14.0
+      numpy_version: 1.14
       pandas_version: 0.23.0
       python_version: 3.5
+      wheel_version: 0.31.1
     artifacts:
       - pyarrow-{version}-cp35-cp35m-macosx_10_6_intel.whl
 
@@ -195,10 +199,10 @@ tasks:
     platform: osx
     template: python-wheels/travis.osx.yml
     params:
-      numpy_build_version: 1.11.3
-      numpy_test_version: 1.14.0
+      numpy_version: 1.14
       pandas_version: 0.23.0
       python_version: 3.6
+      wheel_version: 0.31.1
     artifacts:
       - pyarrow-{version}-cp36-cp36m-macosx_10_6_intel.whl
 

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -58,7 +58,7 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
     PATH="$PATH:${CPYTHON_PATH}"
 
     # pin wheel, because auditwheel is not compatible with wheel=0.32
-    $PIP install wheel=${WHEEL_VERSION:-0.31.1}
+    $PIP install "wheel==${WHEEL_VERSION:-0.31.1}"
 
     # TensorFlow is not supported for Python 2.7 with unicode width 16 or with Python 3.7
     if [ $PYTHON != "2.7" ] || [ $U_WIDTH = "32" ]; then

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -66,6 +66,7 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
 
     # pin wheel, because auditwheel is not compatible with wheel=0.32
     # pin after installing tensorflow, because it updates to wheel=0.32
+    # TODO(kszucs): remove after auditwheel properly supports wheel>0.31
     $PIP install "wheel==${WHEEL_VERSION:-0.31.1}"
 
     echo "=== (${PYTHON}) Building Arrow C++ libraries ==="

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -57,6 +57,9 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
     PIP="${CPYTHON_PATH}/bin/pip"
     PATH="$PATH:${CPYTHON_PATH}"
 
+    # pin wheel, because auditwheel is not compatible with wheel=0.32
+    $PIP install wheel=${WHEEL_VERSION:-0.31.1}
+
     # TensorFlow is not supported for Python 2.7 with unicode width 16 or with Python 3.7
     if [ $PYTHON != "2.7" ] || [ $U_WIDTH = "32" ]; then
       if [ $PYTHON != "3.7" ]; then

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -57,15 +57,16 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
     PIP="${CPYTHON_PATH}/bin/pip"
     PATH="$PATH:${CPYTHON_PATH}"
 
-    # pin wheel, because auditwheel is not compatible with wheel=0.32
-    $PIP install "wheel==${WHEEL_VERSION:-0.31.1}"
-
     # TensorFlow is not supported for Python 2.7 with unicode width 16 or with Python 3.7
     if [ $PYTHON != "2.7" ] || [ $U_WIDTH = "32" ]; then
       if [ $PYTHON != "3.7" ]; then
         $PIP install --ignore-installed --upgrade tensorflow
       fi
     fi
+
+    # pin wheel, because auditwheel is not compatible with wheel=0.32
+    # pin after installing tensorflow, because it updates to wheel=0.32
+    $PIP install "wheel==${WHEEL_VERSION:-0.31.1}"
 
     echo "=== (${PYTHON}) Building Arrow C++ libraries ==="
     ARROW_BUILD_DIR=/tmp/build-PY${PYTHON}-${U_WIDTH}


### PR DESCRIPTION
Wheel builds: https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=build-324

- Updated numpy version
- Pinned multibuild version
- Pinned wheel version to `0.31.1` until auditwheel and multibuild compatibility issues are resolved
