### PR TITLE
ARROW-3841: [C++] Suppress catching polymorphic type by value warning

### DIFF
--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -914,7 +914,7 @@ TEST_F(TestCast, StringToNumber) {
   try {
     // French locale uses the comma as decimal point
     std::locale::global(std::locale("fr_FR.UTF-8"));
-  } catch (std::runtime_error) {
+  } catch (std::runtime_error&) {
     // Locale unavailable, ignore
   }
   CheckCase<StringType, std::string, FloatType, float>(utf8(), v_float, is_valid,

--- a/cpp/src/arrow/util/parsing-util-test.cc
+++ b/cpp/src/arrow/util/parsing-util-test.cc
@@ -48,7 +48,7 @@ class LocaleGuard {
   explicit LocaleGuard(const char* new_locale) : global_locale_(std::locale()) {
     try {
       std::locale::global(std::locale(new_locale));
-    } catch (std::runtime_error) {
+    } catch (std::runtime_error&) {
       // Locale unavailable, ignore
     }
   }


### PR DESCRIPTION
    ../src/arrow/compute/compute-test.cc: In member function 'virtual void arrow::compute::TestCast_StringToNumber_Test::TestBody()':
    ../src/arrow/compute/compute-test.cc:917:17: warning: catching polymorphic type 'class std::runtime_error' by value [-Wcatch-value=]
       } catch (std::runtime_error) {
                     ^~~~~~~~~~~~~