### PR TITLE
ARROW-4108: [INTEGRATION] Spark integration tests does not work

### DIFF
--- a/dev/spark_integration/Dockerfile
+++ b/dev/spark_integration/Dockerfile
@@ -56,6 +56,9 @@ RUN conda create -y -q -c conda-forge -n pyarrow-dev \
       zstd \
       setuptools \
       setuptools_scm \
+      double-conversion \
+      glog \
+      autoconf \
  && conda clean --all
 
 ADD . /apache-arrow


### PR DESCRIPTION
Because some commands in spark_integration.sh fail Spark integration test on Docker container does not work.