### PR TITLE
ARROW-3629: [Python] Add write_to_dataset to Python Sphinx API listing

### DIFF
--- a/python/doc/source/api.rst
+++ b/python/doc/source/api.rst
@@ -372,6 +372,7 @@ Apache Parquet
    read_schema
    write_metadata
    write_table
+   write_to_dataset
 
 .. currentmodule:: pyarrow
 


### PR DESCRIPTION
Not sure whether this was all that was wanted. The new Sphinx theme is working, by the way. More comments in the JIRA. Screenshot with `write_to_dataset` highlighted: 
<img width="663" alt="screen shot 2018-12-04 at 11 43 07 am" src="https://user-images.githubusercontent.com/7432951/49462054-c40d8c00-f7ba-11e8-8bdd-aad09f01b6a5.png">
