### PR TITLE
ARROW-4422: [Plasma] Enforce memory limit in plasma, rather than relying on dlmalloc_set_footprint_limit

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -76,6 +76,7 @@ set(PLASMA_SRCS
   io.cc
   malloc.cc
   plasma.cc
+  plasma_allocator.cc
   protocol.cc
   thirdparty/ae/ae.c)
 

--- a/cpp/src/plasma/eviction_policy.h
+++ b/cpp/src/plasma/eviction_policy.h
@@ -126,8 +126,6 @@ class EvictionPolicy {
   void RemoveObject(const ObjectID& object_id);
 
  private:
-  /// The amount of memory (in bytes) currently being used.
-  int64_t memory_used_;
   /// Pointer to the plasma store info.
   PlasmaStoreInfo* store_info_;
   /// Datastructure for the LRU cache.

--- a/cpp/src/plasma/plasma.cc
+++ b/cpp/src/plasma/plasma.cc
@@ -23,20 +23,17 @@
 
 #include "plasma/common.h"
 #include "plasma/common_generated.h"
+#include "plasma/plasma_allocator.h"
 #include "plasma/protocol.h"
 
 namespace fb = plasma::flatbuf;
 
 namespace plasma {
 
-extern "C" {
-void dlfree(void* mem);
-}
-
 ObjectTableEntry::ObjectTableEntry() : pointer(nullptr), ref_count(0) {}
 
 ObjectTableEntry::~ObjectTableEntry() {
-  dlfree(pointer);
+  PlasmaAllocator::Free(pointer, data_size + metadata_size);
   pointer = nullptr;
 }
 

--- a/cpp/src/plasma/plasma.h
+++ b/cpp/src/plasma/plasma.h
@@ -104,9 +104,6 @@ enum class ObjectStatus : int {
 struct PlasmaStoreInfo {
   /// Objects that are in the Plasma store.
   ObjectTable objects;
-  /// The amount of memory (in bytes) that we allow to be allocated in the
-  /// store.
-  int64_t memory_capacity;
   /// Boolean flag indicating whether to start the object store with hugepages
   /// support enabled. Huge pages are substantially larger than normal memory
   /// pages (e.g. 2MB or 1GB instead of 4KB) and using them can reduce

--- a/cpp/src/plasma/plasma_allocator.cc
+++ b/cpp/src/plasma/plasma_allocator.cc
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <arrow/util/logging.h>
+
+#include "plasma/malloc.h"
+#include "plasma/plasma_allocator.h"
+
+namespace plasma {
+
+extern "C" {
+void* dlmemalign(size_t alignment, size_t bytes);
+void dlfree(void* mem);
+}
+
+int64_t PlasmaAllocator::footprint_limit_ = 0;
+int64_t PlasmaAllocator::allocated_ = 0;
+
+void* PlasmaAllocator::Memalign(size_t alignment, size_t bytes) {
+  if (allocated_ + static_cast<int64_t>(bytes) > footprint_limit_) {
+    return nullptr;
+  }
+  void* mem = dlmemalign(alignment, bytes);
+  ARROW_CHECK(mem);
+  allocated_ += bytes;
+  return mem;
+}
+
+void PlasmaAllocator::Free(void* mem, size_t bytes) {
+  dlfree(mem);
+  allocated_ -= bytes;
+}
+
+void PlasmaAllocator::SetFootprintLimit(size_t bytes) {
+  footprint_limit_ = static_cast<int64_t>(bytes);
+}
+
+int64_t PlasmaAllocator::GetFootprintLimit() { return footprint_limit_; }
+
+int64_t PlasmaAllocator::Allocated() { return allocated_; }
+
+}  // namespace plasma

--- a/cpp/src/plasma/plasma_allocator.h
+++ b/cpp/src/plasma/plasma_allocator.h
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PLASMA_ALLOCATOR_H
+#define PLASMA_ALLOCATOR_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace plasma {
+
+class PlasmaAllocator {
+ public:
+  /// Allocates size bytes and returns a pointer to the allocated memory. The
+  /// memory address will be a multiple of alignment, which must be a power of two.
+  ///
+  /// \param alignment Memory alignment.
+  /// \param bytes Number of bytes.
+  /// \return Pointer to allocated memory.
+  static void* Memalign(size_t alignment, size_t bytes);
+
+  /// Frees the memory space pointed to by mem, which must have been returned by
+  /// a previous call to Memalign()
+  ///
+  /// \param mem Pointer to memory to free.
+  /// \param bytes Number of bytes to be freed.
+  static void Free(void* mem, size_t bytes);
+
+  /// Sets the memory footprint limit for Plasma.
+  ///
+  /// \param bytes Plasma memory footprint limit in bytes.
+  static void SetFootprintLimit(size_t bytes);
+
+  /// Get the memory footprint limit for Plasma.
+  ///
+  /// \return Plasma memory footprint limit in bytes.
+  static int64_t GetFootprintLimit();
+
+  /// Get the number of bytes allocated by Plasma so far.
+  /// \return Number of bytes allocated by Plasma so far.
+  static int64_t Allocated();
+
+ private:
+  static int64_t allocated_;
+  static int64_t footprint_limit_;
+};
+
+}  // namespace plasma
+
+#endif  // ARROW_PLASMA_ALLOCATOR_H

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -75,8 +75,7 @@ class PlasmaStore {
   using NotificationMap = std::unordered_map<int, NotificationQueue>;
 
   // TODO: PascalCase PlasmaStore methods.
-  PlasmaStore(EventLoop* loop, int64_t system_memory, std::string directory,
-              bool hugetlbfs_enabled);
+  PlasmaStore(EventLoop* loop, std::string directory, bool hugetlbfs_enabled);
 
   ~PlasmaStore();
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-4422

This implementation imposes memory limit at Plasma by tracking the number of bytes allocated and freed using malloc and free calls. Whenever the allocation reaches the set limit, we fail any subsequent allocations (by returning NULL from malloc). This allows Plasma to not be tied to dlmalloc, and also provides more accurate tracking of memory allocation/capacity.

cc @pcmoritz 