### PR TITLE
ARROW-4051: [Gandiva] [GLib] Add support for null literal

### DIFF
--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -486,10 +486,10 @@ ggandiva_null_literal_node_new(GArrowDataType *return_type)
 {
   auto arrow_data_type = garrow_data_type_get_raw(return_type);
   auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_data_type);
-  if (gandiva_node == nullptr) {
-    return NULL;
-  } else {
+  if (gandiva_node) {
     return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  } else {
+    return NULL;
   }
 }
 

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -166,6 +166,22 @@ ggandiva_node_class_init(GGandivaNodeClass *klass)
   g_object_class_install_property(gobject_class, PROP_NODE, spec);
 }
 
+/**
+ * ggandiva_node_get_return_type:
+ * @node: A #GGandivaNode.
+ *
+ * Returns: (transfer full): The return type of the node.
+ *
+ * Since: 0.12.0
+ */
+GArrowDataType *
+ggandiva_node_get_return_type(GGandivaNode *node)
+{
+  auto gandiva_node = ggandiva_node_get_raw(node);
+  auto arrow_data_type = gandiva_node->return_type();
+  return garrow_data_type_new_raw(&arrow_data_type);
+}
+
 
 typedef struct GGandivaFieldNodePrivate_ {
   GArrowField *field;

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -293,12 +293,10 @@ ggandiva_field_node_new(GArrowField *field)
 typedef struct GGandivaFunctionNodePrivate_ {
   gchar *name;
   GList *parameters;
-  GArrowDataType *return_type;
 } GGandivaFunctionNodePrivate;
 
 enum {
-  PROP_NAME = 1,
-  PROP_RETURN_TYPE
+  PROP_NAME = 1
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE(GGandivaFunctionNode,
@@ -322,11 +320,6 @@ ggandiva_function_node_dispose(GObject *object)
     }
     g_list_free(priv->parameters);
     priv->parameters = nullptr;
-  }
-
-  if (priv->return_type) {
-    g_object_unref(priv->return_type);
-    priv->return_type = nullptr;
   }
 
   G_OBJECT_CLASS(ggandiva_function_node_parent_class)->dispose(object);
@@ -354,9 +347,6 @@ ggandiva_function_node_set_property(GObject *object,
   case PROP_NAME:
     priv->name = g_value_dup_string(value);
     break;
-  case PROP_RETURN_TYPE:
-    priv->return_type = GARROW_DATA_TYPE(g_value_dup_object(value));
-    break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     break;
@@ -374,9 +364,6 @@ ggandiva_function_node_get_property(GObject *object,
   switch (prop_id) {
   case PROP_NAME:
     g_value_set_string(value, priv->name);
-    break;
-  case PROP_RETURN_TYPE:
-    g_value_set_object(value, priv->return_type);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -409,14 +396,6 @@ ggandiva_function_node_class_init(GGandivaFunctionNodeClass *klass)
                              static_cast<GParamFlags>(G_PARAM_READWRITE |
                                                       G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_NAME, spec);
-
-  spec = g_param_spec_object("return-type",
-                             "Return type",
-                             "The return type of the function",
-                             GARROW_TYPE_DATA_TYPE,
-                             static_cast<GParamFlags>(G_PARAM_READWRITE |
-                                                      G_PARAM_CONSTRUCT_ONLY));
-  g_object_class_install_property(gobject_class, PROP_RETURN_TYPE, spec);
 }
 
 /**
@@ -445,8 +424,7 @@ ggandiva_function_node_new(const gchar *name,
                                                              arrow_return_type);
   return ggandiva_function_node_new_raw(&gandiva_node,
                                         name,
-                                        parameters,
-                                        return_type);
+                                        parameters);
 }
 
 /**
@@ -1167,13 +1145,11 @@ ggandiva_field_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
 GGandivaFunctionNode *
 ggandiva_function_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                                const gchar *name,
-                               GList *parameters,
-                               GArrowDataType *return_type)
+                               GList *parameters)
 {
   auto function_node = g_object_new(GGANDIVA_TYPE_FUNCTION_NODE,
                                     "node", gandiva_node,
                                     "name", name,
-                                    "return-type", return_type,
                                     NULL);
   auto priv = GGANDIVA_FUNCTION_NODE_GET_PRIVATE(function_node);
   for (auto node = parameters; node; node = g_list_next(node)) {

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -1219,15 +1219,12 @@ ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
 
   auto gandiva_literal_node =
     std::static_pointer_cast<gandiva::LiteralNode>(*gandiva_node);
-  auto arrow_data_type = (*gandiva_node)->return_type();
-  if (!return_type) {
-    return_type = garrow_data_type_new_raw(&arrow_data_type);
-  }
+  auto arrow_return_type = (*gandiva_node)->return_type();
 
   if (gandiva_literal_node->is_null()) {
     type = GGANDIVA_TYPE_NULL_LITERAL_NODE;
   } else {
-    switch (arrow_data_type->id()) {
+    switch (arrow_return_type->id()) {
     case arrow::Type::BOOL:
       type = GGANDIVA_TYPE_BOOLEAN_LITERAL_NODE;
       break;
@@ -1271,11 +1268,16 @@ ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
       type = GGANDIVA_TYPE_LITERAL_NODE;
       break;
     }
+
+    return_type = garrow_data_type_new_raw(&arrow_return_type);
   }
   auto literal_node =
     GGANDIVA_LITERAL_NODE(g_object_new(type,
                                        "node", gandiva_node,
                                        "return-type", return_type,
                                        NULL));
+  if (!gandiva_literal_node->is_null()) {
+    g_object_unref(return_type);
+  }
   return literal_node;
 }

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -459,6 +459,37 @@ ggandiva_literal_node_class_init(GGandivaLiteralNodeClass *klass)
 }
 
 
+G_DEFINE_TYPE(GGandivaNullLiteralNode,
+              ggandiva_null_literal_node,
+              GGANDIVA_TYPE_LITERAL_NODE)
+
+static void
+ggandiva_null_literal_node_init(GGandivaNullLiteralNode *null_literal_node)
+{
+}
+
+static void
+ggandiva_null_literal_node_class_init(GGandivaNullLiteralNodeClass *klass)
+{
+}
+
+/**
+ * ggandiva_null_literal_node_new:
+ * @return_type: A #GArrowDataType.
+ *
+ * Returns: A newly created #GGandivaNullLiteralNode.
+ *
+ * Since: 0.12.0
+ */
+GGandivaNullLiteralNode *
+ggandiva_null_literal_node_new(GArrowDataType *return_type)
+{
+  auto arrow_data_type = garrow_data_type_get_raw(return_type);
+  auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_data_type);
+  return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+}
+
+
 G_DEFINE_TYPE(GGandivaBooleanLiteralNode,
               ggandiva_boolean_literal_node,
               GGANDIVA_TYPE_LITERAL_NODE)
@@ -1089,37 +1120,6 @@ ggandiva_string_literal_node_get_value(GGandivaStringLiteralNode *node)
 {
   auto value = ggandiva_literal_node_get<std::string>(GGANDIVA_LITERAL_NODE(node));
   return value.c_str();
-}
-
-
-G_DEFINE_TYPE(GGandivaNullLiteralNode,
-              ggandiva_null_literal_node,
-              GGANDIVA_TYPE_LITERAL_NODE)
-
-static void
-ggandiva_null_literal_node_init(GGandivaNullLiteralNode *null_literal_node)
-{
-}
-
-static void
-ggandiva_null_literal_node_class_init(GGandivaNullLiteralNodeClass *klass)
-{
-}
-
-/**
- * ggandiva_null_literal_node_new:
- * @return_type: A #GArrowDataType.
- *
- * Returns: A newly created #GGandivaNullLiteralNode.
- *
- * Since: 0.12.0
- */
-GGandivaNullLiteralNode *
-ggandiva_null_literal_node_new(GArrowDataType *return_type)
-{
-  auto arrow_data_type = garrow_data_type_get_raw(return_type);
-  auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_data_type);
-  return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
 }
 
 G_END_DECLS

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -1184,10 +1184,14 @@ GGandivaFieldNode *
 ggandiva_field_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                             GArrowField *field)
 {
+  auto arrow_return_type = (*gandiva_node)->return_type();
+  auto return_type = garrow_data_type_new_raw(&arrow_return_type);
   auto field_node = g_object_new(GGANDIVA_TYPE_FIELD_NODE,
                                  "node", gandiva_node,
                                  "field", field,
+                                 "return-type", return_type,
                                  NULL);
+  g_object_unref(return_type);
   return GGANDIVA_FIELD_NODE(field_node);
 }
 

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -1194,7 +1194,7 @@ ggandiva_field_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                             GArrowField *field)
 {
   auto arrow_return_type = (*gandiva_node)->return_type();
-  auto return_type = garrow_data_type_new_raw(&arrow_return_type);
+  auto return_type = garrow_field_get_data_type(field);
   auto field_node = g_object_new(GGANDIVA_TYPE_FIELD_NODE,
                                  "node", gandiva_node,
                                  "field", field,

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -514,8 +514,8 @@ ggandiva_null_literal_node_class_init(GGandivaNullLiteralNodeClass *klass)
 GGandivaNullLiteralNode *
 ggandiva_null_literal_node_new(GArrowDataType *return_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(return_type);
-  auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_data_type);
+  auto arrow_return_type = garrow_data_type_get_raw(return_type);
+  auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_return_type);
   if (gandiva_node) {
     return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
                                                                     return_type));

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -517,7 +517,8 @@ ggandiva_null_literal_node_new(GArrowDataType *return_type)
   auto arrow_data_type = garrow_data_type_get_raw(return_type);
   auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_data_type);
   if (gandiva_node) {
-    return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+    return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    return_type));
   } else {
     return NULL;
   }
