### PR TITLE
ARROW-4585: [C++] Add protoc dependency to flight_testing

### DIFF
--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -91,6 +91,7 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
                 test-util.cc
                 DEPENDENCIES
                 ${GTEST_LIBRARY}
+                flight_grpc_gen
                 SHARED_LINK_LIBS
                 arrow_shared
                 arrow_flight_shared


### PR DESCRIPTION
This leads to the necessary change in `build.ninja`
```diff
--- build.ninja.orig	2019-02-15 16:07:48.000000000 +0100
+++ build.ninja	2019-02-15 16:10:25.000000000 +0100
@@ -4863,7 +4863,7 @@
 #############################################
 # Order-only phony target for arrow_flight_testing_objlib

-build cmake_object_order_depends_target_arrow_flight_testing_objlib: phony || src/arrow/flight/CMakeFiles/arrow_flight_testing_objlib.dir
+build cmake_object_order_depends_target_arrow_flight_testing_objlib: phony || src/arrow/flight/flight_grpc_gen
```