### PR TITLE
ARROW-3466: [CI] Pin protobuf version to 3.6.0 [skip appveyor]

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -78,7 +78,8 @@ fi
 # fi
 
 if [ $TRAVIS_OS_NAME != "osx" ]; then
-  conda install -y -c conda-forge tensorflow
+  # Pin protobuf version to work around ARROW-3466
+  conda install -y -c conda-forge tensorflow protobuf=3.6.0
   PYARROW_PYTEST_FLAGS="$PYARROW_PYTEST_FLAGS --tensorflow"
 fi
 


### PR DESCRIPTION
Work around a crash with tensorflow and protobuf 3.6.1.

The change that triggered the crash seems to be the following:
https://github.com/protocolbuffers/protobuf/pull/4878