### PR TITLE
ARROW-4595: [Rust] Implement Table API (a.k.a DataFrame)

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -26,7 +26,6 @@ use std::mem::size_of;
 use std::ops::{Add, Div, Mul, Sub};
 use std::slice::from_raw_parts;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use packed_simd::*;
 use serde_derive::{Deserialize, Serialize};
@@ -751,22 +750,6 @@ impl Schema {
         json!({
             "fields": self.fields.iter().map(|field| field.to_json()).collect::<Vec<Value>>(),
         })
-    }
-
-    /// Create a new schema by applying a projection to this schema's fields
-    pub fn projection(&self, projection: &Vec<usize>) -> Result<Arc<Schema>> {
-        let mut fields: Vec<Field> = Vec::with_capacity(projection.len());
-        for i in projection {
-            if *i < self.fields().len() {
-                fields.push(self.field(*i).clone());
-            } else {
-                return Err(ArrowError::InvalidArgumentError(format!(
-                    "Invalid column index {} in projection",
-                    i
-                )));
-            }
-        }
-        Ok(Arc::new(Schema::new(fields)))
     }
 }
 

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -25,8 +25,8 @@ use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::{RecordBatchIterator, ScanResult, Table};
-use crate::error::Result;
+use crate::datasource::{RecordBatchIterator, ScanResult, TableProvider};
+use crate::execution::error::Result;
 
 /// Represents a CSV file with a provided schema
 // TODO: usage example (rather than documenting `new()`)
@@ -47,7 +47,7 @@ impl CsvFile {
     }
 }
 
