### PR TITLE
ARROW-4205: [Gandiva] Support for decimal multiply

### DIFF
--- a/ci/travis_script_manylinux.sh
+++ b/ci/travis_script_manylinux.sh
@@ -53,7 +53,7 @@ for PYTHON_TUPLE in ${PYTHON_VERSIONS}; do
     -e UNICODE_WIDTH=$UNICODE_WIDTH \
     -v $PWD:/io \
     -v $PWD/../../:/arrow \
-    quay.io/xhochy/arrow_manylinux1_x86_64_base:latest \
+    quay.io/pravindra/arrow_manylinux1_x86_64_base:latest \
     /io/build_arrow.sh
 
   # create a testing conda environment

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -122,6 +122,7 @@ static const BasicDecimal128 ScaleMultipliersHalf[] = {
 static constexpr uint64_t kIntMask = 0xFFFFFFFF;
 static constexpr auto kCarryBit = static_cast<uint64_t>(1) << static_cast<uint64_t>(32);
 
+// same as ScaleMultipliers[38] - 1
 static constexpr BasicDecimal128 kMaxValue =
     BasicDecimal128(5421010862427522170LL, 687399551400673280ULL - 1);
 

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -122,6 +122,9 @@ static const BasicDecimal128 ScaleMultipliersHalf[] = {
 static constexpr uint64_t kIntMask = 0xFFFFFFFF;
 static constexpr auto kCarryBit = static_cast<uint64_t>(1) << static_cast<uint64_t>(32);
 
+static constexpr BasicDecimal128 kMaxValue =
+    BasicDecimal128(5421010862427522170LL, 687399551400673280ULL - 1);
+
 BasicDecimal128::BasicDecimal128(const uint8_t* bytes)
     : BasicDecimal128(
           BitUtil::FromLittleEndian(reinterpret_cast<const int64_t*>(bytes)[1]),
@@ -149,6 +152,11 @@ BasicDecimal128& BasicDecimal128::Negate() {
 }
 
 BasicDecimal128& BasicDecimal128::Abs() { return *this < 0 ? Negate() : *this; }
+
+BasicDecimal128 BasicDecimal128::Abs(const BasicDecimal128& in) {
+  BasicDecimal128 result(in);
+  return result.Abs();
+}
 
 BasicDecimal128& BasicDecimal128::operator+=(const BasicDecimal128& right) {
   const uint64_t sum = low_bits_ + right.low_bits_;
@@ -649,6 +657,8 @@ const BasicDecimal128& BasicDecimal128::GetScaleMultiplier(int32_t scale) {
   return ScaleMultipliers[scale];
 }
 
+const BasicDecimal128& BasicDecimal128::GetMaxValue() { return kMaxValue; }
+
 BasicDecimal128 BasicDecimal128::IncreaseScaleBy(int32_t increase_by) const {
   DCHECK_GE(increase_by, 0);
   DCHECK_LE(increase_by, 38);
@@ -659,6 +669,10 @@ BasicDecimal128 BasicDecimal128::IncreaseScaleBy(int32_t increase_by) const {
 BasicDecimal128 BasicDecimal128::ReduceScaleBy(int32_t reduce_by, bool round) const {
   DCHECK_GE(reduce_by, 0);
   DCHECK_LE(reduce_by, 38);
+
+  if (reduce_by == 0) {
+    return *this;
+  }
 
   BasicDecimal128 divisor(ScaleMultipliers[reduce_by]);
   BasicDecimal128 result;

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -66,6 +66,9 @@ class ARROW_EXPORT BasicDecimal128 {
   /// \brief Absolute value (in-place)
   BasicDecimal128& Abs();
 
+  /// \brief Absolute value
+  static BasicDecimal128 Abs(const BasicDecimal128& left);
+
   /// \brief Add a number to this one. The result is truncated to 128 bits.
   BasicDecimal128& operator+=(const BasicDecimal128& right);
 
@@ -137,6 +140,9 @@ class ARROW_EXPORT BasicDecimal128 {
 
   /// \brief count the number of leading binary zeroes.
   int32_t CountLeadingBinaryZeros() const;
+
+  /// \brief Get the maximum valid unscaled decimal value.
+  static const BasicDecimal128& GetMaxValue();
 
  private:
   uint64_t low_bits_;

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -544,6 +544,7 @@ TEST(Decimal128Test, GetWholeAndFractionNegative) {
   ASSERT_EQ(-123456, out);
 }
 
+
 TEST(Decimal128Test, IncreaseScale) {
   Decimal128 result;
   int32_t out;

--- a/cpp/src/arrow/util/decimal-test.cc
+++ b/cpp/src/arrow/util/decimal-test.cc
@@ -544,10 +544,13 @@ TEST(Decimal128Test, GetWholeAndFractionNegative) {
   ASSERT_EQ(-123456, out);
 }
 
-
 TEST(Decimal128Test, IncreaseScale) {
   Decimal128 result;
   int32_t out;
+
+  result = Decimal128("1234").IncreaseScaleBy(0);
+  ASSERT_OK(result.ToInteger(&out));
+  ASSERT_EQ(1234, out);
 
   result = Decimal128("1234").IncreaseScaleBy(3);
   ASSERT_OK(result.ToInteger(&out));
@@ -561,6 +564,10 @@ TEST(Decimal128Test, IncreaseScale) {
 TEST(Decimal128Test, ReduceScaleAndRound) {
   Decimal128 result;
   int32_t out;
+
+  result = Decimal128("123456").ReduceScaleBy(0);
+  ASSERT_OK(result.ToInteger(&out));
+  ASSERT_EQ(123456, out);
 
   result = Decimal128("123456").ReduceScaleBy(1, false);
   ASSERT_OK(result.ToInteger(&out));

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SRC_FILES
     context_helper.cc
     decimal_ir.cc
     decimal_type_util.cc
+    decimal_xlarge.cc
     engine.cc
     date_utils.cc
     expr_decomposer.cc

--- a/cpp/src/gandiva/basic_decimal_scalar.h
+++ b/cpp/src/gandiva/basic_decimal_scalar.h
@@ -55,4 +55,8 @@ inline bool operator==(const BasicDecimalScalar128& left,
          left.scale() == right.scale();
 }
 
+inline BasicDecimalScalar128 operator-(const BasicDecimalScalar128& operand) {
+  return BasicDecimalScalar128{-operand.value(), operand.precision(), operand.scale()};
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/basic_decimal_scalar.h
+++ b/cpp/src/gandiva/basic_decimal_scalar.h
@@ -27,14 +27,15 @@ using arrow::BasicDecimal128;
 /// Represents a 128-bit decimal value along with its precision and scale.
 class BasicDecimalScalar128 {
  public:
-  BasicDecimalScalar128(int64_t high_bits, uint64_t low_bits, int32_t precision,
-                        int32_t scale)
+  constexpr BasicDecimalScalar128(int64_t high_bits, uint64_t low_bits, int32_t precision,
+                                  int32_t scale)
       : value_(high_bits, low_bits), precision_(precision), scale_(scale) {}
 
-  BasicDecimalScalar128(const BasicDecimal128& value, int32_t precision, int32_t scale)
+  constexpr BasicDecimalScalar128(const BasicDecimal128& value, int32_t precision,
+                                  int32_t scale)
       : value_(value), precision_(precision), scale_(scale) {}
 
-  BasicDecimalScalar128(int32_t precision, int32_t scale)
+  constexpr BasicDecimalScalar128(int32_t precision, int32_t scale)
       : precision_(precision), scale_(scale) {}
 
   int32_t scale() const { return scale_; }

--- a/cpp/src/gandiva/decimal_ir.cc
+++ b/cpp/src/gandiva/decimal_ir.cc
@@ -383,6 +383,7 @@ Status DecimalIR::BuildMultiply() {
   ir_builder()->SetInsertPoint(entry);
 
   // Make call to pre-compiled IR function.
+  // TODO: add fast paths.
   auto block = ir_builder()->GetInsertBlock();
   auto out_high_ptr = new llvm::AllocaInst(types()->i64_type(), 0, "out_hi", block);
   auto out_low_ptr = new llvm::AllocaInst(types()->i64_type(), 0, "out_low", block);

--- a/cpp/src/gandiva/decimal_ir.cc
+++ b/cpp/src/gandiva/decimal_ir.cc
@@ -383,7 +383,6 @@ Status DecimalIR::BuildMultiply() {
   ir_builder()->SetInsertPoint(entry);
 
   // Make call to pre-compiled IR function.
-  // TODO: add fast paths.
   auto block = ir_builder()->GetInsertBlock();
   auto out_high_ptr = new llvm::AllocaInst(types()->i64_type(), 0, "out_hi", block);
   auto out_low_ptr = new llvm::AllocaInst(types()->i64_type(), 0, "out_low", block);

--- a/cpp/src/gandiva/decimal_ir.h
+++ b/cpp/src/gandiva/decimal_ir.h
@@ -146,6 +146,9 @@ class DecimalIR : public FunctionIRBuilder {
   // Build the function for decimal subtraction.
   Status BuildSubtract();
 
+  // Build the function for decimal multiplication.
+  Status BuildMultiply();
+
   // Add a trace in IR code.
   void AddTrace(const std::string& fmt, std::vector<llvm::Value*> args);
 

--- a/cpp/src/gandiva/decimal_scalar.h
+++ b/cpp/src/gandiva/decimal_scalar.h
@@ -39,6 +39,10 @@ class DecimalScalar128 : public BasicDecimalScalar128 {
   DecimalScalar128(const std::string& value, int32_t precision, int32_t scale)
       : BasicDecimalScalar128(Decimal128(value), precision, scale) {}
 
+  /// \brief constructor creates a DecimalScalar128 from a BasicDecimalScalar128.
+  constexpr DecimalScalar128(const BasicDecimalScalar128& scalar) noexcept
+      : BasicDecimalScalar128(scalar) {}
+
   inline std::string ToString() const {
     Decimal128 dvalue(value());
     return dvalue.ToString(0) + "," + std::to_string(precision()) + "," +

--- a/cpp/src/gandiva/decimal_scalar.h
+++ b/cpp/src/gandiva/decimal_scalar.h
@@ -40,7 +40,7 @@ class DecimalScalar128 : public BasicDecimalScalar128 {
       : BasicDecimalScalar128(Decimal128(value), precision, scale) {}
 
   /// \brief constructor creates a DecimalScalar128 from a BasicDecimalScalar128.
-  DecimalScalar128(const BasicDecimalScalar128& scalar) noexcept
+  constexpr DecimalScalar128(const BasicDecimalScalar128& scalar) noexcept
       : BasicDecimalScalar128(scalar) {}
 
   inline std::string ToString() const {

--- a/cpp/src/gandiva/decimal_scalar.h
+++ b/cpp/src/gandiva/decimal_scalar.h
@@ -40,7 +40,7 @@ class DecimalScalar128 : public BasicDecimalScalar128 {
       : BasicDecimalScalar128(Decimal128(value), precision, scale) {}
 
   /// \brief constructor creates a DecimalScalar128 from a BasicDecimalScalar128.
-  constexpr DecimalScalar128(const BasicDecimalScalar128& scalar) noexcept
+  DecimalScalar128(const BasicDecimalScalar128& scalar) noexcept
       : BasicDecimalScalar128(scalar) {}
 
   inline std::string ToString() const {

--- a/cpp/src/gandiva/decimal_xlarge.cc
+++ b/cpp/src/gandiva/decimal_xlarge.cc
@@ -52,9 +52,9 @@ void ExportedDecimalFunctions::AddMappings(Engine* engine) const {
           types->i64_ptr_type(),  // uint64_t* out_low
           types->i8_ptr_type()};  // bool* overflow
 
-  engine->AddGlobalMappingForFunc("gdv_multiply_and_scale_down",
+  engine->AddGlobalMappingForFunc("gdv_xlarge_multiply_and_scale_down",
                                   types->void_type() /*return_type*/, args,
-                                  reinterpret_cast<void*>(gdv_multiply_and_scale_down));
+                                  reinterpret_cast<void*>(gdv_xlarge_multiply_and_scale_down));
 }
 }  // namespace gandiva
 
@@ -139,7 +139,7 @@ static int256_t ReduceScaleBy(int256_t in, int32_t reduce_by) {
 
 extern "C" {
 
-void gdv_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
+void gdv_xlarge_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
                                  uint64_t y_low, int32_t reduce_scale_by,
                                  int64_t* out_high, uint64_t* out_low, bool* overflow) {
   BasicDecimal128 x{x_high, x_low};

--- a/cpp/src/gandiva/decimal_xlarge.cc
+++ b/cpp/src/gandiva/decimal_xlarge.cc
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Operations that can deal with very large values (256-bit).
+//
+// The intermediate results with decimal can be larger than what can fit into 128-bit,
+// but the final results can fit in 128-bit after scaling down. These functions deal
+// with operations on the intermediate values.
+//
+
+#include "gandiva/decimal_xlarge.h"
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <limits>
+#include <vector>
+
+#include "arrow/util/basic_decimal.h"
+#include "gandiva/decimal_type_util.h"
+#include "gandiva/logging.h"
+
+#ifndef GANDIVA_UNIT_TEST
+#include "gandiva/engine.h"
+#include "gandiva/exported_funcs.h"
+
+namespace gandiva {
+
+void ExportedDecimalFunctions::AddMappings(Engine* engine) const {
+  std::vector<llvm::Type*> args;
+  auto types = engine->types();
+
+  // gdv_multiply_and_scale_down
+  args = {types->i64_type(),      // int64_t x_high
+          types->i64_type(),      // uint64_t x_low
+          types->i64_type(),      // int64_t y_high
+          types->i64_type(),      // uint64_t x_low
+          types->i32_type(),      // int32_t reduce_scale_by
+          types->i64_ptr_type(),  // int64_t* out_high
+          types->i64_ptr_type(),  // uint64_t* out_low
+          types->i8_ptr_type()};  // bool* overflow
+
+  engine->AddGlobalMappingForFunc("gdv_multiply_and_scale_down",
+                                  types->void_type() /*return_type*/, args,
+                                  reinterpret_cast<void*>(gdv_multiply_and_scale_down));
+}
+}  // namespace gandiva
+
+#endif  // !GANDIVA_UNIT_TEST
+
+using arrow::BasicDecimal128;
+using boost::multiprecision::int256_t;
+
+namespace gandiva {
+namespace internal {
+
+// Convert to 256-bit integer from 128-bit decimal.
+static int256_t ConvertToInt256(BasicDecimal128 in) {
+  int256_t v = in.high_bits();
+  v <<= 64;
+  v |= in.low_bits();
+  return v;
+}
+
+// Convert to 128-bit decimal from 256-bit integer.
+// If there is an overflow, the output is undefined.
+static BasicDecimal128 ConvertToDecimal128(int256_t in, bool* overflow) {
+  BasicDecimal128 result;
+  constexpr uint64_t mask = std::numeric_limits<uint64_t>::max();
+
+  int256_t in_abs = abs(in);
+  bool is_negative = in < 0;
+  uint64_t low = in_abs.convert_to<uint64_t>() & mask;
+  in_abs >>= 64;
+  uint64_t high = in_abs.convert_to<uint64_t>() & mask;
+  in_abs >>= 64;
+
+  if (in_abs > 0) {
+    // we've shifted in by 128-bit, so nothing should be left.
+    *overflow = true;
+  } else if (high > std::numeric_limits<int64_t>::max()) {
+    // the high-bit must not be set (signed 128-bit).
+    *overflow = true;
+  } else {
+    result = BasicDecimal128(static_cast<int64_t>(high), low);
+    if (result > BasicDecimal128::GetMaxValue()) {
+      *overflow = true;
+    }
+  }
+  return is_negative ? -result : result;
+}
+
+// Similar to BasicDecimal128::ReduceScaleBy
+static int256_t ReduceScaleBy(int256_t in, int32_t reduce_by) {
+  int256_t divisor;
+
+  if (reduce_by <= DecimalTypeUtil::kMaxPrecision) {
+    divisor = ConvertToInt256(BasicDecimal128::GetScaleMultiplier(reduce_by));
+  } else {
+    DCHECK_LE(reduce_by, 2 * DecimalTypeUtil::kMaxPrecision);
+    divisor = ConvertToInt256(
+        BasicDecimal128::GetScaleMultiplier(DecimalTypeUtil::kMaxPrecision));
+    for (auto i = DecimalTypeUtil::kMaxPrecision; i < reduce_by; i++) {
+      divisor *= 10;
+    }
+  }
+
+  DCHECK_GT(divisor, 0);
+  DCHECK_EQ(divisor % 2, 0);  // multiple of 10.
+  auto result = in / divisor;
+  auto remainder = in % divisor;
+  if (abs(remainder) >= (divisor >> 1)) {
+    result += (in > 0 ? 1 : -1);
+  }
+  return result;
+}
+
+}  // namespace internal
+}  // namespace gandiva
+
+extern "C" {
+
+void gdv_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
+                                 uint64_t y_low, int32_t reduce_scale_by,
+                                 int64_t* out_high, uint64_t* out_low, bool* overflow) {
+  BasicDecimal128 x{x_high, x_low};
+  BasicDecimal128 y{y_high, y_low};
+  auto intermediate_result =
+      gandiva::internal::ConvertToInt256(x) * gandiva::internal::ConvertToInt256(y);
+  intermediate_result =
+      gandiva::internal::ReduceScaleBy(intermediate_result, reduce_scale_by);
+  auto result = gandiva::internal::ConvertToDecimal128(intermediate_result, overflow);
+  *out_high = result.high_bits();
+  *out_low = result.low_bits();
+}
+
+}  // extern "C"

--- a/cpp/src/gandiva/decimal_xlarge.h
+++ b/cpp/src/gandiva/decimal_xlarge.h
@@ -1,0 +1,29 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+
+/// Stub functions to deal with extra large decimals that can be accessed from LLVM-IR
+/// code.
+extern "C" {
+
+void gdv_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
+                                 uint64_t y_low, int32_t reduce_scale_by,
+                                 int64_t* out_high, uint64_t* out_low, bool* overflow);
+}

--- a/cpp/src/gandiva/decimal_xlarge.h
+++ b/cpp/src/gandiva/decimal_xlarge.h
@@ -24,6 +24,7 @@
 extern "C" {
 
 void gdv_xlarge_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
-                                 uint64_t y_low, int32_t reduce_scale_by,
-                                 int64_t* out_high, uint64_t* out_low, bool* overflow);
+                                        uint64_t y_low, int32_t reduce_scale_by,
+                                        int64_t* out_high, uint64_t* out_low,
+                                        bool* overflow);
 }

--- a/cpp/src/gandiva/decimal_xlarge.h
+++ b/cpp/src/gandiva/decimal_xlarge.h
@@ -23,7 +23,7 @@
 /// code.
 extern "C" {
 
-void gdv_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
+void gdv_xlarge_multiply_and_scale_down(int64_t x_high, uint64_t x_low, int64_t y_high,
                                  uint64_t y_low, int32_t reduce_scale_by,
                                  int64_t* out_high, uint64_t* out_low, bool* overflow);
 }

--- a/cpp/src/gandiva/exported_funcs.h
+++ b/cpp/src/gandiva/exported_funcs.h
@@ -45,11 +45,17 @@ class ExportedContextFunctions : public ExportedFuncsBase {
 };
 REGISTER_EXPORTED_FUNCS(ExportedContextFunctions);
 
-// Class for exporting Context functions
+// Class for exporting Time functions
 class ExportedTimeFunctions : public ExportedFuncsBase {
   void AddMappings(Engine* engine) const override;
 };
 REGISTER_EXPORTED_FUNCS(ExportedTimeFunctions);
+
+// Class for exporting Decimal functions
+class ExportedDecimalFunctions : public ExportedFuncsBase {
+  void AddMappings(Engine* engine) const override;
+};
+REGISTER_EXPORTED_FUNCS(ExportedDecimalFunctions);
 
 }  // namespace gandiva
 

--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -28,9 +28,6 @@ namespace gandiva {
 #define BINARY_RELATIONAL_BOOL_DATE_FN(name) \
   NUMERIC_DATE_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, name)
 
-#define UNARY_OCTET_LEN_FN(name) \
-  UNARY_SAFE_NULL_IF_NULL(name, utf8, int32), UNARY_SAFE_NULL_IF_NULL(name, binary, int32)
-
 #define UNARY_CAST_TO_FLOAT64(name) UNARY_SAFE_NULL_IF_NULL(castFLOAT8, name, float64)
 
 #define UNARY_CAST_TO_FLOAT32(name) UNARY_SAFE_NULL_IF_NULL(castFLOAT4, name, float32)
@@ -59,6 +56,7 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
 
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(add, decimal128),
       BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(subtract, decimal128),
+      BINARY_SYMMETRIC_SAFE_NULL_IF_NULL(multiply, decimal128),
 
       BINARY_RELATIONAL_BOOL_FN(equal),
       BINARY_RELATIONAL_BOOL_FN(not_equal),
@@ -66,14 +64,7 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       BINARY_RELATIONAL_BOOL_DATE_FN(less_than),
       BINARY_RELATIONAL_BOOL_DATE_FN(less_than_or_equal_to),
       BINARY_RELATIONAL_BOOL_DATE_FN(greater_than),
-      BINARY_RELATIONAL_BOOL_DATE_FN(greater_than_or_equal_to),
-
-      UNARY_OCTET_LEN_FN(octet_length),
-      UNARY_OCTET_LEN_FN(bit_length),
-
-      UNARY_UNSAFE_NULL_IF_NULL(char_length, utf8, int32),
-      UNARY_UNSAFE_NULL_IF_NULL(length, utf8, int32),
-      UNARY_UNSAFE_NULL_IF_NULL(lengthUtf8, binary, int32)};
+      BINARY_RELATIONAL_BOOL_DATE_FN(greater_than_or_equal_to)};
 
   return arithmetic_fn_registry_;
 }

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -26,6 +26,9 @@ namespace gandiva {
 #define BINARY_RELATIONAL_SAFE_NULL_IF_NULL_UTF8_FN(name) \
   BINARY_RELATIONAL_SAFE_NULL_IF_NULL(name, utf8)
 
+#define UNARY_OCTET_LEN_FN(name) \
+  UNARY_SAFE_NULL_IF_NULL(name, utf8, int32), UNARY_SAFE_NULL_IF_NULL(name, binary, int32)
+
 std::vector<NativeFunction> GetStringFunctionRegistry() {
   static std::vector<NativeFunction> string_fn_registry_ = {
       BINARY_RELATIONAL_SAFE_NULL_IF_NULL_FN(equal),
@@ -37,6 +40,13 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
 
       BINARY_RELATIONAL_SAFE_NULL_IF_NULL_UTF8_FN(starts_with),
       BINARY_RELATIONAL_SAFE_NULL_IF_NULL_UTF8_FN(ends_with),
+
+      UNARY_OCTET_LEN_FN(octet_length),
+      UNARY_OCTET_LEN_FN(bit_length),
+
+      UNARY_UNSAFE_NULL_IF_NULL(char_length, utf8, int32),
+      UNARY_UNSAFE_NULL_IF_NULL(length, utf8, int32),
+      UNARY_UNSAFE_NULL_IF_NULL(lengthUtf8, binary, int32),
 
       NativeFunction("upper", DataTypeVector{utf8()}, utf8(), kResultNullIfNull,
                      "upper_utf8", NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -128,5 +128,5 @@ if(ARROW_BUILD_TESTS)
   add_precompiled_unit_test(arithmetic_ops_test.cc arithmetic_ops.cc ../context_helper.cc)
   add_precompiled_unit_test(extended_math_ops_test.cc extended_math_ops.cc
                             ../context_helper.cc)
-  add_precompiled_unit_test(decimal_ops_test.cc decimal_ops.cc ../decimal_type_util.cc)
+  add_precompiled_unit_test(decimal_ops_test.cc decimal_ops.cc ../decimal_type_util.cc ../decimal_xlarge.cc)
 endif()

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -128,5 +128,6 @@ if(ARROW_BUILD_TESTS)
   add_precompiled_unit_test(arithmetic_ops_test.cc arithmetic_ops.cc ../context_helper.cc)
   add_precompiled_unit_test(extended_math_ops_test.cc extended_math_ops.cc
                             ../context_helper.cc)
-  add_precompiled_unit_test(decimal_ops_test.cc decimal_ops.cc ../decimal_type_util.cc ../decimal_xlarge.cc)
+  add_precompiled_unit_test(decimal_ops_test.cc decimal_ops.cc ../decimal_type_util.cc
+                            ../decimal_xlarge.cc)
 endif()

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -27,7 +27,7 @@
 
 namespace gandiva {
 
-namespace verylarge {
+namespace xlarge {
 
 // Operations that can deal with very large values (256-bit).
 //
@@ -110,7 +110,7 @@ static void MultiplyAndScaleDown(int64_t x_high, uint64_t x_low, int64_t y_high,
   *out_low = result.low_bits();
 }
 
-}  // namespace verylarge
+}  // namespace xlarge
 
 namespace decimalops {
 
@@ -346,7 +346,7 @@ static BasicDecimal128 MultiplyMaxPrecision(const BasicDecimalScalar128& x,
     int64_t result_high;
     uint64_t result_low;
 
-    gandiva::verylarge::MultiplyAndScaleDown(
+    gandiva::xlarge::MultiplyAndScaleDown(
         x.value().high_bits(), x.value().low_bits(), y.value().high_bits(),
         y.value().low_bits(), delta_scale, &result_high, &result_low, overflow);
     result = BasicDecimal128(result_high, result_low);

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -227,12 +227,12 @@ BasicDecimal128 Subtract(const BasicDecimalScalar128& x, const BasicDecimalScala
   return Add(x, {-y.value(), y.precision(), y.scale()}, out_precision, out_scale);
 }
 
-
 // Multiply when the out_precision is 38, and there is no trimming of the scale i.e
 // the intermediate value is the same as the final value.
 static BasicDecimal128 MultiplyMaxPrecisionNoScaleDown(const BasicDecimalScalar128& x,
                                                        const BasicDecimalScalar128& y,
-                                                       int32_t out_scale, bool* overflow) {
+                                                       int32_t out_scale,
+                                                       bool* overflow) {
   DCHECK_EQ(x.scale() + y.scale(), out_scale);
 
   BasicDecimal128 result;
@@ -252,8 +252,9 @@ static BasicDecimal128 MultiplyMaxPrecisionNoScaleDown(const BasicDecimalScalar1
 // Multiply when the out_precision is 38, and there is trimming of the scale i.e
 // the intermediate value could be larger than the final value.
 static BasicDecimal128 MultiplyMaxPrecisionAndScaleDown(const BasicDecimalScalar128& x,
-                                            const BasicDecimalScalar128& y,
-                                            int32_t out_scale, bool* overflow) {
+                                                        const BasicDecimalScalar128& y,
+                                                        int32_t out_scale,
+                                                        bool* overflow) {
   auto delta_scale = x.scale() + y.scale() - out_scale;
   DCHECK_GT(delta_scale, 0);
 
@@ -278,8 +279,8 @@ static BasicDecimal128 MultiplyMaxPrecisionAndScaleDown(const BasicDecimalScalar
     // avoid references to boost from the precompiled-to-ir code (this causes issues
     // with symbol resolution at runtime), we use a wrapper exported from the CPP code.
     gdv_xlarge_multiply_and_scale_down(x.value().high_bits(), x.value().low_bits(),
-                                y.value().high_bits(), y.value().low_bits(), delta_scale,
-                                &result_high, &result_low, overflow);
+                                       y.value().high_bits(), y.value().low_bits(),
+                                       delta_scale, &result_high, &result_low, overflow);
     result = BasicDecimal128(result_high, result_low);
   } else {
     if (ARROW_PREDICT_TRUE(delta_scale <= 38)) {
@@ -310,7 +311,6 @@ static BasicDecimal128 MultiplyMaxPrecisionAndScaleDown(const BasicDecimalScalar
 static BasicDecimal128 MultiplyMaxPrecision(const BasicDecimalScalar128& x,
                                             const BasicDecimalScalar128& y,
                                             int32_t out_scale, bool* overflow) {
-
   auto delta_scale = x.scale() + y.scale() - out_scale;
   DCHECK_GE(delta_scale, 0);
   if (delta_scale == 0) {

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -20,98 +20,12 @@
 #include "gandiva/precompiled/decimal_ops.h"
 
 #include <algorithm>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include "gandiva/decimal_type_util.h"
+#include "gandiva/decimal_xlarge.h"
 #include "gandiva/logging.h"
 
 namespace gandiva {
-
-namespace xlarge {
-
-// Operations that can deal with very large values (256-bit).
-//
-// The intermediate results with decimal can be larger than what can fit into 128-bit,
-// but the final results can fit in 128-bit after scaling down. These functions deal
-// with operations on the intermediate values.
-//
-using boost::multiprecision::int256_t;
-
-// Convert to 256-bit integer from 128-bit decimal.
-static int256_t ConvertToInt256(BasicDecimal128 in) {
-  int256_t v = in.high_bits();
-  v <<= 64;
-  v |= in.low_bits();
-  return v;
-}
-
-// Convert to 128-bit decimal from 256-bit integer.
-// If there is an overflow, the output is undefined.
-static BasicDecimal128 ConvertToDecimal128(int256_t in, bool* overflow) {
-  BasicDecimal128 result;
-  constexpr uint64_t mask = std::numeric_limits<uint64_t>::max();
-
-  int256_t in_abs = abs(in);
-  bool is_negative = in < 0;
-  uint64_t low = in_abs.convert_to<uint64_t>() & mask;
-  in_abs >>= 64;
-  uint64_t high = in_abs.convert_to<uint64_t>() & mask;
-  in_abs >>= 64;
-
-  if (in_abs > 0) {
-    // we've shifted in by 128-bit, so nothing should be left.
-    *overflow = true;
-  } else if (high > std::numeric_limits<int64_t>::max()) {
-    // the high-bit must not be set (signed 128-bit).
-    *overflow = true;
-  } else {
-    result = BasicDecimal128(static_cast<int64_t>(high), low);
-    if (result > BasicDecimal128::GetMaxValue()) {
-      *overflow = true;
-    }
-  }
-  return is_negative ? -result : result;
-}
-
-// Similar to BasicDecimal128::ReduceScaleBy
-static int256_t ReduceScaleBy(int256_t in, int32_t reduce_by) {
-  int256_t divisor;
-
-  if (reduce_by <= DecimalTypeUtil::kMaxPrecision) {
-    divisor = ConvertToInt256(BasicDecimal128::GetScaleMultiplier(reduce_by));
-  } else {
-    DCHECK_LE(reduce_by, 2 * DecimalTypeUtil::kMaxPrecision);
-    divisor = ConvertToInt256(
-        BasicDecimal128::GetScaleMultiplier(DecimalTypeUtil::kMaxPrecision));
-    for (auto i = DecimalTypeUtil::kMaxPrecision; i < reduce_by; i++) {
-      divisor *= 10;
-    }
-  }
-
-  DCHECK_GT(divisor, 0);
-  DCHECK_EQ(divisor % 2, 0);  // multiple of 10.
-  auto result = in / divisor;
-  auto remainder = in % divisor;
-  if (abs(remainder) >= (divisor >> 1)) {
-    result += (in > 0 ? 1 : -1);
-  }
-  return result;
-}
-
-static void MultiplyAndScaleDown(int64_t x_high, uint64_t x_low, int64_t y_high,
-                                 uint64_t y_low, int32_t reduce_scale_by,
-                                 int64_t* out_high, uint64_t* out_low, bool* overflow) {
-  BasicDecimal128 x{x_high, x_low};
-  BasicDecimal128 y{y_high, y_low};
-  auto intermediate_result = ConvertToInt256(x) * ConvertToInt256(y);
-  intermediate_result = ReduceScaleBy(intermediate_result, reduce_scale_by);
-  auto result = ConvertToDecimal128(intermediate_result, overflow);
-  *out_high = result.high_bits();
-  *out_low = result.low_bits();
-}
-
-}  // namespace xlarge
-
 namespace decimalops {
 
 using arrow::BasicDecimal128;
@@ -346,9 +260,9 @@ static BasicDecimal128 MultiplyMaxPrecision(const BasicDecimalScalar128& x,
     int64_t result_high;
     uint64_t result_low;
 
-    gandiva::xlarge::MultiplyAndScaleDown(
-        x.value().high_bits(), x.value().low_bits(), y.value().high_bits(),
-        y.value().low_bits(), delta_scale, &result_high, &result_low, overflow);
+    gdv_multiply_and_scale_down(x.value().high_bits(), x.value().low_bits(),
+                                y.value().high_bits(), y.value().low_bits(), delta_scale,
+                                &result_high, &result_low, overflow);
     result = BasicDecimal128(result_high, result_low);
   } else {
     if (ARROW_PREDICT_TRUE(delta_scale <= 38)) {

--- a/cpp/src/gandiva/precompiled/decimal_ops.h
+++ b/cpp/src/gandiva/precompiled/decimal_ops.h
@@ -35,5 +35,10 @@ arrow::BasicDecimal128 Subtract(const BasicDecimalScalar128& x,
                                 const BasicDecimalScalar128& y, int32_t out_precision,
                                 int32_t out_scale);
 
+/// Multiply 'x' from 'y', and return the result.
+arrow::BasicDecimal128 Multiply(const BasicDecimalScalar128& x,
+                                const BasicDecimalScalar128& y, int32_t out_precision,
+                                int32_t out_scale, bool* overflow);
+
 }  // namespace decimalops
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/decimal_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops_test.cc
@@ -50,6 +50,10 @@ class TestDecimalSql : public ::testing::Test {
                          bool expected_overflow) {
     return Verify(DecimalTypeUtil::kOpMultiply, x, y, expected_result, expected_overflow);
   }
+
+  void MultiplyAndVerifyAllSign(const DecimalScalar128& x, const DecimalScalar128& y,
+                                const DecimalScalar128& expected_result,
+                                bool expected_overflow);
 };
 
 #define EXPECT_DECIMAL_EQ(op, x, y, expected_result, expected_overflow, actual_result, \
@@ -152,58 +156,128 @@ TEST_F(TestDecimalSql, Subtract) {
       DecimalScalar128{"-99999999999999999999999999999989999990", 38, 6});
 }
 
+void TestDecimalSql::MultiplyAndVerifyAllSign(const DecimalScalar128& left,
+                                              const DecimalScalar128& right,
+                                              const DecimalScalar128& expected_output,
+                                              bool expected_overflow) {
+  // both +ve
+  MultiplyAndVerify(left, right, expected_output, expected_overflow);
+
+  // left -ve
+  MultiplyAndVerify(-left, right, -expected_output, expected_overflow);
+
+  // right -ve
+  MultiplyAndVerify(left, -right, -expected_output, expected_overflow);
+
+  // both -ve
+  MultiplyAndVerify(-left, -right, expected_output, expected_overflow);
+}
+
 TEST_F(TestDecimalSql, Multiply) {
-#if 0
-  // fast-path : both +ve
-  MultiplyAndVerify(DecimalScalar128{"201", 10, 3},    // x
-                    DecimalScalar128{"301", 10, 2},    // y
-                    DecimalScalar128{"60501", 21, 5},  // expected
+  const std::string thirty_five_9s(35, '9');
+  const std::string thirty_six_9s(36, '9');
+  const std::string thirty_eight_9s(38, '9');
+
+  // fast-path : out_precision < 38
+  MultiplyAndVerifyAllSign(DecimalScalar128{"201", 10, 3},    // x
+                           DecimalScalar128{"301", 10, 2},    // y
+                           DecimalScalar128{"60501", 21, 5},  // expected
+                           false);                            // overflow
+
+  // right 0
+  MultiplyAndVerify(DecimalScalar128{"201", 20, 3},  // x
+                    DecimalScalar128{"0", 20, 2},    // y
+                    DecimalScalar128{"0", 38, 5},    // expected
+                    false);                          // overflow
+
+  // left 0
+  MultiplyAndVerify(DecimalScalar128{"0", 20, 3},    // x
+                    DecimalScalar128{"301", 20, 2},  // y
+                    DecimalScalar128{"0", 38, 5},    // expected
+                    false);                          // overflow
+
+  // out_precision == 38, small input values, no trimming of scale (scale <= 6 doesn't
+  // get trimmed).
+  MultiplyAndVerify(DecimalScalar128{"201", 20, 3},    // x
+                    DecimalScalar128{"301", 20, 2},    // y
+                    DecimalScalar128{"60501", 38, 5},  // expected
                     false);                            // overflow
 
-  // fast-path : right -ve
-  MultiplyAndVerify(DecimalScalar128{"201", 10, 3},    // x
-                    DecimalScalar128{"-301", 10, 2},    // y
-                    DecimalScalar128{"-60501", 21, 5},  // expected
-                    false);                            // overflow
-
-  // fast-path : left -ve
-  MultiplyAndVerify(DecimalScalar128{"-201", 10, 3},    // x
-                    DecimalScalar128{"301", 10, 2},    // y
-                    DecimalScalar128{"-60501", 21, 5},  // expected
-                    false);                            // overflow
-#endif
-
-  // fast-path : both -ve
-  MultiplyAndVerify(DecimalScalar128{"-201", 10, 3},    // x
-                    DecimalScalar128{"-301", 10, 2},    // y
-                    DecimalScalar128{"60501", 21, 5},  // expected
-                    false);                            // overflow
-#if 0
-  MultiplyAndVerify(DecimalScalar128{"201", 30, 3},    // x
-                    DecimalScalar128{"301", 30, 3},    // y
-                    DecimalScalar128{"60501", 38, 6},  // expected
-                    false);                            // overflow
-
-  // max precision
-  MultiplyAndVerify(
-      DecimalScalar128{"09999999999999999999999999999999000000", 38, 5},  // x
-      DecimalScalar128{"100", 38, 7},                                     // y
-      DecimalScalar128{"999999999999999999999999999999900", 38, 6},  // expected
+  // out_precision == 38, large values, no trimming of scale (scale <= 6 doesn't
+  // get trimmed).
+  MultiplyAndVerifyAllSign(
+      DecimalScalar128{"201", 20, 3},                                     // x
+      DecimalScalar128{thirty_five_9s, 35, 2},                            // y
+      DecimalScalar128{"20099999999999999999999999999999999799", 38, 5},  // expected
       false);                                                             // overflow
 
-  // Both -ve
-  MultiplyAndVerify(DecimalScalar128{"-201", 30, 3},   // x
-                    DecimalScalar128{"-301", 30, 2},   // y
-                    DecimalScalar128{"605010", 38, 5},  // expected
-                    false);                            // overflow
+  // out_precision == 38, very large values, no trimming of scale (scale <= 6 doesn't
+  // get trimmed). overflow expected.
+  MultiplyAndVerifyAllSign(DecimalScalar128{"201", 20, 3},          // x
+                           DecimalScalar128{thirty_six_9s, 35, 2},  // y
+                           DecimalScalar128{"0", 38, 5},            // expected
+                           true);                                   // overflow
 
-  // -ve and max precision
-  MultiplyAndVerify(
-      DecimalScalar128{"-09999999999999999999999999999999000000", 38, 5},  // x
-      DecimalScalar128{"-100", 38, 7},                                     // y
-      DecimalScalar128{"999999999999999999999999999999900", 38, 6},  // expected
-      false);                                                              // overflow
-#endif
+  MultiplyAndVerifyAllSign(DecimalScalar128{"201", 20, 3},            // x
+                           DecimalScalar128{thirty_eight_9s, 35, 2},  // y
+                           DecimalScalar128{"0", 38, 5},              // expected
+                           true);                                     // overflow
+
+  // out_precision == 38, small input values, trimming of scale.
+  MultiplyAndVerifyAllSign(DecimalScalar128{"201", 20, 5},  // x
+                           DecimalScalar128{"301", 20, 5},  // y
+                           DecimalScalar128{"61", 38, 7},   // expected
+                           false);                          // overflow
+
+  // out_precision == 38, large values, trimming of scale.
+  MultiplyAndVerifyAllSign(
+      DecimalScalar128{"201", 20, 5},                                 // x
+      DecimalScalar128{thirty_five_9s, 35, 5},                        // y
+      DecimalScalar128{"2010000000000000000000000000000000", 38, 6},  // expected
+      false);                                                         // overflow
+
+  // out_precision == 38, very large values, trimming of scale (requires convert to 256).
+  MultiplyAndVerifyAllSign(
+      DecimalScalar128{thirty_five_9s, 38, 20},                          // x
+      DecimalScalar128{thirty_six_9s, 38, 20},                           // y
+      DecimalScalar128{"9999999999999999999999999999999999890", 38, 6},  // expected
+      false);                                                            // overflow
+
+  // out_precision == 38, very large values, trimming of scale (requires convert to 256).
+  // should cause overflow.
+  MultiplyAndVerifyAllSign(DecimalScalar128{thirty_five_9s, 38, 4},  // x
+                           DecimalScalar128{thirty_six_9s, 38, 4},   // y
+                           DecimalScalar128{"0", 38, 6},             // expected
+                           true);                                    // overflow
+
+  // corner cases.
+  MultiplyAndVerifyAllSign(
+      DecimalScalar128{0, UINT64_MAX, 38, 4},                            // x
+      DecimalScalar128{0, UINT64_MAX, 38, 4},                            // y
+      DecimalScalar128{"3402823669209384634264811192843491082", 38, 6},  // expected
+      false);                                                            // overflow
+
+  MultiplyAndVerifyAllSign(
+      DecimalScalar128{0, UINT64_MAX, 38, 4},                            // x
+      DecimalScalar128{0, INT64_MAX, 38, 4},                             // y
+      DecimalScalar128{"1701411834604692317040171876053197783", 38, 6},  // expected
+      false);                                                            // overflow
+
+  MultiplyAndVerifyAllSign(DecimalScalar128{"201", 38, 38},  // x
+                           DecimalScalar128{"301", 38, 38},  // y
+                           DecimalScalar128{"0", 38, 37},    // expected
+                           false);                           // overflow
+
+  MultiplyAndVerifyAllSign(DecimalScalar128{0, UINT64_MAX, 38, 38},  // x
+                           DecimalScalar128{0, UINT64_MAX, 38, 38},  // y
+                           DecimalScalar128{"0", 38, 37},            // expected
+                           false);                                   // overflow
+
+  MultiplyAndVerifyAllSign(
+      DecimalScalar128{thirty_five_9s, 38, 38},                       // x
+      DecimalScalar128{thirty_six_9s, 38, 38},                        // y
+      DecimalScalar128{"100000000000000000000000000000000", 38, 37},  // expected
+      false);                                                         // overflow
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -34,4 +34,22 @@ void add_large_decimal128_decimal128(int64_t x_high, uint64_t x_low, int32_t x_p
   *out_low = out.low_bits();
 }
 
+FORCE_INLINE
+void multiply_internal_decimal128_decimal128(int64_t x_high, uint64_t x_low,
+                                             int32_t x_precision, int32_t x_scale,
+                                             int64_t y_high, uint64_t y_low,
+                                             int32_t y_precision, int32_t y_scale,
+                                             int32_t out_precision, int32_t out_scale,
+                                             int64_t* out_high, uint64_t* out_low) {
+  gandiva::BasicDecimalScalar128 x(x_high, x_low, x_precision, x_scale);
+  gandiva::BasicDecimalScalar128 y(y_high, y_low, y_precision, y_scale);
+  bool overflow;
+
+  // TODO ravindra: handle overflows (ARROW-4570).
+  arrow::BasicDecimal128 out =
+      gandiva::decimalops::Multiply(x, y, out_precision, out_scale, &overflow);
+  *out_high = out.high_bits();
+  *out_low = out.low_bits();
+}
+
 }  // extern "C"

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -45,7 +45,7 @@ void multiply_internal_decimal128_decimal128(int64_t x_high, uint64_t x_low,
   gandiva::BasicDecimalScalar128 y(y_high, y_low, y_precision, y_scale);
   bool overflow;
 
-  // TODO ravindra: handle overflows (ARROW-4570).
+  // TODO ravindra: generate error on overflows (ARROW-4570).
   arrow::BasicDecimal128 out =
       gandiva::decimalops::Multiply(x, y, out_precision, out_scale, &overflow);
   *out_high = out.high_bits();

--- a/cpp/src/gandiva/tests/decimal_single_test.cc
+++ b/cpp/src/gandiva/tests/decimal_single_test.cc
@@ -61,6 +61,11 @@ class TestDecimalOps : public ::testing::Test {
     Verify(DecimalTypeUtil::kOpSubtract, "subtract", x, y, expected);
   }
 
+  void MultiplyAndVerify(const DecimalScalar128& x, const DecimalScalar128& y,
+                         const DecimalScalar128& expected) {
+    Verify(DecimalTypeUtil::kOpMultiply, "multiply", x, y, expected);
+  }
+
  protected:
   arrow::MemoryPool* pool_;
 };
@@ -251,6 +256,19 @@ TEST_F(TestDecimalOps, TestSubtract) {
   SubtractAndVerify(decimal_literal("-201", 30, 3),    // x
                     decimal_literal("301", 30, 2),     // y
                     decimal_literal("-3211", 32, 3));  // expected
+}
+
+// Lots of unit tests for multiply in decimal_ops_test.cc. So, keeping this basic.
+TEST_F(TestDecimalOps, TestMultiply) {
+  // fast-path
+  MultiplyAndVerify(decimal_literal("201", 10, 3),     // x
+                    decimal_literal("301", 10, 2),     // y
+                    decimal_literal("60501", 21, 5));  // expected
+
+  // max precision
+  MultiplyAndVerify(DecimalScalar128(std::string(35, '9'), 38, 20),  // x
+                    DecimalScalar128(std::string(36, '9'), 38, 20),  // x
+                    DecimalScalar128("9999999999999999999999999999999999890", 38, 6));
 }
 
 }  // namespace gandiva

--- a/python/manylinux1/scripts/build_boost.sh
+++ b/python/manylinux1/scripts/build_boost.sh
@@ -25,7 +25,7 @@ mkdir /arrow_boost
 pushd /boost_${BOOST_VERSION_UNDERSCORE}
 ./bootstrap.sh
 ./b2 tools/bcp
-./dist/bin/bcp --namespace=arrow_boost --namespace-alias filesystem date_time system regex build algorithm locale format variant multi_precision/cpp_int /arrow_boost
+./dist/bin/bcp --namespace=arrow_boost --namespace-alias filesystem date_time system regex build algorithm locale format variant multiprecision/cpp_int /arrow_boost
 popd
 
 pushd /arrow_boost


### PR DESCRIPTION
- fastpath : safe multiply the two values (when result precision is < 38)
- if large values, convert to 256-bit (boost), multiply and then, scale down
- avoid converting to 256-bit wherever possible
- track overflow (TODO: generate errors on overflow)