### PR TITLE
ARROW-3888: [C++] Fix various compiler warnings

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -344,7 +344,7 @@ class TimestampConverter : public ConcreteConverter {
     StringConverter<TimestampType> converter(type_);
 
     auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
-      value_type value;
+      value_type value = 0;
       if (IsNull(data, size, quoted)) {
         builder.UnsafeAppendNull();
         return Status::OK();

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -854,8 +854,8 @@ TEST_F(TestInt96ParquetIO, ReadIntoTimestamp) {
   Int96 day;
   day.value[2] = UINT32_C(2440589);
   int64_t seconds = (11 * 60 + 35) * 60;
-  *(reinterpret_cast<int64_t*>(&(day.value))) =
-      seconds * INT64_C(1000) * INT64_C(1000) * INT64_C(1000) + 145738543;
+  Int96SetNanoSeconds(
+      day, seconds * INT64_C(1000) * INT64_C(1000) * INT64_C(1000) + 145738543);
   // Compute the corresponding nanosecond timestamp
   struct tm datetime;
   memset(&datetime, 0, sizeof(struct tm));

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -76,7 +76,9 @@ constexpr int64_t kNanosecondsInADay = kMillisecondsInADay * 1000LL * 1000LL;
 
 static inline int64_t impala_timestamp_to_nanoseconds(const Int96& impala_timestamp) {
   int64_t days_since_epoch = impala_timestamp.value[2] - kJulianToUnixEpochDays;
-  int64_t nanoseconds = *(reinterpret_cast<const int64_t*>(&(impala_timestamp.value)));
+  int64_t nanoseconds = 0;
+
+  memcpy(&nanoseconds, &impala_timestamp.value, sizeof(int64_t));
   return days_since_epoch * kNanosecondsInADay + nanoseconds;
 }
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -865,9 +865,9 @@ Status ArrowColumnWriter::Write(const Array& data) {
   RETURN_NOT_OK(GetLeafType(*data.type(), &values_type));
 
   std::shared_ptr<Array> _values_array;
-  int64_t values_offset;
-  int64_t num_levels;
-  int64_t num_values;
+  int64_t values_offset = 0;
+  int64_t num_levels = 0;
+  int64_t num_values = 0;
   LevelBuilder level_builder(ctx_->memory_pool);
 
   std::shared_ptr<Buffer> def_levels_buffer, rep_levels_buffer;

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -47,6 +47,7 @@ class PARQUET_EXPORT ArrowWriterProperties {
     Builder()
         : write_nanos_as_int96_(false),
           coerce_timestamps_enabled_(false),
+          coerce_timestamps_unit_(::arrow::TimeUnit::SECOND),
           truncated_timestamps_allowed_(false) {}
     virtual ~Builder() {}
 

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -188,6 +188,10 @@ static inline std::string ByteArrayToString(const ByteArray& a) {
   return std::string(reinterpret_cast<const char*>(a.ptr), a.len);
 }
 
+static inline void Int96SetNanoSeconds(parquet::Int96& i96, int64_t nanoseconds) {
+  std::memcpy(&i96.value, &nanoseconds, sizeof(nanoseconds));
+}
+
 static inline std::string Int96ToString(const Int96& a) {
   std::ostringstream result;
   std::copy(a.value, a.value + 3, std::ostream_iterator<uint32_t>(result, " "));

--- a/cpp/src/parquet/util/comparison-test.cc
+++ b/cpp/src/parquet/util/comparison-test.cc
@@ -166,25 +166,25 @@ TEST(Comparison, UnsignedInt96) {
   aaa.value[2] = 2451545;  // 2000-01-01
   bbb.value[2] = 2451546;  // 2000-01-02
   // 12 hours + 34 minutes + 56 seconds.
-  reinterpret_cast<uint64_t*>(&aaa.value[0])[0] = 45296000000000;
+  Int96SetNanoSeconds(aaa, 45296000000000);
   // 12 hours + 34 minutes + 50 seconds.
-  reinterpret_cast<uint64_t*>(&bbb.value[0])[0] = 45290000000000;
+  Int96SetNanoSeconds(bbb, 45290000000000);
   ASSERT_TRUE(uless(aaa, bbb));
 
   aaa.value[2] = 2451545;  // 2000-01-01
   bbb.value[2] = 2451545;  // 2000-01-01
   // 11 hours + 34 minutes + 56 seconds.
-  reinterpret_cast<uint64_t*>(&aaa.value[0])[0] = 41696000000000;
+  Int96SetNanoSeconds(aaa, 41696000000000);
   // 12 hours + 34 minutes + 50 seconds.
-  reinterpret_cast<uint64_t*>(&bbb.value[0])[0] = 45290000000000;
+  Int96SetNanoSeconds(bbb, 45290000000000);
   ASSERT_TRUE(uless(aaa, bbb));
 
   aaa.value[2] = 2451545;  // 2000-01-01
   bbb.value[2] = 2451545;  // 2000-01-01
   // 12 hours + 34 minutes + 55 seconds.
-  reinterpret_cast<uint64_t*>(&aaa.value[0])[0] = 45295000000000;
+  Int96SetNanoSeconds(aaa, 45295000000000);
   // 12 hours + 34 minutes + 56 seconds.
-  reinterpret_cast<uint64_t*>(&bbb.value[0])[0] = 45296000000000;
+  Int96SetNanoSeconds(bbb, 45296000000000);
   ASSERT_TRUE(uless(aaa, bbb));
 }
 


### PR DESCRIPTION
- Use of uninitialized variables
- Strict aliasing