### PR TITLE
ARROW-3472: [Gandiva] remove gandiva_helpers library

### DIFF
--- a/cpp/cmake_modules/GandivaBuildUtils.cmake
+++ b/cpp/cmake_modules/GandivaBuildUtils.cmake
@@ -107,7 +107,6 @@ function(add_precompiled_unit_test REL_TEST_NAME)
   target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
   target_link_libraries(${TEST_NAME} PRIVATE ${GANDIVA_TEST_LINK_LIBS})
   target_compile_definitions(${TEST_NAME} PRIVATE GANDIVA_UNIT_TEST=1)
-  target_compile_definitions(${TEST_NAME} PRIVATE -DGDV_HELPERS)
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
   set_property(TEST ${TEST_NAME} PROPERTY LABELS gandiva,unittest ${TEST_NAME})
 endfunction(add_precompiled_unit_test REL_TEST_NAME)
@@ -118,7 +117,10 @@ function(add_gandiva_integ_test REL_TEST_NAME GANDIVA_LIB)
 
   add_executable(${TEST_NAME}_${GANDIVA_LIB} ${REL_TEST_NAME} ${ARGN})
   target_include_directories(${TEST_NAME}_${GANDIVA_LIB} PRIVATE ${CMAKE_SOURCE_DIR})
-  target_link_libraries(${TEST_NAME}_${GANDIVA_LIB} PRIVATE ${GANDIVA_LIB} ${GANDIVA_TEST_LINK_LIBS})
+  target_link_libraries(${TEST_NAME}_${GANDIVA_LIB} PRIVATE
+    ${GANDIVA_LIB}
+    ${GANDIVA_TEST_LINK_LIBS}
+  )
 
   add_test(NAME ${TEST_NAME}_${GANDIVA_LIB} COMMAND ${TEST_NAME}_${GANDIVA_LIB})
   set_property(TEST ${TEST_NAME}_${GANDIVA_LIB} PROPERTY LABELS gandiva,integ ${TEST_NAME}_${GANDIVA_LIB})

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -32,31 +32,15 @@ set(GANDIVA_BC_FILE_NAME irhelpers.bc)
 set(GANDIVA_BC_INSTALL_PATH ${GANDIVA_BC_INSTALL_DIR}/${GANDIVA_BC_FILE_NAME})
 set(GANDIVA_BC_OUTPUT_PATH ${CMAKE_BINARY_DIR}/${GANDIVA_BC_FILE_NAME})
 
-# Set the path where the so lib file will be installed.
-if (APPLE)
-  set(GANDIVA_HELPER_LIB_FILE_NAME libgandiva_helpers.dylib)
-else()
-  set(GANDIVA_HELPER_LIB_FILE_NAME libgandiva_helpers.so)
-endif(APPLE)
-
-set(GANDIVA_HELPER_LIB_INSTALL_PATH ${GANDIVA_BC_INSTALL_DIR}/${GANDIVA_HELPER_LIB_FILE_NAME})
-set(GANDIVA_HELPER_LIB_OUTPUT_PATH ${CMAKE_BINARY_DIR}/debug/${GANDIVA_HELPER_LIB_FILE_NAME})
-
 set(BC_FILE_PATH_CC "${CMAKE_CURRENT_BINARY_DIR}/bc_file_path.cc")
 configure_file(bc_file_path.cc.in ${BC_FILE_PATH_CC})
