### PR TITLE
ARROW-3694: [Java] Avoid superfluous string creation when logging level is disabled 

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
@@ -82,7 +82,7 @@ public class ArrowFileReader extends ArrowReader {
         throw new InvalidArrowFileException("invalid footer length: " + footerLength);
       }
       long footerOffset = footerLengthOffset - footerLength;
-      LOGGER.debug("Footer starts at %d, length: %d", footerOffset, footerLength);
+      LOGGER.debug("Footer starts at {}, length: {}", footerOffset, footerLength);
       ByteBuffer footerBuffer = ByteBuffer.allocate(footerLength);
       in.setPosition(footerOffset);
       in.readFully(footerBuffer);
@@ -141,7 +141,7 @@ public class ArrowFileReader extends ArrowReader {
   private ArrowDictionaryBatch readDictionaryBatch(SeekableReadChannel in,
                                                    ArrowBlock block,
                                                    BufferAllocator allocator) throws IOException {
-    LOGGER.debug("DictionaryRecordBatch at %d, metadata: %d, body: %d",
+    LOGGER.debug("DictionaryRecordBatch at {}, metadata: {}, body: {}",
         block.getOffset(), block.getMetadataLength(), block.getBodyLength());
     in.setPosition(block.getOffset());
     ArrowDictionaryBatch batch = MessageSerializer.deserializeDictionaryBatch(in, block, allocator);
@@ -154,7 +154,7 @@ public class ArrowFileReader extends ArrowReader {
   private ArrowRecordBatch readRecordBatch(SeekableReadChannel in,
                                            ArrowBlock block,
                                            BufferAllocator allocator) throws IOException {
-    LOGGER.debug("RecordBatch at %d, metadata: %d, body: %d",
+    LOGGER.debug("RecordBatch at {}, metadata: {}, body: {}",
         block.getOffset(), block.getMetadataLength(),
         block.getBodyLength());
     in.setPosition(block.getOffset());

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
@@ -82,7 +82,7 @@ public class ArrowFileReader extends ArrowReader {
         throw new InvalidArrowFileException("invalid footer length: " + footerLength);
       }
       long footerOffset = footerLengthOffset - footerLength;
-      LOGGER.debug(String.format("Footer starts at %d, length: %d", footerOffset, footerLength));
+      LOGGER.debug("Footer starts at %d, length: %d", footerOffset, footerLength);
       ByteBuffer footerBuffer = ByteBuffer.allocate(footerLength);
       in.setPosition(footerOffset);
       in.readFully(footerBuffer);
@@ -141,8 +141,8 @@ public class ArrowFileReader extends ArrowReader {
   private ArrowDictionaryBatch readDictionaryBatch(SeekableReadChannel in,
                                                    ArrowBlock block,
                                                    BufferAllocator allocator) throws IOException {
-    LOGGER.debug(String.format("DictionaryRecordBatch at %d, metadata: %d, body: %d",
-        block.getOffset(), block.getMetadataLength(), block.getBodyLength()));
+    LOGGER.debug("DictionaryRecordBatch at %d, metadata: %d, body: %d",
+        block.getOffset(), block.getMetadataLength(), block.getBodyLength());
     in.setPosition(block.getOffset());
     ArrowDictionaryBatch batch = MessageSerializer.deserializeDictionaryBatch(in, block, allocator);
     if (batch == null) {
@@ -154,9 +154,9 @@ public class ArrowFileReader extends ArrowReader {
   private ArrowRecordBatch readRecordBatch(SeekableReadChannel in,
                                            ArrowBlock block,
                                            BufferAllocator allocator) throws IOException {
-    LOGGER.debug(String.format("RecordBatch at %d, metadata: %d, body: %d",
+    LOGGER.debug("RecordBatch at %d, metadata: %d, body: %d",
         block.getOffset(), block.getMetadataLength(),
-        block.getBodyLength()));
+        block.getBodyLength());
     in.setPosition(block.getOffset());
     ArrowRecordBatch batch = MessageSerializer.deserializeRecordBatch(in, block, allocator);
     if (batch == null) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -72,9 +72,9 @@ public class ArrowFileWriter extends ArrowWriter {
       throw new InvalidArrowFileException("invalid footer");
     }
     out.writeIntLittleEndian(footerLength);
-    LOGGER.debug(String.format("Footer starts at %d, length: %d", footerStart, footerLength));
+    LOGGER.debug("Footer starts at %d, length: %d", footerStart, footerLength);
     ArrowMagic.writeMagic(out, false);
-    LOGGER.debug(String.format("magic written, now at %d", out.getCurrentPosition()));
+    LOGGER.debug("magic written, now at %d", out.getCurrentPosition());
   }
 
   @VisibleForTesting

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -72,9 +72,9 @@ public class ArrowFileWriter extends ArrowWriter {
       throw new InvalidArrowFileException("invalid footer");
     }
     out.writeIntLittleEndian(footerLength);
-    LOGGER.debug("Footer starts at %d, length: %d", footerStart, footerLength);
+    LOGGER.debug("Footer starts at {}, length: {}", footerStart, footerLength);
     ArrowMagic.writeMagic(out, false);
-    LOGGER.debug("magic written, now at %d", out.getCurrentPosition());
+    LOGGER.debug("magic written, now at {}", out.getCurrentPosition());
   }
 
   @VisibleForTesting

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -107,14 +107,14 @@ public abstract class ArrowWriter implements AutoCloseable {
 
   protected ArrowBlock writeDictionaryBatch(ArrowDictionaryBatch batch) throws IOException {
     ArrowBlock block = MessageSerializer.serialize(out, batch);
-    LOGGER.debug("DictionaryRecordBatch at %d, metadata: %d, body: %d",
+    LOGGER.debug("DictionaryRecordBatch at {}, metadata: {}, body: {}",
         block.getOffset(), block.getMetadataLength(), block.getBodyLength());
     return block;
   }
 
   protected ArrowBlock writeRecordBatch(ArrowRecordBatch batch) throws IOException {
     ArrowBlock block = MessageSerializer.serialize(out, batch);
-    LOGGER.debug("RecordBatch at %d, metadata: %d, body: %d",
+    LOGGER.debug("RecordBatch at {}, metadata: {}, body: {}",
         block.getOffset(), block.getMetadataLength(), block.getBodyLength());
     return block;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -107,15 +107,15 @@ public abstract class ArrowWriter implements AutoCloseable {
 
   protected ArrowBlock writeDictionaryBatch(ArrowDictionaryBatch batch) throws IOException {
     ArrowBlock block = MessageSerializer.serialize(out, batch);
-    LOGGER.debug(String.format("DictionaryRecordBatch at %d, metadata: %d, body: %d",
-        block.getOffset(), block.getMetadataLength(), block.getBodyLength()));
+    LOGGER.debug("DictionaryRecordBatch at %d, metadata: %d, body: %d",
+        block.getOffset(), block.getMetadataLength(), block.getBodyLength());
     return block;
   }
 
   protected ArrowBlock writeRecordBatch(ArrowRecordBatch batch) throws IOException {
     ArrowBlock block = MessageSerializer.serialize(out, batch);
-    LOGGER.debug(String.format("RecordBatch at %d, metadata: %d, body: %d",
-        block.getOffset(), block.getMetadataLength(), block.getBodyLength()));
+    LOGGER.debug("RecordBatch at %d, metadata: %d, body: %d",
+        block.getOffset(), block.getMetadataLength(), block.getBodyLength());
     return block;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -50,7 +50,7 @@ public class ReadChannel implements AutoCloseable {
    * @throws IOException if nit enough bytes left to read
    */
   public int readFully(ByteBuffer buffer) throws IOException {
-    LOGGER.debug("Reading buffer with size: %d", buffer.remaining());
+    LOGGER.debug("Reading buffer with size: {}", buffer.remaining());
     int totalRead = 0;
     while (buffer.remaining() != 0) {
       int read = in.read(buffer);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -50,7 +50,7 @@ public class ReadChannel implements AutoCloseable {
    * @throws IOException if nit enough bytes left to read
    */
   public int readFully(ByteBuffer buffer) throws IOException {
-    LOGGER.debug("Reading buffer with size: " + buffer.remaining());
+    LOGGER.debug("Reading buffer with size: %d", buffer.remaining());
     int totalRead = 0;
     while (buffer.remaining() != 0) {
       int read = in.read(buffer);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -75,7 +75,7 @@ public class WriteChannel implements AutoCloseable {
 
   public long write(ByteBuffer buffer) throws IOException {
     long length = buffer.remaining();
-    LOGGER.debug("Writing buffer with size: %d", length);
+    LOGGER.debug("Writing buffer with size: {}", length);
     while (buffer.hasRemaining()) {
       out.write(buffer);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -75,7 +75,7 @@ public class WriteChannel implements AutoCloseable {
 
   public long write(ByteBuffer buffer) throws IOException {
     long length = buffer.remaining();
-    LOGGER.debug("Writing buffer with size: " + length);
+    LOGGER.debug("Writing buffer with size: %d", length);
     while (buffer.hasRemaining()) {
       out.write(buffer);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -72,7 +72,7 @@ public class ArrowRecordBatch implements ArrowMessage {
       arrowBuf.retain();
       long size = arrowBuf.readableBytes();
       arrowBuffers.add(new ArrowBuffer(offset, size));
-      LOGGER.debug(String.format("Buffer in RecordBatch at %d, length: %d", offset, size));
+      LOGGER.debug("Buffer in RecordBatch at %d, length: %d", offset, size);
       offset += size;
       if (alignBuffers && offset % 8 != 0) { // align on 8 byte boundaries
         offset += 8 - (offset % 8);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -72,7 +72,7 @@ public class ArrowRecordBatch implements ArrowMessage {
       arrowBuf.retain();
       long size = arrowBuf.readableBytes();
       arrowBuffers.add(new ArrowBuffer(offset, size));
-      LOGGER.debug("Buffer in RecordBatch at %d, length: %d", offset, size);
+      LOGGER.debug("Buffer in RecordBatch at {}, length: {}", offset, size);
       offset += size;
       if (alignBuffers && offset % 8 != 0) { // align on 8 byte boundaries
         offset += 8 - (offset % 8);


### PR DESCRIPTION
There are a few places where strings were unnecessarily created for logging purpose. For the scenario I profiled, for MessageSerializer.deserialize(), roughly 2/3 of the total CPU was spent in string.format() (inside ArrowRecordBatch)