### PR TITLE
ARROW-3404: [C++] Make CSV chunker faster

### DIFF
--- a/cpp/src/arrow/csv/chunker.h
+++ b/cpp/src/arrow/csv/chunker.h
@@ -28,8 +28,6 @@
 namespace arrow {
 namespace csv {
 
-constexpr int32_t kMaxChunkerNumRows = 100000;
-
 /// \class Chunker
 /// \brief A reusable block-based chunker for CSV data
 ///
@@ -42,15 +40,13 @@ constexpr int32_t kMaxChunkerNumRows = 100000;
 /// with LF (0x0a), the chunker will consider the leading newline as an empty line.
 class ARROW_EXPORT Chunker {
  public:
-  explicit Chunker(ParseOptions options, int32_t max_num_rows = kMaxChunkerNumRows);
+  explicit Chunker(ParseOptions options);
 
   /// \brief Carve up a chunk in a block of data
   ///
-  /// Process a block of CSV data, reading up to max_num_rows rows.
+  /// Process a block of CSV data, reading up to size bytes.
   /// The number of bytes in the chunk is returned in out_size.
   Status Process(const char* data, uint32_t size, uint32_t* out_size);
-
-  int32_t num_rows() const { return num_rows_; }
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Chunker);
@@ -65,10 +61,6 @@ class ARROW_EXPORT Chunker {
   inline const char* ReadLine(const char* data, const char* data_end);
 
   ParseOptions options_;
-  // The number of rows chunked from the block
-  int32_t num_rows_;
-  // The maximum number of rows to chunk from this block
-  int32_t max_num_rows_;
 };
 
 }  // namespace csv

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -40,6 +40,8 @@ struct ARROW_EXPORT ParseOptions {
   bool escaping = false;
   // Escaping character (if `escaping` is true)
   char escape_char = '\\';
+  // Whether values are allowed to contain CR (0x0d) and LF (0x0a) characters
+  bool newlines_in_values = false;
 
   // XXX Should this be in ReadOptions?
   // Number of header rows to skip
@@ -57,10 +59,9 @@ struct ARROW_EXPORT ReadOptions {
 
   // Whether to use the global CPU thread pool
   bool use_threads = true;
-  // Block size we request from the IO layer
+  // Block size we request from the IO layer; also determines the size of
+  // chunks when use_threads is true
   int32_t block_size = 1 << 20;  // 1 MB
-  // Max num rows per array chunk
-  int32_t num_rows = 100000;
 
   static ReadOptions Defaults();
 };

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -39,14 +39,12 @@ cdef class ReadOptions:
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
-    def __init__(self, use_threads=None, block_size=None, num_rows=None):
+    def __init__(self, use_threads=None, block_size=None):
         self.options = CCSVReadOptions.Defaults()
         if use_threads is not None:
             self.use_threads = use_threads
         if block_size is not None:
             self.block_size = block_size
-        if num_rows is not None:
-            self.num_rows = num_rows
 
     @property
     def use_threads(self):
@@ -64,14 +62,6 @@ cdef class ReadOptions:
     def block_size(self, value):
         self.options.block_size = value
 
-    @property
-    def num_rows(self):
-        return self.options.num_rows
-
-    @num_rows.setter
-    def num_rows(self, value):
-        self.options.num_rows = value
-
 
 cdef class ParseOptions:
     cdef:
@@ -80,7 +70,7 @@ cdef class ParseOptions:
     __slots__ = ()
 
     def __init__(self, delimiter=None, quote_char=None, double_quote=None,
-                 escape_char=None, header_rows=None):
+                 escape_char=None, header_rows=None, newlines_in_values=None):
         self.options = CCSVParseOptions.Defaults()
         if delimiter is not None:
             self.delimiter = delimiter
@@ -92,6 +82,8 @@ cdef class ParseOptions:
             self.escape_char = escape_char
         if header_rows is not None:
             self.header_rows = header_rows
+        if newlines_in_values is not None:
+            self.newlines_in_values = newlines_in_values
 
     @property
     def delimiter(self):
@@ -146,6 +138,14 @@ cdef class ParseOptions:
     @header_rows.setter
     def header_rows(self, value):
         self.options.header_rows = value
+
+    @property
+    def newlines_in_values(self):
+        return self.options.newlines_in_values
+
+    @newlines_in_values.setter
+    def newlines_in_values(self, value):
+        self.options.newlines_in_values = value
 
 
 cdef _get_reader(input_file, shared_ptr[InputStream]* out):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -909,6 +909,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         c_bool escaping
         unsigned char escape_char
         int32_t header_rows
+        c_bool newlines_in_values
 
         @staticmethod
         CCSVParseOptions Defaults()
@@ -920,7 +921,6 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVReadOptions" arrow::csv::ReadOptions":
         c_bool use_threads
         int32_t block_size
-        int32_t num_rows
 
         @staticmethod
         CCSVReadOptions Defaults()

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -65,14 +65,9 @@ def test_read_options():
     opts.use_threads = False
     assert opts.use_threads is False
 
-    assert opts.num_rows > 0
-    opts.num_rows = 456789
-    assert opts.num_rows == 456789
-
-    opts = cls(block_size=1234, use_threads=False, num_rows=42)
+    opts = cls(block_size=1234, use_threads=False)
     assert opts.block_size == 1234
     assert opts.use_threads is False
-    assert opts.num_rows == 42
 
 
 def test_parse_options():
@@ -83,6 +78,7 @@ def test_parse_options():
     assert opts.double_quote is True
     assert opts.escape_char is False
     assert opts.header_rows == 1
+    assert opts.newlines_in_values is False
 
     opts.delimiter = 'x'
     assert opts.delimiter == 'x'
@@ -100,16 +96,20 @@ def test_parse_options():
     assert opts.escape_char is False
     assert opts.quote_char is False
 
+    opts.newlines_in_values = True
+    assert opts.newlines_in_values is True
+
     opts.header_rows = 2
     assert opts.header_rows == 2
 
     opts = cls(delimiter=';', quote_char='%', double_quote=False,
-               escape_char='\\', header_rows=2)
+               escape_char='\\', header_rows=2, newlines_in_values=True)
     assert opts.delimiter == ';'
     assert opts.quote_char == '%'
     assert opts.double_quote is False
     assert opts.escape_char == '\\'
     assert opts.header_rows == 2
+    assert opts.newlines_in_values is True
 
 
 class BaseTestCSVRead:


### PR DESCRIPTION
This speeds up multi-threaded CSV reads by removing the serial bottleneck of detecting newlines when no newlines can be present in CSV values.

On this machine (8-core AMD processor), the speed of reading a CSV file of text column data goes from 600 MB/s (before this patch) to 1.2 GB/s.