### PR TITLE
ARROW-4589: [Rust] Projection push down query optimizer rule

### DIFF
--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -27,5 +27,5 @@ extern crate sqlparser;
 pub mod dfparser;
 pub mod execution;
 pub mod logicalplan;
-pub mod sqlplanner;
 pub mod optimizer;
+pub mod sqlplanner;

--- a/rust/datafusion/src/optimizer/mod.rs
+++ b/rust/datafusion/src/optimizer/mod.rs
@@ -15,17 +15,5 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! DataFusion is a modern distributed compute platform implemented in Rust that uses Apache Arrow
-//! as the memory model
-
-extern crate arrow;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate sqlparser;
-
-pub mod dfparser;
-pub mod execution;
-pub mod logicalplan;
-pub mod sqlplanner;
 pub mod optimizer;
+pub mod projection_push_down;

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -17,8 +17,8 @@
 
 //! Query optimizer traits
 
-use std::rc::Rc;
 use crate::logicalplan::LogicalPlan;
+use std::rc::Rc;
 
 /// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.
 pub trait OptimizerRule {

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -18,9 +18,10 @@
 //! Query optimizer traits
 
 use crate::logicalplan::LogicalPlan;
+use arrow::error::Result;
 use std::rc::Rc;
 
 /// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.
 pub trait OptimizerRule {
-    fn optimize(&mut self, plan: &LogicalPlan) -> Rc<LogicalPlan>;
+    fn optimize(&mut self, plan: &LogicalPlan) -> Result<Rc<LogicalPlan>>;
 }

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -15,17 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! DataFusion is a modern distributed compute platform implemented in Rust that uses Apache Arrow
-//! as the memory model
+//! Query optimizer traits
 
-extern crate arrow;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate sqlparser;
+use std::rc::Rc;
+use crate::logicalplan::LogicalPlan;
 
-pub mod dfparser;
-pub mod execution;
-pub mod logicalplan;
-pub mod sqlplanner;
-pub mod optimizer;
+/// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.
+pub trait OptimizerRule {
+    fn optimize(&mut self, plan: &LogicalPlan) -> Rc<LogicalPlan>;
+}

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Projection Push Down optimizer rule ensures that only referenced columns are loaded into memory
+//! Projection Push Down optimizer rule ensures that only referenced columns are
+//! loaded into memory
 
 use crate::logicalplan::Expr;
 use crate::logicalplan::LogicalPlan;
@@ -26,7 +27,8 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
-/// Projection Push Down optimizer rule ensures that only referenced columns are loaded into memory
+/// Projection Push Down optimizer rule ensures that only referenced columns are
+/// loaded into memory
 pub struct ProjectionPushDown {}
 
 impl OptimizerRule for ProjectionPushDown {
@@ -292,7 +294,11 @@ mod tests {
             input: Rc::new(table_scan),
         };
 
-        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[]], aggr=[[#0]]\n  TableScan: test projection=Some([1])");
+        assert_optimized_plan_eq(
+            &aggregate,
+            "Aggregate: groupBy=[[]], aggr=[[#0]]\n"
+                + "  TableScan: test projection=Some([1])",
+        );
     }
 
     #[test]
@@ -309,7 +315,11 @@ mod tests {
             input: Rc::new(table_scan),
         };
 
-        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[#1]], aggr=[[#0]]\n  TableScan: test projection=Some([1, 2])");
+        assert_optimized_plan_eq(
+            &aggregate,
+            "Aggregate: groupBy=[[#1]], aggr=[[#0]]\n"
+                + "  TableScan: test projection=Some([1, 2])",
+        );
     }
 
     #[test]
@@ -332,7 +342,12 @@ mod tests {
             input: Rc::new(selection),
         };
 
-        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[]], aggr=[[#0]]\n  Selection: #1\n    TableScan: test projection=Some([1, 2])");
+        assert_optimized_plan_eq(
+            &aggregate,
+            "Aggregate: groupBy=[[]], aggr=[[#0]]\n"
+                + "  Selection: #1\n"
+                + "    TableScan: test projection=Some([1, 2])",
+        );
     }
 
     #[test]
@@ -354,7 +369,8 @@ mod tests {
 
         assert_optimized_plan_eq(
             &projection,
-            "Projection: CAST(#0 AS Float64)\n  TableScan: test projection=Some([2])",
+            "Projection: CAST(#0 AS Float64)\n"
+                + "  TableScan: test projection=Some([2])",
         );
     }
 

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -294,11 +294,7 @@ mod tests {
             input: Rc::new(table_scan),
         };
 
-        assert_optimized_plan_eq(
-            &aggregate,
-            "Aggregate: groupBy=[[]], aggr=[[#0]]\n"
-                + "  TableScan: test projection=Some([1])",
-        );
+        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[]], aggr=[[#0]]\n  TableScan: test projection=Some([1])");
     }
 
     #[test]
@@ -315,11 +311,7 @@ mod tests {
             input: Rc::new(table_scan),
         };
 
-        assert_optimized_plan_eq(
-            &aggregate,
-            "Aggregate: groupBy=[[#1]], aggr=[[#0]]\n"
-                + "  TableScan: test projection=Some([1, 2])",
-        );
+        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[#1]], aggr=[[#0]]\n  TableScan: test projection=Some([1, 2])");
     }
 
     #[test]
@@ -342,12 +334,7 @@ mod tests {
             input: Rc::new(selection),
         };
 
-        assert_optimized_plan_eq(
-            &aggregate,
-            "Aggregate: groupBy=[[]], aggr=[[#0]]\n"
-                + "  Selection: #1\n"
-                + "    TableScan: test projection=Some([1, 2])",
-        );
+        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[]], aggr=[[#0]]\n  Selection: #1\n    TableScan: test projection=Some([1, 2])");
     }
 
     #[test]
@@ -369,8 +356,7 @@ mod tests {
 
         assert_optimized_plan_eq(
             &projection,
-            "Projection: CAST(#0 AS Float64)\n"
-                + "  TableScan: test projection=Some([2])",
+            "Projection: CAST(#0 AS Float64)\n  TableScan: test projection=Some([2])",
         );
     }
 

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -17,35 +17,39 @@
 
 //! Projection Push Down optimizer rule ensures that only referenced columns are loaded into memory
 
+use crate::logicalplan::Expr;
+use crate::logicalplan::LogicalPlan;
+use crate::optimizer::optimizer::OptimizerRule;
 use std::collections::HashSet;
 use std::rc::Rc;
-use crate::logicalplan::LogicalPlan;
-use crate::logicalplan::Expr;
-use crate::optimizer::optimizer::OptimizerRule;
 
 /// Projection Push Down optimizer rule ensures that only referenced columns are loaded into memory
-pub struct ProjectionPushDown {
-}
+pub struct ProjectionPushDown {}
 
 impl OptimizerRule for ProjectionPushDown {
-
     fn optimize(&mut self, plan: &LogicalPlan) -> Rc<LogicalPlan> {
         let mut accum = HashSet::new();
         self.optimize_plan(plan, &mut accum)
     }
-
 }
 
 impl ProjectionPushDown {
-
     pub fn new() -> Self {
-        Self {
-        }
+        Self {}
     }
 
-    fn optimize_plan(&self, plan: &LogicalPlan, accum: &mut HashSet<usize>) -> Rc<LogicalPlan> {
+    fn optimize_plan(
+        &self,
+        plan: &LogicalPlan,
+        accum: &mut HashSet<usize>,
+    ) -> Rc<LogicalPlan> {
         match plan {
-            LogicalPlan::Aggregate { input, group_expr, aggr_expr, schema } => {
+            LogicalPlan::Aggregate {
+                input,
+                group_expr,
+                aggr_expr,
+                schema,
+            } => {
                 // collect all columns referenced by grouping and aggregate expressions
                 group_expr.iter().for_each(|e| self.collect_expr(e, accum));
                 aggr_expr.iter().for_each(|e| self.collect_expr(e, accum));
@@ -54,18 +58,28 @@ impl ProjectionPushDown {
                     input: self.optimize_plan(&input, accum),
                     group_expr: group_expr.clone(),
                     aggr_expr: aggr_expr.clone(),
-                    schema: schema.clone()
+                    schema: schema.clone(),
                 })
-            },
-            LogicalPlan::TableScan { schema_name, table_name, schema, .. } => {
+            }
+            LogicalPlan::TableScan {
+                schema_name,
+                table_name,
+                schema,
+                ..
+            } => {
                 // once we reach the table scan, we can use the accumulated set of column indexes as
                 // the projection in the table scan
                 let mut projection: Vec<usize> = Vec::with_capacity(accum.len());
                 accum.iter().for_each(|i| projection.push(*i));
-                Rc::new(LogicalPlan::TableScan { schema_name: schema_name.to_string(), table_name: table_name.to_string(), schema: schema.clone(), projection: Some(projection) })
-            },
+                Rc::new(LogicalPlan::TableScan {
+                    schema_name: schema_name.to_string(),
+                    table_name: table_name.to_string(),
+                    schema: schema.clone(),
+                    projection: Some(projection),
+                })
+            }
             //TODO implement all logical plan variants and remove this unimplemented
-            _ => unimplemented!()
+            _ => unimplemented!(),
         }
     }
 
@@ -73,29 +87,26 @@ impl ProjectionPushDown {
         match expr {
             Expr::Column(i) => {
                 accum.insert(*i);
-            },
+            }
             //TODO implement all expression variants and remove this unimplemented
-            _ => unimplemented!()
+            _ => unimplemented!(),
         }
     }
-
 }
-
 
 #[cfg(test)]
 mod tests {
 
-    use std::rc::Rc;
-    use std::cell::RefCell;
-    use std::sync::Arc;
-    use arrow::datatypes::{Schema, Field, DataType};
-    use crate::logicalplan::LogicalPlan::*;
-    use crate::logicalplan::Expr::*;
     use super::*;
+    use crate::logicalplan::Expr::*;
+    use crate::logicalplan::LogicalPlan::*;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use std::sync::Arc;
 
     #[test]
     fn aggregate_no_group_by() {
-
         let schema = Schema::new(vec![
             Field::new("a", DataType::UInt32, false),
             Field::new("b", DataType::UInt32, false),
@@ -108,22 +119,29 @@ mod tests {
             schema_name: "default".to_string(),
             table_name: "test".to_string(),
             schema: Arc::new(schema),
-            projection: None
+            projection: None,
         };
 
-        let aggregate = Aggregate { group_expr: vec![], aggr_expr: vec![Column(2)],
-            schema: Arc::new(Schema::new(vec![Field::new("MAX(b)", DataType::UInt32, false)])),
+        let aggregate = Aggregate {
+            group_expr: vec![],
+            aggr_expr: vec![Column(1)],
+            schema: Arc::new(Schema::new(vec![Field::new(
+                "MAX(b)",
+                DataType::UInt32,
+                false,
+            )])),
             input: Rc::new(table_scan),
         };
 
         // run optimizer rule
 
-        let rule: Rc<RefCell<OptimizerRule>> = Rc::new(RefCell::new(ProjectionPushDown::new()));
+        let rule: Rc<RefCell<OptimizerRule>> =
+            Rc::new(RefCell::new(ProjectionPushDown::new()));
 
         let optimized_plan = rule.borrow_mut().optimize(&aggregate);
 
-        println!("optimized plan: {:?}", optimized_plan);
+        let formatted_plan = format!("{:?}", optimized_plan);
 
-        //TODO: add assertions
+        assert_eq!(formatted_plan, "Aggregate: groupBy=[[]], aggr=[[#1]]\n  TableScan: test projection=Some([1])");
     }
 }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Projection Push Down optimizer rule ensures that only referenced columns are loaded into memory
+
+use std::collections::HashSet;
+use std::rc::Rc;
+use crate::logicalplan::LogicalPlan;
+use crate::logicalplan::Expr;
+use crate::optimizer::optimizer::OptimizerRule;
+
+/// Projection Push Down optimizer rule ensures that only referenced columns are loaded into memory
+pub struct ProjectionPushDown {
+}
+
+impl OptimizerRule for ProjectionPushDown {
+
+    fn optimize(&mut self, plan: &LogicalPlan) -> Rc<LogicalPlan> {
+        let mut accum = HashSet::new();
+        self.optimize_plan(plan, &mut accum)
+    }
+
+}
+
+impl ProjectionPushDown {
+
+    pub fn new() -> Self {
+        Self {
+        }
+    }
+
+    fn optimize_plan(&self, plan: &LogicalPlan, accum: &mut HashSet<usize>) -> Rc<LogicalPlan> {
+        match plan {
+            LogicalPlan::Aggregate { input, group_expr, aggr_expr, schema } => {
+                // collect all columns referenced by grouping and aggregate expressions
+                group_expr.iter().for_each(|e| self.collect_expr(e, accum));
+                aggr_expr.iter().for_each(|e| self.collect_expr(e, accum));
+
+                Rc::new(LogicalPlan::Aggregate {
+                    input: self.optimize_plan(&input, accum),
+                    group_expr: group_expr.clone(),
+                    aggr_expr: aggr_expr.clone(),
+                    schema: schema.clone()
+                })
+            },
+            LogicalPlan::TableScan { schema_name, table_name, schema, .. } => {
+                // once we reach the table scan, we can use the accumulated set of column indexes as
+                // the projection in the table scan
+                let mut projection: Vec<usize> = Vec::with_capacity(accum.len());
+                accum.iter().for_each(|i| projection.push(*i));
+                Rc::new(LogicalPlan::TableScan { schema_name: schema_name.to_string(), table_name: table_name.to_string(), schema: schema.clone(), projection: Some(projection) })
+            },
+            //TODO implement all logical plan variants and remove this unimplemented
+            _ => unimplemented!()
+        }
+    }
+
+    fn collect_expr(&self, expr: &Expr, accum: &mut HashSet<usize>) {
+        match expr {
+            Expr::Column(i) => {
+                accum.insert(*i);
+            },
+            //TODO implement all expression variants and remove this unimplemented
+            _ => unimplemented!()
+        }
+    }
+
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use std::rc::Rc;
+    use std::cell::RefCell;
+    use std::sync::Arc;
+    use arrow::datatypes::{Schema, Field, DataType};
+    use crate::logicalplan::LogicalPlan::*;
+    use crate::logicalplan::Expr::*;
+    use super::*;
+
+    #[test]
+    fn aggregate_no_group_by() {
+
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::UInt32, false),
+            Field::new("b", DataType::UInt32, false),
+            Field::new("c", DataType::UInt32, false),
+        ]);
+
+        // create unoptimized plan for SELECT MAX(b) FROM default.test
+
+        let table_scan = TableScan {
+            schema_name: "default".to_string(),
+            table_name: "test".to_string(),
+            schema: Arc::new(schema),
+            projection: None
+        };
+
+        let aggregate = Aggregate { group_expr: vec![], aggr_expr: vec![Column(2)],
+            schema: Arc::new(Schema::new(vec![Field::new("MAX(b)", DataType::UInt32, false)])),
+            input: Rc::new(table_scan),
+        };
+
+        // run optimizer rule
+
+        let rule: Rc<RefCell<OptimizerRule>> = Rc::new(RefCell::new(ProjectionPushDown::new()));
+
+        let optimized_plan = rule.borrow_mut().optimize(&aggregate);
+
+        println!("optimized plan: {:?}", optimized_plan);
+
+        //TODO: add assertions
+    }
+}

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -188,12 +188,8 @@ impl ProjectionPushDown {
             }
             Expr::Cast { expr, .. } => self.collect_expr(expr, accum),
             Expr::Sort { expr, .. } => self.collect_expr(expr, accum),
-            Expr::AggregateFunction { args, .. } => {
-                args.iter().for_each(|arg| self.collect_expr(arg, accum))
-            }
-            Expr::ScalarFunction { args, .. } => {
-                args.iter().for_each(|arg| self.collect_expr(arg, accum))
-            }
+            Expr::AggregateFunction { args, .. } => self.collect_exprs(args, accum),
+            Expr::ScalarFunction { args, .. } => self.collect_exprs(args, accum),
         }
     }
 
