### PR TITLE
ARROW-4363: [CI] [C++] Add CMake format checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ matrix:
     os: linux
     language: python
     python: "3.6"
-    env:
-    - ARROW_TRAVIS_CLANG_FORMAT=1
     before_script:
     # Always run RAT checks, in case another build in matrix breaks RAT
     - $TRAVIS_BUILD_DIR/ci/travis_release_audit.sh

--- a/ci/travis_lint.sh
+++ b/ci/travis_lint.sh
@@ -23,6 +23,10 @@ set -ex
 export ARROW_TRAVIS_USE_TOOLCHAIN=0
 source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
+# CMake formatting check
+pip install cmake_format
+$TRAVIS_BUILD_DIR/run-cmake-format.py --check
+
 # C++ code linting
 if [ "$ARROW_CI_CPP_AFFECTED" != "0" ]; then
   mkdir $ARROW_CPP_DIR/lint
@@ -30,10 +34,7 @@ if [ "$ARROW_CI_CPP_AFFECTED" != "0" ]; then
 
   cmake .. -DARROW_ONLY_LINT=ON
   make lint
-
-  if [ "$ARROW_TRAVIS_CLANG_FORMAT" == "1" ]; then
-    make check-format
-  fi
+  make check-format
 
   python $ARROW_CPP_DIR/build-support/lint_cpp_cli.py $ARROW_CPP_DIR/src
 

--- a/cmake-format.py
+++ b/cmake-format.py
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# cmake-format configuration file
+# Use run-cmake-format.py to reformat all cmake files in the source tree
+
+# How wide to allow formatted cmake files
+line_width = 90
+
+# How many spaces to tab for indent
+tab_size = 2
+
+# If arglists are longer than this, break them always
+max_subargs_per_line = 4
+
+# If true, separate flow control names from their parentheses with a space
+separate_ctrl_name_with_space = False
+
+# If true, separate function names from parentheses with a space
+separate_fn_name_with_space = False
+
+# If a statement is wrapped to more than one line, than dangle the closing
+# parenthesis on it's own line
+dangle_parens = False
+
+# What style line endings to use in the output.
+line_ending = 'unix'
+
+# Format command names consistently as 'lower' or 'upper' case
+command_case = 'lower'
+
+# Format keywords consistently as 'lower' or 'upper' case
+keyword_case = 'unchanged'
+
+# enable comment markup parsing and reflow
+enable_markup = False
+
+# If comment markup is enabled, don't reflow the first comment block in
+# eachlistfile. Use this to preserve formatting of your
+# copyright/licensestatements.
+first_comment_is_literal = False
+
+# If comment markup is enabled, don't reflow any comment block which matchesthis
+# (regex) pattern. Default is `None` (disabled).
+literal_comment_pattern = None

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -20,18 +20,17 @@ message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
 set(ARROW_VERSION "0.13.0-SNAPSHOT")
 
-string(REGEX MATCH
-  "^[0-9]+\\.[0-9]+\\.[0-9]+" ARROW_BASE_VERSION "${ARROW_VERSION}")
+string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" ARROW_BASE_VERSION "${ARROW_VERSION}")
 
 project(arrow VERSION "${ARROW_BASE_VERSION}")
 
 set(ARROW_VERSION_MAJOR "${arrow_VERSION_MAJOR}")
 set(ARROW_VERSION_MINOR "${arrow_VERSION_MINOR}")
 set(ARROW_VERSION_PATCH "${arrow_VERSION_PATCH}")
-if (ARROW_VERSION_MAJOR STREQUAL "" OR
-    ARROW_VERSION_MINOR STREQUAL "" OR
-    ARROW_VERSION_PATCH STREQUAL "")
-  MESSAGE(FATAL_ERROR "Failed to determine Arrow version from '${ARROW_VERSION}'")
+if(ARROW_VERSION_MAJOR STREQUAL ""
+   OR ARROW_VERSION_MINOR STREQUAL ""
+   OR ARROW_VERSION_PATCH STREQUAL "")
+  message(FATAL_ERROR "Failed to determine Arrow version from '${ARROW_VERSION}'")
 endif()
 
 # The SO version is also the ABI version
@@ -44,8 +43,8 @@ else()
 endif()
 
 message(STATUS "Arrow version: "
-  "${ARROW_VERSION_MAJOR}.${ARROW_VERSION_MINOR}.${ARROW_VERSION_PATCH} "
-  "(full: '${ARROW_VERSION}')")
+               "${ARROW_VERSION_MAJOR}.${ARROW_VERSION_MINOR}.${ARROW_VERSION_PATCH} "
+               "(full: '${ARROW_VERSION}')")
 
 set(ARROW_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 set(ARROW_BINARY_DIR ${PROJECT_BINARY_DIR})
@@ -75,10 +74,14 @@ endif()
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
 set(ARROW_LLVM_VERSION "7.0")
-STRING(REGEX REPLACE "^([0-9]+)\\.[0-9]+" "\\1" ARROW_LLVM_MAJOR_VERSION "${ARROW_LLVM_VERSION}")
-STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+)" "\\1" ARROW_LLVM_MINOR_VERSION "${ARROW_LLVM_VERSION}")
+string(
+  REGEX
+  REPLACE "^([0-9]+)\\.[0-9]+" "\\1" ARROW_LLVM_MAJOR_VERSION "${ARROW_LLVM_VERSION}")
+string(
+  REGEX
+  REPLACE "^[0-9]+\\.([0-9]+)" "\\1" ARROW_LLVM_MINOR_VERSION "${ARROW_LLVM_VERSION}")
 find_package(ClangTools)
-if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
+if("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
   # Generate a Clang compile_commands.json "compilation database" file for use
   # with various development tools, such as Vim's YouCompleteMe plugin.
   # See http://clang.llvm.org/docs/JSONCompilationDatabase.html
@@ -86,7 +89,7 @@ if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR CLANG_TIDY_FOUND)
 endif()
 
 find_package(InferTools)
-if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR INFER_FOUND)
+if("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1" OR INFER_FOUND)
   # Generate a Clang compile_commands.json "compilation database" file for use
   # with various development tools, such as Vim's YouCompleteMe plugin.
   # See http://clang.llvm.org/docs/JSONCompilationDatabase.html
@@ -98,204 +101,116 @@ endif()
 
 # Top level cmake dir
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  set(ARROW_CXXFLAGS "" CACHE STRING
-    "Compiler flags to append when compiling Arrow")
+  set(ARROW_CXXFLAGS "" CACHE STRING "Compiler flags to append when compiling Arrow")
 
-  option(ARROW_ONLY_LINT
-    "Only define the lint and check-format targets"
-    OFF)
+  option(ARROW_ONLY_LINT "Only define the lint and check-format targets" OFF)
 
-  option(ARROW_BUILD_STATIC
-    "Build static libraries"
-    ON)
+  option(ARROW_BUILD_STATIC "Build static libraries" ON)
 
-  option(ARROW_BUILD_SHARED
-    "Build shared libraries"
-    ON)
+  option(ARROW_BUILD_SHARED "Build shared libraries" ON)
 
-  option(ARROW_TEST_MEMCHECK
-    "Run the test suite using valgrind --tool=memcheck"
-    OFF)
+  option(ARROW_TEST_MEMCHECK "Run the test suite using valgrind --tool=memcheck" OFF)
 
-  option(ARROW_USE_ASAN
-    "Enable Address Sanitizer checks"
-    OFF)
+  option(ARROW_USE_ASAN "Enable Address Sanitizer checks" OFF)
 
-  option(ARROW_USE_CCACHE
-    "Use ccache when compiling (if available)"
-    ON)
+  option(ARROW_USE_CCACHE "Use ccache when compiling (if available)" ON)
 
-  option(ARROW_USE_LD_GOLD
-    "Use ld.gold for linking on Linux (if available)"
-    OFF)
+  option(ARROW_USE_LD_GOLD "Use ld.gold for linking on Linux (if available)" OFF)
 
-  option(ARROW_USE_TSAN
-    "Enable Thread Sanitizer checks"
-    OFF)
+  option(ARROW_USE_TSAN "Enable Thread Sanitizer checks" OFF)
 
-  option(ARROW_BUILD_TESTS
-    "Build the Arrow googletest unit tests, default OFF"
-    OFF)
+  option(ARROW_BUILD_TESTS "Build the Arrow googletest unit tests, default OFF" OFF)
 
-  option(ARROW_BUILD_BENCHMARKS
-    "Build the Arrow micro benchmarks, default OFF"
-    OFF)
+  option(ARROW_BUILD_BENCHMARKS "Build the Arrow micro benchmarks, default OFF" OFF)
 
-  option(ARROW_BUILD_EXAMPLES
-    "Build the Arrow examples, default OFF"
-    OFF)
+  option(ARROW_BUILD_EXAMPLES "Build the Arrow examples, default OFF" OFF)
 
-  set(ARROW_TEST_LINKAGE "shared" CACHE STRING
-    "Linkage of Arrow libraries with unit tests executables. \
+  set(ARROW_TEST_LINKAGE "shared"
+      CACHE STRING "Linkage of Arrow libraries with unit tests executables. \
 static|shared (default shared)")
 
-  option(ARROW_NO_DEPRECATED_API
-    "Exclude deprecated APIs from build"
-    OFF)
+  option(ARROW_NO_DEPRECATED_API "Exclude deprecated APIs from build" OFF)
 
-  option(ARROW_FUZZING
-    "Build Arrow Fuzzing executables"
-    OFF)
+  option(ARROW_FUZZING "Build Arrow Fuzzing executables" OFF)
 
   # Disable this option to exercise non-SIMD fallbacks
-  option(ARROW_USE_SIMD
-    "Build with SIMD optimizations"
-    ON)
+  option(ARROW_USE_SIMD "Build with SIMD optimizations" ON)
 
-  option(ARROW_ALTIVEC
-    "Build Arrow with Altivec"
-    ON)
+  option(ARROW_ALTIVEC "Build Arrow with Altivec" ON)
 
-  option(ARROW_BUILD_UTILITIES
-    "Build Arrow commandline utilities"
-    ON)
+  option(ARROW_BUILD_UTILITIES "Build Arrow commandline utilities" ON)
 
-  option(ARROW_RPATH_ORIGIN
-    "Build Arrow libraries with RATH set to \$ORIGIN"
-    OFF)
+  option(ARROW_RPATH_ORIGIN "Build Arrow libraries with RATH set to \$ORIGIN" OFF)
 
-  option(ARROW_INSTALL_NAME_RPATH
-    "Build Arrow libraries with install_name set to @rpath"
-    ON)
+  option(ARROW_INSTALL_NAME_RPATH "Build Arrow libraries with install_name set to @rpath"
+         ON)
 
-  option(ARROW_GENERATE_COVERAGE
-    "Build with C++ code coverage enabled"
-    OFF)
+  option(ARROW_GENERATE_COVERAGE "Build with C++ code coverage enabled" OFF)
 
-  option(ARROW_VERBOSE_LINT
-    "If off, 'quiet' flags will be passed to linting tools"
-    OFF)
+  option(ARROW_VERBOSE_LINT "If off, 'quiet' flags will be passed to linting tools" OFF)
 
-  option(ARROW_GGDB_DEBUG
-    "Pass -ggdb flag to debug builds"
-    ON)
+  option(ARROW_GGDB_DEBUG "Pass -ggdb flag to debug builds" ON)
 
   #----------------------------------------------------------------------
   # Project components to enable / disable building
 
-  option(ARROW_COMPUTE
-    "Build the Arrow Compute Modules"
-    ON)
+  option(ARROW_COMPUTE "Build the Arrow Compute Modules" ON)
 
   option(ARROW_FLIGHT
-    "Build the Arrow Flight RPC System (requires GRPC, Protocol Buffers)"
-    OFF)
+         "Build the Arrow Flight RPC System (requires GRPC, Protocol Buffers)" OFF)
 
-  option(ARROW_GANDIVA
-    "Build the Gandiva libraries"
-    OFF)
+  option(ARROW_GANDIVA "Build the Gandiva libraries" OFF)
 
-  option(ARROW_PARQUET
-    "Build the Parquet libraries"
-    OFF)
+  option(ARROW_PARQUET "Build the Parquet libraries" OFF)
 
-  option(ARROW_IPC
-    "Build the Arrow IPC extensions"
-    ON)
+  option(ARROW_IPC "Build the Arrow IPC extensions" ON)
 
-  option(ARROW_CUDA
-    "Build the Arrow CUDA extensions (requires CUDA toolkit)"
-    OFF)
+  option(ARROW_CUDA "Build the Arrow CUDA extensions (requires CUDA toolkit)" OFF)
 
-  option(ARROW_ORC
-    "Build the Arrow ORC adapter"
-    OFF)
+  option(ARROW_ORC "Build the Arrow ORC adapter" OFF)
 
-  option(ARROW_TENSORFLOW
-    "Build Arrow with TensorFlow support enabled"
-    OFF)
+  option(ARROW_TENSORFLOW "Build Arrow with TensorFlow support enabled" OFF)
 
-  option(ARROW_JEMALLOC
-    "Build the Arrow jemalloc-based allocator"
-    ON)
+  option(ARROW_JEMALLOC "Build the Arrow jemalloc-based allocator" ON)
 
-  option(ARROW_HDFS
-    "Build the Arrow HDFS bridge"
-    ON)
+  option(ARROW_HDFS "Build the Arrow HDFS bridge" ON)
 
-  option(ARROW_PYTHON
-    "Build the Arrow CPython extensions"
-    OFF)
+  option(ARROW_PYTHON "Build the Arrow CPython extensions" OFF)
 
-  option(ARROW_HIVESERVER2
-    "Build the HiveServer2 client and Arrow adapter"
-    OFF)
+  option(ARROW_HIVESERVER2 "Build the HiveServer2 client and Arrow adapter" OFF)
 
-  option(ARROW_PLASMA
-    "Build the plasma object store along with Arrow"
-    OFF)
+  option(ARROW_PLASMA "Build the plasma object store along with Arrow" OFF)
 
-  option(ARROW_PLASMA_JAVA_CLIENT
-    "Build the plasma object store java client"
-    OFF)
+  option(ARROW_PLASMA_JAVA_CLIENT "Build the plasma object store java client" OFF)
 
   #----------------------------------------------------------------------
   # Thirdparty toolchain options
 
   option(ARROW_VERBOSE_THIRDPARTY_BUILD
-    "If off, output from ExternalProjects will be logged to files rather than shown"
-    OFF)
+         "If off, output from ExternalProjects will be logged to files rather than shown"
+         OFF)
 
-  option(ARROW_BOOST_USE_SHARED
-    "Rely on boost shared libraries where relevant"
-    ON)
+  option(ARROW_BOOST_USE_SHARED "Rely on boost shared libraries where relevant" ON)
 
-  option(ARROW_BOOST_VENDORED
-    "Use vendored Boost instead of existing Boost. \
-Note that this requires linking Boost statically"
-    OFF)
+  option(ARROW_BOOST_VENDORED "Use vendored Boost instead of existing Boost. \
+Note that this requires linking Boost statically" OFF)
 
   option(ARROW_PROTOBUF_USE_SHARED
-    "Rely on Protocol Buffers shared libraries where relevant"
-    OFF)
+         "Rely on Protocol Buffers shared libraries where relevant" OFF)
 
-  option(ARROW_WITH_BACKTRACE
-    "Build with backtrace support"
-    ON)
+  option(ARROW_WITH_BACKTRACE "Build with backtrace support" ON)
 
-  option(ARROW_USE_GLOG
-    "Build libraries with glog support for pluggable logging"
-    ON)
+  option(ARROW_USE_GLOG "Build libraries with glog support for pluggable logging" ON)
 
-  option(ARROW_WITH_BROTLI
-    "Build with Brotli compression"
-    ON)
+  option(ARROW_WITH_BROTLI "Build with Brotli compression" ON)
 
-  option(ARROW_WITH_BZ2
-    "Build with BZ2 compression"
-    OFF)
+  option(ARROW_WITH_BZ2 "Build with BZ2 compression" OFF)
 
-  option(ARROW_WITH_LZ4
-    "Build with lz4 compression"
-    ON)
+  option(ARROW_WITH_LZ4 "Build with lz4 compression" ON)
 
-  option(ARROW_WITH_SNAPPY
-    "Build with Snappy compression"
-    ON)
+  option(ARROW_WITH_SNAPPY "Build with Snappy compression" ON)
 
-  option(ARROW_WITH_ZLIB
-    "Build with zlib compression"
-    ON)
+  option(ARROW_WITH_ZLIB "Build with zlib compression" ON)
 
   if(CMAKE_VERSION VERSION_LESS 3.7)
     set(ARROW_WITH_ZSTD_DEFAULT OFF)
@@ -303,89 +218,83 @@ Note that this requires linking Boost statically"
     # ExternalProject_Add(SOURCE_SUBDIR) is available since CMake 3.7.
     set(ARROW_WITH_ZSTD_DEFAULT ON)
   endif()
-  option(ARROW_WITH_ZSTD
-    "Build with zstd compression"
-    ${ARROW_WITH_ZSTD_DEFAULT})
+  option(ARROW_WITH_ZSTD "Build with zstd compression" ${ARROW_WITH_ZSTD_DEFAULT})
 
   #----------------------------------------------------------------------
   # Windows options
 
-  if (MSVC)
+  if(MSVC)
     option(MSVC_LINK_VERBOSE
-      "Pass verbose linking options when linking libraries and executables"
-      OFF)
+           "Pass verbose linking options when linking libraries and executables" OFF)
 
-    option(ARROW_USE_CLCACHE
-      "Use clcache if available"
-      ON)
+    option(ARROW_USE_CLCACHE "Use clcache if available" ON)
 
-    set(BROTLI_MSVC_STATIC_LIB_SUFFIX "-static" CACHE STRING
-      "Brotli static lib suffix used on Windows with MSVC (default -static)")
-    set(PROTOBUF_MSVC_STATIC_LIB_SUFFIX "" CACHE STRING
-      "Protobuf static lib suffix used on Windows with MSVC (default is empty string)")
-    set(RE2_MSVC_STATIC_LIB_SUFFIX "_static" CACHE STRING
-      "re2 static lib suffix used on Windows with MSVC (default is _static)")
-    set(SNAPPY_MSVC_STATIC_LIB_SUFFIX "_static" CACHE STRING
-      "Snappy static lib suffix used on Windows with MSVC (default is _static)")
-    set(LZ4_MSVC_STATIC_LIB_SUFFIX "_static" CACHE STRING
-      "Lz4 static lib suffix used on Windows with MSVC (default _static)")
-    set(ZSTD_MSVC_STATIC_LIB_SUFFIX "_static" CACHE STRING
-      "ZStd static lib suffix used on Windows with MSVC (default _static)")
+    set(BROTLI_MSVC_STATIC_LIB_SUFFIX "-static"
+        CACHE STRING
+              "Brotli static lib suffix used on Windows with MSVC (default -static)")
+    set(
+      PROTOBUF_MSVC_STATIC_LIB_SUFFIX ""
+      CACHE
+        STRING
+        "Protobuf static lib suffix used on Windows with MSVC (default is empty string)")
+    set(RE2_MSVC_STATIC_LIB_SUFFIX "_static"
+        CACHE STRING
+              "re2 static lib suffix used on Windows with MSVC (default is _static)")
+    set(SNAPPY_MSVC_STATIC_LIB_SUFFIX "_static"
+        CACHE STRING
+              "Snappy static lib suffix used on Windows with MSVC (default is _static)")
+    set(LZ4_MSVC_STATIC_LIB_SUFFIX "_static"
+        CACHE STRING "Lz4 static lib suffix used on Windows with MSVC (default _static)")
+    set(ZSTD_MSVC_STATIC_LIB_SUFFIX "_static"
+        CACHE STRING "ZStd static lib suffix used on Windows with MSVC (default _static)")
 
-    option(ARROW_USE_STATIC_CRT
-      "Build Arrow with statically linked CRT"
-      OFF)
+    option(ARROW_USE_STATIC_CRT "Build Arrow with statically linked CRT" OFF)
   endif()
 
   #----------------------------------------------------------------------
   # Parquet build options
 
   option(PARQUET_MINIMAL_DEPENDENCY
-    "Depend only on Thirdparty headers to build libparquet. \
-Always OFF if building binaries"
-    OFF)
+         "Depend only on Thirdparty headers to build libparquet. \
+Always OFF if building binaries" OFF)
 
   option(PARQUET_BUILD_EXECUTABLES
-    "Build the Parquet executable CLI tools. Requires static libraries to be built."
-    OFF)
+         "Build the Parquet executable CLI tools. Requires static libraries to be built."
+         OFF)
 
   option(PARQUET_BUILD_EXAMPLES
-    "Build the Parquet examples. Requires static libraries to be built."
-    OFF)
+         "Build the Parquet examples. Requires static libraries to be built." OFF)
 
   #----------------------------------------------------------------------
   # Gandiva build options
 
-  option(ARROW_GANDIVA_JAVA
-    "Build the Gandiva JNI wrappers"
-    OFF)
+  option(ARROW_GANDIVA_JAVA "Build the Gandiva JNI wrappers" OFF)
 
   # ARROW-3860: Temporary workaround
-  option(ARROW_GANDIVA_STATIC_LIBSTDCPP
+  option(
+    ARROW_GANDIVA_STATIC_LIBSTDCPP
     "Include -static-libstdc++ -static-libgcc when linking with Gandiva static libraries"
     OFF)
 
-  set(ARROW_GANDIVA_PC_CXX_FLAGS "" CACHE STRING
-    "Compiler flags to append when pre-compiling Gandiva operations")
+  set(ARROW_GANDIVA_PC_CXX_FLAGS ""
+      CACHE STRING "Compiler flags to append when pre-compiling Gandiva operations")
 
   #----------------------------------------------------------------------
   # Advanced developer options
 
-  option(ARROW_EXTRA_ERROR_CONTEXT
-    "Compile with extra error context (line numbers, code)"
-    OFF)
+  option(ARROW_EXTRA_ERROR_CONTEXT "Compile with extra error context (line numbers, code)"
+         OFF)
 
   option(ARROW_OPTIONAL_INSTALL
-    "If enabled install ONLY targets that have already been built. Please be \
+         "If enabled install ONLY targets that have already been built. Please be \
 advised that if this is enabled 'install' will fail silently on components \
-that have not been built"
-    OFF)
+that have not been built" OFF)
 endif()
 
 # Needed for linting targets, etc.
 find_package(PythonInterp)
 
-if (ARROW_USE_CCACHE)
+if(ARROW_USE_CCACHE)
   find_program(CCACHE_FOUND ccache)
   if(CCACHE_FOUND)
     message(STATUS "Using ccache: ${CCACHE_FOUND}")
@@ -394,21 +303,21 @@ if (ARROW_USE_CCACHE)
   endif(CCACHE_FOUND)
 endif()
 
-if (ARROW_OPTIONAL_INSTALL)
+if(ARROW_OPTIONAL_INSTALL)
   # Don't make the "install" target depend on the "all" target
   set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY true)
 
   set(INSTALL_IS_OPTIONAL OPTIONAL)
 endif()
 
-############################################################
+#
 # "make lint" target
-############################################################
-if (NOT ARROW_VERBOSE_LINT)
+#
+if(NOT ARROW_VERBOSE_LINT)
   set(ARROW_LINT_QUIET "--quiet")
 endif()
 
-if (NOT LINT_EXCLUSIONS_FILE)
+if(NOT LINT_EXCLUSIONS_FILE)
   # source files matching a glob from a line in this file
   # will be excluded from linting (cpplint, clang-tidy, clang-format)
   set(LINT_EXCLUSIONS_FILE ${BUILD_SUPPORT_DIR}/lint_exclusions.txt)
@@ -418,68 +327,89 @@ find_program(CPPLINT_BIN NAMES cpplint cpplint.py HINTS ${BUILD_SUPPORT_DIR})
 message(STATUS "Found cpplint executable at ${CPPLINT_BIN}")
 
 add_custom_target(lint
-  ${PYTHON_EXECUTABLE} ${BUILD_SUPPORT_DIR}/run_cpplint.py
-  --cpplint_binary ${CPPLINT_BIN}
-  --exclude_globs ${LINT_EXCLUSIONS_FILE}
-  --source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src
-  ${ARROW_LINT_QUIET})
+                  ${PYTHON_EXECUTABLE}
+                  ${BUILD_SUPPORT_DIR}/run_cpplint.py
+                  --cpplint_binary
+                  ${CPPLINT_BIN}
+                  --exclude_globs
+                  ${LINT_EXCLUSIONS_FILE}
+                  --source_dir
+                  ${CMAKE_CURRENT_SOURCE_DIR}/src
+                  ${ARROW_LINT_QUIET})
 
-############################################################
+#
 # "make format" and "make check-format" targets
-############################################################
-if (${CLANG_FORMAT_FOUND})
+#
+if(${CLANG_FORMAT_FOUND})
   # runs clang format and updates files in place.
   add_custom_target(format
-    ${PYTHON_EXECUTABLE} ${BUILD_SUPPORT_DIR}/run_clang_format.py
-    --clang_format_binary ${CLANG_FORMAT_BIN}
-    --exclude_globs ${LINT_EXCLUSIONS_FILE}
-    --source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src
-    --fix
-    ${ARROW_LINT_QUIET})
+                    ${PYTHON_EXECUTABLE}
+                    ${BUILD_SUPPORT_DIR}/run_clang_format.py
+                    --clang_format_binary
+                    ${CLANG_FORMAT_BIN}
+                    --exclude_globs
+                    ${LINT_EXCLUSIONS_FILE}
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    --fix
+                    ${ARROW_LINT_QUIET})
 
   # runs clang format and exits with a non-zero exit code if any files need to be reformatted
   add_custom_target(check-format
-    ${PYTHON_EXECUTABLE} ${BUILD_SUPPORT_DIR}/run_clang_format.py
-    --clang_format_binary ${CLANG_FORMAT_BIN}
-    --exclude_globs ${LINT_EXCLUSIONS_FILE}
-    --source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${ARROW_LINT_QUIET})
+                    ${PYTHON_EXECUTABLE}
+                    ${BUILD_SUPPORT_DIR}/run_clang_format.py
+                    --clang_format_binary
+                    ${CLANG_FORMAT_BIN}
+                    --exclude_globs
+                    ${LINT_EXCLUSIONS_FILE}
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    ${ARROW_LINT_QUIET})
 endif()
 
