### PR TITLE
ARROW-4475: [Python] Fix recursive serialization of self-containing objects

### DIFF
--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -203,19 +203,19 @@ class SequenceBuilder {
   Status AppendList(PyObject* context, PyObject* list, int32_t recursion_depth,
                     SerializedPyObject* blobs_out) {
     return AppendSequence(context, list, PythonType::LIST, lists_, list_values_,
-                          recursion_depth, blobs_out);
+                          recursion_depth + 1, blobs_out);
   }
 
   Status AppendTuple(PyObject* context, PyObject* tuple, int32_t recursion_depth,
                      SerializedPyObject* blobs_out) {
     return AppendSequence(context, tuple, PythonType::TUPLE, tuples_, tuple_values_,
-                          recursion_depth, blobs_out);
+                          recursion_depth + 1, blobs_out);
   }
 
   Status AppendSet(PyObject* context, PyObject* set, int32_t recursion_depth,
                    SerializedPyObject* blobs_out) {
     return AppendSequence(context, set, PythonType::SET, sets_, set_values_,
-                          recursion_depth, blobs_out);
+                          recursion_depth + 1, blobs_out);
   }
 
   Status AppendDict(PyObject* context, PyObject* dict, int32_t recursion_depth,

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -814,3 +814,39 @@ def test_serialization_determinism():
         buf1 = pa.serialize(obj).to_buffer()
         buf2 = pa.serialize(obj).to_buffer()
         assert buf1.to_pybytes() == buf2.to_pybytes()
+
+
+def test_serialize_recursive_objects():
+    class ClassA(object):
+        pass
+
+    # Make a list that contains itself.
+    lst = []
+    lst.append(lst)
+
+    # Make an object that contains itself as a field.
+    a1 = ClassA()
+    a1.field = a1
+
+    # Make two objects that contain each other as fields.
+    a2 = ClassA()
+    a3 = ClassA()
+    a2.field = a3
+    a3.field = a2
+
+    # Make a dictionary that contains itself.
+    d1 = {}
+    d1["key"] = d1
+
+    # Make a numpy array that contains itself.
+    arr = np.array([None], dtype=object)
+    arr[0] = arr
+
+    # Create a list of recursive objects.
+    recursive_objects = [lst, a1, a2, a3, d1, arr]
+
+    # Check that exceptions are thrown when we serialize the recursive
+    # objects.
+    for obj in recursive_objects:
+        with pytest.raises(Exception):
+            pyarrow.serialize(obj).deserialize()

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -849,4 +849,4 @@ def test_serialize_recursive_objects():
     # objects.
     for obj in recursive_objects:
         with pytest.raises(Exception):
-            pyarrow.serialize(obj).deserialize()
+            pa.serialize(obj).deserialize()


### PR DESCRIPTION
This is a regression from https://github.com/apache/arrow/pull/3423, the recursion depth was incremented for arrays and dicts but not for lists, tuples and sets.

I also added a regression test for this.