### PR TITLE
ARROW-4212: [C++][Python] CudaBuffer view of arbitrary device memory object

### DIFF
--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -343,5 +343,19 @@ TEST_F(TestCudaArrowIpc, BasicWriteRead) {
   CompareBatch(*batch, *cpu_batch);
 }
 
+class TestCudaContext : public TestCudaBufferBase {
+ public:
+  void SetUp() { TestCudaBufferBase::SetUp(); }
+};
+
+TEST_F(TestCudaContext, GetDeviceAddress) {
+  const int64_t kSize = 100;
+  std::shared_ptr<CudaBuffer> buffer;
+  uint8_t* devptr = NULL;
+  ASSERT_OK(context_->Allocate(kSize, &buffer));
+  ASSERT_OK(context_->GetDeviceAddress(buffer.get()->mutable_data(), &devptr));
+  ASSERT_EQ(buffer.get()->mutable_data(), devptr);
+}
+
 }  // namespace cuda
 }  // namespace arrow

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -343,5 +343,12 @@ void* CudaContext::handle() const { return impl_->context_handle(); }
 
 int CudaContext::device_number() const { return impl_->device().device_num; }
 
+Status CudaContext::GetDeviceAddress(uintptr_t addr, uintptr_t* devaddr) {
+  ContextSaver set_temporary(reinterpret_cast<CUcontext>(handle()));
+  CU_RETURN_NOT_OK(
+      cuPointerGetAttribute(devaddr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, addr));
+  return Status::OK();
+}
+
 }  // namespace cuda
 }  // namespace arrow

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -343,10 +343,10 @@ void* CudaContext::handle() const { return impl_->context_handle(); }
 
 int CudaContext::device_number() const { return impl_->device().device_num; }
 
