### PR TITLE
ARROW-4342: [Gandiva][Java] Ignore flaky test.

### DIFF
--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -131,6 +131,8 @@ public class ProjectorTest extends BaseEvaluatorTest {
     executors.awaitTermination(100, java.util.concurrent.TimeUnit.SECONDS);
   }
 
+  // Will be fixed by https://issues.apache.org/jira/browse/ARROW-4371
+  @Ignore
   @Test
   public void testMakeProjector() throws GandivaException {
     Field a = Field.nullable("a", int64);


### PR DESCRIPTION
Ignoring the flaky cache test for now.
Once we have a better mechanism to identify objects returned by Gandiva
we can re-enable the test.