### PR TITLE
ARROW-4775: [Site] Site navbar cannot be expanded

### DIFF
--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark bg-dark">
   <a class="navbar-brand" href="{{ site.baseurl }}/">Apache Arrow&#8482;&nbsp;&nbsp;&nbsp;</a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#arrow-navbar" aria-controls="arrow-navbar" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
 


### PR DESCRIPTION
I found that the navbar at the top of the page cannot be expanded when the page is narrow.
This pull request fixes this problem.