### PR TITLE
ARROW-4268: [C++] Native C type TypeTraits

### DIFF
--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -79,8 +79,7 @@ struct SchemaFromTuple {
     std::vector<std::shared_ptr<Field>> ret =
         SchemaFromTuple<Tuple, N - 1>::MakeSchemaRecursionT(names);
     std::shared_ptr<DataType> type = CTypeTraits<Element>::type_singleton();
-    ret.push_back(
-        field(std::get<N - 1>(names), type, false /* nullable */));
+    ret.push_back(field(std::get<N - 1>(names), type, false /* nullable */));
     return ret;
   }
 

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -24,46 +24,13 @@
 #include <vector>
 
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 
 namespace arrow {
 
 class Schema;
 
 namespace stl {
-
-/// Traits meta class to map standard C/C++ types to equivalent Arrow types.
-template <typename T>
-struct ConversionTraits {};
-
-#define ARROW_STL_CONVERSION(c_type, ArrowType_)    \
-  template <>                                       \
-  struct ConversionTraits<c_type> {                 \
-    static std::shared_ptr<DataType> arrow_type() { \
-      return std::make_shared<ArrowType_>();        \
-    }                                               \
-    constexpr static bool nullable = false;         \
-  };
-
-ARROW_STL_CONVERSION(bool, BooleanType)
-ARROW_STL_CONVERSION(int8_t, Int8Type)
-ARROW_STL_CONVERSION(int16_t, Int16Type)
-ARROW_STL_CONVERSION(int32_t, Int32Type)
-ARROW_STL_CONVERSION(int64_t, Int64Type)
-ARROW_STL_CONVERSION(uint8_t, UInt8Type)
-ARROW_STL_CONVERSION(uint16_t, UInt16Type)
-ARROW_STL_CONVERSION(uint32_t, UInt32Type)
-ARROW_STL_CONVERSION(uint64_t, UInt64Type)
-ARROW_STL_CONVERSION(float, FloatType)
-ARROW_STL_CONVERSION(double, DoubleType)
-ARROW_STL_CONVERSION(std::string, StringType)
-
-template <typename value_c_type>
-struct ConversionTraits<std::vector<value_c_type>> {
-  static std::shared_ptr<DataType> arrow_type() {
-    return list(ConversionTraits<value_c_type>::arrow_type());
-  }
-  constexpr static bool nullable = false;
-};
 
 /// Build an arrow::Schema based upon the types defined in a std::tuple-like structure.
 ///
@@ -82,8 +49,8 @@ struct SchemaFromTuple {
       const std::vector<std::string>& names) {
     std::vector<std::shared_ptr<Field>> ret =
         SchemaFromTuple<Tuple, N - 1>::MakeSchemaRecursion(names);
-    std::shared_ptr<DataType> type = ConversionTraits<Element>::arrow_type();
-    ret.push_back(field(names[N - 1], type, ConversionTraits<Element>::nullable));
+    std::shared_ptr<DataType> type = CTypeTraits<Element>::type_singleton();
+    ret.push_back(field(names[N - 1], type, false /* nullable */));
     return ret;
   }
 
@@ -111,9 +78,9 @@ struct SchemaFromTuple {
       const NamesTuple& names) {
     std::vector<std::shared_ptr<Field>> ret =
         SchemaFromTuple<Tuple, N - 1>::MakeSchemaRecursionT(names);
-    std::shared_ptr<DataType> type = ConversionTraits<Element>::arrow_type();
+    std::shared_ptr<DataType> type = CTypeTraits<Element>::type_singleton();
     ret.push_back(
-        field(std::get<N - 1>(names), type, ConversionTraits<Element>::nullable));
+        field(std::get<N - 1>(names), type, false /* nullable */));
     return ret;
   }
 

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -27,6 +27,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/test-util.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 
 using std::shared_ptr;
@@ -254,27 +255,34 @@ TEST_F(TestSchema, TestRemoveMetadata) {
   ASSERT_TRUE(new_schema->metadata() == nullptr);
 }
 
-#define PRIMITIVE_TEST(KLASS, ENUM, NAME)        \
-  TEST(TypesTest, TestPrimitive_##ENUM) {        \
-    KLASS tp;                                    \
-                                                 \
-    ASSERT_EQ(tp.id(), Type::ENUM);              \
-    ASSERT_EQ(tp.ToString(), std::string(NAME)); \
+#define PRIMITIVE_TEST(KLASS, CTYPE, ENUM, NAME)                              \
+  TEST(TypesTest, ARROW_CONCAT(TestPrimitive_, ENUM)) {                       \
+    KLASS tp;                                                                 \
+                                                                              \
+    ASSERT_EQ(tp.id(), Type::ENUM);                                           \
+    ASSERT_EQ(tp.ToString(), std::string(NAME));                              \
+                                                                              \
+    using CType = TypeTraits<KLASS>::CType;                                   \
+    static_assert(std::is_same<CType, CTYPE>::value, "Not the same c-type!"); \
+                                                                              \
+    using DerivedArrowType = TypeTraits<CTYPE>::ArrowType;                    \
+    static_assert(std::is_same<DerivedArrowType, KLASS>::value,               \
+                  "Not the same arrow-type!");                                \
   }
 
-PRIMITIVE_TEST(Int8Type, INT8, "int8")
-PRIMITIVE_TEST(Int16Type, INT16, "int16")
-PRIMITIVE_TEST(Int32Type, INT32, "int32")
-PRIMITIVE_TEST(Int64Type, INT64, "int64")
-PRIMITIVE_TEST(UInt8Type, UINT8, "uint8")
-PRIMITIVE_TEST(UInt16Type, UINT16, "uint16")
-PRIMITIVE_TEST(UInt32Type, UINT32, "uint32")
-PRIMITIVE_TEST(UInt64Type, UINT64, "uint64")
+PRIMITIVE_TEST(Int8Type, int8_t, INT8, "int8");
+PRIMITIVE_TEST(Int16Type, int16_t, INT16, "int16");
+PRIMITIVE_TEST(Int32Type, int32_t, INT32, "int32");
+PRIMITIVE_TEST(Int64Type, int64_t, INT64, "int64");
+PRIMITIVE_TEST(UInt8Type, uint8_t, UINT8, "uint8");
+PRIMITIVE_TEST(UInt16Type, uint16_t, UINT16, "uint16");
+PRIMITIVE_TEST(UInt32Type, uint32_t, UINT32, "uint32");
+PRIMITIVE_TEST(UInt64Type, uint64_t, UINT64, "uint64");
 
-PRIMITIVE_TEST(FloatType, FLOAT, "float")
-PRIMITIVE_TEST(DoubleType, DOUBLE, "double")
+PRIMITIVE_TEST(FloatType, float, FLOAT, "float");
+PRIMITIVE_TEST(DoubleType, double, DOUBLE, "double");
 
-PRIMITIVE_TEST(BooleanType, BOOL, "bool")
+PRIMITIVE_TEST(BooleanType, bool, BOOL, "bool");
 
 TEST(TestBinaryType, ToString) {
   BinaryType t1;

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -265,7 +265,7 @@ TEST_F(TestSchema, TestRemoveMetadata) {
     using CType = TypeTraits<KLASS>::CType;                                   \
     static_assert(std::is_same<CType, CTYPE>::value, "Not the same c-type!"); \
                                                                               \
-    using DerivedArrowType = TypeTraits<CTYPE>::ArrowType;                    \
+    using DerivedArrowType = CTypeTraits<CTYPE>::ArrowType;                   \
     static_assert(std::is_same<DerivedArrowType, KLASS>::value,               \
                   "Not the same arrow-type!");                                \
   }

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -193,7 +193,7 @@ struct CTypeTraits<std::string> : public TypeTraits<StringType> {
 };
 
 template <>
-struct CTypeTraits<char *> : public TypeTraits<StringType> {
+struct CTypeTraits<char*> : public TypeTraits<StringType> {
   using ArrowType = StringType;
 };
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -41,102 +41,78 @@ struct TypeTraits<NullType> {
 };
 
 template <>
-struct TypeTraits<UInt8Type> {
-  using ArrayType = UInt8Array;
-  using BuilderType = UInt8Builder;
-  using TensorType = UInt8Tensor;
-  static constexpr int64_t bytes_required(int64_t elements) { return elements; }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return uint8(); }
-};
-
-template <>
-struct TypeTraits<Int8Type> {
-  using ArrayType = Int8Array;
-  using BuilderType = Int8Builder;
-  using TensorType = Int8Tensor;
-  static constexpr int64_t bytes_required(int64_t elements) { return elements; }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return int8(); }
-};
-
-template <>
-struct TypeTraits<UInt16Type> {
-  using ArrayType = UInt16Array;
-  using BuilderType = UInt16Builder;
-  using TensorType = UInt16Tensor;
+struct TypeTraits<BooleanType> {
+  using ArrayType = BooleanArray;
+  using BuilderType = BooleanBuilder;
+  using CType = bool;
 
   static constexpr int64_t bytes_required(int64_t elements) {
-    return elements * sizeof(uint16_t);
+    return BitUtil::BytesForBits(elements);
   }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return uint16(); }
+  static inline std::shared_ptr<DataType> type_singleton() { return boolean(); }
 };
 
 template <>
-struct TypeTraits<Int16Type> {
-  using ArrayType = Int16Array;
-  using BuilderType = Int16Builder;
-  using TensorType = Int16Tensor;
+struct TypeTraits<bool> {
+  using ArrayType = BooleanArray;
+  using BuilderType = BooleanBuilder;
+  using ArrowType = BooleanType;
 
   static constexpr int64_t bytes_required(int64_t elements) {
-    return elements * sizeof(int16_t);
+    return BitUtil::BytesForBits(elements);
   }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return int16(); }
+  static inline std::shared_ptr<DataType> type_singleton() { return boolean(); }
 };
 
-template <>
-struct TypeTraits<UInt32Type> {
-  using ArrayType = UInt32Array;
-  using BuilderType = UInt32Builder;
-  using TensorType = UInt32Tensor;
+#define PRIMITIVE_TYPE_TRAITS_DEF_(CType_, ArrowType_, ArrowArrayType, ArrowBuilderType, \
+                                   ArrowTensorType, SingletonType)                       \
+  template <>                                                                            \
+  struct TypeTraits<ArrowType_> {                                                        \
+    using ArrayType = ArrowArrayType;                                                    \
+    using BuilderType = ArrowBuilderType;                                                \
+    using TensorType = ArrowTensorType;                                                  \
+    using CType = CType_;                                                                \
+    static constexpr int64_t bytes_required(int64_t elements) {                          \
+      return elements * sizeof(CType_);                                                  \
+    }                                                                                    \
+    constexpr static bool is_parameter_free = true;                                      \
+    static inline std::shared_ptr<DataType> type_singleton() { return SingletonType(); } \
+  };                                                                                     \
+                                                                                         \
+  template <>                                                                            \
+  struct TypeTraits<CType_> {                                                            \
+    using ArrayType = ArrowArrayType;                                                    \
+    using BuilderType = ArrowBuilderType;                                                \
+    using TensorType = ArrowTensorType;                                                  \
+    using ArrowType = ArrowType_;                                                        \
+    static constexpr int64_t bytes_required(int64_t elements) {                          \
+      return elements * sizeof(CType_);                                                  \
+    }                                                                                    \
+    constexpr static bool is_parameter_free = true;                                      \
+    static inline std::shared_ptr<DataType> type_singleton() { return SingletonType(); } \
+  };
 
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return elements * sizeof(uint32_t);
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return uint32(); }
-};
+#define PRIMITIVE_TYPE_TRAITS_DEF(CType, ArrowShort, SingletonType) \
+  PRIMITIVE_TYPE_TRAITS_DEF_(CType, ARROW_CONCAT(ArrowShort, Type), \
+                             ARROW_CONCAT(ArrowShort, Array),       \
+                             ARROW_CONCAT(ArrowShort, Builder),     \
+                             ARROW_CONCAT(ArrowShort, Tensor), SingletonType)
 
