### PR TITLE
ARROW-3870: [C++] Add Peek to InputStream abstract interface

### DIFF
--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -100,10 +100,6 @@ class ARROW_EXPORT BufferedInputStream : public InputStream {
   static Status Create(std::shared_ptr<InputStream> raw, int64_t buffer_size,
                        MemoryPool* pool, std::shared_ptr<BufferedInputStream>* out);
 
-  /// \brief Return string_view to buffered bytes, up to the indicated
-  /// number. View becomes invalid after any operation on file
-  util::string_view Peek(int64_t nbytes) const;
-
   /// \brief Resize internal read buffer; calls to Read(...) will read at least
   /// \param[in] new_buffer_size the new read buffer size
   /// \return Status
@@ -124,6 +120,7 @@ class ARROW_EXPORT BufferedInputStream : public InputStream {
   std::shared_ptr<InputStream> raw() const;
 
   // InputStream APIs
+  util::string_view Peek(int64_t nbytes) const override;
   Status Close() override;
   bool closed() const override;
 

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -22,6 +22,7 @@
 #include <mutex>
 
 #include "arrow/status.h"
+#include "arrow/util/string_view.h"
 
 namespace arrow {
 namespace io {
@@ -31,6 +32,10 @@ FileInterface::~FileInterface() = default;
 Status InputStream::Advance(int64_t nbytes) {
   std::shared_ptr<Buffer> temp;
   return Read(nbytes, &temp);
+}
+
+util::string_view InputStream::Peek(int64_t ARROW_ARG_UNUSED(nbytes)) const {
+  return util::string_view(nullptr, 0);
 }
 
 bool InputStream::supports_zero_copy() const { return false; }

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "arrow/util/macros.h"
+#include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -120,6 +121,13 @@ class ARROW_EXPORT InputStream : virtual public FileInterface, virtual public Re
   /// \param[in] nbytes the number to move forward
   /// \return Status
   Status Advance(int64_t nbytes);
+
+  /// \brief Return string_view to any buffered bytes, up to the indicated
+  /// number. View becomes invalid after any operation on file. If the
+  /// InputStream is unbuffered, returns 0-length string_view
+  /// \param[in] nbytes the maximum number of bytes to see
+  /// \return arrow::util::string_view
+  virtual util::string_view Peek(int64_t nbytes) const;
 
   /// \brief Return true if InputStream is capable of zero copy Buffer reads
   virtual bool supports_zero_copy() const;

--- a/cpp/src/arrow/io/io-file-test.cc
+++ b/cpp/src/arrow/io/io-file-test.cc
@@ -345,6 +345,15 @@ TEST_F(TestReadableFile, FromFileDescriptor) {
   ASSERT_TRUE(FileIsClosed(fd));
 }
 
+TEST_F(TestReadableFile, Peek) {
+  MakeTestFile();
+  OpenFile();
+
+  // Cannot peek
+  auto view = file_->Peek(4);
+  ASSERT_EQ(0, view.size());
+}
+
 TEST_F(TestReadableFile, SeekTellSize) {
   MakeTestFile();
   OpenFile();

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -173,7 +173,7 @@ TEST(TestBufferReader, Peek) {
 
   view = reader.Peek(20);
   ASSERT_EQ(data.size(), view.size());
-  ASSERT_EQ(data, view);
+  ASSERT_EQ(data, view.to_string());
 }
 
 TEST(TestBufferReader, RetainParentReference) {

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -169,7 +169,7 @@ TEST(TestBufferReader, Peek) {
   auto view = reader.Peek(4);
 
   ASSERT_EQ(4, view.size());
-  ASSERT_EQ(data.substr(0, 4), view);
+  ASSERT_EQ(data.substr(0, 4), view.to_string());
 
   view = reader.Peek(20);
   ASSERT_EQ(data.size(), view.size());

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -161,6 +161,21 @@ TEST(TestBufferReader, Seeking) {
   ASSERT_EQ(pos, 10);
 }
 
+TEST(TestBufferReader, Peek) {
+  std::string data = "data123456";
+
+  BufferReader reader(std::make_shared<Buffer>(data));
+
+  auto view = reader.Peek(4);
+
+  ASSERT_EQ(4, view.size());
+  ASSERT_EQ(data.substr(0, 4), view);
+
+  view = reader.Peek(20);
+  ASSERT_EQ(data.size(), view.size());
+  ASSERT_EQ(data, view);
+}
+
 TEST(TestBufferReader, RetainParentReference) {
   // ARROW-387
   std::string data = "data123456";

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -287,6 +287,12 @@ Status BufferReader::Tell(int64_t* position) const {
   return Status::OK();
 }
 
+util::string_view BufferReader::Peek(int64_t nbytes) const {
+  const int64_t bytes_available = std::min(nbytes, size_ - position_);
+  return util::string_view(reinterpret_cast<const char*>(data_) + position_,
+                           static_cast<size_t>(bytes_available));
+}
+
 bool BufferReader::supports_zero_copy() const { return true; }
 
 Status BufferReader::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -140,14 +140,16 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
   // Zero copy read
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
+  util::string_view Peek(int64_t nbytes) const override;
+
+  bool supports_zero_copy() const override;
+
   Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                 void* out) override;
   Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   Status GetSize(int64_t* size) override;
   Status Seek(int64_t position) override;
-
-  bool supports_zero_copy() const override;
 
   std::shared_ptr<Buffer> buffer() const { return buffer_; }
 


### PR DESCRIPTION
Default implementation returns a 0-length `arrow::util::string_view`