@@ -550,7 +551,8 @@ GGandivaBooleanLiteralNode *
 ggandiva_boolean_literal_node_new(gboolean value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(static_cast<bool>(value));
-  return GGANDIVA_BOOLEAN_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_BOOLEAN_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                     NULL));
 }
 
 /**
@@ -595,7 +597,8 @@ GGandivaInt8LiteralNode *
 ggandiva_int8_literal_node_new(gint8 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_INT8_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_INT8_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                  NULL));
 }
 
 /**
@@ -639,7 +642,8 @@ GGandivaUInt8LiteralNode *
 ggandiva_uint8_literal_node_new(guint8 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_UINT8_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_UINT8_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                   NULL));
 }
 
 /**
@@ -683,7 +687,8 @@ GGandivaInt16LiteralNode *
 ggandiva_int16_literal_node_new(gint16 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_INT16_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_INT16_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                   NULL));
 }
 
 /**
@@ -727,7 +732,8 @@ GGandivaUInt16LiteralNode *
 ggandiva_uint16_literal_node_new(guint16 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_UINT16_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_UINT16_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    NULL));
 }
 
 /**
@@ -771,7 +777,8 @@ GGandivaInt32LiteralNode *
 ggandiva_int32_literal_node_new(gint32 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_INT32_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_INT32_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                   NULL));
 }
 
 /**
@@ -815,7 +822,8 @@ GGandivaUInt32LiteralNode *
 ggandiva_uint32_literal_node_new(guint32 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_UINT32_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_UINT32_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    NULL));
 }
 
 /**
@@ -859,7 +867,8 @@ GGandivaInt64LiteralNode *
 ggandiva_int64_literal_node_new(gint64 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_INT64_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_INT64_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                   NULL));
 }
 
 /**
@@ -903,7 +912,8 @@ GGandivaUInt64LiteralNode *
 ggandiva_uint64_literal_node_new(guint64 value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_UINT64_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_UINT64_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    NULL));
 }
 
 /**
@@ -947,7 +957,8 @@ GGandivaFloatLiteralNode *
 ggandiva_float_literal_node_new(gfloat value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_FLOAT_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_FLOAT_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                   NULL));
 }
 
 /**
@@ -991,7 +1002,8 @@ GGandivaDoubleLiteralNode *
 ggandiva_double_literal_node_new(gdouble value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeLiteral(value);
-  return GGANDIVA_DOUBLE_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_DOUBLE_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    NULL));
 }
 
 /**
@@ -1064,7 +1076,8 @@ ggandiva_binary_literal_node_new(const guint8 *value,
   auto gandiva_node =
     gandiva::TreeExprBuilder::MakeBinaryLiteral(std::string(reinterpret_cast<const char *>(value),
                                                             size));
-  return GGANDIVA_BINARY_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_BINARY_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    NULL));
 }
 
 /**
@@ -1084,7 +1097,8 @@ ggandiva_binary_literal_node_new_bytes(GBytes *value)
     gandiva::TreeExprBuilder::MakeBinaryLiteral(
       std::string(reinterpret_cast<const char *>(raw_value),
                   value_size));
-  auto literal_node = ggandiva_literal_node_new_raw(&gandiva_node);
+  auto literal_node = ggandiva_literal_node_new_raw(&gandiva_node,
+                                                    NULL);
   auto priv = GGANDIVA_BINARY_LITERAL_NODE_GET_PRIVATE(literal_node);
   priv->value = value;
   g_bytes_ref(priv->value);
@@ -1138,7 +1152,8 @@ GGandivaStringLiteralNode *
 ggandiva_string_literal_node_new(const gchar *value)
 {
   auto gandiva_node = gandiva::TreeExprBuilder::MakeStringLiteral(value);
-  return GGANDIVA_STRING_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  return GGANDIVA_STRING_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node,
+                                                                    NULL));
 }
 
 /**
@@ -1197,13 +1212,17 @@ ggandiva_function_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
 }
 
 GGandivaLiteralNode *
-ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node)
+ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
+                              GArrowDataType *return_type)
 {
   GType type;
 
   auto gandiva_literal_node =
     std::static_pointer_cast<gandiva::LiteralNode>(*gandiva_node);
   auto arrow_data_type = (*gandiva_node)->return_type();
+  if (!return_type) {
+    return_type = garrow_data_type_new_raw(&arrow_data_type);
+  }
 
   if (gandiva_literal_node->is_null()) {
     type = GGANDIVA_TYPE_NULL_LITERAL_NODE;
@@ -1253,11 +1272,10 @@ ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node)
       break;
     }
   }
-  auto data_type = garrow_data_type_new_raw(&arrow_data_type);
   auto literal_node =
     GGANDIVA_LITERAL_NODE(g_object_new(type,
                                        "node", gandiva_node,
-                                       "return-type", data_type,
+                                       "return-type", return_type,
                                        NULL));
   return literal_node;
 }

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -477,7 +477,7 @@ ggandiva_null_literal_node_class_init(GGandivaNullLiteralNodeClass *klass)
  * ggandiva_null_literal_node_new:
  * @return_type: A #GArrowDataType.
  *
- * Returns: A newly created #GGandivaNullLiteralNode.
+ * Returns: (nullable): A newly created #GGandivaNullLiteralNode.
  *
  * Since: 0.12.0
  */
