### PR TITLE
ARROW-3624: [Python/C++] Support for zero-sized device buffers and device-to-device copying

### DIFF
--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -100,6 +100,14 @@ class CudaContext::CudaContextImpl {
     return Status::OK();
   }
 
+  Status CopyDeviceToDevice(void* dst, const void* src, int64_t nbytes) {
+    ContextSaver set_temporary(context_);
+    CU_RETURN_NOT_OK(cuMemcpyDtoD(reinterpret_cast<CUdeviceptr>(dst),
+                                  reinterpret_cast<const CUdeviceptr>(src),
+                                  static_cast<size_t>(nbytes)));
+    return Status::OK();
+  }
+
   Status Synchronize(void) {
     ContextSaver set_temporary(context_);
     CU_RETURN_NOT_OK(cuCtxSynchronize());
@@ -287,6 +295,10 @@ Status CudaContext::CopyHostToDevice(void* dst, const void* src, int64_t nbytes)
 
 Status CudaContext::CopyDeviceToHost(void* dst, const void* src, int64_t nbytes) {
   return impl_->CopyDeviceToHost(dst, src, nbytes);
+}
+
+Status CudaContext::CopyDeviceToDevice(void* dst, const void* src, int64_t nbytes) {
+  return impl_->CopyDeviceToDevice(dst, src, nbytes);
 }
 
 Status CudaContext::Synchronize(void) { return impl_->Synchronize(); }

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -125,6 +125,7 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
   Status ExportIpcBuffer(void* data, std::shared_ptr<CudaIpcMemHandle>* handle);
   Status CopyHostToDevice(void* dst, const void* src, int64_t nbytes);
   Status CopyDeviceToHost(void* dst, const void* src, int64_t nbytes);
+  Status CopyDeviceToDevice(void* dst, const void* src, int64_t nbytes);
   Status Free(void* device_ptr, int64_t nbytes);
 
   class CudaContextImpl;

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -122,7 +122,8 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
  private:
   CudaContext();
 
-  Status ExportIpcBuffer(void* data, std::shared_ptr<CudaIpcMemHandle>* handle);
+  Status ExportIpcBuffer(void* data, int64_t size,
+                         std::shared_ptr<CudaIpcMemHandle>* handle);
   Status CopyHostToDevice(void* dst, const void* src, int64_t nbytes);
   Status CopyDeviceToHost(void* dst, const void* src, int64_t nbytes);
   Status CopyDeviceToDevice(void* dst, const void* src, int64_t nbytes);

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -138,6 +138,12 @@ Status CudaBuffer::CopyFromHost(const int64_t position, const void* data,
   return context_->CopyHostToDevice(mutable_data_ + position, data, nbytes);
 }
 
+Status CudaBuffer::CopyFromDevice(const int64_t position, const void* data,
+                                  int64_t nbytes) {
+  DCHECK_LE(nbytes, size_ - position) << "Copy would overflow buffer";
+  return context_->CopyDeviceToDevice(mutable_data_ + position, data, nbytes);
+}
+
 Status CudaBuffer::ExportForIpc(std::shared_ptr<CudaIpcMemHandle>* handle) {
   if (is_ipc_) {
     return Status::Invalid("Buffer has already been exported for IPC");

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -40,15 +40,27 @@ namespace gpu {
 // CUDA IPC memory handle
 
 struct CudaIpcMemHandle::CudaIpcMemHandleImpl {
-  explicit CudaIpcMemHandleImpl(const void* handle) {
-    memcpy(&ipc_handle, handle, sizeof(CUipcMemHandle));
+  explicit CudaIpcMemHandleImpl(const uint8_t* handle) {
+    memcpy(&memory_size, handle, sizeof(memory_size));
+    if (memory_size != 0)
+      memcpy(&ipc_handle, handle + sizeof(memory_size), sizeof(CUipcMemHandle));
   }
 
-  CUipcMemHandle ipc_handle;
+  explicit CudaIpcMemHandleImpl(int64_t memory_size, const void* cu_handle)
+      : memory_size(memory_size) {
+    if (memory_size != 0) memcpy(&ipc_handle, cu_handle, sizeof(CUipcMemHandle));
+  }
+
+  CUipcMemHandle ipc_handle;  /// initialized only when memory_size != 0
+  int64_t memory_size;        /// size of the memory that ipc_handle refers to
 };
 
 CudaIpcMemHandle::CudaIpcMemHandle(const void* handle) {
-  impl_.reset(new CudaIpcMemHandleImpl(handle));
+  impl_.reset(new CudaIpcMemHandleImpl(reinterpret_cast<const uint8_t*>(handle)));
+}
+
+CudaIpcMemHandle::CudaIpcMemHandle(int64_t memory_size, const void* cu_handle) {
+  impl_.reset(new CudaIpcMemHandleImpl(memory_size, cu_handle));
 }
 
 CudaIpcMemHandle::~CudaIpcMemHandle() {}
@@ -61,14 +73,21 @@ Status CudaIpcMemHandle::FromBuffer(const void* opaque_handle,
 
 Status CudaIpcMemHandle::Serialize(MemoryPool* pool, std::shared_ptr<Buffer>* out) const {
   std::shared_ptr<Buffer> buffer;
-  constexpr size_t kHandleSize = sizeof(CUipcMemHandle);
+  int64_t size = impl_->memory_size;
+  size_t kHandleSize =
+      (size > 0 ? sizeof(int64_t) + sizeof(CUipcMemHandle) : sizeof(int64_t));
   RETURN_NOT_OK(AllocateBuffer(pool, static_cast<int64_t>(kHandleSize), &buffer));
-  memcpy(buffer->mutable_data(), &impl_->ipc_handle, kHandleSize);
+  memcpy(buffer->mutable_data(), &impl_->memory_size, sizeof(impl_->memory_size));
+  if (size > 0)
+    memcpy(buffer->mutable_data() + sizeof(impl_->memory_size), &impl_->ipc_handle,
+           sizeof(impl_->ipc_handle));
   *out = buffer;
   return Status::OK();
 }
 
 const void* CudaIpcMemHandle::handle() const { return &impl_->ipc_handle; }
+
+int64_t CudaIpcMemHandle::memory_size() const { return impl_->memory_size; }
 
 // ----------------------------------------------------------------------
 
@@ -148,7 +167,7 @@ Status CudaBuffer::ExportForIpc(std::shared_ptr<CudaIpcMemHandle>* handle) {
   if (is_ipc_) {
     return Status::Invalid("Buffer has already been exported for IPC");
   }
-  RETURN_NOT_OK(context_->ExportIpcBuffer(mutable_data_, handle));
+  RETURN_NOT_OK(context_->ExportIpcBuffer(mutable_data_, size_, handle));
   own_data_ = false;
   return Status::OK();
 }

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -125,11 +125,13 @@ class ARROW_EXPORT CudaIpcMemHandle {
 
  private:
   explicit CudaIpcMemHandle(const void* handle);
+  CudaIpcMemHandle(int64_t memory_size, const void* cu_handle);
 
   struct CudaIpcMemHandleImpl;
   std::unique_ptr<CudaIpcMemHandleImpl> impl_;
 
   const void* handle() const;
+  int64_t memory_size() const;
 
   friend CudaBuffer;
   friend CudaContext;

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -51,7 +51,8 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   /// \param[out] out conversion result
   /// \return Status
   ///
-  /// This function returns an error if the buffer isn't backed by GPU memory
+  /// \note This function returns an error if the buffer isn't backed
+  /// by GPU memory
   static Status FromBuffer(std::shared_ptr<Buffer> buffer,
                            std::shared_ptr<CudaBuffer>* out);
 
@@ -66,6 +67,16 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   /// \param[in] nbytes number of bytes to copy
   /// \return Status
   Status CopyFromHost(const int64_t position, const void* data, int64_t nbytes);
+
+  /// \brief Copy memory from device to device at position
+  /// \param[in] position start position to copy bytes
+  /// \param[in] data the device data to copy
+  /// \param[in] nbytes number of bytes to copy
+  /// \return Status
+  ///
+  /// \note It is assumed that both source and destination device
+  /// memories have been allocated within the same context.
+  Status CopyFromDevice(const int64_t position, const void* data, int64_t nbytes);
 
   /// \brief Expose this device buffer as IPC memory which can be used in other processes
   /// \param[out] handle the exported IPC handle

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -214,10 +214,8 @@ cdef class Context:
         cbuf : CudaBuffer
           Device buffer with copied data.
         """
-        if pyarrow_is_cudabuffer(data):
-            raise NotImplementedError('copying data from device to device')
-
-        buf = as_buffer(data)
+        is_host_data = not pyarrow_is_cudabuffer(data)
+        buf = as_buffer(data) if is_host_data else data
 
         bsize = buf.size
         if offset < 0 or (bsize and offset >= bsize):
@@ -232,7 +230,10 @@ cdef class Context:
             buf = buf.slice(offset, size)
 
         result = self.new_buffer(size)
-        result.copy_from_host(buf, position=0, nbytes=size)
+        if is_host_data:
+            result.copy_from_host(buf, position=0, nbytes=size)
+        else:
+            result.copy_from_device(buf, position=0, nbytes=size)
         return result
 
 
@@ -466,6 +467,58 @@ cdef class CudaBuffer(Buffer):
         with nogil:
             check_status(self.cuda_buffer.get().
                          CopyFromHost(position_, buf_.get().data(), nbytes_))
+        return nbytes_
+
+    def copy_from_device(self, buf, int64_t position=0, int64_t nbytes=-1):
+        """Copy data from device to device.
+
+        The destination device buffer must be pre-allocated within the
+        same context as source device buffer.
+
+        Parameters
+        ----------
+        buf : CudaBuffer
+          Specify source device buffer.
+        position : int
+          Specify the starting position of the copy in devive buffer.
+          Default: 0.
+        nbytes : int
+          Specify the number of bytes to copy. Default: -1 (all from
+          source until device buffer, starting from position, is full)
+
+        Returns
+        -------
+        nbytes : int
+          Number of bytes copied.
+
+        """
+        if self.context.handle != buf.context.handle:
+            raise ValueError('device source and destination buffers must be '
+                             'within the same context')
+        if position < 0 or position > self.size:
+            raise ValueError('position argument is out-of-range')
+        cdef int64_t nbytes_
+
+        if nbytes < 0:
+            # copy from source device buffer to device buffer starting
+            # from position until device buffer is full
+            nbytes_ = min(self.size - position, buf.size)
+        else:
+            if nbytes > buf.size:
+                raise ValueError(
+                    'requested more to copy than available from device buffer')
+            if nbytes > self.size - position:
+                raise ValueError(
+                    'requested more to copy than available in device buffer')
+            # copy nbytes from source device buffer to device buffer
+            # starting from position
+            nbytes_ = nbytes
+
+        cdef shared_ptr[CCudaBuffer] buf_ = pyarrow_unwrap_cudabuffer(buf)
+        cdef int64_t position_ = position
+        with nogil:
+            check_status(self.cuda_buffer.get().
+                         CopyFromDevice(position_, buf_.get().data(), nbytes_))
         return nbytes_
 
     def export_for_ipc(self):

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -200,7 +200,7 @@ cdef class Context:
 
         Parameters
         ----------
-        data : {HostBuffer, Buffer, array-like}
+        data : {CudaBuffer, HostBuffer, Buffer, array-like}
           Specify data to be copied to device buffer.
         offset : int
           Specify the offset of input buffer for device data

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -68,6 +68,8 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::gpu" nogil:
                            void* out) const
         CStatus CopyFromHost(const int64_t position, const void* data,
                              int64_t nbytes)
+        CStatus CopyFromDevice(const int64_t position, const void* data,
+                               int64_t nbytes)
         CStatus ExportForIpc(shared_ptr[CCudaIpcMemHandle]* handle)
         shared_ptr[CCudaContext] context() const
 


### PR DESCRIPTION
This PR extends Arrow CUDA support for zero-size buffers.