### PR TITLE
ARROW-3557: [Python] Set Cython language level

### DIFF
--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -18,6 +18,7 @@
 # cython: profile=False
 # distutils: language = c++
 # cython: embedsignature = True
+# cython: language_level = 3
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *

--- a/python/pyarrow/_cuda.pxd
+++ b/python/pyarrow/_cuda.pxd
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# cython: language_level = 3
+
 from pyarrow.lib cimport *
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *

--- a/python/pyarrow/_orc.pxd
+++ b/python/pyarrow/_orc.pxd
@@ -16,6 +16,7 @@
 # under the License.
 
 # distutils: language = c++
+# cython: language_level = 3
 
 from libc.string cimport const_char
 from libcpp.vector cimport vector as std_vector

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -16,6 +16,7 @@
 # under the License.
 
 # distutils: language = c++
+# cython: language_level = 3
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport (CArray, CSchema, CStatus,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -589,7 +589,7 @@ cdef int check_compression_name(name) except -1:
     return 0
 
 
-cdef ParquetCompression compression_from_name(str name):
+cdef ParquetCompression compression_from_name(name):
     name = name.upper()
     if name == 'SNAPPY':
         return ParquetCompression_SNAPPY

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -18,6 +18,7 @@
 # cython: profile=False
 # distutils: language = c++
 # cython: embedsignature = True
+# cython: language_level = 3
 
 from libcpp cimport bool as c_bool, nullptr
 from libcpp.memory cimport shared_ptr, unique_ptr, make_shared
@@ -282,8 +283,8 @@ cdef class PlasmaClient:
     def __cinit__(self):
         self.client.reset(new CPlasmaClient())
         self.notification_fd = -1
-        self.store_socket_name = ""
-        self.manager_socket_name = ""
+        self.store_socket_name = b""
+        self.manager_socket_name = b""
 
     cdef _get_object_buffers(self, object_ids, int64_t timeout_ms,
                              c_vector[CObjectBuffer]* result):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1132,7 +1132,7 @@ cdef CompressionType _get_compression_type(object name):
                          .format(str(name)))
 
 
-cdef CompressionType _get_compression_type_by_filename(str filename):
+cdef CompressionType _get_compression_type_by_filename(filename):
     if filename.endswith('.gz'):
         return CompressionType_GZIP
     elif filename.endswith('.lz4'):

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# cython: language_level = 3
+
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow cimport CStatus

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -17,6 +17,8 @@
 
 from cpython.ref cimport PyObject
 
+import six
+
 from pyarrow.compat import pickle
 
 
@@ -28,7 +30,7 @@ def is_named_tuple(cls):
     f = getattr(cls, "_fields", None)
     if not isinstance(f, tuple):
         return False
-    return all(type(n) == str for n in f)
+    return all(isinstance(n, six.string_types) for n in f)
 
 
 class SerializationCallbackError(ArrowSerializationError):

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -20,11 +20,14 @@ UNTESTED:
 read_message
 """
 
+import sys
+import sysconfig
 
 import pytest
+
 import pyarrow as pa
 import numpy as np
-import sysconfig
+
 
 cuda = pytest.importorskip("pyarrow.cuda")
 
@@ -114,12 +117,7 @@ def test_context_device_buffer():
 
     # CudaBuffer does not support buffer protocol
     with pytest.raises(BufferError):
-        try:
-            np.frombuffer(cudabuf, dtype=np.uint8)
-        except Exception as e_info:
-            assert str(e_info).startswith(
-                "buffer protocol for device buffer not supported")
-            raise
+        memoryview(cudabuf)
 
     # Creating device buffer from array:
     cudabuf = global_context.buffer_from_data(arr)
@@ -565,6 +563,7 @@ def other_process_for_test_IPC(handle_buffer, expected_arr):
 
 
 @cuda_ipc
+@pytest.mark.skipif(sys.version_info[0] == 2, reason="test needs Python 3")
 def test_IPC():
     import multiprocessing
     ctx = multiprocessing.get_context('spawn')


### PR DESCRIPTION
This avoids a warning and makes us ready for the default setting of using Python 3 semantics.