### PR TITLE
ARROW-3952: [Rust] Upgrade to Rust 2018 Edition

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,6 +28,7 @@ include = [
     "src/**/*.rs",
     "Cargo.toml",
 ]
+edition = "2018"
 
 [lib]
 name = "arrow"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ include = [
     "src/**/*.rs",
     "Cargo.toml",
 ]
-#edition = "2018"
+edition = "2018"
 
 [lib]
 name = "arrow"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ include = [
     "src/**/*.rs",
     "Cargo.toml",
 ]
-edition = "2018"
+#edition = "2018"
 
 [lib]
 name = "arrow"

--- a/rust/src/array.rs
+++ b/rust/src/array.rs
@@ -22,12 +22,12 @@ use std::io::Write;
 use std::mem;
 use std::sync::Arc;
 
-use array_data::{ArrayData, ArrayDataRef};
-use buffer::{Buffer, MutableBuffer};
-use builder::*;
-use datatypes::*;
-use memory;
-use util::bit_util;
+use crate::array_data::{ArrayData, ArrayDataRef};
+use crate::buffer::{Buffer, MutableBuffer};
+use crate::builder::*;
+use crate::datatypes::*;
+use crate::memory;
+use crate::util::bit_util;
 
 /// Trait for dealing with different types of array at runtime when the type of the
 /// array is not known in advance
