### PR TITLE
ARROW-3394: [Java] Remove duplicate dependency in Flight for grpc-netty

### DIFF
--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -54,12 +54,6 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-netty</artifactId>
-      <version>${dep.grpc.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
       <version>${dep.grpc.version}</version>
       <scope>provided</scope>


### PR DESCRIPTION
This removes the duplicate entry of grpc-netty in the Flight pom, which leads to the following warning:

```
[WARNING] Some problems were encountered while building the effective model for org.apache.arrow:arrow-flight:jar:0.11.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.grpc:grpc-netty:jar -> duplicate declaration of version ${dep.grpc.version} @ org.apache.arrow:arrow-flight:[unknown-version], /home/bryan/git/arrow/java/flight/pom.xml, line 55, column 17
```