### PR TITLE
ARROW-3423: [Packaging] Remove RC information from deb/rpm packages

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -599,13 +599,19 @@ def submit(ctx, task, group, job_prefix, config_path, arrow_version, dry_run):
     if arrow_version:
         target.version = arrow_version
 
+    no_rc_version = re.sub(r'-rc\d+\Z', '', target.version)
+    params = {
+        'version': target.version,
+        'no_rc_version': no_rc_version,
+    }
+
     # task and group variables are lists, containing multiple values
     tasks = {}
     task_configs = load_tasks_from_config(config_path, task, group)
     for name, task in task_configs.items():
         # replace version number and create task instance from configuration
         artifacts = task.pop('artifacts', None) or []  # because of yaml
-        artifacts = [fn.format(version=target.version) for fn in artifacts]
+        artifacts = [fn.format(**params) for fn in artifacts]
         tasks[name] = Task(artifacts=artifacts, **task)
 
     # create job instance, doesn't mutate git data yet

--- a/dev/tasks/linux-packages/Rakefile
+++ b/dev/tasks/linux-packages/Rakefile
@@ -22,7 +22,10 @@ require_relative "package-task"
 class ApacheArrowPackageTask < PackageTask
   def initialize
     release_time = detect_release_time
-    super("apache-arrow", detect_version(release_time), release_time)
+    super("apache-arrow",
+          detect_version(release_time),
+          release_time,
+          :rc_build_type => :release)
     @rpm_package = "arrow"
   end
 

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -22,7 +22,7 @@ require "time"
 class PackageTask
   include Rake::DSL
 
-  def initialize(package, version, release_time)
+  def initialize(package, version, release_time, options={})
     @package = package
     @version = version
     @release_time = release_time
@@ -33,12 +33,19 @@ class PackageTask
 
     @rpm_package = @package
     case @version
-    when /-((?:dev|rc)\d+)\z/
+    when /-((dev|rc)\d+)\z/
       base_version = $PREMATCH
       sub_version = $1
-      @deb_upstream_version = "#{base_version}~#{sub_version}"
-      @rpm_version = base_version
-      @rpm_release = "0.#{sub_version}"
+      type = $2
+      if type == "rc" and options[:rc_build_type] == :release
+        @deb_upstream_version = base_version
+        @rpm_version = base_version
+        @rpm_release = "1"
+      else
+        @deb_upstream_version = "#{base_version}~#{sub_version}"
+        @rpm_version = base_version
+        @rpm_release = "0.#{sub_version}"
+      end
     else
       @deb_upstream_version = @version
       @rpm_version = @version

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -239,35 +239,35 @@ tasks:
         - .debian.tar.xz
         - .orig.tar.gz
     artifacts:
