### PR TITLE
ARROW-3202: [C++] Fix compilation on Alpine Linux by using ARROW_WITH_BACKTRACE define

### DIFF
--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -17,7 +17,7 @@
 
 #include "arrow/util/logging.h"
 
-#ifndef _WIN32
+#ifdef ARROW_WITH_BACKTRACE
 #include <execinfo.h>
 #endif
 #include <cstdlib>


### PR DESCRIPTION
Should fix #2818.