### PR TITLE
ARROW-3536: [C++] Add UTF8 validation functions

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -743,3 +743,29 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+The file cpp/src/arrow/util/utf8.h includes code adapted from the page
+  https://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+with the following license (MIT)
+
+Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -50,10 +50,11 @@ set(ARROW_SRCS
   util/decimal.cc
   util/hash.cc
   util/io-util.cc
+  util/logging.cc
   util/key_value_metadata.cc
   util/task-group.cc
   util/thread-pool.cc
-  util/logging.cc
+  util/utf8.cc
 )
 
 if ("${COMPILER_FAMILY}" STREQUAL "clang")

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -51,6 +51,7 @@ install(FILES
   string.h
   thread-pool.h
   type_traits.h
+  utf8.h
   variant.h
   visibility.h
   windows_compatibility.h
@@ -87,18 +88,20 @@ ADD_ARROW_TEST(checked-cast-test)
 ADD_ARROW_TEST(compression-test)
 ADD_ARROW_TEST(decimal-test)
 ADD_ARROW_TEST(key-value-metadata-test)
-ADD_ARROW_TEST(rle-encoding-test)
-ADD_ARROW_TEST(parsing-util-test)
-ADD_ARROW_TEST(stl-util-test)
-ADD_ARROW_TEST(thread-pool-test)
-ADD_ARROW_TEST(task-group-test)
 ADD_ARROW_TEST(lazy-test)
 ADD_ARROW_TEST(logging-test)
+ADD_ARROW_TEST(parsing-util-test)
+ADD_ARROW_TEST(rle-encoding-test)
+ADD_ARROW_TEST(stl-util-test)
+ADD_ARROW_TEST(task-group-test)
+ADD_ARROW_TEST(thread-pool-test)
+ADD_ARROW_TEST(utf8-util-test)
 
 ADD_ARROW_BENCHMARK(bit-util-benchmark)
 ADD_ARROW_BENCHMARK(compression-benchmark)
 ADD_ARROW_BENCHMARK(decimal-benchmark)
 ADD_ARROW_BENCHMARK(lazy-benchmark)
 ADD_ARROW_BENCHMARK(number-parsing-benchmark)
+ADD_ARROW_BENCHMARK(utf8-util-benchmark)
 
 add_subdirectory(variant)

--- a/cpp/src/arrow/util/utf8-util-benchmark.cc
+++ b/cpp/src/arrow/util/utf8-util-benchmark.cc
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include "arrow/test-util.h"
+#include "arrow/util/utf8.h"
+
+namespace arrow {
+namespace util {
+
+static const char* tiny_valid_ascii = "characters";
+static const char* tiny_valid_non_ascii = "caractères";
+
+static const char* valid_ascii =
+    "UTF-8 is a variable width character encoding capable of encoding all 1,112,064 "
+    "valid code points in Unicode using one to four 8-bit bytes";
+// Note this is almost ASCII.  We could devise a harder benchmark with lots
+// of non-ASCII characters inside.
+static const char* valid_non_ascii =
+    "UTF-8 est un codage de caractères informatiques conçu pour coder l’ensemble des "
+    "caractères du « répertoire universel de caractères codés »";
+
+static std::string MakeLargeString(const std::string& base, int64_t nbytes) {
+  int64_t nrepeats = (nbytes + base.size() - 1) / base.size();
+  std::string s;
+  s.reserve(nrepeats * nbytes);
+  for (int64_t i = 0; i < nrepeats; ++i) {
+    s += base;
+  }
+  return s;
+}
+
+static void BenchmarkUTF8Validation(
+    benchmark::State& state,  // NOLINT non-const reference
+    const std::string& s, bool expected) {
+  auto data = reinterpret_cast<const uint8_t*>(s.data());
+  auto data_size = static_cast<int64_t>(s.size());
+
+  bool b = ValidateUTF8(data, data_size);
+  if (b != expected) {
+    std::cerr << "Unexpected validation result" << std::endl;
+    std::abort();
+  }
+
+  while (state.KeepRunning()) {
+    bool b = ValidateUTF8(data, data_size);
+    benchmark::DoNotOptimize(b);
+  }
+  state.SetBytesProcessed(state.iterations() * s.size());
+}
+
+static void BM_ValidateTinyAscii(benchmark::State& state) {  // NOLINT non-const reference
+  BenchmarkUTF8Validation(state, tiny_valid_ascii, true);
+}
+
+static void BM_ValidateTinyNonAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  BenchmarkUTF8Validation(state, tiny_valid_non_ascii, true);
+}
+
+static void BM_ValidateSmallAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  BenchmarkUTF8Validation(state, valid_ascii, true);
+}
+
+static void BM_ValidateSmallNonAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  BenchmarkUTF8Validation(state, valid_non_ascii, true);
+}
+
+static void BM_ValidateLargeAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  auto s = MakeLargeString(valid_ascii, 100000);
+  BenchmarkUTF8Validation(state, s, true);
+}
+
+static void BM_ValidateLargeNonAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  auto s = MakeLargeString(valid_non_ascii, 100000);
+  BenchmarkUTF8Validation(state, s, true);
+}
+
+static const int kRepetitions = 1;
+
+BENCHMARK(BM_ValidateTinyAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateTinyNonAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateSmallAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateSmallNonAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateLargeAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateLargeNonAscii)->Repetitions(kRepetitions);
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/utf8-util-benchmark.cc
+++ b/cpp/src/arrow/util/utf8-util-benchmark.cc
@@ -33,11 +33,12 @@ static const char* tiny_valid_non_ascii = "caractères";
 static const char* valid_ascii =
     "UTF-8 is a variable width character encoding capable of encoding all 1,112,064 "
     "valid code points in Unicode using one to four 8-bit bytes";
