### PR TITLE
ARROW-3964: [Go] Refactor examples of csv reader

### DIFF
--- a/go/arrow/csv/csv_test.go
+++ b/go/arrow/csv/csv_test.go
@@ -20,8 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/apache/arrow/go/arrow"
@@ -30,17 +28,24 @@ import (
 )
 
 func Example() {
-	f, err := os.Open("testdata/simple.csv")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
+	f := bytes.NewBufferString(`## a simple set of data: int64;float64;string
+0;0;str-0
+1;1;str-1
+2;2;str-2
+3;3;str-3
+4;4;str-4
+5;5;str-5
+6;6;str-6
+7;7;str-7
+8;8;str-8
+9;9;str-9
+`)
 
 	schema := arrow.NewSchema(
 		[]arrow.Field{
-			arrow.Field{Name: "i64", Type: arrow.PrimitiveTypes.Int64},
-			arrow.Field{Name: "f64", Type: arrow.PrimitiveTypes.Float64},
-			arrow.Field{Name: "str", Type: arrow.BinaryTypes.String},
+			{Name: "i64", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "f64", Type: arrow.PrimitiveTypes.Float64},
+			{Name: "str", Type: arrow.BinaryTypes.String},
 		},
 		nil,
 	)
@@ -90,17 +95,24 @@ func Example() {
 }
 
 func Example_withChunk() {
-	f, err := os.Open("testdata/simple.csv")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
+	f := bytes.NewBufferString(`## a simple set of data: int64;float64;string
+0;0;str-0
+1;1;str-1
+2;2;str-2
+3;3;str-3
+4;4;str-4
+5;5;str-5
+6;6;str-6
+7;7;str-7
+8;8;str-8
+9;9;str-9
+`)
 
 	schema := arrow.NewSchema(
 		[]arrow.Field{
-			arrow.Field{Name: "i64", Type: arrow.PrimitiveTypes.Int64},
-			arrow.Field{Name: "f64", Type: arrow.PrimitiveTypes.Float64},
-			arrow.Field{Name: "str", Type: arrow.BinaryTypes.String},
+			{Name: "i64", Type: arrow.PrimitiveTypes.Int64},
+			{Name: "f64", Type: arrow.PrimitiveTypes.Float64},
+			{Name: "str", Type: arrow.BinaryTypes.String},
 		},
 		nil,
 	)


### PR DESCRIPTION
Example of godoc doesn't include input file(testdata/simple.csv). So it's hard to understand the output. This PR refactors it.

<img width="652" alt="screenshot" src="https://user-images.githubusercontent.com/5564044/49687567-0f6fc380-fb48-11e8-895a-ee0d554ef7c8.png">

https://godoc.org/github.com/apache/arrow/go/arrow/csv