### PR TITLE
ARROW-4234: [C++] Improve memory bandwidth test

### DIFF
--- a/cpp/src/arrow/io/memory-benchmark.cc
+++ b/cpp/src/arrow/io/memory-benchmark.cc
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
 #include <immintrin.h>
+#endif
+
 #include <iostream>
 
 #include "arrow/api.h"
@@ -86,7 +91,7 @@ BENCHMARK_TEMPLATE(MemoryBandwidth, Write)->ThreadRange(1, kNumCores)->UseRealTi
 BENCHMARK_TEMPLATE(MemoryBandwidth, ReadWrite)->ThreadRange(1, kNumCores)->UseRealTime();
 
 static void ParallelMemoryCopy(benchmark::State& state) {  // NOLINT non-const reference
-  const size_t n_threads = state.range(0);
+  const int n_threads = state.range(0);
   const int64_t buffer_size = kMemoryPerCore;
 
   std::shared_ptr<Buffer> src, dst;
@@ -102,7 +107,7 @@ static void ParallelMemoryCopy(benchmark::State& state) {  // NOLINT non-const r
   }
 
   state.SetBytesProcessed(int64_t(state.iterations()) * buffer_size);
-  state.counters["threads"] = n_threads;
+  state.counters["threads"] = static_cast<double>(n_threads);
 }
 
 BENCHMARK(ParallelMemoryCopy)->RangeMultiplier(2)->Range(1, kNumCores)->UseRealTime();

--- a/cpp/src/arrow/io/memory-benchmark.cc
+++ b/cpp/src/arrow/io/memory-benchmark.cc
@@ -91,7 +91,7 @@ BENCHMARK_TEMPLATE(MemoryBandwidth, Write)->ThreadRange(1, kNumCores)->UseRealTi
 BENCHMARK_TEMPLATE(MemoryBandwidth, ReadWrite)->ThreadRange(1, kNumCores)->UseRealTime();
 
 static void ParallelMemoryCopy(benchmark::State& state) {  // NOLINT non-const reference
-  const int n_threads = state.range(0);
+  const int64_t n_threads = state.range(0);
   const int64_t buffer_size = kMemoryPerCore;
 
   std::shared_ptr<Buffer> src, dst;

--- a/cpp/src/arrow/io/memory-benchmark.cc
+++ b/cpp/src/arrow/io/memory-benchmark.cc
@@ -102,7 +102,7 @@ static void ParallelMemoryCopy(benchmark::State& state) {  // NOLINT non-const r
 
   while (state.KeepRunning()) {
     io::FixedSizeBufferWriter writer(dst);
-    writer.set_memcopy_threads(n_threads);
+    writer.set_memcopy_threads(static_cast<int>(n_threads));
     ABORT_NOT_OK(writer.Write(src->data(), src->size()));
   }
 


### PR DESCRIPTION
- Kept the existing memcopy benchmark, but made the number of threads a benchmark variable.
- Added 3 explicit pure bandwidth tests: Read, Write, ReadWrite.
