### PR TITLE
[C++] SnappyCodec::MakeCompressor is override

### DIFF
--- a/cpp/src/arrow/util/compression_snappy.h
+++ b/cpp/src/arrow/util/compression_snappy.h
@@ -38,7 +38,7 @@ class ARROW_EXPORT SnappyCodec : public Codec {
 
   int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input) override;
 
-  Status MakeCompressor(std::shared_ptr<Compressor>* out);
+  Status MakeCompressor(std::shared_ptr<Compressor>* out) override;
 
   Status MakeDecompressor(std::shared_ptr<Decompressor>* out) override;
 


### PR DESCRIPTION
```
In file included from /Users/romain/git/apache/arrow/cpp/src/arrow/util/compression.cc:27:
/Users/romain/git/apache/arrow/cpp/src/arrow/util/compression_snappy.h:41:10: warning: 'MakeCompressor' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  Status MakeCompressor(std::shared_ptr<Compressor>* out);
         ^
/Users/romain/git/apache/arrow/cpp/src/arrow/util/compression.h:125:18: note: overridden virtual function is here
  virtual Status MakeCompressor(std::shared_ptr<Compressor>* out) = 0;
                 ^
1 warning generated.
```