### PR TITLE
ARROW-4130: [Go] offset not used when accessing binary array

### DIFF
--- a/go/arrow/array/binary_test.go
+++ b/go/arrow/array/binary_test.go
@@ -134,7 +134,7 @@ func TestBinarySliceData(t *testing.T) {
 				t.Fatalf("got=%d, want=%d", got, want)
 			}
 
-			vs = vs[:slice.Len()]
+			vs := make([]string, slice.Len())
 
 			for i := range vs {
 				vs[i] = slice.ValueString(i)
@@ -226,7 +226,7 @@ func TestBinarySliceDataWithNull(t *testing.T) {
 				t.Errorf("got=%d, want=%d", got, want)
 			}
 
-			vs = vs[:slice.Len()]
+			vs := make([]string, slice.Len())
 
 			for i := range vs {
 				vs[i] = slice.ValueString(i)

--- a/go/arrow/array/binary_test.go
+++ b/go/arrow/array/binary_test.go
@@ -84,10 +84,9 @@ func TestBinarySliceData(t *testing.T) {
 		t.Fatalf("got=%d, want=%d", got, want)
 	}
 
-	l := arr.Len()
-	vs := make([]string, l)
+	vs := make([]string, arr.Len())
 
-	for i := 0; i < l; i++ {
+	for i := range vs {
 		vs[i] = arr.ValueString(i)
 	}
 
@@ -135,10 +134,9 @@ func TestBinarySliceData(t *testing.T) {
 				t.Fatalf("got=%d, want=%d", got, want)
 			}
 
-			l = slice.Len()
-			vs = vs[:l]
+			vs = vs[:slice.Len()]
 
-			for i := 0; i < l; i++ {
+			for i := range vs {
 				vs[i] = slice.ValueString(i)
 			}
 
@@ -172,10 +170,9 @@ func TestBinarySliceDataWithNull(t *testing.T) {
 		t.Fatalf("got=%d, want=%d", got, want)
 	}
 
-	l := arr.Len()
-	vs := make([]string, l)
+	vs := make([]string, arr.Len())
 
-	for i := 0; i < l; i++ {
+	for i := range vs {
 		vs[i] = arr.ValueString(i)
 	}
 
@@ -229,11 +226,10 @@ func TestBinarySliceDataWithNull(t *testing.T) {
 				t.Errorf("got=%d, want=%d", got, want)
 			}
 
-			l = slice.Len()
-			vs = vs[:0]
+			vs = vs[:slice.Len()]
 
-			for i := 0; i < l; i++ {
-				vs = append(vs, slice.ValueString(i))
+			for i := range vs {
+				vs[i] = slice.ValueString(i)
 			}
 
 			if got, want := vs, tc.want; !reflect.DeepEqual(got, want) {

--- a/go/arrow/array/binary_test.go
+++ b/go/arrow/array/binary_test.go
@@ -283,11 +283,13 @@ func TestBinarySliceOutOfBounds(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 
+			var val string
+
 			if tc.panic {
 				defer func() {
 					e := recover()
 					if e == nil {
-						t.Fatalf("this should have panicked, but did not")
+						t.Fatalf("this should have panicked, but did not; slice value %q", val)
 					}
 					if got, want := e.(string), "arrow/array: index out of range"; got != want {
 						t.Fatalf("invalid error. got=%q, want=%q", got, want)
@@ -301,7 +303,7 @@ func TestBinarySliceOutOfBounds(t *testing.T) {
 				}()
 			}
 
-			slice.ValueString(tc.index)
+			val = slice.ValueString(tc.index)
 		})
 	}
 }

--- a/go/arrow/array/binary_test.go
+++ b/go/arrow/array/binary_test.go
@@ -17,6 +17,7 @@
 package array
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,4 +62,348 @@ func TestBinary(t *testing.T) {
 	a.Release()
 
 	b.Release()
+}
+
+func TestBinarySliceData(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "def", "g", "hijk", "lm", "n", "opq", "rs", "tu"}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	for _, v := range values {
+		b.AppendString(v)
+	}
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	if got, want := arr.Len(), len(values); got != want {
+		t.Fatalf("got=%d, want=%d", got, want)
+	}
+
+	l := arr.Len()
+	vs := make([]string, l)
+
+	for i := 0; i < l; i++ {
+		vs[i] = arr.ValueString(i)
+	}
+
+	if got, want := vs, values; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got=%v, want=%v", got, want)
+	}
+
+	tests := []struct {
+		interval [2]int64
+		want     []string
+	}{
+		{
+			interval: [2]int64{0, 0},
+			want:     []string{},
+		},
+		{
+			interval: [2]int64{0, 5},
+			want:     []string{"a", "bc", "def", "g", "hijk"},
+		},
+		{
+			interval: [2]int64{0, 10},
+			want:     []string{"a", "bc", "def", "g", "hijk", "lm", "n", "opq", "rs", "tu"},
+		},
+		{
+			interval: [2]int64{5, 10},
+			want:     []string{"lm", "n", "opq", "rs", "tu"},
+		},
+		{
+			interval: [2]int64{10, 10},
+			want:     []string{},
+		},
+		{
+			interval: [2]int64{2, 7},
+			want:     []string{"def", "g", "hijk", "lm", "n"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+
+			slice := NewSlice(arr, tc.interval[0], tc.interval[1]).(*Binary)
+			defer slice.Release()
+
+			if got, want := slice.Len(), len(tc.want); got != want {
+				t.Fatalf("got=%d, want=%d", got, want)
+			}
+
+			l = slice.Len()
+			vs = vs[:l]
+
+			for i := 0; i < l; i++ {
+				vs[i] = slice.ValueString(i)
+			}
+
+			if got, want := vs, tc.want; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}
+
+func TestBinarySliceDataWithNull(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "", "", "hijk", "lm", "", "opq", "", "tu"}
+	valids := []bool{true, true, false, false, true, true, true, true, false, true}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	b.AppendStringValues(values, valids)
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	if got, want := arr.Len(), len(values); got != want {
+		t.Fatalf("got=%d, want=%d", got, want)
+	}
+
+	if got, want := arr.NullN(), 3; got != want {
+		t.Fatalf("got=%d, want=%d", got, want)
+	}
+
+	l := arr.Len()
+	vs := make([]string, l)
+
+	for i := 0; i < l; i++ {
+		vs[i] = arr.ValueString(i)
+	}
+
+	if got, want := vs, values; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got=%v, want=%v", got, want)
+	}
+
+	tests := []struct {
+		interval [2]int64
+		nulls    int
+		want     []string
+	}{
+		{
+			interval: [2]int64{0, 2},
+			nulls:    0,
+			want:     []string{"a", "bc"},
+		},
+		{
+			interval: [2]int64{0, 3},
+			nulls:    1,
+			want:     []string{"a", "bc", ""},
+		},
+		{
+			interval: [2]int64{0, 4},
+			nulls:    2,
+			want:     []string{"a", "bc", "", ""},
+		},
+		{
+			interval: [2]int64{4, 8},
+			nulls:    0,
+			want:     []string{"hijk", "lm", "", "opq"},
+		},
+		{
+			interval: [2]int64{2, 9},
+			nulls:    3,
+			want:     []string{"", "", "hijk", "lm", "", "opq", ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+
+			slice := NewSlice(arr, tc.interval[0], tc.interval[1]).(*Binary)
+			defer slice.Release()
+
+			if got, want := slice.Len(), len(tc.want); got != want {
+				t.Fatalf("got=%d, want=%d", got, want)
+			}
+
+			if got, want := slice.NullN(), tc.nulls; got != want {
+				t.Errorf("got=%d, want=%d", got, want)
+			}
+
+			l = slice.Len()
+			vs = vs[:0]
+
+			for i := 0; i < l; i++ {
+				vs = append(vs, slice.ValueString(i))
+			}
+
+			if got, want := vs, tc.want; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got=%v, want=%v", got, want)
+			}
+		})
+	}
+}
+
+func TestBinarySliceOutOfBounds(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "def", "g", "hijk", "lm", "n", "opq", "rs", "tu"}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	for _, v := range values {
+		b.AppendString(v)
+	}
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	slice := NewSlice(arr, 3, 8).(*Binary)
+	defer slice.Release()
+
+	tests := []struct {
+		index int
+		panic bool
+	}{
+		{
+			index: -1,
+			panic: true,
+		},
+		{
+			index: 5,
+			panic: true,
+		},
+		{
+			index: 0,
+			panic: false,
+		},
+		{
+			index: 4,
+			panic: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+
+			if tc.panic {
+				defer func() {
+					e := recover()
+					if e == nil {
+						t.Fatalf("this should have panicked, but did not")
+					}
+					if got, want := e.(string), "arrow/array: index out of range"; got != want {
+						t.Fatalf("invalid error. got=%q, want=%q", got, want)
+					}
+				}()
+			} else {
+				defer func() {
+					if e := recover(); e != nil {
+						t.Fatalf("unexpected panic: %v", e)
+					}
+				}()
+			}
+
+			slice.ValueString(tc.index)
+		})
+	}
+}
+
+func TestBinaryValueOffset(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "", "", "hijk", "lm", "", "opq", "", "tu"}
+	valids := []bool{true, true, false, false, true, true, true, true, false, true}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	b.AppendStringValues(values, valids)
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	slice := NewSlice(arr, 2, 9).(*Binary)
+	defer slice.Release()
+
+	offset := 3
+	vs := values[2:9]
+
+	for i, v := range vs {
+		assert.Equal(t, offset, slice.ValueOffset(i))
+		offset += len(v)
+	}
+}
+
+func TestBinaryValueLen(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "", "", "hijk", "lm", "", "opq", "", "tu"}
+	valids := []bool{true, true, false, false, true, true, true, true, false, true}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	b.AppendStringValues(values, valids)
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	slice := NewSlice(arr, 2, 9).(*Binary)
+	defer slice.Release()
+
+	vs := values[2:9]
+
+	for i, v := range vs {
+		assert.Equal(t, len(v), slice.ValueLen(i))
+	}
+}
+
+func TestBinaryValueOffsets(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "", "", "hijk", "lm", "", "opq", "", "tu"}
+	valids := []bool{true, true, false, false, true, true, true, true, false, true}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	b.AppendStringValues(values, valids)
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	assert.Equal(t, []int32{0, 1, 3, 3, 3, 7, 9, 9, 12, 12, 14}, arr.ValueOffsets())
+
+	slice := NewSlice(arr, 2, 9).(*Binary)
+	defer slice.Release()
+
+	assert.Equal(t, []int32{3, 3, 3, 7, 9, 9, 12, 12}, slice.ValueOffsets())
+}
+
+func TestBinaryValueBytes(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	values := []string{"a", "bc", "", "", "hijk", "lm", "", "opq", "", "tu"}
+	valids := []bool{true, true, false, false, true, true, true, true, false, true}
+
+	b := NewBinaryBuilder(mem, arrow.BinaryTypes.Binary)
+	defer b.Release()
+
+	b.AppendStringValues(values, valids)
+
+	arr := b.NewArray().(*Binary)
+	defer arr.Release()
+
+	assert.Equal(t, []byte{'a', 'b', 'c', 'h', 'i', 'j', 'k', 'l', 'm', 'o', 'p', 'q', 't', 'u'}, arr.ValueBytes())
+
+	slice := NewSlice(arr, 2, 9).(*Binary)
+	defer slice.Release()
+
+	assert.Equal(t, []byte{'h', 'i', 'j', 'k', 'l', 'm', 'o', 'p', 'q'}, slice.ValueBytes())
 }


### PR DESCRIPTION
Closes https://github.com/apache/arrow/issues/3270 .