### PR TITLE
ARROW-4496: [Python] Pin to gfortran<4

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -41,7 +41,7 @@ CONDA_ENV_DIR=$TRAVIS_BUILD_DIR/pyarrow-test-$PYTHON_VERSION
 # python-test fails.
 export ZLIB_HOME=$CONDA_ENV_DIR
 
-if [ $ARROW_TRAVIS_PYTHON_JVM == "1" ]; then
+if [ "$ARROW_TRAVIS_PYTHON_JVM" == "1" ]; then
   CONDA_JVM_DEPS="jpype1"
 fi
 
@@ -50,6 +50,7 @@ conda create -y -q -p $CONDA_ENV_DIR \
       nomkl \
       pip \
       numpy=1.14 \
+      'libgfortran<4' \
       python=${PYTHON_VERSION} \
       ${CONDA_JVM_DEPS}
 


### PR DESCRIPTION
This is currently broken in the conda-forge pinning. While they fix it, we need to explicitly pin it.