### PR TITLE
ARROW-4654: [C++] Explicit flight.cc source dependencies

### DIFF
--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -46,6 +46,7 @@ set(ARROW_PYTHON_SRCS
 
 if(ARROW_FLIGHT)
   set(ARROW_PYTHON_SRCS ${ARROW_PYTHON_SRCS} flight.cc)
+  set_source_files_properties(flight.cc PROPERTIES OBJECT_DEPENDS flight_grpc_gen)
 endif()
 
 if("${COMPILER_FAMILY}" STREQUAL "clang")


### PR DESCRIPTION
When building protobuf from sources and using ninja, python/flight.cc
would build before the generated sources. This explicit a dependency
between the generated files.