-template <>
-struct TypeTraits<Int32Type> {
-  using ArrayType = Int32Array;
-  using BuilderType = Int32Builder;
-  using TensorType = Int32Tensor;
+PRIMITIVE_TYPE_TRAITS_DEF(uint8_t, UInt8, uint8)
+PRIMITIVE_TYPE_TRAITS_DEF(int8_t, Int8, int8)
+PRIMITIVE_TYPE_TRAITS_DEF(uint16_t, UInt16, uint16)
+PRIMITIVE_TYPE_TRAITS_DEF(int16_t, Int16, int16)
+PRIMITIVE_TYPE_TRAITS_DEF(uint32_t, UInt32, uint32)
+PRIMITIVE_TYPE_TRAITS_DEF(int32_t, Int32, int32)
+PRIMITIVE_TYPE_TRAITS_DEF(uint64_t, UInt64, uint64)
+PRIMITIVE_TYPE_TRAITS_DEF(int64_t, Int64, int64)
+PRIMITIVE_TYPE_TRAITS_DEF(float, Float, float32)
+PRIMITIVE_TYPE_TRAITS_DEF(double, Double, float64)
 
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return elements * sizeof(int32_t);
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return int32(); }
-};
-
-template <>
-struct TypeTraits<UInt64Type> {
-  using ArrayType = UInt64Array;
-  using BuilderType = UInt64Builder;
-  using TensorType = UInt64Tensor;
-
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return elements * sizeof(uint64_t);
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return uint64(); }
-};
-
-template <>
-struct TypeTraits<Int64Type> {
-  using ArrayType = Int64Array;
-  using BuilderType = Int64Builder;
-  using TensorType = Int64Tensor;
-
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return elements * sizeof(int64_t);
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return int64(); }
-};
+#undef PRIMITIVE_TYPE_TRAITS_DEF
+#undef PRIMITIVE_TYPE_TRAITS_DEF_
 
 template <>
 struct TypeTraits<Date64Type> {
@@ -209,48 +185,10 @@ struct TypeTraits<HalfFloatType> {
 };
 
 template <>
-struct TypeTraits<FloatType> {
-  using ArrayType = FloatArray;
-  using BuilderType = FloatBuilder;
-  using TensorType = FloatTensor;
-
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return static_cast<int64_t>(elements * sizeof(float));
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return float32(); }
-};
-
-template <>
-struct TypeTraits<DoubleType> {
-  using ArrayType = DoubleArray;
-  using BuilderType = DoubleBuilder;
-  using TensorType = DoubleTensor;
-
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return static_cast<int64_t>(elements * sizeof(double));
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return float64(); }
-};
-
-template <>
 struct TypeTraits<Decimal128Type> {
   using ArrayType = Decimal128Array;
   using BuilderType = Decimal128Builder;
   constexpr static bool is_parameter_free = false;
-};
-
-template <>
-struct TypeTraits<BooleanType> {
-  using ArrayType = BooleanArray;
-  using BuilderType = BooleanBuilder;
-
-  static constexpr int64_t bytes_required(int64_t elements) {
-    return BitUtil::BytesForBits(elements);
-  }
-  constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return boolean(); }
 };
 
 template <>

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -67,7 +67,7 @@ struct TypeTraits<bool> {
 };
 
 #define PRIMITIVE_TYPE_TRAITS_DEF_(CType_, ArrowType_, ArrowArrayType, ArrowBuilderType, \
