### PR TITLE
ARROW-3960: [Rust] remove extern crate for Rust 2018

### DIFF
--- a/rust/src/csv/reader.rs
+++ b/rust/src/csv/reader.rs
@@ -44,13 +44,15 @@ use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
 
+use csv as csv_crate;
+
 use crate::array::{ArrayRef, BinaryArray};
 use crate::builder::*;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
 
-use csv_crate::{StringRecord, StringRecordsIntoIter};
+use self::csv_crate::{StringRecord, StringRecordsIntoIter};
 
 /// CSV file reader
 pub struct Reader {

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -26,8 +26,10 @@ use std::mem::size_of;
 use std::slice::from_raw_parts;
 use std::str::FromStr;
 
+use serde_derive::{Deserialize, Serialize};
+use serde_json::{json, json_internal, Value};
+
 use crate::error::{ArrowError, Result};
-use serde_json::Value;
 
 /// The possible relative types that are supported.
 ///

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -27,7 +27,7 @@ use std::slice::from_raw_parts;
 use std::str::FromStr;
 
 use serde_derive::{Deserialize, Serialize};
-use serde_json::{json, json_internal, Value};
+use serde_json::*;
 
 use crate::error::{ArrowError, Result};
 

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -27,7 +27,7 @@ use std::slice::from_raw_parts;
 use std::str::FromStr;
 
 use serde_derive::{Deserialize, Serialize};
-use serde_json::*;
+use serde_json::{json, Value};
 
 use crate::error::{ArrowError, Result};
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,14 +17,6 @@
 
 #![feature(specialization)]
 
-extern crate csv as csv_crate;
-
-#[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
-extern crate serde_json;
-
 pub mod array;
 pub mod array_data;
 pub mod bitmap;


### PR DESCRIPTION
This is a trivial change to remove "extern crate" definitions
in lib.rs, to follow the new module system in Rust 2018 edition.