### PR TITLE
WIP ARROW-4260: [Python] NumPy buffer protocol failure

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -97,7 +97,7 @@ if "%JOB%" == "Build_Debug" (
 
 conda create -n arrow -q -y ^
       python=%PYTHON% ^
-      six pytest setuptools numpy pandas cython hypothesis ^
+      --file=ci\conda_env_python.yml ^
       thrift-cpp=0.11.0 boost-cpp ^
       -c conda-forge
 

--- a/ci/conda_env_python.yml
+++ b/ci/conda_env_python.yml
@@ -18,8 +18,9 @@
 cython
 cloudpickle
 hypothesis
-numpy
+numpy=1.15.4
 pandas
 pytest
 setuptools
 setuptools_scm
+six


### PR DESCRIPTION
I'm opening this to pin NumPy at 1.15.4 (1.16.0 was released in the last 24 hours, around when the build failures started occurring) to see if it fixes the Windows builds