### PR TITLE
ARROW-1572: [C++] Implement "value counts" kernels for tabulating value frequencies

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -494,6 +494,22 @@ void TestPrimitiveBuilder<PBoolean>::Check(const std::unique_ptr<BooleanBuilder>
   ASSERT_EQ(0, builder->null_count());
 }
 
+TEST(NumericBuilderAccessors, TestSettersGetters) {
+  int64_t datum = 42; 
+  int64_t new_datum = 43;
+  NumericBuilder<Int64Type> builder(int64(), default_memory_pool());
+
+  builder.Reset();
+  ASSERT_OK(builder.Append(datum));
+  ASSERT_EQ(builder.GetValue(0), datum);
+
+  // Now update the value.
+  builder[0] = new_datum;
+
+  ASSERT_EQ(builder.GetValue(0), new_datum);
+  ASSERT_EQ(((const NumericBuilder<Int64Type>&)builder)[0], new_datum);
+}
+
 typedef ::testing::Types<PBoolean, PUInt8, PUInt16, PUInt32, PUInt64, PInt8, PInt16,
                          PInt32, PInt64, PFloat, PDouble>
     Primitives;

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -495,7 +495,7 @@ void TestPrimitiveBuilder<PBoolean>::Check(const std::unique_ptr<BooleanBuilder>
 }
 
 TEST(NumericBuilderAccessors, TestSettersGetters) {
-  int64_t datum = 42; 
+  int64_t datum = 42;
   int64_t new_datum = 43;
   NumericBuilder<Int64Type> builder(int64(), default_memory_pool());
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -92,6 +92,10 @@ class NumericBuilder : public ArrayBuilder {
     return ArrayBuilder::Resize(capacity);
   }
 
+  value_type& operator[](int64_t index) {
+    return reinterpret_cast<value_type*>(data_->mutable_data())[index];
+  }
+
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values a contiguous C array of values
   /// \param[in] length the number of values to append

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -92,9 +92,7 @@ class NumericBuilder : public ArrayBuilder {
     return ArrayBuilder::Resize(capacity);
   }
 
-  value_type operator[](int64_t index) const {
-    return GetValue(index);
-  }
+  value_type operator[](int64_t index) const { return GetValue(index); }
 
   value_type& operator[](int64_t index) {
     return reinterpret_cast<value_type*>(data_->mutable_data())[index];

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -95,7 +95,7 @@ class NumericBuilder : public ArrayBuilder {
   value_type operator[](int64_t index) const { return GetValue(index); }
 
   value_type& operator[](int64_t index) {
-    return reinterpret_cast<value_type*>(data_->mutable_data())[index];
+    return reinterpret_cast<value_type*>(data_builder_.mutable_data())[index];
   }
 
   /// \brief Append a sequence of elements in one shot

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -92,6 +92,10 @@ class NumericBuilder : public ArrayBuilder {
     return ArrayBuilder::Resize(capacity);
   }
 
+  value_type operator[](int64_t index) const {
+    return GetValue(index);
+  }
+
   value_type& operator[](int64_t index) {
     return reinterpret_cast<value_type*>(data_->mutable_data())[index];
   }

--- a/cpp/src/arrow/compute/kernels/boolean-test.cc
+++ b/cpp/src/arrow/compute/kernels/boolean-test.cc
@@ -129,7 +129,6 @@ TEST_F(TestBooleanKernel, Invert) {
 }
 
 TEST_F(TestBooleanKernel, InvertEmptyArray) {
-  auto type = boolean();
   std::vector<std::shared_ptr<Buffer>> data_buffers(2);
   Datum input;
   input.value = ArrayData::Make(boolean(), 0 /* length */, std::move(data_buffers),

--- a/cpp/src/arrow/compute/kernels/hash-test.cc
+++ b/cpp/src/arrow/compute/kernels/hash-test.cc
@@ -69,8 +69,8 @@ template <typename Type, typename T>
 void CheckValueCountsNull(FunctionContext* ctx, const shared_ptr<DataType>& type) {
   std::vector<std::shared_ptr<Buffer>> data_buffers(2);
   Datum input;
-  input.value = ArrayData::Make(type, 0 /* length */, std::move(data_buffers),
-                                0 /* null_count */);
+  input.value =
+      ArrayData::Make(type, 0 /* length */, std::move(data_buffers), 0 /* null_count */);
 
   shared_ptr<Array> ex_values = _MakeArray<Type, T>(type, {}, {});
   shared_ptr<Array> ex_counts = _MakeArray<Int64Type, int64_t>(int64(), {}, {});
@@ -82,7 +82,6 @@ void CheckValueCountsNull(FunctionContext* ctx, const shared_ptr<DataType>& type
   ASSERT_ARRAYS_EQUAL(*ex_values, *result_struct->GetFieldByName("Values"));
   ASSERT_ARRAYS_EQUAL(*ex_counts, *result_struct->GetFieldByName("Counts"));
 }
-
 
 template <typename Type, typename T>
 void CheckValueCounts(FunctionContext* ctx, const shared_ptr<DataType>& type,
@@ -151,8 +150,6 @@ TYPED_TEST(TestHashKernelPrimitive, ValueCounts) {
   CheckValueCounts<TypeParam, T>(&this->ctx_, type, {}, {}, {}, {}, {});
   CheckValueCountsNull<TypeParam, T>(&this->ctx_, type);
 }
-
-
 
 TYPED_TEST(TestHashKernelPrimitive, DictEncode) {
   using T = typename TypeParam::c_type;

--- a/cpp/src/arrow/compute/kernels/hash-test.cc
+++ b/cpp/src/arrow/compute/kernels/hash-test.cc
@@ -383,7 +383,7 @@ TEST_F(TestHashKernel, DictEncodeDecimal) {
                                               {}, {0, 0, 1, 0, 2});
 }
 
-/* TODO(ARROW-XXXX): Determine if we wan to do something that is reproducable with floats.
+/* TODO(ARROW-4124): Determine if we wan to do something that is reproducable with floats.
 TEST_F(TestHashKernel, CountValuesFloat) {
 
     // No nulls

--- a/cpp/src/arrow/compute/kernels/hash-test.cc
+++ b/cpp/src/arrow/compute/kernels/hash-test.cc
@@ -298,12 +298,15 @@ TEST_F(TestHashKernel, BinaryResizeTable) {
   }
 
   CheckUnique<BinaryType, std::string>(&this->ctx_, binary(), values, {}, uniques, {});
+  CheckCountValues<BinaryType, std::string>(&this->ctx_, binary(), values, {}, uniques,
+                                            {}, counts);
+
   CheckDictEncode<BinaryType, std::string>(&this->ctx_, binary(), values, {}, uniques, {},
                                            indices);
 
   CheckUnique<StringType, std::string>(&this->ctx_, utf8(), values, {}, uniques, {});
-  CheckCountValues<FixedSizeBinaryType, std::string>(&this->ctx_, type, values, {},
-                                                     uniques, {}, counts);
+  CheckCountValues<StringType, std::string>(&this->ctx_, utf8(), values, {}, uniques, {},
+                                            counts);
   CheckDictEncode<StringType, std::string>(&this->ctx_, utf8(), values, {}, uniques, {},
                                            indices);
 }
@@ -379,6 +382,20 @@ TEST_F(TestHashKernel, DictEncodeDecimal) {
                                               {true, false, true, true, true}, expected,
                                               {}, {0, 0, 1, 0, 2});
 }
+
+/* TODO(ARROW-XXXX): Determine if we wan to do something that is reproducable with floats.
+TEST_F(TestHashKernel, CountValuesFloat) {
+
+    // No nulls
+  CheckCountValues<FloatType, float>(&this->ctx_, float32(), {1.0f, 0.0f, -0.0f,
+std::nan("1"), std::nan("2")  },
+                                      {}, {0.0f, 1.0f, std::nan("1")}, {}, {});
+
+  CheckCountValues<DoubleType, double>(&this->ctx_, float64(), {1.0f, 0.0f, -0.0f,
+std::nan("1"), std::nan("2")  },
+                                      {}, {0.0f, 1.0f, std::nan("1")}, {}, {});
+}
+*/
 
 TEST_F(TestHashKernel, ChunkedArrayInvoke) {
   vector<std::string> values1 = {"foo", "bar", "foo"};

--- a/cpp/src/arrow/compute/kernels/hash-test.cc
+++ b/cpp/src/arrow/compute/kernels/hash-test.cc
@@ -79,8 +79,8 @@ void CheckValueCountsNull(FunctionContext* ctx, const shared_ptr<DataType>& type
   ASSERT_OK(ValueCounts(ctx, input, &result));
   auto result_struct = std::dynamic_pointer_cast<StructArray>(result);
   // TODO: We probably shouldn't rely on value ordering.
-  ASSERT_ARRAYS_EQUAL(*ex_values, *result_struct->GetFieldByName("Values"));
-  ASSERT_ARRAYS_EQUAL(*ex_counts, *result_struct->GetFieldByName("Counts"));
+  ASSERT_ARRAYS_EQUAL(*ex_values, *result_struct->GetFieldByName(kValuesFieldName));
+  ASSERT_ARRAYS_EQUAL(*ex_counts, *result_struct->GetFieldByName(kCountsFieldName));
 }
 
 template <typename Type, typename T>
@@ -97,8 +97,8 @@ void CheckValueCounts(FunctionContext* ctx, const shared_ptr<DataType>& type,
   ASSERT_OK(ValueCounts(ctx, Datum(input), &result));
   auto result_struct = std::dynamic_pointer_cast<StructArray>(result);
   // TODO: We probably shouldn't rely on value ordering.
-  ASSERT_ARRAYS_EQUAL(*ex_values, *result_struct->GetFieldByName("Values"));
-  ASSERT_ARRAYS_EQUAL(*ex_counts, *result_struct->GetFieldByName("Counts"));
+  ASSERT_ARRAYS_EQUAL(*ex_values, *result_struct->field(kValuesFieldIndex));
+  ASSERT_ARRAYS_EQUAL(*ex_counts, *result_struct->field(kCountsFieldIndex));
 }
 
 template <typename Type, typename T>

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -349,43 +349,44 @@ struct HashKernelTraits<Type, Action, enable_if_fixed_size_binary<Type>> {
 
 }  // namespace
 
+#define PROCESS_SUPPORTED_HASH_TYPES \
+  PROCESS(NullType)                  \
+  PROCESS(BooleanType)               \
+  PROCESS(UInt8Type)                 \
+  PROCESS(Int8Type)                  \
+  PROCESS(UInt16Type)                \
+  PROCESS(Int16Type)                 \
+  PROCESS(UInt32Type)                \
+  PROCESS(Int32Type)                 \
+  PROCESS(UInt64Type)                \
+  PROCESS(Int64Type)                 \
+  PROCESS(FloatType)                 \
+  PROCESS(DoubleType)                \
+  PROCESS(Date32Type)                \
+  PROCESS(Date64Type)                \
+  PROCESS(Time32Type)                \
+  PROCESS(Time64Type)                \
+  PROCESS(TimestampType)             \
+  PROCESS(BinaryType)                \
+  PROCESS(StringType)                \
+  PROCESS(FixedSizeBinaryType)       \
+  PROCESS(Decimal128Type)
+
 Status GetUniqueKernel(FunctionContext* ctx, const std::shared_ptr<DataType>& type,
                        std::unique_ptr<HashKernel>* out) {
   std::unique_ptr<HashKernel> kernel;
-
-#define UNIQUE_CASE(InType)                                                           \
+  switch (type->id()) {
+#define PROCESS(InType)                                                               \
   case InType::type_id:                                                               \
     kernel.reset(new typename HashKernelTraits<InType, UniqueAction>::HashKernelImpl( \
         type, ctx->memory_pool()));                                                   \
-    break
+    break;
 
-  switch (type->id()) {
-    UNIQUE_CASE(NullType);
-    UNIQUE_CASE(BooleanType);
-    UNIQUE_CASE(UInt8Type);
-    UNIQUE_CASE(Int8Type);
-    UNIQUE_CASE(UInt16Type);
-    UNIQUE_CASE(Int16Type);
-    UNIQUE_CASE(UInt32Type);
-    UNIQUE_CASE(Int32Type);
-    UNIQUE_CASE(UInt64Type);
-    UNIQUE_CASE(Int64Type);
-    UNIQUE_CASE(FloatType);
-    UNIQUE_CASE(DoubleType);
-    UNIQUE_CASE(Date32Type);
-    UNIQUE_CASE(Date64Type);
-    UNIQUE_CASE(Time32Type);
-    UNIQUE_CASE(Time64Type);
-    UNIQUE_CASE(TimestampType);
-    UNIQUE_CASE(BinaryType);
-    UNIQUE_CASE(StringType);
-    UNIQUE_CASE(FixedSizeBinaryType);
-    UNIQUE_CASE(Decimal128Type);
+    PROCESS_SUPPORTED_HASH_TYPES
+#undef PROCESS
     default:
       break;
   }
-
-#undef UNIQUE_CASE
 
   CHECK_IMPLEMENTED(kernel, "unique", type);
   RETURN_NOT_OK(kernel->Reset());
@@ -398,35 +399,16 @@ Status GetDictionaryEncodeKernel(FunctionContext* ctx,
                                  std::unique_ptr<HashKernel>* out) {
   std::unique_ptr<HashKernel> kernel;
 
-#define DICTIONARY_ENCODE_CASE(InType)                                                \
+  switch (type->id()) {
+#define PROCESS(InType)                                                               \
   case InType::type_id:                                                               \
     kernel.reset(new                                                                  \
                  typename HashKernelTraits<InType, DictEncodeAction>::HashKernelImpl( \
                      type, ctx->memory_pool()));                                      \
-    break
+    break;
 
-  switch (type->id()) {
-    DICTIONARY_ENCODE_CASE(NullType);
-    DICTIONARY_ENCODE_CASE(BooleanType);
-    DICTIONARY_ENCODE_CASE(UInt8Type);
-    DICTIONARY_ENCODE_CASE(Int8Type);
-    DICTIONARY_ENCODE_CASE(UInt16Type);
-    DICTIONARY_ENCODE_CASE(Int16Type);
-    DICTIONARY_ENCODE_CASE(UInt32Type);
-    DICTIONARY_ENCODE_CASE(Int32Type);
-    DICTIONARY_ENCODE_CASE(UInt64Type);
-    DICTIONARY_ENCODE_CASE(Int64Type);
-    DICTIONARY_ENCODE_CASE(FloatType);
-    DICTIONARY_ENCODE_CASE(DoubleType);
-    DICTIONARY_ENCODE_CASE(Date32Type);
-    DICTIONARY_ENCODE_CASE(Date64Type);
-    DICTIONARY_ENCODE_CASE(Time32Type);
-    DICTIONARY_ENCODE_CASE(Time64Type);
-    DICTIONARY_ENCODE_CASE(TimestampType);
-    DICTIONARY_ENCODE_CASE(BinaryType);
-    DICTIONARY_ENCODE_CASE(StringType);
-    DICTIONARY_ENCODE_CASE(FixedSizeBinaryType);
-    DICTIONARY_ENCODE_CASE(Decimal128Type);
+    PROCESS_SUPPORTED_HASH_TYPES
+#undef PROCESS
     default:
       break;
   }
@@ -442,40 +424,20 @@ Status GetDictionaryEncodeKernel(FunctionContext* ctx,
 Status GetCountValuesKernel(FunctionContext* ctx, const std::shared_ptr<DataType>& type,
                             std::unique_ptr<HashKernel>* out) {
   std::unique_ptr<HashKernel> kernel;
-#define COUNT_VALUES_CASE(InType)                                                      \
+
+  switch (type->id()) {
+#define PROCESS(InType)                                                                \
   case InType::type_id:                                                                \
     kernel.reset(new                                                                   \
                  typename HashKernelTraits<InType, CountValuesAction>::HashKernelImpl( \
                      type, ctx->memory_pool()));                                       \
-    break
+    break;
 
-  switch (type->id()) {
-    COUNT_VALUES_CASE(NullType);
-    COUNT_VALUES_CASE(BooleanType);
-    COUNT_VALUES_CASE(UInt8Type);
-    COUNT_VALUES_CASE(Int8Type);
-    COUNT_VALUES_CASE(UInt16Type);
-    COUNT_VALUES_CASE(Int16Type);
-    COUNT_VALUES_CASE(UInt32Type);
-    COUNT_VALUES_CASE(Int32Type);
-    COUNT_VALUES_CASE(UInt64Type);
-    COUNT_VALUES_CASE(Int64Type);
-    COUNT_VALUES_CASE(FloatType);
-    COUNT_VALUES_CASE(DoubleType);
-    COUNT_VALUES_CASE(Date32Type);
-    COUNT_VALUES_CASE(Date64Type);
-    COUNT_VALUES_CASE(Time32Type);
-    COUNT_VALUES_CASE(Time64Type);
-    COUNT_VALUES_CASE(TimestampType);
-    COUNT_VALUES_CASE(BinaryType);
-    COUNT_VALUES_CASE(StringType);
-    COUNT_VALUES_CASE(FixedSizeBinaryType);
-    COUNT_VALUES_CASE(Decimal128Type);
+    PROCESS_SUPPORTED_HASH_TYPES
+#undef PROCESS
     default:
       break;
   }
-
-#undef COUNT_VALUES_CASE
 
   CHECK_IMPLEMENTED(kernel, "count-values", type);
   RETURN_NOT_OK(kernel->Reset());
@@ -545,6 +507,6 @@ Status CountValues(FunctionContext* ctx, const Datum& value,
   *out_counts = MakeArray(counts.array());
   return Status::OK();
 }
-
+#undef PROCESS_SUPPORTED_HASH_TYPES
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -196,7 +196,7 @@ class DictEncodeAction : public ActionBase {
 ///
 /// This interface is implemented below using visitor pattern on "Action"
 /// implementations.  It is not consolidate to keep the contract clearer.
-class ARROW_EXPORT HashKernel : public UnaryKernel {
+class HashKernel : public UnaryKernel {
  public:
   // Reset for another run.
   virtual Status Reset() = 0;

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -506,6 +506,10 @@ Status DictionaryEncode(FunctionContext* ctx, const Datum& value, Datum* out) {
   return Status::OK();
 }
 
+const char kValuesFieldName[] = "Values";
+const char kCountsFieldName[] = "Counts";
+const int32_t kValuesFieldIndex = 0;
+const int32_t kCountsFieldIndex = 1;
 Status ValueCounts(FunctionContext* ctx, const Datum& value,
                    std::shared_ptr<Array>* counts) {
   std::unique_ptr<HashKernel> func;

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -104,10 +104,12 @@ class UniqueAction : public ActionBase {
 // ----------------------------------------------------------------------
 // Count values implementation (see HashKernel for description of methods)
 
-class ValueCountsAction {
+class ValueCountsAction : ActionBase {
  public:
+  using ActionBase::ActionBase;
+
   ValueCountsAction(const std::shared_ptr<DataType>& type, MemoryPool* pool)
-      : count_builder_(pool) {}
+      : ActionBase(type, pool), count_builder_(pool) {}
 
   Status Reserve(const int64_t length) {
     // builder size is independent of input array size.
@@ -121,6 +123,8 @@ class ValueCountsAction {
   // Don't do anything on flush beceause we don't want to finalize the builder
   // or incur the cost of memory copies.
   Status Flush(Datum* out) { return Status::OK(); }
+
+  std::shared_ptr<DataType> out_type() const { return type_; }
 
   // Return the counts corresponding the MemoTable keys.
   Status FlushFinal(Datum* out) {

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -287,13 +287,12 @@ class RegularHashKernelImpl : public HashKernelImpl {
     auto on_found = [this](int32_t memo_index) { action_.ObserveFound(memo_index); };
 
     if (with_error_status) {
-
-    Status status;
+      Status status;
       auto on_not_found = [this, &status](int32_t memo_index) {
         action_.ObserveNotFound(memo_index, &status);
       };
       memo_table_->GetOrInsert(value, on_found, on_not_found);
-    return status;
+      return status;
     } else {
       auto on_not_found = [this](int32_t memo_index) {
         action_.ObserveNotFound(memo_index);
@@ -381,7 +380,8 @@ struct HashKernelTraits<Type, Action, with_error_status, enable_if_binary<Type>>
 };
 
 template <typename Type, typename Action, bool with_error_status>
-struct HashKernelTraits<Type, Action, with_error_status, enable_if_fixed_size_binary<Type>> {
+struct HashKernelTraits<Type, Action, with_error_status,
+                        enable_if_fixed_size_binary<Type>> {
   using HashKernelImpl =
       RegularHashKernelImpl<Type, util::string_view, Action, with_error_status>;
 };

--- a/cpp/src/arrow/compute/kernels/hash.h
+++ b/cpp/src/arrow/compute/kernels/hash.h
@@ -34,33 +34,10 @@ namespace compute {
 
 class FunctionContext;
 
-/// \brief Invoke hash table kernel on input array, returning any output
-/// values. Implementations should be thread-safe
-class ARROW_EXPORT HashKernel : public UnaryKernel {
- public:
-  // XXX why are those methods exposed?
-  virtual Status Reset() = 0;
-  virtual Status Append(FunctionContext* ctx, const ArrayData& input) = 0;
-  virtual Status Flush(Datum* out) = 0;
-  virtual Status GetDictionary(std::shared_ptr<ArrayData>* out) = 0;
-};
-
-/// \since 0.8.0
-/// \note API not yet finalized
-ARROW_EXPORT
-Status GetUniqueKernel(FunctionContext* ctx, const std::shared_ptr<DataType>& type,
-                       std::unique_ptr<HashKernel>* kernel);
-
-ARROW_EXPORT
-Status GetDictionaryEncodeKernel(FunctionContext* ctx,
-                                 const std::shared_ptr<DataType>& type,
-                                 std::unique_ptr<HashKernel>* kernel);
-
-ARROW_EXPORT
-Status GetCountValuesKernel(FunctionContext* ctx, const std::shared_ptr<DataType>& type,
-                            std::unique_ptr<HashKernel>* kernel);
-
 /// \brief Compute unique elements from an array-like object
+///
+/// Note if a null occurs in the input it will NOT be included in the output.
+///
 /// \param[in] context the FunctionContext
 /// \param[in] datum array-like input
 /// \param[out] out result as Array
@@ -69,6 +46,26 @@ Status GetCountValuesKernel(FunctionContext* ctx, const std::shared_ptr<DataType
 /// \note API not yet finalized
 ARROW_EXPORT
 Status Unique(FunctionContext* context, const Datum& datum, std::shared_ptr<Array>* out);
+
+/// \brief Return counts of unique elements from an array-like object.
+///
+/// Note that the counts do not include counts for nulls in the array.  These can be
+/// obtained separately from metadata.
+///
+/// For floating point arrays there is no attempt to normalize -0.0, 0.0 and NaN values
+/// which can lead to unexpected results if the input Array has these values.
+///
+/// \param[in] context the FunctionContext
+/// \param[in] value array-like input
+/// \param[out] out_uniques unique elements as Array
+/// \param[out] out_counts counts per element as Array, same shape as out_uniques
+///
+/// \since 0.13.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Status CountValues(FunctionContext* context, const Datum& value,
+                   std::shared_ptr<Array>* out_uniques,
+                   std::shared_ptr<Array>* out_counts);
 
 /// \brief Dictionary-encode values in an array-like object
 /// \param[in] context the FunctionContext
@@ -79,19 +76,6 @@ Status Unique(FunctionContext* context, const Datum& datum, std::shared_ptr<Arra
 /// \note API not yet finalized
 ARROW_EXPORT
 Status DictionaryEncode(FunctionContext* context, const Datum& data, Datum* out);
-
-/// \brief Return counts of unique elements from an array-like object
-/// \param[in] context the FunctionContext
-/// \param[in] value array-like input
-/// \param[out] out_uniques unique elements as Array
-/// \param[out] out_counts counts per element as Array, same shape as out_uniques
-///
-/// \since 0.10.0
-/// \note API not yet finalized
-ARROW_EXPORT
-Status CountValues(FunctionContext* context, const Datum& value,
-                   std::shared_ptr<Array>* out_uniques,
-                   std::shared_ptr<Array>* out_counts);
 
 // TODO(wesm): Define API for incremental dictionary encoding
 
@@ -116,11 +100,6 @@ Status CountValues(FunctionContext* context, const Datum& value,
 // ARROW_EXPORT
 // Status IsIn(FunctionContext* context, const Datum& values, const Datum& member_set,
 //             Datum* out);
-
-// ARROW_EXPORT
-// Status CountValues(FunctionContext* context, const Datum& values,
-//                    std::shared_ptr<Array>* out_uniques,
-//                    std::shared_ptr<Array>* out_counts);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/hash.h
+++ b/cpp/src/arrow/compute/kernels/hash.h
@@ -56,6 +56,10 @@ Status GetDictionaryEncodeKernel(FunctionContext* ctx,
                                  const std::shared_ptr<DataType>& type,
                                  std::unique_ptr<HashKernel>* kernel);
 
+ARROW_EXPORT
+Status GetCountValuesKernel(FunctionContext* ctx, const std::shared_ptr<DataType>& type,
+                            std::unique_ptr<HashKernel>* kernel);
+
 /// \brief Compute unique elements from an array-like object
 /// \param[in] context the FunctionContext
 /// \param[in] datum array-like input
@@ -75,6 +79,19 @@ Status Unique(FunctionContext* context, const Datum& datum, std::shared_ptr<Arra
 /// \note API not yet finalized
 ARROW_EXPORT
 Status DictionaryEncode(FunctionContext* context, const Datum& data, Datum* out);
+
+/// \brief Return counts of unique elements from an array-like object
+/// \param[in] context the FunctionContext
+/// \param[in] value array-like input
+/// \param[out] out_uniques unique elements as Array
+/// \param[out] out_counts counts per element as Array, same shape as out_uniques
+///
+/// \since 0.10.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Status CountValues(FunctionContext* context, const Datum& value,
+                   std::shared_ptr<Array>* out_uniques,
+                   std::shared_ptr<Array>* out_counts);
 
 // TODO(wesm): Define API for incremental dictionary encoding
 

--- a/cpp/src/arrow/compute/kernels/hash.h
+++ b/cpp/src/arrow/compute/kernels/hash.h
@@ -47,6 +47,11 @@ class FunctionContext;
 ARROW_EXPORT
 Status Unique(FunctionContext* context, const Datum& datum, std::shared_ptr<Array>* out);
 
+// Constants for accessing the output of ValueCounts
+ARROW_EXPORT extern const char kValuesFieldName[];
+ARROW_EXPORT extern const char kCountsFieldName[];
+ARROW_EXPORT extern const int32_t kValuesFieldIndex;
+ARROW_EXPORT extern const int32_t kCountsFieldIndex;
 /// \brief Return counts of unique elements from an array-like object.
 ///
 /// Note that the counts do not include counts for nulls in the array.  These can be

--- a/cpp/src/arrow/compute/kernels/hash.h
+++ b/cpp/src/arrow/compute/kernels/hash.h
@@ -57,15 +57,13 @@ Status Unique(FunctionContext* context, const Datum& datum, std::shared_ptr<Arra
 ///
 /// \param[in] context the FunctionContext
 /// \param[in] value array-like input
-/// \param[out] out_uniques unique elements as Array
-/// \param[out] out_counts counts per element as Array, same shape as out_uniques
+/// \param[out] counts An array of  <input type "Values", int64_t "Counts"> structs.
 ///
 /// \since 0.13.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Status CountValues(FunctionContext* context, const Datum& value,
-                   std::shared_ptr<Array>* out_uniques,
-                   std::shared_ptr<Array>* out_counts);
+Status ValueCounts(FunctionContext* context, const Datum& value,
+                   std::shared_ptr<Array>* counts);
 
 /// \brief Dictionary-encode values in an array-like object
 /// \param[in] context the FunctionContext
@@ -81,11 +79,6 @@ Status DictionaryEncode(FunctionContext* context, const Datum& data, Datum* out)
 
 // TODO(wesm): Define API for regularizing DictionaryArray objects with
 // different dictionaries
-
-// class DictionaryEncoder {
-//  public:
-//   virtual Encode(const Datum& data, Datum* out) = 0;
-// };
 
 //
 // ARROW_EXPORT

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -475,7 +475,7 @@ class SmallScalarMemoTable {
   void CopyValues(int32_t start, Scalar* out_data) const {
     DCHECK_GE(start, 0);
     DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
-    int32_t offset = start * static_cast<int32_t>(sizeof(Scalar));
+    int64_t offset = start * static_cast<int32_t>(sizeof(Scalar));
     memcpy(out_data, index_to_value_.data() + offset, (size() - start) * sizeof(Scalar));
   }
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -473,9 +473,9 @@ class SmallScalarMemoTable {
 
   // Copy values starting from index `start` into `out_data`
   void CopyValues(int32_t start, Scalar* out_data) const {
-    if (index_to_value_.size() > 0) {
-      memcpy(out_data, &index_to_value_[start], size() - start);
-    }
+    DCHECK_GE(start, 0);
+    DCHECK_LE(start, index_to_value_.size());
+    std::copy(index_to_value_.begin() + start, index_to_value_.end(), out_data);
   }
 
   void CopyValues(Scalar* out_data) const { CopyValues(0, out_data); }

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -474,7 +474,7 @@ class SmallScalarMemoTable {
   // Copy values starting from index `start` into `out_data`
   void CopyValues(int32_t start, Scalar* out_data) const {
     DCHECK_GE(start, 0);
-    DCHECK_LE(start, index_to_value_.size());
+    DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
     std::copy(index_to_value_.begin() + start, index_to_value_.end(), out_data);
   }
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -475,7 +475,8 @@ class SmallScalarMemoTable {
   void CopyValues(int32_t start, Scalar* out_data) const {
     DCHECK_GE(start, 0);
     DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
-    std::copy(index_to_value_.begin() + start, index_to_value_.end(), out_data);
+    int offset = start * sizeof(Scalar);
+    memcpy(out_data, index_to_value_.data() + offset, (size() - start) * sizeof(Scalar));
   }
 
   void CopyValues(Scalar* out_data) const { CopyValues(0, out_data); }

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -475,7 +475,7 @@ class SmallScalarMemoTable {
   void CopyValues(int32_t start, Scalar* out_data) const {
     DCHECK_GE(start, 0);
     DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
-    int offset = start * sizeof(Scalar);
+    int32_t offset = start * static_cast<int32_t>(sizeof(Scalar));
     memcpy(out_data, index_to_value_.data() + offset, (size() - start) * sizeof(Scalar));
   }
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -473,7 +473,9 @@ class SmallScalarMemoTable {
 
   // Copy values starting from index `start` into `out_data`
   void CopyValues(int32_t start, Scalar* out_data) const {
-    memcpy(out_data, &index_to_value_[start], size() - start);
+    if (index_to_value_.size() > 0) {
+      memcpy(out_data, &index_to_value_[start], size() - start);
+    }
   }
 
   void CopyValues(Scalar* out_data) const { CopyValues(0, out_data); }


### PR DESCRIPTION
Picked up from: https://github.com/apache/arrow/pull/1970

I mostly reused the unit tests as is and modified the rest based on feedback on that PR and adapting to new code.  Some other changes I mae:
1.  Remove the HashKernel and getter from the public API.  I think we can add these back once we have a better idea on how we are doing stateful kernels (i.e. https://github.com/apache/arrow/pull/3407)
2. Add operator[] to NumericBuilder to modify previously added values (this might not be the right place, and I had a little bit of trouble figuring out how to integrate this into the existing TypedTest so the testing is a little bit weak).  This seemed better then using a vector to collect values.

If this approach looks OK for now.  I'm also going to open up a JIRA to try refactor the unittest for Hash kernels (and maybe the headers) since I think there might be a clearer more granular way of laying these out.

other things to discuss:
1.  Handling null values in Count/Unique (it looks like they are dropped today, should this configurable/turned on).
2.  Hashing edge cases for floating point numbers (just opened a JIRA on this).
