### PR TITLE
ARROW-3668: [R} Namespace dependency bit64 is not required

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -28,14 +28,14 @@ Imports:
     withr,
     bit64
 Remotes:
-    romainfrancois/vctrs@bit64, 
-    RcppCore/Rcpp, 
+    romainfrancois/vctrs@bit64,
+    RcppCore/Rcpp,
     r-lib/withr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.0.9000
 Suggests:
     testthat,
-    lubridate, 
+    lubridate,
     hms
 Collate:
     'enums.R'


### PR DESCRIPTION
The R package is currently [broken on Travis](https://travis-ci.org/apache/arrow/jobs/449082414) because dependency `bit64` was recently added but put in `Suggests` instead of `Imports`.

![image](https://user-images.githubusercontent.com/7608904/47832201-185bc100-dd62-11e8-8f4a-ee176807e43a.png)

In R, every package that you add as an `import` or `importFrom` in your `NAMESPACE` file needs to be in `Imports` or `Depends` in `DESCRIPTION`.

Please consider this PR to address this.