### PR TITLE
ARROW-4298: [Java] Add javax.annotation-api dependency for JDK >= 9

### DIFF
--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -103,6 +103,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+     </dependency>
   </dependencies>
   <build>
     <extensions>
@@ -214,7 +218,7 @@
               <goal>analyze-only</goal>
             </goals>
             <configuration>
-              <ignoredDependencies combine.self="append">
+              <ignoredDependencies combine.children="append">
                 <ignoredDependency>io.netty:netty-tcnative-boringssl-static:*</ignoredDependency>
               </ignoredDependencies>
             </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -334,6 +334,10 @@
             <configuration>
               <ignoreNonCompile>true</ignoreNonCompile>
               <failOnWarning>true</failOnWarning>
+              <ignoredDependencies>
+                <!-- source annotations (not kept in compiled code) -->
+                <ignoredDependency>javax.annotation:javax.annotation-api:*</ignoredDependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>
@@ -529,6 +533,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${dep.slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
JDK9 and onwards removed/renamed @Generated annotation used by code
generation tool like grpc, causing build failures.

Adding javax.annotation-api dependency as a substitute and exclude it
from the dependency check as only used at compilation time but not
preserved at runtime.