-############################################################
+#
 # "make clang-tidy" and "make check-clang-tidy" targets
-############################################################
-if (${CLANG_TIDY_FOUND})
+#
+if(${CLANG_TIDY_FOUND})
   # TODO check to make sure .clang-tidy is being respected
 
   # runs clang-tidy and attempts to fix any warning automatically
   add_custom_target(clang-tidy
-    ${PYTHON_EXECUTABLE} ${BUILD_SUPPORT_DIR}/run_clang_tidy.py
-    --clang_tidy_binary ${CLANG_TIDY_BIN}
-    --exclude_globs ${LINT_EXCLUSIONS_FILE}
-    --compile_commands ${CMAKE_BINARY_DIR}/compile_commands.json
-    --source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src
-    --fix
-    ${ARROW_LINT_QUIET})
+                    ${PYTHON_EXECUTABLE}
+                    ${BUILD_SUPPORT_DIR}/run_clang_tidy.py
+                    --clang_tidy_binary
+                    ${CLANG_TIDY_BIN}
+                    --exclude_globs
+                    ${LINT_EXCLUSIONS_FILE}
+                    --compile_commands
+                    ${CMAKE_BINARY_DIR}/compile_commands.json
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    --fix
+                    ${ARROW_LINT_QUIET})
 
   # runs clang-tidy and exits with a non-zero exit code if any errors are found.
   add_custom_target(check-clang-tidy
-    ${PYTHON_EXECUTABLE} ${BUILD_SUPPORT_DIR}/run_clang_tidy.py
-    --clang_tidy_binary ${CLANG_TIDY_BIN}
-    --exclude_globs ${LINT_EXCLUSIONS_FILE}
-    --compile_commands ${CMAKE_BINARY_DIR}/compile_commands.json
-    --source_dir ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${ARROW_LINT_QUIET})
+                    ${PYTHON_EXECUTABLE}
+                    ${BUILD_SUPPORT_DIR}/run_clang_tidy.py
+                    --clang_tidy_binary
+                    ${CLANG_TIDY_BIN}
+                    --exclude_globs
+                    ${LINT_EXCLUSIONS_FILE}
+                    --compile_commands
+                    ${CMAKE_BINARY_DIR}/compile_commands.json
+                    --source_dir
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    ${ARROW_LINT_QUIET})
 endif()
 
-if (ARROW_ONLY_LINT)
+if(ARROW_ONLY_LINT)
   return()
 endif()
 
-
-############################################################
+#
 # Set up various options
-############################################################
+#
 
 if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   # Currently the compression tests require at least these libraries; bz2 and
@@ -500,7 +430,7 @@ if(PARQUET_BUILD_EXAMPLES OR PARQUET_BUILD_EXECUTABLES)
   set(ARROW_BUILD_STATIC ON)
 endif()
 
-if (MSVC)
+if(MSVC)
   # ORC doesn't build on windows
   set(ARROW_ORC OFF)
   # Plasma using glog is not fully tested on windows.
@@ -533,39 +463,40 @@ if(NOT ARROW_BUILD_EXAMPLES)
   set(NO_EXAMPLES 1)
 endif()
 
-if (NOT ARROW_FUZZING)
+if(NOT ARROW_FUZZING)
   set(NO_FUZZING 1)
 endif()
 
-if (MSVC AND ARROW_USE_CLCACHE AND
-     (("${CMAKE_GENERATOR}" STREQUAL "NMake Makefiles") OR
-      ("${CMAKE_GENERATOR}" STREQUAL "Ninja")))
+if(MSVC
+   AND ARROW_USE_CLCACHE
+   AND (("${CMAKE_GENERATOR}" STREQUAL "NMake Makefiles")
+        OR ("${CMAKE_GENERATOR}" STREQUAL "Ninja")))
   find_program(CLCACHE_FOUND clcache)
   if(CLCACHE_FOUND)
     set(CMAKE_CXX_COMPILER ${CLCACHE_FOUND})
   endif(CLCACHE_FOUND)
 endif()
 
-############################################################
+#
 # Compiler flags
-############################################################
+#
 
 # Determine compiler version
 include(CompilerInfo)
 
-if (ARROW_NO_DEPRECATED_API)
+if(ARROW_NO_DEPRECATED_API)
   add_definitions(-DARROW_NO_DEPRECATED_API)
 endif()
 
-if (ARROW_EXTRA_ERROR_CONTEXT)
+if(ARROW_EXTRA_ERROR_CONTEXT)
   add_definitions(-DARROW_EXTRA_ERROR_CONTEXT)
 endif()
 
 include(SetupCxxFlags)
 
-############################################################
+#
 # Dependencies
-############################################################
+#
 
 include(BuildUtils)
 enable_testing()
@@ -593,7 +524,7 @@ endif()
 include(san-config)
 
 # Code coverage
-if ("${ARROW_GENERATE_COVERAGE}")
+if("${ARROW_GENERATE_COVERAGE}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -DCOVERAGE_BUILD")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -DCOVERAGE_BUILD")
 endif()
@@ -603,21 +534,22 @@ message(STATUS "CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
 message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 # set compile output directory
-string (TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
+string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
 
 # If build in-source, create the latest symlink. If build out-of-source, which is
 # preferred, simply output the binaries in the build folder
-if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-  set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/${BUILD_SUBDIR_NAME}/")
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+  set(BUILD_OUTPUT_ROOT_DIRECTORY
+      "${CMAKE_CURRENT_BINARY_DIR}/build/${BUILD_SUBDIR_NAME}/")
   # Link build/latest to the current build directory, to avoid developers
   # accidentally running the latest debug build when in fact they're building
   # release builds.
-  FILE(MAKE_DIRECTORY ${BUILD_OUTPUT_ROOT_DIRECTORY})
-  if (NOT APPLE)
+  file(MAKE_DIRECTORY ${BUILD_OUTPUT_ROOT_DIRECTORY})
+  if(NOT APPLE)
     set(MORE_ARGS "-T")
   endif()
-EXECUTE_PROCESS(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
-  ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
+  execute_process(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
+                          ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
 else()
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUBDIR_NAME}/")
 endif()
@@ -636,9 +568,9 @@ set(EXECUTABLE_OUTPUT_PATH "${BUILD_OUTPUT_ROOT_DIRECTORY}")
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
 include_directories(src)
 
-############################################################
+#
 # Visibility
-############################################################
+#
 # For generate_export_header() and add_compiler_export_flags().
 include(GenerateExportHeader)
 
@@ -652,70 +584,128 @@ if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()
 
-if (PARQUET_BUILD_SHARED)
-  if (POLICY CMP0063)
+if(PARQUET_BUILD_SHARED)
+  if(POLICY CMP0063)
     set_target_properties(arrow_shared
-      PROPERTIES
-      C_VISIBILITY_PRESET hidden
-      CXX_VISIBILITY_PRESET hidden
-      VISIBILITY_INLINES_HIDDEN 1)
+                          PROPERTIES C_VISIBILITY_PRESET
+                                     hidden
+                                     CXX_VISIBILITY_PRESET
+                                     hidden
+                                     VISIBILITY_INLINES_HIDDEN
+                                     1)
   else()
     # Sets -fvisibility=hidden for gcc
     add_compiler_export_flags()
   endif()
 endif()
 
-############################################################
+#
 # "make ctags" target
-############################################################
-if (UNIX)
+#
+if(UNIX)
   add_custom_target(ctags ctags -R --languages=c++,c)
-endif (UNIX)
+endif(UNIX)
 
-############################################################
+#
 # "make etags" target
-############################################################
-if (UNIX)
-  add_custom_target(tags etags --members --declarations
-  `find ${CMAKE_CURRENT_SOURCE_DIR}/src
-   -name \\*.cc -or -name \\*.hh -or -name \\*.cpp -or -name \\*.h -or -name \\*.c -or
-   -name \\*.f`)
+#
+if(UNIX)
+  add_custom_target(tags
+                    etags
+                    --members
+                    --declarations
+                    `find
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src
+                    -name
+                    \\*.cc
+                    -or
+                    -name
+                    \\*.hh
+                    -or
+                    -name
+                    \\*.cpp
+                    -or
+                    -name
+                    \\*.h
+                    -or
+                    -name
+                    \\*.c
+                    -or
+                    -name
+                    \\*.f`)
   add_custom_target(etags DEPENDS tags)
-endif (UNIX)
+endif(UNIX)
 
-############################################################
+#
 # "make cscope" target
-############################################################
-if (UNIX)
+#
+if(UNIX)
   add_custom_target(cscope find ${CMAKE_CURRENT_SOURCE_DIR}
-  ( -name \\*.cc -or -name \\*.hh -or -name \\*.cpp -or
-    -name \\*.h -or -name \\*.c -or -name \\*.f )
-  -exec echo \"{}\" \; > cscope.files && cscope -q -b VERBATIM)
-endif (UNIX)
+                    (-name
+                     \\*.cc
+                     -or
+                     -name
+                     \\*.hh
+                     -or
+                     -name
+                     \\*.cpp
+                     -or
+                     -name
+                     \\*.h
+                     -or
+                     -name
+                     \\*.c
+                     -or
+                     -name
+                     \\*.f)
+                    -exec
+                    echo
+                    \"{}\"
+                    \;
+                    >
+                    cscope.files
+                    &&
+                    cscope
+                    -q
+                    -b
+                    VERBATIM)
+endif(UNIX)
 
-############################################################
+#
 # "make infer" target
-############################################################
+#
 
-if (${INFER_FOUND})
+if(${INFER_FOUND})
   # runs infer capture
-  add_custom_target(infer ${BUILD_SUPPORT_DIR}/run-infer.sh ${INFER_BIN} ${CMAKE_BINARY_DIR}/compile_commands.json 1)
+  add_custom_target(infer
+                    ${BUILD_SUPPORT_DIR}/run-infer.sh
+                    ${INFER_BIN}
+                    ${CMAKE_BINARY_DIR}/compile_commands.json
+                    1)
   # runs infer analyze
-  add_custom_target(infer-analyze ${BUILD_SUPPORT_DIR}/run-infer.sh ${INFER_BIN} ${CMAKE_BINARY_DIR}/compile_commands.json 2)
+  add_custom_target(infer-analyze
+                    ${BUILD_SUPPORT_DIR}/run-infer.sh
+                    ${INFER_BIN}
+                    ${CMAKE_BINARY_DIR}/compile_commands.json
+                    2)
   # runs infer report
-  add_custom_target(infer-report ${BUILD_SUPPORT_DIR}/run-infer.sh ${INFER_BIN} ${CMAKE_BINARY_DIR}/compile_commands.json 3)
+  add_custom_target(infer-report
+                    ${BUILD_SUPPORT_DIR}/run-infer.sh
+                    ${INFER_BIN}
+                    ${CMAKE_BINARY_DIR}/compile_commands.json
+                    3)
 endif()
 
-############################################################
+#
 # "make iwyu" target
-############################################################
+#
 if(UNIX)
   add_custom_target(iwyu ${BUILD_SUPPORT_DIR}/iwyu/iwyu.sh)
 endif(UNIX)
 
-############################################################
+#
 # Linker and Dependencies
-############################################################
+#
 
 set(ARROW_LINK_LIBS)
 set(ARROW_SHARED_INSTALL_INTERFACE_LIBS)
@@ -725,50 +715,43 @@ set(ARROW_STATIC_INSTALL_INTERFACE_LIBS)
 set(ARROW_STATIC_LINK_LIBS double-conversion_static)
 set(ARROW_STATIC_INSTALL_INTERFACE_LIBS double-conversion)
 
-if (ARROW_WITH_BROTLI)
-  list(APPEND
-    ARROW_STATIC_LINK_LIBS
-    brotli_dec_static
-    brotli_enc_static
-    brotli_common_static)
-  list(APPEND
-    ARROW_STATIC_INSTALL_INTERFACE_LIBS
-    brotlidec
-    brotlienc
-    brotlicommon)
+if(ARROW_WITH_BROTLI)
+  list(APPEND ARROW_STATIC_LINK_LIBS brotli_dec_static brotli_enc_static
+              brotli_common_static)
+  list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS brotlidec brotlienc brotlicommon)
 endif()
 
-if (ARROW_WITH_BZ2)
+if(ARROW_WITH_BZ2)
   list(APPEND ARROW_STATIC_LINK_LIBS bz2_static)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS bz2)
 endif()
 
-if (ARROW_WITH_LZ4)
+if(ARROW_WITH_LZ4)
   list(APPEND ARROW_STATIC_LINK_LIBS lz4_static)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS lz4)
 endif()
 
-if (ARROW_WITH_SNAPPY)
+if(ARROW_WITH_SNAPPY)
   list(APPEND ARROW_STATIC_LINK_LIBS snappy_static)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS snappy)
 endif()
 
-if (ARROW_WITH_ZLIB)
+if(ARROW_WITH_ZLIB)
   list(APPEND ARROW_STATIC_LINK_LIBS ${ZLIB_LIBRARY})
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS z)
 endif()
 
-if (ARROW_WITH_ZSTD)
+if(ARROW_WITH_ZSTD)
   list(APPEND ARROW_STATIC_LINK_LIBS zstd_static)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS zstd)
 endif()
 
-if (ARROW_ORC)
+if(ARROW_ORC)
   list(APPEND ARROW_STATIC_LINK_LIBS orc_static)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS orc)
 endif()
 
-if (ARROW_USE_GLOG)
+if(ARROW_USE_GLOG)
   list(APPEND ARROW_STATIC_LINK_LIBS glog_static)
   list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS glog)
   add_definitions("-DARROW_USE_GLOG")
@@ -777,65 +760,52 @@ endif()
 add_custom_target(arrow_dependencies)
 add_dependencies(arrow_dependencies toolchain)
 
-if (ARROW_STATIC_LINK_LIBS)
+if(ARROW_STATIC_LINK_LIBS)
   add_dependencies(arrow_dependencies ${ARROW_STATIC_LINK_LIBS})
 endif()
 
 set(ARROW_SHARED_PRIVATE_LINK_LIBS
-  ${ARROW_STATIC_LINK_LIBS}
-  ${BOOST_SYSTEM_LIBRARY}
-  ${BOOST_FILESYSTEM_LIBRARY}
-  ${BOOST_REGEX_LIBRARY})
+    ${ARROW_STATIC_LINK_LIBS}
+    ${BOOST_SYSTEM_LIBRARY}
+    ${BOOST_FILESYSTEM_LIBRARY}
+    ${BOOST_REGEX_LIBRARY})
 
-list(APPEND
-  ARROW_STATIC_LINK_LIBS
-  ${BOOST_SYSTEM_LIBRARY}
-  ${BOOST_FILESYSTEM_LIBRARY}
-  ${BOOST_REGEX_LIBRARY})
+list(APPEND ARROW_STATIC_LINK_LIBS ${BOOST_SYSTEM_LIBRARY} ${BOOST_FILESYSTEM_LIBRARY}
+            ${BOOST_REGEX_LIBRARY})
 
-list(APPEND
-  ARROW_STATIC_INSTALL_INTERFACE_LIBS
-  boost_system
-  boost_filesystem
-  boost_regex)
+list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS boost_system boost_filesystem boost_regex)
 
-if (NOT MSVC)
-  list(APPEND
-    ARROW_LINK_LIBS
-    ${CMAKE_DL_LIBS})
-  list(APPEND
-    ARROW_SHARED_INSTALL_INTERFACE_LIBS
-    ${CMAKE_DL_LIBS})
+if(NOT MSVC)
+  list(APPEND ARROW_LINK_LIBS ${CMAKE_DL_LIBS})
+  list(APPEND ARROW_SHARED_INSTALL_INTERFACE_LIBS ${CMAKE_DL_LIBS})
 endif()
 
 set(ARROW_TEST_STATIC_LINK_LIBS
-  arrow_testing_static
-  arrow_static
-  ${ARROW_LINK_LIBS}
-  ${GTEST_LIBRARY}
-  ${GMOCK_MAIN_LIBRARY}
-  ${GMOCK_LIBRARY})
+    arrow_testing_static
+    arrow_static
+    ${ARROW_LINK_LIBS}
+    ${GTEST_LIBRARY}
+    ${GMOCK_MAIN_LIBRARY}
+    ${GMOCK_LIBRARY})
 
 set(ARROW_TEST_SHARED_LINK_LIBS
-  arrow_testing_shared
-  arrow_shared
-  ${ARROW_LINK_LIBS}
-  double-conversion_static
-  ${BOOST_SYSTEM_LIBRARY}
-  ${BOOST_FILESYSTEM_LIBRARY}
-  ${BOOST_REGEX_LIBRARY}
-  ${GTEST_LIBRARY}
-  ${GMOCK_MAIN_LIBRARY}
-  ${GMOCK_LIBRARY})
+    arrow_testing_shared
+    arrow_shared
+    ${ARROW_LINK_LIBS}
+    double-conversion_static
+    ${BOOST_SYSTEM_LIBRARY}
+    ${BOOST_FILESYSTEM_LIBRARY}
+    ${BOOST_REGEX_LIBRARY}
+    ${GTEST_LIBRARY}
+    ${GMOCK_MAIN_LIBRARY}
+    ${GMOCK_LIBRARY})
 
 if(NOT MSVC)
-  set(ARROW_TEST_SHARED_LINK_LIBS
-    ${ARROW_TEST_SHARED_LINK_LIBS}
-    ${CMAKE_DL_LIBS})
+  set(ARROW_TEST_SHARED_LINK_LIBS ${ARROW_TEST_SHARED_LINK_LIBS} ${CMAKE_DL_LIBS})
 endif()
 
-if (ARROW_BUILD_TESTS AND "${ARROW_TEST_LINKAGE}" STREQUAL "shared")
-  if (NOT ARROW_BUILD_SHARED)
+if(ARROW_BUILD_TESTS AND "${ARROW_TEST_LINKAGE}" STREQUAL "shared")
+  if(NOT ARROW_BUILD_SHARED)
     message(FATAL_ERROR "If using shared linkage for unit tests, must also \
 pass ARROW_BUILD_SHARED=on")
   endif()
@@ -843,7 +813,7 @@ pass ARROW_BUILD_SHARED=on")
   set(ARROW_TEST_LINK_LIBS ${ARROW_TEST_SHARED_LINK_LIBS})
   set(ARROW_EXAMPLE_LINK_LIBS arrow_shared)
 else()
-  if (NOT ARROW_BUILD_STATIC)
+  if(NOT ARROW_BUILD_STATIC)
     message(FATAL_ERROR "If using static linkage for unit tests, must also \
 pass ARROW_BUILD_STATIC=on")
   endif()
@@ -851,25 +821,23 @@ pass ARROW_BUILD_STATIC=on")
   set(ARROW_EXAMPLE_LINK_LIBS arrow_static)
 endif()
 
-if (ARROW_BUILD_BENCHMARKS)
-  set(ARROW_BENCHMARK_LINK_LIBS
-    arrow_benchmark_main
-    ${ARROW_TEST_LINK_LIBS})
+if(ARROW_BUILD_BENCHMARKS)
+  set(ARROW_BENCHMARK_LINK_LIBS arrow_benchmark_main ${ARROW_TEST_LINK_LIBS})
 endif()
 
 set(ARROW_SYSTEM_LINK_LIBS)
 
-if (ARROW_JEMALLOC)
+if(ARROW_JEMALLOC)
   add_definitions(-DARROW_JEMALLOC)
   add_definitions(-DARROW_JEMALLOC_INCLUDE_DIR=${JEMALLOC_INCLUDE_DIR})
   list(APPEND ARROW_SYSTEM_LINK_LIBS jemalloc_static)
 endif(ARROW_JEMALLOC)
 
-if (THREADS_FOUND)
+if(THREADS_FOUND)
   list(APPEND ARROW_SYSTEM_LINK_LIBS Threads::Threads)
 endif()
 
-if (NOT WIN32 AND NOT APPLE)
+if(NOT WIN32 AND NOT APPLE)
   # Pass -lrt on Linux only
   list(APPEND ARROW_SYSTEM_LINK_LIBS rt)
 endif()
@@ -879,9 +847,9 @@ list(APPEND ARROW_STATIC_LINK_LIBS ${ARROW_SYSTEM_LINK_LIBS})
 list(APPEND ARROW_SHARED_INSTALL_INTERFACE_LIBS ${ARROW_SYSTEM_LINK_LIBS})
 list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS ${ARROW_SYSTEM_LINK_LIBS})
 
-############################################################
+#
 # Subdirectories
-############################################################
+#
 
 if(NOT WIN32 AND ARROW_PLASMA)
   add_subdirectory(src/plasma)
@@ -892,7 +860,7 @@ add_subdirectory(src/arrow)
 if(ARROW_PARQUET)
   add_subdirectory(src/parquet)
   add_subdirectory(tools/parquet)
-  if (PARQUET_BUILD_EXAMPLES)
+  if(PARQUET_BUILD_EXAMPLES)
     add_subdirectory(examples/parquet)
   endif()
 endif()
@@ -913,14 +881,16 @@ export(EXPORT ${PROJECT_NAME}-targets
        FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake")
 configure_package_config_file(${PROJECT_NAME}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-                              INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-                                 VERSION ${${PROJECT_NAME}_VERSION}
-                                 COMPATIBILITY AnyNewerVersion)
+                              INSTALL_DESTINATION
+                              "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  VERSION ${${PROJECT_NAME}_VERSION}
+  COMPATIBILITY AnyNewerVersion)
 
 install(EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}Targets.cmake
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -496,6 +496,12 @@ root path for the clang tools) with the environment variable
 `$CLANG_TOOLS_PATH` or by passing `-DClangTools_PATH=$PATH_TO_CLANG_TOOLS` when
 invoking CMake.
 
+Additionally, all CMake files should go through an automatic formatter.
+You'll need Python 3 and [cmake_format](https://github.com/cheshirekow/cmake_format)
+installed.  Then in the top-level directory run the `run-cmake-format.py`
+script.
+
+
 ## Checking for ABI and API stability
 
 To build ABI compliance reports, you need to install the two tools

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -26,193 +26,191 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
   set(options)
   set(one_value_args PREFIX)
   set(multi_value_args LABELS)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
 
-  if (ARG_PREFIX)
+  if(ARG_PREFIX)
     set(PREFIX ${ARG_PREFIX})
   else()
     set(PREFIX "arrow")
   endif()
 
-  if (ARG_LABELS)
+  if(ARG_LABELS)
     set(LABELS ${ARG_LABELS})
   else()
     set(LABELS "arrow-tests")
   endif()
 
-  ADD_TEST_CASE(${REL_TEST_NAME}
-    PREFIX ${PREFIX}
-    LABELS ${LABELS}
-    ${ARG_UNPARSED_ARGUMENTS})
+  add_test_case(${REL_TEST_NAME}
+                PREFIX
+                ${PREFIX}
+                LABELS
+                ${LABELS}
+                ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
 function(ADD_ARROW_BENCHMARK REL_TEST_NAME)
   set(options)
   set(one_value_args PREFIX)
   set(multi_value_args)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
-  if (ARG_PREFIX)
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
+  if(ARG_PREFIX)
     set(PREFIX ${ARG_PREFIX})
   else()
     set(PREFIX "arrow")
   endif()
-  ADD_BENCHMARK(${REL_TEST_NAME}
-    PREFIX ${PREFIX}
-    LABELS "arrow-benchmarks"
-    ${ARG_UNPARSED_ARGUMENTS})
+  add_benchmark(${REL_TEST_NAME}
+                PREFIX
+                ${PREFIX}
+                LABELS
+                "arrow-benchmarks"
+                ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
 set(ARROW_SRCS
-  array.cc
+    array.cc
+    builder.cc
+    array/builder_adaptive.cc
+    array/builder_base.cc
+    array/builder_binary.cc
+    array/builder_decimal.cc
+    array/builder_dict.cc
+    array/builder_nested.cc
+    array/builder_primitive.cc
+    array/builder_union.cc
+    buffer.cc
+    compare.cc
+    memory_pool.cc
+    pretty_print.cc
+    record_batch.cc
+    status.cc
+    table.cc
+    table_builder.cc
+    tensor.cc
+    sparse_tensor.cc
+    type.cc
+    visitor.cc
+    csv/converter.cc
+    csv/chunker.cc
+    csv/column-builder.cc
+    csv/options.cc
+    csv/parser.cc
+    csv/reader.cc
+    io/buffered.cc
+    io/compressed.cc
+    io/file.cc
+    io/interfaces.cc
+    io/memory.cc
+    io/readahead.cc
+    testing/util.cc
+    util/basic_decimal.cc
+    util/bit-util.cc
+    util/compression.cc
+    util/cpu-info.cc
+    util/decimal.cc
+    util/int-util.cc
+    util/io-util.cc
+    util/logging.cc
+    util/key_value_metadata.cc
+    util/task-group.cc
+    util/thread-pool.cc
+    util/trie.cc
+    util/utf8.cc
+    vendored/datetime/tz.cpp)
 
-  builder.cc
-  array/builder_adaptive.cc
-  array/builder_base.cc
-  array/builder_binary.cc
-  array/builder_decimal.cc
-  array/builder_dict.cc
-  array/builder_nested.cc
-  array/builder_primitive.cc
-  array/builder_union.cc
-
-  buffer.cc
-  compare.cc
-  memory_pool.cc
-  pretty_print.cc
-  record_batch.cc
-  status.cc
-  table.cc
-  table_builder.cc
-  tensor.cc
-  sparse_tensor.cc
-  type.cc
-  visitor.cc
-
-  csv/converter.cc
-  csv/chunker.cc
-  csv/column-builder.cc
-  csv/options.cc
-  csv/parser.cc
-  csv/reader.cc
-
-  io/buffered.cc
-  io/compressed.cc
-  io/file.cc
-  io/interfaces.cc
-  io/memory.cc
-  io/readahead.cc
-
-  testing/util.cc
-
-  util/basic_decimal.cc
-  util/bit-util.cc
-  util/compression.cc
-  util/cpu-info.cc
-  util/decimal.cc
-  util/int-util.cc
-  util/io-util.cc
-  util/logging.cc
-  util/key_value_metadata.cc
-  util/task-group.cc
-  util/thread-pool.cc
-  util/trie.cc
-  util/utf8.cc
-
-  vendored/datetime/tz.cpp
-)
-
-if ("${COMPILER_FAMILY}" STREQUAL "clang")
+if("${COMPILER_FAMILY}" STREQUAL "clang")
   set_property(SOURCE util/io-util.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS
-    " -Wno-unused-macros ")
+               APPEND_STRING
+               PROPERTY COMPILE_FLAGS " -Wno-unused-macros ")
 endif()
 