@@ -692,14 +692,13 @@ impl From<Vec<(Field, ArrayRef)>> for StructArray {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-
     use super::*;
-    use array_data::ArrayData;
-    use buffer::Buffer;
-    use datatypes::{DataType, Field, ToByteSlice};
-    use memory;
+    use crate::array_data::ArrayData;
+    use crate::buffer::Buffer;
+    use crate::datatypes::{DataType, Field, ToByteSlice};
+    use crate::memory;
     use std::sync::Arc;
+    use std::thread;
 
     #[test]
     fn test_primitive_array_from_vec() {

--- a/rust/src/array_data.rs
+++ b/rust/src/array_data.rs
@@ -17,10 +17,10 @@
 
 use std::sync::Arc;
 
-use bitmap::Bitmap;
-use buffer::Buffer;
-use datatypes::DataType;
-use util::bit_util;
+use crate::bitmap::Bitmap;
+use crate::buffer::Buffer;
+use crate::datatypes::DataType;
+use crate::util::bit_util;
 
 /// An generic representation of Arrow array data which encapsulates common attributes and
 /// operations for Arrow array. Specific operations for different arrays types (e.g.,
@@ -225,8 +225,8 @@ mod tests {
     use std::sync::Arc;
 
     use super::{ArrayData, DataType};
-    use buffer::Buffer;
-    use util::bit_util;
+    use crate::buffer::Buffer;
+    use crate::util::bit_util;
 
     #[test]
     fn test_new() {

--- a/rust/src/bitmap.rs
+++ b/rust/src/bitmap.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::buffer::Buffer;
-use util::bit_util;
+use crate::util::bit_util;
 
 #[derive(PartialEq, Debug)]
 pub struct Bitmap {

--- a/rust/src/buffer.rs
+++ b/rust/src/buffer.rs
@@ -20,9 +20,9 @@ use std::io::{Error as IoError, ErrorKind, Result as IoResult, Write};
 use std::mem;
 use std::sync::Arc;
 
-use error::Result;
-use memory;
-use util::bit_util;
+use crate::error::Result;
+use crate::memory;
+use crate::util::bit_util;
 
 /// Buffer is a contiguous memory region of fixed size and is aligned at a 64-byte
 /// boundary. Buffer is immutable.
@@ -314,9 +314,9 @@ unsafe impl Send for MutableBuffer {}
 
 #[cfg(test)]
 mod tests {
+    use crate::util::bit_util;
     use std::ptr::null_mut;
     use std::thread;
-    use util::bit_util;
 
     use super::*;
 

--- a/rust/src/builder.rs
+++ b/rust/src/builder.rs
@@ -23,12 +23,12 @@ use std::io::Write;
 use std::marker::PhantomData;
 use std::mem;
 
-use array::*;
-use array_data::ArrayData;
-use buffer::{Buffer, MutableBuffer};
-use datatypes::*;
-use error::{ArrowError, Result};
-use util::bit_util;
+use crate::array::*;
+use crate::array_data::ArrayData;
+use crate::buffer::{Buffer, MutableBuffer};
+use crate::datatypes::*;
+use crate::error::{ArrowError, Result};
+use crate::util::bit_util;
 
 /// Buffer builder with zero-copy build method
 pub struct BufferBuilder<T: ArrowPrimitiveType> {
@@ -456,7 +456,7 @@ impl BinaryArrayBuilder {
 
 #[cfg(test)]
 mod tests {
-    use array::Array;
+    use crate::array::Array;
 
     use super::*;
 
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_binary_array_builder() {
-        use array::BinaryArray;
+        use crate::array::BinaryArray;
         let mut builder = BinaryArrayBuilder::new(20);
 
         builder.push(b'h').unwrap();
@@ -860,7 +860,7 @@ mod tests {
 
     #[test]
     fn test_binary_array_builder_push_string() {
-        use array::BinaryArray;
+        use crate::array::BinaryArray;
         let mut builder = BinaryArrayBuilder::new(20);
 
         let var = "hello".to_owned();

--- a/rust/src/csv/reader.rs
+++ b/rust/src/csv/reader.rs
@@ -44,11 +44,11 @@ use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
 
-use array::{ArrayRef, BinaryArray};
-use builder::*;
-use datatypes::*;
-use error::{ArrowError, Result};
-use record_batch::RecordBatch;
+use crate::array::{ArrayRef, BinaryArray};
+use crate::builder::*;
+use crate::datatypes::*;
+use crate::error::{ArrowError, Result};
+use crate::record_batch::RecordBatch;
 
 use csv_crate::{StringRecord, StringRecordsIntoIter};
 
@@ -161,7 +161,7 @@ impl Reader {
                     &DataType::Float32 => build_primitive_array::<Float32Type>(rows, i),
                     &DataType::Float64 => build_primitive_array::<Float64Type>(rows, i),
                     &DataType::Utf8 => {
-                        let mut values_builder: UInt8Builder = UInt8Builder::new(rows.len() as i64);
+                        let values_builder: UInt8Builder = UInt8Builder::new(rows.len() as i64);
                         let mut list_builder = ListArrayBuilder::new(values_builder);
                         for row_index in 0..rows.len() {
                             match rows[row_index].get(*i) {
@@ -195,8 +195,8 @@ impl Reader {
 mod tests {
 
     use super::*;
-    use array::*;
-    use datatypes::Field;
+    use crate::array::*;
+    use crate::datatypes::Field;
 
     #[test]
     fn test_csv() {

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -26,7 +26,7 @@ use std::mem::size_of;
 use std::slice::from_raw_parts;
 use std::str::FromStr;
 
-use error::{ArrowError, Result};
+use crate::error::{ArrowError, Result};
 use serde_json::Value;
 
 /// The possible relative types that are supported.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,7 +25,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
-
 pub mod array;
 pub mod array_data;
 pub mod bitmap;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,9 +17,7 @@
 
 #![feature(specialization)]
 
-extern crate bytes;
 extern crate csv as csv_crate;
-extern crate libc;
 
 #[macro_use]
 extern crate serde_derive;
@@ -27,9 +25,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
-extern crate serde;
-
-extern crate rand;
 
 pub mod array;
 pub mod array_data;

--- a/rust/src/memory.rs
+++ b/rust/src/memory.rs
@@ -19,7 +19,7 @@ use libc;
 use std::cmp;
 use std::mem;
 
-use super::error::{ArrowError, Result};
+use crate::error::{ArrowError, Result};
 
 const ALIGNMENT: usize = 64;
 

--- a/rust/src/record_batch.rs
+++ b/rust/src/record_batch.rs
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::array::*;
-use super::datatypes::*;
+use crate::array::*;
+use crate::datatypes::*;
 use std::sync::Arc;
 
 /// A batch of column-oriented data
@@ -67,8 +67,8 @@ unsafe impl Sync for RecordBatch {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use array_data::*;
-    use buffer::*;
+    use crate::array_data::*;
+    use crate::buffer::*;
 
     #[test]
     fn create_record_batch() {

--- a/rust/src/tensor.rs
+++ b/rust/src/tensor.rs
@@ -19,8 +19,8 @@
 use std::marker::PhantomData;
 use std::mem;
 
-use buffer::Buffer;
-use datatypes::*;
+use crate::buffer::Buffer;
+use crate::datatypes::*;
 
 /// Computes the strides required assuming a row major memory layout
 fn compute_row_major_strides<T: ArrowPrimitiveType>(shape: &Vec<i64>) -> Vec<i64> {
@@ -216,8 +216,8 @@ impl<'a, T: ArrowPrimitiveType> Tensor<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use buffer::Buffer;
-    use builder::*;
+    use crate::buffer::Buffer;
+    use crate::builder::*;
 
     #[test]
     fn test_compute_row_major_strides() {


### PR DESCRIPTION
See https://hacks.mozilla.org/2018/12/rust-2018-is-here/ for more info.

Changes:

- Add `edition = "2018"` to Cargo.toml
- Change lots of import statements due to changes in module system in Rust 2018
- Remove `mut` from one variable assignment