### PR TITLE
ARROW-3793: [C++] TestScalarAppendUnsafe is not testing unsafe appends

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1515,6 +1515,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
       }
     }
   }
+  ASSERT_EQ(builder_->value_data_length(), total_length * reps);
   Done();
   ASSERT_OK(ValidateArray(*result_));
   ASSERT_EQ(reps * N, result_->length());

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1499,15 +1499,17 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
   vector<uint8_t> is_null = {0, 0, 0, 1, 0};
 
   int N = static_cast<int>(strings.size());
-  int reps = 10;
+  int reps = 13;
+  int total_length = 0;
+  for (auto &&s : strings) total_length += s.size();
 
-  ASSERT_OK(builder_->Reserve(5));
-  ASSERT_OK(builder_->ReserveData(6));
+  ASSERT_OK(builder_->Reserve(N * reps));
+  ASSERT_OK(builder_->ReserveData(total_length * reps));
 
   for (int j = 0; j < reps; ++j) {
     for (int i = 0; i < N; ++i) {
       if (is_null[i]) {
-        ASSERT_OK(builder_->AppendNull());
+        ASSERT_OK(builder_->UnsafeAppendNull());
       } else {
         builder_->UnsafeAppend(strings[i]);
       }
@@ -1517,7 +1519,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
   ASSERT_OK(ValidateArray(*result_));
   ASSERT_EQ(reps * N, result_->length());
   ASSERT_EQ(reps, result_->null_count());
-  ASSERT_EQ(reps * 6, result_->value_data()->size());
+  ASSERT_EQ(reps * total_length, result_->value_data()->size());
 
   int32_t length;
   for (int i = 0; i < N * reps; ++i) {

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1509,7 +1509,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
   for (int j = 0; j < reps; ++j) {
     for (int i = 0; i < N; ++i) {
       if (is_null[i]) {
-        ASSERT_OK(builder_->UnsafeAppendNull());
+        builder_->UnsafeAppendNull();
       } else {
         builder_->UnsafeAppend(strings[i]);
       }

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1501,7 +1501,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
   int N = static_cast<int>(strings.size());
   int reps = 13;
   int total_length = 0;
-  for (auto&& s : strings) total_length += s.size();
+  for (auto&& s : strings) total_length += static_cast<int>(s.size());
 
   ASSERT_OK(builder_->Reserve(N * reps));
   ASSERT_OK(builder_->ReserveData(total_length * reps));

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1501,7 +1501,7 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
   int N = static_cast<int>(strings.size());
   int reps = 13;
   int total_length = 0;
-  for (auto &&s : strings) total_length += s.size();
+  for (auto&& s : strings) total_length += s.size();
 
   ASSERT_OK(builder_->Reserve(N * reps));
   ASSERT_OK(builder_->ReserveData(total_length * reps));

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1284,7 +1284,7 @@ Status BinaryBuilder::AppendNull() {
 
 void BinaryBuilder::UnsafeAppendNull() {
   const int64_t num_bytes = value_data_builder_.length();
-  offsets_builder_.UnsafeAppend(num_bytes);
+  offsets_builder_.UnsafeAppend(static_cast<int32_t>(num_bytes));
   UnsafeAppendToBitmap(false);
 }
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1282,6 +1282,12 @@ Status BinaryBuilder::AppendNull() {
   return Status::OK();
 }
 
+void BinaryBuilder::UnsafeAppendNull() {
+  const int64_t num_bytes = value_data_builder_.length();
+  offsets_builder_.UnsafeAppend(num_bytes);
+  UnsafeAppendToBitmap(false);
+}
+
 Status BinaryBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   // Write final offset (values length)
   RETURN_NOT_OK(AppendNextOffset());

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -1282,12 +1282,6 @@ Status BinaryBuilder::AppendNull() {
   return Status::OK();
 }
 
-void BinaryBuilder::UnsafeAppendNull() {
-  const int64_t num_bytes = value_data_builder_.length();
-  offsets_builder_.UnsafeAppend(static_cast<int32_t>(num_bytes));
-  UnsafeAppendToBitmap(false);
-}
-
 Status BinaryBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   // Write final offset (values length)
   RETURN_NOT_OK(AppendNextOffset());

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -52,10 +52,12 @@ constexpr int64_t kListMaximumElements = std::numeric_limits<int32_t>::max() - 1
 constexpr int64_t kMinBuilderCapacity = 1 << 5;
 
 /// Base class for all data array builders.
-//
+///
 /// This class provides a facilities for incrementally building the null bitmap
 /// (see Append methods) and as a side effect the current number of slots and
 /// the null count.
+///
+/// NB: Users are expected to cast to one of the concrete types below before use
 class ARROW_EXPORT ArrayBuilder {
  public:
   explicit ArrayBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -79,16 +79,6 @@ class ARROW_EXPORT ArrayBuilder {
   int64_t null_count() const { return null_count_; }
   int64_t capacity() const { return capacity_; }
 
-  /// Append to null bitmap
-  Status AppendToBitmap(bool is_valid);
-
-  /// Vector append. Treat each zero byte as a null.   If valid_bytes is null
-  /// assume all of length bits are valid.
-  Status AppendToBitmap(const uint8_t* valid_bytes, int64_t length);
-
-  /// Set the next length bits to not null (i.e. valid).
-  Status SetNotNull(int64_t length);
-
   /// \brief Ensure that enough memory has been allocated to fit the indicated
   /// number of total elements in the builder, including any that have already
   /// been appended. Does not account for reallocations that may be due to
@@ -130,7 +120,22 @@ class ARROW_EXPORT ArrayBuilder {
 
   std::shared_ptr<DataType> type() const { return type_; }
 
+ protected:
+  ArrayBuilder() {}
+
+  /// Append to null bitmap
+  Status AppendToBitmap(bool is_valid);
+
+  /// Vector append. Treat each zero byte as a null.   If valid_bytes is null
+  /// assume all of length bits are valid.
+  Status AppendToBitmap(const uint8_t* valid_bytes, int64_t length);
+
+  /// Set the next length bits to not null (i.e. valid).
+  Status SetNotNull(int64_t length);
+
   // Unsafe operations (don't check capacity/don't resize)
+
+  void UnsafeAppendNull() { UnsafeAppendToBitmap(false); }
 
   // Append to null bitmap, update the length
   void UnsafeAppendToBitmap(bool is_valid) {
@@ -174,10 +179,14 @@ class ARROW_EXPORT ArrayBuilder {
     length_ += std::distance(begin, end);
   }
 
-  void UnsafeAppendNull() { UnsafeAppendToBitmap(false); }
+  // Vector append. Treat each zero byte as a nullzero. If valid_bytes is null
+  // assume all of length bits are valid.
+  void UnsafeAppendToBitmap(const uint8_t* valid_bytes, int64_t length);
 
- protected:
-  ArrayBuilder() {}
+  void UnsafeAppendToBitmap(const std::vector<bool>& is_valid);
+
+  // Set the next length bits to not null (i.e. valid).
+  void UnsafeSetNotNull(int64_t length);
 
   std::shared_ptr<DataType> type_;
   MemoryPool* pool_;
@@ -193,15 +202,6 @@ class ARROW_EXPORT ArrayBuilder {
 
   // Child value array builders. These are owned by this class
   std::vector<std::unique_ptr<ArrayBuilder>> children_;
-
-  // Vector append. Treat each zero byte as a nullzero. If valid_bytes is null
-  // assume all of length bits are valid.
-  void UnsafeAppendToBitmap(const uint8_t* valid_bytes, int64_t length);
-
-  void UnsafeAppendToBitmap(const std::vector<bool>& is_valid);
-
-  // Set the next length bits to not null (i.e. valid).
-  void UnsafeSetNotNull(int64_t length);
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(ArrayBuilder);
@@ -370,6 +370,11 @@ class ARROW_EXPORT NumericBuilder : public PrimitiveBuilder<T> {
           ARROW_MEMORY_POOL_DEFAULT)
       : PrimitiveBuilder<T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
+  using ArrayBuilder::AppendToBitmap;
+  using ArrayBuilder::SetNotNull;
+  using ArrayBuilder::UnsafeAppendNull;
+  using ArrayBuilder::UnsafeAppendToBitmap;
+  using ArrayBuilder::UnsafeSetNotNull;
   using PrimitiveBuilder<T>::AppendValues;
   using PrimitiveBuilder<T>::Resize;
   using PrimitiveBuilder<T>::Reserve;
@@ -626,6 +631,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   explicit BooleanBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
 
   using ArrayBuilder::Advance;
+  using ArrayBuilder::UnsafeAppendNull;
 
   /// Write nulls as uint8_t* (0 value indicates null) into pre-allocated memory
   Status AppendNulls(const uint8_t* valid_bytes, int64_t length) {
@@ -858,6 +864,8 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
   }
 
   Status AppendNull();
+
+  void UnsafeAppendNull();
 
   /// \brief Append without checking capacity
   ///

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -749,7 +749,7 @@ class DictEncodeImpl : public HashTableKernel<Type, DictEncodeImpl<Type>> {
 
   Status Reserve(const int64_t length) { return indices_builder_.Reserve(length); }
 
-  void ObserveNull() { indices_builder_.UnsafeAppendToBitmap(false); }
+  void ObserveNull() { indices_builder_.UnsafeAppendNull(); }
 
   void ObserveFound(const hash_slot_t slot) { indices_builder_.UnsafeAppend(slot); }
 

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -61,47 +61,47 @@ Status Codec::Create(Compression::type codec_type, std::unique_ptr<Codec>* resul
     case Compression::SNAPPY:
 #ifdef ARROW_WITH_SNAPPY
       result->reset(new SnappyCodec());
+      break;
 #else
       return Status::NotImplemented("Snappy codec support not built");
 #endif
-      break;
     case Compression::GZIP:
 #ifdef ARROW_WITH_ZLIB
       result->reset(new GZipCodec());
+      break;
 #else
       return Status::NotImplemented("Gzip codec support not built");
 #endif
-      break;
     case Compression::LZO:
       return Status::NotImplemented("LZO codec not implemented");
     case Compression::BROTLI:
 #ifdef ARROW_WITH_BROTLI
       result->reset(new BrotliCodec());
+      break;
 #else
       return Status::NotImplemented("Brotli codec support not built");
 #endif
-      break;
     case Compression::LZ4:
 #ifdef ARROW_WITH_LZ4
       result->reset(new Lz4Codec());
+      break;
 #else
       return Status::NotImplemented("LZ4 codec support not built");
 #endif
-      break;
     case Compression::ZSTD:
 #ifdef ARROW_WITH_ZSTD
       result->reset(new ZSTDCodec());
+      break;
 #else
       return Status::NotImplemented("ZSTD codec support not built");
 #endif
-      break;
     case Compression::BZ2:
 #ifdef ARROW_WITH_BZ2
       result->reset(new BZ2Codec());
+      break;
 #else
       return Status::NotImplemented("BZ2 codec support not built");
 #endif
-      break;
     default:
       return Status::Invalid("Unrecognized codec");
   }


### PR DESCRIPTION
Perform enough repetitions that the Buffers will be more than the minimum allocation size (64 bytes) and reserve enough space for all repetitions. Also use UnsafeAppendNull rather than AppendNull to ensure that nothing is calling Reserve in the test's loop