@@ -486,7 +486,11 @@ ggandiva_null_literal_node_new(GArrowDataType *return_type)
 {
   auto arrow_data_type = garrow_data_type_get_raw(return_type);
   auto gandiva_node = gandiva::TreeExprBuilder::MakeNull(arrow_data_type);
-  return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  if (gandiva_node == nullptr) {
+    return NULL;
+  } else {
+    return GGANDIVA_NULL_LITERAL_NODE(ggandiva_literal_node_new_raw(&gandiva_node));
+  }
 }
 
 

--- a/c_glib/gandiva-glib/node.h
+++ b/c_glib/gandiva-glib/node.h
@@ -35,6 +35,9 @@ struct _GGandivaNodeClass
   GObjectClass parent_class;
 };
 
+GArrowDataType *
+ggandiva_node_get_return_type(GGandivaNode *node);
+
 
 #define GGANDIVA_TYPE_FIELD_NODE (ggandiva_field_node_get_type())
 G_DECLARE_DERIVABLE_TYPE(GGandivaFieldNode,

--- a/c_glib/gandiva-glib/node.h
+++ b/c_glib/gandiva-glib/node.h
@@ -35,6 +35,7 @@ struct _GGandivaNodeClass
   GObjectClass parent_class;
 };
 
+
 #define GGANDIVA_TYPE_FIELD_NODE (ggandiva_field_node_get_type())
 G_DECLARE_DERIVABLE_TYPE(GGandivaFieldNode,
                          ggandiva_field_node,
@@ -302,5 +303,20 @@ GGandivaStringLiteralNode *
 ggandiva_string_literal_node_new(const gchar *value);
 const gchar *
 ggandiva_string_literal_node_get_value(GGandivaStringLiteralNode *node);
+
+
+#define GGANDIVA_TYPE_NULL_LITERAL_NODE (ggandiva_null_literal_node_get_type())
+G_DECLARE_DERIVABLE_TYPE(GGandivaNullLiteralNode,
+                         ggandiva_null_literal_node,
+                         GGANDIVA,
+                         NULL_LITERAL_NODE,
+                         GGandivaLiteralNode)
+struct _GGandivaNullLiteralNodeClass
+{
+  GGandivaLiteralNodeClass parent_class;
+};
+
+GGandivaNullLiteralNode *
+ggandiva_null_literal_node_new(GArrowDataType *data_type);
 
 G_END_DECLS

--- a/c_glib/gandiva-glib/node.h
+++ b/c_glib/gandiva-glib/node.h
@@ -35,9 +35,6 @@ struct _GGandivaNodeClass
   GObjectClass parent_class;
 };
 
