### PR TITLE
ARROW-4676: [C++] Add support for debug build with MinGW

### DIFF
--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -17,8 +17,8 @@
 
 @echo on
 
-set CMAKE_BUILD_TYPE=release
-set MESON_BUILD_TYPE=release
+set CMAKE_BUILD_TYPE=debug
+set MESON_BUILD_TYPE=debug
 
 set INSTALL_DIR=%HOMEDRIVE%%HOMEPATH%\install
 set PATH=%INSTALL_DIR%\bin;%PATH%

--- a/cpp/src/arrow/util/cpu-info.cc
+++ b/cpp/src/arrow/util/cpu-info.cc
@@ -68,6 +68,7 @@ static struct {
 };
 static const int64_t num_flags = sizeof(flag_mappings) / sizeof(flag_mappings[0]);
 
+#ifndef _WIN32
 namespace {
 
 // Helper function to parse for hardware flags.
@@ -85,6 +86,7 @@ int64_t ParseCPUFlags(const std::string& values) {
 }
 
 }  // namespace
+#endif
 
 #ifdef _WIN32
 bool RetrieveCacheSize(int64_t* cache_sizes) {
@@ -94,7 +96,7 @@ bool RetrieveCacheSize(int64_t* cache_sizes) {
   PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer = nullptr;
   PSYSTEM_LOGICAL_PROCESSOR_INFORMATION buffer_position = nullptr;
   DWORD buffer_size = 0;
-  DWORD offset = 0;
+  size_t offset = 0;
   typedef BOOL(WINAPI * GetLogicalProcessorInformationFuncPointer)(void*, void*);
   GetLogicalProcessorInformationFuncPointer func_pointer =
       (GetLogicalProcessorInformationFuncPointer)GetProcAddress(
@@ -156,9 +158,9 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
   highest_extended_valid_id = cpu_info[0];
 
   // Retrieve CPU model name
-  if (highest_extended_valid_id >= 0x80000004) {
+  if (highest_extended_valid_id >= static_cast<int>(0x80000004)) {
     model_name->clear();
-    for (int i = 0x80000002; i <= 0x80000004; ++i) {
+    for (int i = 0x80000002; i <= static_cast<int>(0x80000004); ++i) {
       __cpuidex(cpu_info.data(), i, 0);
       *model_name +=
           std::string(reinterpret_cast<char*>(cpu_info.data()), sizeof(cpu_info));

--- a/cpp/src/arrow/util/io-util.cc
+++ b/cpp/src/arrow/util/io-util.cc
@@ -401,7 +401,7 @@ Status FileRead(int fd, uint8_t* buffer, int64_t nbytes, int64_t* bytes_read) {
   while (*bytes_read < nbytes) {
     int64_t chunksize =
         std::min(static_cast<int64_t>(ARROW_MAX_IO_CHUNKSIZE), nbytes - *bytes_read);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     int64_t ret =
         static_cast<int64_t>(_read(fd, buffer, static_cast<uint32_t>(chunksize)));
 #else
@@ -468,7 +468,7 @@ Status FileWrite(int fd, const uint8_t* buffer, const int64_t nbytes) {
   while (ret != -1 && bytes_written < nbytes) {
     int64_t chunksize =
         std::min(static_cast<int64_t>(ARROW_MAX_IO_CHUNKSIZE), nbytes - bytes_written);
-#if defined(_MSC_VER)
+#if defined(_WIN32)
     ret = static_cast<int>(
         _write(fd, buffer + bytes_written, static_cast<uint32_t>(chunksize)));
 #else


### PR DESCRIPTION
We need to suppress all warnings for debug build.

Messages:


    cpp/src/arrow/util/cpu-info.cc: In function 'bool arrow::internal::RetrieveCacheSize(int64_t*)':
    cpp/src/arrow/util/cpu-info.cc:127:12: error: conversion from 'long long unsigned int' to 'DWORD' {aka 'long unsigned int'} may change value [-Werror=conversion]
         offset += sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION);
         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    cpp/src/arrow/util/cpu-info.cc: In function 'bool arrow::internal::RetrieveCPUInfo(int64_t*, std::__cxx11::string*)':
    cpp/src/arrow/util/cpu-info.cc:159:33: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
       if (highest_extended_valid_id >= 0x80000004) {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
    cpp/src/arrow/util/cpu-info.cc:161:32: warning: comparison of integer expressions of different signedness: 'int' and 'unsigned int' [-Wsign-compare]
         for (int i = 0x80000002; i <= 0x80000004; ++i) {
                                  ~~^~~~~~~~~~~~~
    cpp/src/arrow/util/cpu-info.cc: At global scope:
    cpp/src/arrow/util/cpu-info.cc:77:9: warning: 'int64_t arrow::internal::{anonymous}::ParseCPUFlags(const string&)' defined but not used [-Wunused-function]
     int64_t ParseCPUFlags(const std::string& values) {
             ^~~~~~~~~~~~~

    cpp/src/arrow/util/io-util.cc: In function 'arrow::Status arrow::internal::FileRead(int, uint8_t*, int64_t, int64_t*)':
    cpp/src/arrow/util/io-util.cc:408:57: error: conversion from 'size_t' {aka 'long long unsigned int'} to 'unsigned int' may change value [-Werror=conversion]
         int64_t ret = static_cast<int64_t>(read(fd, buffer, static_cast<size_t>(chunksize)));
                                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    cpp/src/arrow/util/io-util.cc: In function 'arrow::Status arrow::internal::FileWrite(int, const uint8_t*, int64_t)':
    cpp/src/arrow/util/io-util.cc:476:43: [ error: 75conversion from '%  size_tBuilding CXX object src/arrow/CMakeFiles/arrow_objlib.dir/util/memory.cc.obj' {aka '
    long long unsigned int'} to 'unsigned int' may change value [-Werror=conversion]
             write(fd, buffer + bytes_written, static_cast<size_t>(chunksize)));
                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
