### PR TITLE
ARROW-3555: [Plasma] Unify plasma client get function using metadata.

### DIFF
--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -33,8 +33,8 @@ import collections
 import pyarrow
 import random
 
-from pyarrow.lib cimport (Buffer, NativeFile, check_status, pyarrow_wrap_buffer,
-                          pyarrow_unwrap_buffer)
+from pyarrow.lib cimport (Buffer, NativeFile, check_status,
+                          pyarrow_wrap_buffer, pyarrow_unwrap_buffer)
 from pyarrow.includes.libarrow cimport (CBuffer, CMutableBuffer,
                                         CFixedSizeBufferWriter, CStatus)
 

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -399,7 +399,7 @@ cdef class PlasmaClient:
             If with_meta=False, this is a list of PlasmaBuffers for the data
             associated with the object_ids and None if the object was not
             available. If with_meta=True, this is a list of tuples of
-            PlasmaBuffer and metadate bytes.
+            PlasmaBuffer and metadata bytes.
         """
         cdef c_vector[CObjectBuffer] object_buffers
         self._get_object_buffers(object_ids, timeout_ms, &object_buffers)

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -220,8 +220,8 @@ class TestPlasmaClient(object):
             self.plasma_client.create_and_seal(object_id, i * b'a', i * b'b')
 
         for i in range(1000):
-            data_tuple = self.plasma_client.get_buffers(object_ids[i],
-                                                        with_meta=True)
+            [data_tuple] = self.plasma_client.get_buffers([object_ids[i]],
+                                                          with_meta=True)
             assert data_tuple[1].to_pybytes() == i * b'a'
             assert (self.plasma_client.get_metadata(
                         [object_ids[i]])[0].to_pybytes()
@@ -287,13 +287,12 @@ class TestPlasmaClient(object):
         object_id = random_object_id()
         self.plasma_client.create(object_id, 10, b"metadata")
         assert self.plasma_client.get_buffers(
-            object_id, timeout_ms=0, with_meta=True)[1] is None
+            [object_id], timeout_ms=0, with_meta=True)[0][1] is None
         assert self.plasma_client.get_buffers(
-            object_id, timeout_ms=1, with_meta=True)[1] is None
+            [object_id], timeout_ms=1, with_meta=True)[0][1] is None
         self.plasma_client.seal(object_id)
-        assert (self.plasma_client.get_buffers(
-            object_id, timeout_ms=0, with_meta=True)[1]
-                is not None)
+        assert self.plasma_client.get_buffers(
+            [object_id], timeout_ms=0, with_meta=True)[0][1]is not None
 
     def test_buffer_lifetime(self):
         # ARROW-2195
@@ -357,13 +356,15 @@ class TestPlasmaClient(object):
                     value, metadata=use_meta)
             else:
                 object_id = self.plasma_client.put(value)
-            [result] = self.plasma_client.get_buffers([object_id])
+            [result] = self.plasma_client.get_buffers([object_id],
+                                                      with_meta=True)
             result = deserialize_or_output(result)
             assert result == value
 
             object_id = random_object_id()
-            [result] = self.plasma_client.get_buffers(
-                [object_id], timeout_ms=0)
+            [result] = self.plasma_client.get_buffers([object_id],
+                                                      timeout_ms=0,
+                                                      with_meta=True)
             result = deserialize_or_output(result)
             assert result == pa.plasma.ObjectNotAvailable
 


### PR DESCRIPTION
Sometimes, it is very hard for the data consumer to know whether an object is a buffer or other types of object. If we use `try-catch` statement to catch the pyarrow deserialization exception and then using `plasma_client.get_buffer`, the code is not clean.

As discussed with @robertnishihara , we may leverage the metadata which is not used at all to mark the buffer data. Furthermore, this will avoid output `None` when the object is actually not available, which is showed in the test.

In the client of other language, corresponding change would be easy.