### PR TITLE
ARROW-3740: [C++] Builder should not downsize

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -261,6 +261,16 @@ TEST_F(TestBuilder, TestReserve) {
   ASSERT_EQ(BitUtil::NextPower2(1030), builder.capacity());
 }
 
+TEST_F(TestBuilder, TestResizeDownsize) {
+  UInt8Builder builder(pool_);
+
+  ASSERT_OK(builder.Resize(1000));
+  ASSERT_EQ(1000, builder.capacity());
+
+  // Can't downsize.
+  ASSERT_RAISES(Invalid, builder.Resize(500));
+}
+
 template <typename Attrs>
 class TestPrimitiveBuilder : public TestBuilder {
  public:
@@ -888,6 +898,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestReserve) {
   ASSERT_OK(this->builder_->Reserve(90));
   ASSERT_OK(this->builder_->Advance(100));
   ASSERT_OK(this->builder_->Reserve(kMinBuilderCapacity));
+
+  ASSERT_RAISES(Invalid, this->builder_->Resize(1));
 
   ASSERT_EQ(BitUtil::NextPower2(kMinBuilderCapacity + 100), this->builder_->capacity());
 }

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -87,7 +87,9 @@ class ARROW_EXPORT ArrayBuilder {
   /// been appended. Does not account for reallocations that may be due to
   /// variable size data, like binary values. To make space for incremental
   /// appends, use Reserve instead.
-  /// \param[in] capacity the minimum number of additional array values
+  ///
+  /// \param[in] capacity the minimum number of total array values to
+  ///            accommodate. Must be greater than the current capacity.
   /// \return Status
   virtual Status Resize(int64_t capacity);
 


### PR DESCRIPTION
Downsizing is a tricky business, it is safer to invoke Reset() then Reserve().