### PR TITLE
ARROW-3528: [R] Fixed typo in R package documentation

### DIFF
--- a/r/R/dictionary.R
+++ b/r/R/dictionary.R
@@ -32,7 +32,7 @@
 #'
 #' @param type indices type, e.g. [int32()]
 #' @param values values array, typically an arrow array of strings
-#' @param ordered Is this an ordred dictionary
+#' @param ordered Is this an ordered dictionary
 #'
 #' @export
 dictionary <- function(type, values, ordered = FALSE) {

--- a/r/man/dictionary.Rd
+++ b/r/man/dictionary.Rd
@@ -11,7 +11,7 @@ dictionary(type, values, ordered = FALSE)
 
 \item{values}{values array, typically an arrow array of strings}
 
-\item{ordered}{Is this an ordred dictionary}
+\item{ordered}{Is this an ordered dictionary}
 }
 \description{
 dictionary type factory


### PR DESCRIPTION
Please consider this PR to fix a small typo in the R package's documentation.