@@ -235,10 +231,7 @@ impl ProjectionPushDown {
                 return_type,
             } => Ok(Expr::AggregateFunction {
                 name: name.to_string(),
-                args: args
-                    .iter()
-                    .map(|arg| self.rewrite_expr(arg, mapping))
-                    .collect::<Result<Vec<Expr>>>()?,
+                args: self.rewrite_exprs(args, mapping)?,
                 return_type: return_type.clone(),
             }),
             Expr::ScalarFunction {
@@ -247,10 +240,7 @@ impl ProjectionPushDown {
                 return_type,
             } => Ok(Expr::ScalarFunction {
                 name: name.to_string(),
-                args: args
-                    .iter()
-                    .map(|arg| self.rewrite_expr(arg, mapping))
-                    .collect::<Result<Vec<Expr>>>()?,
+                args: self.rewrite_exprs(args, mapping)?,
                 return_type: return_type.clone(),
             }),
         }

--- a/rust/datafusion/src/sqlplanner.rs
+++ b/rust/datafusion/src/sqlplanner.rs
@@ -584,7 +584,7 @@ mod tests {
         quick_test(
             "SELECT state, MIN(age), MAX(age) FROM person GROUP BY state",
             "Aggregate: groupBy=[[#4]], aggr=[[MIN(#3), MAX(#3)]]\
-             \n  TableScan: person projection=TBD",
+             \n  TableScan: person projection=None",
         );
     }
 

--- a/rust/datafusion/src/sqlplanner.rs
+++ b/rust/datafusion/src/sqlplanner.rs
@@ -584,7 +584,7 @@ mod tests {
         quick_test(
             "SELECT state, MIN(age), MAX(age) FROM person GROUP BY state",
             "Aggregate: groupBy=[[#4]], aggr=[[MIN(#3), MAX(#3)]]\
-             \n  TableScan: person projection=None",
+             \n  TableScan: person projection=TBD",
         );
     }
 


### PR DESCRIPTION
This PR adds the first query optimizer rule, which rewrites a logical plan to push the projection down to the TableScan.

Once this is merged, I will create a follow up PR to integrate this into the query engine so that only the necessary columns are loaded from disk.
