### PR TITLE
ARROW-4328: Add a ARROW_USE_OLD_CXXABI configure var to R

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -24,6 +24,13 @@ Then the R package:
 devtools::install_github("apache/arrow/r")
 ```
 
+If libarrow was built with the old CXXABI then you need to pass
+the ARROW_USE_OLD_CXXABI configuration variable.
+
+``` r
+devtools::install_github("apache/arrow/r", args=c("--configure-vars=ARROW_USE_OLD_CXXABI=1"))
+```
+
 ## Example
 
 ``` r

--- a/r/configure
+++ b/r/configure
@@ -71,6 +71,12 @@ CXX11FLAGS=$("${R_HOME}"/bin/R CMD config CXX11FLAGS)
 CXX11STD=$("${R_HOME}"/bin/R CMD config CXX11STD)
 CPPFLAGS=$("${R_HOME}"/bin/R CMD config CPPFLAGS)
 
+# If libarrow uses the old GLIBCXX ABI, so we have to use it too
+PKG_CXXFLAGS="$C_VISIBILITY"
+if [ "$ARROW_USE_OLD_CXXABI" ]; then
+  PKG_CXXFLAGS="$PKG_CXXFLAGS -D_GLIBCXX_USE_CXX11_ABI=0"
+fi
+
 # Test configuration
 echo "#include $PKG_TEST_HEADER" | ${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXX11FLAGS} ${CXX11STD} -xc++ - >/dev/null 2>&1
 
@@ -91,7 +97,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Write to Makevars
-sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|@visibility@|$C_VISIBILITY|" src/Makevars.in > src/Makevars
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" -e "s|@pkgcxxflags@|$PKG_CXXFLAGS|" src/Makevars.in > src/Makevars
 
 # Success
 exit 0

--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -16,7 +16,7 @@
 # under the License.
 
 PKG_CPPFLAGS=@cflags@
-PKG_CXXFLAGS=@visibility@
+PKG_CXXFLAGS=@pkgcxxflags@
 CXX_STD=CXX11
 PKG_LIBS=@libs@  -Wl,-rpath,/usr/local/lib
 #CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"


### PR DESCRIPTION
Sets GLIBCXX_USE_CXX11_ABI=0 so that the R lib will be compatible with a shared library built
with -DARROW_TENSORFLOW=ON