### PR TITLE
ARROW-585: [C++] Experimental public API for user-defined extension types and arrays

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -87,6 +87,7 @@ set(ARROW_SRCS
     array/builder_union.cc
     buffer.cc
     compare.cc
+    extension_type.cc
     memory_pool.cc
     pretty_print.cc
     record_batch.cc
@@ -308,6 +309,12 @@ add_arrow_test(array-test
                array-list-test.cc
                array-struct-test.cc)
 add_arrow_test(buffer-test)
+
+if(ARROW_IPC)
+  # The extension type unit tests require IPC / Flatbuffers support
+  add_arrow_test(extension_type-test)
+endif()
+
 add_arrow_test(memory_pool-test)
 add_arrow_test(pretty_print-test)
 add_arrow_test(public-api-test)

--- a/cpp/src/arrow/api.h
+++ b/cpp/src/arrow/api.h
@@ -20,19 +20,20 @@
 #ifndef ARROW_API_H
 #define ARROW_API_H
 
-#include "arrow/array.h"          // IYWU pragma: export
-#include "arrow/buffer.h"         // IYWU pragma: export
-#include "arrow/builder.h"        // IYWU pragma: export
-#include "arrow/compare.h"        // IYWU pragma: export
-#include "arrow/memory_pool.h"    // IYWU pragma: export
-#include "arrow/pretty_print.h"   // IYWU pragma: export
-#include "arrow/record_batch.h"   // IYWU pragma: export
-#include "arrow/status.h"         // IYWU pragma: export
-#include "arrow/table.h"          // IYWU pragma: export
-#include "arrow/table_builder.h"  // IYWU pragma: export
-#include "arrow/tensor.h"         // IYWU pragma: export
-#include "arrow/type.h"           // IYWU pragma: export
-#include "arrow/visitor.h"        // IYWU pragma: export
+#include "arrow/array.h"           // IYWU pragma: export
+#include "arrow/buffer.h"          // IYWU pragma: export
+#include "arrow/builder.h"         // IYWU pragma: export
+#include "arrow/compare.h"         // IYWU pragma: export
+#include "arrow/extension_type.h"  // IYWU pragma: export
+#include "arrow/memory_pool.h"     // IYWU pragma: export
+#include "arrow/pretty_print.h"    // IYWU pragma: export
+#include "arrow/record_batch.h"    // IYWU pragma: export
+#include "arrow/status.h"          // IYWU pragma: export
+#include "arrow/table.h"           // IYWU pragma: export
+#include "arrow/table_builder.h"   // IYWU pragma: export
+#include "arrow/tensor.h"          // IYWU pragma: export
+#include "arrow/type.h"            // IYWU pragma: export
+#include "arrow/visitor.h"         // IYWU pragma: export
 
 /// \brief Top-level namespace for Apache Arrow C++ API
 namespace arrow {}

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -896,12 +896,7 @@ class ArrayDataWrapper {
   }
 
   Status Visit(const ExtensionType& type) {
-    auto ext_name = type.extension_name();
-    ExtensionTypeAdapter* adapter = GetExtensionType(ext_name);
-    if (adapter == nullptr) {
-      return Status::Invalid("Unrecognized extension type: ", ext_name);
-    }
-    *out_ = adapter->WrapArray(data_);
+    *out_ = type.MakeArray(data_);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -26,6 +26,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/compare.h"
+#include "arrow/extension_type.h"
 #include "arrow/pretty_print.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
@@ -866,6 +867,8 @@ struct ValidateVisitor {
     }
     return Status::OK();
   }
+
+  Status Visit(const ExtensionArray& array) { return ValidateArray(*array.storage()); }
 };
 
 }  // namespace internal
