### PR TITLE
ARROW-4602: [Rust] [DataFusion] Integrate query optimizer with ExecutionContext

### DIFF
--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -319,8 +319,17 @@ impl<R: Read> Reader<R> {
             })
             .collect();
 
+        let schema_fields = self.schema.fields();
+
+        let projected_fields: Vec<Field> = projection
+            .iter()
+            .map(|i| schema_fields[*i].clone())
+            .collect();
+
+        let projected_schema = Arc::new(Schema::new(projected_fields));
+
         match arrays {
-            Ok(arr) => Ok(Some(RecordBatch::new(self.schema.clone(), arr))),
+            Ok(arr) => Ok(Some(RecordBatch::new(projected_schema, arr))),
             Err(e) => Err(e),
         }
     }

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -48,3 +48,7 @@ sqlparser = "0.2.0"
 [dev-dependencies]
 criterion = "0.2.0"
 
+[[bench]]
+name = "aggregate_query_sql"
+harness = false
+

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     fn load_csv(filename: &str, schema: &Arc<Schema>) -> Rc<RefCell<Relation>> {
-        let ds = CsvDataSource::new(filename, schema.clone(), 1024);
+        let ds = CsvDataSource::new(filename, schema.clone(), true, &None, 1024);
         Rc::new(RefCell::new(DataSourceRelation::new(Rc::new(
             RefCell::new(ds),
         ))))

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -104,9 +104,12 @@ mod tests {
             Field::new("c11", DataType::Float64, false),
             Field::new("c12", DataType::Utf8, false),
         ]));
+
         let ds = CsvDataSource::new(
             "../../testing/data/csv/aggregate_test_100.csv",
             schema.clone(),
+            true,
+            &None,
             1024,
         );
         let relation = Rc::new(RefCell::new(DataSourceRelation::new(Rc::new(

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -26,8 +26,9 @@ use arrow::array::*;
 use arrow::datatypes::{DataType, Field, Schema};
 
 use datafusion::execution::context::ExecutionContext;
-use datafusion::execution::datasource::CsvDataSource;
 use datafusion::execution::relation::Relation;
+
+const DEFAULT_BATCH_SIZE: usize = 1024 * 1024;
 
 #[test]
 fn csv_query_with_predicate() {
@@ -159,13 +160,12 @@ fn register_csv(
     filename: &str,
     schema: &Arc<Schema>,
 ) {
-    let csv_datasource = CsvDataSource::new(filename, schema.clone(), 1024);
-    ctx.register_datasource(name, Rc::new(RefCell::new(csv_datasource)));
+    ctx.register_csv(name, filename, &schema, true);
 }
 
 /// Execute query and return result set as tab delimited string
 fn execute(ctx: &mut ExecutionContext, sql: &str) -> String {
-    let results = ctx.sql(&sql).unwrap();
+    let results = ctx.sql(&sql, DEFAULT_BATCH_SIZE).unwrap();
     result_str(&results)
 }
 


### PR DESCRIPTION
Instead of registering `DataSource` with the context, we now register `DataSourceProvider`. This trait has a `scan()` method where we can pass the projection.

`ExecutionContext` calls the optimizer rule for all SQL queries now, so that only the necessary columns are loaded from disk. 

There is also a simpler API for registering CSV files with the context, with a `register_csv` method. 

I added some criterion benchmarks too but they are not ideal since they load from disk each time. I am working on another PR to add support for running queries against RecordBatches already loaded into memory and will update the benchmarks to use these as part of that PR.