### PR TITLE
ARROW-3616: [Java] Fix remaining checkstyle issues

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
@@ -37,8 +37,8 @@ import com.google.common.base.Preconditions;
  * <p>
  * This utility uses following data mapping to map JDBC/SQL datatype to Arrow data types.
  * <p>
- * CHAR	--> ArrowType.Utf8
- * NCHAR	--> ArrowType.Utf8
+ * CHAR --> ArrowType.Utf8
+ * NCHAR --> ArrowType.Utf8
  * VARCHAR --> ArrowType.Utf8
  * NVARCHAR --> ArrowType.Utf8
  * LONGVARCHAR --> ArrowType.Utf8

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -95,8 +95,8 @@ public class JdbcToArrowUtils {
    * <p>
    * This method currently performs following type mapping for JDBC SQL data types to corresponding Arrow data types.
    * <p>
-   * CHAR	--> ArrowType.Utf8
-   * NCHAR	--> ArrowType.Utf8
+   * CHAR --> ArrowType.Utf8
+   * NCHAR --> ArrowType.Utf8
    * VARCHAR --> ArrowType.Utf8
    * NVARCHAR --> ArrowType.Utf8
    * LONGVARCHAR --> ArrowType.Utf8

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowDataTypesTest.java
@@ -210,6 +210,9 @@ public class JdbcToArrowDataTypesTest extends AbstractJdbcToArrowTest {
         assertFloat4VectorValues((Float4Vector) root.getVector(table.getVector()), table.getValues().length,
             table.getFloatValues());
         break;
+      default:
+        // do nothing
+        break;
     }
   }
 }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
@@ -115,6 +115,9 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
       case SELECTED_NULL_COLUMN:
         sqlToArrowTestSelectedNullColumnsValues(table.getVectors(), root, table.getRowCount());
         break;
+      default:
+        // do nothing
+        break;
     }
   }
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTimeZoneTest.java
@@ -132,6 +132,9 @@ public class JdbcToArrowTimeZoneTest extends AbstractJdbcToArrowTest {
         assertTimeStampVectorValues((TimeStampVector) root.getVector(table.getVector()), table.getValues().length,
             table.getLongValues());
         break;
+      default:
+        // do nothing
+        break;
     }
   }
 

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -247,7 +247,7 @@
             <property name="ignoreInlineTags" value="false"/>
         </module>
         <module name="EmptyCatchBlock">
-            <property name="exceptionVariableName" value="expected"/>
+            <property name="exceptionVariableName" value="expected|ignore"/>
         </module>
         <module name="CommentsIndentation"/>
     </module>

--- a/java/dev/checkstyle/suppressions.xml
+++ b/java/dev/checkstyle/suppressions.xml
@@ -33,10 +33,9 @@
   <suppress checks="Header" files="AutoCloseables.java|Collections2.java" />
 
   <!-- TODO: Temporarily suppress Javadoc checks -->
-  <suppress checks="Javadoc.*" files=".*" />
+  <suppress checks="javadoc.*" files=".*" />
 
-  <!-- TODO: Temporarily suppress all but certain checks to fix in increments -->
-  <suppress
-    checks="^(?!.*(Header|ImportOrder|LineLength|Indentation|OperatorWrapCheck|SeparatorWrapCheck|NewlineAtEndOfFileCheck|WhitespaceAroundCheck|EmptyLineSeparatorCheck|LocalVariableNameCheck|CatchParameterNameCheck|ParameterNameCheck|MemberNameCheck|ClassTypeParameterName|MethodTypeParameterName|InterfaceTypeParameterName)).*"
-    files=".*" />
+  <!-- TODO: Temporarily suppress certain check requiring many code changes -->
+  <suppress checks="OverloadMethodsDeclarationOrder|VariableDeclarationUsageDistance" files=".*" />
+
 </suppressions>

--- a/java/dev/checkstyle/suppressions.xml
+++ b/java/dev/checkstyle/suppressions.xml
@@ -36,6 +36,6 @@
   <suppress checks="javadoc.*" files=".*" />
 
   <!-- TODO: Temporarily suppress certain check requiring many code changes -->
