### PR TITLE
ARROW-4168: [GLib] Use property to keep GArrowDataType passed in garrow_field_new()

### DIFF
--- a/c_glib/arrow-glib/column.cpp
+++ b/c_glib/arrow-glib/column.cpp
@@ -322,8 +322,11 @@ garrow_column_get_field(GArrowColumn *column)
   } else {
     const auto arrow_column = garrow_column_get_raw(column);
     auto arrow_field = arrow_column->field();
-    return garrow_field_new_raw(&arrow_field,
-                                garrow_column_get_data_type(column));
+    auto data_type = garrow_column_get_data_type(column);
+    auto field = garrow_field_new_raw(&arrow_field,
+                                      data_type);
+    g_object_unref(data_type);
+    return field;
   }
 }
 

--- a/c_glib/arrow-glib/column.cpp
+++ b/c_glib/arrow-glib/column.cpp
@@ -323,8 +323,7 @@ garrow_column_get_field(GArrowColumn *column)
     const auto arrow_column = garrow_column_get_raw(column);
     auto arrow_field = arrow_column->field();
     auto data_type = garrow_column_get_data_type(column);
-    auto field = garrow_field_new_raw(&arrow_field,
-                                      data_type);
+    auto field = garrow_field_new_raw(&arrow_field, data_type);
     g_object_unref(data_type);
     return field;
   }

--- a/c_glib/arrow-glib/column.cpp
+++ b/c_glib/arrow-glib/column.cpp
@@ -322,7 +322,8 @@ garrow_column_get_field(GArrowColumn *column)
   } else {
     const auto arrow_column = garrow_column_get_raw(column);
     auto arrow_field = arrow_column->field();
-    return garrow_field_new_raw(&arrow_field);
+    return garrow_field_new_raw(&arrow_field,
+                                garrow_column_get_data_type(column));
   }
 }
 

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -92,14 +92,15 @@ garrow_list_data_type_new(GArrowField *field)
 GArrowField *
 garrow_list_data_type_get_value_field(GArrowListDataType *list_data_type)
 {
+  auto data_type = GARROW_DATA_TYPE(list_data_type);
   auto arrow_data_type =
-    garrow_data_type_get_raw(GARROW_DATA_TYPE(list_data_type));
+    garrow_data_type_get_raw(data_type);
   auto arrow_list_data_type =
     static_cast<arrow::ListType *>(arrow_data_type.get());
 
   auto arrow_field = arrow_list_data_type->value_field();
   auto field = garrow_field_new_raw(&arrow_field,
-                                    GARROW_DATA_TYPE(list_data_type));
+                                    data_type);
 
   return field;
 }
@@ -159,7 +160,7 @@ garrow_struct_data_type_get_n_fields(GArrowStructDataType *data_type)
 
 /**
  * garrow_struct_data_type_get_fields:
- * @data_type: A #GArrowStructDataType.
+ * @struct_data_type: A #GArrowStructDataType.
  *
  * Returns: (transfer full) (element-type GArrowField):
  *   The fields of the struct data type.
@@ -167,23 +168,24 @@ garrow_struct_data_type_get_n_fields(GArrowStructDataType *data_type)
  * Since: 0.12.0
  */
 GList *
-garrow_struct_data_type_get_fields(GArrowStructDataType *data_type)
+garrow_struct_data_type_get_fields(GArrowStructDataType *struct_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto data_type = GARROW_DATA_TYPE(struct_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto arrow_fields = arrow_data_type->children();
 
   GList *fields = NULL;
   for (auto arrow_field : arrow_fields) {
     fields = g_list_prepend(fields,
                             garrow_field_new_raw(&arrow_field,
-                                                 GARROW_DATA_TYPE(data_type)));
+                                                 data_type));
   }
   return g_list_reverse(fields);
 }
 
 /**
  * garrow_struct_data_type_get_field:
- * @data_type: A #GArrowStructDataType.
+ * @struct_data_type: A #GArrowStructDataType.
  * @i: The index of the target field.
  *
  * Returns: (transfer full) (nullable):
@@ -192,10 +194,11 @@ garrow_struct_data_type_get_fields(GArrowStructDataType *data_type)
  * Since: 0.12.0
  */
 GArrowField *
