### PR TITLE
ARROW-4674: [JS] Update arrow2csv to new Row API

### DIFF
--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -39,10 +39,9 @@ export type IntBitWidth = 8 | 16 | 32 | 64;
 export type IsSigned = { 'true': true; 'false': false };
 /** @ignore */
 export type RowLike<T extends { [key: string]: DataType }> =
-      { readonly length: number }
-    & ( Iterable<T[keyof T]['TValue']> )
-    & { [P in keyof T]: T[P]['TValue'] }
-    & { get<K extends keyof T>(key: K): T[K]['TValue']; }
+      ( Iterable<T[keyof T]['TValue'] | null> )
+    & { [P in keyof T]: T[P]['TValue'] | null }
+    & { get<K extends keyof T>(key: K): T[K]['TValue'] | null; }
     ;
 
 export interface DataType<TType extends Type = Type, TChildren extends { [key: string]: DataType } = any> {

--- a/js/src/util/pretty.ts
+++ b/js/src/util/pretty.ts
@@ -21,7 +21,11 @@
 export function valueToString(x: any) {
     if (x === null) { return 'null'; }
     if (x === undf) { return 'undefined'; }
-    if (typeof x === 'string') { return `"${x}"`; }
+    switch (typeof x) {
+        case 'number': return `${x}`;
+        case 'bigint': return `${x}`;
+        case 'string': return `"${x}"`;
+    }
     // If [Symbol.toPrimitive] is implemented (like in BN)
     // use it instead of JSON.stringify(). This ensures we
     // print BigInts, Decimals, and Binary in their native

--- a/js/src/vector/map.ts
+++ b/js/src/vector/map.ts
@@ -15,14 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { RowProxyGenerator } from './row';
+import { Field } from '../schema';
 import { Vector } from '../vector';
 import { BaseVector } from './base';
+import { RowProxyGenerator } from './row';
 import { DataType, Map_, Struct } from '../type';
 
 export class MapVector<T extends { [key: string]: DataType } = any> extends BaseVector<Map_<T>> {
     public asStruct() {
-        return Vector.new(this.data.clone(new Struct<T>(this.type.children)));
+        return Vector.new(this.data.clone(new Struct<T>(this.type.children as Field<T[keyof T]>[])));
     }
     // @ts-ignore
     private _rowProxy: RowProxyGenerator<T>;

--- a/js/src/vector/row.ts
+++ b/js/src/vector/row.ts
@@ -108,6 +108,5 @@ export class RowProxyGenerator<T extends { [key: string]: DataType }> {
         const bound = Object.create(this.rowPrototype);
         bound[kRowIndex] = rowIndex;
         return bound;
-        //return new this.RowProxy(rowIndex);
     }
 }

--- a/js/src/vector/struct.ts
+++ b/js/src/vector/struct.ts
@@ -15,14 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { RowProxyGenerator } from './row';
+import { Field } from '../schema';
 import { Vector } from '../vector';
 import { BaseVector } from './base';
+import { RowProxyGenerator } from './row';
 import { DataType, Map_, Struct } from '../type';
 
 export class StructVector<T extends { [key: string]: DataType } = any> extends BaseVector<Struct<T>> {
     public asMap(keysSorted: boolean = false) {
-        return Vector.new(this.data.clone(new Map_<T>(this.type.children, keysSorted)));
+        return Vector.new(this.data.clone(new Map_<T>(this.type.children as Field<T[keyof T]>[], keysSorted)));
     }
     // @ts-ignore
     private _rowProxy: RowProxyGenerator<T>;


### PR DESCRIPTION
This PR updates `arrow2csv` cell measurement to iterate the Row values, now that `length` is a Symbol. Closes https://issues.apache.org/jira/browse/ARROW-4674.

Before:
```
       "row_id" | "0: Float64" | "1: Utf8"
              0 | 3.141592653589793 |     "foo"
              1 | 1.5707963267948966 |     "bar"
              2 | 1.0471975511965976 |     "baz"
              3 |          0.7 |    "bork"
```

After:
```
       "row_id" |       "0: Float64" | "1: Utf8"
              0 |  3.141592653589793 |     "foo"
              1 | 1.5707963267948966 |     "bar"
              2 | 1.0471975511965976 |     "baz"
              3 |                0.7 |    "bork"
```