### PR TITLE
ARROW-4172: [Rust] more consistent naming in array builders

### DIFF
--- a/rust/arrow/examples/builders.rs
+++ b/rust/arrow/examples/builders.rs
@@ -29,14 +29,14 @@ fn main() {
     // Create a new builder with a capacity of 100
     let mut primitive_array_builder = Int32Builder::new(100);
 
-    // Push an individual primitive value
-    primitive_array_builder.push(55).unwrap();
+    // Append an individual primitive value
+    primitive_array_builder.append_value(55).unwrap();
 
-    // Push a null value
-    primitive_array_builder.push_null().unwrap();
+    // Append a null value
+    primitive_array_builder.append_null().unwrap();
 
-    // Push a slice of primitive values
-    primitive_array_builder.push_slice(&[39, 89, 12]).unwrap();
+    // Append a slice of primitive values
+    primitive_array_builder.append_slice(&[39, 89, 12]).unwrap();
 
     // Build the `PrimitiveArray`
     let _primitive_array = primitive_array_builder.finish();

--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -201,8 +201,8 @@ impl<T: ArrowNumericType> PrimitiveArray<T> {
     }
 
     // Returns a new primitive array builder
-    pub fn builder(capacity: usize) -> PrimitiveArrayBuilder<T> {
-        PrimitiveArrayBuilder::<T>::new(capacity)
+    pub fn builder(capacity: usize) -> PrimitiveBuilder<T> {
+        PrimitiveBuilder::<T>::new(capacity)
     }
 }
 

--- a/rust/arrow/src/array_ops.rs
+++ b/rust/arrow/src/array_ops.rs
@@ -22,7 +22,7 @@ use std::ops::{Add, Div, Mul, Sub};
 use num::Zero;
 
 use crate::array::{Array, BooleanArray, PrimitiveArray};
-use crate::builder::PrimitiveArrayBuilder;
+use crate::builder::PrimitiveBuilder;
 use crate::datatypes;
 use crate::datatypes::ArrowNumericType;
 use crate::error::{ArrowError, Result};
@@ -102,13 +102,13 @@ where
             "Cannot perform math operation on arrays of different length".to_string(),
         ));
     }
-    let mut b = PrimitiveArrayBuilder::<T>::new(left.len());
+    let mut b = PrimitiveBuilder::<T>::new(left.len());
     for i in 0..left.len() {
         let index = i;
         if left.is_null(i) || right.is_null(i) {
-            b.push_null()?;
+            b.append_null()?;
         } else {
-            b.push(op(left.value(index), right.value(index))?)?;
+            b.append_value(op(left.value(index), right.value(index))?)?;
         }
     }
     Ok(b.finish())
@@ -276,7 +276,7 @@ where
         } else {
             Some(right.value(index))
         };
-        b.push(op(l, r))?;
+        b.append_value(op(l, r))?;
     }
     Ok(b.finish())
 }
