### PR TITLE
ARROW-4662: [Python] Add support of type_codes in UnionType

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -284,6 +284,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CUnionType(const vector[shared_ptr[CField]]& fields,
                    const vector[uint8_t]& type_codes, UnionMode mode)
         UnionMode mode()
+        const vector[uint8_t]& type_codes()
 
     cdef cppclass CSchema" arrow::Schema":
         CSchema(const vector[shared_ptr[CField]]& fields)

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -296,10 +296,12 @@ def test_union_type():
         ty = pa.union(fields, mode=mode)
         assert ty.mode == 'sparse'
         check_fields(ty, fields)
+        assert ty.type_codes == [0, 1]
     for mode in ('dense', pa.lib.UnionMode_DENSE):
         ty = pa.union(fields, mode=mode)
         assert ty.mode == 'dense'
         check_fields(ty, fields)
+        assert ty.type_codes == [0, 1]
     for mode in ('unknown', 2):
         with pytest.raises(ValueError, match='Invalid union mode'):
             pa.union(fields, mode=mode)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -323,6 +323,14 @@ cdef class UnionType(DataType):
             return 'sparse'
         assert 0
 
+    @property
+    def type_codes(self):
+        """
+        The type code to indicate each data type in this union.
+        """
+        cdef CUnionType* type = <CUnionType*> self.sp_type.get()
+        return type.type_codes()
+
     def __len__(self):
         """
         Like num_children()


### PR DESCRIPTION
UnionType should have `type_codes` property.