### PR TITLE
ARROW-4084: [C++] Make Status static method support variadic arguments

### DIFF
--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -58,13 +58,11 @@ Status ListBuilder::AppendValues(const int32_t* offsets, int64_t length,
 }
 
 Status ListBuilder::AppendNextOffset() {
-  int64_t num_values = value_builder_->length();
-  if (ARROW_PREDICT_FALSE(num_values > kListMaximumElements)) {
-    std::stringstream ss;
-    ss << "ListArray cannot contain more then INT32_MAX - 1 child elements,"
-       << " have " << num_values;
-    return Status::CapacityError(ss.str());
-  }
+  const int64_t num_values = value_builder_->length();
+  ARROW_RETURN_IF(
+      num_values > kListMaximumElements,
+      Status::CapacityError("ListArray cannot contain more then 2^31 - 1 child elements,",
+                            " have ", num_values));
   return offsets_builder_.Append(static_cast<int32_t>(num_values));
 }
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -93,9 +93,8 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
     }
 
     default: {
-      std::stringstream ss;
-      ss << "MakeBuilder: cannot construct builder for type " << type->ToString();
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("MakeBuilder: cannot construct builder for type ",
+                                    type->ToString());
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -56,11 +56,9 @@ namespace compute {
 
 namespace {
 
-#define CHECK_IMPLEMENTED(KERNEL, FUNCNAME, TYPE)                  \
-  if (!KERNEL) {                                                   \
-    std::stringstream ss;                                          \
-    ss << FUNCNAME << " not implemented for " << type->ToString(); \
-    return Status::NotImplemented(ss.str());                       \
+#define CHECK_IMPLEMENTED(KERNEL, FUNCNAME, TYPE)                                       \
+  if (!KERNEL) {                                                                        \
+    return Status::NotImplemented(FUNCNAME, " not implemented for ", type->ToString()); \
   }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -40,10 +40,9 @@ namespace {
 
 Status GenericConversionError(const std::shared_ptr<DataType>& type, const uint8_t* data,
                               uint32_t size) {
-  std::stringstream ss;
-  ss << "CSV conversion error to " << type->ToString() << ": invalid value '"
-     << std::string(reinterpret_cast<const char*>(data), size) << "'";
-  return Status::Invalid(ss.str());
+  return Status::Invalid("CSV conversion error to ", type->ToString(),
+                         ": invalid value '",
+                         std::string(reinterpret_cast<const char*>(data), size), "'");
 }
 
 inline bool IsWhitespace(uint8_t c) {
@@ -214,9 +213,8 @@ class VarSizeBinaryConverter : public ConcreteConverter {
 
     auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
       if (CheckUTF8 && ARROW_PREDICT_FALSE(!util::ValidateUTF8(data, size))) {
-        std::stringstream ss;
-        ss << "CSV conversion error to " << type_->ToString() << ": invalid UTF8 data";
-        return Status::Invalid(ss.str());
+        return Status::Invalid("CSV conversion error to ", type_->ToString(),
+                               ": invalid UTF8 data");
       }
       builder.UnsafeAppend(data, size);
       return Status::OK();
@@ -256,10 +254,8 @@ Status FixedSizeBinaryConverter::Convert(const BlockParser& parser, int32_t col_
 
   auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
     if (ARROW_PREDICT_FALSE(size != byte_width)) {
-      std::stringstream ss;
-      ss << "CSV conversion error to " << type_->ToString() << ": got a " << size
-         << "-byte long string";
-      return Status::Invalid(ss.str());
+      return Status::Invalid("CSV conversion error to ", type_->ToString(), ": got a ",
+                             size, "-byte long string");
     }
     return builder.Append(data);
   };
@@ -410,9 +406,8 @@ Status Converter::Make(const std::shared_ptr<DataType>& type,
       break;
 
     default: {
-      std::stringstream ss;
-      ss << "CSV conversion to " << type->ToString() << " is not supported";
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("CSV conversion to ", type->ToString(),
+                                    " is not supported");
     }
 
 #undef CONVERTER_CASE

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -30,9 +30,7 @@ namespace arrow {
 namespace csv {
 
 static Status ParseError(const char* message) {
-  std::stringstream ss;
-  ss << "CSV parse error: " << message;
-  return Status::Invalid(ss.str());
+  return Status::Invalid("CSV parse error: ", message);
 }
 
 static Status MismatchingColumns(int32_t expected, int32_t actual) {

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -355,10 +355,8 @@ class ThreadedTableReader : public BaseTableReader {
                                       chunk_size, &parsed_size));
           if (parsed_size != chunk_size) {
             DCHECK_EQ(parsed_size, chunk_size);
-            std::stringstream ss;
-            ss << "Chunker and parser disagree on block size: " << chunk_size << " vs "
-               << parsed_size;
-            return Status::Invalid(ss.str());
+            return Status::Invalid("Chunker and parser disagree on block size: ",
+                                   chunk_size, " vs ", parsed_size);
           }
           RETURN_NOT_OK(ProcessData(parser, chunk_index));
           // Keep chunk buffer alive within closure and release it at the end

--- a/cpp/src/arrow/dbi/hiveserver2/hiveserver2-test.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/hiveserver2-test.cc
@@ -97,10 +97,8 @@ Status Wait(const std::unique_ptr<Operation>& op,
   if (op_state == state) {
     return Status::OK();
   } else {
-    std::stringstream ss;
-    ss << "Failed to reach state '" << OperationStateToString(state) << "' after "
-       << retries << " retries.";
-    return Status::IOError(ss.str());
+    return Status::IOError("Failed to reach state '", OperationStateToString(state),
+                           "' after ", retries, " retries");
   }
 }
 

--- a/cpp/src/arrow/dbi/hiveserver2/service.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/service.cc
@@ -92,9 +92,7 @@ Service::Service(const string& host, int port, int conn_timeout,
 
 Status Service::Open() {
   if (impl_->protocol_version < hs2::TProtocolVersion::HIVE_CLI_SERVICE_PROTOCOL_V6) {
-    std::stringstream ss;
-    ss << "Unsupported protocol: " << impl_->protocol_version;
-    return Status::NotImplemented(ss.str());
+    return Status::NotImplemented("Unsupported protocol: ", impl_->protocol_version);
   }
 
   impl_->socket.reset(new TSocket(host_, port_));

--- a/cpp/src/arrow/dbi/hiveserver2/thrift-internal.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/thrift-internal.cc
@@ -204,11 +204,7 @@ Status TStatusToStatus(const hs2::TStatus& tstatus) {
       return Status::IOError(tstatus.errorMessage);
     case hs2::TStatusCode::INVALID_HANDLE_STATUS:
       return Status::Invalid("Invalid handle");
-    default: {
-      std::stringstream ss;
-      ss << "Unknown TStatusCode " << tstatus.statusCode;
-      return Status::UnknownError(ss.str());
-    }
+    default: { return Status::UnknownError("Unknown TStatusCode ", tstatus.statusCode); }
   }
 }
 

--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -37,16 +37,13 @@ Status FromGrpcStatus(const grpc::Status& grpc_status) {
   if (grpc_status.ok()) {
     return Status::OK();
   }
-  std::stringstream ss;
 
   if (grpc_status.error_code() == grpc::StatusCode::UNIMPLEMENTED) {
-    ss << "gRPC returned unimplemented error, with message: "
-       << grpc_status.error_message();
-    return Status::NotImplemented(ss.str());
+    return Status::NotImplemented("gRPC returned unimplemented error, with message: ",
+                                  grpc_status.error_message());
   } else {
-    ss << "gRPC failed with error code " << grpc_status.error_code()
-       << " and message: " << grpc_status.error_message();
-    return Status::IOError(ss.str());
+    return Status::IOError("gRPC failed with error code ", grpc_status.error_code(),
+                           " and message: ", grpc_status.error_message());
   }
 }
 

--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
@@ -82,9 +82,8 @@ Status ReadMessage(CudaBufferReader* reader, MemoryPool* pool,
   RETURN_NOT_OK(AllocateBuffer(pool, message_length, &metadata));
   RETURN_NOT_OK(reader->Read(message_length, &bytes_read, metadata->mutable_data()));
   if (bytes_read != message_length) {
-    std::stringstream ss;
-    ss << "Expected " << message_length << " metadata bytes, but only got " << bytes_read;
-    return Status::IOError(ss.str());
+    return Status::IOError("Expected ", message_length, " metadata bytes, but only got ",
+                           bytes_read);
   }
 
   return ipc::Message::ReadFrom(metadata, reader, out);

--- a/cpp/src/arrow/gpu/cuda_common.h
+++ b/cpp/src/arrow/gpu/cuda_common.h
@@ -34,15 +34,13 @@ namespace cuda {
     (void)ret;            \
   } while (0)
 
-#define CU_RETURN_NOT_OK(STMT)                                                \
-  do {                                                                        \
-    CUresult ret = (STMT);                                                    \
-    if (ret != CUDA_SUCCESS) {                                                \
-      std::stringstream ss;                                                   \
-      ss << "Cuda Driver API call in " << __FILE__ << " at line " << __LINE__ \
-         << " failed with code " << ret << ": " << #STMT;                     \
-      return Status::IOError(ss.str());                                       \
-    }                                                                         \
+#define CU_RETURN_NOT_OK(STMT)                                                  \
+  do {                                                                          \
+    CUresult ret = (STMT);                                                      \
+    if (ret != CUDA_SUCCESS) {                                                  \
+      return Status::IOError("Cuda Driver API call in ", __FILE__, " at line ", \
+                             __LINE__, " failed with code ", ret, ": ", #STMT); \
+    }                                                                           \
   } while (0)
 
 }  // namespace cuda

--- a/cpp/src/arrow/io/file-test.cc
+++ b/cpp/src/arrow/io/file-test.cc
@@ -460,9 +460,7 @@ class MyMemoryPool : public MemoryPool {
     *ptr = reinterpret_cast<uint8_t*>(std::realloc(*ptr, new_size));
 
     if (*ptr == NULL) {
-      std::stringstream ss;
-      ss << "realloc of size " << new_size << " failed";
-      return Status::OutOfMemory(ss.str());
+      return Status::OutOfMemory("realloc of size ", new_size, " failed");
     }
 
     return Status::OK();

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -479,9 +479,7 @@ class MemoryMappedFile::MemoryMap : public MutableBuffer {
     void* result = mmap(nullptr, static_cast<size_t>(initial_size), prot_flags_,
                         map_mode_, file_->fd(), 0);
     if (result == MAP_FAILED) {
-      std::stringstream ss;
-      ss << "Memory mapping file failed: " << std::strerror(errno);
-      return Status::IOError(ss.str());
+      return Status::IOError("Memory mapping file failed: ", std::strerror(errno));
     }
     size_ = capacity_ = initial_size;
     data_ = mutable_data_ = static_cast<uint8_t*>(result);

--- a/cpp/src/arrow/io/hdfs-internal.cc
+++ b/cpp/src/arrow/io/hdfs-internal.cc
@@ -218,9 +218,7 @@ static arrow::Status try_dlopen(std::vector<fs::path> potential_paths, const cha
   }
 
   if (out_handle == NULL) {
-    std::stringstream ss;
-    ss << "Unable to load " << name;
-    return arrow::Status::IOError(ss.str());
+    return arrow::Status::IOError("Unable to load ", name);
   }
 
   return arrow::Status::OK();
@@ -243,9 +241,7 @@ static arrow::Status try_dlopen(std::vector<fs::path> potential_paths, const cha
   }
 
   if (out_handle == NULL) {
-    std::stringstream ss;
-    ss << "Unable to load " << name;
-    return arrow::Status::IOError(ss.str());
+    return arrow::Status::IOError("Unable to load ", name);
   }
 
   return arrow::Status::OK();

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -464,7 +464,8 @@ class HadoopFileSystem::HadoopFileSystemImpl {
       if ((errno == 0) || (errno == ENOENT && Exists(path))) {
         num_entries = 0;
       } else {
-        return Status::IOError("HDFS list directory failed, errno: ", TranslateErrno(errno));
+        return Status::IOError("HDFS list directory failed, errno: ",
+                               TranslateErrno(errno));
       }
     }
 

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -57,13 +57,11 @@ std::string TranslateErrno(int error_code) {
 
 }  // namespace
 
-#define CHECK_FAILURE(RETURN_VALUE, WHAT)                                   \
-  do {                                                                      \
-    if (RETURN_VALUE == -1) {                                               \
-      std::stringstream ss;                                                 \
-      ss << "HDFS " << WHAT << " failed, errno: " << TranslateErrno(errno); \
-      return Status::IOError(ss.str());                                     \
-    }                                                                       \
+#define CHECK_FAILURE(RETURN_VALUE, WHAT)                                               \
+  do {                                                                                  \
+    if (RETURN_VALUE == -1) {                                                           \
+      return Status::IOError("HDFS ", WHAT, " failed, errno: ", TranslateErrno(errno)); \
+    }                                                                                   \
   } while (0)
 
 static constexpr int kDefaultHdfsBufferSize = 1 << 16;
@@ -466,10 +464,7 @@ class HadoopFileSystem::HadoopFileSystemImpl {
       if ((errno == 0) || (errno == ENOENT && Exists(path))) {
         num_entries = 0;
       } else {
-        std::stringstream ss;
-        ss << "HDFS list directory of " << path
-           << " failed, errno: " << TranslateErrno(errno);
-        return Status::IOError(ss.str());
+        return Status::IOError("HDFS list directory failed, errno: ", TranslateErrno(errno));
       }
     }
 
@@ -492,14 +487,9 @@ class HadoopFileSystem::HadoopFileSystemImpl {
     hdfsFile handle = driver_->OpenFile(fs_, path.c_str(), O_RDONLY, buffer_size, 0, 0);
 
     if (handle == nullptr) {
-      std::stringstream ss;
-      if (!Exists(path)) {
-        ss << "HDFS file does not exist: " << path;
-      } else {
-        // TODO(wesm): determine other causes of failure
-        ss << "HDFS path exists, but opening file failed: " << path;
-      }
-      return Status::IOError(ss.str());
+      const char* msg = !Exists(path) ? "HDFS file does not exist: "
+                                      : "HDFS path exists, but opening file failed: ";
+      return Status::IOError(msg, path);
     }
 
     // std::make_shared does not work with private ctors
@@ -521,10 +511,7 @@ class HadoopFileSystem::HadoopFileSystemImpl {
                           static_cast<tSize>(default_block_size));
 
     if (handle == nullptr) {
-      // TODO(wesm): determine cause of failure
-      std::stringstream ss;
-      ss << "Unable to open file " << path;
-      return Status::IOError(ss.str());
+      return Status::IOError("Unable to open file ", path);
     }
 
     // std::make_shared does not work with private ctors

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -34,9 +34,7 @@ Status DictionaryMemo::GetDictionary(int64_t id,
                                      std::shared_ptr<Array>* dictionary) const {
   auto it = id_to_dictionary_.find(id);
   if (it == id_to_dictionary_.end()) {
-    std::stringstream ss;
-    ss << "Dictionary with id " << id << " not found";
-    return Status::KeyError(ss.str());
+    return Status::KeyError("Dictionary with id ", id, " not found");
   }
   *dictionary = it->second;
   return Status::OK();
@@ -70,9 +68,7 @@ bool DictionaryMemo::HasDictionaryId(int64_t id) const {
 Status DictionaryMemo::AddDictionary(int64_t id,
                                      const std::shared_ptr<Array>& dictionary) {
   if (HasDictionaryId(id)) {
-    std::stringstream ss;
-    ss << "Dictionary with id " << id << " already exists";
-    return Status::KeyError(ss.str());
+    return Status::KeyError("Dictionary with id ", id, " already exists");
   }
   intptr_t address = reinterpret_cast<intptr_t>(dictionary.get());
   id_to_dictionary_[id] = dictionary;

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -642,9 +642,7 @@ class TableWriter::TableWriterImpl : public ArrayVisitor {
 
   Status LoadArrayMetadata(const Array& values, ArrayMetadata* meta) {
     if (!(is_primitive(values.type_id()) || is_binary_like(values.type_id()))) {
-      std::stringstream ss;
-      ss << "Array is not primitive type: " << values.type()->ToString();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Array is not primitive type: ", values.type()->ToString());
     }
 
     meta->type = ToFlatbufferType(values.type_id());

--- a/cpp/src/arrow/ipc/json-integration-test.cc
+++ b/cpp/src/arrow/ipc/json-integration-test.cc
@@ -170,10 +170,8 @@ static Status ValidateArrowVsJson(const std::string& arrow_path,
   const int arrow_nbatches = arrow_reader->num_record_batches();
 
   if (json_nbatches != arrow_nbatches) {
-    std::stringstream ss;
-    ss << "Different number of record batches: " << json_nbatches << " (JSON) vs "
-       << arrow_nbatches << " (Arrow)";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Different number of record batches: ", json_nbatches,
+                           " (JSON) vs ", arrow_nbatches, " (Arrow)");
   }
 
   std::shared_ptr<RecordBatch> arrow_batch;
@@ -231,9 +229,7 @@ Status RunCommand(const std::string& json_path, const std::string& arrow_path,
 
     return ValidateArrowVsJson(arrow_path, json_path);
   } else {
-    std::stringstream ss;
-    ss << "Unknown command: " << command;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Unknown command: ", command);
   }
 }
 

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -633,9 +633,7 @@ static Status GetInteger(const rj::Value::ConstObject& json_type,
       *type = is_signed ? int64() : uint64();
       break;
     default:
-      std::stringstream ss;
-      ss << "Invalid bit width: " << bit_width;
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Invalid bit width: ", bit_width);
   }
   return Status::OK();
 }
@@ -654,9 +652,7 @@ static Status GetFloatingPoint(const RjObject& json_type,
   } else if (precision == "HALF") {
     *type = float16();
   } else {
-    std::stringstream ss;
-    ss << "Invalid precision: " << precision;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Invalid precision: ", precision);
   }
   return Status::OK();
 }
@@ -693,9 +689,7 @@ static Status GetDate(const RjObject& json_type, std::shared_ptr<DataType>* type
   } else if (unit_str == "MILLISECOND") {
     *type = date64();
   } else {
-    std::stringstream ss;
-    ss << "Invalid date unit: " << unit_str;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Invalid date unit: ", unit_str);
   }
   return Status::OK();
 }
@@ -718,9 +712,7 @@ static Status GetTime(const RjObject& json_type, std::shared_ptr<DataType>* type
   } else if (unit_str == "NANOSECOND") {
     *type = time64(TimeUnit::NANO);
   } else {
-    std::stringstream ss;
-    ss << "Invalid time unit: " << unit_str;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Invalid time unit: ", unit_str);
   }
 
   const auto& fw_type = checked_cast<const FixedWidthType&>(**type);
@@ -749,9 +741,7 @@ static Status GetTimestamp(const RjObject& json_type, std::shared_ptr<DataType>*
   } else if (unit_str == "NANOSECOND") {
     unit = TimeUnit::NANO;
   } else {
-    std::stringstream ss;
-    ss << "Invalid time unit: " << unit_str;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Invalid time unit: ", unit_str);
   }
 
   const auto& it_tz = json_type.FindMember("timezone");
@@ -778,9 +768,7 @@ static Status GetUnion(const RjObject& json_type,
   } else if (mode_str == "DENSE") {
     mode = UnionMode::DENSE;
   } else {
-    std::stringstream ss;
-    ss << "Invalid union mode: " << mode_str;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Invalid union mode: ", mode_str);
   }
 
   const auto& it_type_codes = json_type.FindMember("typeIds");
@@ -838,9 +826,7 @@ static Status GetType(const RjObject& json_type,
   } else if (type_name == "union") {
     return GetUnion(json_type, children, type);
   } else {
-    std::stringstream ss;
-    ss << "Unrecognized type name: " << type_name;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Unrecognized type name: ", type_name);
   }
   return Status::OK();
 }
@@ -1235,10 +1221,8 @@ class ArrayReader {
     const auto& json_children_arr = json_children->value.GetArray();
 
     if (type.num_children() != static_cast<int>(json_children_arr.Size())) {
-      std::stringstream ss;
-      ss << "Expected " << type.num_children() << " children, but got "
-         << json_children_arr.Size();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Expected ", type.num_children(), " children, but got ",
+                             json_children_arr.Size());
     }
 
     for (int i = 0; i < static_cast<int>(json_children_arr.Size()); ++i) {
@@ -1342,9 +1326,7 @@ static Status ReadDictionary(const RjObject& obj, const DictionaryTypeMap& id_to
 
   auto it = id_to_field.find(id);
   if (it == id_to_field.end()) {
-    std::stringstream ss;
-    ss << "No dictionary with id " << id;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("No dictionary with id ", id);
   }
   std::vector<std::shared_ptr<Field>> fields = {it->second};
 
@@ -1489,9 +1471,7 @@ Status ReadArray(MemoryPool* pool, const rj::Value& json_array, const Schema& sc
   }
 
   if (result == nullptr) {
-    std::stringstream ss;
-    ss << "Field named " << name << " not found in schema";
-    return Status::KeyError(ss.str());
+    return Status::KeyError("Field named ", name, " not found in schema");
   }
 
   return ReadArray(pool, json_array, result->type(), array);

--- a/cpp/src/arrow/ipc/json-internal.h
+++ b/cpp/src/arrow/ipc/json-internal.h
@@ -49,56 +49,39 @@ using RjWriter = rj::Writer<rj::StringBuffer>;
 using RjArray = rj::Value::ConstArray;
 using RjObject = rj::Value::ConstObject;
 
-#define RETURN_NOT_FOUND(TOK, NAME, PARENT) \
-  if (NAME == (PARENT).MemberEnd()) {       \
-    std::stringstream ss;                   \
-    ss << "field " << TOK << " not found";  \
-    return Status::Invalid(ss.str());       \
+#define RETURN_NOT_FOUND(TOK, NAME, PARENT)              \
+  if (NAME == (PARENT).MemberEnd()) {                    \
+    return Status::Invalid("field ", TOK, " not found"); \
   }
 
-#define RETURN_NOT_STRING(TOK, NAME, PARENT) \
-  RETURN_NOT_FOUND(TOK, NAME, PARENT);       \
-  if (!NAME->value.IsString()) {             \
-    std::stringstream ss;                    \
-    ss << "field was not a string"           \
-       << " line " << __LINE__;              \
-    return Status::Invalid(ss.str());        \
+#define RETURN_NOT_STRING(TOK, NAME, PARENT)                          \
+  RETURN_NOT_FOUND(TOK, NAME, PARENT);                                \
+  if (!NAME->value.IsString()) {                                      \
+    return Status::Invalid("field was not a string line ", __LINE__); \
   }
 
-#define RETURN_NOT_BOOL(TOK, NAME, PARENT) \
-  RETURN_NOT_FOUND(TOK, NAME, PARENT);     \
-  if (!NAME->value.IsBool()) {             \
-    std::stringstream ss;                  \
-    ss << "field was not a boolean"        \
-       << " line " << __LINE__;            \
-    return Status::Invalid(ss.str());      \
+#define RETURN_NOT_BOOL(TOK, NAME, PARENT)                             \
+  RETURN_NOT_FOUND(TOK, NAME, PARENT);                                 \
+  if (!NAME->value.IsBool()) {                                         \
+    return Status::Invalid("field was not a boolean line ", __LINE__); \
   }
 
-#define RETURN_NOT_INT(TOK, NAME, PARENT) \
-  RETURN_NOT_FOUND(TOK, NAME, PARENT);    \
-  if (!NAME->value.IsInt()) {             \
-    std::stringstream ss;                 \
-    ss << "field was not an int"          \
-       << " line " << __LINE__;           \
-    return Status::Invalid(ss.str());     \
+#define RETURN_NOT_INT(TOK, NAME, PARENT)                           \
+  RETURN_NOT_FOUND(TOK, NAME, PARENT);                              \
+  if (!NAME->value.IsInt()) {                                       \
+    return Status::Invalid("field was not an int line ", __LINE__); \
   }
 
-#define RETURN_NOT_ARRAY(TOK, NAME, PARENT) \
-  RETURN_NOT_FOUND(TOK, NAME, PARENT);      \
-  if (!NAME->value.IsArray()) {             \
-    std::stringstream ss;                   \
-    ss << "field was not an array"          \
-       << " line " << __LINE__;             \
-    return Status::Invalid(ss.str());       \
+#define RETURN_NOT_ARRAY(TOK, NAME, PARENT)                           \
+  RETURN_NOT_FOUND(TOK, NAME, PARENT);                                \
+  if (!NAME->value.IsArray()) {                                       \
+    return Status::Invalid("field was not an array line ", __LINE__); \
   }
 
-#define RETURN_NOT_OBJECT(TOK, NAME, PARENT) \
-  RETURN_NOT_FOUND(TOK, NAME, PARENT);       \
-  if (!NAME->value.IsObject()) {             \
-    std::stringstream ss;                    \
-    ss << "field was not an object"          \
-       << " line " << __LINE__;              \
-    return Status::Invalid(ss.str());        \
+#define RETURN_NOT_OBJECT(TOK, NAME, PARENT)                           \
+  RETURN_NOT_FOUND(TOK, NAME, PARENT);                                 \
+  if (!NAME->value.IsObject()) {                                       \
+    return Status::Invalid("field was not an object line ", __LINE__); \
   }
 
 namespace arrow {

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -153,10 +153,8 @@ Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStrea
   std::shared_ptr<Buffer> body;
   RETURN_NOT_OK(stream->Read(body_length, &body));
   if (body->size() < body_length) {
-    std::stringstream ss;
-    ss << "Expected to be able to read " << body_length << " bytes for message body, got "
-       << body->size();
-    return Status::IOError(ss.str());
+    return Status::IOError("Expected to be able to read ", body_length,
+                           " bytes for message body, got ", body->size());
   }
 
   return Message::Open(metadata, body, out);
@@ -171,10 +169,8 @@ Status Message::ReadFrom(const int64_t offset, const std::shared_ptr<Buffer>& me
   std::shared_ptr<Buffer> body;
   RETURN_NOT_OK(file->ReadAt(offset, body_length, &body));
   if (body->size() < body_length) {
-    std::stringstream ss;
-    ss << "Expected to be able to read " << body_length << " bytes for message body, got "
-       << body->size();
-    return Status::IOError(ss.str());
+    return Status::IOError("Expected to be able to read ", body_length,
+                           " bytes for message body, got ", body->size());
   }
 
   return Message::Open(metadata, body, out);
@@ -238,19 +234,16 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
   RETURN_NOT_OK(file->ReadAt(offset, metadata_length, &buffer));
 
   if (buffer->size() < metadata_length) {
-    std::stringstream ss;
-    ss << "Expected to read " << metadata_length << " metadata bytes but got "
-       << buffer->size();
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Expected to read ", metadata_length,
+                           " metadata bytes but got ", buffer->size());
   }
 
   int32_t flatbuffer_size = *reinterpret_cast<const int32_t*>(buffer->data());
 
   if (flatbuffer_size + static_cast<int>(sizeof(int32_t)) > metadata_length) {
-    std::stringstream ss;
-    ss << "flatbuffer size " << metadata_length << " invalid. File offset: " << offset
-       << ", metadata length: " << metadata_length;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("flatbuffer size ", metadata_length,
+                           " invalid. File offset: ", offset,
+                           ", metadata length: ", metadata_length);
   }
 
   auto metadata = SliceBuffer(buffer, 4, buffer->size() - 4);
@@ -303,10 +296,8 @@ Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* message) {
   std::shared_ptr<Buffer> metadata;
   RETURN_NOT_OK(file->Read(message_length, &metadata));
   if (metadata->size() != message_length) {
-    std::stringstream ss;
-    ss << "Expected to read " << message_length << " metadata bytes, but "
-       << "only read " << metadata->size();
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Expected to read ", message_length, " metadata bytes, but ",
+                           "only read ", metadata->size());
   }
 
   return Message::ReadFrom(metadata, file, message);

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -443,9 +443,7 @@ static Status TypeToFlatbuffer(FBB& fbb, const DataType& type,
       return UnionToFlatBuffer(fbb, *value_type, children, dictionary_memo, offset);
     default:
       *out_type = flatbuf::Type_NONE;  // Make clang-tidy happy
-      std::stringstream ss;
-      ss << "Unable to convert type: " << type.ToString() << std::endl;
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unable to convert type: ", type.ToString());
   }
   return Status::OK();
 }
@@ -483,9 +481,7 @@ static Status TensorTypeToFlatbuffer(FBB& fbb, const DataType& type,
       break;
     default:
       *out_type = flatbuf::Type_NONE;  // Make clang-tidy happy
-      std::stringstream ss;
-      ss << "Unable to convert type: " << type.ToString() << std::endl;
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unable to convert type: ", type.ToString());
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -225,9 +225,7 @@ class ArrayLoader {
 
     const int num_children = type.num_children();
     if (num_children != 1) {
-      std::stringstream ss;
-      ss << "Wrong number of children: " << num_children;
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Wrong number of children: ", num_children);
     }
 
     return LoadChildren(type.children());
@@ -343,9 +341,7 @@ Status ReadDictionary(const Buffer& metadata, const DictionaryTypeMap& dictionar
   int64_t id = *dictionary_id = dictionary_batch->id();
   auto it = dictionary_types.find(id);
   if (it == dictionary_types.end()) {
-    std::stringstream ss;
-    ss << "Do not have type metadata for dictionary with id: " << id;
-    return Status::KeyError(ss.str());
+    return Status::KeyError("Do not have type metadata for dictionary with id: ", id);
   }
 
   std::vector<std::shared_ptr<Field>> fields = {it->second};
@@ -372,10 +368,8 @@ static Status ReadMessageAndValidate(MessageReader* reader, Message::Type expect
   RETURN_NOT_OK(reader->ReadNextMessage(message));
 
   if (!(*message) && !allow_null) {
-    std::stringstream ss;
-    ss << "Expected " << FormatMessageType(expected_type)
-       << " message in stream, was null or length 0";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Expected ", FormatMessageType(expected_type),
+                           " message in stream, was null or length 0");
   }
 
   if ((*message) == nullptr) {
@@ -383,10 +377,9 @@ static Status ReadMessageAndValidate(MessageReader* reader, Message::Type expect
   }
 
   if ((*message)->type() != expected_type) {
-    std::stringstream ss;
-    ss << "Message not expected type: " << FormatMessageType(expected_type)
-       << ", was: " << (*message)->type();
-    return Status::IOError(ss.str());
+    return Status::IOError(
+        "Message not expected type: ", FormatMessageType(expected_type),
+        ", was: ", (*message)->type());
   }
   return Status::OK();
 }
@@ -512,9 +505,7 @@ class RecordBatchFileReader::RecordBatchFileReaderImpl {
     int magic_size = static_cast<int>(strlen(kArrowMagicBytes));
 
     if (footer_offset_ <= magic_size * 2 + 4) {
-      std::stringstream ss;
-      ss << "File is too small: " << footer_offset_;
-      return Status::Invalid(ss.str());
+      return Status::Invalid("File is too small: ", footer_offset_);
     }
 
     std::shared_ptr<Buffer> buffer;
@@ -523,9 +514,7 @@ class RecordBatchFileReader::RecordBatchFileReaderImpl {
 
     const int64_t expected_footer_size = magic_size + sizeof(int32_t);
     if (buffer->size() < expected_footer_size) {
-      std::stringstream ss;
-      ss << "Unable to read " << expected_footer_size << "from end of file";
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Unable to read ", expected_footer_size, "from end of file");
     }
 
     if (memcmp(buffer->data() + sizeof(int32_t), kArrowMagicBytes, magic_size)) {

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -55,31 +55,23 @@ Status AllocateAligned(int64_t size, uint8_t** out) {
   *out =
       reinterpret_cast<uint8_t*>(_aligned_malloc(static_cast<size_t>(size), kAlignment));
   if (!*out) {
-    std::stringstream ss;
-    ss << "malloc of size " << size << " failed";
-    return Status::OutOfMemory(ss.str());
+    return Status::OutOfMemory("malloc of size ", size, " failed");
   }
 #elif defined(ARROW_JEMALLOC)
   *out = reinterpret_cast<uint8_t*>(mallocx(
       std::max(static_cast<size_t>(size), kAlignment), MALLOCX_ALIGN(kAlignment)));
   if (*out == NULL) {
-    std::stringstream ss;
-    ss << "malloc of size " << size << " failed";
-    return Status::OutOfMemory(ss.str());
+    return Status::OutOfMemory("malloc of size ", size, " failed");
   }
 #else
   const int result = posix_memalign(reinterpret_cast<void**>(out), kAlignment,
                                     static_cast<size_t>(size));
   if (result == ENOMEM) {
-    std::stringstream ss;
-    ss << "malloc of size " << size << " failed";
-    return Status::OutOfMemory(ss.str());
+    return Status::OutOfMemory("malloc of size ", size, " failed");
   }
 
   if (result == EINVAL) {
-    std::stringstream ss;
-    ss << "invalid alignment parameter: " << kAlignment;
-    return Status::Invalid(ss.str());
+    return Status::Invalid("invalid alignment parameter: ", kAlignment);
   }
 #endif
   return Status::OK();
@@ -118,10 +110,8 @@ class DefaultMemoryPool : public MemoryPool {
     *ptr = reinterpret_cast<uint8_t*>(
         rallocx(*ptr, static_cast<size_t>(new_size), MALLOCX_ALIGN(kAlignment)));
     if (*ptr == NULL) {
-      std::stringstream ss;
-      ss << "realloc of size " << new_size << " failed";
       *ptr = previous_ptr;
-      return Status::OutOfMemory(ss.str());
+      return Status::OutOfMemory("realloc of size ", new_size, " failed");
     }
 #else
     // Note: We cannot use realloc() here as it doesn't guarantee alignment.

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -215,10 +215,8 @@ struct PyBytesView {
       this->ref.reset();
       return Status::OK();
     } else {
-      std::stringstream ss;
-      ss << "Expected " << expected_msg << ", got a '" << Py_TYPE(obj)->tp_name
-         << "' object";
-      return Status::TypeError(ss.str());
+      return Status::TypeError("Expected ", expected_msg, ", got a '",
+                               Py_TYPE(obj)->tp_name, "' object");
     }
   }
 

--- a/cpp/src/arrow/python/decimal.cc
+++ b/cpp/src/arrow/python/decimal.cc
@@ -125,11 +125,9 @@ Status DecimalFromPythonDecimal(PyObject* python_decimal, const DecimalType& arr
   const int32_t scale = arrow_type.scale();
 
   if (ARROW_PREDICT_FALSE(inferred_precision > precision)) {
-    std::stringstream buf;
-    buf << "Decimal type with precision " << inferred_precision
-        << " does not fit into precision inferred from first array element: "
-        << precision;
-    return Status::Invalid(buf.str());
+    return Status::Invalid(
+        "Decimal type with precision ", inferred_precision,
+        " does not fit into precision inferred from first array element: ", precision);
   }
 
   if (scale != inferred_scale) {

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -164,11 +164,10 @@ namespace {
 
 Status IntegerOverflowStatus(PyObject* obj, const std::string& overflow_message) {
   if (overflow_message.empty()) {
-    std::stringstream ss;
     std::string obj_as_stdstring;
     RETURN_NOT_OK(PyObject_StdStringStr(obj, &obj_as_stdstring));
-    ss << "Value " << obj_as_stdstring << " too large to fit in C integer type";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Value ", obj_as_stdstring,
+                           " too large to fit in C integer type");
   } else {
     return Status::Invalid(overflow_message);
   }
@@ -299,13 +298,10 @@ bool PandasObjectIsNull(PyObject* obj) {
 }
 
 Status InvalidValue(PyObject* obj, const std::string& why) {
-  std::stringstream ss;
-
   std::string obj_as_str;
   RETURN_NOT_OK(internal::PyObject_StdStringStr(obj, &obj_as_str));
-  ss << "Could not convert " << obj_as_str << " with type " << Py_TYPE(obj)->tp_name
-     << ": " << why;
-  return Status::Invalid(ss.str());
+  return Status::Invalid("Could not convert ", obj_as_str, " with type ",
+                         Py_TYPE(obj)->tp_name, ": ", why);
 }
 
 Status UnboxIntegerAsInt64(PyObject* obj, int64_t* out) {
@@ -355,10 +351,8 @@ Status IntegerScalarToDoubleSafe(PyObject* obj, double* out) {
   constexpr int64_t kDoubleMin = -(1LL << 53);
 
   if (value < kDoubleMin || value > kDoubleMax) {
-    std::stringstream ss;
-    ss << "Integer value " << value << " is outside of the range exactly"
-       << " representable by a IEEE 754 double precision value";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Integer value ", value, " is outside of the range exactly",
+                           " representable by a IEEE 754 double precision value");
   }
   *out = static_cast<double>(value);
   return Status::OK();
@@ -372,10 +366,8 @@ Status IntegerScalarToFloat32Safe(PyObject* obj, float* out) {
   constexpr int64_t kFloatMin = -(1LL << 24);
 
   if (value < kFloatMin || value > kFloatMax) {
-    std::stringstream ss;
-    ss << "Integer value " << value << " is outside of the range exactly"
-       << " representable by a IEEE 754 single precision value";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Integer value ", value, " is outside of the range exactly",
+                           " representable by a IEEE 754 single precision value");
   }
   *out = static_cast<float>(value);
   return Status::OK();

--- a/cpp/src/arrow/python/inference.cc
+++ b/cpp/src/arrow/python/inference.cc
@@ -58,10 +58,9 @@ class NumPyDtypeUnifier {
   NumPyDtypeUnifier() : current_type_num_(-1), current_dtype_(NULLPTR) {}
 
   Status InvalidMix(int new_dtype) {
-    std::stringstream ss;
-    ss << "Cannot mix NumPy dtypes " << GetNumPyTypeName(current_type_num_) << " and "
-       << GetNumPyTypeName(new_dtype);
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Cannot mix NumPy dtypes ",
+                           GetNumPyTypeName(current_type_num_), " and ",
+                           GetNumPyTypeName(new_dtype));
   }
 
   int Observe_BOOL(PyArray_Descr* descr, int dtype) { return INVALID; }
@@ -250,9 +249,7 @@ class NumPyDtypeUnifier {
         action = Observe_DATETIME(descr);
         break;
       default:
-        std::stringstream ss;
-        ss << "Unsupported numpy type " << GetNumPyTypeName(dtype) << std::endl;
-        return Status::NotImplemented(ss.str());
+        return Status::NotImplemented("Unsupported numpy type ", GetNumPyTypeName(dtype));
     }
 
     if (action == INVALID) {
@@ -480,10 +477,8 @@ class TypeInferrer {
       } else if (PyBytes_Check(key_obj)) {
         key = internal::PyBytes_AsStdString(key_obj);
       } else {
-        std::stringstream ss;
-        ss << "Expected dict key of type str or bytes, got '" << Py_TYPE(key_obj)->tp_name
-           << "'";
-        return Status::TypeError(ss.str());
+        return Status::TypeError("Expected dict key of type str or bytes, got '",
+                                 Py_TYPE(key_obj)->tp_name, "'");
       }
       // Get or create visitor for this key
       auto it = struct_inferrers_.find(key);

--- a/cpp/src/arrow/python/numpy-internal.h
+++ b/cpp/src/arrow/python/numpy-internal.h
@@ -143,9 +143,8 @@ inline Status VisitNumpyArrayInline(PyArrayObject* arr, VISITOR* visitor) {
     TYPE_VISIT_INLINE(DATETIME);
     TYPE_VISIT_INLINE(OBJECT);
   }
-  std::stringstream ss;
-  ss << "NumPy type not implemented: " << GetNumPyTypeName(PyArray_TYPE(arr));
-  return Status::NotImplemented(ss.str());
+  return Status::NotImplemented("NumPy type not implemented: ",
+                                GetNumPyTypeName(PyArray_TYPE(arr)));
 }
 
 #undef TYPE_VISIT_INLINE

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -92,9 +92,7 @@ Status GetTensorType(PyObject* dtype, std::shared_ptr<DataType>* out) {
     TO_ARROW_TYPE_CASE(FLOAT32, float32);
     TO_ARROW_TYPE_CASE(FLOAT64, float64);
     default: {
-      std::stringstream ss;
-      ss << "Unsupported numpy type " << descr->type_num << std::endl;
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unsupported numpy type ", descr->type_num);
     }
   }
   return Status::OK();
@@ -119,9 +117,7 @@ Status GetNumPyType(const DataType& type, int* type_num) {
     NUMPY_TYPE_CASE(FLOAT, FLOAT32);
     NUMPY_TYPE_CASE(DOUBLE, FLOAT64);
     default: {
-      std::stringstream ss;
-      ss << "Unsupported tensor type: " << type.ToString() << std::endl;
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unsupported tensor type: ", type.ToString());
     }
   }
 #undef NUMPY_TYPE_CASE
@@ -181,9 +177,7 @@ Status NumPyDtypeToArrow(PyArray_Descr* descr, std::shared_ptr<DataType>* out) {
       }
     } break;
     default: {
-      std::stringstream ss;
-      ss << "Unsupported numpy type " << descr->type_num << std::endl;
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unsupported numpy type ", descr->type_num);
     }
   }
 

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -283,9 +283,8 @@ class NumPyConverter {
   }
 
   Status TypeNotImplemented(std::string type_name) {
-    std::stringstream ss;
-    ss << "NumPyConverter doesn't implement <" << type_name << "> conversion. ";
-    return Status::NotImplemented(ss.str());
+    return Status::NotImplemented("NumPyConverter doesn't implement <", type_name,
+                                  "> conversion. ");
   }
 
   MemoryPool* pool_;
@@ -574,9 +573,8 @@ Status NumPyConverter::Visit(const FixedSizeBinaryType& type) {
   auto byte_width = type.byte_width();
 
   if (itemsize_ != byte_width) {
-    std::stringstream ss;
-    ss << "Got bytestring of length " << itemsize_ << " (expected " << byte_width << ")";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Got bytestring of length ", itemsize_, " (expected ",
+                           byte_width, ")");
   }
 
   FixedSizeBinaryBuilder builder(::arrow::fixed_size_binary(byte_width), pool_);
@@ -651,9 +649,8 @@ Status NumPyConverter::Visit(const StringType& type) {
       if (ARROW_PREDICT_TRUE(util::ValidateUTF8(data, itemsize_))) {
         return builder.Append(data, itemsize_);
       } else {
-        std::stringstream ss;
-        ss << "Encountered non-UTF8 binary value: " << HexEncode(data, itemsize_);
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Encountered non-UTF8 binary value: ",
+                               HexEncode(data, itemsize_));
       }
     } else {
       return AppendUTF32(reinterpret_cast<const char*>(data), itemsize_, byteorder,
@@ -697,9 +694,7 @@ Status NumPyConverter::Visit(const StructType& type) {
     for (auto field : type.children()) {
       PyObject* tup = PyDict_GetItemString(dtype_->fields, field->name().c_str());
       if (tup == NULL) {
-        std::stringstream ss;
-        ss << "Missing field '" << field->name() << "' in struct array";
-        return Status::TypeError(ss.str());
+        return Status::TypeError("Missing field '", field->name(), "' in struct array");
       }
       PyArray_Descr* sub_dtype =
           reinterpret_cast<PyArray_Descr*>(PyTuple_GET_ITEM(tup, 0));

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -402,10 +402,7 @@ class TimestampConverter : public TypedConverter<TimestampType, TimestampConvert
       std::shared_ptr<DataType> type;
       RETURN_NOT_OK(NumPyDtypeToArrow(PyArray_DescrFromScalar(obj), &type));
       if (type->id() != Type::TIMESTAMP) {
-        std::ostringstream ss;
-        ss << "Expected np.datetime64 but got: ";
-        ss << type->ToString();
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Expected np.datetime64 but got: ", type->ToString());
       }
       const TimestampType& ttype = checked_cast<const TimestampType&>(*type);
       if (unit_ != ttype.unit()) {
@@ -705,10 +702,7 @@ Status ListConverter::AppendNdarrayItem(PyObject* obj) {
       return value_converter_->AppendSingleVirtual(obj);
     }
     default: {
-      std::stringstream ss;
-      ss << "Unknown list item type: ";
-      ss << value_type_->ToString();
-      return Status::TypeError(ss.str());
+      return Status::TypeError("Unknown list item type: ", value_type_->ToString());
     }
   }
 }
@@ -911,9 +905,8 @@ Status GetConverter(const std::shared_ptr<DataType>& type, bool from_pandas,
           new StructConverter(from_pandas, strict_conversions));
       break;
     default:
-      std::stringstream ss;
-      ss << "Sequence converter for type " << type->ToString() << " not implemented";
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Sequence converter for type ", type->ToString(),
+                                    " not implemented");
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -407,10 +407,9 @@ Status CallCustomCallback(PyObject* context, PyObject* method_name, PyObject* el
                           PyObject** result) {
   *result = NULL;
   if (context == Py_None) {
-    std::stringstream ss;
-    ss << "error while calling callback on " << internal::PyObject_StdStringRepr(elem)
-       << ": handler not registered";
-    return Status::SerializationError(ss.str());
+    return Status::SerializationError("error while calling callback on ",
+                                      internal::PyObject_StdStringRepr(elem),
+                                      ": handler not registered");
   } else {
     *result = PyObject_CallMethodObjArgs(context, method_name, elem, NULL);
     return PassPyError();

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -199,9 +199,7 @@ static inline Status PyTime_convert_int(int64_t val, const TimeUnit::type unit,
   switch (unit) {
     case TimeUnit::NANO:
       if (val % 1000 != 0) {
-        std::stringstream ss;
-        ss << "Value " << val << " has non-zero nanoseconds";
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Value ", val, " has non-zero nanoseconds");
       }
       val /= 1000;
     // fall through

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -95,16 +95,13 @@ class SimpleRecordBatch : public RecordBatch {
     DCHECK(column != nullptr);
 
     if (!field->type()->Equals(column->type())) {
-      std::stringstream ss;
-      ss << "Column data type " << field->type()->name()
-         << " does not match field data type " << column->type()->name();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Column data type ", field->type()->name(),
+                             " does not match field data type ", column->type()->name());
     }
     if (column->length() != num_rows_) {
-      std::stringstream ss;
-      ss << "Added column's length must match record batch's length. Expected length "
-         << num_rows_ << " but got length " << column->length();
-      return Status::Invalid(ss.str());
+      return Status::Invalid(
+          "Added column's length must match record batch's length. Expected length ",
+          num_rows_, " but got length ", column->length());
     }
 
     std::shared_ptr<Schema> new_schema;
@@ -229,17 +226,14 @@ Status RecordBatch::Validate() const {
     auto arr_shared = this->column_data(i);
     const ArrayData& arr = *arr_shared;
     if (arr.length != num_rows_) {
-      std::stringstream ss;
-      ss << "Number of rows in column " << i << " did not match batch: " << arr.length
-         << " vs " << num_rows_;
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Number of rows in column ", i,
+                             " did not match batch: ", arr.length, " vs ", num_rows_);
     }
     const auto& schema_type = *schema_->field(i)->type();
     if (!arr.type->Equals(schema_type)) {
-      std::stringstream ss;
-      ss << "Column " << i << " type not match schema: " << arr.type->ToString() << " vs "
-         << schema_type.ToString();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Column ", i,
+                             " type not match schema: ", arr.type->ToString(), " vs ",
+                             schema_type.ToString());
     }
   }
   return Status::OK();

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -13,6 +13,7 @@
 #include "arrow/status.h"
 
 #include <assert.h>
+#include <sstream>
 
 namespace arrow {
 

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -25,15 +25,16 @@
 #endif
 
 #include "arrow/util/macros.h"
+#include "arrow/util/string_builder.h"
 #include "arrow/util/visibility.h"
 
 #ifdef ARROW_EXTRA_ERROR_CONTEXT
 
-/// \brief Propagate any non-successful Status to the caller
-#define ARROW_RETURN_NOT_OK(s)                                                      \
+/// \brief Return with given status if condition is met.
+#define ARROW_RETURN_IF(condition, status)                                          \
   do {                                                                              \
-    ::arrow::Status _s = (s);                                                       \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) {                                            \
+    if (ARROW_PREDICT_FALSE(condition)) {                                           \
+      ::arrow::Status _s = (status);                                                \
       std::stringstream ss;                                                         \
       ss << __FILE__ << ":" << __LINE__ << " code: " << #s << "\n" << _s.message(); \
       return ::arrow::Status(_s.code(), ss.str());                                  \
@@ -42,16 +43,22 @@
 
 #else
 
-/// \brief Propagate any non-successful Status to the caller
-#define ARROW_RETURN_NOT_OK(s)           \
-  do {                                   \
-    ::arrow::Status _s = (s);            \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) { \
-      return _s;                         \
-    }                                    \
-  } while (false)
+#define ARROW_RETURN_IF(condition, status) \
+  do {                                     \
+    if (ARROW_PREDICT_FALSE(condition)) {  \
+      return (status);                     \
+    }                                      \
+  } while (0)
 
 #endif  // ARROW_EXTRA_ERROR_CONTEXT
+
+/// \brief Propagate any non-successful Status to the caller
+#define ARROW_RETURN_NOT_OK(status)  \
+  do {                               \
+    ::arrow::Status __s = (status);  \
+    ARROW_RETURN_IF(!__s.ok(), __s); \
+                                     \
+  } while (false)
 
 #define RETURN_NOT_OK_ELSE(s, else_) \
   do {                               \
@@ -61,17 +68,6 @@
       return _s;                     \
     }                                \
   } while (false)
-
-#define ARROW_RETURN_FAILURE_IF_FALSE(condition, status)                                 \
-  do {                                                                                   \
-    if (!(condition)) {                                                                  \
-      Status _status = (status);                                                         \
-      std::stringstream ss;                                                              \
-      ss << __FILE__ << ":" << __LINE__ << " code: " << _status.CodeAsString() << " \n " \
-         << _status.message();                                                           \
-      return ::arrow::Status(_status.code(), ss.str());                                  \
-    }                                                                                    \
-  } while (0)
 
 // This is an internal-use macro and should not be used in public headers.
 #ifndef RETURN_NOT_OK
@@ -149,84 +145,106 @@ class ARROW_EXPORT Status {
   static Status OK() { return Status(); }
 
   /// Return a success status with a specific message
-  static Status OK(const std::string& msg) { return Status(StatusCode::OK, msg); }
+  template <typename... Args>
+  static Status OK(Args... args) {
+    return Status(StatusCode::OK, util::StringBuilder(args...));
+  }
 
   /// Return an error status for out-of-memory conditions
-  static Status OutOfMemory(const std::string& msg) {
-    return Status(StatusCode::OutOfMemory, msg);
+  template <typename... Args>
+  static Status OutOfMemory(Args... args) {
+    return Status(StatusCode::OutOfMemory, util::StringBuilder(args...));
   }
 
   /// Return an error status for failed key lookups (e.g. column name in a table)
-  static Status KeyError(const std::string& msg) {
-    return Status(StatusCode::KeyError, msg);
+  template <typename... Args>
+  static Status KeyError(Args... args) {
+    return Status(StatusCode::KeyError, util::StringBuilder(args...));
   }
 
   /// Return an error status for type errors (such as mismatching data types)
-  static Status TypeError(const std::string& msg) {
-    return Status(StatusCode::TypeError, msg);
+  template <typename... Args>
+  static Status TypeError(Args... args) {
+    return Status(StatusCode::TypeError, util::StringBuilder(args...));
   }
 
   /// Return an error status for unknown errors
-  static Status UnknownError(const std::string& msg) {
-    return Status(StatusCode::UnknownError, msg);
+  template <typename... Args>
+  static Status UnknownError(Args... args) {
+    return Status(StatusCode::UnknownError, util::StringBuilder(args...));
   }
 
   /// Return an error status when an operation or a combination of operation and
   /// data types is unimplemented
-  static Status NotImplemented(const std::string& msg) {
-    return Status(StatusCode::NotImplemented, msg);
+  template <typename... Args>
+  static Status NotImplemented(Args... args) {
+    return Status(StatusCode::NotImplemented, util::StringBuilder(args...));
   }
 
   /// Return an error status for invalid data (for example a string that fails parsing)
-  static Status Invalid(const std::string& msg) {
-    return Status(StatusCode::Invalid, msg);
+  template <typename... Args>
+  static Status Invalid(Args... args) {
+    return Status(StatusCode::Invalid, util::StringBuilder(args...));
   }
 
   /// Return an error status when a container's capacity would exceed its limits
-  static Status CapacityError(const std::string& msg) {
-    return Status(StatusCode::CapacityError, msg);
+  template <typename... Args>
+  static Status CapacityError(Args... args) {
+    return Status(StatusCode::CapacityError, util::StringBuilder(args...));
   }
 
   /// Return an error status when some IO-related operation failed
-  static Status IOError(const std::string& msg) {
-    return Status(StatusCode::IOError, msg);
+  template <typename... Args>
+  static Status IOError(Args... args) {
+    return Status(StatusCode::IOError, util::StringBuilder(args...));
   }
 
   /// Return an error status when some (de)serialization operation failed
-  static Status SerializationError(const std::string& msg) {
-    return Status(StatusCode::SerializationError, msg);
+  template <typename... Args>
+  static Status SerializationError(Args... args) {
+    return Status(StatusCode::SerializationError, util::StringBuilder(args...));
   }
 
-  static Status RError(const std::string& msg) { return Status(StatusCode::RError, msg); }
-
-  static Status PlasmaObjectExists(const std::string& msg) {
-    return Status(StatusCode::PlasmaObjectExists, msg);
+  template <typename... Args>
+  static Status RError(Args... args) {
+    return Status(StatusCode::RError, util::StringBuilder(args...));
   }
 
-  static Status PlasmaObjectNonexistent(const std::string& msg) {
-    return Status(StatusCode::PlasmaObjectNonexistent, msg);
+  template <typename... Args>
+  static Status PlasmaObjectExists(Args... args) {
+    return Status(StatusCode::PlasmaObjectExists, util::StringBuilder(args...));
   }
 
-  static Status PlasmaObjectAlreadySealed(const std::string& msg) {
-    return Status(StatusCode::PlasmaObjectAlreadySealed, msg);
+  template <typename... Args>
+  static Status PlasmaObjectNonexistent(Args... args) {
+    return Status(StatusCode::PlasmaObjectNonexistent, util::StringBuilder(args...));
   }
 
-  static Status PlasmaStoreFull(const std::string& msg) {
-    return Status(StatusCode::PlasmaStoreFull, msg);
+  template <typename... Args>
+  static Status PlasmaObjectAlreadySealed(Args... args) {
+    return Status(StatusCode::PlasmaObjectAlreadySealed, util::StringBuilder(args...));
+  }
+
+  template <typename... Args>
+  static Status PlasmaStoreFull(Args... args) {
+    return Status(StatusCode::PlasmaStoreFull, util::StringBuilder(args...));
   }
 
   static Status StillExecuting() { return Status(StatusCode::StillExecuting, ""); }
 
-  static Status CodeGenError(const std::string& msg) {
-    return Status(StatusCode::CodeGenError, msg);
+  template <typename... Args>
+  static Status CodeGenError(Args... args) {
+    return Status(StatusCode::CodeGenError, util::StringBuilder(args...));
   }
 
-  static Status ExpressionValidationError(const std::string& msg) {
-    return Status(StatusCode::ExpressionValidationError, msg);
+  template <typename... Args>
+  static Status ExpressionValidationError(Args... args) {
+    return Status(StatusCode::ExpressionValidationError, util::StringBuilder(args...));
   }
 
-  static Status ExecutionError(const std::string& msg) {
-    return Status(StatusCode::ExecutionError, msg);
+  template <typename... Args>
+  static Status ExecutionError(Args... args) {
+    return Status(StatusCode::ExecutionError, util::StringBuilder(args...));
   }
 
   /// Return true iff the status indicates success.

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -146,105 +146,118 @@ class ARROW_EXPORT Status {
 
   /// Return a success status with a specific message
   template <typename... Args>
-  static Status OK(Args... args) {
-    return Status(StatusCode::OK, util::StringBuilder(args...));
+  static Status OK(Args&&... args) {
+    return Status(StatusCode::OK, util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status for out-of-memory conditions
   template <typename... Args>
-  static Status OutOfMemory(Args... args) {
-    return Status(StatusCode::OutOfMemory, util::StringBuilder(args...));
+  static Status OutOfMemory(Args&&... args) {
+    return Status(StatusCode::OutOfMemory,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status for failed key lookups (e.g. column name in a table)
   template <typename... Args>
-  static Status KeyError(Args... args) {
-    return Status(StatusCode::KeyError, util::StringBuilder(args...));
+  static Status KeyError(Args&&... args) {
+    return Status(StatusCode::KeyError, util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status for type errors (such as mismatching data types)
   template <typename... Args>
-  static Status TypeError(Args... args) {
-    return Status(StatusCode::TypeError, util::StringBuilder(args...));
+  static Status TypeError(Args&&... args) {
+    return Status(StatusCode::TypeError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status for unknown errors
   template <typename... Args>
-  static Status UnknownError(Args... args) {
-    return Status(StatusCode::UnknownError, util::StringBuilder(args...));
+  static Status UnknownError(Args&&... args) {
+    return Status(StatusCode::UnknownError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status when an operation or a combination of operation and
   /// data types is unimplemented
   template <typename... Args>
-  static Status NotImplemented(Args... args) {
-    return Status(StatusCode::NotImplemented, util::StringBuilder(args...));
+  static Status NotImplemented(Args&&... args) {
+    return Status(StatusCode::NotImplemented,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status for invalid data (for example a string that fails parsing)
   template <typename... Args>
-  static Status Invalid(Args... args) {
-    return Status(StatusCode::Invalid, util::StringBuilder(args...));
+  static Status Invalid(Args&&... args) {
+    return Status(StatusCode::Invalid, util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status when a container's capacity would exceed its limits
   template <typename... Args>
-  static Status CapacityError(Args... args) {
-    return Status(StatusCode::CapacityError, util::StringBuilder(args...));
+  static Status CapacityError(Args&&... args) {
+    return Status(StatusCode::CapacityError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status when some IO-related operation failed
   template <typename... Args>
-  static Status IOError(Args... args) {
-    return Status(StatusCode::IOError, util::StringBuilder(args...));
+  static Status IOError(Args&&... args) {
+    return Status(StatusCode::IOError, util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return an error status when some (de)serialization operation failed
   template <typename... Args>
-  static Status SerializationError(Args... args) {
-    return Status(StatusCode::SerializationError, util::StringBuilder(args...));
+  static Status SerializationError(Args&&... args) {
+    return Status(StatusCode::SerializationError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status RError(Args... args) {
-    return Status(StatusCode::RError, util::StringBuilder(args...));
+  static Status RError(Args&&... args) {
+    return Status(StatusCode::RError, util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status PlasmaObjectExists(Args... args) {
-    return Status(StatusCode::PlasmaObjectExists, util::StringBuilder(args...));
+  static Status PlasmaObjectExists(Args&&... args) {
+    return Status(StatusCode::PlasmaObjectExists,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status PlasmaObjectNonexistent(Args... args) {
-    return Status(StatusCode::PlasmaObjectNonexistent, util::StringBuilder(args...));
+  static Status PlasmaObjectNonexistent(Args&&... args) {
+    return Status(StatusCode::PlasmaObjectNonexistent,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status PlasmaObjectAlreadySealed(Args... args) {
-    return Status(StatusCode::PlasmaObjectAlreadySealed, util::StringBuilder(args...));
+  static Status PlasmaObjectAlreadySealed(Args&&... args) {
+    return Status(StatusCode::PlasmaObjectAlreadySealed,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status PlasmaStoreFull(Args... args) {
-    return Status(StatusCode::PlasmaStoreFull, util::StringBuilder(args...));
+  static Status PlasmaStoreFull(Args&&... args) {
+    return Status(StatusCode::PlasmaStoreFull,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   static Status StillExecuting() { return Status(StatusCode::StillExecuting, ""); }
 
   template <typename... Args>
-  static Status CodeGenError(Args... args) {
-    return Status(StatusCode::CodeGenError, util::StringBuilder(args...));
+  static Status CodeGenError(Args&&... args) {
+    return Status(StatusCode::CodeGenError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status ExpressionValidationError(Args... args) {
-    return Status(StatusCode::ExpressionValidationError, util::StringBuilder(args...));
+  static Status ExpressionValidationError(Args&&... args) {
+    return Status(StatusCode::ExpressionValidationError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   template <typename... Args>
-  static Status ExecutionError(Args... args) {
-    return Status(StatusCode::ExecutionError, util::StringBuilder(args...));
+  static Status ExecutionError(Args&&... args) {
+    return Status(StatusCode::ExecutionError,
+                  util::StringBuilder(std::forward<Args>(args)...));
   }
 
   /// Return true iff the status indicates success.

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -31,14 +31,14 @@
 #ifdef ARROW_EXTRA_ERROR_CONTEXT
 
 /// \brief Return with given status if condition is met.
-#define ARROW_RETURN_IF(condition, status)                                          \
-  do {                                                                              \
-    if (ARROW_PREDICT_FALSE(condition)) {                                           \
-      ::arrow::Status _s = (status);                                                \
-      std::stringstream ss;                                                         \
-      ss << __FILE__ << ":" << __LINE__ << " code: " << #s << "\n" << _s.message(); \
-      return ::arrow::Status(_s.code(), ss.str());                                  \
-    }                                                                               \
+#define ARROW_RETURN_IF(condition, status)                        \
+  do {                                                            \
+    if (ARROW_PREDICT_FALSE(condition)) {                         \
+      ::arrow::Status _s = (status);                              \
+      std::stringstream ss;                                       \
+      ss << __FILE__ << ":" << __LINE__ << " : " << _s.message(); \
+      return ::arrow::Status(_s.code(), ss.str());                \
+    }                                                             \
   } while (0)
 
 #else

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -234,10 +234,8 @@ Status Column::ValidateData() {
   for (int i = 0; i < data_->num_chunks(); ++i) {
     std::shared_ptr<DataType> type = data_->chunk(i)->type();
     if (!this->type()->Equals(type)) {
-      std::stringstream ss;
-      ss << "In chunk " << i << " expected type " << this->type()->ToString()
-         << " but saw " << type->ToString();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("In chunk ", i, " expected type ", this->type()->ToString(),
+                             " but saw ", type->ToString());
     }
   }
   return Status::OK();
@@ -301,10 +299,9 @@ class SimpleTable : public Table {
     DCHECK(col != nullptr);
 
     if (col->length() != num_rows_) {
-      std::stringstream ss;
-      ss << "Added column's length must match table's length. Expected length "
-         << num_rows_ << " but got length " << col->length();
-      return Status::Invalid(ss.str());
+      return Status::Invalid(
+          "Added column's length must match table's length. Expected length ", num_rows_,
+          " but got length ", col->length());
     }
 
     std::shared_ptr<Schema> new_schema;
@@ -319,10 +316,9 @@ class SimpleTable : public Table {
     DCHECK(col != nullptr);
 
     if (col->length() != num_rows_) {
-      std::stringstream ss;
-      ss << "Added column's length must match table's length. Expected length "
-         << num_rows_ << " but got length " << col->length();
-      return Status::Invalid(ss.str());
+      return Status::Invalid(
+          "Added column's length must match table's length. Expected length ", num_rows_,
+          " but got length ", col->length());
     }
 
     std::shared_ptr<Schema> new_schema;
@@ -363,15 +359,11 @@ class SimpleTable : public Table {
     for (int i = 0; i < num_columns(); ++i) {
       const Column* col = columns_[i].get();
       if (col == nullptr) {
-        std::stringstream ss;
-        ss << "Column " << i << " was null";
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Column ", i, " was null");
       }
       if (!col->field()->Equals(*schema_->field(i))) {
-        std::stringstream ss;
-        ss << "Column field " << i << " named " << col->name()
-           << " is inconsistent with schema";
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Column field ", i, " named ", col->name(),
+                               " is inconsistent with schema");
       }
     }
 
@@ -379,10 +371,8 @@ class SimpleTable : public Table {
     for (int i = 0; i < num_columns(); ++i) {
       const Column* col = columns_[i].get();
       if (col->length() != num_rows_) {
-        std::stringstream ss;
-        ss << "Column " << i << " named " << col->name() << " expected length "
-           << num_rows_ << " but got length " << col->length();
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Column ", i, " named ", col->name(), " expected length ",
+                               num_rows_, " but got length ", col->length());
       }
     }
     return Status::OK();
@@ -414,11 +404,9 @@ Status Table::FromRecordBatches(const std::shared_ptr<Schema>& schema,
 
   for (int i = 0; i < nbatches; ++i) {
     if (!batches[i]->schema()->Equals(*schema, false)) {
-      std::stringstream ss;
-      ss << "Schema at index " << static_cast<int>(i) << " was different: \n"
-         << schema->ToString() << "\nvs\n"
-         << batches[i]->schema()->ToString();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Schema at index ", static_cast<int>(i),
+                             " was different: \n", schema->ToString(), "\nvs\n",
+                             batches[i]->schema()->ToString());
     }
   }
 
@@ -458,11 +446,9 @@ Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
 
   for (int i = 1; i < ntables; ++i) {
     if (!tables[i]->schema()->Equals(*schema, false)) {
-      std::stringstream ss;
-      ss << "Schema at index " << static_cast<int>(i) << " was different: \n"
-         << schema->ToString() << "\nvs\n"
-         << tables[i]->schema()->ToString();
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Schema at index ", static_cast<int>(i),
+                             " was different: \n", schema->ToString(), "\nvs\n",
+                             tables[i]->schema()->ToString());
     }
   }
 

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -81,9 +81,7 @@ class BrotliDecompressor : public Decompressor {
   Status BrotliError(const char* msg) { return Status::IOError(msg); }
 
   Status BrotliError(BrotliDecoderErrorCode code, const char* prefix_msg) {
-    std::stringstream ss;
-    ss << prefix_msg << BrotliDecoderErrorString(code);
-    return Status::IOError(ss.str());
+    return Status::IOError(prefix_msg, BrotliDecoderErrorString(code));
   }
 
   BrotliDecoderState* state_ = nullptr;

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -31,6 +31,10 @@
 namespace arrow {
 namespace util {
 
+static Status LZ4Error(LZ4F_errorCode_t ret, const char* prefix_msg) {
+  return Status::IOError(prefix_msg, LZ4F_getErrorName(ret));
+}
+
 // ----------------------------------------------------------------------
 // Lz4 decompressor implementation
 
@@ -79,12 +83,6 @@ class LZ4Decompressor : public Decompressor {
   bool IsFinished() override { return finished_; }
 
  protected:
-  Status LZ4Error(LZ4F_errorCode_t ret, const char* prefix_msg) {
-    std::stringstream ss;
-    ss << prefix_msg << LZ4F_getErrorName(ret);
-    return Status::IOError(ss.str());
-  }
-
   LZ4F_dctx* ctx_ = nullptr;
   bool finished_;
 };
@@ -125,12 +123,6 @@ class LZ4Compressor : public Compressor {
              bool* should_retry) override;
 
  protected:
-  Status LZ4Error(LZ4F_errorCode_t ret, const char* prefix_msg) {
-    std::stringstream ss;
-    ss << prefix_msg << LZ4F_getErrorName(ret);
-    return Status::IOError(ss.str());
-  }
-
   LZ4F_cctx* ctx_ = nullptr;
   LZ4F_preferences_t prefs_;
   bool first_time_;

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -57,10 +57,8 @@ Status SnappyCodec::Decompress(int64_t input_len, const uint8_t* input,
     return Status::IOError("Corrupt snappy compressed data.");
   }
   if (output_buffer_len < static_cast<int64_t>(decompressed_size)) {
-    std::stringstream ss;
-    ss << "Output buffer size (" << output_buffer_len << ") must be " << decompressed_size
-       << " or larger.";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("Output buffer size (", output_buffer_len, ") must be ",
+                           decompressed_size, " or larger.");
   }
   if (output_len) {
     *output_len = static_cast<int64_t>(decompressed_size);

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -36,9 +36,7 @@ namespace util {
 constexpr int kZSTDDefaultCompressionLevel = 1;
 
 static Status ZSTDError(size_t ret, const char* prefix_msg) {
-  std::stringstream ss;
-  ss << prefix_msg << ZSTD_getErrorName(ret);
-  return Status::IOError(ss.str());
+  return Status::IOError(prefix_msg, ZSTD_getErrorName(ret));
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -345,9 +345,7 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
 
   DecimalComponents dec;
   if (!ParseDecimalComponents(s.data(), s.size(), &dec)) {
-    std::stringstream ss;
-    ss << "The string '" << s << "' is not a valid decimal number";
-    return Status::Invalid(ss.str());
+    return Status::Invalid("The string '", s, "' is not a valid decimal number");
   }
   std::string exponent_value = dec.exponent_sign + dec.exponent_digits;
 
@@ -878,11 +876,9 @@ Status Decimal128::Rescale(int32_t original_scale, int32_t new_scale,
 
   // Fail if we overflow or truncate
   if (ARROW_PREDICT_FALSE(rescale_would_cause_data_loss)) {
-    std::stringstream buf;
-    buf << "Rescaling decimal value " << ToString(original_scale)
-        << " from original scale of " << original_scale << " to new scale of "
-        << new_scale << " would cause data loss";
-    return Status::Invalid(buf.str());
+    return Status::Invalid("Rescaling decimal value ", ToString(original_scale),
+                           " from original scale of ", original_scale,
+                           " to new scale of ", new_scale, " would cause data loss");
   }
 
   return Status::OK();
@@ -909,11 +905,9 @@ Status Decimal128::FromBigEndian(const uint8_t* bytes, int32_t length, Decimal12
   int64_t high, low;
 
   if (length < kMinDecimalBytes || length > kMaxDecimalBytes) {
-    std::ostringstream stream;
-    stream << "Length of byte array passed to Decimal128::FromBigEndian ";
-    stream << "was " << length << ", but must be between ";
-    stream << kMinDecimalBytes << " and " << kMaxDecimalBytes;
-    return Status::Invalid(stream.str());
+    return Status::Invalid("Length of byte array passed to Decimal128::FromBigEndian ",
+                           "was ", length, ", but must be between ", kMinDecimalBytes,
+                           " and ", kMaxDecimalBytes);
   }
 
   // Bytes are coming in big-endian, so the first byte is the MSB and therefore holds the

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -149,9 +149,8 @@ class ARROW_EXPORT Decimal128 {
     constexpr auto max_value = std::numeric_limits<T>::max();
     const auto& self = *this;
     if (self < min_value || self > max_value) {
-      std::stringstream buf;
-      buf << "Invalid cast from Decimal128 to " << sizeof(T) << " byte integer";
-      return Status::Invalid(buf.str());
+      return Status::Invalid("Invalid cast from Decimal128 to ", sizeof(T),
+                             " byte integer");
     }
     *out = static_cast<T>(low_bits_);
     return Status::OK();

--- a/cpp/src/arrow/util/io-util.cc
+++ b/cpp/src/arrow/util/io-util.cc
@@ -113,10 +113,8 @@ static inline Status CheckFileOpResult(int ret, int errno_actual,
                                        const PlatformFilename& file_name,
                                        const char* opname) {
   if (ret == -1) {
-    std::stringstream ss;
-    ss << "Failed to " << opname << " file: " << file_name.string();
-    ss << " , error: " << std::strerror(errno_actual);
-    return Status::IOError(ss.str());
+    return Status::IOError("Failed to ", opname, " file: ", file_name.string(),
+                           " , error: ", std::strerror(errno_actual));
   }
   return Status::OK();
 }
@@ -232,10 +230,16 @@ Status CreatePipe(int fd[2]) {
 #endif
 
   if (ret == -1) {
-    return Status::IOError(std::string("Error creating pipe: ") +
-                           std::string(strerror(errno)));
+    return Status::IOError("Error creating pipe: ", std::strerror(errno));
   }
   return Status::OK();
+}
+
+static Status StatusFromErrno(const char *prefix) {
+#ifdef _WIN32
+    errno = __map_mman_error(GetLastError(), EPERM);
+#endif
+    return Status::IOError(prefix, std::strerror(errno));
 }
 
 //
@@ -251,18 +255,12 @@ Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
   HANDLE fm, h;
 
   if (!UnmapViewOfFile(addr)) {
-    errno = __map_mman_error(GetLastError(), EPERM);
-    std::stringstream ss;
-    ss << "UnmapViewOfFile failed: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("UnmapViewOfFile failed: ");
   }
 
   h = reinterpret_cast<HANDLE>(_get_osfhandle(fildes));
   if (h == INVALID_HANDLE_VALUE) {
-    errno = __map_mman_error(GetLastError(), EPERM);
-    std::stringstream ss;
-    ss << "cannot get file handle: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("Cannot get file handle: ");
   }
 
   LONG new_size_low = static_cast<LONG>(new_size & 0xFFFFFFFFL);
@@ -272,18 +270,12 @@ Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
   SetEndOfFile(h);
   fm = CreateFileMapping(h, NULL, PAGE_READWRITE, 0, 0, "");
   if (fm == NULL) {
-    errno = __map_mman_error(GetLastError(), EPERM);
-    std::stringstream ss;
-    ss << "mremap failed: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("CreateFileMapping failed: ");
   }
   *new_addr = MapViewOfFile(fm, FILE_MAP_WRITE, 0, 0, new_size);
   CloseHandle(fm);
   if (new_addr == NULL) {
-    errno = __map_mman_error(GetLastError(), EPERM);
-    std::stringstream ss;
-    ss << "mremap failed: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("MapViewOfFile failed: ");
   }
   return Status::OK();
 #else
@@ -291,26 +283,26 @@ Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
   // we have to close the mmap first, truncate the file to the new size
   // and recreate the mmap
   if (munmap(addr, old_size) == -1) {
-    std::stringstream ss;
-    ss << "munmap failed: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("munmap failed: ");
   }
   if (ftruncate(fildes, new_size) == -1) {
-    std::stringstream ss;
-    ss << "cannot truncate file: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("ftruncate failed: ");
   }
   // we set READ / WRITE flags on the new map, since we could only have
   // unlarged a RW map in the first place
   *new_addr = mmap(NULL, new_size, PROT_READ | PROT_WRITE, MAP_SHARED, fildes, 0);
+  if (*new_addr == MAP_FAILED) {
+    return StatusFromErrno("mmap failed: ");
+  }
   return Status::OK();
 #else
   if (ftruncate(fildes, new_size) == -1) {
-    std::stringstream ss;
-    ss << "file truncate failed: " << std::strerror(errno);
-    return Status::IOError(ss.str());
+    return StatusFromErrno("ftruncate failed: ");
   }
   *new_addr = mremap(addr, old_size, new_size, MREMAP_MAYMOVE);
+  if (*new_addr == MAP_FAILED) {
+    return StatusFromErrno("mremap failed: ");
+  }
   return Status::OK();
 #endif
 #endif

--- a/cpp/src/arrow/util/io-util.cc
+++ b/cpp/src/arrow/util/io-util.cc
@@ -235,11 +235,11 @@ Status CreatePipe(int fd[2]) {
   return Status::OK();
 }
 
-static Status StatusFromErrno(const char *prefix) {
+static Status StatusFromErrno(const char* prefix) {
 #ifdef _WIN32
-    errno = __map_mman_error(GetLastError(), EPERM);
+  errno = __map_mman_error(GetLastError(), EPERM);
 #endif
-    return Status::IOError(prefix, std::strerror(errno));
+  return Status::IOError(prefix, std::strerror(errno));
 }
 
 //

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -20,6 +20,7 @@
 
 #include <sstream>
 #include <string>
+#include <utility>
 
 namespace arrow {
 namespace util {

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -25,21 +25,21 @@ namespace arrow {
 namespace util {
 
 template <typename Head>
-void StringBuilderRecursive(std::stringstream& stream, Head head) {
+void StringBuilderRecursive(std::stringstream& stream, Head&& head) {
   stream << head;
 }
 
 template <typename Head, typename... Tail>
-void StringBuilderRecursive(std::stringstream& stream, Head head, Tail... tail) {
-  StringBuilderRecursive(stream, head);
-  StringBuilderRecursive(stream, tail...);
+void StringBuilderRecursive(std::stringstream& stream, Head&& head, Tail&&... tail) {
+  StringBuilderRecursive(stream, std::forward<Head>(head));
+  StringBuilderRecursive(stream, std::forward<Tail>(tail)...);
 }
 
 template <typename... Args>
-std::string StringBuilder(Args... args) {
+std::string StringBuilder(Args&&... args) {
   std::stringstream stream;
 
-  StringBuilderRecursive(stream, args...);
+  StringBuilderRecursive(stream, std::forward<Args>(args)...);
 
   return stream.str();
 }

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -19,6 +19,7 @@
 #define ARROW_UTIL_STRING_BUILDER_H
 
 #include <sstream>
+#include <string>
 
 namespace arrow {
 namespace util {

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. template <typename T>
+
+#ifndef ARROW_UTIL_STRING_BUILDER_H
+#define ARROW_UTIL_STRING_BUILDER_H
+
+#include <sstream>
+
+namespace arrow {
+namespace util {
+
+template <typename Head>
+void StringBuilderRecursive(std::stringstream& stream, Head head) {
+  stream << head;
+}
+
+template <typename Head, typename... Tail>
+void StringBuilderRecursive(std::stringstream& stream, Head head, Tail... tail) {
+  StringBuilderRecursive(stream, head);
+  StringBuilderRecursive(stream, tail...);
+}
+
+template <typename... Args>
+std::string StringBuilder(Args... args) {
+  std::stringstream stream;
+
+  StringBuilderRecursive(stream, args...);
+
+  return stream.str();
+}
+
+}  // namespace util
+}  // namespace arrow
+
+#endif  // ARROW_UTIL_STRING_BUILDER_H

--- a/cpp/src/gandiva/date_utils.cc
+++ b/cpp/src/gandiva/date_utils.cc
@@ -75,11 +75,8 @@ Status DateUtils::ToInternalFormat(const std::string& format,
         buffer.str("");
         continue;
       } else {
-        if (buffer.str().length() > 0) {
-          std::stringstream err_msg;
-          err_msg << "Invalid date format string '" << format << "' at position " << i;
-          return Status::Invalid(err_msg.str());
-        }
+        ARROW_RETURN_IF(buffer.str().length() > 0,
+                        Status::Invalid("Invalid date format string '", format, "'"));
 
         is_in_quoted_text = true;
         continue;
@@ -156,10 +153,7 @@ Status DateUtils::ToInternalFormat(const std::string& format,
         }
       }
     } else {
-      // no potential matches found
-      std::stringstream err_msg;
-      err_msg << "Invalid date format string '" << format << "' at position " << i;
-      return Status::Invalid(err_msg.str());
+      return Status::Invalid("Invalid date format string '", format, "'");
     }
   }
 
@@ -170,11 +164,10 @@ Status DateUtils::ToInternalFormat(const std::string& format,
     if (exactMatches.size() == 1 && exactMatches[0].length() == buffer.str().length()) {
       builder << sql_date_format_to_boost_map_[exactMatches[0]];
     } else {
-      // we didn't successfully parse the entire string
+      // Format partially parsed
       int64_t pos = format.length() - buffer.str().length();
-      std::stringstream err_msg;
-      err_msg << "Invalid date format string '" << format << "' at position " << pos;
-      return Status::Invalid(err_msg.str());
+      return Status::Invalid("Invalid date format string '", format, "' at position ",
+                             pos);
     }
   }
   std::string final_pattern = builder.str();

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -123,7 +123,8 @@ Status Projector::Evaluate(const arrow::RecordBatch& batch, arrow::MemoryPool* p
   for (auto& field : output_fields_) {
     ArrayDataPtr output_data;
 
-    ARROW_RETURN_NOT_OK(AllocArrayData(field->type(), batch.num_rows(), pool, &output_data));
+    ARROW_RETURN_NOT_OK(
+        AllocArrayData(field->type(), batch.num_rows(), pool, &output_data));
     output_data_vecs.push_back(output_data);
   }
 

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -45,12 +45,10 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
 Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
                        std::shared_ptr<Configuration> configuration,
                        std::shared_ptr<Projector>* projector) {
-  ARROW_RETURN_FAILURE_IF_FALSE(schema != nullptr,
-                                Status::Invalid("schema cannot be null"));
-  ARROW_RETURN_FAILURE_IF_FALSE(!exprs.empty(),
-                                Status::Invalid("expressions need to be non-empty"));
-  ARROW_RETURN_FAILURE_IF_FALSE(configuration != nullptr,
-                                Status::Invalid("configuration cannot be null"));
+  ARROW_RETURN_IF(schema == nullptr, Status::Invalid("Schema cannot be null"));
+  ARROW_RETURN_IF(exprs.empty(), Status::Invalid("Expressions cannot be empty"));
+  ARROW_RETURN_IF(configuration == nullptr,
+                  Status::Invalid("Configuration cannot be null"));
 
   // see if equivalent projector was already built
   static Cache<ProjectorCacheKey, std::shared_ptr<Projector>> cache;
@@ -63,23 +61,21 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
 
   // Build LLVM generator, and generate code for the specified expressions
   std::unique_ptr<LLVMGenerator> llvm_gen;
-  Status status = LLVMGenerator::Make(configuration, &llvm_gen);
-  ARROW_RETURN_NOT_OK(status);
+  ARROW_RETURN_NOT_OK(LLVMGenerator::Make(configuration, &llvm_gen));
 
   // Run the validation on the expressions.
   // Return if any of the expression is invalid since
   // we will not be able to process further.
   ExprValidator expr_validator(llvm_gen->types(), schema);
   for (auto& expr : exprs) {
-    status = expr_validator.Validate(expr);
-    ARROW_RETURN_NOT_OK(status);
+    ARROW_RETURN_NOT_OK(expr_validator.Validate(expr));
   }
 
-  status = llvm_gen->Build(exprs);
-  ARROW_RETURN_NOT_OK(status);
+  ARROW_RETURN_NOT_OK(llvm_gen->Build(exprs));
 
   // save the output field types. Used for validation at Evaluate() time.
   std::vector<FieldPtr> output_fields;
+  output_fields.reserve(exprs.size());
   for (auto& expr : exprs) {
     output_fields.push_back(expr->result());
   }
@@ -94,86 +90,69 @@ Status Projector::Make(SchemaPtr schema, const ExpressionVector& exprs,
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch,
                            const ArrayDataVector& output_data_vecs) {
-  Status status = ValidateEvaluateArgsCommon(batch);
-  ARROW_RETURN_NOT_OK(status);
-
-  if (output_data_vecs.size() != output_fields_.size()) {
-    std::stringstream ss;
-    ss << "number of buffers for output_data_vecs is " << output_data_vecs.size()
-       << ", expected " << output_fields_.size();
-    return Status::Invalid(ss.str());
-  }
+  ARROW_RETURN_NOT_OK(ValidateEvaluateArgsCommon(batch));
+  ARROW_RETURN_IF(
+      output_data_vecs.size() != output_fields_.size(),
+      Status::Invalid("Number of output buffers must match number of fields"));
 
   int idx = 0;
   for (auto& array_data : output_data_vecs) {
+    const auto output_field = output_fields_[idx];
     if (array_data == nullptr) {
-      std::stringstream ss;
-      ss << "array for output field " << output_fields_[idx]->name() << "is null.";
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Output array for field ", output_field->name(),
+                             " should not be null");
     }
 
-    Status status =
-        ValidateArrayDataCapacity(*array_data, *(output_fields_[idx]), batch.num_rows());
-    ARROW_RETURN_NOT_OK(status);
+    ARROW_RETURN_NOT_OK(
+        ValidateArrayDataCapacity(*array_data, *output_field, batch.num_rows()));
     ++idx;
   }
+
   return llvm_generator_->Execute(batch, output_data_vecs);
 }
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch, arrow::MemoryPool* pool,
                            arrow::ArrayVector* output) {
-  Status status = ValidateEvaluateArgsCommon(batch);
-  ARROW_RETURN_NOT_OK(status);
-
-  if (output == nullptr) {
-    return Status::Invalid("output must be non-null.");
-  }
-
-  if (pool == nullptr) {
-    return Status::Invalid("memory pool must be non-null.");
-  }
+  ARROW_RETURN_NOT_OK(ValidateEvaluateArgsCommon(batch));
+  ARROW_RETURN_IF(output == nullptr, Status::Invalid("Output must be non-null."));
+  ARROW_RETURN_IF(pool == nullptr, Status::Invalid("Memory pool must be non-null."));
 
   // Allocate the output data vecs.
   ArrayDataVector output_data_vecs;
+  output_data_vecs.reserve(output_fields_.size());
   for (auto& field : output_fields_) {
     ArrayDataPtr output_data;
 
-    status = AllocArrayData(field->type(), batch.num_rows(), pool, &output_data);
-    ARROW_RETURN_NOT_OK(status);
-
+    ARROW_RETURN_NOT_OK(AllocArrayData(field->type(), batch.num_rows(), pool, &output_data));
     output_data_vecs.push_back(output_data);
   }
 
   // Execute the expression(s).
-  status = llvm_generator_->Execute(batch, output_data_vecs);
-  ARROW_RETURN_NOT_OK(status);
+  ARROW_RETURN_NOT_OK(llvm_generator_->Execute(batch, output_data_vecs));
 
   // Create and return array arrays.
   output->clear();
   for (auto& array_data : output_data_vecs) {
     output->push_back(arrow::MakeArray(array_data));
   }
+
   return Status::OK();
 }
 
 // TODO : handle variable-len vectors
 Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
                                  arrow::MemoryPool* pool, ArrayDataPtr* array_data) {
-  if (!arrow::is_primitive(type->id())) {
-    return Status::Invalid("Unsupported output data type " + type->ToString());
-  }
+  ARROW_RETURN_IF(!arrow::is_primitive(type->id()),
+                  Status::Invalid("Unsupported output data type ", type));
 
-  arrow::Status astatus;
   std::shared_ptr<arrow::Buffer> null_bitmap;
-  int64_t size = arrow::BitUtil::BytesForBits(num_records);
-  astatus = arrow::AllocateBuffer(pool, size, &null_bitmap);
-  ARROW_RETURN_NOT_OK(astatus);
+  int64_t bitmap_bytes = arrow::BitUtil::BytesForBits(num_records);
+  ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(pool, bitmap_bytes, &null_bitmap));
 
   std::shared_ptr<arrow::Buffer> data;
   const auto& fw_type = dynamic_cast<const arrow::FixedWidthType&>(*type);
   int64_t data_len = arrow::BitUtil::BytesForBits(num_records * fw_type.bit_width());
-  astatus = arrow::AllocateBuffer(pool, data_len, &data);
-  ARROW_RETURN_NOT_OK(astatus);
+  ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(pool, data_len, &data));
 
   // Valgrind detects unitialized memory at byte level. Boolean types use bits
   // and can leave buffer memory uninitialized in the last byte.
@@ -186,47 +165,33 @@ Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
 }
 
 Status Projector::ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) {
-  if (!batch.schema()->Equals(*schema_)) {
-    return Status::Invalid("Schema in RecordBatch must match the schema in Make()");
-  }
-  if (batch.num_rows() == 0) {
-    return Status::Invalid("RecordBatch must be non-empty.");
-  }
+  ARROW_RETURN_IF(!batch.schema()->Equals(*schema_),
+                  Status::Invalid("Schema in RecordBatch must match schema in Make()"));
+  ARROW_RETURN_IF(batch.num_rows() == 0,
+                  Status::Invalid("RecordBatch must be non-empty."));
+
   return Status::OK();
 }
 
 Status Projector::ValidateArrayDataCapacity(const arrow::ArrayData& array_data,
                                             const arrow::Field& field,
                                             int64_t num_records) {
-  // verify that there are atleast two buffers (validity and data).
-  if (array_data.buffers.size() < 2) {
-    std::stringstream ss;
-    ss << "number of buffers for output field " << field.name() << "is "
-       << array_data.buffers.size() << ", must have minimum 2.";
-    return Status::Invalid(ss.str());
-  }
+  ARROW_RETURN_IF(array_data.buffers.size() < 2,
+                  Status::Invalid("ArrayData must have at least 2 buffers"));
 
-  // verify size of bitmap buffer.
   int64_t min_bitmap_len = arrow::BitUtil::BytesForBits(num_records);
   int64_t bitmap_len = array_data.buffers[0]->capacity();
-  if (bitmap_len < min_bitmap_len) {
-    std::stringstream ss;
-    ss << "bitmap buffer for output field " << field.name() << "has size " << bitmap_len
-       << ", must have minimum size " << min_bitmap_len;
-    return Status::Invalid(ss.str());
-  }
+  ARROW_RETURN_IF(bitmap_len < min_bitmap_len,
+                  Status::Invalid("Bitmap buffer too small for ", field.name()));
 
   // verify size of data buffer.
   // TODO : handle variable-len vectors
   const auto& fw_type = dynamic_cast<const arrow::FixedWidthType&>(*field.type());
   int64_t min_data_len = arrow::BitUtil::BytesForBits(num_records * fw_type.bit_width());
   int64_t data_len = array_data.buffers[1]->capacity();
-  if (data_len < min_data_len) {
-    std::stringstream ss;
-    ss << "data buffer for output field " << field.name() << " has size " << data_len
-       << ", must have minimum size " << min_data_len;
-    return Status::Invalid(ss.str());
-  }
+  ARROW_RETURN_IF(data_len < min_data_len,
+                  Status::Invalid("Data buffer too small for ", field.name()));
+
   return Status::OK();
 }
 

--- a/cpp/src/gandiva/regex_util.cc
+++ b/cpp/src/gandiva/regex_util.cc
@@ -38,20 +38,16 @@ Status RegexUtil::SqlLikePatternToPcre(const std::string& sql_pattern, char esca
     if (cur == escape_char) {
       // escape char must be followed by '_', '%' or the escape char itself.
       ++idx;
-      if (idx == sql_pattern.size()) {
-        std::stringstream msg;
-        msg << "unexpected escape char at the end of pattern " << sql_pattern;
-        return Status::Invalid(msg.str());
-      }
+      ARROW_RETURN_IF(
+          idx == sql_pattern.size(),
+          Status::Invalid("Unexpected escape char at the end of pattern ", sql_pattern));
 
       cur = sql_pattern.at(idx);
       if (cur == '_' || cur == '%' || cur == escape_char) {
         pcre_pattern += cur;
       } else {
-        std::stringstream msg;
-        msg << "invalid escape sequence in pattern " << sql_pattern << " at offset "
-            << idx;
-        return Status::Invalid(msg.str());
+        return Status::Invalid("Invalid escape sequence in pattern ", sql_pattern,
+                               " at offset ", idx);
       }
     } else if (cur == '_') {
       pcre_pattern += '.';

--- a/cpp/src/gandiva/tests/projector_build_validation_test.cc
+++ b/cpp/src/gandiva/tests/projector_build_validation_test.cc
@@ -218,8 +218,6 @@ TEST_F(TestProjector, TestElseNotMatchingReturnType) {
   std::shared_ptr<Projector> projector;
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
-  std::string expected_error = "Return type of if int32 and else bool not matching.";
-  EXPECT_EQ(status.message(), expected_error);
 }
 
 TEST_F(TestProjector, TestElseNotSupportedType) {
@@ -245,8 +243,7 @@ TEST_F(TestProjector, TestElseNotSupportedType) {
   std::shared_ptr<Projector> projector;
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
-  std::string expected_error = "Field c has unsupported data type list";
-  EXPECT_TRUE(status.message().find(expected_error) != std::string::npos);
+  EXPECT_EQ(status.code(), StatusCode::ExpressionValidationError);
 }
 
 TEST_F(TestProjector, TestAndMinChildren) {
@@ -266,8 +263,6 @@ TEST_F(TestProjector, TestAndMinChildren) {
   std::shared_ptr<Projector> projector;
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
-  std::string expected_error = "Boolean expression has 1 children, expected atleast two";
-  EXPECT_EQ(status.message(), expected_error);
 }
 
 TEST_F(TestProjector, TestAndBooleanArgType) {
@@ -289,10 +284,6 @@ TEST_F(TestProjector, TestAndBooleanArgType) {
   std::shared_ptr<Projector> projector;
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
-  std::string expected_error =
-      "Boolean expression has a child with return type int32, expected return type "
-      "boolean";
-  EXPECT_EQ(status.message(), expected_error);
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/projector_build_validation_test.cc
+++ b/cpp/src/gandiva/tests/projector_build_validation_test.cc
@@ -192,7 +192,7 @@ TEST_F(TestProjector, TestIfNotMatchingReturnType) {
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
   std::string expected_error = "Return type of if bool and then int32 not matching.";
-  EXPECT_TRUE(status.message().find(expected_error) != std::string::npos);
+  EXPECT_EQ(status.message(), expected_error);
 }
 
 TEST_F(TestProjector, TestElseNotMatchingReturnType) {
@@ -219,7 +219,7 @@ TEST_F(TestProjector, TestElseNotMatchingReturnType) {
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
   std::string expected_error = "Return type of if int32 and else bool not matching.";
-  EXPECT_TRUE(status.message().find(expected_error) != std::string::npos);
+  EXPECT_EQ(status.message(), expected_error);
 }
 
 TEST_F(TestProjector, TestElseNotSupportedType) {
@@ -267,7 +267,7 @@ TEST_F(TestProjector, TestAndMinChildren) {
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
   std::string expected_error = "Boolean expression has 1 children, expected atleast two";
-  EXPECT_TRUE(status.message().find(expected_error) != std::string::npos);
+  EXPECT_EQ(status.message(), expected_error);
 }
 
 TEST_F(TestProjector, TestAndBooleanArgType) {
@@ -292,7 +292,7 @@ TEST_F(TestProjector, TestAndBooleanArgType) {
   std::string expected_error =
       "Boolean expression has a child with return type int32, expected return type "
       "boolean";
-  EXPECT_TRUE(status.message().find(expected_error) != std::string::npos);
+  EXPECT_EQ(status.message(), expected_error);
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/projector_build_validation_test.cc
+++ b/cpp/src/gandiva/tests/projector_build_validation_test.cc
@@ -191,8 +191,6 @@ TEST_F(TestProjector, TestIfNotMatchingReturnType) {
   std::shared_ptr<Projector> projector;
   Status status = Projector::Make(schema, {expr}, &projector);
   EXPECT_TRUE(status.IsExpressionValidationError());
-  std::string expected_error = "Return type of if bool and then int32 not matching.";
-  EXPECT_EQ(status.message(), expected_error);
 }
 
 TEST_F(TestProjector, TestElseNotMatchingReturnType) {

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -690,10 +690,8 @@ Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indice
   int max_num = num_row_groups();
   for (auto row_group_index : row_group_indices) {
     if (row_group_index < 0 || row_group_index >= max_num) {
-      std::ostringstream ss;
-      ss << "Some index in row_group_indices is " << row_group_index
-         << ", which is either < 0 or >= num_row_groups(" << max_num << ")";
-      return Status::Invalid(ss.str());
+      return Status::Invalid("Some index in row_group_indices is ", row_group_index,
+                             ", which is either < 0 or >= num_row_groups(", max_num, ")");
     }
   }
 
@@ -1495,9 +1493,8 @@ Status PrimitiveImpl::NextBatch(int64_t records_to_read,
       TRANSFER_CASE(TIME32, ::arrow::Time32Type, Int32Type)
       TRANSFER_CASE(TIME64, ::arrow::Time64Type, Int64Type)
     default:
-      std::stringstream ss;
-      ss << "No support for reading columns of type " << field_->type()->ToString();
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("No support for reading columns of type ",
+                                    field_->type()->ToString());
   }
 
   DCHECK_NE(result.kind(), Datum::NONE);

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -80,10 +80,9 @@ static Status FromFLBA(const PrimitiveNode& node, std::shared_ptr<ArrowType>* ou
       *out = MakeDecimal128Type(node);
       break;
     default:
-      std::stringstream ss;
-      ss << "Unhandled logical type " << LogicalTypeToString(node.logical_type())
-         << " for fixed-length binary array";
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unhandled logical type ",
+                                    LogicalTypeToString(node.logical_type()),
+                                    " for fixed-length binary array");
   }
 
   return Status::OK();
@@ -122,10 +121,9 @@ static Status FromInt32(const PrimitiveNode& node, std::shared_ptr<ArrowType>* o
       *out = MakeDecimal128Type(node);
       break;
     default:
-      std::stringstream ss;
-      ss << "Unhandled logical type " << LogicalTypeToString(node.logical_type())
-         << " for INT32";
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unhandled logical type ",
+                                    LogicalTypeToString(node.logical_type()),
+                                    " for INT32");
   }
   return Status::OK();
 }
@@ -154,10 +152,9 @@ static Status FromInt64(const PrimitiveNode& node, std::shared_ptr<ArrowType>* o
       *out = ::arrow::time64(::arrow::TimeUnit::MICRO);
       break;
     default:
-      std::stringstream ss;
-      ss << "Unhandled logical type " << LogicalTypeToString(node.logical_type())
-         << " for INT64";
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented("Unhandled logical type ",
+                                    LogicalTypeToString(node.logical_type()),
+                                    " for INT64");
   }
   return Status::OK();
 }
@@ -613,10 +610,9 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     }
     default: {
       // TODO: DENSE_UNION, SPARE_UNION, JSON_SCALAR, DECIMAL_TEXT, VARCHAR
-      std::stringstream ss;
-      ss << "Unhandled type for Arrow to Parquet schema conversion: ";
-      ss << field->type()->ToString();
-      return Status::NotImplemented(ss.str());
+      return Status::NotImplemented(
+          "Unhandled type for Arrow to Parquet schema conversion: ",
+          field->type()->ToString());
     }
   }
   PARQUET_CATCH_NOT_OK(*out =

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -676,10 +676,8 @@ Status ArrowColumnWriter::WriteTimestampsCoerce(const bool truncated_timestamps_
   auto DivideBy = [&](const int64_t factor) {
     for (int64_t i = 0; i < array.length(); i++) {
       if (!truncated_timestamps_allowed && !data.IsNull(i) && (values[i] % factor != 0)) {
-        std::stringstream ss;
-        ss << "Casting from " << type.ToString() << " to " << target_type->ToString()
-           << " would lose data: " << values[i];
-        return Status::Invalid(ss.str());
+        return Status::Invalid("Casting from ", type.ToString(), " to ",
+                               target_type->ToString(), " would lose data: ", values[i]);
       }
       buffer[i] = values[i] / factor;
     }
@@ -950,9 +948,8 @@ Status ArrowColumnWriter::Write(const Array& data) {
     default:
       break;
   }
-  std::stringstream ss;
-  ss << "Data type not supported as list value: " << values_array->type()->ToString();
-  return Status::NotImplemented(ss.str());
+  return Status::NotImplemented("Data type not supported as list value: ",
+                                values_array->type()->ToString());
 }
 
 }  // namespace

--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -49,7 +49,7 @@ Status WriteBytes(int fd, uint8_t* cursor, size_t length) {
       if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
         continue;
       }
-      return Status::IOError(std::string(strerror(errno)));
+      return Status::IOError(strerror(errno));
     } else if (nbytes == 0) {
       return Status::IOError("Encountered unexpected EOF");
     }
@@ -80,7 +80,7 @@ Status ReadBytes(int fd, uint8_t* cursor, size_t length) {
       if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
         continue;
       }
-      return Status::IOError(std::string(strerror(errno)));
+      return Status::IOError(strerror(errno));
     } else if (0 == nbytes) {
       return Status::IOError("Encountered unexpected EOF");
     }
@@ -171,12 +171,12 @@ Status ConnectIpcSocketRetry(const std::string& pathname, int num_retries,
     *fd = ConnectIpcSock(pathname);
     --num_retries;
   }
+
   // If we could not connect to the socket, exit.
   if (*fd == -1) {
-    std::stringstream ss;
-    ss << "Could not connect to socket " << pathname;
-    return Status::IOError(ss.str());
+    return Status::IOError("Could not connect to socket ", pathname);
   }
+
   return Status::OK();
 }
 


### PR DESCRIPTION
- Static constructors like `Status::Invalid` now supports variadic
arguments à la `Status::Invalid("my", variable, "error message: ", i)`.

- A new macro was added `ARROW_RETURN_IF(cond, status)` which replaces
the previous `ARROW_RETURN_IF_FALSE` but also adds branch prediction
hints. Note that only gandiva was refactored with this macro as
otherwise the code review would have exploded.

- Fixed a bug in memory map implementations not checking the return
code of `mmap` and `mremap`.