-GArrowDataType *
-ggandiva_node_get_return_type(GGandivaNode *node);
-
 
 #define GGANDIVA_TYPE_FIELD_NODE (ggandiva_field_node_get_type())
 G_DECLARE_DERIVABLE_TYPE(GGandivaFieldNode,

--- a/c_glib/gandiva-glib/node.h
+++ b/c_glib/gandiva-glib/node.h
@@ -93,7 +93,8 @@ struct _GGandivaNullLiteralNodeClass
 };
 
 GGandivaNullLiteralNode *
-ggandiva_null_literal_node_new(GArrowDataType *data_type);
+ggandiva_null_literal_node_new(GArrowDataType *return_type,
+                               GError **error);
 
 
 #define GGANDIVA_TYPE_BOOLEAN_LITERAL_NODE (ggandiva_boolean_literal_node_get_type())

--- a/c_glib/gandiva-glib/node.h
+++ b/c_glib/gandiva-glib/node.h
@@ -84,6 +84,21 @@ struct _GGandivaLiteralNodeClass
 };
 
 
+#define GGANDIVA_TYPE_NULL_LITERAL_NODE (ggandiva_null_literal_node_get_type())
+G_DECLARE_DERIVABLE_TYPE(GGandivaNullLiteralNode,
+                         ggandiva_null_literal_node,
+                         GGANDIVA,
+                         NULL_LITERAL_NODE,
+                         GGandivaLiteralNode)
+struct _GGandivaNullLiteralNodeClass
+{
+  GGandivaLiteralNodeClass parent_class;
+};
+
+GGandivaNullLiteralNode *
+ggandiva_null_literal_node_new(GArrowDataType *data_type);
+
+
 #define GGANDIVA_TYPE_BOOLEAN_LITERAL_NODE (ggandiva_boolean_literal_node_get_type())
 G_DECLARE_DERIVABLE_TYPE(GGandivaBooleanLiteralNode,
                          ggandiva_boolean_literal_node,
@@ -306,20 +321,5 @@ GGandivaStringLiteralNode *
 ggandiva_string_literal_node_new(const gchar *value);
 const gchar *
 ggandiva_string_literal_node_get_value(GGandivaStringLiteralNode *node);
-
-
-#define GGANDIVA_TYPE_NULL_LITERAL_NODE (ggandiva_null_literal_node_get_type())
-G_DECLARE_DERIVABLE_TYPE(GGandivaNullLiteralNode,
-                         ggandiva_null_literal_node,
-                         GGANDIVA,
-                         NULL_LITERAL_NODE,
-                         GGandivaLiteralNode)
-struct _GGandivaNullLiteralNodeClass
-{
-  GGandivaLiteralNodeClass parent_class;
-};
-
-GGandivaNullLiteralNode *
-ggandiva_null_literal_node_new(GArrowDataType *data_type);
 
 G_END_DECLS

--- a/c_glib/gandiva-glib/node.hpp
+++ b/c_glib/gandiva-glib/node.hpp
@@ -36,4 +36,5 @@ ggandiva_function_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                                GList *parameters,
                                GArrowDataType *return_type);
 GGandivaLiteralNode *
-ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node);
+ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
+                              GArrowDataType *return_type);

--- a/c_glib/gandiva-glib/node.hpp
+++ b/c_glib/gandiva-glib/node.hpp
@@ -33,7 +33,6 @@ ggandiva_field_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
 GGandivaFunctionNode *
 ggandiva_function_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                                const gchar *name,
-                               GList *parameters,
-                               GArrowDataType *return_type);
+                               GList *parameters);
 GGandivaLiteralNode *
 ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node);

--- a/c_glib/gandiva-glib/node.hpp
+++ b/c_glib/gandiva-glib/node.hpp
@@ -33,6 +33,7 @@ ggandiva_field_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
 GGandivaFunctionNode *
 ggandiva_function_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                                const gchar *name,
-                               GList *parameters);
+                               GList *parameters,
+                               GArrowDataType *return_type);
 GGandivaLiteralNode *
 ggandiva_literal_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node);

--- a/c_glib/test/gandiva/test-binary-literal-node.rb
+++ b/c_glib/test/gandiva/test-binary-literal-node.rb
@@ -21,14 +21,27 @@ class TestGandivaBinaryLiteralNode < Test::Unit::TestCase
     @value = "\x00\x01\x02\x03\x04"
   end
 
-  def test_new
-    literal_node = Gandiva::BinaryLiteralNode.new(@value)
-    assert_equal(@value, literal_node.value.to_s)
+  sub_test_case(".new") do
+    def test_string
+      node = Gandiva::BinaryLiteralNode.new(@value)
+      assert_equal(@value, node.value.to_s)
+    end
+
+    def test_bytes
+      bytes_value = GLib::Bytes.new(@value)
+      node = Gandiva::BinaryLiteralNode.new(bytes_value)
+      assert_equal(@value, node.value.to_s)
+    end
   end
 