-  <suppress checks="OverloadMethodsDeclarationOrder|VariableDeclarationUsageDistance" files=".*" />
+  <suppress checks="NoFinalizer|OverloadMethodsDeclarationOrder|VariableDeclarationUsageDistance" files=".*" />
 
 </suppressions>

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -55,7 +55,7 @@ import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 
 public class FlightClient implements AutoCloseable {
-  private final static int PENDING_REQUESTS = 5;
+  private static final int PENDING_REQUESTS = 5;
   private final BufferAllocator allocator;
   private final ManagedChannel channel;
   private final FlightServiceBlockingStub blockingStub;

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -46,7 +46,7 @@ import io.grpc.stub.StreamObserver;
 class FlightService extends FlightServiceImplBase {
 
   private static final Logger logger = LoggerFactory.getLogger(FlightService.class);
-  private final static int PENDING_REQUESTS = 5;
+  private static final int PENDING_REQUESTS = 5;
 
   private final BufferAllocator allocator;
   private final FlightProducer producer;

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
@@ -25,7 +25,7 @@ import io.grpc.MethodDescriptor;
 
 public final class AuthConstants {
 
-  public final static String HANDSHAKE_DESCRIPTOR_NAME = MethodDescriptor
+  public static final String HANDSHAKE_DESCRIPTOR_NAME = MethodDescriptor
       .generateFullMethodName(FlightConstants.SERVICE, "Handshake");
   public static final String TOKEN_NAME = "Auth-Token-bin";
   public static final Key<byte[]> TOKEN_KEY = Key.of(TOKEN_NAME, new BinaryMarshaller<byte[]>() {

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/InMemoryStore.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/InMemoryStore.java
@@ -135,9 +135,9 @@ public class InMemoryStore implements FlightProducer, AutoCloseable {
       case "drop":
         return new Result(new byte[0]);
         // not implemented.
+      default:
+        throw new UnsupportedOperationException();
     }
-
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/java/flight/src/test/java/org/apache/arrow/flight/TestBackPressure.java
+++ b/java/flight/src/test/java/org/apache/arrow/flight/TestBackPressure.java
@@ -53,13 +53,13 @@ public class TestBackPressure {
       server.start();
 
       FlightStream fs1 = client.getStream(client.getInfo(
-          TestPerf.getPerfFlightDescriptor(110l * BATCH_SIZE, BATCH_SIZE, 1))
+          TestPerf.getPerfFlightDescriptor(110L * BATCH_SIZE, BATCH_SIZE, 1))
           .getEndpoints().get(0).getTicket());
       consume(fs1, 10);
 
       // stop consuming fs1 but make sure we can consume a large amount of fs2.
       FlightStream fs2 = client.getStream(client.getInfo(
-          TestPerf.getPerfFlightDescriptor(200l * BATCH_SIZE, BATCH_SIZE, 1))
+          TestPerf.getPerfFlightDescriptor(200L * BATCH_SIZE, BATCH_SIZE, 1))
           .getEndpoints().get(0).getTicket());
       consume(fs2, 100);
 
@@ -100,8 +100,8 @@ public class TestBackPressure {
             while (!listener.isReady()) {
               try {
                 Thread.sleep(1);
-                sleepTime.addAndGet(1l);
-              } catch (InterruptedException e) {
+                sleepTime.addAndGet(1L);
+              } catch (InterruptedException ignore) {
               }
             }
 

--- a/java/flight/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
+++ b/java/flight/src/test/java/org/apache/arrow/flight/perf/TestPerf.java
@@ -86,7 +86,7 @@ public class TestPerf {
 
         server.start();
 
-        final FlightInfo info = client.getInfo(getPerfFlightDescriptor(50_000_000l, 4095, 2));
+        final FlightInfo info = client.getInfo(getPerfFlightDescriptor(50_000_000L, 4095, 2));
         ListeningExecutorService pool = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(4));
         List<ListenableFuture<Result>> results = info.getEndpoints()
             .stream()

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -365,7 +365,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
           releaseRecordBatch(batch);
           releaseValueVectors(output);
           evaluator.close();
-        } catch (GandivaException e) {
+        } catch (GandivaException ignore) {
         }
       });
     });

--- a/java/memory/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -135,21 +135,21 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   @Override
   public ByteBuf setShort(int index, int value) {
     wrapped.checkIndex(index, 2);
-    _setShort(index, value);
+    setShort_(index, value);
     return this;
   }
 
   @Override
   public ByteBuf setInt(int index, int value) {
     wrapped.checkIndex(index, 4);
-    _setInt(index, value);
+    setInt_(index, value);
     return this;
   }
 
   @Override
   public ByteBuf setLong(int index, long value) {
     wrapped.checkIndex(index, 8);
-    _setLong(index, value);
+    setLong_(index, value);
     return this;
   }
 
@@ -174,7 +174,7 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   @Override
   public ByteBuf writeShort(int value) {
     wrapped.ensureWritable(2);
-    _setShort(wrapped.writerIndex, value);
+    setShort_(wrapped.writerIndex, value);
     wrapped.writerIndex += 2;
     return this;
   }
@@ -182,7 +182,7 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   @Override
   public ByteBuf writeInt(int value) {
     wrapped.ensureWritable(4);
-    _setInt(wrapped.writerIndex, value);
+    setInt_(wrapped.writerIndex, value);
     wrapped.writerIndex += 4;
     return this;
   }
@@ -190,7 +190,7 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   @Override
   public ByteBuf writeLong(long value) {
     wrapped.ensureWritable(8);
-    _setLong(wrapped.writerIndex, value);
+    setLong_(wrapped.writerIndex, value);
     wrapped.writerIndex += 8;
     return this;
   }
@@ -213,15 +213,15 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
     return this;
   }
 
