### PR TITLE
ARROW-3738: [C++] Parse ISO8601-like timestamps in CSV columns

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -717,7 +717,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------------------
-The file cpp/src/gandiva/precompiled/date.h has the following license (MIT)
+The file cpp/src/arrow/util/date.h has the following license (MIT)
 
 The MIT License (MIT)
 Copyright (c) 2015, 2016, 2017 Howard Hinnant

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -346,10 +346,10 @@ if (UNIX)
             (item MATCHES "xxhash.h") OR
             (item MATCHES "xxhash.cc") OR
             (item MATCHES "config.h") OR
+            (item MATCHES "util/date.h") OR
             (item MATCHES "util/string_view/") OR
             (item MATCHES "util/variant") OR
             (item MATCHES "zmalloc.h") OR
-            (item MATCHES "gandiva/precompiled/date.h") OR
             (item MATCHES "ae.h")))
       LIST(APPEND FILTERED_LINT_FILES ${item})
     ENDIF()

--- a/cpp/build-support/clang_format_exclusions.txt
+++ b/cpp/build-support/clang_format_exclusions.txt
@@ -4,6 +4,7 @@
 *pyarrow_lib.h
 *python/config.h
 *python/platform.h
+*util/date.h
 *util/string_view/*
 *util/variant.h
 *util/variant/*
@@ -11,4 +12,3 @@
 *xxhash.cc
 *xxhash.h
 *RcppExports.cpp*
-*gandiva/precompiled/date.h

--- a/cpp/build-support/lint_cpp_cli.py
+++ b/cpp/build-support/lint_cpp_cli.py
@@ -70,12 +70,12 @@ def lint_file(path):
 
 EXCLUSIONS = [
     'arrow/python/iterators.h',
+    'arrow/util/date.h',
     'arrow/util/macros.h',
     'arrow/util/parallel.h',
     'arrow/util/string_view/string_view.hpp',
     'gandiva/cache.h',
     'gandiva/jni',
-    'gandiva/precompiled/date.h',
     'test',
     'internal'
 ]

--- a/cpp/src/arrow/csv/column-builder.cc
+++ b/cpp/src/arrow/csv/column-builder.cc
@@ -167,7 +167,7 @@ class InferringColumnBuilder : public ColumnBuilder {
   std::shared_ptr<Converter> converter_;
 
   // Current inference status
-  enum class InferKind { Null, Integer, Real, Text, Binary };
+  enum class InferKind { Null, Integer, Real, Timestamp, Text, Binary };
 
   std::shared_ptr<DataType> infer_type_;
   InferKind infer_kind_;
@@ -191,6 +191,9 @@ Status InferringColumnBuilder::LoosenType() {
       infer_kind_ = InferKind::Integer;
       break;
     case InferKind::Integer:
+      infer_kind_ = InferKind::Timestamp;
+      break;
+    case InferKind::Timestamp:
       infer_kind_ = InferKind::Real;
       break;
     case InferKind::Real:
@@ -215,6 +218,11 @@ Status InferringColumnBuilder::UpdateType() {
       break;
     case InferKind::Integer:
       infer_type_ = int64();
+      can_loosen_type_ = true;
+      break;
+    case InferKind::Timestamp:
+      // We don't support parsing second fractions for now
+      infer_type_ = timestamp(TimeUnit::SECOND);
       can_loosen_type_ = true;
       break;
     case InferKind::Real:

--- a/cpp/src/arrow/csv/csv-converter-test.cc
+++ b/cpp/src/arrow/csv/csv-converter-test.cc
@@ -220,6 +220,29 @@ TEST(BooleanConversion, Nulls) {
                                       {{true, true}, {false, true}});
 }
 
+TEST(TimestampConversion, Basics) {
+  auto type = timestamp(TimeUnit::SECOND);
+
+  AssertConversion<TimestampType, int64_t>(
+      type, {"1970-01-01\n2000-02-29\n3989-07-14\n1900-02-28\n"},
+      {{0, 951782400, 63730281600LL, -2203977600LL}});
+  AssertConversion<TimestampType, int64_t>(type,
+                                           {"2018-11-13 17:11:10\n1900-02-28 12:34:56\n"},
+                                           {{1542129070, -2203932304LL}});
+
+  type = timestamp(TimeUnit::NANO);
+  AssertConversion<TimestampType, int64_t>(
+      type, {"1970-01-01\n2000-02-29\n1900-02-28\n"},
+      {{0, 951782400000000000LL, -2203977600000000000LL}});
+}
+
+TEST(TimestampConversion, Nulls) {
+  auto type = timestamp(TimeUnit::MILLI);
+  AssertConversion<TimestampType, int64_t>(type, {"1970-01-01 00:01:00,,N/A\n"},
+                                           {{60000}, {0}, {0}},
+                                           {{true}, {false}, {false}});
+}
+
 TEST(DecimalConversion, NotImplemented) {
   std::shared_ptr<Converter> converter;
   ASSERT_RAISES(NotImplemented,

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -34,6 +34,7 @@ install(FILES
   compression_zlib.h
   compression_zstd.h
   cpu-info.h
+  date.h
   decimal.h
   hash-util.h
   hash.h

--- a/cpp/src/arrow/util/date.h
+++ b/cpp/src/arrow/util/date.h
@@ -1,3 +1,5 @@
+// Vendored from https://github.com/HowardHinnant/date/
+
 #ifndef DATE_H
 #define DATE_H
 
@@ -285,9 +287,9 @@ class day {
   explicit CONSTCD11 day(unsigned d) NOEXCEPT;
 
   CONSTCD14 day& operator++() NOEXCEPT;
-  CONSTCD14 day  operator++(int) NOEXCEPT;
+  CONSTCD14 day operator++(int) NOEXCEPT;
   CONSTCD14 day& operator--() NOEXCEPT;
-  CONSTCD14 day  operator--(int) NOEXCEPT;
+  CONSTCD14 day operator--(int) NOEXCEPT;
 
   CONSTCD14 day& operator+=(const days& d) NOEXCEPT;
   CONSTCD14 day& operator-=(const days& d) NOEXCEPT;
@@ -322,9 +324,9 @@ class month {
   explicit CONSTCD11 month(unsigned m) NOEXCEPT;
 
   CONSTCD14 month& operator++() NOEXCEPT;
-  CONSTCD14 month  operator++(int) NOEXCEPT;
+  CONSTCD14 month operator++(int) NOEXCEPT;
   CONSTCD14 month& operator--() NOEXCEPT;
-  CONSTCD14 month  operator--(int) NOEXCEPT;
+  CONSTCD14 month operator--(int) NOEXCEPT;
 
   CONSTCD14 month& operator+=(const months& m) NOEXCEPT;
   CONSTCD14 month& operator-=(const months& m) NOEXCEPT;
@@ -359,9 +361,9 @@ class year {
   explicit CONSTCD11 year(int y) NOEXCEPT;
 
   CONSTCD14 year& operator++() NOEXCEPT;
-  CONSTCD14 year  operator++(int) NOEXCEPT;
+  CONSTCD14 year operator++(int) NOEXCEPT;
   CONSTCD14 year& operator--() NOEXCEPT;
-  CONSTCD14 year  operator--(int) NOEXCEPT;
+  CONSTCD14 year operator--(int) NOEXCEPT;
 
   CONSTCD14 year& operator+=(const years& y) NOEXCEPT;
   CONSTCD14 year& operator-=(const years& y) NOEXCEPT;
@@ -406,9 +408,9 @@ class weekday {
   CONSTCD11 explicit weekday(const local_days& dp) NOEXCEPT;
 
   CONSTCD14 weekday& operator++() NOEXCEPT;
-  CONSTCD14 weekday  operator++(int) NOEXCEPT;
+  CONSTCD14 weekday operator++(int) NOEXCEPT;
   CONSTCD14 weekday& operator--() NOEXCEPT;
-  CONSTCD14 weekday  operator--(int) NOEXCEPT;
+  CONSTCD14 weekday operator--(int) NOEXCEPT;
 
   CONSTCD14 weekday& operator+=(const days& d) NOEXCEPT;
   CONSTCD14 weekday& operator-=(const days& d) NOEXCEPT;
@@ -1056,7 +1058,7 @@ struct no_overflow {
       -((std::intmax_t(1) << (sizeof(std::intmax_t) * CHAR_BIT - 1)) + 1);
 
   template <std::intmax_t Xp, std::intmax_t Yp, bool overflow>
-  struct mul  { // overflow == false
+  struct mul {  // overflow == false
     static const std::intmax_t value = Xp * Yp;
   };
 
@@ -1206,7 +1208,7 @@ CONSTCD14 inline day& day::operator++() NOEXCEPT {
   ++d_;
   return *this;
 }
-CONSTCD14 inline day day:: operator++(int) NOEXCEPT {
+CONSTCD14 inline day day::operator++(int) NOEXCEPT {
   auto tmp(*this);
   ++(*this);
   return tmp;
@@ -1215,7 +1217,7 @@ CONSTCD14 inline day& day::operator--() NOEXCEPT {
   --d_;
   return *this;
 }
-CONSTCD14 inline day day:: operator--(int) NOEXCEPT {
+CONSTCD14 inline day day::operator--(int) NOEXCEPT {
   auto tmp(*this);
   --(*this);
   return tmp;
@@ -1289,7 +1291,7 @@ CONSTCD14 inline month& month::operator++() NOEXCEPT {
   *this += months{1};
   return *this;
 }
-CONSTCD14 inline month month:: operator++(int) NOEXCEPT {
+CONSTCD14 inline month month::operator++(int) NOEXCEPT {
   auto tmp(*this);
   ++(*this);
   return tmp;
@@ -1298,7 +1300,7 @@ CONSTCD14 inline month& month::operator--() NOEXCEPT {
   *this -= months{1};
   return *this;
 }
-CONSTCD14 inline month month:: operator--(int) NOEXCEPT {
+CONSTCD14 inline month month::operator--(int) NOEXCEPT {
   auto tmp(*this);
   --(*this);
   return tmp;
@@ -1379,7 +1381,7 @@ CONSTCD14 inline year& year::operator++() NOEXCEPT {
   ++y_;
   return *this;
 }
-CONSTCD14 inline year year:: operator++(int) NOEXCEPT {
+CONSTCD14 inline year year::operator++(int) NOEXCEPT {
   auto tmp(*this);
   ++(*this);
   return tmp;
@@ -1388,7 +1390,7 @@ CONSTCD14 inline year& year::operator--() NOEXCEPT {
   --y_;
   return *this;
 }
-CONSTCD14 inline year year:: operator--(int) NOEXCEPT {
+CONSTCD14 inline year year::operator--(int) NOEXCEPT {
   auto tmp(*this);
   --(*this);
   return tmp;
@@ -1498,7 +1500,7 @@ CONSTCD14 inline weekday& weekday::operator++() NOEXCEPT {
   *this += days{1};
   return *this;
 }
-CONSTCD14 inline weekday weekday:: operator++(int) NOEXCEPT {
+CONSTCD14 inline weekday weekday::operator++(int) NOEXCEPT {
   auto tmp(*this);
   ++(*this);
   return tmp;
@@ -1507,7 +1509,7 @@ CONSTCD14 inline weekday& weekday::operator--() NOEXCEPT {
   *this -= days{1};
   return *this;
 }
-CONSTCD14 inline weekday weekday:: operator--(int) NOEXCEPT {
+CONSTCD14 inline weekday weekday::operator--(int) NOEXCEPT {
   auto tmp(*this);
   --(*this);
   return tmp;
@@ -2518,7 +2520,7 @@ inline bool year_month_weekday_last::ok() const NOEXCEPT {
 CONSTCD14
 inline days year_month_weekday_last::to_days() const NOEXCEPT {
   auto const d = sys_days(y_ / m_ / last);
-  return (d - (date::weekday {d} - wdl_.weekday())).time_since_epoch();
+  return (d - (date::weekday{d} - wdl_.weekday())).time_since_epoch();
 }
 
 CONSTCD11
@@ -3140,7 +3142,7 @@ class time_of_day_storage<std::chrono::duration<Rep, Period>, detail::classify::
   }
 
   CONSTCD11 bool in_conventional_range() const NOEXCEPT {
-    return base::in_conventional_range() && m_ < std::chrono::hours {1};
+    return base::in_conventional_range() && m_ < std::chrono::hours{1};
   }
 
   template <class CharT, class Traits>
@@ -3219,7 +3221,7 @@ class time_of_day_storage<std::chrono::duration<Rep, Period>, detail::classify::
   }
 
   CONSTCD11 bool in_conventional_range() const NOEXCEPT {
-    return base::in_conventional_range() && m_ < std::chrono::hours {1} &&
+    return base::in_conventional_range() && m_ < std::chrono::hours{1} &&
            s_.in_conventional_range();
   }
 
@@ -3314,7 +3316,7 @@ class time_of_day_storage<std::chrono::duration<Rep, Period>, detail::classify::
   }
 
   CONSTCD11 bool in_conventional_range() const NOEXCEPT {
-    return base::in_conventional_range() && m_ < std::chrono::hours {1} &&
+    return base::in_conventional_range() && m_ < std::chrono::hours{1} &&
            s_.in_conventional_range();
   }
 
@@ -3617,14 +3619,14 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
                                              const fields<Duration>& fds,
                                              const std::string* abbrev,
                                              const std::chrono::seconds* offset_sec) {
-  using std::chrono::duration_cast;
-  using std::chrono::duration;
-  using std::use_facet;
-  using std::chrono::hours;
-  using std::chrono::minutes;
   using detail::save_ostream;
   using std::ios;
   using std::time_put;
+  using std::use_facet;
+  using std::chrono::duration;
+  using std::chrono::duration_cast;
+  using std::chrono::hours;
+  using std::chrono::minutes;
   date::detail::save_ostream<CharT, Traits> ss(os);
   os.fill(' ');
   os.flags(std::ios::skipws | std::ios::dec);
@@ -3715,11 +3717,11 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
               os << month_names().first[extract_month(os, fds) - 1 + 12] << ' ';
               auto d = static_cast<int>(static_cast<unsigned>(fds.ymd.day()));
               if (d < 10) {
-                 os << ' ';
+                os << ' ';
               }
               os << d << ' ' << make_time(duration_cast<seconds>(fds.tod.to_duration()))
                  << ' ' << fds.ymd.year();
-            } else { // *fmt == 'x'
+            } else {  // *fmt == 'x'
               auto const& ymd = fds.ymd;
               save_ostream<CharT, Traits> _(os);
               os.fill('0');
@@ -4032,10 +4034,10 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
             tm.tm_hour = static_cast<int>(fds.tod.hours().count());
             facet.put(os, os, os.fill(), &tm, begin(f), end(f));
 #else
-            if (fds.tod.hours() < hours {12}) {
+            if (fds.tod.hours() < hours{12}) {
               os << ampm_names().first[0];
             } else {
-                os << ampm_names().first[1];
+              os << ampm_names().first[1];
             }
 #endif
           } else {
@@ -4044,7 +4046,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'r':
@@ -4069,10 +4071,10 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
             os.width(2);
             os << tod.seconds().count() << CharT{' '};
             tod.make24();
-            if (tod.hours() < hours {12}) {
+            if (tod.hours() < hours{12}) {
               os << ampm_names().first[0];
             } else {
-                os << ampm_names().first[1];
+              os << ampm_names().first[1];
             }
 #endif
           } else {
@@ -4081,16 +4083,22 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'R':
         if (command) {
           if (modified == CharT{}) {
-            if (!fds.has_tod) { os.setstate(std::ios::failbit); }
-            if (fds.tod.hours() < hours{10}) { os << CharT{'0'}; }
+            if (!fds.has_tod) {
+              os.setstate(std::ios::failbit);
+            }
+            if (fds.tod.hours() < hours{10}) {
+              os << CharT{'0'};
+            }
             os << fds.tod.hours().count() << CharT{':'};
-            if (fds.tod.minutes() < minutes{10}) { os << CharT{'0'}; }
+            if (fds.tod.minutes() < minutes{10}) {
+              os << CharT{'0'};
+            }
             os << fds.tod.minutes().count();
           } else {
             os << CharT{'%'} << modified << *fmt;
@@ -4128,7 +4136,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 't':
@@ -4141,7 +4149,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           }
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'T':
@@ -4155,15 +4163,14 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           }
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'u':
         if (command) {
           if (modified == CharT{'E'}) {
             os << CharT{'%'} << modified << *fmt;
-          }
-          else {
+          } else {
             auto wd = extract_weekday(os, fds);
 #if !ONLY_C_LOCALE
             if (modified == CharT{})
@@ -4182,7 +4189,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'U':
@@ -4221,7 +4228,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'V':
@@ -4263,7 +4270,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'w':
@@ -4291,7 +4298,7 @@ std::basic_ostream<CharT, Traits>& to_stream(std::basic_ostream<CharT, Traits>& 
           modified = CharT{};
           command = nullptr;
         } else {
-            os << *fmt;
+          os << *fmt;
         }
         break;
       case 'W':
@@ -6364,29 +6371,29 @@ msl(std::ratio<N, D>) {
 
 template <class CharT>
 CONSTCD11 inline string_literal<CharT, 2> msl(std::atto) NOEXCEPT {
-  return string_literal<CharT, 2> {'a'};
+  return string_literal<CharT, 2>{'a'};
 }
 
 template <class CharT>
 CONSTCD11 inline string_literal<CharT, 2> msl(std::femto) NOEXCEPT {
-  return string_literal<CharT, 2> {'f'};
+  return string_literal<CharT, 2>{'f'};
 }
 
 template <class CharT>
 CONSTCD11 inline string_literal<CharT, 2> msl(std::pico) NOEXCEPT {
-  return string_literal<CharT, 2> {'p'};
+  return string_literal<CharT, 2>{'p'};
 }
 
 template <class CharT>
 CONSTCD11 inline string_literal<CharT, 2> msl(std::nano) NOEXCEPT {
-  return string_literal<CharT, 2> {'n'};
+  return string_literal<CharT, 2>{'n'};
 }
 
 template <class CharT>
 CONSTCD11 inline typename std::enable_if<std::is_same<CharT, char>::value,
                                          string_literal<char, 3>>::type
 msl(std::micro) NOEXCEPT {
-  return string_literal<char, 3> {'\xC2', '\xB5'};
+  return string_literal<char, 3>{'\xC2', '\xB5'};
 }
 
 template <class CharT>
@@ -6398,12 +6405,12 @@ msl(std::micro) NOEXCEPT {
 
 template <class CharT>
 CONSTCD11 inline string_literal<CharT, 2> msl(std::milli) NOEXCEPT {
-  return string_literal<CharT, 2> {'m'};
+  return string_literal<CharT, 2>{'m'};
 }
 
 template <class CharT>
 CONSTCD11 inline string_literal<CharT, 2> msl(std::centi) NOEXCEPT {
-  return string_literal<CharT, 2> {'c'};
+  return string_literal<CharT, 2>{'c'};
 }
 
 template <class CharT>

--- a/cpp/src/gandiva/precompiled/epoch_time_point.h
+++ b/cpp/src/gandiva/precompiled/epoch_time_point.h
@@ -19,7 +19,7 @@
 #define GANDIVA_EPOCH_TIME_POINT_H
 
 // TODO(wesm): IR compilation does not have any include directories set
-#include "./date.h"
+#include "../../arrow/util/date.h"
 
 // A point of time measured in millis since epoch.
 class EpochTimePoint {

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -19,7 +19,6 @@
 
 #include <gtest/gtest.h>
 #include "../execution_context.h"
-#include "gandiva/precompiled/date.h"
 #include "gandiva/precompiled/types.h"
 
 namespace gandiva {

--- a/cpp/src/gandiva/to_date_holder.cc
+++ b/cpp/src/gandiva/to_date_holder.cc
@@ -18,10 +18,11 @@
 #include <algorithm>
 #include <string>
 
+#include "arrow/util/date.h"
+
 #include "gandiva/date_utils.h"
 #include "gandiva/execution_context.h"
 #include "gandiva/node.h"
-#include "gandiva/precompiled/date.h"
 #include "gandiva/to_date_holder.h"
 
 namespace gandiva {

--- a/python/doc/source/csv.rst
+++ b/python/doc/source/csv.rst
@@ -29,7 +29,7 @@ The features currently offered are the following:
   such as ``my_data.csv.gz``)
 * fetching column names from the first row in the CSV file
 * column-wise type inference and conversion to one of ``null``, ``int64``,
-  ``float64``, ``string`` or ``binary`` data
+  ``float64``, ``timestamp[s]``, ``string`` or ``binary`` data
 * detecting various spellings of null values such as ``NaN`` or ``#N/A``
 
 Usage
@@ -74,13 +74,6 @@ Customized conversion
 
 To alter how CSV data is converted to Arrow types and data, you should create
 a :class:`ConvertOptions` instance and pass it to :func:`read_csv`.
-
-Limitations
------------
-
-Arrow is not able to detect or convert other data types (such as dates
-and times) than the five mentioned above.  It is also not possible to
-choose the data types of columns explicitly.
 
 Performance
 -----------

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import bz2
+from datetime import datetime
 import gzip
 import io
 import itertools
@@ -218,6 +219,18 @@ class BaseTestCSVRead:
             'c': [u"", u"foo", u"nan"],
             'd': [None, None, None],
             'e': [b"3", b"nan", b"\xff"],
+            }
+
+    def test_simple_timestamps(self):
+        # Infer a timestamp column
+        rows = b"a,b\n1970,1970-01-01\n1989,1989-07-14\n"
+        table = self.read_bytes(rows)
+        schema = pa.schema([('a', pa.int64()),
+                            ('b', pa.timestamp('s'))])
+        assert table.schema == schema
+        assert table.to_pydict() == {
+            'a': [1970, 1989],
+            'b': [datetime(1970, 1, 1), datetime(1989, 7, 14)],
             }
 
     def test_column_types(self):


### PR DESCRIPTION
Second granularity is allowed (we might want to add support for fractions of seconds, e.g. in the "YYYY-MM-DD[T ]hh:mm:ss.ssssss" format).

Timestamp conversion also participates in CSV type inference, since it's unlikely to produce false positives (e.g. a semantically "string" column that would be entirely made of valid timestamp strings).