### PR TITLE
ARROW-4792: [Ruby] Don't raise an error by #==

### DIFF
--- a/ruby/red-arrow/lib/arrow/array.rb
+++ b/ruby/red-arrow/lib/arrow/array.rb
@@ -73,5 +73,10 @@ module Arrow
     def to_arrow
       self
     end
+
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/buffer.rb
+++ b/ruby/red-arrow/lib/arrow/buffer.rb
@@ -16,40 +16,10 @@
 # under the License.
 
 module Arrow
-  class Column
-    include Enumerable
-
+  class Buffer
     alias_method :equal_raw, :==
     def ==(other)
       other.is_a?(self.class) and equal_raw(other)
-    end
-
-    def null?(i)
-      data.null?(i)
-    end
-
-    def valid?(i)
-      data.valid?(i)
-    end
-
-    def [](i)
-      data[i]
-    end
-
-    def each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.each(&block)
-    end
-
-    def reverse_each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.reverse_each(&block)
-    end
-
-    def pack
-      self.class.new(field, data.pack)
     end
   end
 end

--- a/ruby/red-arrow/lib/arrow/chunked-array.rb
+++ b/ruby/red-arrow/lib/arrow/chunked-array.rb
@@ -80,5 +80,10 @@ module Arrow
         first_chunk.class.new(to_a)
       end
     end
+
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/data-type.rb
+++ b/ruby/red-arrow/lib/arrow/data-type.rb
@@ -131,5 +131,10 @@ module Arrow
         Arrow.const_get(data_type_class_name)
       end
     end
+
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/decimal128.rb
+++ b/ruby/red-arrow/lib/arrow/decimal128.rb
@@ -15,41 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-module Arrow
-  class Column
-    include Enumerable
+require "arrow/bigdecimal-extension"
 
+module Arrow
+  class Decimal128
     alias_method :equal_raw, :==
     def ==(other)
       other.is_a?(self.class) and equal_raw(other)
     end
 
-    def null?(i)
-      data.null?(i)
-    end
-
-    def valid?(i)
-      data.valid?(i)
-    end
-
-    def [](i)
-      data[i]
-    end
-
-    def each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.each(&block)
-    end
-
-    def reverse_each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.reverse_each(&block)
-    end
-
-    def pack
-      self.class.new(field, data.pack)
+    alias_method :not_equal_raw, :!=
+    def !=(other)
+      return false unless other.is_a?(self.class)
+      not_equal_raw(other)
     end
   end
 end

--- a/ruby/red-arrow/lib/arrow/field.rb
+++ b/ruby/red-arrow/lib/arrow/field.rb
@@ -114,5 +114,10 @@ module Arrow
 
       initialize_raw(name, data_type)
     end
+
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -33,6 +33,7 @@ module Arrow
     def require_libraries
       require "arrow/array"
       require "arrow/array-builder"
+      require "arrow/buffer"
       require "arrow/chunked-array"
       require "arrow/column"
       require "arrow/compression-type"
@@ -43,6 +44,7 @@ module Arrow
       require "arrow/date32-array-builder"
       require "arrow/date64-array"
       require "arrow/date64-array-builder"
+      require "arrow/decimal128"
       require "arrow/decimal128-array-builder"
       require "arrow/decimal128-data-type"
       require "arrow/dense-union-data-type"

--- a/ruby/red-arrow/lib/arrow/record-batch.rb
+++ b/ruby/red-arrow/lib/arrow/record-batch.rb
@@ -54,6 +54,11 @@ module Arrow
       Table.new(schema, [self])
     end
 
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
+
     def respond_to_missing?(name, include_private)
       return true if find_column(name)
       super

--- a/ruby/red-arrow/lib/arrow/schema.rb
+++ b/ruby/red-arrow/lib/arrow/schema.rb
@@ -93,5 +93,10 @@ module Arrow
     end
 
     alias_method :[], :find_field
+
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -71,6 +71,11 @@ module Arrow
 
     alias_method :[], :find_column
 
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
+
     # TODO
     #
     # @return [Arrow::Table]

--- a/ruby/red-arrow/lib/arrow/tensor.rb
+++ b/ruby/red-arrow/lib/arrow/tensor.rb
@@ -17,6 +17,11 @@
 
 module Arrow
   class Tensor
+    alias_method :equal_raw, :==
+    def ==(other)
+      other.is_a?(self.class) and equal_raw(other)
+    end
+
     def to_arrow
       self
     end

--- a/ruby/red-arrow/test/test-array.rb
+++ b/ruby/red-arrow/test/test-array.rb
@@ -49,5 +49,19 @@ class ArrayTest < Test::Unit::TestCase
                      @array[-1])
       end
     end
