### PR TITLE
ARROW-3854: [GLib] Deprecate garrow_gio_{input,output}_stream_get_raw()

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -435,7 +435,7 @@ garrow_buffer_input_stream_new(GArrowBuffer *buffer)
   auto arrow_buffer = garrow_buffer_get_raw(buffer);
   auto arrow_buffer_reader =
     std::make_shared<arrow::io::BufferReader>(arrow_buffer);
-  return garrow_buffer_input_stream_new_raw_buffer(&arrow_buffer_reader, buffer);
+  return garrow_buffer_input_stream_new_raw(&arrow_buffer_reader, buffer);
 }
 
 /**
@@ -896,14 +896,8 @@ garrow_seekable_input_stream_get_raw(GArrowSeekableInputStream *seekable_input_s
 }
 
 GArrowBufferInputStream *
-garrow_buffer_input_stream_new_raw(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader)
-{
-  return garrow_buffer_input_stream_new_raw_buffer(arrow_buffer_reader, nullptr);
-}
-
-GArrowBufferInputStream *
-garrow_buffer_input_stream_new_raw_buffer(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader,
-                                          GArrowBuffer *buffer)
+garrow_buffer_input_stream_new_raw(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader,
+                                   GArrowBuffer *buffer)
 {
   auto buffer_input_stream =
     GARROW_BUFFER_INPUT_STREAM(g_object_new(GARROW_TYPE_BUFFER_INPUT_STREAM,

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -400,14 +400,13 @@ garrow_buffer_input_stream_init(GArrowBufferInputStream *object)
 static void
 garrow_buffer_input_stream_class_init(GArrowBufferInputStreamClass *klass)
 {
-  GParamSpec *spec;
-
   auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->dispose      = garrow_buffer_input_stream_dispose;
   gobject_class->set_property = garrow_buffer_input_stream_set_property;
   gobject_class->get_property = garrow_buffer_input_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_object("buffer",
                              "Buffer",
                              "The data",
@@ -738,14 +737,13 @@ garrow_gio_input_stream_init(GArrowGIOInputStream *object)
 static void
 garrow_gio_input_stream_class_init(GArrowGIOInputStreamClass *klass)
 {
-  GParamSpec *spec;
-
   auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->dispose      = garrow_gio_input_stream_dispose;
   gobject_class->set_property = garrow_gio_input_stream_set_property;
   gobject_class->get_property = garrow_gio_input_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_object("raw",
                              "Raw",
                              "The raw GInputStream *",
@@ -880,14 +878,13 @@ garrow_compressed_input_stream_init(GArrowCompressedInputStream *object)
 static void
 garrow_compressed_input_stream_class_init(GArrowCompressedInputStreamClass *klass)
 {
-  GParamSpec *spec;
-
   auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->dispose      = garrow_compressed_input_stream_dispose;
   gobject_class->set_property = garrow_compressed_input_stream_set_property;
   gobject_class->get_property = garrow_compressed_input_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_object("codec",
                              "Codec",
                              "The codec for the stream",

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -113,9 +113,7 @@ G_DEFINE_TYPE_WITH_CODE(GArrowInputStream,
 static void
 garrow_input_stream_finalize(GObject *object)
 {
-  GArrowInputStreamPrivate *priv;
-
-  priv = GARROW_INPUT_STREAM_GET_PRIVATE(object);
+  auto priv = GARROW_INPUT_STREAM_GET_PRIVATE(object);
 
   priv->input_stream = nullptr;
 
@@ -128,9 +126,7 @@ garrow_input_stream_set_property(GObject *object,
                                  const GValue *value,
                                  GParamSpec *pspec)
 {
-  GArrowInputStreamPrivate *priv;
-
-  priv = GARROW_INPUT_STREAM_GET_PRIVATE(object);
+  auto priv = GARROW_INPUT_STREAM_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_INPUT_STREAM:
@@ -164,15 +160,13 @@ garrow_input_stream_init(GArrowInputStream *object)
 static void
 garrow_input_stream_class_init(GArrowInputStreamClass *klass)
 {
-  GObjectClass *gobject_class;
-  GParamSpec *spec;
-
-  gobject_class = G_OBJECT_CLASS(klass);
+  auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->finalize     = garrow_input_stream_finalize;
   gobject_class->set_property = garrow_input_stream_set_property;
   gobject_class->get_property = garrow_input_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_pointer("input-stream",
                               "Input stream",
                               "The raw std::shared<arrow::io::InputStream> *",
@@ -956,9 +950,7 @@ garrow_input_stream_new_raw(std::shared_ptr<arrow::io::InputStream> *arrow_input
 std::shared_ptr<arrow::io::InputStream>
 garrow_input_stream_get_raw(GArrowInputStream *input_stream)
 {
-  GArrowInputStreamPrivate *priv;
-
-  priv = GARROW_INPUT_STREAM_GET_PRIVATE(input_stream);
+  auto priv = GARROW_INPUT_STREAM_GET_PRIVATE(input_stream);
   return priv->input_stream;
 }
 

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -567,14 +567,14 @@ namespace garrow {
     }
 
     arrow::Status ReadAt(int64_t position, int64_t n_bytes,
-			 int64_t *n_read_bytes, void* out) override {
-	return arrow::io::RandomAccessFile::ReadAt(
-	    position, n_bytes, n_read_bytes, out);
+                         int64_t *n_read_bytes, void* out) override {
+      return arrow::io::RandomAccessFile::ReadAt(
+        position, n_bytes, n_read_bytes, out);
     }
 
     arrow::Status ReadAt(int64_t position, int64_t n_bytes,
-			 std::shared_ptr<arrow::Buffer>* out) override {
-	return arrow::io::RandomAccessFile::ReadAt(position, n_bytes, out);
+                         std::shared_ptr<arrow::Buffer>* out) override {
+      return arrow::io::RandomAccessFile::ReadAt(position, n_bytes, out);
     }
 
     arrow::Status Read(int64_t n_bytes,

--- a/c_glib/arrow-glib/input-stream.h
+++ b/c_glib/arrow-glib/input-stream.h
@@ -182,7 +182,11 @@ struct _GArrowGIOInputStreamClass
 GType garrow_gio_input_stream_get_type(void) G_GNUC_CONST;
 
 GArrowGIOInputStream *garrow_gio_input_stream_new(GInputStream *gio_input_stream);
-GInputStream *garrow_gio_input_stream_get_raw(GArrowGIOInputStream *input_stream);
+#ifndef GARROW_DISABLE_DEPRECATED
+G_GNUC_DEPRECATED
+GInputStream *
+garrow_gio_input_stream_get_raw(GArrowGIOInputStream *input_stream);
+#endif
 
 #define GARROW_TYPE_COMPRESSED_INPUT_STREAM     \
   (garrow_compressed_input_stream_get_type())

--- a/c_glib/arrow-glib/input-stream.hpp
+++ b/c_glib/arrow-glib/input-stream.hpp
@@ -31,9 +31,9 @@ std::shared_ptr<arrow::io::InputStream> garrow_input_stream_get_raw(GArrowInputS
 
 std::shared_ptr<arrow::io::RandomAccessFile> garrow_seekable_input_stream_get_raw(GArrowSeekableInputStream *input_stream);
 
-GArrowBufferInputStream *garrow_buffer_input_stream_new_raw(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader);
-GArrowBufferInputStream *garrow_buffer_input_stream_new_raw_buffer(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader,
-                                                                   GArrowBuffer *buffer);
+GArrowBufferInputStream *
+garrow_buffer_input_stream_new_raw(std::shared_ptr<arrow::io::BufferReader> *arrow_buffer_reader,
+                                   GArrowBuffer *buffer);
 std::shared_ptr<arrow::io::BufferReader> garrow_buffer_input_stream_get_raw(GArrowBufferInputStream *input_stream);
 
 GArrowMemoryMappedInputStream *garrow_memory_mapped_input_stream_new_raw(std::shared_ptr<arrow::io::MemoryMappedFile> *arrow_memory_mapped_file);

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -462,14 +462,13 @@ garrow_gio_output_stream_init(GArrowGIOOutputStream *object)
 static void
 garrow_gio_output_stream_class_init(GArrowGIOOutputStreamClass *klass)
 {
-  GParamSpec *spec;
-
   auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->dispose      = garrow_gio_output_stream_dispose;
   gobject_class->set_property = garrow_gio_output_stream_set_property;
   gobject_class->get_property = garrow_gio_output_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_object("raw",
                              "Raw",
                              "The raw GOutputStream *",
@@ -602,14 +601,13 @@ garrow_compressed_output_stream_init(GArrowCompressedOutputStream *object)
 static void
 garrow_compressed_output_stream_class_init(GArrowCompressedOutputStreamClass *klass)
 {
-  GParamSpec *spec;
-
   auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->dispose      = garrow_compressed_output_stream_dispose;
   gobject_class->set_property = garrow_compressed_output_stream_set_property;
   gobject_class->get_property = garrow_compressed_output_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_object("codec",
                              "Codec",
                              "The codec for the stream",

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -394,18 +394,95 @@ namespace garrow {
 
 G_BEGIN_DECLS
 
-G_DEFINE_TYPE(GArrowGIOOutputStream,
-              garrow_gio_output_stream,
-              GARROW_TYPE_OUTPUT_STREAM);
+typedef struct GArrowGIOOutputStreamPrivate_ {
+  GOutputStream *raw;
+} GArrowGIOOutputStreamPrivate;
+
+enum {
+  PROP_GIO_RAW = 1
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowGIOOutputStream,
+                           garrow_gio_output_stream,
+                           GARROW_TYPE_OUTPUT_STREAM);
+
+#define GARROW_GIO_OUTPUT_STREAM_GET_PRIVATE(object)    \
+  static_cast<GArrowGIOOutputStreamPrivate *>(          \
+    garrow_gio_output_stream_get_instance_private(      \
+      GARROW_GIO_OUTPUT_STREAM(object)))
 
 static void
-garrow_gio_output_stream_init(GArrowGIOOutputStream *gio_output_stream)
+garrow_gio_output_stream_dispose(GObject *object)
+{
+  auto priv = GARROW_GIO_OUTPUT_STREAM_GET_PRIVATE(object);
+
+  if (priv->raw) {
+    g_object_unref(priv->raw);
+    priv->raw = nullptr;
+  }
+
+  G_OBJECT_CLASS(garrow_gio_output_stream_parent_class)->dispose(object);
+}
+
+static void
+garrow_gio_output_stream_set_property(GObject *object,
+                                      guint prop_id,
+                                      const GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto priv = GARROW_GIO_OUTPUT_STREAM_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_GIO_RAW:
+    priv->raw = G_OUTPUT_STREAM(g_value_dup_object(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_gio_output_stream_get_property(GObject *object,
+                                      guint prop_id,
+                                      GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto priv = GARROW_GIO_OUTPUT_STREAM_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_GIO_RAW:
+    g_value_set_object(value, priv->raw);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_gio_output_stream_init(GArrowGIOOutputStream *object)
 {
 }
 
 static void
 garrow_gio_output_stream_class_init(GArrowGIOOutputStreamClass *klass)
 {
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose      = garrow_gio_output_stream_dispose;
+  gobject_class->set_property = garrow_gio_output_stream_set_property;
+  gobject_class->get_property = garrow_gio_output_stream_get_property;
+
+  spec = g_param_spec_object("raw",
+                             "Raw",
+                             "The raw GOutputStream *",
+                             G_TYPE_OUTPUT_STREAM,
+                             static_cast<GParamFlags>(G_PARAM_READWRITE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_GIO_RAW, spec);
 }
 
 /**
@@ -421,6 +498,7 @@ garrow_gio_output_stream_new(GOutputStream *gio_output_stream)
     std::make_shared<garrow::GIOOutputStream>(gio_output_stream);
   auto object = g_object_new(GARROW_TYPE_GIO_OUTPUT_STREAM,
                              "output-stream", &arrow_output_stream,
+                             "raw", gio_output_stream,
                              NULL);
   auto output_stream = GARROW_GIO_OUTPUT_STREAM(object);
   return output_stream;
@@ -433,16 +511,14 @@ garrow_gio_output_stream_new(GOutputStream *gio_output_stream)
  * Returns: (transfer none): The wrapped #GOutputStream.
  *
  * Since: 0.5.0
+ *
+ * Deprecated: 0.12.0: Use GArrowGIOOutputStream::raw property instead.
  */
 GOutputStream *
 garrow_gio_output_stream_get_raw(GArrowGIOOutputStream *output_stream)
 {
-  auto arrow_output_stream =
-    garrow_output_stream_get_raw(GARROW_OUTPUT_STREAM(output_stream));
-  auto arrow_gio_output_stream =
-    std::static_pointer_cast<garrow::GIOOutputStream>(arrow_output_stream);
-  auto gio_output_stream = arrow_gio_output_stream->get_output_stream();
-  return gio_output_stream;
+  auto priv = GARROW_GIO_OUTPUT_STREAM_GET_PRIVATE(output_stream);
+  return priv->raw;
 }
 
 typedef struct GArrowCompressedOutputStreamPrivate_ {

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -111,9 +111,7 @@ G_DEFINE_TYPE_WITH_CODE(GArrowOutputStream,
 static void
 garrow_output_stream_finalize(GObject *object)
 {
-  GArrowOutputStreamPrivate *priv;
-
-  priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(object);
+  auto priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(object);
 
   priv->output_stream = nullptr;
 
@@ -126,9 +124,7 @@ garrow_output_stream_set_property(GObject *object,
                                           const GValue *value,
                                           GParamSpec *pspec)
 {
-  GArrowOutputStreamPrivate *priv;
-
-  priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(object);
+  auto priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_OUTPUT_STREAM:
@@ -162,15 +158,13 @@ garrow_output_stream_init(GArrowOutputStream *object)
 static void
 garrow_output_stream_class_init(GArrowOutputStreamClass *klass)
 {
-  GObjectClass *gobject_class;
-  GParamSpec *spec;
-
-  gobject_class = G_OBJECT_CLASS(klass);
+  auto gobject_class = G_OBJECT_CLASS(klass);
 
   gobject_class->finalize     = garrow_output_stream_finalize;
   gobject_class->set_property = garrow_output_stream_set_property;
   gobject_class->get_property = garrow_output_stream_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_pointer("output-stream",
                               "io::OutputStream",
                               "The raw std::shared<arrow::io::OutputStream> *",
@@ -679,9 +673,7 @@ garrow_output_stream_new_raw(std::shared_ptr<arrow::io::OutputStream> *arrow_out
 std::shared_ptr<arrow::io::OutputStream>
 garrow_output_stream_get_raw(GArrowOutputStream *output_stream)
 {
-  GArrowOutputStreamPrivate *priv;
-
-  priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(output_stream);
+  auto priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(output_stream);
   return priv->output_stream;
 }
 

--- a/c_glib/arrow-glib/output-stream.h
+++ b/c_glib/arrow-glib/output-stream.h
@@ -193,7 +193,11 @@ struct _GArrowGIOOutputStreamClass
 GType garrow_gio_output_stream_get_type(void) G_GNUC_CONST;
 
 GArrowGIOOutputStream *garrow_gio_output_stream_new(GOutputStream *gio_output_stream);
-GOutputStream *garrow_gio_output_stream_get_raw(GArrowGIOOutputStream *output_stream);
+#ifndef GARROW_DISABLE_DEPRECATED
+G_GNUC_DEPRECATED
+GOutputStream *
+garrow_gio_output_stream_get_raw(GArrowGIOOutputStream *output_stream);
+#endif
 
 #define GARROW_TYPE_COMPRESSED_OUTPUT_STREAM    \
   (garrow_compressed_output_stream_get_type())


### PR DESCRIPTION
Because we use `_get_raw()` name for functions that return C++ object.

We can provide getter for raw `GInputStream`/`GOutputStream` via GObject property mechanism. We used the mechanism for `GArrowCompressed{Input,Output}Stream`.

This pull request includes some implementation cleanups (sorry):

  * Removed internal `garrow_buffer_input_stream_new_raw_buffer()` API
  * Fixed indent.
  * Changed to use `auto`.
  * Moved `GParamSpec *spec` position.