### PR TITLE
fix R parquet

### DIFF
--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -26,7 +26,7 @@
 #'
 #' @export
 read_parquet <- function(file, as_tibble = TRUE, use_threads = TRUE, ...) {
-  tab <- shared_ptr(`arrow::Table`, read_parquet_file(f))
+  tab <- shared_ptr(`arrow::Table`, read_parquet_file(file))
   if (isTRUE(as_tibble)) {
     tab <- as_tibble(tab, use_threads = use_threads)
   }


### PR DESCRIPTION
Hi @romainfrancois , this is a one line fix to `read_parquet`. We accidentally left filename as `f`, when it should be `file`