-Status CudaContext::GetDeviceAddress(uintptr_t addr, uintptr_t* devaddr) {
+Status CudaContext::GetDeviceAddress(uint8_t* addr, uint8_t** devaddr) {
   ContextSaver set_temporary(reinterpret_cast<CUcontext>(handle()));
-  CU_RETURN_NOT_OK(
-      cuPointerGetAttribute(devaddr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, addr));
+  CU_RETURN_NOT_OK(cuPointerGetAttribute(devaddr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER,
+                                         reinterpret_cast<CUdeviceptr>(addr)));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -119,11 +119,19 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
   /// \brief Return device number
   int device_number() const;
 
-  /// \brief Get device address for the context
-  /// \param[in] addr device address
-  /// \param[out] devaddr the device address for the context
+  /// \brief Return the device address that is reachable from kernels
+  /// running in the context
+  /// \param[in] addr memory address value
+  /// \param[out] devaddr the device address
   /// \return Status
-  Status GetDeviceAddress(uintptr_t addr, uintptr_t* devaddr);
+  ///
+  /// The device address is defined as a memory address accessible by
+  /// device. While it is often a device memory address but it can be
+  /// also a host memory address, for instance, when the memory is
+  /// allocated as host memory (using cudaMallocHost or cudaHostAlloc)
+  /// or as managed memory (using cudaMallocManaged) or the host
+  /// memory is page-locked (using cudaHostRegister).
+  Status GetDeviceAddress(uint8_t* addr, uint8_t** devaddr);
 
  private:
   CudaContext();

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -119,6 +119,12 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
   /// \brief Return device number
   int device_number() const;
 
+  /// \brief Get device address for the context
+  /// \param[in] addr device address
+  /// \param[out] devaddr the device address for the context
+  /// \return Status
+  Status GetDeviceAddress(uintptr_t addr, uintptr_t* devaddr);
+
  private:
   CudaContext();
 

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -121,12 +121,12 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
 
   /// \brief Return the device address that is reachable from kernels
   /// running in the context
-  /// \param[in] addr memory address value
+  /// \param[in] addr device or host memory address
   /// \param[out] devaddr the device address
   /// \return Status
   ///
   /// The device address is defined as a memory address accessible by
-  /// device. While it is often a device memory address but it can be
+  /// device. While it is often a device memory address, it can be
   /// also a host memory address, for instance, when the memory is
   /// allocated as host memory (using cudaMallocHost or cudaHostAlloc)
   /// or as managed memory (using cudaMallocManaged) or the host

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -19,7 +19,7 @@
 from pyarrow.compat import tobytes
 from pyarrow.lib cimport *
 from pyarrow.includes.libarrow_cuda cimport *
-from pyarrow.lib import py_buffer, allocate_buffer, as_buffer
+from pyarrow.lib import py_buffer, allocate_buffer, as_buffer, ArrowTypeError
 from pyarrow.util import get_contiguous_span
 cimport cpython as cp
 
@@ -324,12 +324,8 @@ cdef class Context:
                 desc['shape'], desc.get('strides'),
                 np.dtype(desc['typestr']).itemsize)
             return self.foreign_buffer(addr + start, end - start)
-        from numba.cuda.cudadrv.driver import MemoryPointer
-        if isinstance(obj, MemoryPointer):
-            addr = obj.device_pointer.value
-            return self.foreign_buffer(addr, obj.size)
-        raise NotImplementedError('cannot create device buffer view from'
-                                  ' `%s` object' % (type(obj)))
+        raise ArrowTypeError('cannot create device buffer view from'
+                             ' `%s` object' % (type(obj)))
 
 
 cdef class IpcMemHandle:

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -46,6 +46,7 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
         int64_t bytes_allocated() const
         const void* handle() const
         int device_number() const
+        CStatus GetDeviceAddress(uintptr_t addr, uintptr_t* devaddr)
 
     cdef cppclass CCudaIpcMemHandle" arrow::cuda::CudaIpcMemHandle":
         @staticmethod

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -46,7 +46,7 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
         int64_t bytes_allocated() const
         const void* handle() const
         int device_number() const
-        CStatus GetDeviceAddress(uintptr_t addr, uintptr_t* devaddr)
+        CStatus GetDeviceAddress(uint8_t* addr, uint8_t** devaddr)
 
     cdef cppclass CCudaIpcMemHandle" arrow::cuda::CudaIpcMemHandle":
         @staticmethod

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -60,7 +60,7 @@ def test_Context():
         cuda.Context(cuda.Context.get_num_devices())
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_manage_allocate_free_host(size):
     buf = cuda.new_host_buffer(size)
     arr = np.frombuffer(buf, dtype=np.uint8)
@@ -102,7 +102,7 @@ def make_random_buffer(size, target='host'):
     raise ValueError('invalid target value')
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_context_device_buffer(size):
     # Creating device buffer from host buffer;
     arr, buf = make_random_buffer(size)
@@ -262,7 +262,7 @@ def test_context_from_object(size):
         ctx.buffer_from_object(np.array([1, 2, 3]))
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_CudaBuffer(size):
     arr, buf = make_random_buffer(size)
     assert arr.tobytes() == buf.to_pybytes()
@@ -287,7 +287,7 @@ def test_CudaBuffer(size):
         cuda.CudaBuffer()
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_HostBuffer(size):
     arr, buf = make_random_buffer(size)
     assert arr.tobytes() == buf.to_pybytes()
@@ -313,7 +313,7 @@ def test_HostBuffer(size):
         cuda.HostBuffer()
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_copy_from_to_host(size):
 
     # Create a buffer in host containing range(size)
@@ -338,7 +338,7 @@ def test_copy_from_to_host(size):
     np.testing.assert_equal(arr, arr2)
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_copy_to_host(size):
     arr, dbuf = make_random_buffer(size, target='device')
 
@@ -398,7 +398,7 @@ def test_copy_to_host(size):
             dbuf.copy_to_host(buf=buf, position=position, nbytes=nbytes)
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_copy_from_device(size):
     arr, buf = make_random_buffer(size=size, target='device')
     lst = arr.tolist()
@@ -442,7 +442,7 @@ def test_copy_from_device(size):
             put(position=position, nbytes=nbytes)
 
 
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_copy_from_host(size):
     arr, buf = make_random_buffer(size=size, target='host')
     lst = arr.tolist()
@@ -649,7 +649,7 @@ def other_process_for_test_IPC(handle_buffer, expected_arr):
 
 @cuda_ipc
 @pytest.mark.skipif(sys.version_info[0] == 2, reason="test needs Python 3")
-@pytest.mark.parametrize("size", [0, 1, 8, 1000])
+@pytest.mark.parametrize("size", [0, 1, 1000])
 def test_IPC(size):
     import multiprocessing
     ctx = multiprocessing.get_context('spawn')

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -256,7 +256,7 @@ def test_context_from_object(size):
         ctx.buffer_from_object(pa.py_buffer(b"123"))
 
     # Trying to create a device buffer from numpy.array
-    with pytest.raises(NotImplementedError,
+    with pytest.raises(pa.ArrowTypeError,
                        match=('cannot create device buffer view from'
                               ' `<class \'numpy.ndarray\'>` object')):
         ctx.buffer_from_object(np.array([1, 2, 3]))

--- a/python/pyarrow/tests/test_cuda_numba_interop.py
+++ b/python/pyarrow/tests/test_cuda_numba_interop.py
@@ -90,12 +90,6 @@ def test_from_object(c, dtype, size):
     arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
     np.testing.assert_equal(arr, arr2)
 
-    # Creating device buffer from a device buffer
-    cbuf2 = ctx.buffer_from_object(cbuf2)
-    assert cbuf2.size == cbuf.size
-    arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
-    np.testing.assert_equal(arr, arr2)
-
     # Creating device buffer from numba DeviceNDArray:
     darr = DeviceNDArray((size,), (np.dtype(dtype).itemsize,), np.dtype(dtype),
                          gpu_data=mem)
@@ -143,25 +137,6 @@ def test_from_object(c, dtype, size):
     assert cbuf2.size == cbuf.size
     arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
     np.testing.assert_equal(arr, arr2)
-
-    # Creating device buffer from a CUDA host buffer
-    hbuf = cuda.new_host_buffer(size * arr.dtype.itemsize)
-    np.frombuffer(hbuf, dtype=dtype)[:] = arr
-    cbuf2 = ctx.buffer_from_object(hbuf)
-    assert cbuf2.size == cbuf.size
-    arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
-    np.testing.assert_equal(arr, arr2)
-
-    # Trying to create a device buffer from a Buffer
-    with pytest.raises(pa.ArrowTypeError,
-                       match=('buffer is not backed by a CudaBuffer')):
-        ctx.buffer_from_object(pa.py_buffer(b"123"))
-
-    # Trying to create a device buffer from numpy.array
-    with pytest.raises(NotImplementedError,
-                       match=('cannot create device buffer view from'
-                              ' `<class \'numpy.ndarray\'>` object')):
-        ctx.buffer_from_object(np.array([1,2,3]))
 
 
 @pytest.mark.parametrize("c", range(len(context_choice_ids)),

--- a/python/pyarrow/tests/test_cuda_numba_interop.py
+++ b/python/pyarrow/tests/test_cuda_numba_interop.py
@@ -83,19 +83,8 @@ def test_from_object(c, dtype, size):
     ctx, nb_ctx = context_choices[c]
     arr, cbuf = make_random_buffer(size, target='device', dtype=dtype, ctx=ctx)
 
-    # Creating device buffer from numba MemoryObject:
-    mem = cbuf.to_numba()
-    cbuf2 = ctx.buffer_from_object(mem)
-    assert cbuf2.size == cbuf.size
-    arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
-    np.testing.assert_equal(arr, arr2)
-
     # Creating device buffer from numba DeviceNDArray:
     darr = nb_cuda.to_device(arr)
-    darr = DeviceNDArray(size,
-                         np.dtype(dtype).itemsize,
-                         np.dtype(dtype),
-                         gpu_data=mem)
     cbuf2 = ctx.buffer_from_object(darr)
     assert cbuf2.size == cbuf.size
     arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
@@ -116,23 +105,13 @@ def test_from_object(c, dtype, size):
             arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
             np.testing.assert_equal(arr[s], arr2[s2])
 
-        # slice with negative strides
-        rdarr = darr[::-1]
-        if 1:
-            # workaround numba bug [numba issue 3705]:
-            from numba.cuda.cudadrv.driver import MemoryPointer
-            import ctypes
-            rdarr.shape = arr[::-1].shape
-            addr = (darr.__cuda_array_interface__['data'][0]
-                    + (arr[::-1].__array_interface__['data'][0]
-                       - arr.__array_interface__['data'][0]))
-            mem = MemoryPointer(nb_ctx, pointer=ctypes.c_void_p(addr),
-                                size=size)
-            rdarr.gpu_data = mem
-        cbuf2 = ctx.buffer_from_object(rdarr)
-        assert cbuf2.size == cbuf.size
-        arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
-        np.testing.assert_equal(arr, arr2)
+        # cannot test negative strides due to numba bug, see its issue 3705
+        if 0:
+            rdarr = darr[::-1]
+            cbuf2 = ctx.buffer_from_object(rdarr)
+            assert cbuf2.size == cbuf.size
+            arr2 = np.frombuffer(cbuf2.copy_to_host(), dtype=dtype)
+            np.testing.assert_equal(arr, arr2)
 
     # Creating device buffer from a 2-dimensional numba DeviceNDArray:
     if size >= 8:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -91,7 +91,7 @@ def product(seq):
 
 def get_contiguous_span(shape, strides, itemsize):
     """
-    Return a span of N-D array data.
+    Return a contiguous span of N-D array data.
 
     Parameters
     ----------
@@ -120,4 +120,6 @@ def get_contiguous_span(shape, strides, itemsize):
                 end += stride * (dim - 1)
             elif stride < 0:
                 start += stride * (dim - 1)
+        if end - start != itemsize * product(shape):
+            raise ValueError('array data is non-contiguous')
     return start, end

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -17,9 +17,9 @@
 
 # Miscellaneous utility code
 
+import functools
 import six
 import warnings
-import functools
 
 
 try:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -19,6 +19,8 @@
 
 import six
 import warnings
+import functools
+
 
 try:
     from textwrap import indent
@@ -78,3 +80,44 @@ def _stringify_path(path):
             return str(path)
 
     raise TypeError("not a path-like object")
+
+
+def product(seq):
+    """
+    Return a product of sequence items.
+    """
+    return functools.reduce(lambda a, b: a*b, seq, 1)
+
+
+def get_contiguous_span(shape, strides, itemsize):
+    """
+    Return a span of N-D array data.
+
+    Parameters
+    ----------
+    shape : tuple
+    strides : tuple
+    itemsize : int
+      Specify array shape data
+
+    Returns
+    -------
+    start, end : int
+      The span end points.
+    """
+    if not strides:
+        start = 0
+        end = itemsize * product(shape)
+    else:
+        start = 0
+        end = itemsize
+        for i, dim in enumerate(shape):
+            if dim == 0:
+                start = end = 0
+                break
+            stride = strides[i]
+            if stride > 0:
+                end += stride * (dim - 1)
+            elif stride < 0:
+                start += stride * (dim - 1)
+    return start, end


### PR DESCRIPTION
This PR implements the following new features:
1. `CudaContext::GetDeviceAddress` method
2. `pyarrow.cuda.Context.get_device_address` method
3. `pyarrow.cuda.Context.buffer_from_object` method to create a CudaBuffer view of arbitrary device memory object that implements `__cuda_array_interface__` attribute or that is `CudaBuffer` or `CudaHostBuffer` or numba `MemoryPointer` object.
4. Tests for `buffer_from_object` method

and the following improvements:
1. `pyarrow.cuda.Context.foreign_buffer` ensures that the used device memory address is valid for the given context.
