### PR TITLE
ARROW-4401: [Python] Alpine dockerfile fails to build because pandas requires numpy as build dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,22 @@
 
 version: '3.5'
 
+# TODO(kszucs): set arrow's mount to :ro mode, once all of the builds are
+# passing without write access to the source directory. The following builds
+# are contaminating the source directory:
+# - docs
+# - python-alpine (writes .egg directory)
+# - rust (writes Cargo.lock)
+# - java (without the rsync trick)
+
 x-ubuntu-volumes:
   &ubuntu-volumes
-  - .:/arrow:ro  # ensures that docker won't contaminate the host directory
+  - .:/arrow
   - ubuntu-cache:/build:delegated
 
 x-alpine-volumes:
   &alpine-volumes
-  - .:/arrow:ro  # ensures that docker won't contaminate the host directory
+  - .:/arrow
   - alpine-cache:/build:delegated
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,12 +29,12 @@ version: '3.5'
 
 x-ubuntu-volumes:
   &ubuntu-volumes
-  - .:/arrow
+  - .:/arrow:delegated
   - ubuntu-cache:/build:delegated
 
 x-alpine-volumes:
   &alpine-volumes
-  - .:/arrow
+  - .:/arrow:delegated
   - alpine-cache:/build:delegated
 
 volumes:

--- a/python/Dockerfile.alpine
+++ b/python/Dockerfile.alpine
@@ -17,6 +17,9 @@
 
 FROM arrow:cpp-alpine
 
+# better compatibility for the scripts
+RUN apk add --no-cache coreutils
+
 # install python, either python3(3.6) or python2(2.7)
 ARG PYTHON_VERSION=3.6
 RUN export PYTHON_MAJOR=${PYTHON_VERSION:0:1} && \
@@ -26,12 +29,8 @@ RUN export PYTHON_MAJOR=${PYTHON_VERSION:0:1} && \
     ln -sf /usr/bin/python${PYTHON_MAJOR} /usr/bin/python && \
     pip install --upgrade pip setuptools
 
-# install python requirements
-ADD python/requirements.txt \
-    python/requirements-test.txt \
-    /arrow/python/
 # pandas requires numpy at build time, so install the requirements separately
-RUN pip install -r /arrow/python/requirements.txt && \
+RUN pip install -r /arrow/python/requirements.txt cython && \
     pip install -r /arrow/python/requirements-test.txt
 
 ENV ARROW_PYTHON=ON \

--- a/python/Dockerfile.alpine
+++ b/python/Dockerfile.alpine
@@ -30,10 +30,9 @@ RUN export PYTHON_MAJOR=${PYTHON_VERSION:0:1} && \
 ADD python/requirements.txt \
     python/requirements-test.txt \
     /arrow/python/
-RUN pip install \
-    -r /arrow/python/requirements.txt \
-    -r /arrow/python/requirements-test.txt \
-    cython
+# pandas requires numpy at build time, so install the requirements separately
+RUN pip install -r /arrow/python/requirements.txt && \
+    pip install -r /arrow/python/requirements-test.txt
 
 ENV ARROW_PYTHON=ON \
     PYARROW_WITH_ORC=0 \

--- a/python/Dockerfile.alpine
+++ b/python/Dockerfile.alpine
@@ -29,6 +29,10 @@ RUN export PYTHON_MAJOR=${PYTHON_VERSION:0:1} && \
     ln -sf /usr/bin/python${PYTHON_MAJOR} /usr/bin/python && \
     pip install --upgrade pip setuptools
 
+# install python requirements
+ADD python/requirements.txt \
+    python/requirements-test.txt \
+    /arrow/python/
 # pandas requires numpy at build time, so install the requirements separately
 RUN pip install -r /arrow/python/requirements.txt cython && \
     pip install -r /arrow/python/requirements-test.txt


### PR DESCRIPTION
It's enough to install them sequentially: [kszucs/crossbow/build-433](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=build-433)