### PR TITLE
ARROW-3648: [Plasma][Java] Add API to get metadata and data at the same time

### DIFF
--- a/java/plasma/pom.xml
+++ b/java/plasma/pom.xml
@@ -18,16 +18,16 @@
     </parent>
     <artifactId>arrow-plasma</artifactId>
     <name>Arrow Plasma Client</name>
-    <build>  
-        <plugins>  
-            <plugin>  
-                <groupId>org.apache.maven.plugins</groupId>  
-                <artifactId>maven-compiler-plugin</artifactId>  
-                <configuration>  
-                    <source>1.8</source>  
-                    <target>1.8</target>  
-                </configuration>  
-            </plugin>  
-        </plugins>  
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/java/plasma/pom.xml
+++ b/java/plasma/pom.xml
@@ -32,9 +32,8 @@
     </build>
     <dependencies>
          <dependency>
-             <groupId>org.apache.commons</groupId>
-             <artifactId>commons-lang3</artifactId>
-             <version>3.4</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
          </dependency>
     </dependencies>
 </project>

--- a/java/plasma/pom.xml
+++ b/java/plasma/pom.xml
@@ -30,4 +30,11 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+         <dependency>
+             <groupId>org.apache.commons</groupId>
+             <artifactId>commons-lang3</artifactId>
+             <version>3.4</version>
+         </dependency>
+    </dependencies>
 </project>

--- a/java/plasma/pom.xml
+++ b/java/plasma/pom.xml
@@ -30,10 +30,4 @@
             </plugin>
         </plugins>
     </build>
