### PR TITLE
[R] Add R to "allow_failures" until ARROW-3593 resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - jdk: oraclejdk9
+  - language: r
   include:
   # Lint C++, Python, R
   - os: linux


### PR DESCRIPTION
This will cause most builds to not appear to be failed. R patch developers should check to see if the CI is green