### PR TITLE
ARROW-3948: [GLib][CI] Set timeout to Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -332,10 +332,6 @@ after_failure:
       fi
       ls -la ~/Library/Logs/DiagnosticReports/
       cat ~/Library/Logs/DiagnosticReports/*.crash
-      if [[ -f brew.log ]]; then
-        echo "Homebrew log"
-        cat brew.log
-      fi
     else
       COREFILE=$(find . -maxdepth 2 -name "core*" | head -n 1)
       if [[ -f "$COREFILE" ]]; then

--- a/ci/travis_install_osx.sh
+++ b/ci/travis_install_osx.sh
@@ -17,13 +17,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set -x
 set -e
 
 if [ "$ARROW_CI_RUBY_AFFECTED" = "1" ]; then
     brew_log_path=brew.log
     function run_brew() {
         echo brew "$@" >> ${brew_log_path}
-        brew "$@" >> ${brew_log_path} 2>&1
+        if ! gtimeout --signal=KILL 5m brew "$@" >> ${brew_log_path} 2>&1; then
+            cat ${brew_log_path}
+            rm ${brew_log_path}
+            false
+        fi
     }
     run_brew update
     run_brew upgrade python


### PR DESCRIPTION
We can't get Homebrew log when Travis detects hanged Homebrew process and kill the CI job.
We need to detect hanged Homebrew process and kill the Homebrew process to get Homebrew log.