-impl Table for CsvFile {
+impl TableProvider for CsvFile {
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, TableProvider};
-use crate::execution::error::Result;
+use crate::error::Result;
 
 /// Represents a CSV file with a provided schema
 // TODO: usage example (rather than documenting `new()`)

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -29,7 +29,7 @@ use crate::error::Result;
 pub type ScanResult = Arc<Mutex<RecordBatchIterator>>;
 
 /// Source table
-pub trait Table {
+pub trait TableProvider {
     /// Get a reference to the schema for this table
     fn schema(&self) -> &Arc<Schema>;
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex};
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::{RecordBatchIterator, ScanResult, Table};
+use crate::datasource::{RecordBatchIterator, ScanResult, TableProvider};
 use crate::error::{ExecutionError, Result};
 
 /// In-memory table

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -49,7 +49,7 @@ impl MemTable {
     }
 
     /// Create a mem table by reading from another data source
-    pub fn load(t: &Table) -> Result<Self> {
+    pub fn load(t: &TableProvider) -> Result<Self> {
         let schema = t.schema();
         let partitions = t.scan(&None, 1024 * 1024)?;
 
@@ -64,7 +64,7 @@ impl MemTable {
     }
 }
 
-impl Table for MemTable {
+impl TableProvider for MemTable {
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -23,5 +23,5 @@ pub mod memory;
 pub mod parquet;
 
 pub use self::csv::{CsvBatchIterator, CsvFile};
-pub use self::datasource::{RecordBatchIterator, ScanResult, Table};
+pub use self::datasource::{RecordBatchIterator, ScanResult, TableProvider};
 pub use self::memory::{MemBatchIterator, MemTable};

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -31,7 +31,7 @@ use parquet::data_type::{ByteArray, Int96};
 use parquet::file::reader::*;
 use parquet::reader::schema::parquet_to_arrow_schema;
 
-use crate::datasource::{RecordBatchIterator, ScanResult, Table};
+use crate::datasource::{RecordBatchIterator, ScanResult, TableProvider};
 use crate::error::{ExecutionError, Result};
 
 /// Table-based representation of a `ParquetFile`
@@ -53,7 +53,7 @@ impl ParquetTable {
     }
 }
 
-impl Table for ParquetTable {
+impl TableProvider for ParquetTable {
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }
@@ -677,7 +677,7 @@ mod tests {
         );
     }
 
-    fn load_table(name: &str) -> Box<Table> {
+    fn load_table(name: &str) -> Box<TableProvider> {
         let testdata = env::var("PARQUET_TEST_DATA").unwrap();
         let filename = format!("{}/{}", testdata, name);
         let table = ParquetTable::try_new(&filename).unwrap();

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -108,6 +108,7 @@ impl ExecutionContext {
             .insert(name.to_string(), provider);
     }
 
+    /// Get a table by name
     pub fn table(&mut self, table_name: &str) -> Result<Arc<Table>> {
         match self.datasources.borrow().get(table_name) {
             Some(provider) => {

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -34,6 +34,7 @@ use crate::execution::filter::FilterRelation;
 use crate::execution::limit::LimitRelation;
 use crate::execution::projection::ProjectRelation;
 use crate::execution::relation::{DataSourceRelation, Relation};
+use crate::execution::table_impl::TableImpl;
 use crate::logicalplan::*;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
@@ -41,10 +42,11 @@ use crate::optimizer::type_coercion::TypeCoercionRule;
 use crate::optimizer::utils;
 use crate::sql::parser::{DFASTNode, DFParser};
 use crate::sql::planner::{SchemaProvider, SqlToRel};
+use crate::datasource::TableProvider;
 
 /// Execution context for registering data sources and executing queries
 pub struct ExecutionContext {
-    datasources: Rc<RefCell<HashMap<String, Rc<Table>>>>,
+    datasources: Rc<RefCell<HashMap<String, Rc<TableProvider>>>>,
 }
 
 impl ExecutionContext {
@@ -100,10 +102,27 @@ impl ExecutionContext {
     }
 
     /// Register a table so that it can be queried from SQL
-    pub fn register_table(&mut self, name: &str, provider: Rc<Table>) {
+    pub fn register_table(&mut self, name: &str, provider: Rc<TableProvider>) {
         self.datasources
             .borrow_mut()
             .insert(name.to_string(), provider);
+    }
+
+    pub fn table(&mut self, table_name: &str) -> Result<Arc<Table>> {
+        match self.datasources.borrow().get(table_name) {
+            Some(provider) => {
+                Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::TableScan {
+                    schema_name: "".to_string(),
+                    table_name: table_name.to_string(),
+                    schema: provider.schema().clone(),
+                    projection: None,
+                }))))
+            }
+            _ => Err(ExecutionError::General(format!(
+                "No table named '{}'",
+                table_name
+            ))),
+        }
     }
 
     /// Optimize the logical plan by applying optimizer rules
@@ -268,7 +287,7 @@ impl ExecutionContext {
 }
 
 struct ExecutionContextSchemaProvider {
-    datasources: Rc<RefCell<HashMap<String, Rc<Table>>>>,
+    datasources: Rc<RefCell<HashMap<String, Rc<TableProvider>>>>,
 }
 impl SchemaProvider for ExecutionContextSchemaProvider {
     fn get_table_meta(&self, name: &str) -> Option<Arc<Schema>> {

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use arrow::datatypes::*;
 
 use crate::datasource::csv::CsvFile;
-use crate::datasource::datasource::Table;
+use crate::datasource::TableProvider;
 use crate::error::{ExecutionError, Result};
 use crate::execution::aggregate::AggregateRelation;
 use crate::execution::expression::*;
@@ -42,7 +42,7 @@ use crate::optimizer::type_coercion::TypeCoercionRule;
 use crate::optimizer::utils;
 use crate::sql::parser::{DFASTNode, DFParser};
 use crate::sql::planner::{SchemaProvider, SqlToRel};
-use crate::datasource::TableProvider;
+use crate::table::Table;
 
 /// Execution context for registering data sources and executing queries
 pub struct ExecutionContext {

--- a/rust/datafusion/src/execution/mod.rs
+++ b/rust/datafusion/src/execution/mod.rs
@@ -24,3 +24,4 @@ pub mod filter;
 pub mod limit;
 pub mod projection;
 pub mod relation;
+pub mod table_impl;

--- a/rust/datafusion/src/execution/table_impl.rs
+++ b/rust/datafusion/src/execution/table_impl.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Implementation of Table API
+
+use std::sync::Arc;
+
+use crate::execution::error::{ExecutionError, Result};
+use crate::logicalplan::{Expr, LogicalPlan};
+use crate::table::*;
+
+use crate::logicalplan::Expr::Literal;
+use crate::logicalplan::ScalarValue;
+
+pub struct TableImpl {
+    plan: Arc<LogicalPlan>,
+}
+
+impl TableImpl {
+    pub fn new(plan: Arc<LogicalPlan>) -> Self {
+        Self { plan }
+    }
+}
+
+impl Table for TableImpl {
+    fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<Table>> {
+        let schema = self.plan.schema();
+        let mut projection: Vec<usize> = Vec::with_capacity(columns.len());
+        let mut expr: Vec<Expr> = Vec::with_capacity(columns.len());
+
+        for column in columns {
+            match schema.column_with_name(column) {
+                Some((i, _)) => {
+                    projection.push(i);
+                    expr.push(Expr::Column(i));
+                }
+                _ => {
+                    return Err(ExecutionError::InvalidColumn(format!(
+                        "No column named '{}'",
+                        column
+                    )));
+                }
+            }
+        }
+
+        Ok(Arc::new(TableImpl::new(Arc::new(
+            LogicalPlan::Projection {
+                expr,
+                input: self.plan.clone(),
+                schema: schema.projection(&projection)?,
+            },
+        ))))
+    }
+
+    fn limit(&self, n: usize) -> Result<Arc<Table>> {
+        Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::Limit {
+            expr: Literal(ScalarValue::UInt32(n as u32)),
+            input: self.plan.clone(),
+            schema: self.plan.schema().clone(),
+        }))))
+    }
+
+    fn to_logical_plan(&self) -> Arc<LogicalPlan> {
+        self.plan.clone()
+    }
+}

--- a/rust/datafusion/src/execution/table_impl.rs
+++ b/rust/datafusion/src/execution/table_impl.rs
@@ -19,24 +19,27 @@
 
 use std::sync::Arc;
 
-use crate::execution::error::{ExecutionError, Result};
+use crate::error::{ExecutionError, Result};
 use crate::logicalplan::{Expr, LogicalPlan};
 use crate::table::*;
 
 use crate::logicalplan::Expr::Literal;
 use crate::logicalplan::ScalarValue;
 
+/// Implementation of Table API
 pub struct TableImpl {
     plan: Arc<LogicalPlan>,
 }
 
 impl TableImpl {
+    /// Create a new Table based on an existing logical plan
     pub fn new(plan: Arc<LogicalPlan>) -> Self {
         Self { plan }
     }
 }
 
 impl Table for TableImpl {
+    /// Apply a projection based on a list of column names
     fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<Table>> {
         let schema = self.plan.schema();
         let mut projection: Vec<usize> = Vec::with_capacity(columns.len());
@@ -66,6 +69,7 @@ impl Table for TableImpl {
         ))))
     }
 
+    /// Limit the number of rows
     fn limit(&self, n: usize) -> Result<Arc<Table>> {
         Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::Limit {
             expr: Literal(ScalarValue::UInt32(n as u32)),
@@ -74,6 +78,7 @@ impl Table for TableImpl {
         }))))
     }
 
+    /// Convert to logical plan
     fn to_logical_plan(&self) -> Arc<LogicalPlan> {
         self.plan.clone()
     }

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -32,3 +32,4 @@ pub mod execution;
 pub mod logicalplan;
 pub mod optimizer;
 pub mod sql;
+pub mod table;

--- a/rust/datafusion/src/table.rs
+++ b/rust/datafusion/src/table.rs
@@ -15,57 +15,72 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use crate::execution::error::Result;
+use crate::logicalplan::LogicalPlan;
 use std::sync::Arc;
-use crate::logicalplan::{Expr, LogicalPlan};
 
 /// Table is an abstraction of a logical query plan
-trait Table {
-
+pub trait Table {
     /// Select columns by name
-    fn select_columns(&self, columns: Vec<&str>) -> Arc<Table>;
-
-    /// Select using expressions
-    fn projection(&self, expr: Vec<Expr>) -> Arc<Table>;
-
-    /// filter
-    fn filter(&self, expr: Expr) -> Arc<Table>;
+    fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<Table>>;
 
     /// limit the number of rows
-    fn limit(&self, n: usize) -> Arc<Table>;
+    fn limit(&self, n: usize) -> Result<Arc<Table>>;
 
-    fn join(&self, other: &Table, join_condition: Expr) -> Arc<Table>;
-
-    fn aggregate(&self, expr: Vec<Expr>) -> Arc<Table>;
-    
-    fn group_by(&self, expr: Vec<Expr>) -> Arc<Table>;
-
-    /// convert to a logical plan
-    fn to_logical_plan(&self) -> LogicalPlan;
-
+    /// Return the logical plan
+    fn to_logical_plan(&self) -> Arc<LogicalPlan>;
 }
-
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::execution::context::ExecutionContext;
+    use arrow::datatypes::*;
 
     #[test]
     fn demonstrate_api_usage() {
+        let mut ctx = ExecutionContext::new();
+        register_aggregate_csv(&mut ctx);
 
-        let t = test_table();
+        let t = ctx.table("aggregate_test_100").unwrap();
 
-        let example = t.select_columns(vec!["a", "b", "c"])
-            .limit(10);
+        let example = t
+            .select_columns(vec!["c1", "c2", "c11"])
+            .unwrap()
+            .limit(10)
+            .unwrap();
 
         let plan = example.to_logical_plan();
 
-        let mut ctx = ExecutionContext::new();
-        let _result = ctx.execute(&plan, 1024*1024).unwrap();
-
+        assert_eq!("Limit: UInt32(10)\n  Projection: #0, #1, #10\n    TableScan: aggregate_test_100 projection=None", format!("{:?}", plan));
     }
 
-    fn test_table() -> Arc<Table> {
-        unimplemented!()
+    fn register_aggregate_csv(ctx: &mut ExecutionContext) {
+        let schema = aggr_test_schema();
+        ctx.register_csv(
+            "aggregate_test_100",
+            "../../testing/data/csv/aggregate_test_100.csv",
+            &schema,
+            true,
+        );
     }
+
+    fn aggr_test_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("c1", DataType::Utf8, false),
+            Field::new("c2", DataType::UInt32, false),
+            Field::new("c3", DataType::Int8, false),
+            Field::new("c4", DataType::Int16, false),
+            Field::new("c5", DataType::Int32, false),
+            Field::new("c6", DataType::Int64, false),
+            Field::new("c7", DataType::UInt8, false),
+            Field::new("c8", DataType::UInt16, false),
+            Field::new("c9", DataType::UInt32, false),
+            Field::new("c10", DataType::UInt64, false),
+            Field::new("c11", DataType::Float32, false),
+            Field::new("c12", DataType::Float64, false),
+            Field::new("c13", DataType::Utf8, false),
+        ]))
+    }
+
 }

