### PR TITLE
ARROW-3967: [Gandiva] [C++] Make node.h public

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -112,9 +112,13 @@ install(FILES
   expression.h
   expression_registry.h
   filter.h
+  func_descriptor.h
   function_signature.h
   gandiva_aliases.h
+  literal_holder.h
   logging.h
+  node.h
+  node_visitor.h
   projector.h
   selection_vector.h
   tree_expr_builder.h


### PR DESCRIPTION
Because some methods in node.h is useful in bindings.
C GLib Gandiva bindings want to use LiteralNode::holder() to access raw literal data.