### PR TITLE
ARROW-4461: [C++] Expose bit map operations that work with raw pointers

### DIFF
--- a/cpp/src/arrow/util/bit-util-test.cc
+++ b/cpp/src/arrow/util/bit-util-test.cc
@@ -454,11 +454,9 @@ class BitmapOp : public TestBase {
           ASSERT_READER_VALUES(reader, result_bits);
 
           // Clear out buffer and try non-allocating version
-          for (int64_t x = out_offset; x < out->size(); x++) {
-            out->mutable_data()[x] = 0;
-          }
-          op.Call(left->mutable_data(), left_offset, right->mutable_data(), right_offset,
-                  length, out_offset, out->mutable_data());
+          std::memset(out->mutable_data(), 0, out->size());
+          ASSERT_OK(op.Call(left->mutable_data(), left_offset, right->mutable_data(),
+                            right_offset, length, out_offset, out->mutable_data()));
           reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
           ASSERT_READER_VALUES(reader, result_bits);
         }
@@ -487,11 +485,9 @@ class BitmapOp : public TestBase {
           ASSERT_READER_VALUES(reader, result_bits);
 
           // Clear out buffer and try non-allocating version
-          for (int x = 0; x < out->size(); x++) {
-            out->mutable_data()[x] = 0;
-          }
-          op.Call(left->mutable_data(), left_offset, right->mutable_data(), right_offset,
-                  length, out_offset, out->mutable_data());
+          std::memset(out->mutable_data(), 0, out->size());
+          ASSERT_OK(op.Call(left->mutable_data(), left_offset, right->mutable_data(),
+                            right_offset, length, out_offset, out->mutable_data()));
           reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
           ASSERT_READER_VALUES(reader, result_bits);
         }

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -296,21 +296,30 @@ void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* 
 }
 
 template <typename BitOp, typename LogicalOp>
+void BitmapOp(const uint8_t* left, int64_t left_offset,
+                const uint8_t* right, int64_t right_offset, int64_t length,
+                int64_t out_offset, uint8_t* dest) {
+  if ((out_offset % 8 == left_offset % 8) && (out_offset % 8 == right_offset % 8)) {
+    // Fast case: can use bytewise AND
+    AlignedBitmapOp<BitOp>(left, left_offset, right, right_offset,
+                           dest, out_offset, length);
+  } else {
+    // Unaligned
+    UnalignedBitmapOp<LogicalOp>(left, left_offset, right, right_offset,
+                                 dest, out_offset, length);
+  }
+}
+
+
+template <typename BitOp, typename LogicalOp>
 Status BitmapOp(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
-  if ((out_offset % 8 == left_offset % 8) && (out_offset % 8 == right_offset % 8)) {
-    // Fast case: can use bytewise AND
-    const int64_t phys_bits = length + out_offset;
-    RETURN_NOT_OK(AllocateEmptyBitmap(pool, phys_bits, out_buffer));
-    AlignedBitmapOp<BitOp>(left, left_offset, right, right_offset,
-                           (*out_buffer)->mutable_data(), out_offset, length);
-  } else {
-    // Unaligned
-    RETURN_NOT_OK(AllocateEmptyBitmap(pool, length + out_offset, out_buffer));
-    UnalignedBitmapOp<LogicalOp>(left, left_offset, right, right_offset,
-                                 (*out_buffer)->mutable_data(), out_offset, length);
-  }
+
+  const int64_t phys_bits = length + out_offset;
+  RETURN_NOT_OK(AllocateEmptyBitmap(pool, phys_bits, out_buffer));
+  uint8_t* out = (*out_buffer)->mutable_data();
+  BitmapOp<BitOp, LogicalOp>(left, left_offset, right, right_offset, length, out_offset, out); 
   return Status::OK();
 }
 
@@ -336,6 +345,28 @@ Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
   return BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(
       pool, left, left_offset, right, right_offset, length, out_offset, out_buffer);
 }
+
+void BitmapAnd(const uint8_t* left, int64_t left_offset,
+                 const uint8_t* right, int64_t right_offset, int64_t length,
+                 int64_t out_offset, uint8_t* out) {
+  BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
+      left, left_offset, right, right_offset, length, out_offset, out);
+}
+
+void BitmapOr(const uint8_t* left, int64_t left_offset,
+                const uint8_t* right, int64_t right_offset, int64_t length,
+                int64_t out_offset, uint8_t* out) {
+  BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
+      left, left_offset, right, right_offset, length, out_offset, out);
+}
+
+void BitmapXor(const uint8_t* left, int64_t left_offset,
+                 const uint8_t* right, int64_t right_offset, int64_t length,
+                 int64_t out_offset, uint8_t* out) {
+  BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(
+      left, left_offset, right, right_offset, length, out_offset, out);
+}
+
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -296,30 +296,28 @@ void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* 
 }
 
 template <typename BitOp, typename LogicalOp>
