### PR TITLE
ARROW-4406: [Python] Exclude HDFS directories in S3 from ParquetManifest

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -769,6 +769,7 @@ class ParquetManifest(object):
 
     def _should_silently_exclude(self, file_name):
         return (file_name.endswith('.crc') or  # Checksums
+                file_name.endswith('_$folder$') or  # HDFS directories in S3
                 file_name.startswith('.') or  # Hidden files
                 file_name in EXCLUDED_PARQUET_PATHS)
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARROW-4406