### PR TITLE
ARROW-3989: [Rust] [CSV] Cast bool string to lower case in reader

### DIFF
--- a/rust/src/csv/reader.rs
+++ b/rust/src/csv/reader.rs
@@ -40,7 +40,6 @@
 //! let batch = csv.next().unwrap().unwrap();
 //! ```
 
-use std::any::TypeId;
 use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
@@ -127,17 +126,17 @@ impl Reader {
             .map(|i| {
                 let field = self.schema.field(*i);
                 match field.data_type() {
-                    &DataType::Boolean => build_primitive_array::<BooleanType>(rows, i),
-                    &DataType::Int8 => build_primitive_array::<Int8Type>(rows, i),
-                    &DataType::Int16 => build_primitive_array::<Int16Type>(rows, i),
-                    &DataType::Int32 => build_primitive_array::<Int32Type>(rows, i),
-                    &DataType::Int64 => build_primitive_array::<Int64Type>(rows, i),
-                    &DataType::UInt8 => build_primitive_array::<UInt8Type>(rows, i),
-                    &DataType::UInt16 => build_primitive_array::<UInt16Type>(rows, i),
-                    &DataType::UInt32 => build_primitive_array::<UInt32Type>(rows, i),
-                    &DataType::UInt64 => build_primitive_array::<UInt64Type>(rows, i),
-                    &DataType::Float32 => build_primitive_array::<Float32Type>(rows, i),
-                    &DataType::Float64 => build_primitive_array::<Float64Type>(rows, i),
+                    &DataType::Boolean => self.build_primitive_array::<BooleanType>(rows, i),
+                    &DataType::Int8 => self.build_primitive_array::<Int8Type>(rows, i),
+                    &DataType::Int16 => self.build_primitive_array::<Int16Type>(rows, i),
+                    &DataType::Int32 => self.build_primitive_array::<Int32Type>(rows, i),
+                    &DataType::Int64 => self.build_primitive_array::<Int64Type>(rows, i),
+                    &DataType::UInt8 => self.build_primitive_array::<UInt8Type>(rows, i),
+                    &DataType::UInt16 => self.build_primitive_array::<UInt16Type>(rows, i),
+                    &DataType::UInt32 => self.build_primitive_array::<UInt32Type>(rows, i),
+                    &DataType::UInt64 => self.build_primitive_array::<UInt64Type>(rows, i),
+                    &DataType::Float32 => self.build_primitive_array::<Float32Type>(rows, i),
+                    &DataType::Float64 => self.build_primitive_array::<Float64Type>(rows, i),
                     &DataType::Utf8 => {
                         let values_builder: UInt8Builder = UInt8Builder::new(rows.len());
                         let mut list_builder = ListArrayBuilder::new(values_builder);
@@ -167,37 +166,38 @@ impl Reader {
             Err(e) => Err(e),
         }
     }
-}
 
-fn build_primitive_array<T: ArrowPrimitiveType>(
-    rows: &[StringRecord],
-    col_idx: &usize,
-) -> Result<ArrayRef> {
-    let mut builder = PrimitiveArrayBuilder::<T>::new(rows.len());
-    let is_boolean_type = TypeId::of::<T>() == TypeId::of::<BooleanType>();
-    for row_index in 0..rows.len() {
-        match rows[row_index].get(*col_idx) {
-            Some(s) if s.len() > 0 => {
-                let t = if is_boolean_type {
-                    s.to_lowercase().parse::<T::Native>()
-                } else {
-                    s.parse::<T::Native>()
-                };
-                match t {
-                    Ok(v) => builder.push(v)?,
-                    Err(_) => {
-                        // TODO: we should surface the underlying error here.
-                        return Err(ArrowError::ParseError(format!(
-                            "Error while parsing value {}",
-                            s
-                        )));
+    fn build_primitive_array<T: ArrowPrimitiveType>(
+        &self,
+        rows: &[StringRecord],
+        col_idx: &usize,
+    ) -> Result<ArrayRef> {
+        let mut builder = PrimitiveArrayBuilder::<T>::new(rows.len());
+        let is_boolean_type = *self.schema.field(*col_idx).data_type() == DataType::Boolean;
+        for row_index in 0..rows.len() {
+            match rows[row_index].get(*col_idx) {
+                Some(s) if s.len() > 0 => {
+                    let t = if is_boolean_type {
+                        s.to_lowercase().parse::<T::Native>()
+                    } else {
+                        s.parse::<T::Native>()
+                    };
+                    match t {
+                        Ok(v) => builder.push(v)?,
+                        Err(_) => {
+                            // TODO: we should surface the underlying error here.
+                            return Err(ArrowError::ParseError(format!(
+                                "Error while parsing value {}",
+                                s
+                            )));
+                        }
                     }
                 }
+                _ => builder.push_null()?,
             }
-            _ => builder.push_null()?,
         }
+        Ok(Arc::new(builder.finish()) as ArrayRef)
     }
-    Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
 #[cfg(test)]

--- a/rust/test/data/null_test.csv
+++ b/rust/test/data/null_test.csv
@@ -1,6 +1,6 @@
 c_int,c_float,c_string,c_bool
-1,1.1,"1.11",true
-2,2.2,"2.22",true
+1,1.1,"1.11",True
+2,2.2,"2.22",TRUE
 3,,"3.33",true
-4,4.4,,false
-5,6.6,"",false
+4,4.4,,False
+5,6.6,"",FALSE


### PR DESCRIPTION
The csv reader currently only handles boolean types if the string is explicitly `true|false`. Excel saves bools as `TRUE|FALSE`, and Python/Pandas as `True|False`.

This PR adds a condition that lowercases booleans when casting them to Arrow types.

@andygrove @sunchao I believe it's ready for review.