### PR TITLE
ARROW-3291: [C++] Add string_view-based constructor for BufferReader

### DIFF
--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -36,8 +36,7 @@ Status FlightInfo::GetSchema(std::shared_ptr<Schema>* out) const {
   }
   /// XXX(wesm): arrow::ipc::ReadSchema in its current form will not suffice
   /// for reading schemas with dictionaries. See ARROW-3144
-  io::BufferReader schema_reader(reinterpret_cast<const uint8_t*>(data_.schema.c_str()),
-                                 static_cast<int64_t>(data_.schema.size()));
+  io::BufferReader schema_reader(data_.schema);
   RETURN_NOT_OK(ipc::ReadSchema(&schema_reader, &schema_));
   reconstructed_schema_ = true;
   *out = schema_;

--- a/cpp/src/arrow/io/io-memory-test.cc
+++ b/cpp/src/arrow/io/io-memory-test.cc
@@ -139,11 +139,29 @@ TEST(TestFixedSizeBufferWriter, Basics) {
   ASSERT_OK(writer.Close());
 }
 
+TEST(TestBufferReader, FromStrings) {
+  // ARROW-3291: construct BufferReader from std::string or
+  // arrow::util::string_view
+
+  std::string data = "data123456";
+  auto view = util::string_view(data);
+
+  BufferReader reader1(data);
+  BufferReader reader2(view);
+
+  std::shared_ptr<Buffer> piece;
+  ASSERT_OK(reader1.Read(4, &piece));
+  ASSERT_EQ(0, memcmp(piece->data(), data.data(), 4));
+
+  ASSERT_OK(reader2.Seek(2));
+  ASSERT_OK(reader2.Read(4, &piece));
+  ASSERT_EQ(0, memcmp(piece->data(), data.data() + 2, 4));
+}
+
 TEST(TestBufferReader, Seeking) {
   std::string data = "data123456";
 
-  auto buffer = std::make_shared<Buffer>(data);
-  BufferReader reader(buffer);
+  BufferReader reader(data);
   int64_t pos;
   ASSERT_OK(reader.Tell(&pos));
   ASSERT_EQ(pos, 0);

--- a/cpp/src/arrow/io/io-readahead-test.cc
+++ b/cpp/src/arrow/io/io-readahead-test.cc
@@ -59,9 +59,8 @@ static void busy_wait(double seconds, std::function<bool()> predicate) {
 
 std::shared_ptr<BufferReader> DataReader(const std::string& data) {
   std::shared_ptr<Buffer> buffer;
-  ABORT_NOT_OK(AllocateBuffer(data.length(), &buffer));
-  memcpy(buffer->mutable_data(), data.data(), data.length());
-  return std::make_shared<BufferReader>(std::move(buffer));
+  ABORT_NOT_OK(Buffer::FromString(data, &buffer));
+  return std::make_shared<BufferReader>(buffer);
 }
 
 static int64_t WaitForPosition(const RandomAccessFile& file, int64_t expected,

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -25,6 +25,7 @@
 
 #include "arrow/io/interfaces.h"
 #include "arrow/memory_pool.h"
+#include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -132,6 +133,12 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
   explicit BufferReader(const std::shared_ptr<Buffer>& buffer);
   explicit BufferReader(const Buffer& buffer);
   BufferReader(const uint8_t* data, int64_t size);
+
+  /// \brief Instantiate from std::string or arrow::util::string_view. Does not
+  /// own data
+  explicit BufferReader(const util::string_view& data)
+      : BufferReader(reinterpret_cast<const uint8_t*>(data.data()),
+                     static_cast<int64_t>(data.size())) {}
 
   Status Close() override;
   bool closed() const override;

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -289,7 +289,7 @@ class TestTableReader : public ::testing::Test {
 
     ASSERT_OK(stream_->Finish(&output_));
 
-    std::shared_ptr<io::BufferReader> buffer(new io::BufferReader(output_));
+    auto buffer = std::make_shared<io::BufferReader>(output_);
     ASSERT_OK(TableReader::Open(buffer, &reader_));
   }
 
@@ -364,7 +364,7 @@ class TestTableWriter : public ::testing::Test {
 
     ASSERT_OK(stream_->Finish(&output_));
 
-    std::shared_ptr<io::BufferReader> buffer(new io::BufferReader(output_));
+    auto buffer = std::make_shared<io::BufferReader>(output_);
     ASSERT_OK(TableReader::Open(buffer, &reader_));
   }
 

--- a/cpp/src/parquet/util/memory-test.cc
+++ b/cpp/src/parquet/util/memory-test.cc
@@ -99,9 +99,8 @@ TEST(TestBufferedInputStream, Basics) {
 
 TEST(TestArrowInputFile, ReadAt) {
   std::string data = "this is the data";
-  auto data_buffer = reinterpret_cast<const uint8_t*>(data.c_str());
 
-  auto file = std::make_shared<::arrow::io::BufferReader>(data_buffer, data.size());
+  auto file = std::make_shared<::arrow::io::BufferReader>(data);
   auto source = std::make_shared<ArrowInputFile>(file);
 
   ASSERT_EQ(0, source->Tell());
@@ -119,7 +118,7 @@ TEST(TestArrowInputFile, Read) {
   std::string data = "this is the data";
   auto data_buffer = reinterpret_cast<const uint8_t*>(data.c_str());
 
-  auto file = std::make_shared<::arrow::io::BufferReader>(data_buffer, data.size());
+  auto file = std::make_shared<::arrow::io::BufferReader>(data);
   auto source = std::make_shared<ArrowInputFile>(file);
 
   ASSERT_EQ(0, source->Tell());


### PR DESCRIPTION
This makes the API simpler for creating emphemeral IO sources. The caller is responsible for managing memory lifetime in this case