### PR TITLE
ARROW-4523,ARROW-4524: [JS] Add row proxy generation benchmark, improve performance

### DIFF
--- a/js/perf/index.js
+++ b/js/perf/index.js
@@ -44,10 +44,12 @@ for (let { name, buffers } of require('./table_config')) {
 for (let {name, buffers, countBys, counts} of require('./table_config')) {
     const table = Table.from(buffers);
 
+    const tableIterateSuiteName = `Table Iterate "${name}"`;
     const dfCountBySuiteName = `DataFrame Count By "${name}"`;
     const dfFilterCountSuiteName = `DataFrame Filter-Scan Count "${name}"`;
     const dfDirectCountSuiteName = `DataFrame Direct Count "${name}"`;
 
+    suites.push(createTestSuite(tableIterateSuiteName, createTableIterateTest(table)));
     suites.push(...countBys.map((countBy) => createTestSuite(dfCountBySuiteName, createDataFrameCountByTest(table, countBy))));
     suites.push(...counts.map(({ col, test, value }) => createTestSuite(dfFilterCountSuiteName, createDataFrameFilterCountTest(table, col, test, value))));
     suites.push(...counts.map(({ col, test, value }) => createTestSuite(dfDirectCountSuiteName, createDataFrameDirectCountTest(table, col, test, value))));
@@ -132,6 +134,15 @@ function createGetByIndexTest(vector, name) {
                 value = vector.get(i);
             }
         }
+    };
+}
+
+function createTableIterateTest(table) {
+    let value;
+    return {
+        async: true,
+        name: `length: ${table.length}\n`,
+        fn() { for (value of table) {} }
     };
 }
 

--- a/js/src/util/vector.ts
+++ b/js/src/util/vector.ts
@@ -96,8 +96,8 @@ export function createElementComparator(search: any) {
             return true;
         };
     }
