### PR TITLE
ARROW-3858: [GLib] Use {class_name}_get_instance_private

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -243,10 +243,10 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GArrowArrayBuilder,
                                     garrow_array_builder,
                                     G_TYPE_OBJECT)
 
-#define GARROW_ARRAY_BUILDER_GET_PRIVATE(obj)                           \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                                   \
-                               GARROW_TYPE_ARRAY_BUILDER,               \
-                               GArrowArrayBuilderPrivate))
+#define GARROW_ARRAY_BUILDER_GET_PRIVATE(obj)         \
+  static_cast<GArrowArrayBuilderPrivate *>(           \
+     garrow_array_builder_get_instance_private(       \
+       GARROW_ARRAY_BUILDER(obj)))
 
 static void
 garrow_array_builder_finalize(GObject *object)
@@ -2940,10 +2940,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowListArrayBuilder,
                            garrow_list_array_builder,
                            GARROW_TYPE_ARRAY_BUILDER)
 
-#define GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(obj)              \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
-                               GARROW_TYPE_LIST_ARRAY_BUILDER,  \
-                               GArrowListArrayBuilderPrivate))
+#define GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(obj)         \
+  static_cast<GArrowListArrayBuilderPrivate *>(            \
+     garrow_list_array_builder_get_instance_private(       \
+       GARROW_LIST_ARRAY_BUILDER(obj)))
 
 static void
 garrow_list_array_builder_dispose(GObject *object)
@@ -3110,10 +3110,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowStructArrayBuilder,
                            garrow_struct_array_builder,
                            GARROW_TYPE_ARRAY_BUILDER)
 
-#define GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(obj)                    \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                                   \
-                               GARROW_TYPE_STRUCT_ARRAY_BUILDER,        \
-                               GArrowStructArrayBuilderPrivate))
+#define GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(obj)         \
+  static_cast<GArrowStructArrayBuilderPrivate *>(            \
+     garrow_struct_array_builder_get_instance_private(       \
+       GARROW_STRUCT_ARRAY_BUILDER(obj)))
 
 static void
 garrow_struct_array_builder_dispose(GObject *object)

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -211,8 +211,10 @@ enum {
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowArray, garrow_array, G_TYPE_OBJECT)
 
-#define GARROW_ARRAY_GET_PRIVATE(obj)                                   \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj), GARROW_TYPE_ARRAY, GArrowArrayPrivate))
+#define GARROW_ARRAY_GET_PRIVATE(obj)         \
+  static_cast<GArrowArrayPrivate *>(          \
+     garrow_array_get_instance_private(       \
+       GARROW_ARRAY(obj)))
 
 static void
 garrow_array_finalize(GObject *object)

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -101,10 +101,10 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GArrowDataType,
                                     garrow_data_type,
                                     G_TYPE_OBJECT)
 
-#define GARROW_DATA_TYPE_GET_PRIVATE(obj)               \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                   \
-                               GARROW_TYPE_DATA_TYPE,   \
-                               GArrowDataTypePrivate))
+#define GARROW_DATA_TYPE_GET_PRIVATE(obj)         \
+  static_cast<GArrowDataTypePrivate *>(           \
+     garrow_data_type_get_instance_private(       \
+       GARROW_DATA_TYPE(obj)))
 
 static void
 garrow_data_type_finalize(GObject *object)

--- a/c_glib/arrow-glib/buffer.cpp
+++ b/c_glib/arrow-glib/buffer.cpp
@@ -55,8 +55,10 @@ enum {
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowBuffer, garrow_buffer, G_TYPE_OBJECT)
 
-#define GARROW_BUFFER_GET_PRIVATE(obj) \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj), GARROW_TYPE_BUFFER, GArrowBufferPrivate))
+#define GARROW_BUFFER_GET_PRIVATE(obj)         \
+  static_cast<GArrowBufferPrivate *>(          \
+     garrow_buffer_get_instance_private(       \
+       GARROW_BUFFER(obj)))
 
 static void
 garrow_buffer_dispose(GObject *object)

--- a/c_glib/arrow-glib/chunked-array.cpp
+++ b/c_glib/arrow-glib/chunked-array.cpp
@@ -52,10 +52,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowChunkedArray,
                            garrow_chunked_array,
                            G_TYPE_OBJECT)
 
-#define GARROW_CHUNKED_ARRAY_GET_PRIVATE(obj)                   \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
-                               GARROW_TYPE_CHUNKED_ARRAY,       \
-                               GArrowChunkedArrayPrivate))
+#define GARROW_CHUNKED_ARRAY_GET_PRIVATE(obj)         \
+  static_cast<GArrowChunkedArrayPrivate *>(           \
+     garrow_chunked_array_get_instance_private(       \
+       GARROW_CHUNKED_ARRAY(obj)))
 
 static void
 garrow_chunked_array_finalize(GObject *object)

--- a/c_glib/arrow-glib/decimal.cpp
+++ b/c_glib/arrow-glib/decimal.cpp
@@ -49,10 +49,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowDecimal128,
                            garrow_decimal128,
                            G_TYPE_OBJECT)
 