+
+    sub_test_case("#==") do
+      test("Arrow::Array") do
+        assert do
+          @array == @array
+        end
+      end
+
+      test("not Arrow::Array") do
+        assert do
+          not (@array == 29)
+        end
+      end
+    end
   end
 end

--- a/ruby/red-arrow/test/test-buffer.rb
+++ b/ruby/red-arrow/test/test-buffer.rb
@@ -15,41 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-module Arrow
-  class Column
-    include Enumerable
-
-    alias_method :equal_raw, :==
-    def ==(other)
-      other.is_a?(self.class) and equal_raw(other)
+class BufferTest < Test::Unit::TestCase
+  sub_test_case("instance methods") do
+    def setup
+      @buffer = Arrow::Buffer.new("Hello")
     end
 
-    def null?(i)
-      data.null?(i)
-    end
+    sub_test_case("#==") do
+      test("Arrow::Buffer") do
+        assert do
+          @buffer == @buffer
+        end
+      end
 
-    def valid?(i)
-      data.valid?(i)
-    end
-
-    def [](i)
-      data[i]
-    end
-
-    def each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.each(&block)
-    end
-
-    def reverse_each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.reverse_each(&block)
-    end
-
-    def pack
-      self.class.new(field, data.pack)
+      test("not Arrow::Buffer") do
+        assert do
+          not (@buffer == 29)
+        end
+      end
     end
   end
 end

--- a/ruby/red-arrow/test/test-chunked-array.rb
+++ b/ruby/red-arrow/test/test-chunked-array.rb
@@ -62,4 +62,26 @@ class ChunkedArrayTest < Test::Unit::TestCase
                    ])
     end
   end
+
+  sub_test_case("#==") do
+    def setup
+      arrays = [
+        Arrow::BooleanArray.new([true]),
+        Arrow::BooleanArray.new([false, true]),
+      ]
+      @chunked_array = Arrow::ChunkedArray.new(arrays)
+    end
+
+    test("Arrow::ChunkedArray") do
+      assert do
+        @chunked_array == @chunked_array
+      end
+    end
+
+    test("not Arrow::ChunkedArray") do
+      assert do
+        not (@chunked_array == 29)
+      end
+    end
+  end
 end

--- a/ruby/red-arrow/test/test-column.rb
+++ b/ruby/red-arrow/test/test-column.rb
@@ -40,4 +40,28 @@ class ColumnTest < Test::Unit::TestCase
     assert_equal([1, [true, false, nil, true]],
                  [packed_column.data.n_chunks, packed_column.to_a])
   end
+
+  sub_test_case("#==") do
+    def setup
+      arrays = [
+        Arrow::BooleanArray.new([true]),
+        Arrow::BooleanArray.new([false, true]),
+      ]
+      chunked_array = Arrow::ChunkedArray.new(arrays)
+      @column = Arrow::Column.new(Arrow::Field.new("visible", :boolean),
+                                  chunked_array)
+    end
+
+    test("Arrow::Column") do
+      assert do
+        @column == @column
+      end
+    end
+
+    test("not Arrow::Column") do
+      assert do
+        not (@column == 29)
+      end
+    end
+  end
 end

--- a/ruby/red-arrow/test/test-data-type.rb
+++ b/ruby/red-arrow/test/test-data-type.rb
@@ -44,4 +44,24 @@ class DataTypeTest < Test::Unit::TestCase
                    Arrow::DataType.resolve(type: :list, field: field))
     end
   end
+
+  sub_test_case("instance methods") do
+    def setup
+      @data_type = Arrow::StringDataType.new
+    end
+
+    sub_test_case("#==") do
+      test("Arrow::DataType") do
+        assert do
+          @data_type == @data_type
+        end
+      end
+
+      test("not Arrow::DataType") do
+        assert do
+          not (@data_type == 29)
+        end
+      end
+    end
+  end
 end

--- a/ruby/red-arrow/test/test-decimal128.rb
+++ b/ruby/red-arrow/test/test-decimal128.rb
@@ -15,41 +15,38 @@
 # specific language governing permissions and limitations
 # under the License.
 
-module Arrow
-  class Column
-    include Enumerable
-
-    alias_method :equal_raw, :==
-    def ==(other)
-      other.is_a?(self.class) and equal_raw(other)
+class Decimal128Test < Test::Unit::TestCase
+  sub_test_case("instance methods") do
+    def setup
+      @decimal128 = Arrow::Decimal128.new("10.1")
     end
 
