### PR TITLE
ARROW-3587: [Python] Efficient serialization for Arrow Objects (array, table, tensor, etc)

### DIFF
--- a/cpp/src/arrow/python/deserialize.h
+++ b/cpp/src/arrow/python/deserialize.h
@@ -50,14 +50,15 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out);
 /// SerializedPyObject::GetComponents.
 ///
 /// \param[in] num_tensors number of tensors in the object
+/// \param[in] num_ndarrays number of numpy Ndarrays in the object
 /// \param[in] num_buffers number of buffers in the object
 /// \param[in] data a list containing pyarrow.Buffer instances. Must be 1 +
 /// num_tensors * 2 + num_buffers in length
 /// \param[out] out the reconstructed object
 /// \return Status
 ARROW_EXPORT
-Status GetSerializedFromComponents(int num_tensors, int num_buffers, PyObject* data,
-                                   SerializedPyObject* out);
+Status GetSerializedFromComponents(int num_tensors, int num_ndarrays, int num_buffers,
+                                   PyObject* data, SerializedPyObject* out);
 
 /// \brief Reconstruct Python object from Arrow-serialized representation
 /// \param[in] context Serialization context which contains custom serialization

--- a/cpp/src/arrow/python/serialize.h
+++ b/cpp/src/arrow/python/serialize.h
@@ -50,6 +50,7 @@ namespace py {
 struct ARROW_EXPORT SerializedPyObject {
   std::shared_ptr<RecordBatch> batch;
   std::vector<std::shared_ptr<Tensor>> tensors;
+  std::vector<std::shared_ptr<Tensor>> ndarrays;
   std::vector<std::shared_ptr<Buffer>> buffers;
 
   /// \brief Write serialized Python object to OutputStream

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1121,7 +1121,8 @@ cdef extern from "arrow/python/api.h" namespace 'arrow::py' nogil:
     CStatus ReadSerializedObject(RandomAccessFile* src,
                                  CSerializedPyObject* out)
 
-    CStatus GetSerializedFromComponents(int num_tensors, int num_buffers,
+    CStatus GetSerializedFromComponents(int num_tensors, int num_ndarrays,
+                                        int num_buffers,
                                         object buffers,
                                         CSerializedPyObject* out)
 

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -281,12 +281,14 @@ cdef class SerializedPyObject:
         """
         cdef:
             int num_tensors = components['num_tensors']
+            int num_ndarrays = components['num_ndarrays']
             int num_buffers = components['num_buffers']
             list buffers = components['data']
             SerializedPyObject result = SerializedPyObject()
 
         with nogil:
-            check_status(GetSerializedFromComponents(num_tensors, num_buffers,
+            check_status(GetSerializedFromComponents(num_tensors, num_ndarrays,
+                                                     num_buffers,
                                                      buffers, &result.data))
 
         return result

--- a/python/pyarrow/tests/test_plasma_tf_op.py
+++ b/python/pyarrow/tests/test_plasma_tf_op.py
@@ -70,6 +70,7 @@ def run_tensorflow_test_with_dtype(tf, plasma, plasma_store_name,
     # Try getting the data from Python
     plasma_object_id = plasma.ObjectID(object_id)
     obj = client.get(plasma_object_id)
+    obj = obj.to_numpy()
 
     # Deserialized Tensor should be 64-byte aligned.
     assert obj.ctypes.data % 64 == 0


### PR DESCRIPTION
This PR enables efficient serialization for Arrow Objects (array, table, tensor, record batch).