--- a/rust/datafusion/src/table.rs
+++ b/rust/datafusion/src/table.rs
@@ -18,7 +18,7 @@
 //! Table API for building a logical query plan. This is similar to the Table API in Ibis and
 //! the DataFrame API in Apache Spark
 
-use crate::execution::error::Result;
+use crate::error::Result;
 use crate::logicalplan::LogicalPlan;
 use std::sync::Arc;
 

--- a/rust/datafusion/src/table.rs
+++ b/rust/datafusion/src/table.rs
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+use crate::logicalplan::{Expr, LogicalPlan};
+
+/// Table is an abstraction of a logical query plan
+trait Table {
+
+    /// Select columns by name
+    fn select_columns(&self, columns: Vec<&str>) -> Arc<Table>;
+
+    /// Select using expressions
+    fn projection(&self, expr: Vec<Expr>) -> Arc<Table>;
+
+    /// filter
+    fn filter(&self, expr: Expr) -> Arc<Table>;
+
+    /// limit the number of rows
+    fn limit(&self, n: usize) -> Arc<Table>;
+
+    fn join(&self, other: &Table, join_condition: Expr) -> Arc<Table>;
+
+    fn aggregate(&self, expr: Vec<Expr>) -> Arc<Table>;
+    
+    fn group_by(&self, expr: Vec<Expr>) -> Arc<Table>;
+
+    /// convert to a logical plan
+    fn to_logical_plan(&self) -> LogicalPlan;
+
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::context::ExecutionContext;
+
+    #[test]
+    fn demonstrate_api_usage() {
+
+        let t = test_table();
+
+        let example = t.select_columns(vec!["a", "b", "c"])
+            .limit(10);
+
+        let plan = example.to_logical_plan();
+
+        let mut ctx = ExecutionContext::new();
+        let _result = ctx.execute(&plan, 1024*1024).unwrap();
+
+    }
+
+    fn test_table() -> Arc<Table> {
+        unimplemented!()
+    }
+}

