### PR TITLE
ARROW-3133: [C++] Remove allocation from Binary Boolean Kernels.

### DIFF
--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -54,6 +54,9 @@ class FunctionContext;
 class ARROW_EXPORT OpKernel {
  public:
   virtual ~OpKernel() = default;
+  /// \brief EXPERIMENTAL The output data type of the kernel
+  /// \return the output type
+  virtual std::shared_ptr<DataType> out_type() const = 0;
 };
 
 /// \class Datum
@@ -188,10 +191,6 @@ class ARROW_EXPORT UnaryKernel : public OpKernel {
   /// there will be a more generic mechansim for understanding the necessary
   /// contracts.
   virtual Status Call(FunctionContext* ctx, const Datum& input, Datum* out) = 0;
-
-  /// \brief EXPERIMENTAL The output data type of the kernel
-  /// \return the output type
-  virtual std::shared_ptr<DataType> out_type() const = 0;
 };
 
 /// \class BinaryKernel

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -20,6 +20,7 @@ arrow_install_all_headers("arrow/compute/kernels")
 add_arrow_test(boolean-test PREFIX "arrow-compute")
 add_arrow_test(cast-test PREFIX "arrow-compute")
 add_arrow_test(hash-test PREFIX "arrow-compute")
+add_arrow_test(util-internal-test PREFIX "arrow-compute")
 
 # Aggregates
 add_arrow_test(aggregate-test PREFIX "arrow-compute")

