### PR TITLE
ARROW-3380: [Python] Support reading gzipped CSV files 

### DIFF
--- a/cpp/src/arrow/io/api.h
+++ b/cpp/src/arrow/io/api.h
@@ -18,6 +18,7 @@
 #ifndef ARROW_IO_API_H
 #define ARROW_IO_API_H
 
+#include "arrow/io/compressed.h"
 #include "arrow/io/file.h"
 #include "arrow/io/hdfs.h"
 #include "arrow/io/interfaces.h"

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -22,7 +22,7 @@
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport (check_status, MemoryPool, maybe_unbox_memory_pool,
-                          pyarrow_wrap_table, get_reader)
+                          pyarrow_wrap_table, get_input_stream)
 
 
 cdef unsigned char _single_char(s) except 0:
@@ -149,10 +149,8 @@ cdef class ParseOptions:
 
 
 cdef _get_reader(input_file, shared_ptr[InputStream]* out):
-    cdef shared_ptr[RandomAccessFile] result
     use_memory_map = False
-    get_reader(input_file, use_memory_map, &result)
-    out[0] = <shared_ptr[InputStream]> result
+    get_input_stream(input_file, use_memory_map, out)
 
 
 cdef _get_read_options(ReadOptions read_options, CCSVReadOptions* out):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -663,6 +663,16 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
 
         int file_descriptor()
 
+    cdef cppclass CompressedInputStream(InputStream):
+        @staticmethod
+        CStatus Make(CMemoryPool* pool, CCodec* codec,
+                     shared_ptr[InputStream] raw,
+                     shared_ptr[CompressedInputStream]* out)
+
+        @staticmethod
+        CStatus Make(CCodec* codec, shared_ptr[InputStream] raw,
+                     shared_ptr[CompressedInputStream]* out)
+
     # ----------------------------------------------------------------------
     # HDFS
 

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -118,7 +118,7 @@ cdef class MessageReader:
         cdef MessageReader result = MessageReader.__new__(MessageReader)
         cdef shared_ptr[InputStream] in_stream
         cdef unique_ptr[CMessageReader] reader
-        get_input_stream(source, &in_stream)
+        _get_input_stream(source, &in_stream)
         with nogil:
             reader = CMessageReader.Open(in_stream)
             result.reader.reset(reader.release())
@@ -227,7 +227,7 @@ cdef class _RecordBatchWriter:
         self.closed = True
 
 
-cdef get_input_stream(object source, shared_ptr[InputStream]* out):
+cdef _get_input_stream(object source, shared_ptr[InputStream]* out):
     cdef:
         shared_ptr[RandomAccessFile] file_handle
 
@@ -253,7 +253,7 @@ cdef class _RecordBatchReader:
         pass
 
     def _open(self, source):
-        get_input_stream(source, &self.in_stream)
+        _get_input_stream(source, &self.in_stream)
         with nogil:
             check_status(CRecordBatchStreamReader.Open(
                 self.in_stream.get(), &self.reader))

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -369,6 +369,8 @@ cdef class NativeFile:
     cdef read_handle(self, shared_ptr[RandomAccessFile]* file)
     cdef write_handle(self, shared_ptr[OutputStream]* file)
 
+cdef get_input_stream(object source, c_bool use_memory_map,
+                      shared_ptr[InputStream]* reader)
 cdef get_reader(object source, c_bool use_memory_map,
                 shared_ptr[RandomAccessFile]* reader)
 cdef get_writer(object source, shared_ptr[OutputStream]* writer)


### PR DESCRIPTION
Also works for other bundled compression types.

Based on PR #2777.