### PR TITLE
ARROW-3733: [GLib] Add to_string() to GArrowTable and GArrowColumn

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -29,7 +29,6 @@
 #include <arrow-glib/type.hpp>
 #include <arrow-glib/decimal.hpp>
 
-#include <iostream>
 #include <sstream>
 
 template <typename T>

--- a/c_glib/arrow-glib/column.cpp
+++ b/c_glib/arrow-glib/column.cpp
@@ -25,7 +25,10 @@
 #include <arrow-glib/chunked-array.hpp>
 #include <arrow-glib/column.hpp>
 #include <arrow-glib/data-type.hpp>
+#include <arrow-glib/error.hpp>
 #include <arrow-glib/field.hpp>
+
+#include <sstream>
 
 G_BEGIN_DECLS
 
@@ -362,6 +365,31 @@ garrow_column_get_data(GArrowColumn *column)
   const auto arrow_column = garrow_column_get_raw(column);
   auto arrow_chunked_array = arrow_column->data();
   return garrow_chunked_array_new_raw(&arrow_chunked_array);
+}
+
+/**
+ * garrow_column_to_string:
+ * @column: A #GArrowColumn.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The formatted column content or %NULL on error.
+ *
+ *   The returned string should be freed when with g_free() when no
+ *   longer needed.
+ *
+ * Since: 0.12.0
+ */
+gchar *
+garrow_column_to_string(GArrowColumn *column, GError **error)
+{
+  const auto arrow_column = garrow_column_get_raw(column);
+  std::stringstream sink;
+  auto status = arrow::PrettyPrint(*arrow_column, 0, &sink);
+  if (garrow_error_check(error, status, "[column][to-string]")) {
+    return g_strdup(sink.str().c_str());
+  } else {
+    return NULL;
+  }
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/column.h
+++ b/c_glib/arrow-glib/column.h
@@ -25,47 +25,16 @@
 
 G_BEGIN_DECLS
 
-#define GARROW_TYPE_COLUMN                      \
-  (garrow_column_get_type())
-#define GARROW_COLUMN(obj)                              \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                    \
-                              GARROW_TYPE_COLUMN,       \
-                              GArrowColumn))
-#define GARROW_COLUMN_CLASS(klass)              \
-  (G_TYPE_CHECK_CLASS_CAST((klass),             \
-                           GARROW_TYPE_COLUMN,  \
-                           GArrowColumnClass))
-#define GARROW_IS_COLUMN(obj)                           \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj),                    \
-                              GARROW_TYPE_COLUMN))
-#define GARROW_IS_COLUMN_CLASS(klass)           \
-  (G_TYPE_CHECK_CLASS_TYPE((klass),             \
-                           GARROW_TYPE_COLUMN))
-#define GARROW_COLUMN_GET_CLASS(obj)                    \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                     \
-                             GARROW_TYPE_COLUMN,        \
-                             GArrowColumnClass))
-
-typedef struct _GArrowColumn         GArrowColumn;
-typedef struct _GArrowColumnClass    GArrowColumnClass;
-
-/**
- * GArrowColumn:
- *
- * It wraps `arrow::Column`.
- */
-struct _GArrowColumn
-{
-  /*< private >*/
-  GObject parent_instance;
-};
-
+#define GARROW_TYPE_COLUMN (garrow_column_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowColumn,
+                         garrow_column,
+                         GARROW,
+                         COLUMN,
+                         GObject)
 struct _GArrowColumnClass
 {
   GObjectClass parent_class;
 };
-
-GType               garrow_column_get_type      (void) G_GNUC_CONST;
 
 GArrowColumn *garrow_column_new_array(GArrowField *field,
                                       GArrowArray *array);
@@ -84,5 +53,7 @@ GArrowField        *garrow_column_get_field     (GArrowColumn *column);
 const gchar        *garrow_column_get_name      (GArrowColumn *column);
 GArrowDataType     *garrow_column_get_data_type (GArrowColumn *column);
 GArrowChunkedArray *garrow_column_get_data      (GArrowColumn *column);
