### PR TITLE
ARROW-4640: [Python] Add docker-compose configuration to build and test the project without pandas installed

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -21,7 +21,7 @@
 # $ make -f Makefile.docker cpp
 
 LANGUAGES = cpp cpp-alpine cpp-cmake32 c_glib go java js python python-alpine rust r
-MISC = lint iwyu clang-format docs pandas-master
+MISC = lint iwyu clang-format docs pandas-master python-nopandas
 SERVERS = dask hdfs-integration spark-integration
 
 # declare images dependencies

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -21,16 +21,17 @@
 # $ make -f Makefile.docker cpp
 
 LANGUAGES = cpp cpp-alpine cpp-cmake32 c_glib go java js python python-alpine rust r
-MISC = lint iwyu clang-format docs pandas-master python-nopandas
-SERVERS = dask hdfs-integration spark-integration
+MISC = lint iwyu clang-format docs pandas-master
+TESTS = dask hdfs-integration spark-integration python-nopandas
 
 # declare images dependencies
 DEPENDS_ON_CPP = build-c_glib build-python build-r
 DEPENDS_ON_CPP_ALPINE = build-python-alpine
-DEPENDS_ON_PYTHON = build-lint build-docs build-dask build-hdfs-integration build-spark-integration
+DEPENDS_ON_PYTHON = build-lint build-docs build-dask build-hdfs-integration \
+                    build-spark-integration build-python-nopandas
 DEPENDS_ON_LINT = build-iwyu build-clang-format
 
-SERVICES = $(LANGUAGES) $(MISC) $(SERVERS)
+SERVICES = $(LANGUAGES) $(MISC) $(TESTS)
 .PHONY: clean build-% run-% $(SERVICES)
 
 DC := docker-compose

--- a/dev/tasks/tests.yml
+++ b/dev/tasks/tests.yml
@@ -31,6 +31,8 @@ groups:
     - docker-python-3.7
     - docker-python-2.7-alpine
     - docker-python-3.6-alpine
+    - docker-python-2.7-nopandas
+    - docker-python-3.6-nopandas
     - docker-java
     - docker-js
     - docker-docs
@@ -54,8 +56,10 @@ groups:
     - docker-cpp-cmake32
     - docker-python-2.7
     - docker-python-2.7-alpine
+    - docker-python-2.7-nopandas
     - docker-python-3.6
     - docker-python-3.6-alpine
+    - docker-python-3.6-nopandas
     - docker-python-3.7
 
 tasks:
@@ -198,6 +202,30 @@ tasks:
         - docker-compose build cpp-alpine
         - docker-compose build python-alpine
         - docker-compose run python-alpine
+
+  docker-python-2.7-nopandas:
+    platform: linux
+    template: docker-tests/travis.linux.yml
+    params:
+      environment:
+        PYTHON_VERSION: 2.7
+      commands:
+        - docker-compose build cpp
+        - docker-compose build python
+        - docker-compose build python-nopandas
+        - docker-compose run python-nopandas
+
+  docker-python-3.6-alpine:
+    platform: linux
+    template: docker-tests/travis.linux.yml
+    params:
+      environment:
+        PYTHON_VERSION: 3.6
+      commands:
+        - docker-compose build cpp
+        - docker-compose build python
+        - docker-compose build python-nopandas
+        - docker-compose run python-nopandas
 
   ###################### Documentation building tests #########################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -274,6 +274,22 @@ services:
         PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
     volumes: *alpine-volumes
 
+  python-nopandas:
+    # Usage:
+    #   export PYTHON_VERSION=2.7|3.6|3.7
+    #   docker-compose build cpp
+    #   docker-compose build python
+    #   docker-compose build python-nopandas
+    #   docker-compose run python-nopandas
+    image: arrow:python-${PYTHON_VERSION:-3.6}-nopandas
+    shm_size: 2G
+    build:
+      context: .
+      dockerfile: python/Dockerfile.nopandas
+      args:
+        PYTHON_VERSION: ${PYTHON_VERSION:-3.6}
+    volumes: *ubuntu-volumes
+
   rust:
     # Usage:
     #   docker-compose build rust

--- a/python/Dockerfile.nopandas
+++ b/python/Dockerfile.nopandas
@@ -1,0 +1,7 @@
+ARG PYTHON_VERSION=3.6
+FROM arrow:python-$PYTHON_VERSION
+
+# not installing pandas doesn't mean that it's not grabbed as a transitive
+# dependency, so We remove it explicitly to make sure We don't have pandas
+# installed
+RUN conda remove pandas && conda clean -a

--- a/python/Dockerfile.nopandas
+++ b/python/Dockerfile.nopandas
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ARG PYTHON_VERSION=3.6
 FROM arrow:python-$PYTHON_VERSION
 


### PR DESCRIPTION
```bash
make -f Makefile.docker python-nopandas
make -f Makefile.docker run python-nopandas
```

OR

```bash
$ docker-compose build cpp
$ docker-compose build python
$ docker-compose build python-nopandas
$ docker-compose run --rm python-nopandas
```

The tests will fail until [ARROW-4794: [Python] Make pandas an optional test dependency](https://issues.apache.org/jira/browse/ARROW-4794) is implemented.