@@ -889,6 +892,16 @@ class ArrayDataWrapper {
   Status Visit(const T&) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
     *out_ = std::make_shared<ArrayType>(data_);
+    return Status::OK();
+  }
+
+  Status Visit(const ExtensionType& type) {
+    auto ext_name = type.extension_name();
+    ExtensionTypeAdapter* adapter = GetExtensionType(ext_name);
+    if (adapter == nullptr) {
+      return Status::Invalid("Unrecognized extension type: ", ext_name);
+    }
+    *out_ = adapter->WrapArray(data_);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -299,6 +299,14 @@ class RangeEqualsVisitor {
     return Status::OK();
   }
 
+  Status Visit(const ExtensionArray& left) {
+    result_ = (right_.type()->Equals(*left.type()) &&
+               ArrayRangeEquals(*left.storage(),
+                                *static_cast<const ExtensionArray&>(right_).storage(),
+                                left_start_idx_, left_end_idx_, right_start_idx_));
+    return Status::OK();
+  }
+
   bool result() const { return result_; }
 
  protected:
@@ -502,6 +510,13 @@ class ArrayEqualsVisitor : public RangeEqualsVisitor {
   Visit(const T& left) {
     return RangeEqualsVisitor::Visit(left);
   }
+
+  Status Visit(const ExtensionArray& left) {
+    result_ = (right_.type()->Equals(*left.type()) &&
+               ArrayEquals(*left.storage(),
+                           *static_cast<const ExtensionArray&>(right_).storage()));
+    return Status::OK();
+  }
 };
 
 template <typename TYPE>
@@ -685,6 +700,11 @@ class TypeEqualsVisitor {
     result_ = left.index_type()->Equals(right.index_type()) &&
               left.dictionary()->Equals(right.dictionary()) &&
               (left.ordered() == right.ordered());
+    return Status::OK();
+  }
+
+  Status Visit(const ExtensionType& left) {
+    result_ = left.ExtensionEquals(static_cast<const ExtensionType&>(right_));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -49,7 +49,12 @@ bool ARROW_EXPORT ArrayRangeEquals(const Array& left, const Array& right,
                                    int64_t other_start_idx);
 
 /// Returns true if the type metadata are exactly equal
-bool ARROW_EXPORT TypeEquals(const DataType& left, const DataType& right);
+/// \param[in] left a DataType
+/// \param[in] right a DataType
+/// \param[in] check_metadata whether to compare KeyValueMetadata for child
+/// fields
+bool ARROW_EXPORT TypeEquals(const DataType& left, const DataType& right,
+                             bool check_metadata = true);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/extension_type-test.cc
+++ b/cpp/src/arrow/extension_type-test.cc
@@ -1,0 +1,142 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/array.h"
+#include "arrow/buffer-builder.h"
+#include "arrow/buffer.h"
+#include "arrow/extension_type.h"
+#include "arrow/io/memory.h"
+#include "arrow/ipc/reader.h"
+#include "arrow/ipc/writer.h"
+#include "arrow/record_batch.h"
+#include "arrow/status.h"
+#include "arrow/testing/gtest_common.h"
+#include "arrow/testing/util.h"
+#include "arrow/type.h"
+
+namespace arrow {
+
+class UUIDType : public ExtensionType {
+ public:
+  UUIDType() : ExtensionType(::arrow::fixed_size_binary(16)) {}
+
+  std::string extension_name() const override { return "uuid"; }
+
+  bool ExtensionEquals(const ExtensionType& other) const override {
+    const auto& other_ext = static_cast<const ExtensionType&>(other);
+    if (other_ext.extension_name() != this->extension_name()) {
+      return false;
+    }
+    return true;
+  }
+};
+
+class UUIDArray : public ExtensionArray {
+ public:
+  explicit UUIDArray(const std::shared_ptr<ArrayData>& data) : ExtensionArray(data) {}
+};
+
+class UUIDTypeAdapter : public ExtensionTypeAdapter {
+ public:
+  std::shared_ptr<Array> WrapArray(std::shared_ptr<ArrayData> data) override {
+    DCHECK_EQ(data->type->id(), Type::EXTENSION);
+    DCHECK_EQ("uuid", static_cast<const ExtensionType&>(*data->type).extension_name());
+    return std::make_shared<UUIDArray>(data);
+  }
+
+  Status Deserialize(std::shared_ptr<DataType> storage_type,
+                     const std::string& serialized,
+                     std::shared_ptr<DataType>* out) override {
+    if (serialized != "uuid-type-unique-code") {
+      return Status::Invalid("Type identifier did not match");
+    }
+    DCHECK(storage_type->Equals(*fixed_size_binary(16)));
+    *out = std::make_shared<UUIDType>();
+    return Status::OK();
+  }
+
+  std::string Serialize(const ExtensionType& type) override {
+    return "uuid-type-unique-code";
+  }
+};
+
+class TestExtensionType : public ::testing::Test {
+ public:
+  void SetUp() {
+    auto adapter = std::unique_ptr<ExtensionTypeAdapter>(new UUIDTypeAdapter());
+    ASSERT_OK(::arrow::RegisterExtensionType("uuid", std::move(adapter)));
+  }
+
+  void TearDown() { ASSERT_OK(::arrow::UnregisterExtensionType("uuid")); }
+};
+
+TEST_F(TestExtensionType, AdapterTest) {
+  auto adapter_not_exist = GetExtensionType("uuid-unknown");
+  ASSERT_EQ(adapter_not_exist, nullptr);
+
+  auto adapter = GetExtensionType("uuid");
+  ASSERT_NE(adapter, nullptr);
+
+  auto type = std::make_shared<UUIDType>();
+
+  std::string serialized = adapter->Serialize(*type);
+
+  std::shared_ptr<DataType> deserialized;
+  ASSERT_OK(adapter->Deserialize(fixed_size_binary(16), serialized, &deserialized));
+  ASSERT_TRUE(deserialized->Equals(*type));
+  ASSERT_FALSE(deserialized->Equals(*fixed_size_binary(16)));
+}
+
+TEST_F(TestExtensionType, IpcRoundtrip) {
+  auto storage_type = fixed_size_binary(16);
+  auto ext_type = std::make_shared<UUIDType>();
+
+  auto arr = ArrayFromJSON(
+      storage_type,
+      "[null, \"abcdefghijklmno0\", \"abcdefghijklmno1\", \"abcdefghijklmno2\"]");
+
+  auto ext_data = arr->data()->Copy();
+  ext_data->type = ext_type;
+  auto ext_arr = MakeArray(ext_data);
+
+  auto batch = RecordBatch::Make(schema({field("f0", ext_type)}), 4, {ext_arr});
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_OK(ipc::SerializeRecordBatch(*batch, default_memory_pool(), &buffer));
+
+  io::BufferReader stream(buffer);
+  std::shared_ptr<RecordBatch> read_batch;
+  ASSERT_OK(ipc::ReadRecordBatch(batch->schema(), &stream, &read_batch));
+
+  CompareBatch(*batch, *read_batch);
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/extension_type.cc
+++ b/cpp/src/arrow/extension_type.cc
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/extension_type.h"
+
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "arrow/array.h"
+#include "arrow/type.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+std::string ExtensionType::ToString() const {
+  std::stringstream ss;
+  ss << "extension<" << this->extension_name() << ">";
+  return ss.str();
+}
+
+std::string ExtensionType::name() const { return "extension"; }
+
+void ExtensionArray::SetData(const std::shared_ptr<ArrayData>& data) {
+  this->Array::SetData(data);
+
+  auto storage_data = data->Copy();
+  storage_data->type = (static_cast<const ExtensionType&>(*data->type).storage_type());
+  storage_ = MakeArray(storage_data);
+}
+
+std::unordered_map<std::string, std::unique_ptr<ExtensionTypeAdapter>>
+    g_extension_registry;
+std::mutex g_extension_registry_guard;
+
+Status RegisterExtensionType(const std::string& type_name,
+                             std::unique_ptr<ExtensionTypeAdapter> wrapper) {
+  std::lock_guard<std::mutex> lock_(g_extension_registry_guard);
+  auto it = g_extension_registry.find(type_name);
+  if (it != g_extension_registry.end()) {
+    return Status::KeyError("A type extension with name ", type_name, " already defined");
+  }
+  g_extension_registry[type_name] = std::move(wrapper);
+  return Status::OK();
+}
+
+Status UnregisterExtensionType(const std::string& type_name) {
+  std::lock_guard<std::mutex> lock_(g_extension_registry_guard);
+  auto it = g_extension_registry.find(type_name);
+  if (it == g_extension_registry.end()) {
+    return Status::KeyError("No type extension with name ", type_name, " found");
+  }
+  g_extension_registry.erase(it);
+  return Status::OK();
+}
+
+ExtensionTypeAdapter* GetExtensionType(const std::string& type_name) {
+  std::lock_guard<std::mutex> lock_(g_extension_registry_guard);
+  auto it = g_extension_registry.find(type_name);
+  if (it == g_extension_registry.end()) {
+    return nullptr;
+  } else {
+    return it->second.get();
+  }
+  return nullptr;
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// User-defined extension types. EXPERIMENTAL in 0.13.0
+/// \since 0.13.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "arrow/array.h"
+#include "arrow/type.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class TypeVisitor;
+
+class ExtensionTypeTraits {
+ public:
+  virtual ~ExtensionTypeTraits() = default;
+
+  /// \brief Name used for serialization, and lookups for deeserialization
+  virtual std::string extension_name() const = 0;
+
+  /// \brief Determine if two instances of the same extension types are
+  /// equal. Invoked from ExtensionType::Equals
+  /// \param[in] other the type to compare this type with
+  /// \return bool true if type instances are equal
+  virtual bool ExtensionEquals(const ExtensionType& other) const = 0;
+};
+
+/// \brief The base class for custom / user-defined types.
+class ARROW_EXPORT ExtensionType : public DataType, public ExtensionTypeTraits {
+ public:
+  static constexpr Type::type type_id = Type::EXTENSION;
+
+  std::shared_ptr<DataType> storage_type() const { return storage_type_; }
+
+  std::string ToString() const override;
+  std::string name() const override;
+
+ protected:
+  explicit ExtensionType(std::shared_ptr<DataType> storage_type)
+      : DataType(Type::EXTENSION), storage_type_(storage_type) {}
+
+  std::shared_ptr<DataType> storage_type_;
+};
+
+class ARROW_EXPORT ExtensionArray : public Array {
+ public:
+  /// \brief The physical storage for the extension array
+  std::shared_ptr<Array> storage() const { return storage_; }
+
+ protected:
+  explicit ExtensionArray(const std::shared_ptr<ArrayData>& data) { SetData(data); }
+
+  void SetData(const std::shared_ptr<ArrayData>& data);
+
+  std::shared_ptr<Array> storage_;
+};
+
+/// \brief Serializer interface for user-defined types
+class ExtensionTypeAdapter {
+ public:
+  /// \brief Wrap built-in Array type in a user-defined ExtensionArray instance
+  /// \param[in] data the physical storage for the extension type
+  virtual std::shared_ptr<Array> WrapArray(std::shared_ptr<ArrayData> data) = 0;
+
+  virtual Status Deserialize(std::shared_ptr<DataType> storage_type,
+                             const std::string& serialized_data,
+                             std::shared_ptr<DataType>* out) = 0;
+
+  virtual std::string Serialize(const ExtensionType& type) = 0;
+};
+
+/// \brief
+ARROW_EXPORT
+Status RegisterExtensionType(const std::string& type_name,
+                             std::unique_ptr<ExtensionTypeAdapter> wrapper);
+
+ARROW_EXPORT
+Status UnregisterExtensionType(const std::string& type_name);
+
+ARROW_EXPORT
+ExtensionTypeAdapter* GetExtensionType(const std::string& type_name);
+
+}  // namespace arrow

--- a/cpp/src/arrow/extension_type.h
+++ b/cpp/src/arrow/extension_type.h
@@ -82,14 +82,13 @@ class ARROW_EXPORT ExtensionType : public DataType {
 /// \brief Base array class for user-defined extension types
 class ARROW_EXPORT ExtensionArray : public Array {
  public:
+  explicit ExtensionArray(const std::shared_ptr<ArrayData>& data) { SetData(data); }
+
   /// \brief The physical storage for the extension array
   std::shared_ptr<Array> storage() const { return storage_; }
 
  protected:
-  explicit ExtensionArray(const std::shared_ptr<ArrayData>& data) { SetData(data); }
-
   void SetData(const std::shared_ptr<ArrayData>& data);
-
   std::shared_ptr<Array> storage_;
 };
 

--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -343,6 +343,10 @@ class SchemaWriter {
     return VisitType(*type.dictionary()->type());
   }
 
+  Status Visit(const ExtensionType& type) {
+    return Status::NotImplemented("extension type");
+  }
+
  private:
   DictionaryMemo dictionary_memo_;
 
@@ -578,6 +582,10 @@ class ArrayWriter {
       children.emplace_back(array.child(i));
     }
     return WriteChildren(type.children(), children);
+  }
+
+  Status Visit(const ExtensionArray& array) {
+    return Status::NotImplemented("extension array");
   }
 
  private:
@@ -1200,6 +1208,10 @@ class ArrayReader {
   Status Visit(const NullType& type) {
     result_ = std::make_shared<NullArray>(length_);
     return Status::OK();
+  }
+
+  Status Visit(const ExtensionType& type) {
+    return Status::NotImplemented("extension type");
   }
 
   Status Visit(const DictionaryType& type) {

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -20,11 +20,13 @@
 #include <cstdint>
 #include <memory>
 #include <sstream>
+#include <unordered_map>
 #include <utility>
 
 #include <flatbuffers/flatbuffers.h>
 
 #include "arrow/array.h"
+#include "arrow/extension_type.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/ipc/File_generated.h"  // IWYU pragma: keep
 #include "arrow/ipc/Message_generated.h"
@@ -38,6 +40,7 @@
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
+#include "arrow/visitor_inline.h"
 
 namespace arrow {
 
@@ -55,6 +58,10 @@ using RecordBatchOffset = flatbuffers::Offset<flatbuf::RecordBatch>;
 using SparseTensorOffset = flatbuffers::Offset<flatbuf::SparseTensor>;
 using Offset = flatbuffers::Offset<void>;
 using FBString = flatbuffers::Offset<flatbuffers::String>;
+using KVVector = flatbuffers::Vector<KeyValueOffset>;
+
+static const char kExtensionTypeKeyName[] = "arrow_extension_name";
+static const char kExtensionDataKeyName[] = "arrow_extension_data";
 
 MetadataVersion GetMetadataVersion(flatbuf::MetadataVersion version) {
   switch (version) {
@@ -139,22 +146,6 @@ static Status AppendChildFields(FBB& fbb, const DataType& type,
   return Status::OK();
 }
 
-static Status ListToFlatbuffer(FBB& fbb, const DataType& type,
-                               std::vector<FieldOffset>* out_children,
-                               DictionaryMemo* dictionary_memo, Offset* offset) {
-  RETURN_NOT_OK(AppendChildFields(fbb, type, out_children, dictionary_memo));
-  *offset = flatbuf::CreateList(fbb).Union();
-  return Status::OK();
-}
-
-static Status StructToFlatbuffer(FBB& fbb, const DataType& type,
-                                 std::vector<FieldOffset>* out_children,
-                                 DictionaryMemo* dictionary_memo, Offset* offset) {
-  RETURN_NOT_OK(AppendChildFields(fbb, type, out_children, dictionary_memo));
-  *offset = flatbuf::CreateStruct_(fbb).Union();
-  return Status::OK();
-}
-
 // ----------------------------------------------------------------------
 // Union implementation
 
@@ -180,29 +171,6 @@ static Status UnionFromFlatbuffer(const flatbuf::Union* union_data,
   }
 
   *out = union_(children, type_codes, mode);
-  return Status::OK();
-}
-
-static Status UnionToFlatBuffer(FBB& fbb, const DataType& type,
-                                std::vector<FieldOffset>* out_children,
-                                DictionaryMemo* dictionary_memo, Offset* offset) {
-  RETURN_NOT_OK(AppendChildFields(fbb, type, out_children, dictionary_memo));
-
-  const auto& union_type = checked_cast<const UnionType&>(type);
-
-  flatbuf::UnionMode mode = union_type.mode() == UnionMode::SPARSE
-                                ? flatbuf::UnionMode_Sparse
-                                : flatbuf::UnionMode_Dense;
-
-  std::vector<int32_t> type_ids;
-  type_ids.reserve(union_type.type_codes().size());
-  for (uint8_t code : union_type.type_codes()) {
-    type_ids.push_back(code);
-  }
-
-  auto fb_type_ids = fbb.CreateVector(type_ids);
-
-  *offset = flatbuf::CreateUnion(fbb, mode, fb_type_ids).Union();
   return Status::OK();
 }
 
@@ -244,9 +212,9 @@ static inline TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
   return TimeUnit::SECOND;
 }
 
-static Status TypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
-                                 const std::vector<std::shared_ptr<Field>>& children,
-                                 std::shared_ptr<DataType>* out) {
+static Status ConcreteTypeFromFlatbuffer(
+    flatbuf::Type type, const void* type_data,
+    const std::vector<std::shared_ptr<Field>>& children, std::shared_ptr<DataType>* out) {
   switch (type) {
     case flatbuf::Type_NONE:
       return Status::Invalid("Type metadata cannot be none");
@@ -336,117 +304,31 @@ static Status TypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
   }
 }
 
-// TODO(wesm): Convert this to visitor pattern
-static Status TypeToFlatbuffer(FBB& fbb, const DataType& type,
-                               std::vector<FieldOffset>* children,
-                               flatbuf::Type* out_type, DictionaryMemo* dictionary_memo,
-                               Offset* offset) {
-  const DataType* value_type = &type;
+static Status TypeFromFlatbuffer(const flatbuf::Field* field,
+                                 const std::vector<std::shared_ptr<Field>>& children,
+                                 const KeyValueMetadata* field_metadata,
+                                 std::shared_ptr<DataType>* out) {
+  RETURN_NOT_OK(
+      ConcreteTypeFromFlatbuffer(field->type_type(), field->type(), children, out));
 
-  if (type.id() == Type::DICTIONARY) {
-    // In this library, the dictionary "type" is a logical construct. Here we
-    // pass through to the value type, as we've already captured the index
-    // type in the DictionaryEncoding metadata in the parent field
-    value_type = checked_cast<const DictionaryType&>(type).dictionary()->type().get();
-  }
+  // Look for extension metadata in custom_metadata field
+  // TODO(wesm): Should this be part of the Field Flatbuffers table?
+  if (field_metadata != nullptr) {
+    int name_index = field_metadata->FindKey(kExtensionTypeKeyName);
+    if (name_index == -1) {
+      return Status::OK();
+    }
+    std::string type_name = field_metadata->value(name_index);
+    int data_index = field_metadata->FindKey(kExtensionDataKeyName);
+    std::string type_data = data_index == -1 ? "" : field_metadata->value(data_index);
 
-  switch (value_type->id()) {
-    case Type::NA:
-      *out_type = flatbuf::Type_Null;
-      *offset = flatbuf::CreateNull(fbb).Union();
-      break;
-    case Type::BOOL:
-      *out_type = flatbuf::Type_Bool;
-      *offset = flatbuf::CreateBool(fbb).Union();
-      break;
-    case Type::UINT8:
-      INT_TO_FB_CASE(8, false);
-    case Type::INT8:
-      INT_TO_FB_CASE(8, true);
-    case Type::UINT16:
-      INT_TO_FB_CASE(16, false);
-    case Type::INT16:
-      INT_TO_FB_CASE(16, true);
-    case Type::UINT32:
-      INT_TO_FB_CASE(32, false);
-    case Type::INT32:
-      INT_TO_FB_CASE(32, true);
-    case Type::UINT64:
-      INT_TO_FB_CASE(64, false);
-    case Type::INT64:
-      INT_TO_FB_CASE(64, true);
-    case Type::HALF_FLOAT:
-      *out_type = flatbuf::Type_FloatingPoint;
-      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision_HALF);
-      break;
-    case Type::FLOAT:
-      *out_type = flatbuf::Type_FloatingPoint;
-      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision_SINGLE);
-      break;
-    case Type::DOUBLE:
-      *out_type = flatbuf::Type_FloatingPoint;
-      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision_DOUBLE);
-      break;
-    case Type::FIXED_SIZE_BINARY: {
-      const auto& fw_type = checked_cast<const FixedSizeBinaryType&>(*value_type);
-      *out_type = flatbuf::Type_FixedSizeBinary;
-      *offset = flatbuf::CreateFixedSizeBinary(fbb, fw_type.byte_width()).Union();
-    } break;
-    case Type::BINARY:
-      *out_type = flatbuf::Type_Binary;
-      *offset = flatbuf::CreateBinary(fbb).Union();
-      break;
-    case Type::STRING:
-      *out_type = flatbuf::Type_Utf8;
-      *offset = flatbuf::CreateUtf8(fbb).Union();
-      break;
-    case Type::DATE32:
-      *out_type = flatbuf::Type_Date;
-      *offset = flatbuf::CreateDate(fbb, flatbuf::DateUnit_DAY).Union();
-      break;
-    case Type::DATE64:
-      *out_type = flatbuf::Type_Date;
-      *offset = flatbuf::CreateDate(fbb, flatbuf::DateUnit_MILLISECOND).Union();
-      break;
-    case Type::TIME32: {
-      const auto& time_type = checked_cast<const Time32Type&>(*value_type);
-      *out_type = flatbuf::Type_Time;
-      *offset = flatbuf::CreateTime(fbb, ToFlatbufferUnit(time_type.unit()), 32).Union();
-    } break;
-    case Type::TIME64: {
-      const auto& time_type = checked_cast<const Time64Type&>(*value_type);
-      *out_type = flatbuf::Type_Time;
-      *offset = flatbuf::CreateTime(fbb, ToFlatbufferUnit(time_type.unit()), 64).Union();
-    } break;
-    case Type::TIMESTAMP: {
-      const auto& ts_type = checked_cast<const TimestampType&>(*value_type);
-      *out_type = flatbuf::Type_Timestamp;
-
-      flatbuf::TimeUnit fb_unit = ToFlatbufferUnit(ts_type.unit());
-      FBString fb_timezone = 0;
-      if (ts_type.timezone().size() > 0) {
-        fb_timezone = fbb.CreateString(ts_type.timezone());
-      }
-      *offset = flatbuf::CreateTimestamp(fbb, fb_unit, fb_timezone).Union();
-    } break;
-    case Type::DECIMAL: {
-      const auto& dec_type = checked_cast<const Decimal128Type&>(*value_type);
-      *out_type = flatbuf::Type_Decimal;
-      *offset =
-          flatbuf::CreateDecimal(fbb, dec_type.precision(), dec_type.scale()).Union();
-    } break;
-    case Type::LIST:
-      *out_type = flatbuf::Type_List;
-      return ListToFlatbuffer(fbb, *value_type, children, dictionary_memo, offset);
-    case Type::STRUCT:
-      *out_type = flatbuf::Type_Struct_;
-      return StructToFlatbuffer(fbb, *value_type, children, dictionary_memo, offset);
-    case Type::UNION:
-      *out_type = flatbuf::Type_Union;
-      return UnionToFlatBuffer(fbb, *value_type, children, dictionary_memo, offset);
-    default:
-      *out_type = flatbuf::Type_NONE;  // Make clang-tidy happy
-      return Status::NotImplemented("Unable to convert type: ", type.ToString());
+    ExtensionTypeAdapter* adapter = GetExtensionType(type_name);
+    if (adapter == nullptr) {
+      // TODO(wesm): Extension type is unknown; we do not raise here and simply
+      // return the raw data
+      return Status::OK();
+    }
+    RETURN_NOT_OK(adapter->Deserialize(*out, type_data, out));
   }
   return Status::OK();
 }
@@ -505,26 +387,21 @@ static DictionaryOffset GetDictionaryEncoding(FBB& fbb, const DictionaryType& ty
                                            type.ordered());
 }
 
-static flatbuffers::Offset<flatbuffers::Vector<KeyValueOffset>>
-KeyValueMetadataToFlatbuffer(FBB& fbb, const KeyValueMetadata& metadata) {
-  std::vector<KeyValueOffset> key_value_offsets;
-
-  size_t metadata_size = metadata.size();
-  key_value_offsets.reserve(metadata_size);
-
-  for (size_t i = 0; i < metadata_size; ++i) {
-    const auto& key = metadata.key(i);
-    const auto& value = metadata.value(i);
-    key_value_offsets.push_back(
-        flatbuf::CreateKeyValue(fbb, fbb.CreateString(key), fbb.CreateString(value)));
-  }
-
-  return fbb.CreateVector(key_value_offsets);
+KeyValueOffset AppendKeyValue(FBB& fbb, const std::string& key,
+                              const std::string& value) {
+  return flatbuf::CreateKeyValue(fbb, fbb.CreateString(key), fbb.CreateString(value));
 }
 
-static Status KeyValueMetadataFromFlatbuffer(
-    const flatbuffers::Vector<KeyValueOffset>* fb_metadata,
-    std::shared_ptr<KeyValueMetadata>* out) {
+void AppendKeyValueMetadata(FBB& fbb, const KeyValueMetadata& metadata,
+                            std::vector<KeyValueOffset>* key_values) {
+  key_values->reserve(metadata.size());
+  for (int i = 0; i < metadata.size(); ++i) {
+    key_values->push_back(AppendKeyValue(fbb, metadata.key(i), metadata.value(i)));
+  }
+}
+
+static Status KeyValueMetadataFromFlatbuffer(const KVVector* fb_metadata,
+                                             std::shared_ptr<KeyValueMetadata>* out) {
   auto metadata = std::make_shared<KeyValueMetadata>();
 
   metadata->reserve(fb_metadata->size());
@@ -545,34 +422,229 @@ static Status KeyValueMetadataFromFlatbuffer(
   return Status::OK();
 }
 
+class FieldToFlatbufferVisitor {
+ public:
+  FieldToFlatbufferVisitor(FBB& fbb, DictionaryMemo* dictionary_memo)
+      : fbb_(fbb), dictionary_memo_(dictionary_memo) {}
+
+  Status VisitType(const DataType& type) { return VisitTypeInline(type, this); }
+
+  Status Visit(const NullType& type) {
+    fb_type_ = flatbuf::Type_Null;
+    type_offset_ = flatbuf::CreateNull(fbb_).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const BooleanType& type) {
+    fb_type_ = flatbuf::Type_Bool;
+    type_offset_ = flatbuf::CreateBool(fbb_).Union();
+    return Status::OK();
+  }
+
+  template <int BitWidth, bool IsSigned, typename T>
+  Status Visit(const T& type) {
+    fb_type_ = flatbuf::Type_Int;
+    type_offset_ = IntToFlatbuffer(fbb_, BitWidth, IsSigned);
+    return Status::OK();
+  }
+
+  template <typename T>
+  typename std::enable_if<IsInteger<T>::value, Status>::type Visit(const T& type) {
+    return Visit<sizeof(typename T::c_type) * 8, IsSignedInt<T>::value>(type);
+  }
+
+  Status Visit(const HalfFloatType& type) {
+    fb_type_ = flatbuf::Type_FloatingPoint;
+    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision_HALF);
+    return Status::OK();
+  }
+
+  Status Visit(const FloatType& type) {
+    fb_type_ = flatbuf::Type_FloatingPoint;
+    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision_SINGLE);
+    return Status::OK();
+  }
+
+  Status Visit(const DoubleType& type) {
+    fb_type_ = flatbuf::Type_FloatingPoint;
+    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision_DOUBLE);
+    return Status::OK();
+  }
+
+  Status Visit(const FixedSizeBinaryType& type) {
+    const auto& fw_type = checked_cast<const FixedSizeBinaryType&>(type);
+    fb_type_ = flatbuf::Type_FixedSizeBinary;
+    type_offset_ = flatbuf::CreateFixedSizeBinary(fbb_, fw_type.byte_width()).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const BinaryType& type) {
+    fb_type_ = flatbuf::Type_Binary;
+    type_offset_ = flatbuf::CreateBinary(fbb_).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const StringType& type) {
+    fb_type_ = flatbuf::Type_Utf8;
+    type_offset_ = flatbuf::CreateUtf8(fbb_).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const Date32Type& type) {
+    fb_type_ = flatbuf::Type_Date;
+    type_offset_ = flatbuf::CreateDate(fbb_, flatbuf::DateUnit_DAY).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const Date64Type& type) {
+    fb_type_ = flatbuf::Type_Date;
+    type_offset_ = flatbuf::CreateDate(fbb_, flatbuf::DateUnit_MILLISECOND).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const Time32Type& type) {
+    const auto& time_type = checked_cast<const Time32Type&>(type);
+    fb_type_ = flatbuf::Type_Time;
+    type_offset_ =
+        flatbuf::CreateTime(fbb_, ToFlatbufferUnit(time_type.unit()), 32).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const Time64Type& type) {
+    const auto& time_type = checked_cast<const Time64Type&>(type);
+    fb_type_ = flatbuf::Type_Time;
+    type_offset_ =
+        flatbuf::CreateTime(fbb_, ToFlatbufferUnit(time_type.unit()), 64).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const TimestampType& type) {
+    const auto& ts_type = checked_cast<const TimestampType&>(type);
+    fb_type_ = flatbuf::Type_Timestamp;
+    flatbuf::TimeUnit fb_unit = ToFlatbufferUnit(ts_type.unit());
+    FBString fb_timezone = 0;
+    if (ts_type.timezone().size() > 0) {
+      fb_timezone = fbb_.CreateString(ts_type.timezone());
+    }
+    type_offset_ = flatbuf::CreateTimestamp(fbb_, fb_unit, fb_timezone).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const DecimalType& type) {
+    const auto& dec_type = checked_cast<const Decimal128Type&>(type);
+    fb_type_ = flatbuf::Type_Decimal;
+    type_offset_ =
+        flatbuf::CreateDecimal(fbb_, dec_type.precision(), dec_type.scale()).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const ListType& type) {
+    fb_type_ = flatbuf::Type_List;
+    RETURN_NOT_OK(AppendChildFields(fbb_, type, &children_, dictionary_memo_));
+    type_offset_ = flatbuf::CreateList(fbb_).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const StructType& type) {
+    fb_type_ = flatbuf::Type_Struct_;
+    RETURN_NOT_OK(AppendChildFields(fbb_, type, &children_, dictionary_memo_));
+    type_offset_ = flatbuf::CreateStruct_(fbb_).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const UnionType& type) {
+    fb_type_ = flatbuf::Type_Union;
+    RETURN_NOT_OK(AppendChildFields(fbb_, type, &children_, dictionary_memo_));
+
+    const auto& union_type = checked_cast<const UnionType&>(type);
+
+    flatbuf::UnionMode mode = union_type.mode() == UnionMode::SPARSE
+                                  ? flatbuf::UnionMode_Sparse
+                                  : flatbuf::UnionMode_Dense;
+
+    std::vector<int32_t> type_ids;
+    type_ids.reserve(union_type.type_codes().size());
+    for (uint8_t code : union_type.type_codes()) {
+      type_ids.push_back(code);
+    }
+
+    auto fb_type_ids = fbb_.CreateVector(type_ids);
+
+    type_offset_ = flatbuf::CreateUnion(fbb_, mode, fb_type_ids).Union();
+    return Status::OK();
+  }
+
+  Status Visit(const DictionaryType& type) {
+    // In this library, the dictionary "type" is a logical construct. Here we
+    // pass through to the value type, as we've already captured the index
+    // type in the DictionaryEncoding metadata in the parent field
+    return VisitType(*checked_cast<const DictionaryType&>(type).dictionary()->type());
+  }
+
+  Status Visit(const ExtensionType& type) {
+    auto ext_name = type.extension_name();
+    auto adapter = ::arrow::GetExtensionType(ext_name);
+    if (adapter == nullptr) {
+      return Status::Invalid("No serializer available for extension type ", ext_name);
+    }
+    extra_type_metadata_[kExtensionTypeKeyName] = ext_name;
+    extra_type_metadata_[kExtensionDataKeyName] = adapter->Serialize(type);
+    return Status::OK();
+  }
+
+  Status GetResult(const Field& field, FieldOffset* offset) {
+    auto fb_name = fbb_.CreateString(field.name());
+    RETURN_NOT_OK(VisitType(*field.type()));
+    auto fb_children = fbb_.CreateVector(children_);
+
+    DictionaryOffset dictionary = 0;
+    if (field.type()->id() == Type::DICTIONARY) {
+      dictionary = GetDictionaryEncoding(
+          fbb_, checked_cast<const DictionaryType&>(*field.type()), dictionary_memo_);
+    }
+
+    auto metadata = field.metadata();
+
+    flatbuffers::Offset<KVVector> fb_custom_metadata;
+    std::vector<KeyValueOffset> key_values;
+    if (metadata != nullptr) {
+      AppendKeyValueMetadata(fbb_, *metadata, &key_values);
+    }
+
+    for (auto it : extra_type_metadata_) {
+      key_values.push_back(AppendKeyValue(fbb_, it.first, it.second));
+    }
+
+    if (key_values.size() > 0) {
+      fb_custom_metadata = fbb_.CreateVector(key_values);
+    }
+    *offset =
+        flatbuf::CreateField(fbb_, fb_name, field.nullable(), fb_type_, type_offset_,
+                             dictionary, fb_children, fb_custom_metadata);
+    return Status::OK();
+  }
+
+ private:
+  FBB& fbb_;
+  DictionaryMemo* dictionary_memo_;
+  flatbuf::Type fb_type_;
+  Offset type_offset_;
+  std::vector<FieldOffset> children_;
+  std::unordered_map<std::string, std::string> extra_type_metadata_;
+};
+
 static Status FieldToFlatbuffer(FBB& fbb, const Field& field,
                                 DictionaryMemo* dictionary_memo, FieldOffset* offset) {
-  auto fb_name = fbb.CreateString(field.name());
+  FieldToFlatbufferVisitor field_visitor(fbb, dictionary_memo);
+  return field_visitor.GetResult(field, offset);
+}
 
-  flatbuf::Type type_enum;
-  Offset type_offset;
-  std::vector<FieldOffset> children;
-
-  RETURN_NOT_OK(TypeToFlatbuffer(fbb, *field.type(), &children, &type_enum,
-                                 dictionary_memo, &type_offset));
-  auto fb_children = fbb.CreateVector(children);
-
-  DictionaryOffset dictionary = 0;
-  if (field.type()->id() == Type::DICTIONARY) {
-    dictionary = GetDictionaryEncoding(
-        fbb, checked_cast<const DictionaryType&>(*field.type()), dictionary_memo);
+static Status GetFieldMetadata(const flatbuf::Field* field,
+                               std::shared_ptr<KeyValueMetadata>* metadata) {
+  auto fb_metadata = field->custom_metadata();
+  if (fb_metadata != nullptr) {
+    RETURN_NOT_OK(KeyValueMetadataFromFlatbuffer(fb_metadata, metadata));
   }
-
-  auto metadata = field.metadata();
-  if (metadata != nullptr) {
-    auto fb_custom_metadata = KeyValueMetadataToFlatbuffer(fbb, *metadata);
-    *offset = flatbuf::CreateField(fbb, fb_name, field.nullable(), type_enum, type_offset,
-                                   dictionary, fb_children, fb_custom_metadata);
-  } else {
-    *offset = flatbuf::CreateField(fbb, fb_name, field.nullable(), type_enum, type_offset,
-                                   dictionary, fb_children);
-  }
-
   return Status::OK();
 }
 
@@ -583,6 +655,9 @@ static Status FieldFromFlatbuffer(const flatbuf::Field* field,
 
   const flatbuf::DictionaryEncoding* encoding = field->dictionary();
 
+  std::shared_ptr<KeyValueMetadata> metadata;
+  RETURN_NOT_OK(GetFieldMetadata(field, &metadata));
+
   if (encoding == nullptr) {
     // The field is not dictionary encoded. We must potentially visit its
     // children to fully reconstruct the data type
@@ -592,8 +667,7 @@ static Status FieldFromFlatbuffer(const flatbuf::Field* field,
       RETURN_NOT_OK(
           FieldFromFlatbuffer(children->Get(i), dictionary_memo, &child_fields[i]));
     }
-    RETURN_NOT_OK(
-        TypeFromFlatbuffer(field->type_type(), field->type(), child_fields, &type));
+    RETURN_NOT_OK(TypeFromFlatbuffer(field, child_fields, metadata.get(), &type));
   } else {
     // The field is dictionary encoded. The type of the dictionary values has
     // been determined elsewhere, and is stored in the DictionaryMemo. Here we
@@ -605,13 +679,6 @@ static Status FieldFromFlatbuffer(const flatbuf::Field* field,
     std::shared_ptr<DataType> index_type;
     RETURN_NOT_OK(IntFromFlatbuffer(encoding->indexType(), &index_type));
     type = ::arrow::dictionary(index_type, dictionary, encoding->isOrdered());
-  }
-
-  auto fb_metadata = field->custom_metadata();
-  std::shared_ptr<KeyValueMetadata> metadata;
-
-  if (fb_metadata != nullptr) {
-    RETURN_NOT_OK(KeyValueMetadataFromFlatbuffer(fb_metadata, &metadata));
   }
 
   *out = std::make_shared<Field>(field->name()->str(), type, field->nullable(), metadata);
@@ -633,10 +700,11 @@ static Status FieldFromFlatbufferDictionary(const flatbuf::Field* field,
     RETURN_NOT_OK(FieldFromFlatbuffer(children->Get(i), dummy_memo, &child_fields[i]));
   }
 
-  RETURN_NOT_OK(
-      TypeFromFlatbuffer(field->type_type(), field->type(), child_fields, &type));
+  std::shared_ptr<KeyValueMetadata> metadata;
+  RETURN_NOT_OK(GetFieldMetadata(field, &metadata));
 
-  *out = std::make_shared<Field>(field->name()->str(), type, field->nullable());
+  RETURN_NOT_OK(TypeFromFlatbuffer(field, child_fields, metadata.get(), &type));
+  *out = std::make_shared<Field>(field->name()->str(), type, field->nullable(), metadata);
   return Status::OK();
 }
 
@@ -666,13 +734,14 @@ static Status SchemaToFlatbuffer(FBB& fbb, const Schema& schema,
 
   /// Custom metadata
   auto metadata = schema.metadata();
-  if (metadata != nullptr) {
-    auto fb_custom_metadata = KeyValueMetadataToFlatbuffer(fbb, *metadata);
-    *out = flatbuf::CreateSchema(fbb, endianness(), fb_offsets, fb_custom_metadata);
-  } else {
-    *out = flatbuf::CreateSchema(fbb, endianness(), fb_offsets);
-  }
 
+  flatbuffers::Offset<KVVector> fb_custom_metadata;
+  std::vector<KeyValueOffset> key_values;
+  if (metadata != nullptr) {
+    AppendKeyValueMetadata(fbb, *metadata, &key_values);
+    fb_custom_metadata = fbb.CreateVector(key_values);
+  }
+  *out = flatbuf::CreateSchema(fbb, endianness(), fb_offsets, fb_custom_metadata);
   return Status::OK();
 }
 
@@ -1033,7 +1102,7 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
     }
   }
 
-  return TypeFromFlatbuffer(tensor->type_type(), tensor->type(), {}, type);
+  return ConcreteTypeFromFlatbuffer(tensor->type_type(), tensor->type(), {}, type);
 }
 
 Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type,
@@ -1079,7 +1148,8 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
       return Status::Invalid("Unrecognized sparse index type");
   }
 
-  return TypeFromFlatbuffer(sparse_tensor->type_type(), sparse_tensor->type(), {}, type);
+  return ConcreteTypeFromFlatbuffer(sparse_tensor->type_type(), sparse_tensor->type(), {},
+                                    type);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -582,6 +582,7 @@ class FieldToFlatbufferVisitor {
   }
 
   Status Visit(const ExtensionType& type) {
+    RETURN_NOT_OK(VisitType(*type.storage_type()));
     extra_type_metadata_[kExtensionTypeKeyName] = type.extension_name();
     extra_type_metadata_[kExtensionDataKeyName] = type.Serialize();
     return Status::OK();

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -260,6 +260,12 @@ class ArrayLoader {
     return Status::OK();
   }
 
+  Status Visit(const ExtensionType& type) {
+    RETURN_NOT_OK(LoadArray(type.storage_type(), context_, out_));
+    out_->type = type_;
+    return Status::OK();
+  }
+
  private:
   const std::shared_ptr<DataType> type_;
   ArrayLoaderContext* context_;

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -26,6 +26,7 @@
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"
+#include "arrow/extension_type.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
 #include "arrow/ipc/dictionary.h"
@@ -447,6 +448,10 @@ class RecordBatchSerializer : public ArrayVisitor {
   Status Visit(const DictionaryArray& array) override {
     // Dictionary written out separately. Slice offset contained in the indices
     return array.indices()->Accept(this);
+  }
+
+  Status Visit(const ExtensionArray& array) override {
+    return array.storage()->Accept(this);
   }
 
   // Destination for output buffers

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -114,10 +114,9 @@ void PrettyPrinter::Indent() {
 
 class ArrayPrinter : public PrettyPrinter {
  public:
-  ArrayPrinter(const Array& array, int indent, int indent_size, int window,
-               const std::string& null_rep, bool skip_new_lines, std::ostream* sink)
+  ArrayPrinter(int indent, int indent_size, int window, const std::string& null_rep,
+               bool skip_new_lines, std::ostream* sink)
       : PrettyPrinter(indent, indent_size, window, skip_new_lines, sink),
-        array_(array),
         null_rep_(null_rep) {}
 
   template <typename FormatFunction>
@@ -247,7 +246,7 @@ class ArrayPrinter : public PrettyPrinter {
 
   Status Visit(const IntervalArray&) { return Status::NotImplemented("interval"); }
 
-  Status Visit(const ExtensionArray&) { return Status::NotImplemented("extension"); }
+  Status Visit(const ExtensionArray& array) { return Print(*array.storage()); }
 
   Status WriteValidityBitmap(const Array& array);
 
@@ -314,14 +313,13 @@ class ArrayPrinter : public PrettyPrinter {
     return PrettyPrint(*array.indices(), indent_ + indent_size_, sink_);
   }
 
-  Status Print() {
-    RETURN_NOT_OK(VisitArrayInline(array_, this));
+  Status Print(const Array& array) {
+    RETURN_NOT_OK(VisitArrayInline(array, this));
     Flush();
     return Status::OK();
   }
 
  private:
-  const Array& array_;
   std::string null_rep_;
 };
 
@@ -341,15 +339,15 @@ Status ArrayPrinter::WriteValidityBitmap(const Array& array) {
 }
 
 Status PrettyPrint(const Array& arr, int indent, std::ostream* sink) {
-  ArrayPrinter printer(arr, indent, 2, 10, "null", false, sink);
-  return printer.Print();
+  ArrayPrinter printer(indent, 2, 10, "null", false, sink);
+  return printer.Print(arr);
 }
 
 Status PrettyPrint(const Array& arr, const PrettyPrintOptions& options,
                    std::ostream* sink) {
-  ArrayPrinter printer(arr, options.indent, options.indent_size, options.window,
+  ArrayPrinter printer(options.indent, options.indent_size, options.window,
                        options.null_rep, options.skip_new_lines, sink);
-  return printer.Print();
+  return printer.Print(arr);
 }
 
 Status PrettyPrint(const Array& arr, const PrettyPrintOptions& options,
@@ -385,10 +383,9 @@ Status PrettyPrint(const ChunkedArray& chunked_arr, const PrettyPrintOptions& op
       i = num_chunks - window - 1;
       skip_comma = true;
     } else {
-      ArrayPrinter printer(*chunked_arr.chunk(i), indent + options.indent_size,
-                           options.indent_size, window, options.null_rep,
-                           options.skip_new_lines, sink);
-      RETURN_NOT_OK(printer.Print());
+      ArrayPrinter printer(indent + options.indent_size, options.indent_size, window,
+                           options.null_rep, options.skip_new_lines, sink);
+      RETURN_NOT_OK(printer.Print(*chunked_arr.chunk(i)));
     }
   }
   (*sink) << "\n";

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -247,6 +247,8 @@ class ArrayPrinter : public PrettyPrinter {
 
   Status Visit(const IntervalArray&) { return Status::NotImplemented("interval"); }
 
+  Status Visit(const ExtensionArray&) { return Status::NotImplemented("extension"); }
+
   Status WriteValidityBitmap(const Array& array);
 
   Status PrintChildren(const std::vector<std::shared_ptr<Array>>& fields, int64_t offset,

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1891,6 +1891,10 @@ class ArrowDeserializer {
 
   Status Visit(const UnionType& type) { return Status::NotImplemented("union type"); }
 
+  Status Visit(const ExtensionType& type) {
+    return Status::NotImplemented("extension type");
+  }
+
   Status Convert(PyObject** out) {
     RETURN_NOT_OK(VisitTypeInline(*col_->type(), this));
     *out = result_;

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -240,6 +240,8 @@ class NumPyConverter {
 
   Status Visit(const NestedType& type) { return TypeNotImplemented(type.ToString()); }
 
+  Status Visit(const ExtensionType& type) { return TypeNotImplemented(type.ToString()); }
+
  protected:
   Status InitNullBitmap() {
     RETURN_NOT_OK(AllocateNullBitmap(pool_, length_, &null_bitmap_));

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -142,8 +142,9 @@ void AssertTablesEqual(const Table& expected, const Table& actual,
   }
 }
 
-void CompareBatch(const RecordBatch& left, const RecordBatch& right) {
-  if (!left.schema()->Equals(*right.schema())) {
+void CompareBatch(const RecordBatch& left, const RecordBatch& right,
+                  bool compare_metadata) {
+  if (!left.schema()->Equals(*right.schema(), compare_metadata)) {
     FAIL() << "Left schema: " << left.schema()->ToString()
            << "\nRight schema: " << right.schema()->ToString();
   }

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -146,7 +146,8 @@ void AssertNumericDataEqual(const C_TYPE* raw_data,
   }
 }
 
-ARROW_EXPORT void CompareBatch(const RecordBatch& left, const RecordBatch& right);
+ARROW_EXPORT void CompareBatch(const RecordBatch& left, const RecordBatch& right,
+                               bool compare_metadata = true);
 
 // Check if the padding of the buffers of the array is zero.
 // Also cause valgrind warnings if the padding bytes are uninitialized.

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -31,7 +31,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/stl.h"
-#include "arrow/visitor.h"
+#include "arrow/visitor_inline.h"
 
 namespace arrow {
 
@@ -507,25 +507,9 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>>&& fields,
 // ----------------------------------------------------------------------
 // Visitors and factory functions
 
-#define ACCEPT_VISITOR(TYPE) \
-  Status TYPE::Accept(TypeVisitor* visitor) const { return visitor->Visit(*this); }
-
-ACCEPT_VISITOR(NullType)
-ACCEPT_VISITOR(BooleanType)
-ACCEPT_VISITOR(BinaryType)
-ACCEPT_VISITOR(FixedSizeBinaryType)
-ACCEPT_VISITOR(StringType)
-ACCEPT_VISITOR(ListType)
-ACCEPT_VISITOR(StructType)
-ACCEPT_VISITOR(Decimal128Type)
-ACCEPT_VISITOR(UnionType)
-ACCEPT_VISITOR(Date32Type)
-ACCEPT_VISITOR(Date64Type)
-ACCEPT_VISITOR(Time32Type)
-ACCEPT_VISITOR(Time64Type)
-ACCEPT_VISITOR(TimestampType)
-ACCEPT_VISITOR(IntervalType)
-ACCEPT_VISITOR(DictionaryType)
+Status DataType::Accept(TypeVisitor* visitor) const {
+  return VisitTypeInline(*this, visitor);
+}
 
 #define TYPE_FACTORY(NAME, KLASS)                                        \
   std::shared_ptr<DataType> NAME() {                                     \

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -74,7 +74,7 @@ bool Field::Equals(const Field& other, bool check_metadata) const {
     return true;
   }
   if (this->name_ == other.name_ && this->nullable_ == other.nullable_ &&
-      this->type_->Equals(*other.type_.get())) {
+      this->type_->Equals(*other.type_.get(), check_metadata)) {
     if (!check_metadata) {
       return true;
     } else if (this->HasMetadata() && other.HasMetadata()) {
@@ -103,7 +103,9 @@ std::string Field::ToString() const {
 
 DataType::~DataType() {}
 
-bool DataType::Equals(const DataType& other) const { return TypeEquals(*this, other); }
+bool DataType::Equals(const DataType& other, bool check_metadata) const {
+  return TypeEquals(*this, other, check_metadata);
+}
 
 bool DataType::Equals(const std::shared_ptr<DataType>& other) const {
   if (!other) {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -158,7 +158,8 @@ class ARROW_EXPORT DataType {
   ///
   /// Types that are logically convertible from one to another (e.g. List<UInt8>
   /// and Binary) are NOT equal.
-  virtual bool Equals(const DataType& other) const;
+  bool Equals(const DataType& other, bool check_metadata = true) const;
+
   /// \brief Return whether the types are equal
   bool Equals(const std::shared_ptr<DataType>& other) const;
 
@@ -168,7 +169,7 @@ class ARROW_EXPORT DataType {
 
   int num_children() const { return static_cast<int>(children_.size()); }
 
-  virtual Status Accept(TypeVisitor* visitor) const;
+  Status Accept(TypeVisitor* visitor) const;
 
   /// \brief A string representation of the type, including any children
   virtual std::string ToString() const = 0;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -133,7 +133,10 @@ struct Type {
     DICTIONARY,
 
     /// Map, a repeated struct logical type
-    MAP
+    MAP,
+
+    /// Custom data type, implemented by user
+    EXTENSION
   };
 };
 
@@ -165,7 +168,7 @@ class ARROW_EXPORT DataType {
 
   int num_children() const { return static_cast<int>(children_.size()); }
 
-  virtual Status Accept(TypeVisitor* visitor) const = 0;
+  virtual Status Accept(TypeVisitor* visitor) const;
 
   /// \brief A string representation of the type, including any children
   virtual std::string ToString() const = 0;
@@ -307,10 +310,6 @@ class ARROW_EXPORT CTypeImpl : public BASE {
 
   int bit_width() const override { return static_cast<int>(sizeof(C_TYPE) * CHAR_BIT); }
 
-  Status Accept(TypeVisitor* visitor) const override {
-    return visitor->Visit(internal::checked_cast<const DERIVED&>(*this));
-  }
-
   std::string ToString() const override { return this->name(); }
 };
 
@@ -328,7 +327,6 @@ class ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
 
   NullType() : DataType(Type::NA) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   std::string name() const override { return "null"; }
@@ -341,7 +339,6 @@ class ARROW_EXPORT BooleanType : public FixedWidthType, public NoExtraMeta {
 
   BooleanType() : FixedWidthType(Type::BOOL) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   int bit_width() const override { return 1; }
@@ -449,7 +446,6 @@ class ARROW_EXPORT ListType : public NestedType {
 
   std::shared_ptr<DataType> value_type() const { return children_[0]->type(); }
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   std::string name() const override { return "list"; }
@@ -462,7 +458,6 @@ class ARROW_EXPORT BinaryType : public DataType, public NoExtraMeta {
 
   BinaryType() : BinaryType(Type::BINARY) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "binary"; }
 
@@ -481,7 +476,6 @@ class ARROW_EXPORT FixedSizeBinaryType : public FixedWidthType, public Parametri
   explicit FixedSizeBinaryType(int32_t byte_width, Type::type override_type_id)
       : FixedWidthType(override_type_id), byte_width_(byte_width) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "fixed_size_binary"; }
 
@@ -499,7 +493,6 @@ class ARROW_EXPORT StringType : public BinaryType {
 
   StringType() : BinaryType(Type::STRING) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "utf8"; }
 };
@@ -511,7 +504,6 @@ class ARROW_EXPORT StructType : public NestedType {
 
   explicit StructType(const std::vector<std::shared_ptr<Field>>& fields);
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "struct"; }
 
@@ -561,7 +553,6 @@ class ARROW_EXPORT Decimal128Type : public DecimalType {
 
   explicit Decimal128Type(int32_t precision, int32_t scale);
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "decimal"; }
 };
@@ -581,7 +572,6 @@ class ARROW_EXPORT UnionType : public NestedType {
 
   std::string ToString() const override;
   std::string name() const override { return "union"; }
-  Status Accept(TypeVisitor* visitor) const override;
 
   const std::vector<uint8_t>& type_codes() const { return type_codes_; }
 
@@ -622,7 +612,6 @@ class ARROW_EXPORT Date32Type : public DateType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   std::string name() const override { return "date32"; }
@@ -641,7 +630,6 @@ class ARROW_EXPORT Date64Type : public DateType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   std::string name() const override { return "date64"; }
@@ -690,7 +678,6 @@ class ARROW_EXPORT Time32Type : public TimeType {
 
   explicit Time32Type(TimeUnit::type unit = TimeUnit::MILLI);
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   std::string name() const override { return "time32"; }
@@ -705,7 +692,6 @@ class ARROW_EXPORT Time64Type : public TimeType {
 
   explicit Time64Type(TimeUnit::type unit = TimeUnit::MILLI);
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
 
   std::string name() const override { return "time64"; }
@@ -726,7 +712,6 @@ class ARROW_EXPORT TimestampType : public FixedWidthType, public ParametricType 
   explicit TimestampType(TimeUnit::type unit, const std::string& timezone)
       : FixedWidthType(Type::TIMESTAMP), unit_(unit), timezone_(timezone) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "timestamp"; }
 
@@ -750,7 +735,6 @@ class ARROW_EXPORT IntervalType : public FixedWidthType {
   explicit IntervalType(Unit unit = Unit::YEAR_MONTH)
       : FixedWidthType(Type::INTERVAL), unit_(unit) {}
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override { return name(); }
   std::string name() const override { return "date"; }
 
@@ -777,7 +761,6 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 
   std::shared_ptr<Array> dictionary() const;
 
-  Status Accept(TypeVisitor* visitor) const override;
   std::string ToString() const override;
   std::string name() const override { return "dictionary"; }
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -152,6 +152,9 @@ class IntervalType;
 using IntervalArray = NumericArray<IntervalType>;
 class IntervalScalar;
 
+class ExtensionType;
+class ExtensionArray;
+
 // ----------------------------------------------------------------------
 // (parameter-free) Factory functions
 // Other factory functions are in type.h

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -265,6 +265,12 @@ struct TypeTraits<DictionaryType> {
   constexpr static bool is_parameter_free = false;
 };
 
+template <>
+struct TypeTraits<ExtensionType> {
+  using ArrayType = ExtensionArray;
+  constexpr static bool is_parameter_free = false;
+};
+
 //
 // Useful type predicates
 //

--- a/cpp/src/arrow/util/key-value-metadata-test.cc
+++ b/cpp/src/arrow/util/key-value-metadata-test.cc
@@ -84,6 +84,16 @@ TEST(KeyValueMetadataTest, Copy) {
   ASSERT_TRUE(metadata.Equals(*metadata2));
 }
 
+TEST(KeyValueMetadataTest, FindKey) {
+  std::vector<std::string> keys = {"foo", "bar"};
+  std::vector<std::string> values = {"bizz", "buzz"};
+  KeyValueMetadata metadata(keys, values);
+
+  ASSERT_EQ(0, metadata.FindKey("foo"));
+  ASSERT_EQ(1, metadata.FindKey("bar"));
+  ASSERT_EQ(-1, metadata.FindKey("baz"));
+}
+
 TEST(KeyValueMetadataTest, Equals) {
   std::vector<std::string> keys = {"foo", "bar"};
   std::vector<std::string> values = {"bizz", "buzz"};

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -93,16 +93,25 @@ int64_t KeyValueMetadata::size() const {
   return static_cast<int64_t>(keys_.size());
 }
 
-std::string KeyValueMetadata::key(int64_t i) const {
+const std::string& KeyValueMetadata::key(int64_t i) const {
   DCHECK_GE(i, 0);
   DCHECK_LT(static_cast<size_t>(i), keys_.size());
   return keys_[i];
 }
 
-std::string KeyValueMetadata::value(int64_t i) const {
+const std::string& KeyValueMetadata::value(int64_t i) const {
   DCHECK_GE(i, 0);
   DCHECK_LT(static_cast<size_t>(i), values_.size());
   return values_[i];
+}
+
+int KeyValueMetadata::FindKey(const std::string& key) const {
+  for (size_t i = 0; i < keys_.size(); ++i) {
+    if (keys_[i] == key) {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
 }
 
 std::shared_ptr<KeyValueMetadata> KeyValueMetadata::Copy() const {

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -29,6 +29,7 @@
 
 namespace arrow {
 
+/// \brief A container for key-value pair type metadata. Not thread-safe
 class ARROW_EXPORT KeyValueMetadata {
  public:
   KeyValueMetadata();
@@ -44,8 +45,11 @@ class ARROW_EXPORT KeyValueMetadata {
   void reserve(int64_t n);
   int64_t size() const;
 
-  std::string key(int64_t i) const;
-  std::string value(int64_t i) const;
+  const std::string& key(int64_t i) const;
+  const std::string& value(int64_t i) const;
+
+  /// \brief Perform linear search for key, returning -1 if not found
+  int FindKey(const std::string& key) const;
 
   std::shared_ptr<KeyValueMetadata> Copy() const;
 

--- a/cpp/src/arrow/visitor.cc
+++ b/cpp/src/arrow/visitor.cc
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "arrow/array.h"
+#include "arrow/extension_type.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 
@@ -57,6 +58,7 @@ ARRAY_VISITOR_DEFAULT(StructArray)
 ARRAY_VISITOR_DEFAULT(UnionArray)
 ARRAY_VISITOR_DEFAULT(DictionaryArray)
 ARRAY_VISITOR_DEFAULT(Decimal128Array)
+ARRAY_VISITOR_DEFAULT(ExtensionArray)
 
 #undef ARRAY_VISITOR_DEFAULT
 
@@ -95,6 +97,7 @@ TYPE_VISITOR_DEFAULT(ListType)
 TYPE_VISITOR_DEFAULT(StructType)
 TYPE_VISITOR_DEFAULT(UnionType)
 TYPE_VISITOR_DEFAULT(DictionaryType)
+TYPE_VISITOR_DEFAULT(ExtensionType)
 
 #undef TYPE_VISITOR_DEFAULT
 

--- a/cpp/src/arrow/visitor.h
+++ b/cpp/src/arrow/visitor.h
@@ -54,7 +54,8 @@ class ARROW_EXPORT ArrayVisitor {
   virtual Status Visit(const ListArray& array);
   virtual Status Visit(const StructArray& array);
   virtual Status Visit(const UnionArray& array);
-  virtual Status Visit(const DictionaryArray& type);
+  virtual Status Visit(const DictionaryArray& array);
+  virtual Status Visit(const ExtensionArray& array);
 };
 
 class ARROW_EXPORT TypeVisitor {
@@ -88,6 +89,7 @@ class ARROW_EXPORT TypeVisitor {
   virtual Status Visit(const StructType& type);
   virtual Status Visit(const UnionType& type);
   virtual Status Visit(const DictionaryType& type);
+  virtual Status Visit(const ExtensionType& type);
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -21,6 +21,7 @@
 #define ARROW_VISITOR_INLINE_H
 
 #include "arrow/array.h"
+#include "arrow/extension_type.h"
 #include "arrow/status.h"
 #include "arrow/tensor.h"
 #include "arrow/type.h"
@@ -30,39 +31,43 @@
 
 namespace arrow {
 
+#define ARROW_GENERATE_FOR_ALL_TYPES(ACTION) \
+  ACTION(Null);                              \
+  ACTION(Boolean);                           \
+  ACTION(Int8);                              \
+  ACTION(UInt8);                             \
+  ACTION(Int16);                             \
+  ACTION(UInt16);                            \
+  ACTION(Int32);                             \
+  ACTION(UInt32);                            \
+  ACTION(Int64);                             \
+  ACTION(UInt64);                            \
+  ACTION(HalfFloat);                         \
+  ACTION(Float);                             \
+  ACTION(Double);                            \
+  ACTION(String);                            \
+  ACTION(Binary);                            \
+  ACTION(FixedSizeBinary);                   \
+  ACTION(Date32);                            \
+  ACTION(Date64);                            \
+  ACTION(Timestamp);                         \
+  ACTION(Time32);                            \
+  ACTION(Time64);                            \
+  ACTION(Decimal128);                        \
+  ACTION(List);                              \
+  ACTION(Struct);                            \
+  ACTION(Union);                             \
+  ACTION(Dictionary);                        \
+  ACTION(Extension)
+
 #define TYPE_VISIT_INLINE(TYPE_CLASS) \
-  case TYPE_CLASS::type_id:           \
-    return visitor->Visit(internal::checked_cast<const TYPE_CLASS&>(type));
+  case TYPE_CLASS##Type::type_id:     \
+    return visitor->Visit(internal::checked_cast<const TYPE_CLASS##Type&>(type));
 
 template <typename VISITOR>
 inline Status VisitTypeInline(const DataType& type, VISITOR* visitor) {
   switch (type.id()) {
-    TYPE_VISIT_INLINE(NullType);
-    TYPE_VISIT_INLINE(BooleanType);
-    TYPE_VISIT_INLINE(Int8Type);
-    TYPE_VISIT_INLINE(UInt8Type);
-    TYPE_VISIT_INLINE(Int16Type);
-    TYPE_VISIT_INLINE(UInt16Type);
-    TYPE_VISIT_INLINE(Int32Type);
-    TYPE_VISIT_INLINE(UInt32Type);
-    TYPE_VISIT_INLINE(Int64Type);
-    TYPE_VISIT_INLINE(UInt64Type);
-    TYPE_VISIT_INLINE(HalfFloatType);
-    TYPE_VISIT_INLINE(FloatType);
-    TYPE_VISIT_INLINE(DoubleType);
-    TYPE_VISIT_INLINE(StringType);
-    TYPE_VISIT_INLINE(BinaryType);
-    TYPE_VISIT_INLINE(FixedSizeBinaryType);
-    TYPE_VISIT_INLINE(Date32Type);
-    TYPE_VISIT_INLINE(Date64Type);
-    TYPE_VISIT_INLINE(TimestampType);
-    TYPE_VISIT_INLINE(Time32Type);
-    TYPE_VISIT_INLINE(Time64Type);
-    TYPE_VISIT_INLINE(Decimal128Type);
-    TYPE_VISIT_INLINE(ListType);
-    TYPE_VISIT_INLINE(StructType);
-    TYPE_VISIT_INLINE(UnionType);
-    TYPE_VISIT_INLINE(DictionaryType);
+    ARROW_GENERATE_FOR_ALL_TYPES(TYPE_VISIT_INLINE);
     default:
       break;
   }
@@ -71,41 +76,16 @@ inline Status VisitTypeInline(const DataType& type, VISITOR* visitor) {
 
 #undef TYPE_VISIT_INLINE
 
-#define ARRAY_VISIT_INLINE(TYPE_CLASS)                                             \
-  case TYPE_CLASS::type_id:                                                        \
-    return visitor->Visit(                                                         \
-        internal::checked_cast<const typename TypeTraits<TYPE_CLASS>::ArrayType&>( \
+#define ARRAY_VISIT_INLINE(TYPE_CLASS)                                                   \
+  case TYPE_CLASS##Type::type_id:                                                        \
+    return visitor->Visit(                                                               \
+        internal::checked_cast<const typename TypeTraits<TYPE_CLASS##Type>::ArrayType&>( \
             array));
 
 template <typename VISITOR>
 inline Status VisitArrayInline(const Array& array, VISITOR* visitor) {
   switch (array.type_id()) {
-    ARRAY_VISIT_INLINE(NullType);
-    ARRAY_VISIT_INLINE(BooleanType);
-    ARRAY_VISIT_INLINE(Int8Type);
-    ARRAY_VISIT_INLINE(UInt8Type);
-    ARRAY_VISIT_INLINE(Int16Type);
-    ARRAY_VISIT_INLINE(UInt16Type);
-    ARRAY_VISIT_INLINE(Int32Type);
-    ARRAY_VISIT_INLINE(UInt32Type);
-    ARRAY_VISIT_INLINE(Int64Type);
-    ARRAY_VISIT_INLINE(UInt64Type);
-    ARRAY_VISIT_INLINE(HalfFloatType);
-    ARRAY_VISIT_INLINE(FloatType);
-    ARRAY_VISIT_INLINE(DoubleType);
-    ARRAY_VISIT_INLINE(StringType);
-    ARRAY_VISIT_INLINE(BinaryType);
-    ARRAY_VISIT_INLINE(FixedSizeBinaryType);
-    ARRAY_VISIT_INLINE(Date32Type);
-    ARRAY_VISIT_INLINE(Date64Type);
-    ARRAY_VISIT_INLINE(TimestampType);
-    ARRAY_VISIT_INLINE(Time32Type);
-    ARRAY_VISIT_INLINE(Time64Type);
-    ARRAY_VISIT_INLINE(Decimal128Type);
-    ARRAY_VISIT_INLINE(ListType);
-    ARRAY_VISIT_INLINE(StructType);
-    ARRAY_VISIT_INLINE(UnionType);
-    ARRAY_VISIT_INLINE(DictionaryType);
+    ARROW_GENERATE_FOR_ALL_TYPES(ARRAY_VISIT_INLINE);
     default:
       break;
   }

--- a/cpp/src/gandiva/expression_registry.cc
+++ b/cpp/src/gandiva/expression_registry.cc
@@ -146,6 +146,7 @@ void ExpressionRegistry::AddArrowTypesToVector(arrow::Type::type& type,
     case arrow::Type::type::STRUCT:
     case arrow::Type::type::UNION:
     case arrow::Type::type::DICTIONARY:
+    case arrow::Type::type::EXTENSION:
       // un-supported types. test ensures that
       // when one of these are added build breaks.
       DCHECK(false);

--- a/cpp/src/gandiva/jni/expression_registry_helper.cc
+++ b/cpp/src/gandiva/jni/expression_registry_helper.cc
@@ -134,6 +134,7 @@ void ArrowToProtobuf(DataTypePtr type, types::ExtGandivaType* gandiva_data_type)
     case arrow::Type::type::STRUCT:
     case arrow::Type::type::UNION:
     case arrow::Type::type::DICTIONARY:
+    case arrow::Type::type::EXTENSION:
       // un-supported types. test ensures that
       // when one of these are added build breaks.
       DCHECK(false);

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -119,6 +119,7 @@ class LevelBuilder {
   NOT_IMPLEMENTED_VISIT(Struct)
   NOT_IMPLEMENTED_VISIT(Union)
   NOT_IMPLEMENTED_VISIT(Dictionary)
+  NOT_IMPLEMENTED_VISIT(Extension)
 
   Status GenerateLevels(const Array& array, const std::shared_ptr<Field>& field,
                         int64_t* values_offset, int64_t* num_values, int64_t* num_levels,


### PR DESCRIPTION
This patch proposes a public API for user-defined C++ types that can be sent and received faithfully in Arrow's IPC protocol. 

Summary of approach:

* User implements subclass of `arrow::ExtensionType`, which wraps an underlying "storage type", how the data is represented in memory. This includes serialization, deserialization, and array wrapper APIs
* User implements subclass of `arrow::ExtensionArray`, their custom container for the user-defined type. This wraps data matching the "storage" type 
* The extension type is registered globally with `arrow::RegisterExtensionType`
* Extension type metadata is embedded in the `Field::custom_metadata` Flatbuffers field in two keys, `arrow_extension_name` and `arrow_extension_data`. This represent the name of the type and the serialized internals of the type, if any
* If a receiver does not have any special handling for the extension type, they can still handle the data as though it were an instance of the storage type

I implemented an example `UUIDType` in the unit tests. It is implemented like this:

* The extension type name is `"uuid"`
* The storage type is `fixed_size_binary(16)`

One issue I uncovered while working on this is that `DataType::Equals` does not compare Field metadata for nested fields. I implemented this and will open a JIRA about doing some follow-on testing to harden this.

I also implemented ARROW-572 in this patch which modifies the IPC metadata serialization to use the visitor pattern, removing a long-standing TODO

Per ARROW-1587 I would like to have extension types as a formal construct in the protocol, so I will propose additions to the Flatbuffers files in a separate patch, and then we can easily change the implementation here to conform to whatever decision is reached in the protocol. 

Some next steps would be to provide a way for UDT's to be implemented in pure Python.