### PR TITLE
ARROW-4780: [JS] Package sourcemap files, update default package JS version

### DIFF
--- a/js/gulp/arrow-task.js
+++ b/js/gulp/arrow-task.js
@@ -29,23 +29,25 @@ const { Observable, ReplaySubject } = require('rxjs');
 
 const arrowTask = ((cache) => memoizeTask(cache, function copyMain(target) {
     const out = targetDir(target);
-    const dtsGlob = `${targetDir(`es2015`, `cjs`)}/**/*.ts`;
-    const cjsGlob = `${targetDir(`es2015`, `cjs`)}/**/*.js`;
+    const dtsGlob = `${targetDir(`esnext`, `cjs`)}/**/*.ts`;
+    const cjsGlob = `${targetDir(`esnext`, `cjs`)}/**/*.js`;
     const esmGlob = `${targetDir(`esnext`, `esm`)}/**/*.js`;
     const es5UmdGlob = `${targetDir(`es5`, `umd`)}/*.js`;
-    const es5UmdMaps = `${targetDir(`es5`, `umd`)}/*.map`;
-    const es2015UmdGlob = `${targetDir(`es2015`, `umd`)}/*.js`;
-    const es2015UmdMaps = `${targetDir(`es2015`, `umd`)}/*.map`;
-    const ch_ext = (ext) => gulpRename((p) => { p.extname = ext; });
-    const append = (ap) => gulpRename((p) => { p.basename += ap; });
+    const esnextUmdGlob = `${targetDir(`esnext`, `umd`)}/*.js`;
+    const cjsSourceMapsGlob = `${targetDir(`esnext`, `cjs`)}/**/*.map`;
+    const esmSourceMapsGlob = `${targetDir(`esnext`, `esm`)}/**/*.map`;
+    const es5UmdSourceMapsGlob = `${targetDir(`es5`, `umd`)}/*.map`;
+    const esnextUmdSourceMapsGlob = `${targetDir(`esnext`, `umd`)}/*.map`;
     return Observable.forkJoin(
-      observableFromStreams(gulp.src(dtsGlob), gulp.dest(out)), // copy d.ts files
-      observableFromStreams(gulp.src(cjsGlob), gulp.dest(out)), // copy es2015 cjs files
-      observableFromStreams(gulp.src(esmGlob), ch_ext(`.mjs`), gulp.dest(out)), // copy es2015 esm files and rename to `.mjs`
-      observableFromStreams(gulp.src(es5UmdGlob), append(`.es5.min`), gulp.dest(out)), // copy es5 umd files and add `.min`
-      observableFromStreams(gulp.src(es5UmdMaps),                     gulp.dest(out)), // copy es5 umd sourcemap files, but don't rename
-      observableFromStreams(gulp.src(es2015UmdGlob), append(`.es2015.min`), gulp.dest(out)), // copy es2015 umd files and add `.es2015.min`
-      observableFromStreams(gulp.src(es2015UmdMaps),                        gulp.dest(out)), // copy es2015 umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(dtsGlob),                 gulp.dest(out)), // copy d.ts files
+        observableFromStreams(gulp.src(cjsGlob),                 gulp.dest(out)), // copy es2015 cjs files
+        observableFromStreams(gulp.src(cjsSourceMapsGlob),       gulp.dest(out)), // copy es2015 cjs sourcemaps
+        observableFromStreams(gulp.src(esmSourceMapsGlob),       gulp.dest(out)), // copy es2015 esm sourcemaps
+        observableFromStreams(gulp.src(es5UmdSourceMapsGlob),    gulp.dest(out)), // copy es5 umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(esnextUmdSourceMapsGlob), gulp.dest(out)), // copy es2015 umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(esmGlob),       gulpRename((p) => { p.extname = '.mjs'; }),          gulp.dest(out)), // copy es2015 esm files and rename to `.mjs`
+        observableFromStreams(gulp.src(es5UmdGlob),    gulpRename((p) => { p.basename += `.es5.min`; }),    gulp.dest(out)), // copy es5 umd files and add `.min`
+        observableFromStreams(gulp.src(esnextUmdGlob), gulpRename((p) => { p.basename += `.es2015.min`; }), gulp.dest(out)), // copy es2015 umd files and add `.es2015.min`
     ).publish(new ReplaySubject()).refCount();
 }))({});
 