-  private void _setShort(int index, int value) {
+  private void setShort_(int index, int value) {
     PlatformDependent.putShort(addr(index), (short) value);
   }
 
-  private void _setInt(int index, int value) {
+  private void setInt_(int index, int value) {
     PlatformDependent.putInt(addr(index), value);
   }
 
-  private void _setLong(int index, long value) {
+  private void setLong_(int index, long value) {
     PlatformDependent.putLong(addr(index), value);
   }
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -775,9 +775,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
             final StringBuilder sb = new StringBuilder();
             print(sb, 0, Verbosity.LOG_WITH_STACKTRACE);
             logger.debug(sb.toString());
-            throw new IllegalStateException(
-                String.format("Didn't find closing reservation[%d]", System.identityHashCode
-                    (this)));
+            throw new IllegalStateException(String.format("Didn't find closing reservation[%d]",
+                System.identityHashCode(this)));
           }
 
           historicalLog.recordEvent("closed");

--- a/java/memory/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
@@ -255,8 +255,11 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     Preconditions.checkNotNull(key);
 
     boolean hashedOk;
-    int index, next, hash;
-    Object result, object;
+    int index;
+    int next;
+    int hash;
+    Object result;
+    Object object;
     index = next = findIndex(key, elementData);
 
     if (elementData[index] == null || ((V)elementData[index]).getKey() != key) {

--- a/java/memory/src/test/java/io/netty/buffer/TestArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestArrowBuf.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 public class TestArrowBuf {
 
-  private final static int MAX_ALLOCATION = 8 * 1024;
+  private static final int MAX_ALLOCATION = 8 * 1024;
   private static RootAllocator allocator;
   
   @BeforeClass

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -31,7 +31,7 @@ import io.netty.buffer.ArrowBuf.TransferResult;
 
 public class TestBaseAllocator {
 
-  private final static int MAX_ALLOCATION = 8 * 1024;
+  private static final int MAX_ALLOCATION = 8 * 1024;
 
   /*
   // ---------------------------------------- DEBUG -----------------------------------

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClientJNI.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClientJNI.java
@@ -24,27 +24,27 @@ import java.nio.ByteBuffer;
  */
 public class PlasmaClientJNI {
 
-  native public static long connect(String storeSocketName, String managerSocketName, int releaseDelay);
+  public static native long connect(String storeSocketName, String managerSocketName, int releaseDelay);
 
-  native public static void disconnect(long conn);
+  public static native void disconnect(long conn);
 
-  native public static ByteBuffer create(long conn, byte[] objectId, int size, byte[] metadata);
+  public static native ByteBuffer create(long conn, byte[] objectId, int size, byte[] metadata);
 
-  native public static byte[] hash(long conn, byte[] objectId);
+  public static native byte[] hash(long conn, byte[] objectId);
 
-  native public static void seal(long conn, byte[] objectId);
+  public static native void seal(long conn, byte[] objectId);
 
-  native public static void release(long conn, byte[] objectId);
+  public static native void release(long conn, byte[] objectId);
 
-  native public static ByteBuffer[][] get(long conn, byte[][] objectIds, int timeoutMs);
+  public static native ByteBuffer[][] get(long conn, byte[][] objectIds, int timeoutMs);
 
-  native public static boolean contains(long conn, byte[] objectId);
+  public static native boolean contains(long conn, byte[] objectId);
 
-  native public static void fetch(long conn, byte[][] objectIds);
+  public static native void fetch(long conn, byte[][] objectIds);
 
-  native public static byte[][] wait(long conn, byte[][] objectIds, int timeoutMs,
+  public static native byte[][] wait(long conn, byte[][] objectIds, int timeoutMs,
       int numReturns);
 
-  native public static long evict(long conn, long numBytes);
+  public static native long evict(long conn, long numBytes);
 
 }

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -44,8 +44,7 @@ public class PlasmaClientTest {
       this.startObjectStore(plasmaStorePath);
       System.loadLibrary("plasma_java");
       pLink = new PlasmaClient(this.getStoreAddress(), "", 0);
-    }
-    catch (Throwable t) {
+    } catch (Throwable t) {
       cleanup();
       throw t;
     }

--- a/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
@@ -227,7 +227,7 @@ public class Integration {
       this.jsonExists = jsonExists;
     }
 
-    abstract public void execute(File arrowFile, File jsonFile) throws IOException;
+    public abstract void execute(File arrowFile, File jsonFile) throws IOException;
 
   }
 

--- a/java/tools/src/test/java/org/apache/arrow/tools/TestIntegration.java
+++ b/java/tools/src/test/java/org/apache/arrow/tools/TestIntegration.java
@@ -172,7 +172,8 @@ public class TestIntegration {
 
     BufferedReader orig = readNormalized(testJSONFile);
     BufferedReader rt = readNormalized(testRoundTripJSONFile);
-    String i, o;
+    String i;
+    String o;
     int j = 0;
     while ((i = orig.readLine()) != null && (o = rt.readLine()) != null) {
       assertEquals("line: " + j, i, o);
@@ -202,7 +203,8 @@ public class TestIntegration {
 
     BufferedReader orig = readNormalized(testJSONFile);
     BufferedReader rt = readNormalized(testRoundTripJSONFile);
-    String i, o;
+    String i;
+    String o;
     int j = 0;
     while ((i = orig.readLine()) != null && (o = rt.readLine()) != null) {
       assertEquals("line: " + j, i, o);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
@@ -27,7 +27,7 @@ public class BufferLayout {
     VALIDITY("VALIDITY"),
     TYPE("TYPE");
 
-    final private String name;
+    private final String name;
 
     BufferType(String name) {
       this.name = name;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -38,7 +38,7 @@ import org.apache.arrow.vector.util.TransferPair;
 import io.netty.buffer.ArrowBuf;
 
 public class ZeroVector implements FieldVector {
-  public final static ZeroVector INSTANCE = new ZeroVector();
+  public static final ZeroVector INSTANCE = new ZeroVector();
 
   private final TransferPair defaultPair = new TransferPair() {
     @Override
@@ -219,17 +219,26 @@ public class ZeroVector implements FieldVector {
   }
 
   @Override
-  public int getValueCount() { return 0; }
+  public int getValueCount() {
+    return 0;
+  }
 
   @Override
-  public void setValueCount(int valueCount) { }
+  public void setValueCount(int valueCount) {
+  }
 
   @Override
-  public Object getObject(int index) { return null; }
+  public Object getObject(int index) {
+    return null;
+  }
 
   @Override
-  public int getNullCount() { return 0; }
+  public int getNullCount() {
+    return 0;
+  }
 
   @Override
-  public boolean isNull(int index) { return false; }
+  public boolean isNull(int index) {
+    return false;
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -45,10 +45,10 @@ import io.netty.buffer.ArrowBuf;
 
 public abstract class BaseRepeatedValueVector extends BaseValueVector implements RepeatedValueVector {
 
-  public final static FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
-  public final static String DATA_VECTOR_NAME = "$data$";
+  public static final FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
+  public static final String DATA_VECTOR_NAME = "$data$";
 
-  public final static byte OFFSET_WIDTH = 4;
+  public static final byte OFFSET_WIDTH = 4;
   protected ArrowBuf offsetBuffer;
   protected FieldVector vector;
   protected final CallBack callBack;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -26,7 +26,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.*;
+import org.apache.arrow.vector.DensityAwareVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.impl.SingleStructReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.ComplexHolder;
@@ -68,7 +70,7 @@ public class NonNullableStructVector extends AbstractStructVector {
     return reader;
   }
 
-  transient private StructTransferPair ephPair;
+  private transient StructTransferPair ephPair;
 
   public void copyFromSafe(int fromIndex, int thisIndex, NonNullableStructVector from) {
     if (ephPair == null || ephPair.from != from) {
@@ -264,10 +266,14 @@ public class NonNullableStructVector extends AbstractStructVector {
   }
 
   @Override
-  public boolean isNull(int index) { return false; }
+  public boolean isNull(int index) {
+    return false;
+  }
 
   @Override
-  public int getNullCount() { return 0; }
+  public int getNullCount() {
+    return 0;
+  }
 
   public void get(int index, ComplexHolder holder) {
     reader.setPosition(index);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedValueVector.java
@@ -30,7 +30,7 @@ import org.apache.arrow.vector.ValueVector;
  */
 public interface RepeatedValueVector extends ValueVector, DensityAwareVector {
 
-  final static int DEFAULT_REPEAT_PER_RECORD = 5;
+  static final int DEFAULT_REPEAT_PER_RECORD = 5;
 
   /**
    * @return the underlying offset vector or null if none exists.

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -96,6 +96,8 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.clear();
         break;
+      default:
+        throw new RuntimeException("Unexpected mode:" + mode);
     }
   }
 
@@ -108,6 +110,8 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.setValueCount(count);
         break;
+      default:
+        throw new RuntimeException("Unexpected mode:" + mode);
     }
   }
 
@@ -121,6 +125,8 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.setPosition(index);
         break;
+      default:
+        throw new RuntimeException("Unexpected mode:" + mode);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -48,7 +48,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   private final ListVector listVector;
   private final NullableStructWriterFactory nullableStructWriterFactory;
   private int position;
-  private final static int MAX_DECIMAL_PRECISION = 38;
+  private static final int MAX_DECIMAL_PRECISION = 38;
 
   private enum State {
     UNTYPED, SINGLE, UNION

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -204,7 +204,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
   }
 
   private abstract class BufferReader {
-    abstract protected ArrowBuf read(BufferAllocator allocator, int count) throws IOException;
+    protected abstract ArrowBuf read(BufferAllocator allocator, int count) throws IOException;
 
     ArrowBuf readBuffer(BufferAllocator allocator, int count) throws IOException {
       readToken(START_ARRAY);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
@@ -122,7 +122,8 @@ public class Field {
     Map<String, String> metadata = new HashMap<>();
     for (int i = 0; i < field.customMetadataLength(); i++) {
       KeyValue kv = field.customMetadata(i);
-      String key = kv.key(), value = kv.value();
+      String key = kv.key();
+      String value = kv.value();
       metadata.put(key == null ? "" : key, value == null ? "" : value);
     }
     metadata = Collections.unmodifiableMap(metadata);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
@@ -85,7 +85,8 @@ public class Schema {
     Map<String, String> metadata = new HashMap<>();
     for (int i = 0; i < schema.customMetadataLength(); i++) {
       KeyValue kv = schema.customMetadata(i);
-      String key = kv.key(), value = kv.value();
+      String key = kv.key();
+      String value = kv.value();
       metadata.put(key == null ? "" : key, value == null ? "" : value);
     }
     return new Schema(Collections2.immutableListCopy(fields), Collections2.immutableMapCopy(metadata));

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
@@ -25,12 +25,12 @@ import io.netty.buffer.ArrowBuf;
 
 public class DecimalUtility {
 
-  public final static int MAX_DIGITS = 9;
-  public final static int DIGITS_BASE = 1000000000;
-  public final static int DIGITS_MAX = 999999999;
-  public final static int INTEGER_SIZE = (Integer.SIZE / 8);
+  public static final int MAX_DIGITS = 9;
+  public static final int DIGITS_BASE = 1000000000;
+  public static final int DIGITS_MAX = 999999999;
+  public static final int INTEGER_SIZE = (Integer.SIZE / 8);
 
-  public final static String[] decimalToString = {"",
+  public static final String[] decimalToString = {"",
       "0",
       "00",
       "000",
@@ -41,7 +41,7 @@ public class DecimalUtility {
       "00000000",
       "000000000"};
 
-  public final static long[] scale_long_constants = {
+  public static final long[] scale_long_constants = {
       1,
       10,
       100,
@@ -52,15 +52,15 @@ public class DecimalUtility {
       10000000,
       100000000,
       1000000000,
-      10000000000l,
-      100000000000l,
-      1000000000000l,
-      10000000000000l,
-      100000000000000l,
-      1000000000000000l,
-      10000000000000000l,
-      100000000000000000l,
-      1000000000000000000l};
+      10000000000L,
+      100000000000L,
+      1000000000000L,
+      10000000000000L,
+      100000000000000L,
+      1000000000000000L,
+      10000000000000000L,
+      100000000000000000L,
+      1000000000000000000L};
 
   public static final int DECIMAL_BYTE_LENGTH = 16;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
@@ -53,7 +53,7 @@ import io.netty.util.collection.IntObjectMap;
  */
 
 public class MapWithOrdinal<K, V> implements Map<K, V> {
-  private final static Logger logger = LoggerFactory.getLogger(MapWithOrdinal.class);
+  private static final Logger logger = LoggerFactory.getLogger(MapWithOrdinal.class);
 
   private final Map<K, Entry<Integer, V>> primary = new HashMap<>();
   private final IntObjectHashMap<V> secondary = new IntObjectHashMap<>();

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
@@ -454,7 +454,7 @@ public class Text {
     return bytes;
   }
 
-  static final public int DEFAULT_MAX_LEN = 1024 * 1024;
+  public static final int DEFAULT_MAX_LEN = 1024 * 1024;
 
   // //// states for validateUTF8
 
@@ -601,29 +601,35 @@ public class Text {
       case 5:
         ch += (bytes.get() & 0xFF);
         ch <<= 6; /* remember, illegal UTF-8 */
+        // fall through
       case 4:
         ch += (bytes.get() & 0xFF);
         ch <<= 6; /* remember, illegal UTF-8 */
+        // fall through
       case 3:
         ch += (bytes.get() & 0xFF);
         ch <<= 6;
+        // fall through
       case 2:
         ch += (bytes.get() & 0xFF);
         ch <<= 6;
+        // fall through
       case 1:
         ch += (bytes.get() & 0xFF);
         ch <<= 6;
+        // fall through
       case 0:
         ch += (bytes.get() & 0xFF);
+        break;
+      default:  // do nothing
     }
     ch -= offsetsFromUTF8[extraBytesToRead];
 
     return ch;
   }
 
-  static final int offsetsFromUTF8[] =
-      {0x00000000, 0x00003080,
-          0x000E2080, 0x03C82080, 0xFA082080, 0x82082080};
+  static final int[] offsetsFromUTF8 =
+      {0x00000000, 0x00003080, 0x000E2080, 0x03C82080, 0xFA082080, 0x82082080};
 
   /**
    * For the given string, returns the number of UTF-8 bytes required to encode the string.

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVector.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestBitVector {
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 
@@ -237,8 +237,7 @@ public class TestBitVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           assertEquals("unexpected cleared bit at index: " + i, 1, vector.get(i));
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, vector.isNull(i));
         }
       }
@@ -256,8 +255,7 @@ public class TestBitVector {
       for (int i = 0; i < valueCapacity * 2; i++) {
         if (((i & 1) == 1) || (i == valueCapacity)) {
           assertEquals("unexpected cleared bit at index: " + i, 1, vector.get(i));
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, vector.isNull(i));
         }
       }
@@ -275,8 +273,7 @@ public class TestBitVector {
       for (int i = 0; i < valueCapacity * 4; i++) {
         if (((i & 1) == 1) || (i == valueCapacity) || (i == valueCapacity * 2)) {
           assertEquals("unexpected cleared bit at index: " + i, 1, vector.get(i));
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, vector.isNull(i));
         }
       }
@@ -296,12 +293,10 @@ public class TestBitVector {
           if (((i & 1) == 1) || (i == valueCapacity) ||
                   (i == valueCapacity * 2) || (i == valueCapacity * 4)) {
             assertEquals("unexpected cleared bit at index: " + i, 1, toVector.get(i));
-          }
-          else {
+          } else {
             assertTrue("unexpected set bit at index: " + i, toVector.isNull(i));
           }
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, toVector.isNull(i));
         }
       }
@@ -326,8 +321,7 @@ public class TestBitVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           assertFalse("unexpected cleared bit at index: " + i, vector.isNull(i));
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, vector.isNull(i));
         }
       }
@@ -345,8 +339,7 @@ public class TestBitVector {
       for (int i = 0; i < valueCapacity * 2; i++) {
         if (((i & 1) == 1) || (i == valueCapacity)) {
           assertFalse("unexpected cleared bit at index: " + i, vector.isNull(i));
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, vector.isNull(i));
         }
       }
@@ -364,8 +357,7 @@ public class TestBitVector {
       for (int i = 0; i < valueCapacity * 4; i++) {
         if (((i & 1) == 1) || (i == valueCapacity) || (i == valueCapacity * 2)) {
           assertFalse("unexpected cleared bit at index: " + i, vector.isNull(i));
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, vector.isNull(i));
         }
       }
@@ -385,12 +377,10 @@ public class TestBitVector {
           if (((i & 1) == 1) || (i == valueCapacity) ||
                   (i == valueCapacity * 2) || (i == valueCapacity * 4)) {
             assertFalse("unexpected cleared bit at index: " + i, toVector.isNull(i));
-          }
-          else {
+          } else {
             assertTrue("unexpected set bit at index: " + i, toVector.isNull(i));
           }
-        }
-        else {
+        } else {
           assertTrue("unexpected set bit at index: " + i, toVector.isNull(i));
         }
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -53,7 +53,7 @@ import org.junit.Test;
 
 public class TestCopyFrom {
 
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 
@@ -70,8 +70,8 @@ public class TestCopyFrom {
   @Test /* NullableVarChar */
   public void testCopyFromWithNulls() {
     try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator);
-         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator))
-    {
+         final VarCharVector vector2 =
+             newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
       vector.allocateNew();
       int capacity = vector.getValueCapacity();
       assertEquals(4095, capacity);
@@ -130,8 +130,8 @@ public class TestCopyFrom {
   @Test /* NullableVarChar */
   public void testCopyFromWithNulls1() {
     try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator);
-         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator))
-    {
+         final VarCharVector vector2 =
+             newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
       vector.allocateNew();
       int capacity = vector.getValueCapacity();
       assertEquals(4095, capacity);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestOutOfMemoryForValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestOutOfMemoryForValueVector.java
@@ -29,7 +29,7 @@ import org.junit.Test;
  */
 public class TestOutOfMemoryForValueVector {
 
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestOversizedAllocationForValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestOversizedAllocationForValueVector.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  */
 public class TestOversizedAllocationForValueVector {
 
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import io.netty.buffer.ArrowBuf;
 
 public class TestUnionVector {
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 
@@ -339,22 +339,18 @@ public class TestUnionVector {
 
       try {
         long offsetAddress = vector.getOffsetBufferAddress();
-      }
-      catch (UnsupportedOperationException ue) {
+      } catch (UnsupportedOperationException ue) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
 
       try {
         long dataAddress = vector.getDataBufferAddress();
-      }
-      catch (UnsupportedOperationException ue) {
+      } catch (UnsupportedOperationException ue) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
       }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -51,7 +51,7 @@ import io.netty.buffer.ArrowBuf;
 
 public class TestValueVector {
 
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 
@@ -60,16 +60,16 @@ public class TestValueVector {
     allocator = new RootAllocator(Long.MAX_VALUE);
   }
 
-  private final static Charset utf8Charset = Charset.forName("UTF-8");
-  private final static byte[] STR1 = "AAAAA1".getBytes(utf8Charset);
-  private final static byte[] STR2 = "BBBBBBBBB2".getBytes(utf8Charset);
-  private final static byte[] STR3 = "CCCC3".getBytes(utf8Charset);
-  private final static byte[] STR4 = "DDDDDDDD4".getBytes(utf8Charset);
-  private final static byte[] STR5 = "EEE5".getBytes(utf8Charset);
-  private final static byte[] STR6 = "FFFFF6".getBytes(utf8Charset);
-  private final static int MAX_VALUE_COUNT =
+  private static final Charset utf8Charset = Charset.forName("UTF-8");
+  private static final byte[] STR1 = "AAAAA1".getBytes(utf8Charset);
+  private static final byte[] STR2 = "BBBBBBBBB2".getBytes(utf8Charset);
+  private static final byte[] STR3 = "CCCC3".getBytes(utf8Charset);
+  private static final byte[] STR4 = "DDDDDDDD4".getBytes(utf8Charset);
+  private static final byte[] STR5 = "EEE5".getBytes(utf8Charset);
+  private static final byte[] STR6 = "FFFFF6".getBytes(utf8Charset);
+  private static final int MAX_VALUE_COUNT =
             Integer.getInteger("arrow.vector.max_allocation_bytes", Integer.MAX_VALUE) / 4;
-  private final static int MAX_VALUE_COUNT_8BYTE = MAX_VALUE_COUNT / 2;
+  private static final int MAX_VALUE_COUNT_8BYTE = MAX_VALUE_COUNT / 2;
 
   @After
   public void terminate() throws Exception {
@@ -125,22 +125,18 @@ public class TestValueVector {
 
       try {
         vector.set(1024, 10000);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
 
       try {
         vector.get(1024);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -185,11 +181,9 @@ public class TestValueVector {
 
       try {
         intVector.setInitialCapacity(MAX_VALUE_COUNT + 1);
-      }
-      catch (OversizedAllocationException oe) {
+      } catch (OversizedAllocationException oe) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -212,11 +206,9 @@ public class TestValueVector {
 
       try {
         intVector.set(16, 9);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -230,11 +222,9 @@ public class TestValueVector {
 
       try {
         intVector.get(16);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -277,11 +267,9 @@ public class TestValueVector {
 
       try {
         floatVector.setInitialCapacity(MAX_VALUE_COUNT + 1);
-      }
-      catch (OversizedAllocationException oe) {
+      } catch (OversizedAllocationException oe) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -309,11 +297,9 @@ public class TestValueVector {
 
       try {
         floatVector.set(16, 9.5f);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -330,11 +316,9 @@ public class TestValueVector {
 
       try {
         floatVector.get(16);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -381,11 +365,9 @@ public class TestValueVector {
 
       try {
         floatVector.setInitialCapacity(MAX_VALUE_COUNT_8BYTE + 1);
-      }
-      catch (OversizedAllocationException oe) {
+      } catch (OversizedAllocationException oe) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -411,11 +393,9 @@ public class TestValueVector {
 
       try {
         floatVector.set(16, 9.53);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -432,11 +412,9 @@ public class TestValueVector {
 
       try {
         floatVector.get(16);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -515,22 +493,18 @@ public class TestValueVector {
 
       try {
         vector.set(1024, 10000);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
 
       try {
         vector.get(1024);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -600,11 +574,9 @@ public class TestValueVector {
 
       try {
         vector.set(16, 90.5f);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -629,11 +601,9 @@ public class TestValueVector {
 
       try {
         vector.get(16);
-      }
-      catch (IndexOutOfBoundsException ie) {
+      } catch (IndexOutOfBoundsException ie) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
         error = false;
       }
@@ -700,8 +670,7 @@ public class TestValueVector {
       for (int i = 0; i <= 1023; i++) {
         if ((i >= 2 && i <= 99) || (i >= 101 && i <= 1021)) {
           assertTrue("non-null data not expected at index: " + i, vector.isNull(i));
-        }
-        else {
+        } else {
           assertFalse("null data not expected at index: " + i, vector.isNull(i));
           assertEquals("unexpected value at index: " + i, j, vector.get(i));
           j++;
@@ -740,8 +709,7 @@ public class TestValueVector {
       for (int i = 0; i < (initialCapacity * 2); i++) {
         if ((i > 1024) || (i >= 2 && i <= 99) || (i >= 101 && i <= 1021)) {
           assertTrue("non-null data not expected at index: " + i, vector.isNull(i));
-        }
-        else {
+        } else {
           assertFalse("null data not expected at index: " + i, vector.isNull(i));
           assertEquals("unexpected value at index: " + i, j, vector.get(i));
           j++;
@@ -1034,8 +1002,7 @@ public class TestValueVector {
       for (int i = 0; i < (initialDefaultCapacity * 8); i++) {
         if (i < (initialDefaultCapacity * 4)) {
           assertEquals(baseValue + (double)i, toVector.get(i), 0);
-        }
-        else {
+        } else {
           assertTrue(toVector.isNull(i));
         }
       }
@@ -1121,8 +1088,7 @@ public class TestValueVector {
           assertFalse("unexpected null value at index: " + i, toVector.isNull(i));
           double value = toVector.get(i);
           assertEquals("unexpected value at index: " + i, baseValue + (double)i, value, 0);
-        }
-        else {
+        } else {
           assertTrue("unexpected non-null value at index: " + i, toVector.isNull(i));
         }
       }
@@ -1143,8 +1109,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           vector.set(i, STR1);
-        }
-        else {
+        } else {
           vector.set(i, STR2);
         }
       }
@@ -1153,8 +1118,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           assertArrayEquals(STR1, vector.get(i));
-        }
-        else {
+        } else {
           assertArrayEquals(STR2, vector.get(i));
         }
       }
@@ -1167,8 +1131,7 @@ public class TestValueVector {
       for (int i = valueCapacity; i < vector.getValueCapacity(); i++) {
         if ((i & 1) == 1) {
           vector.set(i, STR1);
-        }
-        else {
+        } else {
           vector.set(i, STR2);
         }
       }
@@ -1178,8 +1141,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           assertArrayEquals(STR1, vector.get(i));
-        }
-        else {
+        } else {
           assertArrayEquals(STR2, vector.get(i));
         }
       }
@@ -1192,8 +1154,7 @@ public class TestValueVector {
       for (int i = valueCapacity; i < vector.getValueCapacity(); i++) {
         if ((i & 1) == 1) {
           vector.set(i, STR1);
-        }
-        else {
+        } else {
           vector.set(i, STR2);
         }
       }
@@ -1203,8 +1164,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           assertArrayEquals(STR1, vector.get(i));
-        }
-        else {
+        } else {
           assertArrayEquals(STR2, vector.get(i));
         }
       }
@@ -1221,8 +1181,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 1) {
           assertArrayEquals(STR1, toVector.get(i));
-        }
-        else {
+        } else {
           assertArrayEquals(STR2, toVector.get(i));
         }
       }
@@ -1252,8 +1211,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 0) {
           assertEquals(1000 + i, vector.get(i));
-        }
-        else {
+        } else {
           assertTrue(vector.isNull(i));
         }
       }
@@ -1274,8 +1232,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 0) {
           assertEquals(1000 + i, vector.get(i));
-        }
-        else {
+        } else {
           assertTrue(vector.isNull(i));
         }
       }
@@ -1296,8 +1253,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 0) {
           assertEquals(1000 + i, vector.get(i));
-        }
-        else {
+        } else {
           assertTrue(vector.isNull(i));
         }
       }
@@ -1317,8 +1273,7 @@ public class TestValueVector {
       for (int i = 0; i < valueCapacity; i++) {
         if ((i & 1) == 0) {
           assertEquals(1000 + i, toVector.get(i));
-        }
-        else {
+        } else {
           assertTrue(toVector.isNull(i));
         }
       }
@@ -1413,8 +1368,8 @@ public class TestValueVector {
   @Test
   public void testCopyFromWithNulls() {
     try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator);
-         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator))
-    {
+         final VarCharVector vector2 =
+             newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
 
       vector.allocateNew();
       int capacity = vector.getValueCapacity();
@@ -1474,8 +1429,8 @@ public class TestValueVector {
   @Test
   public void testCopyFromWithNulls1() {
     try (final VarCharVector vector = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator);
-         final VarCharVector vector2 = newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator))
-    {
+         final VarCharVector vector2 =
+             newVector(VarCharVector.class, EMPTY_SCHEMA_PATH, MinorType.VARCHAR, allocator)) {
 
       vector.allocateNew();
       int capacity = vector.getValueCapacity();
@@ -1882,11 +1837,9 @@ public class TestValueVector {
 
       try {
         long offsetAddress = vector.getOffsetBufferAddress();
-      }
-      catch (UnsupportedOperationException ue) {
+      } catch (UnsupportedOperationException ue) {
         error = true;
-      }
-      finally {
+      } finally {
         assertTrue(error);
       }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
@@ -24,7 +24,11 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.complex.*;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeList;
 import org.apache.arrow.vector.types.pojo.ArrowType.Int;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -43,7 +43,10 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 import io.netty.buffer.ArrowBuf;
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
@@ -34,7 +34,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestPromotableWriter {
-  private final static String EMPTY_SCHEMA_PATH = "";
+  private static final String EMPTY_SCHEMA_PATH = "";
 
   private BufferAllocator allocator;
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -498,6 +498,8 @@ public class BaseFileTest {
           unionReader.reader("timestamp").read(h);
           Assert.assertEquals(i, h.value);
           break;
+        default:
+          assert false : "Unexpected value in switch statement: " + i;
       }
     }
   }
@@ -539,6 +541,8 @@ public class BaseFileTest {
           structWriter.timeStampMilli("timestamp").writeTimeStampMilli(i);
           structWriter.end();
           break;
+        default:
+          assert false : "Unexpected value in switch statement: " + i;
       }
     }
     writer.setValueCount(count);

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -44,8 +44,9 @@ public class TestArrowStream extends BaseFileTest {
 
     // Write the stream.
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    try (ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out)) {
-    }
+    ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out);
+    writer.close();
+    Assert.assertTrue(out.size() > 0);
 
     ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
     try (ArrowStreamReader reader = new ArrowStreamReader(in, allocator)) {


### PR DESCRIPTION
Enable and fix remaining checkstyle rules except for NoFinalizer, OverloadMethodsDeclarationOrder, VariableDeclarationUsageDistance due to large code changes or possibly having an adverse effect.