### PR TITLE
ARROW-3466: [C++] Avoid leaking protobuf symbols

### DIFF
--- a/cpp/src/arrow/symbols.map
+++ b/cpp/src/arrow/symbols.map
@@ -62,6 +62,9 @@
     je_arrow_*;
     # ORC destructors
     _ZThn8_N3orc*;
+    # Protobuf symbols that aren't hidden by the C++ section below
+    # (destructors, vtables, other stuff)
+    *N6google8protobuf*;
 
     extern "C++" {
       # devtoolset or -static-libstdc++ - the Red Hat devtoolset statically


### PR DESCRIPTION
Our linker script hides "google::*" symbols exported from various C++ modules, but that isn't enough to actually hide all symbols.  Some symbols (vtables, destructors, "guard variables"...) aren't hidden.

The ORC library links protobuf statically, and we link ORC statically. So we ended up exporting protobuf symbols.  When linking another protobuf instance dynamically (like tensorflow does), this can wreak havoc.  Hiding all symbols fixes the issue.