### PR TITLE
ARROW-4660: [C++] Use set_target_properties for defining GFLAGS_IS_A_DLL

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -655,11 +655,11 @@ if(ARROW_NEED_GFLAGS)
     ADD_THIRDPARTY_LIB(gflags
       STATIC_LIB ${GFLAGS_STATIC_LIB})
     set(GFLAGS_LIBRARY gflags_static)
-    target_compile_definitions(${GFLAGS_LIBRARY} INTERFACE "GFLAGS_IS_A_DLL=0")
-    if(MSVC)
+    if(WIN32)
       set_target_properties(${GFLAGS_LIBRARY}
 	PROPERTIES
-	INTERFACE_LINK_LIBRARIES "shlwapi.lib")
+	INTERFACE_LINK_LIBRARIES "shlwapi.lib"
+	INTERFACE_COMPILE_DEFINITIONS "GFLAGS_IS_A_DLL=0")
     endif()
     add_dependencies(${GFLAGS_LIBRARY} gflags_ep)
   endif()


### PR DESCRIPTION
target_compile_definitions() for imported library needs CMake 3.11 or
later.