### PR TITLE
ARROW-3985: [C++] Let ccache preserve comments

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -302,6 +302,9 @@ if(ARROW_USE_CCACHE)
     message(STATUS "Using ccache: ${CCACHE_FOUND}")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_FOUND})
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_FOUND})
+    # ARROW-3985: let ccache preserve C++ comments, because some of them may be
+    # meaningful to the compiler
+    set(ENV{CCACHE_COMMENTS} "1")
   endif(CCACHE_FOUND)
 endif()
 

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1336,21 +1336,21 @@ static Status GetPandasBlockType(const Column& col, const PandasOptions& options
     case Type::DOUBLE:
       *output_type = PandasBlock::DOUBLE;
       break;
-    case Type::STRING:
+    case Type::STRING:  // fall through
     case Type::BINARY:
       if (options.strings_to_categorical) {
         *output_type = PandasBlock::CATEGORICAL;
         break;
-      }
-    case Type::NA:
-    case Type::FIXED_SIZE_BINARY:
-    case Type::STRUCT:
-    case Type::TIME32:
-    case Type::TIME64:
-    case Type::DECIMAL:
+      }                            // fall through
+    case Type::NA:                 // fall through
+    case Type::FIXED_SIZE_BINARY:  // fall through
+    case Type::STRUCT:             // fall through
+    case Type::TIME32:             // fall through
+    case Type::TIME64:             // fall through
+    case Type::DECIMAL:            // fall through
       *output_type = PandasBlock::OBJECT;
       break;
-    case Type::DATE32:
+    case Type::DATE32:  // fall through
     case Type::DATE64:
       *output_type = options.date_as_object ? PandasBlock::OBJECT : PandasBlock::DATETIME;
       break;

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -225,7 +225,7 @@ static inline Status PyDate_convert_int(int64_t val, const DateUnit unit, int64_
                                         int64_t* month, int64_t* day) {
   switch (unit) {
     case DateUnit::MILLI:
-      val /= 86400000LL;
+      val /= 86400000LL;  // fall through
     case DateUnit::DAY:
       get_date_from_days(val, year, month, day);
     default:

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -121,6 +121,7 @@ LogicalType::type get_logical_type(const ::DataType& type) {
           DCHECK(false) << "Only MILLI and MICRO units supported for Arrow timestamps "
                            "with Parquet.";
       }
+      break;
     }
     case ArrowId::TIME32:
       return LogicalType::TIME_MILLIS;

--- a/cpp/src/parquet/murmur3.cc
+++ b/cpp/src/parquet/murmur3.cc
@@ -126,38 +126,38 @@ void Hash_x64_128(const void* key, const int len, const uint32_t seed, uint64_t 
 
   switch (len & 15) {
     case 15:
-      k2 ^= ((uint64_t)tail[14]) << 48;
+      k2 ^= ((uint64_t)tail[14]) << 48;  // fall through
     case 14:
-      k2 ^= ((uint64_t)tail[13]) << 40;
+      k2 ^= ((uint64_t)tail[13]) << 40;  // fall through
     case 13:
-      k2 ^= ((uint64_t)tail[12]) << 32;
+      k2 ^= ((uint64_t)tail[12]) << 32;  // fall through
     case 12:
-      k2 ^= ((uint64_t)tail[11]) << 24;
+      k2 ^= ((uint64_t)tail[11]) << 24;  // fall through
     case 11:
-      k2 ^= ((uint64_t)tail[10]) << 16;
+      k2 ^= ((uint64_t)tail[10]) << 16;  // fall through
     case 10:
-      k2 ^= ((uint64_t)tail[9]) << 8;
+      k2 ^= ((uint64_t)tail[9]) << 8;  // fall through
     case 9:
       k2 ^= ((uint64_t)tail[8]) << 0;
       k2 *= c2;
       k2 = ROTL64(k2, 33);
       k2 *= c1;
-      h2 ^= k2;
+      h2 ^= k2;  // fall through
 
     case 8:
-      k1 ^= ((uint64_t)tail[7]) << 56;
+      k1 ^= ((uint64_t)tail[7]) << 56;  // fall through
     case 7:
-      k1 ^= ((uint64_t)tail[6]) << 48;
+      k1 ^= ((uint64_t)tail[6]) << 48;  // fall through
     case 6:
-      k1 ^= ((uint64_t)tail[5]) << 40;
+      k1 ^= ((uint64_t)tail[5]) << 40;  // fall through
     case 5:
-      k1 ^= ((uint64_t)tail[4]) << 32;
+      k1 ^= ((uint64_t)tail[4]) << 32;  // fall through
     case 4:
-      k1 ^= ((uint64_t)tail[3]) << 24;
+      k1 ^= ((uint64_t)tail[3]) << 24;  // fall through
     case 3:
-      k1 ^= ((uint64_t)tail[2]) << 16;
+      k1 ^= ((uint64_t)tail[2]) << 16;  // fall through
     case 2:
-      k1 ^= ((uint64_t)tail[1]) << 8;
+      k1 ^= ((uint64_t)tail[1]) << 8;  // fall through
     case 1:
       k1 ^= ((uint64_t)tail[0]) << 0;
       k1 *= c1;

--- a/cpp/src/plasma/common.cc
+++ b/cpp/src/plasma/common.cc
@@ -78,17 +78,17 @@ uint64_t MurmurHash64A(const void* key, int len, unsigned int seed) {
 
   switch (len & 7) {
     case 7:
-      h ^= uint64_t(data2[6]) << 48;
+      h ^= uint64_t(data2[6]) << 48;  // fall through
     case 6:
-      h ^= uint64_t(data2[5]) << 40;
+      h ^= uint64_t(data2[5]) << 40;  // fall through
     case 5:
-      h ^= uint64_t(data2[4]) << 32;
+      h ^= uint64_t(data2[4]) << 32;  // fall through
     case 4:
-      h ^= uint64_t(data2[3]) << 24;
+      h ^= uint64_t(data2[3]) << 24;  // fall through
     case 3:
-      h ^= uint64_t(data2[2]) << 16;
+      h ^= uint64_t(data2[2]) << 16;  // fall through
     case 2:
-      h ^= uint64_t(data2[1]) << 8;
+      h ^= uint64_t(data2[1]) << 8;  // fall through
     case 1:
       h ^= uint64_t(data2[0]);
       h *= m;


### PR DESCRIPTION
Some comments may be meaningful to the compiler, such as when a warnings needs to be prevented.