### PR TITLE
ARROW-3874: [C++] Add LLVM_DIR to find_package in FindLLVM.cmake

### DIFF
--- a/cpp/cmake_modules/FindLLVM.cmake
+++ b/cpp/cmake_modules/FindLLVM.cmake
@@ -23,7 +23,8 @@
 set(GANDIVA_LLVM_VERSION 6.0)
 find_package(LLVM ${GANDIVA_LLVM_VERSION} REQUIRED CONFIG HINTS
              /usr/local/opt/llvm
-             /usr/share)
+             /usr/share
+             ${LLVM_DIR})
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 


### PR DESCRIPTION
Identical to the cmake patch from [ARROW-3874](https://issues.apache.org/jira/browse/ARROW-3874).