-#define GARROW_DECIMAL128_GET_PRIVATE(obj)                 \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                      \
-                               GARROW_TYPE_DECIMAL128,     \
-                               GArrowDecimal128Private))
+#define GARROW_DECIMAL128_GET_PRIVATE(obj)         \
+  static_cast<GArrowDecimal128Private *>(          \
+     garrow_decimal128_get_instance_private(       \
+       GARROW_DECIMAL128(obj)))
 
 static void
 garrow_decimal128_finalize(GObject *object)

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -48,10 +48,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowField,
                            garrow_field,
                            G_TYPE_OBJECT)
 
-#define GARROW_FIELD_GET_PRIVATE(obj)               \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),               \
-                               GARROW_TYPE_FIELD,   \
-                               GArrowFieldPrivate))
+#define GARROW_FIELD_GET_PRIVATE(obj)         \
+  static_cast<GArrowFieldPrivate *>(          \
+     garrow_field_get_instance_private(       \
+       GARROW_FIELD(obj)))
 
 static void
 garrow_field_finalize(GObject *object)

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -105,10 +105,10 @@ G_DEFINE_TYPE_WITH_CODE(GArrowInputStream,
                         G_IMPLEMENT_INTERFACE(GARROW_TYPE_READABLE,
                                               garrow_input_stream_readable_interface_init));
 
-#define GARROW_INPUT_STREAM_GET_PRIVATE(obj)                    \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
-                               GARROW_TYPE_INPUT_STREAM,        \
-                               GArrowInputStreamPrivate))
+#define GARROW_INPUT_STREAM_GET_PRIVATE(obj)         \
+  static_cast<GArrowInputStreamPrivate *>(           \
+     garrow_input_stream_get_instance_private(       \
+       GARROW_INPUT_STREAM(obj)))
 
 static void
 garrow_input_stream_finalize(GObject *object)
@@ -338,10 +338,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowBufferInputStream,
                            garrow_buffer_input_stream,
                            GARROW_TYPE_SEEKABLE_INPUT_STREAM);
 
-#define GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(obj)                     \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                                   \
-                               GARROW_TYPE_BUFFER_INPUT_STREAM,         \
-                               GArrowBufferInputStreamPrivate))
+#define GARROW_BUFFER_INPUT_STREAM_GET_PRIVATE(obj)         \
+  static_cast<GArrowBufferInputStreamPrivate *>(            \
+     garrow_buffer_input_stream_get_instance_private(       \
+       GARROW_BUFFER_INPUT_STREAM(obj)))
 
 static void
 garrow_buffer_input_stream_dispose(GObject *object)

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -103,10 +103,10 @@ G_DEFINE_TYPE_WITH_CODE(GArrowOutputStream,
                         G_IMPLEMENT_INTERFACE(GARROW_TYPE_WRITABLE,
                                               garrow_output_stream_writable_interface_init));
 
-#define GARROW_OUTPUT_STREAM_GET_PRIVATE(obj)                   \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
-                               GARROW_TYPE_OUTPUT_STREAM,       \
-                               GArrowOutputStreamPrivate))
+#define GARROW_OUTPUT_STREAM_GET_PRIVATE(obj)         \
+  static_cast<GArrowOutputStreamPrivate *>(           \
+     garrow_output_stream_get_instance_private(       \
+       GARROW_OUTPUT_STREAM(obj)))
 
 static void
 garrow_output_stream_finalize(GObject *object)

--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -70,10 +70,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchReader,
                            garrow_record_batch_reader,
                            G_TYPE_OBJECT);
 
-#define GARROW_RECORD_BATCH_READER_GET_PRIVATE(obj)             \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
-                               GARROW_TYPE_RECORD_BATCH_READER, \
-                               GArrowRecordBatchReaderPrivate))
+#define GARROW_RECORD_BATCH_READER_GET_PRIVATE(obj)         \
+  static_cast<GArrowRecordBatchReaderPrivate *>(            \
+     garrow_record_batch_reader_get_instance_private(       \
+       GARROW_RECORD_BATCH_READER(obj)))
 
 static void
 garrow_record_batch_reader_finalize(GObject *object)
@@ -322,10 +322,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchFileReader,
                            garrow_record_batch_file_reader,
                            G_TYPE_OBJECT);
 
-#define GARROW_RECORD_BATCH_FILE_READER_GET_PRIVATE(obj)                \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                                   \
-                               GARROW_TYPE_RECORD_BATCH_FILE_READER,    \
-                               GArrowRecordBatchFileReaderPrivate))
+#define GARROW_RECORD_BATCH_FILE_READER_GET_PRIVATE(obj)        \
+  static_cast<GArrowRecordBatchFileReaderPrivate *>(            \
+     garrow_record_batch_file_reader_get_instance_private(      \
+       GARROW_RECORD_BATCH_FILE_READER(obj)))
 
 static void
 garrow_record_batch_file_reader_finalize(GObject *object)

