### PR TITLE
ARROW-3580: [Gandiva][C++] Fix build error with g++ 8.2.0

### DIFF
--- a/cpp/src/gandiva/function_holder_registry.h
+++ b/cpp/src/gandiva/function_holder_registry.h
@@ -18,6 +18,7 @@
 #ifndef GANDIVA_FUNCTION_HOLDER_REGISTRY_H
 #define GANDIVA_FUNCTION_HOLDER_REGISTRY_H
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/cpp/src/gandiva/tree_expr_builder.cc
+++ b/cpp/src/gandiva/tree_expr_builder.cc
@@ -75,9 +75,9 @@ NodePtr TreeExprBuilder::MakeNull(DataTypePtr data_type) {
     case arrow::Type::UINT64:
       return std::make_shared<LiteralNode>(data_type, LiteralHolder((uint64_t)0), true);
     case arrow::Type::FLOAT:
-      return std::make_shared<LiteralNode>(data_type, LiteralHolder((float_t)0), true);
+      return std::make_shared<LiteralNode>(data_type, LiteralHolder((float)0), true);
     case arrow::Type::DOUBLE:
-      return std::make_shared<LiteralNode>(data_type, LiteralHolder((double_t)0), true);
+      return std::make_shared<LiteralNode>(data_type, LiteralHolder((double)0), true);
     case arrow::Type::STRING:
     case arrow::Type::BINARY:
       return std::make_shared<LiteralNode>(data_type, LiteralHolder(empty), true);

--- a/cpp/src/gandiva/tree_expr_builder.cc
+++ b/cpp/src/gandiva/tree_expr_builder.cc
@@ -75,9 +75,9 @@ NodePtr TreeExprBuilder::MakeNull(DataTypePtr data_type) {
     case arrow::Type::UINT64:
       return std::make_shared<LiteralNode>(data_type, LiteralHolder((uint64_t)0), true);
     case arrow::Type::FLOAT:
-      return std::make_shared<LiteralNode>(data_type, LiteralHolder((float)0), true);
+      return std::make_shared<LiteralNode>(data_type, LiteralHolder(static_cast<float>(0)), true);
     case arrow::Type::DOUBLE:
-      return std::make_shared<LiteralNode>(data_type, LiteralHolder((double)0), true);
+      return std::make_shared<LiteralNode>(data_type, LiteralHolder(static_cast<double>(0)), true);
     case arrow::Type::STRING:
     case arrow::Type::BINARY:
       return std::make_shared<LiteralNode>(data_type, LiteralHolder(empty), true);

--- a/cpp/src/gandiva/tree_expr_builder.cc
+++ b/cpp/src/gandiva/tree_expr_builder.cc
@@ -75,9 +75,11 @@ NodePtr TreeExprBuilder::MakeNull(DataTypePtr data_type) {
     case arrow::Type::UINT64:
       return std::make_shared<LiteralNode>(data_type, LiteralHolder((uint64_t)0), true);
     case arrow::Type::FLOAT:
-      return std::make_shared<LiteralNode>(data_type, LiteralHolder(static_cast<float>(0)), true);
+      return std::make_shared<LiteralNode>(data_type,
+                                           LiteralHolder(static_cast<float>(0)), true);
     case arrow::Type::DOUBLE:
-      return std::make_shared<LiteralNode>(data_type, LiteralHolder(static_cast<double>(0)), true);
+      return std::make_shared<LiteralNode>(data_type,
+                                           LiteralHolder(static_cast<double>(0)), true);
     case arrow::Type::STRING:
     case arrow::Type::BINARY:
       return std::make_shared<LiteralNode>(data_type, LiteralHolder(empty), true);


### PR DESCRIPTION
Error message1:

    In file included from /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/expr_decomposer.cc:27:
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:46:27: error: 'function' in namespace 'std' does not name a template type
       using maker_type = std::function<Status(const FunctionNode&, FunctionHolderPtr*)>;
                               ^~~~~~~~
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:46:22: note: 'std::function' is defined in header '<functional>'; did you forget to '#include <functional>'?
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:30:1:
    +#include <functional>

    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:46:22:
       using maker_type = std::function<Status(const FunctionNode&, FunctionHolderPtr*)>;
                          ^~~
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:47:52: error: 'maker_type' was not declared in this scope
       using map_type = std::unordered_map<std::string, maker_type>;
                                                        ^~~~~~~~~~
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:47:52: note: suggested alternative: 'decltype'
       using map_type = std::unordered_map<std::string, maker_type>;
                                                        ^~~~~~~~~~
                                                        decltype
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:47:62: error: template argument 2 is invalid
       using map_type = std::unordered_map<std::string, maker_type>;
                                                                  ^
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:47:62: error: template argument 5 is invalid
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:60:10: error: 'map_type' does not name a type; did you mean 'iswctype'?
       static map_type& makers() {
              ^~~~~~~~
              iswctype
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h: In static member function 'static gandiva::Status gandiva::FunctionHolderRegistry::Make(const string&, const gandiva::FunctionNode&, gandiva::FunctionHolderPtr*)':
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:51:18: error: 'makers' was not declared in this scope
         auto found = makers().find(name);
                      ^~~~~~
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/function_holder_registry.h:51:18: note: suggested alternative: 'Make'
         auto found = makers().find(name);
                      ^~~~~~
                      Make

Message2:

    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/tree_expr_builder.cc: In static member function 'static gandiva::NodePtr gandiva::TreeExprBuilder::MakeNull(gandiva::DataTypePtr)':
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/tree_expr_builder.cc:78:70: error: 'float_t' was not declared in this scope
           return std::make_shared<LiteralNode>(data_type, LiteralHolder((float_t)0), true);
                                                                          ^~~~~~~
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/tree_expr_builder.cc:78:70: note: suggested alternative: 'float'
           return std::make_shared<LiteralNode>(data_type, LiteralHolder((float_t)0), true);
                                                                          ^~~~~~~
                                                                          float
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/tree_expr_builder.cc:80:70: error: 'double_t' was not declared in this scope
           return std::make_shared<LiteralNode>(data_type, LiteralHolder((double_t)0), true);
                                                                          ^~~~~~~~
    /home/kou/work/cpp/arrow.kou/cpp/src/gandiva/tree_expr_builder.cc:80:70: note: suggested alternative: 'double'
           return std::make_shared<LiteralNode>(data_type, LiteralHolder((double_t)0), true);
                                                                          ^~~~~~~~
                                                                          double