-    // Compare Rows and Vectors
-    if ((search instanceof Row) || (search instanceof Vector)) {
+    // Compare Vectors
+    if (search instanceof Vector) {
         const n = search.length;
         const C = search.constructor as any;
         const fns = [] as ((x: any) => boolean)[];
@@ -106,6 +106,21 @@ export function createElementComparator(search: any) {
         }
         return (value: any) => {
             if (!(value instanceof C)) { return false; }
+            if (!(value.length === n)) { return false; }
+            for (let i = -1; ++i < n;) {
+                if (!(fns[i](value.get(i)))) { return false; }
+            }
+            return true;
+        };
+    }
+    // Compare Rows
+    if (search instanceof Row) {
+        const n = search.length;
+        const fns = [] as ((x: any) => boolean)[];
+        for (let i = -1; ++i < n;) {
+            fns[i] = createElementComparator((search as any).get(i));
+        }
+        return (value: any) => {
             if (!(value.length === n)) { return false; }
             for (let i = -1; ++i < n;) {
                 if (!(fns[i](value.get(i)))) { return false; }

--- a/js/src/util/vector.ts
+++ b/js/src/util/vector.ts
@@ -16,7 +16,7 @@
 // under the License.
 
 import { Vector } from '../vector';
-import { Row } from '../vector/row';
+import { Row, kLength } from '../vector/row';
 import { compareArrayLike } from '../util/buffer';
 
 /** @ignore */
@@ -75,75 +75,105 @@ export function createElementComparator(search: any) {
     }
     // Compare Array-likes
     if (Array.isArray(search)) {
-        const n = (search as any).length;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator((search as any)[i]);
-        }
-        return (value: any) => {
-            if (!value || value.length !== n) { return false; }
-            // Handle the case where the search element is an Array, but the
-            // values are Rows or Vectors, e.g. list.indexOf(['foo', 'bar'])
-            if ((value instanceof Row) || (value instanceof Vector)) {
-                for (let i = -1, n = value.length; ++i < n;) {
-                    if (!(fns[i]((value as any).get(i)))) { return false; }
-                }
-                return true;
-            }
-            for (let i = -1, n = value.length; ++i < n;) {
-                if (!(fns[i](value[i]))) { return false; }
-            }
-            return true;
-        };
-    }
-    // Compare Vectors
-    if (search instanceof Vector) {
-        const n = search.length;
-        const C = search.constructor as any;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator((search as any).get(i));
-        }
-        return (value: any) => {
-            if (!(value instanceof C)) { return false; }
-            if (!(value.length === n)) { return false; }
-            for (let i = -1; ++i < n;) {
-                if (!(fns[i](value.get(i)))) { return false; }
-            }
-            return true;
-        };
+        return createArrayLikeComparator(search);
     }
     // Compare Rows
     if (search instanceof Row) {
-        const n = search.length;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator((search as any).get(i));
-        }
-        return (value: any) => {
-            if (!(value.length === n)) { return false; }
-            for (let i = -1; ++i < n;) {
-                if (!(fns[i](value.get(i)))) { return false; }
-            }
-            return true;
-        };
+        return createRowComparator(search);
+    }
+    // Compare Vectors
+    if (search instanceof Vector) {
+        return createVectorComparator(search);
     }
     // Compare non-empty Objects
     const keys = Object.keys(search);
     if (keys.length > 0) {
-        const n = keys.length;
-        const fns = [] as ((x: any) => boolean)[];
-        for (let i = -1; ++i < n;) {
-            fns[i] = createElementComparator(search[keys[i]]);
-        }
-        return (value: any) => {
-            if (!value || typeof value !== 'object') { return false; }
-            for (let i = -1; ++i < n;) {
-                if (!(fns[i](value[keys[i]]))) { return false; }
-            }
-            return true;
-        };
+        return createObjectKeysComparator(search, keys);
     }
     // No valid comparator
     return () => false;
+}
+
+/** @ignore */
+function createArrayLikeComparator(search: ArrayLike<any>) {
+    const n = search.length;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator((search as any)[i]);
+    }
+    return (value: any) => {
+        if (!value) { return false; }
+        // Handle the case where the search element is an Array, but the
+        // values are Rows or Vectors, e.g. list.indexOf(['foo', 'bar'])
+        if (value instanceof Row) {
+            if (value[kLength] !== n) { return false; }
+            for (let i = -1; ++i < n;) {
+                if (!(fns[i](value.get(i)))) { return false; }
+            }
+            return true;
+        }
+        if (value.length !== n) { return false; }
+        if (value instanceof Vector) {
+            for (let i = -1; ++i < n;) {
+                if (!(fns[i](value.get(i)))) { return false; }
+            }
+            return true;
+        }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value[i]))) { return false; }
+        }
+        return true;
+    };
+}
+
+/** @ignore */
+function createRowComparator(search: Row<any>) {
+    const n = search[kLength];
+    const C = search.constructor as any;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator(search.get(i));
+    }
+    return (value: any) => {
+        if (!(value instanceof C)) { return false; }
+        if (!(value[kLength] === n)) { return false; }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value.get(i)))) { return false; }
+        }
+        return true;
+    };
+}
+
+/** @ignore */
+function createVectorComparator(search: Vector<any>) {
+    const n = search.length;
+    const C = search.constructor as any;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator((search as any).get(i));
+    }
+    return (value: any) => {
+        if (!(value instanceof C)) { return false; }
+        if (!(value.length === n)) { return false; }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value.get(i)))) { return false; }
+        }
+        return true;
+    };
+}
+
+/** @ignore */
+function createObjectKeysComparator(search: any, keys: string[]) {
+    const n = keys.length;
+    const fns = [] as ((x: any) => boolean)[];
+    for (let i = -1; ++i < n;) {
+        fns[i] = createElementComparator(search[keys[i]]);
+    }
+    return (value: any) => {
+        if (!value || typeof value !== 'object') { return false; }
+        for (let i = -1; ++i < n;) {
+            if (!(fns[i](value[keys[i]]))) { return false; }
+        }
+        return true;
+    };
 }

--- a/js/src/vector/map.ts
+++ b/js/src/vector/map.ts
@@ -27,6 +27,6 @@ export class MapVector<T extends { [key: string]: DataType } = any> extends Base
     // @ts-ignore
     private _rowProxy: RowProxyGenerator<T>;
     public get rowProxy(): RowProxyGenerator<T> {
-        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this.type.children || [], true));
+        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this, this.type.children || [], true));
     }
 }

--- a/js/src/vector/map.ts
+++ b/js/src/vector/map.ts
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Row } from './row';
+import { RowProxyGenerator } from './row';
 import { Vector } from '../vector';
 import { BaseVector } from './base';
 import { DataType, Map_, Struct } from '../type';