-  def test_new_bytes
-    bytes_value = GLib::Bytes.new(@value)
-    literal_node = Gandiva::BinaryLiteralNode.new(bytes_value)
-    assert_equal(@value, literal_node.value.to_s)
+  sub_test_case("instance methods") do
+    def setup
+      super
+      @node = Gandiva::BinaryLiteralNode.new(@value)
+    end
+
+    def test_return_type
+      assert_equal(Arrow::BinaryDataType.new, @node.return_type)
+    end
   end
 end

--- a/c_glib/test/gandiva/test-boolean-literal-node.rb
+++ b/c_glib/test/gandiva/test-boolean-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaBooleanLiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = true
+    @node = Gandiva::BooleanLiteralNode.new(@value)
   end
 
   def test_value
-    value = true
-    literal_node = Gandiva::BooleanLiteralNode.new(value)
-    assert_equal(value, literal_node.value?)
+    assert_equal(@value, @node.value?)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::BooleanDataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-double-literal-node.rb
+++ b/c_glib/test/gandiva/test-double-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaDoubleLiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = 1.5
+    @node = Gandiva::DoubleLiteralNode.new(@value)
   end
 
   def test_value
-    value = 1.5
-    literal_node = Gandiva::DoubleLiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::DoubleDataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-field-node.rb
+++ b/c_glib/test/gandiva/test-field-node.rb
@@ -18,18 +18,15 @@
 class TestGandivaFieldNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @field = Arrow::Field.new("valid", Arrow::BooleanDataType.new)
