### PR TITLE
ARROW-3931: [C++] Make possible to build regardless of LANG

### DIFF
--- a/cpp/cmake_modules/CompilerInfo.cmake
+++ b/cpp/cmake_modules/CompilerInfo.cmake
@@ -21,18 +21,21 @@ if (NOT MSVC)
   set(COMPILER_GET_VERSION_SWITCH "-v")
 endif()
 
+set(COMPILER_VERSION_COMMAND "${CMAKE_CXX_COMPILER}" "${COMPILER_GET_VERSION_SWITCH}")
+
 if (UNIX OR APPLE)
-  set(COMPILER_EXEC_ENVIRONMENT "env" "LANG=C")
+  set(COMPILER_VERSION_COMMAND "env" "LANG=C" ${COMPILER_VERSION_COMMAND})
 endif()
 
-message(INFO "Compiler command: ${CMAKE_CXX_COMPILER}")
+string(REPLACE ";" " " COMPILER_VERSION_COMMAND_STR "${COMPILER_VERSION_COMMAND}")
+message(STATUS "Compiler command: ${COMPILER_VERSION_COMMAND_STR}")
 # Some gcc seem to output their version on stdout, most do it on stderr, simply
 # merge both pipes into a single variable
-execute_process(COMMAND ${COMPILER_EXEC_ENVIRONMENT} "${CMAKE_CXX_COMPILER}" "${COMPILER_GET_VERSION_SWITCH}"
+execute_process(COMMAND ${COMPILER_VERSION_COMMAND}
                 OUTPUT_VARIABLE COMPILER_VERSION_FULL
                 ERROR_VARIABLE COMPILER_VERSION_FULL)
-message(INFO "Compiler version: ${COMPILER_VERSION_FULL}")
-message(INFO "Compiler id: ${CMAKE_CXX_COMPILER_ID}")
+message(STATUS "Compiler version: ${COMPILER_VERSION_FULL}")
+message(STATUS "Compiler id: ${CMAKE_CXX_COMPILER_ID}")
 string(TOLOWER "${COMPILER_VERSION_FULL}" COMPILER_VERSION_FULL_LOWER)
 
 if(MSVC)

--- a/cpp/cmake_modules/CompilerInfo.cmake
+++ b/cpp/cmake_modules/CompilerInfo.cmake
@@ -24,7 +24,7 @@ endif()
 message(INFO "Compiler command: ${CMAKE_CXX_COMPILER}")
 # Some gcc seem to output their version on stdout, most do it on stderr, simply
 # merge both pipes into a single variable
-execute_process(COMMAND "${CMAKE_CXX_COMPILER}" ${COMPILER_GET_VERSION_SWITCH}
+execute_process(COMMAND bash -c "LANG=C ${CMAKE_CXX_COMPILER} ${COMPILER_GET_VERSION_SWITCH}"
                 OUTPUT_VARIABLE COMPILER_VERSION_FULL
                 ERROR_VARIABLE COMPILER_VERSION_FULL)
 message(INFO "Compiler version: ${COMPILER_VERSION_FULL}")

--- a/cpp/cmake_modules/CompilerInfo.cmake
+++ b/cpp/cmake_modules/CompilerInfo.cmake
@@ -21,10 +21,14 @@ if (NOT MSVC)
   set(COMPILER_GET_VERSION_SWITCH "-v")
 endif()
 
+if (UNIX OR APPLE)
+  set(COMPILER_EXEC_ENVIRONMENT "env" "LANG=C")
+endif()
+
 message(INFO "Compiler command: ${CMAKE_CXX_COMPILER}")
 # Some gcc seem to output their version on stdout, most do it on stderr, simply
 # merge both pipes into a single variable
-execute_process(COMMAND bash -c "LANG=C ${CMAKE_CXX_COMPILER} ${COMPILER_GET_VERSION_SWITCH}"
+execute_process(COMMAND ${COMPILER_EXEC_ENVIRONMENT} "${CMAKE_CXX_COMPILER}" "${COMPILER_GET_VERSION_SWITCH}"
                 OUTPUT_VARIABLE COMPILER_VERSION_FULL
                 ERROR_VARIABLE COMPILER_VERSION_FULL)
 message(INFO "Compiler version: ${COMPILER_VERSION_FULL}")


### PR DESCRIPTION
At the time of building C++ libs, CompilerInfo.cmake checks the version of compiler to be used.
How to check is string matching of output of gcc -v or like clang -v.
When LANG is not related to English, build will fail because string match fails.
The following is the case of  ja_JP.UTF-8 (Japanese).

```
CMake Error at cmake_modules/CompilerInfo.cmake:92 (message):                                                                                                                                                                                 
  Unknown compiler.  Version info:                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
  組み込み spec を使用しています。                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
  COLLECT_GCC=/usr/bin/c++                                                                                                                                                                                                                    
                                                                                                                                                                                                                                              
  COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-redhat-linux/4.8.5/lto-wrapper                                                                                                                                                                  
                                                                                                                                                                                                                                              
  ターゲット: x86_64-redhat-linux                                                                                                                                                                                                             
                                                                                                                                                                                                                                              
  configure 設定: ../configure --prefix=/usr --mandir=/usr/share/man                                                                                                                                                                          
  --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla                                                                                                                                                                 
  --enable-bootstrap --enable-shared --enable-threads=posix                                                                                                                                                                                   
  --enable-checking=release --with-system-zlib --enable-__cxa_atexit                                                                                                                                                                          
  --disable-libunwind-exceptions --enable-gnu-unique-object                                                                                                                                                                                   
  --enable-linker-build-id --with-linker-hash-style=gnu                                                                                                                                                                                       
  --enable-languages=c,c++,objc,obj-c++,java,fortran,ada,go,lto                                                                                                                                                                               
  --enable-plugin --enable-initfini-array --disable-libgcj                                                                                                                                                                                    
  --with-isl=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/isl-install                                                                                                                                                     
  --with-cloog=/builddir/build/BUILD/gcc-4.8.5-20150702/obj-x86_64-redhat-linux/cloog-install                                                                                                                                                 
  --enable-gnu-indirect-function --with-tune=generic --with-arch_32=x86-64                                                                                                                                                                    
  --build=x86_64-redhat-linux                                                                                                                                                                                                                 
                                                                                                                                                                                                                                              
  スレッドモデル: posix                                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
  gcc バージョン 4.8.5 20150623 (Red Hat 4.8.5-11) (GCC) 
```

I fixed this issue by modifying CompilerInfo.cmake.