### PR TITLE
ARROW-4394: [C++] Force inline NumericArray methods

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -416,14 +416,14 @@ class ARROW_EXPORT NumericArray : public PrimitiveArray {
       : PrimitiveArray(TypeTraits<T1>::type_singleton(), length, data, null_bitmap,
                        null_count, offset) {}
 
-  const value_type* raw_values() const {
+  ARROW_FORCE_INLINE const value_type* raw_values() const {
     return reinterpret_cast<const value_type*>(raw_values_) + data_->offset;
   }
 
-  value_type Value(int64_t i) const { return raw_values()[i]; }
+  ARROW_FORCE_INLINE value_type Value(int64_t i) const { return raw_values()[i]; }
 
   // For API compatibility with BinaryArray etc.
-  value_type GetView(int64_t i) const { return Value(i); }
+  ARROW_FORCE_INLINE value_type GetView(int64_t i) const { return Value(i); }
 
  protected:
   using PrimitiveArray::PrimitiveArray;

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -60,6 +60,14 @@
 #define ARROW_MUST_USE_RESULT
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define ARROW_FORCE_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define ARROW_FORCE_INLINE __forceinline
+#else
+#define ARROW_FORCE_INLINE
+#endif
+
 // ----------------------------------------------------------------------
 // C++/CLI support macros (see ARROW-1134)
 


### PR DESCRIPTION
Because we can't refer them from DLL built with MinGW. If we build a
library that uses libarrow.dll such as libarrow_python.dll with -O0,
the build is failed with undefined reference:

    ...
    cpp/src/arrow/python/arrow_to_pandas.cc:389: undefined reference to `arrow::NumericArray<arrow::UInt8Type>::GetView(long long) const'
    ...
    cpp/src/arrow/python/arrow_to_pandas.cc:389: undefined reference to `arrow::NumericArray<arrow::Int8Type>::GetView(long long) const'
    ...

These symbols exist in libarrow.dll but we can't refer them:

    > nm --demangle build\cpp\debug\libarrow.dll | grep NumericArray | grep ::GetView
    0000000064590880 T arrow::NumericArray<arrow::Date32Type>::GetView(long long) const
    0000000064590920 T arrow::NumericArray<arrow::Date64Type>::GetView(long long) const
    00000000645909d0 T arrow::NumericArray<arrow::DoubleType>::GetView(long long) const
    0000000064590a80 T arrow::NumericArray<arrow::Time32Type>::GetView(long long) const
    0000000064590b20 T arrow::NumericArray<arrow::Time64Type>::GetView(long long) const
    0000000064590bc0 T arrow::NumericArray<arrow::UInt16Type>::GetView(long long) const
    0000000064590c60 T arrow::NumericArray<arrow::UInt32Type>::GetView(long long) const
    0000000064590d00 T arrow::NumericArray<arrow::UInt64Type>::GetView(long long) const
    0000000064590da0 T arrow::NumericArray<arrow::HalfFloatType>::GetView(long long) const
    0000000064590e40 T arrow::NumericArray<arrow::TimestampType>::GetView(long long) const
    0000000064590ee0 T arrow::NumericArray<arrow::Int8Type>::GetView(long long) const
    0000000064590f90 T arrow::NumericArray<arrow::FloatType>::GetView(long long) const
    0000000064591030 T arrow::NumericArray<arrow::Int16Type>::GetView(long long) const
    00000000645910d0 T arrow::NumericArray<arrow::Int32Type>::GetView(long long) const
    0000000064591170 T arrow::NumericArray<arrow::Int64Type>::GetView(long long) const
    0000000064591210 T arrow::NumericArray<arrow::UInt8Type>::GetView(long long) const

I'm not sure that this is the right solution but we can build Arrow
C++ with -DCMAKE_BUILD_TYPE=debug option by this change.