### PR TITLE
PARQUET-1402: [C++]: parquet-mr writes zero dictionary_page_offset

### DIFF
--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -97,7 +97,8 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     auto col = row_group_metadata_->ColumnChunk(i);
 
     int64_t col_start = col->data_page_offset();
-    if (col->has_dictionary_page() && col_start > col->dictionary_page_offset()) {
+    if (col->has_dictionary_page() && col->dictionary_page_offset() > 0 &&
+        col_start > col->dictionary_page_offset()) {
       col_start = col->dictionary_page_offset();
     }
 


### PR DESCRIPTION
when it is (supposed?) equal to data_page_offset