### PR TITLE
ARROW-3604: [R] Support to collect int64s as R integers

### DIFF
--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -798,8 +798,16 @@ SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array) {
       return arrow::r::promotion_Array_to_Vector<REALSXP, arrow::UInt32Type>(array);
 
     // lossy promotions to numeric vector
-    case Type::INT64:
-      return arrow::r::IntFromInt64Array(array);
+    case Type::INT64: {
+      Function get_option("getOption");
+      SEXP option = get_option("arrow.int64");
+      if (!Rf_isNull(option) && std::string("integer") == CHAR(STRING_ELT(option, 0))) {
+        return arrow::r::IntFromInt64Array(array);
+      }
+      else {
+        return arrow::r::Int64Array(array);
+      }
+    }
 
     default:
       break;

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -724,11 +724,8 @@ SEXP IntFromInt64Array(const std::shared_ptr<Array>& array) {
       if (p_values[i] > MAX_INT32 || p_values[i] < MIN_INT32) {
         overflowed++;
         p_vec[i] = NA_INTEGER;
-      }
-      else {
-        p_vec[i] = bitmap_reader.IsNotSet()
-        ? NA_INTEGER
-        : p_values[i];
+      } else {
+        p_vec[i] = bitmap_reader.IsNotSet() ? NA_INTEGER : p_values[i];
       }
     }
   } else {
@@ -736,15 +733,17 @@ SEXP IntFromInt64Array(const std::shared_ptr<Array>& array) {
       if (p_values[i] > MAX_INT32 || p_values[i] < MIN_INT32) {
         overflowed++;
         p_vec[i] = NA_INTEGER;
-      }
-      else {
+      } else {
         p_vec[i] = p_values[i];
       }
     }
   }
 
   if (overflowed > 0) {
-    Rcpp::warning(tfm::format("Integer overflow, %i values replaced with NAs. Consider using 'options(arrow.int64 = \"bit64\")'.", overflowed));
+    Rcpp::warning(
+        tfm::format("Integer overflow, %i values replaced with NAs. Consider using "
+                    "'options(arrow.int64 = \"bit64\")'.",
+                    overflowed));
   }
 
   return vec;
@@ -803,8 +802,7 @@ SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array) {
       SEXP option = get_option("arrow.int64");
       if (!Rf_isNull(option) && std::string("integer") == CHAR(STRING_ELT(option, 0))) {
         return arrow::r::IntFromInt64Array(array);
-      }
-      else {
+      } else {
         return arrow::r::Int64Array(array);
       }
     }


### PR DESCRIPTION
Fix for, https://issues.apache.org/jira/browse/ARROW-3604

Enabled collecting `int64`s as R `integers` by replacing overflows and underflows with `NA`s and triggering a waring.

In `sparklyr`, this enables:

```r
> sdf_len(sc, 10) %>% dplyr::transmute(new = cast("123456789123451234" %as% BIGINT))
# Source: spark<?> [?? x 1]
     new
 * <int>
 1    NA
 2    NA
 3    NA
 4    NA
 5    NA
 6    NA
 7    NA
 8    NA
 9    NA
10    NA
# ... with more rows
Warning message:
In RecordBatch__to_dataframe(x) :
  Integer overflow, 10 values replaced with NAs. Consider using 'options(arrow.int64 = "bit64")'.
```

CC: @romainfrancois