### PR TITLE
ARROW-3866: [Python] Column metadata is not transferred to tables in pyarrow

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -636,13 +636,12 @@ cdef class Column:
 
 cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     cdef:
-        bint nullable
-        Column col
-        c_string c_name
-        vector[shared_ptr[CField]] fields
-        shared_ptr[CDataType] type_
         Py_ssize_t K = len(arrays)
+        c_string c_name
+        CColumn* c_column
+        shared_ptr[CDataType] c_type
         shared_ptr[CKeyValueMetadata] c_meta
+        vector[shared_ptr[CField]] c_fields
 
     if metadata is not None:
         if not isinstance(metadata, dict):
@@ -650,19 +649,15 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
         c_meta = pyarrow_unwrap_metadata(metadata)
 
     if K == 0:
-        schema.reset(new CSchema(fields, c_meta))
+        schema.reset(new CSchema(c_fields, c_meta))
         return
 
-    fields.resize(K)
+    c_fields.resize(K)
 
     if isinstance(arrays[0], Column):
         for i in range(K):
-            col = arrays[i]
-            type_ = col.sp_column.get().type()
-            c_name = tobytes(col.name)
-            nullable = col.field.nullable.__bool__()
-            c_meta = pyarrow_unwrap_metadata(col.field.metadata)
-            fields[i].reset(new CField(c_name, type_, nullable, c_meta))
+            c_column = (<Column>arrays[i]).column
+            c_fields[i] = c_column.field()
     else:
         if names is None:
             raise ValueError('Must pass names when constructing '
@@ -673,7 +668,7 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
         for i in range(K):
             val = arrays[i]
             if isinstance(val, (Array, ChunkedArray)):
-                type_ = (<DataType> val.type).sp_type
+                c_type = (<DataType> val.type).sp_type
             else:
                 raise TypeError(type(val))
 
@@ -681,9 +676,9 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
                 c_name = tobytes(u'None')
             else:
                 c_name = tobytes(names[i])
-            fields[i].reset(new CField(c_name, type_, True))
+            c_fields[i].reset(new CField(c_name, c_type, True))
 
-    schema.reset(new CSchema(fields, c_meta))
+    schema.reset(new CSchema(c_fields, c_meta))
 
 
 cdef class RecordBatch:

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -636,6 +636,7 @@ cdef class Column:
 
 cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
     cdef:
+        bint nullable
         Column col
         c_string c_name
         vector[shared_ptr[CField]] fields
@@ -659,7 +660,9 @@ cdef _schema_from_arrays(arrays, names, metadata, shared_ptr[CSchema]* schema):
             col = arrays[i]
             type_ = col.sp_column.get().type()
             c_name = tobytes(col.name)
-            fields[i].reset(new CField(c_name, type_, True))
+            nullable = col.field.nullable.__bool__()
+            c_meta = pyarrow_unwrap_metadata(col.field.metadata)
+            fields[i].reset(new CField(c_name, type_, nullable, c_meta))
     else:
         if names is None:
             raise ValueError('Must pass names when constructing '

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -578,13 +578,20 @@ def test_table_basics():
 
     assert table.columns == columns
 
+
+def test_table_from_arrays_preserves_column_metadata():
     # Added to test https://issues.apache.org/jira/browse/ARROW-3866
-    columns = []
-    for col in table.itercolumns():
-        new_field = col.field.add_metadata({"a": "A", "b": "B"})
-        columns.append(pa.column(new_field, col.data))
+    arr0 = pa.array([1, 2])
+    arr1 = pa.array([3, 4])
+    field0 = pa.field('field1', pa.int64(), metadata=dict(a="A", b="B"))
+    field1 = pa.field('field2', pa.int64(), nullable=False)
+    columns = [
+        pa.column(field0, arr0),
+        pa.column(field1, arr1)
+    ]
     table = pa.Table.from_arrays(columns)
     assert b"a" in table.column(0).field.metadata
+    assert table.column(1).field.nullable is False
 
 
 def test_table_from_arrays_invalid_names():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -578,6 +578,14 @@ def test_table_basics():
 
     assert table.columns == columns
 
+    # Added to test https://issues.apache.org/jira/browse/ARROW-3866
+    columns = []
+    for col in table.itercolumns():
+        new_field = col.field.add_metadata({"a": "A", "b": "B"})
+        columns.append(pa.column(new_field, col.data))
+    table = pa.Table.from_arrays(columns)
+    assert b"a" in table.column(0).field.metadata
+
 
 def test_table_from_arrays_invalid_names():
     data = [


### PR DESCRIPTION
Use columns' existing metadata to create the new fields in `Table.from_arrays()`.
Also persists the original `nullable` value.

Happy to change things! Thank you for putting a newbie label on it.