### PR TITLE
ARROW-4583: [Plasma] Fix some small bugs reported by code scan tool

### DIFF
--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -85,7 +85,7 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
     // to make sure the reference count is decremented by letting the OwnedRef
     // go out of scope at the end.
     int ret = PyDict_SetItem(result.obj(), PyList_GET_ITEM(keys.obj(), i - start_idx),
-                   PyList_GET_ITEM(vals.obj(), i - start_idx));
+                             PyList_GET_ITEM(vals.obj(), i - start_idx));
     if (ret != 0) {
       return Status(StatusCode::PythonError, "PyDict_SetItem failed.");
     }

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -87,7 +87,7 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
     int ret = PyDict_SetItem(result.obj(), PyList_GET_ITEM(keys.obj(), i - start_idx),
                              PyList_GET_ITEM(vals.obj(), i - start_idx));
     if (ret != 0) {
-      return ConvertPyError(StatusCode::PythonError);
+      return ConvertPyError();
     }
   }
   static PyObject* py_type = PyUnicode_FromString("_pytype_");

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -86,7 +86,7 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
     // go out of scope at the end.
     int ret = PyDict_SetItem(result.obj(), PyList_GET_ITEM(keys.obj(), i - start_idx),
                    PyList_GET_ITEM(vals.obj(), i - start_idx));
