### PR TITLE
ARROW-4434: [Python] Allow creating trivial StructArray

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -385,11 +385,11 @@ def _ensure_filesystem(fs):
     # interface and return it
     if not issubclass(fs_type, FileSystem):
         for mro in inspect.getmro(fs_type):
-            if mro.__name__ is 'S3FileSystem':
+            if mro.__name__ == 'S3FileSystem':
                 return S3FSWrapper(fs)
             # In case its a simple LocalFileSystem (e.g. dask) use native arrow
             # FS
-            elif mro.__name__ is 'LocalFileSystem':
+            elif mro.__name__ == 'LocalFileSystem':
                 return LocalFileSystem.get_instance()
 
         raise IOError('Unrecognized filesystem: {0}'.format(fs_type))

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -867,6 +867,11 @@ def test_empty_range():
 
 
 def test_structarray():
+    arr = pa.StructArray.from_arrays([], names=[])
+    assert arr.type == pa.struct([])
+    assert len(arr) == 0
+    assert arr.to_pylist() == []
+
     ints = pa.array([None, 2, 3], type=pa.int64())
     strs = pa.array([u'a', None, u'c'], type=pa.string())
     bools = pa.array([True, False, None], type=pa.bool_())
@@ -882,6 +887,10 @@ def test_structarray():
 
     pylist = arr.to_pylist()
     assert pylist == expected, (pylist, expected)
+
+    # len(names) != len(arrays)
+    with pytest.raises(ValueError):
+        pa.StructArray.from_arrays([ints], ['ints', 'strs'])
 
 
 def test_struct_from_dicts():


### PR DESCRIPTION
Also fix an unrelated flake8 error with the latest flake8.