-// Note this is almost ASCII.  We could devise a harder benchmark with lots
-// of non-ASCII characters inside.
-static const char* valid_non_ascii =
+static const char* valid_almost_ascii =
     "UTF-8 est un codage de caractères informatiques conçu pour coder l’ensemble des "
     "caractères du « répertoire universel de caractères codés »";
+static const char* valid_non_ascii =
+    "UTF-8 はISO/IEC 10646 (UCS) "
+    "とUnicodeで使える8ビット符号単位の文字符号化形式及び文字符号化スキーム。 ";
 
 static std::string MakeLargeString(const std::string& base, int64_t nbytes) {
   int64_t nrepeats = (nbytes + base.size() - 1) / base.size();
@@ -83,6 +84,11 @@ static void BM_ValidateSmallAscii(
   BenchmarkUTF8Validation(state, valid_ascii, true);
 }
 
+static void BM_ValidateSmallAlmostAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  BenchmarkUTF8Validation(state, valid_almost_ascii, true);
+}
+
 static void BM_ValidateSmallNonAscii(
     benchmark::State& state) {  // NOLINT non-const reference
   BenchmarkUTF8Validation(state, valid_non_ascii, true);
@@ -91,6 +97,12 @@ static void BM_ValidateSmallNonAscii(
 static void BM_ValidateLargeAscii(
     benchmark::State& state) {  // NOLINT non-const reference
   auto s = MakeLargeString(valid_ascii, 100000);
+  BenchmarkUTF8Validation(state, s, true);
+}
+
+static void BM_ValidateLargeAlmostAscii(
+    benchmark::State& state) {  // NOLINT non-const reference
+  auto s = MakeLargeString(valid_almost_ascii, 100000);
   BenchmarkUTF8Validation(state, s, true);
 }
 
@@ -105,8 +117,10 @@ static const int kRepetitions = 1;
 BENCHMARK(BM_ValidateTinyAscii)->Repetitions(kRepetitions);
 BENCHMARK(BM_ValidateTinyNonAscii)->Repetitions(kRepetitions);
 BENCHMARK(BM_ValidateSmallAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateSmallAlmostAscii)->Repetitions(kRepetitions);
 BENCHMARK(BM_ValidateSmallNonAscii)->Repetitions(kRepetitions);
 BENCHMARK(BM_ValidateLargeAscii)->Repetitions(kRepetitions);
+BENCHMARK(BM_ValidateLargeAlmostAscii)->Repetitions(kRepetitions);
 BENCHMARK(BM_ValidateLargeNonAscii)->Repetitions(kRepetitions);
 
 }  // namespace util

--- a/cpp/src/arrow/util/utf8-util-benchmark.cc
+++ b/cpp/src/arrow/util/utf8-util-benchmark.cc
@@ -55,6 +55,7 @@ static void BenchmarkUTF8Validation(
   auto data = reinterpret_cast<const uint8_t*>(s.data());
   auto data_size = static_cast<int64_t>(s.size());
 
+  InitializeUTF8();
   bool b = ValidateUTF8(data, data_size);
   if (b != expected) {
     std::cerr << "Unexpected validation result" << std::endl;

--- a/cpp/src/arrow/util/utf8-util-test.cc
+++ b/cpp/src/arrow/util/utf8-util-test.cc
@@ -30,6 +30,8 @@ namespace util {
 class UTF8Test : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
+    InitializeUTF8();
+
     all_valid_sequences.clear();
     for (const auto& v :
          {valid_sequences_1, valid_sequences_2, valid_sequences_3, valid_sequences_4}) {

--- a/cpp/src/arrow/util/utf8-util-test.cc
+++ b/cpp/src/arrow/util/utf8-util-test.cc
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <random>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/util/string.h"
+#include "arrow/util/utf8.h"
+
+namespace arrow {
+namespace util {
+
+class UTF8Test : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    all_valid_sequences.clear();
+    for (const auto& v :
+         {valid_sequences_1, valid_sequences_2, valid_sequences_3, valid_sequences_4}) {
+      all_valid_sequences.insert(all_valid_sequences.end(), v.begin(), v.end());
+    }
+
+    all_invalid_sequences.clear();
+    for (const auto& v : {invalid_sequences_1, invalid_sequences_2, invalid_sequences_3,
+                          invalid_sequences_4}) {
+      all_invalid_sequences.insert(all_invalid_sequences.end(), v.begin(), v.end());
+    }
+  }
+
+  static std::vector<std::string> valid_sequences_1;
+  static std::vector<std::string> valid_sequences_2;
+  static std::vector<std::string> valid_sequences_3;
+  static std::vector<std::string> valid_sequences_4;
+
+  static std::vector<std::string> all_valid_sequences;
+
+  static std::vector<std::string> invalid_sequences_1;
+  static std::vector<std::string> invalid_sequences_2;
+  static std::vector<std::string> invalid_sequences_3;
+  static std::vector<std::string> invalid_sequences_4;
+
+  static std::vector<std::string> all_invalid_sequences;
+};
+
+std::vector<std::string> UTF8Test::valid_sequences_1 = {"a", "\x7f"};
+std::vector<std::string> UTF8Test::valid_sequences_2 = {"\xc2\x80", "\xc3\xbf",
+                                                        "\xdf\xbf"};
+std::vector<std::string> UTF8Test::valid_sequences_3 = {"\xe0\xa0\x80", "\xe8\x9d\xa5",
+                                                        "\xef\xbf\xbf"};
+std::vector<std::string> UTF8Test::valid_sequences_4 = {
+    "\xf0\x90\x80\x80", "\xf0\x9f\xbf\xbf", "\xf4\x80\x80\x80", "\xf4\x8f\xbf\xbf"};
+
+std::vector<std::string> UTF8Test::all_valid_sequences;
+
+std::vector<std::string> UTF8Test::invalid_sequences_1 = {"\x80", "\xa0", "\xbf", "\xc0",
+                                                          "\xc1"};
+std::vector<std::string> UTF8Test::invalid_sequences_2 = {
+    "\x80\x80", "\x80\xbf", "\xbf\x80", "\xbf\xbf",
+    "\xc1\x80", "\xc2\x7f", "\xc3\xff", "\xdf\xc0"};
+std::vector<std::string> UTF8Test::invalid_sequences_3 = {
+    "\xe0\x80\x80", "\xe0\x9f\x80", "\xef\xbf\xc0", "\xef\xc0\xbf", "\xef\xff\xff",
+    // Surrogates
+    "\xed\xa0\x80", "\xed\xbf\xbf"};
+std::vector<std::string> UTF8Test::invalid_sequences_4 = {
+    "\xf0\x80\x80\x80", "\xf0\x8f\x80\x80", "\xf4\x8f\xbf\xc0", "\xf4\x8f\xc0\xbf",
+    "\xf4\x90\x80\x80"};
+
+std::vector<std::string> UTF8Test::all_invalid_sequences;
+
+class UTF8ValidationTest : public UTF8Test {};
+
+::testing::AssertionResult IsValidUTF8(const std::string& s) {
+  if (ValidateUTF8(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
+    return ::testing::AssertionSuccess();
+  } else {
+    std::string h = HexEncode(reinterpret_cast<const uint8_t*>(s.data()),
+                              static_cast<int32_t>(s.size()));
+    return ::testing::AssertionFailure()
+           << "string '" << h << "' didn't validate as UTF8";
+  }
+}
+
+::testing::AssertionResult IsInvalidUTF8(const std::string& s) {
+  if (!ValidateUTF8(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
+    return ::testing::AssertionSuccess();
+  } else {
+    std::string h = HexEncode(reinterpret_cast<const uint8_t*>(s.data()),
+                              static_cast<int32_t>(s.size()));
+    return ::testing::AssertionFailure() << "string '" << h << "' validated as UTF8";
+  }
+}
+
+void AssertValidUTF8(const std::string& s) { ASSERT_TRUE(IsValidUTF8(s)); }
+
+void AssertInvalidUTF8(const std::string& s) { ASSERT_TRUE(IsInvalidUTF8(s)); }
+
+TEST_F(UTF8ValidationTest, EmptyString) { AssertValidUTF8(""); }
+
+TEST_F(UTF8ValidationTest, OneCharacterValid) {
+  for (const auto& s : all_valid_sequences) {
+    AssertValidUTF8(s);
+  }
+}
+
+TEST_F(UTF8ValidationTest, TwoCharacterValid) {
+  for (const auto& s1 : all_valid_sequences) {
+    for (const auto& s2 : all_valid_sequences) {
+      AssertValidUTF8(s1 + s2);
+    }
+  }
+}
+
+TEST_F(UTF8ValidationTest, RandomValid) {
+#ifdef ARROW_VALGRIND
+  const int niters = 50;
+#else
+  const int niters = 1000;
+#endif
+  const int nchars = 100;
+  std::default_random_engine gen(42);
+  std::uniform_int_distribution<size_t> valid_dist(0, all_valid_sequences.size() - 1);
+
+  for (int i = 0; i < niters; ++i) {
+    std::string s;
+    s.reserve(nchars * 4);
+    for (int j = 0; j < nchars; ++j) {
+      s += all_valid_sequences[valid_dist(gen)];
+    }
+    AssertValidUTF8(s);
+  }
+}
+
+TEST_F(UTF8ValidationTest, OneCharacterTruncated) {
+  for (const auto& s : all_valid_sequences) {
+    if (s.size() > 1) {
+      AssertInvalidUTF8(s.substr(0, s.size() - 1));
+    }
+  }
+}
+
+TEST_F(UTF8ValidationTest, TwoCharacterTruncated) {
+  for (const auto& s1 : all_valid_sequences) {
+    for (const auto& s2 : all_valid_sequences) {
+      if (s2.size() > 1) {
+        AssertInvalidUTF8(s1 + s2.substr(0, s2.size() - 1));
+        AssertInvalidUTF8(s2.substr(0, s2.size() - 1) + s1);
+      }
+    }
+  }
+}
+
+TEST_F(UTF8ValidationTest, OneCharacterInvalid) {
+  for (const auto& s : all_invalid_sequences) {
+    AssertInvalidUTF8(s);
+  }
+}
+
+TEST_F(UTF8ValidationTest, TwoCharacterInvalid) {
+  for (const auto& s1 : all_valid_sequences) {
+    for (const auto& s2 : all_invalid_sequences) {
+      AssertInvalidUTF8(s1 + s2);
+      AssertInvalidUTF8(s2 + s1);
+    }
+  }
+  for (const auto& s1 : all_invalid_sequences) {
+    for (const auto& s2 : all_invalid_sequences) {
+      AssertInvalidUTF8(s1 + s2);
+    }
+  }
+}
+
+TEST_F(UTF8ValidationTest, RandomInvalid) {
+#ifdef ARROW_VALGRIND
+  const int niters = 50;
+#else
+  const int niters = 1000;
+#endif
+  const int nchars = 100;
+  std::default_random_engine gen(42);
+  std::uniform_int_distribution<size_t> valid_dist(0, all_valid_sequences.size() - 1);
+  std::uniform_int_distribution<int> invalid_pos_dist(0, nchars - 1);
+  std::uniform_int_distribution<size_t> invalid_dist(0, all_invalid_sequences.size() - 1);
+
+  for (int i = 0; i < niters; ++i) {
+    std::string s;
+    s.reserve(nchars * 4);
+    // Stuff a single invalid sequence somewhere in a valid UTF8 stream
+    int invalid_pos = invalid_pos_dist(gen);
+    for (int j = 0; j < nchars; ++j) {
+      if (j == invalid_pos) {
+        s += all_invalid_sequences[invalid_dist(gen)];
+      } else {
+        s += all_valid_sequences[valid_dist(gen)];
+      }
+    }
+    AssertInvalidUTF8(s);
+  }
+}
+
+TEST_F(UTF8ValidationTest, RandomTruncated) {
+#ifdef ARROW_VALGRIND
+  const int niters = 50;
+#else
+  const int niters = 1000;
+#endif
+  const int nchars = 100;
+  std::default_random_engine gen(42);
+  std::uniform_int_distribution<size_t> valid_dist(0, all_valid_sequences.size() - 1);
+  std::uniform_int_distribution<int> invalid_pos_dist(0, nchars - 1);
+
+  for (int i = 0; i < niters; ++i) {
+    std::string s;
+    s.reserve(nchars * 4);
+    // Truncate a single sequence somewhere in a valid UTF8 stream
+    int invalid_pos = invalid_pos_dist(gen);
+    for (int j = 0; j < nchars; ++j) {
+      if (j == invalid_pos) {
+        while (true) {
+          // Ensure we truncate a 2-byte or more sequence
+          const std::string& t = all_valid_sequences[valid_dist(gen)];
+          if (t.size() > 1) {
+            s += t.substr(0, t.size() - 1);
+            break;
+          }
+        }
+      } else {
+        s += all_valid_sequences[valid_dist(gen)];
+      }
+    }
+    AssertInvalidUTF8(s);
+  }
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <mutex>
+
+#include "arrow/util/logging.h"
+#include "arrow/util/utf8.h"
+
+namespace arrow {
+namespace util {
+namespace internal {
+
+// Copyright (c) 2008-2010 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+// See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+// clang-format off
+const uint8_t utf8_small_table[] = { // NOLINT
+  // The first part of the table maps bytes to character classes that
+  // to reduce the size of the transition table and create bitmasks.
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,  9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,  // NOLINT
+   7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  // NOLINT
+   8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  // NOLINT
+  10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,  // NOLINT
+
+  // The second part is a transition table that maps a combination
+  // of a state of the automaton and a character class to a state.
+  // Character classes are between 0 and 11, states are multiples of 12.
+   0,12,24,36,60,96,84,12,12,12,48,72, 12,12,12,12,12,12,12,12,12,12,12,12,  // NOLINT
+  12, 0,12,12,12,12,12, 0,12, 0,12,12, 12,24,12,12,12,12,12,24,12,24,12,12,  // NOLINT
+  12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,  // NOLINT
+  12,12,12,12,12,12,12,36,12,36,12,12, 12,36,12,12,12,12,12,36,12,36,12,12,  // NOLINT
+  12,36,12,12,12,12,12,12,12,12,12,12,  // NOLINT
+};
+// clang-format on
+
+uint16_t utf8_large_table[9 * 256] = {0xffff};
+
+static void InitializeLargeTable() {
+  for (uint32_t state = 0; state < 9; ++state) {
+    for (uint32_t byte = 0; byte < 256; ++byte) {
+      uint32_t byte_class = utf8_small_table[byte];
+      uint8_t next_state = utf8_small_table[256 + state * 12 + byte_class] / 12;
+      DCHECK_LT(next_state, 9);
+      utf8_large_table[state * 256 + byte] = next_state * 256;
+    }
+  }
+}
+
+#ifndef NDEBUG
+ARROW_EXPORT void CheckUTF8Initialized() {
+  DCHECK_EQ(utf8_large_table[0], 0)
+      << "InitializeUTF8() must be called before calling UTF8 routines";
+}
+#endif
+
+}  // namespace internal
+
+static std::once_flag utf8_initialized;
+
+void InitializeUTF8() {
+  std::call_once(utf8_initialized, internal::InitializeLargeTable);
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -59,7 +59,7 @@ static void InitializeLargeTable() {
       uint32_t byte_class = utf8_small_table[byte];
       uint8_t next_state = utf8_small_table[256 + state * 12 + byte_class] / 12;
       DCHECK_LT(next_state, 9);
-      utf8_large_table[state * 256 + byte] = next_state * 256;
+      utf8_large_table[state * 256 + byte] = static_cast<uint16_t>(next_state * 256);
     }
   }
 }

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_UTIL_UTF8_H
+#define ARROW_UTIL_UTF8_H
+
+#include <cstdint>
+#include <memory>
+
+#include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace util {
+
+namespace internal {
+
+// Copyright (c) 2008-2010 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+// See http://bjoern.hoehrmann.de/utf-8/decoder/dfa/ for details.
+
+static constexpr uint8_t kUTF8Accept = 0;
+static constexpr uint8_t kUTF8Reject = 12;
+
+// clang-format off
+static const uint8_t utf8d[] = { // NOLINT
+  // The first part of the table maps bytes to character classes that
+  // to reduce the size of the transition table and create bitmasks.
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  // NOLINT
+   1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,  9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,  // NOLINT
+   7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  // NOLINT
+   8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  // NOLINT
+  10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,  // NOLINT
+
+  // The second part is a transition table that maps a combination
+  // of a state of the automaton and a character class to a state.
+  // Character classes are between 0 and 11, states are multiples of 12.
+   0,12,24,36,60,96,84,12,12,12,48,72, 12,12,12,12,12,12,12,12,12,12,12,12,  // NOLINT
+  12, 0,12,12,12,12,12, 0,12, 0,12,12, 12,24,12,12,12,12,12,24,12,24,12,12,  // NOLINT
+  12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,  // NOLINT
+  12,12,12,12,12,12,12,36,12,36,12,12, 12,36,12,12,12,12,12,36,12,36,12,12,  // NOLINT
+  12,36,12,12,12,12,12,12,12,12,12,12,  // NOLINT
+};
+// clang-format on
+
+static inline uint8_t DecodeOneUTF8Byte(uint8_t byte, uint8_t state, uint32_t* codep) {
+  uint8_t type = utf8d[byte];
+
+  *codep =
+      (state != kUTF8Accept) ? (byte & 0x3fu) | (*codep << 6) : (0xff >> type) & (byte);
+
+  state = utf8d[256 + state + type];
+  return state;
+}
+
+static inline uint8_t ValidateOneUTF8Byte(uint8_t byte, uint8_t state) {
+  uint32_t codepoint;
+  return DecodeOneUTF8Byte(byte, state, &codepoint);
+}
+
+}  // namespace internal
+
+inline bool ValidateUTF8(const uint8_t* data, int64_t size) {
+  static constexpr int64_t high_bits = 0x8080808080808080LL;
+
+  while (size >= 8) {
+    // XXX This is doing an unaligned access.  Contemporary architectures
+    // accept it and often have good performance nevertheless.
+    int64_t mask = *reinterpret_cast<const int64_t*>(data) & high_bits;
+    if (ARROW_PREDICT_TRUE(mask == 0)) {
+      // 8 bytes of pure ASCII, move forward
+      size -= 8;
+      data += 8;
+    } else {
+      // Loop over individual bytes until we either get a full char or a rejection
+      uint8_t state = internal::kUTF8Accept;
+      do {
+        state = internal::ValidateOneUTF8Byte(*data++, state);
+        --size;
+      } while (state > internal::kUTF8Reject);
+      if (ARROW_PREDICT_FALSE(state == internal::kUTF8Reject)) {
+        return false;
+      }
+    }
+  }
+
+  // Validate string tail one byte at a time
+  // Note the state table is designed so that, once in the reject state,
+  // we remain in that state until the end.  So we needn't check for
+  // rejection at each char (we don't gain much by short-circuiting at the end).
+  uint8_t state = internal::kUTF8Accept;
+  while (size-- > 0) {
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+  }
+  return ARROW_PREDICT_TRUE(state == internal::kUTF8Accept);
+}
+
+}  // namespace util
+}  // namespace arrow
+
+#endif

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -79,12 +79,13 @@ static inline uint8_t ValidateOneUTF8Byte(uint8_t byte, uint8_t state) {
 
 inline bool ValidateUTF8(const uint8_t* data, int64_t size) {
   static constexpr uint64_t high_bits_64 = 0x8080808080808080ULL;
+  // For some reason, defining this variable outside the loop helps clang
+  uint64_t mask;
 
   while (size >= 8) {
     // XXX This is doing an unaligned access.  Contemporary architectures
     // (x86-64, AArch64, PPC64) support it natively and often have good
     // performance nevertheless.
-    uint64_t mask;
     memcpy(&mask, data, 8);
     if (ARROW_PREDICT_TRUE((mask & high_bits_64) == 0)) {
       // 8 bytes of pure ASCII, move forward

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -19,6 +19,7 @@
 #define ARROW_UTIL_UTF8_H
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 
 #include "arrow/util/macros.h"
@@ -77,33 +78,73 @@ static inline uint8_t ValidateOneUTF8Byte(uint8_t byte, uint8_t state) {
 }  // namespace internal
 
 inline bool ValidateUTF8(const uint8_t* data, int64_t size) {
-  static constexpr int64_t high_bits = 0x8080808080808080LL;
+  static constexpr uint64_t high_bits_64 = 0x8080808080808080ULL;
 
   while (size >= 8) {
     // XXX This is doing an unaligned access.  Contemporary architectures
-    // accept it and often have good performance nevertheless.
-    int64_t mask = *reinterpret_cast<const int64_t*>(data) & high_bits;
-    if (ARROW_PREDICT_TRUE(mask == 0)) {
+    // (x86-64, AArch64, PPC64) support it natively and often have good
+    // performance nevertheless.
+    uint64_t mask;
+    memcpy(&mask, data, 8);
+    if (ARROW_PREDICT_TRUE((mask & high_bits_64) == 0)) {
       // 8 bytes of pure ASCII, move forward
       size -= 8;
       data += 8;
-    } else {
-      // Loop over individual bytes until we either get a full char or a rejection
-      uint8_t state = internal::kUTF8Accept;
-      do {
-        state = internal::ValidateOneUTF8Byte(*data++, state);
-        --size;
-      } while (state > internal::kUTF8Reject);
-      if (ARROW_PREDICT_FALSE(state == internal::kUTF8Reject)) {
-        return false;
-      }
+      continue;
     }
+    // Non-ASCII run detected.
+    // We process at least 4 bytes, to avoid too many spurious 64-bit reads
+    // in case the non-ASCII bytes are at the end of the tested 64-bit word.
+    // We also only check for rejection at the end since that state is stable
+    // (once in reject state, we always remain in reject state).
+    // It is guaranteed that size >= 8 when arriving here, which allows
+    // us to avoid size checks.
+    uint8_t state = internal::kUTF8Accept;
+    // Byte 0
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    // Byte 1
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    // Byte 2
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    // Byte 3
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    // Byte 4
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    if (state == internal::kUTF8Accept) {
+      continue;  // Got full char, switch back to ASCII detection
+    }
+    // Byte 5
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    if (state == internal::kUTF8Accept) {
+      continue;  // Got full char, switch back to ASCII detection
+    }
+    // Byte 6
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    if (state == internal::kUTF8Accept) {
+      continue;  // Got full char, switch back to ASCII detection
+    }
+    // Byte 7
+    state = internal::ValidateOneUTF8Byte(*data++, state);
+    --size;
+    if (state == internal::kUTF8Accept) {
+      continue;  // Got full char, switch back to ASCII detection
+    }
+    // kUTF8Accept not reached along 4 transitions has to mean a rejection
+    assert(state == internal::kUTF8Reject);
+    return false;
   }
 
   // Validate string tail one byte at a time
   // Note the state table is designed so that, once in the reject state,
   // we remain in that state until the end.  So we needn't check for
-  // rejection at each char (we don't gain much by short-circuiting at the end).
+  // rejection at each char (we don't gain much by short-circuiting here).
   uint8_t state = internal::kUTF8Accept;
   while (size-- > 0) {
     state = internal::ValidateOneUTF8Byte(*data++, state);


### PR DESCRIPTION
The baseline UTF8 decoder is adapted from Bjoern Hoehrmann's DFA-based implementation.
The common case of runs of ASCII chars benefit from a fast path handling 8 bytes at a time.

Benchmark results (on a Ryzen 7 machine with gcc 7.3):
```
-----------------------------------------------------------------------------
Benchmark                                      Time           CPU Iterations
-----------------------------------------------------------------------------
BM_ValidateTinyAscii/repeats:1                 3 ns          3 ns  245245630   3.26202GB/s
BM_ValidateTinyNonAscii/repeats:1              7 ns          7 ns  104679950   1.54295GB/s
BM_ValidateSmallAscii/repeats:1               10 ns         10 ns   66365983   13.0928GB/s
BM_ValidateSmallAlmostAscii/repeats:1         37 ns         37 ns   18755439   3.69415GB/s
BM_ValidateSmallNonAscii/repeats:1            68 ns         68 ns   10267387   1.82934GB/s
BM_ValidateLargeAscii/repeats:1             4140 ns       4140 ns     171331   22.5003GB/s
BM_ValidateLargeAlmostAscii/repeats:1      24472 ns      24468 ns      28565   3.80816GB/s
BM_ValidateLargeNonAscii/repeats:1         50420 ns      50411 ns      13830   1.84927GB/s
```

The case of tiny strings is probably the most important for the use case of CSV type inference.

PS: benchmarks on the same machine with clang 6.0:
```
-----------------------------------------------------------------------------
Benchmark                                      Time           CPU Iterations
-----------------------------------------------------------------------------
BM_ValidateTinyAscii/repeats:1                 3 ns          3 ns  213945214   2.84658GB/s
BM_ValidateTinyNonAscii/repeats:1              8 ns          8 ns   90916423   1.33072GB/s
BM_ValidateSmallAscii/repeats:1                7 ns          7 ns   91498265   17.4425GB/s
BM_ValidateSmallAlmostAscii/repeats:1         34 ns         34 ns   20750233   4.08138GB/s
BM_ValidateSmallNonAscii/repeats:1            58 ns         58 ns   12063206   2.14002GB/s
BM_ValidateLargeAscii/repeats:1             3999 ns       3999 ns     175099   23.2937GB/s
BM_ValidateLargeAlmostAscii/repeats:1      21783 ns      21779 ns      31738   4.27822GB/s
BM_ValidateLargeNonAscii/repeats:1         55162 ns      55153 ns      12526   1.69028GB/s
```
