### PR TITLE
ARROW-3591: [R] Support for collecting decimal types

### DIFF
--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -301,6 +301,14 @@ Schema__ToString <- function(s) {
     .Call(`_arrow_Schema__ToString`, s)
 }
 
+Schema__num_fields <- function(s) {
+    .Call(`_arrow_Schema__num_fields`, s)
+}
+
+Schema__field <- function(s, i) {
+    .Call(`_arrow_Schema__field`, s, i)
+}
+
 ListType__ToString <- function(type) {
     .Call(`_arrow_ListType__ToString`, type)
 }

--- a/r/R/Schema.R
+++ b/r/R/Schema.R
@@ -20,7 +20,9 @@
 `arrow::Schema` <- R6Class("arrow::Schema",
   inherit = `arrow::Object`,
   public = list(
-    ToString = function() Schema__ToString(self)
+    ToString = function() Schema__ToString(self),
+    num_fields = function() Schema__num_fields(self),
+    field = function(i) construct(`arrow::Field`, Schema__field(self, i))
   )
 )
 

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -832,6 +832,29 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// Schema__num_fields
+int Schema__num_fields(const std::shared_ptr<arrow::Schema>& s);
+RcppExport SEXP _arrow_Schema__num_fields(SEXP sSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::shared_ptr<arrow::Schema>& >::type s(sSEXP);
+    rcpp_result_gen = Rcpp::wrap(Schema__num_fields(s));
+    return rcpp_result_gen;
+END_RCPP
+}
+// Schema__field
+std::shared_ptr<arrow::Field> Schema__field(const std::shared_ptr<arrow::Schema>& s, int i);
+RcppExport SEXP _arrow_Schema__field(SEXP sSEXP, SEXP iSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::shared_ptr<arrow::Schema>& >::type s(sSEXP);
+    Rcpp::traits::input_parameter< int >::type i(iSEXP);
+    rcpp_result_gen = Rcpp::wrap(Schema__field(s, i));
+    return rcpp_result_gen;
+END_RCPP
+}
 // ListType__ToString
 std::string ListType__ToString(const std::shared_ptr<arrow::ListType>& type);
 RcppExport SEXP _arrow_ListType__ToString(SEXP typeSEXP) {
@@ -1737,6 +1760,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_arrow_DataType__id", (DL_FUNC) &_arrow_DataType__id, 1},
     {"_arrow_schema_", (DL_FUNC) &_arrow_schema_, 1},
     {"_arrow_Schema__ToString", (DL_FUNC) &_arrow_Schema__ToString, 1},
+    {"_arrow_Schema__num_fields", (DL_FUNC) &_arrow_Schema__num_fields, 1},
+    {"_arrow_Schema__field", (DL_FUNC) &_arrow_Schema__field, 2},
     {"_arrow_ListType__ToString", (DL_FUNC) &_arrow_ListType__ToString, 1},
     {"_arrow_FixedWidthType__bit_width", (DL_FUNC) &_arrow_FixedWidthType__bit_width, 1},
     {"_arrow_DateType__unit", (DL_FUNC) &_arrow_DateType__unit, 1},

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -698,6 +698,38 @@ SEXP Int64Array(const std::shared_ptr<Array>& array) {
   return vec;
 }
 
+SEXP DecimalArray(const std::shared_ptr<Array>& array) {
+  auto n = array->length();
+  NumericVector vec(n);
+
+  if (n == 0) return vec;
+
+  auto null_count = array->null_count();
+  if (null_count == n) {
+    std::fill(vec.begin(), vec.end(), NA_REAL);
+    return vec;
+  }
+
+  auto p_vec = reinterpret_cast<double*>(vec.begin());
+  const auto& decimals_arr = internal::checked_cast<const arrow::Decimal128Array&>(*array);
+
+  if (array->null_count()) {
+    internal::BitmapReader bitmap_reader(array->null_bitmap()->data(), array->offset(),
+                                         n);
+
+    for (size_t i = 0; i < n; i++, bitmap_reader.Next()) {
+      p_vec[i] = bitmap_reader.IsNotSet() ? NA_REAL : std::stod(decimals_arr.FormatValue(i).c_str());
+    }
+  }
+  else {
+    for (size_t i = 0; i < n; i++) {
+      p_vec[i] = std::stod(decimals_arr.FormatValue(i).c_str());
+    }
+  }
+
+  return vec;
+}
+
 }  // namespace r
 }  // namespace arrow
 
