### PR TITLE
ARROW-295: [Documentation] Add DOAP file

### DIFF
--- a/site/arrow.rdf
+++ b/site/arrow.rdf
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="https://arrow.apache.org">
+    <created>2016-02-17</created>
+    <license rdf:resource="http://usefulinc.com/doap/licenses/asl20" />
+    <name>Apache arrow</name>
+    <homepage rdf:resource="http://arrow.apache.org/" />
+    <asfext:pmc rdf:resource="http://arrow.apache.org" />
+    <shortdesc>Apache Arrow is a cross-language development platform for in-memory data.</shortdesc>
+    <description>Apache Arrow is a cross-language development platform for in-memory data.</description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/ARROW" />
+    <mailing-list rdf:resource="http://mail-archives.apache.org/mod_mbox/arrow-dev/" />
+    <download-page rdf:resource="http://arrow.apache.org/release/" />
+    <programming-language>C</programming-language>
+    <programming-language>C++</programming-language>
+    <programming-language>C#</programming-language>
+    <programming-language>Go</programming-language>
+    <programming-language>Java</programming-language>
+    <programming-language>JavaScript</programming-language>
+    <programming-language>Python</programming-language>
+    <programming-language>R</programming-language>
+    <programming-language>Ruby</programming-language>
+    <programming-language>Rust</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/library" />
+    <category rdf:resource="http://projects.apache.org/category/big-data" />
+    <release>
+      <Version>
+        <name>Apache Arrow</name>
+        <created>2018-10-19</created>
+        <revision>0.11.1</revision>
+      </Version>
+    </release>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://github.com/apache/arrow.git"/>
+        <browse rdf:resource="https://github.com/apache/arrow/"/>
+      </GitRepository>
+    </repository>
+  </Project>
+</rdf:RDF>

--- a/site/arrow.rdf
+++ b/site/arrow.rdf
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl"?>
 <rdf:RDF xml:lang="en"
-         xmlns="http://usefulinc.com/ns/doap#" 
-         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:asfext="http://projects.apache.org/ns/asfext#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
 <!--
@@ -12,9 +12,9 @@
     The ASF licenses this file to You under the Apache License, Version 2.0
     (the "License"); you may not use this file except in compliance with
     the License.  You may obtain a copy of the License at
-   
+
          http://www.apache.org/licenses/LICENSE-2.0
-   
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,6 +38,7 @@
     <programming-language>Go</programming-language>
     <programming-language>Java</programming-language>
     <programming-language>JavaScript</programming-language>
+    <programming-language>MATLAB</programming-language>
     <programming-language>Python</programming-language>
     <programming-language>R</programming-language>
     <programming-language>Ruby</programming-language>
@@ -47,8 +48,8 @@
     <release>
       <Version>
         <name>Apache Arrow</name>
-        <created>2018-10-19</created>
-        <revision>0.11.1</revision>
+        <created>2019-01-20</created>
+        <revision>0.12.0</revision>
       </Version>
     </release>
     <repository>


### PR DESCRIPTION
Hi,

Went to have a look at the [Apache Project listing](https://projects.apache.org/projects.html?language) and couldn't find Arrow there, so quickly grabbed Avro's DOAP, compared with a few Commons' DOAP files, and here's the result.

Notes:

- Use GitHub instead of git-wip (as far as I know, [git-wip is EOL](https://blogs.apache.org/infra/entry/relocation-of-apache-git-repositories), and all projects have to migrate to GitBox).
- Couldn't find a Wikipedia page for Arrow. That's where I normally find when the project was created, so used the [TLP project announcement](https://blogs.apache.org/foundation/entry/the_apache_software_foundation_announces87) date for the project `created` value.
- Use README's list of programming languages to create the list in this DOAP file.
- Some projects include updating DOAP release notes during/after the release, but it is not mandatory, and some (most?) ASF projects have outdated dates for the release in their DOAP files... having a DOAP file with valid metadata is still useful.

Happy to update branch it if necessary. 

Other comments:

- Validated with W3C RDF validator, looks OK
- Built site locally and pushed to my fork to test that the DOAP file appeared correctly in the [browser](https://kinow.github.io/arrow/arrow.rdf). Basically, by having the file in the `site` directory and not including it in the `_config.yaml` to be excluded seems to be enough
- If/once merged, the ASF project listing would still lack Arrow. That's because someone (a PMC or committer) still needs to follow the [documentation for projects](https://projects.apache.org/create.html) and updated the [ASF SVN XML](https://svn.apache.org/repos/asf/comdev/projects.apache.org/trunk/data/projects.xml) used. But that's just one line, pointing to http://arrowapache.org/arrow.rdf

Cheers
Bruno