@@ -25,8 +25,8 @@ export class MapVector<T extends { [key: string]: DataType } = any> extends Base
         return Vector.new(this.data.clone(new Struct<T>(this.type.children)));
     }
     // @ts-ignore
-    private _rowProxy: Row<T>;
-    public get rowProxy(): Row<T> {
-        return this._rowProxy || (this._rowProxy = Row.new<T>(this.type.children || [], true));
+    private _rowProxy: RowProxyGenerator<T>;
+    public get rowProxy(): RowProxyGenerator<T> {
+        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this.type.children || [], true));
     }
 }

--- a/js/src/vector/row.ts
+++ b/js/src/vector/row.ts
@@ -59,9 +59,8 @@ export class Row<T extends { [key: string]: DataType }> implements Iterable<T[ke
 
 interface RowConstructor<T extends { [key: string]: DataType }> {
     readonly prototype: Row<T>;
-    new(rowIndex: number): T & Row<T>
+    new(rowIndex: number): T & Row<T>;
 }
-
 
 /** @ignore */
 export class RowProxyGenerator<T extends { [key: string]: DataType }> {
@@ -93,7 +92,7 @@ export class RowProxyGenerator<T extends { [key: string]: DataType }> {
             columnDescriptor.get = function() {
                 const child = (this as any as Row<T>).parent.getChildAt(columnIndex);
                 return child ? child.get((this as any as Row<T>).rowIndex) : null;
-            }
+            };
             // set configurable to true to ensure Object.defineProperty
             // doesn't throw in the case of duplicate column names
             columnDescriptor.configurable = true;
@@ -105,10 +104,10 @@ export class RowProxyGenerator<T extends { [key: string]: DataType }> {
             columnDescriptor.get = null as any;
         });
 
-        this.RowProxy = (BoundRow as any)
+        this.RowProxy = (BoundRow as any);
     }
     public bind(rowIndex: number) {
-        const bound = Object.create(this.RowProxy.prototype)
+        const bound = Object.create(this.RowProxy.prototype);
         bound.rowIndex = rowIndex;
         return bound;
         //return new this.RowProxy(rowIndex);

--- a/js/src/vector/struct.ts
+++ b/js/src/vector/struct.ts
@@ -27,6 +27,6 @@ export class StructVector<T extends { [key: string]: DataType } = any> extends B
     // @ts-ignore
     private _rowProxy: RowProxyGenerator<T>;
     public get rowProxy(): RowProxyGenerator<T> {
-        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this.type.children || [], false));
+        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this, this.type.children || [], false));
     }
 }

--- a/js/src/vector/struct.ts
+++ b/js/src/vector/struct.ts
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Row } from './row';
+import { RowProxyGenerator } from './row';
 import { Vector } from '../vector';
 import { BaseVector } from './base';
 import { DataType, Map_, Struct } from '../type';
@@ -25,8 +25,8 @@ export class StructVector<T extends { [key: string]: DataType } = any> extends B
         return Vector.new(this.data.clone(new Map_<T>(this.type.children, keysSorted)));
     }
     // @ts-ignore
-    private _rowProxy: Row<T>;
-    public get rowProxy(): Row<T> {
-        return this._rowProxy || (this._rowProxy = Row.new<T>(this.type.children || [], false));
+    private _rowProxy: RowProxyGenerator<T>;
+    public get rowProxy(): RowProxyGenerator<T> {
+        return this._rowProxy || (this._rowProxy = RowProxyGenerator.new<T>(this.type.children || [], false));
     }
 }

--- a/js/src/visitor/get.ts
+++ b/js/src/visitor/get.ts
@@ -211,7 +211,7 @@ const getNested = <
     S extends { [key: string]: DataType },
     V extends Vector<Map_<S>> | Vector<Struct<S>>
 >(vector: V, index: number): V['TValue'] => {
-    return vector.rowProxy.bind(vector, index);
+    return vector.rowProxy.bind(index);
 };
 
 /* istanbul ignore next */


### PR DESCRIPTION
It seems that using `Object.create` in the `bind` method slows down proxy generation substantially. I separated the `Row` and `RowProxyGenerator` concepts - now the generator creates a prototype based on `Row` and the parent vector when it is created, and constructs instances based on that prototype repeatedly in `bind`.

This change improved the included benchmark from 1,114.78 ms to 154.96 ms on my laptop (Intel i5-7200U).