### PR TITLE
ARROW-3272: [Java][Docs] Add documentation about Java code style

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -50,11 +50,11 @@ deprecation warnings.
 Arrow Java follows the Google style guide [here][3] with the following
 differences:
 
-* Imports should be grouped, from top to bottom, in order: static imports,
+* Imports are grouped, from top to bottom, in this order: static imports,
 standard Java, org.\*, com.\*
-* Line length up to 120 characters
+* Line length can be up to 120 characters
 * Operators for line wrapping are at end-of-line
-* Naming rules for methods, parameters, etc have been relaxed
+* Naming rules for methods, parameters, etc. have been relaxed
 * Disabled `NoFinalizer`, `OverloadMethodsDeclarationOrder`, and
 `VariableDeclarationUsageDistance` due to the existing code base. These rules
 should be followed when possible.

--- a/java/README.md
+++ b/java/README.md
@@ -45,6 +45,22 @@ mvn install -P gandiva -pl gandiva -am -Dgandiva.cpp.build.dir=../../debug
 This library is still in Alpha stages, and subject to API changes without
 deprecation warnings.
 
+## Java Code Style Guide
+
+Arrow Java follows the Google style guide [here][3] with the following
+differences:
+
+* Imports should be grouped, from top to bottom, in order: static imports,
+standard Java, org.\*, com.\*
+* Line length up to 120 characters
+* Operators for line wrapping are at end-of-line
+* Naming rules for methods, parameters, etc have been relaxed
+* Disabled `NoFinalizer`, `OverloadMethodsDeclarationOrder`, and
+`VariableDeclarationUsageDistance` due to the existing code base. These rules
+should be followed when possible.
+
+Refer to `java/dev/checkstyle/checkstyle.xml for rule specifics.
+
 ## Test Logging Configuration
 
 When running tests, Arrow Java uses the Logback logger with SLF4J. By default,
@@ -65,3 +81,4 @@ See [Logback Configuration][1] for more details.
 
 [1]: https://logback.qos.ch/manual/configuration.html
 [2]: https://github.com/apache/arrow/blob/master/cpp/README.md
+[3]: http://google.github.io/styleguide/javaguide.html


### PR DESCRIPTION
The Java code style is based off of the Google style guide with some small differences. This adds documentation with a link to the Google style guide and a list of what is different.