### PR TITLE
ARROW-4610: [Plasma] Avoid Crash in Plasma Java Client

### DIFF
--- a/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaClientException.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaClientException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.plasma.exceptions;
+
+public class PlasmaClientException extends RuntimeException {
+
+  public PlasmaClientException(String message) {
+    super(message);
+  }
+
+  public PlasmaClientException(String message, Throwable t) {
+    super(message, t);
+  }
+}

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.apache.arrow.plasma.exceptions.DuplicateObjectException;
+import org.apache.arrow.plasma.exceptions.PlasmaClientException;
 import org.junit.Assert;
 
 public class PlasmaClientTest {
@@ -205,7 +206,32 @@ public class PlasmaClientTest {
     assert !pLink.contains(id6);
     System.out.println("Plasma java client delete test success.");
     
-    cleanup();
+    // Test calling shuntdown while getting the object.
+    Thread thread = new Thread(() -> {
+      try {
+        TimeUnit.SECONDS.sleep(1);
+        cleanup();
+      } catch (InterruptedException e) {
+        throw new RuntimeException("Got InterruptedException when sleeping.", e);
+      }
+    });
+    thread.start();
+
+    try {
+      byte[] idNone =  new byte[20];
+      Arrays.fill(idNone, (byte)987);
+      pLink.get(idNone, timeoutMs, false);
+      Assert.fail("Fail to throw PlasmaClientException when get an object " +
+                  "when object store shutdown.");
+    } catch (PlasmaClientException e) {
+      System.out.println(String.format("Expected PlasmaClientException: %s", e));
+    }
+
+    try {
+      thread.join();
+    } catch (Exception e) {
+      System.out.println(String.format("Excpetion caught: %s", e));
+    }
     System.out.println("All test success.");
 
   }


### PR DESCRIPTION
This PR removes all `ARROW_CHECK` from the JNI code to avoid Java client from crashing. The Java client will throw exception instead. For one thing, it is better to throw exceptions from the lower part and let the upper user to decide how to handle it. For another, JVM should not crash at all times and there are a lot of JVM core dump files when we are doing some failover tests by killing Plasma Server.