### PR TITLE
ARROW-3665: [Rust] Implement StructArrayBuilder

### DIFF
--- a/rust/arrow/examples/builders.rs
+++ b/rust/arrow/examples/builders.rs
@@ -18,7 +18,7 @@
 ///! Many builders are available to easily create different types of arrow arrays
 extern crate arrow;
 
-use arrow::builder::{ArrayBuilder, Int32Builder};
+use arrow::builder::Int32Builder;
 
 fn main() {
     // Primitive Arrays

--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -568,11 +568,17 @@ impl From<ListArray> for BinaryArray {
             "BinaryArray can only be created from List<u8> arrays, mismatched data types."
         );
 
-        let data = ArrayData::builder(DataType::Utf8)
+        let mut builder = ArrayData::builder(DataType::Utf8)
             .len(v.len())
             .add_buffer(v.data().buffers()[0].clone())
-            .add_buffer(v.data().child_data()[0].buffers()[0].clone())
-            .build();
+            .add_buffer(v.data().child_data()[0].buffers()[0].clone());
+        if let Some(bitmap) = v.data().null_bitmap() {
+            builder = builder
+                .null_count(v.data().null_count())
+                .null_bit_buffer(bitmap.bits.clone())
+        }
+
+        let data = builder.build();
         Self::from(data)
     }
 }

--- a/rust/arrow/src/array_ops.rs
+++ b/rust/arrow/src/array_ops.rs
@@ -22,7 +22,7 @@ use std::ops::{Add, Div, Mul, Sub};
 use num::Zero;
 
 use crate::array::{Array, BooleanArray, PrimitiveArray};
