### PR TITLE
ARROW-4125: [Python] Don't fail ASV if Plasma extension is not built (e.g. on Windows)

### DIFF
--- a/python/benchmarks/plasma.py
+++ b/python/benchmarks/plasma.py
@@ -18,8 +18,12 @@
 import numpy as np
 import timeit
 
-import pyarrow.plasma as plasma
-
+try:
+    import pyarrow.plasma as plasma
+except ImportError:
+    # TODO(wesm): These are not asv benchmarks, so we can just fail
+    # silently here
+    pass
 
 class SimplePlasmaThroughput(object):
     """Benchmark plasma store throughput with a single client."""

--- a/python/benchmarks/plasma.py
+++ b/python/benchmarks/plasma.py
@@ -25,6 +25,7 @@ except ImportError:
     # silently here
     pass
 
+
 class SimplePlasmaThroughput(object):
     """Benchmark plasma store throughput with a single client."""
 

--- a/python/pyarrow/plasma.py
+++ b/python/pyarrow/plasma.py
@@ -27,6 +27,7 @@ import time
 from pyarrow._plasma import (ObjectID, ObjectNotAvailable, # noqa
                              PlasmaBuffer, PlasmaClient, connect)
 
+
 # The Plasma TensorFlow Operator needs to be compiled on the end user's
 # machine since the TensorFlow ABI is not stable between versions.
 # The following code checks if the operator is already present. If not,

--- a/python/pyarrow/plasma.py
+++ b/python/pyarrow/plasma.py
@@ -24,8 +24,14 @@ import sys
 import tempfile
 import time
 
-from pyarrow._plasma import (ObjectID, ObjectNotAvailable, # noqa
-                             PlasmaBuffer, PlasmaClient, connect)
+
+try:
+    from pyarrow._plasma import (ObjectID, ObjectNotAvailable, # noqa
+                                 PlasmaBuffer, PlasmaClient, connect)
+except ImportError:
+    # TODO(wesm): These are not asv benchmarks, so we can just fail
+    # silently here
+    pass
 
 
 # The Plasma TensorFlow Operator needs to be compiled on the end user's

--- a/python/pyarrow/plasma.py
+++ b/python/pyarrow/plasma.py
@@ -24,15 +24,8 @@ import sys
 import tempfile
 import time
 
-
-try:
-    from pyarrow._plasma import (ObjectID, ObjectNotAvailable, # noqa
-                                 PlasmaBuffer, PlasmaClient, connect)
-except ImportError:
-    # TODO(wesm): These are not asv benchmarks, so we can just fail
-    # silently here
-    pass
-
+from pyarrow._plasma import (ObjectID, ObjectNotAvailable, # noqa
+                             PlasmaBuffer, PlasmaClient, connect)
 
 # The Plasma TensorFlow Operator needs to be compiled on the end user's
 # machine since the TensorFlow ABI is not stable between versions.


### PR DESCRIPTION
I would guess I'm the first person to try to run the benchmark suite on Windows!