### PR TITLE
ARROW-3925: [Python] Add autoconf to conda install instructions

### DIFF
--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+autoconf
 boost-cpp
 brotli
 bzip2

--- a/ci/conda_env_unix.yml
+++ b/ci/conda_env_unix.yml
@@ -15,21 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-boost-cpp
-brotli
-bzip2
-cmake
-double-conversion
-flatbuffers
-gflags
-glog
-gtest
-libprotobuf
-lz4-c
-python
-rapidjson
-re2
-snappy
-thrift-cpp
-zlib
-zstd
+# conda package dependencies specific to Unix-like environments (Linux and macOS)
+
+autoconf

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -20,8 +20,6 @@ FROM ubuntu:18.04
 # install build essentials
 RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
-      autoconf \
-      automake \
       ca-certificates \
       ccache \
       g++ \

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -37,7 +37,8 @@ ADD ci/docker_install_conda.sh \
     /arrow/ci/
 RUN arrow/ci/docker_install_conda.sh && \
     conda install -c conda-forge \
-        --file arrow/ci/conda_env_cpp.yml && \
+        --file arrow/ci/conda_env_cpp.yml \
+        --file arrow/ci/conda_env_unix.yml && \
     conda clean --all
 
 ENV CC=gcc \

--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -81,7 +81,7 @@ from conda-forge:
    conda create -y -q -n pyarrow-dev \
          python=3.6 numpy six setuptools cython pandas pytest \
          cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib \
-         gflags brotli jemalloc lz4-c zstd -c conda-forge
+         gflags brotli jemalloc lz4-c zstd autoconf -c conda-forge
    conda activate pyarrow-dev
 
 We need to set some environment variables to let Arrow's build system know

--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -76,14 +76,23 @@ Using Conda
 Let's create a conda environment with all the C++ build and Python dependencies
 from conda-forge:
 
+On Linux and OSX:
+
 .. code-block:: shell
 
-   conda create -y -q -n pyarrow-dev \
-         python=3.6 numpy six setuptools cython pandas pytest \
-         cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib \
-         gflags brotli jemalloc lz4-c zstd autoconf glog \
-         -c conda-forge
-   conda activate pyarrow-dev
+    conda create -y -n pyarrow-dev -c conda-forge \
+        --file arrow/ci/conda_env_cpp.yml \
+        --file arrow/ci/conda_env_python.yml \
+        python=3.6
+
+On Windows:
+
+.. code-block:: shell
+
+    conda create -y -n pyarrow-dev -c conda-forge ^
+        --file arrow\\ci\\conda_env_cpp.yml ^
+        --file arrow\\ci\\conda_env_python.yml ^
+        python=3.6
 
 We need to set some environment variables to let Arrow's build system know
 about our build toolchain:

--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -90,8 +90,8 @@ On Windows:
 .. code-block:: shell
 
     conda create -y -n pyarrow-dev -c conda-forge ^
-        --file arrow\\ci\\conda_env_cpp.yml ^
-        --file arrow\\ci\\conda_env_python.yml ^
+        --file arrow\ci\conda_env_cpp.yml ^
+        --file arrow\ci\conda_env_python.yml ^
         python=3.6
 
 We need to set some environment variables to let Arrow's build system know

--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -81,6 +81,7 @@ On Linux and OSX:
 .. code-block:: shell
 
     conda create -y -n pyarrow-dev -c conda-forge \
+        --file arrow/ci/conda_env_unix.yml \
         --file arrow/ci/conda_env_cpp.yml \
         --file arrow/ci/conda_env_python.yml \
         python=3.6

--- a/python/doc/source/development.rst
+++ b/python/doc/source/development.rst
@@ -81,7 +81,8 @@ from conda-forge:
    conda create -y -q -n pyarrow-dev \
          python=3.6 numpy six setuptools cython pandas pytest \
          cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib \
-         gflags brotli jemalloc lz4-c zstd autoconf -c conda-forge
+         gflags brotli jemalloc lz4-c zstd autoconf glog \
+         -c conda-forge
    conda activate pyarrow-dev
 
 We need to set some environment variables to let Arrow's build system know


### PR DESCRIPTION
autoconf is required by the jemalloc build