### PR TITLE
ARROW-4459: [Testing] Add arrow-testing repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing


### PR DESCRIPTION
This PR adds the arrow-testing repo as a submodule in the directory `testing`.