### PR TITLE
ARROW-3882: [Rust] Cast Kernel for most types

### DIFF
--- a/rust/arrow/src/compute/cast_kernels.rs
+++ b/rust/arrow/src/compute/cast_kernels.rs
@@ -427,7 +427,8 @@ where
 
 /// Cast Boolean types to numeric
 ///
-/// Any zero value returns `false` while non-zero returns `true`
+/// `false` returns 0 while `true` returns 1. Although this cast supports floats, they are
+/// unsupported in the upstream cast
 fn cast_bool_to_numeric<T>(from: &BooleanArray) -> Result<PrimitiveArray<T>>
 where
     T: ArrowPrimitiveType + ArrowNumericType,

--- a/rust/arrow/src/compute/cast_kernels.rs
+++ b/rust/arrow/src/compute/cast_kernels.rs
@@ -18,6 +18,37 @@
 //! Defines cast kernels for `ArrayRef`.
 //!
 //! Allows casting arrays between supported datatypes.
+//!
+//! ## Behavior
+//!
+//! * Boolean to Utf8: `true` => '1', `false` => `0`
+//! * Utf8 to numeric: strings that can't be parsed to numbers return null, float strings
+//!   in integer casts return null
+//! * Numeric to boolean: 0 returns `false`, any other value returns `true`
+//!
+//! ## Unsupported Casts
+//!
+//! * To or from `StructArray`
+//! * To or from `ListArray`
+//! * Boolean to float
+//! * Utf8 to boolean
+//!
+//! Example:
+//!
+//! ```
+//! use arrow::array::*;
+//! use arrow::compute::cast;
+//! use arrow::datatypes::DataType;
+//! use std::sync::Arc;
+//!
+//! let a = Int32Array::from(vec![5, 6, 7]);
+//! let array = Arc::new(a) as ArrayRef;
+//! let b = cast(&array, &DataType::Float64).unwrap();
+//! let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
+//! assert_eq!(5.0, c.value(0));
+//! assert_eq!(6.0, c.value(1));
+//! assert_eq!(7.0, c.value(2));
+//! ```
 
 use std::sync::Arc;
 
@@ -25,9 +56,6 @@ use crate::array::*;
 use crate::builder::*;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
-
-// TODO:
-//  * remove downcast unwraps and replace with explicit errors
 
 /// Macro rule to cast between numeric types
 macro_rules! cast_numeric_arrays {
@@ -69,6 +97,31 @@ macro_rules! cast_string_to_numeric {
     }};
 }
 
