### PR TITLE
ARROW-3939: [Rust] Remove macro definition for ListArrayBuilder

### DIFF
--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -281,7 +281,7 @@ impl Field {
                     _ => {
                         return Err(ArrowError::ParseError(
                             "Field missing 'name' attribute".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let nullable = match map.get("nullable") {
@@ -289,7 +289,7 @@ impl Field {
                     _ => {
                         return Err(ArrowError::ParseError(
                             "Field missing 'nullable' attribute".to_string(),
-                        ))
+                        ));
                     }
                 };
                 let data_type = match map.get("type") {
@@ -297,7 +297,7 @@ impl Field {
                     _ => {
                         return Err(ArrowError::ParseError(
                             "Field missing 'type' attribute".to_string(),
-                        ))
+                        ));
                     }
                 };
                 Ok(Field {


### PR DESCRIPTION
Currently we only implemented a few value builder types for `ListArrayBuilder` via macros. This removes the macro definitions and use generic definition instead. As result, list builders with arbitrary value builder types can be defined. One more nice thing is that with Rust's type inference we don't need to explicitly specify the generic type parameters in most situations.
