### PR TITLE
ARROW-4148: [CI/Python] Disable ORC on nightly Alpine builds

### DIFF
--- a/python/Dockerfile.alpine
+++ b/python/Dockerfile.alpine
@@ -30,7 +30,10 @@ RUN export PYTHON_MAJOR=${PYTHON_VERSION:0:1} && \
 ADD python/requirements.txt \
     python/requirements-test.txt \
     /arrow/python/
-RUN pip install -r /arrow/python/requirements-test.txt cython
+RUN pip install \
+    -r /arrow/python/requirements.txt \
+    -r /arrow/python/requirements-test.txt \
+    cython
 
 ENV ARROW_PYTHON=ON \
     PYARROW_WITH_ORC=0 \

--- a/python/Dockerfile.alpine
+++ b/python/Dockerfile.alpine
@@ -33,6 +33,7 @@ ADD python/requirements.txt \
 RUN pip install -r /arrow/python/requirements-test.txt cython
 
 ENV ARROW_PYTHON=ON \
+    PYARROW_WITH_ORC=0 \
     PYARROW_WITH_PARQUET=0
 
 # build and test


### PR DESCRIPTION
Nightly Python Alpine builds were [failing](https://travis-ci.org/kszucs/crossbow/builds/474545492) because PYARROW_WITH_ORC is enabled by default, but the underlying cpp image doesn't build against ORC. 

Crossbow builds: 
- ~[kszucs/crossbow/build-391](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=391)~
- [kszucs/crossbow/build-393](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=393) [GREEN]