### PR TITLE
ARROW-3638: [C++][Python] Move reading from Feather as Table feature to C++ from Python

### DIFF
--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -333,7 +333,7 @@ TEST_F(TestTableReader, ReadIndices) {
 
   std::vector<int> indices({3, 0, 5});
   std::shared_ptr<Table> result;
-  reader_->Read(indices, &result);
+  ASSERT_OK(reader_->Read(indices, &result));
   std::vector<std::shared_ptr<Field>> fields;
   std::vector<std::shared_ptr<Array>> arrays;
   fields.push_back(std::make_shared<Field>("f0", int32()));
@@ -359,7 +359,7 @@ TEST_F(TestTableReader, ReadNames) {
 
   std::vector<std::string> names({"f3", "f0", "f5"});
   std::shared_ptr<Table> result;
-  reader_->Read(names, &result);
+  ASSERT_OK(reader_->Read(names, &result));
   std::vector<std::shared_ptr<Field>> fields;
   std::vector<std::shared_ptr<Array>> arrays;
   fields.push_back(std::make_shared<Field>("f0", int32()));

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -265,6 +265,112 @@ void CheckArrays(const Array& expected, const Array& result) {
   }
 }
 
+void CheckBatches(const RecordBatch& expected, const RecordBatch& result) {
+  if (!result.Equals(expected)) {
+    std::stringstream pp_result;
+    std::stringstream pp_expected;
+
+    EXPECT_OK(PrettyPrint(result, 0, &pp_result));
+    EXPECT_OK(PrettyPrint(expected, 0, &pp_expected));
+    FAIL() << "Got: " << pp_result.str() << "\nExpected: " << pp_expected.str();
+  }
+}
+
+std::shared_ptr<RecordBatch> TableToBatch(const Table &table) {
+  TableBatchReader reader(table);
+  std::shared_ptr<RecordBatch> batch;
+  EXPECT_OK(reader.ReadNext(&batch));
+  return batch;
+}
+
+void CheckTables(const Table& expected, const Table& result) {
+  if (!result.Equals(expected)) {
+    std::stringstream pp_result;
+    std::stringstream pp_expected;
+
+    EXPECT_OK(PrettyPrint(*TableToBatch(result), 0, &pp_result));
+    EXPECT_OK(PrettyPrint(*TableToBatch(expected), 0, &pp_expected));
+    FAIL() << "Got: " << pp_result.str() << "\nExpected: " << pp_expected.str();
+  }
+}
+
+class TestTableReader : public ::testing::Test {
+ public:
+  void SetUp() {
+    ASSERT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &stream_));
+    ASSERT_OK(TableWriter::Open(stream_, &writer_));
+  }
+
+  void Finish() {
+    // Write table footer
+    ASSERT_OK(writer_->Finalize());
+
+    ASSERT_OK(stream_->Finish(&output_));
+
+    std::shared_ptr<io::BufferReader> buffer(new io::BufferReader(output_));
+    ASSERT_OK(TableReader::Open(buffer, &reader_));
+  }
+
+ protected:
+  std::shared_ptr<io::BufferOutputStream> stream_;
+  std::unique_ptr<TableWriter> writer_;
+  std::unique_ptr<TableReader> reader_;
+
+  std::shared_ptr<Buffer> output_;
+};
+
+TEST_F(TestTableReader, ReadIndices) {
+  std::shared_ptr<RecordBatch> batch1;
+  ASSERT_OK(MakeIntRecordBatch(&batch1));
+  std::shared_ptr<RecordBatch> batch2;
+  ASSERT_OK(MakeIntRecordBatch(&batch2));
+
+  ASSERT_OK(writer_->Append("f0", *batch1->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch1->column(1)));
+  ASSERT_OK(writer_->Append("f2", *batch2->column(0)));
+  ASSERT_OK(writer_->Append("f3", *batch2->column(1)));
+  Finish();
+
+  std::vector<int> indices({3, 0, 5});
+  std::shared_ptr<Table> result;
+  reader_->Read(indices, &result);
+  std::vector<std::shared_ptr<Field>> fields;
+  std::vector<std::shared_ptr<Array>> arrays;
+  fields.push_back(std::make_shared<Field>("f0", int32()));
+  arrays.push_back(batch1->column(0));
+  fields.push_back(std::make_shared<Field>("f3", int32()));
+  arrays.push_back(batch2->column(1));
+  auto expected = Table::Make(std::make_shared<Schema>(fields),
+                              arrays);
+  CheckTables(*expected, *result);
+}
+
+TEST_F(TestTableReader, ReadNames) {
+  std::shared_ptr<RecordBatch> batch1;
+  ASSERT_OK(MakeIntRecordBatch(&batch1));
+  std::shared_ptr<RecordBatch> batch2;
+  ASSERT_OK(MakeIntRecordBatch(&batch2));
+
+  ASSERT_OK(writer_->Append("f0", *batch1->column(0)));
+  ASSERT_OK(writer_->Append("f1", *batch1->column(1)));
+  ASSERT_OK(writer_->Append("f2", *batch2->column(0)));
+  ASSERT_OK(writer_->Append("f3", *batch2->column(1)));
+  Finish();
+
+  std::vector<std::string> names({"f3", "f0", "f5"});
+  std::shared_ptr<Table> result;
+  reader_->Read(names, &result);
+  std::vector<std::shared_ptr<Field>> fields;
+  std::vector<std::shared_ptr<Array>> arrays;
+  fields.push_back(std::make_shared<Field>("f0", int32()));
+  arrays.push_back(batch1->column(0));
+  fields.push_back(std::make_shared<Field>("f3", int32()));
+  arrays.push_back(batch2->column(1));
+  auto expected = Table::Make(std::make_shared<Schema>(fields),
+                              arrays);
+  CheckTables(*expected, *result);
+}
+
 class TestTableWriter : public ::testing::Test {
  public:
   void SetUp() {
@@ -288,12 +394,12 @@ class TestTableWriter : public ::testing::Test {
     }
     Finish();
 
-    std::shared_ptr<Column> col;
-    for (int i = 0; i < batch.num_columns(); ++i) {
-      ASSERT_OK(reader_->GetColumn(i, &col));
-      ASSERT_EQ(batch.column_name(i), col->name());
-      CheckArrays(*batch.column(i), *col->data()->chunk(0));
-    }
+    std::shared_ptr<Table> table;
+    ASSERT_OK(reader_->Read(&table));
+    TableBatchReader table_batch_reader(*table);
+    std::shared_ptr<RecordBatch> result;
+    ASSERT_OK(table_batch_reader.ReadNext(&result));
+    CheckBatches(batch, *result);
   }
 
  protected:

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -276,7 +276,7 @@ void CheckBatches(const RecordBatch& expected, const RecordBatch& result) {
   }
 }
 
