### PR TITLE
ARROW-3527: [R] remove unused variables

### DIFF
--- a/r/src/DataType.cpp
+++ b/r/src/DataType.cpp
@@ -115,7 +115,6 @@ SEXP list__(SEXP x) {
 
 template <typename T>
 std::vector<std::shared_ptr<T>> List_to_shared_ptr_vector(List x) {
-  int n = x.size();
   std::vector<std::shared_ptr<T>> vec;
   for (SEXP element : x) {
     vec.push_back(as<std::shared_ptr<T>>(element));

--- a/r/src/RecordBatch.cpp
+++ b/r/src/RecordBatch.cpp
@@ -129,7 +129,6 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__from_dataframe(DataFrame tbl) {
   std::vector<std::shared_ptr<arrow::Field>> fields;
   std::vector<std::shared_ptr<arrow::Array>> arrays;
 
-  int nc = tbl.size();
   for (int i = 0; i < tbl.size(); i++) {
     arrays.push_back(Array__from_vector(tbl[i]));
     fields.push_back(


### PR DESCRIPTION
I'm so excited about the Arrow R package! Started working with it tonight to see where I may be able to help.

While doing this, I noticed a few "unused variable" compiler warnings.

```
DataType.cpp:118:7: warning: unused variable 'n' [-Wunused-variable]
int n = x.size();

RecordBatch.cpp:132:7: warning: unused variable 'nc' [-Wunused-variable]
int nc = tbl.size();
```

Please consider this PR to remove the offending lines.