### PR TITLE
ARROW-3795: [R] Support for retrieving NAs from INT64 arrays

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -32,7 +32,7 @@ Remotes:
     RcppCore/Rcpp, 
     r-lib/withr
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.0.9000
+RoxygenNote: 6.1.1
 Suggests:
     testthat,
     lubridate, 

--- a/r/src/array.cpp
+++ b/r/src/array.cpp
@@ -34,7 +34,7 @@ inline bool isna<REALSXP>(double x) {
 }
 
 // the integer64 sentinel
-static const int64_t NA_INT64 = std::numeric_limits<int64_t>::min();
+constexpr int64_t NA_INT64 = std::numeric_limits<int64_t>::min();
 
 template <int RTYPE, typename Type>
 std::shared_ptr<Array> SimpleArray(SEXP x) {
@@ -801,7 +801,7 @@ struct Converter_Int64 {
   void Ingest(const std::shared_ptr<arrow::Array>& array, R_xlen_t start, R_xlen_t n) {
     auto null_count = array->null_count();
     if (null_count == n) {
-      std::fill_n(data.begin() + start, n, NA_INT64);
+      std::fill_n(reinterpret_cast<int64_t*>(data.begin()) + start, n, NA_INT64);
     } else {
       auto p_values = GetValuesSafely<int64_t>(array->data(), 1, array->offset());
       STOP_IF_NULL(p_values);

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -259,6 +259,12 @@ test_that("array supports integer64", {
   expect_true(a$IsNull(3L))
 })
 
+test_that("array$as_vector() correctly handles all NA inte64 (ARROW-3795)", {
+  x <- bit64::as.integer64(NA)
+  a <- array(x)
+  expect_true(is.na(a$as_vector()))
+})
+
 test_that("array supports difftime", {
   time <- hms::hms(56, 34, 12)
   a <- array(time, time)


### PR DESCRIPTION
``` r
library(arrow)
#> 
#> Attaching package: 'arrow'
#> The following object is masked from 'package:utils':
#> 
#>     timestamp
#> The following objects are masked from 'package:base':
#> 
#>     array, table

x <- bit64::as.integer64(c(NA))
a <- array(x)
a$as_vector()
#> integer64
#> [1] <NA>
```

<sup>Created on 2018-11-16 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>