### PR TITLE
ARROW-4598: [CI] Remove needless LLVM_DIR for macOS

### DIFF
--- a/ci/travis_before_script_cpp.sh
+++ b/ci/travis_before_script_cpp.sh
@@ -151,7 +151,6 @@ else
     if [ "$using_homebrew" = "yes" ]; then
 	# build against homebrew's boost if we're using it
 	export BOOST_ROOT=$(brew --prefix boost)
-	export LLVM_DIR=$(brew --prefix llvm@6)/lib/cmake/llvm
 	export THRIFT_HOME=$(brew --prefix thrift)
     fi
     cmake $CMAKE_COMMON_FLAGS \


### PR DESCRIPTION
We can detect LLVM installed by Homebrew automatically in CMake.