### PR TITLE
ARROW-4353: [CI] Add MinGW builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ only_commits:
   # Skip commits not related to Python, C++ or Rust
   files:
     - appveyor.yml
+    - c_glib/
     - ci/
     - cpp/
     - format/
@@ -34,6 +35,14 @@ cache:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    # Can't build with 32-bit MinGW for now.
+    # See https://issues.apache.org/jira/browse/ARROW-4297
+    - JOB: "MinGW32"
+      MINGW_PACKAGE_PREFIX: mingw-w64-i686
+      MINGW_PREFIX: c:\msys64\mingw32
+      MSYSTEM: MINGW32
+      USE_CLCACHE: false
 
 environment:
   global:
@@ -60,13 +69,21 @@ environment:
       GENERATOR: Ninja
       CONFIGURATION: "Release"
       BUILD_SCRIPT: "CMake_Build_Script"
+    - JOB: "MinGW32"
+      MINGW_PACKAGE_PREFIX: mingw-w64-i686
+      MINGW_PREFIX: c:\msys64\mingw32
+      MSYSTEM: MINGW32
+      USE_CLCACHE: false
+    - JOB: "MinGW64"
+      MINGW_PACKAGE_PREFIX: mingw-w64-x86_64
+      MINGW_PREFIX: c:\msys64\mingw64
+      MSYSTEM: MINGW64
+      USE_CLCACHE: false
     - JOB: "Rust"
       TARGET: x86_64-pc-windows-msvc
       USE_CLCACHE: false
 
   MSVC_DEFAULT_OPTIONS: ON
-  BOOST_ROOT: C:\Libraries\boost_1_67_0
-  BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.0
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 install:

--- a/ci/appveyor-build.bat
+++ b/ci/appveyor-build.bat
@@ -22,7 +22,9 @@ if "%JOB%" == "Rust" (
 ) else (
     git config core.symlinks true
     git reset --hard
-    if "%JOB%"=="Cmake_Script_Tests" (
+    if "%JOB:~,5%" == "MinGW" (
+        call ci\appveyor-cpp-build-mingw.bat
+    ) else if "%JOB%" == "Cmake_Script_Tests" (
         call ci\appveyor-cpp-test-cmake-script.bat
     ) else (
         call ci\appveyor-cpp-build.bat

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -1,0 +1,61 @@
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem   http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+
+@echo on
+
+set CMAKE_BUILD_TYPE=release
+set MESON_BUILD_TYPE=release
+
+set INSTALL_DIR=%HOMEDRIVE%%HOMEPATH%\install
+set PATH=%INSTALL_DIR%\bin;%PATH%
+set PKG_CONFIG_PATH=%INSTALL_DIR%\lib\pkgconfig
+
+set CPP_BUILD_DIR=cpp\build
+mkdir %CPP_BUILD_DIR%
+pushd %CPP_BUILD_DIR%
+
+set BOOST_ROOT=%MINGW_PREFIX%
+set LZ4_HOME=%MINGW_PREFIX%
+set ZSTD_HOME=%MINGW_PREFIX%
+set SNAPPY_HOME=%MINGW_PREFIX%
+set BROTLI_HOME=%MINGW_PREFIX%
+set FLATBUFFERS_HOME=%MINGW_PREFIX%
+cmake ^
+    -G "MSYS Makefiles" ^
+    -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ^
+    -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
+    -DARROW_VERBOSE_THIRDPARTY_BUILD=OFF ^
+    -DARROW_JEMALLOC=OFF ^
+    -DARROW_USE_GLOG=OFF ^
+    -DARROW_PYTHON=ON ^
+    -DPythonInterp_FIND_VERSION=ON ^
+    -DPythonInterp_FIND_VERSION_MAJOR=3 ^
+    .. || exit /B
+make -j4 || exit /B
+make install || exit /B
+popd
+
+set C_GLIB_BUILD_DIR=c_glib\build
+meson ^
+    setup ^
+    --prefix=%INSTALL_DIR% ^
+    --buildtype=%MESON_BUILD_TYPE% ^
+    %C_GLIB_BUILD_DIR% ^
+    c_glib || exit /B
+sed -i'' -s 's/\r//g' %C_GLIB_BUILD_DIR%/arrow-glib/version.h || exit /B
+ninja -C %C_GLIB_BUILD_DIR% || exit /B
+ninja -C %C_GLIB_BUILD_DIR% install || exit /B

--- a/ci/appveyor-cpp-setup-mingw.bat
+++ b/ci/appveyor-cpp-setup-mingw.bat
@@ -17,19 +17,20 @@
 
 @echo on
 
-if "%JOB%" == "Rust" (
-    curl -sSf -o rustup-init.exe https://win.rustup.rs/
-    rustup-init.exe -y --default-host %TARGET% --default-toolchain stable
-    set "PATH=%PATH%;C:\Users\Appveyor\.cargo\bin"
-    rustup install stable
-    rustup install nightly
-    rustc -Vv
-    cargo -V
-) else if "%JOB:~,5%" == "MinGW" (
-    call ci\appveyor-cpp-setup-mingw.bat
-) else (
-    set "PATH=C:\Miniconda36-x64;C:\Miniconda36-x64\Scripts;C:\Miniconda36-x64\Library\bin;%PATH%"
-    set BOOST_ROOT=C:\Libraries\boost_1_67_0
-    set BOOST_LIBRARYDIR=C:\Libraries\boost_1_67_0\lib64-msvc-14.0
-    call ci\appveyor-cpp-setup.bat
-)
+set PATH=%MINGW_PREFIX%\bin;C:\msys64\usr\bin;%PATH%
+
+pacman -S --noconfirm ^
+    "%MINGW_PACKAGE_PREFIX%-boost" ^
+    "%MINGW_PACKAGE_PREFIX%-brotli" ^
+    "%MINGW_PACKAGE_PREFIX%-cmake" ^
+    "%MINGW_PACKAGE_PREFIX%-flatbuffers" ^
+    "%MINGW_PACKAGE_PREFIX%-gcc" ^
+    "%MINGW_PACKAGE_PREFIX%-gobject-introspection" ^
+    "%MINGW_PACKAGE_PREFIX%-gtk-doc" ^
+    "%MINGW_PACKAGE_PREFIX%-lz4" ^
+    "%MINGW_PACKAGE_PREFIX%-meson" ^
+    "%MINGW_PACKAGE_PREFIX%-protobuf" ^
+    "%MINGW_PACKAGE_PREFIX%-python3-numpy" ^
+    "%MINGW_PACKAGE_PREFIX%-snappy" ^
+    "%MINGW_PACKAGE_PREFIX%-zlib" ^
+    "%MINGW_PACKAGE_PREFIX%-zstd" || exit /B

--- a/ci/appveyor-filter-changes.bat
+++ b/ci/appveyor-filter-changes.bat
@@ -22,6 +22,13 @@ if "%JOB%" == "Rust" (
         echo ===
         appveyor exit
     )
+) else if "%JOB%" == "MinGW" (
+    if "%ARROW_CI_GLIB_AFFECTED%" == "0" (
+        echo ===
+        echo === No C++, or GLib changes, exiting job
+        echo ===
+        appveyor exit
+    )
 ) else (
     if "%ARROW_CI_PYTHON_AFFECTED%" == "0" (
         echo ===


### PR DESCRIPTION
32-bit MinGW build isn't available for now:
https://issues.apache.org/jira/browse/ARROW-4297

So it's listed in allow_failures.