### PR TITLE
ARROW-3852: [C++] Suppress used uninitialized warning

### DIFF
--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -312,7 +312,7 @@ Status CudaContext::OpenIpcBuffer(const CudaIpcMemHandle& ipc_handle,
                                   std::shared_ptr<CudaBuffer>* out) {
   if (ipc_handle.memory_size() > 0) {
     ContextSaver set_temporary(reinterpret_cast<CUcontext>(handle()));
-    uint8_t* data;
+    uint8_t* data = nullptr;
     RETURN_NOT_OK(impl_->OpenIpcBuffer(ipc_handle, &data));
     // Need to ask the device how big the buffer is
     size_t allocation_size = 0;

--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -744,7 +744,7 @@ TEST(BitUtil, RoundUpToPowerOf2) {
 }
 
 static void TestZigZag(int32_t v) {
-  uint8_t buffer[BitUtil::BitReader::MAX_VLQ_BYTE_LEN];
+  uint8_t buffer[BitUtil::BitReader::MAX_VLQ_BYTE_LEN] = {};
   BitUtil::BitWriter writer(buffer, sizeof(buffer));
   BitUtil::BitReader reader(buffer, sizeof(buffer));
   writer.PutZigZagVlqInt(v);


### PR DESCRIPTION
    In file included from ../src/arrow/util/bit-util-test.cc:35:
    ../src/arrow/util/bit-stream-utils.h: In function 'void arrow::TestZigZag(int32_t)':
    ../src/arrow/util/bit-stream-utils.h:110:11: warning: 'buffer' is used uninitialized in this function [-Wuninitialized]
         memcpy(&buffered_values_, buffer_ + byte_offset_, num_bytes);
         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    ../src/arrow/gpu/cuda_context.cc: In member function 'arrow::Status arrow::gpu::CudaContext::OpenIpcBuffer(const arrow::gpu::CudaIpcMemHandle&, std::shared_ptr<arrow::gpu::CudaBuffer>*)':
    ../src/arrow/gpu/cuda_context.cc:315:14: warning: 'data' may be used uninitialized in this function [-Wmaybe-uninitialized]
         uint8_t* data;
                  ^~~~
