### PR TITLE
ARROW-4295: [C++] [Plasma] Fix incorrect log message

### DIFF
--- a/cpp/src/plasma/eviction_policy.cc
+++ b/cpp/src/plasma/eviction_policy.cc
@@ -85,7 +85,7 @@ bool EvictionPolicy::RequireSpace(int64_t size, std::vector<ObjectID>* objects_t
   ARROW_LOG(INFO) << "There is not enough space to create this object, so evicting "
                   << objects_to_evict->size() << " objects to free up "
                   << num_bytes_evicted << " bytes. The number of bytes in use (before "
-                  << "this eviction) is " << memory_used_ << ".";
+                  << "this eviction) is " << (memory_used_ + num_bytes_evicted) << ".";
   return num_bytes_evicted >= required_space && num_bytes_evicted > 0;
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-4295

Fixes incorrect message printed when evicting objects in plasma. 