### PR TITLE
ARROW-4679: [Rust] Implement in-memory data source for DataFusion

### DIFF
--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -27,6 +27,7 @@ use crate::array::*;
 use crate::datatypes::*;
 
 /// A batch of column-oriented data
+#[derive(Clone)]
 pub struct RecordBatch {
     schema: Arc<Schema>,
     columns: Vec<Arc<Array>>,

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -67,7 +67,7 @@ fn create_context() -> Rc<RefCell<ExecutionContext>> {
         true,
     );
 
-    let mem_table = MemTable::load(&csv);
+    let mem_table = MemTable::load(&csv).unwrap();
 
     // create local execution context
     let ctx = Rc::new(RefCell::new(ExecutionContext::new()));

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -19,6 +19,8 @@
 extern crate criterion;
 use criterion::Criterion;
 
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 extern crate arrow;
@@ -26,12 +28,21 @@ extern crate datafusion;
 
 use arrow::datatypes::{DataType, Field, Schema};
 
+use datafusion::datasource::{CsvFile, MemTable};
 use datafusion::execution::context::ExecutionContext;
 
-fn aggregate_query(sql: &str) {
-    // create local execution context
-    let mut ctx = ExecutionContext::new();
+fn aggregate_query(ctx: &Rc<RefCell<ExecutionContext>>, sql: &str) {
+    // execute the query
+    let mut mut_ctx = ctx.borrow_mut();
+    let relation = mut_ctx.sql(&sql, 1024 * 1024).unwrap();
 
+    // display the relation
+    let mut results = relation.borrow_mut();
+
+    while let Some(_) = results.next().unwrap() {}
+}
+
+fn create_context() -> Rc<RefCell<ExecutionContext>> {
     // define schema for data source (csv file)
     let schema = Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),
@@ -49,43 +60,53 @@ fn aggregate_query(sql: &str) {
         Field::new("c13", DataType::Utf8, false),
     ]));
 