--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -72,10 +72,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatch,
                            garrow_record_batch,
                            G_TYPE_OBJECT)
 
-#define GARROW_RECORD_BATCH_GET_PRIVATE(obj)               \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),               \
-                               GARROW_TYPE_RECORD_BATCH,   \
-                               GArrowRecordBatchPrivate))
+#define GARROW_RECORD_BATCH_GET_PRIVATE(obj)         \
+  static_cast<GArrowRecordBatchPrivate *>(           \
+     garrow_record_batch_get_instance_private(       \
+       GARROW_RECORD_BATCH(obj)))
 
 static void
 garrow_record_batch_finalize(GObject *object)

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -48,10 +48,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowSchema,
                            garrow_schema,
                            G_TYPE_OBJECT)
 
-#define GARROW_SCHEMA_GET_PRIVATE(obj)                  \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                   \
-                               GARROW_TYPE_SCHEMA,      \
-                               GArrowSchemaPrivate))
+#define GARROW_SCHEMA_GET_PRIVATE(obj)         \
+  static_cast<GArrowSchemaPrivate *>(          \
+     garrow_schema_get_instance_private(       \
+       GARROW_SCHEMA(obj)))
 
 static void
 garrow_schema_finalize(GObject *object)

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -51,10 +51,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowTable,
                            garrow_table,
                            G_TYPE_OBJECT)
 
-#define GARROW_TABLE_GET_PRIVATE(obj)               \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),               \
-                               GARROW_TYPE_TABLE,   \
-                               GArrowTablePrivate))
+#define GARROW_TABLE_GET_PRIVATE(obj)         \
+  static_cast<GArrowTablePrivate *>(          \
+     garrow_table_get_instance_private(       \
+       GARROW_TABLE(obj)))
 
 static void
 garrow_table_dispose(GObject *object)

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -51,8 +51,10 @@ enum {
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowTensor, garrow_tensor, G_TYPE_OBJECT)
 
-#define GARROW_TENSOR_GET_PRIVATE(obj)                                   \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj), GARROW_TYPE_TENSOR, GArrowTensorPrivate))
+#define GARROW_TENSOR_GET_PRIVATE(obj)         \
+  static_cast<GArrowTensorPrivate *>(          \
+     garrow_tensor_get_instance_private(       \
+       GARROW_TENSOR(obj)))
 
 static void
 garrow_tensor_dispose(GObject *object)

--- a/c_glib/arrow-glib/writer.cpp
+++ b/c_glib/arrow-glib/writer.cpp
@@ -65,10 +65,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchWriter,
                            garrow_record_batch_writer,
                            G_TYPE_OBJECT);
 
-#define GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(obj)             \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                           \
-                               GARROW_TYPE_RECORD_BATCH_WRITER, \
-                               GArrowRecordBatchWriterPrivate))
+#define GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(obj)         \
+  static_cast<GArrowRecordBatchWriterPrivate *>(            \
+     garrow_record_batch_writer_get_instance_private(       \
+       GARROW_RECORD_BATCH_WRITER(obj)))
 
 static void
 garrow_record_batch_writer_finalize(GObject *object)

--- a/c_glib/gandiva-glib/projector.cpp
+++ b/c_glib/gandiva-glib/projector.cpp
@@ -55,10 +55,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GGandivaProjector,
                            ggandiva_projector,
                            G_TYPE_OBJECT)
 
-#define GGANDIVA_PROJECTOR_GET_PRIVATE(obj)                 \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                       \
-                               GGANDIVA_TYPE_PROJECTOR,     \
-                               GGandivaProjectorPrivate))
+#define GGANDIVA_PROJECTOR_GET_PRIVATE(obj)         \
+  static_cast<GGandivaProjectorPrivate *>(          \
+     ggandiva_projector_get_instance_private(       \
+       GGANDIVA_PROJECTOR(obj)))
 
 static void
 ggandiva_projector_finalize(GObject *object)

--- a/c_glib/plasma-glib/client.cpp
+++ b/c_glib/plasma-glib/client.cpp
@@ -51,10 +51,10 @@ G_DEFINE_TYPE_WITH_PRIVATE(GPlasmaClient,
                            gplasma_client,
                            G_TYPE_OBJECT)
 
-#define GPLASMA_CLIENT_GET_PRIVATE(obj)                 \
-  (G_TYPE_INSTANCE_GET_PRIVATE((obj),                   \
-                               GPLASMA_TYPE_CLIENT,     \
-                               GPlasmaClientPrivate))
+#define GPLASMA_CLIENT_GET_PRIVATE(obj)         \
+  static_cast<GPlasmaClientPrivate *>(          \
+     gplasma_client_get_instance_private(       \
+       GPLASMA_CLIENT(obj)))
 
 static void
 gplasma_client_finalize(GObject *object)


### PR DESCRIPTION
Because `G_TYPE_INSTANCE_GET_PRIVATE` has been deprecated since version 2.58.
https://developer.gnome.org/gobject/stable/gobject-Type-Information.html#G-TYPE-INSTANCE-GET-PRIVATE
