### PR TITLE
ARROW-3769: [C++] Add support for reading non-dictionary encoded binary Parquet columns directly as DictionaryArray

### DIFF
--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -198,6 +198,35 @@ class ARROW_EXPORT RandomArrayGenerator {
     }
   }
 
+  /// \brief Generates a random StringArray
+  ///
+  /// \param[in] size the size of the array to generate
+  /// \param[in] min_length the lower bound of the string length
+  ///            determined by the uniform distribution
+  /// \param[in] max_length the upper bound of the string length
+  ///            determined by the uniform distribution
+  /// \param[in] null_probability the probability of a row being null
+  ///
+  /// \return a generated Array
+  std::shared_ptr<arrow::Array> String(int64_t size, int32_t min_length,
+                                       int32_t max_length, double null_probability);
+
+  /// \brief Generates a random StringArray with repeated values
+  ///
+  /// \param[in] size the size of the array to generate
+  /// \param[in] unique the number of unique string values used
+  ///            to populate the array
+  /// \param[in] min_length the lower bound of the string length
+  ///            determined by the uniform distribution
+  /// \param[in] max_length the upper bound of the string length
+  ///            determined by the uniform distribution
+  /// \param[in] null_probability the probability of a row being null
+  ///
+  /// \return a generated Array
+  std::shared_ptr<arrow::Array> StringWithRepeats(int64_t size, int64_t unique,
+                                                  int32_t min_length, int32_t max_length,
+                                                  double null_probability);
+
  private:
   SeedType seed() { return seed_distribution_(seed_rng_); }
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -710,7 +710,7 @@ Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                   reader);
 }
 
-Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
+Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                 ::arrow::MemoryPool* allocator, const ArrowReaderProperties& properties,
                 std::unique_ptr<FileReader>* reader) {
   std::unique_ptr<RandomAccessSource> io_wrapper(new ArrowInputFile(file));

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -101,6 +101,11 @@ Status GetSingleChunk(const ChunkedArray& chunked, std::shared_ptr<Array>* out) 
 
 }  // namespace
 
