### PR TITLE
ARROW-3993: [JS] CI Jobs Failing

### DIFF
--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -1053,7 +1053,7 @@ class CPPTester(Tester):
         'ARROW_CPP_EXE_PATH',
         os.path.join(ARROW_HOME, 'cpp/build/debug'))
 
-    CPP_INTEGRATION_EXE = os.path.join(EXE_PATH, 'json-integration-test')
+    CPP_INTEGRATION_EXE = os.path.join(EXE_PATH, 'arrow-json-integration-test')
     STREAM_TO_FILE = os.path.join(EXE_PATH, 'stream-to-file')
     FILE_TO_STREAM = os.path.join(EXE_PATH, 'file-to-stream')
 

--- a/js/package.json
+++ b/js/package.json
@@ -72,7 +72,7 @@
     "del": "3.0.0",
     "glob": "7.1.3",
     "google-closure-compiler": "20181008.0.0",
-    "gulp": "next",
+    "gulp": "4.0.0",
     "gulp-json-transform": "0.4.5",
     "gulp-rename": "1.4.0",
     "gulp-sourcemaps": "2.6.4",


### PR DESCRIPTION
Use `gulp@4.0.0` rather than `gulp@next`