### PR TITLE
ARROW-3020: [C++/Python] Allow empty arrow::Table objects to be written as empty Parquet row groups

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -355,35 +355,38 @@ if (NOT ARROW_VERBOSE_LINT)
   set(ARROW_LINT_QUIET "--quiet")
 endif()
 
-file(GLOB_RECURSE LINT_FILES
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
-  )
+if (UNIX)
 
-FOREACH(item ${LINT_FILES})
-  IF(NOT ((item MATCHES "_generated.h") OR
-          (item MATCHES "pyarrow_api.h") OR
-          (item MATCHES "pyarrow_lib.h") OR
-          (item MATCHES "config.h") OR
-          (item MATCHES "vendored/") OR
-          (item MATCHES "zmalloc.h") OR
-          (item MATCHES "ae.h")))
-    LIST(APPEND FILTERED_LINT_FILES ${item})
-  ENDIF()
-ENDFOREACH(item ${LINT_FILES})
+  file(GLOB_RECURSE LINT_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
+    )
 
-find_program(CPPLINT_BIN NAMES cpplint cpplint.py HINTS ${BUILD_SUPPORT_DIR})
-message(STATUS "Found cpplint executable at ${CPPLINT_BIN}")
+  FOREACH(item ${LINT_FILES})
+    IF(NOT ((item MATCHES "_generated.h") OR
+            (item MATCHES "pyarrow_api.h") OR
+            (item MATCHES "pyarrow_lib.h") OR
+            (item MATCHES "config.h") OR
+            (item MATCHES "vendored/") OR
+            (item MATCHES "zmalloc.h") OR
+            (item MATCHES "ae.h")))
+      LIST(APPEND FILTERED_LINT_FILES ${item})
+    ENDIF()
+  ENDFOREACH(item ${LINT_FILES})
 
-# Full lint
-# Balancing act: cpplint.py takes a non-trivial time to launch,
-# so process 12 files per invocation, while still ensuring parallelism
-add_custom_target(lint echo ${FILTERED_LINT_FILES} | xargs -n12 -P8
+  find_program(CPPLINT_BIN NAMES cpplint cpplint.py HINTS ${BUILD_SUPPORT_DIR})
+  message(STATUS "Found cpplint executable at ${CPPLINT_BIN}")
+
+  # Full lint
+  # Balancing act: cpplint.py takes a non-trivial time to launch,
+  # so process 12 files per invocation, while still ensuring parallelism
+  add_custom_target(lint echo ${FILTERED_LINT_FILES} | xargs -n12 -P8
   ${CPPLINT_BIN}
   --verbose=2 ${ARROW_LINT_QUIET}
   --linelength=90
   --filter=-whitespace/comments,-readability/todo,-build/header_guard,-build/c++11,-runtime/references,-build/include_order
-)
+  )
+endif (UNIX)
 
 ############################################################
 # "make format" and "make check-format" targets

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -355,38 +355,35 @@ if (NOT ARROW_VERBOSE_LINT)
   set(ARROW_LINT_QUIET "--quiet")
 endif()
 
-if (UNIX)
+file(GLOB_RECURSE LINT_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
+  )
 
-  file(GLOB_RECURSE LINT_FILES
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
-    )
+FOREACH(item ${LINT_FILES})
+  IF(NOT ((item MATCHES "_generated.h") OR
+          (item MATCHES "pyarrow_api.h") OR
+          (item MATCHES "pyarrow_lib.h") OR
+          (item MATCHES "config.h") OR
+          (item MATCHES "vendored/") OR
+          (item MATCHES "zmalloc.h") OR
+          (item MATCHES "ae.h")))
+    LIST(APPEND FILTERED_LINT_FILES ${item})
+  ENDIF()
+ENDFOREACH(item ${LINT_FILES})
 
-  FOREACH(item ${LINT_FILES})
-    IF(NOT ((item MATCHES "_generated.h") OR
-            (item MATCHES "pyarrow_api.h") OR
-            (item MATCHES "pyarrow_lib.h") OR
-            (item MATCHES "config.h") OR
-            (item MATCHES "vendored/") OR
-            (item MATCHES "zmalloc.h") OR
-            (item MATCHES "ae.h")))
-      LIST(APPEND FILTERED_LINT_FILES ${item})
-    ENDIF()
-  ENDFOREACH(item ${LINT_FILES})
+find_program(CPPLINT_BIN NAMES cpplint cpplint.py HINTS ${BUILD_SUPPORT_DIR})
+message(STATUS "Found cpplint executable at ${CPPLINT_BIN}")
 
-  find_program(CPPLINT_BIN NAMES cpplint cpplint.py HINTS ${BUILD_SUPPORT_DIR})
-  message(STATUS "Found cpplint executable at ${CPPLINT_BIN}")
-
-  # Full lint
-  # Balancing act: cpplint.py takes a non-trivial time to launch,
-  # so process 12 files per invocation, while still ensuring parallelism
-  add_custom_target(lint echo ${FILTERED_LINT_FILES} | xargs -n12 -P8
+# Full lint
+# Balancing act: cpplint.py takes a non-trivial time to launch,
+# so process 12 files per invocation, while still ensuring parallelism
+add_custom_target(lint echo ${FILTERED_LINT_FILES} | xargs -n12 -P8
   ${CPPLINT_BIN}
   --verbose=2 ${ARROW_LINT_QUIET}
   --linelength=90
   --filter=-whitespace/comments,-readability/todo,-build/header_guard,-build/c++11,-runtime/references,-build/include_order
-  )
-endif (UNIX)
+)
 
 ############################################################
 # "make format" and "make check-format" targets

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -909,17 +909,16 @@ cdef class ParquetWriter:
                 check_status(self.sink.get().Close())
 
     def write_table(self, Table table, row_group_size=None):
-        cdef CTable* ctable = table.table
+        cdef:
+            CTable* ctable = table.table
+            int64_t c_row_group_size
 
         if row_group_size is None or row_group_size == -1:
-            if ctable.num_rows() > 0:
-                row_group_size = ctable.num_rows()
-            else:
-                row_group_size = 1
+            c_row_group_size = ctable.num_rows()
         elif row_group_size == 0:
             raise ValueError('Row group size cannot be 0')
-
-        cdef int64_t c_row_group_size = row_group_size
+        else:
+            c_row_group_size = row_group_size
 
         with nogil:
             check_status(self.writer.get()


### PR DESCRIPTION
While it's unclear how useful this is, it at least preserves the intent of the user if they decide to call `write_table` with an empty table