### PR TITLE
[CI] Manually patch version in java/gandiva/pom.xml pending fix for ARROW-4301

### DIFF
--- a/java/gandiva/pom.xml
+++ b/java/gandiva/pom.xml
@@ -16,7 +16,7 @@
     <parent>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-java-root</artifactId>
-      <version>0.12.0-SNAPSHOT</version>
+      <version>0.13.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.apache.arrow.gandiva</groupId>


### PR DESCRIPTION
Builds on master are failing because of ARROW-4301. This triages the problem until a proper fix can be sorted out for the future 0.13 release