### PR TITLE
ARROW-3884: [Python] Add LLVM6 to manylinux1 base image

### DIFF
--- a/python/manylinux1/Dockerfile-x86_64_base
+++ b/python/manylinux1/Dockerfile-x86_64_base
@@ -17,7 +17,7 @@
 FROM quay.io/pypa/manylinux1_x86_64:latest
 
 # Install dependencies
-RUN yum install -y ccache flex wget && yum clean all
+RUN yum install -y xz ccache flex wget && yum clean all
 
 ADD scripts/build_zlib.sh /
 RUN /build_zlib.sh
@@ -79,3 +79,9 @@ RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild &
 
 ADD scripts/build_virtualenvs.sh /
 RUN /build_virtualenvs.sh
+
+ADD scripts/build_llvm.sh /
+RUN /build_llvm.sh
+
+ADD scripts/build_clang.sh /
+RUN /build_clang.sh

--- a/python/manylinux1/scripts/build_boost.sh
+++ b/python/manylinux1/scripts/build_boost.sh
@@ -25,7 +25,7 @@ mkdir /arrow_boost
 pushd /boost_${BOOST_VERSION_UNDERSCORE}
 ./bootstrap.sh
 ./b2 tools/bcp
-./dist/bin/bcp --namespace=arrow_boost --namespace-alias filesystem date_time system regex build algorithm locale format /arrow_boost
+./dist/bin/bcp --namespace=arrow_boost --namespace-alias filesystem date_time system regex build algorithm locale format variant /arrow_boost
 popd
 
 pushd /arrow_boost

--- a/python/manylinux1/scripts/build_clang.sh
+++ b/python/manylinux1/scripts/build_clang.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -ex
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,4 +16,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-dist/
+source /multibuild/manylinux_utils.sh
+
+export LLVM_VERSION="6.0.0"
+curl -sL http://releases.llvm.org/${LLVM_VERSION}/cfe-${LLVM_VERSION}.src.tar.xz -o cfe-${LLVM_VERSION}.src.tar.xz
+unxz cfe-${LLVM_VERSION}.src.tar.xz
+tar xf cfe-${LLVM_VERSION}.src.tar
+pushd cfe-${LLVM_VERSION}.src
+mkdir build
+pushd build
+cmake  \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCLANG_INCLUDE_TESTS=OFF \
+    -DCLANG_INCLUDE_DOCS=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLVM_INCLUDE_DOCS=OFF \
+    -GNinja \
+    ..
+ninja install
+popd
+popd
+rm -rf cfe-${LLVM_VERSION}.src.tar.xz cfe-${LLVM_VERSION}.src.tar cfe-${LLVM_VERSION}.src

--- a/python/manylinux1/scripts/build_llvm.sh
+++ b/python/manylinux1/scripts/build_llvm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -ex
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+source /multibuild/manylinux_utils.sh
+
+export LLVM_VERSION="6.0.0"
+curl -sL http://releases.llvm.org/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz -o llvm-${LLVM_VERSION}.src.tar.xz
+unxz llvm-${LLVM_VERSION}.src.tar.xz
+tar xf llvm-${LLVM_VERSION}.src.tar
+pushd llvm-${LLVM_VERSION}.src
+mkdir build
+pushd build
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=host \
+    -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_UTILS=OFF \
+    -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF \
+    -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_USE_INTEL_JITEVENTS=ON \
+    -DPYTHON_EXECUTABLE="$(cpython_path 2.7 32)/bin/python" \
+    -GNinja \
+    ..
+ninja install
+popd
+popd
+rm -rf llvm-${LLVM_VERSION}.src.tar.xz llvm-${LLVM_VERSION}.src.tar llvm-${LLVM_VERSION}


### PR DESCRIPTION
I had to remove the `.dockerignore` file to make `quay.io` work again. I have a successful local build with Gandiva in the wheels but there are still some build systems we need to fix to activate Gandiva directly in the wheels.