### PR TITLE
ARROW-4629: [Python] Pandas arrow conversion slowed down by imports

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -170,8 +170,9 @@ def array(object obj, type=None, mask=None, size=None, bint from_pandas=False,
                 from_pandas=True, safe=safe,
                 memory_pool=memory_pool)
         else:
-            values, type = pdcompat.get_datetimetz_type(values, obj.dtype,
-                                                        type)
+            if HAVE_PANDAS:
+                values, type = pdcompat.get_datetimetz_type(
+                    values, obj.dtype, type)
             return _ndarray_to_array(values, mask, type, from_pandas, safe,
                                      pool)
     else:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -15,7 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import pyarrow.pandas_compat as pdcompat
+from pyarrow.compat import HAVE_PANDAS
+
+if HAVE_PANDAS:
+    import pyarrow.pandas_compat as pdcompat
+
 
 cdef _sequence_to_array(object sequence, object mask, object size,
                         DataType type, CMemoryPool* pool, c_bool from_pandas):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pyarrow.pandas_compat as pdcompat
 
 cdef _sequence_to_array(object sequence, object mask, object size,
                         DataType type, CMemoryPool* pool, c_bool from_pandas):
@@ -165,7 +166,6 @@ def array(object obj, type=None, mask=None, size=None, bint from_pandas=False,
                 from_pandas=True, safe=safe,
                 memory_pool=memory_pool)
         else:
-            import pyarrow.pandas_compat as pdcompat
             values, type = pdcompat.get_datetimetz_type(values, obj.dtype,
                                                         type)
             return _ndarray_to_array(values, mask, type, from_pandas, safe,

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -28,7 +28,7 @@ import pandas as pd
 import six
 
 import pyarrow as pa
-from pyarrow.compat import builtin_pickle, PY2, zip_longest  # noqa
+from pyarrow.compat import builtin_pickle, DatetimeTZDtype, PY2, zip_longest  # noqa
 
 
 def infer_dtype(column):
@@ -447,8 +447,6 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None,
 
 
 def get_datetimetz_type(values, dtype, type_):
-    from pyarrow.compat import DatetimeTZDtype
-
     if values.dtype.type != np.datetime64:
         return values, type_
 
@@ -543,7 +541,6 @@ def _reconstruct_block(item):
 
 
 def _make_datetimetz(tz):
-    from pyarrow.compat import DatetimeTZDtype
     tz = pa.lib.string_to_tzinfo(tz)
     return DatetimeTZDtype('ns', tz=tz)
 
@@ -554,7 +551,6 @@ def _make_datetimetz(tz):
 
 def table_to_blockmanager(options, table, categories=None,
                           ignore_metadata=False):
-    from pyarrow.compat import DatetimeTZDtype
 
     index_columns = []
     columns = []


### PR DESCRIPTION
The local imports slow down the conversion from pandas to arrow significantly (see [here](https://issues.apache.org/jira/browse/ARROW-4629))