-void BitmapOp(const uint8_t* left, int64_t left_offset,
-                const uint8_t* right, int64_t right_offset, int64_t length,
-                int64_t out_offset, uint8_t* dest) {
+void BitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* dest) {
   if ((out_offset % 8 == left_offset % 8) && (out_offset % 8 == right_offset % 8)) {
     // Fast case: can use bytewise AND
-    AlignedBitmapOp<BitOp>(left, left_offset, right, right_offset,
-                           dest, out_offset, length);
+    AlignedBitmapOp<BitOp>(left, left_offset, right, right_offset, dest, out_offset,
+                           length);
   } else {
     // Unaligned
-    UnalignedBitmapOp<LogicalOp>(left, left_offset, right, right_offset,
-                                 dest, out_offset, length);
+    UnalignedBitmapOp<LogicalOp>(left, left_offset, right, right_offset, dest, out_offset,
+                                 length);
   }
 }
-
 
 template <typename BitOp, typename LogicalOp>
 Status BitmapOp(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
-
   const int64_t phys_bits = length + out_offset;
   RETURN_NOT_OK(AllocateEmptyBitmap(pool, phys_bits, out_buffer));
   uint8_t* out = (*out_buffer)->mutable_data();
-  BitmapOp<BitOp, LogicalOp>(left, left_offset, right, right_offset, length, out_offset, out); 
+  BitmapOp<BitOp, LogicalOp>(left, left_offset, right, right_offset, length, out_offset,
+                             out);
   return Status::OK();
 }
 
@@ -346,27 +344,23 @@ Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
       pool, left, left_offset, right, right_offset, length, out_offset, out_buffer);
 }
 
-void BitmapAnd(const uint8_t* left, int64_t left_offset,
-                 const uint8_t* right, int64_t right_offset, int64_t length,
-                 int64_t out_offset, uint8_t* out) {
+void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
   BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
       left, left_offset, right, right_offset, length, out_offset, out);
 }
 
-void BitmapOr(const uint8_t* left, int64_t left_offset,
-                const uint8_t* right, int64_t right_offset, int64_t length,
-                int64_t out_offset, uint8_t* out) {
+void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
   BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
       left, left_offset, right, right_offset, length, out_offset, out);
 }
 
-void BitmapXor(const uint8_t* left, int64_t left_offset,
-                 const uint8_t* right, int64_t right_offset, int64_t length,
-                 int64_t out_offset, uint8_t* out) {
+void BitmapXor(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
   BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(
       left, left_offset, right, right_offset, length, out_offset, out);
 }
-
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -330,6 +330,12 @@ Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
       pool, left, left_offset, right, right_offset, length, out_offset, out_buffer);
 }
 
+void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
+  BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
+      left, left_offset, right, right_offset, length, out_offset, out);
+}
+
 Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
@@ -337,23 +343,17 @@ Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
       pool, left, left_offset, right, right_offset, length, out_offset, out_buffer);
 }
 
+void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
+  BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
+      left, left_offset, right, right_offset, length, out_offset, out);
+}
+
 Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
   return BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(
       pool, left, left_offset, right, right_offset, length, out_offset, out_buffer);
-}
-
-void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
-  BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
-      left, left_offset, right, right_offset, length, out_offset, out);
-}
-
-void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
-  BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
-      left, left_offset, right, right_offset, length, out_offset, out);
 }
 
 void BitmapXor(const uint8_t* left, int64_t left_offset, const uint8_t* right,

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -772,8 +772,7 @@ Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
 /// starting at the given bit-offset.
 ARROW_EXPORT
 void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-              int64_t right_offset, int64_t length, int64_t out_offset,
-              uint8_t* out);
+              int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
 
 /// \brief Do a "bitmap xor" for the given bit-length on right and left
 /// buffers starting at their respective bit-offsets and put the results in

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -749,9 +749,8 @@ Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.
 ARROW_EXPORT
-void BitmapAnd(const uint8_t* left, int64_t left_offset,
-                 const uint8_t* right, int64_t right_offset, int64_t length,
-                 int64_t out_offset, uint8_t* out);
+void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
 
 /// \brief Do a "bitmap or" for the given bit length on right and left buffers
 /// starting at their respective bit-offsets and put the results in out
@@ -768,15 +767,14 @@ Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
 /// starting at their respective bit-offsets and put the results in out
 /// starting at the given bit-offset.
 ARROW_EXPORT