-      - apache-arrow_{version}-1.debian.tar.xz
-      - apache-arrow_{version}-1.dsc
-      - apache-arrow_{version}.orig.tar.gz
-      - gir1.2-arrow-1.0_{version}-1_amd64.deb
-      - gir1.2-arrow-gpu-1.0_{version}-1_amd64.deb
-      - gir1.2-parquet-1.0_{version}-1_amd64.deb
-      - libarrow-dev_{version}-1_amd64.deb
-      - libarrow-glib-dev_{version}-1_amd64.deb
-      - libarrow-glib-doc_{version}-1_all.deb
-      - libarrow-glib11-dbgsym_{version}-1_amd64.deb
-      - libarrow-glib11_{version}-1_amd64.deb
-      - libarrow-gpu-dev_{version}-1_amd64.deb
-      - libarrow-gpu-glib-dev_{version}-1_amd64.deb
-      - libarrow-gpu-glib11-dbgsym_{version}-1_amd64.deb
-      - libarrow-gpu-glib11_{version}-1_amd64.deb
-      - libarrow-gpu11-dbgsym_{version}-1_amd64.deb
-      - libarrow-gpu11_{version}-1_amd64.deb
-      - libarrow-python-dev_{version}-1_amd64.deb
-      - libarrow-python11-dbgsym_{version}-1_amd64.deb
-      - libarrow-python11_{version}-1_amd64.deb
-      - libarrow11-dbgsym_{version}-1_amd64.deb
-      - libarrow11_{version}-1_amd64.deb
-      - libparquet-dev_{version}-1_amd64.deb
-      - libparquet-glib-dev_{version}-1_amd64.deb
-      - libparquet-glib-doc_{version}-1_all.deb
-      - libparquet-glib11-dbgsym_{version}-1_amd64.deb
-      - libparquet-glib11_{version}-1_amd64.deb
-      - libparquet11-dbgsym_{version}-1_amd64.deb
-      - libparquet11_{version}-1_amd64.deb
+      - apache-arrow_{no_rc_version}-1.debian.tar.xz
+      - apache-arrow_{no_rc_version}-1.dsc
+      - apache-arrow_{no_rc_version}.orig.tar.gz
+      - gir1.2-arrow-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-arrow-gpu-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-parquet-1.0_{no_rc_version}-1_amd64.deb
+      - libarrow-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-doc_{no_rc_version}-1_all.deb
+      - libarrow-glib11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libarrow-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu11_{no_rc_version}-1_amd64.deb
+      - libarrow-python-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-python11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libarrow-python11_{no_rc_version}-1_amd64.deb
+      - libarrow11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libarrow11_{no_rc_version}-1_amd64.deb
+      - libparquet-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-doc_{no_rc_version}-1_all.deb
+      - libparquet-glib11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libparquet-glib11_{no_rc_version}-1_amd64.deb
+      - libparquet11-dbgsym_{no_rc_version}-1_amd64.deb
+      - libparquet11_{no_rc_version}-1_amd64.deb
 
   ubuntu-trusty:
     platform: linux
@@ -280,21 +280,21 @@ tasks:
         - .debian.tar.gz
         - .orig.tar.gz
     artifacts:
-      - apache-arrow_{version}-1.debian.tar.gz
-      - apache-arrow_{version}-1.dsc
-      - apache-arrow_{version}.orig.tar.gz
-      - gir1.2-arrow-1.0_{version}-1_amd64.deb
-      - gir1.2-parquet-1.0_{version}-1_amd64.deb
-      - libarrow-dev_{version}-1_amd64.deb
-      - libarrow-glib-dev_{version}-1_amd64.deb
-      - libarrow-glib-doc_{version}-1_all.deb
-      - libarrow-glib11_{version}-1_amd64.deb
-      - libarrow11_{version}-1_amd64.deb
-      - libparquet-dev_{version}-1_amd64.deb
-      - libparquet-glib-dev_{version}-1_amd64.deb
-      - libparquet-glib-doc_{version}-1_all.deb
-      - libparquet-glib11_{version}-1_amd64.deb
-      - libparquet11_{version}-1_amd64.deb
+      - apache-arrow_{no_rc_version}-1.debian.tar.gz
+      - apache-arrow_{no_rc_version}-1.dsc
+      - apache-arrow_{no_rc_version}.orig.tar.gz
+      - gir1.2-arrow-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-parquet-1.0_{no_rc_version}-1_amd64.deb
+      - libarrow-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-doc_{no_rc_version}-1_all.deb
+      - libarrow-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow11_{no_rc_version}-1_amd64.deb
+      - libparquet-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-doc_{no_rc_version}-1_all.deb
+      - libparquet-glib11_{no_rc_version}-1_amd64.deb
+      - libparquet11_{no_rc_version}-1_amd64.deb
 
   ubuntu-xenial:
     platform: linux
@@ -307,28 +307,28 @@ tasks:
         - .debian.tar.xz
         - .orig.tar.gz
     artifacts:
