### PR TITLE
ARROW-3493: [Java] Make sure bound checks are off

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
@@ -23,10 +23,16 @@ public class BoundsChecking {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BoundsChecking.class);
 
   static {
+    String oldPropertry = System.getProperty("drill.enable_unsafe_memory_access");
+    if (oldPropertry != null) {
+      logger.warn("\"drill.enable_unsafe_memory_access\" has been renamed to \"arrow.check_unsafe_memory_access\"");
+      logger.warn("\"arrow.check_unsafe_memory_access\" can be set to: true (to check) or false (not to check)");
+    }
     boolean isAssertEnabled = false;
     assert isAssertEnabled = true;
     BOUNDS_CHECKING_ENABLED = isAssertEnabled ||
-      "true".equals(System.getProperty("arrow.check_unsafe_memory_access"));
+      "true".equals(System.getProperty("arrow.check_unsafe_memory_access")) ||
+      !"true".equals(oldPropertry);
   }
 
   private BoundsChecking() {

--- a/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
@@ -25,13 +25,14 @@ public class BoundsChecking {
   static {
     String oldPropertry = System.getProperty("drill.enable_unsafe_memory_access");
     if (oldPropertry != null) {
-      logger.warn("\"drill.enable_unsafe_memory_access\" has been renamed to \"arrow.check_unsafe_memory_access\"");
-      logger.warn("\"arrow.check_unsafe_memory_access\" can be set to: true (to check) or false (not to check)");
+      logger.warn("\"drill.enable_unsafe_memory_access\" has been renamed to \"arrow.enable_unsafe_memory_access\"");
+      logger.warn("\"arrow.enable_unsafe_memory_access\" can be set to: " +
+              " true (to not check) or false (to check, default)");
     }
     boolean isAssertEnabled = false;
     assert isAssertEnabled = true;
     BOUNDS_CHECKING_ENABLED = isAssertEnabled ||
-      "true".equals(System.getProperty("arrow.check_unsafe_memory_access")) ||
+      !"true".equals(System.getProperty("arrow.enable_unsafe_memory_access")) ||
       !"true".equals(oldPropertry);
   }
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
@@ -26,7 +26,7 @@ public class BoundsChecking {
     boolean isAssertEnabled = false;
     assert isAssertEnabled = true;
     BOUNDS_CHECKING_ENABLED = isAssertEnabled ||
-      !"true".equals(System.getProperty("drill.enable_unsafe_memory_access"));
+      "true".equals(System.getProperty("arrow.check_unsafe_memory_access"));
   }
 
   private BoundsChecking() {

--- a/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
@@ -23,8 +23,8 @@ public class BoundsChecking {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BoundsChecking.class);
 
   static {
-    String oldPropertry = System.getProperty("drill.enable_unsafe_memory_access");
-    if (oldPropertry != null) {
+    String oldProperty = System.getProperty("drill.enable_unsafe_memory_access");
+    if (oldProperty != null) {
       logger.warn("\"drill.enable_unsafe_memory_access\" has been renamed to \"arrow.enable_unsafe_memory_access\"");
       logger.warn("\"arrow.enable_unsafe_memory_access\" can be set to: " +
               " true (to not check) or false (to check, default)");
@@ -33,7 +33,7 @@ public class BoundsChecking {
     assert isAssertEnabled = true;
     BOUNDS_CHECKING_ENABLED = isAssertEnabled ||
       !"true".equals(System.getProperty("arrow.enable_unsafe_memory_access")) ||
-      !"true".equals(oldPropertry);
+      !"true".equals(oldProperty);
   }
 
   private BoundsChecking() {


### PR DESCRIPTION
As discussed previously on the mailing list, I found
that the bound checks have significant performance
penalty. This commit:
* renames the property from "drill.enable_unsafe_memory_access"
  to "arrow.check_unsafe_memory_access"
* set the default value to false

For somehow doing debugging, they can set it back to true.

Signed-off-by: Animesh Trivedi <atrivedi@apache.org>