-if (ARROW_COMPUTE)
+if(ARROW_COMPUTE)
   add_subdirectory(compute)
-  set(ARROW_SRCS ${ARROW_SRCS}
-    compute/context.cc
-    compute/kernels/aggregate.cc
-    compute/kernels/boolean.cc
-    compute/kernels/cast.cc
-    compute/kernels/hash.cc
-    compute/kernels/sum.cc
-    compute/kernels/util-internal.cc
-  )
+  set(ARROW_SRCS
+      ${ARROW_SRCS}
+      compute/context.cc
+      compute/kernels/aggregate.cc
+      compute/kernels/boolean.cc
+      compute/kernels/cast.cc
+      compute/kernels/hash.cc
+      compute/kernels/sum.cc
+      compute/kernels/util-internal.cc)
 endif()
 
-if (ARROW_CUDA)
+if(ARROW_CUDA)
   # IPC extensions required to build the CUDA library
   set(ARROW_IPC ON)
   add_subdirectory(gpu)
 endif()
 
-if (ARROW_JEMALLOC AND JEMALLOC_VENDORED)
+if(ARROW_JEMALLOC AND JEMALLOC_VENDORED)
   add_dependencies(arrow_dependencies jemalloc_static)
 endif()
 
-if (ARROW_WITH_BROTLI)
+if(ARROW_WITH_BROTLI)
   add_definitions(-DARROW_WITH_BROTLI)
-  SET(ARROW_SRCS util/compression_brotli.cc ${ARROW_SRCS})
+  set(ARROW_SRCS util/compression_brotli.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_WITH_BZ2)
+if(ARROW_WITH_BZ2)
   add_definitions(-DARROW_WITH_BZ2)
-  SET(ARROW_SRCS util/compression_bz2.cc ${ARROW_SRCS})
+  set(ARROW_SRCS util/compression_bz2.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_WITH_LZ4)
+if(ARROW_WITH_LZ4)
   add_definitions(-DARROW_WITH_LZ4)
-  SET(ARROW_SRCS util/compression_lz4.cc ${ARROW_SRCS})
+  set(ARROW_SRCS util/compression_lz4.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_WITH_SNAPPY)
+if(ARROW_WITH_SNAPPY)
   add_definitions(-DARROW_WITH_SNAPPY)
-  SET(ARROW_SRCS util/compression_snappy.cc ${ARROW_SRCS})
+  set(ARROW_SRCS util/compression_snappy.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_WITH_ZLIB)
+if(ARROW_WITH_ZLIB)
   add_definitions(-DARROW_WITH_ZLIB)
-  SET(ARROW_SRCS util/compression_zlib.cc ${ARROW_SRCS})
+  set(ARROW_SRCS util/compression_zlib.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_WITH_ZSTD)
+if(ARROW_WITH_ZSTD)
   add_definitions(-DARROW_WITH_ZSTD)
-  SET(ARROW_SRCS util/compression_zstd.cc ${ARROW_SRCS})
+  set(ARROW_SRCS util/compression_zstd.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_ORC)
+if(ARROW_ORC)
   add_subdirectory(adapters/orc)
-  SET(ARROW_SRCS adapters/orc/adapter.cc ${ARROW_SRCS})
+  set(ARROW_SRCS adapters/orc/adapter.cc ${ARROW_SRCS})
 endif()
 
-if (ARROW_TENSORFLOW)
+if(ARROW_TENSORFLOW)
   add_subdirectory(adapters/tensorflow)
 endif()
 
-if (NOT ARROW_BOOST_HEADER_ONLY)
-  set(ARROW_SRCS ${ARROW_SRCS}
-    io/hdfs.cc
-    io/hdfs-internal.cc
-  )
+if(NOT ARROW_BOOST_HEADER_ONLY)
+  set(ARROW_SRCS ${ARROW_SRCS} io/hdfs.cc io/hdfs-internal.cc)
 endif()
 
-if (ARROW_IPC)
+if(ARROW_IPC)
   add_subdirectory(ipc)
 
   set(ARROW_IPC_SRCS
-    ipc/dictionary.cc
-    ipc/feather.cc
-    ipc/json.cc
-    ipc/json-internal.cc
-    ipc/json-simple.cc
-    ipc/message.cc
-    ipc/metadata-internal.cc
-    ipc/reader.cc
-    ipc/writer.cc
-  )
-  SET(ARROW_SRCS ${ARROW_SRCS}
-    ${ARROW_IPC_SRCS})
+      ipc/dictionary.cc
+      ipc/feather.cc
+      ipc/json.cc
+      ipc/json-internal.cc
+      ipc/json-simple.cc
+      ipc/message.cc
+      ipc/metadata-internal.cc
+      ipc/reader.cc
+      ipc/writer.cc)
+  set(ARROW_SRCS ${ARROW_SRCS} ${ARROW_IPC_SRCS})
 
   add_dependencies(arrow_dependencies metadata_fbs)
 endif()
@@ -221,86 +219,102 @@ if(NOT APPLE AND NOT MSVC)
   # Localize thirdparty symbols using a linker version script. This hides them
   # from the client application. The OS X linker does not support the
   # version-script option.
-  set(ARROW_SHARED_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  set(ARROW_SHARED_LINK_FLAGS
+      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
 endif()
 
-set(ARROW_ALL_SRCS
-  ${ARROW_SRCS})
+set(ARROW_ALL_SRCS ${ARROW_SRCS})
 
-ADD_ARROW_LIB(arrow
-  SOURCES ${ARROW_ALL_SRCS}
-  OUTPUTS ARROW_LIBRARIES
-  DEPENDENCIES arrow_dependencies
-  SHARED_LINK_FLAGS ${ARROW_SHARED_LINK_FLAGS}
-  SHARED_LINK_LIBS ${ARROW_LINK_LIBS}
-  SHARED_PRIVATE_LINK_LIBS ${ARROW_SHARED_PRIVATE_LINK_LIBS}
-  STATIC_LINK_LIBS ${ARROW_STATIC_LINK_LIBS}
-  SHARED_INSTALL_INTERFACE_LIBS ${ARROW_SHARED_INSTALL_INTERFACE_LIBS}
-  STATIC_INSTALL_INTERFACE_LIBS ${ARROW_STATIC_INSTALL_INTERFACE_LIBS})
+add_arrow_lib(arrow
+              SOURCES
+              ${ARROW_ALL_SRCS}
+              OUTPUTS
+              ARROW_LIBRARIES
+              DEPENDENCIES
+              arrow_dependencies
+              SHARED_LINK_FLAGS
+              ${ARROW_SHARED_LINK_FLAGS}
+              SHARED_LINK_LIBS
+              ${ARROW_LINK_LIBS}
+              SHARED_PRIVATE_LINK_LIBS
+              ${ARROW_SHARED_PRIVATE_LINK_LIBS}
+              STATIC_LINK_LIBS
+              ${ARROW_STATIC_LINK_LIBS}
+              SHARED_INSTALL_INTERFACE_LIBS
+              ${ARROW_SHARED_INSTALL_INTERFACE_LIBS}
+              STATIC_INSTALL_INTERFACE_LIBS
+              ${ARROW_STATIC_INSTALL_INTERFACE_LIBS})
 
 add_dependencies(arrow ${ARROW_LIBRARIES})
 
-if (ARROW_BUILD_STATIC AND WIN32)
+if(ARROW_BUILD_STATIC AND WIN32)
   target_compile_definitions(arrow_static PUBLIC ARROW_STATIC)
 endif()
 
-if (ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
+if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   # that depend on gtest
-  ADD_ARROW_LIB(arrow_testing
-    SOURCES testing/gtest_util.cc testing/random.cc
-    OUTPUTS ARROW_TESTING_LIBRARIES
-    DEPENDENCIES ${GTEST_LIBRARY}
-    SHARED_LINK_LIBS arrow_shared ${GTEST_LIBRARY}
-    STATIC_LINK_LIBS arrow_static)
+  add_arrow_lib(arrow_testing
+                SOURCES
+                testing/gtest_util.cc
+                testing/random.cc
+                OUTPUTS
+                ARROW_TESTING_LIBRARIES
+                DEPENDENCIES
+                ${GTEST_LIBRARY}
+                SHARED_LINK_LIBS
+                arrow_shared
+                ${GTEST_LIBRARY}
+                STATIC_LINK_LIBS
+                arrow_static)
 
-  if (ARROW_BUILD_STATIC AND WIN32)
+  if(ARROW_BUILD_STATIC AND WIN32)
     target_compile_definitions(arrow_testing_static PUBLIC ARROW_STATIC)
   endif()
 
-  set(ARROW_LIBRARIES
-    ${ARROW_LIBRARIES}
-    ${ARROW_TESTING_LIBRARIES})
+  set(ARROW_LIBRARIES ${ARROW_LIBRARIES} ${ARROW_TESTING_LIBRARIES})
 endif()
 
 find_package(Backtrace)
 
 foreach(LIB_TARGET ${ARROW_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET}
-    PRIVATE ARROW_EXPORTING)
-  if (Backtrace_FOUND AND ARROW_WITH_BACKTRACE)
-    target_compile_definitions(${LIB_TARGET}
-      PRIVATE ARROW_WITH_BACKTRACE)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
+  if(Backtrace_FOUND AND ARROW_WITH_BACKTRACE)
+    target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_WITH_BACKTRACE)
   endif()
 endforeach()
 
 # Headers: top level
-ARROW_INSTALL_ALL_HEADERS("arrow")
+arrow_install_all_headers("arrow")
 
 # pkg-config support
-ARROW_ADD_PKG_CONFIG("arrow")
+arrow_add_pkg_config("arrow")
 
-#######################################
+#
 # Unit tests
-#######################################
+#
 
-ADD_ARROW_TEST(allocator-test)
-ADD_ARROW_TEST(array-test
-  SOURCES array-test.cc array-binary-test.cc array-dict-test.cc
-          array-list-test.cc array-struct-test.cc)
-ADD_ARROW_TEST(buffer-test)
-ADD_ARROW_TEST(memory_pool-test)
-ADD_ARROW_TEST(pretty_print-test)
-ADD_ARROW_TEST(public-api-test)
-ADD_ARROW_TEST(status-test)
-ADD_ARROW_TEST(stl-test)
-ADD_ARROW_TEST(type-test)
-ADD_ARROW_TEST(table-test)
-ADD_ARROW_TEST(table_builder-test)
-ADD_ARROW_TEST(tensor-test)
-ADD_ARROW_TEST(sparse_tensor-test)
+add_arrow_test(allocator-test)
+add_arrow_test(array-test
+               SOURCES
+               array-test.cc
+               array-binary-test.cc
+               array-dict-test.cc
+               array-list-test.cc
+               array-struct-test.cc)
+add_arrow_test(buffer-test)
+add_arrow_test(memory_pool-test)
+add_arrow_test(pretty_print-test)
+add_arrow_test(public-api-test)
+add_arrow_test(status-test)
+add_arrow_test(stl-test)
+add_arrow_test(type-test)
+add_arrow_test(table-test)
+add_arrow_test(table_builder-test)
+add_arrow_test(tensor-test)
+add_arrow_test(sparse_tensor-test)
 
-ADD_ARROW_BENCHMARK(builder-benchmark)
-ADD_ARROW_BENCHMARK(column-benchmark)
+add_arrow_benchmark(builder-benchmark)
+add_arrow_benchmark(column-benchmark)
 
 add_subdirectory(array)
 add_subdirectory(csv)

--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -15,19 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#######################################
+#
 # arrow_orc
-#######################################
+#
 
 # Headers: top level
-install(FILES
-        adapter.h
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/adapters/orc")
+install(FILES adapter.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/adapters/orc")
 
 # pkg-config support
-configure_file(arrow-orc.pc.in
-  "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc"
-  @ONLY)
-install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc"
-  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+configure_file(arrow-orc.pc.in "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")

--- a/cpp/src/arrow/adapters/tensorflow/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/tensorflow/CMakeLists.txt
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARROW_INSTALL_ALL_HEADERS("arrow/adapters/tensorflow")
+arrow_install_all_headers("arrow/adapters/tensorflow")

--- a/cpp/src/arrow/array/CMakeLists.txt
+++ b/cpp/src/arrow/array/CMakeLists.txt
@@ -16,4 +16,4 @@
 # under the License.
 
 # Headers: top level
-ARROW_INSTALL_ALL_HEADERS("arrow/array")
+arrow_install_all_headers("arrow/array")

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -15,16 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARROW_INSTALL_ALL_HEADERS("arrow/compute")
+arrow_install_all_headers("arrow/compute")
 
 # pkg-config support
-ARROW_ADD_PKG_CONFIG("arrow-compute")
+arrow_add_pkg_config("arrow-compute")
 
-#######################################
+#
 # Unit tests
-#######################################
+#
 
-ADD_ARROW_TEST(compute-test)
-ADD_ARROW_BENCHMARK(compute-benchmark)
+add_arrow_test(compute-test)
+add_arrow_benchmark(compute-benchmark)
 
 add_subdirectory(kernels)

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARROW_INSTALL_ALL_HEADERS("arrow/compute/kernels")
+arrow_install_all_headers("arrow/compute/kernels")
 
-ADD_ARROW_TEST(boolean-test PREFIX "arrow-compute")
-ADD_ARROW_TEST(cast-test PREFIX "arrow-compute")
-ADD_ARROW_TEST(hash-test PREFIX "arrow-compute")
+add_arrow_test(boolean-test PREFIX "arrow-compute")
+add_arrow_test(cast-test PREFIX "arrow-compute")
+add_arrow_test(hash-test PREFIX "arrow-compute")
 
 # Aggregates
-ADD_ARROW_TEST(aggregate-test PREFIX "arrow-compute")
-ADD_ARROW_BENCHMARK(aggregate-benchmark PREFIX "arrow-compute")
+add_arrow_test(aggregate-test PREFIX "arrow-compute")
+add_arrow_benchmark(aggregate-benchmark PREFIX "arrow-compute")

--- a/cpp/src/arrow/csv/CMakeLists.txt
+++ b/cpp/src/arrow/csv/CMakeLists.txt
@@ -15,18 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ADD_ARROW_TEST(chunker-test
-  PREFIX "arrow-csv")
-ADD_ARROW_TEST(column-builder-test
-  PREFIX "arrow-csv")
-ADD_ARROW_TEST(converter-test
-  PREFIX "arrow-csv")
-ADD_ARROW_TEST(parser-test
-  PREFIX "arrow-csv")
+add_arrow_test(chunker-test PREFIX "arrow-csv")
+add_arrow_test(column-builder-test PREFIX "arrow-csv")
+add_arrow_test(converter-test PREFIX "arrow-csv")
+add_arrow_test(parser-test PREFIX "arrow-csv")
 
-ADD_ARROW_BENCHMARK(converter-benchmark
-  PREFIX "arrow-csv")
-ADD_ARROW_BENCHMARK(parser-benchmark
-  PREFIX "arrow-csv")
+add_arrow_benchmark(converter-benchmark PREFIX "arrow-csv")
+add_arrow_benchmark(parser-benchmark PREFIX "arrow-csv")
 
-ARROW_INSTALL_ALL_HEADERS("arrow/csv")
+arrow_install_all_headers("arrow/csv")

--- a/cpp/src/arrow/dbi/hiveserver2/CMakeLists.txt
+++ b/cpp/src/arrow/dbi/hiveserver2/CMakeLists.txt
@@ -19,47 +19,48 @@ add_custom_target(arrow_hiveserver2)
 add_custom_target(arrow_hiveserver2-tests)
 
 # Headers: top level
-ARROW_INSTALL_ALL_HEADERS("arrow/dbi/hiveserver2")
+arrow_install_all_headers("arrow/dbi/hiveserver2")
 
 set(ARROW_HIVESERVER2_SRCS
-  columnar-row-set.cc
-  service.cc
-  session.cc
-  operation.cc
-  sample-usage.cc
-  thrift-internal.cc
-  types.cc
-  util.cc
-)
+    columnar-row-set.cc
+    service.cc
+    session.cc
+    operation.cc
+    sample-usage.cc
+    thrift-internal.cc
+    types.cc
+    util.cc)
 
 add_subdirectory(thrift)
 
 set(HIVESERVER2_THRIFT_SRC
-  ErrorCodes_constants.cpp
-  ErrorCodes_types.cpp
-  ImpalaService.cpp
-  ImpalaService_constants.cpp
-  ImpalaService_types.cpp
-  ImpalaHiveServer2Service.cpp
-  beeswax_constants.cpp
-  beeswax_types.cpp
-  BeeswaxService.cpp
-  TCLIService.cpp
-  TCLIService_constants.cpp
-  TCLIService_types.cpp
-  ExecStats_constants.cpp
-  ExecStats_types.cpp
-  hive_metastore_constants.cpp
-  hive_metastore_types.cpp
-  Status_constants.cpp
-  Status_types.cpp
-  Types_constants.cpp
-  Types_types.cpp
-)
+    ErrorCodes_constants.cpp
+    ErrorCodes_types.cpp
+    ImpalaService.cpp
+    ImpalaService_constants.cpp
+    ImpalaService_types.cpp
+    ImpalaHiveServer2Service.cpp
+    beeswax_constants.cpp
+    beeswax_types.cpp
+    BeeswaxService.cpp
+    TCLIService.cpp
+    TCLIService_constants.cpp
+    TCLIService_types.cpp
+    ExecStats_constants.cpp
+    ExecStats_types.cpp
+    hive_metastore_constants.cpp
+    hive_metastore_types.cpp
+    Status_constants.cpp
+    Status_types.cpp
+    Types_constants.cpp
+    Types_types.cpp)
 
-set_source_files_properties(${HIVESERVER2_THRIFT_SRC} PROPERTIES
-  COMPILE_FLAGS "-Wno-unused-variable -Wno-shadow-field"
-  GENERATED TRUE)
+set_source_files_properties(${HIVESERVER2_THRIFT_SRC}
+                            PROPERTIES
+                            COMPILE_FLAGS
+                            "-Wno-unused-variable -Wno-shadow-field"
+                            GENERATED
+                            TRUE)
 
 # keep everything in one library, the object files reference
 # each other
@@ -74,43 +75,47 @@ add_library(arrow_hiveserver2_thrift STATIC ${HIVESERVER2_THRIFT_SRC})
 
 add_dependencies(arrow_hiveserver2_thrift hs2-thrift-cpp)
 
-set_target_properties(arrow_hiveserver2_thrift
-  PROPERTIES
-  LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
+set_target_properties(
+  arrow_hiveserver2_thrift
+  PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
 
-ADD_ARROW_LIB(arrow_hiveserver2
-  SOURCES ${ARROW_HIVESERVER2_SRCS}
-  OUTPUTS ARROW_HIVESERVER2_LIBRARIES
-  DEPENDENCIES arrow_hiveserver2_thrift
-  SHARED_LINK_FLAGS ""
-  SHARED_LINK_LIBS ${ARROW_PYTHON_SHARED_LINK_LIBS}
-)
+add_arrow_lib(arrow_hiveserver2
+              SOURCES
+              ${ARROW_HIVESERVER2_SRCS}
+              OUTPUTS
+              ARROW_HIVESERVER2_LIBRARIES
+              DEPENDENCIES
+              arrow_hiveserver2_thrift
+              SHARED_LINK_FLAGS
+              ""
+              SHARED_LINK_LIBS
+              ${ARROW_PYTHON_SHARED_LINK_LIBS})
 
 add_dependencies(arrow_hiveserver2 ${ARROW_HIVESERVER2_LIBRARIES})
 
 foreach(LIB_TARGET ${ARROW_HIVESERVER2_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET}
-    PRIVATE ARROW_EXPORTING)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
 endforeach()
 
 set_property(SOURCE ${ARROW_HIVESERVER2_SRCS}
-  APPEND_STRING PROPERTY COMPILE_FLAGS
-  " -Wno-shadow-field")
+             APPEND_STRING
+             PROPERTY COMPILE_FLAGS " -Wno-shadow-field")
 
 set(ARROW_HIVESERVER2_TEST_LINK_LIBS
-  arrow_hiveserver2_static
-  arrow_hiveserver2_thrift
-  ${ARROW_TEST_LINK_LIBS}
-  thriftstatic)
+    arrow_hiveserver2_static
+    arrow_hiveserver2_thrift
+    ${ARROW_TEST_LINK_LIBS}
+    thriftstatic)
 
-if (ARROW_BUILD_TESTS)
-  ADD_TEST_CASE(hiveserver2-test
-    STATIC_LINK_LIBS "${ARROW_HIVESERVER2_TEST_LINK_LIBS}"
-    LABELS "arrow_hiveserver2-tests"
-  )
-  if (TARGET arrow-hiveserver2-test)
+if(ARROW_BUILD_TESTS)
+  add_test_case(hiveserver2-test
+                STATIC_LINK_LIBS
+                "${ARROW_HIVESERVER2_TEST_LINK_LIBS}"
+                LABELS
+                "arrow_hiveserver2-tests")
+  if(TARGET arrow-hiveserver2-test)
     set_property(TARGET arrow-hiveserver2-test
-      APPEND_STRING PROPERTY COMPILE_FLAGS
-      " -Wno-shadow-field")
+                 APPEND_STRING
+                 PROPERTY COMPILE_FLAGS " -Wno-shadow-field")
   endif()
 endif(ARROW_BUILD_TESTS)

--- a/cpp/src/arrow/dbi/hiveserver2/thrift/CMakeLists.txt
+++ b/cpp/src/arrow/dbi/hiveserver2/thrift/CMakeLists.txt
@@ -27,10 +27,10 @@
 # cmake seems to be case sensitive for some keywords. Changing the first IF check to lower
 # case makes it not work.  TODO: investigate this
 function(HS2_THRIFT_GEN VAR)
-  IF (NOT ARGN)
-    MESSAGE(SEND_ERROR "Error: THRIFT_GEN called without any src files")
-    RETURN()
-  ENDIF(NOT ARGN)
+  if(NOT ARGN)
+    message(SEND_ERROR "Error: THRIFT_GEN called without any src files")
+    return()
+  endif(NOT ARGN)
 
   set(${VAR})
   foreach(FIL ${ARGN})
@@ -45,10 +45,10 @@ function(HS2_THRIFT_GEN VAR)
     #   - Does not include .skeleton.cpp files
     #   - Does not include java output files
     set(OUTPUT_BE_FILE
-      "${GEN_DIR}/${FIL_WE}_types.cpp"
-      "${GEN_DIR}/${FIL_WE}_types.h"
-      "${GEN_DIR}/${FIL_WE}_constants.cpp"
-      "${GEN_DIR}/${FIL_WE}_constants.h")
+        "${GEN_DIR}/${FIL_WE}_types.cpp"
+        "${GEN_DIR}/${FIL_WE}_types.h"
+        "${GEN_DIR}/${FIL_WE}_constants.cpp"
+        "${GEN_DIR}/${FIL_WE}_constants.h")
     list(APPEND ${VAR} ${OUTPUT_BE_FILE})
 
     # BeeswaxService thrift generation
@@ -56,21 +56,19 @@ function(HS2_THRIFT_GEN VAR)
     # The java dependency is handled by maven.
     # We need to generate C++ src file for the parent dependencies using the "-r" option.
     set(CPP_ARGS -nowarn --gen cpp -out ${GEN_DIR})
-    IF (FIL STREQUAL "beeswax.thrift")
+    if(FIL STREQUAL "beeswax.thrift")
       set(CPP_ARGS -r -nowarn --gen cpp -out ${GEN_DIR})
-    ENDIF(FIL STREQUAL "beeswax.thrift")
+    endif(FIL STREQUAL "beeswax.thrift")
 
     # Be able to include generated ErrorCodes.thrift file
     set(CPP_ARGS ${CPP_ARGS} -I ${CMAKE_CURRENT_BINARY_DIR})
 
