### PR TITLE
ARROW-4536: [GLib] Add data_type argument in garrow_list_array_new

### DIFF
--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -75,6 +75,7 @@ garrow_list_array_class_init(GArrowListArrayClass *klass)
 
 /**
  * garrow_list_array_new:
+ * @data_type: The data type of the list.
  * @length: The number of elements.
  * @value_offsets: The offsets of @values in Arrow format.
  * @values: The values as #GArrowArray.
@@ -90,16 +91,17 @@ garrow_list_array_class_init(GArrowListArrayClass *klass)
  * Since: 0.4.0
  */
 GArrowListArray *
-garrow_list_array_new(gint64 length,
+garrow_list_array_new(GArrowDataType *data_type,
+                      gint64 length,
                       GArrowBuffer *value_offsets,
                       GArrowArray *values,
                       GArrowBuffer *null_bitmap,
                       gint64 n_nulls)
 {
+  const auto arrow_data_type = garrow_data_type_get_raw(data_type);
   const auto arrow_value_offsets = garrow_buffer_get_raw(value_offsets);
   const auto arrow_values = garrow_array_get_raw(values);
   const auto arrow_bitmap = garrow_buffer_get_raw(null_bitmap);
-  auto arrow_data_type = arrow::list(arrow_values->type());
   auto arrow_list_array =
     std::make_shared<arrow::ListArray>(arrow_data_type,
                                        length,

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -68,7 +68,8 @@ struct _GArrowListArrayClass
 
 GType garrow_list_array_get_type(void) G_GNUC_CONST;
 
-GArrowListArray *garrow_list_array_new(gint64 length,
+GArrowListArray *garrow_list_array_new(GArrowDataType *data_type,
+                                       gint64 length,
                                        GArrowBuffer *value_offsets,
                                        GArrowArray *values,
                                        GArrowBuffer *null_bitmap,

--- a/c_glib/test/test-list-array.rb
+++ b/c_glib/test/test-list-array.rb
@@ -19,13 +19,16 @@ class TestListArray < Test::Unit::TestCase
   include Helper::Buildable
 
   def test_new
+    field = Arrow::Field.new("item", Arrow::Int8DataType.new)
+    data_type = Arrow::ListDataType.new(field)
     value_offsets = Arrow::Buffer.new([0, 2, 5, 5].pack("l*"))
     data = Arrow::Buffer.new([1, 2, 3, 4, 5].pack("c*"))
     nulls = Arrow::Buffer.new([0b11111].pack("C*"))
     values = Arrow::Int8Array.new(5, data, nulls, 0)
     assert_equal(build_list_array(Arrow::Int8DataType.new,
                                   [[1, 2], [3, 4, 5], nil]),
-                 Arrow::ListArray.new(3,
+                 Arrow::ListArray.new(data_type,
+                                      3,
                                       value_offsets,
                                       values,
                                       Arrow::Buffer.new([0b011].pack("C*")),


### PR DESCRIPTION
This pull-request adds `data_type` argument as the 1st argument of `garrow_list_array_new()` function to allow programmers to specify the field name of the resultant array.

@kou Please check this.