### PR TITLE
ARROW-3814: [R] RecordBatch$from_arrays()

### DIFF
--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -693,10 +693,6 @@ RecordBatch__column <- function(batch, i) {
     .Call(`_arrow_RecordBatch__column`, batch, i)
 }
 
-RecordBatch__from_dataframe <- function(tbl) {
-    .Call(`_arrow_RecordBatch__from_dataframe`, tbl)
-}
-
 RecordBatch__Equals <- function(self, other) {
     .Call(`_arrow_RecordBatch__Equals`, self, other)
 }

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -813,8 +813,8 @@ Table__columns <- function(table) {
     .Call(`_arrow_Table__columns`, table)
 }
 
-Table__from_arrays <- function(lst) {
-    .Call(`_arrow_Table__from_arrays`, lst)
+Table__from_dots <- function(lst, schema_sxp) {
+    .Call(`_arrow_Table__from_dots`, lst, schema_sxp)
 }
 
 #' Get the capacity of the global thread pool

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -813,8 +813,8 @@ Table__columns <- function(table) {
     .Call(`_arrow_Table__columns`, table)
 }
 
-Table__from_arrays <- function(schema_sxp, lst) {
-    .Call(`_arrow_Table__from_arrays`, schema_sxp, lst)
+Table__from_arrays <- function(lst) {
+    .Call(`_arrow_Table__from_arrays`, lst)
 }
 
 #' Get the capacity of the global thread pool

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -729,6 +729,10 @@ ipc___ReadRecordBatch__InputStream__Schema <- function(stream, schema) {
     .Call(`_arrow_ipc___ReadRecordBatch__InputStream__Schema`, stream, schema)
 }
 
+RecordBatch__from_arrays <- function(schema, lst) {
+    .Call(`_arrow_RecordBatch__from_arrays`, schema, lst)
+}
+
 RecordBatchReader__schema <- function(reader) {
     .Call(`_arrow_RecordBatchReader__schema`, reader)
 }

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -793,10 +793,6 @@ ipc___RecordBatchStreamWriter__Open <- function(stream, schema) {
     .Call(`_arrow_ipc___RecordBatchStreamWriter__Open`, stream, schema)
 }
 
-Table__from_dataframe <- function(tbl) {
-    .Call(`_arrow_Table__from_dataframe`, tbl)
-}
-
 Table__num_columns <- function(x) {
     .Call(`_arrow_Table__num_columns`, x)
 }
@@ -815,6 +811,10 @@ Table__column <- function(table, i) {
 
 Table__columns <- function(table) {
     .Call(`_arrow_Table__columns`, table)
+}
+
+Table__from_arrays <- function(schema_sxp, lst) {
+    .Call(`_arrow_Table__from_arrays`, schema_sxp, lst)
 }
 
 #' Get the capacity of the global thread pool

--- a/r/R/RcppExports.R
+++ b/r/R/RcppExports.R
@@ -729,8 +729,8 @@ ipc___ReadRecordBatch__InputStream__Schema <- function(stream, schema) {
     .Call(`_arrow_ipc___ReadRecordBatch__InputStream__Schema`, stream, schema)
 }
 
-RecordBatch__from_arrays <- function(schema, lst) {
-    .Call(`_arrow_RecordBatch__from_arrays`, schema, lst)
+RecordBatch__from_arrays <- function(schema_sxp, lst) {
+    .Call(`_arrow_RecordBatch__from_arrays`, schema_sxp, lst)
 }
 
 RecordBatchReader__schema <- function(reader) {

--- a/r/R/RecordBatch.R
+++ b/r/R/RecordBatch.R
@@ -89,14 +89,6 @@
   RecordBatch__to_dataframe(x, use_threads = use_threads)
 }
 
-to_array <- function(x) {
-  if (inherits(x, "arrow::Array")) {
-    x
-  } else {
-    array(x)
-  }
-}
-
 #' Create an [arrow::RecordBatch][arrow__RecordBatch] from a data frame
 #'
 #' @param ... A variable number of arrow::Array
@@ -107,5 +99,5 @@ to_array <- function(x) {
 record_batch <- function(..., schema = NULL){
   arrays <- tibble::lst(...)
   stopifnot(length(arrays) > 0)
-  shared_ptr(`arrow::RecordBatch`, RecordBatch__from_arrays(schema, arrays) )
+  shared_ptr(`arrow::RecordBatch`, RecordBatch__from_arrays(schema, arrays))
 }

--- a/r/R/RecordBatch.R
+++ b/r/R/RecordBatch.R
@@ -99,7 +99,8 @@ to_array <- function(x) {
 
 #' Create an [arrow::RecordBatch][arrow__RecordBatch] from a data frame
 #'
-#' @param .data a data frame
+#' @param ... A variable number of arrow::Array
+#' @param schema a arrow::Schema
 #'
 #' @return a [arrow::RecordBatch][arrow__RecordBatch]
 #' @export

--- a/r/R/RecordBatch.R
+++ b/r/R/RecordBatch.R
@@ -105,13 +105,7 @@ to_array <- function(x) {
 #' @return a [arrow::RecordBatch][arrow__RecordBatch]
 #' @export
 record_batch <- function(..., schema = NULL){
-  # TODO: maybe this can be done internally in parallel
-  arrays <- map(tibble::lst(...), to_array)
+  arrays <- tibble::lst(...)
   stopifnot(length(arrays) > 0)
-
-  if (!inherits(schema, "arrow::Schema")){
-    schema <- schema(!!!map(arrays, ~.$type))
-  }
-
   shared_ptr(`arrow::RecordBatch`, RecordBatch__from_arrays(schema, arrays) )
 }

--- a/r/R/Schema.R
+++ b/r/R/Schema.R
@@ -61,7 +61,7 @@
 #'
 #' @export
 schema <- function(...){
-  shared_ptr(`arrow::Schema`, schema_(.fields(list(...))))
+  shared_ptr(`arrow::Schema`, schema_(.fields(list2(...))))
 }
 
 #' read a Schema from a stream

--- a/r/R/Table.R
+++ b/r/R/Table.R
@@ -54,13 +54,13 @@
 #' Create an arrow::Table from a data frame
 #'
 #' @param ... arrays, chunked arrays, or R vectors
-#' @param schema NULL or a schema
+#' @param schema NULL or a schema (currently ignored)
 #'
 #' @export
 table <- function(..., schema = NULL){
-  arrays <- tibble::lst(...)
-  stopifnot(length(arrays) > 0)
-  shared_ptr(`arrow::Table`, Table__from_arrays(schema, arrays))
+  dots <- tibble::lst(...)
+  stopifnot(length(dots) > 0)
+  shared_ptr(`arrow::Table`, Table__from_arrays(dots))
 }
 
 #' @export

--- a/r/R/Table.R
+++ b/r/R/Table.R
@@ -54,13 +54,15 @@
 #' Create an arrow::Table from a data frame
 #'
 #' @param ... arrays, chunked arrays, or R vectors
-#' @param schema NULL or a schema (currently ignored)
+#' @param schema a schema. The default (`NULL`) infers the schema from the `...`
+#'
+#' @return an arrow::Table
 #'
 #' @export
 table <- function(..., schema = NULL){
   dots <- tibble::lst(...)
   stopifnot(length(dots) > 0)
-  shared_ptr(`arrow::Table`, Table__from_arrays(dots))
+  shared_ptr(`arrow::Table`, Table__from_dots(dots, schema))
 }
 
 #' @export

--- a/r/R/Table.R
+++ b/r/R/Table.R
@@ -53,11 +53,14 @@
 
 #' Create an arrow::Table from a data frame
 #'
-#' @param .data a data frame
+#' @param ... arrays, chunked arrays, or R vectors
+#' @param schema NULL or a schema
 #'
 #' @export
-table <- function(.data){
-  shared_ptr(`arrow::Table`, Table__from_dataframe(.data))
+table <- function(..., schema = NULL){
+  arrays <- tibble::lst(...)
+  stopifnot(length(arrays) > 0)
+  shared_ptr(`arrow::Table`, Table__from_arrays(schema, arrays))
 }
 
 #' @export

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -72,6 +72,11 @@ write_feather.default <- function(data, stream) {
 
 #' @export
 write_feather.data.frame <- function(data, stream) {
+  # splice the columns in the record_batch() call
+  # e.g. if we had data <- data.frame(x = <...>, y = <...>)
+  # then record_batch(!!!data) is the same as
+  # record_batch(x = data$x, y = data$y)
+  # see ?rlang::list2()
   write_feather(record_batch(!!!data), stream)
 }
 

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -72,7 +72,7 @@ write_feather.default <- function(data, stream) {
 
 #' @export
 write_feather.data.frame <- function(data, stream) {
-  write_feather(record_batch(data), stream)
+  write_feather(record_batch(!!!data), stream)
 }
 
 #' @method write_feather arrow::RecordBatch

--- a/r/R/write_arrow.R
+++ b/r/R/write_arrow.R
@@ -21,6 +21,9 @@ to_arrow <- function(x) {
 
 `to_arrow.arrow::RecordBatch` <- function(x) x
 `to_arrow.arrow::Table` <- function(x) x
+
+# splice the data frame as arguments of table()
+# see ?rlang::list2()
 `to_arrow.data.frame` <- function(x) table(!!!x)
 
 #' serialize an [arrow::Table][arrow__Table], an [arrow::RecordBatch][arrow__RecordBatch], or a

--- a/r/R/write_arrow.R
+++ b/r/R/write_arrow.R
@@ -21,7 +21,7 @@ to_arrow <- function(x) {
 
 `to_arrow.arrow::RecordBatch` <- function(x) x
 `to_arrow.arrow::Table` <- function(x) x
-`to_arrow.data.frame` <- function(x) table(x)
+`to_arrow.data.frame` <- function(x) table(!!!x)
 
 #' serialize an [arrow::Table][arrow__Table], an [arrow::RecordBatch][arrow__RecordBatch], or a
 #'   data frame to either the streaming format or the binary file format

--- a/r/lint.sh
+++ b/r/lint.sh
@@ -33,4 +33,4 @@ CPPLINT=$CPP_BUILD_SUPPORT/cpplint.py
 $CPP_BUILD_SUPPORT/run_cpplint.py \
     --cpplint_binary=$CPPLINT \
     --exclude_glob=$CPP_BUILD_SUPPORT/lint_exclusions.txt \
-    --source_dir=$SOURCE_DIR/src --quiet $1
+    --source_dir=$SOURCE_DIR/src --quiet

--- a/r/man/record_batch.Rd
+++ b/r/man/record_batch.Rd
@@ -7,7 +7,9 @@
 record_batch(..., schema = NULL)
 }
 \arguments{
-\item{.data}{a data frame}
+\item{...}{A variable number of arrow::Array}
+
+\item{schema}{a arrow::Schema}
 }
 \value{
 a \link[=arrow__RecordBatch]{arrow::RecordBatch}

--- a/r/man/record_batch.Rd
+++ b/r/man/record_batch.Rd
@@ -4,7 +4,7 @@
 \alias{record_batch}
 \title{Create an \link[=arrow__RecordBatch]{arrow::RecordBatch} from a data frame}
 \usage{
-record_batch(.data)
+record_batch(..., schema = NULL)
 }
 \arguments{
 \item{.data}{a data frame}

--- a/r/man/table.Rd
+++ b/r/man/table.Rd
@@ -4,10 +4,12 @@
 \alias{table}
 \title{Create an arrow::Table from a data frame}
 \usage{
-table(.data)
+table(..., schema = NULL)
 }
 \arguments{
-\item{.data}{a data frame}
+\item{...}{arrays, chunked arrays, or R vectors}
+
+\item{schema}{NULL or a schema}
 }
 \description{
 Create an arrow::Table from a data frame

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -1940,17 +1940,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// RecordBatch__from_dataframe
-std::shared_ptr<arrow::RecordBatch> RecordBatch__from_dataframe(Rcpp::DataFrame tbl);
-RcppExport SEXP _arrow_RecordBatch__from_dataframe(SEXP tblSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< Rcpp::DataFrame >::type tbl(tblSEXP);
-    rcpp_result_gen = Rcpp::wrap(RecordBatch__from_dataframe(tbl));
-    return rcpp_result_gen;
-END_RCPP
-}
 // RecordBatch__Equals
 bool RecordBatch__Equals(const std::shared_ptr<arrow::RecordBatch>& self, const std::shared_ptr<arrow::RecordBatch>& other);
 RcppExport SEXP _arrow_RecordBatch__Equals(SEXP selfSEXP, SEXP otherSEXP) {
@@ -2047,13 +2036,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // RecordBatch__from_arrays
-std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP schema_sxp, List_ lst);
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP schema_sxp, SEXP lst);
 RcppExport SEXP _arrow_RecordBatch__from_arrays(SEXP schema_sxpSEXP, SEXP lstSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type schema_sxp(schema_sxpSEXP);
-    Rcpp::traits::input_parameter< List_ >::type lst(lstSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type lst(lstSEXP);
     rcpp_result_gen = Rcpp::wrap(RecordBatch__from_arrays(schema_sxp, lst));
     return rcpp_result_gen;
 END_RCPP
@@ -2498,7 +2487,6 @@ static const R_CallMethodDef CallEntries[] = {
     {"_arrow_RecordBatch__schema", (DL_FUNC) &_arrow_RecordBatch__schema, 1},
     {"_arrow_RecordBatch__columns", (DL_FUNC) &_arrow_RecordBatch__columns, 1},
     {"_arrow_RecordBatch__column", (DL_FUNC) &_arrow_RecordBatch__column, 2},
-    {"_arrow_RecordBatch__from_dataframe", (DL_FUNC) &_arrow_RecordBatch__from_dataframe, 1},
     {"_arrow_RecordBatch__Equals", (DL_FUNC) &_arrow_RecordBatch__Equals, 2},
     {"_arrow_RecordBatch__RemoveColumn", (DL_FUNC) &_arrow_RecordBatch__RemoveColumn, 2},
     {"_arrow_RecordBatch__column_name", (DL_FUNC) &_arrow_RecordBatch__column_name, 2},

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -2281,14 +2281,15 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// Table__from_arrays
-std::shared_ptr<arrow::Table> Table__from_arrays(SEXP lst);
-RcppExport SEXP _arrow_Table__from_arrays(SEXP lstSEXP) {
+// Table__from_dots
+std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp);
+RcppExport SEXP _arrow_Table__from_dots(SEXP lstSEXP, SEXP schema_sxpSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< SEXP >::type lst(lstSEXP);
-    rcpp_result_gen = Rcpp::wrap(Table__from_arrays(lst));
+    Rcpp::traits::input_parameter< SEXP >::type schema_sxp(schema_sxpSEXP);
+    rcpp_result_gen = Rcpp::wrap(Table__from_dots(lst, schema_sxp));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2517,7 +2518,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_arrow_Table__schema", (DL_FUNC) &_arrow_Table__schema, 1},
     {"_arrow_Table__column", (DL_FUNC) &_arrow_Table__column, 2},
     {"_arrow_Table__columns", (DL_FUNC) &_arrow_Table__columns, 1},
-    {"_arrow_Table__from_arrays", (DL_FUNC) &_arrow_Table__from_arrays, 1},
+    {"_arrow_Table__from_dots", (DL_FUNC) &_arrow_Table__from_dots, 2},
     {"_arrow_GetCpuThreadPoolCapacity", (DL_FUNC) &_arrow_GetCpuThreadPoolCapacity, 0},
     {"_arrow_SetCpuThreadPoolCapacity", (DL_FUNC) &_arrow_SetCpuThreadPoolCapacity, 1},
     {NULL, NULL, 0}

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -2046,6 +2046,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// RecordBatch__from_arrays
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(const std::shared_ptr<arrow::Schema>& schema, List_ lst);
+RcppExport SEXP _arrow_RecordBatch__from_arrays(SEXP schemaSEXP, SEXP lstSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< const std::shared_ptr<arrow::Schema>& >::type schema(schemaSEXP);
+    Rcpp::traits::input_parameter< List_ >::type lst(lstSEXP);
+    rcpp_result_gen = Rcpp::wrap(RecordBatch__from_arrays(schema, lst));
+    return rcpp_result_gen;
+END_RCPP
+}
 // RecordBatchReader__schema
 std::shared_ptr<arrow::Schema> RecordBatchReader__schema(const std::shared_ptr<arrow::RecordBatchReader>& reader);
 RcppExport SEXP _arrow_RecordBatchReader__schema(SEXP readerSEXP) {
@@ -2495,6 +2507,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_arrow_RecordBatch__Slice2", (DL_FUNC) &_arrow_RecordBatch__Slice2, 3},
     {"_arrow_ipc___SerializeRecordBatch__Raw", (DL_FUNC) &_arrow_ipc___SerializeRecordBatch__Raw, 1},
     {"_arrow_ipc___ReadRecordBatch__InputStream__Schema", (DL_FUNC) &_arrow_ipc___ReadRecordBatch__InputStream__Schema, 2},
+    {"_arrow_RecordBatch__from_arrays", (DL_FUNC) &_arrow_RecordBatch__from_arrays, 2},
     {"_arrow_RecordBatchReader__schema", (DL_FUNC) &_arrow_RecordBatchReader__schema, 1},
     {"_arrow_RecordBatchReader__ReadNext", (DL_FUNC) &_arrow_RecordBatchReader__ReadNext, 1},
     {"_arrow_ipc___RecordBatchStreamReader__Open", (DL_FUNC) &_arrow_ipc___RecordBatchStreamReader__Open, 1},

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -2225,17 +2225,6 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// Table__from_dataframe
-std::shared_ptr<arrow::Table> Table__from_dataframe(DataFrame tbl);
-RcppExport SEXP _arrow_Table__from_dataframe(SEXP tblSEXP) {
-BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
-    Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< DataFrame >::type tbl(tblSEXP);
-    rcpp_result_gen = Rcpp::wrap(Table__from_dataframe(tbl));
-    return rcpp_result_gen;
-END_RCPP
-}
 // Table__num_columns
 int Table__num_columns(const std::shared_ptr<arrow::Table>& x);
 RcppExport SEXP _arrow_Table__num_columns(SEXP xSEXP) {
@@ -2289,6 +2278,18 @@ BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::shared_ptr<arrow::Table>& >::type table(tableSEXP);
     rcpp_result_gen = Rcpp::wrap(Table__columns(table));
+    return rcpp_result_gen;
+END_RCPP
+}
+// Table__from_arrays
+std::shared_ptr<arrow::Table> Table__from_arrays(SEXP schema_sxp, SEXP lst);
+RcppExport SEXP _arrow_Table__from_arrays(SEXP schema_sxpSEXP, SEXP lstSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< SEXP >::type schema_sxp(schema_sxpSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type lst(lstSEXP);
+    rcpp_result_gen = Rcpp::wrap(Table__from_arrays(schema_sxp, lst));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2512,12 +2513,12 @@ static const R_CallMethodDef CallEntries[] = {
     {"_arrow_ipc___RecordBatchWriter__Close", (DL_FUNC) &_arrow_ipc___RecordBatchWriter__Close, 1},
     {"_arrow_ipc___RecordBatchFileWriter__Open", (DL_FUNC) &_arrow_ipc___RecordBatchFileWriter__Open, 2},
     {"_arrow_ipc___RecordBatchStreamWriter__Open", (DL_FUNC) &_arrow_ipc___RecordBatchStreamWriter__Open, 2},
-    {"_arrow_Table__from_dataframe", (DL_FUNC) &_arrow_Table__from_dataframe, 1},
     {"_arrow_Table__num_columns", (DL_FUNC) &_arrow_Table__num_columns, 1},
     {"_arrow_Table__num_rows", (DL_FUNC) &_arrow_Table__num_rows, 1},
     {"_arrow_Table__schema", (DL_FUNC) &_arrow_Table__schema, 1},
     {"_arrow_Table__column", (DL_FUNC) &_arrow_Table__column, 2},
     {"_arrow_Table__columns", (DL_FUNC) &_arrow_Table__columns, 1},
+    {"_arrow_Table__from_arrays", (DL_FUNC) &_arrow_Table__from_arrays, 2},
     {"_arrow_GetCpuThreadPoolCapacity", (DL_FUNC) &_arrow_GetCpuThreadPoolCapacity, 0},
     {"_arrow_SetCpuThreadPoolCapacity", (DL_FUNC) &_arrow_SetCpuThreadPoolCapacity, 1},
     {NULL, NULL, 0}

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -2047,14 +2047,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // RecordBatch__from_arrays
-std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(const std::shared_ptr<arrow::Schema>& schema, List_ lst);
-RcppExport SEXP _arrow_RecordBatch__from_arrays(SEXP schemaSEXP, SEXP lstSEXP) {
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP schema_sxp, List_ lst);
+RcppExport SEXP _arrow_RecordBatch__from_arrays(SEXP schema_sxpSEXP, SEXP lstSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< const std::shared_ptr<arrow::Schema>& >::type schema(schemaSEXP);
+    Rcpp::traits::input_parameter< SEXP >::type schema_sxp(schema_sxpSEXP);
     Rcpp::traits::input_parameter< List_ >::type lst(lstSEXP);
-    rcpp_result_gen = Rcpp::wrap(RecordBatch__from_arrays(schema, lst));
+    rcpp_result_gen = Rcpp::wrap(RecordBatch__from_arrays(schema_sxp, lst));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/r/src/RcppExports.cpp
+++ b/r/src/RcppExports.cpp
@@ -2282,14 +2282,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // Table__from_arrays
-std::shared_ptr<arrow::Table> Table__from_arrays(SEXP schema_sxp, SEXP lst);
-RcppExport SEXP _arrow_Table__from_arrays(SEXP schema_sxpSEXP, SEXP lstSEXP) {
+std::shared_ptr<arrow::Table> Table__from_arrays(SEXP lst);
+RcppExport SEXP _arrow_Table__from_arrays(SEXP lstSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< SEXP >::type schema_sxp(schema_sxpSEXP);
     Rcpp::traits::input_parameter< SEXP >::type lst(lstSEXP);
-    rcpp_result_gen = Rcpp::wrap(Table__from_arrays(schema_sxp, lst));
+    rcpp_result_gen = Rcpp::wrap(Table__from_arrays(lst));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -2518,7 +2517,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_arrow_Table__schema", (DL_FUNC) &_arrow_Table__schema, 1},
     {"_arrow_Table__column", (DL_FUNC) &_arrow_Table__column, 2},
     {"_arrow_Table__columns", (DL_FUNC) &_arrow_Table__columns, 1},
-    {"_arrow_Table__from_arrays", (DL_FUNC) &_arrow_Table__from_arrays, 2},
+    {"_arrow_Table__from_arrays", (DL_FUNC) &_arrow_Table__from_arrays, 1},
     {"_arrow_GetCpuThreadPoolCapacity", (DL_FUNC) &_arrow_GetCpuThreadPoolCapacity, 0},
     {"_arrow_SetCpuThreadPoolCapacity", (DL_FUNC) &_arrow_SetCpuThreadPoolCapacity, 1},
     {NULL, NULL, 0}

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -298,14 +298,13 @@ struct Unbox<Type, enable_if_integer<Type>> {
           return IngestRange<int64_t>(builder, reinterpret_cast<int64_t*>(REAL(obj)),
                                       XLENGTH(obj), NA_INT64);
         }
-      // TODO: handle aw and logical
+      // TODO: handle raw and logical
       default:
         break;
     }
 
-    return Status::Invalid(
-        tfm::format("Cannot convert R vector of type %s to integer Arrow array",
-                    Rcpp::type2name(obj)));
+    return Status::Invalid(tfm::format(
+        "Cannot convert R vector of type %s to integer Arrow array", Rcpp::type2name(obj)));
   }
 
   template <typename T>
@@ -593,7 +592,11 @@ class TimeConverter : public VectorConverter {
   using BuilderType = typename TypeTraits<Type>::BuilderType;
 
  public:
+<<<<<<< HEAD
   explicit TimeConverter(TimeUnit::type unit)
+=======
+  TimeConverter(TimeUnit::type unit)
+>>>>>>> Also run cpplint and clang-format on .cpp files
       : unit_(unit), multiplier_(get_time_multiplier(unit)) {}
 
   Status Init(ArrayBuilder* builder) override {
@@ -655,10 +658,17 @@ class TimeConverter : public VectorConverter {
 
 class TimestampConverter : public TimeConverter<TimestampType> {
  public:
+<<<<<<< HEAD
   explicit TimestampConverter(TimeUnit::type unit) : TimeConverter<TimestampType>(unit) {}
 
  protected:
   bool valid_R_object(SEXP obj) override {
+=======
+  TimestampConverter(TimeUnit::type unit) : TimeConverter<TimestampType>(unit) {}
+
+ protected:
+  virtual bool valid_R_object(SEXP obj) override {
+>>>>>>> Also run cpplint and clang-format on .cpp files
     return TYPEOF(obj) == REALSXP && Rf_inherits(obj, "POSIXct");
   }
 
@@ -670,20 +680,34 @@ class TimestampConverter : public TimeConverter<TimestampType> {
 
 class Time32Converter : public TimeConverter<Time32Type> {
  public:
+<<<<<<< HEAD
   explicit Time32Converter(TimeUnit::type unit) : TimeConverter<Time32Type>(unit) {}
 
  protected:
   bool valid_R_object(SEXP obj) override {
+=======
+  Time32Converter(TimeUnit::type unit) : TimeConverter<Time32Type>(unit) {}
+
+ protected:
+  virtual bool valid_R_object(SEXP obj) override {
+>>>>>>> Also run cpplint and clang-format on .cpp files
     return TYPEOF(obj) == REALSXP && Rf_inherits(obj, "difftime");
   }
 };
 
 class Time64Converter : public TimeConverter<Time64Type> {
  public:
+<<<<<<< HEAD
   explicit Time64Converter(TimeUnit::type unit) : TimeConverter<Time64Type>(unit) {}
 
  protected:
   bool valid_R_object(SEXP obj) override {
+=======
+  Time64Converter(TimeUnit::type unit) : TimeConverter<Time64Type>(unit) {}
+
+ protected:
+  virtual bool valid_R_object(SEXP obj) override {
+>>>>>>> Also run cpplint and clang-format on .cpp files
     return TYPEOF(obj) == REALSXP && Rf_inherits(obj, "difftime");
   }
 };
@@ -879,8 +903,14 @@ std::shared_ptr<Array> MakeSimpleArray(SEXP x) {
     buffers[0] = std::move(null_bitmap);
   }
 
+<<<<<<< HEAD
   auto data = ArrayData::Make(std::make_shared<Type>(), LENGTH(x), std::move(buffers),
                               null_count, 0);
+=======
+  auto data = ArrayData::Make(
+      std::make_shared<Type>(), LENGTH(x), std::move(buffers), null_count, 0 /*offset*/
+  );
+>>>>>>> Also run cpplint and clang-format on .cpp files
 
   // return the right Array class
   return std::make_shared<typename TypeTraits<Type>::ArrayType>(data);

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -270,8 +270,7 @@ class VectorConverter {
   virtual Status Ingest(SEXP obj) = 0;
 
   virtual Status GetResult(std::shared_ptr<arrow::Array>* result) {
-    RETURN_NOT_OK(builder_->Finish(result));
-    return Status::OK();
+    return builder_->Finish(result);
   }
 
   ArrayBuilder* builder() const { return builder_; }

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -303,8 +303,9 @@ struct Unbox<Type, enable_if_integer<Type>> {
         break;
     }
 
-    return Status::Invalid(tfm::format(
-        "Cannot convert R vector of type %s to integer Arrow array", Rcpp::type2name(obj)));
+    return Status::Invalid(
+        tfm::format("Cannot convert R vector of type %s to integer Arrow array",
+                    Rcpp::type2name(obj)));
   }
 
   template <typename T>
@@ -592,11 +593,7 @@ class TimeConverter : public VectorConverter {
   using BuilderType = typename TypeTraits<Type>::BuilderType;
 
  public:
-<<<<<<< HEAD
   explicit TimeConverter(TimeUnit::type unit)
-=======
-  TimeConverter(TimeUnit::type unit)
->>>>>>> Also run cpplint and clang-format on .cpp files
       : unit_(unit), multiplier_(get_time_multiplier(unit)) {}
 
   Status Init(ArrayBuilder* builder) override {
@@ -658,17 +655,10 @@ class TimeConverter : public VectorConverter {
 
 class TimestampConverter : public TimeConverter<TimestampType> {
  public:
-<<<<<<< HEAD
   explicit TimestampConverter(TimeUnit::type unit) : TimeConverter<TimestampType>(unit) {}
 
  protected:
   bool valid_R_object(SEXP obj) override {
-=======
-  TimestampConverter(TimeUnit::type unit) : TimeConverter<TimestampType>(unit) {}
-
- protected:
-  virtual bool valid_R_object(SEXP obj) override {
->>>>>>> Also run cpplint and clang-format on .cpp files
     return TYPEOF(obj) == REALSXP && Rf_inherits(obj, "POSIXct");
   }
 
@@ -680,34 +670,20 @@ class TimestampConverter : public TimeConverter<TimestampType> {
 
 class Time32Converter : public TimeConverter<Time32Type> {
  public:
-<<<<<<< HEAD
   explicit Time32Converter(TimeUnit::type unit) : TimeConverter<Time32Type>(unit) {}
 
  protected:
   bool valid_R_object(SEXP obj) override {
-=======
-  Time32Converter(TimeUnit::type unit) : TimeConverter<Time32Type>(unit) {}
-
- protected:
-  virtual bool valid_R_object(SEXP obj) override {
->>>>>>> Also run cpplint and clang-format on .cpp files
     return TYPEOF(obj) == REALSXP && Rf_inherits(obj, "difftime");
   }
 };
 
 class Time64Converter : public TimeConverter<Time64Type> {
  public:
-<<<<<<< HEAD
   explicit Time64Converter(TimeUnit::type unit) : TimeConverter<Time64Type>(unit) {}
 
  protected:
   bool valid_R_object(SEXP obj) override {
-=======
-  Time64Converter(TimeUnit::type unit) : TimeConverter<Time64Type>(unit) {}
-
- protected:
-  virtual bool valid_R_object(SEXP obj) override {
->>>>>>> Also run cpplint and clang-format on .cpp files
     return TYPEOF(obj) == REALSXP && Rf_inherits(obj, "difftime");
   }
 };
@@ -903,14 +879,8 @@ std::shared_ptr<Array> MakeSimpleArray(SEXP x) {
     buffers[0] = std::move(null_bitmap);
   }
 
-<<<<<<< HEAD
   auto data = ArrayData::Make(std::make_shared<Type>(), LENGTH(x), std::move(buffers),
-                              null_count, 0);
-=======
-  auto data = ArrayData::Make(
-      std::make_shared<Type>(), LENGTH(x), std::move(buffers), null_count, 0 /*offset*/
-  );
->>>>>>> Also run cpplint and clang-format on .cpp files
+                              null_count, 0 /*offset*/);
 
   // return the right Array class
   return std::make_shared<typename TypeTraits<Type>::ArrayType>(data);

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -19,6 +19,7 @@
 
 #include <limits>
 #include <memory>
+#include <vector>
 
 #include <RcppCommon.h>
 
@@ -216,7 +217,8 @@ std::vector<std::shared_ptr<T>> list_to_shared_ptr_vector(SEXP lst) {
   return res;
 }
 
-std::shared_ptr<arrow::Array> Array__from_vector(SEXP x, const std::shared_ptr<arrow::DataType>& type, bool type_infered);
+std::shared_ptr<arrow::Array> Array__from_vector(
+    SEXP x, const std::shared_ptr<arrow::DataType>& type, bool type_infered);
 
 }  // namespace r
 }  // namespace arrow

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -36,11 +36,12 @@
 #include <arrow/type.h>
 #include <arrow/util/compression.h>
 
-#define STOP_IF_NOT(TEST, MSG)    \
-  do {                            \
-    if (!(TEST)) Rcpp::stop(MSG); \
-  } while (0)
+#define STOP_IF(TEST, MSG)    \
+do {                              \
+  if (TEST) Rcpp::stop(MSG);   \
+} while (0)
 
+#define STOP_IF_NOT(TEST, MSG) STOP_IF(!(TEST), MSG)
 #define STOP_IF_NOT_OK(s) STOP_IF_NOT(s.ok(), s.ToString())
 
 template <typename T>

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -216,5 +216,7 @@ std::vector<std::shared_ptr<T>> list_to_shared_ptr_vector(SEXP lst) {
   return res;
 }
 
+std::shared_ptr<arrow::Array> Array__from_vector(SEXP x, const std::shared_ptr<arrow::DataType>& type, bool type_infered);
+
 }  // namespace r
 }  // namespace arrow

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -212,8 +212,7 @@ std::vector<std::shared_ptr<T>> list_to_shared_ptr_vector(SEXP lst) {
   R_xlen_t n = XLENGTH(lst);
   std::vector<std::shared_ptr<T>> res(n);
   for (R_xlen_t i = 0; i < n; i++) {
-    res[i] = Rcpp::ConstReferenceSmartPtrInputParameter<std::shared_ptr<T>>(
-        VECTOR_ELT(lst, i));
+    res[i] = extract<T>(VECTOR_ELT(lst, i));
   }
   return res;
 }

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -213,7 +213,7 @@ std::vector<std::shared_ptr<T>> list_to_shared_ptr_vector(SEXP lst) {
   std::vector<std::shared_ptr<T>> res(n);
   for (R_xlen_t i = 0; i < n; i++) {
     res[i] = Rcpp::ConstReferenceSmartPtrInputParameter<std::shared_ptr<T>>(
-      VECTOR_ELT(lst, i));
+        VECTOR_ELT(lst, i));
   }
   return res;
 }

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -178,8 +178,7 @@ inline constexpr Rbyte default_value<RAWSXP>() {
 SEXP ChunkedArray__as_vector(const std::shared_ptr<arrow::ChunkedArray>& chunked_array);
 SEXP Array__as_vector(const std::shared_ptr<arrow::Array>& array);
 std::shared_ptr<arrow::Array> Array__from_vector(SEXP x, SEXP type);
-std::shared_ptr<arrow::RecordBatch> RecordBatch__from_dataframe(Rcpp::DataFrame tbl);
-std::shared_ptr<arrow::DataType> Array__infer_type(SEXP x);
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP, SEXP);
 
 namespace arrow {
 namespace r {

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -207,5 +207,16 @@ inline std::shared_ptr<T> extract(SEXP x) {
   return Rcpp::ConstReferenceSmartPtrInputParameter<std::shared_ptr<T>>(x);
 }
 
+template <typename T>
+std::vector<std::shared_ptr<T>> list_to_shared_ptr_vector(SEXP lst) {
+  R_xlen_t n = XLENGTH(lst);
+  std::vector<std::shared_ptr<T>> res(n);
+  for (R_xlen_t i = 0; i < n; i++) {
+    res[i] = Rcpp::ConstReferenceSmartPtrInputParameter<std::shared_ptr<T>>(
+      VECTOR_ELT(lst, i));
+  }
+  return res;
+}
+
 }  // namespace r
 }  // namespace arrow

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -36,10 +36,10 @@
 #include <arrow/type.h>
 #include <arrow/util/compression.h>
 
-#define STOP_IF(TEST, MSG)    \
-do {                              \
-  if (TEST) Rcpp::stop(MSG);   \
-} while (0)
+#define STOP_IF(TEST, MSG)     \
+  do {                         \
+    if (TEST) Rcpp::stop(MSG); \
+  } while (0)
 
 #define STOP_IF_NOT(TEST, MSG) STOP_IF(!(TEST), MSG)
 #define STOP_IF_NOT_OK(s) STOP_IF_NOT(s.ok(), s.ToString())

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -145,3 +145,18 @@ std::shared_ptr<arrow::RecordBatch> ipc___ReadRecordBatch__InputStream__Schema(
   STOP_IF_NOT_OK(arrow::ipc::ReadRecordBatch(schema, &memo, stream.get(), &batch));
   return batch;
 }
+
+// [[Rcpp::export]]
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(const std::shared_ptr<arrow::Schema>& schema, List_ lst) {
+  auto arrays = arrow::r::list_to_shared_ptr_vector<arrow::Array>(lst);
+
+  // check all sizes are the same
+  int64_t num_rows= arrays[0]->length();
+  for(int64_t i = 1; i<arrays.size(); i++) {
+    if (arrays[i]->length() != num_rows) {
+      Rcpp::stop("All arrays must have the same length");
+    }
+  }
+
+  return arrow::RecordBatch::Make(schema, num_rows, arrays);
+}

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -128,20 +128,23 @@ std::shared_ptr<arrow::RecordBatch> ipc___ReadRecordBatch__InputStream__Schema(
   return batch;
 }
 
-Status check_consistent_array_size(const std::vector<std::shared_ptr<arrow::Array>>& arrays, int64_t* num_rows) {
+arrow::Status check_consistent_array_size(
+    const std::vector<std::shared_ptr<arrow::Array>>& arrays, int64_t* num_rows) {
   *num_rows = arrays[0]->length();
-  for(int64_t i = 1; i<arrays.size(); i++) {
+  for (int64_t i = 1; i < arrays.size(); i++) {
     if (arrays[i]->length() != *num_rows) {
-      return Status::Invalid("All arrays must have the same length");
+      return arrow::Status::Invalid("All arrays must have the same length");
     }
   }
-  return Status::OK();
+  return arrow::Status::OK();
 }
 
-std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__known_schema(const std::shared_ptr<arrow::Schema>& schema, SEXP lst) {
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__known_schema(
+    const std::shared_ptr<arrow::Schema>& schema, SEXP lst) {
   R_xlen_t n_arrays = XLENGTH(lst);
-  if(schema->num_fields() != n_arrays) {
-    Rcpp::stop("incompatible. schema has %d fields, and %d arrays are supplied", schema->num_fields(), n_arrays);
+  if (schema->num_fields() != n_arrays) {
+    Rcpp::stop("incompatible. schema has %d fields, and %d arrays are supplied",
+               schema->num_fields(), n_arrays);
   }
 
   // convert lst to a vector of arrow::Array
@@ -149,11 +152,13 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__known_schema(const
   SEXP names = Rf_getAttrib(lst, R_NamesSymbol);
   bool has_names = !Rf_isNull(names);
 
-  for(R_xlen_t i=0; i<n_arrays; i++) {
+  for (R_xlen_t i = 0; i < n_arrays; i++) {
     if (has_names && schema->field(i)->name() != CHAR(STRING_ELT(names, i))) {
-      Rcpp::stop("field at index %d has name '%s' != '%s'", i+1, schema->field(i)->name(), CHAR(STRING_ELT(names, i)));
+      Rcpp::stop("field at index %d has name '%s' != '%s'", i + 1,
+                 schema->field(i)->name(), CHAR(STRING_ELT(names, i)));
     }
-    arrays[i] = arrow::r::Array__from_vector(VECTOR_ELT(lst, i), schema->field(i)->type(), false);
+    arrays[i] =
+        arrow::r::Array__from_vector(VECTOR_ELT(lst, i), schema->field(i)->type(), false);
   }
 
   int64_t num_rows;
@@ -164,33 +169,35 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__known_schema(const
 // [[Rcpp::export]]
 std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP schema_sxp, SEXP lst) {
   if (Rf_inherits(schema_sxp, "arrow::Schema")) {
-    return RecordBatch__from_arrays__known_schema(arrow::r::extract<arrow::Schema>(schema_sxp), lst);
+    return RecordBatch__from_arrays__known_schema(
+        arrow::r::extract<arrow::Schema>(schema_sxp), lst);
   }
 
   R_xlen_t n_arrays = XLENGTH(lst);
 
   // convert lst to a vector of arrow::Array
   std::vector<std::shared_ptr<arrow::Array>> arrays(n_arrays);
-  for(R_xlen_t i=0; i<n_arrays; i++) {
+  for (R_xlen_t i = 0; i < n_arrays; i++) {
     arrays[i] = Array__from_vector(VECTOR_ELT(lst, i), R_NilValue);
   }
 
   // generate schema from the types that have been infered
   std::shared_ptr<arrow::Schema> schema;
-  if( Rf_inherits(schema_sxp, "arrow::Schema")) {
+  if (Rf_inherits(schema_sxp, "arrow::Schema")) {
     schema = arrow::r::extract<arrow::Schema>(schema_sxp);
   } else {
     Rcpp::CharacterVector names(Rf_getAttrib(lst, R_NamesSymbol));
     std::vector<std::shared_ptr<arrow::Field>> fields(n_arrays);
-    for (R_xlen_t i=0; i<n_arrays; i++) {
-      fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), arrays[i]->type());
+    for (R_xlen_t i = 0; i < n_arrays; i++) {
+      fields[i] =
+          std::make_shared<arrow::Field>(std::string(names[i]), arrays[i]->type());
     }
     schema = std::make_shared<arrow::Schema>(std::move(fields));
   }
 
   Rcpp::CharacterVector names(Rf_getAttrib(lst, R_NamesSymbol));
   std::vector<std::shared_ptr<arrow::Field>> fields(n_arrays);
-  for (R_xlen_t i=0; i<n_arrays; i++) {
+  for (R_xlen_t i = 0; i < n_arrays; i++) {
     fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), arrays[i]->type());
   }
   schema = std::make_shared<arrow::Schema>(std::move(fields));

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -138,7 +138,7 @@ Status check_consistent_array_size(const std::vector<std::shared_ptr<arrow::Arra
   return Status::OK();
 }
 
-std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__knwon_schema(const std::shared_ptr<arrow::Schema>& schema, SEXP lst) {
+std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__known_schema(const std::shared_ptr<arrow::Schema>& schema, SEXP lst) {
   R_xlen_t n_arrays = XLENGTH(lst);
   if(schema->num_fields() != n_arrays) {
     Rcpp::stop("incompatible. schema has %d fields, and %d arrays are supplied", schema->num_fields(), n_arrays);
@@ -164,7 +164,7 @@ std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays__knwon_schema(const
 // [[Rcpp::export]]
 std::shared_ptr<arrow::RecordBatch> RecordBatch__from_arrays(SEXP schema_sxp, SEXP lst) {
   if (Rf_inherits(schema_sxp, "arrow::Schema")) {
-    return RecordBatch__from_arrays__knwon_schema(arrow::r::extract<arrow::Schema>(schema_sxp), lst);
+    return RecordBatch__from_arrays__known_schema(arrow::r::extract<arrow::Schema>(schema_sxp), lst);
   }
 
   R_xlen_t n_arrays = XLENGTH(lst);

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -101,7 +101,7 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
         fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), array->type());
         columns[i] = std::make_shared<arrow::Column>(fields[i], array);
       } else {
-        auto array = Array__from_vector(x);
+        auto array = Array__from_vector(x, R_NilValue);
         fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), array->type());
         columns[i] = std::make_shared<arrow::Column>(fields[i], array);
       }
@@ -122,7 +122,8 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
         auto array = arrow::r::extract<arrow::Array>(x);
         columns[i] = std::make_shared<arrow::Column>(schema->field(i), array);
       } else {
-        auto array = Array__from_vector(x);
+        auto type = schema->field(i)->type();
+        auto array = arrow::r::Array__from_vector(x, type, false);
         columns[i] = std::make_shared<arrow::Column>(schema->field(i), array);
       }
     }

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -23,15 +23,6 @@
 using Rcpp::DataFrame;
 
 // [[Rcpp::export]]
-std::shared_ptr<arrow::Table> Table__from_dataframe(DataFrame tbl) {
-  auto rb = RecordBatch__from_arrays(R_NilValue, tbl);
-
-  std::shared_ptr<arrow::Table> out;
-  STOP_IF_NOT_OK(arrow::Table::FromRecordBatches({std::move(rb)}, &out));
-  return out;
-}
-
-// [[Rcpp::export]]
 int Table__num_columns(const std::shared_ptr<arrow::Table>& x) {
   return x->num_columns();
 }
@@ -59,4 +50,13 @@ std::vector<std::shared_ptr<arrow::Column>> Table__columns(
     res[i] = table->column(i);
   }
   return res;
+}
+
+// [[Rcpp::export]]
+std::shared_ptr<arrow::Table> Table__from_arrays(SEXP schema_sxp, SEXP lst) {
+  auto rb = RecordBatch__from_arrays(R_NilValue, lst);
+
+  std::shared_ptr<arrow::Table> out;
+  STOP_IF_NOT_OK(arrow::Table::FromRecordBatches({std::move(rb)}, &out));
+  return out;
 }

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -24,7 +24,7 @@ using Rcpp::DataFrame;
 
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Table> Table__from_dataframe(DataFrame tbl) {
-  auto rb = RecordBatch__from_dataframe(tbl);
+  auto rb = RecordBatch__from_arrays(R_NilValue, tbl);
 
   std::shared_ptr<arrow::Table> out;
   STOP_IF_NOT_OK(arrow::Table::FromRecordBatches({std::move(rb)}, &out));

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -52,9 +52,9 @@ std::vector<std::shared_ptr<arrow::Column>> Table__columns(
   return res;
 }
 
-bool all_record_batches(SEXP lst){
+bool all_record_batches(SEXP lst) {
   R_xlen_t n = XLENGTH(lst);
-  for(R_xlen_t i = 0; i<n; i++) {
+  for (R_xlen_t i = 0; i < n; i++) {
     if (!Rf_inherits(VECTOR_ELT(lst, i), "arrow::RecordBatch")) return false;
   }
   return true;
@@ -69,7 +69,7 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
     auto batches = arrow::r::list_to_shared_ptr_vector<arrow::RecordBatch>(lst);
     std::shared_ptr<arrow::Table> tab;
 
-    if(Rf_inherits(schema_sxp, "arrow::Schema")){
+    if (Rf_inherits(schema_sxp, "arrow::Schema")) {
       auto schema = arrow::r::extract<arrow::Schema>(schema_sxp);
       STOP_IF_NOT_OK(arrow::Table::FromRecordBatches(schema, batches, &tab));
     } else {
@@ -85,16 +85,17 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
   if (Rf_isNull(schema_sxp)) {
     // infer the schema from the ...
     std::vector<std::shared_ptr<arrow::Field>> fields(n);
-    CharacterVector names(Rf_getAttrib(lst, R_NamesSymbol));
+    Rcpp::CharacterVector names(Rf_getAttrib(lst, R_NamesSymbol));
 
-    for (R_xlen_t i = 0; i<n; i++) {
+    for (R_xlen_t i = 0; i < n; i++) {
       SEXP x = VECTOR_ELT(lst, i);
       if (Rf_inherits(x, "arrow::Column")) {
         columns[i] = arrow::r::extract<arrow::Column>(x);
         fields[i] = columns[i]->field();
       } else if (Rf_inherits(x, "arrow::ChunkedArray")) {
         auto chunked_array = arrow::r::extract<arrow::ChunkedArray>(x);
-        fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), chunked_array->type());
+        fields[i] =
+            std::make_shared<arrow::Field>(std::string(names[i]), chunked_array->type());
         columns[i] = std::make_shared<arrow::Column>(fields[i], chunked_array);
       } else if (Rf_inherits(x, "arrow::Array")) {
         auto array = arrow::r::extract<arrow::Array>(x);
@@ -111,7 +112,7 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
     // use the schema that is given
     schema = arrow::r::extract<arrow::Schema>(schema_sxp);
 
-    for (R_xlen_t i = 0; i<n; i++) {
+    for (R_xlen_t i = 0; i < n; i++) {
       SEXP x = VECTOR_ELT(lst, i);
       if (Rf_inherits(x, "arrow::Column")) {
         columns[i] = arrow::r::extract<arrow::Column>(x);
@@ -130,5 +131,4 @@ std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
   }
 
   return arrow::Table::Make(schema, columns);
-
 }

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -61,46 +61,73 @@ bool all_record_batches(SEXP lst){
 }
 
 // [[Rcpp::export]]
-std::shared_ptr<arrow::Table> Table__from_arrays(SEXP lst) {
-  // lst can be aither:
+std::shared_ptr<arrow::Table> Table__from_dots(SEXP lst, SEXP schema_sxp) {
+  // lst can be either:
   // - a list of record batches, in which case we call Table::FromRecordBatches
 
   if (all_record_batches(lst)) {
     auto batches = arrow::r::list_to_shared_ptr_vector<arrow::RecordBatch>(lst);
     std::shared_ptr<arrow::Table> tab;
-    STOP_IF_NOT_OK(arrow::Table::FromRecordBatches(batches, &tab));
+
+    if(Rf_inherits(schema_sxp, "arrow::Schema")){
+      auto schema = arrow::r::extract<arrow::Schema>(schema_sxp);
+      STOP_IF_NOT_OK(arrow::Table::FromRecordBatches(schema, batches, &tab));
+    } else {
+      STOP_IF_NOT_OK(arrow::Table::FromRecordBatches(batches, &tab));
+    }
     return tab;
   }
 
-  // - a list of arrays, chunked arrays or r vectors
-
-  CharacterVector names(Rf_getAttrib(lst, R_NamesSymbol));
-
   R_xlen_t n = XLENGTH(lst);
   std::vector<std::shared_ptr<arrow::Column>> columns(n);
-  std::vector<std::shared_ptr<arrow::Field>> fields(n);
+  std::shared_ptr<arrow::Schema> schema;
 
-  for (R_xlen_t i = 0; i<n; i++) {
-    SEXP x = VECTOR_ELT(lst, i);
-    if (Rf_inherits(x, "arrow::Column")) {
-      columns[i] = arrow::r::extract<arrow::Column>(x);
-      fields[i] = columns[i]->field();
-    } else if (Rf_inherits(x, "arrow::ChunkedArray")) {
-      auto chunked_array = arrow::r::extract<arrow::ChunkedArray>(x);
-      fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), chunked_array->type());
-      columns[i] = std::make_shared<arrow::Column>(fields[i], chunked_array);
-    } else if (Rf_inherits(x, "arrow::Array")) {
-      auto array = arrow::r::extract<arrow::Array>(x);
-      fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), array->type());
-      columns[i] = std::make_shared<arrow::Column>(fields[i], array);
-    } else {
-      auto array = Array__from_vector(x);
-      fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), array->type());
-      columns[i] = std::make_shared<arrow::Column>(fields[i], array);
+  if (Rf_isNull(schema_sxp)) {
+    // infer the schema from the ...
+    std::vector<std::shared_ptr<arrow::Field>> fields(n);
+    CharacterVector names(Rf_getAttrib(lst, R_NamesSymbol));
+
+    for (R_xlen_t i = 0; i<n; i++) {
+      SEXP x = VECTOR_ELT(lst, i);
+      if (Rf_inherits(x, "arrow::Column")) {
+        columns[i] = arrow::r::extract<arrow::Column>(x);
+        fields[i] = columns[i]->field();
+      } else if (Rf_inherits(x, "arrow::ChunkedArray")) {
+        auto chunked_array = arrow::r::extract<arrow::ChunkedArray>(x);
+        fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), chunked_array->type());
+        columns[i] = std::make_shared<arrow::Column>(fields[i], chunked_array);
+      } else if (Rf_inherits(x, "arrow::Array")) {
+        auto array = arrow::r::extract<arrow::Array>(x);
+        fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), array->type());
+        columns[i] = std::make_shared<arrow::Column>(fields[i], array);
+      } else {
+        auto array = Array__from_vector(x);
+        fields[i] = std::make_shared<arrow::Field>(std::string(names[i]), array->type());
+        columns[i] = std::make_shared<arrow::Column>(fields[i], array);
+      }
+    }
+    schema = std::make_shared<arrow::Schema>(std::move(fields));
+  } else {
+    // use the schema that is given
+    schema = arrow::r::extract<arrow::Schema>(schema_sxp);
+
+    for (R_xlen_t i = 0; i<n; i++) {
+      SEXP x = VECTOR_ELT(lst, i);
+      if (Rf_inherits(x, "arrow::Column")) {
+        columns[i] = arrow::r::extract<arrow::Column>(x);
+      } else if (Rf_inherits(x, "arrow::ChunkedArray")) {
+        auto chunked_array = arrow::r::extract<arrow::ChunkedArray>(x);
+        columns[i] = std::make_shared<arrow::Column>(schema->field(i), chunked_array);
+      } else if (Rf_inherits(x, "arrow::Array")) {
+        auto array = arrow::r::extract<arrow::Array>(x);
+        columns[i] = std::make_shared<arrow::Column>(schema->field(i), array);
+      } else {
+        auto array = Array__from_vector(x);
+        columns[i] = std::make_shared<arrow::Column>(schema->field(i), array);
+      }
     }
   }
 
-  auto schema = std::make_shared<arrow::Schema>(std::move(fields));
   return arrow::Table::Make(schema, columns);
 
 }

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -109,7 +109,7 @@ test_that("RecordBatch with 0 rows are supported", {
 })
 
 test_that("RecordBatch cast (ARROW-3741)", {
-  batch <- record_batch(x = 1:10, y  = 1:10)
+  batch <- record_batch(x = 1:10, y = 1:10)
 
   expect_error(batch$cast(schema(x = int32())))
   expect_error(batch$cast(schema(x = int32(), z = int32())))
@@ -119,6 +119,19 @@ test_that("RecordBatch cast (ARROW-3741)", {
   expect_equal(batch2$schema, s2)
   expect_equal(batch2$column(0L)$type, int16())
   expect_equal(batch2$column(1L)$type, int64())
+})
+
+test_that("record_batch() handles schema= argument", {
+  s <- schema(x = int32(), y = int32())
+  batch <- record_batch(x = 1:10, y = 1:10, schema = s)
+  expect_equal(s, batch$schema)
+
+  s <- schema(x = int32(), y = float64())
+  batch <- record_batch(x = 1:10, y = 1:10, schema = s)
+  expect_equal(s, batch$schema)
+
+  s <- schema(x = int32(), y = utf8())
+  expect_error(record_batch(x = 1:10, y = 1:10, schema = s))
 })
 
 test_that("RecordBatch dim() and nrow() (ARROW-3816)", {

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -109,7 +109,7 @@ test_that("RecordBatch with 0 rows are supported", {
 })
 
 test_that("RecordBatch cast (ARROW-3741)", {
-  batch <- record_batch(tibble::tibble(x = 1:10, y  = 1:10))
+  batch <- record_batch(x = 1:10, y  = 1:10)
 
   expect_error(batch$cast(schema(x = int32())))
   expect_error(batch$cast(schema(x = int32(), z = int32())))
@@ -122,7 +122,7 @@ test_that("RecordBatch cast (ARROW-3741)", {
 })
 
 test_that("RecordBatch dim() and nrow() (ARROW-3816)", {
-  batch <- record_batch(tibble::tibble(x = 1:10, y  = 1:10))
+  batch <- record_batch(x = 1:10, y  = 1:10)
   expect_equal(dim(batch), c(10L, 2L))
   expect_equal(nrow(batch), 10L)
 })

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -24,7 +24,7 @@ test_that("RecordBatch", {
     chr = letters[1:10],
     fct = factor(letters[1:10])
   )
-  batch <- record_batch(tbl)
+  batch <- record_batch(!!!tbl)
 
   expect_true(batch == batch)
   expect_equal(
@@ -93,7 +93,7 @@ test_that("RecordBatch with 0 rows are supported", {
     fct = factor(character(), levels = c("a", "b"))
   )
 
-  batch <- record_batch(tbl)
+  batch <- record_batch(!!!tbl)
   expect_equal(batch$num_columns, 5L)
   expect_equal(batch$num_rows, 0L)
   expect_equal(

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -134,6 +134,12 @@ test_that("record_batch() handles schema= argument", {
   expect_error(record_batch(x = 1:10, y = 1:10, schema = s))
 })
 
+test_that("record_batch(schema=) does some basic consistency checking of the schema", {
+  s <- schema(x = int32())
+  expect_error(record_batch(x = 1:10, y = 1:10, schema = s))
+  expect_error(record_batch(z = 1:10, schema = s))
+})
+
 test_that("RecordBatch dim() and nrow() (ARROW-3816)", {
   batch <- record_batch(x = 1:10, y  = 1:10)
   expect_equal(dim(batch), c(10L, 2L))

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -101,3 +101,21 @@ test_that("table() handles record batches with splicing", {
     vctrs::vec_rbind(!!!purrr::map(batches, as_tibble))
   )
 })
+
+test_that("table() handles ... of arrays, chunked arrays, vectors", {
+  a <- array(1:10)
+  ca <- chunked_array(1:5, 6:10)
+  v <- rnorm(10)
+  tbl <- tibble::tibble(x = 1:10, y = letters[1:10])
+
+  tab <- table(a = a, b = ca, c = v, !!!tbl)
+  expect_equal(
+    tab$schema,
+    schema(a = int32(), b = int32(), c = float64(), x = int32(), y = utf8())
+  )
+  res <- as_tibble(tab)
+  expect_equal(names(res), c("a", "b", "c", "x", "y"))
+  expect_equal(res,
+    tibble::tibble(a = 1:10, b = 1:10, c = v, x = 1:10, y = letters[1:10])
+  )
+})

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -77,7 +77,7 @@ test_that("Table cast (ARROW-3741)", {
 })
 
 test_that("Table dim() and nrow() (ARROW-3816)", {
-  tab <- table(tibble::tibble(x = 1:10, y  = 1:10))
+  tab <- table(x = 1:10, y  = 1:10)
   expect_equal(dim(tab), c(10L, 2L))
   expect_equal(nrow(tab), 10L)
 })

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -23,7 +23,7 @@ test_that("read_table handles various input streams (ARROW-3450, ARROW-3505)", {
     lgl = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
     chr = letters[1:10]
   )
-  tab <- arrow::table(tbl)
+  tab <- arrow::table(!!!tbl)
 
   tf <- tempfile()
   write_arrow(tab, tf)
@@ -64,7 +64,7 @@ test_that("read_table handles various input streams (ARROW-3450, ARROW-3505)", {
 })
 
 test_that("Table cast (ARROW-3741)", {
-  tab <- table(tibble::tibble(x = 1:10, y  = 1:10))
+  tab <- table(x = 1:10, y = 1:10)
 
   expect_error(tab$cast(schema(x = int32())))
   expect_error(tab$cast(schema(x = int32(), z = int32())))

--- a/r/tests/testthat/test-arrow-csv-.R
+++ b/r/tests/testthat/test-arrow-csv-.R
@@ -27,7 +27,7 @@ test_that("Can read csv file", {
   tab3 <- read_csv_arrow(ReadableFile(tf))
 
   iris$Species <- as.character(iris$Species)
-  tab0 <- table(iris)
+  tab0 <- table(!!!iris)
   expect_equal(tab0, tab1)
   expect_equal(tab0, tab2)
   expect_equal(tab0, tab3)

--- a/r/tests/testthat/test-message.R
+++ b/r/tests/testthat/test-message.R
@@ -18,7 +18,7 @@
 context("arrow::ipc::Message")
 
 test_that("read_message can read from input stream", {
-  batch <- record_batch(tibble::tibble(x = 1:10))
+  batch <- record_batch(x = 1:10)
   bytes <- batch$serialize()
   stream <- BufferReader(bytes)
 

--- a/r/tests/testthat/test-messagereader.R
+++ b/r/tests/testthat/test-messagereader.R
@@ -18,7 +18,7 @@
 context("arrow::ipc::MessageReader")
 
 test_that("MessageReader can be created from raw vectors", {
-  batch <- record_batch(tibble::tibble(x = 1:10))
+  batch <- record_batch(x = 1:10)
   bytes <- batch$serialize()
 
   reader <- MessageReader(bytes)
@@ -34,7 +34,7 @@ test_that("MessageReader can be created from raw vectors", {
 })
 
 test_that("MessageReader can be created from input stream", {
-  batch <- record_batch(tibble::tibble(x = 1:10))
+  batch <- record_batch(x = 1:10)
   bytes <- batch$serialize()
 
   stream <- BufferReader(bytes)

--- a/r/tests/testthat/test-read-write.R
+++ b/r/tests/testthat/test-read-write.R
@@ -24,7 +24,7 @@ test_that("arrow::table round trip", {
     raw = as.raw(1:10)
   )
 
-  tab <- arrow::table(tbl)
+  tab <- arrow::table(!!!tbl)
   expect_equal(tab$num_columns, 3L)
   expect_equal(tab$num_rows, 10L)
 
@@ -99,7 +99,7 @@ test_that("arrow::table round trip handles NA in integer and numeric", {
     raw = as.raw(1:10)
   )
 
-  tab <- arrow::table(tbl)
+  tab <- arrow::table(!!!tbl)
   expect_equal(tab$num_columns, 3L)
   expect_equal(tab$num_rows, 10L)
 

--- a/r/tests/testthat/test-read_record_batch.R
+++ b/r/tests/testthat/test-read_record_batch.R
@@ -48,7 +48,7 @@ test_that("read_record_batch() handles (raw|Buffer|InputStream, Schema) (ARROW-3
     lgl = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
     chr = letters[1:10]
   )
-  batch <- record_batch(tbl)
+  batch <- record_batch(!!!tbl)
   schema <- batch$schema
 
   raw <- batch$serialize()
@@ -64,7 +64,7 @@ test_that("read_record_batch() handles (raw|Buffer|InputStream, Schema) (ARROW-3
 })
 
 test_that("read_record_batch() can handle (Message, Schema) parameters (ARROW-3499)", {
-  batch <- record_batch(tibble::tibble(x = 1:10))
+  batch <- record_batch(x = 1:10)
   schema <- batch$schema
 
   raw <- batch$serialize()

--- a/r/tests/testthat/test-read_record_batch.R
+++ b/r/tests/testthat/test-read_record_batch.R
@@ -18,11 +18,12 @@
 context("read_record_batch()")
 
 test_that("RecordBatchFileWriter / RecordBatchFileReader roundtrips", {
-  tab <- table(tibble::tibble(
-    int = 1:10, dbl = as.numeric(1:10),
+  tab <- table(
+    int = 1:10,
+    dbl = as.numeric(1:10),
     lgl = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
     chr = letters[1:10]
-  ))
+  )
   tf <- tempfile()
 
   writer <- RecordBatchFileWriter(tf, tab$schema)

--- a/r/tests/testthat/test-recordbatchreader.R
+++ b/r/tests/testthat/test-recordbatchreader.R
@@ -18,10 +18,10 @@
 context("arrow::RecordBatch.*(Reader|Writer)")
 
 test_that("RecordBatchStreamReader / Writer", {
-  batch <- record_batch(tibble::tibble(
+  batch <- record_batch(
     x = 1:10,
     y = letters[1:10]
-  ))
+  )
 
   sink <- BufferOutputStream()
   writer <- RecordBatchStreamWriter(sink, batch$schema)
@@ -43,10 +43,10 @@ test_that("RecordBatchStreamReader / Writer", {
 })
 
 test_that("RecordBatchFileReader / Writer", {
-  batch <- record_batch(tibble::tibble(
+  batch <- record_batch(
     x = 1:10,
     y = letters[1:10]
-  ))
+  )
 
   sink <- BufferOutputStream()
   writer <- RecordBatchFileWriter(sink, batch$schema)

--- a/r/tests/testthat/test-schema.R
+++ b/r/tests/testthat/test-schema.R
@@ -20,7 +20,7 @@ context("arrow::Schema")
 test_that("reading schema from Buffer", {
   # TODO: this uses the streaming format, i.e. from RecordBatchStreamWriter
   #       maybe there is an easier way to serialize a schema
-  batch <- record_batch(tibble::tibble(x = 1:10))
+  batch <- record_batch(x = 1:10)
   expect_is(batch, "arrow::RecordBatch")
 
   stream <- BufferOutputStream()


### PR DESCRIPTION
This started out as an implementation of `RecordBatch$from_arrays()` (i.e. https://issues.apache.org/jira/browse/ARROW-3814?filter=12344983) but now looks more like this issue: https://issues.apache.org/jira/browse/ARROW-3815?filter=12344983

The idea being that the record batch factory `record_batch()` would work with `...` and `schema`, where each thing in the `...` could be: 
  - an `arrow::Array`
  - an R vector that can be converted to an array using `array()` 

So where we had this before: 

```r
record_batch(tibble::tibble(x = 1:10, y = 1:10))
```

we would now have: 

```r
record_batch(x = 1:10, y = 1:10)
```

We would still be able to start from a data frame, via splicing, e.g.: 

```
tbl <- tibble::tibble(x = 1:10, y = 1:10)
record_batch(!!!tbl)
```

So there would be no need for a `RecordBatch$fromArray()` method. 
