### PR TITLE
ARROW-4672: [CI] Fix clang-7 build entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ matrix:
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_lint.sh
   - name: "C++ unit tests w/ Valgrind, clang 7.0"
-    language: cpp
     os: linux
     env:
     - ARROW_TRAVIS_VALGRIND=1


### PR DESCRIPTION
The current entry defines the `CC` and `CXX` variables in the `env`
section. The 2 variables are then redefined by travis with the
`language: cpp` directive. This ensure that the variables are not
overwritten.
