### PR TITLE
ARROW-3959: [Rust] Add date/time data types

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -66,13 +66,13 @@ pub enum DataType {
     Struct(Vec<Field>),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DateUnit {
     Day,
     Millisecond,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TimeUnit {
     Second,
     Millisecond,
@@ -80,7 +80,7 @@ pub enum TimeUnit {
     Nanosecond,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum IntervalUnit {
     YearMonth,
     DayTime,

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -350,14 +350,12 @@ impl DataType {
                 DateUnit::Day => "DAY",
                 DateUnit::Millisecond => "MILLISECOND",
             }}),
-            DataType::Timestamp(unit) => {
-                json!({"name": "timestamp", "unit": match unit {
-                    TimestampUnit::Second => "SECOND",
-                    TimestampUnit::Millisecond => "MILLISECOND",
-                    TimestampUnit::Microsecond => "MICROSECOND",
-                    TimestampUnit::Nanosecond => "NANOSECOND",
-                }})
-            }
+            DataType::Timestamp(unit) => json!({"name": "timestamp", "unit": match unit {
+                TimestampUnit::Second => "SECOND",
+                TimestampUnit::Millisecond => "MILLISECOND",
+                TimestampUnit::Microsecond => "MICROSECOND",
+                TimestampUnit::Nanosecond => "NANOSECOND",
+            }}),
             DataType::Interval(unit) => json!({"name": "interval", "unit": match unit {
                 IntervalUnit::YearMonth => "YEAR_MONTH",
                 IntervalUnit::DayTime => "DAY_TIME",
@@ -639,18 +637,41 @@ mod tests {
     #[test]
     fn create_schema_string() {
         let _person = Schema::new(vec![
-            Field::new("first_name", DataType::Utf8, false),
-            Field::new("last_name", DataType::Utf8, false),
+            Field::new("c1", DataType::Utf8, false),
+            Field::new("c2", DataType::Date(DateUnit::Day), false),
+            Field::new("c3", DataType::Date(DateUnit::Millisecond), false),
+            Field::new("c7", DataType::Time32(TimeUnit::Second), false),
+            Field::new("c8", DataType::Time32(TimeUnit::Millisecond), false),
+            Field::new("c9", DataType::Time32(TimeUnit::Microsecond), false),
+            Field::new("c10", DataType::Time32(TimeUnit::Nanosecond), false),
+            Field::new("c11", DataType::Time64(TimeUnit::Second), false),
+            Field::new("c12", DataType::Time64(TimeUnit::Millisecond), false),
+            Field::new("c13", DataType::Time64(TimeUnit::Microsecond), false),
+            Field::new("c14", DataType::Time64(TimeUnit::Nanosecond), false),
+            Field::new("c15", DataType::Timestamp(TimestampUnit::Second), false),
             Field::new(
-                "address",
+                "c16",
+                DataType::Timestamp(TimestampUnit::Millisecond),
+                false,
+            ),
+            Field::new(
+                "c17",
+                DataType::Timestamp(TimestampUnit::Microsecond),
+                false,
+            ),
+            Field::new("c18", DataType::Timestamp(TimestampUnit::Nanosecond), false),
+            Field::new("c19", DataType::Interval(IntervalUnit::DayTime), false),
+            Field::new("c20", DataType::Interval(IntervalUnit::YearMonth), false),
+            Field::new(
+                "c21",
                 DataType::Struct(vec![
-                    Field::new("street", DataType::Utf8, false),
-                    Field::new("zip", DataType::UInt16, false),
+                    Field::new("a", DataType::Utf8, false),
+                    Field::new("b", DataType::UInt16, false),
                 ]),
                 false,
             ),
         ]);
-        assert_eq!(_person.to_string(), "first_name: Utf8, last_name: Utf8, address: Struct([Field { name: \"street\", data_type: Utf8, nullable: false }, Field { name: \"zip\", data_type: UInt16, nullable: false }])")
+        assert_eq!(_person.to_string(), "c1: Utf8, c2: Date(Day), c3: Date(Millisecond), c7: Time32(Second), c8: Time32(Millisecond), c9: Time32(Microsecond), c10: Time32(Nanosecond), c11: Time64(Second), c12: Time64(Millisecond), c13: Time64(Microsecond), c14: Time64(Nanosecond), c15: Timestamp(Second), c16: Timestamp(Millisecond), c17: Timestamp(Microsecond), c18: Timestamp(Nanosecond), c19: Interval(DayTime), c20: Interval(YearMonth), c21: Struct([Field { name: \"a\", data_type: Utf8, nullable: false }, Field { name: \"b\", data_type: UInt16, nullable: false }])")
     }
 
     #[test]

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -56,7 +56,7 @@ pub enum DataType {
     Float16,
     Float32,
     Float64,
-    Timestamp(TimestampUnit),
+    Timestamp(TimeUnit),
     Date(DateUnit),
     Time32(TimeUnit),
     Time64(TimeUnit),
@@ -64,14 +64,6 @@ pub enum DataType {
     Utf8,
     List(Box<DataType>),
     Struct(Vec<Field>),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub enum TimestampUnit {
-    Second,
-    Millisecond,
-    Microsecond,
-    Nanosecond,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -209,16 +201,10 @@ impl DataType {
                     )),
                 },
                 Some(s) if s == "timestamp" => match map.get("unit") {
-                    Some(p) if p == "SECOND" => Ok(DataType::Timestamp(TimestampUnit::Second)),
-                    Some(p) if p == "MILLISECOND" => {
-                        Ok(DataType::Timestamp(TimestampUnit::Millisecond))
-                    }
-                    Some(p) if p == "MICROSECOND" => {
-                        Ok(DataType::Timestamp(TimestampUnit::Microsecond))
-                    }
-                    Some(p) if p == "NANOSECOND" => {
-                        Ok(DataType::Timestamp(TimestampUnit::Nanosecond))
-                    }
+                    Some(p) if p == "SECOND" => Ok(DataType::Timestamp(TimeUnit::Second)),
+                    Some(p) if p == "MILLISECOND" => Ok(DataType::Timestamp(TimeUnit::Millisecond)),
+                    Some(p) if p == "MICROSECOND" => Ok(DataType::Timestamp(TimeUnit::Microsecond)),
+                    Some(p) if p == "NANOSECOND" => Ok(DataType::Timestamp(TimeUnit::Nanosecond)),
                     _ => Err(ArrowError::ParseError(
                         "timestamp unit missing or invalid".to_string(),
                     )),
@@ -351,10 +337,10 @@ impl DataType {
                 DateUnit::Millisecond => "MILLISECOND",
             }}),
             DataType::Timestamp(unit) => json!({"name": "timestamp", "unit": match unit {
-                TimestampUnit::Second => "SECOND",
-                TimestampUnit::Millisecond => "MILLISECOND",
-                TimestampUnit::Microsecond => "MICROSECOND",
-                TimestampUnit::Nanosecond => "NANOSECOND",
+                TimeUnit::Second => "SECOND",
+                TimeUnit::Millisecond => "MILLISECOND",
+                TimeUnit::Microsecond => "MICROSECOND",
+                TimeUnit::Nanosecond => "NANOSECOND",
             }}),
             DataType::Interval(unit) => json!({"name": "interval", "unit": match unit {
                 IntervalUnit::YearMonth => "YEAR_MONTH",
@@ -655,18 +641,10 @@ mod tests {
             Field::new("c12", DataType::Time64(TimeUnit::Millisecond), false),
             Field::new("c13", DataType::Time64(TimeUnit::Microsecond), false),
             Field::new("c14", DataType::Time64(TimeUnit::Nanosecond), false),
-            Field::new("c15", DataType::Timestamp(TimestampUnit::Second), false),
-            Field::new(
-                "c16",
-                DataType::Timestamp(TimestampUnit::Millisecond),
-                false,
-            ),
-            Field::new(
-                "c17",
-                DataType::Timestamp(TimestampUnit::Microsecond),
-                false,
-            ),
-            Field::new("c18", DataType::Timestamp(TimestampUnit::Nanosecond), false),
+            Field::new("c15", DataType::Timestamp(TimeUnit::Second), false),
+            Field::new("c16", DataType::Timestamp(TimeUnit::Millisecond), false),
+            Field::new("c17", DataType::Timestamp(TimeUnit::Microsecond), false),
+            Field::new("c18", DataType::Timestamp(TimeUnit::Nanosecond), false),
             Field::new("c19", DataType::Interval(IntervalUnit::DayTime), false),
             Field::new("c20", DataType::Interval(IntervalUnit::YearMonth), false),
             Field::new(

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -351,7 +351,7 @@ impl DataType {
                 DateUnit::Millisecond => "MILLISECOND",
             }}),
             DataType::Timestamp(unit) => {
-                json!({"name": "timestamp", "precision": "DOUBLE", "unit": match unit {
+                json!({"name": "timestamp", "unit": match unit {
                     TimestampUnit::Second => "SECOND",
                     TimestampUnit::Millisecond => "MILLISECOND",
                     TimestampUnit::Microsecond => "MICROSECOND",


### PR DESCRIPTION
This only adds the date/time types to the DataTypes enum as well as JSON serialization for meta data.

This PR also implements `Schema::to_json`