### PR TITLE
ARROW-3826: [C++] Do not cache ccache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ services:
   - docker
 
 cache:
-  ccache: true
   directories:
     - $HOME/.m2  # Maven
 


### PR DESCRIPTION
Our cache has grown quite large. I am interested to see if turning this off changes build times