@@ -291,9 +291,9 @@ pub fn and(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     let mut b = BooleanArray::builder(left.len());
     for i in 0..left.len() {
         if left.is_null(i) || right.is_null(i) {
-            b.push_null()?;
+            b.append_null()?;
         } else {
-            b.push(left.value(i) && right.value(i))?;
+            b.append_value(left.value(i) && right.value(i))?;
         }
     }
     Ok(b.finish())
@@ -309,9 +309,9 @@ pub fn or(left: &BooleanArray, right: &BooleanArray) -> Result<BooleanArray> {
     let mut b = BooleanArray::builder(left.len());
     for i in 0..left.len() {
         if left.is_null(i) || right.is_null(i) {
-            b.push_null()?;
+            b.append_null()?;
         } else {
-            b.push(left.value(i) || right.value(i))?;
+            b.append_value(left.value(i) || right.value(i))?;
         }
     }
     Ok(b.finish())
@@ -322,9 +322,9 @@ pub fn not(left: &BooleanArray) -> Result<BooleanArray> {
     let mut b = BooleanArray::builder(left.len());
     for i in 0..left.len() {
         if left.is_null(i) {
-            b.push_null()?;
+            b.append_null()?;
         } else {
-            b.push(!left.value(i))?;
+            b.append_value(!left.value(i))?;
         }
     }
     Ok(b.finish())

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -138,10 +138,10 @@ impl Reader {
                     &DataType::Float32 => self.build_primitive_array::<Float32Type>(rows, i),
                     &DataType::Float64 => self.build_primitive_array::<Float64Type>(rows, i),
                     &DataType::Utf8 => {
-                        let mut builder = BinaryArrayBuilder::new(rows.len());
+                        let mut builder = BinaryBuilder::new(rows.len());
                         for row_index in 0..rows.len() {
                             match rows[row_index].get(*i) {
-                                Some(s) => builder.push_string(s).unwrap(),
+                                Some(s) => builder.append_string(s).unwrap(),
                                 _ => builder.append(false).unwrap(),
                             }
                         }
@@ -166,7 +166,7 @@ impl Reader {
         rows: &[StringRecord],
         col_idx: &usize,
     ) -> Result<ArrayRef> {
-        let mut builder = PrimitiveArrayBuilder::<T>::new(rows.len());
+        let mut builder = PrimitiveBuilder::<T>::new(rows.len());
         let is_boolean_type = *self.schema.field(*col_idx).data_type() == DataType::Boolean;
         for row_index in 0..rows.len() {
             match rows[row_index].get(*col_idx) {
@@ -177,7 +177,7 @@ impl Reader {
                         s.parse::<T::Native>()
                     };
                     match t {
-                        Ok(v) => builder.push(v)?,
+                        Ok(v) => builder.append_value(v)?,
                         Err(_) => {
                             // TODO: we should surface the underlying error here.
                             return Err(ArrowError::ParseError(format!(
@@ -187,7 +187,7 @@ impl Reader {
                         }
                     }
                 }
-                _ => builder.push_null()?,
+                _ => builder.append_null()?,
             }
         }
         Ok(Arc::new(builder.finish()))

--- a/rust/arrow/src/tensor.rs
+++ b/rust/arrow/src/tensor.rs
@@ -279,7 +279,7 @@ mod tests {
     fn test_tensor() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.push(i).unwrap();
+            builder.append(i).unwrap();
         }
         let buf = builder.finish();
         let tensor = Int32Tensor::new(buf, Some(vec![2, 8]), None, None);
@@ -294,7 +294,7 @@ mod tests {
     fn test_new_row_major() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.push(i).unwrap();
+            builder.append(i).unwrap();
         }
         let buf = builder.finish();
         let tensor = Int32Tensor::new_row_major(buf, Some(vec![2, 8]), None);
@@ -312,7 +312,7 @@ mod tests {
     fn test_new_column_major() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.push(i).unwrap();
+            builder.append(i).unwrap();
         }
         let buf = builder.finish();
         let tensor = Int32Tensor::new_column_major(buf, Some(vec![2, 8]), None);
@@ -330,7 +330,7 @@ mod tests {
     fn test_with_names() {
         let mut builder = Int64BufferBuilder::new(8);
         for i in 0..8 {
-            builder.push(i).unwrap();
+            builder.append(i).unwrap();
         }
         let buf = builder.finish();
         let names = vec!["Dim 1", "Dim 2"];
@@ -351,7 +351,7 @@ mod tests {
     fn test_inconsistent_strides() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.push(i).unwrap();
+            builder.append(i).unwrap();
         }
         let buf = builder.finish();
         Int32Tensor::new(buf, Some(vec![2, 8]), Some(vec![2, 8, 1]), None);
@@ -362,7 +362,7 @@ mod tests {
     fn test_inconsistent_names() {
         let mut builder = Int32BufferBuilder::new(16);
         for i in 0..16 {
-            builder.push(i).unwrap();
+            builder.append(i).unwrap();
         }
         let buf = builder.finish();
         Int32Tensor::new(


### PR DESCRIPTION
This is to make the namings in `builder.rs` more consistent:

1. Changes `PrimitiveArrayBuilder` to `PrimitiveBuilder`, similarly for
   `ListArrayBuilder`, `BinaryArrayBuilder` and `StructArrayBuilder`.
    The `Array` seems redundant.
2. Currently we use both `push` and `append`, which is a bit confusing.
   This unifies them by using `append`.