### PR TITLE
ARROW-4397: [C++] Add dim_names in Tensor and SparseTensor

### DIFF
--- a/cpp/src/arrow/sparse_tensor-test.cc
+++ b/cpp/src/arrow/sparse_tensor-test.cc
@@ -51,10 +51,12 @@ TEST(TestSparseCOOTensor, CreationEmptyTensor) {
   ASSERT_EQ(24, st1.size());
   ASSERT_EQ(24, st2.size());
 
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st2.dim_names());
   ASSERT_EQ("foo", st2.dim_name(0));
   ASSERT_EQ("bar", st2.dim_name(1));
   ASSERT_EQ("baz", st2.dim_name(2));
 
+  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
   ASSERT_EQ("", st1.dim_name(0));
   ASSERT_EQ("", st1.dim_name(1));
   ASSERT_EQ("", st1.dim_name(2));
@@ -76,10 +78,12 @@ TEST(TestSparseCOOTensor, CreationFromNumericTensor) {
   ASSERT_EQ(12, st1.non_zero_length());
   ASSERT_TRUE(st1.is_mutable());
 
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st2.dim_names());
   ASSERT_EQ("foo", st2.dim_name(0));
   ASSERT_EQ("bar", st2.dim_name(1));
   ASSERT_EQ("baz", st2.dim_name(2));
 
+  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
   ASSERT_EQ("", st1.dim_name(0));
   ASSERT_EQ("", st1.dim_name(1));
   ASSERT_EQ("", st1.dim_name(2));
@@ -139,10 +143,12 @@ TEST(TestSparseCOOTensor, CreationFromTensor) {
   ASSERT_EQ(12, st1.non_zero_length());
   ASSERT_TRUE(st1.is_mutable());
 
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st2.dim_names());
   ASSERT_EQ("foo", st2.dim_name(0));
   ASSERT_EQ("bar", st2.dim_name(1));
   ASSERT_EQ("baz", st2.dim_name(2));
 
+  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
   ASSERT_EQ("", st1.dim_name(0));
   ASSERT_EQ("", st1.dim_name(1));
   ASSERT_EQ("", st1.dim_name(2));
@@ -203,10 +209,12 @@ TEST(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   ASSERT_EQ(12, st1.non_zero_length());
   ASSERT_TRUE(st1.is_mutable());
 
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st2.dim_names());
   ASSERT_EQ("foo", st2.dim_name(0));
   ASSERT_EQ("bar", st2.dim_name(1));
   ASSERT_EQ("baz", st2.dim_name(2));
 
+  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
   ASSERT_EQ("", st1.dim_name(0));
   ASSERT_EQ("", st1.dim_name(1));
   ASSERT_EQ("", st1.dim_name(2));

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -135,6 +135,7 @@ class ARROW_EXPORT SparseTensor {
 
   int ndim() const { return static_cast<int>(shape_.size()); }
 
+  const std::vector<std::string>& dim_names() const { return dim_names_; }
   const std::string& dim_name(int i) const;
 
   /// Total number of value cells in the sparse tensor

--- a/cpp/src/arrow/tensor-test.cc
+++ b/cpp/src/arrow/tensor-test.cc
@@ -66,8 +66,11 @@ TEST(TestTensor, BasicCtors) {
   ASSERT_EQ(strides, t1.strides());
   ASSERT_EQ(strides, t2.strides());
 
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar"}), t3.dim_names());
   ASSERT_EQ("foo", t3.dim_name(0));
   ASSERT_EQ("bar", t3.dim_name(1));
+
+  ASSERT_EQ(std::vector<std::string>({}), t1.dim_names());
   ASSERT_EQ("", t1.dim_name(0));
   ASSERT_EQ("", t1.dim_name(1));
 }

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -81,6 +81,7 @@ class ARROW_EXPORT Tensor {
 
   int ndim() const { return static_cast<int>(shape_.size()); }
 
+  const std::vector<std::string>& dim_names() const { return dim_names_; }
   const std::string& dim_name(int i) const;
 
   /// Total number of value cells in the tensor


### PR DESCRIPTION
Along with [ARROW-4388](https://issues.apache.org/jira/browse/ARROW-4388), it would be useful to introduce dim_names in Tensor and SparseTensor of C++ library.