--- a/cpp/src/arrow/compute/kernels/boolean-test.cc
+++ b/cpp/src/arrow/compute/kernels/boolean-test.cc
@@ -49,7 +49,7 @@ class TestBooleanKernel : public ComputeFixture, public TestBase {
     ASSERT_OK(kernel(&this->ctx_, left, right, &result));
     ASSERT_EQ(Datum::ARRAY, result.kind());
     std::shared_ptr<Array> result_array = result.make_array();
-    ASSERT_TRUE(result_array->Equals(expected));
+    ASSERT_ARRAYS_EQUAL(*expected, *result_array);
   }
 
   void TestChunkedArrayBinary(const BinaryKernelFunc& kernel,
@@ -99,25 +99,23 @@ class TestBooleanKernel : public ComputeFixture, public TestBase {
 };
 
 TEST_F(TestBooleanKernel, Invert) {
-  vector<bool> values1 = {true, false, true};
-  vector<bool> values2 = {false, true, false};
+  vector<bool> values1 = {true, false, true, false};
+  vector<bool> values2 = {false, true, false, true};
 
   auto type = boolean();
-  auto a1 = _MakeArray<BooleanType, bool>(type, values1, {});
-  auto a2 = _MakeArray<BooleanType, bool>(type, values2, {});
+  auto a1 = _MakeArray<BooleanType, bool>(type, values1, {true, true, true, false});
+  auto a2 = _MakeArray<BooleanType, bool>(type, values2, {true, true, true, false});
 
   // Plain array
   Datum result;
   ASSERT_OK(Invert(&this->ctx_, a1, &result));
   ASSERT_EQ(Datum::ARRAY, result.kind());
-  std::shared_ptr<Array> result_array = result.make_array();
-  ASSERT_TRUE(result_array->Equals(a2));
+  ASSERT_ARRAYS_EQUAL(*a2, *result.make_array());
 
   // Array with offset
   ASSERT_OK(Invert(&this->ctx_, a1->Slice(1), &result));
   ASSERT_EQ(Datum::ARRAY, result.kind());
-  result_array = result.make_array();
-  ASSERT_TRUE(result_array->Equals(a2->Slice(1)));
+  ASSERT_ARRAYS_EQUAL(*a2->Slice(1), *result.make_array());
 
   // ChunkedArray
   std::vector<std::shared_ptr<Array>> ca1_arrs = {a1, a1->Slice(1)};
@@ -127,7 +125,7 @@ TEST_F(TestBooleanKernel, Invert) {
   ASSERT_OK(Invert(&this->ctx_, ca1, &result));
   ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
   std::shared_ptr<ChunkedArray> result_ca = result.chunked_array();
-  ASSERT_TRUE(result_ca->Equals(ca2));
+  ASSERT_ARRAYS_EQUAL(*ca2, *result_ca);
 }
 
 TEST_F(TestBooleanKernel, InvertEmptyArray) {
@@ -139,7 +137,20 @@ TEST_F(TestBooleanKernel, InvertEmptyArray) {
 
   Datum result;
   ASSERT_OK(Invert(&this->ctx_, input, &result));
-  ASSERT_TRUE(result.make_array()->Equals(input.make_array()));
+  ASSERT_ARRAYS_EQUAL(*input.make_array(), *result.make_array());
+}
+
+TEST_F(TestBooleanKernel, BinaryOpOnEmptyArray) {
+  auto type = boolean();
+  std::vector<std::shared_ptr<Buffer>> data_buffers(2);
+  Datum input;
+  input.value = ArrayData::Make(boolean(), 0 /* length */, std::move(data_buffers),
+                                0 /* null_count */);
+
+  Datum result;
+  ASSERT_OK(And(&this->ctx_, input, input, &result));
+  // Result should be empty as well.
+  ASSERT_ARRAYS_EQUAL(*input.make_array(), *result.make_array());
 }
 
 TEST_F(TestBooleanKernel, And) {

--- a/cpp/src/arrow/compute/kernels/boolean.h
+++ b/cpp/src/arrow/compute/kernels/boolean.h
@@ -37,7 +37,7 @@ class FunctionContext;
 ARROW_EXPORT
 Status Invert(FunctionContext* context, const Datum& value, Datum* out);
 
-/// \brief Element-wise AND of two boolean dates
+/// \brief Element-wise AND of two boolean datums
 /// \param[in] context the FunctionContext
 /// \param[in] left left operand (array)
 /// \param[in] right right operand (array)
@@ -48,7 +48,7 @@ Status Invert(FunctionContext* context, const Datum& value, Datum* out);
 ARROW_EXPORT
 Status And(FunctionContext* context, const Datum& left, const Datum& right, Datum* out);
 
-/// \brief Element-wise OR of two boolean dates
+/// \brief Element-wise OR of two boolean datums
 /// \param[in] context the FunctionContext
 /// \param[in] left left operand (array)
 /// \param[in] right right operand (array)
@@ -59,7 +59,7 @@ Status And(FunctionContext* context, const Datum& left, const Datum& right, Datu
 ARROW_EXPORT
 Status Or(FunctionContext* context, const Datum& left, const Datum& right, Datum* out);
 
-/// \brief Element-wise XOR of two boolean dates
+/// \brief Element-wise XOR of two boolean datums
 /// \param[in] context the FunctionContext
 /// \param[in] left left operand (array)
 /// \param[in] right right operand (array)

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -634,7 +634,7 @@ Status InvokeWithAllocation(FunctionContext* ctx, UnaryKernel* func, const Datum
   std::vector<Datum> result;
   if (NeedToPreallocate(*func->out_type())) {
     // Create wrapper that allocates output memory for primitive types
-    detail::PrimitiveAllocatingUnaryKernel wrapper(func, func->out_type());
+    detail::PrimitiveAllocatingUnaryKernel wrapper(func);
     RETURN_NOT_OK(detail::InvokeUnaryArrayKernel(ctx, &wrapper, input, &result));
   } else {
     RETURN_NOT_OK(detail::InvokeUnaryArrayKernel(ctx, func, input, &result));

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -531,6 +531,9 @@ struct CastFunctor<Date64Type, TimestampType> {
 
     ShiftTime<int64_t, int64_t>(ctx, options, conversion.first, conversion.second, input,
                                 output);
+    if (!ctx->status().ok()) {
+      return;
+    }
 
     // Ensure that intraday milliseconds have been zeroed out
     auto out_data = output->GetMutableValues<int64_t>(1);

--- a/cpp/src/arrow/compute/kernels/util-internal-test.cc
+++ b/cpp/src/arrow/compute/kernels/util-internal-test.cc
@@ -1,0 +1,232 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#include <memory>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_common.h"
+#include "arrow/testing/gtest_util.h"
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/compute/kernels/util-internal.h"
+#include "arrow/compute/test-util.h"
+
+namespace arrow {
+namespace compute {
+namespace detail {
+
+using ::testing::_;
+using ::testing::AllOf;
+using ::testing::Each;
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::Eq;
+using ::testing::Ge;
+using ::testing::IsNull;
+using ::testing::Ne;
+using ::testing::NotNull;
+using ::testing::Return;
+
+TEST(PropagateNulls, UnknownNullCountWithNullsZeroCopies) {
+  ArrayData input(boolean(), /*length=*/16, kUnknownNullCount);
+  constexpr uint8_t validity_bitmap[8] = {254, 0, 0, 0, 0, 0, 0, 0};
+  std::shared_ptr<Buffer> nulls = std::make_shared<Buffer>(validity_bitmap, 8);
+  input.buffers.push_back(nulls);
+  FunctionContext ctx(default_memory_pool());
+  ArrayData output;
+
+  ASSERT_OK(PropagateNulls(&ctx, input, &output));
+
+  ASSERT_THAT(output.buffers, ElementsAre(Eq(nulls)));
+  ASSERT_THAT(output.null_count, 9);
+}
+
+TEST(PropagateNulls, UnknownNullCountWithoutNullsLeavesNullptr) {
+  ArrayData input(boolean(), /*length=*/16, kUnknownNullCount);
+  constexpr uint8_t validity_bitmap[8] = {255, 255, 0, 0, 0, 0, 0, 0};
+  std::shared_ptr<Buffer> nulls = std::make_shared<Buffer>(validity_bitmap, 8);
+  input.buffers.push_back(nulls);
+  FunctionContext ctx(default_memory_pool());
+  ArrayData output;
+
+  ASSERT_OK(PropagateNulls(&ctx, input, &output));
+
+  EXPECT_THAT(output.null_count, Eq(0));
+  EXPECT_THAT(output.buffers, ElementsAre(IsNull())) << output.buffers[0]->data()[0];
+}
+
+TEST(PropagateNulls, OffsetAndHasNulls) {
+  ArrayData input(boolean(), /*length=*/16, kUnknownNullCount,  // slice off the first 8
+                  /*offset=*/7);
+  constexpr uint8_t validity_bitmap[8] = {0, 1, 0, 0, 0, 0, 0, 0};
+  std::shared_ptr<Buffer> nulls = std::make_shared<Buffer>(validity_bitmap, 8);
+  input.buffers.push_back(nulls);
+  FunctionContext ctx(default_memory_pool());
+  ArrayData output;
+
+  ASSERT_OK(PropagateNulls(&ctx, input, &output));
+
+  // Copy is made.
+  EXPECT_THAT(output.null_count, Eq(15));
+  ASSERT_THAT(output.buffers, ElementsAre(AllOf(Ne(nulls), NotNull())));
+  const auto& output_buffer = *output.buffers[0];
+  // the slice shifts the bit one over
+  ASSERT_THAT(std::vector<uint8_t>(output_buffer.data(),
+                                   output_buffer.data() + output_buffer.size()),
+              ElementsAreArray({2, 0}));
+  ASSERT_THAT(std::vector<uint8_t>(output_buffer.data() + output_buffer.size(),
+                                   output_buffer.data() + output_buffer.capacity()),
+              Each(0));
+}
+
+TEST(AssignNullIntersection, ZeroCopyWhenZeroNullsOnOneInput) {
+  ArrayData some_nulls(boolean(), /* length= */ 16, kUnknownNullCount);
+  constexpr uint8_t validity_bitmap[8] = {254, 0, 0, 0, 0, 0, 0, 0};
+  std::shared_ptr<Buffer> nulls = std::make_shared<Buffer>(validity_bitmap, 8);
+  some_nulls.buffers.push_back(nulls);
+
+  ArrayData no_nulls(boolean(), /* length= */ 16, /*null_count=*/0);
+
+  FunctionContext ctx(default_memory_pool());
+  ArrayData output;
+  output.length = 16;
+
+  ASSERT_OK(AssignNullIntersection(&ctx, some_nulls, no_nulls, &output));
+  ASSERT_THAT(output.buffers, ElementsAre(Eq(nulls)));
+  ASSERT_THAT(output.null_count, 9);
+
+  output.buffers[0] = nullptr;
+  ASSERT_OK(AssignNullIntersection(&ctx, no_nulls, some_nulls, &output));
+  ASSERT_THAT(output.buffers, ElementsAre(Eq(nulls)));
+  ASSERT_THAT(output.null_count, 9);
+}
+
+TEST(AssignNullIntersection, IntersectsNullsWhenSomeOnBoth) {
+  ArrayData left(boolean(), /* length= */ 16, kUnknownNullCount);
+  constexpr uint8_t left_validity_bitmap[8] = {254, 0, 0, 0, 0, 0, 0, 0};
+  std::shared_ptr<Buffer> left_nulls = std::make_shared<Buffer>(left_validity_bitmap, 8);
+  left.buffers.push_back(left_nulls);
+
+  ArrayData right(boolean(), /* length= */ 16, kUnknownNullCount);
+  constexpr uint8_t right_validity_bitmap[8] = {127, 0, 0, 0, 0, 0, 0, 0};
+  std::shared_ptr<Buffer> right_nulls =
+      std::make_shared<Buffer>(right_validity_bitmap, 8);
+  right.buffers.push_back(right_nulls);
+
+  FunctionContext ctx(default_memory_pool());
+  ArrayData output;
+  output.length = 16;
+
+  ASSERT_OK(AssignNullIntersection(&ctx, left, right, &output));
+
+  EXPECT_THAT(output.null_count, 10);
+  ASSERT_THAT(output.buffers, ElementsAre(NotNull()));
+  const auto& output_buffer = *output.buffers[0];
+  EXPECT_THAT(std::vector<uint8_t>(output_buffer.data(),
+                                   output_buffer.data() + output_buffer.size()),
+              ElementsAreArray({126, 0}));
+  EXPECT_THAT(std::vector<uint8_t>(output_buffer.data() + output_buffer.size(),
+                                   output_buffer.data() + output_buffer.capacity()),
+              Each(0));
+}
+
+TEST(PrimitiveAllocatingUnaryKernel, BooleanFunction) {
+  MockUnaryKernel mock;
+  EXPECT_CALL(mock, out_type).WillRepeatedly(Return(boolean()));
+  EXPECT_CALL(mock, Call(_, _, _)).WillOnce(Return(Status::OK()));
+  PrimitiveAllocatingUnaryKernel kernel(&mock);
+
+  auto input =
+      std::make_shared<ArrayData>(boolean(), /* length= */ 16, kUnknownNullCount);
+  FunctionContext ctx(default_memory_pool());
+  Datum output;
+  output.value = ArrayData::Make(kernel.out_type(), input->length);
+  ASSERT_OK(kernel.Call(&ctx, input, &output));
+
+  ASSERT_THAT(output.array()->buffers, ElementsAre(IsNull(), NotNull()));
+  auto value_buffer = output.array()->buffers[1];
+  EXPECT_THAT(value_buffer->size(), Eq(2));
+  EXPECT_THAT(value_buffer->capacity(), Ge(2));
+  // Booleans should have this always zeroed out.
+  EXPECT_THAT(*(value_buffer->data() + value_buffer->size() - 1), Eq(0));
+}
+
+TEST(PrimitiveAllocatingUnaryKernel, NonBoolean) {
+  MockUnaryKernel mock;
+  EXPECT_CALL(mock, out_type).WillRepeatedly(Return(int32()));
+  EXPECT_CALL(mock, Call(_, _, _)).WillOnce(Return(Status::OK()));
+  PrimitiveAllocatingUnaryKernel kernel(&mock);
+
+  auto input =
+      std::make_shared<ArrayData>(boolean(), /* length= */ 16, kUnknownNullCount);
+  FunctionContext ctx(default_memory_pool());
+  Datum output;
+  output.value = ArrayData::Make(kernel.out_type(), input->length);
+  ASSERT_OK(kernel.Call(&ctx, input, &output));
+
+  ASSERT_THAT(output.array()->buffers, ElementsAre(IsNull(), NotNull()));
+  auto value_buffer = output.array()->buffers[1];
+  EXPECT_THAT(value_buffer->size(), Eq(64));
+  EXPECT_THAT(value_buffer->capacity(), Ge(64));
+}
+
+TEST(PrimitiveAllocatingBinaryKernel, BooleanFunction) {
+  MockBinaryKernel mock;
+  EXPECT_CALL(mock, out_type).WillRepeatedly(Return(boolean()));
+  EXPECT_CALL(mock, Call(_, _, _, _)).WillOnce(Return(Status::OK()));
+  PrimitiveAllocatingBinaryKernel kernel(&mock);
+
+  auto input =
+      std::make_shared<ArrayData>(boolean(), /* length= */ 16, kUnknownNullCount);
+  FunctionContext ctx(default_memory_pool());
+  Datum output;
+  output.value = ArrayData::Make(kernel.out_type(), input->length);
+  ASSERT_OK(kernel.Call(&ctx, input, input, &output));
+
+  ASSERT_THAT(output.array()->buffers, ElementsAre(IsNull(), NotNull()));
+  auto value_buffer = output.array()->buffers[1];
+  EXPECT_THAT(value_buffer->size(), Eq(2));
+  EXPECT_THAT(value_buffer->capacity(), Ge(2));
+  // Booleans should have this always zeroed out.
+  EXPECT_THAT(*(value_buffer->data() + value_buffer->size() - 1), Eq(0));
+}
+
+TEST(PrimitiveAllocatingBinaryKernel, NonBoolean) {
+  MockBinaryKernel mock;
+  EXPECT_CALL(mock, out_type).WillRepeatedly(Return(int32()));
+  EXPECT_CALL(mock, Call(_, _, _, _)).WillOnce(Return(Status::OK()));
+  PrimitiveAllocatingBinaryKernel kernel(&mock);
+
+  auto input =
+      std::make_shared<ArrayData>(boolean(), /* length= */ 16, kUnknownNullCount);
+  FunctionContext ctx(default_memory_pool());
+  Datum output;
+  output.value = ArrayData::Make(kernel.out_type(), input->length);
+  ASSERT_OK(kernel.Call(&ctx, input, input, &output));
+
+  ASSERT_THAT(output.array()->buffers, ElementsAre(IsNull(), NotNull()));
+  auto value_buffer = output.array()->buffers[1];
+  EXPECT_THAT(value_buffer->size(), Eq(64));
+  EXPECT_THAT(value_buffer->capacity(), Ge(64));
+}
+
+}  // namespace detail
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/test-util.h
+++ b/cpp/src/arrow/compute/test-util.h
@@ -46,11 +46,14 @@ class ComputeFixture {
 class MockUnaryKernel : public UnaryKernel {
  public:
   MOCK_METHOD3(Call, Status(FunctionContext* ctx, const Datum& input, Datum* out));
+  MOCK_CONST_METHOD0(out_type, std::shared_ptr<DataType>());
 };
 
 class MockBinaryKernel : public BinaryKernel {
+ public:
   MOCK_METHOD4(Call, Status(FunctionContext* ctx, const Datum& left, const Datum& right,
                             Datum* out));
+  MOCK_CONST_METHOD0(out_type, std::shared_ptr<DataType>());
 };
 
 template <typename Type, typename T>


### PR DESCRIPTION
Also:
- ARROW-3135: add a helper for validity bitmap propagation
- ARROW-4572: remove memory zeroing in Allocator kernel
- Fix regression in InvertKernel where nulls were not being handled (add a unit test to cover this case)
- Add some unit tests for util-internal.h
- lift out_type to OpKernel