### PR TITLE
Permit passing DataType class to DataType.resolve

### DIFF
--- a/ruby/red-arrow/lib/arrow/data-type.rb
+++ b/ruby/red-arrow/lib/arrow/data-type.rb
@@ -97,6 +97,7 @@ module Arrow
               "data type description must have :type value: #{data_type.inspect}"
             raise ArgumentError, message
           end
+          return type if type.is_a?(DataType)
           data_type_class = resolve_class(type)
           if description.empty?
             data_type_class.new

--- a/ruby/red-arrow/test/test-data-type.rb
+++ b/ruby/red-arrow/test/test-data-type.rb
@@ -38,10 +38,17 @@ class DataTypeTest < Test::Unit::TestCase
                    Arrow::DataType.resolve([:list, field]))
     end
 
-    test("Hash") do
-      field = Arrow::Field.new(:visible, :boolean)
-      assert_equal(Arrow::ListDataType.new(field),
-                   Arrow::DataType.resolve(type: :list, field: field))
+    sub_test_case("Hash") do
+      test("with type name") do
+        field = Arrow::Field.new(:visible, :boolean)
+        assert_equal(Arrow::ListDataType.new(field),
+                     Arrow::DataType.resolve(type: :list, field: field))
+      end
+
+      test("with class") do
+        assert_equal(Arrow::DataType.resolve(type: :decimal128, precision: 8, scale: 2),
+                     Arrow::DataType.resolve(type: Arrow::Decimal128DataType.new(8, 2)))
+      end
     end
   end
 end


### PR DESCRIPTION
This pull requet permits to create the type `list<decimal: decimal(8, 2)>` by the code given below:

```
data_type = Arrow::Decimal128DataType.new(8, 2)
Arrow::ListDataType.new(name: :decimal, type: data_type)
```

I know we already can do `Arrow::ListDataType.new(name: :decimal, data_type: data_type)` for such purpose.  However, `type:` and `data_type:` are similar, so I feel that using them appropriately depending on the situation is difficult.

@kou How do you think?