-    // register csv file with the execution context
-    ctx.register_csv(
-        "aggregate_test_100",
+    // create CSV data source
+    let csv = CsvFile::new(
         "../../testing/data/csv/aggregate_test_100.csv",
         &schema,
         true,
     );
 
-    // execute the query
-    let relation = ctx.sql(&sql, 1024 * 1024).unwrap();
+    let mem_table = MemTable::load(&csv);
 
-    // display the relation
-    let mut results = relation.borrow_mut();
+    // create local execution context
+    let ctx = Rc::new(RefCell::new(ExecutionContext::new()));
 
-    while let Some(_) = results.next().unwrap() {}
+    let mut mut_ctx = ctx.borrow_mut();
+
+    mut_ctx.register_table("aggregate_test_100", Rc::new(mem_table));
+
+    ctx.clone()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("aggregate_query_no_group_by", |b| {
+        let ctx = create_context();
         b.iter(|| {
             aggregate_query(
+                &ctx,
                 "SELECT MIN(c12), MAX(c12) \
                  FROM aggregate_test_100",
             )
         })
     });
+
     c.bench_function("aggregate_query_group_by", |b| {
+        let ctx = create_context();
         b.iter(|| {
             aggregate_query(
+                &ctx,
                 "SELECT c1, MIN(c12), MAX(c12) \
                  FROM aggregate_test_100 GROUP BY c1",
             )
         })
     });
+
     c.bench_function("aggregate_query_group_by_with_filter", |b| {
+        let ctx = create_context();
         b.iter(|| {
             aggregate_query(
+                &ctx,
                 "SELECT c1, MIN(c12), MAX(c12) \
                  FROM aggregate_test_100 \
                  WHERE c11 > 0.1 AND c11 < 0.9 GROUP BY c1",

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -67,7 +67,7 @@ impl Table for CsvFile {
     }
 }
 
-/// CSV result set
+/// Iterator over CSV batches
 pub struct CsvBatchIterator {
     schema: Arc<Schema>,
     reader: csv::Reader<File>,

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -27,7 +27,7 @@ use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::{RecordBatchIterator, Table};
+use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::execution::error::Result;
 
 /// Represents a CSV file with a provided schema
@@ -56,14 +56,14 @@ impl Table for CsvFile {
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
-    ) -> Rc<RefCell<RecordBatchIterator>> {
-        Rc::new(RefCell::new(CsvBatchIterator::new(
+    ) -> Result<ScanResult> {
+        Ok(Rc::new(RefCell::new(CsvBatchIterator::new(
             &self.filename,
             self.schema.clone(),
             self.has_header,
             projection,
             batch_size,
-        )))
+        ))))
     }
 }
 

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Data sources
+//! CSV Data source
 
 use std::cell::RefCell;
 use std::fs::File;
@@ -27,12 +27,8 @@ use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use super::error::Result;
-
-pub trait DataSource {
-    fn schema(&self) -> &Arc<Schema>;
-    fn next(&mut self) -> Result<Option<RecordBatch>>;
-}
+use crate::datasource::{DataSource, DataSourceProvider};
+use crate::execution::error::Result;
 
 /// CSV data source
 pub struct CsvDataSource {
@@ -84,23 +80,14 @@ impl DataSource for CsvDataSource {
     }
 }
 
-pub trait DataSourceProvider {
-    fn schema(&self) -> &Arc<Schema>;
-    fn scan(
-        &self,
-        projection: &Option<Vec<usize>>,
-        batch_size: usize,
-    ) -> Rc<RefCell<DataSource>>;
-}
-
 /// Represents a CSV file with a provided schema
-pub struct CsvProvider {
+pub struct CsvDataSourceProvider {
     filename: String,
     schema: Arc<Schema>,
     has_header: bool,
 }
 
-impl CsvProvider {
+impl CsvDataSourceProvider {
     pub fn new(filename: &str, schema: &Schema, has_header: bool) -> Self {
         Self {
             filename: String::from(filename),
@@ -110,7 +97,7 @@ impl CsvProvider {
     }
 }
 
-impl DataSourceProvider for CsvProvider {
+impl DataSourceProvider for CsvDataSourceProvider {
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -15,18 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! DataFusion is a modern distributed compute platform implemented in Rust that uses
-//! Apache Arrow as the memory model
+//! Data source traits
 
-extern crate arrow;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate sqlparser;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
 
-pub mod datasource;
-pub mod dfparser;
-pub mod execution;
-pub mod logicalplan;
-pub mod optimizer;
-pub mod sqlplanner;
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+
+use crate::execution::error::Result;
+
+pub trait DataSource {
+    fn schema(&self) -> &Arc<Schema>;
+    fn next(&mut self) -> Result<Option<RecordBatch>>;
+}
+
+pub trait DataSourceProvider {
+    fn schema(&self) -> &Arc<Schema>;
+    fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        batch_size: usize,
+    ) -> Rc<RefCell<DataSource>>;
+}

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -41,6 +41,9 @@ pub trait Table {
 
 /// Iterator for reading a series of record batches with a known schema
 pub trait RecordBatchIterator {
+    /// Get the schema of this iterator
     fn schema(&self) -> &Arc<Schema>;
+
+    /// Get the next batch in this iterator
     fn next(&mut self) -> Result<Option<RecordBatch>>;
 }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -31,8 +31,7 @@ pub trait Table {
     /// Get a reference to the schema for this table
     fn schema(&self) -> &Arc<Schema>;
 
-    /// Perform a scan of a table and return one or more iterators (one iterator per
-    /// partition)
+    /// Perform a scan of a table and return an iterator over the data
     fn scan(
         &self,
         projection: &Option<Vec<usize>>,

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -26,6 +26,8 @@ use arrow::record_batch::RecordBatch;
 
 use crate::execution::error::Result;
 
+pub type ScanResult = Rc<RefCell<RecordBatchIterator>>;
+
 /// Source table
 pub trait Table {
     /// Get a reference to the schema for this table
@@ -36,7 +38,7 @@ pub trait Table {
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
-    ) -> Rc<RefCell<RecordBatchIterator>>;
+    ) -> Result<ScanResult>;
 }
 
 /// Iterator for reading a series of record batches with a known schema

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -26,16 +26,22 @@ use arrow::record_batch::RecordBatch;
 
 use crate::execution::error::Result;
 
-pub trait DataSource {
+/// Source table
+pub trait Table {
+    /// Get a reference to the schema for this table
     fn schema(&self) -> &Arc<Schema>;
-    fn next(&mut self) -> Result<Option<RecordBatch>>;
-}
 
-pub trait DataSourceProvider {
-    fn schema(&self) -> &Arc<Schema>;
+    /// Perform a scan of a table and return one or more iterators (one iterator per
+    /// partition)
     fn scan(
         &self,
         projection: &Option<Vec<usize>>,
         batch_size: usize,
-    ) -> Rc<RefCell<DataSource>>;
+    ) -> Rc<RefCell<RecordBatchIterator>>;
+}
+
+/// Iterator for reading a series of record batches with a known schema
+pub trait RecordBatchIterator {
+    fn schema(&self) -> &Arc<Schema>;
+    fn next(&mut self) -> Result<Option<RecordBatch>>;
 }

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -222,7 +222,9 @@ mod tests {
         let projection: Vec<usize> = vec![0, 4];
 
         match provider.scan(&Some(projection), 1024) {
-            Err(_) => {}
+            Err(ExecutionError::General(e)) => {
+                assert_eq!("\"Projection index out of range\"", format!("{:?}", e))
+            }
             _ => panic!("Scan should failed on invalid projection"),
         };
     }
@@ -251,7 +253,10 @@ mod tests {
         );
 
         match MemTable::new(schema2, vec![batch]) {
-            Err(_) => {}
+            Err(ExecutionError::General(e)) => assert_eq!(
+                "\"Mismatch between schema and batches\"",
+                format!("{:?}", e)
+            ),
             _ => panic!("MemTable::new should have failed due to schema mismatch"),
         }
     }

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! In-memory data source for presenting a Vec<RecordBatch> as a data source that can be
+//! queried by DataFusion. This allows data to be pre-loaded into memory and then repeatedly
+//! queried without incurring additional file I/O overhead.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+
+use crate::datasource::{DataSource, DataSourceProvider};
+use crate::execution::error::Result;
+
+pub struct InMemoryDataSource {
+    schema: Arc<Schema>,
+    index: usize,
+    batches: Vec<RecordBatch>,
+}
+
+impl DataSource for InMemoryDataSource {
+    fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
+
+    fn next(&mut self) -> Result<Option<RecordBatch>> {
+        if self.index < self.batches.len() {
+            self.index += 1;
+            Ok(Some(self.batches[self.index - 1].clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub struct InMemoryDataSourceProvider {
+    schema: Arc<Schema>,
+    batches: Vec<RecordBatch>,
+}
+
+impl InMemoryDataSourceProvider {
+    pub fn new(schema: Arc<Schema>, batches: Vec<RecordBatch>) -> Self {
+        Self { schema, batches }
+    }
+}
+
+impl DataSourceProvider for InMemoryDataSourceProvider {
+    fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
+
+    fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        _batch_size: usize,
+    ) -> Rc<RefCell<DataSource>> {
+        let columns: Vec<usize> = match projection {
+            Some(p) => p.clone(),
+            None => {
+                let l = self.schema.fields().len();
+                let mut v = Vec::with_capacity(l);
+                for i in 0..l {
+                    v.push(i);
+                }
+                v
+            }
+        };
+
+        let projected_schema = Arc::new(Schema::new(
+            columns
+                .iter()
+                .map(|i| self.schema.field(*i).clone())
+                .collect(),
+        ));
+
+        Rc::new(RefCell::new(InMemoryDataSource {
+            schema: self.schema.clone(),
+            index: 0,
+            batches: self
+                .batches
+                .iter()
+                .map(|batch| {
+                    RecordBatch::new(
+                        projected_schema.clone(),
+                        columns.iter().map(|i| batch.column(*i).clone()).collect(),
+                    )
+                })
+                .collect(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    #[test]
+    fn test1() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        );
+
+        let provider = InMemoryDataSourceProvider::new(schema, vec![batch]);
+
+        // scan with no projection
+        let scan1 = provider.scan(&None, 1024);
+        let batch1 = scan1.borrow_mut().next().unwrap().unwrap();
+        assert_eq!(3, batch1.schema().fields().len());
+        assert_eq!(3, batch1.num_columns());
+
+        // scan with projection
+        let scan2 = provider.scan(&Some(vec![2, 1]), 1024);
+        let batch2 = scan2.borrow_mut().next().unwrap().unwrap();
+        assert_eq!(2, batch2.schema().fields().len());
+        assert_eq!("c", batch2.schema().field(0).name());
+        assert_eq!("b", batch2.schema().field(1).name());
+        assert_eq!(2, batch2.num_columns());
+    }
+}

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -20,5 +20,5 @@ pub mod datasource;
 pub mod memory;
 
 pub use self::csv::{CsvBatchIterator, CsvFile};
-pub use self::datasource::{RecordBatchIterator, Table};
+pub use self::datasource::{RecordBatchIterator, ScanResult, Table};
 pub use self::memory::{MemBatchIterator, MemTable};

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -15,18 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! DataFusion is a modern distributed compute platform implemented in Rust that uses
-//! Apache Arrow as the memory model
-
-extern crate arrow;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-extern crate sqlparser;
-
+pub mod csv;
 pub mod datasource;
-pub mod dfparser;
-pub mod execution;
-pub mod logicalplan;
-pub mod optimizer;
-pub mod sqlplanner;
+pub mod memory;
+
+pub use self::csv::{CsvDataSource, CsvDataSourceProvider};
+pub use self::datasource::{DataSource, DataSourceProvider};
+pub use self::memory::{InMemoryDataSource, InMemoryDataSourceProvider};

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -19,6 +19,6 @@ pub mod csv;
 pub mod datasource;
 pub mod memory;
 
-pub use self::csv::{CsvDataSource, CsvDataSourceProvider};
-pub use self::datasource::{DataSource, DataSourceProvider};
-pub use self::memory::{InMemoryDataSource, InMemoryDataSourceProvider};
+pub use self::csv::{CsvBatchIterator, CsvFile};
+pub use self::datasource::{RecordBatchIterator, Table};
+pub use self::memory::{MemBatchIterator, MemTable};

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -29,9 +29,9 @@ use arrow::compute;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
-use super::error::{ExecutionError, Result};
-use super::expression::{AggregateType, RuntimeExpr};
-use super::relation::Relation;
+use crate::execution::error::{ExecutionError, Result};
+use crate::execution::expression::{AggregateType, RuntimeExpr};
+use crate::execution::relation::Relation;
 use crate::logicalplan::ScalarValue;
 
 use fnv::FnvHashMap;
@@ -1014,12 +1014,12 @@ impl AggregateRelation {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::logicalplan::Expr;
-    use super::super::context::ExecutionContext;
-    use super::super::datasource::CsvDataSource;
-    use super::super::expression;
-    use super::super::relation::DataSourceRelation;
     use super::*;
+    use crate::datasource::CsvDataSource;
+    use crate::execution::context::ExecutionContext;
+    use crate::execution::expression;
+    use crate::execution::relation::DataSourceRelation;
+    use crate::logicalplan::Expr;
     use arrow::datatypes::{DataType, Field, Schema};
 
     #[test]

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -1015,7 +1015,7 @@ impl AggregateRelation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datasource::CsvDataSource;
+    use crate::datasource::CsvBatchIterator;
     use crate::execution::context::ExecutionContext;
     use crate::execution::expression;
     use crate::execution::relation::DataSourceRelation;
@@ -1208,7 +1208,7 @@ mod tests {
     }
 
     fn load_csv(filename: &str, schema: &Arc<Schema>) -> Rc<RefCell<Relation>> {
-        let ds = CsvDataSource::new(filename, schema.clone(), true, &None, 1024);
+        let ds = CsvBatchIterator::new(filename, schema.clone(), true, &None, 1024);
         Rc::new(RefCell::new(DataSourceRelation::new(Rc::new(
             RefCell::new(ds),
         ))))

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -25,19 +25,20 @@ use std::sync::Arc;
 
 use arrow::datatypes::*;
 
-use super::super::dfparser::{DFASTNode, DFParser};
-use super::super::logicalplan::*;
-use super::super::optimizer::optimizer::OptimizerRule;
-use super::super::optimizer::projection_push_down::ProjectionPushDown;
-use super::super::sqlplanner::{SchemaProvider, SqlToRel};
-use super::aggregate::AggregateRelation;
-use super::datasource::{CsvProvider, DataSourceProvider};
-use super::error::{ExecutionError, Result};
-use super::expression::*;
-use super::filter::FilterRelation;
-use super::limit::LimitRelation;
-use super::projection::ProjectRelation;
-use super::relation::{DataSourceRelation, Relation};
+use crate::datasource::csv::CsvDataSourceProvider;
+use crate::datasource::datasource::DataSourceProvider;
+use crate::dfparser::{DFASTNode, DFParser};
+use crate::execution::aggregate::AggregateRelation;
+use crate::execution::error::{ExecutionError, Result};
+use crate::execution::expression::*;
+use crate::execution::filter::FilterRelation;
+use crate::execution::limit::LimitRelation;
+use crate::execution::projection::ProjectRelation;
+use crate::execution::relation::{DataSourceRelation, Relation};
+use crate::logicalplan::*;
+use crate::optimizer::optimizer::OptimizerRule;
+use crate::optimizer::projection_push_down::ProjectionPushDown;
+use crate::sqlplanner::{SchemaProvider, SqlToRel};
 
 pub struct ExecutionContext {
     datasources: Rc<RefCell<HashMap<String, Rc<DataSourceProvider>>>>,
@@ -89,7 +90,7 @@ impl ExecutionContext {
     ) {
         self.datasources.borrow_mut().insert(
             name.to_string(),
-            Rc::new(CsvProvider::new(filename, schema, has_header)),
+            Rc::new(CsvDataSourceProvider::new(filename, schema, has_header)),
         );
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -118,7 +118,7 @@ impl ExecutionContext {
                 ..
             } => match self.datasources.borrow().get(table_name) {
                 Some(provider) => {
-                    let ds = provider.scan(projection, batch_size);
+                    let ds = provider.scan(projection, batch_size)?;
                     Ok(Rc::new(RefCell::new(DataSourceRelation::new(ds))))
                 }
                 _ => Err(ExecutionError::General(format!(

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -88,10 +88,7 @@ impl ExecutionContext {
         schema: &Schema,
         has_header: bool,
     ) {
-        self.register_table(
-            name,
-            Rc::new(CsvFile::new(filename, schema, has_header)),
-        );
+        self.register_table(name, Rc::new(CsvFile::new(filename, schema, has_header)));
     }
 
     /// Register a table so that it can be queried from SQL

--- a/rust/datafusion/src/execution/mod.rs
+++ b/rust/datafusion/src/execution/mod.rs
@@ -17,7 +17,6 @@
 
 pub mod aggregate;
 pub mod context;
-pub mod datasource;
 pub mod error;
 pub mod expression;
 pub mod filter;

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -25,9 +25,9 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use super::error::Result;
-use super::expression::RuntimeExpr;
-use super::relation::Relation;
+use crate::execution::error::Result;
+use crate::execution::expression::RuntimeExpr;
+use crate::execution::relation::Relation;
 
 pub struct ProjectRelation {
     schema: Arc<Schema>,
@@ -79,12 +79,12 @@ impl Relation for ProjectRelation {
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::logicalplan::Expr;
-    use super::super::context::ExecutionContext;
-    use super::super::datasource::CsvDataSource;
-    use super::super::expression;
-    use super::super::relation::DataSourceRelation;
     use super::*;
+    use crate::datasource::CsvDataSource;
+    use crate::execution::context::ExecutionContext;
+    use crate::execution::expression;
+    use crate::execution::relation::DataSourceRelation;
+    use crate::logicalplan::Expr;
     use arrow::datatypes::{DataType, Field, Schema};
 
     #[test]

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -80,7 +80,7 @@ impl Relation for ProjectRelation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::datasource::CsvDataSource;
+    use crate::datasource::CsvBatchIterator;
     use crate::execution::context::ExecutionContext;
     use crate::execution::expression;
     use crate::execution::relation::DataSourceRelation;
@@ -105,7 +105,7 @@ mod tests {
             Field::new("c12", DataType::Utf8, false),
         ]));
 
-        let ds = CsvDataSource::new(
+        let ds = CsvBatchIterator::new(
             "../../testing/data/csv/aggregate_test_100.csv",
             schema.clone(),
             true,

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::DataSource;
+use crate::datasource::RecordBatchIterator;
 use crate::execution::error::Result;
 
 /// trait for all relations (a relation is essentially just an iterator over rows with
@@ -36,11 +36,11 @@ pub trait Relation {
 
 pub struct DataSourceRelation {
     schema: Arc<Schema>,
-    ds: Rc<RefCell<DataSource>>,
+    ds: Rc<RefCell<RecordBatchIterator>>,
 }
 
 impl DataSourceRelation {
-    pub fn new(ds: Rc<RefCell<DataSource>>) -> Self {
+    pub fn new(ds: Rc<RefCell<RecordBatchIterator>>) -> Self {
         let schema = ds.borrow().schema().clone();
         Self { ds, schema }
     }

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -22,8 +22,8 @@ use std::sync::Arc;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-use super::datasource::DataSource;
-use super::error::Result;
+use crate::datasource::DataSource;
+use crate::execution::error::Result;
 
 /// trait for all relations (a relation is essentially just an iterator over rows with
 /// a known schema)


### PR DESCRIPTION
This PR adds a new memory-based table implementation and updates the DataFusion benchmarks to load CSV data into memory before the benchmark starts and then measure the performance of executing queries against in-memory data.

This PR also renames the data source traits and organizes them better in a new namespace. 

Finally, it is now possible to register arbitrary data sources with the execution context.