### PR TITLE
ARROW-1382: [Python] Raise an exception when serializing objects containing multiple copie…

### DIFF
--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -658,8 +658,8 @@ Status SerializeSequences(PyObject* context, std::vector<PyObject*> sequences,
   for (const auto& sequence : sequences) {
     RETURN_NOT_OK(internal::VisitIterable(
         sequence, [&](PyObject* obj, bool* keep_going /* unused */) {
-          return Append(context, obj, &builder, distinct_objects, &sublists, &subtuples, &subdicts,
-                        &subsets, blobs_out);
+          return Append(context, obj, &builder, distinct_objects, &sublists, &subtuples,
+                        &subdicts, &subsets, blobs_out);
         }));
   }
   std::shared_ptr<Array> list;
@@ -741,8 +741,8 @@ Status SerializeDict(PyObject* context, std::vector<PyObject*> dicts,
   }
   std::shared_ptr<Array> val_set_arr;
   if (val_sets.size() > 0) {
-    RETURN_NOT_OK(SerializeSequences(context, val_sets, recursion_depth + 1, distinct_objects,
-                                     &val_set_arr, blobs_out));
+    RETURN_NOT_OK(SerializeSequences(context, val_sets, recursion_depth + 1,
+                                     distinct_objects, &val_set_arr, blobs_out));
   }
   RETURN_NOT_OK(result.Finish(key_tuples_arr.get(), key_dicts_arr.get(),
                               val_list_arr.get(), val_tuples_arr.get(),

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -789,5 +789,5 @@ def test_distinct_objects():
             pa.serialize([{'a': obj}, [[{'b': obj}]]], context=context)
 
     # Make sure the following do not cause errors.
-    for obj in [(), 1, 'a', b'a']:
+    for obj in [(), 1, 'a', b'a', None, True, False]:
         pa.serialize([obj, obj], context=context)


### PR DESCRIPTION
…s of the same object.

This is one approach to addressing a long-standing issue in which Python objects that contain multiple copies of the same object are serialized (by `pyarrow.serialize`) as if they contain distinct copies of that object, e.g., the object `1000 * [np.zeros(10**8)]` will be serialized to contain 1000 distinct arrays. For graph data structures, this can lead to exponential size blowups and incorrect behavior (in the sense of not preserving the structure of the Python object).

This PR raises an exception when we detect that we are in this scenario.

A complementary (and desirable) approach would be to use dictionary encodings to actually serialize more objects correctly.