### PR TITLE
ARROW-4469: [CI] Pin conda-forge binutils version to 2.31 for now

### DIFF
--- a/ci/travis_env_common.sh
+++ b/ci/travis_env_common.sh
@@ -21,6 +21,7 @@
 export NODE_NO_WARNINGS=1
 export MINICONDA=$HOME/miniconda
 export CONDA_PKGS_DIRS=$HOME/.conda_packages
+export CONDA_BINUTILS_VERSION=2.31
 
 export ARROW_CPP_DIR=$TRAVIS_BUILD_DIR/cpp
 export ARROW_PYTHON_DIR=$TRAVIS_BUILD_DIR/python

--- a/ci/travis_install_toolchain.sh
+++ b/ci/travis_install_toolchain.sh
@@ -34,7 +34,7 @@ if [ ! -e $CPP_TOOLCHAIN ]; then
             CONDA_LABEL=" -c conda-forge/label/cf201901"
         else
             # Use newer binutils when linking against conda-provided libraries
-            CONDA_PACKAGES="$CONDA_PACKAGES binutils"
+            CONDA_PACKAGES="$CONDA_PACKAGES binutils=$CONDA_BINUTILS_VERSION"
         fi
     fi
 


### PR DESCRIPTION
Seeing if this fixes the failures we are seeing. The conda-forge binutils package was just updated 2 days ago