+ArrowReaderProperties default_arrow_reader_properties() {
+  static ArrowReaderProperties default_reader_props;
+  return default_reader_props;
+}
+
 // ----------------------------------------------------------------------
 // Iteration utilities
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -236,8 +236,9 @@ using FileColumnIteratorFactory =
 
 class FileReader::Impl {
  public:
-  Impl(MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader)
-      : pool_(pool), reader_(std::move(reader)), use_threads_(false) {}
+  Impl(MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader,
+       const ArrowReaderProperties& properties)
+      : pool_(pool), reader_(std::move(reader)), reader_properties_(properties) {}
 
   virtual ~Impl() {}
 
@@ -279,14 +280,16 @@ class FileReader::Impl {
 
   int num_columns() const { return reader_->metadata()->num_columns(); }
 
-  void set_use_threads(bool use_threads) { use_threads_ = use_threads; }
+  void set_use_threads(bool use_threads) {
+    reader_properties_.set_use_threads(use_threads);
+  }
 
   ParquetFileReader* reader() { return reader_.get(); }
 
  private:
   MemoryPool* pool_;
   std::unique_ptr<ParquetFileReader> reader_;
-  bool use_threads_;
+  ArrowReaderProperties reader_properties_;
 };
 
 class ColumnReader::ColumnReaderImpl {
@@ -302,9 +305,10 @@ class ColumnReader::ColumnReaderImpl {
 // Reader implementation for primitive arrays
 class PARQUET_NO_EXPORT PrimitiveImpl : public ColumnReader::ColumnReaderImpl {
  public:
-  PrimitiveImpl(MemoryPool* pool, std::unique_ptr<FileColumnIterator> input)
+  PrimitiveImpl(MemoryPool* pool, std::unique_ptr<FileColumnIterator> input,
+                const bool read_dictionary)
       : pool_(pool), input_(std::move(input)), descr_(input_->descr()) {
-    record_reader_ = RecordReader::Make(descr_, pool_);
+    record_reader_ = RecordReader::Make(descr_, pool_, read_dictionary);
     Status s = NodeToField(*input_->descr()->schema_node(), &field_);
     DCHECK_OK(s);
     NextRowGroup();
@@ -358,17 +362,19 @@ class PARQUET_NO_EXPORT StructImpl : public ColumnReader::ColumnReaderImpl {
                  const std::vector<std::shared_ptr<ColumnReaderImpl>>& children);
 };
 
-FileReader::FileReader(MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader)
-    : impl_(new FileReader::Impl(pool, std::move(reader))) {}
+FileReader::FileReader(MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader,
+                       const ArrowReaderProperties& properties)
+    : impl_(new FileReader::Impl(pool, std::move(reader), properties)) {}
 
 FileReader::~FileReader() {}
 
 Status FileReader::Impl::GetColumn(int i, FileColumnIteratorFactory iterator_factory,
                                    std::unique_ptr<ColumnReader>* out) {
   std::unique_ptr<FileColumnIterator> input(iterator_factory(i, reader_.get()));
+  bool read_dict = reader_properties_.read_dictionary(i);
 
   std::unique_ptr<ColumnReader::ColumnReaderImpl> impl(
-      new PrimitiveImpl(pool_, std::move(input)));
+      new PrimitiveImpl(pool_, std::move(input), read_dict));
   *out = std::unique_ptr<ColumnReader>(new ColumnReader(std::move(impl)));
   return Status::OK();
 }
@@ -552,7 +558,7 @@ Status FileReader::Impl::ReadRowGroup(int row_group_index,
     return Status::OK();
   };
 
-  if (use_threads_) {
+  if (reader_properties_.use_threads()) {
     std::vector<std::future<Status>> futures;
     auto pool = ::arrow::internal::GetCpuThreadPool();
     for (int i = 0; i < num_fields; i++) {
@@ -599,7 +605,7 @@ Status FileReader::Impl::ReadTable(const std::vector<int>& indices,
     return Status::OK();
   };
 
-  if (use_threads_) {
+  if (reader_properties_.use_threads()) {
     std::vector<std::future<Status>> futures;
     auto pool = ::arrow::internal::GetCpuThreadPool();
     for (int i = 0; i < num_fields; i++) {
@@ -681,6 +687,18 @@ Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                 MemoryPool* allocator, std::unique_ptr<FileReader>* reader) {
   return OpenFile(file, allocator, ::parquet::default_reader_properties(), nullptr,
                   reader);
+}
+
+Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
+                ::arrow::MemoryPool* allocator, const ArrowReaderProperties& properties,
+                std::unique_ptr<FileReader>* reader) {
+  std::unique_ptr<RandomAccessSource> io_wrapper(new ArrowInputFile(file));
+  std::unique_ptr<ParquetReader> pq_reader;
+  PARQUET_CATCH_NOT_OK(
+      pq_reader = ParquetReader::Open(std::move(io_wrapper),
+                                      ::parquet::default_reader_properties(), nullptr));
+  reader->reset(new FileReader(allocator, std::move(pq_reader), properties));
+  return Status::OK();
 }
 
 Status FileReader::GetColumn(int i, std::unique_ptr<ColumnReader>* out) {
@@ -1138,15 +1156,6 @@ struct TransferFunctor<
   Status operator()(RecordReader* reader, MemoryPool* pool,
                     const std::shared_ptr<::arrow::DataType>& type, Datum* out) {
     std::vector<std::shared_ptr<Array>> chunks = reader->GetBuilderChunks();
-
-    if (type->id() == ::arrow::Type::STRING) {
-      // Convert from BINARY type to STRING
-      for (size_t i = 0; i < chunks.size(); ++i) {
-        auto new_data = chunks[i]->data()->Copy();
-        new_data->type = type;
-        chunks[i] = ::arrow::MakeArray(new_data);
-      }
-    }
     *out = std::make_shared<ChunkedArray>(chunks);
     return Status::OK();
   }

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -53,39 +53,38 @@ class ColumnReader;
 class RowGroupReader;
 
 static constexpr bool DEFAULT_USE_THREADS = false;
-static constexpr bool DEFAULT_READ_DICTIONARY = false;
 
+/// EXPERIMENTAL: Properties for configuring FileReader behavior.
 class PARQUET_EXPORT ArrowReaderProperties {
  public:
-  explicit ArrowReaderProperties(const bool use_threads = DEFAULT_USE_THREADS,
-                                 bool read_dict = DEFAULT_READ_DICTIONARY)
-      : use_threads_(use_threads), default_read_dict_(read_dict), read_dict_indices_() {}
+  explicit ArrowReaderProperties(bool use_threads = DEFAULT_USE_THREADS)
+      : use_threads_(use_threads), read_dict_indices_() {}
 
-  void set_use_threads(const bool use_threads) { use_threads_ = use_threads; }
+  void set_use_threads(bool use_threads) { use_threads_ = use_threads; }
 
   bool use_threads() const { return use_threads_; }
 
-  void set_read_dictionary(const int column_index, const bool read_dict) {
+  void set_read_dictionary(int column_index, bool read_dict) {
     if (read_dict) {
-      read_dict_indices_.emplace(column_index);
+      read_dict_indices_.insert(column_index);
     } else {
       read_dict_indices_.erase(column_index);
     }
   }
-  bool read_dictionary(const int column_index) const {
+  bool read_dictionary(int column_index) const {
     if (read_dict_indices_.find(column_index) != read_dict_indices_.end()) {
       return true;
     } else {
-      return default_read_dict_;
+      return false;
     }
   }
 
  private:
   bool use_threads_;
-  bool default_read_dict_;
   std::unordered_set<int> read_dict_indices_;
 };
 
+/// EXPERIMENTAL: Constructs the default ArrowReaderProperties
 PARQUET_EXPORT
 ArrowReaderProperties default_arrow_reader_properties();
 

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -87,10 +87,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
 };
 
 PARQUET_EXPORT
-ArrowReaderProperties default_arrow_reader_properties() {
-  static ArrowReaderProperties default_reader_props;
-  return default_reader_props;
-}
+ArrowReaderProperties default_arrow_reader_properties();
 
 // Arrow read adapter class for deserializing Parquet files as Arrow row
 // batches.

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -330,7 +330,7 @@ class PARQUET_EXPORT ColumnReader {
 };
 
 // Helper function to create a file reader from an implementation of an Arrow
-// readable file
+// random access file
 //
 // metadata : separately-computed file metadata, can be nullptr
 PARQUET_EXPORT
@@ -346,7 +346,7 @@ PARQUET_EXPORT
                          std::unique_ptr<FileReader>* reader);
 
 PARQUET_EXPORT
-::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
+::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                          ::arrow::MemoryPool* allocator,
                          const ArrowReaderProperties& properties,
                          std::unique_ptr<FileReader>* reader);

--- a/cpp/src/parquet/arrow/record_reader.cc
+++ b/cpp/src/parquet/arrow/record_reader.cc
@@ -458,7 +458,7 @@ class TypedRecordReader : public RecordReader::RecordReaderImpl {
 
   void ResetDecoders() override { decoders_.clear(); }
 
-  virtual inline void ReadValuesSpaced(int64_t values_with_nulls, int64_t null_count) {
+  virtual void ReadValuesSpaced(int64_t values_with_nulls, int64_t null_count) {
     uint8_t* valid_bits = valid_bits_->mutable_data();
     const int64_t valid_bits_offset = values_written_;
 
@@ -468,7 +468,7 @@ class TypedRecordReader : public RecordReader::RecordReaderImpl {
     DCHECK_EQ(num_decoded, values_with_nulls);
   }
 
-  virtual inline void ReadValuesDense(int64_t values_to_read) {
+  virtual void ReadValuesDense(int64_t values_to_read) {
     int64_t num_decoded =
         current_decoder_->Decode(ValuesHead<T>(), static_cast<int>(values_to_read));
     DCHECK_EQ(num_decoded, values_to_read);

--- a/cpp/src/parquet/arrow/record_reader.cc
+++ b/cpp/src/parquet/arrow/record_reader.cc
@@ -449,35 +449,16 @@ class RecordReader::RecordReaderImpl {
 };
 
 template <typename DType>
-struct RecordReaderTraits {
-  using BuilderType = ::arrow::ArrayBuilder;
-};
-
-template <>
-struct RecordReaderTraits<ByteArrayType> {
-  using BuilderType = ::arrow::internal::ChunkedBinaryBuilder;
-};
-
-template <>
-struct RecordReaderTraits<FLBAType> {
-  using BuilderType = ::arrow::FixedSizeBinaryBuilder;
-};
-
-template <typename DType>
 class TypedRecordReader : public RecordReader::RecordReaderImpl {
  public:
   using T = typename DType::c_type;
 
-  using BuilderType = typename RecordReaderTraits<DType>::BuilderType;
-
   TypedRecordReader(const ColumnDescriptor* descr, ::arrow::MemoryPool* pool)
-      : RecordReader::RecordReaderImpl(descr, pool), current_decoder_(nullptr) {
-    InitializeBuilder();
-  }
+      : RecordReader::RecordReaderImpl(descr, pool), current_decoder_(nullptr) {}
 
   void ResetDecoders() override { decoders_.clear(); }
 
-  inline void ReadValuesSpaced(int64_t values_with_nulls, int64_t null_count) {
+  virtual inline void ReadValuesSpaced(int64_t values_with_nulls, int64_t null_count) {
     uint8_t* valid_bits = valid_bits_->mutable_data();
     const int64_t valid_bits_offset = values_written_;
 
@@ -487,7 +468,7 @@ class TypedRecordReader : public RecordReader::RecordReaderImpl {
     DCHECK_EQ(num_decoded, values_with_nulls);
   }
 
-  inline void ReadValuesDense(int64_t values_to_read) {
+  virtual inline void ReadValuesDense(int64_t values_to_read) {
     int64_t num_decoded =
         current_decoder_->Decode(ValuesHead<T>(), static_cast<int>(values_to_read));
     DCHECK_EQ(num_decoded, values_to_read);
@@ -568,17 +549,16 @@ class TypedRecordReader : public RecordReader::RecordReaderImpl {
     throw ParquetException("GetChunks only implemented for binary types");
   }
 
- private:
+ protected:
   using DecoderType = typename EncodingTraits<DType>::Decoder;
 
+  DecoderType* current_decoder_;
+
+ private:
   // Map of encoding type to the respective decoder object. For example, a
   // column chunk's data pages may include both dictionary-encoded and
   // plain-encoded data.
   std::unordered_map<int, std::unique_ptr<DecoderType>> decoders_;
-
-  std::unique_ptr<BuilderType> builder_;
-
-  DecoderType* current_decoder_;
 
   // Initialize repetition and definition level decoders on the next data page.
   int64_t InitializeLevelDecoders(const DataPage& page,
@@ -590,9 +570,132 @@ class TypedRecordReader : public RecordReader::RecordReaderImpl {
   // Advance to the next data page
   bool ReadNewPage() override;
 
-  void InitializeBuilder() {}
-
   void ConfigureDictionary(const DictionaryPage* page);
+};
+
+class FLBARecordReader : public TypedRecordReader<FLBAType> {
+ public:
+  FLBARecordReader(const ColumnDescriptor* descr, ::arrow::MemoryPool* pool)
+      : TypedRecordReader<FLBAType>(descr, pool), builder_(nullptr) {
+    DCHECK_EQ(descr_->physical_type(), Type::FIXED_LEN_BYTE_ARRAY);
+    int byte_width = descr_->type_length();
+    std::shared_ptr<::arrow::DataType> type = ::arrow::fixed_size_binary(byte_width);
+    builder_.reset(new ::arrow::FixedSizeBinaryBuilder(type, pool_));
+  }
+
+  ::arrow::ArrayVector GetBuilderChunks() override {
+    std::shared_ptr<::arrow::Array> chunk;
+    PARQUET_THROW_NOT_OK(builder_->Finish(&chunk));
+    return ::arrow::ArrayVector({chunk});
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    auto values = ValuesHead<FLBA>();
+    int64_t num_decoded =
+        current_decoder_->Decode(values, static_cast<int>(values_to_read));
+    DCHECK_EQ(num_decoded, values_to_read);
+
+    for (int64_t i = 0; i < num_decoded; i++) {
+      PARQUET_THROW_NOT_OK(builder_->Append(values[i].ptr));
+    }
+    ResetValues();
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    uint8_t* valid_bits = valid_bits_->mutable_data();
+    const int64_t valid_bits_offset = values_written_;
+    auto values = ValuesHead<FLBA>();
+
+    int64_t num_decoded = current_decoder_->DecodeSpaced(
+        values, static_cast<int>(values_to_read), static_cast<int>(null_count),
+        valid_bits, valid_bits_offset);
+    DCHECK_EQ(num_decoded, values_to_read);
+
+    for (int64_t i = 0; i < num_decoded; i++) {
+      if (::arrow::BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
+        PARQUET_THROW_NOT_OK(builder_->Append(values[i].ptr));
+      } else {
+        PARQUET_THROW_NOT_OK(builder_->AppendNull());
+      }
+    }
+    ResetValues();
+  }
+
+ private:
+  std::unique_ptr<::arrow::FixedSizeBinaryBuilder> builder_;
+};
+
+class ByteArrayChunkedRecordReader : public TypedRecordReader<ByteArrayType> {
+ public:
+  ByteArrayChunkedRecordReader(const ColumnDescriptor* descr, ::arrow::MemoryPool* pool)
+      : TypedRecordReader<ByteArrayType>(descr, pool), builder_(nullptr) {
+    // Maximum of 16MB chunks
+    constexpr int32_t kBinaryChunksize = 1 << 24;
+    DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
+    if (descr_->logical_type() == LogicalType::UTF8) {
+      builder_.reset(
+          new ::arrow::internal::ChunkedStringBuilder(kBinaryChunksize, pool_));
+    } else {
+      builder_.reset(
+          new ::arrow::internal::ChunkedBinaryBuilder(kBinaryChunksize, pool_));
+    }
+  }
+
+  ::arrow::ArrayVector GetBuilderChunks() override {
+    ::arrow::ArrayVector chunks;
+    PARQUET_THROW_NOT_OK(builder_->Finish(&chunks));
+    return chunks;
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    int64_t num_decoded = current_decoder_->DecodeArrowNonNull(
+        static_cast<int>(values_to_read), builder_.get());
+    DCHECK_EQ(num_decoded, values_to_read);
+    ResetValues();
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    int64_t num_decoded = current_decoder_->DecodeArrow(
+        static_cast<int>(values_to_read), static_cast<int>(null_count),
+        valid_bits_->mutable_data(), values_written_, builder_.get());
+    DCHECK_EQ(num_decoded, values_to_read);
+    ResetValues();
+  }
+
+ private:
+  std::unique_ptr<::arrow::internal::ChunkedBinaryBuilder> builder_;
+};
+
+template <typename BuilderType>
+class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType> {
+ public:
+  ByteArrayDictionaryRecordReader(const ColumnDescriptor* descr,
+                                  ::arrow::MemoryPool* pool)
+      : TypedRecordReader<ByteArrayType>(descr, pool), builder_(new BuilderType(pool)) {}
+
+  ::arrow::ArrayVector GetBuilderChunks() override {
+    std::shared_ptr<::arrow::Array> chunk;
+    PARQUET_THROW_NOT_OK(builder_->Finish(&chunk));
+    return ::arrow::ArrayVector({chunk});
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    int64_t num_decoded = current_decoder_->DecodeArrowNonNull(
+        static_cast<int>(values_to_read), builder_.get());
+    DCHECK_EQ(num_decoded, values_to_read);
+    ResetValues();
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    int64_t num_decoded = current_decoder_->DecodeArrow(
+        static_cast<int>(values_to_read), static_cast<int>(null_count),
+        valid_bits_->mutable_data(), values_written_, builder_.get());
+    DCHECK_EQ(num_decoded, values_to_read);
+    ResetValues();
+  }
+
+ private:
+  std::unique_ptr<BuilderType> builder_;
 };
 
 // TODO(wesm): Implement these to some satisfaction
@@ -604,89 +707,6 @@ void TypedRecordReader<ByteArrayType>::DebugPrintState() {}
 
 template <>
 void TypedRecordReader<FLBAType>::DebugPrintState() {}
-
-template <>
-void TypedRecordReader<ByteArrayType>::InitializeBuilder() {
-  // Maximum of 16MB chunks
-  constexpr int32_t kBinaryChunksize = 1 << 24;
-  DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
-  builder_.reset(new ::arrow::internal::ChunkedBinaryBuilder(kBinaryChunksize, pool_));
-}
-
-template <>
-void TypedRecordReader<FLBAType>::InitializeBuilder() {
-  DCHECK_EQ(descr_->physical_type(), Type::FIXED_LEN_BYTE_ARRAY);
-  int byte_width = descr_->type_length();
-  std::shared_ptr<::arrow::DataType> type = ::arrow::fixed_size_binary(byte_width);
-  builder_.reset(new ::arrow::FixedSizeBinaryBuilder(type, pool_));
-}
-
-template <>
-::arrow::ArrayVector TypedRecordReader<ByteArrayType>::GetBuilderChunks() {
-  ::arrow::ArrayVector chunks;
-  PARQUET_THROW_NOT_OK(builder_->Finish(&chunks));
-  return chunks;
-}
-
-template <>
-::arrow::ArrayVector TypedRecordReader<FLBAType>::GetBuilderChunks() {
-  std::shared_ptr<::arrow::Array> chunk;
-  PARQUET_THROW_NOT_OK(builder_->Finish(&chunk));
-  return ::arrow::ArrayVector({chunk});
-}
-
-template <>
-inline void TypedRecordReader<ByteArrayType>::ReadValuesDense(int64_t values_to_read) {
-  int64_t num_decoded = current_decoder_->DecodeArrowNonNull(
-      static_cast<int>(values_to_read), builder_.get());
-  DCHECK_EQ(num_decoded, values_to_read);
-  ResetValues();
-}
-
-template <>
-inline void TypedRecordReader<FLBAType>::ReadValuesDense(int64_t values_to_read) {
-  auto values = ValuesHead<FLBA>();
-  int64_t num_decoded =
-      current_decoder_->Decode(values, static_cast<int>(values_to_read));
-  DCHECK_EQ(num_decoded, values_to_read);
-
-  for (int64_t i = 0; i < num_decoded; i++) {
-    PARQUET_THROW_NOT_OK(builder_->Append(values[i].ptr));
-  }
-  ResetValues();
-}
-
-template <>
-inline void TypedRecordReader<ByteArrayType>::ReadValuesSpaced(int64_t values_to_read,
-                                                               int64_t null_count) {
-  int64_t num_decoded = current_decoder_->DecodeArrow(
-      static_cast<int>(values_to_read), static_cast<int>(null_count),
-      valid_bits_->mutable_data(), values_written_, builder_.get());
-  DCHECK_EQ(num_decoded, values_to_read);
-  ResetValues();
-}
-
-template <>
-inline void TypedRecordReader<FLBAType>::ReadValuesSpaced(int64_t values_to_read,
-                                                          int64_t null_count) {
-  uint8_t* valid_bits = valid_bits_->mutable_data();
-  const int64_t valid_bits_offset = values_written_;
-  auto values = ValuesHead<FLBA>();
-
-  int64_t num_decoded = current_decoder_->DecodeSpaced(
-      values, static_cast<int>(values_to_read), static_cast<int>(null_count), valid_bits,
-      valid_bits_offset);
-  DCHECK_EQ(num_decoded, values_to_read);
-
-  for (int64_t i = 0; i < num_decoded; i++) {
-    if (::arrow::BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
-      PARQUET_THROW_NOT_OK(builder_->Append(values[i].ptr));
-    } else {
-      PARQUET_THROW_NOT_OK(builder_->AppendNull());
-    }
-  }
-  ResetValues();
-}
 
 template <typename DType>
 inline void TypedRecordReader<DType>::ConfigureDictionary(const DictionaryPage* page) {
@@ -845,8 +865,27 @@ bool TypedRecordReader<DType>::ReadNewPage() {
   return true;
 }
 
+std::shared_ptr<RecordReader> RecordReader::MakeByteArrayRecordReader(
+    const ColumnDescriptor* descr, arrow::MemoryPool* pool, bool read_dictionary) {
+  if (read_dictionary) {
+    if (descr->logical_type() == LogicalType::UTF8) {
+      using Builder = ::arrow::StringDictionaryBuilder;
+      return std::shared_ptr<RecordReader>(
+          new RecordReader(new ByteArrayDictionaryRecordReader<Builder>(descr, pool)));
+    } else {
+      using Builder = ::arrow::BinaryDictionaryBuilder;
+      return std::shared_ptr<RecordReader>(
+          new RecordReader(new ByteArrayDictionaryRecordReader<Builder>(descr, pool)));
+    }
+  } else {
+    return std::shared_ptr<RecordReader>(
+        new RecordReader(new ByteArrayChunkedRecordReader(descr, pool)));
+  }
+}
+
 std::shared_ptr<RecordReader> RecordReader::Make(const ColumnDescriptor* descr,
-                                                 MemoryPool* pool) {
+                                                 MemoryPool* pool,
+                                                 const bool read_dictionary) {
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::shared_ptr<RecordReader>(
@@ -867,11 +906,10 @@ std::shared_ptr<RecordReader> RecordReader::Make(const ColumnDescriptor* descr,
       return std::shared_ptr<RecordReader>(
           new RecordReader(new TypedRecordReader<DoubleType>(descr, pool)));
     case Type::BYTE_ARRAY:
-      return std::shared_ptr<RecordReader>(
-          new RecordReader(new TypedRecordReader<ByteArrayType>(descr, pool)));
+      return RecordReader::MakeByteArrayRecordReader(descr, pool, read_dictionary);
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::shared_ptr<RecordReader>(
-          new RecordReader(new TypedRecordReader<FLBAType>(descr, pool)));
+          new RecordReader(new FLBARecordReader(descr, pool)));
     default: {
       // PARQUET-1481: This can occur if the file is corrupt
       std::stringstream ss;

--- a/cpp/src/parquet/arrow/record_reader.h
+++ b/cpp/src/parquet/arrow/record_reader.h
@@ -51,7 +51,8 @@ class RecordReader {
 
   static std::shared_ptr<RecordReader> Make(
       const ColumnDescriptor* descr,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
+      const bool read_dictionary = false);
 
   virtual ~RecordReader();
 
@@ -111,6 +112,10 @@ class RecordReader {
  private:
   std::unique_ptr<RecordReaderImpl> impl_;
   explicit RecordReader(RecordReaderImpl* impl);
+
+  static std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
+      const ColumnDescriptor* descr, ::arrow::MemoryPool* pool,
+      const bool read_dictionary);
 };
 
 }  // namespace internal

--- a/cpp/src/parquet/encoding-benchmark.cc
+++ b/cpp/src/parquet/encoding-benchmark.cc
@@ -186,7 +186,7 @@ std::shared_ptr<::arrow::Array> MakeRandomStringsWithRepeats(size_t num_unique,
   std::vector<std::string> dictionary(num_unique);
 
   uint32_t seed = 0;
-  std::default_random_engine gen(seed);
+  std::mt19937 gen(seed);
   std::uniform_int_distribution<int64_t> length_dist(min_length, max_length);
 
   std::generate(dictionary.begin(), dictionary.end(), [&] {

--- a/cpp/src/parquet/encoding-benchmark.cc
+++ b/cpp/src/parquet/encoding-benchmark.cc
@@ -54,7 +54,7 @@ static void BM_PlainEncodingBoolean(benchmark::State& state) {
   auto encoder = MakeEncoder(Type::BOOLEAN, Encoding::PLAIN);
   auto typed_encoder = dynamic_cast<BooleanEncoder*>(encoder.get());
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     typed_encoder->Put(values, static_cast<int>(values.size()));
     typed_encoder->FlushValues();
   }
@@ -71,7 +71,7 @@ static void BM_PlainDecodingBoolean(benchmark::State& state) {
   typed_encoder->Put(values, static_cast<int>(values.size()));
   std::shared_ptr<Buffer> buf = encoder->FlushValues();
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto decoder = MakeTypedDecoder<BooleanType>(Encoding::PLAIN);
     decoder->SetData(static_cast<int>(values.size()), buf->data(),
                      static_cast<int>(buf->size()));
@@ -87,7 +87,7 @@ BENCHMARK(BM_PlainDecodingBoolean)->Range(MIN_RANGE, MAX_RANGE);
 static void BM_PlainEncodingInt64(benchmark::State& state) {
   std::vector<int64_t> values(state.range(0), 64);
   auto encoder = MakeTypedEncoder<Int64Type>(Encoding::PLAIN);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     encoder->Put(values.data(), static_cast<int>(values.size()));
     encoder->FlushValues();
   }
@@ -102,7 +102,7 @@ static void BM_PlainDecodingInt64(benchmark::State& state) {
   encoder->Put(values.data(), static_cast<int>(values.size()));
   std::shared_ptr<Buffer> buf = encoder->FlushValues();
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto decoder = MakeTypedDecoder<Int64Type>(Encoding::PLAIN);
     decoder->SetData(static_cast<int>(values.size()), buf->data(),
                      static_cast<int>(buf->size()));
@@ -141,7 +141,7 @@ static void DecodeDict(std::vector<typename Type::c_type>& values,
 
   PARQUET_THROW_NOT_OK(indices->Resize(actual_bytes));
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto dict_decoder = MakeTypedDecoder<Type>(Encoding::PLAIN, descr.get());
     dict_decoder->SetData(dict_traits->num_entries(), dict_buffer->data(),
                           static_cast<int>(dict_buffer->size()));
@@ -253,7 +253,7 @@ class BM_PlainDecodingByteArray : public ::benchmark::Fixture {
 
 BENCHMARK_DEFINE_F(BM_PlainDecodingByteArray, DecodeArrow_Dense)
 (benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN);
     decoder->SetData(num_values_, buffer_->data(), static_cast<int>(buffer_->size()));
     ::arrow::internal::ChunkedBinaryBuilder builder(static_cast<int>(buffer_->size()),
@@ -269,7 +269,7 @@ BENCHMARK_REGISTER_F(BM_PlainDecodingByteArray, DecodeArrow_Dense)
 
 BENCHMARK_DEFINE_F(BM_PlainDecodingByteArray, DecodeArrowNonNull_Dense)
 (benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN);
     decoder->SetData(num_values_, buffer_->data(), static_cast<int>(buffer_->size()));
     ::arrow::internal::ChunkedBinaryBuilder builder(static_cast<int>(buffer_->size()),
@@ -285,7 +285,7 @@ BENCHMARK_REGISTER_F(BM_PlainDecodingByteArray, DecodeArrowNonNull_Dense)
 
 BENCHMARK_DEFINE_F(BM_PlainDecodingByteArray, DecodeArrow_Dict)
 (benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN);
     decoder->SetData(num_values_, buffer_->data(), static_cast<int>(buffer_->size()));
     ::arrow::BinaryDictionaryBuilder builder(::arrow::default_memory_pool());
@@ -300,7 +300,7 @@ BENCHMARK_REGISTER_F(BM_PlainDecodingByteArray, DecodeArrow_Dict)
 
 BENCHMARK_DEFINE_F(BM_PlainDecodingByteArray, DecodeArrowNonNull_Dict)
 (benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN);
     decoder->SetData(num_values_, buffer_->data(), static_cast<int>(buffer_->size()));
     ::arrow::BinaryDictionaryBuilder builder(::arrow::default_memory_pool());

--- a/cpp/src/parquet/encoding-benchmark.cc
+++ b/cpp/src/parquet/encoding-benchmark.cc
@@ -186,7 +186,7 @@ std::shared_ptr<::arrow::Array> MakeRandomStringsWithRepeats(size_t num_unique,
   std::vector<std::string> dictionary(num_unique);
 
   uint32_t seed = 0;
-  std::mt19937 gen(seed);
+  std::default_random_engine gen(seed);
   std::uniform_int_distribution<int64_t> length_dist(min_length, max_length);
 
   std::generate(dictionary.begin(), dictionary.end(), [&] {

--- a/cpp/src/parquet/encoding-benchmark.cc
+++ b/cpp/src/parquet/encoding-benchmark.cc
@@ -216,7 +216,8 @@ class BM_PlainDecodingByteArray : public ::benchmark::Fixture {
 
     for (int64_t i = 0; i < binary_array.length(); i++) {
       auto view = binary_array.GetView(i);
-      values_.emplace_back(view.length(), reinterpret_cast<const uint8_t*>(view.data()));
+      values_.emplace_back(static_cast<uint32_t>(view.length()),
+                           reinterpret_cast<const uint8_t*>(view.data()));
       total_size_ += view.length();
     }
 

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -341,7 +341,7 @@ class TestDecodeArrow : public ::testing::Test {
     const auto& binary_array = static_cast<const ::arrow::BinaryArray&>(*expected_array_);
     for (int64_t i = 0; i < binary_array.length(); i++) {
       auto view = binary_array.GetView(i);
-      input_data_.emplace_back(view.length(),
+      input_data_.emplace_back(static_cast<uint32_t>(view.length()),
                                reinterpret_cast<const uint8_t*>(view.data()));
     }
 

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -380,10 +380,34 @@ TEST_F(TestDecodeArrow, DecodeDense) {
       << "Actual: " << actual_vec[0] << "\nExpected: " << expected_array_;
 }
 
+TEST_F(TestDecodeArrow, DecodeNonNullDense) {
+  ::arrow::internal::ChunkedBinaryBuilder builder(static_cast<int>(buffer_->size()),
+                                                  allocator_);
+  auto actual_num_values = decoder_->DecodeArrowNonNull(num_values_, &builder);
+
+  ASSERT_EQ(actual_num_values, num_values_);
+  ::arrow::ArrayVector actual_vec;
+  ASSERT_OK(builder.Finish(&actual_vec));
+  ASSERT_EQ(actual_vec.size(), 1);
+  ASSERT_TRUE(actual_vec[0]->Equals(expected_array_))
+      << "Actual: " << actual_vec[0] << "\nExpected: " << expected_array_;
+}
+
 TEST_F(TestDecodeArrow, DecodeDictionary) {
   ::arrow::BinaryDictionaryBuilder builder(allocator_);
   auto actual_num_values =
       decoder_->DecodeArrow(num_values_, 0, valid_bits_.data(), 0, &builder);
+
+  ASSERT_EQ(actual_num_values, num_values_);
+  std::shared_ptr<::arrow::Array> actual;
+  ASSERT_OK(builder.Finish(&actual));
+  ASSERT_TRUE(actual->Equals(expected_dict_))
+      << "Actual: " << actual << "\nExpected: " << expected_dict_;
+}
+
+TEST_F(TestDecodeArrow, DecodeNonNullDictionary) {
+  ::arrow::BinaryDictionaryBuilder builder(allocator_);
+  auto actual_num_values = decoder_->DecodeArrowNonNull(num_values_, &builder);
 
   ASSERT_EQ(actual_num_values, num_values_);
   std::shared_ptr<::arrow::Array> actual;

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -350,15 +350,15 @@ class TestArrowBuilderDecoding : public ::testing::Test {
   using DenseBuilder = typename BuilderTraits<DType>::DenseArrayBuilder;
   using DictBuilder = typename BuilderTraits<DType>::DictArrayBuilder;
 
-  void SetUp() override { null_probabilities_ = {0.1}; }
+  void SetUp() override { null_probabilities_ = {0.0, 0.5, 1.0}; }
   void TearDown() override {}
 
   void InitTestCase(double null_probability) {
-    InitFromJSON(null_probability);
+    GenerateInputData(null_probability);
     SetupEncoderDecoder();
   }
 
-  void InitFromJSON(double null_probability) {
+  void GenerateInputData(double null_probability) {
     constexpr int num_unique = 100;
     constexpr int repeat = 10;
     constexpr int64_t min_length = 2;
@@ -484,6 +484,7 @@ class TestArrowBuilderDecoding : public ::testing::Test {
   using TestArrowBuilderDecoding<DType>::encoder_;    \
   using TestArrowBuilderDecoding<DType>::decoder_;    \
   using TestArrowBuilderDecoding<DType>::input_data_; \
+  using TestArrowBuilderDecoding<DType>::valid_bits_; \
   using TestArrowBuilderDecoding<DType>::num_values_; \
   using TestArrowBuilderDecoding<DType>::buffer_
 
@@ -530,7 +531,7 @@ class DictEncoding : public TestArrowBuilderDecoding<DType> {
     descr_ = std::unique_ptr<ColumnDescriptor>(new ColumnDescriptor(node, 0, 0));
     encoder_ = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
                                                descr_.get());
-    ASSERT_NO_THROW(encoder_->Put(input_data_.data(), num_values_));
+    ASSERT_NO_THROW(encoder_->PutSpaced(input_data_.data(), num_values_, valid_bits_, 0));
     buffer_ = encoder_->FlushValues();
 
     auto dict_encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder_.get());
@@ -562,21 +563,21 @@ class DictEncoding : public TestArrowBuilderDecoding<DType> {
 
 TYPED_TEST_CASE(DictEncoding, BuilderArrayTypes);
 
-//TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDenseBuilder) {
-//  this->CheckDecodeArrowUsingDenseBuilder();
-//}
-//
-// TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDictBuilder) {
-//  this->CheckDecodeArrowUsingDictBuilder();
-//}
-//
-// TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDenseBuilder) {
-//  this->CheckDecodeArrowNonNullUsingDenseBuilder();
-//}
-//
-// TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDictBuilder) {
-//  this->CheckDecodeArrowNonNullUsingDictBuilder();
-//}
+TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDenseBuilder) {
+  this->CheckDecodeArrowUsingDenseBuilder();
+}
+
+TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDictBuilder) {
+  this->CheckDecodeArrowUsingDictBuilder();
+}
+
+TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDenseBuilder) {
+  this->CheckDecodeArrowNonNullUsingDenseBuilder();
+}
+
+TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDictBuilder) {
+  this->CheckDecodeArrowNonNullUsingDictBuilder();
+}
 
 }  // namespace test
 

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -562,21 +562,21 @@ class DictEncoding : public TestArrowBuilderDecoding<DType> {
 
 TYPED_TEST_CASE(DictEncoding, BuilderArrayTypes);
 
-TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDenseBuilder) {
-  this->CheckDecodeArrowUsingDenseBuilder();
-}
-
- TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDictBuilder) {
-  this->CheckDecodeArrowUsingDictBuilder();
-}
-
- TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDenseBuilder) {
-  this->CheckDecodeArrowNonNullUsingDenseBuilder();
-}
-
- TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDictBuilder) {
-  this->CheckDecodeArrowNonNullUsingDictBuilder();
-}
+//TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDenseBuilder) {
+//  this->CheckDecodeArrowUsingDenseBuilder();
+//}
+//
+// TYPED_TEST(DictEncoding, CheckDecodeArrowUsingDictBuilder) {
+//  this->CheckDecodeArrowUsingDictBuilder();
+//}
+//
+// TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDenseBuilder) {
+//  this->CheckDecodeArrowNonNullUsingDenseBuilder();
+//}
+//
+// TYPED_TEST(DictEncoding, CheckDecodeArrowNonNullDictBuilder) {
+//  this->CheckDecodeArrowNonNullUsingDictBuilder();
+//}
 
 }  // namespace test
 

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -494,7 +494,7 @@ class PlainEncoding : public TestArrowBuilderDecoding<DType> {
   void SetupEncoderDecoder() override {
     encoder_ = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN);
     decoder_ = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN);
-    ASSERT_NO_THROW(encoder_->Put(input_data_.data(), num_values_));
+    ASSERT_NO_THROW(encoder_->PutSpaced(input_data_.data(), num_values_, valid_bits_, 0));
     buffer_ = encoder_->FlushValues();
     decoder_->SetData(num_values_, buffer_->data(), static_cast<int>(buffer_->size()));
   }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -759,19 +759,19 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     int64_t data_size = len_;
     int bytes_decoded = 0;
     while (i < num_values) {
-      uint32_t len = *reinterpret_cast<const uint32_t*>(data);
-      increment = static_cast<int>(sizeof(uint32_t) + len);
-      if (data_size < increment) {
-        ParquetException::EofException();
-      }
       if (bit_reader.IsSet()) {
+        uint32_t len = *reinterpret_cast<const uint32_t*>(data);
+        increment = static_cast<int>(sizeof(uint32_t) + len);
+        if (data_size < increment) {
+          ParquetException::EofException();
+        }
         ARROW_RETURN_NOT_OK(out->Append(data + sizeof(uint32_t), len));
+        data += increment;
+        data_size -= increment;
+        bytes_decoded += increment;
       } else {
         ARROW_RETURN_NOT_OK(out->AppendNull());
       }
-      data += increment;
-      data_size -= increment;
-      bytes_decoded += increment;
       bit_reader.Next();
       ++i;
     }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -715,6 +715,15 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     return result;
   }
 
+  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
+                  int64_t valid_bits_offset,
+                  ::arrow::StringDictionaryBuilder* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(
+        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
+    return result;
+  }
+
   int DecodeArrowNonNull(int num_values,
                          ::arrow::internal::ChunkedBinaryBuilder* out) override {
     int result = 0;
@@ -723,6 +732,12 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
   }
 
   int DecodeArrowNonNull(int num_values, ::arrow::BinaryDictionaryBuilder* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
+    return result;
+  }
+
+  int DecodeArrowNonNull(int num_values, ::arrow::StringDictionaryBuilder* out) override {
     int result = 0;
     PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
     return result;
@@ -941,6 +956,15 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
     return result;
   }
 
+  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
+                  int64_t valid_bits_offset,
+                  ::arrow::StringDictionaryBuilder* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(
+        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
+    return result;
+  }
+
   int DecodeArrowNonNull(int num_values,
                          ::arrow::internal::ChunkedBinaryBuilder* out) override {
     int result = 0;
@@ -949,6 +973,12 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
   }
 
   int DecodeArrowNonNull(int num_values, ::arrow::BinaryDictionaryBuilder* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
+    return result;
+  }
+
+  int DecodeArrowNonNull(int num_values, ::arrow::StringDictionaryBuilder* out) override {
     int result = 0;
     PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
     return result;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -697,61 +697,12 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
   using Base::DecodeSpaced;
   using Base::PlainDecoder;
 
-  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                  int64_t valid_bits_offset,
-                  ::arrow::internal::ChunkedBinaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(
-        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
-    return result;
-  }
-
-  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                  int64_t valid_bits_offset,
-                  ::arrow::BinaryDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(
-        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
-    return result;
-  }
-
-  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                  int64_t valid_bits_offset,
-                  ::arrow::StringDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(
-        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
-    return result;
-  }
-
-  int DecodeArrowNonNull(int num_values,
-                         ::arrow::internal::ChunkedBinaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
-    return result;
-  }
-
-  int DecodeArrowNonNull(int num_values, ::arrow::BinaryDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
-    return result;
-  }
-
-  int DecodeArrowNonNull(int num_values, ::arrow::StringDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
-    return result;
-  }
-
  private:
-  template <typename BuilderType>
   ::arrow::Status DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                              int64_t valid_bits_offset, BuilderType* out,
-                              int* values_decoded) {
+                              int64_t valid_bits_offset, WrappedBuilderInterface* builder,
+                              int* values_decoded) override {
     num_values = std::min(num_values, num_values_);
-
-    ARROW_RETURN_NOT_OK(out->Reserve(num_values));
-
+    builder->Reserve(num_values);
     ::arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
     int increment;
     int i = 0;
@@ -765,12 +716,12 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
         if (data_size < increment) {
           ParquetException::EofException();
         }
-        ARROW_RETURN_NOT_OK(out->Append(data + sizeof(uint32_t), len));
+        builder->Append(data + sizeof(uint32_t), len);
         data += increment;
         data_size -= increment;
         bytes_decoded += increment;
       } else {
-        ARROW_RETURN_NOT_OK(out->AppendNull());
+        builder->AppendNull();
       }
       bit_reader.Next();
       ++i;
@@ -783,20 +734,20 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     return ::arrow::Status::OK();
   }
 
-  template <typename BuilderType>
-  ::arrow::Status DecodeArrowNonNull(int num_values, BuilderType* out,
-                                     int* values_decoded) {
+  ::arrow::Status DecodeArrowNonNull(int num_values, WrappedBuilderInterface* builder,
+                                     int* values_decoded) override {
     num_values = std::min(num_values, num_values_);
-    ARROW_RETURN_NOT_OK(out->Reserve(num_values));
+    builder->Reserve(num_values);
     int i = 0;
     const uint8_t* data = data_;
     int64_t data_size = len_;
     int bytes_decoded = 0;
+
     while (i < num_values) {
       uint32_t len = *reinterpret_cast<const uint32_t*>(data);
       int increment = static_cast<int>(sizeof(uint32_t) + len);
       if (data_size < increment) ParquetException::EofException();
-      ARROW_RETURN_NOT_OK(out->Append(data + sizeof(uint32_t), len));
+      builder->Append(data + sizeof(uint32_t), len);
       data += increment;
       data_size -= increment;
       bytes_decoded += increment;
@@ -938,60 +889,13 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
   using BASE = DictDecoderImpl<ByteArrayType>;
   using BASE::DictDecoderImpl;
 
-  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                  int64_t valid_bits_offset,
-                  ::arrow::internal::ChunkedBinaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(
-        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
-    return result;
-  }
-
-  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                  int64_t valid_bits_offset,
-                  ::arrow::BinaryDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(
-        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
-    return result;
-  }
-
-  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                  int64_t valid_bits_offset,
-                  ::arrow::StringDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(
-        DecodeArrow(num_values, null_count, valid_bits, valid_bits_offset, out, &result));
-    return result;
-  }
-
-  int DecodeArrowNonNull(int num_values,
-                         ::arrow::internal::ChunkedBinaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
-    return result;
-  }
-
-  int DecodeArrowNonNull(int num_values, ::arrow::BinaryDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
-    return result;
-  }
-
-  int DecodeArrowNonNull(int num_values, ::arrow::StringDictionaryBuilder* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
-    return result;
-  }
-
  private:
-  template <typename BuilderType>
   ::arrow::Status DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                              int64_t valid_bits_offset, BuilderType* builder,
-                              int* out_num_values) {
+                              int64_t valid_bits_offset, WrappedBuilderInterface* builder,
+                              int* out_num_values) override {
     constexpr int32_t buffer_size = 1024;
     int32_t indices_buffer[buffer_size];
-
+    builder->Reserve(num_values);
     ::arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
 
     int values_decoded = 0;
@@ -1009,10 +913,10 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
           // Consume all indices
           if (is_valid) {
             const auto& val = dictionary_[indices_buffer[i]];
-            ARROW_RETURN_NOT_OK(builder->Append(val.ptr, val.len));
+            builder->Append(val.ptr, val.len);
             ++i;
           } else {
-            ARROW_RETURN_NOT_OK(builder->AppendNull());
+            builder->AppendNull();
             --null_count;
           }
           ++values_decoded;
@@ -1025,7 +929,7 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
           bit_reader.Next();
         }
       } else {
-        ARROW_RETURN_NOT_OK(builder->AppendNull());
+        builder->AppendNull();
         --null_count;
         ++values_decoded;
       }
@@ -1038,19 +942,20 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
     return ::arrow::Status::OK();
   }
 
-  template <typename BuilderType>
-  ::arrow::Status DecodeArrowNonNull(int num_values, BuilderType* builder,
-                                     int* out_num_values) {
+  ::arrow::Status DecodeArrowNonNull(int num_values, WrappedBuilderInterface* builder,
+                                     int* out_num_values) override {
     constexpr int32_t buffer_size = 2048;
     int32_t indices_buffer[buffer_size];
     int values_decoded = 0;
+    builder->Reserve(num_values);
+
     while (values_decoded < num_values) {
       int32_t batch_size = std::min<int32_t>(buffer_size, num_values - values_decoded);
       int num_indices = idx_decoder_.GetBatch(indices_buffer, batch_size);
       if (num_indices == 0) break;
       for (int i = 0; i < num_indices; ++i) {
         const auto& val = dictionary_[indices_buffer[i]];
-        PARQUET_THROW_NOT_OK(builder->Append(val.ptr, val.len));
+        builder->Append(val.ptr, val.len);
       }
       values_decoded += num_indices;
     }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -759,19 +759,19 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     int64_t data_size = len_;
     int bytes_decoded = 0;
     while (i < num_values) {
+      uint32_t len = *reinterpret_cast<const uint32_t*>(data);
+      increment = static_cast<int>(sizeof(uint32_t) + len);
+      if (data_size < increment) {
+        ParquetException::EofException();
+      }
       if (bit_reader.IsSet()) {
-        uint32_t len = *reinterpret_cast<const uint32_t*>(data);
-        increment = static_cast<int>(sizeof(uint32_t) + len);
-        if (data_size < increment) {
-          ParquetException::EofException();
-        }
         ARROW_RETURN_NOT_OK(out->Append(data + sizeof(uint32_t), len));
-        data += increment;
-        data_size -= increment;
-        bytes_decoded += increment;
       } else {
         ARROW_RETURN_NOT_OK(out->AppendNull());
       }
+      data += increment;
+      data_size -= increment;
+      bytes_decoded += increment;
       bit_reader.Next();
       ++i;
     }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -24,7 +24,6 @@
 #include <utility>
 #include <vector>
 
-#include "arrow/builder.h"
 #include "arrow/status.h"
 #include "arrow/util/bit-stream-utils.h"
 #include "arrow/util/bit-util.h"

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -754,11 +754,11 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
         data += increment;
         data_size -= increment;
         bytes_decoded += increment;
-        ++i;
       } else {
         ARROW_RETURN_NOT_OK(out->AppendNull());
       }
       bit_reader.Next();
+      ++i;
     }
 
     data_ += bytes_decoded;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -722,6 +722,12 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     return result;
   }
 
+  int DecodeArrowNonNull(int num_values, ::arrow::BinaryDictionaryBuilder* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
+    return result;
+  }
+
  private:
   template <typename BuilderType>
   ::arrow::Status DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
@@ -762,8 +768,8 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     return ::arrow::Status::OK();
   }
 
-  ::arrow::Status DecodeArrowNonNull(int num_values,
-                                     ::arrow::internal::ChunkedBinaryBuilder* out,
+  template <typename BuilderType>
+  ::arrow::Status DecodeArrowNonNull(int num_values, BuilderType* out,
                                      int* values_decoded) {
     num_values = std::min(num_values, num_values_);
     ARROW_RETURN_NOT_OK(out->Reserve(num_values));
@@ -779,6 +785,7 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
       data += increment;
       data_size -= increment;
       bytes_decoded += increment;
+      ++i;
     }
 
     data_ += bytes_decoded;
@@ -936,6 +943,12 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
 
   int DecodeArrowNonNull(int num_values,
                          ::arrow::internal::ChunkedBinaryBuilder* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
+    return result;
+  }
+
+  int DecodeArrowNonNull(int num_values, ::arrow::BinaryDictionaryBuilder* out) override {
     int result = 0;
     PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, out, &result));
     return result;

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1015,7 +1015,8 @@ class DictByteArrayDecoder : public DictDecoderImpl<ByteArrayType>,
     int32_t indices_buffer[buffer_size];
     int values_decoded = 0;
     while (values_decoded < num_values) {
-      int num_indices = idx_decoder_.GetBatch(indices_buffer, buffer_size);
+      int32_t batch_size = std::min<int32_t>(buffer_size, num_values - values_decoded);
+      int num_indices = idx_decoder_.GetBatch(indices_buffer, batch_size);
       if (num_indices == 0) break;
       for (int i = 0; i < num_indices; ++i) {
         const auto& val = dictionary_[indices_buffer[i]];

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -202,6 +202,7 @@ class ByteArrayDecoder : virtual public TypedDecoder<ByteArrayType> {
     virtual void Reserve(int64_t values) = 0;
     virtual void Append(const uint8_t* value, uint32_t length) = 0;
     virtual void AppendNull() = 0;
+    virtual ~WrappedBuilderInterface() = default;
   };
 
   template <typename Builder>

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -215,8 +215,6 @@ class ByteArrayDecoder : virtual public TypedDecoder<ByteArrayType> {
                           int64_t valid_bits_offset,
                           ::arrow::BinaryDictionaryBuilder* builder) = 0;
 
-  // TODO(wesm): Implement DecodeArrowNonNull as part of ARROW-3325
-  // See also ARROW-3772, ARROW-3769
   virtual int DecodeArrowNonNull(int num_values,
                                  ::arrow::internal::ChunkedBinaryBuilder* builder) = 0;
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -35,6 +35,7 @@
 namespace arrow {
 
 class BinaryDictionaryBuilder;
+class StringDictionaryBuilder;
 
 namespace internal {
 
@@ -215,11 +216,18 @@ class ByteArrayDecoder : virtual public TypedDecoder<ByteArrayType> {
                           int64_t valid_bits_offset,
                           ::arrow::BinaryDictionaryBuilder* builder) = 0;
 
+  virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
+                          int64_t valid_bits_offset,
+                          ::arrow::StringDictionaryBuilder* builder) = 0;
+
   virtual int DecodeArrowNonNull(int num_values,
                                  ::arrow::internal::ChunkedBinaryBuilder* builder) = 0;
 
   virtual int DecodeArrowNonNull(int num_values,
                                  ::arrow::BinaryDictionaryBuilder* builder) = 0;
+
+  virtual int DecodeArrowNonNull(int num_values,
+                                 ::arrow::StringDictionaryBuilder* builder) = 0;
 };
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -208,26 +208,60 @@ using DoubleDecoder = TypedDecoder<DoubleType>;
 class ByteArrayDecoder : virtual public TypedDecoder<ByteArrayType> {
  public:
   using TypedDecoder<ByteArrayType>::DecodeSpaced;
-  virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                          int64_t valid_bits_offset,
-                          ::arrow::internal::ChunkedBinaryBuilder* builder) = 0;
 
-  virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                          int64_t valid_bits_offset,
-                          ::arrow::BinaryDictionaryBuilder* builder) = 0;
+  class WrappedBuilderInterface {
+   public:
+    virtual void Reserve(int64_t values) = 0;
+    virtual void Append(const uint8_t* value, uint32_t length) = 0;
+    virtual void AppendNull() = 0;
+  };
 
-  virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
-                          int64_t valid_bits_offset,
-                          ::arrow::StringDictionaryBuilder* builder) = 0;
+  template <typename Builder>
+  class WrappedBuilder : public WrappedBuilderInterface {
+   public:
+    explicit WrappedBuilder(Builder* builder) : builder_(builder) {}
 
-  virtual int DecodeArrowNonNull(int num_values,
-                                 ::arrow::internal::ChunkedBinaryBuilder* builder) = 0;
+    void Reserve(int64_t values) override {
+      PARQUET_THROW_NOT_OK(builder_->Reserve(values));
+    }
+    void Append(const uint8_t* value, uint32_t length) override {
+      PARQUET_THROW_NOT_OK(builder_->Append(value, length));
+    }
 
-  virtual int DecodeArrowNonNull(int num_values,
-                                 ::arrow::BinaryDictionaryBuilder* builder) = 0;
+    void AppendNull() override { PARQUET_THROW_NOT_OK(builder_->AppendNull()); }
 
-  virtual int DecodeArrowNonNull(int num_values,
-                                 ::arrow::StringDictionaryBuilder* builder) = 0;
+   private:
+    Builder* builder_;
+  };
+
+  template <typename Builder>
+  int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
+                  int64_t valid_bits_offset, Builder* builder) {
+    int result = 0;
+    WrappedBuilder<Builder> wrapped_builder(builder);
+    PARQUET_THROW_NOT_OK(DecodeArrow(num_values, null_count, valid_bits,
+                                     valid_bits_offset, &wrapped_builder, &result));
+    return result;
+  }
+
+  template <typename Builder>
+  int DecodeArrowNonNull(int num_values, Builder* builder) {
+    int result = 0;
+    WrappedBuilder<Builder> wrapped_builder(builder);
+    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, &wrapped_builder, &result));
+    return result;
+  }
+
+ private:
+  virtual ::arrow::Status DecodeArrow(int num_values, int null_count,
+                                      const uint8_t* valid_bits,
+                                      int64_t valid_bits_offset,
+                                      WrappedBuilderInterface* builder,
+                                      int* values_decoded) = 0;
+
+  virtual ::arrow::Status DecodeArrowNonNull(int num_values,
+                                             WrappedBuilderInterface* builder,
+                                             int* values_decoded) = 0;
 };
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -219,6 +219,9 @@ class ByteArrayDecoder : virtual public TypedDecoder<ByteArrayType> {
   // See also ARROW-3772, ARROW-3769
   virtual int DecodeArrowNonNull(int num_values,
                                  ::arrow::internal::ChunkedBinaryBuilder* builder) = 0;
+
+  virtual int DecodeArrowNonNull(int num_values,
+                                 ::arrow::BinaryDictionaryBuilder* builder) = 0;
 };
 
 class FLBADecoder : virtual public TypedDecoder<FLBAType> {

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -32,18 +32,6 @@
 #include "parquet/util/memory.h"
 #include "parquet/util/visibility.h"
 
-namespace arrow {
-
-class BinaryDictionaryBuilder;
-class StringDictionaryBuilder;
-
-namespace internal {
-
-class ChunkedBinaryBuilder;
-
-}  // namespace internal
-}  // namespace arrow
-
 namespace parquet {
 
 class ColumnDescriptor;


### PR DESCRIPTION
This patch addresses the following JIRAS:

* [ARROW-3769](https://issues.apache.org/jira/browse/ARROW-3769): refactored record reader logic to toggle between the different builder depending on the column type (String or Binary) and the requested array type (Chunked "dense" or Dictionary).  These changes are covered by unittests and benchmarks.
* [PARQUET-1537](https://issues.apache.org/jira/browse/PARQUET-1537): fixed increment and covered by unittests.

Also included is an experimental class `ArrowReaderProperties` that can be used to select which columns are read directly as an `arrow::DictionaryArray`.  I think some more work is needed to fully address the requests in [ARROW-3772](https://issues.apache.org/jira/browse/ARROW-3772).  Namely, the ability automatically infer which columns in a parquet file should be read as `DictionaryArray`.  My current thinking is that this would be solved by introducing optional arrow type metadata to files written with the `parquet::arrow::FileWriter`.  There are some limitations with this approach but it would seem to satisfy the requests for users working with parquet files within the supported arrow ecosystem.

Note that the behavior with this patch is that incremental reading of a parquet file will not resolve the global dictionary for all of the row groups.  There are a few possible solutions for this:

* Introduce a concept of an "unknown" dictionary.  This will enable concatenating multiple row groups together so long as we define unknown dictionaries as equal (assuming indices have the same data type)
* Add an API for merging the schemas from multiple tables together.  This could be used after reading multiple row groups to enable concatenating the tables together into one.
* Add an API for inferring the global dictionary for the entire file.  This could be an expensive operation so ideally would be made optional.
* Allow a user-specified dictionary.  This could be useful in the limited case where a caller already knows the global dictionary list (computed through some other mechanism).