### PR TITLE
ARROW-4246: [Plasma][Python][Follow-up] Ensure plasma::ObjectTableEntry always has the same size regardless of whether built with CUDA support

### DIFF
--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -72,6 +72,12 @@ enum class ObjectState : int {
   PLASMA_SEALED
 };
 
+namespace internal {
+
+struct CudaIpcPlaceholder {};
+
+}  //  namespace internal
+
 /// This type is used by the Plasma store. It is here because it is exposed to
 /// the eviction policy.
 struct ObjectTableEntry {
@@ -106,10 +112,10 @@ struct ObjectTableEntry {
   unsigned char digest[kDigestSize];
 
 #ifdef PLASMA_CUDA
-  /// Put CUDA related members at the last to create Python bindings easily.
-
   /// IPC GPU handle to share with clients.
   std::shared_ptr<::arrow::cuda::CudaIpcMemHandle> ipc_handle;
+#else
+  std::shared_ptr<internal::CudaIpcPlaceholder> ipc_handle;
 #endif
 };
 

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -45,6 +45,8 @@ PLASMA_WAIT_TIMEOUT = 2 ** 30
 
 
 cdef extern from "plasma/common.h" nogil:
+    cdef cppclass CCudaIpcPlaceholder" plasma::internal::CudaIpcPlaceholder":
+        pass
 
     cdef cppclass CUniqueID" plasma::UniqueID":
 
@@ -79,6 +81,7 @@ cdef extern from "plasma/common.h" nogil:
         int64_t create_time
         int64_t construct_duration
         CObjectState state
+        shared_ptr[CCudaIpcPlaceholder] ipc_handle
 
     ctypedef unordered_map[CUniqueID, unique_ptr[CObjectTableEntry]] \
         CObjectTable" plasma::ObjectTable"


### PR DESCRIPTION
This ensures that the struct size remains constant whether `PLASMA_CUDA` is on or off. How this is handled on the Cython side will have to be done in a separate patch