### PR TITLE
ARROW-3837: [C++] Add GFLAGS_IS_A_DLL define to fix Windows build

### DIFF
--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -15,6 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// ARROW-3837: Depending on how gflags was built, this might be set to
+// 1 or 0 by default, making it so that we cannot statically link
+// gflags on Windows if it is set to 1
+#define GFLAGS_IS_A_DLL 0
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
I'm not sure why this only broke now with gflags 2.2.2, but the default value for this define is generated by the gflags build system, and may be 1 or 0. Setting it to 0 indicates that it's our intent to statically link, and so the `__declspec(dllimport)` annotations won't be enabled