### PR TITLE
ARROW-4257: [Release] Update release verification script to check binaries on Bintray

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -87,24 +87,56 @@ fetch_archive() {
   shasum -a 512 -c ${dist_name}.tar.gz.sha512
 }
 
-verify_binary_artifacts() {
-  # --show-progress not supported on wget < 1.16
-  wget --help | grep -q '\--show-progress' && \
-      _WGET_PROGRESS_OPT="-q --show-progress" || _WGET_PROGRESS_OPT=""
+bintray() {
+  local command=$1
+  shift
+  local path=$1
+  shift
+  local url=https://bintray.com/api/v1${path}
+  echo "${command} ${url}" 1>&2
+  curl \
+    --fail \
+    --basic \
+    --user "${BINTRAY_USER}:${BINTRAY_PASSWORD}" \
+    --header "Content-Type: application/json" \
+    --request ${command} \
+    ${url} \
+    "$@" | \
+      jq .
+}
 
-  # download the binaries folder for the current RC
-  rcname=apache-arrow-${VERSION}-rc${RC_NUMBER}
-  wget -P "$rcname" \
-    --quiet \
-    --no-host-directories \
-    --cut-dirs=5 \
-    $_WGET_PROGRESS_OPT \
-    --no-parent \
-    --reject 'index.html*' \
-    --recursive "$ARROW_DIST_URL/$rcname/binaries/"
+download_bintray_files() {
+  local target=$1
+
+  local version_name=${VERSION}-rc${RC_NUMBER}
+
+  local files=$(
+    bintray \
+      GET /packages/${BINTRAY_REPOSITORY}/${target}-rc/versions/${version_name}/files | \
+      jq -r ".[].path")
+
+  for file in ${files}; do
+    mkdir -p "$(dirname ${file})"
+    curl \
+      --fail \
+      --location \
+      --output ${file} \
+      https://dl.bintray.com/${BINTRAY_REPOSITORY}/${file}
+  done
+}
+
+verify_binary_artifacts() {
+  local download_dir=binaries
+  mkdir -p ${download_dir}
+  pushd ${download_dir}
+
+  # takes longer on slow network
+  for target in centos debian python ubuntu; do
+    download_bintray_files ${target}
+  done
 
   # verify the signature and the checksums of each artifact
-  find $rcname/binaries -name '*.asc' | while read sigfile; do
+  find . -name '*.asc' | while read sigfile; do
     artifact=${sigfile/.asc/}
     gpg --verify $sigfile $artifact || exit 1
 
@@ -112,10 +144,14 @@ verify_binary_artifacts() {
     # basename of the artifact
     pushd $(dirname $artifact)
     base_artifact=$(basename $artifact)
-    shasum -a 256 -c $base_artifact.sha256 || exit 1
+    if [ -f $base_artifact.sha256 ]; then
+      shasum -a 256 -c $base_artifact.sha256 || exit 1
+    fi
     shasum -a 512 -c $base_artifact.sha512 || exit 1
     popd
   done
+
+  popd
 }
 
 setup_tempdir() {
@@ -343,7 +379,14 @@ if [ "$ARTIFACT" == "source" ]; then
   test_integration
   test_rust
 else
-  # takes longer on slow network
+  if [ -z "${BINTRAY_PASSWORD}" ]; then
+    echo "BINTRAY_PASSWORD is empty"
+    exit 1
+  fi
+
+  : ${BINTRAY_USER:=$USER}
+  : ${BINTRAY_REPOSITORY:=apache/arrow}
+
   verify_binary_artifacts
 fi
 


### PR DESCRIPTION
You need to set the `BINTRAY_PASSWORD` environment variable to run this.
If you use different user name with `$USER` on Bintray, you also need to set the `BINTRAY_USER` environment variable.