-garrow_struct_data_type_get_field(GArrowStructDataType *data_type,
+garrow_struct_data_type_get_field(GArrowStructDataType *struct_data_type,
                                   gint i)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto data_type = GARROW_DATA_TYPE(struct_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
 
   if (i < 0) {
     i += arrow_data_type->num_children();
@@ -210,7 +213,7 @@ garrow_struct_data_type_get_field(GArrowStructDataType *data_type,
   auto arrow_field = arrow_data_type->child(i);
   if (arrow_field) {
     return garrow_field_new_raw(&arrow_field,
-                                GARROW_DATA_TYPE(data_type));
+                                data_type);
   } else {
     return NULL;
   }
@@ -218,7 +221,7 @@ garrow_struct_data_type_get_field(GArrowStructDataType *data_type,
 
 /**
  * garrow_struct_data_type_get_field_by_name:
- * @data_type: A #GArrowStructDataType.
+ * @struct_data_type: A #GArrowStructDataType.
  * @name: The name of the target field.
  *
  * Returns: (transfer full) (nullable):
@@ -227,17 +230,18 @@ garrow_struct_data_type_get_field(GArrowStructDataType *data_type,
  * Since: 0.12.0
  */
 GArrowField *
-garrow_struct_data_type_get_field_by_name(GArrowStructDataType *data_type,
+garrow_struct_data_type_get_field_by_name(GArrowStructDataType *struct_data_type,
                                           const gchar *name)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto data_type = GARROW_DATA_TYPE(struct_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto arrow_struct_data_type =
     std::static_pointer_cast<arrow::StructType>(arrow_data_type);
 
   auto arrow_field = arrow_struct_data_type->GetFieldByName(name);
   if (arrow_field) {
     return garrow_field_new_raw(&arrow_field,
-                                GARROW_DATA_TYPE(data_type));
+                                data_type);
   } else {
     return NULL;
   }
@@ -296,7 +300,7 @@ garrow_union_data_type_get_n_fields(GArrowUnionDataType *data_type)
 
 /**
  * garrow_union_data_type_get_fields:
- * @data_type: A #GArrowUnionDataType.
+ * @union_data_type: A #GArrowUnionDataType.
  *
  * Returns: (transfer full) (element-type GArrowField):
  *   The fields of the union data type.
@@ -304,23 +308,24 @@ garrow_union_data_type_get_n_fields(GArrowUnionDataType *data_type)
  * Since: 0.12.0
  */
 GList *
-garrow_union_data_type_get_fields(GArrowUnionDataType *data_type)
+garrow_union_data_type_get_fields(GArrowUnionDataType *union_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto data_type = GARROW_DATA_TYPE(union_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto arrow_fields = arrow_data_type->children();
 
   GList *fields = NULL;
   for (auto arrow_field : arrow_fields) {
     fields = g_list_prepend(fields,
                             garrow_field_new_raw(&arrow_field,
-                                                 GARROW_DATA_TYPE(data_type)));
+                                                 data_type));
   }
   return g_list_reverse(fields);
 }
 
 /**
  * garrow_union_data_type_get_field:
- * @data_type: A #GArrowUnionDataType.
+ * @union_data_type: A #GArrowUnionDataType.
  * @i: The index of the target field.
  *
  * Returns: (transfer full) (nullable):
@@ -329,10 +334,11 @@ garrow_union_data_type_get_fields(GArrowUnionDataType *data_type)
  * Since: 0.12.0
  */
 GArrowField *
-garrow_union_data_type_get_field(GArrowUnionDataType *data_type,
-                                  gint i)
+garrow_union_data_type_get_field(GArrowUnionDataType *union_data_type,
+                                 gint i)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto data_type = GARROW_DATA_TYPE(union_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
 
   if (i < 0) {
     i += arrow_data_type->num_children();
@@ -347,7 +353,7 @@ garrow_union_data_type_get_field(GArrowUnionDataType *data_type,
   auto arrow_field = arrow_data_type->child(i);
   if (arrow_field) {
     return garrow_field_new_raw(&arrow_field,
-                                GARROW_DATA_TYPE(data_type));
+                                data_type);
   } else {
     return NULL;
   }

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -93,16 +93,12 @@ GArrowField *
 garrow_list_data_type_get_value_field(GArrowListDataType *list_data_type)
 {
   auto data_type = GARROW_DATA_TYPE(list_data_type);
-  auto arrow_data_type =
-    garrow_data_type_get_raw(data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto arrow_list_data_type =
     static_cast<arrow::ListType *>(arrow_data_type.get());
 
   auto arrow_field = arrow_list_data_type->value_field();
-  auto field = garrow_field_new_raw(&arrow_field,
-                                    data_type);
-
-  return field;
+  return garrow_field_new_raw(&arrow_field, data_type);
 }
 
 
@@ -177,8 +173,7 @@ garrow_struct_data_type_get_fields(GArrowStructDataType *struct_data_type)
   GList *fields = NULL;
   for (auto arrow_field : arrow_fields) {
     fields = g_list_prepend(fields,
-                            garrow_field_new_raw(&arrow_field,
-                                                 data_type));
+                            garrow_field_new_raw(&arrow_field, data_type));
   }
   return g_list_reverse(fields);
 }
@@ -212,8 +207,7 @@ garrow_struct_data_type_get_field(GArrowStructDataType *struct_data_type,
 
   auto arrow_field = arrow_data_type->child(i);
   if (arrow_field) {
-    return garrow_field_new_raw(&arrow_field,
-                                data_type);
+    return garrow_field_new_raw(&arrow_field, data_type);
   } else {
     return NULL;
   }
@@ -240,8 +234,7 @@ garrow_struct_data_type_get_field_by_name(GArrowStructDataType *struct_data_type
 
   auto arrow_field = arrow_struct_data_type->GetFieldByName(name);
   if (arrow_field) {
-    return garrow_field_new_raw(&arrow_field,
-                                data_type);
+    return garrow_field_new_raw(&arrow_field, data_type);
   } else {
     return NULL;
   }
@@ -317,8 +310,7 @@ garrow_union_data_type_get_fields(GArrowUnionDataType *union_data_type)
   GList *fields = NULL;
   for (auto arrow_field : arrow_fields) {
     fields = g_list_prepend(fields,
-                            garrow_field_new_raw(&arrow_field,
-                                                 data_type));
+                            garrow_field_new_raw(&arrow_field, data_type));
   }
   return g_list_reverse(fields);
 }
@@ -352,8 +344,7 @@ garrow_union_data_type_get_field(GArrowUnionDataType *union_data_type,
 
   auto arrow_field = arrow_data_type->child(i);
   if (arrow_field) {
-    return garrow_field_new_raw(&arrow_field,
-                                data_type);
+    return garrow_field_new_raw(&arrow_field, data_type);
   } else {
     return NULL;
   }

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -98,7 +98,8 @@ garrow_list_data_type_get_value_field(GArrowListDataType *list_data_type)
     static_cast<arrow::ListType *>(arrow_data_type.get());
 
   auto arrow_field = arrow_list_data_type->value_field();
-  auto field = garrow_field_new_raw(&arrow_field);
+  auto field = garrow_field_new_raw(&arrow_field,
+                                    GARROW_DATA_TYPE(list_data_type));
 
   return field;
 }
@@ -173,7 +174,9 @@ garrow_struct_data_type_get_fields(GArrowStructDataType *data_type)
 
   GList *fields = NULL;
   for (auto arrow_field : arrow_fields) {
-    fields = g_list_prepend(fields, garrow_field_new_raw(&arrow_field));
+    fields = g_list_prepend(fields,
+                            garrow_field_new_raw(&arrow_field,
+                                                 GARROW_DATA_TYPE(data_type)));
   }
   return g_list_reverse(fields);
 }
@@ -206,7 +209,8 @@ garrow_struct_data_type_get_field(GArrowStructDataType *data_type,
 
   auto arrow_field = arrow_data_type->child(i);
   if (arrow_field) {
-    return garrow_field_new_raw(&arrow_field);
+    return garrow_field_new_raw(&arrow_field,
+                                GARROW_DATA_TYPE(data_type));
   } else {
     return NULL;
   }
@@ -232,7 +236,8 @@ garrow_struct_data_type_get_field_by_name(GArrowStructDataType *data_type,
 
   auto arrow_field = arrow_struct_data_type->GetFieldByName(name);
   if (arrow_field) {
-    return garrow_field_new_raw(&arrow_field);
+    return garrow_field_new_raw(&arrow_field,
+                                GARROW_DATA_TYPE(data_type));
   } else {
     return NULL;
   }
@@ -306,7 +311,9 @@ garrow_union_data_type_get_fields(GArrowUnionDataType *data_type)
 
   GList *fields = NULL;
   for (auto arrow_field : arrow_fields) {
-    fields = g_list_prepend(fields, garrow_field_new_raw(&arrow_field));
+    fields = g_list_prepend(fields,
+                            garrow_field_new_raw(&arrow_field,
+                                                 GARROW_DATA_TYPE(data_type)));
   }
   return g_list_reverse(fields);
 }
@@ -339,7 +346,8 @@ garrow_union_data_type_get_field(GArrowUnionDataType *data_type,
 
   auto arrow_field = arrow_data_type->child(i);
   if (arrow_field) {
-    return garrow_field_new_raw(&arrow_field);
+    return garrow_field_new_raw(&arrow_field,
+                                GARROW_DATA_TYPE(data_type));
   } else {
     return NULL;
   }

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -145,16 +145,16 @@ garrow_struct_data_type_new(GList *fields)
 
 /**
  * garrow_struct_data_type_get_n_fields:
- * @data_type: A #GArrowStructDataType.
+ * @struct_data_type: A #GArrowStructDataType.
  *
  * Returns: The number of fields of the struct data type.
  *
  * Since: 0.12.0
  */
 gint
-garrow_struct_data_type_get_n_fields(GArrowStructDataType *data_type)
+garrow_struct_data_type_get_n_fields(GArrowStructDataType *struct_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(struct_data_type));
   return arrow_data_type->num_children();
 }
 
@@ -249,7 +249,7 @@ garrow_struct_data_type_get_field_by_name(GArrowStructDataType *struct_data_type
 
 /**
  * garrow_struct_data_type_get_field_index:
- * @data_type: A #GArrowStructDataType.
+ * @struct_data_type: A #GArrowStructDataType.
  * @name: The name of the target field.
  *
  * Returns: The index of the target index in the struct data type
@@ -258,10 +258,10 @@ garrow_struct_data_type_get_field_by_name(GArrowStructDataType *struct_data_type
  * Since: 0.12.0
  */
 gint
-garrow_struct_data_type_get_field_index(GArrowStructDataType *data_type,
+garrow_struct_data_type_get_field_index(GArrowStructDataType *struct_data_type,
                                         const gchar *name)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(struct_data_type));
   auto arrow_struct_data_type =
     std::static_pointer_cast<arrow::StructType>(arrow_data_type);
 
@@ -285,16 +285,16 @@ garrow_union_data_type_class_init(GArrowUnionDataTypeClass *klass)
 
 /**
  * garrow_union_data_type_get_n_fields:
- * @data_type: A #GArrowUnionDataType.
+ * @union_data_type: A #GArrowUnionDataType.
  *
  * Returns: The number of fields of the union data type.
  *
  * Since: 0.12.0
  */
 gint
-garrow_union_data_type_get_n_fields(GArrowUnionDataType *data_type)
+garrow_union_data_type_get_n_fields(GArrowUnionDataType *union_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(union_data_type));
   return arrow_data_type->num_children();
 }
 
@@ -361,7 +361,7 @@ garrow_union_data_type_get_field(GArrowUnionDataType *union_data_type,
 
 /**
  * garrow_union_data_type_get_type_codes:
- * @data_type: A #GArrowUnionDataType.
+ * @union_data_type: A #GArrowUnionDataType.
  * @n_type_codes: (out): The number of type codes.
  *
  * Returns: (transfer full) (array length=n_type_codes):
@@ -372,10 +372,10 @@ garrow_union_data_type_get_field(GArrowUnionDataType *union_data_type,
  * Since: 0.12.0
  */
 guint8 *
-garrow_union_data_type_get_type_codes(GArrowUnionDataType *data_type,
+garrow_union_data_type_get_type_codes(GArrowUnionDataType *union_data_type,
                                       gsize *n_type_codes)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(union_data_type));
   auto arrow_union_data_type =
     std::static_pointer_cast<arrow::UnionType>(arrow_data_type);
 
@@ -529,16 +529,16 @@ garrow_dictionary_data_type_new(GArrowDataType *index_data_type,
 
 /**
  * garrow_dictionary_data_type_get_index_data_type:
- * @data_type: The #GArrowDictionaryDataType.
+ * @dictionary_data_type: The #GArrowDictionaryDataType.
  *
  * Returns: (transfer full): The #GArrowDataType of index.
  *
  * Since: 0.8.0
  */
 GArrowDataType *
-garrow_dictionary_data_type_get_index_data_type(GArrowDictionaryDataType *data_type)
+garrow_dictionary_data_type_get_index_data_type(GArrowDictionaryDataType *dictionary_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(dictionary_data_type));
   auto arrow_dictionary_data_type =
     std::static_pointer_cast<arrow::DictionaryType>(arrow_data_type);
   auto arrow_index_data_type = arrow_dictionary_data_type->index_type();
@@ -547,16 +547,16 @@ garrow_dictionary_data_type_get_index_data_type(GArrowDictionaryDataType *data_t
 
 /**
  * garrow_dictionary_data_type_get_dictionary:
- * @data_type: The #GArrowDictionaryDataType.
+ * @dictionary_data_type: The #GArrowDictionaryDataType.
  *
  * Returns: (transfer full): The dictionary as #GArrowArray.
  *
  * Since: 0.8.0
  */
 GArrowArray *
-garrow_dictionary_data_type_get_dictionary(GArrowDictionaryDataType *data_type)
+garrow_dictionary_data_type_get_dictionary(GArrowDictionaryDataType *dictionary_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(dictionary_data_type));
   auto arrow_dictionary_data_type =
     std::static_pointer_cast<arrow::DictionaryType>(arrow_data_type);
   auto arrow_dictionary = arrow_dictionary_data_type->dictionary();
@@ -565,16 +565,16 @@ garrow_dictionary_data_type_get_dictionary(GArrowDictionaryDataType *data_type)
 
 /**
  * garrow_dictionary_data_type_is_ordered:
- * @data_type: The #GArrowDictionaryDataType.
+ * @dictionary_data_type: The #GArrowDictionaryDataType.
  *
  * Returns: Whether dictionary contents are ordered or not.
  *
  * Since: 0.8.0
  */
 gboolean
-garrow_dictionary_data_type_is_ordered(GArrowDictionaryDataType *data_type)
+garrow_dictionary_data_type_is_ordered(GArrowDictionaryDataType *dictionary_data_type)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto arrow_data_type = garrow_data_type_get_raw(GARROW_DATA_TYPE(dictionary_data_type));
   auto arrow_dictionary_data_type =
     std::static_pointer_cast<arrow::DictionaryType>(arrow_data_type);
   return arrow_dictionary_data_type->ordered();

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -85,12 +85,12 @@ GArrowStructDataType *garrow_struct_data_type_new      (GList *fields);
 gint
 garrow_struct_data_type_get_n_fields(GArrowStructDataType *data_type);
 GList *
-garrow_struct_data_type_get_fields(GArrowStructDataType *data_type);
+garrow_struct_data_type_get_fields(GArrowStructDataType *struct_data_type);
 GArrowField *
-garrow_struct_data_type_get_field(GArrowStructDataType *data_type,
+garrow_struct_data_type_get_field(GArrowStructDataType *struct_data_type,
                                   gint i);
 GArrowField *
-garrow_struct_data_type_get_field_by_name(GArrowStructDataType *data_type,
+garrow_struct_data_type_get_field_by_name(GArrowStructDataType *struct_data_type,
                                           const gchar *name);
 gint
 garrow_struct_data_type_get_field_index(GArrowStructDataType *data_type,
@@ -111,9 +111,9 @@ struct _GArrowUnionDataTypeClass
 gint
 garrow_union_data_type_get_n_fields(GArrowUnionDataType *data_type);
 GList *
-garrow_union_data_type_get_fields(GArrowUnionDataType *data_type);
+garrow_union_data_type_get_fields(GArrowUnionDataType *union_data_type);
 GArrowField *
-garrow_union_data_type_get_field(GArrowUnionDataType *data_type,
+garrow_union_data_type_get_field(GArrowUnionDataType *union_data_type,
                                  gint i);
 guint8 *
 garrow_union_data_type_get_type_codes(GArrowUnionDataType *data_type,

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -83,7 +83,7 @@ struct _GArrowStructDataTypeClass
 
 GArrowStructDataType *garrow_struct_data_type_new      (GList *fields);
 gint
-garrow_struct_data_type_get_n_fields(GArrowStructDataType *data_type);
+garrow_struct_data_type_get_n_fields(GArrowStructDataType *struct_data_type);
 GList *
 garrow_struct_data_type_get_fields(GArrowStructDataType *struct_data_type);
 GArrowField *
@@ -93,7 +93,7 @@ GArrowField *
 garrow_struct_data_type_get_field_by_name(GArrowStructDataType *struct_data_type,
                                           const gchar *name);
 gint
-garrow_struct_data_type_get_field_index(GArrowStructDataType *data_type,
+garrow_struct_data_type_get_field_index(GArrowStructDataType *struct_data_type,
                                         const gchar *name);
 
 
@@ -109,14 +109,14 @@ struct _GArrowUnionDataTypeClass
 };
 
 gint
-garrow_union_data_type_get_n_fields(GArrowUnionDataType *data_type);
+garrow_union_data_type_get_n_fields(GArrowUnionDataType *union_data_type);
 GList *
 garrow_union_data_type_get_fields(GArrowUnionDataType *union_data_type);
 GArrowField *
 garrow_union_data_type_get_field(GArrowUnionDataType *union_data_type,
                                  gint i);
 guint8 *
-garrow_union_data_type_get_type_codes(GArrowUnionDataType *data_type,
+garrow_union_data_type_get_type_codes(GArrowUnionDataType *union_data_type,
                                       gsize *n_type_codes);
 
 
@@ -172,11 +172,11 @@ garrow_dictionary_data_type_new(GArrowDataType *index_data_type,
                                 GArrowArray *dictionary,
                                 gboolean ordered);
 GArrowDataType *
-garrow_dictionary_data_type_get_index_data_type(GArrowDictionaryDataType *data_type);
+garrow_dictionary_data_type_get_index_data_type(GArrowDictionaryDataType *dictionary_data_type);
 GArrowArray *
-garrow_dictionary_data_type_get_dictionary(GArrowDictionaryDataType *data_type);
+garrow_dictionary_data_type_get_dictionary(GArrowDictionaryDataType *dictionary_data_type);
 gboolean
-garrow_dictionary_data_type_is_ordered(GArrowDictionaryDataType *data_type);
+garrow_dictionary_data_type_is_ordered(GArrowDictionaryDataType *dictionary_data_type);
 
 
 G_END_DECLS

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -59,7 +59,7 @@ garrow_field_dispose(GObject *object)
 {
   auto priv = GARROW_FIELD_GET_PRIVATE(object);
 
-   if (priv->data_type) {
+  if (priv->data_type) {
     g_object_unref(priv->data_type);
     priv->data_type = nullptr;
   }

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -37,11 +37,12 @@ G_BEGIN_DECLS
 
 typedef struct GArrowFieldPrivate_ {
   std::shared_ptr<arrow::Field> field;
+  GArrowDataType *data_type;
 } GArrowFieldPrivate;
 
 enum {
-  PROP_0,
-  PROP_FIELD
+  PROP_FIELD = 1,
+  PROP_DATA_TYPE
 };
 
 G_DEFINE_TYPE_WITH_PRIVATE(GArrowField,
@@ -54,11 +55,22 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowField,
        GARROW_FIELD(obj)))
 
 static void
+garrow_field_dispose(GObject *object)
+{
+  auto priv = GARROW_FIELD_GET_PRIVATE(object);
+
+   if (priv->data_type) {
+    g_object_unref(priv->data_type);
+    priv->data_type = nullptr;
+  }
+
+  G_OBJECT_CLASS(garrow_field_parent_class)->dispose(object);
+}
+
+static void
 garrow_field_finalize(GObject *object)
 {
-  GArrowFieldPrivate *priv;
-
-  priv = GARROW_FIELD_GET_PRIVATE(object);
+  auto priv = GARROW_FIELD_GET_PRIVATE(object);
 
   priv->field = nullptr;
 
@@ -80,19 +92,9 @@ garrow_field_set_property(GObject *object,
     priv->field =
       *static_cast<std::shared_ptr<arrow::Field> *>(g_value_get_pointer(value));
     break;
-  default:
-    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+  case PROP_DATA_TYPE:
+    priv->data_type = GARROW_DATA_TYPE(g_value_dup_object(value));
     break;
-  }
-}
-
-static void
-garrow_field_get_property(GObject *object,
-                          guint prop_id,
-                          GValue *value,
-                          GParamSpec *pspec)
-{
-  switch (prop_id) {
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     break;
@@ -107,21 +109,27 @@ garrow_field_init(GArrowField *object)
 static void
 garrow_field_class_init(GArrowFieldClass *klass)
 {
-  GObjectClass *gobject_class;
-  GParamSpec *spec;
+  auto gobject_class = G_OBJECT_CLASS(klass);
 
-  gobject_class = G_OBJECT_CLASS(klass);
-
+  gobject_class->dispose      = garrow_field_dispose;
   gobject_class->finalize     = garrow_field_finalize;
   gobject_class->set_property = garrow_field_set_property;
-  gobject_class->get_property = garrow_field_get_property;
 
+  GParamSpec *spec;
   spec = g_param_spec_pointer("field",
                               "Field",
                               "The raw std::shared<arrow::Field> *",
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_FIELD, spec);
+
+  spec = g_param_spec_object("data-type",
+                             "Data type",
+                             "The data type",
+                             GARROW_TYPE_DATA_TYPE,
+                             static_cast<GParamFlags>(G_PARAM_WRITABLE |
+                                                      G_PARAM_CONSTRUCT_ONLY));
+  g_object_class_install_property(gobject_class, PROP_DATA_TYPE, spec);
 }
 
 /**
@@ -137,7 +145,7 @@ garrow_field_new(const gchar *name,
 {
   auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto arrow_field = std::make_shared<arrow::Field>(name, arrow_data_type);
-  return garrow_field_new_raw(&arrow_field);
+  return garrow_field_new_raw(&arrow_field, data_type);
 }
 
 /**
@@ -157,7 +165,7 @@ garrow_field_new_full(const gchar *name,
     std::make_shared<arrow::Field>(name,
                                    garrow_data_type_get_raw(data_type),
                                    nullable);
-  return garrow_field_new_raw(&arrow_field);
+  return garrow_field_new_raw(&arrow_field, data_type);
 }
 
 /**
@@ -177,14 +185,13 @@ garrow_field_get_name(GArrowField *field)
  * garrow_field_get_data_type:
  * @field: A #GArrowField.
  *
- * Returns: (transfer full): The data type of the field.
+ * Returns: (transfer none): The data type of the field.
  */
 GArrowDataType *
 garrow_field_get_data_type(GArrowField *field)
 {
-  const auto arrow_field = garrow_field_get_raw(field);
-  auto type = arrow_field->type();
-  return garrow_data_type_new_raw(&type);
+  auto priv = GARROW_FIELD_GET_PRIVATE(field);
+  return priv->data_type;
 }
 
 /**
@@ -233,10 +240,12 @@ garrow_field_to_string(GArrowField *field)
 G_END_DECLS
 
 GArrowField *
-garrow_field_new_raw(std::shared_ptr<arrow::Field> *arrow_field)
+garrow_field_new_raw(std::shared_ptr<arrow::Field> *arrow_field,
+                     GArrowDataType *data_type)
 {
   auto field = GARROW_FIELD(g_object_new(GARROW_TYPE_FIELD,
                                          "field", arrow_field,
+                                         "data-type", data_type,
                                          NULL));
   return field;
 }

--- a/c_glib/arrow-glib/field.hpp
+++ b/c_glib/arrow-glib/field.hpp
@@ -23,5 +23,6 @@
 
 #include <arrow-glib/field.h>
 
-GArrowField *garrow_field_new_raw(std::shared_ptr<arrow::Field> *arrow_field);
+GArrowField *garrow_field_new_raw(std::shared_ptr<arrow::Field> *arrow_field,
+                                  GArrowDataType *data_type);
 std::shared_ptr<arrow::Field> garrow_field_get_raw(GArrowField *field);

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -21,6 +21,7 @@
 #  include <config.h>
 #endif
 
+#include <arrow-glib/basic-data-type.hpp>
 #include <arrow-glib/error.hpp>
 #include <arrow-glib/field.hpp>
 #include <arrow-glib/schema.hpp>
@@ -173,7 +174,12 @@ garrow_schema_get_field(GArrowSchema *schema, guint i)
 {
   const auto arrow_schema = garrow_schema_get_raw(schema);
   auto arrow_field = arrow_schema->field(i);
-  return garrow_field_new_raw(&arrow_field);
+  auto arrow_data_type = arrow_field->type();
+  auto data_type = garrow_data_type_new_raw(&arrow_data_type);
+  auto field = garrow_field_new_raw(&arrow_field,
+                                    data_type);
+  g_object_unref(data_type);
+  return field;
 }
 
 /**
@@ -192,7 +198,12 @@ garrow_schema_get_field_by_name(GArrowSchema *schema,
   if (arrow_field == nullptr) {
     return NULL;
   } else {
-    return garrow_field_new_raw(&arrow_field);
+    auto arrow_data_type = arrow_field->type();
+    auto data_type = garrow_data_type_new_raw(&arrow_data_type);
+    auto field =  garrow_field_new_raw(&arrow_field,
+                                       data_type);
+    g_object_unref(data_type);
+    return field;
   }
 }
 
@@ -223,7 +234,11 @@ garrow_schema_get_fields(GArrowSchema *schema)
 
   GList *fields = NULL;
   for (auto arrow_field : arrow_schema->fields()) {
-    GArrowField *field = garrow_field_new_raw(&arrow_field);
+    auto arrow_data_type = arrow_field->type();
+    auto data_type = garrow_data_type_new_raw(&arrow_data_type);
+    auto field = garrow_field_new_raw(&arrow_field,
+                                      data_type);
+    g_object_unref(data_type);
     fields = g_list_prepend(fields, field);
   }
 

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -176,8 +176,7 @@ garrow_schema_get_field(GArrowSchema *schema, guint i)
   auto arrow_field = arrow_schema->field(i);
   auto arrow_data_type = arrow_field->type();
   auto data_type = garrow_data_type_new_raw(&arrow_data_type);
-  auto field = garrow_field_new_raw(&arrow_field,
-                                    data_type);
+  auto field = garrow_field_new_raw(&arrow_field, data_type);
   g_object_unref(data_type);
   return field;
 }
@@ -200,8 +199,7 @@ garrow_schema_get_field_by_name(GArrowSchema *schema,
   } else {
     auto arrow_data_type = arrow_field->type();
     auto data_type = garrow_data_type_new_raw(&arrow_data_type);
-    auto field =  garrow_field_new_raw(&arrow_field,
-                                       data_type);
+    auto field =  garrow_field_new_raw(&arrow_field, data_type);
     g_object_unref(data_type);
     return field;
   }
@@ -236,8 +234,7 @@ garrow_schema_get_fields(GArrowSchema *schema)
   for (auto arrow_field : arrow_schema->fields()) {
     auto arrow_data_type = arrow_field->type();
     auto data_type = garrow_data_type_new_raw(&arrow_data_type);
-    auto field = garrow_field_new_raw(&arrow_field,
-                                      data_type);
+    auto field = garrow_field_new_raw(&arrow_field, data_type);
     g_object_unref(data_type);
     fields = g_list_prepend(fields, field);
   }

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -1200,7 +1200,6 @@ ggandiva_field_node_new_raw(std::shared_ptr<gandiva::Node> *gandiva_node,
                                  "field", field,
                                  "return-type", return_type,
                                  NULL);
-  g_object_unref(return_type);
   return GGANDIVA_FIELD_NODE(field_node);
 }
 


### PR DESCRIPTION
This is follow-up of https://github.com/apache/arrow/pull/3197#pullrequestreview-186349753