### PR TITLE
ARROW-2113/3768: [Python] set classpath to all hadoop jars when HADOOP_HOME present

### DIFF
--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -128,11 +128,18 @@ def _maybe_set_hadoop_classpath():
         return
 
     if 'HADOOP_HOME' in os.environ:
-        hadoop_bin = '{0}/bin/hadoop'.format(os.environ['HADOOP_HOME'])
+        find_args = ('find', os.environ['HADOOP_HOME'], '-name', '*.jar')
+        find = subprocess.Popen(find_args, stdout=subprocess.PIPE)
+        xargs_echo = subprocess.Popen(('xargs', 'echo'),
+                                      stdin=find.stdout,
+                                      stdout=subprocess.PIPE)
+        classpath = subprocess.check_output(('tr', "' '", "':'"),
+                                            stdin=xargs_echo.stdout)
     else:
         hadoop_bin = 'hadoop'
+        hadoop_classpath_args = (hadoop_bin, 'classpath', '--glob')
+        classpath = subprocess.check_output(hadoop_classpath_args)
 
-    classpath = subprocess.check_output([hadoop_bin, 'classpath', '--glob'])
     os.environ['CLASSPATH'] = classpath.decode('utf-8')
 
 


### PR DESCRIPTION
Per the [documentation](https://arrow.apache.org/docs/python/filesystems.html) it appears classpath should be set to the `hdfs` executable rather than `hadoop`.

```
export CLASSPATH=`$HADOOP_HOME/bin/hdfs classpath --glob`
```

This **might** be sufficient for https://issues.apache.org/jira/browse/ARROW-2113