### PR TITLE
ARROW-3194: [JAVA] Use split length in splitAndTransfer to set value count

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/Accountant.java
@@ -216,6 +216,15 @@ class Accountant implements AutoCloseable {
   }
 
   /**
+   * Return the initial reservation.
+   *
+   * @return reservation in bytes.
+   */
+  public long getInitReservation() {
+    return reservation;
+  }
+
+  /**
    * Set the maximum amount of memory that can be allocated in the this Accountant before failing
    * an allocation.
    *

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -106,6 +106,13 @@ public interface BufferAllocator extends AutoCloseable {
   public long getLimit();
 
   /**
+   * Return the initial reservation.
+   *
+   * @return reservation in bytes.
+   */
+  public long getInitReservation();
+
+  /**
    * Set the maximum amount of memory this allocator is allowed to allocate.
    *
    * @param newLimit The new Limit to apply to allocations

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -739,6 +739,17 @@ public class TestBaseAllocator {
   }
 
   @Test
+  public void testInitReservationAndLimit() throws Exception {
+    try (final RootAllocator rootAllocator = new RootAllocator(MAX_ALLOCATION)) {
+      try (final BufferAllocator childAllocator = rootAllocator.newChildAllocator(
+              "child", 2048, 4096)) {
+        assertEquals(2048, childAllocator.getInitReservation());
+        assertEquals(4096, childAllocator.getLimit());
+      }
+    }
+  }
+
+  @Test
   public void multiple() throws Exception {
     final String owner = "test";
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -707,8 +707,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     splitAndTransferValidityBuffer(startIndex, length, target);
     splitAndTransferOffsetBuffer(startIndex, length, target);
     target.setLastSet(length - 1);
-    if (this.valueCount > 0) {
-      target.setValueCount(this.valueCount);
+    if (length > 0) {
+      target.setValueCount(length);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -134,7 +134,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
 
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
-    return new NullableStructTransferPair(this, (StructVector) to, true);
+    return new NullableStructTransferPair(this, (StructVector) to, false);
   }
 
   @Override

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestSplitAndTransfer.java
@@ -61,13 +61,12 @@ public class TestSplitAndTransfer {
   
       final TransferPair tp = varCharVector.getTransferPair(allocator);
       final VarCharVector newVarCharVector = (VarCharVector) tp.getTo();
-      final int[][] startLengths = {{0, 201}, {201, 200}, {401, 99}};
+      final int[][] startLengths = {{0, 201}, {201, 0}, {201, 200}, {401, 99}};
   
       for (final int[] startLength : startLengths) {
         final int start = startLength[0];
         final int length = startLength[1];
         tp.splitAndTransfer(start, length);
-        newVarCharVector.setValueCount(length);
         for (int i = 0; i < length; i++) {
           final boolean expectedSet = ((start + i) % 3) == 0;
           if (expectedSet) {
@@ -78,6 +77,34 @@ public class TestSplitAndTransfer {
             assertTrue(newVarCharVector.isNull(i));
           }
         }
+        newVarCharVector.clear();
+      }
+    }
+  }
+
+  @Test
+  public void testMemoryConstrainedTransfer() {
+    try (final VarCharVector varCharVector = new VarCharVector("myvector", allocator)) {
+      allocator.setLimit(32768); /* set limit of 32KB */
+
+      varCharVector.allocateNew(10000, 1000);
+
+      final int valueCount = 1000;
+
+      for (int i = 0; i < valueCount; i += 3) {
+        final String s = String.format("%010d", i);
+        varCharVector.set(i, s.getBytes());
+      }
+      varCharVector.setValueCount(valueCount);
+
+      final TransferPair tp = varCharVector.getTransferPair(allocator);
+      final VarCharVector newVarCharVector = (VarCharVector) tp.getTo();
+      final int[][] startLengths = {{0, 700}, {700, 299}};
+
+      for (final int[] startLength : startLengths) {
+        final int start = startLength[0];
+        final int length = startLength[1];
+        tp.splitAndTransfer(start, length);
         newVarCharVector.clear();
       }
     }


### PR DESCRIPTION
(1) Use split length to set the value count of target vector in splitAndTransfer
(2) Do not allocate memory for inner vectors in nullable map when creating transfer pairs
(3) Add getInitReservation() API to Accountant