### PR TITLE
ARROW-4667: [C++] Suppress unused function warnings with MinGW

### DIFF
--- a/cpp/src/arrow/io/mman.h
+++ b/cpp/src/arrow/io/mman.h
@@ -77,7 +77,8 @@ static inline DWORD __map_mmap_prot_file(const int prot) {
   return desiredAccess;
 }
 
-static inline void* mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t off) {
+static inline void* mmap(void* addr, size_t len, int prot, int flags, int fildes,
+                         off_t off) {
   HANDLE fm, h;
 
   void* map = MAP_FAILED;

--- a/cpp/src/arrow/io/mman.h
+++ b/cpp/src/arrow/io/mman.h
@@ -45,13 +45,13 @@
 #define FILE_MAP_EXECUTE 0x0020
 #endif
 
-static int __map_mman_error(const DWORD err, const int deferr) {
+static inline int __map_mman_error(const DWORD err, const int deferr) {
   if (err == 0) return 0;
   // TODO: implement
   return err;
 }
 
-static DWORD __map_mmap_prot_page(const int prot) {
+static inline DWORD __map_mmap_prot_page(const int prot) {
   DWORD protect = 0;
 
   if (prot == PROT_NONE) return protect;
@@ -65,7 +65,7 @@ static DWORD __map_mmap_prot_page(const int prot) {
   return protect;
 }
 
-static DWORD __map_mmap_prot_file(const int prot) {
+static inline DWORD __map_mmap_prot_file(const int prot) {
   DWORD desiredAccess = 0;
 
   if (prot == PROT_NONE) return desiredAccess;
@@ -77,7 +77,7 @@ static DWORD __map_mmap_prot_file(const int prot) {
   return desiredAccess;
 }
 
-static void* mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t off) {
+static inline void* mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t off) {
   HANDLE fm, h;
 
   void* map = MAP_FAILED;
@@ -141,7 +141,7 @@ static void* mmap(void* addr, size_t len, int prot, int flags, int fildes, off_t
   return map;
 }
 
-static int munmap(void* addr, size_t len) {
+static inline int munmap(void* addr, size_t len) {
   if (UnmapViewOfFile(addr)) return 0;
 
   errno = __map_mman_error(GetLastError(), EPERM);
@@ -149,7 +149,7 @@ static int munmap(void* addr, size_t len) {
   return -1;
 }
 
-static int mprotect(void* addr, size_t len, int prot) {
+static inline int mprotect(void* addr, size_t len, int prot) {
   DWORD newProtect = __map_mmap_prot_page(prot);
   DWORD oldProtect = 0;
 
@@ -160,7 +160,7 @@ static int mprotect(void* addr, size_t len, int prot) {
   return -1;
 }
 
-static int msync(void* addr, size_t len, int flags) {
+static inline int msync(void* addr, size_t len, int flags) {
   if (FlushViewOfFile(addr, len)) return 0;
 
   errno = __map_mman_error(GetLastError(), EPERM);
@@ -168,7 +168,7 @@ static int msync(void* addr, size_t len, int flags) {
   return -1;
 }
 
-static int mlock(const void* addr, size_t len) {
+static inline int mlock(const void* addr, size_t len) {
   if (VirtualLock((LPVOID)addr, len)) return 0;
 
   errno = __map_mman_error(GetLastError(), EPERM);
@@ -176,7 +176,7 @@ static int mlock(const void* addr, size_t len) {
   return -1;
 }
 
-static int munlock(const void* addr, size_t len) {
+static inline int munlock(const void* addr, size_t len) {
   if (VirtualUnlock((LPVOID)addr, len)) return 0;
 
   errno = __map_mman_error(GetLastError(), EPERM);


### PR DESCRIPTION
Messages:

    In file included from C:/projects/arrow/cpp/src/arrow/io/file.cc:25:
    C:/projects/arrow/cpp/src/arrow/io/mman.h:179:12: warning: 'int munlock(const void*, size_t)' defined but not used [-Wunused-function]
     static int munlock(const void* addr, size_t len) {
                ^~~~~~~
    C:/projects/arrow/cpp/src/arrow/io/mman.h:171:12: warning: 'int mlock(const void*, size_t)' defined but not used [-Wunused-function]
     static int mlock(const void* addr, size_t len) {
                ^~~~~
    C:/projects/arrow/cpp/src/arrow/io/mman.h:163:12: warning: 'int msync(void*, size_t, int)' defined but not used [-Wunused-function]
     static int msync(void* addr, size_t len, int flags) {
                ^~~~~
    C:/projects/arrow/cpp/src/arrow/io/mman.h:152:12: warning: 'int mprotect(void*, size_t, int)' defined but not used [-Wunused-function]
     static int mprotect(void* addr, size_t len, int prot) {
                ^~~~~~~~