### PR TITLE
ARROW-3983: [Gandiva][Crossbow] Link Boost statically in JAR packaging scripts

### DIFF
--- a/dev/tasks/gandiva-jars/build-cpp.sh
+++ b/dev/tasks/gandiva-jars/build-cpp.sh
@@ -29,6 +29,7 @@ pushd arrow/cpp
           -DARROW_GANDIVA=ON \
           -DARROW_GANDIVA_STATIC_LIBSTDCPP=ON \
           -DARROW_BUILD_UTILITIES=OFF \
+          -DARROW_BOOST_USE_SHARED=OFF \
           ..
     make -j4
     ctest


### PR DESCRIPTION
Use static boost libraries while packaging Gandiva.