### PR TITLE
ARROW-4565: [R] Fix decimal record batches with no null values

### DIFF
--- a/r/src/array__to_vector.cpp
+++ b/r/src/array__to_vector.cpp
@@ -460,12 +460,19 @@ class Converter_Decimal : public Converter {
     const auto& decimals_arr =
         internal::checked_cast<const arrow::Decimal128Array&>(*array);
 
-    internal::BitmapReader bitmap_reader(array->null_bitmap()->data(), array->offset(),
-                                         n);
+    if (array->null_count()) {
+      internal::BitmapReader bitmap_reader(array->null_bitmap()->data(), array->offset(),
+                                           n);
 
-    for (size_t i = 0; i < n; i++, bitmap_reader.Next(), ++p_data) {
-      *p_data = bitmap_reader.IsSet() ? std::stod(decimals_arr.FormatValue(i).c_str())
-                                      : NA_REAL;
+      for (size_t i = 0; i < n; i++, bitmap_reader.Next(), ++p_data) {
+        *p_data = bitmap_reader.IsSet() ? std::stod(decimals_arr.FormatValue(i).c_str())
+                                        : NA_REAL;
+      }
+    }
+    else {
+      for (size_t i = 0; i < n; i++, ++p_data) {
+        *p_data = std::stod(decimals_arr.FormatValue(i).c_str());
+      }
     }
 
     return Status::OK();


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/ARROW-4565. We were missing to handle cases where decimal arrays have no null values.

Regarding adding a test, there seems to be no way to convert arrays to `DecimalType`, if someone can thing of a workaround I'll add a test. Otherwise, there are a bunch of Arrow tests running in the [sparklyr](https://github.com/rstudio/sparklyr/) repo. I'm also planning to start testing against arrow devel in our Travis builds.