### PR TITLE
ARROW-3589: [Gandiva] Make gandiva JNI wrappers optional

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -305,6 +305,10 @@ Always OFF if building binaries"
     "Build the Gandiva libraries"
     OFF)
 
+  option(ARROW_GANDIVA_JAVA
+    "Build the Gandiva JNI wrappers"
+    ON)
+
 endif()
 
 if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -181,7 +181,9 @@ add_gandiva_unit_test(selection_vector_test.cc selection_vector.cc)
 add_gandiva_unit_test(lru_cache_test.cc)
 add_gandiva_unit_test(to_date_holder_test.cc to_date_holder.cc date_utils.cc execution_context.cc)
 
-add_subdirectory(jni)
+if (ARROW_GANDIVA_JAVA)
+  add_subdirectory(jni)
+endif()
 add_subdirectory(precompiled)
 
 include(CTest)


### PR DESCRIPTION
I introduced `ARROW_GANDIVA_JAVA` flag that allows switching off building the JNI gandiva bindings.

Alternatively we could also have a global `ARROW_JNI` flag as suggested in https://issues.apache.org/jira/browse/ARROW-3589 which switches off all JNI wrappers (we also have JNI wrappers in plasma, which are off by default and switched on with `ARROW_PLASMA_JAVA_CLIENT`). It might make sense to configure them individually but let me know if you have a strong preference to one or the other.