### PR TITLE
ARROW-3583: [Python/Java] Create RecordBatch from VectorSchemaRoot

### DIFF
--- a/python/pyarrow/jvm.py
+++ b/python/pyarrow/jvm.py
@@ -276,3 +276,28 @@ def array(jvm_array):
                for buf in list(jvm_array.getBuffers(False))]
     null_count = jvm_array.getNullCount()
     return pa.Array.from_buffers(dtype, length, buffers, null_count)
+
+
+def record_batch(jvm_vector_schema_root):
+    """
+    Construct a (Python) RecordBatch from a JVM VectorSchemaRoot
+
+    Parameters
+    ----------
+    jvm_vector_schema_root : org.apache.arrow.vector.VectorSchemaRoot
+
+    Returns
+    -------
+    record_batch: pyarrow.RecordBatch
+    """
+    pa_schema = schema(jvm_vector_schema_root.getSchema())
+
+    arrays = []
+    for name in pa_schema.names:
+        arrays.append(array(jvm_vector_schema_root.getVector(name)))
+
+    return pa.RecordBatch.from_arrays(
+        arrays,
+        pa_schema.names,
+        metadata=pa_schema.metadata
+    )


### PR DESCRIPTION
There is sadly a lot of duplication in the parametrization. Sadly they are currently all a bit separate as not all types are equally passable from the JVM. In follow-up PRs, I'll try to add the missing features so that we can remove some of the code duplication.