### PR TITLE
ARROW-4296: [C++] [Plasma] Update dlmemalign call to prevent plasma store crash with -f flag

### DIFF
--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -913,7 +913,7 @@ class PlasmaStoreRunner {
     // achieve that by mallocing and freeing a single large amount of space.
     // that maximum allowed size up front.
     if (use_one_memory_mapped_file) {
-      void* pointer = plasma::dlmemalign(kBlockSize, system_memory);
+      void* pointer = plasma::dlmemalign(kBlockSize, system_memory - 8192);
       ARROW_CHECK(pointer != nullptr);
       plasma::dlfree(pointer);
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-4296

Starting Plasma with use_one_memory_mapped_file (-f flag) causes a crash, most likely due to improper memory alignment. Changing the dlmemalign call during initialization to use slightly smaller memory (by ~8KB) resolves this.