### PR TITLE
ARROW-4488: [Rust] From AsRef<[u8]> for Buffer does not ensure correct padding

### DIFF
--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -132,7 +132,8 @@ impl<T: AsRef<[u8]>> From<T> for Buffer {
         // allocate aligned memory buffer
         let slice = p.as_ref();
         let len = slice.len() * mem::size_of::<u8>();
-        let buffer = memory::allocate_aligned(len).unwrap();
+        let capacity = bit_util::round_upto_multiple_of_64(len);
+        let buffer = memory::allocate_aligned(capacity).unwrap();
         unsafe {
             memory::memcpy(buffer, slice.as_ptr(), len);
         }


### PR DESCRIPTION
Padding for all memory allocations needs to be a multiple of 64 bytes to make SIMD implementations easier and more efficient to implement.