### PR TITLE
ARROW-3781: [C++] Implement BufferedOutputStream::SetBufferSize. Allocate buffer from MemoryPool

### DIFF
--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -16,14 +16,16 @@
 // under the License.
 
 #include "arrow/io/buffered.h"
-#include "arrow/status.h"
-#include "arrow/util/logging.h"
 
 #include <cstring>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
+
+#include "arrow/buffer.h"
+#include "arrow/status.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
 namespace io {
@@ -33,13 +35,8 @@ namespace io {
 
 class BufferedOutputStream::Impl {
  public:
-  explicit Impl(std::shared_ptr<OutputStream> raw)
-      : raw_(raw),
-        is_open_(true),
-        buffer_(std::string(BUFFER_SIZE, '\0')),
-        buffer_data_(const_cast<char*>(buffer_.data())),
-        buffer_pos_(0),
-        raw_pos_(-1) {}
+  explicit Impl(const std::shared_ptr<OutputStream>& raw)
+      : raw_(raw), is_open_(true), buffer_pos_(0), buffer_size_(0), raw_pos_(-1) {}
 
   ~Impl() { DCHECK(Close().ok()); }
 
@@ -77,15 +74,15 @@ class BufferedOutputStream::Impl {
     if (nbytes == 0) {
       return Status::OK();
     }
-    if (nbytes + buffer_pos_ >= BUFFER_SIZE) {
+    if (nbytes + buffer_pos_ >= buffer_size_) {
       RETURN_NOT_OK(FlushUnlocked());
       DCHECK_EQ(buffer_pos_, 0);
-      if (nbytes >= BUFFER_SIZE) {
+      if (nbytes >= buffer_size_) {
         // Direct write
         return raw_->Write(data, nbytes);
       }
     }
-    DCHECK_LE(buffer_pos_ + nbytes, BUFFER_SIZE);
+    DCHECK_LE(buffer_pos_ + nbytes, buffer_size_);
     std::memcpy(buffer_data_ + buffer_pos_, data, nbytes);
     buffer_pos_ += nbytes;
     return Status::OK();
@@ -108,23 +105,55 @@ class BufferedOutputStream::Impl {
 
   std::shared_ptr<OutputStream> raw() const { return raw_; }
 
- private:
-  // This size chosen so that memcpy() remains cheap
-  static const int64_t BUFFER_SIZE = 4096;
+  Status SetBufferSize(int64_t new_buffer_size) {
+    if (!buffer_) {
+      RETURN_NOT_OK(AllocateResizableBuffer(new_buffer_size, &buffer_));
+    } else {
+      if (buffer_pos_ >= new_buffer_size) {
+        // If the buffer is shrinking, first flush to the raw OutputStream
+        RETURN_NOT_OK(Flush());
+      }
+      RETURN_NOT_OK(buffer_->Resize(new_buffer_size));
+    }
+    buffer_data_ = reinterpret_cast<char*>(buffer_->mutable_data());
+    buffer_pos_ = 0;
+    buffer_size_ = new_buffer_size;
+    return Status::OK();
+  }
 
+  int64_t buffer_size() const { return buffer_size_; }
+
+ private:
   std::shared_ptr<OutputStream> raw_;
   bool is_open_;
-  std::string buffer_;
+
+  std::shared_ptr<ResizableBuffer> buffer_;
   char* buffer_data_;
   int64_t buffer_pos_;
+  int64_t buffer_size_;
   mutable int64_t raw_pos_;
   mutable std::mutex lock_;
 };
 
-BufferedOutputStream::BufferedOutputStream(std::shared_ptr<OutputStream> raw)
-    : impl_(new BufferedOutputStream::Impl(std::move(raw))) {}
+BufferedOutputStream::BufferedOutputStream(const std::shared_ptr<OutputStream>& raw)
+    : impl_(new BufferedOutputStream::Impl(raw)) {}
+
+Status BufferedOutputStream::Create(const std::shared_ptr<OutputStream>& raw,
+                                    int64_t buffer_size,
+                                    std::shared_ptr<BufferedOutputStream>* out) {
+  auto result = std::shared_ptr<BufferedOutputStream>(new BufferedOutputStream(raw));
+  RETURN_NOT_OK(result->SetBufferSize(buffer_size));
+  *out = std::move(result);
+  return Status::OK();
+}
 
 BufferedOutputStream::~BufferedOutputStream() {}
+
+Status BufferedOutputStream::SetBufferSize(int64_t new_buffer_size) {
+  return impl_->SetBufferSize(new_buffer_size);
+}
+
+int64_t BufferedOutputStream::buffer_size() const { return impl_->buffer_size(); }
 
 Status BufferedOutputStream::Close() { return impl_->Close(); }
 

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -110,13 +110,14 @@ class BufferedOutputStream::Impl {
   std::shared_ptr<OutputStream> raw() const { return raw_; }
 
   Status SetBufferSize(int64_t new_buffer_size) {
+    std::lock_guard<std::mutex> guard(lock_);
     DCHECK_GT(new_buffer_size, 0);
     if (!buffer_) {
       RETURN_NOT_OK(AllocateResizableBuffer(new_buffer_size, &buffer_));
     } else {
       if (buffer_pos_ >= new_buffer_size) {
         // If the buffer is shrinking, first flush to the raw OutputStream
-        RETURN_NOT_OK(Flush());
+        RETURN_NOT_OK(FlushUnlocked());
       }
       RETURN_NOT_OK(buffer_->Resize(new_buffer_size));
     }

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -37,7 +37,21 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   ~BufferedOutputStream() override;
 
   /// \brief Create a buffered output stream wrapping the given output stream.
-  explicit BufferedOutputStream(std::shared_ptr<OutputStream> raw);
+  /// \param[in] raw another OutputStream
+  /// \param[in] buffer_size the size of the temporary buffer. Allocates from
+  /// the default memory pool
+  /// \param[out] out the created BufferedOutputStream
+  /// \return Status
+  static Status Create(const std::shared_ptr<OutputStream>& raw, int64_t buffer_size,
+                       std::shared_ptr<BufferedOutputStream>* out);
+
+  /// \brief Resize internal buffer
+  /// \param[in] new_buffer_size the new buffer size
+  /// \return Status
+  Status SetBufferSize(int64_t new_buffer_size);
+
+  /// \brief Return the current size of the internal buffer
+  int64_t buffer_size() const;
 
   // OutputStream interface
 
@@ -56,6 +70,8 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   std::shared_ptr<OutputStream> raw() const;
 
  private:
+  explicit BufferedOutputStream(const std::shared_ptr<OutputStream>& raw);
+
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
 };

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -42,7 +42,7 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   /// the default memory pool
   /// \param[out] out the created BufferedOutputStream
   /// \return Status
-  static Status Create(const std::shared_ptr<OutputStream>& raw, int64_t buffer_size,
+  static Status Create(std::shared_ptr<OutputStream> raw, int64_t buffer_size,
                        std::shared_ptr<BufferedOutputStream>* out);
 
   /// \brief Resize internal buffer
@@ -70,7 +70,7 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   std::shared_ptr<OutputStream> raw() const;
 
  private:
-  explicit BufferedOutputStream(const std::shared_ptr<OutputStream>& raw);
+  explicit BufferedOutputStream(std::shared_ptr<OutputStream> raw);
 
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;

--- a/cpp/src/arrow/io/io-file-benchmark.cc
+++ b/cpp/src/arrow/io/io-file-benchmark.cc
@@ -41,6 +41,8 @@ std::string GetNullFile() { return "/dev/null"; }
 const std::valarray<int64_t> small_sizes = {8, 24, 33, 1, 32, 192, 16, 40};
 const std::valarray<int64_t> large_sizes = {8192, 100000};
 
+constexpr int64_t kBufferSize = 4096;
+
 class BackgroundReader {
   // A class that reads data in the background from a file descriptor
 
@@ -161,7 +163,7 @@ static void BM_BufferedOutputStreamSmallWritesToNull(
   ABORT_NOT_OK(io::FileOutputStream::Open(GetNullFile(), &file));
 
   std::shared_ptr<io::BufferedOutputStream> buffered_file;
-  ABORT_NOT_OK(io::BufferedOutputStream::Create(file, 4096, &buffered_file));
+  ABORT_NOT_OK(io::BufferedOutputStream::Create(file, kBufferSize, &buffered_file));
   BenchmarkStreamingWrites(state, small_sizes, buffered_file.get());
 }
 
@@ -194,7 +196,7 @@ static void BM_BufferedOutputStreamSmallWritesToPipe(
   SetupPipeWriter(&stream, &reader);
 
   std::shared_ptr<io::BufferedOutputStream> buffered_stream;
-  ABORT_NOT_OK(io::BufferedOutputStream::Create(stream, 4096, &buffered_stream));
+  ABORT_NOT_OK(io::BufferedOutputStream::Create(stream, kBufferSize, &buffered_stream));
   BenchmarkStreamingWrites(state, small_sizes, buffered_stream.get(), reader.get());
 }
 
@@ -205,7 +207,7 @@ static void BM_BufferedOutputStreamLargeWritesToPipe(
   SetupPipeWriter(&stream, &reader);
 
   std::shared_ptr<io::BufferedOutputStream> buffered_stream;
-  ABORT_NOT_OK(io::BufferedOutputStream::Create(stream, 4096, &buffered_stream));
+  ABORT_NOT_OK(io::BufferedOutputStream::Create(stream, kBufferSize, &buffered_stream));
 
   BenchmarkStreamingWrites(state, large_sizes, buffered_stream.get(), reader.get());
 }


### PR DESCRIPTION
Since the `BufferedOutputStream` ctor was using `std::string` to allocate a buffer internally, I needed to use a static ctor that returns Status for creating the output stream with an arbitrary buffer size. 