### PR TITLE
ARROW-4525: [Rust] [Parquet] Enable conversion of ArrowError to ParquetError

### DIFF
--- a/rust/parquet/src/errors.rs
+++ b/rust/parquet/src/errors.rs
@@ -19,6 +19,7 @@
 
 use std::{cell, convert, io, result};
 
+use arrow::error::ArrowError;
 use quick_error::quick_error;
 use snap;
 use thrift;
@@ -55,6 +56,7 @@ quick_error! {
       ArrowError(message:  String) {
           display("Arrow: {}", message)
               description(message)
+              from(e: ArrowError) -> (format!("underlying Arrow error: {:?}", e))
       }
   }
 }


### PR DESCRIPTION
This is useful when integrating arrow with parquet, e.g. when reading parquet data into arrow.