### PR TITLE
ARROW-4323: [Packaging] Fix failing OSX clang conda forge builds

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -33,10 +33,6 @@ set(PLASMA_FULL_SO_VERSION "${ARROW_FULL_SO_VERSION}")
 
 include_directories("${FLATBUFFERS_INCLUDE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/" "${CMAKE_CURRENT_LIST_DIR}/thirdparty/" "${CMAKE_CURRENT_LIST_DIR}/../")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=200809L")
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-conversion")
-
 # Compile flatbuffers
 
 set(PLASMA_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/plasma.fbs" "${CMAKE_CURRENT_LIST_DIR}/format/common.fbs")

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -33,6 +33,8 @@ set(PLASMA_FULL_SO_VERSION "${ARROW_FULL_SO_VERSION}")
 
 include_directories("${FLATBUFFERS_INCLUDE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/" "${CMAKE_CURRENT_LIST_DIR}/thirdparty/" "${CMAKE_CURRENT_LIST_DIR}/../")
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-conversion")
+
 # Compile flatbuffers
 
 set(PLASMA_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/plasma.fbs" "${CMAKE_CURRENT_LIST_DIR}/format/common.fbs")

--- a/dev/tasks/conda-recipes/appveyor.yml
+++ b/dev/tasks/conda-recipes/appveyor.yml
@@ -36,7 +36,7 @@ install:
   - cmd: set PYTHONUNBUFFERED=1
 
   # Configure the VM.
-  - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2
+  - cmd: conda.exe install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
 
 # Skip .NET project specific build phase.
 build: off

--- a/dev/tasks/conda-recipes/arrow-cpp/build.sh
+++ b/dev/tasks/conda-recipes/arrow-cpp/build.sh
@@ -40,7 +40,9 @@ cmake \
     -DARROW_PYTHON=ON \
     -DARROW_PARQUET=ON \
     -DARROW_ORC=ON \
+    -DCMAKE_AR=${AR} \
+    -DCMAKE_RANLIB=${RANLIB} \
+    -GNinja \
     ..
 
-make -j${CPU_COUNT}
-make install
+ninja install

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   build:
     - cmake
     - autoconf  # [unix]
+    - ninja
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:

--- a/dev/tasks/conda-recipes/travis.linux.yml
+++ b/dev/tasks/conda-recipes/travis.linux.yml
@@ -44,7 +44,7 @@ install:
     echo ""
     echo "Configuring conda."
     source /home/travis/miniconda3/bin/activate root
-    conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2
+    conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
 
 before_script:
   - git clone -b {{ arrow.branch }} {{ arrow.remote }} arrow

--- a/dev/tasks/conda-recipes/travis.osx.yml
+++ b/dev/tasks/conda-recipes/travis.osx.yml
@@ -52,8 +52,7 @@ install:
     echo ""
     echo "Configuring conda."
     source /Users/travis/miniconda3/bin/activate root
-
-    conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2
+    conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
 
 
 before_script:
@@ -63,12 +62,19 @@ before_script:
 
   # Configure conda
   - setup_conda_rc ./ ./ variants/{{ config }}.yaml
-  - source run_conda_forge_build_setup
+
+  # XXX: workaround, see run_conda_forge_build_setup_osx#L33
+  - mkdir -p ./.ci_support
+  - cp variants/{{ config }}.yaml ./.ci_support/{{ config }}.yaml
+  - CONFIG={{ config }} source run_conda_forge_build_setup
+
+  # Compiler cleanup
+  - mangle_compiler ./ ./ ./.ci_support/{{ config }}.yaml
 
 script:
   - |
     conda build --output-folder . \
-                -m variants/{{ config }}.yaml \
+                -m ./.ci_support/{{ config }}.yaml \
                 parquet-cpp arrow-cpp pyarrow
 
 deploy:


### PR DESCRIPTION
@xhochy I've managed to fix the xcode errors, now it's failing with the `mach_port_t` compile error.

Does your [patch](https://github.com/conda-forge/arrow-cpp-feedstock/pull/72/commits/81ef94ad9041e28e417c03cc6bab1bd0a0ee9a21) work?