### PR TITLE
ARROW-4527: [Packaging][Linux] Use LLVM 7

### DIFF
--- a/dev/tasks/linux-packages/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apt/debian-stretch/Dockerfile
@@ -30,10 +30,17 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
+    gnupg \
+    wget && \
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" > \
+    /etc/apt/sources.list.d/llvm.list && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
     autoconf-archive \
     bison \
     build-essential \
-    clang-6.0 \
+    clang-7 \
     cmake \
     debhelper\
     devscripts \

--- a/dev/tasks/linux-packages/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apt/ubuntu-bionic/Dockerfile
@@ -28,7 +28,7 @@ RUN \
     autoconf-archive \
     bison \
     build-essential \
-    clang-6.0 \
+    clang-7 \
     cmake \
     debhelper\
     devscripts \

--- a/dev/tasks/linux-packages/apt/ubuntu-cosmic/Dockerfile
+++ b/dev/tasks/linux-packages/apt/ubuntu-cosmic/Dockerfile
@@ -28,7 +28,7 @@ RUN \
     autoconf-archive \
     bison \
     build-essential \
-    clang-6.0 \
+    clang-7 \
     cmake \
     debhelper\
     devscripts \

--- a/dev/tasks/linux-packages/apt/ubuntu-xenial/Dockerfile
+++ b/dev/tasks/linux-packages/apt/ubuntu-xenial/Dockerfile
@@ -25,10 +25,17 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
+    gnupg \
+    wget && \
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" > \
+    /etc/apt/sources.list.d/llvm.list && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
     autoconf-archive \
     bison \
     build-essential \
-    clang-6.0 \
+    clang-7 \
     cmake \
     debhelper\
     devscripts \

--- a/dev/tasks/linux-packages/debian/control
+++ b/dev/tasks/linux-packages/debian/control
@@ -5,7 +5,7 @@ Maintainer: Kouhei Sutou <kou@clear-code.com>
 Build-Depends:
   autoconf-archive,
   bison,
-  clang-6.0,
+  clang-7,
   cmake,
   debhelper (>= 9.20160115),
   dh-autoreconf,

--- a/site/install.md
+++ b/site/install.md
@@ -82,7 +82,33 @@ Apache Arrow GLib (C). Here are supported platforms:
 * CentOS 6
 * CentOS 7
 
-Debian GNU/Linux and Ubuntu 18.04 LTS or later:
+Debian GNU/Linux:
+
+```shell
+sudo apt update
+sudo apt install -y -V apt-transport-https lsb-release
+sudo wget -O /usr/share/keyrings/apache-arrow-keyring.gpg https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-keyring.gpg
+sudo tee /etc/apt/sources.list.d/apache-arrow.list <<APT_LINE
+deb [arch=amd64 signed-by=/usr/share/keyrings/apache-arrow-keyring.gpg] https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/ $(lsb_release --codename --short) main
+deb-src [signed-by=/usr/share/keyrings/apache-arrow-keyring.gpg] https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/ $(lsb_release --codename --short) main
+APT_LINE
+curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo tee /etc/apt/sources.list.d/llvm.list <<APT_LINE
+deb http://apt.llvm.org/$(lsb_release --codename --short)/ llvm-toolchain-$(lsb_release --codename --short)-7 main
+deb-src http://apt.llvm.org/$(lsb_release --codename --short)/ llvm-toolchain-$(lsb_release --codename --short)-7 main
+APT_LINE
+sudo apt update
+sudo apt install -y -V libarrow-dev # For C++
+sudo apt install -y -V libarrow-glib-dev # For GLib (C)
+sudo apt install -y -V libplasma-dev # For Plasma C++
+sudo apt install -y -V libplasma-glib-dev # For Plasma GLib (C)
+sudo apt install -y -V libgandiva-dev # For Gandiva C++
+sudo apt install -y -V libgandiva-glib-dev # For Gandiva GLib (C)
+sudo apt install -y -V libparquet-dev # For Apache Parquet C++
+sudo apt install -y -V libparquet-glib-dev # For Apache Parquet GLib (C)
+```
+
+Ubuntu 18.04 LTS or later:
 
 ```shell
 sudo apt update
@@ -103,7 +129,33 @@ sudo apt install -y -V libparquet-dev # For Apache Parquet C++
 sudo apt install -y -V libparquet-glib-dev # For Apache Parquet GLib (C)
 ```
 
-Debian Ubuntu 16.04 LTS or earlier:
+Ubuntu 16.04 LTS:
+
+```shell
+sudo apt update
+sudo apt install -y -V apt-transport-https lsb-release
+curl https://dist.apache.org/repos/dist/dev/arrow/KEYS | sudo apt-key add -
+sudo tee /etc/apt/sources.list.d/apache-arrow.list <<APT_LINE
+deb [arch=amd64] https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/ $(lsb_release --codename --short) main
+deb-src https://dl.bintray.com/apache/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/ $(lsb_release --codename --short) main
+APT_LINE
+curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo tee /etc/apt/sources.list.d/llvm.list <<APT_LINE
+deb http://apt.llvm.org/$(lsb_release --codename --short)/ llvm-toolchain-$(lsb_release --codename --short)-7 main
+deb-src http://apt.llvm.org/$(lsb_release --codename --short)/ llvm-toolchain-$(lsb_release --codename --short)-7 main
+APT_LINE
+sudo apt update
+sudo apt install -y -V libarrow-dev # For C++
+sudo apt install -y -V libarrow-glib-dev # For GLib (C)
+sudo apt install -y -V libplasma-dev # For Plasma C++
+sudo apt install -y -V libplasma-glib-dev # For Plasma GLib (C)
+sudo apt install -y -V libgandiva-dev # For Gandiva C++
+sudo apt install -y -V libgandiva-glib-dev # For Gandiva GLib (C)
+sudo apt install -y -V libparquet-dev # For Apache Parquet C++
+sudo apt install -y -V libparquet-glib-dev # For Apache Parquet GLib (C)
+```
+
+Ubuntu 14.04 LTS:
 
 ```shell
 sudo apt update
@@ -118,8 +170,6 @@ sudo apt install -y -V libarrow-dev # For C++
 sudo apt install -y -V libarrow-glib-dev # For GLib (C)
 sudo apt install -y -V libplasma-dev # For Plasma C++
 sudo apt install -y -V libplasma-glib-dev # For Plasma GLib (C)
-sudo apt install -y -V libgandiva-dev # For Gandiva C++
-sudo apt install -y -V libgandiva-glib-dev # For Gandiva GLib (C)
 sudo apt install -y -V libparquet-dev # For Apache Parquet C++
 sudo apt install -y -V libparquet-glib-dev # For Apache Parquet GLib (C)
 ```


### PR DESCRIPTION
We use https://apt.llvm.org/ for Debian strech and Ubuntu Xenial for Gandiva packages.
If users who don't use Gandiva packages, they don't need to enable the LLVM APT repository.