--- a/rust/datafusion/src/table.rs
+++ b/rust/datafusion/src/table.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Table API for building a logical query plan. This is similar to the Table API in Ibis and
+//! the DataFrame API in Apache Spark
+
 use crate::execution::error::Result;
 use crate::logicalplan::LogicalPlan;
 use std::sync::Arc;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -27,7 +27,7 @@ use arrow::array::*;
 use arrow::datatypes::{DataType, Field, Schema};
 
 use datafusion::datasource::parquet::ParquetTable;
-use datafusion::datasource::Table;
+use datafusion::datasource::TableProvider;
 use datafusion::execution::context::ExecutionContext;
 use datafusion::execution::relation::Relation;
 
@@ -179,7 +179,7 @@ fn register_csv(
     ctx.register_csv(name, filename, &schema, true);
 }
 
-fn load_parquet_table(name: &str) -> Rc<Table> {
+fn load_parquet_table(name: &str) -> Rc<TableProvider> {
     let testdata = env::var("PARQUET_TEST_DATA").unwrap();
     let filename = format!("{}/{}", testdata, name);
     let table = ParquetTable::try_new(&filename).unwrap();


### PR DESCRIPTION
This PR adds a `DataFrame` trait styled loosely after Apache Spark. I would love to get feedback on this idea, especially from the point of view of people with experience of Pandas and other DataFrame implementations.