### PR TITLE
ARROW-3804: [R] Support older versions of R runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -303,6 +303,7 @@ matrix:
     - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   # R
   - language: r
+    r: 3.1
     cache: packages
     latex: false
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -303,7 +303,6 @@ matrix:
     - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   # R
   - language: r
-    r: 3.1
     cache: packages
     latex: false
     before_install:

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
     person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
   )
 Description: R Integration to 'Apache' 'Arrow'.
-Depends: R (>= 3.5)
+Depends: R (>= 3.1)
 License: Apache License (>= 2.0)
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
`vctrs` requires `3.1`: https://github.com/r-lib/vctrs/blob/master/DESCRIPTION#L15, but no functionality makes use of `3.5`, at least, not yet.

Fix for: https://issues.apache.org/jira/browse/ARROW-3804