### PR TITLE
ARROW-3532: [Python] Emit warning when looking up for duplicate struct or schema fields

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -314,4 +314,11 @@ inline void BitmapFromVector(const std::vector<T>& is_valid,
   ASSERT_OK(GetBitmapFromVector(is_valid, out));
 }
 
+template <typename T>
+void AssertSortedEquals(std::vector<T> u, std::vector<T> v) {
+  std::sort(u.begin(), u.end());
+  std::sort(v.begin(), v.end());
+  ASSERT_EQ(u, v);
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -518,9 +518,15 @@ class ARROW_EXPORT StructType : public NestedType {
   /// Returns null if name not found
   std::shared_ptr<Field> GetFieldByName(const std::string& name) const;
 
+  /// Return all fields having this name
+  std::vector<std::shared_ptr<Field>> GetAllFieldsByName(const std::string& name) const;
+
   /// Returns -1 if name not found or if there are multiple fields having the
   /// same name
   int GetFieldIndex(const std::string& name) const;
+
+  /// Return the indices of all fields having this name
+  std::vector<int> GetAllFieldIndices(const std::string& name) const;
 
   ARROW_DEPRECATED("Use GetFieldByName")
   std::shared_ptr<Field> GetChildByName(const std::string& name) const;
@@ -529,7 +535,7 @@ class ARROW_EXPORT StructType : public NestedType {
   int GetChildIndex(const std::string& name) const;
 
  private:
-  std::unordered_map<std::string, int> name_to_index_;
+  std::unordered_multimap<std::string, int> name_to_index_;
 };
 
 /// \brief Base type class for (fixed-size) decimal data
@@ -826,8 +832,14 @@ class ARROW_EXPORT Schema {
   /// Returns null if name not found
   std::shared_ptr<Field> GetFieldByName(const std::string& name) const;
 
+  /// Return all fields having this name
+  std::vector<std::shared_ptr<Field>> GetAllFieldsByName(const std::string& name) const;
+
   /// Returns -1 if name not found
   int GetFieldIndex(const std::string& name) const;
+
+  /// Return the indices of all fields having this name
+  std::vector<int> GetAllFieldIndices(const std::string& name) const;
 
   const std::vector<std::shared_ptr<Field>>& fields() const { return fields_; }
 
@@ -866,7 +878,7 @@ class ARROW_EXPORT Schema {
  private:
   std::vector<std::shared_ptr<Field>> fields_;
 
-  std::unordered_map<std::string, int> name_to_index_;
+  std::unordered_multimap<std::string, int> name_to_index_;
 
   std::shared_ptr<const KeyValueMetadata> metadata_;
 };

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -277,6 +277,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CStructType(const vector[shared_ptr[CField]]& fields)
 
         shared_ptr[CField] GetFieldByName(const c_string& name)
+        vector[shared_ptr[CField]] GetAllFieldsByName(const c_string& name)
         int GetFieldIndex(const c_string& name)
 
     cdef cppclass CUnionType" arrow::UnionType"(CDataType):
@@ -298,7 +299,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CField] field(int i)
         shared_ptr[const CKeyValueMetadata] metadata()
         shared_ptr[CField] GetFieldByName(const c_string& name)
+        vector[shared_ptr[CField]] GetAllFieldsByName(const c_string& name)
         int64_t GetFieldIndex(const c_string& name)
+        vector[int64_t] GetAllFieldIndice(const c_string& name)
         int num_fields()
         c_string ToString()
 

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -22,7 +22,6 @@ import pytest
 import hypothesis as h
 import hypothesis.strategies as st
 
-import pandas as pd
 import numpy as np
 import pyarrow as pa
 import pyarrow.types as types
@@ -249,8 +248,9 @@ def test_struct_type():
     assert ty['b'] == ty[2]
 
     # Duplicate
-    with pytest.raises(KeyError):
-        ty['a']
+    with pytest.warns(UserWarning):
+        with pytest.raises(KeyError):
+            ty['a']
 
     # Not found
     with pytest.raises(KeyError):
@@ -519,16 +519,6 @@ def test_field_add_remove_metadata():
     assert f5.equals(f6)
 
 
-def test_empty_table():
-    schema = pa.schema([
-        pa.field('oneField', pa.int64())
-    ])
-    table = schema.empty_table()
-    assert isinstance(table, pa.Table)
-    assert table.num_rows == 0
-    assert table.schema == schema
-
-
 def test_is_integer_value():
     assert pa.types.is_integer_value(1)
     assert pa.types.is_integer_value(np.int64(1))
@@ -548,23 +538,6 @@ def test_is_boolean_value():
     assert pa.types.is_boolean_value(False)
     assert pa.types.is_boolean_value(np.bool_(True))
     assert pa.types.is_boolean_value(np.bool_(False))
-
-
-@pytest.mark.parametrize('data', [
-    list(range(10)),
-    pd.Categorical(list(range(10))),
-    ['foo', 'bar', None, 'baz', 'qux'],
-    np.array([
-        '2007-07-13T01:23:34.123456789',
-        '2006-01-13T12:34:56.432539784',
-        '2010-08-13T05:46:57.437699912'
-    ], dtype='datetime64[ns]')
-])
-def test_schema_from_pandas(data):
-    df = pd.DataFrame({'a': data})
-    schema = pa.Schema.from_pandas(df)
-    expected = pa.Table.from_pandas(df).schema
-    assert schema == expected
 
 
 @h.given(


### PR DESCRIPTION
Also provide C++ APIs to get all fields having a given name.