### PR TITLE
ARROW-4801: [GLib] Suppress Meson warnings

### DIFF
--- a/c_glib/arrow-cuda-glib/meson.build
+++ b/c_glib/arrow-cuda-glib/meson.build
@@ -50,12 +50,12 @@ arrow_cuda_glib = declare_dependency(link_with: libarrow_cuda_glib,
                                      include_directories: base_include_directories,
                                      dependencies: dependencies)
 
-pkgconfig.generate(filebase: 'arrow-cuda-glib',
+pkgconfig.generate(libarrow_cuda_glib,
+                   filebase: 'arrow-cuda-glib',
                    name: 'Apache Arrow CUDA GLib',
                    description: 'C API for Apache Arrow CUDA based on GLib',
                    version: version,
-                   requires: ['arrow-glib', 'arrow-cuda'],
-                   libraries: [libarrow_cuda_glib])
+                   requires: ['arrow-glib', 'arrow-cuda'])
 
 gir_dependencies = [
   declare_dependency(sources: arrow_glib_gir),

--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -208,12 +208,12 @@ arrow_glib = declare_dependency(link_with: libarrow_glib,
                                 dependencies: dependencies,
                                 sources: enums_header)
 
-pkgconfig.generate(filebase: meson.project_name(),
+pkgconfig.generate(libarrow_glib,
+                   filebase: meson.project_name(),
                    name: 'Apache Arrow GLib',
                    description: 'C API for Apache Arrow based on GLib',
                    version: version,
-                   requires: ['gio-2.0', 'arrow'],
-                   libraries: [libarrow_glib])
+                   requires: ['gio-2.0', 'arrow'])
 if have_arrow_orc
   pkgconfig.generate(filebase: 'arrow-orc-glib',
                      name: 'Apache Arrow GLib ORC',

--- a/c_glib/gandiva-glib/meson.build
+++ b/c_glib/gandiva-glib/meson.build
@@ -58,12 +58,12 @@ gandiva_glib = declare_dependency(link_with: libgandiva_glib,
                                   dependencies: dependencies,
                                   sources: enums_header)
 
-pkgconfig.generate(filebase: project_name,
+pkgconfig.generate(libgandiva_glib,
+                   filebase: project_name,
                    name: 'Apache Arrow Gandiva GLib',
                    description: 'C API for Apache Arrow Gandiva based on GLib',
                    version: version,
-                   requires: ['gandiva', 'arrow-glib'],
-                   libraries: [libgandiva_glib])
+                   requires: ['gandiva', 'arrow-glib'])
 
 gnome.generate_gir(libgandiva_glib,
                    dependencies: declare_dependency(sources: arrow_glib_gir),

--- a/c_glib/parquet-glib/meson.build
+++ b/c_glib/parquet-glib/meson.build
@@ -56,12 +56,12 @@ parquet_glib = declare_dependency(link_with: libparquet_glib,
                                   include_directories: base_include_directories,
                                   dependencies: dependencies)
 
-pkgconfig.generate(filebase: project_name,
+pkgconfig.generate(libparquet_glib,
+                   filebase: project_name,
                    name: 'Apache Parquet GLib',
                    description: 'C API for Apache Parquet based on GLib',
                    version: version,
-                   requires: ['parquet', 'arrow-glib'],
-                   libraries: [libparquet_glib])
+                   requires: ['parquet', 'arrow-glib'])
 
 gnome.generate_gir(libparquet_glib,
                    dependencies: declare_dependency(sources: arrow_glib_gir),
@@ -72,10 +72,10 @@ gnome.generate_gir(libparquet_glib,
                    symbol_prefix: 'gparquet',
                    export_packages: 'parquet-glib',
                    includes: [
-		     'Arrow-1.0',
+                     'Arrow-1.0',
                    ],
                    install: true,
                    extra_args: [
-		     '--warn-all',
-		     '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
+                     '--warn-all',
+                     '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
                    ])

--- a/c_glib/plasma-glib/meson.build
+++ b/c_glib/plasma-glib/meson.build
@@ -81,12 +81,12 @@ plasma_glib = declare_dependency(link_with: libplasma_glib,
                                  include_directories: base_include_directories,
                                  dependencies: dependencies)
 
-pkgconfig.generate(filebase: project_name,
+pkgconfig.generate(libplasma_glib,
+                   filebase: project_name,
                    name: 'Apache Arrow Plasma GLib',
                    description: 'C API for Apache Arrow Plasma based on GLib',
                    version: version,
-                   requires: pkg_config_requires,
-                   libraries: [libplasma_glib])
+                   requires: pkg_config_requires)
 
 gnome.generate_gir(libplasma_glib,
                    dependencies: gir_dependencies,


### PR DESCRIPTION
Messages:

    arrow-glib/meson.build:211: DEPRECATION: Library arrow-glib was passed to the "libraries" keyword argument of a previous call to generate() method instead of first positional argument. Adding arrow-glib to "Requires" field, but this is a deprecated behaviour that will change in a future version of Meson. Please report the issue if this warning cannot be avoided in your case.
    arrow-cuda-glib/meson.build:53: DEPRECATION: Library arrow-cuda-glib was passed to the "libraries" keyword argument of a previous call to generate() method instead of first positional argument. Adding arrow-cuda-glib to "Requires" field, but this is a deprecated behaviour that will change in a future version of Meson. Please report the issue if this warning cannot be avoided in your case.