@@ -748,6 +780,8 @@ SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array) {
     // lossy promotions to numeric vector
     case Type::INT64:
       return arrow::r::Int64Array(array);
+    case Type::DECIMAL:
+      return arrow::r::DecimalArray(array);
 
     default:
       break;

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -711,17 +711,19 @@ SEXP DecimalArray(const std::shared_ptr<Array>& array) {
   }
 
   auto p_vec = reinterpret_cast<double*>(vec.begin());
-  const auto& decimals_arr = internal::checked_cast<const arrow::Decimal128Array&>(*array);
+  const auto& decimals_arr =
+      internal::checked_cast<const arrow::Decimal128Array&>(*array);
 
   if (array->null_count()) {
     internal::BitmapReader bitmap_reader(array->null_bitmap()->data(), array->offset(),
                                          n);
 
     for (size_t i = 0; i < n; i++, bitmap_reader.Next()) {
-      p_vec[i] = bitmap_reader.IsNotSet() ? NA_REAL : std::stod(decimals_arr.FormatValue(i).c_str());
+      p_vec[i] = bitmap_reader.IsNotSet()
+                     ? NA_REAL
+                     : std::stod(decimals_arr.FormatValue(i).c_str());
     }
-  }
-  else {
+  } else {
     for (size_t i = 0; i < n; i++) {
       p_vec[i] = std::stod(decimals_arr.FormatValue(i).c_str());
     }

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -700,7 +700,7 @@ SEXP Int64Array(const std::shared_ptr<Array>& array) {
 
 SEXP DecimalArray(const std::shared_ptr<Array>& array) {
   auto n = array->length();
-  NumericVector vec(n);
+  NumericVector vec(no_init(n));
 
   if (n == 0) return vec;
 

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -174,6 +174,21 @@ std::string Schema__ToString(const std::shared_ptr<arrow::Schema>& s) {
 }
 
 // [[Rcpp::export]]
+int Schema__num_fields(const std::shared_ptr<arrow::Schema>& s) {
+  return s->num_fields();
+}
+
+// [[Rcpp::export]]
+std::shared_ptr<arrow::Field> Schema__field(const std::shared_ptr<arrow::Schema>& s,
+                                             int i) {
+  if (i >= s->num_fields()) {
+    Rcpp::stop("Invalid field index for schema.");
+  }
+
+  return s->field(i);
+}
+
+// [[Rcpp::export]]
 std::string ListType__ToString(const std::shared_ptr<arrow::ListType>& type) {
   return type->ToString();
 }

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -181,7 +181,7 @@ int Schema__num_fields(const std::shared_ptr<arrow::Schema>& s) {
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Field> Schema__field(const std::shared_ptr<arrow::Schema>& s,
                                              int i) {
-  if (i >= s->num_fields()) {
+  if (i >= s->num_fields() || i < 0) {
     Rcpp::stop("Invalid field index for schema.");
   }
 

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -180,7 +180,7 @@ int Schema__num_fields(const std::shared_ptr<arrow::Schema>& s) {
 
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Field> Schema__field(const std::shared_ptr<arrow::Schema>& s,
-                                             int i) {
+                                            int i) {
   if (i >= s->num_fields() || i < 0) {
     Rcpp::stop("Invalid field index for schema.");
   }


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/ARROW-3591, implemented following Python string to decimal conversion: https://github.com/apache/arrow/blob/master/cpp/src/arrow/python/arrow_to_pandas.cc#L723.

Note: We could consider a more efficient conversion from decimal to R's integer or numeric types depending on the precision/scale from Arrows decimal; however, my guess is that this has been explored before for other languages and there is no straightforward `memcpy()` version of cross language decimal type conversions since the internal representation has been implemented as language specific.

Bonus: Added accessors in the `schema` wrapper for `num_fields()` and `field()` which can help diagnose schema issues.