### PR TITLE
ARROW-4049: [C++] Arrow never use glog even though glog is linked.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -713,6 +713,7 @@ endif()
 
 if (ARROW_USE_GLOG)
   SET(ARROW_STATIC_LINK_LIBS glog_static ${ARROW_STATIC_LINK_LIBS})
+  add_definitions("-DARROW_USE_GLOG")
 endif()
 
 if (ARROW_STATIC_LINK_LIBS)


### PR DESCRIPTION
The following is a part of arrow/util/logging.cc.

```
#ifdef ARROW_USE_GLOG
typedef google::LogMessage LoggingProvider;
#else
typedef CerrLog LoggingProvider;
#endif
```

As you see, when ARROW_USE_GLOG is defined, glog is intended to be used but it's not never defined and glog is never used.

I've fixed this by adding `add_definition` command when  CMake variable `ARROW_USE_GLOG` is ON.