-    add_custom_command(
-      OUTPUT ${OUTPUT_BE_FILE}
-      COMMAND ${THRIFT_COMPILER} ${CPP_ARGS} ${FIL}
-      DEPENDS ${ABS_FIL}
-      COMMENT "Running thrift compiler on ${FIL}"
-	  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      VERBATIM
-    )
+    add_custom_command(OUTPUT ${OUTPUT_BE_FILE}
+                       COMMAND ${THRIFT_COMPILER} ${CPP_ARGS} ${FIL}
+                       DEPENDS ${ABS_FIL}
+                       COMMENT "Running thrift compiler on ${FIL}"
+                       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                       VERBATIM)
   endforeach(FIL)
 
   set(${VAR} ${${VAR}} PARENT_SCOPE)
@@ -82,30 +80,29 @@ set(OUTPUT_DIR ${ARROW_BINARY_DIR}/src)
 file(MAKE_DIRECTORY ${OUTPUT_DIR})
 
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift
-  COMMAND python generate_error_codes.py ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS generate_error_codes.py
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+                   COMMAND python generate_error_codes.py ${CMAKE_CURRENT_BINARY_DIR}
+                   DEPENDS generate_error_codes.py
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 set(SRC_FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift
-  beeswax.thrift
-  TCLIService.thrift
-  ExecStats.thrift
-  ImpalaService.thrift
-  Status.thrift
-  Types.thrift
-)
+    ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift
+    beeswax.thrift
+    TCLIService.thrift
+    ExecStats.thrift
+    ImpalaService.thrift
+    Status.thrift
+    Types.thrift)
 
-SET_SOURCE_FILES_PROPERTIES(Status.thrift PROPERTIES OBJECT_DEPENDS
-  ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift)
+set_source_files_properties(Status.thrift PROPERTIES OBJECT_DEPENDS
+                            ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift)
 
 # Create a build command for each of the thrift src files and generate
 # a list of files they produce
-HS2_THRIFT_GEN(THRIFT_ALL_FILES ${SRC_FILES})
+hs2_thrift_gen(THRIFT_ALL_FILES ${SRC_FILES})
 
 # Add a custom target that generates all the thrift files
 add_custom_target(hs2-thrift-cpp ALL DEPENDS ${THRIFT_ALL_FILES})
 
-add_custom_target(hs2-thrift-generated-files-error DEPENDS
-  ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift)
+add_custom_target(hs2-thrift-generated-files-error
+                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ErrorCodes.thrift)
 add_dependencies(hs2-thrift-cpp hs2-thrift-generated-files-error)

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -18,22 +18,22 @@
 add_custom_target(arrow_flight)
 
 # Header files
-ARROW_INSTALL_ALL_HEADERS("arrow/flight")
+arrow_install_all_headers("arrow/flight")
 
-SET(ARROW_FLIGHT_STATIC_LINK_LIBS
-  protobuf_static
-  grpc_grpcpp_static
-  grpc_grpc_static
-  grpc_gpr_static
-  grpc_address_sorting_static
-  cares_static)
+set(ARROW_FLIGHT_STATIC_LINK_LIBS
+    protobuf_static
+    grpc_grpcpp_static
+    grpc_grpc_static
+    grpc_gpr_static
+    grpc_address_sorting_static
+    cares_static)
 
-SET(ARROW_FLIGHT_TEST_STATIC_LINK_LIBS
-  arrow_static
-  arrow_flight_static
-  arrow_testing_static
-  ${ARROW_FLIGHT_STATIC_LINK_LIBS}
-  ${PROTOBUF_LIBRARY})
+set(ARROW_FLIGHT_TEST_STATIC_LINK_LIBS
+    arrow_static
+    arrow_flight_static
+    arrow_testing_static
+    ${ARROW_FLIGHT_STATIC_LINK_LIBS}
+    ${PROTOBUF_LIBRARY})
 
 # TODO(wesm): Protobuf shared vs static linking
 
@@ -41,108 +41,94 @@ set(FLIGHT_PROTO_PATH "${ARROW_SOURCE_DIR}/../format")
 set(FLIGHT_PROTO ${ARROW_SOURCE_DIR}/../format/Flight.proto)
 
 set(FLIGHT_GENERATED_PROTO_FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/Flight.pb.cc"
-  "${CMAKE_CURRENT_BINARY_DIR}/Flight.pb.h"
-  "${CMAKE_CURRENT_BINARY_DIR}/Flight.grpc.pb.cc"
-  "${CMAKE_CURRENT_BINARY_DIR}/Flight.grpc.pb.h")
+    "${CMAKE_CURRENT_BINARY_DIR}/Flight.pb.cc"
+    "${CMAKE_CURRENT_BINARY_DIR}/Flight.pb.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/Flight.grpc.pb.cc"
+    "${CMAKE_CURRENT_BINARY_DIR}/Flight.grpc.pb.h")
 
 set(PROTO_DEPENDS ${FLIGHT_PROTO} ${PROTOBUF_LIBRARY} grpc)
 
 add_custom_command(
   OUTPUT ${FLIGHT_GENERATED_PROTO_FILES}
-  COMMAND ${PROTOBUF_EXECUTABLE}
-  "-I${FLIGHT_PROTO_PATH}"
-  "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
-  "${FLIGHT_PROTO}"
-  DEPENDS ${PROTO_DEPENDS}
-  ARGS
-  COMMAND ${PROTOBUF_EXECUTABLE}
-  "-I${FLIGHT_PROTO_PATH}"
-  "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
-  "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
-  "${FLIGHT_PROTO}")
+  COMMAND ${PROTOBUF_EXECUTABLE} "-I${FLIGHT_PROTO_PATH}"
+          "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" "${FLIGHT_PROTO}"
+  DEPENDS ${PROTO_DEPENDS} ARGS
+  COMMAND ${PROTOBUF_EXECUTABLE} "-I${FLIGHT_PROTO_PATH}"
+          "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
+          "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}" "${FLIGHT_PROTO}")
 
-set_source_files_properties(${FLIGHT_GENERATED_PROTO_FILES}
-  PROPERTIES GENERATED TRUE)
+set_source_files_properties(${FLIGHT_GENERATED_PROTO_FILES} PROPERTIES GENERATED TRUE)
 
 set(ARROW_FLIGHT_SRCS
-  client.cc
-  Flight.pb.cc
-  Flight.grpc.pb.cc
-  internal.cc
-  serialization-internal.cc
-  server.cc
-  types.cc
-)
+    client.cc
+    Flight.pb.cc
+    Flight.grpc.pb.cc
+    internal.cc
+    serialization-internal.cc
+    server.cc
+    types.cc)
 
-ADD_ARROW_LIB(arrow_flight
-  SOURCES ${ARROW_FLIGHT_SRCS}
-  SHARED_LINK_LIBS arrow_shared ${ARROW_FLIGHT_STATIC_LINK_LIBS}
-  STATIC_LINK_LIBS arrow_static ${ARROW_FLIGHT_STATIC_LINK_LIBS})
+add_arrow_lib(arrow_flight
+              SOURCES
+              ${ARROW_FLIGHT_SRCS}
+              SHARED_LINK_LIBS
+              arrow_shared
+              ${ARROW_FLIGHT_STATIC_LINK_LIBS}
+              STATIC_LINK_LIBS
+              arrow_static
+              ${ARROW_FLIGHT_STATIC_LINK_LIBS})
 
-ADD_ARROW_TEST(flight-test
-  EXTRA_LINK_LIBS ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS}
-  LABELS "arrow_flight")
+add_arrow_test(flight-test
+               EXTRA_LINK_LIBS
+               ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS}
+               LABELS
+               "arrow_flight")
 
 # Build test server for unit tests or benchmarks
-if (ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
+if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   add_executable(flight-test-server test-server.cc)
-  target_link_libraries(flight-test-server
-    ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS}
-    gflags_static
-    ${GTEST_LIBRARY})
+  target_link_libraries(flight-test-server ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS}
+                        gflags_static ${GTEST_LIBRARY})
 
   add_executable(flight-test-integration-server test-integration-server.cc)
   target_link_libraries(flight-test-integration-server
-    ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS}
-    gflags_static
-    gtest_static)
+                        ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS} gflags_static gtest_static)
 
   add_executable(flight-test-integration-client test-integration-client.cc)
   target_link_libraries(flight-test-integration-client
-    ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS}
-    gflags_static
-    gtest_static)
+                        ${ARROW_FLIGHT_TEST_STATIC_LINK_LIBS} gflags_static gtest_static)
 
   # This is needed for the unit tests
-  if (ARROW_BUILD_TESTS)
+  if(ARROW_BUILD_TESTS)
     add_dependencies(arrow-flight-test flight-test-server)
   endif()
 endif()
 
-if (ARROW_BUILD_BENCHMARKS)
+if(ARROW_BUILD_BENCHMARKS)
   # Perf server for benchmarks
-  set(PERF_PROTO_GENERATED_FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/perf.pb.cc"
-    "${CMAKE_CURRENT_BINARY_DIR}/perf.pb.h")
+  set(PERF_PROTO_GENERATED_FILES "${CMAKE_CURRENT_BINARY_DIR}/perf.pb.cc"
+      "${CMAKE_CURRENT_BINARY_DIR}/perf.pb.h")
 
-  add_custom_command(
-    OUTPUT ${PERF_PROTO_GENERATED_FILES}
-    COMMAND ${PROTOBUF_EXECUTABLE}
-    "-I${CMAKE_CURRENT_SOURCE_DIR}"
-    "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
-    "perf.proto"
-    DEPENDS ${PROTO_DEPENDS})
+  add_custom_command(OUTPUT ${PERF_PROTO_GENERATED_FILES}
+                     COMMAND ${PROTOBUF_EXECUTABLE} "-I${CMAKE_CURRENT_SOURCE_DIR}"
+                             "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" "perf.proto"
+                     DEPENDS ${PROTO_DEPENDS})
 
-  add_executable(flight-perf-server
-    perf-server.cc
-    perf.pb.cc)
+  add_executable(flight-perf-server perf-server.cc perf.pb.cc)
   target_link_libraries(flight-perf-server
-    arrow_flight_static
-    arrow_testing_static
-    ${ARROW_FLIGHT_STATIC_LINK_LIBS}
-    gflags_static
-    ${GTEST_LIBRARY})
+                        arrow_flight_static
+                        arrow_testing_static
+                        ${ARROW_FLIGHT_STATIC_LINK_LIBS}
+                        gflags_static
+                        ${GTEST_LIBRARY})
 
-  add_executable(flight-benchmark
-    flight-benchmark.cc
-    perf.pb.cc)
+  add_executable(flight-benchmark flight-benchmark.cc perf.pb.cc)
   target_link_libraries(flight-benchmark
-    arrow_flight_static
-    arrow_testing_static
-    ${ARROW_FLIGHT_STATIC_LINK_LIBS}
-    gflags_static
-    ${GTEST_LIBRARY})
+                        arrow_flight_static
+                        arrow_testing_static
+                        ${ARROW_FLIGHT_STATIC_LINK_LIBS}
+                        gflags_static
+                        ${GTEST_LIBRARY})
 
   add_dependencies(flight-benchmark flight-perf-server)
 endif(ARROW_BUILD_BENCHMARKS)

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#######################################
+#
 # arrow_cuda
-#######################################
+#
 
 add_custom_target(arrow_cuda-all)
 add_custom_target(arrow_cuda)
@@ -25,7 +25,7 @@ add_custom_target(arrow_cuda-benchmarks)
 add_custom_target(arrow_cuda-tests)
 add_dependencies(arrow_cuda-all arrow_cuda arrow_cuda-tests arrow_cuda-benchmarks)
 
-if (DEFINED ENV{CUDA_HOME})
+if(DEFINED ENV{CUDA_HOME})
   set(CUDA_TOOLKIT_ROOT_DIR "$ENV{CUDA_HOME}")
 endif()
 
@@ -34,61 +34,49 @@ include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
 
 message(STATUS "CUDA Libraries: ${CUDA_LIBRARIES}")
 
-set(ARROW_CUDA_SRCS
-  cuda_arrow_ipc.cc
-  cuda_context.cc
-  cuda_memory.cc
-)
+set(ARROW_CUDA_SRCS cuda_arrow_ipc.cc cuda_context.cc cuda_memory.cc)
 
-set(ARROW_CUDA_SHARED_LINK_LIBS
-  ${CUDA_LIBRARIES}
-  ${CUDA_CUDA_LIBRARY}
-)
+set(ARROW_CUDA_SHARED_LINK_LIBS ${CUDA_LIBRARIES} ${CUDA_CUDA_LIBRARY})
 
-ADD_ARROW_LIB(arrow_cuda
-  SOURCES ${ARROW_CUDA_SRCS}
-  OUTPUTS ARROW_CUDA_LIBRARIES
-  DEPENDENCIES metadata_fbs
-  SHARED_LINK_FLAGS ""
-  SHARED_LINK_LIBS arrow_shared ${ARROW_CUDA_SHARED_LINK_LIBS}
-  # Static arrow_cuda must also link against CUDA shared libs
-  STATIC_LINK_LIBS ${ARROW_CUDA_SHARED_LINK_LIBS}
-)
+add_arrow_lib(arrow_cuda
+              SOURCES
+              ${ARROW_CUDA_SRCS}
+              OUTPUTS
+              ARROW_CUDA_LIBRARIES
+              DEPENDENCIES
+              metadata_fbs
+              SHARED_LINK_FLAGS
+              ""
+              SHARED_LINK_LIBS
+              arrow_shared
+              ${ARROW_CUDA_SHARED_LINK_LIBS}
+              # Static arrow_cuda must also link against CUDA shared libs
+              STATIC_LINK_LIBS ${ARROW_CUDA_SHARED_LINK_LIBS})
 
 add_dependencies(arrow_cuda ${ARROW_CUDA_LIBRARIES})
 
 foreach(LIB_TARGET ${ARROW_CUDA_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET}
-    PRIVATE ARROW_EXPORTING)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
 endforeach()
 
 # CUDA build version
-configure_file(cuda_version.h.in
-  "${CMAKE_CURRENT_BINARY_DIR}/cuda_version.h"
-  @ONLY)
+configure_file(cuda_version.h.in "${CMAKE_CURRENT_BINARY_DIR}/cuda_version.h" @ONLY)
 
-install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/cuda_version.h"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/gpu")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cuda_version.h"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/gpu")
 
-ARROW_INSTALL_ALL_HEADERS("arrow/gpu")
-ARROW_ADD_PKG_CONFIG("arrow-cuda")
+arrow_install_all_headers("arrow/gpu")
+arrow_add_pkg_config("arrow-cuda")
 
-set(ARROW_CUDA_TEST_LINK_LIBS
-  arrow_cuda_shared
-  ${ARROW_TEST_LINK_LIBS})
+set(ARROW_CUDA_TEST_LINK_LIBS arrow_cuda_shared ${ARROW_TEST_LINK_LIBS})
 
-if (ARROW_BUILD_TESTS)
-  ADD_ARROW_TEST(cuda-test
-    STATIC_LINK_LIBS ${ARROW_CUDA_TEST_LINK_LIBS}
-    NO_VALGRIND)
+if(ARROW_BUILD_TESTS)
+  add_arrow_test(cuda-test STATIC_LINK_LIBS ${ARROW_CUDA_TEST_LINK_LIBS} NO_VALGRIND)
 endif()
 
-if (ARROW_BUILD_BENCHMARKS)
+if(ARROW_BUILD_BENCHMARKS)
   cuda_add_executable(arrow-cuda-benchmark cuda-benchmark.cc)
-  target_link_libraries(arrow-cuda-benchmark
-    arrow_cuda_shared
-    ${GTEST_LIBRARY}
-    ${ARROW_BENCHMARK_LINK_LIBS})
+  target_link_libraries(arrow-cuda-benchmark arrow_cuda_shared ${GTEST_LIBRARY}
+                        ${ARROW_BENCHMARK_LINK_LIBS})
   add_dependencies(arrow_cuda-benchmarks arrow-cuda-benchmark)
 endif()

--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -18,27 +18,19 @@
 # ----------------------------------------------------------------------
 # arrow_io : Arrow IO interfaces
 
-ADD_ARROW_TEST(buffered-test
-  PREFIX "arrow-io")
-ADD_ARROW_TEST(compressed-test
-  PREFIX "arrow-io")
-ADD_ARROW_TEST(file-test
-  PREFIX "arrow-io")
+add_arrow_test(buffered-test PREFIX "arrow-io")
+add_arrow_test(compressed-test PREFIX "arrow-io")
+add_arrow_test(file-test PREFIX "arrow-io")
 
-if (ARROW_HDFS AND NOT ARROW_BOOST_HEADER_ONLY)
-  ADD_ARROW_TEST(hdfs-test NO_VALGRIND
-    PREFIX "arrow-io")
+if(ARROW_HDFS AND NOT ARROW_BOOST_HEADER_ONLY)
+  add_arrow_test(hdfs-test NO_VALGRIND PREFIX "arrow-io")
 endif()
 
-ADD_ARROW_TEST(memory-test
-  PREFIX "arrow-io")
-ADD_ARROW_TEST(readahead-test
-  PREFIX "arrow-io")
+add_arrow_test(memory-test PREFIX "arrow-io")
+add_arrow_test(readahead-test PREFIX "arrow-io")
 
-ADD_ARROW_BENCHMARK(file-benchmark
-  PREFIX "arrow-io")
-ADD_ARROW_BENCHMARK(memory-benchmark
-  PREFIX "arrow-io")
+add_arrow_benchmark(file-benchmark PREFIX "arrow-io")
+add_arrow_benchmark(memory-benchmark PREFIX "arrow-io")
 
 # Headers: top level
-ARROW_INSTALL_ALL_HEADERS("arrow/io")
+arrow_install_all_headers("arrow/io")

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -19,28 +19,24 @@
 add_custom_target(integration)
 add_dependencies(arrow-tests integration)
 
-#######################################
+#
 # Messaging and interprocess communication
 
-ADD_ARROW_TEST(feather-test)
-ADD_ARROW_TEST(read-write-test
-  PREFIX "arrow-ipc")
-ADD_ARROW_TEST(json-simple-test
-  PREFIX "arrow-ipc")
-ADD_ARROW_TEST(json-test
-  PREFIX "arrow-ipc")
+add_arrow_test(feather-test)
+add_arrow_test(read-write-test PREFIX "arrow-ipc")
+add_arrow_test(json-simple-test PREFIX "arrow-ipc")
+add_arrow_test(json-test PREFIX "arrow-ipc")
 
-if (NOT ARROW_BOOST_HEADER_ONLY)
-  ADD_ARROW_TEST(json-integration-test
-    EXTRA_LINK_LIBS gflags_static)
+if(NOT ARROW_BOOST_HEADER_ONLY)
+  add_arrow_test(json-integration-test EXTRA_LINK_LIBS gflags_static)
 
   # Test is being built
-  if (TARGET arrow-json-integration-test)
+  if(TARGET arrow-json-integration-test)
     add_dependencies(integration arrow-json-integration-test)
-    if (UNIX)
-      if (APPLE)
+    if(UNIX)
+      if(APPLE)
         set_target_properties(arrow-json-integration-test
-          PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+                              PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
       else()
         target_link_libraries(arrow-json-integration-test PRIVATE pthread)
       endif()
@@ -54,17 +50,15 @@ set_source_files_properties(feather_generated.h PROPERTIES GENERATED TRUE)
 set_source_files_properties(File_generated.h PROPERTIES GENERATED TRUE)
 
 set(OUTPUT_DIR ${ARROW_BINARY_DIR}/src/arrow/ipc)
-set(FBS_OUTPUT_FILES
-  "${OUTPUT_DIR}/File_generated.h"
-  "${OUTPUT_DIR}/Message_generated.h"
-  "${OUTPUT_DIR}/feather_generated.h")
+set(FBS_OUTPUT_FILES "${OUTPUT_DIR}/File_generated.h" "${OUTPUT_DIR}/Message_generated.h"
+    "${OUTPUT_DIR}/feather_generated.h")
 
 set(FBS_SRC
-  ${ARROW_SOURCE_DIR}/../format/Message.fbs
-  ${ARROW_SOURCE_DIR}/../format/File.fbs
-  ${ARROW_SOURCE_DIR}/../format/Schema.fbs
-  ${ARROW_SOURCE_DIR}/../format/Tensor.fbs
-  ${CMAKE_CURRENT_SOURCE_DIR}/feather.fbs)
+    ${ARROW_SOURCE_DIR}/../format/Message.fbs
+    ${ARROW_SOURCE_DIR}/../format/File.fbs
+    ${ARROW_SOURCE_DIR}/../format/Schema.fbs
+    ${ARROW_SOURCE_DIR}/../format/Tensor.fbs
+    ${CMAKE_CURRENT_SOURCE_DIR}/feather.fbs)
 
 foreach(FIL ${FBS_SRC})
   get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
@@ -77,26 +71,24 @@ else()
   set(FBS_DEPENDS ${ABS_FBS_SRC})
 endif()
 
-add_custom_command(
-  OUTPUT ${FBS_OUTPUT_FILES}
-  COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${ABS_FBS_SRC}
-  DEPENDS ${FBS_DEPENDS}
-  COMMENT "Running flatc compiler on ${ABS_FBS_SRC}"
-  VERBATIM
-)
+add_custom_command(OUTPUT ${FBS_OUTPUT_FILES}
+                   COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${ABS_FBS_SRC}
+                   DEPENDS ${FBS_DEPENDS}
+                   COMMENT "Running flatc compiler on ${ABS_FBS_SRC}"
+                   VERBATIM)
 
 add_custom_target(metadata_fbs DEPENDS ${FBS_OUTPUT_FILES})
 
 # Headers: top level
-ARROW_INSTALL_ALL_HEADERS("arrow/ipc")
+arrow_install_all_headers("arrow/ipc")
 
-if (ARROW_BUILD_STATIC)
+if(ARROW_BUILD_STATIC)
   set(ARROW_UTIL_LIB arrow_static)
 else()
   set(ARROW_UTIL_LIB arrow_shared)
 endif()
 
-if (ARROW_BUILD_UTILITIES)
+if(ARROW_BUILD_UTILITIES)
   add_executable(arrow-file-to-stream file-to-stream.cc)
   target_link_libraries(arrow-file-to-stream ${ARROW_UTIL_LIB})
   add_executable(arrow-stream-to-file stream-to-file.cc)
@@ -106,6 +98,5 @@ if (ARROW_BUILD_UTILITIES)
   add_dependencies(integration arrow-stream-to-file)
 endif()
 
-ADD_ARROW_BENCHMARK(read-write-benchmark
-  PREFIX "arrow-ipc")
-ADD_ARROW_FUZZING(ipc-fuzzing-test)
+add_arrow_benchmark(read-write-benchmark PREFIX "arrow-ipc")
+add_arrow_fuzzing(ipc-fuzzing-test)

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#######################################
+#
 # arrow_python
-#######################################
+#
 
 find_package(PythonLibsNew REQUIRED)
 find_package(NumPy REQUIRED)
@@ -28,113 +28,103 @@ add_custom_target(arrow_python-tests)
 add_dependencies(arrow_python-all arrow_python arrow_python-tests)
 
 set(ARROW_PYTHON_SRCS
-  arrow_to_pandas.cc
-  benchmark.cc
-  common.cc
-  config.cc
-  decimal.cc
-  deserialize.cc
-  helpers.cc
-  inference.cc
-  init.cc
-  io.cc
-  numpy_convert.cc
-  numpy_to_arrow.cc
-  python_to_arrow.cc
-  pyarrow.cc
-  serialize.cc
-)
+    arrow_to_pandas.cc
+    benchmark.cc
+    common.cc
+    config.cc
+    decimal.cc
+    deserialize.cc
+    helpers.cc
+    inference.cc
+    init.cc
+    io.cc
+    numpy_convert.cc
+    numpy_to_arrow.cc
+    python_to_arrow.cc
+    pyarrow.cc
+    serialize.cc)
 
-if ("${COMPILER_FAMILY}" STREQUAL "clang")
-  set_property(SOURCE pyarrow.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS
-    " -Wno-cast-qual ")
+if("${COMPILER_FAMILY}" STREQUAL "clang")
+  set_property(SOURCE pyarrow.cc APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-cast-qual ")
 endif()
 
-set(ARROW_PYTHON_SHARED_LINK_LIBS
-  arrow_shared
-  ${PYTHON_OTHER_LIBS}
-)
+set(ARROW_PYTHON_SHARED_LINK_LIBS arrow_shared ${PYTHON_OTHER_LIBS})
 
-if (WIN32)
-  set(ARROW_PYTHON_SHARED_LINK_LIBS
-    ${ARROW_PYTHON_SHARED_LINK_LIBS}
-    ${PYTHON_LIBRARIES}
-    )
+if(WIN32)
+  set(ARROW_PYTHON_SHARED_LINK_LIBS ${ARROW_PYTHON_SHARED_LINK_LIBS} ${PYTHON_LIBRARIES})
 endif()
 
-set(ARROW_PYTHON_INCLUDES
-  ${NUMPY_INCLUDE_DIRS}
-  ${PYTHON_INCLUDE_DIRS})
+set(ARROW_PYTHON_INCLUDES ${NUMPY_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS})
 
-ADD_ARROW_LIB(arrow_python
-  SOURCES ${ARROW_PYTHON_SRCS}
-  OUTPUTS ARROW_PYTHON_LIBRARIES
-  SHARED_LINK_FLAGS ""
-  SHARED_LINK_LIBS ${ARROW_PYTHON_SHARED_LINK_LIBS}
-  STATIC_LINK_LIBS ${PYTHON_OTHER_LIBS}
-  EXTRA_INCLUDES "${ARROW_PYTHON_INCLUDES}"
-)
+add_arrow_lib(arrow_python
+              SOURCES
+              ${ARROW_PYTHON_SRCS}
+              OUTPUTS
+              ARROW_PYTHON_LIBRARIES
+              SHARED_LINK_FLAGS
+              ""
+              SHARED_LINK_LIBS
+              ${ARROW_PYTHON_SHARED_LINK_LIBS}
+              STATIC_LINK_LIBS
+              ${PYTHON_OTHER_LIBS}
+              EXTRA_INCLUDES
+              "${ARROW_PYTHON_INCLUDES}")
 
 add_dependencies(arrow_python ${ARROW_PYTHON_LIBRARIES})
 
 foreach(LIB_TARGET ${ARROW_PYTHON_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET}
-    PRIVATE ARROW_PYTHON_EXPORTING)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_PYTHON_EXPORTING)
 endforeach()
 
