### PR TITLE
ARROW-4448: [Java][Flight] Disable flaky TestBackPressure

### DIFF
--- a/java/flight/src/test/java/org/apache/arrow/flight/TestBackPressure.java
+++ b/java/flight/src/test/java/org/apache/arrow/flight/TestBackPressure.java
@@ -41,6 +41,7 @@ public class TestBackPressure {
   /**
    * Make sure that failing to consume one stream doesn't block other streams.
    */
+  @Ignore
   @Test
   public void ensureIndependentSteams() throws Exception {
 


### PR DESCRIPTION
Until ARROW-4765 is resolved, this test is disabled to improve travis
reliability.