+gchar              *garrow_column_to_string     (GArrowColumn *column,
+                                                 GError **error);
 
 G_END_DECLS

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -135,9 +135,8 @@ GArrowField *
 garrow_field_new(const gchar *name,
                  GArrowDataType *data_type)
 {
-  auto arrow_field =
-    std::make_shared<arrow::Field>(name,
-                                   garrow_data_type_get_raw(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  auto arrow_field = std::make_shared<arrow::Field>(name, arrow_data_type);
   return garrow_field_new_raw(&arrow_field);
 }
 

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -26,6 +26,8 @@
 #include <arrow-glib/schema.hpp>
 #include <arrow-glib/table.hpp>
 
+#include <sstream>
+
 G_BEGIN_DECLS
 
 /**
@@ -301,6 +303,31 @@ garrow_table_replace_column(GArrowTable *table,
   auto status = arrow_table->SetColumn(i, arrow_column, &arrow_new_table);
   if (garrow_error_check(error, status, "[table][replace-column]")) {
     return garrow_table_new_raw(&arrow_new_table);
+  } else {
+    return NULL;
+  }
+}
+
+/**
+ * garrow_table_to_string:
+ * @table: A #GArrowTable.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable): The formatted table content or %NULL on error.
+ *
+ *   The returned string should be freed when with g_free() when no
+ *   longer needed.
+ *
+ * Since: 0.12.0
+ */
+gchar *
+garrow_table_to_string(GArrowTable *table, GError **error)
+{
+  const auto arrow_table = garrow_table_get_raw(table);
+  std::stringstream sink;
+  auto status = arrow::PrettyPrint(*arrow_table, 0, &sink);
+  if (garrow_error_check(error, status, "[table][to-string]")) {
+    return g_strdup(sink.str().c_str());
   } else {
     return NULL;
   }

--- a/c_glib/arrow-glib/table.h
+++ b/c_glib/arrow-glib/table.h
@@ -58,5 +58,7 @@ GArrowTable    *garrow_table_replace_column(GArrowTable *table,
                                             guint i,
                                             GArrowColumn *column,
                                             GError **error);
+gchar          *garrow_table_to_string     (GArrowTable *table,
+                                            GError **error);
 
 G_END_DECLS

--- a/c_glib/test/parquet/test-arrow-file-writer.rb
+++ b/c_glib/test/parquet/test-arrow-file-writer.rb
@@ -34,23 +34,13 @@ class TestParquetArrowFileWriter < Test::Unit::TestCase
 
     reader = Parquet::ArrowFileReader.new(@file.path)
     reader.use_threads = true
-    assert_equal(enabled_values.length / chunk_size, reader.n_row_groups)
-    table = reader.read_table
-    table = reader.read_table
-    table_data = table.n_columns.times.collect do |i|
-      column = table.get_column(i)
-      data = []
-      column.data.chunks.each do |chunk|
-        chunk.length.times do |j|
-          if chunk.null?(j)
-            data << nil
-          else
-            data << chunk.get_value(j)
-          end
-        end
-      end
-      [column.name, data]
-    end
-    assert_equal([["enabled", enabled_values]], table_data)
+    assert_equal([
+                   enabled_values.length / chunk_size,
+                   table,
+                 ],
+                 [
+                   reader.n_row_groups,
+                   reader.read_table,
+                 ])
   end
 end

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -118,5 +118,21 @@ class TestTable < Test::Unit::TestCase
       assert_equal(["added", "valid"],
                    new_table.schema.fields.collect(&:name))
     end
+
+    def test_to_s
+      table = build_table("valid" => build_boolean_array([true, false, true]))
+      assert_equal(<<-TABLE, table.to_s)
+valid: bool
+----
+valid:
+  [
+    [
+      true,
+      false,
+      true
+    ]
+  ]
+      TABLE
+    end
   end
 end


### PR DESCRIPTION
This changes have many test code change. It's caused by changing table check way from dumped text comparison to direct table comparison. If we use direct table comparison, dump text format change doesn't effect test code. We'll get more stable test suite by this change.