### PR TITLE
PARQUET-1532: [C++] Fix build error with MinGW

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -248,7 +248,7 @@ foreach(LIB_TARGET ${PARQUET_LIBRARIES})
                              HAVE_INTTYPES_H
                              PRIVATE
                              HAVE_NETDB_H)
-  if(MSVC)
+  if(WIN32)
     target_compile_definitions(${LIB_TARGET} PRIVATE NOMINMAX)
   else()
     target_compile_definitions(${LIB_TARGET} PRIVATE HAVE_NETINET_IN_H)


### PR DESCRIPTION
Error message:

    In file included from C:/msys64/mingw64/include/thrift/TApplicationException.h:23,
                     from C:/Users/kou/work/arrow/arrow.kou/cpp/src/parquet/thrift.h:35,
                     from C:/Users/kou/work/arrow/arrow.kou/cpp/src/parquet/column_reader.cc:36:
    C:/msys64/mingw64/include/thrift/Thrift.h:32:10: fatal error: netinet/in.h: No such file or directory
     #include <netinet/in.h>
              ^~~~~~~~~~~~~~