### PR TITLE
ARROW-3542: [C++] Use unsafe appends when building array from CSV

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -208,7 +208,8 @@ Status VarSizeBinaryConverter<T>::Convert(const BlockParser& parser, int32_t col
   // TODO handle nulls
 
   auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
-    return builder.Append(data, size);
+    builder.UnsafeAppend(data, size);
+    return Status::OK();
   };
   RETURN_NOT_OK(builder.Resize(parser.num_rows()));
   RETURN_NOT_OK(builder.ReserveData(parser.num_bytes()));
@@ -282,7 +283,8 @@ Status NumericConverter<T>::Convert(const BlockParser& parser, int32_t col_index
             !converter(reinterpret_cast<const char*>(data), size, &value))) {
       return GenericConversionError(type_, data, size);
     }
-    return builder.Append(value);
+    builder.UnsafeAppend(value);
+    return Status::OK();
   };
   RETURN_NOT_OK(builder.Resize(parser.num_rows()));
   RETURN_NOT_OK(parser.VisitColumn(col_index, visit));

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -73,7 +73,8 @@ class ARROW_EXPORT BlockParser {
 
   /// \brief Visit parsed values in a column
   ///
-  /// The signature of the visitor is (const uint8_t* data, uint32_t size, bool quoted)
+  /// The signature of the visitor is
+  /// Status(const uint8_t* data, uint32_t size, bool quoted)
   template <typename Visitor>
   Status VisitColumn(int32_t col_index, Visitor&& visit) const {
 #ifdef CSV_PARSER_USE_BITFIELD


### PR DESCRIPTION
This makes reading a CSV file of binary string columns 5-10% faster.