### PR TITLE
PARQUET-1374: [C++] Fix segfault on writing a parquet file with zero columns

### DIFF
--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1850,11 +1850,17 @@ TEST(TestArrowReadWrite, TableWithDuplicateColumns) {
 }
 
 TEST(TestArrowReadWrite, ZeroColumnsNoSegfault) {
-  // See ARROW-1374
+  // See ARROW-1374. Previously writing zero columns
+  // segfaulted. Parquet still doesn't support zero
+  // columns but at least it doesn't segfault. This test
+  // checks that doesn't regress.
   auto schema = ::arrow::schema({});
   auto table = Table::Make(schema, std::vector<std::shared_ptr<Column>>());
   auto sink = std::make_shared<InMemoryOutputStream>();
-  ASSERT_EXIT((WriteTable(*table, ::arrow::default_memory_pool(), sink, 123, default_writer_properties(), default_arrow_writer_properties()), exit(0)), ::testing::ExitedWithCode(0), ".*");
+  ASSERT_EXIT((static_cast<void>(WriteTable(*table,
+    ::arrow::default_memory_pool(), sink, 123, default_writer_properties(),
+    default_arrow_writer_properties())), exit(0)),
+    ::testing::ExitedWithCode(0), ".*");
 }
 
 TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1857,10 +1857,9 @@ TEST(TestArrowReadWrite, ZeroColumnsNoSegfault) {
   auto schema = ::arrow::schema({});
   auto table = Table::Make(schema, std::vector<std::shared_ptr<Column>>());
   auto sink = std::make_shared<InMemoryOutputStream>();
-  ASSERT_EXIT((static_cast<void>(WriteTable(*table,
-    ::arrow::default_memory_pool(), sink, 123, default_writer_properties(),
-    default_arrow_writer_properties())), exit(0)),
-    ::testing::ExitedWithCode(0), ".*");
+  static_cast<void>(WriteTable(*table, ::arrow::default_memory_pool(), sink, 123,
+                               default_writer_properties(),
+                               default_arrow_writer_properties()));
 }
 
 TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -1849,6 +1849,14 @@ TEST(TestArrowReadWrite, TableWithDuplicateColumns) {
   ASSERT_NO_FATAL_FAILURE(CheckSimpleRoundtrip(table, table->num_rows()));
 }
 
+TEST(TestArrowReadWrite, ZeroColumnsNoSegfault) {
+  // See ARROW-1374
+  auto schema = ::arrow::schema({});
+  auto table = Table::Make(schema, std::vector<std::shared_ptr<Column>>());
+  auto sink = std::make_shared<InMemoryOutputStream>();
+  ASSERT_EXIT((WriteTable(*table, ::arrow::default_memory_pool(), sink, 123, default_writer_properties(), default_arrow_writer_properties()), exit(0)), ::testing::ExitedWithCode(0), ".*");
+}
+
 TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
   // This is a regression test for this:
   //

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -252,7 +252,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
   void Close() override {
     if (is_open_) {
       is_open_ = false;
-      
+
       if (row_group_writer_) {
         num_rows_ += row_group_writer_->num_rows();
         row_group_writer_->Close();

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -251,6 +251,8 @@ class FileSerializer : public ParquetFileWriter::Contents {
 
   void Close() override {
     if (is_open_) {
+      is_open_ = false;
+      
       if (row_group_writer_) {
         num_rows_ += row_group_writer_->num_rows();
         row_group_writer_->Close();
@@ -262,7 +264,6 @@ class FileSerializer : public ParquetFileWriter::Contents {
       WriteFileMetaData(*metadata, sink_.get());
 
       sink_->Close();
-      is_open_ = false;
     }
   }
 


### PR DESCRIPTION
Please see https://issues.apache.org/jira/browse/PARQUET-1374.

This isn't a fix to the ticket, but it fixes something which appears to be wrong which results in a segfault rather than an exception when writing zero columns.