### PR TITLE
ARROW-3976: [Ruby] Try to upgrade git to avoid errors caused by Homebrew on older git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,7 +256,6 @@ matrix:
     - ARROW_TRAVIS_PLASMA=1
     cache:
     addons:
-    rvm: 2.2
     before_script:
     - if [ $ARROW_CI_RUBY_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_osx.sh

--- a/ci/travis_install_osx.sh
+++ b/ci/travis_install_osx.sh
@@ -27,9 +27,7 @@ if [ "$ARROW_CI_RUBY_AFFECTED" = "1" ]; then
         local n_tries=3
         while [[ $((i++)) < ${n_tries} ]]; do
             echo "${i}: brew" "$@" >> ${brew_log_path}
-            if travis_wait 15 \
-                   gtimeout --signal=KILL 14m brew "$@" \
-                       >> ${brew_log_path} 2>&1; then
+            if gtimeout --signal=KILL 9m brew "$@" >> ${brew_log_path} 2>&1; then
                 break
             elif [[ ${i} == ${n_tries} ]]; then
                 cat ${brew_log_path}

--- a/ci/travis_install_osx.sh
+++ b/ci/travis_install_osx.sh
@@ -30,6 +30,11 @@ if [ "$ARROW_CI_RUBY_AFFECTED" = "1" ]; then
             false
         fi
     }
+    # ARROW-3976 Old versions of git can cause failures when Homebrew prints a
+    # donation solicitation. Attempt to update git
+    git --version
+    run_brew install git
+
     run_brew update
     run_brew upgrade python
     run_brew uninstall postgis

--- a/ci/travis_install_osx.sh
+++ b/ci/travis_install_osx.sh
@@ -24,7 +24,7 @@ if [ "$ARROW_CI_RUBY_AFFECTED" = "1" ]; then
     brew_log_path=brew.log
     function run_brew() {
         echo brew "$@" >> ${brew_log_path}
-        if ! gtimeout --signal=KILL 5m brew "$@" >> ${brew_log_path} 2>&1; then
+        if ! gtimeout --signal=KILL 29m brew "$@" >> ${brew_log_path} 2>&1; then
             cat ${brew_log_path}
             rm ${brew_log_path}
             false
@@ -33,7 +33,7 @@ if [ "$ARROW_CI_RUBY_AFFECTED" = "1" ]; then
     # ARROW-3976 Old versions of git can cause failures when Homebrew prints a
     # donation solicitation. Attempt to update git
     git --version
-    run_brew install git
+    run_brew upgrade git
 
     run_brew update
     run_brew upgrade python


### PR DESCRIPTION
It seems that `brew update` can fail if the git version is too old, see https://github.com/Linuxbrew/brew/issues/820. Also adds retry logic