### PR TITLE
ARROW-4155: [Rust] Implement array_ops::sum() for PrimitiveArray<T>

### DIFF
--- a/rust/src/array_ops.rs
+++ b/rust/src/array_ops.rs
@@ -178,9 +178,10 @@ where
         n = n + m;
     }
     if all_nulls {
-        return None;
+        None
+    } else {
+        Some(n)
     }
-    Some(n)
 }
 
 /// Perform `left == right` operation on two arrays.

--- a/rust/src/array_ops.rs
+++ b/rust/src/array_ops.rs
@@ -155,6 +155,24 @@ where
     n
 }
 
+/// Returns the sum of values in the array.
+pub fn sum<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
+where
+    T: ArrowNumericType,
+    T::Native: Add<Output = T::Native>
+{
+    let mut n: T::Native = T::default_value();
+    let data = array.data();
+    for i in 0..data.len() {
+        if data.is_null(i) {
+            continue;
+        }
+        let m = array.value(i);
+        n = n + m;
+    }
+    Some(n)
+}
+
 /// Perform `left == right` operation on two arrays.
 pub fn eq<T>(left: &PrimitiveArray<T>, right: &PrimitiveArray<T>) -> Result<BooleanArray>
 where
@@ -397,6 +415,24 @@ mod tests {
         assert_eq!(false, c.is_null(2));
         assert_eq!(true, c.is_null(3));
         assert_eq!(13, c.value(2));
+    }
+
+    #[test]
+    fn test_primitive_array_sum() {
+        let a = Int32Array::from(vec![1, 2, 3, 4, 5]);
+        assert_eq!(15, sum(&a).unwrap());
+    }
+
+    #[test]
+    fn test_primitive_array_float_sum() {
+        let a = Float64Array::from(vec![1.1, 2.2, 3.3, 4.4, 5.5]);
+        assert_eq!(16.5, sum(&a).unwrap());
+    }
+
+    #[test]
+    fn test_primitive_array_sum_with_nulls() {
+        let a = Int32Array::from(vec![None, Some(2), Some(3), None, Some(5)]);
+        assert_eq!(10, sum(&a).unwrap());
     }
 
     #[test]

--- a/rust/src/array_ops.rs
+++ b/rust/src/array_ops.rs
@@ -159,7 +159,7 @@ where
 pub fn sum<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
 where
     T: ArrowNumericType,
-    T::Native: Add<Output = T::Native>
+    T::Native: Add<Output = T::Native>,
 {
     let mut n: T::Native = T::default_value();
     let data = array.data();

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -83,10 +83,15 @@ pub trait ArrowPrimitiveType: 'static {
 
     /// Returns the bit width of this primitive type.
     fn get_bit_width() -> usize;
+
+    /// Returns a default value of this primitive type.
+    /// 
+    /// This is useful for aggregate array ops like `sum()`, `mean()`.
+    fn default_value() -> Self::Native;
 }
 
 macro_rules! make_type {
-    ($name:ident, $native_ty:ty, $data_ty:path, $bit_width:expr) => {
+    ($name:ident, $native_ty:ty, $data_ty:path, $bit_width:expr, $default_val:expr) => {
         impl ArrowNativeType for $native_ty {}
 
         pub struct $name {}
@@ -101,21 +106,25 @@ macro_rules! make_type {
             fn get_bit_width() -> usize {
                 $bit_width
             }
+
+            fn default_value() -> Self::Native {
+                $default_val
+            }
         }
     };
 }
 
-make_type!(BooleanType, bool, DataType::Boolean, 1);
-make_type!(Int8Type, i8, DataType::Int8, 8);
-make_type!(Int16Type, i16, DataType::Int16, 16);
-make_type!(Int32Type, i32, DataType::Int32, 32);
-make_type!(Int64Type, i64, DataType::Int64, 64);
-make_type!(UInt8Type, u8, DataType::UInt8, 8);
-make_type!(UInt16Type, u16, DataType::UInt16, 16);
-make_type!(UInt32Type, u32, DataType::UInt32, 32);
-make_type!(UInt64Type, u64, DataType::UInt64, 64);
-make_type!(Float32Type, f32, DataType::Float32, 32);
-make_type!(Float64Type, f64, DataType::Float64, 64);
+make_type!(BooleanType, bool, DataType::Boolean, 1, false);
+make_type!(Int8Type, i8, DataType::Int8, 8, 0i8);
+make_type!(Int16Type, i16, DataType::Int16, 16, 0i16);
+make_type!(Int32Type, i32, DataType::Int32, 32, 0i32);
+make_type!(Int64Type, i64, DataType::Int64, 64, 0i64);
+make_type!(UInt8Type, u8, DataType::UInt8, 8, 0u8);
+make_type!(UInt16Type, u16, DataType::UInt16, 16, 0u16);
+make_type!(UInt32Type, u32, DataType::UInt32, 32, 0u32);
+make_type!(UInt64Type, u64, DataType::UInt64, 64, 0u64);
+make_type!(Float32Type, f32, DataType::Float32, 32, 0.0f32);
+make_type!(Float64Type, f64, DataType::Float64, 64, 0.0f64);
 
 /// A subtype of primitive type that represents numeric values.
 pub trait ArrowNumericType: ArrowPrimitiveType {}

--- a/rust/src/datatypes.rs
+++ b/rust/src/datatypes.rs
@@ -85,7 +85,7 @@ pub trait ArrowPrimitiveType: 'static {
     fn get_bit_width() -> usize;
 
     /// Returns a default value of this primitive type.
-    /// 
+    ///
     /// This is useful for aggregate array ops like `sum()`, `mean()`.
     fn default_value() -> Self::Native;
 }


### PR DESCRIPTION
Adds the ability to return the sum of column