### PR TITLE
ARROW-4562: [C++] Avoid copies when serializing Flight data

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -68,7 +68,7 @@ class FlightStreamReader : public RecordBatchReader {
   std::shared_ptr<Schema> schema() const override { return schema_; }
 
   Status ReadNext(std::shared_ptr<RecordBatch>* out) override {
-    FlightData data;
+    internal::FlightData data;
 
     if (stream_finished_) {
       *out = nullptr;

--- a/cpp/src/arrow/flight/flight-test.cc
+++ b/cpp/src/arrow/flight/flight-test.cc
@@ -15,12 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef _WIN32
-#include <sys/stat.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#endif
-
 #include <chrono>
 #include <cstdint>
 #include <cstdio>

--- a/cpp/src/arrow/flight/serialization-internal.h
+++ b/cpp/src/arrow/flight/serialization-internal.h
@@ -23,32 +23,19 @@
 // Enable gRPC customizations
 #include "arrow/flight/protocol-internal.h"  // IWYU pragma: keep
 
-#include <cstdint>
-#include <limits>
 #include <memory>
 
 #include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
-#include <google/protobuf/wire_format_lite.h>
-#include <grpcpp/grpcpp.h>
-#include <grpcpp/impl/codegen/proto_utils.h>
-#include "grpc/byte_buffer_reader.h"
-
-#include "arrow/ipc/writer.h"
-#include "arrow/record_batch.h"
-#include "arrow/status.h"
-#include "arrow/util/logging.h"
 
 #include "arrow/flight/internal.h"
 #include "arrow/flight/types.h"
 
-namespace pb = arrow::flight::protocol;
-
-constexpr int64_t kInt32Max = std::numeric_limits<int32_t>::max();
-
 namespace arrow {
+
+class Buffer;
+
 namespace flight {
+namespace internal {
 
 /// Internal, not user-visible type used for memory-efficient reads from gRPC
 /// stream
@@ -63,49 +50,6 @@ struct FlightData {
   std::shared_ptr<Buffer> body;
 };
 
-namespace internal {
-
-using google::protobuf::io::CodedInputStream;
-using google::protobuf::io::CodedOutputStream;
-
-bool ReadBytesZeroCopy(const std::shared_ptr<arrow::Buffer>& source_data,
-                       CodedInputStream* input, std::shared_ptr<arrow::Buffer>* out);
-
 }  // namespace internal
 }  // namespace flight
 }  // namespace arrow
-
-namespace grpc {
-
-using arrow::flight::FlightData;
-
-using google::protobuf::internal::WireFormatLite;
-using google::protobuf::io::ArrayOutputStream;
-using google::protobuf::io::CodedInputStream;
-using google::protobuf::io::CodedOutputStream;
-
-// Helper to log status code, as gRPC doesn't expose why
-// (de)serialization fails
-inline Status FailSerialization(Status status) {
-  if (!status.ok()) {
-    ARROW_LOG(WARNING) << "Error deserializing Flight message: "
-                       << status.error_message();
-  }
-  return status;
-}
-
-inline arrow::Status FailSerialization(arrow::Status status) {
-  if (!status.ok()) {
-    ARROW_LOG(WARNING) << "Error deserializing Flight message: " << status.ToString();
-  }
-  return status;
-}
-
-// Write FlightData to a grpc::ByteBuffer without extra copying
-Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out, bool* own_buffer);
-
-// Read internal::FlightData from grpc::ByteBuffer containing FlightData
-// protobuf without copying
-Status FlightDataDeserialize(ByteBuffer* buffer, FlightData* out);
-
-}  // namespace grpc

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -73,7 +73,7 @@ class FlightMessageReaderImpl : public FlightMessageReader {
       return Status::OK();
     }
 
-    FlightData data;
+    internal::FlightData data;
     // Pretend to be pb::FlightData and intercept in SerializationTraits
     if (reader_->Read(reinterpret_cast<pb::FlightData*>(&data))) {
       std::unique_ptr<ipc::Message> message;
@@ -209,7 +209,7 @@ class FlightServiceImpl : public FlightService::Service {
   grpc::Status DoPut(ServerContext* context, grpc::ServerReader<pb::FlightData>* reader,
                      pb::PutResult* response) {
     // Get metadata
-    FlightData data;
+    internal::FlightData data;
     if (reader->Read(reinterpret_cast<pb::FlightData*>(&data))) {
       // Message only lives as long as data
       std::unique_ptr<ipc::Message> message;


### PR DESCRIPTION
Also massage the Flight headers to avoid unnecessary includes and declarations.