### PR TITLE
ARROW-3659: [CI] Fix Travis matrix entry 2 documentation to use gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_lint.sh
-  # C++ & Python w/ clang 6.0
+  # C++ & Python w/ gcc 4.9
   - compiler: gcc
     language: cpp
     os: linux
@@ -80,12 +80,11 @@ matrix:
     - ARROW_TRAVIS_JAVA_BUILD_ONLY=1
     # ARROW-2999 Benchmarks are disabled in Travis CI for the time being
     # - ARROW_TRAVIS_PYTHON_BENCHMARKS=1
-    - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+    - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     before_script:
     # (ARROW_CI_CPP_AFFECTED implies ARROW_CI_PYTHON_AFFECTED)
     - if [ $ARROW_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_linux.sh
-    - $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
     # If either C++ or Python changed, we must install the C++ libraries
     - git submodule update --init
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ matrix:
     # (ARROW_CI_CPP_AFFECTED implies ARROW_CI_PYTHON_AFFECTED)
     - if [ $ARROW_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_linux.sh
+    - $TRAVIS_BUILD_DIR/ci/travis_install_clang_tools.sh
     # If either C++ or Python changed, we must install the C++ libraries
     - git submodule update --init
     - $TRAVIS_BUILD_DIR/ci/travis_before_script_cpp.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,7 @@ matrix:
     - ARROW_TRAVIS_JAVA_BUILD_ONLY=1
     # ARROW-2999 Benchmarks are disabled in Travis CI for the time being
     # - ARROW_TRAVIS_PYTHON_BENCHMARKS=1
-    - CC="clang-6.0"
-    - CXX="clang++-6.0"
+    - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
     before_script:
     # (ARROW_CI_CPP_AFFECTED implies ARROW_CI_PYTHON_AFFECTED)
     - if [ $ARROW_CI_PYTHON_AFFECTED != "1" ]; then exit; fi

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -137,6 +137,7 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-parentheses-equality")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-constant-logical-operand")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-declarations")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sometimes-uninitialized")
 
   # We have public Cython APIs which return C++ types, which are in an extern
   # "C" blog (no symbol mangling) and clang doesn't like this

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -137,7 +137,6 @@ if ("${COMPILER_FAMILY}" STREQUAL "clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-parentheses-equality")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-constant-logical-operand")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-declarations")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-sometimes-uninitialized")
 
   # We have public Cython APIs which return C++ types, which are in an extern
   # "C" blog (no symbol mangling) and clang doesn't like this


### PR DESCRIPTION
This is a little subtle and is needed because of the order in which Travis evaluates the command line variable definitions (see the JIRA issue).

I also needed to remove a warning due to this: https://github.com/cython/cython/issues/2269
We might be able to bring the warning back once we can depend on cython with https://github.com/cython/cython/pull/2669