### PR TITLE
ARROW-4769: [Rust] Improve array limit fn where max_records >= len

### DIFF
--- a/rust/datafusion/src/execution/limit.rs
+++ b/rust/datafusion/src/execution/limit.rs
@@ -59,7 +59,7 @@ impl Relation for LimitRelation {
 
                 if batch.num_rows() >= capacity {
                     let limited_columns: Result<Vec<ArrayRef>> = (0..batch.num_columns())
-                        .map(|i| match limit(batch.column(i).as_ref(), capacity) {
+                        .map(|i| match limit(batch.column(i), capacity) {
                             Ok(result) => Ok(result),
                             Err(error) => Err(ExecutionError::from(error)),
                         })


### PR DESCRIPTION
This yields a ~55% reduction in runtime.