### PR TITLE
ARROW-3669: [Python] Raise error on Numpy byte-swapped array

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -424,6 +424,11 @@ Status CopyStridedArray(PyArrayObject* arr, const int64_t length, MemoryPool* po
 
 template <typename ArrowType>
 inline Status NumPyConverter::PrepareInputData(std::shared_ptr<Buffer>* data) {
+  if (PyArray_ISBYTESWAPPED(arr_)) {
+    // TODO
+    return Status::NotImplemented("Byte-swapped arrays not supported");
+  }
+
   if (is_strided()) {
     RETURN_NOT_OK(CopyStridedArray<ArrowType>(arr_, length_, pool_, data));
   } else if (dtype_->type_num == NPY_BOOL) {

--- a/python/pyarrow/tests/test_convert_pandas.py
+++ b/python/pyarrow/tests/test_convert_pandas.py
@@ -607,6 +607,20 @@ class TestConvertPrimitiveTypes(object):
             arr = pa.array(np_arr)
             assert arr.to_pylist() == np_arr.tolist()
 
+    def test_integer_byteorder(self):
+        # Byteswapped arrays are not supported yet
+        int_dtypes = ['i1', 'i2', 'i4', 'i8', 'u1', 'u2', 'u4', 'u8']
+        for dt in int_dtypes:
+            for order in '=<>':
+                data = np.array([1, 2, 42], dtype=order + dt)
+                for np_arr in (data, data[::2]):
+                    if data.dtype.isnative:
+                        arr = pa.array(data)
+                        assert arr.to_pylist() == data.tolist()
+                    else:
+                        with pytest.raises(NotImplementedError):
+                            arr = pa.array(data)
+
     def test_integer_with_nulls(self):
         # pandas requires upcast to float dtype
 


### PR DESCRIPTION
Previously we would return an incorrect result.