-      - apache-arrow_{version}-1.debian.tar.xz
-      - apache-arrow_{version}-1.dsc
-      - apache-arrow_{version}.orig.tar.gz
-      - gir1.2-arrow-1.0_{version}-1_amd64.deb
-      - gir1.2-arrow-gpu-1.0_{version}-1_amd64.deb
-      - gir1.2-parquet-1.0_{version}-1_amd64.deb
-      - libarrow-dev_{version}-1_amd64.deb
-      - libarrow-glib-dev_{version}-1_amd64.deb
-      - libarrow-glib-doc_{version}-1_all.deb
-      - libarrow-glib11_{version}-1_amd64.deb
-      - libarrow-gpu-dev_{version}-1_amd64.deb
-      - libarrow-gpu-glib-dev_{version}-1_amd64.deb
-      - libarrow-gpu-glib11_{version}-1_amd64.deb
-      - libarrow-gpu11_{version}-1_amd64.deb
-      - libarrow-python-dev_{version}-1_amd64.deb
-      - libarrow-python11_{version}-1_amd64.deb
-      - libarrow11_{version}-1_amd64.deb
-      - libparquet-dev_{version}-1_amd64.deb
-      - libparquet-glib-dev_{version}-1_amd64.deb
-      - libparquet-glib-doc_{version}-1_all.deb
-      - libparquet-glib11_{version}-1_amd64.deb
-      - libparquet11_{version}-1_amd64.deb
+      - apache-arrow_{no_rc_version}-1.debian.tar.xz
+      - apache-arrow_{no_rc_version}-1.dsc
+      - apache-arrow_{no_rc_version}.orig.tar.gz
+      - gir1.2-arrow-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-arrow-gpu-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-parquet-1.0_{no_rc_version}-1_amd64.deb
+      - libarrow-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-doc_{no_rc_version}-1_all.deb
+      - libarrow-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu11_{no_rc_version}-1_amd64.deb
+      - libarrow-python-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-python11_{no_rc_version}-1_amd64.deb
+      - libarrow11_{no_rc_version}-1_amd64.deb
+      - libparquet-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-doc_{no_rc_version}-1_all.deb
+      - libparquet-glib11_{no_rc_version}-1_amd64.deb
+      - libparquet11_{no_rc_version}-1_amd64.deb
 
   ubuntu-bionic:
     platform: linux
@@ -341,28 +341,28 @@ tasks:
         - .debian.tar.xz
         - .orig.tar.gz
     artifacts:
-      - apache-arrow_{version}-1.debian.tar.xz
-      - apache-arrow_{version}-1.dsc
-      - apache-arrow_{version}.orig.tar.gz
-      - gir1.2-arrow-1.0_{version}-1_amd64.deb
-      - gir1.2-arrow-gpu-1.0_{version}-1_amd64.deb
-      - gir1.2-parquet-1.0_{version}-1_amd64.deb
-      - libarrow-dev_{version}-1_amd64.deb
-      - libarrow-glib-dev_{version}-1_amd64.deb
-      - libarrow-glib-doc_{version}-1_all.deb
-      - libarrow-glib11_{version}-1_amd64.deb
-      - libarrow-gpu-dev_{version}-1_amd64.deb
-      - libarrow-gpu-glib-dev_{version}-1_amd64.deb
-      - libarrow-gpu-glib11_{version}-1_amd64.deb
-      - libarrow-gpu11_{version}-1_amd64.deb
-      - libarrow-python-dev_{version}-1_amd64.deb
-      - libarrow-python11_{version}-1_amd64.deb
-      - libarrow11_{version}-1_amd64.deb
-      - libparquet-dev_{version}-1_amd64.deb
-      - libparquet-glib-dev_{version}-1_amd64.deb
-      - libparquet-glib-doc_{version}-1_all.deb
-      - libparquet-glib11_{version}-1_amd64.deb
-      - libparquet11_{version}-1_amd64.deb
+      - apache-arrow_{no_rc_version}-1.debian.tar.xz
+      - apache-arrow_{no_rc_version}-1.dsc
+      - apache-arrow_{no_rc_version}.orig.tar.gz
+      - gir1.2-arrow-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-arrow-gpu-1.0_{no_rc_version}-1_amd64.deb
+      - gir1.2-parquet-1.0_{no_rc_version}-1_amd64.deb
+      - libarrow-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-glib-doc_{no_rc_version}-1_all.deb
+      - libarrow-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu-glib11_{no_rc_version}-1_amd64.deb
+      - libarrow-gpu11_{no_rc_version}-1_amd64.deb
+      - libarrow-python-dev_{no_rc_version}-1_amd64.deb
+      - libarrow-python11_{no_rc_version}-1_amd64.deb
+      - libarrow11_{no_rc_version}-1_amd64.deb
+      - libparquet-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-dev_{no_rc_version}-1_amd64.deb
+      - libparquet-glib-doc_{no_rc_version}-1_all.deb
+      - libparquet-glib11_{no_rc_version}-1_amd64.deb
+      - libparquet11_{no_rc_version}-1_amd64.deb
 
   centos-6:
     platform: linux
