### PR TITLE
ARROW-4299: [Ruby] Depend on the same version as Red Arrow

### DIFF
--- a/ruby/red-arrow-cuda/red-arrow-cuda.gemspec
+++ b/ruby/red-arrow-cuda/red-arrow-cuda.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
   spec.extensions = ["dependency-check/Rakefile"]
 
-  spec.add_runtime_dependency("red-arrow")
+  spec.add_runtime_dependency("red-arrow", "= #{spec.version}")
 
   spec.add_development_dependency("bundler")
   spec.add_development_dependency("rake")

--- a/ruby/red-gandiva/red-gandiva.gemspec
+++ b/ruby/red-gandiva/red-gandiva.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
   spec.extensions = ["dependency-check/Rakefile"]
 
-  spec.add_runtime_dependency("red-arrow")
+  spec.add_runtime_dependency("red-arrow", "= #{spec.version}")
 
   spec.add_development_dependency("bundler")
   spec.add_development_dependency("rake")

--- a/ruby/red-parquet/red-parquet.gemspec
+++ b/ruby/red-parquet/red-parquet.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
   spec.extensions = ["dependency-check/Rakefile"]
 
-  spec.add_runtime_dependency("red-arrow")
+  spec.add_runtime_dependency("red-arrow", "= #{spec.version}")
 
   spec.add_development_dependency("bundler")
   spec.add_development_dependency("rake")

--- a/ruby/red-plasma/red-plasma.gemspec
+++ b/ruby/red-plasma/red-plasma.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.test_files += Dir.glob("test/**/*")
   spec.extensions = ["dependency-check/Rakefile"]
 
-  spec.add_runtime_dependency("red-arrow")
+  spec.add_runtime_dependency("red-arrow", "= #{spec.version}")
 
   spec.add_development_dependency("bundler")
   spec.add_development_dependency("rake")


### PR DESCRIPTION
Because Red Arrow CUDA, Red Plasma, Red Gandiva and Red Parquet don't work well without the same Red Arrow version.