### PR TITLE
ARROW-4297: [C++] Fix build error with MinGW-w64 32-bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,14 +36,6 @@ cache:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    # Can't build with 32-bit MinGW for now.
-    # See https://issues.apache.org/jira/browse/ARROW-4297
-    - JOB: "MinGW32"
-      MINGW_PACKAGE_PREFIX: mingw-w64-i686
-      MINGW_PREFIX: c:\msys64\mingw32
-      MSYSTEM: MINGW32
-      USE_CLCACHE: false
 
 environment:
   global:

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -24,15 +24,6 @@ set INSTALL_DIR=%HOMEDRIVE%%HOMEPATH%\install
 set PATH=%INSTALL_DIR%\bin;%PATH%
 set PKG_CONFIG_PATH=%INSTALL_DIR%\lib\pkgconfig
 
-for /f "usebackq" %%v in (`python3 -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))"`) do (
-  set PYTHON_VERSION=%%v
-)
-
-set PYTHONHOME=%MINGW_PREFIX%\lib\python%PYTHON_VERSION%
-set PYTHONPATH=%PYTHONHOME%
-set PYTHONPATH=%PYTHONPATH%;%MINGW_PREFIX%\lib\python%PYTHON_VERSION%\lib-dynload
-set PYTHONPATH=%PYTHONPATH%;%MINGW_PREFIX%\lib\python%PYTHON_VERSION%\site-packages
-
 set CPP_BUILD_DIR=cpp\build
 mkdir %CPP_BUILD_DIR%
 pushd %CPP_BUILD_DIR%
@@ -54,6 +45,7 @@ cmake ^
     -DPythonInterp_FIND_VERSION=ON ^
     -DPythonInterp_FIND_VERSION_MAJOR=3 ^
     -DARROW_BUILD_TESTS=ON ^
+    -DARROW_PYTHON=OFF ^
     .. || exit /B
 make -j4 || exit /B
 ctest --output-on-failure -j2 || exit /B

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -44,8 +44,10 @@ cmake ^
     -DARROW_PYTHON=ON ^
     -DPythonInterp_FIND_VERSION=ON ^
     -DPythonInterp_FIND_VERSION_MAJOR=3 ^
+    -DARROW_BUILD_TESTS=ON ^
     .. || exit /B
 make -j4 || exit /B
+make test || exit /B
 make install || exit /B
 popd
 

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -45,6 +45,7 @@ cmake ^
     -DPythonInterp_FIND_VERSION=ON ^
     -DPythonInterp_FIND_VERSION_MAJOR=3 ^
     -DARROW_BUILD_TESTS=ON ^
+    -DARROW_PYTHON=OFF ^
     .. || exit /B
 make -j4 || exit /B
 make test || exit /B

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -24,6 +24,15 @@ set INSTALL_DIR=%HOMEDRIVE%%HOMEPATH%\install
 set PATH=%INSTALL_DIR%\bin;%PATH%
 set PKG_CONFIG_PATH=%INSTALL_DIR%\lib\pkgconfig
 
+for /f "usebackq" %%v in (`python3 -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))"`) do (
+  set PYTHON_VERSION=%%v
+)
+
+set PYTHONHOME=%MINGW_PREFIX%\lib\python%PYTHON_VERSION%
+set PYTHONPATH=%PYTHONHOME%
+set PYTHONPATH=%PYTHONPATH%;%MINGW_PREFIX%\lib\python%PYTHON_VERSION%\lib-dynload
+set PYTHONPATH=%PYTHONPATH%;%MINGW_PREFIX%\lib\python%PYTHON_VERSION%\site-packages
+
 set CPP_BUILD_DIR=cpp\build
 mkdir %CPP_BUILD_DIR%
 pushd %CPP_BUILD_DIR%
@@ -45,7 +54,6 @@ cmake ^
     -DPythonInterp_FIND_VERSION=ON ^
     -DPythonInterp_FIND_VERSION_MAJOR=3 ^
     -DARROW_BUILD_TESTS=ON ^
-    -DARROW_PYTHON=OFF ^
     .. || exit /B
 make -j4 || exit /B
 ctest --output-on-failure -j2 || exit /B

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -48,7 +48,7 @@ cmake ^
     -DARROW_PYTHON=OFF ^
     .. || exit /B
 make -j4 || exit /B
-make test || exit /B
+ctest --output-on-failure -j2 || exit /B
 make install || exit /B
 popd
 

--- a/ci/appveyor-cpp-setup-mingw.bat
+++ b/ci/appveyor-cpp-setup-mingw.bat
@@ -25,6 +25,7 @@ pacman -S --noconfirm ^
     "%MINGW_PACKAGE_PREFIX%-cmake" ^
     "%MINGW_PACKAGE_PREFIX%-flatbuffers" ^
     "%MINGW_PACKAGE_PREFIX%-gcc" ^
+    "%MINGW_PACKAGE_PREFIX%-gflags" ^
     "%MINGW_PACKAGE_PREFIX%-gobject-introspection" ^
     "%MINGW_PACKAGE_PREFIX%-gtk-doc" ^
     "%MINGW_PACKAGE_PREFIX%-lz4" ^

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -302,22 +302,13 @@ arrow_add_pkg_config("arrow")
 
 add_arrow_test(allocator-test)
 
