### PR TITLE
ARROW-3937: [Rust] Fix Rust nightly build (formatting rules changed)

### DIFF
--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -281,7 +281,7 @@ impl Field {
                     _ => {
                         return Err(ArrowError::ParseError(
                             "Field missing 'name' attribute".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let nullable = match map.get("nullable") {
@@ -289,7 +289,7 @@ impl Field {
                     _ => {
                         return Err(ArrowError::ParseError(
                             "Field missing 'nullable' attribute".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let data_type = match map.get("type") {
@@ -297,7 +297,7 @@ impl Field {
                     _ => {
                         return Err(ArrowError::ParseError(
                             "Field missing 'type' attribute".to_string(),
-                        ))
+                        ));
                     }
                 };
                 Ok(Field {


### PR DESCRIPTION
Fix formatting using rustc 1.32.0-nightly (b3af09205 2018-12-04) .. looks like formatting rules changed recently