### PR TITLE
ARROW-4105: [Rust] Add rust-toolchain to enforce user to use nightly toolchain for building

### DIFF
--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -179,3 +179,4 @@ r/README.Rmd
 r/man/*.Rd
 .gitattributes
 rust/test/data/*.csv
+rust/rust-toolchain

--- a/rust/rust-toolchain
+++ b/rust/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
The Rust binding needs to be built by nightly toolchain so if we supply rust-toolchain file, user can build without changing the toolchain explicitly.