### PR TITLE
ARROW-3894: [C++] Ensure that IPC file is properly initialized even if no record batches are written

### DIFF
--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -949,6 +949,10 @@ class RecordBatchFileWriter::RecordBatchFileWriterImpl
   }
 
   Status Close() override {
+    // Write the schema if not already written
+    // User is responsible for closing the OutputStream
+    RETURN_NOT_OK(CheckStarted());
+
     // Write metadata
     RETURN_NOT_OK(UpdatePosition());
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -654,3 +654,4 @@ def test_write_empty_ipc_file():
     reader = pa.RecordBatchFileReader(pa.BufferReader(buf))
     table = reader.read_all()
     assert len(table) == 0
+    assert table.schema.equals(schema)

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -639,3 +639,18 @@ def read_file(source):
     reader = pa.open_file(source)
     return [reader.get_batch(i)
             for i in range(reader.num_record_batches)]
+
+
+def test_write_empty_ipc_file():
+    # ARROW-3894: IPC file was not being properly initialized when no record
+    # batches are being written
+    schema = pa.schema([('field', pa.int64())])
+
+    sink = pa.BufferOutputStream()
+    writer = pa.RecordBatchFileWriter(sink, schema)
+    writer.close()
+
+    buf = sink.getvalue()
+    reader = pa.RecordBatchFileReader(pa.BufferReader(buf))
+    table = reader.read_all()
+    assert len(table) == 0


### PR DESCRIPTION
Without invoking `Start()`, the file cannot be read