### PR TITLE
ARROW-3407: [C++] Add UTF8 handling to CSV conversion

### DIFF
--- a/cpp/src/arrow/csv/column-builder.cc
+++ b/cpp/src/arrow/csv/column-builder.cc
@@ -155,7 +155,7 @@ class InferringColumnBuilder : public ColumnBuilder {
   std::shared_ptr<Converter> converter_;
 
   // Current inference status
-  enum class InferKind { Null, Integer, Real, Text };
+  enum class InferKind { Null, Integer, Real, Text, Binary };
 
   std::shared_ptr<DataType> infer_type_;
   InferKind infer_kind_;
@@ -185,6 +185,9 @@ Status InferringColumnBuilder::LoosenType() {
       infer_kind_ = InferKind::Text;
       break;
     case InferKind::Text:
+      infer_kind_ = InferKind::Binary;
+      break;
+    case InferKind::Binary:
       return Status::UnknownError("Shouldn't come here");
   }
   return UpdateType();
@@ -207,6 +210,10 @@ Status InferringColumnBuilder::UpdateType() {
       can_loosen_type_ = true;
       break;
     case InferKind::Text:
+      infer_type_ = utf8();
+      can_loosen_type_ = true;
+      break;
+    case InferKind::Binary:
       infer_type_ = binary();
       can_loosen_type_ = false;
       break;

--- a/cpp/src/arrow/csv/converter.h
+++ b/cpp/src/arrow/csv/converter.h
@@ -55,6 +55,8 @@ class ARROW_EXPORT Converter {
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Converter);
 
+  virtual Status Initialize() = 0;
+
   ConvertOptions options_;
   MemoryPool* pool_;
   std::shared_ptr<DataType> type_;

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -51,6 +51,11 @@ struct ARROW_EXPORT ParseOptions {
 };
 
 struct ARROW_EXPORT ConvertOptions {
+  // Conversion options
+
+  // Whether to check UTF8 validity of string columns
+  bool check_utf8 = true;
+
   static ConvertOptions Defaults();
 };
 

--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -350,6 +350,7 @@ CSV Files
 
    ReadOptions
    ParseOptions
+   ConvertOptions
    read_csv
 
 .. currentmodule:: pyarrow.parquet

--- a/python/doc/source/csv.rst
+++ b/python/doc/source/csv.rst
@@ -29,7 +29,7 @@ The features currently offered are the following:
   such as ``my_data.csv.gz``)
 * fetching column names from the first row in the CSV file
 * column-wise type inference and conversion to one of ``null``, ``int64``,
-  ``float64`` or ``binary`` data
+  ``float64``, ``string`` or ``binary`` data
 * detecting various spellings of null values such as ``NaN`` or ``#N/A``
 
 Usage
@@ -46,21 +46,21 @@ with the file path you want to read from::
    pyarrow.Table
    total_bill: double
    tip: double
-   sex: binary
-   smoker: binary
-   day: binary
-   time: binary
+   sex: string
+   smoker: string
+   day: string
+   time: string
    size: int64
    >>> len(table)
    244
    >>> df = table.to_pandas()
    >>> df.head()
-      total_bill   tip        sex smoker     day       time  size
-   0       16.99  1.01  b'Female'  b'No'  b'Sun'  b'Dinner'     2
-   1       10.34  1.66    b'Male'  b'No'  b'Sun'  b'Dinner'     3
-   2       21.01  3.50    b'Male'  b'No'  b'Sun'  b'Dinner'     3
-   3       23.68  3.31    b'Male'  b'No'  b'Sun'  b'Dinner'     2
-   4       24.59  3.61  b'Female'  b'No'  b'Sun'  b'Dinner'     4
+      total_bill   tip     sex smoker  day    time  size
+   0       16.99  1.01  Female     No  Sun  Dinner     2
+   1       10.34  1.66    Male     No  Sun  Dinner     3
+   2       21.01  3.50    Male     No  Sun  Dinner     3
+   3       23.68  3.31    Male     No  Sun  Dinner     2
+   4       24.59  3.61  Female     No  Sun  Dinner     4
 
 Customized parsing
 ------------------
@@ -69,11 +69,17 @@ To alter the default parsing settings in case of reading CSV files with an
 unusual structure, you should create a :class:`ParseOptions` instance
 and pass it to :func:`read_csv`.
 
+Customized conversion
+---------------------
+
+To alter how CSV data is converted to Arrow types and data, you should create
+a :class:`ConvertOptions` instance and pass it to :func:`read_csv`.
+
 Limitations
 -----------
 
 Arrow is not able to detect or convert other data types (such as dates
-and times) than the four mentioned above.  It is also not possible to
+and times) than the five mentioned above.  It is also not possible to
 choose the data types of columns explicitly.
 
 Performance

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -215,6 +215,38 @@ cdef class ParseOptions:
         self.options.newlines_in_values = value
 
 
