### PR TITLE
ARROW-4641: [C++][Flight] Suppress strict aliasing warnings from "unsafe" casts in client.cc

### DIFF
--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -72,16 +72,6 @@ set(ARROW_FLIGHT_SRCS
     server.cc
     types.cc)
 
-if(UNIX)
-  # ARROW-4641: Our gRPC optimizations trigger -Wstrict-aliasing in gcc
-  set_property(SOURCE client.cc
-               APPEND_STRING
-               PROPERTY COMPILE_FLAGS " -fno-strict-aliasing ")
-  set_property(SOURCE server.cc
-               APPEND_STRING
-               PROPERTY COMPILE_FLAGS " -fno-strict-aliasing ")
-endif()
-
 add_arrow_lib(arrow_flight
               SOURCES
               ${ARROW_FLIGHT_SRCS}

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -72,6 +72,16 @@ set(ARROW_FLIGHT_SRCS
     server.cc
     types.cc)
 
+if(UNIX)
+  # ARROW-4641: Our gRPC optimizations trigger -Wstrict-aliasing in gcc
+  set_property(SOURCE client.cc
+               APPEND_STRING
+               PROPERTY COMPILE_FLAGS " -fno-strict-aliasing ")
+  set_property(SOURCE server.cc
+               APPEND_STRING
+               PROPERTY COMPILE_FLAGS " -fno-strict-aliasing ")
+endif()
+
 add_arrow_lib(arrow_flight
               SOURCES
               ${ARROW_FLIGHT_SRCS}

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -123,8 +123,15 @@ class FlightPutWriter::FlightPutWriterImpl : public ipc::RecordBatchWriter {
     RETURN_NOT_OK(
         ipc::internal::GetRecordBatchPayload(batch, pool_, &payload.ipc_message));
 
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
     if (!writer_->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
                         grpc::WriteOptions())) {
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
       std::stringstream ss;
       ss << "Could not write record batch to stream: "
          << rpc_->context.debug_error_string();
@@ -307,8 +314,15 @@ class FlightClient::FlightClientImpl {
     pb_descr.SerializeToString(&str_descr);
     RETURN_NOT_OK(Buffer::FromString(str_descr, &payload.descriptor));
 
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
     if (!write_stream->Write(*reinterpret_cast<const pb::FlightData*>(&payload),
                              grpc::WriteOptions())) {
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
       std::stringstream ss;
       ss << "Could not write descriptor and schema to stream: "
          << rpc->context.debug_error_string();


### PR DESCRIPTION
The type-casting trick we are using to sneak a different kind of object into `SerializationTraits<pb::FlightData>` looks like a `-Wstrict-aliasing` violation (which it would be, if any code tried to use the reference as the protobuf type)