### PR TITLE
ARROW-3521: [GLib] Run Python using find_program in meson.build

### DIFF
--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -23,7 +23,7 @@ project('arrow-glib', 'c', 'cpp',
           'cpp_std=c++11',
         ])
 
-python = find_program('python3', 'python', 'python2')
+python = find_program('python', 'python3', 'python2')
 version = run_command(python, 'tool/get-version.py').stdout().strip()
 if version.endswith('-SNAPSHOT')
   version_numbers = version.split('-')[0].split('.')

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -23,7 +23,8 @@ project('arrow-glib', 'c', 'cpp',
           'cpp_std=c++11',
         ])
 
-version = run_command('python', 'tool/get-version.py').stdout().strip()
+python = find_program('python3', 'python', 'python2')
+version = run_command(python, 'tool/get-version.py').stdout().strip()
 if version.endswith('-SNAPSHOT')
   version_numbers = version.split('-')[0].split('.')
   version_tag = version.split('-')[1]


### PR DESCRIPTION
Because it is possible to run “python3” or “python2".