### PR TITLE
PARQUET-1469: [C++] Fix data corruption bug in parquet::internal::DefinitionLevelsToBitmap that was triggered through random data

### DIFF
--- a/cpp/src/parquet/arrow/record_reader.h
+++ b/cpp/src/parquet/arrow/record_reader.h
@@ -104,6 +104,8 @@ class RecordReader {
   /// \param[in] reader obtained from RowGroupReader::GetColumnPageReader
   void SetPageReader(std::unique_ptr<PageReader> reader);
 
+  void DebugPrintState();
+
  private:
   std::unique_ptr<RecordReaderImpl> impl_;
   explicit RecordReader(RecordReaderImpl* impl);

--- a/cpp/src/parquet/arrow/test-util.h
+++ b/cpp/src/parquet/arrow/test-util.h
@@ -484,44 +484,6 @@ void ExpectArrayT<::arrow::BooleanType>(void* expected, Array* result) {
   EXPECT_TRUE(result->Equals(*expected_array));
 }
 
-template <typename ParquetType>
-void PrintBufferedLevels(const RecordReader& reader) {
-  using T = typename ::parquet::type_traits<ParquetType::type_num>::value_type;
-
-  const int16_t* def_levels = reader.def_levels();
-  const int16_t* rep_levels = reader.rep_levels();
-  const int64_t total_levels_read = reader.levels_position();
-
-  const T* values = reinterpret_cast<const T*>(reader.values());
-
-  std::cout << "def levels: ";
-  for (int64_t i = 0; i < total_levels_read; ++i) {
-    std::cout << def_levels[i] << " ";
-  }
-  std::cout << std::endl;
-
-  std::cout << "rep levels: ";
-  for (int64_t i = 0; i < total_levels_read; ++i) {
-    std::cout << rep_levels[i] << " ";
-  }
-  std::cout << std::endl;
-
-  std::cout << "values: ";
-  for (int64_t i = 0; i < reader.values_written(); ++i) {
-    std::cout << values[i] << " ";
-  }
-  std::cout << std::endl;
-}
-
-template <>
-void PrintBufferedLevels<ByteArrayType>(const RecordReader& reader) {}
-
-template <>
-void PrintBufferedLevels<FLBAType>(const RecordReader& reader) {}
-
-template <>
-void PrintBufferedLevels<Int96Type>(const RecordReader& reader) {}
-
 }  // namespace arrow
 
 }  // namespace parquet

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -178,9 +178,11 @@ namespace internal {
 static inline void DefinitionLevelsToBitmap(
     const int16_t* def_levels, int64_t num_def_levels, const int16_t max_definition_level,
     const int16_t max_repetition_level, int64_t* values_read, int64_t* null_count,
-    uint8_t* valid_bits, const int64_t valid_bits_offset) {
+    uint8_t* valid_bits, int64_t valid_bits_offset) {
+  // We assume here that valid_bits is large enough to accommodate the
+  // additional definition levels and the ones that have already been written
   ::arrow::internal::BitmapWriter valid_bits_writer(valid_bits, valid_bits_offset,
-                                                    num_def_levels);
+                                                    valid_bits_offset + num_def_levels);
 
   // TODO(itaiin): As an interim solution we are splitting the code path here
   // between repeated+flat column reads, and non-repeated+nested reads.


### PR DESCRIPTION
I also refactored some code to aid with debugging