### PR TITLE
ARROW-4134: [Packaging] Properly setup timezone in docker tests to prevent ORC adapter's abort

### DIFF
--- a/c_glib/Dockerfile
+++ b/c_glib/Dockerfile
@@ -17,9 +17,7 @@
 
 FROM arrow:cpp
 
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -q install --no-install-recommends -y \
-        tzdata \
         ruby-dev \
         pkg-config \
         autoconf-archive \

--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -18,7 +18,8 @@
 FROM ubuntu:18.04
 
 # install build essentials
-RUN apt-get update -y -q && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         ca-certificates \
         ccache \
@@ -27,6 +28,7 @@ RUN apt-get update -y -q && \
         git \
         ninja-build \
         pkg-config \
+        tzdata \
         wget
 
 # install conda and required packages


### PR DESCRIPTION
Python ORC tests were failing because of unset timezone.

Crossbow tests: [kszucs/crossbow/build-388](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=build-388)