@@ -372,12 +372,12 @@ tasks:
       upload_extensions:
         - .rpm
     artifacts:
-      - arrow-{version}-1.el6.src.rpm
-      - arrow-debuginfo-{version}-1.el6.x86_64.rpm
-      - arrow-devel-{version}-1.el6.x86_64.rpm
-      - arrow-libs-{version}-1.el6.x86_64.rpm
-      - arrow-python-devel-{version}-1.el6.x86_64.rpm
-      - arrow-python-libs-{version}-1.el6.x86_64.rpm
+      - arrow-{no_rc_version}-1.el6.src.rpm
+      - arrow-debuginfo-{no_rc_version}-1.el6.x86_64.rpm
+      - arrow-devel-{no_rc_version}-1.el6.x86_64.rpm
+      - arrow-libs-{no_rc_version}-1.el6.x86_64.rpm
+      - arrow-python-devel-{no_rc_version}-1.el6.x86_64.rpm
+      - arrow-python-libs-{no_rc_version}-1.el6.x86_64.rpm
 
   centos-7:
     platform: linux
@@ -387,17 +387,17 @@ tasks:
       upload_extensions:
         - .rpm
     artifacts:
-      - arrow-{version}-1.el7.src.rpm
-      - arrow-debuginfo-{version}-1.el7.x86_64.rpm
-      - arrow-devel-{version}-1.el7.x86_64.rpm
-      - arrow-glib-devel-{version}-1.el7.x86_64.rpm
-      - arrow-glib-doc-{version}-1.el7.x86_64.rpm
-      - arrow-glib-libs-{version}-1.el7.x86_64.rpm
-      - arrow-libs-{version}-1.el7.x86_64.rpm
-      - arrow-python-devel-{version}-1.el7.x86_64.rpm
-      - arrow-python-libs-{version}-1.el7.x86_64.rpm
-      - parquet-devel-{version}-1.el7.x86_64.rpm
-      - parquet-glib-devel-{version}-1.el7.x86_64.rpm
-      - parquet-glib-doc-{version}-1.el7.x86_64.rpm
-      - parquet-glib-libs-{version}-1.el7.x86_64.rpm
-      - parquet-libs-{version}-1.el7.x86_64.rpm
+      - arrow-{no_rc_version}-1.el7.src.rpm
+      - arrow-debuginfo-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-devel-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-glib-devel-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-glib-doc-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-glib-libs-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-libs-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-python-devel-{no_rc_version}-1.el7.x86_64.rpm
+      - arrow-python-libs-{no_rc_version}-1.el7.x86_64.rpm
+      - parquet-devel-{no_rc_version}-1.el7.x86_64.rpm
+      - parquet-glib-devel-{no_rc_version}-1.el7.x86_64.rpm
+      - parquet-glib-doc-{no_rc_version}-1.el7.x86_64.rpm
+      - parquet-glib-libs-{no_rc_version}-1.el7.x86_64.rpm
+      - parquet-libs-{no_rc_version}-1.el7.x86_64.rpm


### PR DESCRIPTION
Because we reuse RC packages as the official release packages when our
vote is passed.