-use crate::builder::{ArrayBuilder, PrimitiveArrayBuilder};
+use crate::builder::PrimitiveArrayBuilder;
 use crate::datatypes;
 use crate::datatypes::ArrowNumericType;
 use crate::error::{ArrowError, Result};

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -20,7 +20,7 @@ use crate::util::bit_util;
 
 #[derive(PartialEq, Debug)]
 pub struct Bitmap {
-    bits: Buffer,
+    pub(crate) bits: Buffer,
 }
 
 impl Bitmap {

--- a/rust/arrow/src/builder.rs
+++ b/rust/arrow/src/builder.rs
@@ -18,6 +18,7 @@
 //! Defines a `BufferBuilder` capable of creating a `Buffer` which can be used as an internal
 //! buffer in an `ArrayData` object.
 
+use std::sync::Arc;
 use std::any::Any;
 use std::io::Write;
 use std::marker::PhantomData;
@@ -211,15 +212,12 @@ impl BufferBuilderTrait<BooleanType> for BufferBuilder<BooleanType> {
 }
 
 /// Trait for dealing with different array builders at runtime
-pub trait ArrayBuilder {
-    /// The type of array that this builder creates
-    type ArrayType: Array;
-
+pub trait ArrayBuilder: Any {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize;
 
     /// Builds the array
-    fn finish(&mut self) -> Self::ArrayType;
+    fn finish(&mut self) -> ArrayRef;
 
     /// Returns the builder as an non-mutable `Any` reference.
     ///
@@ -234,6 +232,9 @@ pub trait ArrayBuilder {
     /// type. In this case, one can first cast this into a `Any`, and then use
     /// `downcast_mut` to get a reference on the specific builder.
     fn as_any_mut(&mut self) -> &mut Any;
+
+    /// Returns the boxed builder as a box of `Any`.
+    fn to_any(self: Box<Self>) -> Box<Any>;
 }
 
 ///  Array builder for fixed-width primitive types
@@ -255,8 +256,6 @@ pub type Float32Builder = PrimitiveArrayBuilder<Float32Type>;
 pub type Float64Builder = PrimitiveArrayBuilder<Float64Type>;
 
 impl<T: ArrowPrimitiveType> ArrayBuilder for PrimitiveArrayBuilder<T> {
-    type ArrayType = PrimitiveArray<T>;
-
     /// Returns the builder as an non-mutable `Any` reference.
     fn as_any(&self) -> &Any {
         self
@@ -267,22 +266,19 @@ impl<T: ArrowPrimitiveType> ArrayBuilder for PrimitiveArrayBuilder<T> {
         self
     }
 
+    /// Returns the boxed builder as a box of `Any`.
+    fn to_any(self: Box<Self>) -> Box<Any> {
+        self
+    }
+
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.values_builder.len
     }
 
-    /// Builds the `PrimitiveArray` and reset this builder.
-    fn finish(&mut self) -> PrimitiveArray<T> {
-        let len = self.len();
-        let null_bit_buffer = self.bitmap_builder.finish();
-        let data = ArrayData::builder(T::get_data_type())
-            .len(len)
-            .null_count(len - bit_util::count_set_bits(null_bit_buffer.data()))
-            .add_buffer(self.values_builder.finish())
-            .null_bit_buffer(null_bit_buffer)
-            .build();
-        PrimitiveArray::<T>::from(data)
+    /// Builds the array and reset this builder.
+    fn finish(&mut self) -> ArrayRef {
+        Arc::new(self.finish())
     }
 }
 
@@ -329,6 +325,23 @@ impl<T: ArrowPrimitiveType> PrimitiveArrayBuilder<T> {
         self.values_builder.push_slice(v)?;
         Ok(())
     }
+
+    /// Builds the `PrimitiveArray` and reset this builder.
+    pub fn finish(&mut self) -> PrimitiveArray<T> {
+        let len = self.len();
+        let null_bit_buffer = self.bitmap_builder.finish();
+        let null_count = len - bit_util::count_set_bits(null_bit_buffer.data());
+        let mut builder = ArrayData::builder(T::get_data_type())
+            .len(len)
+            .add_buffer(self.values_builder.finish());
+        if null_count > 0 {
+            builder = builder
+                .null_count(null_count)
+                .null_bit_buffer(null_bit_buffer);
+        }
+        let data = builder.build();
+        PrimitiveArray::<T>::from(data)
+    }
 }
 
 ///  Array builder for `ListArray`
@@ -353,12 +366,7 @@ impl<T: ArrayBuilder> ListArrayBuilder<T> {
     }
 }
 
-impl<T: ArrayBuilder> ArrayBuilder for ListArrayBuilder<T>
-where
-    T: 'static,
-{
-    type ArrayType = ListArray;
-
+impl<T: ArrayBuilder> ArrayBuilder for ListArrayBuilder<T> where T: 'static {
     /// Returns the builder as an non-mutable `Any` reference.
     fn as_any(&self) -> &Any {
         self
@@ -369,13 +377,42 @@ where
         self
     }
 
+    /// Returns the boxed builder as a box of `Any`.
+    fn to_any(self: Box<Self>) -> Box<Any> {
+        self
+    }
+
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.len
     }
 
+    /// Builds the array and reset this builder.
+    fn finish(&mut self) -> ArrayRef {
+        Arc::new(self.finish())
+    }
+}
+
+impl<T: ArrayBuilder> ListArrayBuilder<T> where T: 'static {
+    /// Returns the child array builder as a mutable reference.
+    ///
+    /// This mutable reference can be used to push values into the child array builder,
+    /// but you must call `append` to delimit each distinct list value.
+    pub fn values(&mut self) -> &mut T {
+        &mut self.values_builder
+    }
+
+    /// Finish the current variable-length list array slot
+    pub fn append(&mut self, is_valid: bool) -> Result<()> {
+        self.offsets_builder
+            .push(self.values_builder.len() as i32)?;
+        self.bitmap_builder.push(is_valid)?;
+        self.len += 1;
+        Ok(())
+    }
+
     /// Builds the `ListArray` and reset this builder.
-    fn finish(&mut self) -> ListArray {
+    pub fn finish(&mut self) -> ListArray {
         let len = self.len();
         self.len = 0;
         let values_arr = self
@@ -401,33 +438,12 @@ where
     }
 }
 
-impl<T: ArrayBuilder> ListArrayBuilder<T> {
-    /// Returns the child array builder as a mutable reference.
-    ///
-    /// This mutable reference can be used to push values into the child array builder,
-    /// but you must call `append` to delimit each distinct list value.
-    pub fn values(&mut self) -> &mut T {
-        &mut self.values_builder
-    }
-
-    /// Finish the current variable-length list array slot
-    pub fn append(&mut self, is_valid: bool) -> Result<()> {
-        self.offsets_builder
-            .push(self.values_builder.len() as i32)?;
-        self.bitmap_builder.push(is_valid)?;
-        self.len += 1;
-        Ok(())
-    }
-}
-
 ///  Array builder for `BinaryArray`
 pub struct BinaryArrayBuilder {
     builder: ListArrayBuilder<UInt8Builder>,
 }
 
 impl ArrayBuilder for BinaryArrayBuilder {
-    type ArrayType = BinaryArray;
-
     /// Returns the builder as an non-mutable `Any` reference.
     fn as_any(&self) -> &Any {
         self
@@ -438,14 +454,19 @@ impl ArrayBuilder for BinaryArrayBuilder {
         self
     }
 
+    /// Returns the boxed builder as a box of `Any`.
+    fn to_any(self: Box<Self>) -> Box<Any> {
+        self
+    }
+
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.builder.len()
     }
 
-    /// Builds the `BinaryArray` and reset this builder.
-    fn finish(&mut self) -> BinaryArray {
-        BinaryArray::from(self.builder.finish())
+    /// Builds the array and reset this builder.
+    fn finish(&mut self) -> ArrayRef {
+        Arc::new(self.finish())
     }
 }
 
@@ -480,6 +501,116 @@ impl BinaryArrayBuilder {
     /// Finish the current variable-length list array slot.
     pub fn append(&mut self, is_valid: bool) -> Result<()> {
         self.builder.append(is_valid)
+    }
+
+    /// Builds the `BinaryArray` and reset this builder.
+    pub fn finish(&mut self) -> BinaryArray {
+        BinaryArray::from(self.builder.finish())
+    }
+}
+
+/// Array builder for Struct types.
+///
+/// Note that callers should make sure that methods of all the child field builders are
+/// properly called to maintain the consistency of the data structure.
+pub struct StructArrayBuilder {
+    fields: Vec<Field>,
+    field_anys: Vec<Box<Any>>,
+    field_builders: Vec<Box<ArrayBuilder>>,
+}
+
+impl ArrayBuilder for StructArrayBuilder {
+    /// Returns the number of array slots in the builder.
+    ///
+    /// Note that this always return the first child field builder's length, and it is
+    /// the caller's responsibility to maintain the consistency that all the child field
+    /// builder should have the equal number of elements.
+    fn len(&self) -> usize {
+        self.field_builders[0].len()
+    }
+
+    /// Builds the array.
+    fn finish(&mut self) -> ArrayRef {
+        Arc::new(self.finish())
+    }
+
+    /// Returns the builder as an non-mutable `Any` reference.
+    ///
+    /// This is most useful when one wants to call non-mutable APIs on a specific builder
+    /// type. In this case, one can first cast this into a `Any`, and then use
+    /// `downcast_ref` to get a reference on the specific builder.
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    /// Returns the builder as an mutable `Any` reference.
+    ///
+    /// This is most useful when one wants to call mutable APIs on a specific builder
+    /// type. In this case, one can first cast this into a `Any`, and then use
+    /// `downcast_mut` to get a reference on the specific builder.
+    fn as_any_mut(&mut self) -> &mut Any {
+        self
+    }
+
+    /// Returns the boxed builder as a box of `Any`.
+    fn to_any(self: Box<Self>) -> Box<Any> {
+        self
+    }
+}
+
+impl StructArrayBuilder {
+    pub fn new(fnames: Vec<Field>, fields: Vec<Box<ArrayBuilder>>) -> Self {
+        let mut field_anys = Vec::with_capacity(fields.len());
+        let mut field_builders = Vec::with_capacity(fields.len());
+
+        // Create and maintain two references for each of the input builder. We need the
+        // extra `Any` reference because we need to cast the builder to a specific type
+        // in `field_builder()` by calling `downcast_mut`.
+        for f in fields.into_iter() {
+            let raw_f = Box::into_raw(f);
+            let raw_f_copy = raw_f;
+            unsafe {
+                field_anys.push(Box::from_raw(raw_f).to_any());
+                field_builders.push(Box::from_raw(raw_f_copy));
+            }
+        }
+        Self {
+            fields: fnames,
+            field_anys,
+            field_builders,
+        }
+    }
+
+    /// Returns a mutable reference to the child field builder at index `i`.
+    /// Result will be `None` if the input type `T` provided doesn't match the actual
+    /// field builder's type.
+    pub fn field_builder<T: ArrayBuilder>(&mut self, i: usize) -> Option<&mut T> {
+        self.field_anys[i].downcast_mut::<T>()
+    }
+
+    /// Returns the number of fields for the struct this builder is building.
+    pub fn num_fields(&self) -> usize {
+        self.field_builders.len()
+    }
+
+    /// Builds the `StructArray` and reset this builder.
+    pub fn finish(&mut self) -> StructArray {
+        let mut f_arrays: Vec<ArrayRef> = Vec::with_capacity(self.field_builders.len());
+        for f in &mut self.field_builders {
+            f_arrays.push(f.finish());
+        }
+        let fields_clone: Vec<Field> = self.fields.iter().map(|f| f.clone()).collect();
+        let zipped: Vec<(Field, ArrayRef)> =
+            fields_clone.into_iter().zip(f_arrays.into_iter()).collect();
+        StructArray::from(zipped)
+    }
+}
+
+impl Drop for StructArrayBuilder {
+    fn drop(&mut self) {
+        // To avoid double drop on the field array builders.
+        let builders = ::std::mem::replace(&mut self.field_builders, Vec::new());
+        ::std::mem::forget(builders);
     }
 }
 
@@ -983,4 +1114,81 @@ mod tests {
         assert_eq!(5, binary_array.value_offset(2));
         assert_eq!(5, binary_array.value_length(2));
     }
+
+    #[test]
+    fn test_struct_array_builder() {
+        let int_builder = Int32Builder::new(10);
+        let bool_builder = BooleanBuilder::new(10);
+
+        let mut fields = Vec::new();
+        let mut field_builders = Vec::new();
+        fields.push(Field::new("f1", DataType::Int32, false));
+        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+        fields.push(Field::new("f2", DataType::Boolean, false));
+        field_builders.push(Box::new(bool_builder) as Box<ArrayBuilder>);
+
+        let mut builder = StructArrayBuilder::new(fields, field_builders);
+        assert_eq!(2, builder.num_fields());
+
+        let int_builder = builder.field_builder::<Int32Builder>(0)
+            .expect("builder at field 0 should be integer builder");
+        int_builder.push_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
+        let boolean_builder = builder.field_builder::<BooleanBuilder>(1)
+            .expect("builder at field 1 should be boolean builder");
+        boolean_builder.push_slice(
+            &[false, true, false, true, false, true, false, true, false, true]).unwrap();
+
+        let arr = builder.finish();
+        let expected_int_arr = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let expected_boolean_arr = BooleanArray::from(
+            vec![false, true, false, true, false, true, false, true, false, true]);
+        assert_eq!(expected_int_arr.data(), arr.column(0).data());
+        assert_eq!(expected_boolean_arr.data(), arr.column(1).data());
+    }
+
+    #[test]
+    fn test_struct_array_builder_finish() {
+        let int_builder = Int32Builder::new(10);
+        let bool_builder = BooleanBuilder::new(10);
+
+        let mut fields = Vec::new();
+        let mut field_builders = Vec::new();
+        fields.push(Field::new("f1", DataType::Int32, false));
+        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+        fields.push(Field::new("f2", DataType::Boolean, false));
+        field_builders.push(Box::new(bool_builder) as Box<ArrayBuilder>);
+
+        let mut builder = StructArrayBuilder::new(fields, field_builders);
+        builder.field_builder::<Int32Builder>(0).unwrap().push_slice(
+            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
+        builder.field_builder::<BooleanBuilder>(1).unwrap().push_slice(
+            &[false, true, false, true, false, true, false, true, false, true]).unwrap();
+
+        let arr = builder.finish();
+        assert_eq!(10, arr.len());
+        assert_eq!(0, builder.len());
+
+        builder.field_builder::<Int32Builder>(0).unwrap().push_slice(
+            &[1, 3, 5, 7, 9]).unwrap();
+        builder.field_builder::<BooleanBuilder>(1).unwrap().push_slice(
+            &[false, true, false, true, false]).unwrap();
+
+        let arr = builder.finish();
+        assert_eq!(5, arr.len());
+        assert_eq!(0, builder.len());
+    }
+
+    #[test]
+    fn test_struct_array_builder_field_builder_type_mismatch() {
+        let int_builder = Int32Builder::new(10);
+
+        let mut fields = Vec::new();
+        let mut field_builders = Vec::new();
+        fields.push(Field::new("f1", DataType::Int32, false));
+        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+
+        let mut builder = StructArrayBuilder::new(fields, field_builders);
+        assert!(builder.field_builder::<BinaryArrayBuilder>(0).is_none());
+    }
+
 }

--- a/rust/arrow/src/builder.rs
+++ b/rust/arrow/src/builder.rs
@@ -18,11 +18,11 @@
 //! Defines a `BufferBuilder` capable of creating a `Buffer` which can be used as an internal
 //! buffer in an `ArrayData` object.
 
-use std::sync::Arc;
 use std::any::Any;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::mem;
+use std::sync::Arc;
 
 use crate::array::*;
 use crate::array_data::ArrayData;
@@ -366,7 +366,10 @@ impl<T: ArrayBuilder> ListArrayBuilder<T> {
     }
 }
 
-impl<T: ArrayBuilder> ArrayBuilder for ListArrayBuilder<T> where T: 'static {
+impl<T: ArrayBuilder> ArrayBuilder for ListArrayBuilder<T>
+where
+    T: 'static,
+{
     /// Returns the builder as an non-mutable `Any` reference.
     fn as_any(&self) -> &Any {
         self
@@ -393,7 +396,10 @@ impl<T: ArrayBuilder> ArrayBuilder for ListArrayBuilder<T> where T: 'static {
     }
 }
 
-impl<T: ArrayBuilder> ListArrayBuilder<T> where T: 'static {
+impl<T: ArrayBuilder> ListArrayBuilder<T>
+where
+    T: 'static,
+{
     /// Returns the child array builder as a mutable reference.
     ///
     /// This mutable reference can be used to push values into the child array builder,
@@ -1130,18 +1136,26 @@ mod tests {
         let mut builder = StructArrayBuilder::new(fields, field_builders);
         assert_eq!(2, builder.num_fields());
 
-        let int_builder = builder.field_builder::<Int32Builder>(0)
+        let int_builder = builder
+            .field_builder::<Int32Builder>(0)
             .expect("builder at field 0 should be integer builder");
-        int_builder.push_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
-        let boolean_builder = builder.field_builder::<BooleanBuilder>(1)
+        int_builder
+            .push_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            .unwrap();
+        let boolean_builder = builder
+            .field_builder::<BooleanBuilder>(1)
             .expect("builder at field 1 should be boolean builder");
-        boolean_builder.push_slice(
-            &[false, true, false, true, false, true, false, true, false, true]).unwrap();
+        boolean_builder
+            .push_slice(&[
+                false, true, false, true, false, true, false, true, false, true,
+            ])
+            .unwrap();
 
         let arr = builder.finish();
         let expected_int_arr = Int32Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        let expected_boolean_arr = BooleanArray::from(
-            vec![false, true, false, true, false, true, false, true, false, true]);
+        let expected_boolean_arr = BooleanArray::from(vec![
+            false, true, false, true, false, true, false, true, false, true,
+        ]);
         assert_eq!(expected_int_arr.data(), arr.column(0).data());
         assert_eq!(expected_boolean_arr.data(), arr.column(1).data());
     }
@@ -1159,19 +1173,33 @@ mod tests {
         field_builders.push(Box::new(bool_builder) as Box<ArrayBuilder>);
 
         let mut builder = StructArrayBuilder::new(fields, field_builders);
-        builder.field_builder::<Int32Builder>(0).unwrap().push_slice(
-            &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
-        builder.field_builder::<BooleanBuilder>(1).unwrap().push_slice(
-            &[false, true, false, true, false, true, false, true, false, true]).unwrap();
+        builder
+            .field_builder::<Int32Builder>(0)
+            .unwrap()
+            .push_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+            .unwrap();
+        builder
+            .field_builder::<BooleanBuilder>(1)
+            .unwrap()
+            .push_slice(&[
+                false, true, false, true, false, true, false, true, false, true,
+            ])
+            .unwrap();
 
         let arr = builder.finish();
         assert_eq!(10, arr.len());
         assert_eq!(0, builder.len());
 
-        builder.field_builder::<Int32Builder>(0).unwrap().push_slice(
-            &[1, 3, 5, 7, 9]).unwrap();
-        builder.field_builder::<BooleanBuilder>(1).unwrap().push_slice(
-            &[false, true, false, true, false]).unwrap();
+        builder
+            .field_builder::<Int32Builder>(0)
+            .unwrap()
+            .push_slice(&[1, 3, 5, 7, 9])
+            .unwrap();
+        builder
+            .field_builder::<BooleanBuilder>(1)
+            .unwrap()
+            .push_slice(&[false, true, false, true, false])
+            .unwrap();
 
         let arr = builder.finish();
         assert_eq!(5, arr.len());

--- a/rust/arrow/src/builder.rs
+++ b/rust/arrow/src/builder.rs
@@ -234,7 +234,7 @@ pub trait ArrayBuilder: Any {
     fn as_any_mut(&mut self) -> &mut Any;
 
     /// Returns the boxed builder as a box of `Any`.
-    fn to_any(self: Box<Self>) -> Box<Any>;
+    fn into_box_any(self: Box<Self>) -> Box<Any>;
 }
 
 ///  Array builder for fixed-width primitive types
@@ -267,7 +267,7 @@ impl<T: ArrowPrimitiveType> ArrayBuilder for PrimitiveArrayBuilder<T> {
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn to_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<Any> {
         self
     }
 
@@ -381,7 +381,7 @@ where
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn to_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<Any> {
         self
     }
 
@@ -461,7 +461,7 @@ impl ArrayBuilder for BinaryArrayBuilder {
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn to_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<Any> {
         self
     }
 
@@ -566,7 +566,7 @@ impl ArrayBuilder for StructArrayBuilder {
     }
 
     /// Returns the boxed builder as a box of `Any`.
-    fn to_any(self: Box<Self>) -> Box<Any> {
+    fn into_box_any(self: Box<Self>) -> Box<Any> {
         self
     }
 }
@@ -583,7 +583,7 @@ impl StructArrayBuilder {
             let raw_f = Box::into_raw(f);
             let raw_f_copy = raw_f;
             unsafe {
-                field_anys.push(Box::from_raw(raw_f).to_any());
+                field_anys.push(Box::from_raw(raw_f).into_box_any());
                 field_builders.push(Box::from_raw(raw_f_copy));
             }
         }

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -350,7 +350,7 @@ impl fmt::Display for Field {
 /// layout.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Schema {
-    fields: Vec<Field>,
+    pub(crate) fields: Vec<Field>,
 }
 
 impl Schema {


### PR DESCRIPTION
This implements `StructArrayBuilder` which can be used to build struct
arrays. There are some trickness in terms of being able to store child
builders of different types. A natural way is to box them into
`ArrayBuilder` trait and store in a vector. But, this makes it
impossible to cast them into specific type in `field_builder()`.

To solve the above issue, this maintains two references to each input
builder instance, one in `Box<Any>` type and another in
`Box<ArrayBuilder>` type. The former is used for casting mentioned
above, while the latter is used for calling general methods on an
builder, such as `len()` and `finish()`.

To enable this, this also changed `ArrayBuilder::finish` to return a
`ArrayRef` instead of a specific array. The old `finish` method is
implemented on each specific array builder, so one can obtain, say,
`Int32Array` from a `Int32ArrayBuilder`.