### PR TITLE
ARROW-3611: [Python] Give better error message when type_id has wrong type.

### DIFF
--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -119,6 +119,10 @@ cdef class SerializationContext:
             This argument is optional, but can be provided to
             deserialize objects of the class in a particular way.
         """
+        if not isinstance(type_id, str):
+           raise ValueError("The type_id argument must be a string. The value "
+                            "passed in has type {}.".format(type(type_id)))
+
         self.type_to_type_id[type_] = type_id
         self.whitelisted_types[type_id] = type_
         if pickle:
@@ -168,7 +172,7 @@ cdef class SerializationContext:
         else:
             assert type_id not in self.types_to_pickle
             if type_id not in self.whitelisted_types:
-                msg = "Type ID " + str(type_id) + " not registered in " \
+                msg = "Type ID " + type_id + " not registered in " \
                       "deserialization callback"
                 raise DeserializationCallbackError(msg, type_id)
             type_ = self.whitelisted_types[type_id]

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -120,8 +120,9 @@ cdef class SerializationContext:
             deserialize objects of the class in a particular way.
         """
         if not isinstance(type_id, str):
-           raise ValueError("The type_id argument must be a string. The value "
-                            "passed in has type {}.".format(type(type_id)))
+            raise ValueError("The type_id argument must be a string. The "
+                             "value passed in has type {}."
+                             .format(type(type_id)))
 
         self.type_to_type_id[type_] = type_id
         self.whitelisted_types[type_id] = type_

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -120,9 +120,8 @@ cdef class SerializationContext:
             deserialize objects of the class in a particular way.
         """
         if not isinstance(type_id, six.string_types):
-            raise ValueError("The type_id argument must be a string. The "
-                             "value passed in has type {}."
-                             .format(type(type_id)))
+            raise TypeError("The type_id argument must be a string. The value "
+                            "passed in has type {}.".format(type(type_id)))
 
         self.type_to_type_id[type_] = type_id
         self.whitelisted_types[type_id] = type_

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -119,7 +119,7 @@ cdef class SerializationContext:
             This argument is optional, but can be provided to
             deserialize objects of the class in a particular way.
         """
-        if not isinstance(type_id, str):
+        if not isinstance(type_id, six.string_types):
             raise ValueError("The type_id argument must be a string. The "
                              "value passed in has type {}."
                              .format(type(type_id)))

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -380,7 +380,7 @@ class TestPlasmaClient(object):
             self.plasma_client.put(val)
 
         serialization_context = pa.SerializationContext()
-        serialization_context.register_type(CustomType, 20*b"\x00")
+        serialization_context.register_type(CustomType, 20*"\x00")
 
         object_id = self.plasma_client.put(
             val, None, serialization_context=serialization_context)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -561,7 +561,7 @@ def test_arrow_limits(self):
 def test_serialization_callback_error():
 
     class TempClass(object):
-            pass
+        pass
 
     # Pass a SerializationContext into serialize, but TempClass
     # is not registered
@@ -571,7 +571,7 @@ def test_serialization_callback_error():
         serialized_object = pa.serialize(val, serialization_context)
     assert err.value.example_object == val
 
-    serialization_context.register_type(TempClass, 20*b"\x00")
+    serialization_context.register_type(TempClass, "TempClass")
     serialized_object = pa.serialize(TempClass(), serialization_context)
     deserialization_context = pa.SerializationContext()
 
@@ -579,7 +579,15 @@ def test_serialization_callback_error():
     # is not registered
     with pytest.raises(pa.DeserializationCallbackError) as err:
         serialized_object.deserialize(deserialization_context)
-    assert err.value.type_id == 20*b"\x00"
+    assert err.value.type_id == "TempClass"
+
+    class TempClass2(object):
+        pass
+
+    # Make sure that we receive an error when we use an inappropriate value for
+    # the type_id argument.
+    with pytest.raises(ValueError):
+        serialization_context.register_type(TempClass2, 1)
 
 
 def test_fallback_to_subclasses():

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -586,7 +586,7 @@ def test_serialization_callback_error():
 
     # Make sure that we receive an error when we use an inappropriate value for
     # the type_id argument.
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         serialization_context.register_type(TempClass2, 1)
 
 


### PR DESCRIPTION
When `type_id` is not a string or can't be cast to a string, `register_type` will succeed, but `_deserialize_callback` can fail.