### PR TITLE
ARROW-3982: [C++] Allow "binary" input in simple JSON format

### DIFF
--- a/cpp/src/arrow/ipc/json-simple.cc
+++ b/cpp/src/arrow/ipc/json-simple.cc
@@ -41,7 +41,8 @@ using ::arrow::internal::checked_cast;
 static constexpr auto kParseFlags = rj::kParseFullPrecisionFlag | rj::kParseNanAndInfFlag;
 
 static Status JSONTypeError(const char* expected_type, rj::Type json_type) {
-  return Status::Invalid("Expected ", expected_type, " or null, got type ", json_type);
+  return Status::Invalid("Expected ", expected_type, " or null, got JSON type ",
+                         json_type);
 }
 
 class Converter {
@@ -91,7 +92,6 @@ class ConcreteConverter : public Converter {
 };
 
 // TODO : dates and times?
-// TODO : binary / fixed size binary?
 
 // ------------------------------------------------------------------------
 // Converter for null arrays
@@ -284,7 +284,7 @@ class DecimalConverter final : public ConcreteConverter<DecimalConverter> {
 };
 
 // ------------------------------------------------------------------------
-// Converter for string arrays
+// Converter for binary and string arrays
 
 class StringConverter final : public ConcreteConverter<StringConverter> {
  public:
@@ -311,6 +311,43 @@ class StringConverter final : public ConcreteConverter<StringConverter> {
 
  protected:
   std::shared_ptr<BinaryBuilder> builder_;
+};
+
+// ------------------------------------------------------------------------
+// Converter for fixed-size binary arrays
+
+class FixedSizeBinaryConverter final
+    : public ConcreteConverter<FixedSizeBinaryConverter> {
+ public:
+  explicit FixedSizeBinaryConverter(const std::shared_ptr<DataType>& type) {
+    this->type_ = type;
+    builder_ = std::make_shared<FixedSizeBinaryBuilder>(type, default_memory_pool());
+  }
+
+  Status AppendNull() override { return builder_->AppendNull(); }
+
+  Status AppendValue(const rj::Value& json_obj) override {
+    if (json_obj.IsNull()) {
+      return AppendNull();
+    }
+    if (json_obj.IsString()) {
+      auto view = util::string_view(json_obj.GetString(), json_obj.GetStringLength());
+      if (view.length() != static_cast<size_t>(builder_->byte_width())) {
+        std::stringstream ss;
+        ss << "Invalid string length " << view.length() << " in JSON input for "
+           << this->type_->ToString();
+        return Status::Invalid(ss.str());
+      }
+      return builder_->Append(view);
+    } else {
+      return JSONTypeError("string", json_obj.GetType());
+    }
+  }
+
+  std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
+
+ protected:
+  std::shared_ptr<FixedSizeBinaryBuilder> builder_;
 };
 
 // ------------------------------------------------------------------------
@@ -449,6 +486,8 @@ Status GetConverter(const std::shared_ptr<DataType>& type,
     SIMPLE_CONVERTER_CASE(Type::LIST, ListConverter)
     SIMPLE_CONVERTER_CASE(Type::STRUCT, StructConverter)
     SIMPLE_CONVERTER_CASE(Type::STRING, StringConverter)
+    SIMPLE_CONVERTER_CASE(Type::BINARY, StringConverter)
+    SIMPLE_CONVERTER_CASE(Type::FIXED_SIZE_BINARY, FixedSizeBinaryConverter)
     SIMPLE_CONVERTER_CASE(Type::DECIMAL, DecimalConverter)
     default: {
       return Status::NotImplemented("JSON conversion to ", type->ToString(),

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -277,18 +277,11 @@ TEST_F(TestPrettyPrint, ListType) {
 
 TEST_F(TestPrettyPrint, FixedSizeBinaryType) {
   std::vector<bool> is_valid = {true, true, false, true, false};
-  std::vector<std::string> values = {"foo", "bar", "baz"};
 
-  std::shared_ptr<Array> array;
   auto type = fixed_size_binary(3);
-  FixedSizeBinaryBuilder builder(type);
+  auto array = ArrayFromJSON(type, "[\"foo\", \"bar\", null, \"baz\"]");
 
-  ASSERT_OK(builder.Append(values[0]));
-  ASSERT_OK(builder.Append(values[1]));
-  ASSERT_OK(builder.Append(values[2]));
-  ASSERT_OK(builder.Finish(&array));
-
-  static const char* ex = "[\n  666F6F,\n  626172,\n  62617A\n]";
+  static const char* ex = "[\n  666F6F,\n  626172,\n  null,\n  62617A\n]";
   CheckArray(*array, {0, 10}, ex);
   static const char* ex_2 = "  [\n    666F6F,\n    ...\n    62617A\n  ]";
   CheckArray(*array, {2, 1}, ex_2);


### PR DESCRIPTION
Since rapidjson doesn't validate UTF8 by default, we can represent arbitrary binary bytes in the JSON input (bytes < 0x20 have to be represented as unicode escapes).