### PR TITLE
ARROW-4659: [CI] Ubuntu/debian nightlies fail because of missing gandiva files

### DIFF
--- a/dev/tasks/linux-packages/debian/libgandiva13.install
+++ b/dev/tasks/linux-packages/debian/libgandiva13.install
@@ -1,2 +1,1 @@
 usr/lib/*/libgandiva.so.*
-usr/lib/*/gandiva/


### PR DESCRIPTION
Crossbow builds: [kszucs/crossbow/build-444](https://github.com/kszucs/crossbow/branches/all?utf8=%E2%9C%93&query=build-444)