### PR TITLE
ARROW-4029: [C++] Exclude headers with 'internal' from installation. Document header file conventions in README

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -313,6 +313,12 @@ which use the default pool without explicitly passing it. You can disable these
 constructors in your application (so that you are accounting properly for all
 memory allocations) by defining `ARROW_NO_DEFAULT_MEMORY_POOL`.
 
+### Header files
+
+We use the `.h` extension for C++ header files. Any header file name not
+containing `internal` is considered to be a public header, and will be
+automatically installed by the build.
+
 ### Error Handling and Exceptions
 
 For error handling, we use `arrow::Status` values instead of throwing C++

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -583,7 +583,23 @@ function(ARROW_INSTALL_ALL_HEADERS PATH)
     set(ARG_PATTERN "*.h")
   endif()
   file(GLOB CURRENT_DIRECTORY_HEADERS ${ARG_PATTERN})
+
+  set(PUBLIC_HEADERS)
+  foreach(HEADER ${CURRENT_DIRECTORY_HEADERS})
+    if (NOT ((HEADER MATCHES "internal")))
+      LIST(APPEND PUBLIC_HEADERS ${HEADER})
+    endif()
+  endforeach()
   install(FILES
-    ${CURRENT_DIRECTORY_HEADERS}
+    ${PUBLIC_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PATH}")
+endfunction()
+
+function(ARROW_ADD_PKG_CONFIG MODULE)
+  configure_file(${MODULE}.pc.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${MODULE}.pc"
+    @ONLY)
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/${MODULE}.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 endfunction()

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -252,12 +252,7 @@ endforeach()
 ARROW_INSTALL_ALL_HEADERS("arrow")
 
 # pkg-config support
-configure_file(arrow.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/arrow.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("arrow")
 
 #######################################
 # Unit tests

--- a/cpp/src/arrow/array/CMakeLists.txt
+++ b/cpp/src/arrow/array/CMakeLists.txt
@@ -16,12 +16,4 @@
 # under the License.
 
 # Headers: top level
-install(FILES
-  builder_adaptive.h
-  builder_base.h
-  builder_binary.h
-  builder_decimal.h
-  builder_dict.h
-  builder_nested.h
-  builder_primitive.h
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/array")
+ARROW_INSTALL_ALL_HEADERS("arrow/array")

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -18,12 +18,7 @@
 ARROW_INSTALL_ALL_HEADERS("arrow/compute")
 
 # pkg-config support
-configure_file(arrow-compute.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/arrow-compute.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-compute.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("arrow-compute")
 
 #######################################
 # Unit tests

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -15,8 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-install(FILES
-  boolean.h
-  cast.h
-  hash.h
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/compute/kernels")
+ARROW_INSTALL_ALL_HEADERS("arrow/compute/kernels")

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -18,12 +18,7 @@
 add_custom_target(arrow_flight)
 
 # Header files
-install(FILES
-  api.h
-  client.h
-  server.h
-  types.h
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/flight")
+ARROW_INSTALL_ALL_HEADERS("arrow/flight")
 
 SET(ARROW_FLIGHT_STATIC_LINK_LIBS
   grpc_grpcpp

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -64,15 +64,7 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/gpu")
 
 ARROW_INSTALL_ALL_HEADERS("arrow/gpu")
-
-# pkg-config support
-configure_file(arrow-cuda.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/arrow-cuda.pc"
-  @ONLY)
-
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-cuda.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("arrow-cuda")
 
 set(ARROW_CUDA_TEST_LINK_LIBS
   arrow_cuda_shared

--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -41,13 +41,4 @@ ADD_ARROW_BENCHMARK(memory-benchmark
   PREFIX "arrow-io")
 
 # Headers: top level
-install(FILES
-  api.h
-  buffered.h
-  compressed.h
-  file.h
-  hdfs.h
-  interfaces.h
-  memory.h
-  readahead.h
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/io")
+ARROW_INSTALL_ALL_HEADERS("arrow/io")

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -94,12 +94,7 @@ endif()
 ARROW_INSTALL_ALL_HEADERS("arrow/python")
 
 # pkg-config support
-configure_file(arrow-python.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/arrow-python.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-python.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("arrow-python")
 
 # ----------------------------------------------------------------------
 

--- a/cpp/src/arrow/util/string_view/CMakeLists.txt
+++ b/cpp/src/arrow/util/string_view/CMakeLists.txt
@@ -17,4 +17,4 @@
 
 install(FILES
   string_view.hpp
-  DESTINATION include/arrow/util/string_view)
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/util/string_view")

--- a/cpp/src/arrow/util/variant/CMakeLists.txt
+++ b/cpp/src/arrow/util/variant/CMakeLists.txt
@@ -19,10 +19,4 @@
 # arrow_util_variant
 #######################################
 
-install(FILES
-  optional.h
-  recursive_wrapper.h
-  variant_cast.h
-  variant_io.h
-  variant_visitor.h
-  DESTINATION include/arrow/util/variant)
+ARROW_INSTALL_ALL_HEADERS("arrow/util/variant")

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -96,12 +96,7 @@ include(GNUInstallDirs)
 ARROW_INSTALL_ALL_HEADERS("gandiva")
 
 # pkg-config support
-configure_file(gandiva.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/gandiva.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/gandiva.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("gandiva")
 
 set(GANDIVA_STATIC_TEST_LINK_LIBS
   gandiva_static

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -249,13 +249,7 @@ install(FILES
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet")
 
 # pkg-config support
-configure_file(parquet.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/parquet.pc"
-  @ONLY)
-
-install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/parquet.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("parquet")
 
 ADD_PARQUET_TEST(bloom_filter-test)
 ADD_PARQUET_TEST(column_reader-test)

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -154,12 +154,7 @@ install(TARGETS plasma_store_server
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # pkg-config support
-configure_file(plasma.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/plasma.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/plasma.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+ARROW_ADD_PKG_CONFIG("plasma")
 
 if(ARROW_PLASMA_JAVA_CLIENT)
   # Plasma java client support


### PR DESCRIPTION
In reviewing what usages of the `install` command we have, I added a helper function to add `.pc` files to reduce code duplication