### PR TITLE
ARROW-4073: [Python] Fix URI parsing on Windows. Also fix test for get_library_dirs when using ARROW_HOME to develop

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -231,4 +231,8 @@ def get_library_dirs():
         if _os.path.exists(_os.path.join(library_lib, 'arrow.lib')):
             library_dirs.append(library_lib)
 
+    # ARROW-4074: Allow for ARROW_HOME to be set to some other directory
+    if 'ARROW_HOME' in _os.environ:
+        library_dirs.append(_os.path.join(_os.environ['ARROW_HOME'], 'lib'))
+
     return library_dirs

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -38,10 +38,17 @@ from pyarrow.filesystem import (LocalFileSystem, _ensure_filesystem,
                                 get_filesystem_from_uri)
 from pyarrow.util import _is_path_like, _stringify_path
 
+_URI_STRIP_SCHEMES = ('hdfs',)
 
 def _parse_uri(path):
     path = _stringify_path(path)
-    return urlparse(path).path
+    parsed_uri = urlparse(path)
+    if parsed_uri.scheme in _URI_STRIP_SCHEMES:
+        return parsed_uri.path
+    else:
+        # ARROW-4073: On Windows returning the path with the scheme
+        # stripped removes the drive letter, if any
+        return path
 
 
 def _get_filesystem_and_path(passed_filesystem, path):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -40,6 +40,7 @@ from pyarrow.util import _is_path_like, _stringify_path
 
 _URI_STRIP_SCHEMES = ('hdfs',)
 
+
 def _parse_uri(path):
     path = _stringify_path(path)
     parsed_uri = urlparse(path)

--- a/python/pyarrow/tests/test_misc.py
+++ b/python/pyarrow/tests/test_misc.py
@@ -28,10 +28,8 @@ def test_get_include():
 
 @pytest.mark.skipif('sys.platform != "win32"')
 def test_get_library_dirs_win32():
-    library_dirs = pa.get_library_dirs()
-
-    library_lib = library_dirs[-1]
-    assert os.path.exists(os.path.join(library_lib, 'arrow.lib'))
+    assert any(os.path.exists(os.path.join(directory, 'arrow.lib'))
+               for directory in pa.get_library_dirs())
 
 
 def test_cpu_count():


### PR DESCRIPTION
Resolves ARROW-4074