### PR TITLE
ARROW-2993: [JS] Document minimum supported NodeJS version

### DIFF
--- a/js/.npmrc
+++ b/js/.npmrc
@@ -1,2 +1,2 @@
 save-prefix=
-package-lock=false
+engine-strict=true

--- a/js/package.json
+++ b/js/package.json
@@ -101,6 +101,9 @@
     "webpack": "4.23.1",
     "xml2js": "0.4.19"
   },
+  "engines": {
+    "node": ">=10.0"
+  },
   "@std/esm": {
     "warnings": false
   },


### PR DESCRIPTION
Adds an engine requirement to package.json, and sets engine-strict in project-level npm config

This makes it so that running `npm install` in arrow/js yields the following error:
```
$ node -v
v9.11.2
$ npm install
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for apache-arrow@0.3.0: wanted: {"node":">=10.0"} (current: {"node":"9.11.2","npm":"5.6.0"})
npm ERR! notsup Not compatible with your version of node/npm: apache-arrow@0.3.0
npm ERR! notsup Not compatible with your version of node/npm: apache-arrow@0.3.0
npm ERR! notsup Required: {"node":">=10.0"}
npm ERR! notsup Actual:   {"npm":"5.6.0","node":"9.11.2"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/hulettbh/.npm/_logs/2018-12-04T16_42_12_911Z-debug.log
```

Users should get a similar error when they install an arrow package if they have engine-strict set in their own npm config.