### PR TITLE
ARROW-3797: [Rust] BinaryArray::value_offset incorrect in offset case

### DIFF
--- a/rust/src/array.rs
+++ b/rust/src/array.rs
@@ -981,10 +981,10 @@ mod tests {
             binary_array.get_value(1)
         );
         assert_eq!("parquet", binary_array.get_string(1));
-        assert_eq!(binary_array.value_offset(0), 5);
-        assert_eq!(binary_array.value_length(0), 0);
-        assert_eq!(binary_array.value_offset(1), 5);
-        assert_eq!(binary_array.value_length(1), 7);
+        assert_eq!(5, binary_array.value_offset(0));
+        assert_eq!(0, binary_array.value_length(0));
+        assert_eq!(5, binary_array.value_offset(1));
+        assert_eq!(7, binary_array.value_length(1));
     }
 
     #[test]

--- a/rust/src/array.rs
+++ b/rust/src/array.rs
@@ -526,7 +526,7 @@ impl BinaryArray {
     /// Note this doesn't do any bound checking, for performance reason.
     #[inline]
     pub fn value_offset(&self, i: i64) -> i32 {
-        self.value_offset_at(i)
+        self.value_offset_at(self.data.offset() + i)
     }
 
     /// Returns the length for the element at index `i`.

--- a/rust/src/array.rs
+++ b/rust/src/array.rs
@@ -981,6 +981,10 @@ mod tests {
             binary_array.get_value(1)
         );
         assert_eq!("parquet", binary_array.get_string(1));
+        assert_eq!(binary_array.value_offset(0), 5);
+        assert_eq!(binary_array.value_length(0), 0);
+        assert_eq!(binary_array.value_offset(1), 5);
+        assert_eq!(binary_array.value_length(1), 7);
     }
 
     #[test]


### PR DESCRIPTION
Fixes a bug in BinaryArray::value_offset. Also added test cases to now cover this method as well as the BinaryArray::value_length method in the case where the underlying ArrayData has a nonzero offset.