--- a/js/gulp/package-task.js
+++ b/js/gulp/package-task.js
@@ -48,15 +48,17 @@ const createMainPackageJson = (target, format) => (orig) => ({
     name: npmPkgName,
     main: `${mainExport}.node`,
     browser: `${mainExport}.dom`,
+    module: `${mainExport}.dom.mjs`,
     types: `${mainExport}.node.d.ts`,
     unpkg: `${mainExport}.es5.min.js`,
     jsdelivr: `${mainExport}.es5.min.js`,
-    [`esm`]: { mode: `all`, sourceMap: true }
+    esm: { mode: `all`, sourceMap: true }
 });
   
 const createTypeScriptPackageJson = (target, format) => (orig) => ({
     ...createScopedPackageJSON(target, format)(orig),
     bin: undefined,
+    module: undefined,
     main: `${mainExport}.node.ts`,
     types: `${mainExport}.node.ts`,
     browser: `${mainExport}.dom.ts`,
@@ -68,23 +70,26 @@ const createTypeScriptPackageJson = (target, format) => (orig) => ({
 });
   
 const createScopedPackageJSON = (target, format) => (({ name, ...orig }) =>
-    conditionallyAddStandardESMEntry(target, format)(
-        packageJSONFields.reduce(
-            (xs, key) => ({ ...xs, [key]: xs[key] || orig[key] }),
-            {
-                name: `${npmOrgName}/${packageName(target, format)}`,
-                browser: format === 'umd' ? undefined : `${mainExport}.dom`,
-                main: format === 'umd' ? `${mainExport}` : `${mainExport}.node`,
-                types: format === 'umd' ? undefined : `${mainExport}.node.d.ts`,
-                version: undefined, unpkg: undefined, jsdelivr: undefined,
-                module: undefined, [`esm`]: undefined,
-            }
-        )
+    packageJSONFields.reduce(
+        (xs, key) => ({ ...xs, [key]: xs[key] || orig[key] }),
+        {
+            // un-set version, since it's automatically applied during the release process
+            version: undefined,
+            // set the scoped package name (e.g. "@apache-arrow/esnext-esm")
+            name: `${npmOrgName}/${packageName(target, format)}`,
+            // set "unpkg"/"jsdeliver" if building scoped UMD target
+            unpkg:    format === 'umd' ? `${mainExport}.js` : undefined,
+            jsdelivr: format === 'umd' ? `${mainExport}.js` : undefined,
+            // set "browser" if building scoped UMD target, otherwise "Arrow.dom"
+            browser:  format === 'umd' ? `${mainExport}.js` : `${mainExport}.dom.js`,
+            // set "main" to "Arrow" if building scoped UMD target, otherwise "Arrow.node"
+            main:     format === 'umd' ? `${mainExport}.js` : `${mainExport}.node`,
+            // set "module" (for https://www.npmjs.com/package/@pika/pack) if building scoped ESM target
+            module:   format === 'esm' ? `${mainExport}.dom.js` : undefined,
+            // include "esm" settings for https://www.npmjs.com/package/esm if building scoped ESM target
+            esm:      format === `esm` ? { mode: `auto`, sourceMap: true } : undefined,
+            // set "types" (for TypeScript/VSCode)
+            types:    format === 'umd' ? undefined : `${mainExport}.node.d.ts`,
+        }
     )
-);
-  
-const conditionallyAddStandardESMEntry = (target, format) => (packageJSON) => (
-    format !== `esm` && format !== `cls`
-        ?      packageJSON
-        : { ...packageJSON, [`esm`]: { mode: `auto`, sourceMap: true } }
 );

--- a/js/gulp/typescript-task.js
+++ b/js/gulp/typescript-task.js
@@ -56,9 +56,13 @@ function compileTypescript(out, tsconfigPath, tsconfigOverrides) {
       tsProject(ts.reporter.defaultReporter())
     );
     const writeDTypes = observableFromStreams(dts, gulp.dest(out));
-    const writeJS = observableFromStreams(js, sourcemaps.write(), gulp.dest(out));
+    const mapFile = tsProject.options.module === 5 ? esmMapFile : cjsMapFile;
+    const writeJS = observableFromStreams(js, sourcemaps.write('./', { mapFile }), gulp.dest(out));
     return Observable.forkJoin(writeDTypes, writeJS);
 }
+
+function cjsMapFile(mapFilePath) { return mapFilePath; }
+function esmMapFile(mapFilePath) { return mapFilePath.replace('.js.map', '.mjs.map'); }
 
 module.exports = typescriptTask;
 module.exports.typescriptTask = typescriptTask;

--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -63,9 +63,9 @@ gulp.task(`build:${npmPkgName}`,
     gulp.series(
         gulp.parallel(
             `build:${taskName(`es5`, `umd`)}`,
-            `build:${taskName(`es2015`, `cjs`)}`,
-            `build:${taskName(`es2015`, `esm`)}`,
-            `build:${taskName(`es2015`, `umd`)}`
+            `build:${taskName(`esnext`, `cjs`)}`,
+            `build:${taskName(`esnext`, `esm`)}`,
+            `build:${taskName(`esnext`, `umd`)}`
         ),
         `clean:${npmPkgName}`,
         `compile:${npmPkgName}`,


### PR DESCRIPTION
Change the way we package sourcemaps to make end-consumer builds faster, bump up the default JS version in the main package (it is now widely supported, and all the major build tools will down-compile as necessary). Also adds a "module" entry so we'll be included in https://www.pikapkg.com/blog/introducing-pika-pack/ search results.

Closes https://issues.apache.org/jira/browse/ARROW-4780