### PR TITLE
ARROW-3908: [Rust] Update rust dockerfile to use nightly toolchain

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM rust
+FROM rustlang/rust:nightly
 
 # sadly cargo doesn't have a command to fetch and build the
 # dependencies without building the library itself


### PR DESCRIPTION
This replaces the base docker image for Rust from stable to nightly. 