### PR TITLE
ARROW-4138: [Python] Fix setuptools_scm version customization on Windows

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -500,8 +500,8 @@ def parse_git(root, **kwargs):
     subprojects, e.g. apache-arrow-js-XXX tags.
     """
     from setuptools_scm.git import parse
-    kwargs['describe_command'] = \
-        "git describe --dirty --tags --long --match 'apache-arrow-[0-9].*'"
+    kwargs['describe_command'] =\
+        'git describe --dirty --tags --long --match "apache-arrow-[0-9].*"'
     return parse(root, **kwargs)
 
 


### PR DESCRIPTION
Using single quotes for the regular expression doesn't work on Windows for some reason. Using double quotes fixes the issue