### PR TITLE
ARROW-4477: [JS] remove constructor override in the bignum mixins

### DIFF
--- a/js/src/util/bn.ts
+++ b/js/src/util/bn.ts
@@ -38,9 +38,9 @@ const BigNumNMixin = {
 };
 
 /** @ignore */
-const SignedBigNumNMixin: any = Object.assign({}, BigNumNMixin, { signed: true, constructor: undefined });
+const SignedBigNumNMixin: any = Object.assign({}, BigNumNMixin, { signed: true });
 /** @ignore */
-const UnsignedBigNumNMixin: any = Object.assign({}, BigNumNMixin, { signed: false, constructor: undefined });
+const UnsignedBigNumNMixin: any = Object.assign({}, BigNumNMixin, { signed: false });
 
 /** @ignore */
 export class BN<T extends BigNumArray> {


### PR DESCRIPTION
Removes the constructor override leftover from the original `Object.create()` implementation of the bignum mixins. Closes https://issues.apache.org/jira/browse/ARROW-4477
