### PR TITLE
ARROW-4549: [C++] Fix benchmark build error on CUDA enabled build

### DIFF
--- a/cpp/src/arrow/gpu/cuda-benchmark.cc
+++ b/cpp/src/arrow/gpu/cuda-benchmark.cc
@@ -24,6 +24,7 @@
 #include "arrow/array.h"
 #include "arrow/memory_pool.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/util.h"
 
 #include "arrow/gpu/cuda_api.h"
 


### PR DESCRIPTION
Error message:
```
    cpp/src/arrow/gpu/cuda-benchmark.cc: In function 'void arrow::cuda::CudaBufferWriterBenchmark(benchmark::State&, int64_t, int64_t, int64_t)':
    cpp/src/arrow/gpu/cuda-benchmark.cc:52:13: error: 'MakeRandomByteBuffer' was not declared in this scope
       ASSERT_OK(MakeRandomByteBuffer(total_bytes, default_memory_pool(), &buffer));
                 ^~~~~~~~~~~~~~~~~~~~
    cpp/src/arrow/testing/gtest_util.h:72:27: note: in definition of macro 'ASSERT_OK'
         ::arrow::Status _s = (expr);                                             
                               ^~~~
```