### PR TITLE
ARROW-4375: [CI] Sphinx dependencies were removed from docs conda environment

### DIFF
--- a/ci/conda_env_sphinx.yml
+++ b/ci/conda_env_sphinx.yml
@@ -16,7 +16,8 @@
 # under the License.
 
 # Requirements for building the documentation
-# You also need to `pip install -r docs/requirements.txt`
-
+breathe
 doxygen
 ipython
+sphinx
+sphinx_rtd_theme

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -62,7 +62,6 @@ which python
 if [ "$ARROW_TRAVIS_PYTHON_DOCS" == "1" ] && [ "$PYTHON_VERSION" == "3.6" ]; then
   # Install documentation dependencies
   conda install -y --file ci/conda_env_sphinx.yml
-  pip install -q -r docs/requirements.txt
 fi
 
 # ARROW-2093: PyTorch increases the size of our conda dependency stack
@@ -123,9 +122,6 @@ popd
 $ARROW_CPP_BUILD_DIR/$ARROW_BUILD_TYPE/arrow-python-test
 
 pushd $ARROW_PYTHON_DIR
-
-# Other stuff pip install
-pip install -q -r requirements.txt
 
 if [ "$PYTHON_VERSION" == "3.6" ]; then
     pip install -q pickle5


### PR DESCRIPTION
Causes nightly test error: https://travis-ci.org/kszucs/crossbow/builds/484315659

Removed in: https://github.com/apache/arrow/commit/dc062656d7da7593764cb35fd0c78ba19856a4f3#diff-f257444d60768be1ea6728173a574f36

Crossbow build: [kszucs/crossbow/build-431](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=build-431)
 