### PR TITLE
ARROW-3704: [Gandiva][C++] Add missing include

### DIFF
--- a/cpp/src/gandiva/node.h
+++ b/cpp/src/gandiva/node.h
@@ -18,6 +18,7 @@
 #ifndef GANDIVA_EXPR_NODE_H
 #define GANDIVA_EXPR_NODE_H
 
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
It's needed for g++ 8.2.0 on Debian GNU/Linux:

    % g++ --version
    g++ (Debian 8.2.0-9) 8.2.0
    Copyright (C) 2018 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Error message:

    [ 67%] Building CXX object src/gandiva/CMakeFiles/expr_decomposer_test.dir/expr_decomposer_test.cc.o
    In file included from arrow/cpp/src/gandiva/expr_decomposer.h:29,
                     from arrow/cpp/src/gandiva/expr_decomposer_test.cc:18:
    arrow/cpp/src/gandiva/node.h: In member function 'virtual std::__cxx11::string gandiva::LiteralNode::ToString() const':
    arrow/cpp/src/gandiva/node.h:67:23: error: aggregate 'std::stringstream ss' has incomplete type and cannot be defined
         std::stringstream ss;
                           ^~
    arrow/cpp/src/gandiva/node.h: In member function 'virtual std::__cxx11::string gandiva::FunctionNode::ToString() const':
    arrow/cpp/src/gandiva/node.h:124:23: error: aggregate 'std::stringstream ss' has incomplete type and cannot be defined
         std::stringstream ss;
                           ^~
    arrow/cpp/src/gandiva/node.h: In member function 'virtual std::__cxx11::string gandiva::IfNode::ToString() const':
    arrow/cpp/src/gandiva/node.h:171:23: error: aggregate 'std::stringstream ss' has incomplete type and cannot be defined
         std::stringstream ss;
                           ^~
    ...