-    <dependencies>
-         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-         </dependency>
-    </dependencies>
 </project>

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
@@ -36,7 +36,7 @@ public interface ObjectStoreLink {
   void put(byte[] objectId, byte[] value, byte[] metadata);
 
   /**
-   * Create a buffer from the PlasmaStore based on the <tt>objectId</tt>.
+   * Get a buffer from the PlasmaStore based on the <tt>objectId</tt>.
    *
    * @param objectId The object ID used to identify the object.
    * @param timeoutMs The number of milliseconds that the get call should block before timing out
@@ -50,7 +50,7 @@ public interface ObjectStoreLink {
   }
 
   /**
-   * Create buffers from the PlasmaStore based on <tt>objectIds</tt>.
+   * Get buffers from the PlasmaStore based on <tt>objectIds</tt>.
    *
    * @param objectIds List of object IDs used to identify some objects.
    * @param timeoutMs The number of milliseconds that the get call should block before timing out
@@ -61,7 +61,7 @@ public interface ObjectStoreLink {
   List<byte[]> get(byte[][] objectIds, int timeoutMs, boolean isMetadata);
 
   /**
-   * Create buffer pairs (data & metadata) from the PlasmaStore based on <tt>objectIds</tt>.
+   * Get buffer pairs (data & metadata) from the PlasmaStore based on <tt>objectIds</tt>.
    *
    * @param objectIds List of object IDs used to identify some objects.
    * @param timeoutMs The number of milliseconds that the get call should block before timing out

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
@@ -19,6 +19,8 @@ package org.apache.arrow.plasma;
 
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 /**
  * Object store interface, which provides the capabilities to put and get raw byte array, and serves
  */
@@ -57,6 +59,16 @@ public interface ObjectStoreLink {
    * @return List of PlasmaBuffers wrapping objects.
    */
   List<byte[]> get(byte[][] objectIds, int timeoutMs, boolean isMetadata);
+
+  /**
+   * Create buffer pairs (data & metadata) from the PlasmaStore based on <tt>objectIds</tt>.
+   *
+   * @param objectIds List of object IDs used to identify some objects.
+   * @param timeoutMs The number of milliseconds that the get call should block before timing out
+   * and returning. Pass -1 if the call should block and 0 if the call should return immediately.
+   * @return List of Pairs of PlasmaBuffer wrapping objects and its metadata.
+   */
+  List<Pair<byte[], byte[]>> get(byte[][] objectIds, int timeoutMs);
 
   /**
    * Wait until <tt>numReturns</tt> objects in <tt>objectIds</tt> are ready.

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
@@ -19,12 +19,21 @@ package org.apache.arrow.plasma;
 
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 /**
  * Object store interface, which provides the capabilities to put and get raw byte array, and serves
  */
 public interface ObjectStoreLink {
+
+  class ObjectStoreData {
+
+    ObjectStoreData(byte[] metadata, byte[] data) {
+      this.data = data;
+      this.metadata = metadata;
+    }
+
+    public final byte[] metadata;
+    public final byte[] data;
+  }
 
   /**
    * Put value in the local plasma store with object ID <tt>objectId</tt>.
@@ -68,7 +77,7 @@ public interface ObjectStoreLink {
    * and returning. Pass -1 if the call should block and 0 if the call should return immediately.
    * @return List of Pairs of PlasmaBuffer wrapping objects and its metadata.
    */
-  List<Pair<byte[], byte[]>> get(byte[][] objectIds, int timeoutMs);
+  List<ObjectStoreData> get(byte[][] objectIds, int timeoutMs);
 
   /**
    * Wait until <tt>numReturns</tt> objects in <tt>objectIds</tt> are ready.

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -22,10 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
-
-
 
 /**
  * The PlasmaClient is used to interface with a plasma store and manager.
@@ -114,16 +110,16 @@ public class PlasmaClient implements ObjectStoreLink {
   }
 
   @Override
-  public List<Pair<byte[], byte[]>> get(byte[][] objectIds, int timeoutMs) {
+  public List<ObjectStoreData> get(byte[][] objectIds, int timeoutMs) {
     ByteBuffer[][] bufs = PlasmaClientJNI.get(conn, objectIds, timeoutMs);
     assert bufs.length == objectIds.length;
 
-    List<Pair<byte[], byte[]>> ret = new ArrayList<>();
+    List<ObjectStoreData> ret = new ArrayList<>();
     for (int i = 0; i < bufs.length; i++) {
       ByteBuffer databuf = bufs[i][0];
       ByteBuffer metabuf = bufs[i][1];
       if (databuf == null) {
-        ret.add(new ImmutablePair<byte[], byte[]>(null, null));
+        ret.add(new ObjectStoreData(null, null));
       } else {
         byte[] data = new byte[databuf.remaining()];
         databuf.get(data);
@@ -134,7 +130,7 @@ public class PlasmaClient implements ObjectStoreLink {
         } else {
           meta = null;
         }
-        ret.add(new ImmutablePair<>(data, meta));
+        ret.add(new ObjectStoreData(data, meta));
       }
     }
     return ret;

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 
@@ -122,7 +123,7 @@ public class PlasmaClient implements ObjectStoreLink {
       ByteBuffer databuf = bufs[i][0];
       ByteBuffer metabuf = bufs[i][1];
       if (databuf == null) {
-        ret.add(Pair.of(null, null));
+        ret.add(new ImmutablePair<byte[], byte[]>(null, null));
       } else {
         byte[] data = new byte[databuf.remaining()];
         databuf.get(data);
@@ -133,7 +134,7 @@ public class PlasmaClient implements ObjectStoreLink {
         } else {
           meta = null;
         }
-        ret.add(Pair.of(data, meta));
+        ret.add(new ImmutablePair<>(data, meta));
       }
     }
     return ret;

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -114,7 +114,7 @@ public class PlasmaClient implements ObjectStoreLink {
 
   @Override
   public List<Pair<byte[], byte[]>> get(byte[][] objectIds, int timeoutMs) {
-    ByteBuffer[][] bufs = PlasmaClientJNI.get(threadConn.get(), objectIds, timeoutMs);
+    ByteBuffer[][] bufs = PlasmaClientJNI.get(conn, objectIds, timeoutMs);
     assert bufs.length == objectIds.length;
 
     List<Pair<byte[], byte[]>> ret = new ArrayList<>();

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.tuple.Pair;
 
 public class PlasmaClientTest {

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -170,15 +170,15 @@ public class PlasmaClientTest {
     Arrays.fill(value5, (byte)15);
     pLink.put(id5, value5, meta5);
 
-    byte[] getValue4_meta = pLink.get(id4, timeoutMs, true);
-    assert Arrays.equals(meta4, getValue4_meta);
-    byte[] getValue4_data = pLink.get(id4, timeoutMs, false);
-    assert Arrays.equals(value4, getValue4_data);
+    byte[] getMeta4 = pLink.get(id4, timeoutMs, true);
+    assert Arrays.equals(meta4, getMeta4);
+    byte[] getValue4 = pLink.get(id4, timeoutMs, false);
+    assert Arrays.equals(value4, getValue4);
 
-    byte[] getValue5_meta = pLink.get(id5, timeoutMs, true);
-    assert Arrays.equals(meta5, getValue5_meta);
-    byte[] getValue5_data = pLink.get(id5, timeoutMs, false);
-    assert Arrays.equals(value5, getValue5_data);
+    byte[] getMeta5 = pLink.get(id5, timeoutMs, true);
+    assert Arrays.equals(meta5, getMeta5);
+    byte[] getValue5 = pLink.get(id5, timeoutMs, false);
+    assert Arrays.equals(value5, getValue5);
     System.out.println("Plasma java client metadata get test success.");
     cleanup();
     System.out.println("All test success.");

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 public class PlasmaClientTest {
 
   private String storeSuffix = "/tmp/store";
@@ -178,9 +176,9 @@ public class PlasmaClientTest {
     assert Arrays.equals(value4, getValue4);
     byte[][] ids4 = new byte[1][];
     ids4[0] = id4;
-    Pair<byte[], byte[]> fullData4 = pLink.get(ids4, timeoutMs).get(0);
-    assert Arrays.equals(meta4, fullData4.getRight());
-    assert Arrays.equals(value4, fullData4.getLeft());
+    ObjectStoreLink.ObjectStoreData fullData4 = pLink.get(ids4, timeoutMs).get(0);
+    assert Arrays.equals(meta4, fullData4.metadata);
+    assert Arrays.equals(value4, fullData4.data);
 
     byte[] getMeta5 = pLink.get(id5, timeoutMs, true);
     assert Arrays.equals(meta5, getMeta5);
@@ -188,9 +186,9 @@ public class PlasmaClientTest {
     assert Arrays.equals(value5, getValue5);
     byte[][] ids5 = new byte[1][];
     ids5[0] = id5;
-    Pair<byte[], byte[]> fullData5 = pLink.get(ids5, timeoutMs).get(0);
-    assert Arrays.equals(meta5, fullData5.getRight());
-    assert Arrays.equals(value5, fullData5.getLeft());
+    ObjectStoreLink.ObjectStoreData fullData5 = pLink.get(ids5, timeoutMs).get(0);
+    assert Arrays.equals(meta5, fullData5.metadata);
+    assert Arrays.equals(value5, fullData5.data);
     System.out.println("Plasma java client metadata get test success.");
     cleanup();
     System.out.println("All test success.");

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -176,7 +176,9 @@ public class PlasmaClientTest {
     assert Arrays.equals(meta4, getMeta4);
     byte[] getValue4 = pLink.get(id4, timeoutMs, false);
     assert Arrays.equals(value4, getValue4);
-    Pair<byte[], byte[]> fullData4 = pLink.get(id4, timeoutMs);
+    byte[][] ids4 = new byte[1][];
+    ids4[0] = id4;
+    Pair<byte[], byte[]> fullData4 = pLink.get(ids4, timeoutMs).get(0);
     assert Arrays.equals(meta4, fullData4.getRight());
     assert Arrays.equals(value4, fullData4.getLeft());
 
@@ -184,7 +186,9 @@ public class PlasmaClientTest {
     assert Arrays.equals(meta5, getMeta5);
     byte[] getValue5 = pLink.get(id5, timeoutMs, false);
     assert Arrays.equals(value5, getValue5);
-    Pair<byte[], byte[]> fullData5 = pLink.get(id5, timeoutMs);
+    byte[][] ids5 = new byte[1][];
+    ids5[0] = id5;
+    Pair<byte[], byte[]> fullData5 = pLink.get(ids5, timeoutMs).get(0);
     assert Arrays.equals(meta5, fullData5.getRight());
     assert Arrays.equals(value5, fullData5.getLeft());
     System.out.println("Plasma java client metadata get test success.");

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -155,6 +155,31 @@ public class PlasmaClientTest {
     boolean notExsit = pLink.contains(id3);
     assert !notExsit;
     System.out.println("Plasma java client contains test success.");
+
+    byte[] id4 =  new byte[20];
+    Arrays.fill(id4, (byte)4);
+    byte[] value4 =  new byte[20];
+    byte[] meta4 = "META4".getBytes();
+    Arrays.fill(value4, (byte)14);
+    pLink.put(id4, value4, meta4);
+
+    byte[] id5 =  new byte[20];
+    Arrays.fill(id5, (byte)5);
+    byte[] value5 =  new byte[20];
+    byte[] meta5 = "META5".getBytes();
+    Arrays.fill(value5, (byte)15);
+    pLink.put(id5, value5, meta5);
+
+    byte[] getValue4_meta = pLink.get(id4, timeoutMs, true);
+    assert Arrays.equals(meta4, getValue4_meta);
+    byte[] getValue4_data = pLink.get(id4, timeoutMs, false);
+    assert Arrays.equals(value4, getValue4_data);
+
+    byte[] getValue5_meta = pLink.get(id5, timeoutMs, true);
+    assert Arrays.equals(meta5, getValue5_meta);
+    byte[] getValue5_data = pLink.get(id5, timeoutMs, false);
+    assert Arrays.equals(value5, getValue5_data);
+    System.out.println("Plasma java client metadata get test success.");
     cleanup();
     System.out.println("All test success.");
 

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class PlasmaClientTest {
 
@@ -174,11 +175,17 @@ public class PlasmaClientTest {
     assert Arrays.equals(meta4, getMeta4);
     byte[] getValue4 = pLink.get(id4, timeoutMs, false);
     assert Arrays.equals(value4, getValue4);
+    Pair<byte[], byte[]> fullData4 = pLink.get(id4, timeoutMs);
+    assert Arrays.equals(meta4, fullData4.getRight());
+    assert Arrays.equals(value4, fullData4.getLeft());
 
     byte[] getMeta5 = pLink.get(id5, timeoutMs, true);
     assert Arrays.equals(meta5, getMeta5);
     byte[] getValue5 = pLink.get(id5, timeoutMs, false);
     assert Arrays.equals(value5, getValue5);
+    Pair<byte[], byte[]> fullData5 = pLink.get(id5, timeoutMs);
+    assert Arrays.equals(meta5, fullData5.getRight());
+    assert Arrays.equals(value5, fullData5.getLeft());
     System.out.println("Plasma java client metadata get test success.");
     cleanup();
     System.out.println("All test success.");

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,7 +37,6 @@
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.9.0</dep.fbs.version>
     <dep.flatc.version>1.9.0</dep.flatc.version>
-    <dep.lang3.version>3.4</dep.lang3.version>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
   </properties>
@@ -530,11 +529,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${dep.slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${dep.lang3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,6 +37,7 @@
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.9.0</dep.fbs.version>
     <dep.flatc.version>1.9.0</dep.flatc.version>
+    <dep.lang3.version>3.4</dep.lang3.version>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
   </properties>
@@ -529,6 +530,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${dep.slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${dep.lang3.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Current Arrow Java Plasma client has no API to get the metadata and data together in one API call. If we split this process into two API calls, the object status could be different. Current observation shows that the first call could be empty(object not stored yet) while the second call will success but the metadata and data does not match.