### PR TITLE
ARROW-3865: [Packaging] Add double-conversion dependency to conda forge recipes and the windows wheel build

### DIFF
--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - boost-cpp
+    - double-conversion
     - thrift-cpp >=0.11
     - libprotobuf
     - flatbuffers

--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -26,7 +26,7 @@ conda install -n arrow -q -y -c conda-forge ^
       git flatbuffers rapidjson ^
       cmake ^
       boost-cpp thrift-cpp ^
-      gflags snappy zlib brotli zstd lz4-c
+      gflags snappy zlib brotli zstd lz4-c double-conversion
 
 call activate arrow
 


### PR DESCRIPTION
Follow-up of https://github.com/apache/arrow/commit/9509220ee76f696c37926b4057c0d16306e0c793, builds: [here](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=build-365)