### PR TITLE
ARROW-4670: [Rust] array_ops::sum performance optimizations

### DIFF
--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -24,6 +24,7 @@ extern crate arrow;
 use arrow::array::*;
 use arrow::builder::*;
 use arrow::compute::arithmetic_kernels::*;
+use arrow::compute::array_ops::sum;
 use arrow::error::Result;
 
 fn create_array(size: usize) -> Float32Array {
@@ -61,6 +62,11 @@ fn multiply_simd(size: usize) {
     criterion::black_box(multiply(&arr_a, &arr_b).unwrap());
 }
 
+fn sum_no_simd(size: usize) {
+    let arr_a = create_array(size);
+    criterion::black_box(sum(&arr_a).unwrap());
+}
+
 fn add_benchmark(c: &mut Criterion) {
     c.bench_function("add 512", |b| {
         b.iter(|| bin_op_no_simd(512, |a, b| Ok(a + b)))
@@ -74,6 +80,7 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bin_op_no_simd(512, |a, b| Ok(a * b)))
     });
     c.bench_function("multiply 512 simd", |b| b.iter(|| multiply_simd(512)));
+    c.bench_function("sum 512 no simd", |b| b.iter(|| sum_no_simd(512)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/src/compute/array_ops.rs
+++ b/rust/arrow/src/compute/array_ops.rs
@@ -80,9 +80,7 @@ where
         if data.is_null(i) {
             continue;
         }
-        if all_nulls {
-            all_nulls = false;
-        }
+        all_nulls = false;
         let m = array.value(i);
         n = n + m;
     }

--- a/rust/arrow/src/compute/array_ops.rs
+++ b/rust/arrow/src/compute/array_ops.rs
@@ -85,7 +85,6 @@ where
             n = n + m[i];
         }
         Some(n)
-
     } else {
         let mut n: T::Native = T::default_value();
         let data = array.data();

--- a/rust/arrow/src/compute/array_ops.rs
+++ b/rust/arrow/src/compute/array_ops.rs
@@ -72,21 +72,29 @@ where
     T: ArrowNumericType,
     T::Native: Add<Output = T::Native>,
 {
-    let mut n: T::Native = T::default_value();
-    // iteratively track whether all values are null (or array is empty)
-    let mut all_nulls = true;
-    let data = array.data();
-    for i in 0..data.len() {
-        if data.is_null(i) {
-            continue;
-        }
-        all_nulls = false;
-        let m = array.value(i);
-        n = n + m;
-    }
-    if all_nulls {
+    let null_count = array.null_count();
+
+    if null_count == array.len() {
         None
+    } else if null_count == 0 {
+        // optimized path for arrays without null values
+        let mut n: T::Native = T::default_value();
+        let data = array.data();
+        let m = array.value_slice(0, data.len());
+        for i in 0..data.len() {
+            n = n + m[i];
+        }
+        Some(n)
+
     } else {
+        let mut n: T::Native = T::default_value();
+        let data = array.data();
+        let m = array.value_slice(0, data.len());
+        for i in 0..data.len() {
+            if data.is_valid(i) {
+                n = n + m[i];
+            }
+        }
         Some(n)
     }
 }

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -58,7 +58,7 @@ fn aggregate_query(sql: &str) {
     );
 
     // execute the query
-    let relation = ctx.sql(&sql).unwrap();
+    let relation = ctx.sql(&sql, 1024*1024).unwrap();
 
     // display the relation
     let mut results = relation.borrow_mut();

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -58,7 +58,7 @@ fn aggregate_query(sql: &str) {
     );
 
     // execute the query
-    let relation = ctx.sql(&sql, 1024*1024).unwrap();
+    let relation = ctx.sql(&sql, 1024 * 1024).unwrap();
 
     // display the relation
     let mut results = relation.borrow_mut();


### PR DESCRIPTION
Optimized implementations of `sum` based on null count. 