### PR TITLE
decrease R requirement to only 3.4

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
     person("Apache Arrow", email = "dev@arrow.apache.org", role = c("aut", "cph"))
   )
 Description: R Integration to 'Apache' 'Arrow'.
-Depends: R (>= 3.5)
+Depends: R (>= 3.4)
 License: Apache License (>= 2.0)
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
Hi @romainfrancois , I would like to propose decreasing the R requirement from 3.5 to 3.4. arrow should be compatible on Ubuntu 16.04, but the only way to get R 3.5 into Ubuntu 16.04 is to modify sources.list (see [here](https://askubuntu.com/questions/1031597/r-3-5-0-for-ubuntu)). The highest version of R that Ubuntu 16.04 can get from apt is 3.4. I believe there is nothing specific to R 3.5 in this package