### PR TITLE
ARROW-4594: [Ruby] Arrow::StructArray#[] returns Arrow::Struct instead of Arrow::Array

### DIFF
--- a/ruby/red-arrow/lib/arrow/struct-array.rb
+++ b/ruby/red-arrow/lib/arrow/struct-array.rb
@@ -19,17 +19,25 @@ require "arrow/struct"
 
 module Arrow
   class StructArray
-    def [](i)
-      warn("Use #{self.class}\#find_field instead. " +
-           "This will returns Arrow::Struct instead of Arrow::Array " +
-           "since 0.13.0.")
-      get_field(i)
-    end
-
+    # @param i [Integer]
+    #   The index of the value to be gotten. You must specify the value index.
+    #
+    #   You can use {Arrow::Array#[]} for convenient value access.
+    #
+    # @return [Arrow::Struct] The `i`-th value.
     def get_value(i)
       Struct.new(self, i)
     end
 
+    # @overload find_field(index)
+    #   @param index [Integer] The index of the field to be found.
+    #   @return [Arrow::Array, nil]
+    #      The `index`-th field or `nil` for out of range.
+    #
+    # @overload find_field(name)
+    #   @param index [String, Symbol] The name of the field to be found.
+    #   @return [Arrow::Array, nil]
+    #      The field that has `name` or `nil` for nonexistent name.
     def find_field(index_or_name)
       case index_or_name
       when String, Symbol

--- a/ruby/red-arrow/lib/arrow/struct.rb
+++ b/ruby/red-arrow/lib/arrow/struct.rb
@@ -64,5 +64,16 @@ module Arrow
       end
       super
     end
+
+    def ==(other)
+      other.is_a?(self.class) and
+        @array == other.array and
+        @index == other.index
+    end
+
+    protected
+    def array
+      @array
+    end
   end
 end

--- a/ruby/red-arrow/test/test-struct-array.rb
+++ b/ruby/red-arrow/test/test-struct-array.rb
@@ -49,9 +49,22 @@ class StructArrayTest < Test::Unit::TestCase
     end
 
     test("#[]") do
-      notify("TODO: Returns Arrow::Struct instead.")
-      assert_equal([[true, false], [1, 2]],
-                   [@array[0].to_a, @array[1].to_a])
+      assert_equal([
+                     Arrow::Struct.new(@array, 0),
+                     Arrow::Struct.new(@array, 1),
+                   ],
+                   @array.to_a)
+    end
+
+    test("#get_value") do
+      assert_equal([
+                     Arrow::Struct.new(@array, 0),
+                     Arrow::Struct.new(@array, 1),
+                   ],
+                   [
+                     @array.get_value(0),
+                     @array.get_value(1),
+                   ])
     end
 
     sub_test_case("#find_field") do


### PR DESCRIPTION
This is a compatibility breaking change but we warn about this change
in 0.12.0.