-    if (ret == 0) {
+    if (ret != 0) {
       return Status(StatusCode::PythonError, "PyDict_SetItem failed.");
     }
   }

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -87,7 +87,7 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
     int ret = PyDict_SetItem(result.obj(), PyList_GET_ITEM(keys.obj(), i - start_idx),
                              PyList_GET_ITEM(vals.obj(), i - start_idx));
     if (ret != 0) {
-      return Status(StatusCode::PythonError, "PyDict_SetItem failed.");
+      return ConvertPyError(StatusCode::PythonError);
     }
   }
   static PyObject* py_type = PyUnicode_FromString("_pytype_");

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -84,8 +84,11 @@ Status DeserializeDict(PyObject* context, const Array& array, int64_t start_idx,
     // The latter two steal references whereas PyDict_SetItem does not. So we need
     // to make sure the reference count is decremented by letting the OwnedRef
     // go out of scope at the end.
-    PyDict_SetItem(result.obj(), PyList_GET_ITEM(keys.obj(), i - start_idx),
+    int ret = PyDict_SetItem(result.obj(), PyList_GET_ITEM(keys.obj(), i - start_idx),
                    PyList_GET_ITEM(vals.obj(), i - start_idx));
+    if (ret == 0) {
+      return Status(StatusCode::PythonError, "PyDict_SetItem failed.");
+    }
   }
   static PyObject* py_type = PyUnicode_FromString("_pytype_");
   if (PyDict_Contains(result.obj(), py_type)) {

--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -152,6 +152,10 @@ void ArrowLog::InstallFailureSignalHandler() {
 #endif
 }
 
+bool ArrowLog::IsLevelEnabled(ArrowLogLevel log_level) {
+  return log_level >= severity_threshold_;
+}
+
 ArrowLog::ArrowLog(const char* file_name, int line_number, ArrowLogLevel severity)
     // glog does not have DEBUG level, we can handle it using is_enabled_.
     : logging_provider_(nullptr), is_enabled_(severity >= severity_threshold_) {

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -55,9 +55,11 @@ enum class ArrowLogLevel : int {
 };
 
 #define ARROW_LOG_INTERNAL(level) ::arrow::util::ArrowLog(__FILE__, __LINE__, level)
+// clang-format off
 #define ARROW_LOG(level) if (                                                       \
   arrow::util::ArrowLog::IsLevelEnabled(arrow::util::ArrowLogLevel::ARROW_##level)) \
-    ARROW_LOG_INTERNAL(arrow::util::ArrowLogLevel::ARROW_##level)
+  ARROW_LOG_INTERNAL(arrow::util::ArrowLogLevel::ARROW_##level)
+// clang-format on
 
 #define ARROW_IGNORE_EXPR(expr) ((void)(expr))
 

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -55,8 +55,8 @@ enum class ArrowLogLevel : int {
 };
 
 #define ARROW_LOG_INTERNAL(level) ::arrow::util::ArrowLog(__FILE__, __LINE__, level)
-#define ARROW_LOG(level)                                                                \
-  if (arrow::util::ArrowLog::IsLevelEnabled(arrow::util::ArrowLogLevel::ARROW_##level)) \
+#define ARROW_LOG(level) if (                                                       \
+  arrow::util::ArrowLog::IsLevelEnabled(arrow::util::ArrowLogLevel::ARROW_##level)) \
     ARROW_LOG_INTERNAL(arrow::util::ArrowLogLevel::ARROW_##level)
 
 #define ARROW_IGNORE_EXPR(expr) ((void)(expr))

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -55,11 +55,7 @@ enum class ArrowLogLevel : int {
 };
 
 #define ARROW_LOG_INTERNAL(level) ::arrow::util::ArrowLog(__FILE__, __LINE__, level)
-// clang-format off
-#define ARROW_LOG(level) if (                                                       \
-  arrow::util::ArrowLog::IsLevelEnabled(arrow::util::ArrowLogLevel::ARROW_##level)) \
-  ARROW_LOG_INTERNAL(arrow::util::ArrowLogLevel::ARROW_##level)
-// clang-format on
+#define ARROW_LOG(level) ARROW_LOG_INTERNAL(::arrow::util::ArrowLogLevel::ARROW_##level)
 
 #define ARROW_IGNORE_EXPR(expr) ((void)(expr))
 

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -55,7 +55,10 @@ enum class ArrowLogLevel : int {
 };
 
 #define ARROW_LOG_INTERNAL(level) ::arrow::util::ArrowLog(__FILE__, __LINE__, level)
-#define ARROW_LOG(level) ARROW_LOG_INTERNAL(::arrow::util::ArrowLogLevel::ARROW_##level)
+#define ARROW_LOG(level)                                                                \
+  if (arrow::util::ArrowLog::IsLevelEnabled(arrow::util::ArrowLogLevel::ARROW_##level)) \
+    ARROW_LOG_INTERNAL(arrow::util::ArrowLogLevel::ARROW_##level)
+
 #define ARROW_IGNORE_EXPR(expr) ((void)(expr))
 
 #define ARROW_CHECK(condition)                                                         \
@@ -172,6 +175,12 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   /// Install the failure signal handler to output call stack when crash.
   /// If glog is not installed, this function won't do anything.
   static void InstallFailureSignalHandler();
+
+  /// Return whether or not the log level is enabled in current setting.
+  ///
+  /// \param log_level The input log level to test.
+  /// \return True if input log level is not lower than the threshold.
+  static bool IsLevelEnabled(ArrowLogLevel log_level);
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowLog);

--- a/cpp/src/plasma/events.cc
+++ b/cpp/src/plasma/events.cc
@@ -87,9 +87,7 @@ void EventLoop::Shutdown() {
   }
 }
 
-EventLoop::~EventLoop() {
-  Shutdown();
-}
+EventLoop::~EventLoop() { Shutdown(); }
 
 int64_t EventLoop::AddTimer(int64_t timeout, const TimerCallback& callback) {
   auto data = std::unique_ptr<TimerCallback>(new TimerCallback(callback));

--- a/cpp/src/plasma/events.cc
+++ b/cpp/src/plasma/events.cc
@@ -80,7 +80,16 @@ void EventLoop::Start() { aeMain(loop_); }
 
 void EventLoop::Stop() { aeStop(loop_); }
 
-void EventLoop::Shutdown() { aeDeleteEventLoop(loop_); }
+void EventLoop::Shutdown() {
+  if (loop_ != nullptr) {
+    aeDeleteEventLoop(loop_);
+    loop_ = nullptr;
+  }
+}
+
+EventLoop::~EventLoop() {
+  Shutdown();
+}
 
 int64_t EventLoop::AddTimer(int64_t timeout, const TimerCallback& callback) {
   auto data = std::unique_ptr<TimerCallback>(new TimerCallback(callback));

--- a/cpp/src/plasma/events.h
+++ b/cpp/src/plasma/events.h
@@ -59,6 +59,8 @@ class EventLoop {
 
   EventLoop();
 
+  ~EventLoop();
+
   /// Add a new file event handler to the event loop.
   ///
   /// \param fd The file descriptor we are listening to.

--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -195,6 +195,7 @@ int ConnectIpcSock(const std::string& pathname) {
   socket_address.sun_family = AF_UNIX;
   if (pathname.size() + 1 > sizeof(socket_address.sun_path)) {
     ARROW_LOG(ERROR) << "Socket pathname is too long.";
+    close(socket_fd);
     return -1;
   }
   strncpy(socket_address.sun_path, pathname.c_str(), pathname.size() + 1);

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -232,6 +232,10 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
   } else {
     pointer = AllocateMemory(total_size, &fd, &map_size, &offset);
     if (!pointer) {
+      ARROW_LOG(ERROR) << "Not enough memory to creat the object " << object_id.hex()
+                           << ", data_size=" << data_size << ", metadata_size="
+                           << metadata_size
+                           << ", will send a reply of PlasmaError::OutOfMemory";
       return PlasmaError::OutOfMemory;
     }
   }
@@ -1036,6 +1040,7 @@ static std::unique_ptr<PlasmaStoreRunner> g_runner = nullptr;
 
 void HandleSignal(int signal) {
   if (signal == SIGTERM) {
+    ARROW_LOG(INFO) << "SIGTERM Signal received, close Plasma Server...";
     if (g_runner != nullptr) {
       g_runner->Stop();
     }

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -233,9 +233,9 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
     pointer = AllocateMemory(total_size, &fd, &map_size, &offset);
     if (!pointer) {
       ARROW_LOG(ERROR) << "Not enough memory to creat the object " << object_id.hex()
-                           << ", data_size=" << data_size << ", metadata_size="
-                           << metadata_size
-                           << ", will send a reply of PlasmaError::OutOfMemory";
+                       << ", data_size=" << data_size << ", metadata_size="
+                       << metadata_size
+                       << ", will send a reply of PlasmaError::OutOfMemory";
       return PlasmaError::OutOfMemory;
     }
   }

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -232,7 +232,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
   } else {
     pointer = AllocateMemory(total_size, &fd, &map_size, &offset);
     if (!pointer) {
-      ARROW_LOG(ERROR) << "Not enough memory to creat the object " << object_id.hex()
+      ARROW_LOG(ERROR) << "Not enough memory to create the object " << object_id.hex()
                        << ", data_size=" << data_size
                        << ", metadata_size=" << metadata_size
                        << ", will send a reply of PlasmaError::OutOfMemory";
@@ -1040,7 +1040,7 @@ static std::unique_ptr<PlasmaStoreRunner> g_runner = nullptr;
 
 void HandleSignal(int signal) {
   if (signal == SIGTERM) {
-    ARROW_LOG(INFO) << "SIGTERM Signal received, close Plasma Server...";
+    ARROW_LOG(INFO) << "SIGTERM Signal received, closing Plasma Server...";
     if (g_runner != nullptr) {
       g_runner->Stop();
     }

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -233,8 +233,8 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
     pointer = AllocateMemory(total_size, &fd, &map_size, &offset);
     if (!pointer) {
       ARROW_LOG(ERROR) << "Not enough memory to creat the object " << object_id.hex()
-                       << ", data_size=" << data_size << ", metadata_size="
-                       << metadata_size
+                       << ", data_size=" << data_size
+                       << ", metadata_size=" << metadata_size
                        << ", will send a reply of PlasmaError::OutOfMemory";
       return PlasmaError::OutOfMemory;
     }

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
@@ -29,7 +29,7 @@ public interface ObjectStoreLink {
 
   class ObjectStoreData {
 
-    ObjectStoreData(byte[] metadata, byte[] data) {
+    public ObjectStoreData(byte[] metadata, byte[] data) {
       this.data = data;
       this.metadata = metadata;
     }

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/PlasmaClient.java
@@ -99,7 +99,7 @@ public class PlasmaClient implements ObjectStoreLink {
         } else {
           meta = null;
         }
-        ret.add(new ObjectStoreData(data, meta));
+        ret.add(new ObjectStoreData(meta, data));
       }
     }
     return ret;


### PR DESCRIPTION
We used a static code scan tool to scan arrow code. There are several possible bugs:
1. The return value of `PyDict_SetItem` is not used.
2. Currently, `EventLoop:: Shutdown` should be called explicitly, which is error-prone and causing leak when the user forgets to call it.
3. There is an unclosed file descriptor in `io.cc` when path name is too long.

Besides, we also made the following small changes:
1. When we use Plasma in Yarn and when a node uses too much memory, a SIGTERM signal will be sent to Plasma. Current plasma will exit silently. We also some log to plasma store to help us to debug.
2. `ARROW_LOG` will always evaluate the output expression even when it is not enabled, which is not efficient.
3. The constructor of Java class `ObjectStoreData` is private, which is not convenient when we want to create a mock plasma store.
4. Fix a call to `ObjectStoreData` which misplaces `meta` and `data` according to https://github.com/apache/arrow/blob/master/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java#L32 .