### PR TITLE
ARROW-4793: [Ruby] Suppress unused variable warning

### DIFF
--- a/ruby/red-arrow/test/test-bigdecimal.rb
+++ b/ruby/red-arrow/test/test-bigdecimal.rb
@@ -17,7 +17,6 @@
 
 class BigDecimalTest < Test::Unit::TestCase
   test("#to_arrow") do
-    arrow_decimal = BigDecimal("3.14").to_arrow
     assert_equal(Arrow::Decimal128.new("3.14"),
                  BigDecimal("3.14").to_arrow)
   end


### PR DESCRIPTION
Message:

    ruby/red-arrow/test/test-bigdecimal.rb:20: warning: assigned but unused variable - arrow_decimal