### PR TITLE
ARROW-1521: [C++] Add BufferOutputStream::Reset method

### DIFF
--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -85,6 +85,26 @@ TEST_F(TestBufferOutputStream, WriteAfterFinish) {
   ASSERT_RAISES(IOError, stream_->Write(data));
 }
 
+TEST_F(TestBufferOutputStream, Reset) {
+  std::string data = "data123456";
+
+  auto stream = checked_cast<BufferOutputStream*>(stream_.get());
+
+  ASSERT_OK(stream->Write(data));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_OK(stream->Finish(&buffer));
+  ASSERT_EQ(buffer->size(), static_cast<int64_t>(data.size()));
+
+  ASSERT_OK(stream->Reset(2048));
+  ASSERT_OK(stream->Write(data));
+  ASSERT_OK(stream->Write(data));
+  std::shared_ptr<Buffer> buffer2;
+  ASSERT_OK(stream->Finish(&buffer2));
+
+  ASSERT_EQ(buffer2->size(), static_cast<int64_t>(data.size() * 2));
+}
+
 TEST(TestFixedSizeBufferWriter, Basics) {
   std::shared_ptr<Buffer> buffer;
   ASSERT_OK(AllocateBuffer(1024, &buffer));

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -36,6 +36,12 @@ namespace io {
 
 static constexpr int64_t kBufferMinimumSize = 256;
 
+BufferOutputStream::BufferOutputStream()
+    : is_open_(false),
+      capacity_(0),
+      position_(0),
+      mutable_data_(nullptr) {}
+
 BufferOutputStream::BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer)
     : buffer_(buffer),
       is_open_(true),
@@ -45,9 +51,17 @@ BufferOutputStream::BufferOutputStream(const std::shared_ptr<ResizableBuffer>& b
 
 Status BufferOutputStream::Create(int64_t initial_capacity, MemoryPool* pool,
                                   std::shared_ptr<BufferOutputStream>* out) {
-  std::shared_ptr<ResizableBuffer> buffer;
-  RETURN_NOT_OK(AllocateResizableBuffer(pool, initial_capacity, &buffer));
-  *out = std::make_shared<BufferOutputStream>(buffer);
+  // ctor is private, so cannot use make_shared
+  *out = std::shared_ptr<BufferOutputStream>(new BufferOutputStream);
+  return (*out)->Reset(initial_capacity, pool);
+}
+
+Status BufferOutputStream::Reset(int64_t initial_capacity, MemoryPool* pool) {
+  RETURN_NOT_OK(AllocateResizableBuffer(pool, initial_capacity, &buffer_));
+  is_open_ = true;
+  capacity_ = initial_capacity;
+  position_ = 0;
+  mutable_data_ = buffer_->mutable_data();
   return Status::OK();
 }
 

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -37,10 +37,7 @@ namespace io {
 static constexpr int64_t kBufferMinimumSize = 256;
 
 BufferOutputStream::BufferOutputStream()
-    : is_open_(false),
-      capacity_(0),
-      position_(0),
-      mutable_data_(nullptr) {}
+    : is_open_(false), capacity_(0), position_(0), mutable_data_(nullptr) {}
 
 BufferOutputStream::BufferOutputStream(const std::shared_ptr<ResizableBuffer>& buffer)
     : buffer_(buffer),

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -59,7 +59,18 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   /// Close the stream and return the buffer
   Status Finish(std::shared_ptr<Buffer>* result);
 
+  /// \brief Initialize state of OutputStream with newly allocated memory and
+  /// set position to 0
+  /// \param[in] initial_capacity the starting allocated capacity
+  /// \param[in,out] pool the memory pool to use for allocations
+  /// \return Status
+  Status Reset(int64_t initial_capacity, MemoryPool* pool);
+
+  int64_t capacity() const { return capacity_; }
+
  private:
+  BufferOutputStream();
+
   // Ensures there is sufficient space available to write nbytes
   Status Reserve(int64_t nbytes);
 

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "arrow/io/interfaces.h"
+#include "arrow/memory_pool.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -56,6 +57,8 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   Status Tell(int64_t* position) const override;
   Status Write(const void* data, int64_t nbytes) override;
 
+  using OutputStream::Write;
+
   /// Close the stream and return the buffer
   Status Finish(std::shared_ptr<Buffer>* result);
 
@@ -64,7 +67,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   /// \param[in] initial_capacity the starting allocated capacity
   /// \param[in,out] pool the memory pool to use for allocations
   /// \return Status
-  Status Reset(int64_t initial_capacity, MemoryPool* pool);
+  Status Reset(int64_t initial_capacity = 1024, MemoryPool* pool = default_memory_pool());
 
   int64_t capacity() const { return capacity_; }
 


### PR DESCRIPTION
This allows a arrow::io::BufferOutputStream to be reused