### PR TITLE
ARROW-4080: [Rust] Improving lengthy build times in Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -282,7 +282,6 @@ matrix:
     - if [ $ARROW_CI_RUST_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_install_cargo.sh
     script:
-    - RUSTUP_TOOLCHAIN=stable $TRAVIS_BUILD_DIR/ci/travis_script_rust.sh || true
     - RUSTUP_TOOLCHAIN=nightly $TRAVIS_BUILD_DIR/ci/travis_script_rust.sh
     after_success:
     - pushd ${TRAVIS_BUILD_DIR}/rust

--- a/ci/rust-build-main.bat
+++ b/ci/rust-build-main.bat
@@ -23,32 +23,12 @@ set PARQUET_TEST_DATA=%CD%\cpp\submodules\parquet-testing\data
 pushd rust
 
 @echo ===================================
-@echo Build with stable toolchain
-@echo ===================================
-
-rustup default stable
-rustup show
-cargo build --target %TARGET%
-cargo build --target %TARGET% --release
-@echo Test (debug)
-@echo ------------
-cargo test --target %TARGET%
-@echo
-@echo Test (release)
-@echo --------------
-cargo test --target %TARGET% --release
-
-@echo ===================================
 @echo Build with nightly toolchain
 @echo ===================================
 
 rustup default nightly
 rustup show
-cargo build --target %TARGET% || exit /B
 cargo build --target %TARGET% --release || exit /B
-@echo Test (debug)
-@echo ------------
-cargo test --target %TARGET% || exit /B
 @echo
 @echo Test (release)
 @echo --------------

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -36,7 +36,6 @@ cargo rustc -- -D warnings
 
 cargo build
 cargo test
-cargo bench
 cargo run --example builders
 cargo run --example dynamic_types
 cargo run --example read_csv

--- a/rust/src/parquet/column/mod.rs
+++ b/rust/src/parquet/column/mod.rs
@@ -35,7 +35,7 @@
 //! The example uses column writer and reader APIs to write raw values, definition and
 //! repetition levels and read them to verify write/read correctness.
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::{fs, path::Path, rc::Rc};
 //!
 //! use arrow::parquet::{
@@ -48,7 +48,7 @@
 //!     schema::parser::parse_message_type,
 //! };
 //!
-//! let path = Path::new("target/debug/examples/column_sample.parquet");
+//! let path = Path::new("/path/to/column_sample.parquet");
 //!
 //! // Writing data using column writer API.
 //!

--- a/rust/src/parquet/file/mod.rs
+++ b/rust/src/parquet/file/mod.rs
@@ -26,7 +26,7 @@
 //!
 //! # Example of writing a new file
 //!
-//! ```rust
+//! ```rust,no_run
 //! use std::{fs, path::Path, rc::Rc};
 //!
 //! use arrow::parquet::{
@@ -37,7 +37,7 @@
 //!     schema::parser::parse_message_type,
 //! };
 //!
-//! let path = Path::new("target/debug/examples/sample.parquet");
+//! let path = Path::new("/path/to/sample.parquet");
 //!
 //! let message_type = "
 //!   message schema {
@@ -61,11 +61,11 @@
 //! ```
 //! # Example of reading an existing file
 //!
-//! ```rust
+//! ```rust,no_run
 //! use arrow::parquet::file::reader::{FileReader, SerializedFileReader};
 //! use std::{fs::File, path::Path};
 //!
-//! let path = Path::new("target/debug/examples/sample.parquet");
+//! let path = Path::new("/path/to/sample.parquet");
 //! if let Ok(file) = File::open(&path) {
 //!     let file = File::open(&path).unwrap();
 //!     let reader = SerializedFileReader::new(file).unwrap();


### PR DESCRIPTION
This tries to cut the build times by skipping:

1. build for stable (it doesn't seem too useful).
1. benchmarks in travis
2. build for dev profiles in windows CI - now we only build with release
   profiles.