### PR TITLE
ARROW-4737: run C# tests in CI

### DIFF
--- a/ci/appveyor-filter-changes.bat
+++ b/ci/appveyor-filter-changes.bat
@@ -29,6 +29,13 @@ if "%JOB%" == "Rust" (
         echo ===
         appveyor exit
     )
+) else if "%JOB%" == "C#" (
+    if "%ARROW_CI_CSHARP_AFFECTED%" == "0" (
+        echo ===
+        echo === No C# changes, exiting job
+        echo ===
+        appveyor exit
+    )
 ) else (
     if "%ARROW_CI_PYTHON_AFFECTED%" == "0" (
         echo ===

--- a/ci/detect-changes.py
+++ b/ci/detect-changes.py
@@ -108,7 +108,7 @@ def list_appveyor_affected_files():
 
 
 LANGUAGE_TOPICS = ['c_glib', 'cpp', 'docs', 'go', 'java', 'js', 'python',
-                   'r', 'ruby', 'rust']
+                   'r', 'ruby', 'rust', 'csharp']
 
 ALL_TOPICS = LANGUAGE_TOPICS + ['integration', 'site', 'dev']
 
@@ -124,7 +124,7 @@ AFFECTED_DEPENDENCIES = {
 }
 
 COMPONENTS = {'cpp', 'java', 'c_glib', 'r', 'ruby', 'integration', 'js',
-              'rust', 'site', 'go', 'docs', 'python', 'dev'}
+              'rust', 'csharp', 'site', 'go', 'docs', 'python', 'dev'}
 
 
 def get_affected_topics(affected_files):
@@ -241,6 +241,7 @@ def test_get_affected_topics():
         'r': True,
         'ruby': True,
         'rust': False,
+        'csharp': False,
         'integration': True,
         'site': False,
         'dev': False
@@ -258,6 +259,7 @@ def test_get_affected_topics():
         'r': True,
         'ruby': True,
         'rust': True,
+        'csharp': True,
         'integration': True,
         'site': False,
         'dev': False


### PR DESCRIPTION
The C# tests aren't running in CI because they are being filtered out. Adding detection logic for C#, so the tests run when `csharp` code changes.

@wesm @chutchinson @pgovind