-if (ARROW_BUILD_STATIC AND MSVC)
+if(ARROW_BUILD_STATIC AND MSVC)
   target_compile_definitions(arrow_python_static PUBLIC ARROW_STATIC)
 endif()
 
-if ("${COMPILER_FAMILY}" STREQUAL "clang")
+if("${COMPILER_FAMILY}" STREQUAL "clang")
   # Clang, be quiet. Python C API has lots of macros
   set_property(SOURCE ${ARROW_PYTHON_SRCS}
-    APPEND_STRING
-    PROPERTY
-    COMPILE_FLAGS -Wno-parentheses-equality)
+               APPEND_STRING
+               PROPERTY COMPILE_FLAGS -Wno-parentheses-equality)
 endif()
 
-ARROW_INSTALL_ALL_HEADERS("arrow/python")
+arrow_install_all_headers("arrow/python")
 
 # pkg-config support
-ARROW_ADD_PKG_CONFIG("arrow-python")
+arrow_add_pkg_config("arrow-python")
 
 # ----------------------------------------------------------------------
 
-if (ARROW_BUILD_TESTS)
-  add_library(arrow_python_test_main STATIC
-	util/test_main.cc)
+if(ARROW_BUILD_TESTS)
+  add_library(arrow_python_test_main STATIC util/test_main.cc)
 
-  target_link_libraries(arrow_python_test_main
-    ${GTEST_LIBRARY})
-  target_include_directories(arrow_python_test_main SYSTEM PUBLIC
-    ${ARROW_PYTHON_INCLUDES})
+  target_link_libraries(arrow_python_test_main ${GTEST_LIBRARY})
+  target_include_directories(arrow_python_test_main SYSTEM
+                             PUBLIC ${ARROW_PYTHON_INCLUDES})
 
