### PR TITLE
ARROW-4307: [C++] Fix Doxygen warnings

### DIFF
--- a/cpp/apidoc/Doxyfile
+++ b/cpp/apidoc/Doxyfile
@@ -518,7 +518,7 @@ HIDE_UNDOC_CLASSES     = NO
 # included in the documentation.
 # The default value is: NO.
 
-HIDE_FRIEND_COMPOUNDS  = NO
+HIDE_FRIEND_COMPOUNDS  = YES
 
 # If the HIDE_IN_BODY_DOCS tag is set to YES, doxygen will hide any
 # documentation blocks found inside the body of a function. If set to NO, these
@@ -779,7 +779,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -858,7 +858,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE =
+EXCLUDE                = ../src/arrow/vendored
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -2075,7 +2075,8 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED = __attribute__(x)= \
              __declspec(x)= \
              ARROW_EXPORT= \
-             ARROW_EXTERN_TEMPLATE=
+             ARROW_EXTERN_TEMPLATE= \
+             ARROW_DEPRECATED(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/cpp/apidoc/index.md
+++ b/cpp/apidoc/index.md
@@ -38,6 +38,5 @@ Table of Contents
  * Instructions on how to build Arrow C++ on [Windows](Windows.md)
  * How to access [HDFS](HDFS.md)
  * Tutorials
-   * [Convert a vector of row-wise data into an Arrow table](tutorials/row_wise_conversion.md)
    * [Using the Plasma In-Memory Object Store](tutorials/plasma.md)
    * [Use Plasma to Access Tensors from C++ in Python](tutorials/tensor_to_py.md)

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -109,7 +109,7 @@ if ("${UPPERCASE_BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
 -Wno-shadow -Wno-switch-enum -Wno-exit-time-destructors \
 -Wno-global-constructors -Wno-weak-template-vtables -Wno-undefined-reinterpret-cast \
 -Wno-implicit-fallthrough -Wno-unreachable-code-return \
--Wno-float-equal -Wno-missing-prototypes \
+-Wno-float-equal -Wno-missing-prototypes -Wno-documentation-unknown-command \
 -Wno-old-style-cast -Wno-covered-switch-default \
 -Wno-cast-align -Wno-vla-extension -Wno-shift-sign-overflow \
 -Wno-used-but-marked-unused -Wno-missing-variable-declarations \

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -263,10 +263,11 @@ class ARROW_EXPORT ResizableBuffer : public MutableBuffer {
   /// Change buffer reported size to indicated size, allocating memory if
   /// necessary.  This will ensure that the capacity of the buffer is a multiple
   /// of 64 bytes as defined in Layout.md.
-  /// Consider using ZeroPadding afterwards, in case you return buffer to a reader.
+  /// Consider using ZeroPadding afterwards, to conform to the Arrow layout
+  /// specification.
   ///
-  /// @param shrink_to_fit On deactivating this option, the capacity of the Buffer won't
-  /// decrease.
+  /// @param new_size The new size for the buffer.
+  /// @param shrink_to_fit Whether to shrink the capacity if new size < current size
   virtual Status Resize(const int64_t new_size, bool shrink_to_fit = true) = 0;
 
   /// Ensure that buffer has enough memory allocated to fit the indicated

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -87,7 +87,7 @@ class ARROW_EXPORT FlightClient {
   /// \brief Given a flight ticket and schema, request to be sent the
   /// stream. Returns record batch stream reader
   /// \param[in] ticket
-  /// \param[in] schema the arrow::Schema for the stream as computed by
+  /// \param[in] schema the schema of the stream data as computed by
   /// GetFlightInfo
   /// \param[out] stream the returned RecordBatchReader
   /// \return Status
@@ -96,6 +96,7 @@ class ARROW_EXPORT FlightClient {
 
   /// \brief Initiate DoPut RPC, returns FlightPutWriter interface to
   /// write. Not yet implemented
+  /// \param[in] schema the schema of the stream data
   /// \param[out] stream the created stream to write record batches to
   /// \return Status
   Status DoPut(const Schema& schema, std::unique_ptr<FlightPutWriter>* stream);

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -115,7 +115,7 @@ class ARROW_EXPORT FlightServerBase {
                                std::unique_ptr<FlightInfo>* info);
 
   /// \brief Get a stream of IPC payloads to put on the wire
-  /// \param[in] ticket an opaque ticket
+  /// \param[in] request an opaque ticket
   /// \param[out] stream the returned stream provider
   /// \return Status
   virtual Status DoGet(const Ticket& request, std::unique_ptr<FlightDataStream>* stream);

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -135,7 +135,10 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
   friend CudaBuffer;
   friend CudaBufferReader;
   friend CudaBufferWriter;
+  /// \cond FALSE
+  // (note: emits warning on Doxygen < 1.8.15)
   friend CudaDeviceManager::CudaDeviceManagerImpl;
+  /// \endcond
 };
 
 }  // namespace cuda

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -57,7 +57,9 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
                            std::shared_ptr<CudaBuffer>* out);
 
   /// \brief Copy memory from GPU device to CPU host
-  /// \param[out] out a pre-allocated output buffer
+  /// \param[in] position start position inside buffer to copy bytes from
+  /// \param[in] nbytes number of bytes to copy
+  /// \param[out] out start address of the host memory area to copy to
   /// \return Status
   Status CopyToHost(const int64_t position, const int64_t nbytes, void* out) const;
 
@@ -69,8 +71,8 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   Status CopyFromHost(const int64_t position, const void* data, int64_t nbytes);
 
   /// \brief Copy memory from device to device at position
-  /// \param[in] position start position to copy bytes
-  /// \param[in] data the device data to copy
+  /// \param[in] position start position inside buffer to copy bytes to
+  /// \param[in] data start address of the device memory area to copy from
   /// \param[in] nbytes number of bytes to copy
   /// \return Status
   ///

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -130,18 +130,18 @@ class ARROW_EXPORT Status {
   Status(StatusCode code, const std::string& msg);
 
   // Copy the specified status.
-  Status(const Status& s);
-  Status& operator=(const Status& s);
+  inline Status(const Status& s);
+  inline Status& operator=(const Status& s);
 
   // Move the specified status.
   inline Status(Status&& s) noexcept;
-  Status& operator=(Status&& s) noexcept;
+  inline Status& operator=(Status&& s) noexcept;
 
   // AND the statuses.
-  Status operator&(const Status& s) const noexcept;
-  Status operator&(Status&& s) const noexcept;
-  Status& operator&=(const Status& s) noexcept;
-  Status& operator&=(Status&& s) noexcept;
+  inline Status operator&(const Status& s) const noexcept;
+  inline Status operator&(Status&& s) const noexcept;
+  inline Status& operator&=(const Status& s) noexcept;
+  inline Status& operator&=(Status&& s) noexcept;
 
   /// Return a success status
   static Status OK() { return Status(); }
@@ -339,7 +339,7 @@ class ARROW_EXPORT Status {
     state_ = NULL;
   }
   void CopyFrom(const Status& s);
-  void MoveFrom(Status& s);
+  inline void MoveFrom(Status& s);
 };
 
 static inline std::ostream& operator<<(std::ostream& os, const Status& x) {
@@ -347,16 +347,16 @@ static inline std::ostream& operator<<(std::ostream& os, const Status& x) {
   return os;
 }
 
-inline void Status::MoveFrom(Status& s) {
+void Status::MoveFrom(Status& s) {
   delete state_;
   state_ = s.state_;
   s.state_ = NULL;
 }
 
-inline Status::Status(const Status& s)
+Status::Status(const Status& s)
     : state_((s.state_ == NULL) ? NULL : new State(*s.state_)) {}
 
-inline Status& Status::operator=(const Status& s) {
+Status& Status::operator=(const Status& s) {
   // The following condition catches both aliasing (when this == &s),
   // and the common case where both s and *this are ok.
   if (state_ != s.state_) {
@@ -365,14 +365,17 @@ inline Status& Status::operator=(const Status& s) {
   return *this;
 }
 
-inline Status::Status(Status&& s) noexcept : state_(s.state_) { s.state_ = NULL; }
+Status::Status(Status&& s) noexcept : state_(s.state_) { s.state_ = NULL; }
 
-inline Status& Status::operator=(Status&& s) noexcept {
+Status& Status::operator=(Status&& s) noexcept {
   MoveFrom(s);
   return *this;
 }
 
-inline Status Status::operator&(const Status& s) const noexcept {
+/// \cond FALSE
+// (note: emits warnings on Doxygen < 1.8.15,
+//  see https://github.com/doxygen/doxygen/issues/6295)
+Status Status::operator&(const Status& s) const noexcept {
   if (ok()) {
     return s;
   } else {
@@ -380,7 +383,7 @@ inline Status Status::operator&(const Status& s) const noexcept {
   }
 }
 
-inline Status Status::operator&(Status&& s) const noexcept {
+Status Status::operator&(Status&& s) const noexcept {
   if (ok()) {
     return std::move(s);
   } else {
@@ -388,19 +391,20 @@ inline Status Status::operator&(Status&& s) const noexcept {
   }
 }
 
-inline Status& Status::operator&=(const Status& s) noexcept {
+Status& Status::operator&=(const Status& s) noexcept {
   if (ok() && !s.ok()) {
     CopyFrom(s);
   }
   return *this;
 }
 
-inline Status& Status::operator&=(Status&& s) noexcept {
+Status& Status::operator&=(Status&& s) noexcept {
   if (ok() && !s.ok()) {
     MoveFrom(s);
   }
   return *this;
 }
+/// \endcond
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -42,14 +42,14 @@ namespace arrow {
 /// Adapted from the Apache ORC C++ implementation
 class ARROW_EXPORT Decimal128 {
  public:
-  /// \brief Create an Decimal128 from the two's complement representation.
+  /// \brief Create a Decimal128 from the two's complement representation.
   constexpr Decimal128(int64_t high, uint64_t low) noexcept
       : low_bits_(low), high_bits_(high) {}
 
-  /// \brief Empty constructor creates an Decimal128 with a value of 0.
+  /// \brief Empty constructor creates a Decimal128 with a value of 0.
   constexpr Decimal128() noexcept : Decimal128(0, 0) {}
 
-  /// \brief Convert any integer value into an Decimal128.
+  /// \brief Convert any integer value into a Decimal128.
   template <typename T,
             typename = typename std::enable_if<std::is_integral<T>::value, T>::type>
   constexpr Decimal128(T value) noexcept
@@ -59,14 +59,14 @@ class ARROW_EXPORT Decimal128 {
   /// \brief Parse the number from a base 10 string representation.
   explicit Decimal128(const std::string& value);
 
-  /// \brief Create an Decimal128 from an array of bytes. Bytes are assumed to be in
-  /// little endian byte order.
+  /// \brief Create a Decimal128 from an array of bytes. Bytes are assumed to be in
+  /// little-endian byte order.
   explicit Decimal128(const uint8_t* bytes);
 
-  /// \brief Negate the current value
+  /// \brief Negate the current value (in-place)
   Decimal128& Negate();
 
-  /// \brief Absolute value
+  /// \brief Absolute value (in-place)
   Decimal128& Abs();
 
   /// \brief Add a number to this one. The result is truncated to 128 bits.
@@ -78,25 +78,27 @@ class ARROW_EXPORT Decimal128 {
   /// \brief Multiply this number by another number. The result is truncated to 128 bits.
   Decimal128& operator*=(const Decimal128& right);
 
-  /// Divide this number by right and return the result. This operation is
-  /// not destructive.
+  /// Divide this number by right and return the result.
+  ///
+  /// This operation is not destructive.
   /// The answer rounds to zero. Signs work like:
   ///   21 /  5 ->  4,  1
   ///  -21 /  5 -> -4, -1
   ///   21 / -5 -> -4,  1
   ///  -21 / -5 ->  4, -1
-  /// \param divisor the number to divide by
-  /// \param remainder the remainder after the division
+  /// \param[in] divisor the number to divide by
+  /// \param[out] result the quotient
+  /// \param[out] remainder the remainder after the division
   Status Divide(const Decimal128& divisor, Decimal128* result,
                 Decimal128* remainder) const;
 
   /// \brief In-place division.
   Decimal128& operator/=(const Decimal128& right);
 
-  /// \brief Bitwise or between two Decimal128.
+  /// \brief Bitwise "or" between two Decimal128.
   Decimal128& operator|=(const Decimal128& right);
 
-  /// \brief Bitwise and between two Decimal128.
+  /// \brief Bitwise "and" between two Decimal128.
   Decimal128& operator&=(const Decimal128& right);
 
   /// \brief Shift left by the given number of bits.
@@ -125,7 +127,7 @@ class ARROW_EXPORT Decimal128 {
   /// \brief Cast this value to an int64_t.
   explicit operator int64_t() const;
 
-  /// \brief Convert a decimal string to an Decimal128 value, optionally including
+  /// \brief Convert a decimal string to a Decimal128 value, optionally including
   /// precision and scale if they're passed in and not null.
   static Status FromString(const std::string& s, Decimal128* out,
                            int32_t* precision = NULLPTR, int32_t* scale = NULLPTR);
@@ -134,8 +136,8 @@ class ARROW_EXPORT Decimal128 {
   static Status FromString(const char* s, Decimal128* out, int32_t* precision = NULLPTR,
                            int32_t* scale = NULLPTR);
 
-  /// \brief Convert from a big endian byte representation. The length must be
-  ///        between 1 and 16
+  /// \brief Convert from a big-endian byte representation. The length must be
+  ///        between 1 and 16.
   /// \return error status if the length is an invalid value
   static Status FromBigEndian(const uint8_t* data, int32_t length, Decimal128* out);
 

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -47,9 +47,10 @@ class Engine {
   LLVMTypes* types() { return types_.get(); }
   llvm::Module* module() { return module_; }
 
-  /// factory method to create and initialize the engine object.
+  /// Factory method to create and initialize the engine object.
   ///
-  /// \param[out] engine the created engine.
+  /// \param[in] config the engine configuration
+  /// \param[out] engine the created engine
   static Status Make(std::shared_ptr<Configuration> config,
                      std::unique_ptr<Engine>* engine);
 

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -99,7 +99,8 @@ class PARQUET_EXPORT BloomFilter {
 
   /// Compute hash for fixed byte array value by using its plain encoding result.
   ///
-  /// @param value the value to hash.
+  /// @param value the value address.
+  /// @param len the value length.
   /// @return hash result.
   virtual uint64_t Hash(const FLBA* value, uint32_t len) const = 0;
 
@@ -186,6 +187,7 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   void InsertHash(uint64_t hash) override;
   void WriteTo(OutputStream* sink) const override;
   uint32_t GetBitsetSize() const override { return num_bytes_; }
+
   uint64_t Hash(int64_t value) const override { return hasher_->Hash(value); }
   uint64_t Hash(float value) const override { return hasher_->Hash(value); }
   uint64_t Hash(double value) const override { return hasher_->Hash(value); }
@@ -195,6 +197,7 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   uint64_t Hash(const FLBA* value, uint32_t len) const override {
     return hasher_->Hash(value, len);
   }
+
   /// Deserialize the Bloom filter from an input stream. It is used when reconstructing
   /// a Bloom filter from a parquet filter.
   ///

--- a/cpp/src/parquet/hasher.h
+++ b/cpp/src/parquet/hasher.h
@@ -63,8 +63,8 @@ class Hasher {
 
   /// Compute hash for fixed byte array value by using its plain encoding result.
   ///
-  /// @param value the value to hash.
-  /// @return hash result.
+  /// @param value the value address.
+  /// @param len the value length.
   virtual uint64_t Hash(const FLBA* value, uint32_t len) const = 0;
 
   virtual ~Hasher() = default;

--- a/docs/source/cpp/api/cuda.rst
+++ b/docs/source/cpp/api/cuda.rst
@@ -1,0 +1,69 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+============
+CUDA support
+============
+
+CUDA Contexts
+=============
+
+.. doxygenclass:: arrow::cuda::CudaDeviceManager
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::cuda::CudaContext
+   :project: arrow_cpp
+   :members:
+
+Device and Host Buffers
+=======================
+
+.. doxygenclass:: arrow::cuda::CudaBuffer
+   :project: arrow_cpp
+   :members:
+
+.. doxygenfunction:: arrow::cuda::AllocateCudaHostBuffer
+   :project: arrow_cpp
+
+.. doxygenclass:: arrow::cuda::CudaHostBuffer
+   :project: arrow_cpp
+   :members:
+
+Device Memory Input / Output
+============================
+
+.. doxygenclass:: arrow::cuda::CudaBufferReader
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::cuda::CudaBufferWriter
+   :project: arrow_cpp
+   :members:
+
+CUDA IPC
+========
+
+.. doxygenclass:: arrow::cuda::CudaIpcMemHandle
+   :project: arrow_cpp
+   :members:
+
+.. doxygenfunction:: arrow::cuda::SerializeRecordBatch
+   :project: arrow_cpp
+
+.. doxygenfunction:: arrow::cuda::ReadRecordBatch
+   :project: arrow_cpp

--- a/docs/source/cpp/api/utilities.rst
+++ b/docs/source/cpp/api/utilities.rst
@@ -15,18 +15,13 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-*************
-API Reference
-*************
+=========
+Utilities
+=========
 
-.. toctree::
-   :maxdepth: 3
+Decimal Numbers
+===============
 
-   api/support
-   api/memory
-   api/datatype
-   api/array
-   api/builder
-   api/table
-   api/utilities
-   api/cuda
+.. doxygenclass:: arrow::Decimal128
+   :project: arrow_cpp
+   :members:


### PR DESCRIPTION
Also document a few more C++ classes, and turn Doxygen warnings into errors.