### PR TITLE
[Documentation][C++] Change build conda create command for Windows developer

### DIFF
--- a/cpp/apidoc/Windows.md
+++ b/cpp/apidoc/Windows.md
@@ -41,7 +41,7 @@ conda config --add channels conda-forge
 Now, you can bootstrap a build environment
 
 ```shell
-conda create -n arrow-dev cmake git boost-cpp flatbuffers rapidjson cmake thrift-cpp snappy zlib brotli gflags lz4-c zstd -c conda-forge
+conda create -n arrow-dev cmake git boost-cpp flatbuffers rapidjson cmake thrift-cpp snappy zlib brotli gflags lz4-c zstd double-conversion -c conda-forge
 ```
 
 > **Note:** Make sure to get the `conda-forge` build of `gflags` as the

--- a/cpp/apidoc/Windows.md
+++ b/cpp/apidoc/Windows.md
@@ -38,10 +38,11 @@ Launch cmd.exe and run following commands:
 conda config --add channels conda-forge
 ```
 
-Now, you can bootstrap a build environment
+Now, you can bootstrap a build environment (call from the root directory of the
+Arrow codebase):
 
 ```shell
-conda create -n arrow-dev cmake git boost-cpp flatbuffers rapidjson cmake thrift-cpp snappy zlib brotli gflags lz4-c zstd double-conversion -c conda-forge
+conda create -n arrow-dev --file=ci\conda_env_cpp.yml
 ```
 
 > **Note:** Make sure to get the `conda-forge` build of `gflags` as the


### PR DESCRIPTION
For Widnows developer, we need to install "double-conversion" package
before build Arrow project. Change the "conda create" command here.
Otherwise will get:
"Could not find a package configuration file provided by "double-conversion" error.