-void BitmapOr(const uint8_t* left, int64_t left_offset,
-                const uint8_t* right, int64_t right_offset, int64_t length,
-                int64_t out_offset, uint8_t* out_buffer);
-
+void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+              int64_t right_offset, int64_t length, int64_t out_offset,
+              uint8_t* out_buffer);
 
 /// \brief Do a "bitmap xor" for the given bit-length on right and left
 /// buffers starting at their respective bit-offsets and put the results in
-/// out_buffer starting at the given bit offset.  
-/// 
+/// out_buffer starting at the given bit offset.
+///
 ///
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.
@@ -785,15 +783,12 @@ Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 
-
 /// \brief Do a "bitmap xor" for the given bit-length on right and left
 /// buffers starting at their respective bit-offsets and put the results in
 /// out starting at the given bit offset.
 ARROW_EXPORT
-void BitmapXor(const uint8_t* left, int64_t left_offset,
-                 const uint8_t* right, int64_t right_offset, int64_t length,
-                 int64_t out_offset, uint8_t* out);
-
+void BitmapXor(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -738,6 +738,12 @@ ARROW_EXPORT
 bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                   int64_t right_offset, int64_t bit_length);
 
+/// \brief Do a "bitmap and" on right and left buffers starting at
+/// their respective bit-offsets for the given bit-length and put
+/// the results in out_buffer starting at the given bit-offset.
+///
+/// out_buffer will be allocated and initialized to zeros using pool before
+/// the operation.
 ARROW_EXPORT
 Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
@@ -746,14 +752,12 @@ Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out starting at the given bit-offset.
-/// out_buffer will be allocated and initialized to zeros using pool before
-/// the operation.
 ARROW_EXPORT
 void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out);
 
 /// \brief Do a "bitmap or" for the given bit length on right and left buffers
-/// starting at their respective bit-offsets and put the results in out
+/// starting at their respective bit-offsets and put the results in out_buffer
 /// starting at the given bit-offset.
 ///
 /// out_buffer will be allocated and initialized to zeros using pool before
@@ -769,12 +773,11 @@ Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
 ARROW_EXPORT
 void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
               int64_t right_offset, int64_t length, int64_t out_offset,
-              uint8_t* out_buffer);
+              uint8_t* out);
 
 /// \brief Do a "bitmap xor" for the given bit-length on right and left
 /// buffers starting at their respective bit-offsets and put the results in
 /// out_buffer starting at the given bit offset.
-///
 ///
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -743,15 +743,57 @@ Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 
+/// \brief Do a "bitmap and" on right and left buffers starting at
+/// their respective bit-offsets for the given bit-length and put
+/// the results in out starting at the given bit-offset.
+/// out_buffer will be allocated and initialized to zeros using pool before
+/// the operation.
+ARROW_EXPORT
+void BitmapAnd(const uint8_t* left, int64_t left_offset,
+                 const uint8_t* right, int64_t right_offset, int64_t length,
+                 int64_t out_offset, uint8_t* out);
+
+/// \brief Do a "bitmap or" for the given bit length on right and left buffers
+/// starting at their respective bit-offsets and put the results in out
+/// starting at the given bit-offset.
+///
+/// out_buffer will be allocated and initialized to zeros using pool before
+/// the operation.
 ARROW_EXPORT
 Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 
+/// \brief Do a "bitmap or" for the given bit length on right and left buffers
+/// starting at their respective bit-offsets and put the results in out
+/// starting at the given bit-offset.
+ARROW_EXPORT
+void BitmapOr(const uint8_t* left, int64_t left_offset,
+                const uint8_t* right, int64_t right_offset, int64_t length,
+                int64_t out_offset, uint8_t* out_buffer);
+
+
+/// \brief Do a "bitmap xor" for the given bit-length on right and left
+/// buffers starting at their respective bit-offsets and put the results in
+/// out_buffer starting at the given bit offset.  
+/// 
+///
+/// out_buffer will be allocated and initialized to zeros using pool before
+/// the operation.
 ARROW_EXPORT
 Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
+
+
+/// \brief Do a "bitmap xor" for the given bit-length on right and left
+/// buffers starting at their respective bit-offsets and put the results in
+/// out starting at the given bit offset.
+ARROW_EXPORT
+void BitmapXor(const uint8_t* left, int64_t left_offset,
+                 const uint8_t* right, int64_t right_offset, int64_t length,
+                 int64_t out_offset, uint8_t* out);
+
 
 }  // namespace internal
 }  // namespace arrow


### PR DESCRIPTION
Precursor to fixing the rest of the boolean computer kernels to not allocate memory.