### PR TITLE
ARROW-4491: [Python] Use StringConverter and stringstream instead of std::stoi and std::to_string

### DIFF
--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -75,6 +75,8 @@ add_arrow_lib(arrow_python
               ${ARROW_PYTHON_SRCS}
               OUTPUTS
               ARROW_PYTHON_LIBRARIES
+              DEPENDENCIES
+              arrow_dependencies
               SHARED_LINK_FLAGS
               ""
               SHARED_LINK_LIBS

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -37,6 +37,7 @@
 #include "arrow/table.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/parsing.h"
 
 #include "arrow/python/common.h"
 #include "arrow/python/helpers.h"
@@ -48,6 +49,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::StringConverter;
 
 namespace py {
 
@@ -195,16 +197,20 @@ Status GetValue(PyObject* context, const Array& arr, int64_t index, int8_t type,
   return Status::OK();
 }
 
-std::vector<int8_t> GetPythonTypes(const UnionArray& data) {
-  std::vector<int8_t> result;
+Status GetPythonTypes(const UnionArray& data, std::vector<int8_t>* result) {
+  ARROW_CHECK(result != nullptr);
   auto type = data.type();
   for (int i = 0; i < type->num_children(); ++i) {
-    std::istringstream convert(type->child(i)->name());
-    int tag;
-    convert >> tag;
-    result.push_back(static_cast<int8_t>(tag));
+    StringConverter<Int8Type> converter;
+    int8_t tag = 0;
+    const std::string& data = type->child(i)->name();
+    if (!converter(data.c_str(), data.size(), &tag)) {
+      return Status::SerializationError("Cannot convert string: \"",
+                                        type->child(i)->name(), "\" to int8_t");
+    }
+    result->push_back(tag);
   }
-  return result;
+  return Status::OK();
 }
 
 template <typename CreateSequenceFn, typename SetItemFn>
@@ -218,7 +224,8 @@ Status DeserializeSequence(PyObject* context, const Array& array, int64_t start_
   RETURN_IF_PYERROR();
   const uint8_t* type_ids = data.raw_type_ids();
   const int32_t* value_offsets = data.raw_value_offsets();
-  auto python_types = GetPythonTypes(data);
+  std::vector<int8_t> python_types;
+  RETURN_NOT_OK(GetPythonTypes(data, &python_types));
   for (int64_t i = start_idx; i < stop_idx; ++i) {
     if (data.IsNull(i)) {
       Py_INCREF(Py_None);

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -21,8 +21,8 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -200,9 +200,9 @@ std::vector<int8_t> GetPythonTypes(const UnionArray& data) {
   auto type = data.type();
   for (int i = 0; i < type->num_children(); ++i) {
     std::istringstream convert(type->child(i)->name());
-    int8_t tag;
+    int tag;
     convert >> tag;
-    result.push_back(tag);
+    result.push_back(static_cast<int8_t>(tag));
   }
   return result;
 }

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -198,8 +199,10 @@ std::vector<int8_t> GetPythonTypes(const UnionArray& data) {
   std::vector<int8_t> result;
   auto type = data.type();
   for (int i = 0; i < type->num_children(); ++i) {
-    // stoi is locale dependent, but should be ok for small integers
-    result.push_back(static_cast<int8_t>(std::stoi(type->child(i)->name())));
+    std::istringstream convert(type->child(i)->name());
+    int8_t tag;
+    convert >> tag;
+    result.push_back(tag);
   }
   return result;
 }

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -91,7 +91,7 @@ class SequenceBuilder {
     if (!*child_builder) {
       child_builder->reset(make_builder());
       std::ostringstream convert;
-      convert << tag;
+      convert << static_cast<int>(tag);
       type_map_[tag] = builder_->AppendChild(*child_builder, convert.str());
     }
     return Update(child_builder->get(), type_map_[tag]);

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -91,6 +91,7 @@ class SequenceBuilder {
     if (!*child_builder) {
       child_builder->reset(make_builder());
       std::ostringstream convert;
+      convert.imbue(std::locale::classic());
       convert << static_cast<int>(tag);
       type_map_[tag] = builder_->AppendChild(*child_builder, convert.str());
     }

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -90,8 +90,9 @@ class SequenceBuilder {
                          MakeBuilderFn make_builder) {
     if (!*child_builder) {
       child_builder->reset(make_builder());
-      // std::to_string is locale dependent, but should be ok for small integers
-      type_map_[tag] = builder_->AppendChild(*child_builder, std::to_string(tag));
+      std::ostringstream convert;
+      convert << tag;
+      type_map_[tag] = builder_->AppendChild(*child_builder, convert.str());
     }
     return Update(child_builder->get(), type_map_[tag]);
   }


### PR DESCRIPTION
@pcmoritz Asked me to continue this PR https://github.com/apache/arrow/pull/3570, but I don't have the right to change the his repro.
