### PR TITLE
ARROW-4340: [C++][CI] Build IWYU for LLVM 7 in iwyu docker-compose job

### DIFF
--- a/dev/lint/Dockerfile
+++ b/dev/lint/Dockerfile
@@ -18,7 +18,7 @@
 FROM arrow:python-3.6
 
 RUN apt-get install -y -q gnupg && \
-    apt update && \
+    apt-get update && \
     apt-get install -y -q \
       clang-7 \
       libclang-7-dev \
@@ -28,3 +28,7 @@ RUN apt-get install -y -q gnupg && \
 
 RUN conda install flake8 && \
     conda clean --all -y
+
+ENV PATH=/opt/iwyu/bin:$PATH
+ADD ci/docker_install_iwyu.sh /arrow/ci/
+RUN arrow/ci/docker_install_iwyu.sh

--- a/dev/lint/Dockerfile
+++ b/dev/lint/Dockerfile
@@ -21,12 +21,10 @@ RUN apt-get install -y -q gnupg && \
     apt update && \
     apt-get install -y -q \
       clang-7 \
+      libclang-7-dev \
       clang-format-7 \
       clang-tidy-7 \
       clang-tools-7
 
 RUN conda install flake8 && \
     conda clean --all -y
-
-# https://bugs.launchpad.net/ubuntu/+source/iwyu/+bug/1769334
-RUN ln -sv /usr/lib/clang/6.0 /usr/lib/clang/5.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,9 +207,6 @@ services:
     #   docker-compose build lint
     #   docker-compose run iwyu
     image: arrow:lint
-    environment:
-      CC: clang
-      CXX: clang++
     command: arrow/dev/lint/run_iwyu.sh
     volumes: *ubuntu-volumes
 


### PR DESCRIPTION
Following the instructions in docker-compose.yml gives me a working IWYU build now

```
export PYTHON_VERSION=3.6
docker-compose build cpp
docker-compose build python
docker-compose build lint
docker-compose run iwyu
```