+macro_rules! cast_numeric_to_bool {
+    ($array:expr, $from_ty:ident) => {{
+        match cast_numeric_to_bool::<$from_ty>(
+            $array
+                .as_any()
+                .downcast_ref::<PrimitiveArray<$from_ty>>()
+                .unwrap(),
+        ) {
+            Ok(to) => Ok(Arc::new(to) as ArrayRef),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+macro_rules! cast_bool_to_numeric {
+    ($array:expr, $to_ty:ident) => {{
+        match cast_bool_to_numeric::<$to_ty>(
+            $array.as_any().downcast_ref::<BooleanArray>().unwrap(),
+        ) {
+            Ok(to) => Ok(Arc::new(to) as ArrayRef),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
 /// Cast array to provided data type
 pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
     use DataType::*;
@@ -85,13 +138,69 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         (_, Struct(_)) => Err(ArrowError::ComputeError(
             "Cannot cast to struct from other types".to_string(),
         )),
-        (List(_), List(_)) => unimplemented!("Casting between lists not yet supported"),
+        (List(_), List(_)) => Err(ArrowError::ComputeError(
+            "Casting between lists not yet supported".to_string(),
+        )),
         (List(_), _) => Err(ArrowError::ComputeError(
             "Cannot cast list to non-list data types".to_string(),
         )),
-        (_, List(_)) => unimplemented!("Casting scalars to lists not yet supported"),
-        (_, Boolean) => unimplemented!("Boolean casts not yet implemented"),
-        (Boolean, _) => unimplemented!("Boolean casts not yet implemented"),
+        (_, List(_)) => Err(ArrowError::ComputeError(
+            "Cannot cast primitive types to lists".to_string(),
+        )),
+        (_, Boolean) => match from_type {
+            UInt8 => cast_numeric_to_bool!(array, UInt8Type),
+            UInt16 => cast_numeric_to_bool!(array, UInt16Type),
+            UInt32 => cast_numeric_to_bool!(array, UInt32Type),
+            UInt64 => cast_numeric_to_bool!(array, UInt64Type),
+            Int8 => cast_numeric_to_bool!(array, Int8Type),
+            Int16 => cast_numeric_to_bool!(array, Int16Type),
+            Int32 => cast_numeric_to_bool!(array, Int32Type),
+            Int64 => cast_numeric_to_bool!(array, Int64Type),
+            Float32 => cast_numeric_to_bool!(array, Float32Type),
+            Float64 => cast_numeric_to_bool!(array, Float64Type),
+            Utf8 => Err(ArrowError::ComputeError(format!(
+                "Casting from {:?} to {:?} not supported",
+                from_type, to_type,
+            ))),
+            _ => Err(ArrowError::ComputeError(format!(
+                "Casting from {:?} to {:?} not supported",
+                from_type, to_type,
+            ))),
+        },
+        (Boolean, _) => match to_type {
+            UInt8 => cast_bool_to_numeric!(array, UInt8Type),
+            UInt16 => cast_bool_to_numeric!(array, UInt16Type),
+            UInt32 => cast_bool_to_numeric!(array, UInt32Type),
+            UInt64 => cast_bool_to_numeric!(array, UInt64Type),
+            Int8 => cast_bool_to_numeric!(array, Int8Type),
+            Int16 => cast_bool_to_numeric!(array, Int16Type),
+            Int32 => cast_bool_to_numeric!(array, Int32Type),
+            Int64 => cast_bool_to_numeric!(array, Int64Type),
+            Float32 | Float64 => Err(ArrowError::ComputeError(format!(
+                "Casting from {:?} to {:?} not supported",
+                from_type, to_type,
+            ))),
+            Utf8 => {
+                let from = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+                let mut b = BinaryBuilder::new(array.len());
+                for i in 0..array.len() {
+                    if array.is_null(i) {
+                        b.append(false)?;
+                    } else {
+                        b.append_string(match from.value(i) {
+                            true => "1",
+                            false => "0",
+                        })?;
+                    }
+                }
+
+                Ok(Arc::new(b.finish()) as ArrayRef)
+            }
+            _ => Err(ArrowError::ComputeError(format!(
+                "Casting from {:?} to {:?} not supported",
+                from_type, to_type,
+            ))),
+        },
         (Utf8, _) => match to_type {
             UInt8 => cast_string_to_numeric!(array, UInt8Type),
             UInt16 => cast_string_to_numeric!(array, UInt16Type),
@@ -103,11 +212,10 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             Int64 => cast_string_to_numeric!(array, Int64Type),
             Float32 => cast_string_to_numeric!(array, Float32Type),
             Float64 => cast_string_to_numeric!(array, Float64Type),
-            _ => unimplemented!(
-                "Casting from {:?} to {:?} not yet implemented",
-                from_type,
-                to_type
-            ),
+            _ => Err(ArrowError::ComputeError(format!(
+                "Casting from {:?} to {:?} not supported",
+                from_type, to_type,
+            ))),
         },
         (_, Utf8) => match from_type {
             UInt8 => cast_numeric_to_string!(array, UInt8Type),
@@ -120,11 +228,10 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             Int64 => cast_numeric_to_string!(array, Int64Type),
             Float32 => cast_numeric_to_string!(array, Float32Type),
             Float64 => cast_numeric_to_string!(array, Float64Type),
-            _ => unimplemented!(
-                "Casting from {:?} to {:?} not yet implemented",
-                from_type,
-                to_type
-            ),
+            _ => Err(ArrowError::ComputeError(format!(
+                "Casting from {:?} to {:?} not supported",
+                from_type, to_type,
+            ))),
         },
 
         // start numeric casts
@@ -218,7 +325,10 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         (Float64, Int64) => cast_numeric_arrays!(array, Float64Type, Int64Type),
         (Float64, Float32) => cast_numeric_arrays!(array, Float64Type, Float32Type),
         // end numeric casts
-        (_, _) => unimplemented!("Unable to cast from {:?} to {:?}", from_type, to_type),
+        (_, _) => Err(ArrowError::ComputeError(format!(
+            "Casting from {:?} to {:?} not supported",
+            from_type, to_type,
+        ))),
     }
 }
 
@@ -291,6 +401,59 @@ where
     Ok(b.finish())
 }
 
+/// Cast numeric types to Boolean
+///
+/// Any zero value returns `false` while non-zero returns `true`
+fn cast_numeric_to_bool<T>(from: &PrimitiveArray<T>) -> Result<BooleanArray>
+where
+    T: ArrowPrimitiveType + ArrowNumericType,
+{
+    let mut b = BooleanBuilder::new(from.len());
+
+    for i in 0..from.len() {
+        if from.is_null(i) {
+            b.append_null()?;
+        } else {
+            if from.value(i) != T::default_value() {
+                b.append_value(true)?;
+            } else {
+                b.append_value(false)?;
+            }
+        }
+    }
+
+    Ok(b.finish())
+}
+
+/// Cast Boolean types to numeric
+///
+/// Any zero value returns `false` while non-zero returns `true`
+fn cast_bool_to_numeric<T>(from: &BooleanArray) -> Result<PrimitiveArray<T>>
+where
+    T: ArrowPrimitiveType + ArrowNumericType,
+    T::Native: num::NumCast,
+{
+    let mut b = PrimitiveBuilder::<T>::new(from.len());
+
+    for i in 0..from.len() {
+        if from.is_null(i) {
+            b.append_null()?;
+        } else {
+            if from.value(i) {
+                // a workaround to cast a primitive to T::Native, infallible
+                match num::cast::cast(1) {
+                    Some(v) => b.append_value(v)?,
+                    None => b.append_null()?,
+                };
+            } else {
+                b.append_value(T::default_value())?;
+            }
+        }
+    }
+
+    Ok(b.finish())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,6 +469,20 @@ mod tests {
         assert_eq!(7.0, c.value(2));
         assert_eq!(8.0, c.value(3));
         assert_eq!(9.0, c.value(4));
+    }
+
+    #[test]
+    fn test_cast_i32_to_u8() {
+        let a = Int32Array::from(vec![-5, 6, -7, 8, 100000000]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::UInt8).unwrap();
+        let c = b.as_any().downcast_ref::<UInt8Array>().unwrap();
+        assert_eq!(false, c.is_valid(0));
+        assert_eq!(6, c.value(1));
+        assert_eq!(false, c.is_valid(2));
+        assert_eq!(8, c.value(3));
+        // overflows return None
+        assert_eq!(false, c.is_valid(4));
     }
 
     #[test]
@@ -332,5 +509,34 @@ mod tests {
         assert_eq!(false, c.is_valid(2));
         assert_eq!(8, c.value(3));
         assert_eq!(false, c.is_valid(2));
+    }
+
+    #[test]
+    fn test_cast_bool_to_i32() {
+        let a = BooleanArray::from(vec![Some(true), Some(false), None]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Int32).unwrap();
+        let c = b.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(1, c.value(0));
+        assert_eq!(0, c.value(1));
+        assert_eq!(false, c.is_valid(2));
+    }
+
+    #[test]
+    #[should_panic(expected = "Casting from Boolean to Float64 not supported")]
+    fn test_cast_bool_to_f64() {
+        let a = BooleanArray::from(vec![Some(true), Some(false), None]);
+        let array = Arc::new(a) as ArrayRef;
+        cast(&array, &DataType::Float64).unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Casting from Int32 to Timestamp(Microsecond) not supported"
+    )]
+    fn test_cast_int32_to_timestamp() {
+        let a = Int32Array::from(vec![Some(2), Some(10), None]);
+        let array = Arc::new(a) as ArrayRef;
+        cast(&array, &DataType::Timestamp(TimeUnit::Microsecond)).unwrap();
     }
 }

--- a/rust/arrow/src/compute/cast_kernels.rs
+++ b/rust/arrow/src/compute/cast_kernels.rs
@@ -1,0 +1,253 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines cast kernels for `ArrayRef`.
+//!
+//! Allows casting arrays between supported datatypes.
+
+use std::sync::Arc;
+
+use crate::array::*;
+use crate::builder::*;
+use crate::datatypes::*;
+use crate::error::{ArrowError, Result};
+
+/// Macro rule to cast between numeric types
+macro_rules! cast_numeric_arrays {
+    ($array:expr, $from_ty:ident, $to_ty:ident) => {{
+        match numeric_cast::<$from_ty, $to_ty>(
+            $array
+                .as_any()
+                .downcast_ref::<PrimitiveArray<$from_ty>>()
+                .unwrap(),
+        ) {
+            Ok(to) => Ok(Arc::new(to) as ArrayRef),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+macro_rules! cast_numeric_to_string {
+    ($array:expr, $from_ty:ident) => {{
+        match cast_numeric_to_string::<$from_ty>(
+            $array
+                .as_any()
+                .downcast_ref::<PrimitiveArray<$from_ty>>()
+                .unwrap(),
+        ) {
+            Ok(to) => Ok(Arc::new(to) as ArrayRef),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+/// Cast array to provided data type
+pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
+    use DataType::*;
+    // to and from have to be compatible
+    let from_type = array.data_type();
+    match (from_type, to_type) {
+        (Struct(_), _) => Err(ArrowError::ComputeError(
+            "Cannot cast from struct to other types".to_string(),
+        )),
+        (_, Struct(_)) => Err(ArrowError::ComputeError(
+            "Cannot cast to struct from other types".to_string(),
+        )),
+        (List(_), List(_)) => unimplemented!("Casting between lists not yet supported"),
+        (List(_), _) => Err(ArrowError::ComputeError(
+            "Cannot cast list to non-list data types".to_string(),
+        )),
+        (_, List(_)) => unimplemented!("Casting scalars to lists not yet supported"),
+        (_, Boolean) => unimplemented!("Boolean casts not yet implemented"),
+        (Boolean, _) => unimplemented!("Boolean casts not yet implemented"),
+        (Utf8, _) => Err(ArrowError::ComputeError("Unable to cast".to_string())),
+        (_, Utf8) => match from_type {
+            UInt8 => cast_numeric_to_string!(array, UInt8Type),
+            UInt16 => cast_numeric_to_string!(array, UInt16Type),
+            UInt32 => cast_numeric_to_string!(array, UInt32Type),
+            UInt64 => cast_numeric_to_string!(array, UInt64Type),
+            Int8 => cast_numeric_to_string!(array, Int8Type),
+            Int16 => cast_numeric_to_string!(array, Int16Type),
+            Int32 => cast_numeric_to_string!(array, Int32Type),
+            Int64 => cast_numeric_to_string!(array, Int64Type),
+            Float32 => cast_numeric_to_string!(array, Float32Type),
+            Float64 => cast_numeric_to_string!(array, Float64Type),
+            _ => unimplemented!(
+                "Casting from {:?} to {:?} not yet implemented",
+                from_type,
+                to_type
+            ),
+        },
+
+        // start numeric casts
+        (UInt8, UInt16) => cast_numeric_arrays!(array, UInt8Type, UInt16Type),
+        (UInt8, UInt32) => cast_numeric_arrays!(array, UInt8Type, UInt32Type),
+        (UInt8, UInt64) => cast_numeric_arrays!(array, UInt8Type, UInt64Type),
+        (UInt8, Int8) => cast_numeric_arrays!(array, UInt8Type, Int8Type),
+        (UInt8, Int16) => cast_numeric_arrays!(array, UInt8Type, Int16Type),
+        (UInt8, Int32) => cast_numeric_arrays!(array, UInt8Type, Int32Type),
+        (UInt8, Int64) => cast_numeric_arrays!(array, UInt8Type, Int64Type),
+        (UInt8, Float32) => cast_numeric_arrays!(array, UInt8Type, Float32Type),
+        (UInt8, Float64) => cast_numeric_arrays!(array, UInt8Type, Float64Type),
+
+        (UInt16, UInt8) => cast_numeric_arrays!(array, UInt16Type, UInt8Type),
+        (UInt16, UInt32) => cast_numeric_arrays!(array, UInt16Type, UInt32Type),
+        (UInt16, UInt64) => cast_numeric_arrays!(array, UInt16Type, UInt64Type),
+        (UInt16, Int8) => cast_numeric_arrays!(array, UInt16Type, Int8Type),
+        (UInt16, Int16) => cast_numeric_arrays!(array, UInt16Type, Int16Type),
+        (UInt16, Int32) => cast_numeric_arrays!(array, UInt16Type, Int32Type),
+        (UInt16, Int64) => cast_numeric_arrays!(array, UInt16Type, Int64Type),
+        (UInt16, Float32) => cast_numeric_arrays!(array, UInt16Type, Float32Type),
+        (UInt16, Float64) => cast_numeric_arrays!(array, UInt16Type, Float64Type),
+
+        (UInt32, UInt8) => cast_numeric_arrays!(array, UInt32Type, UInt8Type),
+        (UInt32, UInt16) => cast_numeric_arrays!(array, UInt32Type, UInt16Type),
+        (UInt32, UInt64) => cast_numeric_arrays!(array, UInt32Type, UInt64Type),
+        (UInt32, Int8) => cast_numeric_arrays!(array, UInt32Type, Int8Type),
+        (UInt32, Int16) => cast_numeric_arrays!(array, UInt32Type, Int16Type),
+        (UInt32, Int32) => cast_numeric_arrays!(array, UInt32Type, Int32Type),
+        (UInt32, Int64) => cast_numeric_arrays!(array, UInt32Type, Int64Type),
+        (UInt32, Float32) => cast_numeric_arrays!(array, UInt32Type, Float32Type),
+        (UInt32, Float64) => cast_numeric_arrays!(array, UInt32Type, Float64Type),
+
+        (UInt64, UInt8) => cast_numeric_arrays!(array, UInt64Type, UInt8Type),
+        (UInt64, UInt16) => cast_numeric_arrays!(array, UInt64Type, UInt16Type),
+        (UInt64, UInt32) => cast_numeric_arrays!(array, UInt64Type, UInt32Type),
+        (UInt64, Int8) => cast_numeric_arrays!(array, UInt64Type, Int8Type),
+        (UInt64, Int16) => cast_numeric_arrays!(array, UInt64Type, Int16Type),
+        (UInt64, Int32) => cast_numeric_arrays!(array, UInt64Type, Int32Type),
+        (UInt64, Int64) => cast_numeric_arrays!(array, UInt64Type, Int64Type),
+        (UInt64, Float32) => cast_numeric_arrays!(array, UInt64Type, Float32Type),
+        (UInt64, Float64) => cast_numeric_arrays!(array, UInt64Type, Float64Type),
+
+        (Int8, UInt8) => cast_numeric_arrays!(array, Int8Type, UInt8Type),
+        (Int8, UInt16) => cast_numeric_arrays!(array, Int8Type, UInt16Type),
+        (Int8, UInt32) => cast_numeric_arrays!(array, Int8Type, UInt32Type),
+        (Int8, UInt64) => cast_numeric_arrays!(array, Int8Type, UInt64Type),
+        (Int8, Int16) => cast_numeric_arrays!(array, Int8Type, Int16Type),
+        (Int8, Int32) => cast_numeric_arrays!(array, Int8Type, Int32Type),
+        (Int8, Int64) => cast_numeric_arrays!(array, Int8Type, Int64Type),
+        (Int8, Float32) => cast_numeric_arrays!(array, Int8Type, Float32Type),
+        (Int8, Float64) => cast_numeric_arrays!(array, Int8Type, Float64Type),
+
+        (Int16, UInt8) => cast_numeric_arrays!(array, Int16Type, UInt8Type),
+        (Int16, UInt16) => cast_numeric_arrays!(array, Int16Type, UInt16Type),
+        (Int16, UInt32) => cast_numeric_arrays!(array, Int16Type, UInt32Type),
+        (Int16, UInt64) => cast_numeric_arrays!(array, Int16Type, UInt64Type),
+        (Int16, Int8) => cast_numeric_arrays!(array, Int16Type, Int8Type),
+        (Int16, Int32) => cast_numeric_arrays!(array, Int16Type, Int32Type),
+        (Int16, Int64) => cast_numeric_arrays!(array, Int16Type, Int64Type),
+        (Int16, Float32) => cast_numeric_arrays!(array, Int16Type, Float32Type),
+        (Int16, Float64) => cast_numeric_arrays!(array, Int16Type, Float64Type),
+
+        (Int32, UInt8) => cast_numeric_arrays!(array, Int32Type, UInt8Type),
+        (Int32, UInt16) => cast_numeric_arrays!(array, Int32Type, UInt16Type),
+        (Int32, UInt32) => cast_numeric_arrays!(array, Int32Type, UInt32Type),
+        (Int32, UInt64) => cast_numeric_arrays!(array, Int32Type, UInt64Type),
+        (Int32, Int8) => cast_numeric_arrays!(array, Int32Type, Int8Type),
+        (Int32, Int16) => cast_numeric_arrays!(array, Int32Type, Int16Type),
+        (Int32, Int64) => cast_numeric_arrays!(array, Int32Type, Int64Type),
+        (Int32, Float32) => cast_numeric_arrays!(array, Int32Type, Float32Type),
+        (Int32, Float64) => cast_numeric_arrays!(array, Int32Type, Float64Type),
+
+        (Float32, UInt8) => cast_numeric_arrays!(array, Float32Type, UInt8Type),
+        (Float32, UInt16) => cast_numeric_arrays!(array, Float32Type, UInt16Type),
+        (Float32, UInt32) => cast_numeric_arrays!(array, Float32Type, UInt32Type),
+        (Float32, UInt64) => cast_numeric_arrays!(array, Float32Type, UInt64Type),
+        (Float32, Int8) => cast_numeric_arrays!(array, Float32Type, Int8Type),
+        (Float32, Int16) => cast_numeric_arrays!(array, Float32Type, Int16Type),
+        (Float32, Int32) => cast_numeric_arrays!(array, Float32Type, Int32Type),
+        (Float32, Int64) => cast_numeric_arrays!(array, Float32Type, Int64Type),
+        (Float32, Float64) => cast_numeric_arrays!(array, Float32Type, Float64Type),
+
+        (Float64, UInt8) => cast_numeric_arrays!(array, Float64Type, UInt8Type),
+        (Float64, UInt16) => cast_numeric_arrays!(array, UInt16Type, Float32Type),
+        (Float64, UInt32) => cast_numeric_arrays!(array, Float64Type, UInt32Type),
+        (Float64, UInt64) => cast_numeric_arrays!(array, Float64Type, UInt64Type),
+        (Float64, Int8) => cast_numeric_arrays!(array, Float64Type, Int8Type),
+        (Float64, Int16) => cast_numeric_arrays!(array, Float64Type, Int16Type),
+        (Float64, Int32) => cast_numeric_arrays!(array, Float64Type, Int32Type),
+        (Float64, Int64) => cast_numeric_arrays!(array, Float64Type, Int64Type),
+        (Float64, Float32) => cast_numeric_arrays!(array, Float64Type, Float32Type),
+        // end numeric casts
+        (_, _) => unimplemented!("Unable to cast from {:?} to {:?}", from_type, to_type),
+    }
+}
+
+/// Natural cast between numeric types
+fn numeric_cast<T, R>(from: &PrimitiveArray<T>) -> Result<PrimitiveArray<R>>
+where
+    T: ArrowNumericType,
+    R: ArrowNumericType,
+    T::Native: num::NumCast,
+    R::Native: num::NumCast,
+{
+    let mut b = PrimitiveBuilder::<R>::new(from.len());
+
+    for i in 0..from.len() {
+        if from.is_null(i) {
+            b.append_null()?;
+        } else {
+            // some casts return None, such as a negative value to u{8|16|32|64}
+            match num::cast::cast(from.value(i)) {
+                Some(v) => b.append_value(v)?,
+                None => b.append_null()?,
+            };
+        }
+    }
+
+    Ok(b.finish())
+}
+
+/// Cast numeric types to Utf8
+///
+/// The trait
+fn cast_numeric_to_string<T>(from: &PrimitiveArray<T>) -> Result<BinaryArray>
+where
+    T: ArrowPrimitiveType + ArrowNumericType,
+    T::Native: ::std::string::ToString,
+{
+    let mut b = BinaryBuilder::new(from.len());
+
+    for i in 0..from.len() {
+        if from.is_null(i) {
+            b.append(false)?;
+        } else {
+            b.append_string(from.value(i).to_string().as_str())?;
+        }
+    }
+
+    Ok(b.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cast_i32_to_f64() {
+        let a = Int32Array::from(vec![5, 6, 7, 8, 9]);
+        let array = Arc::new(a) as ArrayRef;
+        let b = cast(&array, &DataType::Float64).unwrap();
+        let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert_eq!(5.0, c.value(0));
+        assert_eq!(6.0, c.value(1));
+        assert_eq!(7.0, c.value(2));
+        assert_eq!(8.0, c.value(3));
+        assert_eq!(9.0, c.value(4));
+    }
+}

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -15,23 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines cast kernels for `ArrayRef`.
-//!
-//! Allows casting arrays between supported datatypes.
-//!
-//! ## Behavior
-//!
-//! * Boolean to Utf8: `true` => '1', `false` => `0`
-//! * Utf8 to numeric: strings that can't be parsed to numbers return null, float strings
-//!   in integer casts return null
-//! * Numeric to boolean: 0 returns `false`, any other value returns `true`
-//!
-//! ## Unsupported Casts
-//!
-//! * To or from `StructArray`
-//! * To or from `ListArray`
-//! * Boolean to float
-//! * Utf8 to boolean
+//! Defines cast kernels for `ArrayRef`, allowing casting arrays between supported datatypes.
 //!
 //! Example:
 //!
@@ -123,6 +107,18 @@ macro_rules! cast_bool_to_numeric {
 }
 
 /// Cast array to provided data type
+///
+/// Behavior:
+/// * Boolean to Utf8: `true` => '1', `false` => `0`
+/// * Utf8 to numeric: strings that can't be parsed to numbers return null, float strings
+///   in integer casts return null
+/// * Numeric to boolean: 0 returns `false`, any other value returns `true`
+///
+/// Unsupported Casts
+/// * To or from `StructArray`
+/// * To or from `ListArray`
+/// * Boolean to float
+/// * Utf8 to boolean
 pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
     use DataType::*;
     let from_type = array.data_type();

--- a/rust/arrow/src/compute/kernels/mod.rs
+++ b/rust/arrow/src/compute/kernels/mod.rs
@@ -17,16 +17,4 @@
 
 //! Computation kernels on Arrow Arrays
 
-pub mod arithmetic_kernels;
-pub mod array_ops;
-pub mod boolean_kernels;
-pub mod comparison_kernels;
-pub mod kernels;
-
-mod util;
-
-pub use self::arithmetic_kernels::*;
-pub use self::array_ops::*;
-pub use self::boolean_kernels::*;
-pub use self::comparison_kernels::*;
-pub use self::kernels::cast::*;
+pub mod cast;

--- a/rust/arrow/src/compute/mod.rs
+++ b/rust/arrow/src/compute/mod.rs
@@ -20,6 +20,7 @@
 pub mod arithmetic_kernels;
 pub mod array_ops;
 pub mod boolean_kernels;
+pub mod cast_kernels;
 pub mod comparison_kernels;
 
 mod util;
@@ -27,4 +28,5 @@ mod util;
 pub use self::arithmetic_kernels::*;
 pub use self::array_ops::*;
 pub use self::boolean_kernels::*;
+pub use self::cast_kernels::*;
 pub use self::comparison_kernels::*;

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -245,54 +245,6 @@ macro_rules! literal_array {
     }};
 }
 
-// /// Casts a column to an array with a different data type
-// macro_rules! cast_column {
-//     ($INDEX:expr, $TO_TYPE:expr) => {{
-//         Rc::new(move |batch: &RecordBatch| {
-//             // get data and cast to known type
-//             // match batch.column($INDEX).as_any().downcast_ref::<$FROM_TYPE>() {
-//             //     Some(array) => {
-//             //         // create builder for desired type
-//             //         let mut builder = $TO_TYPE::builder(batch.num_rows());
-//             //         for i in 0..batch.num_rows() {
-//             //             if array.is_null(i) {
-//             //                 builder.append_null()?;
-//             //             } else {
-//             //                 builder.append_value(array.value(i) as $DT)?;
-//             //             }
-//             //         }
-//             //         Ok(Arc::new(builder.finish()) as ArrayRef)
-//             //     }
-//             //     None => Err(ExecutionError::InternalError(format!(
-//             //         "Column at index {} is not of expected type",
-//             //         $INDEX
-//             //     ))),
-//             // }
-//             compute::cast(batch.column($INDEX), $TO_TYPE)
-//                 .map_err(|e| ExecutionError::ArrowError(e))
-//         })
-//     }};
-// }
-
-// macro_rules! cast_column_outer {
-//     ($INDEX:expr, $FROM_TYPE:ty, $TO_TYPE:expr) => {{
-//         // match $TO_TYPE {
-//         //     DataType::UInt8 => cast_column!($INDEX, $FROM_TYPE, UInt8Array, u8),
-//         //     DataType::UInt16 => cast_column!($INDEX, $FROM_TYPE, UInt16Array, u16),
-//         //     DataType::UInt32 => cast_column!($INDEX, $FROM_TYPE, UInt32Array, u32),
-//         //     DataType::UInt64 => cast_column!($INDEX, $FROM_TYPE, UInt64Array, u64),
-//         //     DataType::Int8 => cast_column!($INDEX, $FROM_TYPE, Int8Array, i8),
-//         //     DataType::Int16 => cast_column!($INDEX, $FROM_TYPE, Int16Array, i16),
-//         //     DataType::Int32 => cast_column!($INDEX, $FROM_TYPE, Int32Array, i32),
-//         //     DataType::Int64 => cast_column!($INDEX, $FROM_TYPE, Int64Array, i64),
-//         //     DataType::Float32 => cast_column!($INDEX, $FROM_TYPE, Float32Array,
-// f32),         //     DataType::Float64 => cast_column!($INDEX, $FROM_TYPE,
-// Float64Array, f64),         //     _ => unimplemented!(),
-//         // }
-//         cast_column!($INDEX, $TO_TYPE)
-//     }};
-// }
-
 /// Compiles a scalar expression into a closure
 pub fn compile_scalar_expr(
     ctx: &ExecutionContext,
@@ -334,55 +286,14 @@ pub fn compile_scalar_expr(
         } => match expr.as_ref() {
             &Expr::Column(index) => {
                 let col = input_schema.field(index);
+                let dt = data_type.clone();
                 Ok(RuntimeExpr::Compiled {
                     name: col.name().clone(),
                     t: col.data_type().clone(),
-                    f: Rc::new(|batch: &RecordBatch| {
-                        // match compute::cast(batch.column(index), data_type) {
-                        //     Ok(array) => Ok(array),
-                        //     Err(e) => Err(e.into())
-                        // }
-                        compute::cast(batch.column(index).clone(), data_type.clone())
+                    f: Rc::new(move |batch: &RecordBatch| {
+                        compute::cast(batch.column(index), &dt)
                             .map_err(|e| ExecutionError::ArrowError(e))
                     }),
-                    // f: match col.data_type() {
-                    //     DataType::Int8 => {
-                    //         cast_column_outer!(index, Int8Array, &data_type)
-                    //     }
-                    //     DataType::Int16 => {
-                    //         cast_column_outer!(index, Int16Array, &data_type)
-                    //     }
-                    //     DataType::Int32 => {
-                    //         cast_column_outer!(index, Int32Array, &data_type)
-                    //     }
-                    //     DataType::Int64 => {
-                    //         cast_column_outer!(index, Int64Array, &data_type)
-                    //     }
-                    //     DataType::UInt8 => {
-                    //         cast_column_outer!(index, UInt8Array, &data_type)
-                    //     }
-                    //     DataType::UInt16 => {
-                    //         cast_column_outer!(index, UInt16Array, &data_type)
-                    //     }
-                    //     DataType::UInt32 => {
-                    //         cast_column_outer!(index, UInt32Array, &data_type)
-                    //     }
-                    //     DataType::UInt64 => {
-                    //         cast_column_outer!(index, UInt64Array, &data_type)
-                    //     }
-                    //     DataType::Float32 => {
-                    //         cast_column_outer!(index, Float32Array, &data_type)
-                    //     }
-                    //     DataType::Float64 => {
-                    //         cast_column_outer!(index, Float64Array, &data_type)
-                    //     }
-                    //     _ => panic!("unsupported CAST operation"), /*TODO */
-                    //                                                /*Err(ExecutionError::NotImplemented(format!(
-                    //                                                    "CAST column from {:?} to {:?}",
-                    //                                                    col.data_type(),
-                    //                                                    data_type
-                    //                                                )))*/
-                    // },
                 })
             }
             &Expr::Literal(ref value) => {

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -245,50 +245,53 @@ macro_rules! literal_array {
     }};
 }
 
-/// Casts a column to an array with a different data type
-macro_rules! cast_column {
-    ($INDEX:expr, $FROM_TYPE:ty, $TO_TYPE:ident, $DT:ty) => {{
-        Rc::new(move |batch: &RecordBatch| {
-            // get data and cast to known type
-            match batch.column($INDEX).as_any().downcast_ref::<$FROM_TYPE>() {
-                Some(array) => {
-                    // create builder for desired type
-                    let mut builder = $TO_TYPE::builder(batch.num_rows());
-                    for i in 0..batch.num_rows() {
-                        if array.is_null(i) {
-                            builder.append_null()?;
-                        } else {
-                            builder.append_value(array.value(i) as $DT)?;
-                        }
-                    }
-                    Ok(Arc::new(builder.finish()) as ArrayRef)
-                }
-                None => Err(ExecutionError::InternalError(format!(
-                    "Column at index {} is not of expected type",
-                    $INDEX
-                ))),
-            }
-        })
-    }};
-}
+// /// Casts a column to an array with a different data type
+// macro_rules! cast_column {
+//     ($INDEX:expr, $TO_TYPE:expr) => {{
+//         Rc::new(move |batch: &RecordBatch| {
+//             // get data and cast to known type
+//             // match batch.column($INDEX).as_any().downcast_ref::<$FROM_TYPE>() {
+//             //     Some(array) => {
+//             //         // create builder for desired type
+//             //         let mut builder = $TO_TYPE::builder(batch.num_rows());
+//             //         for i in 0..batch.num_rows() {
+//             //             if array.is_null(i) {
+//             //                 builder.append_null()?;
+//             //             } else {
+//             //                 builder.append_value(array.value(i) as $DT)?;
+//             //             }
+//             //         }
+//             //         Ok(Arc::new(builder.finish()) as ArrayRef)
+//             //     }
+//             //     None => Err(ExecutionError::InternalError(format!(
+//             //         "Column at index {} is not of expected type",
+//             //         $INDEX
+//             //     ))),
+//             // }
+//             compute::cast(batch.column($INDEX), $TO_TYPE)
+//                 .map_err(|e| ExecutionError::ArrowError(e))
+//         })
+//     }};
+// }
 
-macro_rules! cast_column_outer {
-    ($INDEX:expr, $FROM_TYPE:ty, $TO_TYPE:expr) => {{
-        match $TO_TYPE {
-            DataType::UInt8 => cast_column!($INDEX, $FROM_TYPE, UInt8Array, u8),
-            DataType::UInt16 => cast_column!($INDEX, $FROM_TYPE, UInt16Array, u16),
-            DataType::UInt32 => cast_column!($INDEX, $FROM_TYPE, UInt32Array, u32),
-            DataType::UInt64 => cast_column!($INDEX, $FROM_TYPE, UInt64Array, u64),
-            DataType::Int8 => cast_column!($INDEX, $FROM_TYPE, Int8Array, i8),
-            DataType::Int16 => cast_column!($INDEX, $FROM_TYPE, Int16Array, i16),
-            DataType::Int32 => cast_column!($INDEX, $FROM_TYPE, Int32Array, i32),
-            DataType::Int64 => cast_column!($INDEX, $FROM_TYPE, Int64Array, i64),
-            DataType::Float32 => cast_column!($INDEX, $FROM_TYPE, Float32Array, f32),
-            DataType::Float64 => cast_column!($INDEX, $FROM_TYPE, Float64Array, f64),
-            _ => unimplemented!(),
-        }
-    }};
-}
+// macro_rules! cast_column_outer {
+//     ($INDEX:expr, $FROM_TYPE:ty, $TO_TYPE:expr) => {{
+//         // match $TO_TYPE {
+//         //     DataType::UInt8 => cast_column!($INDEX, $FROM_TYPE, UInt8Array, u8),
+//         //     DataType::UInt16 => cast_column!($INDEX, $FROM_TYPE, UInt16Array, u16),
+//         //     DataType::UInt32 => cast_column!($INDEX, $FROM_TYPE, UInt32Array, u32),
+//         //     DataType::UInt64 => cast_column!($INDEX, $FROM_TYPE, UInt64Array, u64),
+//         //     DataType::Int8 => cast_column!($INDEX, $FROM_TYPE, Int8Array, i8),
+//         //     DataType::Int16 => cast_column!($INDEX, $FROM_TYPE, Int16Array, i16),
+//         //     DataType::Int32 => cast_column!($INDEX, $FROM_TYPE, Int32Array, i32),
+//         //     DataType::Int64 => cast_column!($INDEX, $FROM_TYPE, Int64Array, i64),
+//         //     DataType::Float32 => cast_column!($INDEX, $FROM_TYPE, Float32Array,
+// f32),         //     DataType::Float64 => cast_column!($INDEX, $FROM_TYPE,
+// Float64Array, f64),         //     _ => unimplemented!(),
+//         // }
+//         cast_column!($INDEX, $TO_TYPE)
+//     }};
+// }
 
 /// Compiles a scalar expression into a closure
 pub fn compile_scalar_expr(
@@ -334,44 +337,52 @@ pub fn compile_scalar_expr(
                 Ok(RuntimeExpr::Compiled {
                     name: col.name().clone(),
                     t: col.data_type().clone(),
-                    f: match col.data_type() {
-                        DataType::Int8 => {
-                            cast_column_outer!(index, Int8Array, &data_type)
-                        }
-                        DataType::Int16 => {
-                            cast_column_outer!(index, Int16Array, &data_type)
-                        }
-                        DataType::Int32 => {
-                            cast_column_outer!(index, Int32Array, &data_type)
-                        }
-                        DataType::Int64 => {
-                            cast_column_outer!(index, Int64Array, &data_type)
-                        }
-                        DataType::UInt8 => {
-                            cast_column_outer!(index, UInt8Array, &data_type)
-                        }
-                        DataType::UInt16 => {
-                            cast_column_outer!(index, UInt16Array, &data_type)
-                        }
-                        DataType::UInt32 => {
-                            cast_column_outer!(index, UInt32Array, &data_type)
-                        }
-                        DataType::UInt64 => {
-                            cast_column_outer!(index, UInt64Array, &data_type)
-                        }
-                        DataType::Float32 => {
-                            cast_column_outer!(index, Float32Array, &data_type)
-                        }
-                        DataType::Float64 => {
-                            cast_column_outer!(index, Float64Array, &data_type)
-                        }
-                        _ => panic!("unsupported CAST operation"), /*TODO */
-                                                                   /*Err(ExecutionError::NotImplemented(format!(
-                                                                       "CAST column from {:?} to {:?}",
-                                                                       col.data_type(),
-                                                                       data_type
-                                                                   )))*/
-                    },
+                    f: Rc::new(|batch: &RecordBatch| {
+                        // match compute::cast(batch.column(index), data_type) {
+                        //     Ok(array) => Ok(array),
+                        //     Err(e) => Err(e.into())
+                        // }
+                        compute::cast(batch.column(index).clone(), data_type.clone())
+                            .map_err(|e| ExecutionError::ArrowError(e))
+                    }),
+                    // f: match col.data_type() {
+                    //     DataType::Int8 => {
+                    //         cast_column_outer!(index, Int8Array, &data_type)
+                    //     }
+                    //     DataType::Int16 => {
+                    //         cast_column_outer!(index, Int16Array, &data_type)
+                    //     }
+                    //     DataType::Int32 => {
+                    //         cast_column_outer!(index, Int32Array, &data_type)
+                    //     }
+                    //     DataType::Int64 => {
+                    //         cast_column_outer!(index, Int64Array, &data_type)
+                    //     }
+                    //     DataType::UInt8 => {
+                    //         cast_column_outer!(index, UInt8Array, &data_type)
+                    //     }
+                    //     DataType::UInt16 => {
+                    //         cast_column_outer!(index, UInt16Array, &data_type)
+                    //     }
+                    //     DataType::UInt32 => {
+                    //         cast_column_outer!(index, UInt32Array, &data_type)
+                    //     }
+                    //     DataType::UInt64 => {
+                    //         cast_column_outer!(index, UInt64Array, &data_type)
+                    //     }
+                    //     DataType::Float32 => {
+                    //         cast_column_outer!(index, Float32Array, &data_type)
+                    //     }
+                    //     DataType::Float64 => {
+                    //         cast_column_outer!(index, Float64Array, &data_type)
+                    //     }
+                    //     _ => panic!("unsupported CAST operation"), /*TODO */
+                    //                                                /*Err(ExecutionError::NotImplemented(format!(
+                    //                                                    "CAST column from {:?} to {:?}",
+                    //                                                    col.data_type(),
+                    //                                                    data_type
+                    //                                                )))*/
+                    // },
                 })
             }
             &Expr::Literal(ref value) => {


### PR DESCRIPTION
This is an implementation of a cast kernel for most Arrow types.

Limitations (when PR is complete):
* Casting to or from `StructArray` not supported
* Casting `ListArray` to non-list array not supported
* Casting of incompatible primitive types not supported (e.g. temporal to boolean)