### PR TITLE
ARROW-4699: [C++] remove json chunker's requirement of null terminated buffers

### DIFF
--- a/cpp/src/arrow/json/CMakeLists.txt
+++ b/cpp/src/arrow/json/CMakeLists.txt
@@ -17,8 +17,7 @@
 
 add_arrow_test(parser-test PREFIX "arrow-json")
 
-# TODO(wesm): ARROW-694 this fails valgrind
-# add_arrow_test(chunker-test PREFIX "arrow-json")
+add_arrow_test(chunker-test PREFIX "arrow-json")
 
 add_arrow_benchmark(parser-benchmark PREFIX "arrow-json")
 

--- a/cpp/src/arrow/json/chunker-test.cc
+++ b/cpp/src/arrow/json/chunker-test.cc
@@ -49,9 +49,9 @@ std::string join(Lines&& lines, std::string delimiter) {
   return joined;
 }
 
-std::string PrettyPrint(std::string one_line) {
+std::string PrettyPrint(string_view one_line) {
   rapidjson::Document document;
-  document.ParseInsitu(const_cast<char*>(one_line.data()));
+  document.Parse(one_line.data());
   rapidjson::StringBuffer sb;
   rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
   document.Accept(writer);
@@ -172,7 +172,8 @@ TEST(ChunkerTest, PrettyPrinted) {
 
 TEST(ChunkerTest, SingleLine) {
   auto chunker = MakeChunker(true);
-  AssertChunking(*chunker, join(lines(), ""), object_count);
+  auto single_line = join(lines(), "");
+  AssertChunking(*chunker, single_line, object_count);
 }
 
 TEST_P(BaseChunkerTest, Straddling) {

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -167,7 +167,9 @@ class ParsingChunker : public Chunker {
     }
     std::size_t total_length = 0;
     for (auto consumed = block;; consumed = block.substr(total_length)) {
-      auto length = ConsumeWholeObject(rapidjson::StringStream(consumed.data()));
+      rapidjson::MemoryStream ms(consumed.data(), consumed.size());
+      auto length = ConsumeWholeObject(
+          rapidjson::EncodedInputStream<rapidjson::UTF8<>, rapidjson::MemoryStream>(ms));
       if (length == string_view::npos || length == 0) {
         // found incomplete object or consumed is empty
         break;

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -167,9 +167,10 @@ class ParsingChunker : public Chunker {
     }
     std::size_t total_length = 0;
     for (auto consumed = block;; consumed = block.substr(total_length)) {
-      rapidjson::MemoryStream ms(consumed.data(), consumed.size());
-      auto length = ConsumeWholeObject(
-          rapidjson::EncodedInputStream<rapidjson::UTF8<>, rapidjson::MemoryStream>(ms));
+      using rapidjson::MemoryStream;
+      MemoryStream ms(consumed.data(), consumed.size());
+      using InputStream = rapidjson::EncodedInputStream<rapidjson::UTF8<>, MemoryStream>;
+      auto length = ConsumeWholeObject(InputStream(ms));
       if (length == string_view::npos || length == 0) {
         // found incomplete object or consumed is empty
         break;

--- a/cpp/src/arrow/json/chunker.h
+++ b/cpp/src/arrow/json/chunker.h
@@ -40,7 +40,7 @@ class ARROW_EXPORT Chunker {
   virtual ~Chunker() = default;
 
   /// \brief Carve up a chunk in a block of data to contain only whole objects
-  /// \param[in] block json data to be chunked, must end with '\0'
+  /// \param[in] block json data to be chunked
   /// \param[out] chunked subrange of block containing whole json objects
   virtual Status Process(util::string_view block, util::string_view* chunked) = 0;
 


### PR DESCRIPTION
Re-enable json chunker test. [This was failing valgrind](https://travis-ci.org/apache/arrow/jobs/494039471#L2140) but that is not currently happening locally