-    def null?(i)
-      data.null?(i)
+    sub_test_case("#==") do
+      test("Arrow::Decimal128") do
+        assert do
+          @decimal128 == @decimal128
+        end
+      end
+
+      test("not Arrow::Decimal128") do
+        assert do
+          not (@decimal128 == 10.1)
+        end
+      end
     end
 
-    def valid?(i)
-      data.valid?(i)
-    end
+    sub_test_case("#!=") do
+      test("Arrow::Decimal128") do
+        assert do
+          not(@decimal128 != @decimal128)
+        end
+      end
 
-    def [](i)
-      data[i]
-    end
-
-    def each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.each(&block)
-    end
-
-    def reverse_each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.reverse_each(&block)
-    end
-
-    def pack
-      self.class.new(field, data.pack)
+      test("not Arrow::Decimal128") do
+        assert do
+          not (@decimal128 != 10.1)
+        end
+      end
     end
   end
 end

--- a/ruby/red-arrow/test/test-field.rb
+++ b/ruby/red-arrow/test/test-field.rb
@@ -68,4 +68,24 @@ class FieldTest < Test::Unit::TestCase
                    Arrow::Field.new(description).to_s)
     end
   end
+
+  sub_test_case("instance methods") do
+    def setup
+      @field = Arrow::Field.new("count", :uint32)
+    end
+
+    sub_test_case("#==") do
+      test("Arrow::Field") do
+        assert do
+          @field == @field
+        end
+      end
+
+      test("not Arrow::Field") do
+        assert do
+          not (@field == 29)
+        end
+      end
+    end
+  end
 end

--- a/ruby/red-arrow/test/test-record-batch.rb
+++ b/ruby/red-arrow/test/test-record-batch.rb
@@ -108,5 +108,19 @@ class RecordBatchTest < Test::Unit::TestCase
       assert_equal(Arrow::Table.new(@schema, [@counts]),
                    @record_batch.to_table)
     end
+
+    sub_test_case("#==") do
+      test("Arrow::RecordBatch") do
+        assert do
+          @record_batch == @record_batch
+        end
+      end
+
+      test("not Arrow::RecordBatch") do
+        assert do
+          not (@record_batch == 29)
+        end
+      end
+    end
   end
 end

--- a/ruby/red-arrow/test/test-schema.rb
+++ b/ruby/red-arrow/test/test-schema.rb
@@ -100,5 +100,19 @@ class SchemaTest < Test::Unit::TestCase
         end
       end
     end
+
+    sub_test_case("#==") do
+      test("Arrow::Schema") do
+        assert do
+          @schema == @schema
+        end
+      end
+
+      test("not Arrow::Schema") do
+        assert do
+          not (@schema == 29)
+        end
+      end
+    end
   end
 end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -596,5 +596,19 @@ visible: false
         end
       end
     end
+
+    sub_test_case("#==") do
+      test("Arrow::Table") do
+        assert do
+          @table == @table
+        end
+      end
+
+      test("not Arrow::Table") do
+        assert do
+          not (@table == 29)
+        end
+      end
+    end
   end
 end

--- a/ruby/red-arrow/test/test-tensor.rb
+++ b/ruby/red-arrow/test/test-tensor.rb
@@ -15,41 +15,42 @@
 # specific language governing permissions and limitations
 # under the License.
 
-module Arrow
-  class Column
-    include Enumerable
+class TensorTest < Test::Unit::TestCase
+  sub_test_case("instance methods") do
+    def setup
+      raw_data = [
+        1, 2,
+        3, 4,
 
-    alias_method :equal_raw, :==
-    def ==(other)
-      other.is_a?(self.class) and equal_raw(other)
+        5, 6,
+        7, 8,
+
+        9, 10,
+        11, 12,
+      ]
+      data = Arrow::Buffer.new(raw_data.pack("c*"))
+      shape = [3, 2, 2]
+      strides = []
+      names = ["a", "b", "c"]
+      @tensor = Arrow::Tensor.new(Arrow::Int8DataType.new,
+                                  data,
+                                  shape,
+                                  strides,
+                                  names)
     end
 
-    def null?(i)
-      data.null?(i)
-    end
+    sub_test_case("#==") do
+      test("Arrow::Tensor") do
+        assert do
+          @tensor == @tensor
+        end
+      end
 
-    def valid?(i)
-      data.valid?(i)
-    end
-
-    def [](i)
-      data[i]
-    end
-
-    def each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.each(&block)
-    end
-
-    def reverse_each(&block)
-      return to_enum(__method__) unless block_given?
-
-      data.reverse_each(&block)
-    end
-
-    def pack
-      self.class.new(field, data.pack)
+      test("not Arrow::Tensor") do
+        assert do
+          not (@tensor == 29)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
== should not raise an error. If argument isn't an expected value, ==
should just return false.