-std::shared_ptr<RecordBatch> TableToBatch(const Table &table) {
+std::shared_ptr<RecordBatch> TableToBatch(const Table& table) {
   TableBatchReader reader(table);
   std::shared_ptr<RecordBatch> batch;
   EXPECT_OK(reader.ReadNext(&batch));
@@ -340,8 +340,7 @@ TEST_F(TestTableReader, ReadIndices) {
   arrays.push_back(batch1->column(0));
   fields.push_back(std::make_shared<Field>("f3", int32()));
   arrays.push_back(batch2->column(1));
-  auto expected = Table::Make(std::make_shared<Schema>(fields),
-                              arrays);
+  auto expected = Table::Make(std::make_shared<Schema>(fields), arrays);
   CheckTables(*expected, *result);
 }
 
@@ -366,8 +365,7 @@ TEST_F(TestTableReader, ReadNames) {
   arrays.push_back(batch1->column(0));
   fields.push_back(std::make_shared<Field>("f3", int32()));
   arrays.push_back(batch2->column(1));
-  auto expected = Table::Make(std::make_shared<Schema>(fields),
-                              arrays);
+  auto expected = Table::Make(std::make_shared<Schema>(fields), arrays);
   CheckTables(*expected, *result);
 }
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -444,6 +444,66 @@ class TableReader::TableReaderImpl {
     return Status::OK();
   }
 
+  Status Read(std::shared_ptr<Table>* out) {
+    std::vector<std::shared_ptr<Field>> fields;
+    std::vector<std::shared_ptr<Column>> columns;
+    for (int64_t i = 0; i < num_columns(); ++i) {
+      std::shared_ptr<Column> column;
+      RETURN_NOT_OK(GetColumn(i, &column));
+      columns.push_back(column);
+      fields.push_back(column->field());
+    }
+    *out = Table::Make(schema(fields), columns);
+    return Status::OK();
+  }
+
+  Status Read(const std::vector<int>& indices, std::shared_ptr<Table>* out) {
+    std::vector<std::shared_ptr<Field>> fields;
+    std::vector<std::shared_ptr<Column>> columns;
+    for (int64_t i = 0; i < num_columns(); ++i) {
+      bool found = false;
+      for (auto j : indices) {
+        if (i == j) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        continue;
+      }
+      std::shared_ptr<Column> column;
+      RETURN_NOT_OK(GetColumn(i, &column));
+      columns.push_back(column);
+      fields.push_back(column->field());
+    }
+    *out = Table::Make(schema(fields), columns);
+    return Status::OK();
+  }
+
+  Status Read(const std::vector<std::string>& names, std::shared_ptr<Table>* out) {
+    std::vector<std::shared_ptr<Field>> fields;
+    std::vector<std::shared_ptr<Column>> columns;
+    for (int64_t i = 0; i < num_columns(); ++i) {
+      auto name = GetColumnName(i);
+      bool found = false;
+      for (auto& n : names) {
+        if (name == n) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        continue;
+      }
+      std::shared_ptr<Column> column;
+      RETURN_NOT_OK(GetColumn(i, &column));
+      columns.push_back(column);
+      fields.push_back(column->field());
+    }
+    *out = Table::Make(schema(fields), columns);
+    return Status::OK();
+  }
+
  private:
   std::shared_ptr<io::RandomAccessFile> source_;
   std::unique_ptr<TableMetadata> metadata_;
@@ -478,6 +538,17 @@ std::string TableReader::GetColumnName(int i) const { return impl_->GetColumnNam
 
 Status TableReader::GetColumn(int i, std::shared_ptr<Column>* out) {
   return impl_->GetColumn(i, out);
+}
+
+Status TableReader::Read(std::shared_ptr<Table>* out) { return impl_->Read(out); }
+
+Status TableReader::Read(const std::vector<int>& indices, std::shared_ptr<Table>* out) {
+  return impl_->Read(indices, out);
+}
+
+Status TableReader::Read(const std::vector<std::string>& names,
+                         std::shared_ptr<Table>* out) {
+  return impl_->Read(names, out);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -447,7 +447,7 @@ class TableReader::TableReaderImpl {
   Status Read(std::shared_ptr<Table>* out) {
     std::vector<std::shared_ptr<Field>> fields;
     std::vector<std::shared_ptr<Column>> columns;
-    for (int64_t i = 0; i < num_columns(); ++i) {
+    for (int i = 0; i < num_columns(); ++i) {
       std::shared_ptr<Column> column;
       RETURN_NOT_OK(GetColumn(i, &column));
       columns.push_back(column);
@@ -460,7 +460,7 @@ class TableReader::TableReaderImpl {
   Status Read(const std::vector<int>& indices, std::shared_ptr<Table>* out) {
     std::vector<std::shared_ptr<Field>> fields;
     std::vector<std::shared_ptr<Column>> columns;
-    for (int64_t i = 0; i < num_columns(); ++i) {
+    for (int i = 0; i < num_columns(); ++i) {
       bool found = false;
       for (auto j : indices) {
         if (i == j) {
@@ -483,7 +483,7 @@ class TableReader::TableReaderImpl {
   Status Read(const std::vector<std::string>& names, std::shared_ptr<Table>* out) {
     std::vector<std::shared_ptr<Field>> fields;
     std::vector<std::shared_ptr<Column>> columns;
-    for (int64_t i = 0; i < num_columns(); ++i) {
+    for (int i = 0; i < num_columns(); ++i) {
       auto name = GetColumnName(i);
       bool found = false;
       for (auto& n : names) {

--- a/cpp/src/arrow/ipc/feather.h
+++ b/cpp/src/arrow/ipc/feather.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "arrow/util/visibility.h"
 
@@ -32,6 +33,7 @@ namespace arrow {
 class Array;
 class Column;
 class Status;
+class Table;
 
 namespace io {
 
@@ -90,6 +92,32 @@ class ARROW_EXPORT TableReader {
   ///
   /// This function is zero-copy if the file source supports zero-copy reads
   Status GetColumn(int i, std::shared_ptr<Column>* out);
+
+  /// \brief Read all columns from the file as an arrow::Table.
+  ///
+  /// \param[out] out the returned table
+  /// \return Status
+  ///
+  /// This function is zero-copy if the file source supports zero-copy reads
+  Status Read(std::shared_ptr<Table>* out);
+
+  /// \brief Read only the specified columns from the file as an arrow::Table.
+  ///
+  /// \param[in] indices the column indices to read
+  /// \param[out] out the returned table
+  /// \return Status
+  ///
+  /// This function is zero-copy if the file source supports zero-copy reads
+  Status Read(const std::vector<int>& indices, std::shared_ptr<Table>* out);
+
+  /// \brief Read only the specified columns from the file as an arrow::Table.
+  ///
+  /// \param[in] names the column names to read
+  /// \param[out] out the returned table
+  /// \return Status
+  ///
+  /// This function is zero-copy if the file source supports zero-copy reads
+  Status Read(const std::vector<std::string>& names, std::shared_ptr<Table>* out);
 
  private:
   class ARROW_NO_EXPORT TableReaderImpl;

--- a/python/pyarrow/feather.pxi
+++ b/python/pyarrow/feather.pxi
@@ -104,3 +104,37 @@ cdef class FeatherReader:
                          .GetColumn(i, &sp_column))
 
         return pyarrow_wrap_column(sp_column)
+
+    def _read(self):
+        cdef shared_ptr[CTable] sp_table
+        with nogil:
+            check_status(self.reader.get()
+                         .Read(&sp_table))
+
+        return pyarrow_wrap_table(sp_table)
+
+    def _read_indices(self, indices):
+        cdef:
+            shared_ptr[CTable] sp_table
+            vector[int] c_indices
+
+        for index in indices:
+            c_indices.push_back(index)
+        with nogil:
+            check_status(self.reader.get()
+                         .Read(c_indices, &sp_table))
+
+        return pyarrow_wrap_table(sp_table)
+
+    def _read_names(self, names):
+        cdef:
+            shared_ptr[CTable] sp_table
+            vector[c_string] c_names
+
+        for name in names:
+            c_names.push_back(tobytes(name))
+        with nogil:
+            check_status(self.reader.get()
+                         .Read(c_names, &sp_table))
+
+        return pyarrow_wrap_table(sp_table)

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -58,9 +58,10 @@ class FeatherReader(ext.FeatherReader):
         elif all(map(lambda t: t == str, column_types)):
             return self._read_names(columns)
 
-        message = "Columns must be indices or names. Got columns {} of types {}"
         column_type_names = [t.__name__ for t in column_types]
-        raise TypeError(message.format(columns, column_type_names))
+        raise TypeError("Columns must be indices or names. "
+                        "Got columns {} of types {}"
+                        .format(columns, column_type_names))
 
     def read_pandas(self, columns=None, use_threads=True):
         return self.read_table(columns=columns).to_pandas(

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -24,7 +24,7 @@ import warnings
 
 from pyarrow.compat import pdapi
 from pyarrow.lib import FeatherError  # noqa
-from pyarrow.lib import RecordBatch, Table, concat_tables
+from pyarrow.lib import RecordBatch, concat_tables
 import pyarrow.lib as ext
 
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -910,6 +910,10 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         CStatus GetColumn(int i, shared_ptr[CColumn]* out)
         c_string GetColumnName(int i)
 
+        CStatus Read(shared_ptr[CTable]* out)
+        CStatus Read(const vector[int] indices, shared_ptr[CTable]* out)
+        CStatus Read(const vector[c_string] names, shared_ptr[CTable]* out)
+
 
 cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
 


### PR DESCRIPTION
It's for using the feature from GLib.

(I know Feather is deprecated format.)