### PR TITLE
ARROW-3700: [C++] Ignore empty lines in CSV files

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -42,9 +42,12 @@ struct ARROW_EXPORT ParseOptions {
   char escape_char = '\\';
   // Whether values are allowed to contain CR (0x0d) and LF (0x0a) characters
   bool newlines_in_values = false;
+  // Whether empty lines are ignored.  If false, an empty line represents
+  // a single empty value (assuming a one-column CSV file).
+  bool ignore_empty_lines = true;
 
   // XXX Should this be in ReadOptions?
-  // Number of header rows to skip
+  // Number of header rows to skip (including the first row containing column names)
   int32_t header_rows = 1;
 
   static ParseOptions Defaults();

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -67,7 +67,9 @@ class ARROW_EXPORT BlockParser {
   /// The last row may lack a trailing line separator.
   Status ParseFinal(const char* data, uint32_t size, uint32_t* out_size);
 
+  /// \brief Return the number of parsed rows
   int32_t num_rows() const { return num_rows_; }
+  /// \brief Return the number of parsed columns
   int32_t num_cols() const { return num_cols_; }
   /// \brief Return the total size in bytes of parsed data
   uint32_t num_bytes() const { return parsed_size_; }

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -107,6 +107,10 @@ cdef class ParseOptions:
         Whether newline characters are allowed in CSV values.
         Setting this to True reduces the performance of multi-threaded
         CSV reading.
+    ignore_empty_lines: bool, optional (default True)
+        Whether empty lines are ignored in CSV input.
+        If False, an empty line is interpreted as containing a single empty
+        value (assuming a one-column CSV file).
     """
     cdef:
         CCSVParseOptions options
@@ -114,7 +118,8 @@ cdef class ParseOptions:
     __slots__ = ()
 
     def __init__(self, delimiter=None, quote_char=None, double_quote=None,
-                 escape_char=None, header_rows=None, newlines_in_values=None):
+                 escape_char=None, header_rows=None, newlines_in_values=None,
+                 ignore_empty_lines=None):
         self.options = CCSVParseOptions.Defaults()
         if delimiter is not None:
             self.delimiter = delimiter
@@ -128,6 +133,8 @@ cdef class ParseOptions:
             self.header_rows = header_rows
         if newlines_in_values is not None:
             self.newlines_in_values = newlines_in_values
+        if ignore_empty_lines is not None:
+            self.ignore_empty_lines = ignore_empty_lines
 
     @property
     def delimiter(self):
@@ -213,6 +220,19 @@ cdef class ParseOptions:
     @newlines_in_values.setter
     def newlines_in_values(self, value):
         self.options.newlines_in_values = value
+
+    @property
+    def ignore_empty_lines(self):
+        """
+        Whether empty lines are ignored in CSV input.
+        If False, an empty line is interpreted as containing a single empty
+        value (assuming a one-column CSV file).
+        """
+        return self.options.ignore_empty_lines
+
+    @ignore_empty_lines.setter
+    def ignore_empty_lines(self, value):
+        self.options.ignore_empty_lines = value
 
 
 cdef _get_reader(input_file, shared_ptr[InputStream]* out):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -942,6 +942,7 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         unsigned char escape_char
         int32_t header_rows
         c_bool newlines_in_values
+        c_bool ignore_empty_lines
 
         @staticmethod
         CCSVParseOptions Defaults()

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -84,6 +84,7 @@ def test_parse_options():
     assert opts.escape_char is False
     assert opts.header_rows == 1
     assert opts.newlines_in_values is False
+    assert opts.ignore_empty_lines is True
 
     opts.delimiter = 'x'
     assert opts.delimiter == 'x'
@@ -104,17 +105,22 @@ def test_parse_options():
     opts.newlines_in_values = True
     assert opts.newlines_in_values is True
 
+    opts.ignore_empty_lines = False
+    assert opts.ignore_empty_lines is False
+
     opts.header_rows = 2
     assert opts.header_rows == 2
 
     opts = cls(delimiter=';', quote_char='%', double_quote=False,
-               escape_char='\\', header_rows=2, newlines_in_values=True)
+               escape_char='\\', header_rows=2, newlines_in_values=True,
+               ignore_empty_lines=False)
     assert opts.delimiter == ';'
     assert opts.quote_char == '%'
     assert opts.double_quote is False
     assert opts.escape_char == '\\'
     assert opts.header_rows == 2
     assert opts.newlines_in_values is True
+    assert opts.ignore_empty_lines is False
 
 
 class BaseTestCSVRead:
@@ -192,9 +198,9 @@ class BaseTestCSVRead:
 
     def test_trivial(self):
         # A bit pointless, but at least it shouldn't crash
-        rows = b"\n\n"
+        rows = b",\n\n"
         table = self.read_bytes(rows)
-        assert table.to_pydict() == {'': [None]}
+        assert table.to_pydict() == {'': []}
 
     def test_invalid_csv(self):
         # Various CSV errors
@@ -204,9 +210,9 @@ class BaseTestCSVRead:
         rows = b"a,b,c\n1,2,3\n4"
         with pytest.raises(pa.ArrowInvalid, match="Expected 3 columns, got 1"):
             self.read_bytes(rows)
-        rows = b""
-        with pytest.raises(pa.ArrowInvalid, match="Empty CSV file"):
-            self.read_bytes(rows)
+        for rows in [b"", b"\n", b"\r\n", b"\r", b"\n\n"]:
+            with pytest.raises(pa.ArrowInvalid, match="Empty CSV file"):
+                self.read_bytes(rows)
 
     def test_options_delimiter(self):
         rows = b"a;b,c\nde,fg;eh\n"


### PR DESCRIPTION
The option is configurable, as it may be legitimate to parse empty lines as null values in a single-column CSV file (though that's probably uncommon).