### PR TITLE
ARROW-2504: [Website] Add ApacheCon NA link

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -77,9 +77,14 @@
           </div>
         </li>
       </ul>
-      <a href="http://www.apache.org/" class="flex-row ml-md-auto">
-        <img style="float:right;" src="{{ site.baseurl }}/img/asf_logo.svg" width="120px"/>
-      </a>
+      <div class="flex-row justify-content-end ml-md-auto">
+        <a class="d-sm-none d-md-inline pr-2" href="https://www.apache.org/events/current-event.html">
+          <img src="https://www.apache.org/events/current-event-234x60.png"/>
+        </a>
+        <a href="http://www.apache.org/">
+          <img src="{{ site.baseurl }}/img/asf_logo.svg" width="120px"/>
+        </a>
+      </div>
       </div><!-- /.navbar-collapse -->
     </div>
   </nav>


### PR DESCRIPTION
Place a 234x60 link in the navbar next to the Apache Software Foundation link.

Screenshot for full width:
![image](https://user-images.githubusercontent.com/7432951/48995065-1213f700-f10c-11e8-944f-e5d26f1bfe8b.png)

Screenshot for medium width:
![image](https://user-images.githubusercontent.com/7432951/48995076-1b04c880-f10c-11e8-8abf-a3d2ef204596.png)

Disappears in small width -- screenshot:
![image](https://user-images.githubusercontent.com/7432951/48995108-31128900-f10c-11e8-96a7-066e377081fa.png)
