### PR TITLE
ARROW-4200: [C++/Python] Enable conda_env_python.yml to work on Windows, simplify python/development.rst

### DIFF
--- a/ci/conda_env_python.yml
+++ b/ci/conda_env_python.yml
@@ -18,10 +18,8 @@
 cython
 cloudpickle
 hypothesis
-nomkl
 numpy
 pandas
 pytest
-rsync
 setuptools
 setuptools_scm

--- a/ci/conda_env_unix.yml
+++ b/ci/conda_env_unix.yml
@@ -18,3 +18,4 @@
 # conda package dependencies specific to Unix-like environments (Linux and macOS)
 
 autoconf
+rsync

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -47,6 +47,7 @@ fi
 
 conda create -y -q -p $CONDA_ENV_DIR \
       --file $TRAVIS_BUILD_DIR/ci/conda_env_python.yml \
+      nomkl \
       cmake \
       pip \
       numpy=1.13.1 \

--- a/docs/source/python/development.rst
+++ b/docs/source/python/development.rst
@@ -88,7 +88,7 @@ On Linux and OSX:
 
    conda activate pyarrow-dev
 
-For Windows, see the section later on this page.
+For Windows, see the `Developing on Windows`_ section below.
 
 We need to set some environment variables to let Arrow's build system know
 about our build toolchain:
@@ -305,7 +305,7 @@ First, starting from fresh clones of Apache Arrow:
         --file arrow\ci\conda_env_cpp.yml ^
         --file arrow\ci\conda_env_python.yml ^
         python=3.7
-   activate pyarrow-dev
+   conda activate pyarrow-dev
 
 Now, we build and install Arrow C++ libraries
 

--- a/docs/source/python/development.rst
+++ b/docs/source/python/development.rst
@@ -86,18 +86,9 @@ On Linux and OSX:
         --file arrow/ci/conda_env_python.yml \
         python=3.6
 
-   source activate pyarrow-dev
+   conda activate pyarrow-dev
 
-On Windows:
-
-.. code-block:: shell
-
-    conda create -y -n pyarrow-dev -c conda-forge ^
-        --file arrow\ci\conda_env_cpp.yml ^
-        --file arrow\ci\conda_env_python.yml ^
-        python=3.6
-
-   activate pyarrow-dev
+For Windows, see the section later on this page.
 
 We need to set some environment variables to let Arrow's build system know
 about our build toolchain:
@@ -310,10 +301,10 @@ First, starting from fresh clones of Apache Arrow:
 
 .. code-block:: shell
 
-   conda create -y -q -n pyarrow-dev ^
-         python=3.6 numpy six setuptools cython pandas pytest ^
-         cmake flatbuffers rapidjson boost-cpp thrift-cpp snappy zlib ^
-         gflags brotli lz4-c zstd -c conda-forge
+    conda create -y -n pyarrow-dev -c conda-forge ^
+        --file arrow\ci\conda_env_cpp.yml ^
+        --file arrow\ci\conda_env_python.yml ^
+        python=3.7
    activate pyarrow-dev
 
 Now, we build and install Arrow C++ libraries

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -21,6 +21,7 @@ FROM arrow:cpp
 ARG PYTHON_VERSION=3.6
 ADD ci/conda_env_python.yml /arrow/ci/
 RUN conda install -c conda-forge \
+        nomkl \
         --file arrow/ci/conda_env_python.yml \
         python=$PYTHON_VERSION && \
     conda clean --all


### PR DESCRIPTION
I also removed nomkl from conda_env_python.yml. It's sort of a developer decision whether or not they want to install the MKL -- we shouldn't force them to _not_ have it