### PR TITLE
ARROW-3657: [R] there is no package called bit64

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     fs,
     tibble,
     crayon,
-    withr
+    withr,
+    bit64
 Remotes:
     romainfrancois/vctrs@bit64, 
     RcppCore/Rcpp, 
@@ -33,9 +34,8 @@ Remotes:
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.0.9000
 Suggests:
-    testthat, 
+    testthat,
     lubridate, 
-    bit64, 
     hms
 Collate:
     'enums.R'


### PR DESCRIPTION
https://github.com/apache/arrow/pull/2867 broke installation, this fixes it with [ARROW-3657](https://issues.apache.org/jira/projects/ARROW/issues/ARROW-3657).

CC: @romainfrancois 