### PR TITLE
ARROW-3796: [Rust] Add Example for PrimitiveArrayBuilder

### DIFF
--- a/ci/rust-build-main.bat
+++ b/ci/rust-build-main.bat
@@ -53,6 +53,7 @@ cargo test --target %TARGET% --release
 @echo
 @echo Run example (release)
 @echo ---------------------
+cargo run --example builders --target %TARGET% --release
 cargo run --example dynamic_types --target %TARGET% --release
 
 popd

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -36,6 +36,7 @@ cargo rustc -- -D warnings
 cargo build
 cargo test
 cargo bench
+cargo run --example builders
 cargo run --example dynamic_types
 
 popd

--- a/rust/README.md
+++ b/rust/README.md
@@ -37,25 +37,16 @@ let array = PrimitiveArray::from(vec![1, 2, 3, 4, 5]);
 println!("array contents: {:?}", array.iter().collect::<Vec<i32>>());
 ```
 
-## Creating an Array from a Builder
-
-```rust
-let mut builder: Builder<i32> = Builder::new();
-for i in 0..10 {
-    builder.push(i);
-}
-let buffer = builder.finish();
-let array = PrimitiveArray::from(buffer);
-
-println!("array contents: {:?}", array.iter().collect::<Vec<i32>>());
-```
-
 ## Run Examples
+
+The examples folder shows how to construct some different types of Arrow
+arrays, including dynamic arrays created at runtime.
 
 Examples can be run using the `cargo run --example` command. For example:
 
 ```bash
-cargo run --example array_from_builder
+cargo run --example builders
+cargo run --example dynamic_types
 ```
 
 ## Run Tests
@@ -74,7 +65,7 @@ instructions](https://doc.rust-lang.org/cargo/reference/publishing.html) to
 create an account and login to crates.io before asking to be added as an owner
 of the [arrow crate](https://crates.io/crates/arrow).
 
-Checkout the tag for the version to be releases. For example:
+Checkout the tag for the version to be released. For example:
 
 ```bash
 git checkout apache-arrow-0.11.0

--- a/rust/examples/builders.rs
+++ b/rust/examples/builders.rs
@@ -21,7 +21,6 @@ extern crate arrow;
 use arrow::builder::*;
 
 fn main() {
-
     // Primitive Arrays
     //
     // Primitive arrays are arrays of fixed-width primitive types (bool, u8, u16, u32, u64, i8, i16,
@@ -30,7 +29,7 @@ fn main() {
     // Create a new builder with a capacity of 100
     let mut primitive_array_builder = PrimitiveArrayBuilder::<i32>::new(100);
 
-    // Push individual primitive values
+    // Push an individual primitive value
     primitive_array_builder.push(55).unwrap();
 
     // Push a null value

--- a/rust/examples/builders.rs
+++ b/rust/examples/builders.rs
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+///! Many builders are available to easily create different types of arrow arrays
+extern crate arrow;
+
+use arrow::builder::*;
+
+fn main() {
+
+    // Primitive Arrays
+    //
+    // Primitive arrays are arrays of fixed-width primitive types (bool, u8, u16, u32, u64, i8, i16,
+    // i32, i64, f32, f64)
+
+    // Create a new builder with a capacity of 100
+    let mut primitive_array_builder = PrimitiveArrayBuilder::<i32>::new(100);
+
+    // Push individual primitive values
+    primitive_array_builder.push(55).unwrap();
+
+    // Push a null value
+    primitive_array_builder.push_null().unwrap();
+
+    // Push a slice of primitive values
+    primitive_array_builder.push_slice(&[39, 89, 12]).unwrap();
+
+    // Build the `PrimitiveArray`
+    let _primitive_array = primitive_array_builder.finish();
+}


### PR DESCRIPTION
I will follow up with examples of `ListArrayBuilder` and `BinaryBuilder` when merged.  The info in the readme keeps going out of date so it's probably better to build up the examples (which are tested by CI) and re-direct new users there.