-
-# helper files that are shared between libgandiva and libgandiva_helpers
-set(SHARED_HELPER_FILES
-      like_holder.cc
-      regex_util.cc
-      execution_context.cc
-      to_date_holder.cc
-      date_utils.cc)
 
 set(SRC_FILES annotator.cc
       bitmap_accumulator.cc
       configuration.cc
+      context_helper.cc
       engine.cc
+      date_utils.cc
       expr_decomposer.cc
       expr_validator.cc
       expression.cc
@@ -64,11 +48,15 @@ set(SRC_FILES annotator.cc
       filter.cc
       function_registry.cc
       function_signature.cc
+      gdv_function_stubs.cc
       llvm_generator.cc
       llvm_types.cc
+      like_holder.cc
       projector.cc
+      regex_util.cc
       selection_vector.cc
       tree_expr_builder.cc
+      to_date_holder.cc
       ${SHARED_HELPER_FILES}
       ${BC_FILE_PATH_CC})
 
@@ -103,39 +91,12 @@ build_gandiva_lib("shared" arrow_shared)
 
 build_gandiva_lib("static" arrow_static)
 
-# Pre-compiled .so library for function helpers.
-add_library(gandiva_helpers SHARED
-  ${SHARED_HELPER_FILES}
-  function_holder_stubs.cc)
-
-add_dependencies(gandiva_helpers arrow_dependencies)
-
-target_compile_definitions(gandiva_helpers
-  PRIVATE -DGDV_HELPERS
-)
-
-target_include_directories(gandiva_helpers
-  PRIVATE
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/src
-    ${ARROW_INCLUDE_DIR}
-)
-
-target_link_libraries(gandiva_helpers PRIVATE Boost::boost re2)
-
-# hide all symbols that are not needed.
-if (NOT APPLE)
-  # apple linker does not support version scripts, not needed since we package from travis.
-  set_target_properties(gandiva_helpers PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/gandiva/symbols-helpers.map")
-  target_link_libraries(gandiva_helpers LINK_PRIVATE -static-libstdc++ -static-libgcc)
-endif()
-
 # install for gandiva
 include(GNUInstallDirs)
 
 # install libgandiva
 install(
-  TARGETS gandiva_shared gandiva_static gandiva_helpers
+  TARGETS gandiva_shared gandiva_static
   DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
@@ -166,20 +127,25 @@ install(
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
 #args: label test-file src-files
-add_gandiva_unit_test(bitmap_accumulator_test.cc bitmap_accumulator.cc execution_context.cc)
-add_gandiva_unit_test(engine_llvm_test.cc engine.cc llvm_types.cc configuration.cc execution_context.cc ${BC_FILE_PATH_CC})
+add_gandiva_unit_test(bitmap_accumulator_test.cc bitmap_accumulator.cc)
+add_gandiva_unit_test(engine_llvm_test.cc engine.cc llvm_types.cc configuration.cc
+    gdv_function_stubs.cc context_helper.cc to_date_holder.cc date_utils.cc ${BC_FILE_PATH_CC})
 add_gandiva_unit_test(function_signature_test.cc function_signature.cc)
 add_gandiva_unit_test(function_registry_test.cc function_registry.cc function_signature.cc)
 add_gandiva_unit_test(llvm_types_test.cc llvm_types.cc)
-add_gandiva_unit_test(llvm_generator_test.cc llvm_generator.cc regex_util.cc engine.cc llvm_types.cc expr_decomposer.cc function_registry.cc annotator.cc bitmap_accumulator.cc configuration.cc  function_signature.cc like_holder.cc to_date_holder.cc date_utils.cc regex_util.cc execution_context.cc ${BC_FILE_PATH_CC})
+add_gandiva_unit_test(llvm_generator_test.cc llvm_generator.cc regex_util.cc engine.cc
+    llvm_types.cc expr_decomposer.cc function_registry.cc annotator.cc
+    bitmap_accumulator.cc configuration.cc  function_signature.cc like_holder.cc
+    to_date_holder.cc date_utils.cc regex_util.cc gdv_function_stubs.cc context_helper.cc
+    ${BC_FILE_PATH_CC})
 add_gandiva_unit_test(annotator_test.cc annotator.cc function_signature.cc)
-add_gandiva_unit_test(tree_expr_test.cc tree_expr_builder.cc expr_decomposer.cc annotator.cc function_registry.cc function_signature.cc like_holder.cc regex_util.cc to_date_holder.cc date_utils.cc execution_context.cc)
-add_gandiva_unit_test(expr_decomposer_test.cc expr_decomposer.cc tree_expr_builder.cc annotator.cc function_registry.cc function_signature.cc like_holder.cc regex_util.cc to_date_holder.cc date_utils.cc execution_context.cc)
+add_gandiva_unit_test(tree_expr_test.cc tree_expr_builder.cc expr_decomposer.cc annotator.cc function_registry.cc function_signature.cc like_holder.cc regex_util.cc to_date_holder.cc date_utils.cc)
+add_gandiva_unit_test(expr_decomposer_test.cc expr_decomposer.cc tree_expr_builder.cc annotator.cc function_registry.cc function_signature.cc like_holder.cc regex_util.cc to_date_holder.cc date_utils.cc)
 add_gandiva_unit_test(status_test.cc)
 add_gandiva_unit_test(expression_registry_test.cc llvm_types.cc expression_registry.cc function_signature.cc function_registry.cc)
 add_gandiva_unit_test(selection_vector_test.cc selection_vector.cc)
 add_gandiva_unit_test(lru_cache_test.cc)
-add_gandiva_unit_test(to_date_holder_test.cc to_date_holder.cc date_utils.cc execution_context.cc)
+add_gandiva_unit_test(to_date_holder_test.cc to_date_holder.cc date_utils.cc)
 
 add_subdirectory(jni)
 add_subdirectory(precompiled)

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRC_FILES annotator.cc
       expr_validator.cc
       expression.cc
       expression_registry.cc
+      exported_funcs_registry.cc
       filter.cc
       function_registry.cc
       function_signature.cc
@@ -129,7 +130,8 @@ install(
 #args: label test-file src-files
 add_gandiva_unit_test(bitmap_accumulator_test.cc bitmap_accumulator.cc)
 add_gandiva_unit_test(engine_llvm_test.cc engine.cc llvm_types.cc configuration.cc
-    gdv_function_stubs.cc context_helper.cc to_date_holder.cc date_utils.cc ${BC_FILE_PATH_CC})
+    gdv_function_stubs.cc context_helper.cc to_date_holder.cc date_utils.cc
+    exported_funcs_registry.cc ${BC_FILE_PATH_CC})
 add_gandiva_unit_test(function_signature_test.cc function_signature.cc)
 add_gandiva_unit_test(function_registry_test.cc function_registry.cc function_signature.cc)
 add_gandiva_unit_test(llvm_types_test.cc llvm_types.cc)
@@ -137,7 +139,7 @@ add_gandiva_unit_test(llvm_generator_test.cc llvm_generator.cc regex_util.cc eng
     llvm_types.cc expr_decomposer.cc function_registry.cc annotator.cc
     bitmap_accumulator.cc configuration.cc  function_signature.cc like_holder.cc
     to_date_holder.cc date_utils.cc regex_util.cc gdv_function_stubs.cc context_helper.cc
-    ${BC_FILE_PATH_CC})
+    exported_funcs_registry.cc ${BC_FILE_PATH_CC})
 add_gandiva_unit_test(annotator_test.cc annotator.cc function_signature.cc)
 add_gandiva_unit_test(tree_expr_test.cc tree_expr_builder.cc expr_decomposer.cc annotator.cc function_registry.cc function_signature.cc like_holder.cc regex_util.cc to_date_holder.cc date_utils.cc)
 add_gandiva_unit_test(expr_decomposer_test.cc expr_decomposer.cc tree_expr_builder.cc annotator.cc function_registry.cc function_signature.cc like_holder.cc regex_util.cc to_date_holder.cc date_utils.cc)

--- a/cpp/src/gandiva/bc_file_path.cc.in
+++ b/cpp/src/gandiva/bc_file_path.cc.in
@@ -20,7 +20,4 @@ namespace gandiva {
 // Path to the byte-code file.
 extern const char kByteCodeFilePath[] = "${GANDIVA_BC_OUTPUT_PATH}";
 
-// Path to the pre-compiled solib file.
-extern const char kHelperLibFilePath[] = "${GANDIVA_HELPER_LIB_OUTPUT_PATH}";
-
 } // namespace gandiva

--- a/cpp/src/gandiva/configuration.h
+++ b/cpp/src/gandiva/configuration.h
@@ -26,7 +26,6 @@
 namespace gandiva {
 
 extern const char kByteCodeFilePath[];
-extern const char kHelperLibFilePath[];
 
 class ConfigurationBuilder;
 /// \brief runtime config for gandiva
@@ -38,20 +37,16 @@ class Configuration {
   friend class ConfigurationBuilder;
 
   const std::string& byte_code_file_path() const { return byte_code_file_path_; }
-  const std::string& helper_lib_file_path() const { return helper_lib_file_path_; }
 
   std::size_t Hash() const;
   bool operator==(const Configuration& other) const;
   bool operator!=(const Configuration& other) const;
 
  private:
-  explicit Configuration(const std::string& byte_code_file_path,
-                         const std::string& helper_lib_file_path)
-      : byte_code_file_path_(byte_code_file_path),
-        helper_lib_file_path_(helper_lib_file_path) {}
+  explicit Configuration(const std::string& byte_code_file_path)
+      : byte_code_file_path_(byte_code_file_path) {}
 
   const std::string byte_code_file_path_;
-  const std::string helper_lib_file_path_;
 };
 
 /// \brief configuration builder for gandiva
@@ -60,24 +55,15 @@ class Configuration {
 /// to override specific values and build a custom instance
 class ConfigurationBuilder {
  public:
-  ConfigurationBuilder()
-      : byte_code_file_path_(kByteCodeFilePath),
-        helper_lib_file_path_(kHelperLibFilePath) {}
+  ConfigurationBuilder() : byte_code_file_path_(kByteCodeFilePath) {}
 
   ConfigurationBuilder& set_byte_code_file_path(const std::string& byte_code_file_path) {
     byte_code_file_path_ = byte_code_file_path;
     return *this;
   }
 
-  ConfigurationBuilder& set_helper_lib_file_path(
-      const std::string& helper_lib_file_path) {
-    helper_lib_file_path_ = helper_lib_file_path;
-    return *this;
-  }
-
   std::shared_ptr<Configuration> build() {
-    std::shared_ptr<Configuration> configuration(
-        new Configuration(byte_code_file_path_, helper_lib_file_path_));
+    std::shared_ptr<Configuration> configuration(new Configuration(byte_code_file_path_));
     return configuration;
   }
 
@@ -87,11 +73,9 @@ class ConfigurationBuilder {
 
  private:
   std::string byte_code_file_path_;
-  std::string helper_lib_file_path_;
 
   static std::shared_ptr<Configuration> InitDefaultConfig() {
-    std::shared_ptr<Configuration> configuration(
-        new Configuration(kByteCodeFilePath, kHelperLibFilePath));
+    std::shared_ptr<Configuration> configuration(new Configuration(kByteCodeFilePath));
     return configuration;
   }
 

--- a/cpp/src/gandiva/context_helper.cc
+++ b/cpp/src/gandiva/context_helper.cc
@@ -15,8 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "gandiva/execution_context.h"
+// This file is also used in the pre-compiled unit tests, which do include
+// llvm/engine/..
+#ifndef GANDIVA_UNIT_TEST
+#include "gandiva/exported_funcs.h"
 #include "gandiva/gdv_function_stubs.h"
+
+#include "gandiva/engine.h"
+
+namespace gandiva {
+
+void ExportedContextFunctions::AddMappings(Engine& engine) const {
+  std::vector<llvm::Type*> args;
+  auto types = engine.types();
+
+  // gdv_fn_context_set_error_msg
+  args = {types.i64_type(),      // int64_t context_ptr
+          types.i8_ptr_type()};  // char const* err_msg
+
+  engine.AddGlobalMappingForFunc("gdv_fn_context_set_error_msg", types.void_type(), args,
+                                 reinterpret_cast<void*>(gdv_fn_context_set_error_msg));
+}
+
+}  // namespace gandiva
+#endif  // !GANDIVA_UNIT_TEST
+
+#include "gandiva/execution_context.h"
 
 extern "C" {
 

--- a/cpp/src/gandiva/context_helper.cc
+++ b/cpp/src/gandiva/context_helper.cc
@@ -16,31 +16,13 @@
 // under the License.
 
 #include "gandiva/execution_context.h"
+#include "gandiva/gdv_function_stubs.h"
 
-namespace gandiva {
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
+extern "C" {
 
-void ExecutionContext::set_error_msg(const char* error_msg) {
-  if (error_msg_.get() == nullptr) {
-    error_msg_.reset(new std::string(error_msg));
-  }
+void gdv_fn_context_set_error_msg(int64_t context_ptr, char const* err_msg) {
+  gandiva::ExecutionContext* execution_context_ptr =
+      reinterpret_cast<gandiva::ExecutionContext*>(context_ptr);
+  (execution_context_ptr)->set_error_msg(err_msg);
 }
-
-std::string ExecutionContext::get_error() const {
-  if (error_msg_.get() != nullptr) {
-    return *(error_msg_.get());
-  }
-  return std::string("");
 }
-
-bool ExecutionContext::has_error() const {
-  return error_msg_.get() != nullptr && !(error_msg_.get()->empty());
-}
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
-
-}  // namespace gandiva

--- a/cpp/src/gandiva/date_utils.cc
+++ b/cpp/src/gandiva/date_utils.cc
@@ -23,10 +23,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 std::vector<std::string> DateUtils::GetMatches(std::string pattern, bool exactMatch) {
   // we are case insensitive
   std::transform(pattern.begin(), pattern.end(), pattern.begin(), ::tolower);
@@ -237,9 +233,5 @@ DateUtils::date_format_converter DateUtils::InitMap() {
 
   return map;
 }
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/date_utils.h
+++ b/cpp/src/gandiva/date_utils.h
@@ -27,10 +27,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 /// \brief Utility class for converting sql date patterns to internal date patterns.
 class DateUtils {
  public:
@@ -50,10 +46,6 @@ class DateUtils {
 
   static std::vector<std::string> GetExactMatches(const std::string& pattern);
 };
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva
 

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -39,6 +39,7 @@
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/Vectorize.h>
+#include "gandiva/gdv_function_stubs.h"
 
 namespace gandiva {
 
@@ -57,6 +58,8 @@ void Engine::InitOnce() {
   llvm::InitializeNativeTargetAsmParser();
   llvm::InitializeNativeTargetDisassembler();
 
+  llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
+
   init_once_done_ = true;
 }
 
@@ -68,6 +71,7 @@ Status Engine::Make(std::shared_ptr<Configuration> config,
   std::call_once(init_once_flag, [&engine_obj] { engine_obj->InitOnce(); });
   engine_obj->context_.reset(new llvm::LLVMContext());
   engine_obj->ir_builder_.reset(new llvm::IRBuilder<>(*(engine_obj->context())));
+  engine_obj->types_.reset(new LLVMTypes(*(engine_obj->context())));
 
   // Create the execution engine
   std::unique_ptr<llvm::Module> cg_module(
@@ -84,33 +88,14 @@ Status Engine::Make(std::shared_ptr<Configuration> config,
     return Status::CodeGenError(engine_obj->llvm_error_);
   }
 
-  auto status = engine_obj->LoadPreCompiledHelperLibs(config->helper_lib_file_path());
-  GANDIVA_RETURN_NOT_OK(status);
+  // Add mappings for functions that can be accessed from LLVM/IR module.
+  engine_obj->AddGlobalMappings();
 
-  status = engine_obj->LoadPreCompiledIRFiles(config->byte_code_file_path());
+  auto status = engine_obj->LoadPreCompiledIRFiles(config->byte_code_file_path());
   GANDIVA_RETURN_NOT_OK(status);
 
   *engine = std::move(engine_obj);
   return Status::OK();
-}
-
-Status Engine::LoadPreCompiledHelperLibs(const std::string& file_path) {
-  int err = 0;
-
-  mtx_.lock();
-  // Load each so lib only once.
-  if (loaded_libs_.find(file_path) == loaded_libs_.end()) {
-    err = llvm::sys::DynamicLibrary::LoadLibraryPermanently(file_path.c_str());
-    if (!err) {
-      loaded_libs_.insert(file_path);
-    }
-  }
-  mtx_.unlock();
-
-  return (err == 0)
-             ? Status::OK()
-             : Status::CodeGenError("loading precompiled native file " + file_path +
-                                    " failed with error " + std::to_string(err));
 }
 
 // Handling for pre-compiled IR libraries.
@@ -157,26 +142,26 @@ Status Engine::FinalizeModule(bool optimise_ir, bool dump_ir) {
   }
 
   // Setup an optimiser pipeline
+  std::unique_ptr<llvm::legacy::PassManager> pass_manager(
+      new llvm::legacy::PassManager());
+
+  // First round : get rid of all functions that don't need to be compiled.
+  // This helps in reducing the overall compilation time.
+  // (Adapted from Apache Impala)
+  //
+  // Done by marking all the unused functions as internal, and then, running
+  // a pass for dead code elimination.
+  std::unordered_set<std::string> used_functions;
+  used_functions.insert(functions_to_compile_.begin(), functions_to_compile_.end());
+
+  pass_manager->add(
+      llvm::createInternalizePass([&used_functions](const llvm::GlobalValue& func) {
+        return (used_functions.find(func.getName().str()) != used_functions.end());
+      }));
+  pass_manager->add(llvm::createGlobalDCEPass());
+  pass_manager->run(*module_);
+
   if (optimise_ir) {
-    std::unique_ptr<llvm::legacy::PassManager> pass_manager(
-        new llvm::legacy::PassManager());
-
-    // First round : get rid of all functions that don't need to be compiled.
-    // This helps in reducing the overall compilation time.
-    // (Adapted from Apache Impala)
-    //
-    // Done by marking all the unused functions as internal, and then, running
-    // a pass for dead code elimination.
-    std::unordered_set<std::string> used_functions;
-    used_functions.insert(functions_to_compile_.begin(), functions_to_compile_.end());
-
-    pass_manager->add(
-        llvm::createInternalizePass([&used_functions](const llvm::GlobalValue& func) {
-          return (used_functions.find(func.getName().str()) != used_functions.end());
-        }));
-    pass_manager->add(llvm::createGlobalDCEPass());
-    pass_manager->run(*module_);
-
     // Second round : misc passes to allow for inlining, vectorization, ..
     pass_manager.reset(new llvm::legacy::PassManager());
     llvm::TargetIRAnalysis target_analysis =
@@ -216,6 +201,45 @@ Status Engine::FinalizeModule(bool optimise_ir, bool dump_ir) {
 void* Engine::CompiledFunction(llvm::Function* irFunction) {
   DCHECK(module_finalized_);
   return execution_engine_->getPointerToFunction(irFunction);
+}
+
+void Engine::AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_type,
+                                     const std::vector<llvm::Type*>& args,
+                                     void* function_ptr) {
+  auto prototype = llvm::FunctionType::get(ret_type, args, false /*isVarArg*/);
+  auto fn = llvm::Function::Create(prototype, llvm::GlobalValue::ExternalLinkage, name,
+                                   module());
+  execution_engine_->addGlobalMapping(fn, function_ptr);
+}
+
+void Engine::AddGlobalMappings() {
+  std::vector<llvm::Type*> args;
+
+  // gdv_fn_like_utf8_utf8
+  args = {types().i64_type(), types().i8_ptr_type(), types().i32_type(),
+          types().i8_ptr_type(), types().i32_type()};
+  AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8", types().i1_type(), args,
+                          reinterpret_cast<void*>(gdv_fn_like_utf8_utf8));
+
+  // gdv_fn_to_date_utf8_utf8_int32
+  args = {types().i64_type(),
+          types().i8_ptr_type(),
+          types().i32_type(),
+          types().i1_type(),
+          types().i8_ptr_type(),
+          types().i32_type(),
+          types().i1_type(),
+          types().i32_type(),
+          types().i1_type(),
+          types().i64_type(),
+          types().ptr_type(types().i8_type())};
+  AddGlobalMappingForFunc("gdv_fn_to_date_utf8_utf8_int32", types().i64_type(), args,
+                          reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8_int32));
+
+  // gdv_fn_context_set_error_msg
+  args = {types().i64_type(), types().i8_ptr_type()};
+  AddGlobalMappingForFunc("gdv_fn_context_set_error_msg", types().void_type(), args,
+                          reinterpret_cast<void*>(gdv_fn_context_set_error_msg));
 }
 
 void Engine::DumpIR(std::string prefix) {

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -39,7 +39,7 @@
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/Vectorize.h>
-#include "gandiva/gdv_function_stubs.h"
+#include "gandiva/exported_funcs_registry.h"
 
 namespace gandiva {
 
@@ -212,35 +212,7 @@ void Engine::AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_ty
   execution_engine_->addGlobalMapping(fn, function_ptr);
 }
 
-void Engine::AddGlobalMappings() {
-  std::vector<llvm::Type*> args;
-
-  // gdv_fn_like_utf8_utf8
-  args = {types().i64_type(), types().i8_ptr_type(), types().i32_type(),
-          types().i8_ptr_type(), types().i32_type()};
-  AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8", types().i1_type(), args,
-                          reinterpret_cast<void*>(gdv_fn_like_utf8_utf8));
-
-  // gdv_fn_to_date_utf8_utf8_int32
-  args = {types().i64_type(),
-          types().i8_ptr_type(),
-          types().i32_type(),
-          types().i1_type(),
-          types().i8_ptr_type(),
-          types().i32_type(),
-          types().i1_type(),
-          types().i32_type(),
-          types().i1_type(),
-          types().i64_type(),
-          types().ptr_type(types().i8_type())};
-  AddGlobalMappingForFunc("gdv_fn_to_date_utf8_utf8_int32", types().i64_type(), args,
-                          reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8_int32));
-
-  // gdv_fn_context_set_error_msg
-  args = {types().i64_type(), types().i8_ptr_type()};
-  AddGlobalMappingForFunc("gdv_fn_context_set_error_msg", types().void_type(), args,
-                          reinterpret_cast<void*>(gdv_fn_context_set_error_msg));
-}
+void Engine::AddGlobalMappings() { ExportedFuncsRegistry::AddMappings(*this); }
 
 void Engine::DumpIR(std::string prefix) {
   std::string str;

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -31,6 +31,7 @@
 #include "arrow/util/macros.h"
 
 #include "gandiva/configuration.h"
+#include "gandiva/llvm_types.h"
 #include "gandiva/logging.h"
 #include "gandiva/status.h"
 
@@ -63,12 +64,7 @@ class Engine {
   /// Get the compiled function corresponding to the irfunction.
   void* CompiledFunction(llvm::Function* irFunction);
 
-  /// check if function from dlsym exists in address space. Returns true on success.
-  bool CheckFunctionFromLoadedLib(const std::string& name) {
-    auto ptr =
-        execution_engine_->getPointerToNamedFunction(name, false /*AbortOnFailure*/);
-    return ptr != NULLPTR;
-  }
+  LLVMTypes& types() { return *types_; }
 
  private:
   /// private constructor to ensure engine is created
@@ -81,17 +77,22 @@ class Engine {
 
   llvm::ExecutionEngine& execution_engine() { return *execution_engine_.get(); }
 
-  /// load pre-compiled so libraries and merge them into the main module.
-  Status LoadPreCompiledHelperLibs(const std::string& helper_lib_file_path);
-
   /// load pre-compiled IR modules and merge them into the main module.
   Status LoadPreCompiledIRFiles(const std::string& byte_code_file_path);
+
+  // Create and add a mapping for the cpp function to make it accessible from LLVM.
+  void AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_type,
+                               const std::vector<llvm::Type*>& args, void* func);
+
+  // Create and add mappings for cpp functions that can be accessed from LLVM.
+  void AddGlobalMappings();
 
   /// dump the IR code to stdout with the prefix string.
   void DumpIR(std::string prefix);
 
   std::unique_ptr<llvm::LLVMContext> context_;
   std::unique_ptr<llvm::ExecutionEngine> execution_engine_;
+  std::unique_ptr<LLVMTypes> types_;
   std::unique_ptr<llvm::IRBuilder<>> ir_builder_;
   llvm::Module* module_;  // This is owned by the execution_engine_, so doesn't need to be
                           // explicitly deleted.

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -66,6 +66,10 @@ class Engine {
 
   LLVMTypes& types() { return *types_; }
 
+  // Create and add a mapping for the cpp function to make it accessible from LLVM.
+  void AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_type,
+                               const std::vector<llvm::Type*>& args, void* func);
+
  private:
   /// private constructor to ensure engine is created
   /// only through the factory.
@@ -79,10 +83,6 @@ class Engine {
 
   /// load pre-compiled IR modules and merge them into the main module.
   Status LoadPreCompiledIRFiles(const std::string& byte_code_file_path);
-
-  // Create and add a mapping for the cpp function to make it accessible from LLVM.
-  void AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_type,
-                               const std::vector<llvm::Type*>& args, void* func);
 
   // Create and add mappings for cpp functions that can be accessed from LLVM.
   void AddGlobalMappings();

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -87,6 +87,9 @@ class Engine {
   // Create and add mappings for cpp functions that can be accessed from LLVM.
   void AddGlobalMappings();
 
+  // Remove unused functions to reduce compile time.
+  Status RemoveUnusedFunctions();
+
   /// dump the IR code to stdout with the prefix string.
   void DumpIR(std::string prefix);
 

--- a/cpp/src/gandiva/execution_context.h
+++ b/cpp/src/gandiva/execution_context.h
@@ -22,23 +22,24 @@
 #include <string>
 
 namespace gandiva {
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-/// Error holder for errors during llvm module execution
+
+/// Execution context during llvm evaluation
 class ExecutionContext {
  public:
-  std::string get_error() const;
+  std::string get_error() const { return error_msg_; }
 
-  void set_error_msg(const char* error_msg);
+  void set_error_msg(const char* error_msg) {
+    // Remember the first error only.
+    if (error_msg_.empty()) {
+      error_msg_ = std::string(error_msg);
+    }
+  }
 
-  bool has_error() const;
+  bool has_error() const { return !error_msg_.empty(); }
 
  private:
-  std::unique_ptr<std::string> error_msg_;
+  std::string error_msg_;
 };
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
+
 }  // namespace gandiva
 #endif  // ERROR_HOLDER_H

--- a/cpp/src/gandiva/exported_funcs.h
+++ b/cpp/src/gandiva/exported_funcs.h
@@ -15,24 +15,34 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef GDV_FUNCTION_STUBS_H
-#define GDV_FUNCTION_STUBS_H
+#ifndef GANDIVA_EXPORTED_FUNCS_H
+#define GANDIVA_EXPORTED_FUNCS_H
 
-#include <cstdint>
+#include <gandiva/exported_funcs_registry.h>
+#include <vector>
 
-/// Stub functions that can be accessed from LLVM.
-extern "C" {
+namespace gandiva {
 
-bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
-                           const char* pattern, int pattern_len);
+class Engine;
 
-int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t ptr, const char* data, int data_len,
-                                       bool in1_validity, const char* pattern,
-                                       int pattern_len, bool in2_validity,
-                                       int32_t suppress_errors, bool in3_validity,
-                                       int64_t execution_context, bool* out_valid);
+// Base-class type for exporting functions that can be accessed from LLVM/IR.
+class ExportedFuncsBase {
+ public:
+  virtual void AddMappings(Engine& engine) const = 0;
+};
 
-void gdv_fn_context_set_error_msg(int64_t context_ptr, const char* err_msg);
-}
+// Class for exporting Stub functions
+class ExportedStubFunctions : public ExportedFuncsBase {
+  void AddMappings(Engine& engine) const override;
+};
+REGISTER_EXPORTED_FUNCS(ExportedStubFunctions);
 
-#endif  // GDV_FUNCTION_STUBS_H
+// Class for exporting Context functions
+class ExportedContextFunctions : public ExportedFuncsBase {
+  void AddMappings(Engine& engine) const override;
+};
+REGISTER_EXPORTED_FUNCS(ExportedContextFunctions);
+
+}  // namespace gandiva
+
+#endif  // GANDIVA_EXPORTED_FUNCS_H

--- a/cpp/src/gandiva/exported_funcs_registry.cc
+++ b/cpp/src/gandiva/exported_funcs_registry.cc
@@ -15,24 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef GDV_FUNCTION_STUBS_H
-#define GDV_FUNCTION_STUBS_H
+#include "gandiva/exported_funcs_registry.h"
 
-#include <cstdint>
+#include "gandiva/exported_funcs.h"
 
-/// Stub functions that can be accessed from LLVM.
-extern "C" {
+namespace gandiva {
 
-bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
-                           const char* pattern, int pattern_len);
-
-int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t ptr, const char* data, int data_len,
-                                       bool in1_validity, const char* pattern,
-                                       int pattern_len, bool in2_validity,
-                                       int32_t suppress_errors, bool in3_validity,
-                                       int64_t execution_context, bool* out_valid);
-
-void gdv_fn_context_set_error_msg(int64_t context_ptr, const char* err_msg);
+void ExportedFuncsRegistry::AddMappings(Engine& engine) {
+  for (auto entry : registered()) {
+    entry->AddMappings(engine);
+  }
 }
 
-#endif  // GDV_FUNCTION_STUBS_H
+}  // namespace gandiva

--- a/cpp/src/gandiva/exported_funcs_registry.h
+++ b/cpp/src/gandiva/exported_funcs_registry.h
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef GANDIVA_EXPORTED_FUNCS_REGISTRY_H
+#define GANDIVA_EXPORTED_FUNCS_REGISTRY_H
+
+#include <vector>
+
+#include <gandiva/engine.h>
+
+namespace gandiva {
+
+class ExportedFuncsBase;
+
+/// Registry for classes that export functions which can be accessed by
+/// LLVM/IR code.
+class ExportedFuncsRegistry {
+ public:
+  using list_type = std::vector<ExportedFuncsBase*>;
+
+  // Add functions from all the registered classes to the engine.
+  static void AddMappings(Engine& engine);
+
+  static bool Register(ExportedFuncsBase* entry) {
+    registered().push_back(entry);
+    return true;
+  }
+
+ private:
+  static list_type& registered() {
+    static list_type registered_list;
+    return registered_list;
+  }
+};
+
+#define REGISTER_EXPORTED_FUNCS(classname) \
+  static bool _registered_##classname = ExportedFuncsRegistry::Register(new classname)
+
+}  // namespace gandiva
+
+#endif  // GANDIVA_EXPORTED_FUNCS_REGISTRY_H

--- a/cpp/src/gandiva/function_registry.cc
+++ b/cpp/src/gandiva/function_registry.cc
@@ -416,10 +416,10 @@ NativeFunction FunctionRegistry::pc_registry_[] = {
     BINARY_RELATIONAL_SAFE_NULL_IF_NULL(ends_with, utf8),
 
     NativeFunction("like", DataTypeVector{utf8(), utf8()}, boolean(), RESULT_NULL_IF_NULL,
-                   "like_utf8_utf8", true /*needs_holder*/),
+                   "gdv_fn_like_utf8_utf8", true /*needs_holder*/),
 
     NativeFunction("to_date", DataTypeVector{utf8(), utf8(), int32()}, date64(),
-                   RESULT_NULL_INTERNAL, "to_date_utf8_utf8_int32", true, true),
+                   RESULT_NULL_INTERNAL, "gdv_fn_to_date_utf8_utf8_int32", true, true),
 
     NativeFunction("castDATE", DataTypeVector{utf8()}, date64(), RESULT_NULL_INTERNAL,
                    "castDATE_utf8", false /*needs_holder*/, true /*needs context*/),

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -15,24 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "gandiva/gdv_function_stubs.h"
+
+#include <string>
+
 #include "gandiva/like_holder.h"
 #include "gandiva/to_date_holder.h"
 
-// Wrapper C functions for "like" to be invoked from LLVM.
-extern "C" bool like_utf8_utf8(int64_t ptr, const char* data, int data_len,
-                               const char* pattern, int pattern_len) {
-  gandiva::helpers::LikeHolder* holder =
-      reinterpret_cast<gandiva::helpers::LikeHolder*>(ptr);
+/// Stub functions that can be accessed from LLVM or the pre-compiled library.
+
+extern "C" {
+
+bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
+                           const char* pattern, int pattern_len) {
+  gandiva::LikeHolder* holder = reinterpret_cast<gandiva::LikeHolder*>(ptr);
   return (*holder)(std::string(data, data_len));
 }
 
-extern "C" int64_t to_date_utf8_utf8_int32(int64_t ptr, const char* data, int data_len,
-                                           bool in1_validity, const char* pattern,
-                                           int pattern_len, bool in2_validity,
-                                           int32_t suppress_errors, bool in3_validity,
-                                           int64_t execution_context, bool* out_valid) {
-  gandiva::helpers::ToDateHolder* holder =
-      reinterpret_cast<gandiva::helpers::ToDateHolder*>(ptr);
+int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t ptr, const char* data, int data_len,
+                                       bool in1_validity, const char* pattern,
+                                       int pattern_len, bool in2_validity,
+                                       int32_t suppress_errors, bool in3_validity,
+                                       int64_t execution_context, bool* out_valid) {
+  gandiva::ToDateHolder* holder = reinterpret_cast<gandiva::ToDateHolder*>(ptr);
   return (*holder)(std::string(data, data_len), in1_validity, execution_context,
                    out_valid);
+}
 }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -18,7 +18,10 @@
 #include "gandiva/gdv_function_stubs.h"
 
 #include <string>
+#include <vector>
 
+#include "gandiva/engine.h"
+#include "gandiva/exported_funcs.h"
 #include "gandiva/like_holder.h"
 #include "gandiva/to_date_holder.h"
 
@@ -42,3 +45,39 @@ int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t ptr, const char* data, int data_l
                    out_valid);
 }
 }
+
+namespace gandiva {
+
+void ExportedStubFunctions::AddMappings(Engine& engine) const {
+  std::vector<llvm::Type*> args;
+  auto types = engine.types();
+
+  // gdv_fn_like_utf8_utf8
+  args = {types.i64_type(),     // int64_t ptr
+          types.i8_ptr_type(),  // const char* data
+          types.i32_type(),     // int data_len
+          types.i8_ptr_type(),  // const char* pattern
+          types.i32_type()};    // int pattern_len
+
+  engine.AddGlobalMappingForFunc("gdv_fn_like_utf8_utf8", types.i1_type() /*return_type*/,
+                                 args, reinterpret_cast<void*>(gdv_fn_like_utf8_utf8));
+
+  // gdv_fn_to_date_utf8_utf8_int32
+  args = {types.i64_type(),                  // int64_t ptr
+          types.i8_ptr_type(),               // const char* data
+          types.i32_type(),                  // int data_len
+          types.i1_type(),                   // bool in1_validity
+          types.i8_ptr_type(),               // const char* pattern
+          types.i32_type(),                  // int pattern_len
+          types.i1_type(),                   // bool in2_validity
+          types.i32_type(),                  // int32_t suppress_errors
+          types.i1_type(),                   // bool in3_validity
+          types.i64_type(),                  // int64_t execution_context
+          types.ptr_type(types.i8_type())};  // bool* out_valid
+
+  engine.AddGlobalMappingForFunc("gdv_fn_to_date_utf8_utf8_int32",
+                                 types.i64_type() /*return_type*/, args,
+                                 reinterpret_cast<void*>(gdv_fn_to_date_utf8_utf8_int32));
+}
+
+}  // namespace gandiva

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -15,15 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef GANDIVA_CONTEXT_HELPER_H
-#define GANDIVA_CONTEXT_HELPER_H
+#include <cstdint>
 
-#include "gandiva/execution_context.h"
-#include "gandiva/precompiled/types.h"
+#ifndef GDV_FUNCTION_STUBS_H
+#define GDV_FUNCTION_STUBS_H
 
-void context_set_error_msg(int64_t context_ptr, char const* err_msg) {
-  gandiva::helpers::ExecutionContext* execution_context_ptr =
-      reinterpret_cast<gandiva::helpers::ExecutionContext*>(context_ptr);
-  (execution_context_ptr)->set_error_msg(err_msg);
+/// Stub functions that can be accessed from LLVM.
+
+extern "C" {
+
+bool gdv_fn_like_utf8_utf8(int64_t ptr, const char* data, int data_len,
+                           const char* pattern, int pattern_len);
+
+int64_t gdv_fn_to_date_utf8_utf8_int32(int64_t ptr, const char* data, int data_len,
+                                       bool in1_validity, const char* pattern,
+                                       int pattern_len, bool in2_validity,
+                                       int32_t suppress_errors, bool in3_validity,
+                                       int64_t execution_context, bool* out_valid);
+
+void gdv_fn_context_set_error_msg(int64_t context_ptr, const char* err_msg);
 }
-#endif
+
+#endif  // GDV_FUNCTION_STUBS_H

--- a/cpp/src/gandiva/jni/config_builder.cc
+++ b/cpp/src/gandiva/jni/config_builder.cc
@@ -36,19 +36,11 @@ Java_org_apache_arrow_gandiva_evaluator_ConfigurationBuilder_buildConfigInstance
     JNIEnv* env, jobject configuration) {
   jstring byte_code_file_path =
       (jstring)env->CallObjectMethod(configuration, byte_code_accessor_method_id_, 0);
-  jstring helper_library_file_path = (jstring)env->CallObjectMethod(
-      configuration, helper_library_accessor_method_id_, 0);
   ConfigurationBuilder configuration_builder;
   if (byte_code_file_path != nullptr) {
     const char* byte_code_file_path_cpp = env->GetStringUTFChars(byte_code_file_path, 0);
     configuration_builder.set_byte_code_file_path(byte_code_file_path_cpp);
     env->ReleaseStringUTFChars(byte_code_file_path, byte_code_file_path_cpp);
-  }
-  if (helper_library_file_path != nullptr) {
-    const char* helper_library_file_path_cpp =
-        env->GetStringUTFChars(helper_library_file_path, 0);
-    configuration_builder.set_helper_lib_file_path(helper_library_file_path_cpp);
-    env->ReleaseStringUTFChars(helper_library_file_path, helper_library_file_path_cpp);
   }
   std::shared_ptr<Configuration> config = configuration_builder.build();
   env->DeleteLocalRef(byte_code_file_path);

--- a/cpp/src/gandiva/jni/env_helper.h
+++ b/cpp/src/gandiva/jni/env_helper.h
@@ -25,6 +25,5 @@ extern jclass configuration_builder_class_;
 
 // method references
 extern jmethodID byte_code_accessor_method_id_;
-extern jmethodID helper_library_accessor_method_id_;
 
 #endif  // ENV_HELPER_H

--- a/cpp/src/gandiva/jni/jni_common.cc
+++ b/cpp/src/gandiva/jni/jni_common.cc
@@ -68,7 +68,6 @@ static jint JNI_VERSION = JNI_VERSION_1_6;
 // extern refs - initialized for other modules.
 jclass configuration_builder_class_;
 jmethodID byte_code_accessor_method_id_;
-jmethodID helper_library_accessor_method_id_;
 
 // refs for self.
 static jclass gandiva_exception_;
@@ -98,9 +97,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   byte_code_accessor_method_id_ =
       env->GetMethodID(configuration_builder_class_, method_name, return_type);
 
-  const char helper_method_name[] = "getHelperLibraryFilePath";
-  helper_library_accessor_method_id_ =
-      env->GetMethodID(configuration_builder_class_, helper_method_name, return_type);
   env->ExceptionDescribe();
 
   return JNI_VERSION;

--- a/cpp/src/gandiva/like_holder.cc
+++ b/cpp/src/gandiva/like_holder.cc
@@ -23,10 +23,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 RE2 LikeHolder::starts_with_regex_(R"((\w|\s)*\.\*)");
 RE2 LikeHolder::ends_with_regex_(R"(\.\*(\w|\s)*)");
 
@@ -91,9 +87,5 @@ Status LikeHolder::Make(const std::string& sql_pattern,
   *holder = lholder;
   return Status::OK();
 }
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/like_holder.h
+++ b/cpp/src/gandiva/like_holder.h
@@ -28,10 +28,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 /// Function Holder for SQL 'like'
 class LikeHolder : public FunctionHolder {
  public:
@@ -56,10 +52,6 @@ class LikeHolder : public FunctionHolder {
   static RE2 starts_with_regex_;  // pre-compiled pattern for matching starts_with
   static RE2 ends_with_regex_;    // pre-compiled pattern for matching ends_with
 };
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva
 

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -58,7 +58,7 @@ class LLVMGenerator {
   Status Execute(const arrow::RecordBatch& record_batch,
                  const ArrayDataVector& output_vector);
 
-  LLVMTypes& types() { return *types_; }
+  LLVMTypes& types() { return engine_->types(); }
   llvm::Module* module() { return engine_->module(); }
 
  private:
@@ -167,10 +167,6 @@ class LLVMGenerator {
   void ClearPackedBitValueIfFalse(llvm::Value* bitmap, llvm::Value* position,
                                   llvm::Value* value);
 
-  /// For non-IR functions, add prototype to the module on first encounter.
-  void CheckAndAddPrototype(const std::string& full_name, llvm::Type* ret_type,
-                            const std::vector<llvm::Value*>& args);
-
   /// Generate code to make a function call (to a pre-compiled IR function) which takes
   /// 'args' and has a return type 'ret_type'.
   llvm::Value* AddFunctionCall(const std::string& full_name, llvm::Type* ret_type,
@@ -194,7 +190,6 @@ class LLVMGenerator {
 
   std::unique_ptr<Engine> engine_;
   std::vector<std::unique_ptr<CompiledExpr>> compiled_exprs_;
-  std::unique_ptr<LLVMTypes> types_;
   FunctionRegistry function_registry_;
   Annotator annotator_;
 

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -45,14 +45,8 @@ TEST_F(TestLLVMGenerator, VerifyPCFunctions) {
 
   llvm::Module* module = generator->module();
   for (auto& iter : registry_) {
-    bool found = false;
     llvm::Function* fn = module->getFunction(iter.pc_name());
-    if (fn == nullptr) {
-      found = generator->engine_->CheckFunctionFromLoadedLib(iter.pc_name());
-    } else {
-      found = true;
-    }
-    EXPECT_EQ(found, true) << "function " << iter.pc_name()
+    EXPECT_NE(fn, nullptr) << "function " << iter.pc_name()
                            << " missing in precompiled module\n";
   }
 }

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -20,7 +20,6 @@ project(gandiva)
 set(PRECOMPILED_SRCS
     arithmetic_ops.cc
     bitmap.cc
-    context_helper.cc
     extended_math_ops.cc
     hash.cc
     print.cc
@@ -37,7 +36,7 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
   add_custom_command(
     OUTPUT ${BC_FILE}
     COMMAND ${CLANG_EXECUTABLE}
-            -D GDV_HELPERS -std=c++11 -emit-llvm -O2 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
+            -std=c++11 -emit-llvm -O2 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
             -I${CMAKE_SOURCE_DIR}/src
     DEPENDS ${SRC_FILE})
   list(APPEND BC_FILES ${BC_FILE})
@@ -56,9 +55,9 @@ add_custom_target(precompiled ALL DEPENDS ${GANDIVA_BC_OUTPUT_PATH})
 # testing
 add_precompiled_unit_test(bitmap_test.cc bitmap.cc)
 add_precompiled_unit_test(epoch_time_point_test.cc)
-add_precompiled_unit_test(time_test.cc time.cc timestamp_arithmetic.cc context_helper.cc ../execution_context.cc)
+add_precompiled_unit_test(time_test.cc time.cc timestamp_arithmetic.cc ../context_helper.cc)
 add_precompiled_unit_test(hash_test.cc hash.cc)
 add_precompiled_unit_test(sample_test.cc sample.cc)
-add_precompiled_unit_test(string_ops_test.cc string_ops.cc context_helper.cc ../execution_context.cc)
-add_precompiled_unit_test(arithmetic_ops_test.cc arithmetic_ops.cc context_helper.cc ../execution_context.cc)
-add_precompiled_unit_test(extended_math_ops_test.cc extended_math_ops.cc context_helper.cc ../execution_context.cc)
+add_precompiled_unit_test(string_ops_test.cc string_ops.cc ../context_helper.cc)
+add_precompiled_unit_test(arithmetic_ops_test.cc arithmetic_ops.cc ../context_helper.cc)
+add_precompiled_unit_test(extended_math_ops_test.cc extended_math_ops.cc ../context_helper.cc)

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -168,7 +168,7 @@ NUMERIC_BOOL_DATE_FUNCTION(IS_NOT_DISTINCT_FROM)
     }                                                                                   \
     if (in2 == 0) {                                                                     \
       char const* err_msg = "divide by zero error";                                     \
-      context_set_error_msg(execution_context, err_msg);                                \
+      gdv_fn_context_set_error_msg(execution_context, err_msg);                         \
       return 0;                                                                         \
     }                                                                                   \
     *out_valid = true;                                                                  \

--- a/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops_test.cc
@@ -37,7 +37,7 @@ TEST(TestArithmeticOps, TestMod) { EXPECT_EQ(mod_int64_int32(10, 0), 10); }
 
 TEST(TestArithmeticOps, TestDivide) {
   boolean is_valid;
-  gandiva::helpers::ExecutionContext error_holder;
+  gandiva::ExecutionContext error_holder;
   int64 out = divide_int64_int64(10, true, 0, true,
                                  reinterpret_cast<int64>(&error_holder), &is_valid);
   EXPECT_EQ(out, 0);
@@ -45,7 +45,7 @@ TEST(TestArithmeticOps, TestDivide) {
   EXPECT_EQ(error_holder.has_error(), true);
   EXPECT_EQ(error_holder.get_error(), "divide by zero error");
 
-  gandiva::helpers::ExecutionContext error_holder1;
+  gandiva::ExecutionContext error_holder1;
   out = divide_int64_int64(10, true, 2, true, reinterpret_cast<int64>(&error_holder),
                            &is_valid);
   EXPECT_EQ(out, 5);

--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -68,7 +68,7 @@ void set_error_for_logbase(int64_t execution_context, double base) {
   int size = static_cast<int>(strlen(prefix)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, "%s %f", prefix, base);
-  context_set_error_msg(execution_context, error);
+  gdv_fn_context_set_error_msg(execution_context, error);
   free(static_cast<char*>(error));
 }
 

--- a/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops_test.cc
@@ -66,7 +66,7 @@ TEST(TestExtendedMathOps, TestPower) {
 
 TEST(TestArithmeticOps, TestLogWithBase) {
   boolean is_valid;
-  gandiva::helpers::ExecutionContext error_holder;
+  gandiva::ExecutionContext error_holder;
   float64 out = log_int32_int32(1, true, 10, true, reinterpret_cast<int64>(&error_holder),
                                 &is_valid);
   EXPECT_EQ(out, 0);
@@ -75,7 +75,7 @@ TEST(TestArithmeticOps, TestLogWithBase) {
   EXPECT_TRUE(error_holder.get_error().find("divide by zero error") != std::string::npos)
       << error_holder.get_error();
 
-  gandiva::helpers::ExecutionContext error_holder1;
+  gandiva::ExecutionContext error_holder1;
   out = log_int32_int32(2, true, 64, true, reinterpret_cast<int64>(&error_holder),
                         &is_valid);
   EXPECT_EQ(out, 6);

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -110,7 +110,7 @@ void set_error_for_invalid_utf(int64_t execution_context, char val) {
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, fmt, (unsigned char)val);
-  context_set_error_msg(execution_context, error);
+  gdv_fn_context_set_error_msg(execution_context, error);
   free(error);
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -70,7 +70,7 @@ TEST(TestStringOps, TestCharLength) {
   EXPECT_TRUE(valid);
 
   // invalid utf8
-  gandiva::helpers::ExecutionContext ctx;
+  gandiva::ExecutionContext ctx;
   std::string c("\xf8\x28");
   EXPECT_EQ(utf8_length(c.data(), static_cast<int>(c.length()), true,
                         reinterpret_cast<int64>(&ctx), &valid),

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -513,7 +513,7 @@ void set_error_for_date(int32 length, const char* input, const char* msg,
   int size = length + static_cast<int>(strlen(msg)) + 1;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, "%s%s", msg, input);
-  context_set_error_msg(execution_context, error);
+  gdv_fn_context_set_error_msg(execution_context, error);
   free(error);
 }
 

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -32,7 +32,7 @@ timestamp StringToTimestamp(const char* buf) {
 
 TEST(TestTime, TestCastDate) {
   const char* date = "1967-12-1";
-  helpers::ExecutionContext context;
+  ExecutionContext context;
   bool valid;
   int64_t cast_to_date = castDATE_utf8(date, 9, true, (int64_t)&context, &valid);
   EXPECT_EQ(cast_to_date, -65836800000);

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -18,8 +18,8 @@
 #ifndef PRECOMPILED_TYPES_H
 #define PRECOMPILED_TYPES_H
 
-#include <gandiva/gdv_function_stubs.h>
 #include <cstdint>
+#include "gandiva/gdv_function_stubs.h"
 
 // Use the same names as in arrow data types. Makes it easy to write pre-processor macros.
 using boolean = bool;

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -18,6 +18,7 @@
 #ifndef PRECOMPILED_TYPES_H
 #define PRECOMPILED_TYPES_H
 
+#include <gandiva/gdv_function_stubs.h>
 #include <cstdint>
 
 // Use the same names as in arrow data types. Makes it easy to write pre-processor macros.
@@ -50,7 +51,6 @@ extern "C" {
 bool bitMapGetBit(const unsigned char* bmap, int64_t position);
 void bitMapSetBit(unsigned char* bmap, int64_t position, bool value);
 void bitMapClearBitIfFalse(unsigned char* bmap, int64_t position, bool value);
-void context_set_error_msg(int64_t context_ptr, const char* err_msg);
 
 int64 extractMillennium_timestamp(timestamp millis);
 int64 extractCentury_timestamp(timestamp millis);

--- a/cpp/src/gandiva/regex_util.cc
+++ b/cpp/src/gandiva/regex_util.cc
@@ -19,10 +19,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 const std::set<char> RegexUtil::pcre_regex_specials_ = {
     '[', ']', '(', ')', '|', '^', '-', '+', '*', '?', '{', '}', '$', '\\'};
 
@@ -67,9 +63,5 @@ Status RegexUtil::SqlLikePatternToPcre(const std::string& sql_pattern, char esca
   }
   return Status::OK();
 }
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/regex_util.h
+++ b/cpp/src/gandiva/regex_util.h
@@ -25,10 +25,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 /// \brief Utility class for converting sql patterns to pcre patterns.
 class RegexUtil {
  public:
@@ -44,10 +40,6 @@ class RegexUtil {
  private:
   static const std::set<char> pcre_regex_specials_;
 };
-
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva
 

--- a/cpp/src/gandiva/to_date_holder.cc
+++ b/cpp/src/gandiva/to_date_holder.cc
@@ -26,10 +26,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 Status ToDateHolder::Make(const FunctionNode& node,
                           std::shared_ptr<ToDateHolder>* holder) {
   if (node.children().size() != 3) {
@@ -111,8 +107,5 @@ void ToDateHolder::return_error(int64_t execution_context, const std::string& da
   std::string err_msg = "Error parsing value " + data + " for given format.";
   (execution_context_ptr)->set_error_msg(err_msg.c_str());
 }
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/to_date_holder.h
+++ b/cpp/src/gandiva/to_date_holder.h
@@ -28,10 +28,6 @@
 
 namespace gandiva {
 
-#ifdef GDV_HELPERS
-namespace helpers {
-#endif
-
 /// Function Holder for SQL 'to_date'
 class ToDateHolder : public FunctionHolder {
  public:
@@ -57,8 +53,5 @@ class ToDateHolder : public FunctionHolder {
   int32_t suppress_errors_;  // should throw exception on runtime errors
 };
 
-#ifdef GDV_HELPERS
-}  // namespace helpers
-#endif
 }  // namespace gandiva
 #endif  // TO_DATE_HOLDER_H

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
@@ -26,7 +26,6 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
 public class ConfigurationBuilder {
 
   private String byteCodeFilePath = "";
-  private String helperLibraryFilePath = "";
 
   private static volatile long defaultConfiguration = 0L;
 
@@ -43,17 +42,8 @@ public class ConfigurationBuilder {
     return this;
   }
 
-  public ConfigurationBuilder withHelperLibraryFilePath(final String helperLibraryFilePath) {
-    this.helperLibraryFilePath = helperLibraryFilePath;
-    return this;
-  }
-
   public String getByteCodeFilePath() {
     return byteCodeFilePath;
-  }
-
-  public String getHelperLibraryFilePath() {
-    return helperLibraryFilePath;
   }
 
   /**
@@ -66,11 +56,9 @@ public class ConfigurationBuilder {
       synchronized (ConfigurationBuilder.class) {
         if (defaultConfiguration == 0L) {
           String defaultByteCodeFilePath = JniWrapper.getInstance().getByteCodeFilePath();
-          String defaultHelperLibraryFilePath = JniWrapper.getInstance().getHelperLibraryFilePath();
 
           defaultConfiguration = new ConfigurationBuilder()
             .withByteCodeFilePath(defaultByteCodeFilePath)
-            .withHelperLibraryFilePath(defaultHelperLibraryFilePath)
             .buildConfigInstance();
         }
       }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
@@ -34,17 +34,14 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
  */
 class JniWrapper {
   private static final String LIBRARY_NAME = "gandiva_jni";
-  private static final String HELPER_LIBRARY_NAME = "gandiva_helpers";
   private static final String IRHELPERS_BC = "irhelpers.bc";
 
   private static volatile JniWrapper INSTANCE;
 
   private final String byteCodeFilePath;
-  private final String helperLibraryFilePath;
 
-  private JniWrapper(String byteCodeFilePath, String helperLibraryFilePath) {
+  private JniWrapper(String byteCodeFilePath) {
     this.byteCodeFilePath = byteCodeFilePath;
-    this.helperLibraryFilePath = helperLibraryFilePath;
   }
 
   static JniWrapper getInstance() throws GandivaException {
@@ -63,10 +60,7 @@ class JniWrapper {
       String tempDir = System.getProperty("java.io.tmpdir");
       loadGandivaLibraryFromJar(tempDir);
       File byteCodeFile = moveFileFromJarToTemp(tempDir, IRHELPERS_BC);
-
-      final String libraryToLoad = System.mapLibraryName(HELPER_LIBRARY_NAME);
-      final File helperLibraryFile = moveFileFromJarToTemp(tempDir, libraryToLoad);
-      return new JniWrapper(byteCodeFile.getAbsolutePath(), helperLibraryFile.getAbsolutePath());
+      return new JniWrapper(byteCodeFile.getAbsolutePath());
     } catch (IOException ioException) {
       throw new GandivaException("unable to create native instance", ioException);
     }
@@ -117,13 +111,6 @@ class JniWrapper {
    */
   public String getByteCodeFilePath() {
     return byteCodeFilePath;
-  }
-
-  /**
-   * Returns the helper library file path extracted from jar.
-   */
-  public String getHelperLibraryFilePath() {
-    return helperLibraryFilePath;
   }
 
   /**

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -516,7 +516,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
   @Test
   public void testRegex() throws GandivaException {
     /*
-     * like "map%"
+     * like "%map%"
      */
 
     Field x = Field.nullable("x", new ArrowType.Utf8());
@@ -524,7 +524,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     TreeNode cond =
         TreeBuilder.makeFunction(
             "like",
-            Lists.newArrayList(TreeBuilder.makeField(x), TreeBuilder.makeStringLiteral("map%")),
+            Lists.newArrayList(TreeBuilder.makeField(x), TreeBuilder.makeStringLiteral("%map%")),
             boolType);
     ExpressionTree expr = TreeBuilder.makeExpression(cond, Field.nullable("res", boolType));
     Schema schema = new Schema(Lists.newArrayList(x));
@@ -533,7 +533,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     int numRows = 5;
     byte[] validity = new byte[]{(byte) 255, 0};
     String[] valuesX = new String[]{"mapD", "maps", "google maps", "map", "MapR"};
-    boolean[] expected = new boolean[]{true, true, false, true, false};
+    boolean[] expected = new boolean[]{true, true, true, true, false};
 
     ArrowBuf validityX = buf(validity);
     List<ArrowBuf> dataBufsX = stringBufs(valuesX);


### PR DESCRIPTION
This change eliminates the gandiva_helpers library, which was needless duplication. Instead, the entry-points required for LLVM from gandiva are now added as a global-symbols at the time of engine startup.