### PR TITLE
ARROW-3653: [C++][Python] Support data copying between different GPU devices

### DIFF
--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -112,6 +112,16 @@ class CudaContext::CudaContextImpl {
     return Status::OK();
   }
 
+  Status CopyDeviceToAnotherDevice(const std::shared_ptr<CudaContext>& dst_ctx, void* dst,
+                                   const void* src, int64_t nbytes) {
+    ContextSaver set_temporary(context_);
+    CU_RETURN_NOT_OK(cuMemcpyPeer(reinterpret_cast<CUdeviceptr>(dst),
+                                  reinterpret_cast<CUcontext>(dst_ctx->handle()),
+                                  reinterpret_cast<const CUdeviceptr>(src), context_,
+                                  static_cast<size_t>(nbytes)));
+    return Status::OK();
+  }
+
   Status Synchronize(void) {
     ContextSaver set_temporary(context_);
     CU_RETURN_NOT_OK(cuCtxSynchronize());
@@ -299,6 +309,12 @@ Status CudaContext::CopyDeviceToHost(void* dst, const void* src, int64_t nbytes)
 
 Status CudaContext::CopyDeviceToDevice(void* dst, const void* src, int64_t nbytes) {
   return impl_->CopyDeviceToDevice(dst, src, nbytes);
+}
+
+Status CudaContext::CopyDeviceToAnotherDevice(const std::shared_ptr<CudaContext>& dst_ctx,
+                                              void* dst, const void* src,
+                                              int64_t nbytes) {
+  return impl_->CopyDeviceToAnotherDevice(dst_ctx, dst, src, nbytes);
 }
 
 Status CudaContext::Synchronize(void) { return impl_->Synchronize(); }

--- a/cpp/src/arrow/gpu/cuda_context.h
+++ b/cpp/src/arrow/gpu/cuda_context.h
@@ -141,6 +141,8 @@ class ARROW_EXPORT CudaContext : public std::enable_shared_from_this<CudaContext
   Status CopyHostToDevice(void* dst, const void* src, int64_t nbytes);
   Status CopyDeviceToHost(void* dst, const void* src, int64_t nbytes);
   Status CopyDeviceToDevice(void* dst, const void* src, int64_t nbytes);
+  Status CopyDeviceToAnotherDevice(const std::shared_ptr<CudaContext>& dst_ctx, void* dst,
+                                   const void* src, int64_t nbytes);
   Status Free(void* device_ptr, int64_t nbytes);
 
   class CudaContextImpl;

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -163,6 +163,14 @@ Status CudaBuffer::CopyFromDevice(const int64_t position, const void* data,
   return context_->CopyDeviceToDevice(mutable_data_ + position, data, nbytes);
 }
 
+Status CudaBuffer::CopyFromAnotherDevice(const std::shared_ptr<CudaContext>& src_ctx,
+                                         const int64_t position, const void* data,
+                                         int64_t nbytes) {
+  DCHECK_LE(nbytes, size_ - position) << "Copy would overflow buffer";
+  return src_ctx->CopyDeviceToAnotherDevice(context_, mutable_data_ + position, data,
+                                            nbytes);
+}
+
 Status CudaBuffer::ExportForIpc(std::shared_ptr<CudaIpcMemHandle>* handle) {
   if (is_ipc_) {
     return Status::Invalid("Buffer has already been exported for IPC");

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -81,7 +81,7 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   Status CopyFromDevice(const int64_t position, const void* data, int64_t nbytes);
 
   /// \brief Copy memory from another device to device at position
-  /// \param[in] src_ctx context of the another device memory
+  /// \param[in] src_ctx context of the source device memory
   /// \param[in] position start position inside buffer to copy bytes to
   /// \param[in] data start address of the another device memory area to copy from
   /// \param[in] nbytes number of bytes to copy

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -64,7 +64,7 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   Status CopyToHost(const int64_t position, const int64_t nbytes, void* out) const;
 
   /// \brief Copy memory to device at position
-  /// \param[in] position start position to copy bytes
+  /// \param[in] position start position to copy bytes to
   /// \param[in] data the host data to copy
   /// \param[in] nbytes number of bytes to copy
   /// \return Status
@@ -79,6 +79,15 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   /// \note It is assumed that both source and destination device
   /// memories have been allocated within the same context.
   Status CopyFromDevice(const int64_t position, const void* data, int64_t nbytes);
+
+  /// \brief Copy memory from another device to device at position
+  /// \param[in] src_ctx context of the another device memory
+  /// \param[in] position start position inside buffer to copy bytes to
+  /// \param[in] data start address of the another device memory area to copy from
+  /// \param[in] nbytes number of bytes to copy
+  /// \return Status
+  Status CopyFromAnotherDevice(const std::shared_ptr<CudaContext>& src_ctx,
+                               const int64_t position, const void* data, int64_t nbytes);
 
   /// \brief Expose this device buffer as IPC memory which can be used in other processes
   /// \param[out] handle the exported IPC handle

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -71,6 +71,9 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
                              int64_t nbytes)
         CStatus CopyFromDevice(const int64_t position, const void* data,
                                int64_t nbytes)
+        CStatus CopyFromAnotherDevice(const shared_ptr[CCudaContext]& src_ctx,
+                                      const int64_t position, const void* data,
+                                      int64_t nbytes)
         CStatus ExportForIpc(shared_ptr[CCudaIpcMemHandle]* handle)
         shared_ptr[CCudaContext] context() const
 

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -406,7 +406,12 @@ def test_copy_to_host(size):
 def test_copy_from_device(dest_ctx, size):
     arr, buf = make_random_buffer(size=size, target='device')
     lst = arr.tolist()
-    dest_ctx = buf.context if dest_ctx == 'same' else global_context1
+    if dest_ctx == 'another':
+        dest_ctx = global_context1
+        if buf.context.device_number == dest_ctx.device_number:
+            pytest.skip("not a multi-GPU system")
+    else:
+        dest_ctx = buf.context
     dbuf = dest_ctx.new_buffer(size)
 
     def put(*args, **kwargs):

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -40,10 +40,12 @@ cuda_ipc = pytest.mark.skipif(
     reason='CUDA IPC not supported in platform `%s`' % (platform))
 
 global_context = None  # for flake8
+global_context1 = None  # for flake8
 
 
 def setup_module(module):
     module.global_context = cuda.Context(0)
+    module.global_context1 = cuda.Context(cuda.Context.get_num_devices() - 1)
 
 
 def teardown_module(module):
@@ -53,6 +55,7 @@ def teardown_module(module):
 def test_Context():
     assert cuda.Context.get_num_devices() > 0
     assert global_context.device_number == 0
+    assert global_context1.device_number == cuda.Context.get_num_devices() - 1
 
     with pytest.raises(ValueError,
                        match=("device_number argument must "
@@ -398,11 +401,13 @@ def test_copy_to_host(size):
             dbuf.copy_to_host(buf=buf, position=position, nbytes=nbytes)
 
 
+@pytest.mark.parametrize("dest_ctx", ['same', 'another'])
 @pytest.mark.parametrize("size", [0, 1, 1000])
-def test_copy_from_device(size):
+def test_copy_from_device(dest_ctx, size):
     arr, buf = make_random_buffer(size=size, target='device')
     lst = arr.tolist()
-    dbuf = buf.context.new_buffer(size)
+    dest_ctx = buf.context if dest_ctx == 'same' else global_context1
+    dbuf = dest_ctx.new_buffer(size)
 
     def put(*args, **kwargs):
         dbuf.copy_from_device(buf, *args, **kwargs)


### PR DESCRIPTION
This PR introduces new C++ methods
  `CudaContext::CopyDeviceToAnotherDevice`
  `CudaBuffer::CopyFromAnotherDevice`
that are used to implement the Python support for copying CUDA buffer data between different devices.