### PR TITLE
ARROW-4319: [C++] [Plasma] plasma/store.h pulls in flatbuffer dependency

### DIFF
--- a/cpp/src/plasma/plasma.cc
+++ b/cpp/src/plasma/plasma.cc
@@ -22,6 +22,7 @@
 #include <unistd.h>
 
 #include "plasma/common.h"
+#include "plasma/common_generated.h"
 #include "plasma/protocol.h"
 
 namespace fb = plasma::flatbuf;

--- a/cpp/src/plasma/plasma.h
+++ b/cpp/src/plasma/plasma.h
@@ -38,13 +38,16 @@
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "plasma/common.h"
-#include "plasma/common_generated.h"
 
 #ifdef PLASMA_CUDA
 using arrow::cuda::CudaIpcMemHandle;
 #endif
 
 namespace plasma {
+
+namespace flatbuf {
+struct ObjectInfoT;
+}  // namespace flatbuf
 
 #define HANDLE_SIGPIPE(s, fd_)                                              \
   do {                                                                      \

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -52,11 +52,14 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/status.h"
+
 #include "plasma/common.h"
 #include "plasma/common_generated.h"
 #include "plasma/fling.h"
 #include "plasma/io.h"
 #include "plasma/malloc.h"
+#include "plasma/protocol.h"
 
 #ifdef PLASMA_CUDA
 #include "arrow/gpu/cuda_api.h"

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -29,9 +29,17 @@
 #include "plasma/events.h"
 #include "plasma/eviction_policy.h"
 #include "plasma/plasma.h"
-#include "plasma/protocol.h"
+
+namespace arrow {
+class Status;
+}  // namespace arrow
 
 namespace plasma {
+
+namespace flatbuf {
+struct ObjectInfoT;
+enum class PlasmaError;
+}  // namespace flatbuf
 
 using flatbuf::ObjectInfoT;
 using flatbuf::PlasmaError;
@@ -176,7 +184,7 @@ class PlasmaStore {
 
   NotificationMap::iterator SendNotifications(NotificationMap::iterator it);
 
-  Status ProcessMessage(Client* client);
+  arrow::Status ProcessMessage(Client* client);
 
  private:
   void PushNotification(ObjectInfoT* object_notification);


### PR DESCRIPTION
The plasma store header leaked the flatbuffer dependency. This PR fixes this by moving the corresponding header to the implementation.