### PR TITLE
ARROW-4153: [GLib] Add builder_append_value() for consistency

### DIFF
--- a/c_glib/arrow-cuda-glib/cuda.cpp
+++ b/c_glib/arrow-cuda-glib/cuda.cpp
@@ -648,7 +648,7 @@ garrow_cuda_ipc_memory_handle_new(const guint8 *data,
  *
  * Returns: (transfer full): A newly created #GArrowBuffer on success,
  *   %NULL on error. The buffer has serialized @handle. The serialized
- *   @handle can be deserialized by garrow_gpu_cuda_ipc_memory_handle_new()
+ *   @handle can be deserialized by garrow_cuda_ipc_memory_handle_new()
  *   in other process.
  *
  * Since: 0.8.0

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -29,10 +29,10 @@
 
 template <typename BUILDER, typename VALUE>
 gboolean
-garrow_array_builder_append(GArrowArrayBuilder *builder,
-                            VALUE value,
-                            GError **error,
-                            const gchar *context)
+garrow_array_builder_append_value(GArrowArrayBuilder *builder,
+                                  VALUE value,
+                                  GError **error,
+                                  const gchar *context)
 {
   auto arrow_builder =
     static_cast<BUILDER>(garrow_array_builder_get_raw(builder));
@@ -446,17 +446,38 @@ garrow_boolean_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_boolean_array_builder_append_value() instead.
  */
 gboolean
 garrow_boolean_array_builder_append(GArrowBooleanArrayBuilder *builder,
                                     gboolean value,
                                     GError **error)
 {
-  return garrow_array_builder_append<arrow::BooleanBuilder *>
+  return garrow_boolean_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_boolean_array_builder_append_value:
+ * @builder: A #GArrowBooleanArrayBuilder.
+ * @value: A boolean value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_boolean_array_builder_append_value(GArrowBooleanArrayBuilder *builder,
+                                          gboolean value,
+                                          GError **error)
+{
+  return garrow_array_builder_append_value<arrow::BooleanBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      static_cast<bool>(value),
      error,
-     "[boolean-array-builder][append]");
+     "[boolean-array-builder][append-value]");
 }
 
 /**
@@ -583,17 +604,38 @@ garrow_int_array_builder_new(void)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.6.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_int_array_builder_append_value() instead.
  */
 gboolean
 garrow_int_array_builder_append(GArrowIntArrayBuilder *builder,
                                 gint64 value,
                                 GError **error)
 {
-  return garrow_array_builder_append<arrow::AdaptiveIntBuilder *>
+  return garrow_int_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_int_array_builder_append_value:
+ * @builder: A #GArrowIntArrayBuilder.
+ * @value: A int value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_int_array_builder_append_value(GArrowIntArrayBuilder *builder,
+                                      gint64 value,
+                                      GError **error)
+{
+  return garrow_array_builder_append_value<arrow::AdaptiveIntBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[int-array-builder][append]");
+     "[int-array-builder][append-value]");
 }
 
 /**
@@ -718,17 +760,38 @@ garrow_uint_array_builder_new(void)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.8.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_uint_array_builder_append_value() instead.
  */
 gboolean
 garrow_uint_array_builder_append(GArrowUIntArrayBuilder *builder,
                                  guint64 value,
                                  GError **error)
 {
-  return garrow_array_builder_append<arrow::AdaptiveUIntBuilder *>
+  return garrow_uint_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_uint_array_builder_append_value:
+ * @builder: A #GArrowUIntArrayBuilder.
+ * @value: A unsigned int value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_uint_array_builder_append_value(GArrowUIntArrayBuilder *builder,
+                                       guint64 value,
+                                       GError **error)
+{
+  return garrow_array_builder_append_value<arrow::AdaptiveUIntBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[uint-array-builder][append]");
+     "[uint-array-builder][append-value]");
 }
 
 /**
@@ -848,17 +911,38 @@ garrow_int8_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_int8_array_builder_append_value() instead.
  */
 gboolean
 garrow_int8_array_builder_append(GArrowInt8ArrayBuilder *builder,
                                  gint8 value,
                                  GError **error)
 {
-  return garrow_array_builder_append<arrow::Int8Builder *>
+  return garrow_int8_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_int8_array_builder_append_value:
+ * @builder: A #GArrowInt8ArrayBuilder.
+ * @value: A int8 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_int8_array_builder_append_value(GArrowInt8ArrayBuilder *builder,
+                                       gint8 value,
+                                       GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Int8Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[int8-array-builder][append]");
+     "[int8-array-builder][append-value]");
 }
 
 /**
@@ -976,17 +1060,38 @@ garrow_uint8_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_uint8_array_builder_append_value() instead.
  */
 gboolean
 garrow_uint8_array_builder_append(GArrowUInt8ArrayBuilder *builder,
                                   guint8 value,
                                   GError **error)
 {
-  return garrow_array_builder_append<arrow::UInt8Builder *>
+  return garrow_uint8_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_uint8_array_builder_append_value:
+ * @builder: A #GArrowUInt8ArrayBuilder.
+ * @value: An uint8 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_uint8_array_builder_append_value(GArrowUInt8ArrayBuilder *builder,
+                                  guint8 value,
+                                  GError **error)
+{
+  return garrow_array_builder_append_value<arrow::UInt8Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[uint8-array-builder][append]");
+     "[uint8-array-builder][append-value]");
 }
 
 /**
@@ -1104,17 +1209,38 @@ garrow_int16_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_int16_array_builder_append_value() instead.
  */
 gboolean
 garrow_int16_array_builder_append(GArrowInt16ArrayBuilder *builder,
                                   gint16 value,
                                   GError **error)
 {
-  return garrow_array_builder_append<arrow::Int16Builder *>
+  return garrow_int16_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_int16_array_builder_append_value:
+ * @builder: A #GArrowInt16ArrayBuilder.
+ * @value: A int16 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_int16_array_builder_append_value(GArrowInt16ArrayBuilder *builder,
+                                        gint16 value,
+                                        GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Int16Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[int16-array-builder][append]");
+     "[int16-array-builder][append-value]");
 }
 
 /**
@@ -1232,17 +1358,38 @@ garrow_uint16_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_uint16_array_builder_append_value() instead.
  */
 gboolean
 garrow_uint16_array_builder_append(GArrowUInt16ArrayBuilder *builder,
                                    guint16 value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::UInt16Builder *>
+  return garrow_uint16_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_uint16_array_builder_append_value:
+ * @builder: A #GArrowUInt16ArrayBuilder.
+ * @value: An uint16 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_uint16_array_builder_append_value(GArrowUInt16ArrayBuilder *builder,
+                                         guint16 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::UInt16Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[uint16-array-builder][append]");
+     "[uint16-array-builder][append-value]");
 }
 
 /**
@@ -1360,17 +1507,38 @@ garrow_int32_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_int32_array_builder_append_value() instead.
  */
 gboolean
 garrow_int32_array_builder_append(GArrowInt32ArrayBuilder *builder,
                                   gint32 value,
                                   GError **error)
 {
-  return garrow_array_builder_append<arrow::Int32Builder *>
+  return garrow_int32_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_int32_array_builder_append_value:
+ * @builder: A #GArrowInt32ArrayBuilder.
+ * @value: A int32 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_int32_array_builder_append_value(GArrowInt32ArrayBuilder *builder,
+                                        gint32 value,
+                                        GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Int32Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[int32-array-builder][append]");
+     "[int32-array-builder][append-value]");
 }
 
 /**
@@ -1488,17 +1656,38 @@ garrow_uint32_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_uint32_array_builder_append_value() instead.
  */
 gboolean
 garrow_uint32_array_builder_append(GArrowUInt32ArrayBuilder *builder,
                                    guint32 value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::UInt32Builder *>
+  return garrow_uint32_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_uint32_array_builder_append_value:
+ * @builder: A #GArrowUInt32ArrayBuilder.
+ * @value: An uint32 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_uint32_array_builder_append_value(GArrowUInt32ArrayBuilder *builder,
+                                         guint32 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::UInt32Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[uint32-array-builder][append]");
+     "[uint32-array-builder][append-value]");
 }
 
 /**
@@ -1616,17 +1805,38 @@ garrow_int64_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_int64_array_builder_append_value() instead.
  */
 gboolean
 garrow_int64_array_builder_append(GArrowInt64ArrayBuilder *builder,
                                   gint64 value,
                                   GError **error)
 {
-  return garrow_array_builder_append<arrow::Int64Builder *>
+  return garrow_int64_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_int64_array_builder_append_value:
+ * @builder: A #GArrowInt64ArrayBuilder.
+ * @value: A int64 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_int64_array_builder_append_value(GArrowInt64ArrayBuilder *builder,
+                                        gint64 value,
+                                        GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Int64Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[int64-array-builder][append]");
+     "[int64-array-builder][append-value]");
 }
 
 /**
@@ -1744,17 +1954,38 @@ garrow_uint64_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_uint64_array_builder_append_value() instead.
  */
 gboolean
 garrow_uint64_array_builder_append(GArrowUInt64ArrayBuilder *builder,
                                   guint64 value,
                                   GError **error)
 {
-  return garrow_array_builder_append<arrow::UInt64Builder *>
+  return garrow_uint64_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_uint64_array_builder_append_value:
+ * @builder: A #GArrowUInt64ArrayBuilder.
+ * @value: An uint64 value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_uint64_array_builder_append_value(GArrowUInt64ArrayBuilder *builder,
+                                         guint64 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::UInt64Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[uint64-array-builder][append]");
+     "[uint64-array-builder][append-value]");
 }
 
 /**
@@ -1872,17 +2103,38 @@ garrow_float_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_float_array_builder_append_value() instead.
  */
 gboolean
 garrow_float_array_builder_append(GArrowFloatArrayBuilder *builder,
                                   gfloat value,
                                   GError **error)
 {
-  return garrow_array_builder_append<arrow::FloatBuilder *>
+  return garrow_float_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_float_array_builder_append_value:
+ * @builder: A #GArrowFloatArrayBuilder.
+ * @value: A float value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_float_array_builder_append_value(GArrowFloatArrayBuilder *builder,
+                                        gfloat value,
+                                        GError **error)
+{
+  return garrow_array_builder_append_value<arrow::FloatBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[float-array-builder][append]");
+     "[float-array-builder][append-value]");
 }
 
 /**
@@ -2000,17 +2252,38 @@ garrow_double_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_double_array_builder_append_value() instead.
  */
 gboolean
 garrow_double_array_builder_append(GArrowDoubleArrayBuilder *builder,
                                    gdouble value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::DoubleBuilder *>
+  return garrow_double_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_double_array_builder_append_value:
+ * @builder: A #GArrowDoubleArrayBuilder.
+ * @value: A double value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_double_array_builder_append_value(GArrowDoubleArrayBuilder *builder,
+                                         gdouble value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::DoubleBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[double-array-builder][append]");
+     "[double-array-builder][append-value]");
 }
 
 /**
@@ -2129,6 +2402,9 @@ garrow_binary_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_binary_array_builder_append_value() instead.
  */
 gboolean
 garrow_binary_array_builder_append(GArrowBinaryArrayBuilder *builder,
@@ -2136,12 +2412,34 @@ garrow_binary_array_builder_append(GArrowBinaryArrayBuilder *builder,
                                    gint32 length,
                                    GError **error)
 {
+  return garrow_binary_array_builder_append_value(builder, value, length, error);
+}
+
+/**
+ * garrow_binary_array_builder_append_value:
+ * @builder: A #GArrowBinaryArrayBuilder.
+ * @value: (array length=length): A binary value.
+ * @length: A value length.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_binary_array_builder_append_value(GArrowBinaryArrayBuilder *builder,
+                                         const guint8 *value,
+                                         gint32 length,
+                                         GError **error)
+{
   auto arrow_builder =
     static_cast<arrow::BinaryBuilder *>(
       garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append(value, length);
-  return garrow_error_check(error, status, "[binary-array-builder][append]");
+  return garrow_error_check(error,
+                            status,
+                            "[binary-array-builder][append-value]");
 }
 
 /**
@@ -2197,11 +2495,32 @@ garrow_string_array_builder_new(void)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_string_array_builder_append_value() instead.
  */
 gboolean
 garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                    const gchar *value,
                                    GError **error)
+{
+  return garrow_string_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_string_array_builder_append_value:
+ * @builder: A #GArrowStringArrayBuilder.
+ * @value: A string value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
+                                         const gchar *value,
+                                         GError **error)
 {
   auto arrow_builder =
     static_cast<arrow::StringBuilder *>(
@@ -2209,7 +2528,9 @@ garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
 
   auto status = arrow_builder->Append(value,
                                       static_cast<gint32>(strlen(value)));
-  return garrow_error_check(error, status, "[string-array-builder][append]");
+  return garrow_error_check(error,
+                            status,
+                            "[string-array-builder][append-value]");
 }
 
 /**
@@ -2290,17 +2611,38 @@ garrow_date32_array_builder_new(void)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.7.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_date32_array_builder_append_value() instead.
  */
 gboolean
 garrow_date32_array_builder_append(GArrowDate32ArrayBuilder *builder,
                                    gint32 value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::Date32Builder *>
+  return garrow_date32_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_date32_array_builder_append_value:
+ * @builder: A #GArrowDate32ArrayBuilder.
+ * @value: The number of days since UNIX epoch in signed 32bit integer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_date32_array_builder_append_value(GArrowDate32ArrayBuilder *builder,
+                                         gint32 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Date32Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[date32-array-builder][append]");
+     "[date32-array-builder][append-value]");
 }
 
 /**
@@ -2425,17 +2767,38 @@ garrow_date64_array_builder_new(void)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.7.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_date64_array_builder_append_value() instead.
  */
 gboolean
 garrow_date64_array_builder_append(GArrowDate64ArrayBuilder *builder,
                                    gint64 value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::Date64Builder *>
+  return garrow_date64_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_date64_array_builder_append_value:
+ * @builder: A #GArrowDate64ArrayBuilder.
+ * @value: The number of milliseconds since UNIX epoch in signed 64bit integer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_date64_array_builder_append_value(GArrowDate64ArrayBuilder *builder,
+                                         gint64 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Date64Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[date64-array-builder][append]");
+     "[date64-array-builder][append-value]");
 }
 
 /**
@@ -2562,17 +2925,38 @@ garrow_timestamp_array_builder_new(GArrowTimestampDataType *data_type)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.7.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_timestamp_array_builder_append_value() instead.
  */
 gboolean
 garrow_timestamp_array_builder_append(GArrowTimestampArrayBuilder *builder,
                                       gint64 value,
                                       GError **error)
 {
-  return garrow_array_builder_append<arrow::TimestampBuilder *>
+  return garrow_timestamp_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_timestamp_array_builder_append_value:
+ * @builder: A #GArrowTimestampArrayBuilder.
+ * @value: The number of milliseconds since UNIX epoch in signed 64bit integer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_timestamp_array_builder_append_value(GArrowTimestampArrayBuilder *builder,
+                                            gint64 value,
+                                            GError **error)
+{
+  return garrow_array_builder_append_value<arrow::TimestampBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[timestamp-array-builder][append]");
+     "[timestamp-array-builder][append-value]");
 }
 
 /**
@@ -2699,17 +3083,38 @@ garrow_time32_array_builder_new(GArrowTime32DataType *data_type)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.7.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_time32_array_builder_append_value() instead.
  */
 gboolean
 garrow_time32_array_builder_append(GArrowTime32ArrayBuilder *builder,
                                    gint32 value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::Time32Builder *>
+  return garrow_time32_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_time32_array_builder_append_value:
+ * @builder: A #GArrowTime32ArrayBuilder.
+ * @value: The number of days since UNIX epoch in signed 32bit integer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_time32_array_builder_append_value(GArrowTime32ArrayBuilder *builder,
+                                         gint32 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Time32Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[time32-array-builder][append]");
+     "[time32-array-builder][append-value]");
 }
 
 /**
@@ -2836,17 +3241,38 @@ garrow_time64_array_builder_new(GArrowTime64DataType *data_type)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.7.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_time64_array_builder_append_value() instead.
  */
 gboolean
 garrow_time64_array_builder_append(GArrowTime64ArrayBuilder *builder,
                                    gint64 value,
                                    GError **error)
 {
-  return garrow_array_builder_append<arrow::Time64Builder *>
+  return garrow_time64_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_time64_array_builder_append_value:
+ * @builder: A #GArrowTime64ArrayBuilder.
+ * @value: The number of milliseconds since UNIX epoch in signed 64bit integer.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_time64_array_builder_append_value(GArrowTime64ArrayBuilder *builder,
+                                         gint64 value,
+                                         GError **error)
+{
+  return garrow_array_builder_append_value<arrow::Time64Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      value,
      error,
-     "[time64-array-builder][append]");
+     "[time64-array-builder][append-value]");
 }
 
 /**
@@ -3047,17 +3473,72 @@ garrow_list_array_builder_new(GArrowListDataType *data_type,
  *   g_object_unref(array);
  * }
  * ]|
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_list_array_builder_append_value() instead.
  */
 gboolean
 garrow_list_array_builder_append(GArrowListArrayBuilder *builder,
                                  GError **error)
+{
+  return garrow_list_array_builder_append_value(builder, error);
+}
+
+/**
+ * garrow_list_array_builder_append_value:
+ * @builder: A #GArrowListArrayBuilder.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * It appends a new list element. To append a new list element, you
+ * need to call this function then append list element values to
+ * `value_builder`. `value_builder` is the #GArrowArrayBuilder
+ * specified to constructor. You can get `value_builder` by
+ * garrow_list_array_builder_get_value_builder().
+ *
+ * |[<!-- language="C" -->
+ * GArrowInt8ArrayBuilder *value_builder;
+ * GArrowListArrayBuilder *builder;
+ *
+ * value_builder = garrow_int8_array_builder_new();
+ * builder = garrow_list_array_builder_new(value_builder, NULL);
+ *
+ * // Start 0th list element: [1, 0, -1]
+ * garrow_list_array_builder_append(builder, NULL);
+ * garrow_int8_array_builder_append(value_builder, 1);
+ * garrow_int8_array_builder_append(value_builder, 0);
+ * garrow_int8_array_builder_append(value_builder, -1);
+ *
+ * // Start 1st list element: [-29, 29]
+ * garrow_list_array_builder_append(builder, NULL);
+ * garrow_int8_array_builder_append(value_builder, -29);
+ * garrow_int8_array_builder_append(value_builder, 29);
+ *
+ * {
+ *   // [[1, 0, -1], [-29, 29]]
+ *   GArrowArray *array = garrow_array_builder_finish(builder);
+ *   // Now, builder is needless.
+ *   g_object_unref(builder);
+ *   g_object_unref(value_builder);
+ *
+ *   // Use array...
+ *   g_object_unref(array);
+ * }
+ * ]|
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_list_array_builder_append_value(GArrowListArrayBuilder *builder,
+                                       GError **error)
 {
   auto arrow_builder =
     static_cast<arrow::ListBuilder *>(
       garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append();
-  return garrow_error_check(error, status, "[list-array-builder][append]");
+  return garrow_error_check(error, status, "[list-array-builder][append-value]");
 }
 
 /**
@@ -3195,17 +3676,49 @@ garrow_struct_array_builder_new(GArrowStructDataType *data_type,
  * |[<!-- language="C" -->
  * // TODO
  * ]|
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_struct_array_builder_append_value() instead.
  */
 gboolean
 garrow_struct_array_builder_append(GArrowStructArrayBuilder *builder,
                                    GError **error)
+{
+  return garrow_struct_array_builder_append_value(builder, error);
+}
+
+/**
+ * garrow_struct_array_builder_append_value:
+ * @builder: A #GArrowStructArrayBuilder.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * It appends a new struct element. To append a new struct element,
+ * you need to call this function then append struct element field
+ * values to all `field_builder`s. `field_value`s are the
+ * #GArrowArrayBuilder specified to constructor. You can get
+ * `field_builder` by garrow_struct_array_builder_get_field_builder()
+ * or garrow_struct_array_builder_get_field_builders().
+ *
+ * |[<!-- language="C" -->
+ * // TODO
+ * ]|
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_struct_array_builder_append_value(GArrowStructArrayBuilder *builder,
+                                         GError **error)
 {
   auto arrow_builder =
     static_cast<arrow::StructBuilder *>(
       garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
   auto status = arrow_builder->Append();
-  return garrow_error_check(error, status, "[struct-array-builder][append]");
+  return garrow_error_check(error,
+                            status,
+                            "[struct-array-builder][append-value]");
 }
 
 /**
@@ -3315,18 +3828,39 @@ garrow_decimal128_array_builder_new(GArrowDecimalDataType *data_type)
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.10.0
+ *
+ * Deprecated: 0.12.0:
+ *   Use garrow_decimal128_array_builder_append_value() instead.
  */
 gboolean
 garrow_decimal128_array_builder_append(GArrowDecimal128ArrayBuilder *builder,
                                        GArrowDecimal128 *value,
                                        GError **error)
 {
+  return garrow_decimal128_array_builder_append_value(builder, value, error);
+}
+
+/**
+ * garrow_decimal128_array_builder_append_value:
+ * @builder: A #GArrowDecimal128ArrayBuilder.
+ * @value: A decimal value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.12.0
+ */
+gboolean
+garrow_decimal128_array_builder_append_value(GArrowDecimal128ArrayBuilder *builder,
+                                             GArrowDecimal128 *value,
+                                             GError **error)
+{
   auto arrow_decimal = garrow_decimal128_get_raw(value);
-  return garrow_array_builder_append<arrow::Decimal128Builder *>
+  return garrow_array_builder_append_value<arrow::Decimal128Builder *>
     (GARROW_ARRAY_BUILDER(builder),
      *arrow_decimal,
      error,
-     "[decimal128-array-builder][append]");
+     "[decimal128-array-builder][append-value]");
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -90,9 +90,16 @@ GType garrow_boolean_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowBooleanArrayBuilder *garrow_boolean_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_boolean_array_builder_append_value)
 gboolean garrow_boolean_array_builder_append(GArrowBooleanArrayBuilder *builder,
                                              gboolean value,
                                              GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_boolean_array_builder_append_value(GArrowBooleanArrayBuilder *builder,
+                                                   gboolean value,
+                                                   GError **error);
 gboolean garrow_boolean_array_builder_append_values(GArrowBooleanArrayBuilder *builder,
                                                     const gboolean *values,
                                                     gint64 values_length,
@@ -150,9 +157,16 @@ GType garrow_int_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowIntArrayBuilder *garrow_int_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_int_array_builder_append_value)
 gboolean garrow_int_array_builder_append(GArrowIntArrayBuilder *builder,
                                          gint64 value,
                                          GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_int_array_builder_append_value(GArrowIntArrayBuilder *builder,
+                                               gint64 value,
+                                               GError **error);
 gboolean garrow_int_array_builder_append_values(GArrowIntArrayBuilder *builder,
                                                 const gint64 *values,
                                                 gint64 values_length,
@@ -179,9 +193,16 @@ struct _GArrowUIntArrayBuilderClass
 
 GArrowUIntArrayBuilder *garrow_uint_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_uint_array_builder_append_value)
 gboolean garrow_uint_array_builder_append(GArrowUIntArrayBuilder *builder,
                                           guint64 value,
                                           GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_uint_array_builder_append_value(GArrowUIntArrayBuilder *builder,
+                                                guint64 value,
+                                                GError **error);
 gboolean garrow_uint_array_builder_append_values(GArrowUIntArrayBuilder *builder,
                                                  const guint64 *values,
                                                  gint64 values_length,
@@ -239,9 +260,16 @@ GType garrow_int8_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowInt8ArrayBuilder *garrow_int8_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_int8_array_builder_append_value)
 gboolean garrow_int8_array_builder_append(GArrowInt8ArrayBuilder *builder,
                                           gint8 value,
                                           GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_int8_array_builder_append_value(GArrowInt8ArrayBuilder *builder,
+                                                gint8 value,
+                                                GError **error);
 gboolean garrow_int8_array_builder_append_values(GArrowInt8ArrayBuilder *builder,
                                                  const gint8 *values,
                                                  gint64 values_length,
@@ -299,9 +327,16 @@ GType garrow_uint8_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowUInt8ArrayBuilder *garrow_uint8_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_uint8_array_builder_append_value)
 gboolean garrow_uint8_array_builder_append(GArrowUInt8ArrayBuilder *builder,
                                            guint8 value,
                                            GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_uint8_array_builder_append_value(GArrowUInt8ArrayBuilder *builder,
+                                                 guint8 value,
+                                                 GError **error);
 gboolean garrow_uint8_array_builder_append_values(GArrowUInt8ArrayBuilder *builder,
                                                   const guint8 *values,
                                                   gint64 values_length,
@@ -359,9 +394,16 @@ GType garrow_int16_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowInt16ArrayBuilder *garrow_int16_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_int16_array_builder_append_value)
 gboolean garrow_int16_array_builder_append(GArrowInt16ArrayBuilder *builder,
                                            gint16 value,
                                            GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_int16_array_builder_append_value(GArrowInt16ArrayBuilder *builder,
+                                                 gint16 value,
+                                                 GError **error);
 gboolean garrow_int16_array_builder_append_values(GArrowInt16ArrayBuilder *builder,
                                                   const gint16 *values,
                                                   gint64 values_length,
@@ -419,9 +461,16 @@ GType garrow_uint16_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowUInt16ArrayBuilder *garrow_uint16_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_uint16_array_builder_append_value)
 gboolean garrow_uint16_array_builder_append(GArrowUInt16ArrayBuilder *builder,
                                             guint16 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_uint16_array_builder_append_value(GArrowUInt16ArrayBuilder *builder,
+                                                  guint16 value,
+                                                  GError **error);
 gboolean garrow_uint16_array_builder_append_values(GArrowUInt16ArrayBuilder *builder,
                                                    const guint16 *values,
                                                    gint64 values_length,
@@ -479,9 +528,16 @@ GType garrow_int32_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowInt32ArrayBuilder *garrow_int32_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_int32_array_builder_append_value)
 gboolean garrow_int32_array_builder_append(GArrowInt32ArrayBuilder *builder,
                                            gint32 value,
                                            GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_int32_array_builder_append_value(GArrowInt32ArrayBuilder *builder,
+                                                 gint32 value,
+                                                 GError **error);
 gboolean garrow_int32_array_builder_append_values(GArrowInt32ArrayBuilder *builder,
                                                   const gint32 *values,
                                                   gint64 values_length,
@@ -539,9 +595,16 @@ GType garrow_uint32_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowUInt32ArrayBuilder *garrow_uint32_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_uint32_array_builder_append_value)
 gboolean garrow_uint32_array_builder_append(GArrowUInt32ArrayBuilder *builder,
                                             guint32 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_uint32_array_builder_append_value(GArrowUInt32ArrayBuilder *builder,
+                                                  guint32 value,
+                                                  GError **error);
 gboolean garrow_uint32_array_builder_append_values(GArrowUInt32ArrayBuilder *builder,
                                                    const guint32 *values,
                                                    gint64 values_length,
@@ -599,9 +662,16 @@ GType garrow_int64_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowInt64ArrayBuilder *garrow_int64_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_int64_array_builder_append_value)
 gboolean garrow_int64_array_builder_append(GArrowInt64ArrayBuilder *builder,
                                            gint64 value,
                                            GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_int64_array_builder_append_value(GArrowInt64ArrayBuilder *builder,
+                                                 gint64 value,
+                                                 GError **error);
 gboolean garrow_int64_array_builder_append_values(GArrowInt64ArrayBuilder *builder,
                                                   const gint64 *values,
                                                   gint64 values_length,
@@ -659,9 +729,16 @@ GType garrow_uint64_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowUInt64ArrayBuilder *garrow_uint64_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_uint64_array_builder_append_value)
 gboolean garrow_uint64_array_builder_append(GArrowUInt64ArrayBuilder *builder,
                                             guint64 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_uint64_array_builder_append_value(GArrowUInt64ArrayBuilder *builder,
+                                                  guint64 value,
+                                                  GError **error);
 gboolean garrow_uint64_array_builder_append_values(GArrowUInt64ArrayBuilder *builder,
                                                    const guint64 *values,
                                                    gint64 values_length,
@@ -719,9 +796,16 @@ GType garrow_float_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowFloatArrayBuilder *garrow_float_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_float_array_builder_append_value)
 gboolean garrow_float_array_builder_append(GArrowFloatArrayBuilder *builder,
                                            gfloat value,
                                            GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_float_array_builder_append_value(GArrowFloatArrayBuilder *builder,
+                                                 gfloat value,
+                                                 GError **error);
 gboolean garrow_float_array_builder_append_values(GArrowFloatArrayBuilder *builder,
                                                   const gfloat *values,
                                                   gint64 values_length,
@@ -779,9 +863,16 @@ GType garrow_double_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowDoubleArrayBuilder *garrow_double_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_double_array_builder_append_value)
 gboolean garrow_double_array_builder_append(GArrowDoubleArrayBuilder *builder,
                                             gdouble value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_double_array_builder_append_value(GArrowDoubleArrayBuilder *builder,
+                                                  gdouble value,
+                                                  GError **error);
 gboolean garrow_double_array_builder_append_values(GArrowDoubleArrayBuilder *builder,
                                                    const gdouble *values,
                                                    gint64 values_length,
@@ -839,10 +930,18 @@ GType garrow_binary_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowBinaryArrayBuilder *garrow_binary_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_binary_array_builder_append_value)
 gboolean garrow_binary_array_builder_append(GArrowBinaryArrayBuilder *builder,
                                             const guint8 *value,
                                             gint32 length,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_binary_array_builder_append_value(GArrowBinaryArrayBuilder *builder,
+                                                  const guint8 *value,
+                                                  gint32 length,
+                                                  GError **error);
 gboolean garrow_binary_array_builder_append_null(GArrowBinaryArrayBuilder *builder,
                                                  GError **error);
 
@@ -891,9 +990,16 @@ GType garrow_string_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowStringArrayBuilder *garrow_string_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_string_array_builder_append_value)
 gboolean garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                             const gchar *value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
+                                                  const gchar *value,
+                                                  GError **error);
 gboolean garrow_string_array_builder_append_values(GArrowStringArrayBuilder *builder,
                                                    const gchar **values,
                                                    gint64 values_length,
@@ -946,9 +1052,16 @@ GType garrow_date32_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowDate32ArrayBuilder *garrow_date32_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_date32_array_builder_append_value)
 gboolean garrow_date32_array_builder_append(GArrowDate32ArrayBuilder *builder,
                                             gint32 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_date32_array_builder_append_value(GArrowDate32ArrayBuilder *builder,
+                                                  gint32 value,
+                                                  GError **error);
 gboolean garrow_date32_array_builder_append_values(GArrowDate32ArrayBuilder *builder,
                                                    const gint32 *values,
                                                    gint64 values_length,
@@ -1006,9 +1119,16 @@ GType garrow_date64_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowDate64ArrayBuilder *garrow_date64_array_builder_new(void);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_date64_array_builder_append_value)
 gboolean garrow_date64_array_builder_append(GArrowDate64ArrayBuilder *builder,
                                             gint64 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_date64_array_builder_append_value(GArrowDate64ArrayBuilder *builder,
+                                                  gint64 value,
+                                                  GError **error);
 gboolean garrow_date64_array_builder_append_values(GArrowDate64ArrayBuilder *builder,
                                                    const gint64 *values,
                                                    gint64 values_length,
@@ -1067,9 +1187,16 @@ GType garrow_timestamp_array_builder_get_type(void) G_GNUC_CONST;
 GArrowTimestampArrayBuilder *
 garrow_timestamp_array_builder_new(GArrowTimestampDataType *data_type);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_timestamp_array_builder_append_value)
 gboolean garrow_timestamp_array_builder_append(GArrowTimestampArrayBuilder *builder,
                                                gint64 value,
                                                GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_timestamp_array_builder_append_value(GArrowTimestampArrayBuilder *builder,
+                                                     gint64 value,
+                                                     GError **error);
 gboolean garrow_timestamp_array_builder_append_values(GArrowTimestampArrayBuilder *builder,
                                                       const gint64 *values,
                                                       gint64 values_length,
@@ -1127,9 +1254,16 @@ GType garrow_time32_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowTime32ArrayBuilder *garrow_time32_array_builder_new(GArrowTime32DataType *data_type);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_time32_array_builder_append_value)
 gboolean garrow_time32_array_builder_append(GArrowTime32ArrayBuilder *builder,
                                             gint32 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_time32_array_builder_append_value(GArrowTime32ArrayBuilder *builder,
+                                                  gint32 value,
+                                                  GError **error);
 gboolean garrow_time32_array_builder_append_values(GArrowTime32ArrayBuilder *builder,
                                                    const gint32 *values,
                                                    gint64 values_length,
@@ -1187,9 +1321,16 @@ GType garrow_time64_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowTime64ArrayBuilder *garrow_time64_array_builder_new(GArrowTime64DataType *data_type);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_time64_array_builder_append_value)
 gboolean garrow_time64_array_builder_append(GArrowTime64ArrayBuilder *builder,
                                             gint64 value,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_time64_array_builder_append_value(GArrowTime64ArrayBuilder *builder,
+                                                  gint64 value,
+                                                  GError **error);
 gboolean garrow_time64_array_builder_append_values(GArrowTime64ArrayBuilder *builder,
                                                    const gint64 *values,
                                                    gint64 values_length,
@@ -1248,8 +1389,14 @@ GType garrow_list_array_builder_get_type(void) G_GNUC_CONST;
 GArrowListArrayBuilder *garrow_list_array_builder_new(GArrowListDataType *data_type,
                                                       GError **error);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_list_array_builder_append_value)
 gboolean garrow_list_array_builder_append(GArrowListArrayBuilder *builder,
                                           GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_list_array_builder_append_value(GArrowListArrayBuilder *builder,
+                                                GError **error);
 gboolean garrow_list_array_builder_append_null(GArrowListArrayBuilder *builder,
                                                GError **error);
 
@@ -1301,8 +1448,14 @@ GType garrow_struct_array_builder_get_type(void) G_GNUC_CONST;
 GArrowStructArrayBuilder *garrow_struct_array_builder_new(GArrowStructDataType *data_type,
                                                           GError **error);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_struct_array_builder_append_value)
 gboolean garrow_struct_array_builder_append(GArrowStructArrayBuilder *builder,
                                             GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_struct_array_builder_append_value(GArrowStructArrayBuilder *builder,
+                                                  GError **error);
 gboolean garrow_struct_array_builder_append_null(GArrowStructArrayBuilder *builder,
                                                  GError **error);
 
@@ -1324,8 +1477,15 @@ struct _GArrowDecimal128ArrayBuilderClass
 
 GArrowDecimal128ArrayBuilder *garrow_decimal128_array_builder_new(GArrowDecimalDataType *data_type);
 
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_0_12_FOR(garrow_decimal128_array_builder_append_value)
 gboolean garrow_decimal128_array_builder_append(GArrowDecimal128ArrayBuilder *builder,
                                                 GArrowDecimal128 *value,
                                                 GError **error);
+#endif
+GARROW_AVAILABLE_IN_0_12
+gboolean garrow_decimal128_array_builder_append_value(GArrowDecimal128ArrayBuilder *builder,
+                                                      GArrowDecimal128 *value,
+                                                      GError **error);
 
 G_END_DECLS

--- a/c_glib/arrow-glib/codec.cpp
+++ b/c_glib/arrow-glib/codec.cpp
@@ -119,7 +119,7 @@ garrow_codec_class_init(GArrowCodecClass *klass)
 
 /**
  * garrow_codec_new:
- * @type: A #GArrowCodompressionType.
+ * @type: A #GArrowCompressionType.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: A newly created #GArrowCodec on success, %NULL on error.

--- a/c_glib/arrow-glib/orc-file-reader.cpp
+++ b/c_glib/arrow-glib/orc-file-reader.cpp
@@ -199,8 +199,7 @@ garrow_orc_file_reader_new(GArrowSeekableInputStream *input,
  * Since: 0.10.0
  *
  * Deprecated: 0.12.0:
- *  Use garrow_orc_file_reader_set_field_indices() instead.
- *
+ *   Use garrow_orc_file_reader_set_field_indices() instead.
  */
 void
 garrow_orc_file_reader_set_field_indexes(GArrowORCFileReader *reader,

--- a/c_glib/example/build.c
+++ b/c_glib/example/build.c
@@ -33,13 +33,13 @@ main(int argc, char **argv)
 
     builder = garrow_int32_array_builder_new();
     if (success) {
-      success = garrow_int32_array_builder_append(builder, 29, &error);
+      success = garrow_int32_array_builder_append_value(builder, 29, &error);
     }
     if (success) {
-      success = garrow_int32_array_builder_append(builder, 2929, &error);
+      success = garrow_int32_array_builder_append_value(builder, 2929, &error);
     }
     if (success) {
-      success = garrow_int32_array_builder_append(builder, 292929, &error);
+      success = garrow_int32_array_builder_append_value(builder, 292929, &error);
     }
     if (!success) {
       g_print("failed to append: %s\n", error->message);

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -135,20 +135,20 @@ module Helper
         data_type = builder.value_data_type
         case data_type
         when Arrow::ListDataType
-          builder.append
+          builder.append_value
           value_builder = builder.value_builder
           value.each do |v|
             append_to_builder(value_builder, v)
           end
         when Arrow::StructDataType
-          builder.append
+          builder.append_value
           value.each do |name, v|
             field_index = data_type.get_field_index(name)
             field_builder = builder.get_field_builder(field_index)
             append_to_builder(field_builder, v)
           end
         else
-          builder.append(value)
+          builder.append_value(value)
         end
       end
     end
@@ -179,7 +179,7 @@ module Helper
         if value.nil?
           builder.append_null
         else
-          builder.append(value)
+          builder.append_value(value)
         end
       end
       builder.finish

--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -42,7 +42,7 @@ class TestArray < Test::Unit::TestCase
   def test_is_null
     builder = Arrow::BooleanArrayBuilder.new
     builder.append_null
-    builder.append(true)
+    builder.append_value(true)
     array = builder.finish
     assert_equal([true, false],
                  array.length.times.collect {|i| array.null?(i)})
@@ -51,7 +51,7 @@ class TestArray < Test::Unit::TestCase
   def test_is_valid
     builder = Arrow::BooleanArrayBuilder.new
     builder.append_null
-    builder.append(true)
+    builder.append_value(true)
     array = builder.finish
     assert_equal([false, true],
                  array.length.times.collect {|i| array.valid?(i)})
@@ -59,7 +59,7 @@ class TestArray < Test::Unit::TestCase
 
   def test_length
     builder = Arrow::BooleanArrayBuilder.new
-    builder.append(true)
+    builder.append_value(true)
     array = builder.finish
     assert_equal(1, array.length)
   end
@@ -75,10 +75,10 @@ class TestArray < Test::Unit::TestCase
   def test_null_bitmap
     builder = Arrow::BooleanArrayBuilder.new
     builder.append_null
-    builder.append(true)
-    builder.append(false)
+    builder.append_value(true)
+    builder.append_value(false)
     builder.append_null
-    builder.append(false)
+    builder.append_value(false)
     array = builder.finish
     assert_equal(0b10110, array.null_bitmap.data.to_s.unpack("c*")[0])
   end
@@ -97,9 +97,9 @@ class TestArray < Test::Unit::TestCase
 
   def test_slice
     builder = Arrow::BooleanArrayBuilder.new
-    builder.append(true)
-    builder.append(false)
-    builder.append(true)
+    builder.append_value(true)
+    builder.append_value(false)
+    builder.append_value(true)
     array = builder.finish
     sub_array = array.slice(1, 2)
     assert_equal([false, true],

--- a/c_glib/test/test-binary-array.rb
+++ b/c_glib/test/test-binary-array.rb
@@ -32,7 +32,7 @@ class TestBinaryArray < Test::Unit::TestCase
   def test_value
     data = "\x00\x01\x02"
     builder = Arrow::BinaryArrayBuilder.new
-    builder.append(data)
+    builder.append_value(data)
     array = builder.finish
     assert_equal(data, array.get_value(0).to_s)
   end
@@ -41,8 +41,8 @@ class TestBinaryArray < Test::Unit::TestCase
     data1 = "\x00\x01\x02"
     data2 = "\x03\x04\x05"
     builder = Arrow::BinaryArrayBuilder.new
-    builder.append(data1)
-    builder.append(data2)
+    builder.append_value(data1)
+    builder.append_value(data2)
     array = builder.finish
     assert_equal(data1 + data2, array.buffer.data.to_s)
   end
@@ -51,8 +51,8 @@ class TestBinaryArray < Test::Unit::TestCase
     data1 = "\x00\x01"
     data2 = "\x02\x03\x04"
     builder = Arrow::BinaryArrayBuilder.new
-    builder.append(data1)
-    builder.append(data2)
+    builder.append_value(data1)
+    builder.append_value(data2)
     array = builder.finish
     byte_per_offset = 4
     assert_equal([0, 2, 5].pack("l*"),

--- a/c_glib/test/test-boolean-array.rb
+++ b/c_glib/test/test-boolean-array.rb
@@ -29,16 +29,16 @@ class TestBooleanArray < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::BooleanArrayBuilder.new
-    builder.append(true)
-    builder.append(false)
-    builder.append(true)
+    builder.append_value(true)
+    builder.append_value(false)
+    builder.append_value(true)
     array = builder.finish
     assert_equal([0b101].pack("C*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::BooleanArrayBuilder.new
-    builder.append(true)
+    builder.append_value(true)
     array = builder.finish
     assert_equal(true, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestBooleanArray < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 3, 1)
     builder = Arrow::BooleanArrayBuilder.new
-    builder.append(true)
-    builder.append(false)
-    builder.append(true)
+    builder.append_value(true)
+    builder.append_value(false)
+    builder.append_value(true)
     array = builder.finish
     assert_equal([true, false, true], array.values)
   end

--- a/c_glib/test/test-date32-array.rb
+++ b/c_glib/test/test-date32-array.rb
@@ -34,9 +34,9 @@ class TestDate32Array < Test::Unit::TestCase
     after_epoch = 17406 # 2017-08-28
 
     builder = Arrow::Date32ArrayBuilder.new
-    builder.append(0)
-    builder.append(after_epoch)
-    builder.append(before_epoch)
+    builder.append_value(0)
+    builder.append_value(after_epoch)
+    builder.append_value(before_epoch)
     array = builder.finish
     assert_equal([0, after_epoch, before_epoch].pack("l*"),
                  array.buffer.data.to_s)
@@ -46,7 +46,7 @@ class TestDate32Array < Test::Unit::TestCase
     after_epoch = 17406 # 2017-08-28
 
     builder = Arrow::Date32ArrayBuilder.new
-    builder.append(after_epoch)
+    builder.append_value(after_epoch)
     array = builder.finish
     assert_equal(after_epoch, array.get_value(0))
   end
@@ -56,9 +56,9 @@ class TestDate32Array < Test::Unit::TestCase
     after_epoch = 17406 # 2017-08-28
 
     builder = Arrow::Date32ArrayBuilder.new
-    builder.append(0)
-    builder.append(after_epoch)
-    builder.append(before_epoch)
+    builder.append_value(0)
+    builder.append_value(after_epoch)
+    builder.append_value(before_epoch)
     array = builder.finish
     assert_equal([0, after_epoch, before_epoch], array.values)
   end

--- a/c_glib/test/test-date64-array.rb
+++ b/c_glib/test/test-date64-array.rb
@@ -34,9 +34,9 @@ class TestDate64Array < Test::Unit::TestCase
     after_epoch = 1503878400000 # 2017-08-28T00:00:00Z
 
     builder = Arrow::Date64ArrayBuilder.new
-    builder.append(0)
-    builder.append(after_epoch)
-    builder.append(before_epoch)
+    builder.append_value(0)
+    builder.append_value(after_epoch)
+    builder.append_value(before_epoch)
     array = builder.finish
     assert_equal([0, after_epoch, before_epoch].pack("q*"),
                  array.buffer.data.to_s)
@@ -46,7 +46,7 @@ class TestDate64Array < Test::Unit::TestCase
     after_epoch = 1503878400000 # 2017-08-28T00:00:00Z
 
     builder = Arrow::Date64ArrayBuilder.new
-    builder.append(after_epoch)
+    builder.append_value(after_epoch)
     array = builder.finish
     assert_equal(after_epoch, array.get_value(0))
   end
@@ -56,9 +56,9 @@ class TestDate64Array < Test::Unit::TestCase
     after_epoch = 1503878400000 # 2017-08-28T00:00:00Z
 
     builder = Arrow::Date64ArrayBuilder.new
-    builder.append(0)
-    builder.append(after_epoch)
-    builder.append(before_epoch)
+    builder.append_value(0)
+    builder.append_value(after_epoch)
+    builder.append_value(before_epoch)
     array = builder.finish
     assert_equal([0, after_epoch, before_epoch], array.values)
   end

--- a/c_glib/test/test-decimal-array.rb
+++ b/c_glib/test/test-decimal-array.rb
@@ -20,7 +20,7 @@ class TestDecimalArray < Test::Unit::TestCase
     data_type = Arrow::DecimalDataType.new(8,2)
     builder = Arrow::Decimal128ArrayBuilder.new(data_type)
     decimal = Arrow::Decimal128.new("23423445")
-    builder.append(decimal)
+    builder.append_value(decimal)
     array = builder.finish
     assert_equal("234234.45", array.format_value(0))
   end
@@ -29,7 +29,7 @@ class TestDecimalArray < Test::Unit::TestCase
     data_type = Arrow::DecimalDataType.new(8,2)
     builder = Arrow::Decimal128ArrayBuilder.new(data_type)
     decimal = Arrow::Decimal128.new("23423445")
-    builder.append(decimal)
+    builder.append_value(decimal)
     array = builder.finish
     assert_equal("234234.45",
                  array.get_value(0).to_string_scale(array.value_data_type.scale))

--- a/c_glib/test/test-double-array.rb
+++ b/c_glib/test/test-double-array.rb
@@ -29,16 +29,16 @@ class TestDoubleArray < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::DoubleArrayBuilder.new
-    builder.append(-1.1)
-    builder.append(2.2)
-    builder.append(-4.4)
+    builder.append_value(-1.1)
+    builder.append_value(2.2)
+    builder.append_value(-4.4)
     array = builder.finish
     assert_equal([-1.1, 2.2, -4.4].pack("d*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::DoubleArrayBuilder.new
-    builder.append(1.5)
+    builder.append_value(1.5)
     array = builder.finish
     assert_in_delta(1.5, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestDoubleArray < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 1, 7)
     builder = Arrow::DoubleArrayBuilder.new
-    builder.append(1.5)
-    builder.append(3)
-    builder.append(4.5)
+    builder.append_value(1.5)
+    builder.append_value(3)
+    builder.append_value(4.5)
     array = builder.finish
     assert_equal([1.5, 3.0, 4.5], array.values)
   end

--- a/c_glib/test/test-float-array.rb
+++ b/c_glib/test/test-float-array.rb
@@ -29,16 +29,16 @@ class TestFloatArray < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::FloatArrayBuilder.new
-    builder.append(-1.1)
-    builder.append(2.2)
-    builder.append(-4.4)
+    builder.append_value(-1.1)
+    builder.append_value(2.2)
+    builder.append_value(-4.4)
     array = builder.finish
     assert_equal([-1.1, 2.2, -4.4].pack("f*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::FloatArrayBuilder.new
-    builder.append(1.5)
+    builder.append_value(1.5)
     array = builder.finish
     assert_in_delta(1.5, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestFloatArray < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 1, 7)
     builder = Arrow::FloatArrayBuilder.new
-    builder.append(1.5)
-    builder.append(3)
-    builder.append(4.5)
+    builder.append_value(1.5)
+    builder.append_value(3)
+    builder.append_value(4.5)
     array = builder.finish
     assert_equal([1.5, 3.0, 4.5], array.values)
   end

--- a/c_glib/test/test-int16-array.rb
+++ b/c_glib/test/test-int16-array.rb
@@ -29,16 +29,16 @@ class TestInt16Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::Int16ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4].pack("s*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::Int16ArrayBuilder.new
-    builder.append(-1)
+    builder.append_value(-1)
     array = builder.finish
     assert_equal(-1, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestInt16Array < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 1, 7)
     builder = Arrow::Int16ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4], array.values)
   end

--- a/c_glib/test/test-int32-array.rb
+++ b/c_glib/test/test-int32-array.rb
@@ -28,25 +28,25 @@ class TestInt32Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::Int32ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4].pack("l*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::Int32ArrayBuilder.new
-    builder.append(-1)
+    builder.append_value(-1)
     array = builder.finish
     assert_equal(-1, array.get_value(0))
   end
 
   def test_values
     builder = Arrow::Int32ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4], array.values)
   end

--- a/c_glib/test/test-int64-array.rb
+++ b/c_glib/test/test-int64-array.rb
@@ -28,25 +28,25 @@ class TestInt64Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::Int64ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4].pack("q*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::Int64ArrayBuilder.new
-    builder.append(-1)
+    builder.append_value(-1)
     array = builder.finish
     assert_equal(-1, array.get_value(0))
   end
 
   def test_values
     builder = Arrow::Int64ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4], array.values)
   end

--- a/c_glib/test/test-int8-array.rb
+++ b/c_glib/test/test-int8-array.rb
@@ -28,25 +28,25 @@ class TestInt8Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::Int8ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4].pack("c*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::Int8ArrayBuilder.new
-    builder.append(-1)
+    builder.append_value(-1)
     array = builder.finish
     assert_equal(-1, array.get_value(0))
   end
 
   def test_values
     builder = Arrow::Int8ArrayBuilder.new
-    builder.append(-1)
-    builder.append(2)
-    builder.append(-4)
+    builder.append_value(-1)
+    builder.append_value(2)
+    builder.append_value(-4)
     array = builder.finish
     assert_equal([-1, 2, -4], array.values)
   end

--- a/c_glib/test/test-list-array.rb
+++ b/c_glib/test/test-list-array.rb
@@ -38,14 +38,14 @@ class TestListArray < Test::Unit::TestCase
     builder = Arrow::ListArrayBuilder.new(data_type)
     value_builder = builder.value_builder
 
-    builder.append
-    value_builder.append(-29)
-    value_builder.append(29)
+    builder.append_value
+    value_builder.append_value(-29)
+    value_builder.append_value(29)
 
-    builder.append
-    value_builder.append(-1)
-    value_builder.append(0)
-    value_builder.append(1)
+    builder.append_value
+    value_builder.append_value(-1)
+    value_builder.append_value(0)
+    value_builder.append_value(1)
 
     array = builder.finish
     value = array.get_value(1)

--- a/c_glib/test/test-string-array.rb
+++ b/c_glib/test/test-string-array.rb
@@ -31,15 +31,15 @@ class TestStringArray < Test::Unit::TestCase
 
   def test_value
     builder = Arrow::StringArrayBuilder.new
-    builder.append("Hello")
+    builder.append_value("Hello")
     array = builder.finish
     assert_equal("Hello", array.get_string(0))
   end
 
   def test_buffer
     builder = Arrow::StringArrayBuilder.new
-    builder.append("Hello")
-    builder.append("World")
+    builder.append_value("Hello")
+    builder.append_value("World")
     array = builder.finish
     assert_equal("HelloWorld", array.buffer.data.to_s)
   end

--- a/c_glib/test/test-struct-array.rb
+++ b/c_glib/test/test-struct-array.rb
@@ -58,13 +58,13 @@ class TestStructArray < Test::Unit::TestCase
     data_type = Arrow::StructDataType.new(fields)
     builder = Arrow::StructArrayBuilder.new(data_type)
 
-    builder.append
-    builder.get_field_builder(0).append(-29)
-    builder.get_field_builder(1).append(true)
+    builder.append_value
+    builder.get_field_builder(0).append_value(-29)
+    builder.get_field_builder(1).append_value(true)
 
-    builder.append
-    builder.field_builders[0].append(2)
-    builder.field_builders[1].append(false)
+    builder.append_value
+    builder.field_builders[0].append_value(2)
+    builder.field_builders[1].append_value(false)
 
     array = builder.finish
     values = array.length.times.collect do |i|

--- a/c_glib/test/test-uint16-array.rb
+++ b/c_glib/test/test-uint16-array.rb
@@ -29,16 +29,16 @@ class TestUInt16Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::UInt16ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4].pack("S*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::UInt16ArrayBuilder.new
-    builder.append(1)
+    builder.append_value(1)
     array = builder.finish
     assert_equal(1, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestUInt16Array < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 1, 7)
     builder = Arrow::UInt16ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4], array.values)
   end

--- a/c_glib/test/test-uint32-array.rb
+++ b/c_glib/test/test-uint32-array.rb
@@ -29,16 +29,16 @@ class TestUInt32Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::UInt32ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4].pack("L*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::UInt32ArrayBuilder.new
-    builder.append(1)
+    builder.append_value(1)
     array = builder.finish
     assert_equal(1, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestUInt32Array < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 1, 7)
     builder = Arrow::UInt32ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4], array.values)
   end

--- a/c_glib/test/test-uint64-array.rb
+++ b/c_glib/test/test-uint64-array.rb
@@ -29,16 +29,16 @@ class TestUInt64Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::UInt64ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4].pack("Q*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::UInt64ArrayBuilder.new
-    builder.append(1)
+    builder.append_value(1)
     array = builder.finish
     assert_equal(1, array.get_value(0))
   end
@@ -46,9 +46,9 @@ class TestUInt64Array < Test::Unit::TestCase
   def test_values
     require_gi_bindings(3, 1, 7)
     builder = Arrow::UInt64ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4], array.values)
   end

--- a/c_glib/test/test-uint8-array.rb
+++ b/c_glib/test/test-uint8-array.rb
@@ -28,25 +28,25 @@ class TestUInt8Array < Test::Unit::TestCase
 
   def test_buffer
     builder = Arrow::UInt8ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4].pack("C*"), array.buffer.data.to_s)
   end
 
   def test_value
     builder = Arrow::UInt8ArrayBuilder.new
-    builder.append(1)
+    builder.append_value(1)
     array = builder.finish
     assert_equal(1, array.get_value(0))
   end
 
   def test_values
     builder = Arrow::UInt8ArrayBuilder.new
-    builder.append(1)
-    builder.append(2)
-    builder.append(4)
+    builder.append_value(1)
+    builder.append_value(2)
+    builder.append_value(4)
     array = builder.finish
     assert_equal([1, 2, 4], array.values)
   end


### PR DESCRIPTION
Because we use builder_append_values() for multiple values.

builder_append() is deprecated.