-  if (APPLE)
-	target_link_libraries(arrow_python_test_main
-      ${CMAKE_DL_LIBS})
-	set_target_properties(arrow_python_test_main
-      PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  if(APPLE)
+    target_link_libraries(arrow_python_test_main ${CMAKE_DL_LIBS})
+    set_target_properties(arrow_python_test_main
+                          PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
   elseif(NOT MSVC)
-	target_link_libraries(arrow_python_test_main
-      pthread
-      ${CMAKE_DL_LIBS})
+    target_link_libraries(arrow_python_test_main pthread ${CMAKE_DL_LIBS})
   endif()
 
   set(ARROW_PYTHON_MIN_TEST_LIBS
-    arrow_python_test_main
-    arrow_python_shared
-    arrow_testing_shared
-    arrow_shared)
+      arrow_python_test_main
+      arrow_python_shared
+      arrow_testing_shared
+      arrow_shared)
 
   set(ARROW_PYTHON_TEST_LINK_LIBS ${ARROW_PYTHON_MIN_TEST_LIBS})
 
-  ADD_ARROW_TEST(python-test
-    STATIC_LINK_LIBS "${ARROW_PYTHON_TEST_LINK_LIBS}"
-    EXTRA_LINK_LIBS ${PYTHON_LIBRARIES}
-    EXTRA_INCLUDES "${ARROW_PYTHON_INCLUDES}"
-    LABELS "arrow_python-tests"
-    NO_VALGRIND)
+  add_arrow_test(python-test
+                 STATIC_LINK_LIBS
+                 "${ARROW_PYTHON_TEST_LINK_LIBS}"
+                 EXTRA_LINK_LIBS
+                 ${PYTHON_LIBRARIES}
+                 EXTRA_INCLUDES
+                 "${ARROW_PYTHON_INCLUDES}"
+                 LABELS
+                 "arrow_python-tests"
+                 NO_VALGRIND)
 endif()

--- a/cpp/src/arrow/python/util/CMakeLists.txt
+++ b/cpp/src/arrow/python/util/CMakeLists.txt
@@ -15,25 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#######################################
+#
 # arrow/python_test_main
-#######################################
+#
 
-if (PYARROW_BUILD_TESTS)
-  add_library(arrow/python_test_main STATIC
-	test_main.cc)
+if(PYARROW_BUILD_TESTS)
+  add_library(arrow/python_test_main STATIC test_main.cc)
 
-  if (APPLE)
-	target_link_libraries(arrow/python_test_main
-      ${GTEST_LIBRARY}
-      dl)
-	set_target_properties(arrow/python_test_main
-      PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  if(APPLE)
+    target_link_libraries(arrow/python_test_main ${GTEST_LIBRARY} dl)
+    set_target_properties(arrow/python_test_main
+                          PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
   else()
-	target_link_libraries(arrow/python_test_main
-      ${GTEST_LIBRARY}
-      pthread
-      dl
-	  )
+    target_link_libraries(arrow/python_test_main ${GTEST_LIBRARY} pthread dl)
   endif()
 endif()

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -15,64 +15,56 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#######################################
+#
 # arrow_util
-#######################################
+#
 
 # Headers: top level
-ARROW_INSTALL_ALL_HEADERS("arrow/util")
+arrow_install_all_headers("arrow/util")
 
-#######################################
+#
 # arrow_test_main
-#######################################
+#
 
-if (ARROW_BUILD_BENCHMARKS)
+if(ARROW_BUILD_BENCHMARKS)
   add_library(arrow_benchmark_main benchmark_main.cc)
-  if (APPLE)
-    target_link_libraries(arrow_benchmark_main
-      gbenchmark_static
-    )
+  if(APPLE)
+    target_link_libraries(arrow_benchmark_main gbenchmark_static)
   elseif(MSVC)
-    target_link_libraries(arrow_benchmark_main
-      gbenchmark_static
-      Shlwapi.lib
-  )
+    target_link_libraries(arrow_benchmark_main gbenchmark_static Shlwapi.lib)
   else()
-    target_link_libraries(arrow_benchmark_main
-      gbenchmark_static
-      pthread
-    )
+    target_link_libraries(arrow_benchmark_main gbenchmark_static pthread)
   endif()
 
   # TODO(wesm): Some benchmarks include gtest.h
   add_dependencies(arrow_benchmark_main ${GTEST_LIBRARY})
 endif()
 
-ADD_ARROW_TEST(bit-util-test)
-ADD_ARROW_TEST(checked-cast-test)
-ADD_ARROW_TEST(compression-test)
-ADD_ARROW_TEST(decimal-test)
-ADD_ARROW_TEST(hashing-test)
-ADD_ARROW_TEST(int-util-test)
-ADD_ARROW_TEST(key-value-metadata-test)
-ADD_ARROW_TEST(lazy-test)
-ADD_ARROW_TEST(logging-test)
-ADD_ARROW_TEST(parsing-util-test)
-ADD_ARROW_TEST(rle-encoding-test)
-ADD_ARROW_TEST(stl-util-test)
-ADD_ARROW_TEST(task-group-test)
-ADD_ARROW_TEST(thread-pool-test)
-ADD_ARROW_TEST(trie-test)
-ADD_ARROW_TEST(utf8-util-test)
+add_arrow_test(bit-util-test)
+add_arrow_test(checked-cast-test)
+add_arrow_test(compression-test)
+add_arrow_test(decimal-test)
+add_arrow_test(hashing-test)
+add_arrow_test(int-util-test)
+add_arrow_test(key-value-metadata-test)
+add_arrow_test(lazy-test)
+add_arrow_test(logging-test)
+add_arrow_test(parsing-util-test)
+add_arrow_test(rle-encoding-test)
+add_arrow_test(stl-util-test)
+add_arrow_test(task-group-test)
+add_arrow_test(thread-pool-test)
+add_arrow_test(trie-test)
+add_arrow_test(utf8-util-test)
 
-ADD_ARROW_BENCHMARK(bit-util-benchmark)
-ADD_ARROW_BENCHMARK(compression-benchmark)
-ADD_ARROW_BENCHMARK(decimal-benchmark)
-ADD_ARROW_BENCHMARK(hashing-benchmark)
-ADD_ARROW_BENCHMARK(int-util-benchmark)
-ADD_ARROW_BENCHMARK(lazy-benchmark)
-ADD_ARROW_BENCHMARK(machine-benchmark)
-ADD_ARROW_BENCHMARK(number-parsing-benchmark)
-ADD_ARROW_BENCHMARK(thread-pool-benchmark)
-ADD_ARROW_BENCHMARK(trie-benchmark)
-ADD_ARROW_BENCHMARK(utf8-util-benchmark)
+add_arrow_benchmark(bit-util-benchmark)
+add_arrow_benchmark(compression-benchmark)
+add_arrow_benchmark(decimal-benchmark)
+add_arrow_benchmark(hashing-benchmark)
+add_arrow_benchmark(int-util-benchmark)
+add_arrow_benchmark(lazy-benchmark)
+add_arrow_benchmark(machine-benchmark)
+add_arrow_benchmark(number-parsing-benchmark)
+add_arrow_benchmark(thread-pool-benchmark)
+add_arrow_benchmark(trie-benchmark)
+add_arrow_benchmark(utf8-util-benchmark)

--- a/cpp/src/arrow/vendored/CMakeLists.txt
+++ b/cpp/src/arrow/vendored/CMakeLists.txt
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARROW_INSTALL_ALL_HEADERS("arrow/vendored")
+arrow_install_all_headers("arrow/vendored")
 
 add_subdirectory(variant)

--- a/cpp/src/arrow/vendored/variant/CMakeLists.txt
+++ b/cpp/src/arrow/vendored/variant/CMakeLists.txt
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ARROW_INSTALL_ALL_HEADERS("arrow/vendored/variant")
+arrow_install_all_headers("arrow/vendored/variant")

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -28,71 +28,61 @@ add_dependencies(gandiva-all gandiva gandiva-tests gandiva-benchmarks)
 find_package(LLVM)
 
 # Set the path where the byte-code files will be installed.
-set(GANDIVA_BC_INSTALL_DIR
-  ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/gandiva)
+set(GANDIVA_BC_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/gandiva)
 
 set(GANDIVA_BC_FILE_NAME irhelpers.bc)
 set(GANDIVA_BC_INSTALL_PATH "${GANDIVA_BC_INSTALL_DIR}/${GANDIVA_BC_FILE_NAME}")
 set(GANDIVA_BC_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/${GANDIVA_BC_FILE_NAME}")
-install(FILES
-  ${GANDIVA_BC_OUTPUT_PATH}
-  DESTINATION ${GANDIVA_BC_INSTALL_DIR})
+install(FILES ${GANDIVA_BC_OUTPUT_PATH} DESTINATION ${GANDIVA_BC_INSTALL_DIR})
 
 set(BC_FILE_PATH_CC "${CMAKE_CURRENT_BINARY_DIR}/bc_file_path.cc")
 configure_file(bc_file_path.cc.in ${BC_FILE_PATH_CC})
 add_definitions(-DGANDIVA_BYTE_COMPILE_FILE_PATH="${GANDIVA_BC_OUTPUT_PATH}")
 
-set(SRC_FILES annotator.cc
-      bitmap_accumulator.cc
-      cast_time.cc
-      configuration.cc
-      context_helper.cc
-      decimal_ir.cc
-      decimal_type_util.cc
-      engine.cc
-      date_utils.cc
-      expr_decomposer.cc
-      expr_validator.cc
-      expression.cc
-      expression_registry.cc
-      exported_funcs_registry.cc
-      filter.cc
-      function_ir_builder.cc
-      function_registry.cc
-      function_registry_arithmetic.cc
-      function_registry_datetime.cc
-      function_registry_hash.cc
-      function_registry_math_ops.cc
-      function_registry_string.cc
-      function_registry_timestamp_arithmetic.cc
-      function_signature.cc
-      gdv_function_stubs.cc
-      llvm_generator.cc
-      llvm_types.cc
-      like_holder.cc
-      projector.cc
-      regex_util.cc
-      selection_vector.cc
-      tree_expr_builder.cc
-      to_date_holder.cc
-      ${BC_FILE_PATH_CC})
+set(SRC_FILES
+    annotator.cc
+    bitmap_accumulator.cc
+    cast_time.cc
+    configuration.cc
+    context_helper.cc
+    decimal_ir.cc
+    decimal_type_util.cc
+    engine.cc
+    date_utils.cc
+    expr_decomposer.cc
+    expr_validator.cc
+    expression.cc
+    expression_registry.cc
+    exported_funcs_registry.cc
+    filter.cc
+    function_ir_builder.cc
+    function_registry.cc
+    function_registry_arithmetic.cc
+    function_registry_datetime.cc
+    function_registry_hash.cc
+    function_registry_math_ops.cc
+    function_registry_string.cc
+    function_registry_timestamp_arithmetic.cc
+    function_signature.cc
+    gdv_function_stubs.cc
+    llvm_generator.cc
+    llvm_types.cc
+    like_holder.cc
+    projector.cc
+    regex_util.cc
+    selection_vector.cc
+    tree_expr_builder.cc
+    to_date_holder.cc
+    ${BC_FILE_PATH_CC})
 
-set(GANDIVA_SHARED_PRIVATE_LINK_LIBS
-  arrow_shared
-  LLVM::LLVM_INTERFACE
-  ${RE2_LIBRARY})
+set(GANDIVA_SHARED_PRIVATE_LINK_LIBS arrow_shared LLVM::LLVM_INTERFACE ${RE2_LIBRARY})
 
-set(GANDIVA_STATIC_LINK_LIBS
-  arrow_static
-  LLVM::LLVM_INTERFACE
-  ${RE2_LIBRARY})
+set(GANDIVA_STATIC_LINK_LIBS arrow_static LLVM::LLVM_INTERFACE ${RE2_LIBRARY})
 
-if (ARROW_GANDIVA_STATIC_LIBSTDCPP
-    AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX))
-  set(GANDIVA_STATIC_LINK_LIBS
-    ${GANDIVA_STATIC_LINK_LIBS}
-    -static-libstdc++
-    -static-libgcc)
+if(ARROW_GANDIVA_STATIC_LIBSTDCPP
+   AND (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX))
+  set(GANDIVA_STATIC_LINK_LIBS ${GANDIVA_STATIC_LINK_LIBS} -static-libstdc++
+      -static-libgcc)
 endif()
 
 # if (MSVC)
@@ -104,23 +94,30 @@ endif()
 #   endforeach()
 # endif()
 
-ADD_ARROW_LIB(gandiva
-  SOURCES ${SRC_FILES}
-  OUTPUTS GANDIVA_LIBRARIES
-  DEPENDENCIES arrow_dependencies precompiled
-  EXTRA_INCLUDES
-  $<TARGET_PROPERTY:LLVM::LLVM_INTERFACE,INTERFACE_INCLUDE_DIRECTORIES>
-  SHARED_LINK_FLAGS ${GANDIVA_SHARED_LINK_FLAGS}
-  SHARED_LINK_LIBS arrow_shared
-  SHARED_PRIVATE_LINK_LIBS ${GANDIVA_SHARED_PRIVATE_LINK_LIBS}
-  STATIC_LINK_LIBS ${GANDIVA_STATIC_LINK_LIBS})
+add_arrow_lib(gandiva
+              SOURCES
+              ${SRC_FILES}
+              OUTPUTS
+              GANDIVA_LIBRARIES
+              DEPENDENCIES
+              arrow_dependencies
+              precompiled
+              EXTRA_INCLUDES
+              $<TARGET_PROPERTY:LLVM::LLVM_INTERFACE,INTERFACE_INCLUDE_DIRECTORIES>
+              SHARED_LINK_FLAGS
+              ${GANDIVA_SHARED_LINK_FLAGS}
+              SHARED_LINK_LIBS
+              arrow_shared
+              SHARED_PRIVATE_LINK_LIBS
+              ${GANDIVA_SHARED_PRIVATE_LINK_LIBS}
+              STATIC_LINK_LIBS
+              ${GANDIVA_STATIC_LINK_LIBS})
 
 foreach(LIB_TARGET ${GANDIVA_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET}
-    PRIVATE GANDIVA_EXPORTING)
+  target_compile_definitions(${LIB_TARGET} PRIVATE GANDIVA_EXPORTING)
 endforeach()
 
-if (ARROW_BUILD_STATIC AND WIN32)
+if(ARROW_BUILD_STATIC AND WIN32)
   target_compile_definitions(gandiva_static PUBLIC GANDIVA_STATIC)
 endif()
 
@@ -130,78 +127,76 @@ add_dependencies(gandiva ${GANDIVA_LIBRARIES})
 include(GNUInstallDirs)
 
 # install the header files.
-ARROW_INSTALL_ALL_HEADERS("gandiva")
+arrow_install_all_headers("gandiva")
 
 # pkg-config support
-ARROW_ADD_PKG_CONFIG("gandiva")
+arrow_add_pkg_config("gandiva")
 
-set(GANDIVA_STATIC_TEST_LINK_LIBS
-  gandiva_static
-  ${RE2_LIBRARY}
-  ${ARROW_TEST_LINK_LIBS})
+set(GANDIVA_STATIC_TEST_LINK_LIBS gandiva_static ${RE2_LIBRARY} ${ARROW_TEST_LINK_LIBS})
 
-set(GANDIVA_SHARED_TEST_LINK_LIBS
-  gandiva_shared
-  ${RE2_LIBRARY}
-  ${ARROW_TEST_LINK_LIBS})
+set(GANDIVA_SHARED_TEST_LINK_LIBS gandiva_shared ${RE2_LIBRARY} ${ARROW_TEST_LINK_LIBS})
 
 function(ADD_GANDIVA_TEST REL_TEST_NAME)
   set(options USE_STATIC_LINKING)
   set(one_value_args)
   set(multi_value_args)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
 
-  if (NO_TESTS)
+  if(NO_TESTS)
     return()
   endif()
 
   set(TEST_ARGUMENTS
-    ENABLED
-    PREFIX "gandiva"
-    LABELS "gandiva-tests"
-    ${ARG_UNPARSED_ARGUMENTS})
+      ENABLED
+      PREFIX
+      "gandiva"
+      LABELS
+      "gandiva-tests"
+      ${ARG_UNPARSED_ARGUMENTS})
 
   # and uses less disk space, but in some cases we need to force static
   # linking (see rationale below).
-  if (ARG_USE_STATIC_LINKING)
-    ADD_TEST_CASE(${REL_TEST_NAME}
-      ${TEST_ARGUMENTS}
-      STATIC_LINK_LIBS ${GANDIVA_STATIC_TEST_LINK_LIBS})
+  if(ARG_USE_STATIC_LINKING)
+    add_test_case(${REL_TEST_NAME} ${TEST_ARGUMENTS} STATIC_LINK_LIBS
+                  ${GANDIVA_STATIC_TEST_LINK_LIBS})
   else()
-    ADD_TEST_CASE(${REL_TEST_NAME}
-      ${TEST_ARGUMENTS}
-      STATIC_LINK_LIBS ${GANDIVA_SHARED_TEST_LINK_LIBS})
+    add_test_case(${REL_TEST_NAME} ${TEST_ARGUMENTS} STATIC_LINK_LIBS
+                  ${GANDIVA_SHARED_TEST_LINK_LIBS})
   endif()
 
   set(TARGET_NAME gandiva-${REL_TEST_NAME})
 
-  if((TARGET ${TARGET_NAME}) AND
-      (${REL_TEST_NAME} MATCHES "llvm" OR
-       ${REL_TEST_NAME} MATCHES "expression_registry"))
+  if((TARGET ${TARGET_NAME})
+     AND (${REL_TEST_NAME} MATCHES "llvm"
+          OR ${REL_TEST_NAME} MATCHES "expression_registry"))
     # If the unit test has llvm in its name, include llvm.
     add_dependencies(${TARGET_NAME} LLVM::LLVM_INTERFACE)
     target_link_libraries(${TARGET_NAME} PRIVATE LLVM::LLVM_INTERFACE)
   endif()
 endfunction()
 
-ADD_GANDIVA_TEST(bitmap_accumulator_test)
-ADD_GANDIVA_TEST(engine_llvm_test)
-ADD_GANDIVA_TEST(function_signature_test)
-ADD_GANDIVA_TEST(function_registry_test)
-ADD_GANDIVA_TEST(llvm_types_test)
-ADD_GANDIVA_TEST(llvm_generator_test)
-ADD_GANDIVA_TEST(annotator_test)
-ADD_GANDIVA_TEST(tree_expr_test)
-ADD_GANDIVA_TEST(expr_decomposer_test)
-ADD_GANDIVA_TEST(expression_registry_test)
-ADD_GANDIVA_TEST(selection_vector_test)
-ADD_GANDIVA_TEST(lru_cache_test)
-ADD_GANDIVA_TEST(to_date_holder_test)
-ADD_GANDIVA_TEST(simple_arena_test)
-ADD_GANDIVA_TEST(like_holder_test)
-ADD_GANDIVA_TEST(decimal_type_util_test)
+add_gandiva_test(bitmap_accumulator_test)
+add_gandiva_test(engine_llvm_test)
+add_gandiva_test(function_signature_test)
+add_gandiva_test(function_registry_test)
+add_gandiva_test(llvm_types_test)
+add_gandiva_test(llvm_generator_test)
+add_gandiva_test(annotator_test)
+add_gandiva_test(tree_expr_test)
+add_gandiva_test(expr_decomposer_test)
+add_gandiva_test(expression_registry_test)
+add_gandiva_test(selection_vector_test)
+add_gandiva_test(lru_cache_test)
+add_gandiva_test(to_date_holder_test)
+add_gandiva_test(simple_arena_test)
+add_gandiva_test(like_holder_test)
+add_gandiva_test(decimal_type_util_test)
 
-if (ARROW_GANDIVA_JAVA)
+if(ARROW_GANDIVA_JAVA)
   add_subdirectory(jni)
 endif()
 

--- a/cpp/src/gandiva/jni/CMakeLists.txt
+++ b/cpp/src/gandiva/jni/CMakeLists.txt
@@ -28,15 +28,17 @@ set(PROTO_OUTPUT_FILES ${PROTO_OUTPUT_FILES} "${PROTO_OUTPUT_DIR}/Types.pb.h")
 
 set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
 
-get_filename_component(ABS_GANDIVA_PROTO ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto ABSOLUTE)
+get_filename_component(ABS_GANDIVA_PROTO ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto
+                       ABSOLUTE)
 
-add_custom_command(
-  OUTPUT ${PROTO_OUTPUT_FILES}
-  COMMAND ${PROTOBUF_EXECUTABLE} --proto_path ${CMAKE_SOURCE_DIR}/src/gandiva/proto --cpp_out ${PROTO_OUTPUT_DIR} ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto
-  DEPENDS ${ABS_GANDIVA_PROTO} ${PROTOBUF_LIBRARY}
-  COMMENT "Running PROTO compiler on Types.proto"
-  VERBATIM
-)
+add_custom_command(OUTPUT ${PROTO_OUTPUT_FILES}
+                   COMMAND ${PROTOBUF_EXECUTABLE}
+                           --proto_path ${CMAKE_SOURCE_DIR}/src/gandiva/proto
+                           --cpp_out ${PROTO_OUTPUT_DIR}
+                                     ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto
+                   DEPENDS ${ABS_GANDIVA_PROTO} ${PROTOBUF_LIBRARY}
+                   COMMENT "Running PROTO compiler on Types.proto"
+                   VERBATIM)
 
 add_custom_target(gandiva_jni_proto ALL DEPENDS ${PROTO_OUTPUT_FILES})
 set(PROTO_SRCS "${PROTO_OUTPUT_DIR}/Types.pb.cc")
@@ -46,37 +48,47 @@ set(PROTO_HDRS "${PROTO_OUTPUT_DIR}/Types.pb.h")
 set(JNI_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/java")
 add_subdirectory(../../../../java/gandiva ./java/gandiva)
 
-set(GANDIVA_LINK_LIBS
-  ${PROTOBUF_LIBRARY}
-  gandiva_static)
+set(GANDIVA_LINK_LIBS ${PROTOBUF_LIBRARY} gandiva_static)
 
-set(GANDIVA_JNI_SOURCES config_builder.cc
-  config_holder.cc
-  expression_registry_helper.cc
-  jni_common.cc
-  ${PROTO_SRCS})
+set(GANDIVA_JNI_SOURCES
+    config_builder.cc
+    config_holder.cc
+    expression_registry_helper.cc
+    jni_common.cc
+    ${PROTO_SRCS})
 
 # For users of gandiva_jni library (including integ tests), include-dir is :
 #   /usr/**/include dir after install,
 #   cpp/include during build
 # For building gandiva_jni library itself, include-dir (in addition to above) is :
 #   cpp/src
-ADD_ARROW_LIB(gandiva_jni
-  SOURCES ${GANDIVA_JNI_SOURCES}
-  OUTPUTS GANDIVA_JNI_LIBRARIES
-  SHARED_PRIVATE_LINK_LIBS ${GANDIVA_LINK_LIBS}
-  STATIC_LINK_LIBS ${GANDIVA_LINK_LIBS}
-  DEPENDENCIES gandiva_java gandiva_jni_proto
-  EXTRA_INCLUDES $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-  ${JNI_HEADERS_DIR}
-  PRIVATE_INCLUDES ${JNI_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
+add_arrow_lib(gandiva_jni
+              SOURCES
+              ${GANDIVA_JNI_SOURCES}
+              OUTPUTS
+              GANDIVA_JNI_LIBRARIES
+              SHARED_PRIVATE_LINK_LIBS
+              ${GANDIVA_LINK_LIBS}
+              STATIC_LINK_LIBS
+              ${GANDIVA_LINK_LIBS}
+              DEPENDENCIES
+              gandiva_java
+              gandiva_jni_proto
+              EXTRA_INCLUDES
+              $<INSTALL_INTERFACE:include>
+              $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+              ${JNI_HEADERS_DIR}
+              PRIVATE_INCLUDES
+              ${JNI_INCLUDE_DIRS}
+              ${CMAKE_CURRENT_BINARY_DIR})
 
 add_dependencies(gandiva ${GANDIVA_JNI_LIBRARIES})
 
 # filter out everything that is not needed for the jni bridge
 # statically linked stdc++ has conflicts with stdc++ loaded by other libraries.
-if (NOT APPLE)
-  set_target_properties(gandiva_jni_shared PROPERTIES
-    LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/gandiva/jni/symbols.map")
+if(NOT APPLE)
+  set_target_properties(
+    gandiva_jni_shared
+    PROPERTIES LINK_FLAGS
+               "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/gandiva/jni/symbols.map")
 endif()

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -30,16 +30,14 @@ set(PRECOMPILED_SRCS
     timestamp_arithmetic.cc
     ../../arrow/util/basic_decimal.cc)
 
-if (MSVC)
+if(MSVC)
   # clang pretends to be a particular version of MSVC. Version 1900 is
   # Visual Studio 2015, and the standard library uses C++14 features,
   # so we have to use that -std version to get the IR compilation to
   # work
-  set(PLATFORM_CLANG_OPTIONS
-    -std=c++14 -fms-compatibility -fms-compatibility-version=19)
+  set(PLATFORM_CLANG_OPTIONS -std=c++14 -fms-compatibility -fms-compatibility-version=19)
 else()
-  set(PLATFORM_CLANG_OPTIONS
-    -std=c++11)
+  set(PLATFORM_CLANG_OPTIONS -std=c++11)
 endif()
 
 # Create bitcode for each of the source files.
@@ -55,8 +53,13 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
             -DNDEBUG # DCHECK macros not implemented in precompiled code
             -DARROW_STATIC # Do not set __declspec(dllimport) on MSVC on Arrow symbols
             -DGANDIVA_STATIC # Do not set __declspec(dllimport) on MSVC on Gandiva symbols
-            -fno-use-cxa-atexit  # Workaround for unresolved __dso_handle
-            -emit-llvm -O3 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
+            -fno-use-cxa-atexit # Workaround for unresolved __dso_handle
+            -emit-llvm
+            -O3
+            -c
+            ${ABSOLUTE_SRC}
+            -o
+            ${BC_FILE}
             ${ARROW_GANDIVA_PC_CXX_FLAGS}
             -I${CMAKE_SOURCE_DIR}/src
     DEPENDS ${SRC_FILE})
@@ -64,12 +67,10 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
 endforeach()
 
 # link all of the bitcode files into a single bitcode file.
-add_custom_command(
-  OUTPUT ${GANDIVA_BC_OUTPUT_PATH}
-  COMMAND ${LLVM_LINK_EXECUTABLE}
-          -o ${GANDIVA_BC_OUTPUT_PATH}
-          ${BC_FILES}
-  DEPENDS ${BC_FILES})
+add_custom_command(OUTPUT ${GANDIVA_BC_OUTPUT_PATH}
+                   COMMAND ${LLVM_LINK_EXECUTABLE} -o ${GANDIVA_BC_OUTPUT_PATH}
+                           ${BC_FILES}
+                   DEPENDS ${BC_FILES})
 
 add_custom_target(precompiled ALL DEPENDS ${GANDIVA_BC_OUTPUT_PATH})
 
@@ -80,29 +81,32 @@ function(add_precompiled_unit_test REL_TEST_NAME)
 
   add_executable(${TEST_NAME} ${REL_TEST_NAME} ${ARGN})
   target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(${TEST_NAME}
-    PRIVATE ${ARROW_TEST_LINK_LIBS} ${RE2_LIBRARY}
-  )
-  target_compile_definitions(${TEST_NAME} PRIVATE
-    GANDIVA_UNIT_TEST=1
-    ARROW_STATIC
-    GANDIVA_STATIC)
+  target_link_libraries(${TEST_NAME} PRIVATE ${ARROW_TEST_LINK_LIBS} ${RE2_LIBRARY})
+  target_compile_definitions(${TEST_NAME}
+                             PRIVATE
+                             GANDIVA_UNIT_TEST=1
+                             ARROW_STATIC
+                             GANDIVA_STATIC)
   set(TEST_PATH "${EXECUTABLE_OUTPUT_PATH}/${TEST_NAME}")
   add_test(${TEST_NAME} ${TEST_PATH})
-  set_property(TEST ${TEST_NAME}
-    APPEND PROPERTY
-    LABELS "unittest;gandiva-tests")
+  set_property(TEST ${TEST_NAME} APPEND PROPERTY LABELS "unittest;gandiva-tests")
   add_dependencies(gandiva-tests ${TEST_NAME})
 endfunction(add_precompiled_unit_test REL_TEST_NAME)
 
 # testing
-if (ARROW_BUILD_TESTS)
+if(ARROW_BUILD_TESTS)
   add_precompiled_unit_test(bitmap_test.cc bitmap.cc)
   add_precompiled_unit_test(epoch_time_point_test.cc)
-  add_precompiled_unit_test(time_test.cc time.cc timestamp_arithmetic.cc ../context_helper.cc ../cast_time.cc ../../arrow/vendored/datetime/tz.cpp)
+  add_precompiled_unit_test(time_test.cc
+                            time.cc
+                            timestamp_arithmetic.cc
+                            ../context_helper.cc
+                            ../cast_time.cc
+                            ../../arrow/vendored/datetime/tz.cpp)
   add_precompiled_unit_test(hash_test.cc hash.cc)
   add_precompiled_unit_test(string_ops_test.cc string_ops.cc ../context_helper.cc)
   add_precompiled_unit_test(arithmetic_ops_test.cc arithmetic_ops.cc ../context_helper.cc)
-  add_precompiled_unit_test(extended_math_ops_test.cc extended_math_ops.cc ../context_helper.cc)
+  add_precompiled_unit_test(extended_math_ops_test.cc extended_math_ops.cc
+                            ../context_helper.cc)
   add_precompiled_unit_test(decimal_ops_test.cc decimal_ops.cc ../decimal_type_util.cc)
 endif()

--- a/cpp/src/gandiva/tests/CMakeLists.txt
+++ b/cpp/src/gandiva/tests/CMakeLists.txt
@@ -15,25 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ADD_GANDIVA_TEST(filter_test)
-ADD_GANDIVA_TEST(projector_test)
-ADD_GANDIVA_TEST(projector_build_validation_test)
-ADD_GANDIVA_TEST(if_expr_test)
-ADD_GANDIVA_TEST(literal_test)
-ADD_GANDIVA_TEST(boolean_expr_test)
-ADD_GANDIVA_TEST(binary_test)
-ADD_GANDIVA_TEST(date_time_test)
-ADD_GANDIVA_TEST(to_string_test)
-ADD_GANDIVA_TEST(hash_test)
-ADD_GANDIVA_TEST(in_expr_test)
-ADD_GANDIVA_TEST(null_validity_test)
-ADD_GANDIVA_TEST(decimal_test)
-ADD_GANDIVA_TEST(decimal_single_test)
+add_gandiva_test(filter_test)
+add_gandiva_test(projector_test)
+add_gandiva_test(projector_build_validation_test)
+add_gandiva_test(if_expr_test)
+add_gandiva_test(literal_test)
+add_gandiva_test(boolean_expr_test)
+add_gandiva_test(binary_test)
+add_gandiva_test(date_time_test)
+add_gandiva_test(to_string_test)
+add_gandiva_test(hash_test)
+add_gandiva_test(in_expr_test)
+add_gandiva_test(null_validity_test)
+add_gandiva_test(decimal_test)
+add_gandiva_test(decimal_single_test)
 
-ADD_GANDIVA_TEST(projector_test_static
-  SOURCES projector_test.cc
-  USE_STATIC_LINKING)
+add_gandiva_test(projector_test_static SOURCES projector_test.cc USE_STATIC_LINKING)
 
-ADD_ARROW_BENCHMARK(micro_benchmarks
-  PREFIX "gandiva"
-  EXTRA_LINK_LIBS gandiva_static)
+add_arrow_benchmark(micro_benchmarks PREFIX "gandiva" EXTRA_LINK_LIBS gandiva_static)

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -32,26 +32,26 @@ function(ADD_PARQUET_TEST REL_TEST_NAME)
   set(options USE_STATIC_LINKING)
   set(one_value_args)
   set(multi_value_args EXTRA_DEPENDENCIES LABELS)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  set(TEST_ARGUMENTS
-    PREFIX "parquet"
-    LABELS "parquet-tests")
+  set(TEST_ARGUMENTS PREFIX "parquet" LABELS "parquet-tests")
 
   # By default we prefer shared linking with libparquet, as it's faster
   # and uses less disk space, but in some cases we need to force static
   # linking (see rationale below).
-  if (ARG_USE_STATIC_LINKING)
-    ADD_TEST_CASE(${REL_TEST_NAME}
-      STATIC_LINK_LIBS ${PARQUET_STATIC_TEST_LINK_LIBS}
-      ${TEST_ARGUMENTS})
+  if(ARG_USE_STATIC_LINKING)
+    add_test_case(${REL_TEST_NAME} STATIC_LINK_LIBS ${PARQUET_STATIC_TEST_LINK_LIBS}
+                  ${TEST_ARGUMENTS})
   else()
-    ADD_TEST_CASE(${REL_TEST_NAME}
-      STATIC_LINK_LIBS ${PARQUET_SHARED_TEST_LINK_LIBS}
-      ${TEST_ARGUMENTS})
+    add_test_case(${REL_TEST_NAME} STATIC_LINK_LIBS ${PARQUET_SHARED_TEST_LINK_LIBS}
+                  ${TEST_ARGUMENTS})
   endif()
 endfunction()
 
@@ -59,17 +59,23 @@ function(ADD_PARQUET_BENCHMARK REL_TEST_NAME)
   set(options)
   set(one_value_args PREFIX)
   set(multi_value_args)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
-  if (ARG_PREFIX)
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
+  if(ARG_PREFIX)
     set(PREFIX ${ARG_PREFIX})
   else()
     set(PREFIX "parquet")
   endif()
-  ADD_BENCHMARK(${REL_TEST_NAME}
-    PREFIX ${PREFIX}
-    LABELS "parquet-benchmarks"
-    ${PARQUET_BENCHMARK_LINK_OPTION}
-    ${ARG_UNPARSED_ARGUMENTS})
+  add_benchmark(${REL_TEST_NAME}
+                PREFIX
+                ${PREFIX}
+                LABELS
+                "parquet-benchmarks"
+                ${PARQUET_BENCHMARK_LINK_OPTION}
+                ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
 # ----------------------------------------------------------------------
@@ -77,153 +83,124 @@ endfunction()
 
 # TODO(wesm): Handling of ABI/SO version
 
-if (ARROW_BUILD_STATIC)
-  set(PARQUET_STATIC_LINK_LIBS
-    arrow_static)
-  set(ARROW_LIBRARIES_FOR_STATIC_TESTS
-    arrow_testing_static
-    arrow_static)
+if(ARROW_BUILD_STATIC)
+  set(PARQUET_STATIC_LINK_LIBS arrow_static)
+  set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_static arrow_static)
 else()
-  set(ARROW_LIBRARIES_FOR_STATIC_TESTS
-    arrow_testing_shared
-    arrow_shared)
+  set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_shared arrow_shared)
 endif()
 
-set(PARQUET_BOOST_LINK_LIBS
-  ${BOOST_REGEX_LIBRARY})
+set(PARQUET_BOOST_LINK_LIBS ${BOOST_REGEX_LIBRARY})
 
 if(MSVC)
-  set(PARQUET_BOOST_LINK_LIBS ${PARQUET_BOOST_LINK_LIBS}
-    ${BOOST_SYSTEM_LIBRARY})
+  set(PARQUET_BOOST_LINK_LIBS ${PARQUET_BOOST_LINK_LIBS} ${BOOST_SYSTEM_LIBRARY})
 endif()
 
-set(PARQUET_MIN_TEST_LIBS
-  ${GTEST_MAIN_LIBRARY}
-  ${GTEST_LIBRARY})
+set(PARQUET_MIN_TEST_LIBS ${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
 
-if (APPLE)
-  set(PARQUET_MIN_TEST_LIBS
-    ${PARQUET_MIN_TEST_LIBS}
-    ${CMAKE_DL_LIBS})
+if(APPLE)
+  set(PARQUET_MIN_TEST_LIBS ${PARQUET_MIN_TEST_LIBS} ${CMAKE_DL_LIBS})
 elseif(NOT MSVC)
-  set(PARQUET_MIN_TEST_LIBS
-    ${PARQUET_MIN_TEST_LIBS}
-    pthread
-    ${CMAKE_DL_LIBS})
+  set(PARQUET_MIN_TEST_LIBS ${PARQUET_MIN_TEST_LIBS} pthread ${CMAKE_DL_LIBS})
 endif()
 
 set(PARQUET_SHARED_TEST_LINK_LIBS
-  arrow_testing_shared
-  ${PARQUET_MIN_TEST_LIBS}
-  parquet_shared
-  thriftstatic)
+    arrow_testing_shared
+    ${PARQUET_MIN_TEST_LIBS}
+    parquet_shared
+    thriftstatic)
 
-set(PARQUET_STATIC_TEST_LINK_LIBS
-  ${PARQUET_MIN_TEST_LIBS}
-  ${ARROW_LIBRARIES_FOR_STATIC_TESTS}
-  parquet_static)
+set(PARQUET_STATIC_TEST_LINK_LIBS ${PARQUET_MIN_TEST_LIBS}
+    ${ARROW_LIBRARIES_FOR_STATIC_TESTS} parquet_static)
 
-if (WIN32)
+if(WIN32)
   # The benchmarks depend on some static Thrift symbols
-  set(PARQUET_BENCHMARK_LINK_OPTION
-    STATIC_LINK_LIBS arrow_benchmark_main
-    parquet_static)
+  set(PARQUET_BENCHMARK_LINK_OPTION STATIC_LINK_LIBS arrow_benchmark_main parquet_static)
 else()
-  set(PARQUET_BENCHMARK_LINK_OPTION
-    EXTRA_LINK_LIBS parquet_shared)
+  set(PARQUET_BENCHMARK_LINK_OPTION EXTRA_LINK_LIBS parquet_shared)
 endif()
 
-############################################################
+#
 # Generated Thrift sources
 
-if (NOT MSVC)
-  set_source_files_properties(src/parquet/parquet_types.cpp PROPERTIES
-    COMPILE_FLAGS -Wno-unused-variable)
+if(NOT MSVC)
+  set_source_files_properties(src/parquet/parquet_types.cpp PROPERTIES COMPILE_FLAGS
+                              -Wno-unused-variable)
 endif()
 
 # List of thrift output targets
 set(THRIFT_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(THRIFT_OUTPUT_FILES "${THRIFT_OUTPUT_DIR}/parquet_types.cpp")
 set(THRIFT_OUTPUT_FILES ${THRIFT_OUTPUT_FILES} "${THRIFT_OUTPUT_DIR}/parquet_types.h")
-set(THRIFT_OUTPUT_FILES ${THRIFT_OUTPUT_FILES} "${THRIFT_OUTPUT_DIR}/parquet_constants.cpp")
+set(THRIFT_OUTPUT_FILES ${THRIFT_OUTPUT_FILES}
+    "${THRIFT_OUTPUT_DIR}/parquet_constants.cpp")
 set(THRIFT_OUTPUT_FILES ${THRIFT_OUTPUT_FILES} "${THRIFT_OUTPUT_DIR}/parquet_constants.h")
 
 set_source_files_properties(${THRIFT_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
 
 get_filename_component(ABS_PARQUET_THRIFT parquet.thrift ABSOLUTE)
 
-add_custom_command(
-  OUTPUT ${THRIFT_OUTPUT_FILES}
-  COMMAND ${THRIFT_COMPILER} --gen cpp -out ${THRIFT_OUTPUT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/parquet.thrift
-  DEPENDS ${ABS_PARQUET_THRIFT} thriftstatic
-  COMMENT "Running thrift compiler on parquet.thrift"
-  VERBATIM
-)
+add_custom_command(OUTPUT ${THRIFT_OUTPUT_FILES}
+                   COMMAND ${THRIFT_COMPILER}
+                           --gen cpp -out ${THRIFT_OUTPUT_DIR}
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/parquet.thrift
+                   DEPENDS ${ABS_PARQUET_THRIFT} thriftstatic
+                   COMMENT "Running thrift compiler on parquet.thrift"
+                   VERBATIM)
 
-############################################################
+#
 # Library config
 
 set(PARQUET_SRCS
-  arrow/reader.cc
-  arrow/record_reader.cc
-  arrow/schema.cc
-  arrow/writer.cc
-  bloom_filter.cc
-  column_reader.cc
-  column_scanner.cc
-  column_writer.cc
-  encoding.cc
-  file_reader.cc
-  file_writer.cc
-  metadata.cc
-  murmur3.cc
-  parquet_constants.cpp
-  parquet_types.cpp
-  printer.cc
-  schema.cc
-  statistics.cc
-  types.cc
-  util/comparison.cc
-  util/memory.cc
-)
+    arrow/reader.cc
+    arrow/record_reader.cc
+    arrow/schema.cc
+    arrow/writer.cc
+    bloom_filter.cc
+    column_reader.cc
+    column_scanner.cc
+    column_writer.cc
+    encoding.cc
+    file_reader.cc
+    file_writer.cc
+    metadata.cc
+    murmur3.cc
+    parquet_constants.cpp
+    parquet_types.cpp
+    printer.cc
+    schema.cc
+    statistics.cc
+    types.cc
+    util/comparison.cc
+    util/memory.cc)
 
 # Ensure that thrift compilation is done before using its generated headers
 # in parquet code.
-add_custom_target(parquet-thrift-deps ALL
-  DEPENDS ${THRIFT_OUTPUT_FILES})
+add_custom_target(parquet-thrift-deps ALL DEPENDS ${THRIFT_OUTPUT_FILES})
 set(PARQUET_DEPENDENCIES ${PARQUET_DEPENDENCIES} parquet-thrift-deps)
 
-if (NOT PARQUET_MINIMAL_DEPENDENCY)
-  set(PARQUET_SHARED_LINK_LIBS
-    arrow_shared)
+if(NOT PARQUET_MINIMAL_DEPENDENCY)
+  set(PARQUET_SHARED_LINK_LIBS arrow_shared)
 
-# These are libraries that we will link privately with parquet_shared (as they
-# do not need to be linked transitively by other linkers)
-  set(PARQUET_SHARED_PRIVATE_LINK_LIBS
-    ${PARQUET_BOOST_LINK_LIBS}
-    thriftstatic
-  )
+  # These are libraries that we will link privately with parquet_shared (as they
+  # do not need to be linked transitively by other linkers)
+  set(PARQUET_SHARED_PRIVATE_LINK_LIBS ${PARQUET_BOOST_LINK_LIBS} thriftstatic)
 
-# Link publicly with # parquet_static (because internal users need to
-# transitively link all dependencies)
-  set(PARQUET_STATIC_LINK_LIBS
-    ${PARQUET_STATIC_LINK_LIBS}
-    ${PARQUET_BOOST_LINK_LIBS}
-    thriftstatic
-  )
+  # Link publicly with # parquet_static (because internal users need to
+  # transitively link all dependencies)
+  set(PARQUET_STATIC_LINK_LIBS ${PARQUET_STATIC_LINK_LIBS} ${PARQUET_BOOST_LINK_LIBS}
+      thriftstatic)
 
-# Although we don't link parquet_objlib against anything, we need it to depend
-# on these libs as we may generate their headers via ExternalProject_Add
-if (ARROW_BUILD_SHARED)
-  set(PARQUET_DEPENDENCIES ${PARQUET_DEPENDENCIES}
-    ${PARQUET_SHARED_LINK_LIBS}
-    ${PARQUET_SHARED_PRIVATE_LINK_LIBS})
-endif()
+  # Although we don't link parquet_objlib against anything, we need it to depend
+  # on these libs as we may generate their headers via ExternalProject_Add
+  if(ARROW_BUILD_SHARED)
+    set(PARQUET_DEPENDENCIES ${PARQUET_DEPENDENCIES} ${PARQUET_SHARED_LINK_LIBS}
+        ${PARQUET_SHARED_PRIVATE_LINK_LIBS})
+  endif()
 
-if (ARROW_BUILD_STATIC)
-  set(PARQUET_DEPENDENCIES ${PARQUET_DEPENDENCIES}
-    ${PARQUET_STATIC_LINK_LIBS})
-endif()
+  if(ARROW_BUILD_STATIC)
+    set(PARQUET_DEPENDENCIES ${PARQUET_DEPENDENCIES} ${PARQUET_STATIC_LINK_LIBS})
+  endif()
 
 endif(NOT PARQUET_MINIMAL_DEPENDENCY)
 
@@ -231,49 +208,57 @@ if(NOT APPLE AND NOT MSVC)
   # Localize thirdparty symbols using a linker version script. This hides them
   # from the client application. The OS X linker does not support the
   # version-script option.
-  set(SHARED_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/parquet/symbols.map")
+  set(SHARED_LINK_FLAGS
+      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/parquet/symbols.map")
 endif()
 
 # Because of PARQUET-1420 (Thrift-generated symbols not exported in DLL),
 # parquet tests must be linked against the static parquet lib.
-if (NO_TESTS)
+if(NO_TESTS)
   set(PARQUET_LIB_OPTIONS)
-else ()
+else()
   set(PARQUET_LIB_OPTIONS "BUILD_STATIC")
 endif()
 
-ADD_ARROW_LIB(parquet
-  ${PARQUET_LIB_OPTIONS}
-  SOURCES ${PARQUET_SRCS}
-  OUTPUTS PARQUET_LIBRARIES
-  DEPENDENCIES ${PARQUET_DEPENDENCIES}
-  SHARED_LINK_FLAGS ${PARQUET_SHARED_LINK_FLAGS}
-  SHARED_LINK_LIBS ${PARQUET_SHARED_LINK_LIBS}
-  SHARED_PRIVATE_LINK_LIBS ${PARQUET_SHARED_PRIVATE_LINK_LIBS}
-  STATIC_LINK_LIBS ${PARQUET_STATIC_LINK_LIBS}
-)
+add_arrow_lib(parquet
+              ${PARQUET_LIB_OPTIONS}
+              SOURCES
+              ${PARQUET_SRCS}
+              OUTPUTS
+              PARQUET_LIBRARIES
+              DEPENDENCIES
+              ${PARQUET_DEPENDENCIES}
+              SHARED_LINK_FLAGS
+              ${PARQUET_SHARED_LINK_FLAGS}
+              SHARED_LINK_LIBS
+              ${PARQUET_SHARED_LINK_LIBS}
+              SHARED_PRIVATE_LINK_LIBS
+              ${PARQUET_SHARED_PRIVATE_LINK_LIBS}
+              STATIC_LINK_LIBS
+              ${PARQUET_STATIC_LINK_LIBS})
 
 add_dependencies(parquet ${PARQUET_LIBRARIES})
 
 # Thrift requires these definitions for some types that we use
 foreach(LIB_TARGET ${PARQUET_LIBRARIES})
   target_compile_definitions(${LIB_TARGET}
-    PRIVATE PARQUET_EXPORTING
-    PRIVATE HAVE_INTTYPES_H
-    PRIVATE HAVE_NETDB_H)
-  if (MSVC)
-    target_compile_definitions(${LIB_TARGET}
-      PRIVATE NOMINMAX)
+                             PRIVATE
+                             PARQUET_EXPORTING
+                             PRIVATE
+                             HAVE_INTTYPES_H
+                             PRIVATE
+                             HAVE_NETDB_H)
+  if(MSVC)
+    target_compile_definitions(${LIB_TARGET} PRIVATE NOMINMAX)
   else()
-    target_compile_definitions(${LIB_TARGET}
-      PRIVATE HAVE_NETINET_IN_H)
+    target_compile_definitions(${LIB_TARGET} PRIVATE HAVE_NETINET_IN_H)
   endif()
 endforeach()
 
 # We always build the Parquet static libraries (see PARQUET-1420) so we add the
 # PARQUET_STATIC public compile definition if we are building the unit tests OR
 # if we are building the static library
-if (WIN32 AND (NOT NO_TESTS OR ARROW_BUILD_STATIC))
+if(WIN32 AND (NOT NO_TESTS OR ARROW_BUILD_STATIC))
   target_compile_definitions(parquet_static PUBLIC PARQUET_STATIC)
 endif()
 
@@ -281,41 +266,38 @@ add_subdirectory(api)
 add_subdirectory(arrow)
 add_subdirectory(util)
 
-ARROW_INSTALL_ALL_HEADERS("parquet")
+arrow_install_all_headers("parquet")
 
-configure_file(parquet_version.h.in
-  "${CMAKE_CURRENT_BINARY_DIR}/parquet_version.h"
-  @ONLY)
+configure_file(parquet_version.h.in "${CMAKE_CURRENT_BINARY_DIR}/parquet_version.h" @ONLY)
 
-install(FILES
-  "${CMAKE_CURRENT_BINARY_DIR}/parquet_version.h"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/parquet_version.h"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet")
 
 # pkg-config support
-ARROW_ADD_PKG_CONFIG("parquet")
+arrow_add_pkg_config("parquet")
 
-ADD_PARQUET_TEST(bloom_filter-test)
-ADD_PARQUET_TEST(column_reader-test)
-ADD_PARQUET_TEST(column_scanner-test)
-ADD_PARQUET_TEST(column_writer-test)
-ADD_PARQUET_TEST(file-serialize-test)
-ADD_PARQUET_TEST(properties-test)
-ADD_PARQUET_TEST(statistics-test)
-ADD_PARQUET_TEST(encoding-test)
-ADD_PARQUET_TEST(metadata-test)
-ADD_PARQUET_TEST(public-api-test)
-ADD_PARQUET_TEST(types-test)
-ADD_PARQUET_TEST(reader-test)
+add_parquet_test(bloom_filter-test)
+add_parquet_test(column_reader-test)
+add_parquet_test(column_scanner-test)
+add_parquet_test(column_writer-test)
+add_parquet_test(file-serialize-test)
+add_parquet_test(properties-test)
+add_parquet_test(statistics-test)
+add_parquet_test(encoding-test)
+add_parquet_test(metadata-test)
+add_parquet_test(public-api-test)
+add_parquet_test(types-test)
+add_parquet_test(reader-test)
 
 # Those tests need to use static linking as they access thrift-generated
 # symbols which are not exported by parquet.dll on Windows (PARQUET-1420).
-ADD_PARQUET_TEST(file-deserialize-test USE_STATIC_LINKING)
-ADD_PARQUET_TEST(schema-test USE_STATIC_LINKING)
+add_parquet_test(file-deserialize-test USE_STATIC_LINKING)
+add_parquet_test(schema-test USE_STATIC_LINKING)
 
-ADD_PARQUET_BENCHMARK(column-io-benchmark)
-ADD_PARQUET_BENCHMARK(encoding-benchmark)
+add_parquet_benchmark(column-io-benchmark)
+add_parquet_benchmark(encoding-benchmark)
 
 # Required for tests, the ExternalProject for zstd does not build on CMake < 3.7
-if (ARROW_WITH_ZSTD)
+if(ARROW_WITH_ZSTD)
   add_definitions(-DARROW_WITH_ZSTD)
 endif()

--- a/cpp/src/parquet/api/CMakeLists.txt
+++ b/cpp/src/parquet/api/CMakeLists.txt
@@ -16,4 +16,4 @@
 # under the License.
 
 # Headers: public api
-ARROW_INSTALL_ALL_HEADERS("parquet/api")
+arrow_install_all_headers("parquet/api")

--- a/cpp/src/parquet/arrow/CMakeLists.txt
+++ b/cpp/src/parquet/arrow/CMakeLists.txt
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ADD_PARQUET_TEST(arrow-schema-test)
-ADD_PARQUET_TEST(arrow-reader-writer-test)
+add_parquet_test(arrow-schema-test)
+add_parquet_test(arrow-reader-writer-test)
 
-ADD_PARQUET_BENCHMARK(reader-writer-benchmark
-  PREFIX "parquet-arrow")
+add_parquet_benchmark(reader-writer-benchmark PREFIX "parquet-arrow")
 
-ARROW_INSTALL_ALL_HEADERS("parquet/arrow")
+arrow_install_all_headers("parquet/arrow")

--- a/cpp/src/parquet/util/CMakeLists.txt
+++ b/cpp/src/parquet/util/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 # Headers: util
-ARROW_INSTALL_ALL_HEADERS("parquet/util")
+arrow_install_all_headers("parquet/util")
 
-ADD_PARQUET_TEST(comparison-test)
-ADD_PARQUET_TEST(memory-test)
+add_parquet_test(comparison-test)
+add_parquet_test(memory-test)

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -31,18 +31,20 @@ find_package(Threads)
 set(PLASMA_SO_VERSION "${ARROW_SO_VERSION}")
 set(PLASMA_FULL_SO_VERSION "${ARROW_FULL_SO_VERSION}")
 
-include_directories("${FLATBUFFERS_INCLUDE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/" "${CMAKE_CURRENT_LIST_DIR}/thirdparty/" "${CMAKE_CURRENT_LIST_DIR}/../")
+include_directories("${FLATBUFFERS_INCLUDE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/"
+                    "${CMAKE_CURRENT_LIST_DIR}/thirdparty/"
+                    "${CMAKE_CURRENT_LIST_DIR}/../")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-conversion")
 
 # Compile flatbuffers
 
-set(PLASMA_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/plasma.fbs" "${CMAKE_CURRENT_LIST_DIR}/format/common.fbs")
+set(PLASMA_FBS_SRC "${CMAKE_CURRENT_LIST_DIR}/format/plasma.fbs"
+    "${CMAKE_CURRENT_LIST_DIR}/format/common.fbs")
 set(OUTPUT_DIR ${ARROW_BINARY_DIR}/src/plasma)
 
-set(PLASMA_FBS_OUTPUT_FILES
-  "${OUTPUT_DIR}/common_generated.h"
-  "${OUTPUT_DIR}/plasma_generated.h")
+set(PLASMA_FBS_OUTPUT_FILES "${OUTPUT_DIR}/common_generated.h"
+    "${OUTPUT_DIR}/plasma_generated.h")
 
 add_custom_target(gen_plasma_fbs DEPENDS ${PLASMA_FBS_OUTPUT_FILES})
 
@@ -52,11 +54,13 @@ endif()
 
 add_custom_command(
   OUTPUT ${PLASMA_FBS_OUTPUT_FILES}
-  # The --gen-object-api flag generates a C++ class MessageT for each
-  # flatbuffers message Message, which can be used to store deserialized
-  # messages in data structures. This is currently used for ObjectInfo for
-  # example.
-  COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${PLASMA_FBS_SRC} --gen-object-api --scoped-enums
+         # The --gen-object-api flag generates a C++ class MessageT for each
+         # flatbuffers message Message, which can be used to store deserialized
+         # messages in data structures. This is currently used for ObjectInfo for
+         # example.
+  COMMAND ${FLATBUFFERS_COMPILER} -c -o ${OUTPUT_DIR} ${PLASMA_FBS_SRC}
+          --gen-object-api
+          --scoped-enums
   DEPENDS ${PLASMA_FBS_SRC}
   COMMENT "Running flatc compiler on ${PLASMA_FBS_SRC}"
   VERBATIM)
@@ -64,61 +68,60 @@ add_custom_command(
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 set(PLASMA_SRCS
-  client.cc
-  common.cc
-  eviction_policy.cc
-  events.cc
-  fling.cc
-  io.cc
-  malloc.cc
-  plasma.cc
-  plasma_allocator.cc
-  protocol.cc
-  thirdparty/ae/ae.c)
+    client.cc
+    common.cc
+    eviction_policy.cc
+    events.cc
+    fling.cc
+    io.cc
+    malloc.cc
+    plasma.cc
+    plasma_allocator.cc
+    protocol.cc
+    thirdparty/ae/ae.c)
 
 set(PLASMA_LINK_LIBS arrow_shared)
 set(PLASMA_STATIC_LINK_LIBS arrow_static)
 
-if (ARROW_CUDA)
+if(ARROW_CUDA)
   set(PLASMA_LINK_LIBS ${PLASMA_LINK_LIBS} arrow_cuda_shared)
   set(PLASMA_STATIC_LINK_LIBS arrow_cuda_static ${PLASMA_STATIC_LINK_LIBS})
   add_definitions(-DPLASMA_CUDA)
 endif()
 
-ADD_ARROW_LIB(plasma
-  SOURCES ${PLASMA_SRCS}
-  OUTPUTS PLASMA_LIBRARIES
-  DEPENDENCIES gen_plasma_fbs
-  SHARED_LINK_LIBS ${PLASMA_LINK_LIBS}
-  STATIC_LINK_LIBS ${PLASMA_STATIC_LINK_LIBS})
+add_arrow_lib(plasma
+              SOURCES
+              ${PLASMA_SRCS}
+              OUTPUTS
+              PLASMA_LIBRARIES
+              DEPENDENCIES
+              gen_plasma_fbs
+              SHARED_LINK_LIBS
+              ${PLASMA_LINK_LIBS}
+              STATIC_LINK_LIBS
+              ${PLASMA_STATIC_LINK_LIBS})
 
 add_dependencies(plasma ${PLASMA_LIBRARIES})
 
 foreach(LIB_TARGET ${PLASMA_LIBRARIES})
-  target_compile_definitions(${LIB_TARGET}
-    PRIVATE ARROW_EXPORTING)
+  target_compile_definitions(${LIB_TARGET} PRIVATE ARROW_EXPORTING)
 endforeach()
 
 # The optimization flag -O3 is suggested by dlmalloc.c, which is #included in
 # malloc.cc; we set it here regardless of whether we do a debug or release build.
-set_source_files_properties(malloc.cc PROPERTIES
-  COMPILE_FLAGS "-O3")
+set_source_files_properties(malloc.cc PROPERTIES COMPILE_FLAGS "-O3")
 
-if ("${COMPILER_FAMILY}" STREQUAL "clang")
+if("${COMPILER_FAMILY}" STREQUAL "clang")
   set_property(SOURCE malloc.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS
-    " -Wno-parentheses-equality \
+               APPEND_STRING
+               PROPERTY COMPILE_FLAGS " -Wno-parentheses-equality \
 -Wno-null-pointer-arithmetic \
 -Wno-shorten-64-to-32 \
 -Wno-unused-macros")
 endif()
 
-if ("${COMPILER_FAMILY}" STREQUAL "gcc")
-  set_property(SOURCE malloc.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS
-    " -Wno-conversion")
+if("${COMPILER_FAMILY}" STREQUAL "gcc")
+  set_property(SOURCE malloc.cc APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-conversion")
 endif()
 
 list(APPEND PLASMA_EXTERNAL_STORE_SOURCES "external_store.cc" "hash_table_store.cc")
@@ -129,32 +132,30 @@ add_executable(plasma_store_server ${PLASMA_EXTERNAL_STORE_SOURCES} store.cc)
 target_link_libraries(plasma_store_server plasma_static ${PLASMA_STATIC_LINK_LIBS})
 add_dependencies(plasma plasma_store_server)
 
-if (ARROW_RPATH_ORIGIN)
-  if (APPLE)
+if(ARROW_RPATH_ORIGIN)
+  if(APPLE)
     set(_lib_install_rpath "@loader_path")
   else()
     set(_lib_install_rpath "\$ORIGIN")
   endif()
-  set_target_properties(plasma_store_server PROPERTIES
-      INSTALL_RPATH ${_lib_install_rpath})
+  set_target_properties(plasma_store_server
+                        PROPERTIES INSTALL_RPATH ${_lib_install_rpath})
 endif()
 
-install(FILES
-  common.h
-  compat.h
-  client.h
-  events.h
-  test-util.h
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/plasma")
+install(FILES common.h
+              compat.h
+              client.h
+              events.h
+              test-util.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/plasma")
 
 # Plasma store
 set_target_properties(plasma_store_server PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-install(TARGETS plasma_store_server
-  ${INSTALL_IS_OPTIONAL}
-  DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS plasma_store_server ${INSTALL_IS_OPTIONAL}
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # pkg-config support
-ARROW_ADD_PKG_CONFIG("plasma")
+arrow_add_pkg_config("plasma")
 
 if(ARROW_PLASMA_JAVA_CLIENT)
   # Plasma java client support
@@ -162,11 +163,11 @@ if(ARROW_PLASMA_JAVA_CLIENT)
   # add jni support
   include_directories(${JAVA_INCLUDE_PATH})
   include_directories(${JAVA_INCLUDE_PATH2})
-  if (JNI_FOUND)
-    message (STATUS "JNI_INCLUDE_DIRS = ${JNI_INCLUDE_DIRS}")
-    message (STATUS "JNI_LIBRARIES = ${JNI_LIBRARIES}")
+  if(JNI_FOUND)
+    message(STATUS "JNI_INCLUDE_DIRS = ${JNI_INCLUDE_DIRS}")
+    message(STATUS "JNI_LIBRARIES = ${JNI_LIBRARIES}")
   else()
-    message (WARNING "Could not find JNI")
+    message(WARNING "Could not find JNI")
   endif()
 
   add_compile_options("-I$ENV{JAVA_HOME}/include/")
@@ -180,38 +181,61 @@ if(ARROW_PLASMA_JAVA_CLIENT)
 
   include_directories("${CMAKE_CURRENT_LIST_DIR}/lib/java")
 
-  file(GLOB PLASMA_LIBRARY_EXT_java_SRC
-    lib/java/*.cc lib/*.cc)
-  add_library(plasma_java SHARED
-    ${PLASMA_LIBRARY_EXT_java_SRC})
+  file(GLOB PLASMA_LIBRARY_EXT_java_SRC lib/java/*.cc lib/*.cc)
+  add_library(plasma_java SHARED ${PLASMA_LIBRARY_EXT_java_SRC})
 
   if(APPLE)
-    target_link_libraries(plasma_java plasma_shared ${PLASMA_LINK_LIBS} "-undefined dynamic_lookup" -Wl,-force_load,${FLATBUFFERS_STATIC_LIB} ${FLATBUFFERS_STATIC_LIB} ${PTHREAD_LIBRARY})
+    target_link_libraries(plasma_java
+                          plasma_shared
+                          ${PLASMA_LINK_LIBS}
+                          "-undefined dynamic_lookup"
+                          -Wl,-force_load,${FLATBUFFERS_STATIC_LIB}
+                          ${FLATBUFFERS_STATIC_LIB}
+                          ${PTHREAD_LIBRARY})
   else(APPLE)
-    target_link_libraries(plasma_java plasma_shared ${PLASMA_LINK_LIBS} -Wl,--whole-archive ${FLATBUFFERS_STATIC_LIB} -Wl,--no-whole-archive ${FLATBUFFERS_STATIC_LIB} ${PTHREAD_LIBRARY})
+    target_link_libraries(plasma_java
+                          plasma_shared
+                          ${PLASMA_LINK_LIBS}
+                          -Wl,--whole-archive
+                          ${FLATBUFFERS_STATIC_LIB}
+                          -Wl,--no-whole-archive
+                          ${FLATBUFFERS_STATIC_LIB}
+                          ${PTHREAD_LIBRARY})
   endif(APPLE)
 endif()
-#######################################
+#
 # Unit tests
-#######################################
+#
 
 # Adding unit tests part of the "arrow" portion of the test suite
 function(ADD_PLASMA_TEST REL_TEST_NAME)
   set(options)
   set(one_value_args)
   set(multi_value_args)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
-  ADD_TEST_CASE(${REL_TEST_NAME}
-    PREFIX "plasma"
-    LABELS "plasma-tests"
-    ${ARG_UNPARSED_ARGUMENTS})
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
+  add_test_case(${REL_TEST_NAME}
+                PREFIX
+                "plasma"
+                LABELS
+                "plasma-tests"
+                ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
-ADD_PLASMA_TEST(test/serialization_tests
-  EXTRA_LINK_LIBS plasma_shared ${PLASMA_LINK_LIBS})
-ADD_PLASMA_TEST(test/client_tests
-  EXTRA_LINK_LIBS plasma_shared ${PLASMA_LINK_LIBS}
-  EXTRA_DEPENDENCIES plasma_store_server)
-ADD_PLASMA_TEST(test/external_store_tests
-  EXTRA_LINK_LIBS plasma_shared ${PLASMA_LINK_LIBS}
-  EXTRA_DEPENDENCIES plasma_store_server)
+add_plasma_test(test/serialization_tests EXTRA_LINK_LIBS plasma_shared
+                ${PLASMA_LINK_LIBS})
+add_plasma_test(test/client_tests
+                EXTRA_LINK_LIBS
+                plasma_shared
+                ${PLASMA_LINK_LIBS}
+                EXTRA_DEPENDENCIES
+                plasma_store_server)
+add_plasma_test(test/external_store_tests
+                EXTRA_LINK_LIBS
+                plasma_shared
+                ${PLASMA_LINK_LIBS}
+                EXTRA_DEPENDENCIES
+                plasma_store_server)

--- a/cpp/tools/parquet/CMakeLists.txt
+++ b/cpp/tools/parquet/CMakeLists.txt
@@ -15,20 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if (PARQUET_BUILD_EXECUTABLES)
-  set(PARQUET_TOOLS
-    parquet-dump-schema
-    parquet-reader
-    parquet-scan)
+if(PARQUET_BUILD_EXECUTABLES)
+  set(PARQUET_TOOLS parquet-dump-schema parquet-reader parquet-scan)
 
   foreach(TOOL ${PARQUET_TOOLS})
     add_executable(${TOOL} "${TOOL}.cc")
     target_link_libraries(${TOOL} parquet_static)
     # Avoid unsetting RPATH when installing
     set_target_properties(${TOOL} PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-    install(TARGETS ${TOOL}
-      ${INSTALL_IS_OPTIONAL}
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(TARGETS ${TOOL} ${INSTALL_IS_OPTIONAL}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   endforeach(TOOL)
 
   add_dependencies(parquet ${PARQUET_TOOLS})

--- a/java/gandiva/CMakeLists.txt
+++ b/java/gandiva/CMakeLists.txt
@@ -23,12 +23,12 @@ include(UseJava)
 include(FindJNI)
 
 message("generating headers to ${JNI_HEADERS_DIR}/jni")
-add_jar(
-  gandiva_java
-    src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
-    src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
-    src/main/java/org/apache/arrow/gandiva/evaluator/ExpressionRegistryJniHelper.java
-    src/main/java/org/apache/arrow/gandiva/exceptions/GandivaException.java
-  GENERATE_NATIVE_HEADERS gandivajni_headers
-    DESTINATION ${JNI_HEADERS_DIR}/jni
-)
+add_jar(gandiva_java
+        src/main/java/org/apache/arrow/gandiva/evaluator/ConfigurationBuilder.java
+        src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
+        src/main/java/org/apache/arrow/gandiva/evaluator/ExpressionRegistryJniHelper.java
+        src/main/java/org/apache/arrow/gandiva/exceptions/GandivaException.java
+        GENERATE_NATIVE_HEADERS
+        gandivajni_headers
+        DESTINATION
+        ${JNI_HEADERS_DIR}/jni)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -23,13 +23,13 @@ project(pyarrow)
 
 # Running from a Python sdist tarball
 set(LOCAL_CMAKE_MODULES "${CMAKE_SOURCE_DIR}/cmake_modules")
-if (EXISTS "${LOCAL_CMAKE_MODULES}")
+if(EXISTS "${LOCAL_CMAKE_MODULES}")
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${LOCAL_CMAKE_MODULES})
 endif()
 
 # Running from a git source tree
 set(CPP_CMAKE_MODULES "${CMAKE_SOURCE_DIR}/../cpp/cmake_modules")
-if (EXISTS "${CPP_CMAKE_MODULES}")
+if(EXISTS "${CPP_CMAKE_MODULES}")
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CPP_CMAKE_MODULES})
 endif()
 
@@ -52,47 +52,25 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9)
 # Generate a Clang compile_commands.json "compilation database" file for use
 # with various development tools, such as Vim's YouCompleteMe plugin.
 # See http://clang.llvm.org/docs/JSONCompilationDatabase.html
-if ("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1")
+if("$ENV{CMAKE_EXPORT_COMPILE_COMMANDS}" STREQUAL "1")
   set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 endif()
 
 # Top level cmake dir
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
-  option(PYARROW_BUILD_CUDA
-    "Build the PyArrow CUDA support"
-    OFF)
-  option(PYARROW_BUILD_GANDIVA
-    "Build the PyArrow Gandiva integration"
-    OFF)
-  option(PYARROW_BUILD_PARQUET
-    "Build the PyArrow Parquet integration"
-    OFF)
-  option(PYARROW_PARQUET_USE_SHARED
-    "Rely on parquet shared libraries where relevant"
-    ON)
+  option(PYARROW_BUILD_CUDA "Build the PyArrow CUDA support" OFF)
+  option(PYARROW_BUILD_GANDIVA "Build the PyArrow Gandiva integration" OFF)
+  option(PYARROW_BUILD_PARQUET "Build the PyArrow Parquet integration" OFF)
+  option(PYARROW_PARQUET_USE_SHARED "Rely on parquet shared libraries where relevant" ON)
   option(PYARROW_BOOST_USE_SHARED
-    "Rely on boost shared libraries on linking static parquet"
-    ON)
-  option(PYARROW_BUILD_PLASMA
-    "Build the PyArrow Plasma integration"
-    OFF)
-  option(PYARROW_USE_TENSORFLOW
-    "Build PyArrow with TensorFlow support"
-    OFF)
-  option(PYARROW_BUILD_ORC
-    "Build the PyArrow ORC integration"
-    OFF)
-  option(PYARROW_BUNDLE_ARROW_CPP
-    "Bundle the Arrow C++ libraries"
-    OFF)
-  option(PYARROW_BUNDLE_BOOST
-    "Bundle the Boost libraries when we bundle Arrow C++"
-    OFF)
-  option(PYARROW_GENERATE_COVERAGE
-    "Build with Cython code coverage enabled"
-    OFF)
-  set(PYARROW_CXXFLAGS "" CACHE STRING
-    "Compiler flags to append when compiling Arrow")
+         "Rely on boost shared libraries on linking static parquet" ON)
+  option(PYARROW_BUILD_PLASMA "Build the PyArrow Plasma integration" OFF)
+  option(PYARROW_USE_TENSORFLOW "Build PyArrow with TensorFlow support" OFF)
+  option(PYARROW_BUILD_ORC "Build the PyArrow ORC integration" OFF)
+  option(PYARROW_BUNDLE_ARROW_CPP "Bundle the Arrow C++ libraries" OFF)
+  option(PYARROW_BUNDLE_BOOST "Bundle the Boost libraries when we bundle Arrow C++" OFF)
+  option(PYARROW_GENERATE_COVERAGE "Build with Cython code coverage enabled" OFF)
+  set(PYARROW_CXXFLAGS "" CACHE STRING "Compiler flags to append when compiling Arrow")
 endif()
 
 find_program(CCACHE_FOUND ccache)
@@ -101,9 +79,9 @@ if(CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-############################################################
+#
 # Compiler flags
-############################################################
+#
 
 include(BuildUtils)
 include(CompilerInfo)
@@ -117,7 +95,7 @@ include(SetupCxxFlags)
 set(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${PYARROW_CXXFLAGS}")
 
-if (NOT MSVC)
+if(NOT MSVC)
   # Enable perf and other tools to work properly
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
 
@@ -140,7 +118,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4804")
 endif()
 
-if ("${COMPILER_FAMILY}" STREQUAL "clang")
+if("${COMPILER_FAMILY}" STREQUAL "clang")
   # Cython warnings in clang
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-parentheses-equality")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-constant-logical-operand")
@@ -158,27 +136,28 @@ set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")
 # Add C++-only flags, like -std=c++11
 set(CMAKE_CXX_FLAGS "${CXX_ONLY_FLAGS} ${CMAKE_CXX_FLAGS}")
 
-if (MSVC)
+if(MSVC)
   # MSVC makes its own output directories based on the build configuration
   set(BUILD_SUBDIR_NAME "")
 else()
   # Set compile output directory
-  string (TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
+  string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_SUBDIR_NAME)
 endif()
 
 # If build in-source, create the latest symlink. If build out-of-source, which is
 # preferred, simply output the binaries in the build folder
-if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
-  set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/build/${BUILD_SUBDIR_NAME}")
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
+  set(BUILD_OUTPUT_ROOT_DIRECTORY
+      "${CMAKE_CURRENT_BINARY_DIR}/build/${BUILD_SUBDIR_NAME}")
   # Link build/latest to the current build directory, to avoid developers
   # accidentally running the latest debug build when in fact they're building
   # release builds.
-  FILE(MAKE_DIRECTORY ${BUILD_OUTPUT_ROOT_DIRECTORY})
-  if (NOT APPLE)
+  file(MAKE_DIRECTORY ${BUILD_OUTPUT_ROOT_DIRECTORY})
+  if(NOT APPLE)
     set(MORE_ARGS "-T")
   endif()
-  EXECUTE_PROCESS(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
-    ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
+  execute_process(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
+                          ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
 else()
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUBDIR_NAME}")
 endif()
@@ -196,26 +175,23 @@ set(LIBRARY_OUTPUT_DIRECTORY "${BUILD_OUTPUT_ROOT_DIRECTORY}")
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_OUTPUT_ROOT_DIRECTORY}")
 
-if (PYARROW_USE_TENSORFLOW)
+if(PYARROW_USE_TENSORFLOW)
   # TensorFlow uses the old GLIBCXX ABI, so we have to use it too
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
 endif()
 
-## Python and libraries
+# Python and libraries
 find_package(PythonLibsNew REQUIRED)
 find_package(NumPy REQUIRED)
 include(UseCython)
 
-include_directories(SYSTEM
-  ${NUMPY_INCLUDE_DIRS}
-  ${PYTHON_INCLUDE_DIRS}
-  src)
+include_directories(SYSTEM ${NUMPY_INCLUDE_DIRS} ${PYTHON_INCLUDE_DIRS} src)
 
-############################################################
+#
 # Dependencies
-############################################################
+#
 
-## Arrow
+# Arrow
 find_package(Arrow REQUIRED)
 include_directories(SYSTEM ${ARROW_INCLUDE_DIR})
 
@@ -223,31 +199,39 @@ function(bundle_arrow_lib library_path)
   set(options)
   set(one_value_args ABI_VERSION SO_VERSION)
   set(multi_value_args)
-  cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(SEND_ERROR "Error: unrecognized arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
   get_filename_component(LIBRARY_DIR ${${library_path}} DIRECTORY)
   get_filename_component(LIBRARY_NAME ${${library_path}} NAME_WE)
-  configure_file(${${library_path}}
-      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-      COPYONLY)
+  configure_file(
+    ${${library_path}}
+    ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX} COPYONLY)
 
-  if (APPLE)
-    configure_file(${LIBRARY_DIR}/${LIBRARY_NAME}.${ARG_ABI_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}.${ARG_ABI_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        COPYONLY)
-    configure_file(${LIBRARY_DIR}/${LIBRARY_NAME}.${ARG_SO_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}.${ARG_SO_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        COPYONLY)
+  if(APPLE)
+    configure_file(
+      ${LIBRARY_DIR}/${LIBRARY_NAME}.${ARG_ABI_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}.${ARG_ABI_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      COPYONLY)
+    configure_file(
+      ${LIBRARY_DIR}/${LIBRARY_NAME}.${ARG_SO_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}.${ARG_SO_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
+      COPYONLY)
   elseif(NOT MSVC)
-    configure_file(${${library_path}}.${ARG_ABI_VERSION}
-        ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}.${ARG_ABI_VERSION}
-        COPYONLY)
-    configure_file(${${library_path}}.${ARG_SO_VERSION}
-        ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}.${ARG_SO_VERSION}
-        COPYONLY)
+    configure_file(
+      ${${library_path}}.${ARG_ABI_VERSION}
+      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}.${ARG_ABI_VERSION}
+      COPYONLY)
+    configure_file(
+      ${${library_path}}.${ARG_SO_VERSION}
+      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}.${ARG_SO_VERSION}
+      COPYONLY)
   endif()
 
 endfunction(bundle_arrow_lib)
@@ -255,26 +239,27 @@ endfunction(bundle_arrow_lib)
 function(bundle_arrow_implib library_path)
   get_filename_component(LIBRARY_DIR ${${library_path}} DIRECTORY)
   get_filename_component(LIBRARY_NAME ${${library_path}} NAME_WE)
-  configure_file(${${library_path}}
-      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}.lib
-      COPYONLY)
+  configure_file(${${library_path}} ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}.lib
+                 COPYONLY)
 endfunction(bundle_arrow_implib)
 
 function(bundle_boost_lib library_path)
   get_filename_component(LIBRARY_NAME ${${library_path}} NAME)
   get_filename_component(LIBRARY_NAME_WE ${${library_path}} NAME_WE)
-  configure_file(${${library_path}}
-      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}
+  configure_file(${${library_path}} ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME}
+                 COPYONLY)
+  set(Boost_SO_VERSION
+      "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+  if(APPLE)
+    configure_file(
+      ${${library_path}}
+      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME_WE}.${Boost_SO_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
       COPYONLY)
-  set(Boost_SO_VERSION "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
-  if (APPLE)
-    configure_file(${${library_path}}
-        ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME_WE}.${Boost_SO_VERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        COPYONLY)
   else()
-    configure_file(${${library_path}}
-        ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME_WE}${CMAKE_SHARED_LIBRARY_SUFFIX}.${Boost_SO_VERSION}
-        COPYONLY)
+    configure_file(
+      ${${library_path}}
+      ${BUILD_OUTPUT_ROOT_DIRECTORY}/${LIBRARY_NAME_WE}${CMAKE_SHARED_LIBRARY_SUFFIX}.${Boost_SO_VERSION}
+      COPYONLY)
   endif()
 endfunction()
 
@@ -282,27 +267,26 @@ function(bundle_zlib)
   # We can assume that manylinux1 and macosx have system zlib.
   # See https://mail.python.org/mm3/archives/list/distutils-sig@python.org/thread/ZZG6GL3XTBLBJXSITYHEXMFKN43EREB7/
   # for manylinux1.
-  if (MSVC)
+  if(MSVC)
     # zlib uses zlib.dll for Windows
     set(ZLIB_SHARED_LIB_NAME zlib.dll)
-    if (DEFINED ENV{ARROW_BUILD_TOOLCHAIN})
+    if(DEFINED ENV{ARROW_BUILD_TOOLCHAIN})
       set(ZLIB_HOME "$ENV{ARROW_BUILD_TOOLCHAIN}")
     endif()
-    if (DEFINED ENV{ZLIB_HOME})
+    if(DEFINED ENV{ZLIB_HOME})
       set(ZLIB_HOME "$ENV{ZLIB_HOME}")
     endif()
-    if ("${ZLIB_HOME}" STREQUAL "")
+    if("${ZLIB_HOME}" STREQUAL "")
       find_library(ZLIB_SHARED_LIB NAMES ${ZLIB_SHARED_LIB_NAME})
     else()
       find_library(ZLIB_SHARED_LIB
-	NAMES ${ZLIB_SHARED_LIB_NAME}
-	PATHS ${ZLIB_HOME} NO_DEFAULT_PATH
-	PATH_SUFFIXES "bin")
+                   NAMES ${ZLIB_SHARED_LIB_NAME}
+                   PATHS ${ZLIB_HOME}
+                   NO_DEFAULT_PATH
+                   PATH_SUFFIXES "bin")
     endif()
-    if (ZLIB_SHARED_LIB)
-      file(COPY
-	${ZLIB_SHARED_LIB}
-	DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY})
+    if(ZLIB_SHARED_LIB)
+      file(COPY ${ZLIB_SHARED_LIB} DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY})
     endif()
   endif()
 endfunction()
@@ -310,33 +294,44 @@ endfunction()
 # Always bundle includes
 file(COPY ${ARROW_INCLUDE_DIR}/arrow DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
 
-if (PYARROW_BUNDLE_ARROW_CPP)
+if(PYARROW_BUNDLE_ARROW_CPP)
   # arrow
   bundle_arrow_lib(ARROW_SHARED_LIB
-    ABI_VERSION ${ARROW_ABI_VERSION}
-    SO_VERSION ${ARROW_SO_VERSION})
+                   ABI_VERSION
+                   ${ARROW_ABI_VERSION}
+                   SO_VERSION
+                   ${ARROW_SO_VERSION})
   bundle_arrow_lib(ARROW_PYTHON_SHARED_LIB
-    ABI_VERSION ${ARROW_ABI_VERSION}
-    SO_VERSION ${ARROW_SO_VERSION})
+                   ABI_VERSION
+                   ${ARROW_ABI_VERSION}
+                   SO_VERSION
+                   ${ARROW_SO_VERSION})
 
   # boost
-  if (PYARROW_BOOST_USE_SHARED AND PYARROW_BUNDLE_BOOST)
+  if(PYARROW_BOOST_USE_SHARED AND PYARROW_BUNDLE_BOOST)
     set(Boost_USE_STATIC_LIBS OFF)
     set(Boost_USE_MULTITHREADED ON)
-    if (MSVC AND ARROW_USE_STATIC_CRT)
+    if(MSVC AND ARROW_USE_STATIC_CRT)
       set(Boost_USE_STATIC_RUNTIME ON)
     endif()
     set(Boost_ADDITIONAL_VERSIONS
-      "1.66.0" "1.66"
-      "1.65.0" "1.65"
-      "1.64.0" "1.64"
-      "1.63.0" "1.63"
-      "1.62.0" "1.61"
-      "1.61.0" "1.62"
-      "1.60.0" "1.60")
+        "1.66.0"
+        "1.66"
+        "1.65.0"
+        "1.65"
+        "1.64.0"
+        "1.64"
+        "1.63.0"
+        "1.63"
+        "1.62.0"
+        "1.61"
+        "1.61.0"
+        "1.62"
+        "1.60.0"
+        "1.60")
     list(GET Boost_ADDITIONAL_VERSIONS 0 BOOST_LATEST_VERSION)
     string(REPLACE "." "_" BOOST_LATEST_VERSION_IN_PATH ${BOOST_LATEST_VERSION})
-    if (MSVC)
+    if(MSVC)
       # disable autolinking in boost
       add_definitions(-DBOOST_ALL_NO_LIB)
     endif()
@@ -348,69 +343,60 @@ if (PYARROW_BUNDLE_ARROW_CPP)
 
   bundle_zlib()
 
-  if (MSVC)
+  if(MSVC)
     bundle_arrow_implib(ARROW_SHARED_IMP_LIB)
     bundle_arrow_implib(ARROW_PYTHON_SHARED_IMP_LIB)
   endif()
 endif()
 
-if (MSVC)
-  ADD_THIRDPARTY_LIB(arrow
-    SHARED_LIB ${ARROW_SHARED_IMP_LIB})
-  ADD_THIRDPARTY_LIB(arrow_python
-    SHARED_LIB ${ARROW_PYTHON_SHARED_IMP_LIB})
+if(MSVC)
+  add_thirdparty_lib(arrow SHARED_LIB ${ARROW_SHARED_IMP_LIB})
+  add_thirdparty_lib(arrow_python SHARED_LIB ${ARROW_PYTHON_SHARED_IMP_LIB})
 else()
-  ADD_THIRDPARTY_LIB(arrow
-    SHARED_LIB ${ARROW_SHARED_LIB})
-  ADD_THIRDPARTY_LIB(arrow_python
-    SHARED_LIB ${ARROW_PYTHON_SHARED_LIB})
+  add_thirdparty_lib(arrow SHARED_LIB ${ARROW_SHARED_LIB})
+  add_thirdparty_lib(arrow_python SHARED_LIB ${ARROW_PYTHON_SHARED_LIB})
 endif()
 
-############################################################
+#
 # Subdirectories
-############################################################
+#
 
-if (UNIX)
+if(UNIX)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 endif()
 
-set(CYTHON_EXTENSIONS
-  lib _csv
-)
+set(CYTHON_EXTENSIONS lib _csv)
 
-set(LINK_LIBS
-  arrow_shared
-  arrow_python_shared
-)
+set(LINK_LIBS arrow_shared arrow_python_shared)
 
-if (PYARROW_BUILD_CUDA)
-  ## Arrow CUDA
+if(PYARROW_BUILD_CUDA)
+  # Arrow CUDA
   find_package(ArrowCuda)
   if(NOT ARROW_CUDA_FOUND)
     message(FATAL_ERROR "Unable to locate Arrow CUDA libraries")
   else()
-    if (PYARROW_BUNDLE_ARROW_CPP)
+    if(PYARROW_BUNDLE_ARROW_CPP)
       bundle_arrow_lib(ARROW_CUDA_SHARED_LIB
-        ABI_VERSION ${ARROW_ABI_VERSION}
-        SO_VERSION ${ARROW_SO_VERSION})
-      if (MSVC)
+                       ABI_VERSION
+                       ${ARROW_ABI_VERSION}
+                       SO_VERSION
+                       ${ARROW_SO_VERSION})
+      if(MSVC)
         bundle_arrow_implib(ARROW_CUDA_SHARED_IMP_LIB)
       endif()
     endif()
-    if (MSVC)
-      ADD_THIRDPARTY_LIB(arrow_cuda
-        SHARED_LIB ${ARROW_CUDA_SHARED_IMP_LIB})
+    if(MSVC)
+      add_thirdparty_lib(arrow_cuda SHARED_LIB ${ARROW_CUDA_SHARED_IMP_LIB})
     else()
-      ADD_THIRDPARTY_LIB(arrow_cuda
-        SHARED_LIB ${ARROW_CUDA_SHARED_LIB})
+      add_thirdparty_lib(arrow_cuda SHARED_LIB ${ARROW_CUDA_SHARED_LIB})
     endif()
     set(LINK_LIBS ${LINK_LIBS} arrow_cuda_shared)
     set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} _cuda)
   endif()
 endif()
 
-if (PYARROW_BUILD_PARQUET)
-  ## Parquet
+if(PYARROW_BUILD_PARQUET)
+  # Parquet
   find_package(Parquet)
 
   if(NOT PARQUET_FOUND)
@@ -418,56 +404,46 @@ if (PYARROW_BUILD_PARQUET)
   endif()
   include_directories(SYSTEM ${PARQUET_INCLUDE_DIR})
 
-  if (PYARROW_BUNDLE_ARROW_CPP)
-    file(COPY ${PARQUET_INCLUDE_DIR}/parquet DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
+  if(PYARROW_BUNDLE_ARROW_CPP)
+    file(COPY ${PARQUET_INCLUDE_DIR}/parquet DESTINATION
+         ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
   endif()
 
-  if (PYARROW_PARQUET_USE_SHARED)
-    if (PYARROW_BUNDLE_ARROW_CPP)
+  if(PYARROW_PARQUET_USE_SHARED)
+    if(PYARROW_BUNDLE_ARROW_CPP)
       bundle_arrow_lib(PARQUET_SHARED_LIB
-        ABI_VERSION ${PARQUET_ABI_VERSION}
-        SO_VERSION ${PARQUET_SO_VERSION})
-      if (MSVC)
+                       ABI_VERSION
+                       ${PARQUET_ABI_VERSION}
+                       SO_VERSION
+                       ${PARQUET_SO_VERSION})
+      if(MSVC)
         bundle_arrow_implib(PARQUET_SHARED_IMP_LIB)
       endif()
     endif()
-    if (MSVC)
-      ADD_THIRDPARTY_LIB(parquet
-        SHARED_LIB ${PARQUET_SHARED_IMP_LIB})
+    if(MSVC)
+      add_thirdparty_lib(parquet SHARED_LIB ${PARQUET_SHARED_IMP_LIB})
     else()
-      ADD_THIRDPARTY_LIB(parquet
-        SHARED_LIB ${PARQUET_SHARED_LIB})
+      add_thirdparty_lib(parquet SHARED_LIB ${PARQUET_SHARED_LIB})
     endif()
-    set(LINK_LIBS
-      ${LINK_LIBS}
-      parquet_shared)
+    set(LINK_LIBS ${LINK_LIBS} parquet_shared)
   else()
     find_package(Thrift)
-    if (PYARROW_BOOST_USE_SHARED)
+    if(PYARROW_BOOST_USE_SHARED)
       set(Boost_USE_STATIC_LIBS OFF)
     else()
       set(Boost_USE_STATIC_LIBS ON)
     endif()
     find_package(Boost COMPONENTS regex REQUIRED)
-    ADD_THIRDPARTY_LIB(boost_regex
-      STATIC_LIB ${Boost_REGEX_LIBRARY_RELEASE})
-    ADD_THIRDPARTY_LIB(parquet
-      STATIC_LIB ${PARQUET_STATIC_LIB})
-    ADD_THIRDPARTY_LIB(thrift
-      STATIC_LIB ${THRIFT_STATIC_LIB})
-    set(LINK_LIBS
-      ${LINK_LIBS}
-      parquet_static
-      thrift_static
-      boost_regex_static)
+    add_thirdparty_lib(boost_regex STATIC_LIB ${Boost_REGEX_LIBRARY_RELEASE})
+    add_thirdparty_lib(parquet STATIC_LIB ${PARQUET_STATIC_LIB})
+    add_thirdparty_lib(thrift STATIC_LIB ${THRIFT_STATIC_LIB})
+    set(LINK_LIBS ${LINK_LIBS} parquet_static thrift_static boost_regex_static)
   endif()
-  set(CYTHON_EXTENSIONS
-    ${CYTHON_EXTENSIONS}
-    _parquet)
+  set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} _parquet)
 endif()
 
-## Plasma
-if (PYARROW_BUILD_PLASMA)
+# Plasma
+if(PYARROW_BUILD_PLASMA)
   find_package(Plasma)
 
   if(NOT PLASMA_FOUND)
@@ -475,34 +451,31 @@ if (PYARROW_BUILD_PLASMA)
   endif()
 
   include_directories(SYSTEM ${PLASMA_INCLUDE_DIR})
-  ADD_THIRDPARTY_LIB(libplasma
-    SHARED_LIB ${PLASMA_SHARED_LIB})
+  add_thirdparty_lib(libplasma SHARED_LIB ${PLASMA_SHARED_LIB})
 
-  file(COPY ${ARROW_INCLUDE_DIR}/plasma DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
+  file(COPY ${ARROW_INCLUDE_DIR}/plasma DESTINATION
+       ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
 
-  if (PYARROW_BUNDLE_ARROW_CPP)
+  if(PYARROW_BUNDLE_ARROW_CPP)
     bundle_arrow_lib(PLASMA_SHARED_LIB
-      ABI_VERSION ${ARROW_ABI_VERSION}
-      SO_VERSION ${ARROW_SO_VERSION})
+                     ABI_VERSION
+                     ${ARROW_ABI_VERSION}
+                     SO_VERSION
+                     ${ARROW_SO_VERSION})
   endif()
-  set(LINK_LIBS
-    ${LINK_LIBS}
-    libplasma_shared)
+  set(LINK_LIBS ${LINK_LIBS} libplasma_shared)
 
   set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} _plasma)
   file(COPY ${PLASMA_EXECUTABLE} DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY})
 endif()
 
-
-if (PYARROW_BUILD_ORC)
-  ## ORC
-  set(CYTHON_EXTENSIONS
-      ${CYTHON_EXTENSIONS}
-      _orc)
+if(PYARROW_BUILD_ORC)
+  # ORC
+  set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} _orc)
 endif()
 
-## Gandiva
-if (PYARROW_BUILD_GANDIVA)
+# Gandiva
+if(PYARROW_BUILD_GANDIVA)
   find_package(Gandiva)
 
   if(NOT GANDIVA_FOUND)
@@ -511,92 +484,87 @@ if (PYARROW_BUILD_GANDIVA)
 
   include_directories(SYSTEM ${GANDIVA_INCLUDE_DIR})
 
-  if (PYARROW_BUNDLE_ARROW_CPP)
-    file(COPY ${GANDIVA_INCLUDE_DIR}/gandiva DESTINATION ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
+  if(PYARROW_BUNDLE_ARROW_CPP)
+    file(COPY ${GANDIVA_INCLUDE_DIR}/gandiva DESTINATION
+         ${BUILD_OUTPUT_ROOT_DIRECTORY}/include)
 
     bundle_arrow_lib(GANDIVA_SHARED_LIB
-      ABI_VERSION ${ARROW_ABI_VERSION}
-      SO_VERSION ${ARROW_SO_VERSION})
+                     ABI_VERSION
+                     ${ARROW_ABI_VERSION}
+                     SO_VERSION
+                     ${ARROW_SO_VERSION})
 
-    if (MSVC)
+    if(MSVC)
       bundle_arrow_implib(GANDIVA_SHARED_IMP_LIB)
     endif()
   endif()
 
-  if (MSVC)
-    ADD_THIRDPARTY_LIB(gandiva
-      SHARED_LIB ${GANDIVA_SHARED_IMP_LIB})
+  if(MSVC)
+    add_thirdparty_lib(gandiva SHARED_LIB ${GANDIVA_SHARED_IMP_LIB})
   else()
-    ADD_THIRDPARTY_LIB(gandiva
-      SHARED_LIB ${GANDIVA_SHARED_LIB})
+    add_thirdparty_lib(gandiva SHARED_LIB ${GANDIVA_SHARED_LIB})
   endif()
 
-  set(LINK_LIBS
-    ${LINK_LIBS}
-    gandiva_shared)
+  set(LINK_LIBS ${LINK_LIBS} gandiva_shared)
   set(CYTHON_EXTENSIONS ${CYTHON_EXTENSIONS} gandiva)
 endif()
 
-
-############################################################
+#
 # Setup and build Cython modules
-############################################################
+#
 
-if (PYARROW_GENERATE_COVERAGE)
+if(PYARROW_GENERATE_COVERAGE)
   set(CYTHON_FLAGS "${CYTHON_FLAGS}" "-Xlinetrace=True")
 endif()
 
 foreach(module ${CYTHON_EXTENSIONS})
-    string(REPLACE "." ";" directories ${module})
-    list(GET directories -1 module_name)
-    list(REMOVE_AT directories -1)
+  string(REPLACE "." ";" directories ${module})
+  list(GET directories -1 module_name)
+  list(REMOVE_AT directories -1)
 
-    string(REPLACE "." "/" module_root "${module}")
-    set(module_SRC pyarrow/${module_root}.pyx)
-    set_source_files_properties(${module_SRC} PROPERTIES CYTHON_IS_CXX 1)
+  string(REPLACE "." "/" module_root "${module}")
+  set(module_SRC pyarrow/${module_root}.pyx)
+  set_source_files_properties(${module_SRC} PROPERTIES CYTHON_IS_CXX 1)
 
-    cython_add_module(${module_name}
-      ${module_name}_pyx
-      ${module_name}_output
-      ${module_SRC})
+  cython_add_module(${module_name} ${module_name}_pyx ${module_name}_output ${module_SRC})
 
-    if (directories)
-        string(REPLACE ";" "/" module_output_directory ${directories})
-        set_target_properties(${module_name} PROPERTIES
-          LIBRARY_OUTPUT_DIRECTORY ${module_output_directory})
+  if(directories)
+    string(REPLACE ";" "/" module_output_directory ${directories})
+    set_target_properties(${module_name}
+                          PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${module_output_directory})
+  endif()
+
+  if(PYARROW_BUNDLE_ARROW_CPP)
+    # In the event that we are bundling the shared libraries (e.g. in a
+    # manylinux1 wheel), we need to set the RPATH of the extensions to the
+    # root of the pyarrow/ package so that libarrow/libarrow_python are able
+    # to be loaded properly
+    if(APPLE)
+      set(module_install_rpath "@loader_path/")
+    else()
+      set(module_install_rpath "\$ORIGIN")
     endif()
 
-    if (PYARROW_BUNDLE_ARROW_CPP)
-      # In the event that we are bundling the shared libraries (e.g. in a
-      # manylinux1 wheel), we need to set the RPATH of the extensions to the
-      # root of the pyarrow/ package so that libarrow/libarrow_python are able
-      # to be loaded properly
-      if(APPLE)
-        set(module_install_rpath "@loader_path/")
-      else()
-        set(module_install_rpath "\$ORIGIN")
-      endif()
+    # XXX(wesm): ARROW-2326 this logic is only needed when we have Cython
+    # modules in interior directories. Since all of our C extensions and
+    # bundled libraries are in the same place, we can skip this part
 
-      # XXX(wesm): ARROW-2326 this logic is only needed when we have Cython
-      # modules in interior directories. Since all of our C extensions and
-      # bundled libraries are in the same place, we can skip this part
+    # list(LENGTH directories i)
+    # while(${i} GREATER 0)
+    #   set(module_install_rpath "${module_install_rpath}/..")
+    #   math(EXPR i "${i} - 1" )
+    # endwhile(${i} GREATER 0)
 
-      # list(LENGTH directories i)
-      # while(${i} GREATER 0)
-      #   set(module_install_rpath "${module_install_rpath}/..")
-      #   math(EXPR i "${i} - 1" )
-      # endwhile(${i} GREATER 0)
+    set_target_properties(${module_name} PROPERTIES INSTALL_RPATH ${module_install_rpath})
+  endif()
 
-      set_target_properties(${module_name} PROPERTIES
-        INSTALL_RPATH ${module_install_rpath})
-    endif()
+  if(PYARROW_GENERATE_COVERAGE)
+    set_target_properties(${module_name}
+                          PROPERTIES COMPILE_DEFINITIONS
+                                     "CYTHON_TRACE=1;CYTHON_TRACE_NOGIL=1")
+  endif()
 
-    if (PYARROW_GENERATE_COVERAGE)
-      set_target_properties(${module_name} PROPERTIES
-        COMPILE_DEFINITIONS "CYTHON_TRACE=1;CYTHON_TRACE_NOGIL=1")
-    endif()
+  target_link_libraries(${module_name} ${LINK_LIBS})
 
-    target_link_libraries(${module_name} ${LINK_LIBS})
-
-    # Generated files will be moved to the right directory by setup.py.
+  # Generated files will be moved to the right directory by setup.py.
 endforeach(module)

--- a/run-cmake-format.py
+++ b/run-cmake-format.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import hashlib
+import pathlib
+import subprocess
+import sys
+
+
+patterns = [
+    'cpp/CMakeLists.txt',
+    'cpp/src/**/CMakeLists.txt',
+    'cpp/tools/**/CMakeLists.txt',
+    'java/gandiva/CMakeLists.txt',
+    'python/CMakeLists.txt',
+]
+
+here = pathlib.Path(__file__).parent
+
+
+def find_cmake_files():
+    for pat in patterns:
+        yield from here.glob(pat)
+
+
+def run_cmake_format(paths):
+    # cmake-format is fast enough that running in parallel doesn't seem necessary
+    cmd = ['cmake-format', '--in-place'] + paths
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError:
+        try:
+            import cmake_format
+        except ImportError:
+            raise ImportError(
+                "Please install cmake-format: `pip install cmake_format`")
+        else:
+            # Other error, re-raise
+            raise
+
+
+def check_cmake_format(paths):
+    hashes = {}
+    for p in paths:
+        contents = p.read_bytes()
+        hashes[p] = hashlib.sha256(contents).digest()
+
+    run_cmake_format(paths)
+
+    # Check contents didn't change
+    changed = []
+    for p in paths:
+        contents = p.read_bytes()
+        if hashes[p] != hashlib.sha256(contents).digest():
+            changed.append(p)
+
+    if changed:
+        items = "\n".join("- %s" % p for p in sorted(changed))
+        print("The following cmake files need re-formatting:\n%s" % (items,))
+        print()
+        print("Consider running `run-cmake-format.py`")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    paths = list(find_cmake_files())
+    if "--check" in sys.argv:
+        check_cmake_format(paths)
+    else:
+        run_cmake_format(paths)


### PR DESCRIPTION
- Add a top-level script that reformats all known CMake files in the source tree
- Add a lint step in Travis that checks CMake files are properly formatted

Requires [cmake_format](https://github.com/cheshirekow/cmake_format) and Python 3.