### PR TITLE
ARROW-4002: [C++][Gandiva] Remove needless CMake version check

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -15,9 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# LLVM/Clang is required by multiple subdirs.
-cmake_minimum_required(VERSION 3.11)
-
 project(gandiva)
 
 find_package(LLVM)


### PR DESCRIPTION
I could build Gandiva with CMake 3.7.2 and LLVM 6.0.0 on Debian
stretch. But I disabled Gandiva JNI.