### PR TITLE
ARROW-4680: [Rust] Remove #![feature(try_from)]

### DIFF
--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -24,7 +24,6 @@
 #![feature(type_ascription)]
 #![feature(rustc_private)]
 #![feature(specialization)]
-#![feature(try_from)]
 // required for matching box in lists
 #![feature(box_syntax, box_patterns)]
 #![allow(dead_code)]

--- a/rust/parquet/src/lib.rs
+++ b/rust/parquet/src/lib.rs
@@ -18,7 +18,6 @@
 #![feature(type_ascription)]
 #![feature(rustc_private)]
 #![feature(specialization)]
-#![feature(try_from)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 


### PR DESCRIPTION
1.34 nightly was emitting warnings and errors about the feature being stable.