### PR TITLE
ARROW-4768: [C++][CI] Don't run flaky tests in MinGW build

### DIFF
--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -48,7 +48,11 @@ cmake ^
     -DARROW_PYTHON=OFF ^
     .. || exit /B
 make -j4 || exit /B
-ctest --output-on-failure -j2 || exit /B
+@rem TODO: Run all tests
+ctest ^
+  --exclude-regex arrow-array-test ^
+  --output-on-failure ^
+  --parallel 2 || exit /B
 make install || exit /B
 popd
 


### PR DESCRIPTION
Example: https://ci.appveyor.com/project/ApacheSoftwareFoundation/arrow/builds/22804493/job/6mbpslm97p4yj31c#L72

The following job isn't finished.

    Start  2: arrow-array-test

We disable the test for now but we should fix the problem and re-enable the test.