### PR TITLE
ARROW-4489: [Rust] PrimitiveArray.value_slice performs bounds checking when it should not

### DIFF
--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -756,6 +756,12 @@ mod tests {
     }
 
     #[test]
+    fn test_value_slice_no_bounds_check() {
+        let arr = Int32Array::from(vec![2, 3, 4]);
+        let _slice = arr.value_slice(0, 4);
+    }
+
+    #[test]
     fn test_primitive_array_builder() {
         // Test building an primitive array with ArrayData builder and offset
         let buf = Buffer::from(&[0, 1, 2, 3, 4].to_byte_slice());

--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -236,8 +236,10 @@ impl<T: ArrowNumericType> PrimitiveArray<T> {
     ///
     /// Note this doesn't do any bound checking, for performance reason.
     pub fn value_slice(&self, offset: usize, len: usize) -> &[T::Native] {
-        let raw = unsafe { std::slice::from_raw_parts(self.raw_values(), self.len()) };
-        &raw[offset..offset + len]
+        let raw = unsafe {
+            std::slice::from_raw_parts(self.raw_values().offset(offset as isize), len)
+        };
+        &raw[..]
     }
 
     // Returns a new primitive array builder


### PR DESCRIPTION
If you run the following test it will fail:
```rust
    #[test]
    fn test_value_slice() {
        let arr = Int32Array::from(vec![2, 3, 4]);
        let _slice = arr.value_slice(0, 4);
    }
```
When working with SIMD I plan to rely on the fact that we have buffers padded to a multiple of 64 bytes.  This makes the implementation easier to maintain and more efficient.  However, it involves reading and writing to the padded region.