### PR TITLE
ARROW-3230: [Python] Missing comparisons on ChunkedArray, Table

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -117,6 +117,12 @@ cdef class ChunkedArray:
             else:
                 index -= self.chunked_array.chunk(j).get().length()
 
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except (TypeError, ValueError):
+            return NotImplemented
+
     def equals(self, ChunkedArray other):
         """
         Return whether the contents of two chunked arrays are equal
@@ -411,14 +417,6 @@ cdef class Column:
 
         return result.getvalue()
 
-    def __richcmp__(Column self, Column other, int op):
-        if op == cp.Py_EQ:
-            return self.equals(other)
-        elif op == cp.Py_NE:
-            return not self.equals(other)
-        else:
-            raise TypeError('Invalid comparison')
-
     def __getitem__(self, key):
         return self.data[key]
 
@@ -539,6 +537,12 @@ cdef class Column:
 
     def __array__(self, dtype=None):
         return self.data.__array__(dtype=dtype)
+
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except (TypeError, ValueError):
+            return NotImplemented
 
     def equals(self, Column other):
         """
@@ -1110,6 +1114,12 @@ cdef class Table:
             check_status(self.table.Flatten(pool, &flattened))
 
         return pyarrow_wrap_table(flattened)
+
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except (TypeError, ValueError):
+            return NotImplemented
 
     def equals(self, Table other):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -120,7 +120,7 @@ cdef class ChunkedArray:
     def __eq__(self, other):
         try:
             return self.equals(other)
-        except (TypeError, ValueError):
+        except TypeError:
             return NotImplemented
 
     def equals(self, ChunkedArray other):
@@ -541,7 +541,7 @@ cdef class Column:
     def __eq__(self, other):
         try:
             return self.equals(other)
-        except (TypeError, ValueError):
+        except TypeError:
             return NotImplemented
 
     def equals(self, Column other):
@@ -1118,7 +1118,7 @@ cdef class Table:
     def __eq__(self, other):
         try:
             return self.equals(other)
-        except (TypeError, ValueError):
+        except TypeError:
             return NotImplemented
 
     def equals(self, Table other):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -117,6 +117,8 @@ def test_chunked_array_equals():
             y = pa.chunked_array(yarrs)
         assert x.equals(y)
         assert y.equals(x)
+        assert x == y
+        assert (x == str(y)) is False
 
     def ne(xarrs, yarrs):
         if isinstance(xarrs, pa.ChunkedArray):
@@ -129,6 +131,7 @@ def test_chunked_array_equals():
             y = pa.chunked_array(yarrs)
         assert not x.equals(y)
         assert not y.equals(x)
+        assert x != y
 
     eq(pa.chunked_array([], type=pa.int32()),
        pa.chunked_array([], type=pa.int32()))
@@ -224,6 +227,9 @@ def test_column_basics():
     assert len(column) == 5
     assert column.shape == (5,)
     assert column.to_pylist() == [-10, -5, 0, 5, 10]
+    assert column == pa.Column.from_array("a", column.data)
+    assert column != pa.Column.from_array("b", column.data)
+    assert (column == column.data) is False
 
 
 def test_column_factory_function():
@@ -577,6 +583,9 @@ def test_table_basics():
             col.data.chunk(col.data.num_chunks)
 
     assert table.columns == columns
+    assert table == pa.Table.from_arrays(columns)
+    assert table != pa.Table.from_arrays(columns[1:])
+    assert (table == columns) is False
 
 
 def test_table_from_arrays_preserves_column_metadata():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -118,7 +118,7 @@ def test_chunked_array_equals():
         assert x.equals(y)
         assert y.equals(x)
         assert x == y
-        assert (x == str(y)) is False
+        assert x != str(y)
 
     def ne(xarrs, yarrs):
         if isinstance(xarrs, pa.ChunkedArray):
@@ -229,7 +229,7 @@ def test_column_basics():
     assert column.to_pylist() == [-10, -5, 0, 5, 10]
     assert column == pa.Column.from_array("a", column.data)
     assert column != pa.Column.from_array("b", column.data)
-    assert (column == column.data) is False
+    assert column != column.data
 
 
 def test_column_factory_function():
@@ -585,7 +585,7 @@ def test_table_basics():
     assert table.columns == columns
     assert table == pa.Table.from_arrays(columns)
     assert table != pa.Table.from_arrays(columns[1:])
-    assert (table == columns) is False
+    assert table != columns
 
 
 def test_table_from_arrays_preserves_column_metadata():


### PR DESCRIPTION
Add `__eq__` method to `Table`, `Column`, and `ChunkedArray`, plus relevant tests.