-if(WIN32)
-  add_arrow_test(array-test
-                 SOURCES
-                 array-test.cc
-                 array-binary-test.cc
-                 array-list-test.cc
-                 array-struct-test.cc)
-else()
-  add_arrow_test(array-test
-                 SOURCES
-                 array-test.cc
-                 array-binary-test.cc
-                 array-dict-test.cc
-                 array-list-test.cc
-                 array-struct-test.cc)
-endif()
+add_arrow_test(array-test
+               SOURCES
+               array-test.cc
+               array-binary-test.cc
+               array-dict-test.cc
+               array-list-test.cc
+               array-struct-test.cc)
 
 add_arrow_test(buffer-test)
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -302,13 +302,22 @@ arrow_add_pkg_config("arrow")
 
 add_arrow_test(allocator-test)
 
-add_arrow_test(array-test
-               SOURCES
-               array-test.cc
-               array-binary-test.cc
-               array-dict-test.cc
-               array-list-test.cc
-               array-struct-test.cc)
+if(WIN32)
+  add_arrow_test(array-test
+                 SOURCES
+                 array-test.cc
+                 array-binary-test.cc
+                 array-list-test.cc
+                 array-struct-test.cc)
+else()
+  add_arrow_test(array-test
+                 SOURCES
+                 array-test.cc
+                 array-binary-test.cc
+                 array-dict-test.cc
+                 array-list-test.cc
+                 array-struct-test.cc)
+endif()
 
 add_arrow_test(buffer-test)
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -301,13 +301,24 @@ arrow_add_pkg_config("arrow")
 #
 
 add_arrow_test(allocator-test)
-add_arrow_test(array-test
-               SOURCES
-               array-test.cc
-               array-binary-test.cc
-               array-dict-test.cc
-               array-list-test.cc
-               array-struct-test.cc)
+
+if(WIN32)
+  add_arrow_test(array-test
+                 SOURCES
+                 array-test.cc
+                 array-binary-test.cc
+                 array-list-test.cc
+                 array-struct-test.cc)
+else()
+  add_arrow_test(array-test
+                 SOURCES
+                 array-test.cc
+                 array-binary-test.cc
+                 array-dict-test.cc
+                 array-list-test.cc
+                 array-struct-test.cc)
+endif()
+
 add_arrow_test(buffer-test)
 
 if(ARROW_IPC)

--- a/cpp/src/arrow/compute/kernels/cast-test.cc
+++ b/cpp/src/arrow/compute/kernels/cast-test.cc
@@ -424,6 +424,7 @@ TEST_F(TestCast, FloatingPointToInt) {
                                                     options);
 }
 
+#if ARROW_BITNESS >= 64
 TEST_F(TestCast, IntToFloatingPoint) {
   auto options = CastOptions::Safe();
 
@@ -438,6 +439,7 @@ TEST_F(TestCast, IntToFloatingPoint) {
                                                     UnsafeVectorCast<double, int64_t>(v1),
                                                     options);
 }
+#endif
 
 TEST_F(TestCast, TimestampToTimestamp) {
   CastOptions options;

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -18,6 +18,8 @@
 #ifndef ARROW_UTIL_MACROS_H
 #define ARROW_UTIL_MACROS_H
 
+#include <cstdint>
+
 #define ARROW_STRINGIFY(x) #x
 #define ARROW_CONCAT(x, y) x##y
 
@@ -121,6 +123,17 @@
 #define ARROW_DISABLE_UBSAN(feature) __attribute__((no_sanitize(feature)))
 #else
 #define ARROW_DISABLE_UBSAN(feature)
+#endif
+
+// ----------------------------------------------------------------------
+// Machine information
+
+#if INTPTR_MAX == INT64_MAX
+#define ARROW_BITNESS 64
+#elif INTPTR_MAX == INT32_MAX
+#define ARROW_BITNESS 32
+#else
+#error Unexpected INTPTR_MAX
 #endif
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/util/sse-util.h
+++ b/cpp/src/arrow/util/sse-util.h
@@ -110,7 +110,12 @@ static inline uint32_t SSE4_crc32_u32(uint32_t crc, uint32_t v) {
 }
 
 static inline uint32_t SSE4_crc32_u64(uint32_t crc, uint64_t v) {
+#if defined(__MINGW32__) && !defined(__MINGW64__)
+  DCHECK(false) << "MinGW-w64 32-bit doesn't support _mm_crc32_u64()";
+  return 0;
+#else
   return static_cast<uint32_t>(_mm_crc32_u64(crc, v));
+#endif
 }
 
 #else  // without SSE 4.2.

--- a/cpp/src/arrow/util/sse-util.h
+++ b/cpp/src/arrow/util/sse-util.h
@@ -110,8 +110,7 @@ static inline uint32_t SSE4_crc32_u32(uint32_t crc, uint32_t v) {
 }
 
 static inline uint32_t SSE4_crc32_u64(uint32_t crc, uint64_t v) {
-#if defined(__MINGW32__) && !defined(__MINGW64__)
-  DCHECK(false) << "MinGW-w64 32-bit doesn't support _mm_crc32_u64()";
+#if ARROW_BITNESS == 32
   return 0;
 #else
   return static_cast<uint32_t>(_mm_crc32_u64(crc, v));


### PR DESCRIPTION
Improvements for [ARROW-4297](https://issues.apache.org/jira/browse/ARROW-4297). This PR is a follow up to the discussed patch from https://github.com/apache/arrow/pull/3443.