### PR TITLE
ARROW-4653: [C++] Fix bug in decimal multiply

### DIFF
--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -243,13 +243,13 @@ BasicDecimal128& BasicDecimal128::operator*=(const BasicDecimal128& right) {
 
   product = L2 * R3;
   sum += product;
+  high_bits_ = static_cast<int64_t>(sum < product ? kCarryBit : 0);
 
   product = L3 * R2;
   sum += product;
 
   low_bits_ += sum << 32;
 
-  high_bits_ = static_cast<int64_t>(sum < product ? kCarryBit : 0);
   if (sum < product) {
     high_bits_ += kCarryBit;
   }

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -466,6 +466,22 @@ TEST(Decimal128Test, TestToInteger) {
   ASSERT_RAISES(Invalid, invalid_int64.ToInteger(&out2));
 }
 
+TEST(Decimal128Test, Multiply) {
+  Decimal128 result;
+
+  result = Decimal128("301") * Decimal128("201");
+  ASSERT_EQ(result.ToIntegerString(), "60501");
+
+  result = Decimal128("-301") * Decimal128("201");
+  ASSERT_EQ(result.ToIntegerString(), "-60501");
+
+  result = Decimal128("301") * Decimal128("-201");
+  ASSERT_EQ(result.ToIntegerString(), "-60501");
+
+  result = Decimal128("-301") * Decimal128("-201");
+  ASSERT_EQ(result.ToIntegerString(), "60501");
+}
+
 TEST(Decimal128Test, GetWholeAndFraction) {
   Decimal128 value("123456");
   Decimal128 whole;


### PR DESCRIPTION
- fixed a bug which was causing multiply to return an incorrect
  value when both args are -ve.