### PR TITLE
ARROW-3610: [C++] Add interface to turn stl_allocator into arrow::MemoryPool

### DIFF
--- a/cpp/src/arrow/allocator-test.cc
+++ b/cpp/src/arrow/allocator-test.cc
@@ -66,19 +66,6 @@ TEST(stl_allocator, TestOOM) {
   ASSERT_THROW(alloc.allocate(to_alloc), std::bad_alloc);
 }
 
-TEST(stl_allocator, FreeLargeMemory) {
-  stl_allocator<uint8_t> alloc;
-
-  uint8_t* data = alloc.allocate(100);
-
-#ifndef NDEBUG
-  EXPECT_DEATH(alloc.deallocate(data, 120),
-               ".*Check failed:.* allocation counter became negative");
-#endif
-
-  alloc.deallocate(data, 100);
-}
-
 TEST(stl_allocator, MaxMemory) {
   auto pool = default_memory_pool();
 

--- a/cpp/src/arrow/allocator-test.cc
+++ b/cpp/src/arrow/allocator-test.cc
@@ -23,8 +23,29 @@
 
 #include "arrow/allocator.h"
 #include "arrow/memory_pool.h"
+#include "arrow/test-util.h"
 
 namespace arrow {
+
+TEST(STLMemoryPool, Base) {
+  std::allocator<uint8_t> allocator;
+  STLMemoryPool<std::allocator<uint8_t>> pool(allocator);
+
+  uint8_t* data = nullptr;
+  ASSERT_OK(pool.Allocate(100, &data));
+  ASSERT_EQ(pool.max_memory(), 100);
+  ASSERT_EQ(pool.bytes_allocated(), 100);
+  ASSERT_NE(data, nullptr);
+
+  ASSERT_OK(pool.Reallocate(100, 150, &data));
+  ASSERT_EQ(pool.max_memory(), 150);
+  ASSERT_EQ(pool.bytes_allocated(), 150);
+
+  pool.Free(data, 150);
+
+  ASSERT_EQ(pool.max_memory(), 150);
+  ASSERT_EQ(pool.bytes_allocated(), 0);
+}
 
 TEST(stl_allocator, MemoryTracking) {
   auto pool = default_memory_pool();

--- a/cpp/src/arrow/allocator.h
+++ b/cpp/src/arrow/allocator.h
@@ -18,6 +18,8 @@
 #ifndef ARROW_ALLOCATOR_H
 #define ARROW_ALLOCATOR_H
 
+#include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <memory>
 #include <utility>
@@ -83,6 +85,48 @@ class stl_allocator {
 
  private:
   MemoryPool* pool_;
+};
+
+template <typename Allocator = std::allocator<uint8_t>>
+class STLMemoryPool : public MemoryPool {
+ public:
+  explicit STLMemoryPool(const Allocator& alloc) : alloc_(alloc) {}
+
+  Status Allocate(int64_t size, uint8_t** out) override {
+    try {
+      *out = alloc_.allocate(size);
+    } catch (std::bad_alloc& e) {
+      return Status::OutOfMemory(e.what());
+    }
+    stats_.UpdateAllocatedBytes(size);
+    return Status::OK();
+  }
+
+  Status Reallocate(int64_t old_size, int64_t new_size, uint8_t** ptr) override {
+    uint8_t* old_ptr = *ptr;
+    try {
+      *ptr = alloc_.allocate(new_size);
+    } catch (std::bad_alloc& e) {
+      return Status::OutOfMemory(e.what());
+    }
+    memcpy(*ptr, old_ptr, std::min(old_size, new_size));
+    alloc_.deallocate(old_ptr, old_size);
+    stats_.UpdateAllocatedBytes(new_size - old_size);
+    return Status::OK();
+  }
+
+  void Free(uint8_t* buffer, int64_t size) override {
+    alloc_.deallocate(buffer, size);
+    stats_.UpdateAllocatedBytes(-size);
+  }
+
+  int64_t bytes_allocated() const override { return stats_.bytes_allocated(); }
+
+  int64_t max_memory() const override { return stats_.max_memory(); }
+
+ private:
+  Allocator alloc_;
+  internal::MemoryPoolStats stats_;
 };
 
 template <class T1, class T2>

--- a/cpp/src/arrow/allocator.h
+++ b/cpp/src/arrow/allocator.h
@@ -19,7 +19,6 @@
 #define ARROW_ALLOCATOR_H
 
 #include <algorithm>
-#include <atomic>
 #include <cstddef>
 #include <memory>
 #include <utility>

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -45,20 +45,6 @@ TEST_F(TestDefaultMemoryPool, Reallocate) { this->TestReallocate(); }
 // googletest documentation
 #if !(defined(ARROW_VALGRIND) || defined(ADDRESS_SANITIZER))
 
-TEST(DefaultMemoryPoolDeathTest, FreeLargeMemory) {
-  MemoryPool* pool = default_memory_pool();
-
-  uint8_t* data;
-  ASSERT_OK(pool->Allocate(100, &data));
-
-#ifndef NDEBUG
-  EXPECT_DEATH(pool->Free(data, 120),
-               ".*Check failed:.* allocation counter became negative");
-#endif
-
-  pool->Free(data, 100);
-}
-
 TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
   MemoryPool* pool = default_memory_pool();
   uint8_t* data1;

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -25,6 +25,35 @@
 
 namespace arrow {
 
+namespace internal {
+
+///////////////////////////////////////////////////////////////////////
+// Helper tracking memory statistics
+
+class MemoryPoolStats {
+ public:
+  MemoryPoolStats() : bytes_allocated_(0), max_memory_(0) {}
+
+  int64_t max_memory() const { return max_memory_.load(); }
+
+  int64_t bytes_allocated() const { return bytes_allocated_.load(); }
+
+  inline void UpdateAllocatedBytes(int64_t diff) {
+    auto allocated = bytes_allocated_.fetch_add(diff) + diff;
+    // "maximum" allocated memory is ill-defined in multi-threaded code,
+    // so don't try to be too rigorous here
+    if (diff > 0 && allocated > max_memory_) {
+      max_memory_ = allocated;
+    }
+  }
+
+ protected:
+  std::atomic<int64_t> bytes_allocated_;
+  std::atomic<int64_t> max_memory_;
+};
+
+}  // namespace internal
+
 class Status;
 
 /// Base class for memory allocation.

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -18,6 +18,7 @@
 #ifndef ARROW_MEMORY_POOL_H
 #define ARROW_MEMORY_POOL_H
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 


### PR DESCRIPTION
First outcome from PyConDE collaboration with @wolfv