### PR TITLE
ARROW-4436: [Documentation] Update building.rst to reflect pyarrow req

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -59,7 +59,15 @@ These two steps are mandatory and must be executed in order.
       doxygen
       popd
 
-#. Build the complete documentation using Sphinx
+#. Build the complete documentation using Sphinx.
+
+   .. note::
+
+      This step requires the the pyarrow library is installed
+      in your python environment.  One way to accomplish
+      this is to follow the build instructions at :ref:`development`
+      but instead don't use the `--inplace` argument with setup.py
+      (it is best to do this in a dedicated conda/virtual environment).
 
    .. code-block:: shell
 

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -66,7 +66,7 @@ These two steps are mandatory and must be executed in order.
       This step requires the the pyarrow library is installed
       in your python environment.  One way to accomplish
       this is to follow the build instructions at :ref:`development`
-      but instead don't use the `--inplace` argument with setup.py
+      and then run `python setup.py install` in arrow/python
       (it is best to do this in a dedicated conda/virtual environment).
 
    .. code-block:: shell


### PR DESCRIPTION
Make note of the fact that pyarrow has to be installed for sphinx to successfully build the documentation.