### PR TITLE
ARROW-4135: [Python] Can't reload a pandas dataframe containing a list of datetime.time

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -921,6 +921,14 @@ def test_date_time_types():
     _assert_unsupported(a7)
 
 
+def test_list_of_datetime_time_roundtrip():
+    # ARROW-4135
+    times = pd.to_datetime(['09:00', '09:30', '10:00', '10:30', '11:00',
+                            '11:30', '12:00'])  # .time
+    df = pd.DataFrame({'time': [times]})
+    _roundtrip_pandas_dataframe(df)
+
+
 def test_large_list_records():
     # This was fixed in PARQUET-1100
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -926,7 +926,7 @@ def test_list_of_datetime_time_roundtrip():
     times = pd.to_datetime(['09:00', '09:30', '10:00', '10:30', '11:00',
                             '11:30', '12:00'])
     df = pd.DataFrame({'time': [times.time]})
-    _roundtrip_pandas_dataframe(df)
+    _roundtrip_pandas_dataframe(df, write_kwargs={})
 
 
 def test_large_list_records():

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -924,8 +924,8 @@ def test_date_time_types():
 def test_list_of_datetime_time_roundtrip():
     # ARROW-4135
     times = pd.to_datetime(['09:00', '09:30', '10:00', '10:30', '11:00',
-                            '11:30', '12:00'])  # .time
-    df = pd.DataFrame({'time': [times]})
+                            '11:30', '12:00'])
+    df = pd.DataFrame({'time': [times.time]})
     _roundtrip_pandas_dataframe(df)
 
 


### PR DESCRIPTION
Reproduced via 0.11.1