### PR TITLE
ARROW-3504: [Plasma] Add support for Plasma Client to put/get raw bytes without pyarrow serialization.

### DIFF
--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -291,6 +291,21 @@ class TestPlasmaClient(object):
             [result] = self.plasma_client.get([object_id], timeout_ms=0)
             assert result == pa.plasma.ObjectNotAvailable
 
+    def test_put_and_get_raw_bytes_without_serialization(self):
+        temp_id = random_object_id()
+        for value in [b"This is a bytes obj", temp_id.binary(), 10 * b"\x00"]:
+            object_id = self.plasma_client.put_raw_bytes(value)
+            [result] = self.plasma_client.get_raw_bytes([object_id])
+            assert result == value
+
+            result = self.plasma_client.get_raw_bytes(object_id)
+            assert result == value
+
+            object_id = random_object_id()
+            [result] = self.plasma_client.get_raw_bytes(
+                [object_id], timeout_ms=0)
+            assert result == None
+
     def test_put_and_get_serialization_context(self):
 
         class CustomType(object):

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -291,18 +291,18 @@ class TestPlasmaClient(object):
             [result] = self.plasma_client.get([object_id], timeout_ms=0)
             assert result == pa.plasma.ObjectNotAvailable
 
-    def test_put_and_get_raw_bytes_without_serialization(self):
+    def test_put_and_get_buffer_without_serialization(self):
         temp_id = random_object_id()
         for value in [b"This is a bytes obj", temp_id.binary(), 10 * b"\x00"]:
-            object_id = self.plasma_client.put_raw_bytes(value)
-            [result] = self.plasma_client.get_raw_bytes([object_id])
+            object_id = self.plasma_client.put_buffer(value)
+            [result] = self.plasma_client.get_buffer([object_id])
             assert result == value
 
-            result = self.plasma_client.get_raw_bytes(object_id)
+            result = self.plasma_client.get_buffer(object_id)
             assert result == value
 
             object_id = random_object_id()
-            [result] = self.plasma_client.get_raw_bytes(
+            [result] = self.plasma_client.get_buffer(
                 [object_id], timeout_ms=0)
             assert result is None
 

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -304,7 +304,7 @@ class TestPlasmaClient(object):
             object_id = random_object_id()
             [result] = self.plasma_client.get_raw_bytes(
                 [object_id], timeout_ms=0)
-            assert result == None
+            assert result is None
 
     def test_put_and_get_serialization_context(self):
 


### PR DESCRIPTION
This is a feature enables Java Client to read data that python client puts (cross-language read/write). 