### PR TITLE
ARROW-3693: [R] Invalid buffer for empty characters with null data

### DIFF
--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -539,7 +539,7 @@ inline SEXP StringArray_to_Vector(const std::shared_ptr<arrow::Array>& array) {
 
   Rcpp::CharacterVector res(no_init(n));
   auto p_offset = GetValuesSafely<int32_t>(array->data(), 1, array->offset());
-  auto p_data = GetValuesSafely<char>(array->data(), 2, *p_offset);
+  auto p_data = GetValuesOrNull<char>(array->data(), 2, *p_offset);
 
   if (null_count) {
     // need to watch for nulls

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -539,7 +539,7 @@ inline SEXP StringArray_to_Vector(const std::shared_ptr<arrow::Array>& array) {
 
   Rcpp::CharacterVector res(no_init(n));
   auto p_offset = GetValuesSafely<int32_t>(array->data(), 1, array->offset());
-  auto p_data = GetValuesOrNull<char>(array->data(), 2, *p_offset);
+  auto p_data = GetValuesSafely<char>(array->data(), 2, *p_offset);
 
   if (null_count) {
     // need to watch for nulls

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -132,17 +132,7 @@ inline const T* GetValuesSafely(const std::shared_ptr<ArrayData>& data, int i,
                                 int64_t offset) {
   auto buffer = data->buffers[i];
   if (!buffer) {
-    Rcpp::stop(tfm::format("invalid data in buffer %d", i));
-  };
-  return reinterpret_cast<const T*>(buffer->data()) + offset;
-}
-
-template <typename T>
-inline const T* GetValuesOrNull(const std::shared_ptr<ArrayData>& data, int i,
-                                int64_t offset) {
-  auto buffer = data->buffers[i];
-  if (!buffer) {
-    return reinterpret_cast<const T*>(NULL);
+    return nullptr;
   } else {
     return reinterpret_cast<const T*>(buffer->data()) + offset;
   }

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -137,6 +137,17 @@ inline const T* GetValuesSafely(const std::shared_ptr<ArrayData>& data, int i,
   return reinterpret_cast<const T*>(buffer->data()) + offset;
 }
 
+template <typename T>
+inline const T* GetValuesOrNull(const std::shared_ptr<ArrayData>& data, int i,
+                                int64_t offset) {
+  auto buffer = data->buffers[i];
+  if (!buffer) {
+    return reinterpret_cast<const T*>(NULL);
+  } else {
+    return reinterpret_cast<const T*>(buffer->data()) + offset;
+  }
+}
+
 template <int RTYPE, typename Vec = Rcpp::Vector<RTYPE>>
 class RBuffer : public MutableBuffer {
  public:


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/ARROW-3693.

Found a case while retrieving nullable-strings from Spark into R where a table like:

```
<database>   <name>    <temp>
""           "A"       TRUE
```

Triggers: `error: Failed to fetch data: invalid data in buffer`.

The issue seems to be that is valid to return a `NULL` array for the data buffer when there are only empty strings, the nulls array won't contain NULLs since the entries are not null, they are just empty and the offsets are set to 0s, since all entries are empty string that start and end at offset 0. There is a memory dump in the JIRA issue which explains this in more detail.

CC: @romainfrancois 