### PR TITLE
ARROW-4642: [R] change f to file in read_parquet_file()

### DIFF
--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -26,7 +26,7 @@
 #'
 #' @export
 read_parquet <- function(file, as_tibble = TRUE, use_threads = TRUE, ...) {
-  tab <- shared_ptr(`arrow::Table`, read_parquet_file(f))
+  tab <- shared_ptr(`arrow::Table`, read_parquet_file(file))
   if (isTRUE(as_tibble)) {
     tab <- as_tibble(tab, use_threads = use_threads)
   }


### PR DESCRIPTION
Otherwise you get the following error:
```
Error in read_parquet_file(f) : object 'f' not found
```