### PR TITLE
ARROW-3460: [Packaging] Add a script to rebase master on local release branch

### DIFF
--- a/dev/release/post-00-rebase.sh
+++ b/dev/release/post-00-rebase.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+set -e
+set -u
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <local-release-branch>"
+  exit
+fi
+
+local_release_branch=$1
+
+echo "Fetch the latest commits"
+git fetch --all --prune
+echo "Checkout the master branch"
+git checkout master
+echo "Apply the latest commits on the master branch"
+git rebase apache/master
+echo "Apply the unpushed commits on the local release branch"
+git rebase ${local_release_branch}
+echo "Push the rebased branch to master"
+git push --force apache master
+
+echo "Success! The rebased commits are available here:"
+echo "  https://github.com/apache/arrow/commits/master"


### PR DESCRIPTION
This script assumes that "apache" remote refers `git@github.com:apache/arrow.git`.