### PR TITLE
ARROW-3524: [C++] Add missing "override" in compression_snappy.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_lint.sh
     # The "compiler: gcc" property will set the CC/CXX variables even if they
     # are overridden in the "env" section
-    - export CC="clang-6.0"
-    - export CXX="clang++-6.0"
+    - export CC="gcc"
+    - export CXX="g++"
     # If either C++ or Python changed, we must install the C++ libraries
     - git submodule update --init
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,6 @@ matrix:
     - ARROW_TRAVIS_JAVA_BUILD_ONLY=1
     # ARROW-2999 Benchmarks are disabled in Travis CI for the time being
     # - ARROW_TRAVIS_PYTHON_BENCHMARKS=1
-    - CC="clang-6.0"
-    - CXX="clang++-6.0"
     before_script:
     # Always run RAT checks, in case another build in matrix breaks RAT
     - $TRAVIS_BUILD_DIR/ci/travis_release_audit.sh
@@ -78,6 +76,10 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_install_linux.sh
     - $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
     - $TRAVIS_BUILD_DIR/ci/travis_lint.sh
+    # The "compiler: gcc" property will set the CC/CXX variables even if they
+    # are overridden in the "env" section
+    - export CC="clang-6.0"
+    - export CXX="clang++-6.0"
     # If either C++ or Python changed, we must install the C++ libraries
     - git submodule update --init
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -25,7 +25,6 @@ source $TRAVIS_BUILD_DIR/ci/travis_install_conda.sh
 export ARROW_HOME=$ARROW_CPP_INSTALL
 export PARQUET_HOME=$ARROW_CPP_INSTALL
 export LD_LIBRARY_PATH=$ARROW_HOME/lib:$LD_LIBRARY_PATH
-export PYARROW_CXXFLAGS="-Werror"
 
 PYARROW_PYTEST_FLAGS=" -r sxX --durations=15 --parquet"
 

--- a/cpp/src/arrow/util/compression_snappy.h
+++ b/cpp/src/arrow/util/compression_snappy.h
@@ -38,7 +38,7 @@ class ARROW_EXPORT SnappyCodec : public Codec {
 
   int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  Status MakeCompressor(std::shared_ptr<Compressor>* out);
+  Status MakeCompressor(std::shared_ptr<Compressor>* out) override;
 
   Status MakeDecompressor(std::shared_ptr<Decompressor>* out) override;
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -137,6 +137,7 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-parentheses-equality")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-constant-logical-operand")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-declarations")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sometimes-uninitialized")
 
   # We have public Cython APIs which return C++ types, which are in an extern
   # "C" blog (no symbol mangling) and clang doesn't like this


### PR DESCRIPTION
This warning showed up with clang 6.0 on Ubuntu 14.04. I'm not sure why it does not in Travis CI