### PR TITLE
ARROW-3559: [Plasma] Static linking for plasma_store_server.

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -82,9 +82,11 @@ set(PLASMA_SRCS
   thirdparty/xxhash.cc)
 
 set(PLASMA_LINK_LIBS arrow_shared)
+set(PLASMA_STATIC_LINK_LIBS arrow_static)
 
 if (ARROW_GPU)
   set(PLASMA_LINK_LIBS ${PLASMA_LINK_LIBS} arrow_gpu_shared)
+  set(PLASMA_STATIC_LINK_LIBS ${PLASMA_STATIC_LINK_LIBS} arrow_static)
   add_definitions(-DPLASMA_GPU)
 endif()
 
@@ -129,7 +131,7 @@ if ("${COMPILER_FAMILY}" STREQUAL "gcc")
 endif()
 
 add_executable(plasma_store_server store.cc)
-target_link_libraries(plasma_store_server plasma_shared ${PLASMA_LINK_LIBS})
+target_link_libraries(plasma_store_server plasma_static ${PLASMA_STATIC_LINK_LIBS})
 
 if (ARROW_RPATH_ORIGIN)
   if (APPLE)

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -130,6 +130,8 @@ if ("${COMPILER_FAMILY}" STREQUAL "gcc")
     " -Wno-conversion")
 endif()
 
+# We use static libraries for the plasma_store_server executable so that it can
+# be copied around and used in different locations.
 add_executable(plasma_store_server store.cc)
 target_link_libraries(plasma_store_server plasma_static ${PLASMA_STATIC_LINK_LIBS})
 


### PR DESCRIPTION
This is related to #2744, which uses shared libraries instead of static libraries to speed up tests and reduce disk space. This PR continues to use shared libraries for the tests, however, for the actual plasma_store_server, I think it's important to be able to copy the executable around and use it without worrying about rpaths and installation.