### PR TITLE
ARROW-4442: [JS] Add explicit type annotation to Chunked typeId getter

### DIFF
--- a/js/src/vector/chunked.ts
+++ b/js/src/vector/chunked.ts
@@ -70,7 +70,7 @@ export class Chunked<T extends DataType = any>
     public get type() { return this._type; }
     public get length() { return this._length; }
     public get chunks() { return this._chunks; }
-    public get typeId() { return this._type.typeId; }
+    public get typeId(): T['TType'] { return this._type.typeId; }
     public get data(): Data<T> {
         return this._chunks[0] ? this._chunks[0].data : <any> null;
     }


### PR DESCRIPTION
Closes https://issues.apache.org/jira/browse/ARROW-4442

Typescript is generating an overly broad type for the `typeId` property of the ChunkedVector class, leading to a type mismatch and failure to infer `Chunked<T>` is a `Vector<T>`:

```ts
let col: Vector<Utf8>;
col = new Chunked(new Utf8());
  ^
/*
Argument of type 'Chunked<Utf8>' is not assignable to parameter of type 'Vector<Utf8>'.
  Type 'Chunked<Utf8>' is not assignable to type 'Vector<Utf8>'.
    Types of property 'typeId' are incompatible.
      Type 'Type' is not assignable to type 'Type.Utf8'.
*/
```

The type being generated currently is:
```ts
    readonly typeId: import("../enum").Type;
```

but it should be:
```ts
    readonly typeId: T['TType'];
```

The fix is to add an explicit return annotation to the Chunked `typeId` getter. Unfortunately this only affects the generated typings (`.d.ts` files) and not the library source, so it's difficult to test. We can look into whether there are any flags to trigger stricter type checking of the compiled code in the unit tests, but I don't know any off the top of my head.