+    @node = Gandiva::FieldNode.new(@field)
   end
 
   def test_field
-    field = Arrow::Field.new("valid", Arrow::BooleanDataType.new)
-    field_node = Gandiva::FieldNode.new(field)
-    assert_equal(field, field_node.field)
+    assert_equal(@field, @node.field)
   end
 
   def test_return_type
-    data_type = Arrow::BooleanDataType.new
-    field = Arrow::Field.new("valid", data_type)
-    field_node = Gandiva::FieldNode.new(field)
-    assert_equal(data_type, field_node.return_type)
+    assert_equal(@field.data_type, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-field-node.rb
+++ b/c_glib/test/gandiva/test-field-node.rb
@@ -25,4 +25,11 @@ class TestGandivaFieldNode < Test::Unit::TestCase
     field_node = Gandiva::FieldNode.new(field)
     assert_equal(field, field_node.field)
   end
+
+  def test_return_type
+    data_type = Arrow::BooleanDataType.new
+    field = Arrow::Field.new("valid", data_type)
+    field_node = Gandiva::FieldNode.new(field)
+    assert_equal(data_type, field_node.return_type)
+  end
 end

--- a/c_glib/test/gandiva/test-float-literal-node.rb
+++ b/c_glib/test/gandiva/test-float-literal-node.rb
@@ -18,17 +18,15 @@
 class TestGandivaFloatLiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
-  end
-
-  def test_new
-    assert_nothing_raised do
-      Gandiva::FloatLiteralNode.new(1.5)
-    end
+    @value = 1.5
+    @node = Gandiva::FloatLiteralNode.new(@value)
   end
 
   def test_value
-    value = 1.5
-    literal_node = Gandiva::FloatLiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::FloatDataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-int16-literal-node.rb
+++ b/c_glib/test/gandiva/test-int16-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaInt16LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = -(2 ** 15)
+    @node = Gandiva::Int16LiteralNode.new(@value)
   end
 
   def test_value
-    value = -3
-    literal_node = Gandiva::Int16LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::Int16DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-int32-literal-node.rb
+++ b/c_glib/test/gandiva/test-int32-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaInt32LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = -(2 ** 31)
+    @node = Gandiva::Int32LiteralNode.new(@value)
   end
 
   def test_value
-    value = -3
-    literal_node = Gandiva::Int32LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::Int32DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-int64-literal-node.rb
+++ b/c_glib/test/gandiva/test-int64-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaInt64LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = -(2 ** 63)
+    @node = Gandiva::Int64LiteralNode.new(@value)
   end
 
   def test_value
-    value = -3
-    literal_node = Gandiva::Int64LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::Int64DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-int8-literal-node.rb
+++ b/c_glib/test/gandiva/test-int8-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaInt8LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = -(2 ** 7)
+    @node = Gandiva::Int8LiteralNode.new(@value)
   end
 
   def test_value
-    value = -3
-    literal_node = Gandiva::Int8LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::Int8DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-null-literal-node.rb
+++ b/c_glib/test/gandiva/test-null-literal-node.rb
@@ -20,6 +20,16 @@ class TestGandivaNullLiteralNode < Test::Unit::TestCase
     omit("Gandiva is required") unless defined?(::Gandiva)
   end
 
+  def test_invalid_type
+    return_type = Arrow::NullDataType.new
+    message =
+      "[gandiva][null-literal-node][new] " +
+      "failed to create: <#{return_type}>"
+    assert_raise(Arrow::Error::Invalid.new(message)) do
+      Gandiva::NullLiteralNode.new(return_type)
+    end
+  end
+
   def test_return_type
     return_type = Arrow::BooleanDataType.new
     literal_node = Gandiva::NullLiteralNode.new(return_type)

--- a/c_glib/test/gandiva/test-null-literal-node.rb
+++ b/c_glib/test/gandiva/test-null-literal-node.rb
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestGandivaNullLiteralNode < Test::Unit::TestCase
+  def setup
+    omit("Gandiva is required") unless defined?(::Gandiva)
+  end
+
+  def test_return_type
+    return_type = Arrow::BooleanDataType.new
+    literal_node = Gandiva::NullLiteralNode.new(return_type)
+    assert_equal(return_type, literal_node.return_type)
+  end
+end

--- a/c_glib/test/gandiva/test-string-literal-node.rb
+++ b/c_glib/test/gandiva/test-string-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaStringLiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = "Hello"
+    @node = Gandiva::StringLiteralNode.new(@value)
   end
 
   def test_value
-    value = "Hello"
-    literal_node = Gandiva::StringLiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::Int16DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-string-literal-node.rb
+++ b/c_glib/test/gandiva/test-string-literal-node.rb
@@ -27,6 +27,6 @@ class TestGandivaStringLiteralNode < Test::Unit::TestCase
   end
 
   def test_return_type
-    assert_equal(Arrow::Int16DataType.new, @node.return_type)
+    assert_equal(Arrow::StringDataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-uint16-literal-node.rb
+++ b/c_glib/test/gandiva/test-uint16-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaUInt16LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = 2 ** 16 - 1
+    @node = Gandiva::UInt16LiteralNode.new(@value)
   end
 
   def test_value
-    value = 3
-    literal_node = Gandiva::UInt16LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::UInt16DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-uint32-literal-node.rb
+++ b/c_glib/test/gandiva/test-uint32-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaUInt32LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = 2 ** 32 - 1
+    @node = Gandiva::UInt32LiteralNode.new(@value)
   end
 
   def test_value
-    value = 3
-    literal_node = Gandiva::UInt32LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::UInt32DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-uint64-literal-node.rb
+++ b/c_glib/test/gandiva/test-uint64-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaUInt64LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = 3
+    @node = Gandiva::UInt64LiteralNode.new(@value)
   end
 
   def test_value
-    value = 3
-    literal_node = Gandiva::UInt64LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::UInt64DataType.new, @node.return_type)
   end
 end

--- a/c_glib/test/gandiva/test-uint8-literal-node.rb
+++ b/c_glib/test/gandiva/test-uint8-literal-node.rb
@@ -18,11 +18,15 @@
 class TestGandivaUInt8LiteralNode < Test::Unit::TestCase
   def setup
     omit("Gandiva is required") unless defined?(::Gandiva)
+    @value = 2 ** 8 - 1
+    @node = Gandiva::UInt8LiteralNode.new(@value)
   end
 
   def test_value
-    value = 3
-    literal_node = Gandiva::UInt8LiteralNode.new(value)
-    assert_equal(value, literal_node.value)
+    assert_equal(@value, @node.value)
+  end
+
+  def test_return_type
+    assert_equal(Arrow::UInt8DataType.new, @node.return_type)
   end
 end


### PR DESCRIPTION
- Add `#GGandivaNullLiteralNode`.
- Remove `return_type` property in `#GGandivaFunctionNode` to use `ggandiva_node_get_return_type()`.