+cdef class ConvertOptions:
+    """
+    Options for converting CSV data.
+
+    Parameters
+    ----------
+    check_utf8 : bool, optional (default True)
+        Whether to check UTF8 validity of string columns.
+    """
+    cdef:
+        CCSVConvertOptions options
+
+    # Avoid mistakingly creating attributes
+    __slots__ = ()
+
+    def __init__(self, check_utf8=None):
+        self.options = CCSVConvertOptions.Defaults()
+        if check_utf8 is not None:
+            self.check_utf8 = check_utf8
+
+    @property
+    def check_utf8(self):
+        """
+        Whether to check UTF8 validity of string columns.
+        """
+        return self.options.check_utf8
+
+    @check_utf8.setter
+    def check_utf8(self, value):
+        self.options.check_utf8 = value
+
+
 cdef _get_reader(input_file, shared_ptr[InputStream]* out):
     use_memory_map = False
     get_input_stream(input_file, use_memory_map, out)
@@ -234,11 +266,12 @@ cdef _get_parse_options(ParseOptions parse_options, CCSVParseOptions* out):
         out[0] = parse_options.options
 
 
-cdef _get_convert_options(convert_options, CCSVConvertOptions* out):
+cdef _get_convert_options(ConvertOptions convert_options,
+                          CCSVConvertOptions* out):
     if convert_options is None:
         out[0] = CCSVConvertOptions.Defaults()
     else:
-        raise NotImplementedError("non-default convert options not supported")
+        out[0] = convert_options.options
 
 
 def read_csv(input_file, read_options=None, parse_options=None,
@@ -257,8 +290,9 @@ def read_csv(input_file, read_options=None, parse_options=None,
     parse_options: ParseOptions, optional
         Options for the CSV parser
         (see ParseOptions constructor for defaults)
-    convert_options: None
-        Currently unused
+    convert_options: ConvertOptions, optional
+        Options for converting CSV data
+        (see ConvertOptions constructor for defaults)
     memory_pool: MemoryPool, optional
         Pool to allocate Table memory from
 

--- a/python/pyarrow/csv.py
+++ b/python/pyarrow/csv.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pyarrow._csv import ReadOptions, ParseOptions, read_csv  # noqa
+from pyarrow._csv import ReadOptions, ParseOptions, ConvertOptions, read_csv  # noqa

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -947,6 +947,8 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         CCSVParseOptions Defaults()
 
     cdef cppclass CCSVConvertOptions" arrow::csv::ConvertOptions":
+        c_bool check_utf8
+
         @staticmethod
         CCSVConvertOptions Defaults()
 


### PR DESCRIPTION
CSV conversion now has distinct paths for string and binary columns. String columns are UTF8-validated by default, but it can be disabled by setting the `check_utf8` option in `ConvertOptions`.

CSV type inference now first attempts string conversion and falls back on binary if UTF8 validation fails (if it's not disabled).

As for performance, on pure ASCII columns single-threaded reading slows down by ~10% (which can be avoided by setting `check_utf8` to false). Multi-threaded reading does not seem affected here.

Based on PR #2916.