### PR TITLE
ARROW-4271: [Rust] Move Parquet specific info to Parquet Readme

### DIFF
--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -37,13 +37,6 @@ is developed and tested against nightly Rust.  The current status is:
 - [ ] Arrow IPC
 - [ ] Interop tests with other implementations
 
-## Dependencies
-
-Parquet support for Apache Arrow requires LLVM.  Our windows CI image
-includes LLVM but to build the libraries locally windows users will have
-to install LLVM. Follow [this](https://github.com/appveyor/ci/issues/2651)
-link for info.
-
 ## Examples
 
 The examples folder shows how to construct some different types of Arrow

--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -74,6 +74,9 @@ version is available. Then simply update version of `parquet-format` crate in Ca
 See [Working with nightly Rust](https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-nightly-rust)
 to install nightly toolchain and set it as default.
 
+Parquet requires LLVM.  Our windows CI image includes LLVM but to build the libraries locally windows
+users will have to install LLVM. Follow [this](https://github.com/appveyor/ci/issues/2651) link for info.
+
 ## Build
 Run `cargo build` or `cargo build --release` to build in release mode.
 Some features take advantage of SSE4.2 instructions, which can be


### PR DESCRIPTION
The arrow readme contains parquet specific info that was copied over from the top level readme, it should be moved to the parquet readme.