### PR TITLE
ARROW-3859: [Arrow][Java] Fixed backward incompatible change.

### DIFF
--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -58,8 +58,8 @@
     // checkstyle:on
     -->
     <module name="SuppressionCommentFilter">
-      <property name="offCommentFormat" value="checkstyle.off\: ([\w\|]+)"/>
-      <property name="onCommentFormat" value="checkstyle.on\: ([\w\|]+)"/>
+      <property name="offCommentFormat" value="checkstyle:off: ([\w\|]+)"/>
+      <property name="onCommentFormat" value="checkstyle:on: ([\w\|]+)"/>
       <property name="checkFormat" value="$1"/>
     </module>
 
@@ -250,5 +250,7 @@
             <property name="exceptionVariableName" value="expected|ignore"/>
         </module>
         <module name="CommentsIndentation"/>
+        <!-- needed so that filters can access file contents -->
+        <module name="FileContentsHolder"/>
     </module>
 </module>

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -89,6 +89,7 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
   @Override
   public void clear() {
+    //checkstyle:off: MissingSwitchDefault
     switch (mode) {
       case STRUCT:
         structRoot.clear();
@@ -96,13 +97,13 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.clear();
         break;
-      default:
-        throw new RuntimeException("Unexpected mode:" + mode);
     }
+    //checkstyle:on: MissingSwitchDefault
   }
 
   @Override
   public void setValueCount(int count) {
+    //checkstyle:off: MissingSwitchDefault
     switch (mode) {
       case STRUCT:
         structRoot.setValueCount(count);
@@ -110,13 +111,13 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.setValueCount(count);
         break;
-      default:
-        throw new RuntimeException("Unexpected mode:" + mode);
     }
+    //checkstyle:on: MissingSwitchDefault
   }
 
   @Override
   public void setPosition(int index) {
+    //checkstyle:off: MissingSwitchDefault
     super.setPosition(index);
     switch (mode) {
       case STRUCT:
@@ -125,9 +126,8 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.setPosition(index);
         break;
-      default:
-        throw new RuntimeException("Unexpected mode:" + mode);
     }
+    //checkstyle:on: MissingSwitchDefault
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -89,7 +89,6 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
   @Override
   public void clear() {
-    //checkstyle:off: MissingSwitchDefault
     switch (mode) {
       case STRUCT:
         structRoot.clear();
@@ -97,13 +96,13 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.clear();
         break;
+      default:
+        break;
     }
-    //checkstyle:on: MissingSwitchDefault
   }
 
   @Override
   public void setValueCount(int count) {
-    //checkstyle:off: MissingSwitchDefault
     switch (mode) {
       case STRUCT:
         structRoot.setValueCount(count);
@@ -111,13 +110,13 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.setValueCount(count);
         break;
+      default:
+        break;
     }
-    //checkstyle:on: MissingSwitchDefault
   }
 
   @Override
   public void setPosition(int index) {
-    //checkstyle:off: MissingSwitchDefault
     super.setPosition(index);
     switch (mode) {
       case STRUCT:
@@ -126,8 +125,9 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.setPosition(index);
         break;
+      default:
+        break;
     }
-    //checkstyle:on: MissingSwitchDefault
   }
 
 


### PR DESCRIPTION
Throwing exceptions on default breaks a lot of existing client code.
Reverting the change for now, we can check for a deprecation and moving to new
method in the future.
Had to fix the checkstyle comment suppression filter too.