-                                   ArrowTensorType, SingletonType)                       \
+                                   ArrowTensorType, SingletonFn)                       \
   template <>                                                                            \
   struct TypeTraits<ArrowType_> {                                                        \
     using ArrayType = ArrowArrayType;                                                    \
@@ -78,7 +78,7 @@ struct TypeTraits<bool> {
       return elements * sizeof(CType_);                                                  \
     }                                                                                    \
     constexpr static bool is_parameter_free = true;                                      \
-    static inline std::shared_ptr<DataType> type_singleton() { return SingletonType(); } \
+    static inline std::shared_ptr<DataType> type_singleton() { return SingletonFn(); } \
   };                                                                                     \
                                                                                          \
   template <>                                                                            \
@@ -91,14 +91,14 @@ struct TypeTraits<bool> {
       return elements * sizeof(CType_);                                                  \
     }                                                                                    \
     constexpr static bool is_parameter_free = true;                                      \
-    static inline std::shared_ptr<DataType> type_singleton() { return SingletonType(); } \
+    static inline std::shared_ptr<DataType> type_singleton() { return SingletonFn(); } \
   };
 
-#define PRIMITIVE_TYPE_TRAITS_DEF(CType, ArrowShort, SingletonType) \
+#define PRIMITIVE_TYPE_TRAITS_DEF(CType, ArrowShort, SingletonFn) \
   PRIMITIVE_TYPE_TRAITS_DEF_(CType, ARROW_CONCAT(ArrowShort, Type), \
                              ARROW_CONCAT(ArrowShort, Array),       \
                              ARROW_CONCAT(ArrowShort, Builder),     \
-                             ARROW_CONCAT(ArrowShort, Tensor), SingletonType)
+                             ARROW_CONCAT(ArrowShort, Tensor), SingletonFn)
 
 PRIMITIVE_TYPE_TRAITS_DEF(uint8_t, UInt8, uint8)
 PRIMITIVE_TYPE_TRAITS_DEF(int8_t, Int8, int8)

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -19,6 +19,7 @@
 #define ARROW_UTIL_MACROS_H
 
 #define ARROW_STRINGIFY(x) #x
+#define ARROW_CONCAT(x, y) x##y
 
 // From Google gutil
 #ifndef ARROW_DISALLOW_COPY_AND_ASSIGN


### PR DESCRIPTION
Add convenience support for native types, e.g. `TypeTraits<int8_t>` or
`auto type = TypeTraits<bool>::singleton_type();`. This is very handy in
tests.