### PR TITLE
ARROW-3481: [Java] Fix java building failure with Maven 3.5.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -364,7 +364,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.0.0-M2</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
This problem happens in some rare case.
When there are arrow lib build by old maven, but now current maven is updated to 3.5.4. This problem could happen and raise a building failure.