### PR TITLE
ARROW-3644: [Rust] Implement ListArrayBuilder

### DIFF
--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -294,11 +294,10 @@ impl_primitive_array_builder!(DataType::Int64, i64);
 impl_primitive_array_builder!(DataType::Float32, f32);
 impl_primitive_array_builder!(DataType::Float64, f64);
 
-
 ///  Array builder for `ListArray`
 pub struct ListArrayBuilder<T>
-    where
-        T: ArrowPrimitiveType,
+where
+    T: ArrowPrimitiveType,
 {
     offsets_builder: BufferBuilder<i32>,
     bitmap_builder: BufferBuilder<bool>,
@@ -336,7 +335,8 @@ macro_rules! impl_list_array_builder {
 
             /// Finish the current variable-length list array slot.
             pub fn append(&mut self, is_valid: bool) -> Result<()> {
-                self.offsets_builder.push(self.values_builder.len() as i32)?;
+                self.offsets_builder
+                    .push(self.values_builder.len() as i32)?;
                 self.bitmap_builder.push(is_valid)?;
                 self.len += 1;
                 Ok(())
@@ -364,7 +364,6 @@ macro_rules! impl_list_array_builder {
     };
 }
 
-
 impl_list_array_builder!(DataType::Boolean, bool);
 impl_list_array_builder!(DataType::UInt8, u8);
 impl_list_array_builder!(DataType::UInt16, u16);
@@ -376,7 +375,6 @@ impl_list_array_builder!(DataType::Int32, i32);
 impl_list_array_builder!(DataType::Int64, i64);
 impl_list_array_builder!(DataType::Float32, f32);
 impl_list_array_builder!(DataType::Float64, f64);
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -209,7 +209,6 @@ impl BufferBuilder<bool> {
 
 /// Trait for dealing with different array builders at runtime
 pub trait ArrayBuilder {
-
     /// The type of array that this builder creates
     type ArrayType;
 
@@ -221,8 +220,7 @@ pub trait ArrayBuilder {
     fn len(&self) -> i64;
 
     /// Builds the array
-    fn finish(self) -> Self:: ArrayType;
-
+    fn finish(self) -> Self::ArrayType;
 }
 
 ///  Array builder for fixed-width primitive types
@@ -367,17 +365,23 @@ macro_rules! impl_list_array_builder {
             /// Builds the `ListArray`
             fn finish(self) -> ListArray {
                 let len = self.len();
-                let values_arr = self.values_builder.into_any().downcast::<$native_ty>().unwrap().finish();
+                let values_arr = self
+                    .values_builder
+                    .into_any()
+                    .downcast::<$native_ty>()
+                    .unwrap()
+                    .finish();
                 let values_data = values_arr.data();
 
                 let null_bit_buffer = self.bitmap_builder.finish();
-                let data = ArrayData::builder(DataType::List(Box::new(values_data.data_type().clone())))
-                    .len(len)
-                    .null_count(len - bit_util::count_set_bits(null_bit_buffer.data()))
-                    .add_buffer(self.offsets_builder.finish())
-                    .add_child_data(values_data)
-                    .null_bit_buffer(null_bit_buffer)
-                    .build();
+                let data =
+                    ArrayData::builder(DataType::List(Box::new(values_data.data_type().clone())))
+                        .len(len)
+                        .null_count(len - bit_util::count_set_bits(null_bit_buffer.data()))
+                        .add_buffer(self.offsets_builder.finish())
+                        .add_child_data(values_data)
+                        .null_bit_buffer(null_bit_buffer)
+                        .build();
 
                 ListArray::from(data)
             }
@@ -400,7 +404,6 @@ macro_rules! impl_list_array_builder {
                 self.len += 1;
                 Ok(())
             }
-
         }
     };
 }
@@ -427,7 +430,6 @@ impl_list_array_builder!(ListArrayBuilder<PrimitiveArrayBuilder<i32>>);
 impl_list_array_builder!(ListArrayBuilder<PrimitiveArrayBuilder<i64>>);
 impl_list_array_builder!(ListArrayBuilder<PrimitiveArrayBuilder<f32>>);
 impl_list_array_builder!(ListArrayBuilder<PrimitiveArrayBuilder<f64>>);
-
 
 #[cfg(test)]
 mod tests {

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -344,7 +344,6 @@ macro_rules! impl_list_array_builder {
 
             /// Builds the `ListArray`
             pub fn finish(self) -> ListArray {
-
                 let len = self.len();
                 let values_arr = self.values_builder.finish();
                 let values_data = values_arr.data();
@@ -644,7 +643,10 @@ mod tests {
         let list_array = builder.finish();
 
         let values = list_array.values().data().buffers()[0].clone();
-        assert_eq!(Buffer::from(&[0, 1, 2, 3, 4, 5, 6, 7].to_byte_slice()), values);
+        assert_eq!(
+            Buffer::from(&[0, 1, 2, 3, 4, 5, 6, 7].to_byte_slice()),
+            values
+        );
         assert_eq!(DataType::Int32, list_array.value_type());
         assert_eq!(3, list_array.len());
         assert_eq!(0, list_array.null_count());


### PR DESCRIPTION
This implementation is only for `List<T>` where `T: ArrowPrimitiveType`.

It would be nice to allow the internal values builder to be any type of builder allowing the creation of `List<List<T>>` for instance.  I tried to do this but I struggled a little on how to design this.

I'm submitting this as an initial implementation, `List<T>` is all I need right now.  However, I'm interested on others thoughts on how we can expand this (maybe I'll follow up on the mailing list).