### PR TITLE
ARROW-4652: [JS] Ensure RBReader transform-stream stays open when autoDestroy=false

### DIFF
--- a/js/src/ipc/node/reader.ts
+++ b/js/src/ipc/node/reader.ts
@@ -77,7 +77,7 @@ class RecordBatchReaderDuplex<T extends { [key: string]: DataType } = any> exten
         while (this.readable && !(r = await reader.next()).done) {
             if (!this.push(r.value) || (size != null && --size <= 0)) { break; }
         }
-        if ((r && r.done || !this.readable)) {
+        if (!this.readable || (r && r.done && (reader.autoDestroy || (await reader.reset().open()).closed))) {
             this.push(null);
             await reader.cancel();
         }


### PR DESCRIPTION
Closes https://issues.apache.org/jira/browse/ARROW-4652. Updates `arrow2csv` to print all tables from stdin, instead of stopping after the first.