### PR TITLE
[Documentation] Fix site link to Intel SIMD docs

### DIFF
--- a/docs/source/format/Layout.rst
+++ b/docs/source/format/Layout.rst
@@ -659,6 +659,6 @@ Apache Drill Documentation - `Value Vectors`_
 .. _least-significant bit (LSB) numbering: https://en.wikipedia.org/wiki/Bit_numbering
 .. _Intel performance guide: https://software.intel.com/en-us/articles/practical-intel-avx-optimization-on-2nd-generation-intel-core-processors
 .. _Endianness: https://en.wikipedia.org/wiki/Endianness
-.. _SIMD: https://software.intel.com/en-us/node/600110
+.. _SIMD: https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-introduction-to-the-simd-data-layout-templates
 .. _Parquet: https://parquet.apache.org/documentation/latest/
 .. _Value Vectors: https://drill.apache.org/docs/value-vectors/


### PR DESCRIPTION
Hi, found one broken link while reading the docs. After searching the Web Archive, and then searching again for some text from the archived page, found what I believe to be the new address for the SIMD documentation.

Cheers
Bruno