### PR TITLE
ARROW-4772: [C++] new ORC adapter interface for stripe and row iteration

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -200,7 +200,10 @@ endif()
 
 if(ARROW_ORC)
   add_subdirectory(adapters/orc)
-  set(ARROW_SRCS adapters/orc/adapter.cc ${ARROW_SRCS})
+  set(ARROW_SRCS
+          adapters/orc/adapter.cc
+          adapters/orc/adapter_util.cc
+          ${ARROW_SRCS})
 endif()
 
 if(ARROW_TENSORFLOW)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -200,10 +200,7 @@ endif()
 
 if(ARROW_ORC)
   add_subdirectory(adapters/orc)
-  set(ARROW_SRCS
-          adapters/orc/adapter.cc
-          adapters/orc/adapter_util.cc
-          ${ARROW_SRCS})
+  set(ARROW_SRCS adapters/orc/adapter.cc adapters/orc/adapter_util.cc ${ARROW_SRCS})
 endif()
 
 if(ARROW_TENSORFLOW)

--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -27,7 +27,7 @@ configure_file(arrow-orc.pc.in "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
 
-set(ORC_MIN_TEST_LIBS ${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
+set(ORC_MIN_TEST_LIBS GTest::Main GTest::GTest)
 
 if(ARROW_BUILD_STATIC)
   set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_static arrow_static)

--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -30,20 +30,18 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc"
 set(ORC_MIN_TEST_LIBS ${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
 
 if(ARROW_BUILD_STATIC)
-    set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_static arrow_static)
+  set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_static arrow_static)
 else()
-    set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_shared arrow_shared)
+  set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_shared arrow_shared)
 endif()
 
 if(APPLE)
-    set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} ${CMAKE_DL_LIBS})
+  set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} ${CMAKE_DL_LIBS})
 elseif(NOT MSVC)
-    set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} pthread ${CMAKE_DL_LIBS})
+  set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} pthread ${CMAKE_DL_LIBS})
 endif()
 
-set(ORC_STATIC_TEST_LINK_LIBS ${ORC_MIN_TEST_LIBS}
-        ${ARROW_LIBRARIES_FOR_STATIC_TESTS} orc_static)
+set(ORC_STATIC_TEST_LINK_LIBS ${ORC_MIN_TEST_LIBS} ${ARROW_LIBRARIES_FOR_STATIC_TESTS}
+    orc_static)
 
-add_arrow_test(adapter-test PREFIX "orc"
-        STATIC_LINK_LIBS
-        ${ORC_STATIC_TEST_LINK_LIBS})
+add_arrow_test(adapter-test PREFIX "orc" STATIC_LINK_LIBS ${ORC_STATIC_TEST_LINK_LIBS})

--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -26,3 +26,24 @@ install(FILES adapter.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/adapters/
 configure_file(arrow-orc.pc.in "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc" @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/arrow-orc.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig/")
+
+set(ORC_MIN_TEST_LIBS ${GTEST_MAIN_LIBRARY} ${GTEST_LIBRARY})
+
+if(ARROW_BUILD_STATIC)
+    set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_static arrow_static)
+else()
+    set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_shared arrow_shared)
+endif()
+
+if(APPLE)
+    set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} ${CMAKE_DL_LIBS})
+elseif(NOT MSVC)
+    set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} pthread ${CMAKE_DL_LIBS})
+endif()
+
+set(ORC_STATIC_TEST_LINK_LIBS ${ORC_MIN_TEST_LIBS}
+        ${ARROW_LIBRARIES_FOR_STATIC_TESTS} orc_static)
+
+add_arrow_test(adapter-test PREFIX "orc"
+        STATIC_LINK_LIBS
+        ${ORC_STATIC_TEST_LINK_LIBS})

--- a/cpp/src/arrow/adapters/orc/adapter-test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter-test.cc
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "adapter.h"
+#include "arrow/array.h"
+#include "arrow/io/api.h"
+#include "orc/OrcFile.hh"
+
+#include <gtest/gtest.h>
+namespace liborc = orc;
+
+namespace arrow {
+
+const int DEFAULT_MEM_STREAM_SIZE = 100 * 1024 * 1024;
+
+class MemoryOutputStream : public liborc::OutputStream {
+  public:
+    MemoryOutputStream(ssize_t capacity) : name("MemoryOutputStream") {
+      data = new char[capacity];
+      length = 0;
+    }
+
+    virtual ~MemoryOutputStream() override { delete[] data; }
+
+    virtual uint64_t getLength() const override { return length; }
+
+    virtual uint64_t getNaturalWriteSize() const override { return naturalWriteSize; }
+
+    virtual void write(const void* buf, size_t size) override  {
+      memcpy(data + length, buf, size);
+      length += size;
+    }
+
+    virtual const std::string& getName() const override { return name; }
+
+    const char * getData() const { return data; }
+
+    void close() override {}
+
+    void reset()  { length = 0; }
+
+  private:
+    char * data;
+    std::string name;
+    uint64_t length, naturalWriteSize;
+  };
+
+  std::unique_ptr<liborc::Writer> createWriter(
+          uint64_t stripeSize,
+          const liborc::Type& type,
+          liborc::OutputStream* stream){
+    liborc::WriterOptions options;
+    options.setStripeSize(stripeSize);
+    options.setCompressionBlockSize(1024);
+    options.setMemoryPool(liborc::getDefaultPool());
+    options.setRowIndexStride(0);
+    return liborc::createWriter(type, stream, options);
+  }
+
+  TEST(TestAdapter, readIntFileMultipleStripes) {
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+    ORC_UNIQUE_PTR<liborc::Type> type(
+            liborc::Type::buildTypeFromString("struct<col1:int,col2:string>"));
+
+    const uint64_t stripeSize = 1024; // 1K
+    const uint64_t stripeCount = 10;
+
+    auto writer = createWriter(stripeSize, *type, &memStream);
+    auto batch = writer->createRowBatch(65535);
+    auto structBatch = dynamic_cast<liborc::StructVectorBatch*>(batch.get());
+    auto longBatch = dynamic_cast<liborc::LongVectorBatch*>(structBatch->fields[0]);
+    auto strBatch = dynamic_cast<liborc::StringVectorBatch*>(structBatch->fields[1]);
+    int64_t accumulated = 0;
+
+
+    for (uint64_t j = 0; j < stripeCount; ++j) {
+      char dataBuffer[327675];
+      uint64_t offset = 0;
+      for (uint64_t i = 0; i < 65535; ++i) {
+        std::ostringstream os;
+        os << accumulated % 65535;
+        longBatch->data[i] = static_cast<int64_t>(accumulated % 65535);
+        strBatch->data[i] = dataBuffer + offset;
+        strBatch->length[i] = static_cast<int64_t>(os.str().size());
+        memcpy(dataBuffer + offset, os.str().c_str(), os.str().size());
+        accumulated++;
+        offset += os.str().size();
+      }
+      structBatch->numElements = 65535;
+      longBatch->numElements = 65535;
+      strBatch->numElements = 65535;
+
+      writer->add(*batch);
+    }
+
+    writer->close();
+
+    std::shared_ptr<io::ReadableFileInterface> inStream(
+            new io::BufferReader(std::make_shared<Buffer>(
+                    reinterpret_cast<const uint8_t*>(memStream.getData()),
+                    static_cast<int64_t>(memStream.getLength()))));
+
+    std::unique_ptr<adapters::orc::ORCFileReader> reader;
+    EXPECT_EQ(Status::OK().code(),
+            adapters::orc::ORCFileReader::Open(inStream, default_memory_pool(), &reader).code());
+
+    EXPECT_EQ(655350, reader->NumberOfRows());
+    EXPECT_EQ(stripeCount, reader->NumberOfStripes());
+    accumulated = 0;
+    std::shared_ptr<RecordBatchReader> stripeReader;
+    EXPECT_TRUE(reader->NextStripeReader(1024, &stripeReader).ok());
+    while (stripeReader) {
+      std::shared_ptr<RecordBatch> recordBatch;
+      EXPECT_TRUE(stripeReader->ReadNext(&recordBatch).ok());
+      while (recordBatch) {
+        auto int32Array = std::dynamic_pointer_cast<Int32Array>(recordBatch->column(0));
+        auto strArray = std::dynamic_pointer_cast<StringArray>(recordBatch->column(1));
+        for (int j = 0; j < recordBatch->num_rows(); ++j) {
+          std::ostringstream os;
+          os << accumulated % 65535;
+          EXPECT_EQ(accumulated % 65535, int32Array->Value(j));
+          EXPECT_EQ(os.str(), strArray->GetString(j));
+          accumulated++;
+        }
+        EXPECT_TRUE(stripeReader->ReadNext(&recordBatch).ok());
+      }
+      EXPECT_TRUE(reader->NextStripeReader(1024, &stripeReader).ok());
+    }
+
+    // test seek operation
+    int64_t startOffset = 830;
+    EXPECT_TRUE(reader->Seek(65535 + startOffset).ok());
+
+    EXPECT_TRUE(reader->NextStripeReader(1024, &stripeReader).ok());
+    std::shared_ptr<RecordBatch> recordBatch;
+    EXPECT_TRUE(stripeReader->ReadNext(&recordBatch).ok());
+    while (recordBatch) {
+      auto int32Array = std::dynamic_pointer_cast<Int32Array>(recordBatch->column(0));
+      auto strArray = std::dynamic_pointer_cast<StringArray>(recordBatch->column(1));
+      for (int j = 0; j < recordBatch->num_rows(); ++j) {
+        std::ostringstream os;
+        os << startOffset % 65535;
+        EXPECT_EQ(startOffset % 65535, int32Array->Value(j));
+        EXPECT_EQ(os.str(), strArray->GetString(j));
+        startOffset++;
+      }
+      EXPECT_TRUE(stripeReader->ReadNext(&recordBatch).ok());
+    }
+  }
+}
+

--- a/cpp/src/arrow/adapters/orc/adapter-test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter-test.cc
@@ -39,7 +39,7 @@ class MemoryOutputStream : public liborc::OutputStream {
 
   uint64_t getLength() const override { return length_; }
 
-  uint64_t getNaturalWriteSize() const override { return naturalWriteSize_; }
+  uint64_t getNaturalWriteSize() const override { return natural_write_size_; }
 
   void write(const void* buf, size_t size) override {
     memcpy(data_ + length_, buf, size);
@@ -57,7 +57,7 @@ class MemoryOutputStream : public liborc::OutputStream {
  private:
   char* data_;
   std::string name_;
-  uint64_t length_, naturalWriteSize_;
+  uint64_t length_, natural_write_size_;
 };
 
 std::unique_ptr<liborc::Writer> CreateWriter(uint64_t stripe_size,
@@ -126,11 +126,11 @@ TEST(TestAdapter, readIntAndStringFileMultipleStripes) {
     std::shared_ptr<RecordBatch> record_batch;
     EXPECT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
     while (record_batch) {
-      auto int32Array = std::dynamic_pointer_cast<Int32Array>(record_batch->column(0));
-      auto strArray = std::dynamic_pointer_cast<StringArray>(record_batch->column(1));
+      auto int32_array = std::dynamic_pointer_cast<Int32Array>(record_batch->column(0));
+      auto str_array = std::dynamic_pointer_cast<StringArray>(record_batch->column(1));
       for (int j = 0; j < record_batch->num_rows(); ++j) {
-        EXPECT_EQ(accumulated % stripe_row_count, int32Array->Value(j));
-        EXPECT_EQ(std::to_string(accumulated % stripe_row_count), strArray->GetString(j));
+        EXPECT_EQ(accumulated % stripe_row_count, int32_array->Value(j));
+        EXPECT_EQ(std::to_string(accumulated % stripe_row_count), str_array->GetString(j));
         accumulated++;
       }
       EXPECT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
@@ -146,13 +146,13 @@ TEST(TestAdapter, readIntAndStringFileMultipleStripes) {
   std::shared_ptr<RecordBatch> record_batch;
   EXPECT_TRUE(stripe_reader->ReadNext(&record_batch).ok());
   while (record_batch) {
-    auto int32Array = std::dynamic_pointer_cast<Int32Array>(record_batch->column(0));
-    auto strArray = std::dynamic_pointer_cast<StringArray>(record_batch->column(1));
+    auto int32_array = std::dynamic_pointer_cast<Int32Array>(record_batch->column(0));
+    auto str_array = std::dynamic_pointer_cast<StringArray>(record_batch->column(1));
     for (int j = 0; j < record_batch->num_rows(); ++j) {
       std::ostringstream os;
       os << start_offset % stripe_row_count;
-      EXPECT_EQ(start_offset % stripe_row_count, int32Array->Value(j));
-      EXPECT_EQ(os.str(), strArray->GetString(j));
+      EXPECT_EQ(start_offset % stripe_row_count, int32_array->Value(j));
+      EXPECT_EQ(os.str(), str_array->GetString(j));
       start_offset++;
     }
     EXPECT_TRUE(stripe_reader->ReadNext(&record_batch).ok());

--- a/cpp/src/arrow/adapters/orc/adapter-test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter-test.cc
@@ -19,8 +19,8 @@
 #include "arrow/array.h"
 #include "arrow/io/api.h"
 
-#include <orc/OrcFile.hh>
 #include <gtest/gtest.h>
+#include <orc/OrcFile.hh>
 
 namespace liborc = orc;
 
@@ -30,11 +30,8 @@ constexpr int DEFAULT_MEM_STREAM_SIZE = 100 * 1024 * 1024;
 
 class MemoryOutputStream : public liborc::OutputStream {
  public:
-  explicit MemoryOutputStream(ssize_t capacity) :
-  data_(capacity),
-  name_("MemoryOutputStream"),
-  length_(0) {
-  }
+  explicit MemoryOutputStream(ssize_t capacity)
+      : data_(capacity), name_("MemoryOutputStream"), length_(0) {}
 
   uint64_t getLength() const override { return length_; }
 
@@ -108,7 +105,7 @@ TEST(TestAdapter, readIntAndStringFileMultipleStripes) {
 
   writer->close();
 
-  std::shared_ptr<io::ReadableFileInterface> in_stream(new io::BufferReader(
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
       std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
                                static_cast<int64_t>(mem_stream.getLength()))));
 

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -112,11 +112,11 @@ constexpr int64_t kReadRowsBatch = 1000;
 class OrcStripeReader : public RecordBatchReader {
  public:
   OrcStripeReader(std::unique_ptr<liborc::RowReader> row_reader,
-                  std::shared_ptr<Schema> schema, int64_t readSize, MemoryPool* pool)
+                  std::shared_ptr<Schema> schema, int64_t batch_size, MemoryPool* pool)
       : row_reader_(std::move(row_reader)),
         schema_(schema),
         pool_(pool),
-        batch_size_{readSize} {}
+        batch_size_{batch_size} {}
 
   std::shared_ptr<Schema> schema() const override { return schema_; }
 

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "arrow/adapters/orc/adapter.h"
+#include "arrow/adapters/orc/adapter_util.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -102,120 +103,63 @@ struct StripeInformation {
   uint64_t offset;
   uint64_t length;
   uint64_t num_rows;
+  uint64_t firstRowOfStripe;
 };
-
-Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
-  // When subselecting fields on read, liborc will set some nodes to nullptr,
-  // so we need to check for nullptr before progressing
-  if (type == nullptr) {
-    *out = null();
-    return Status::OK();
-  }
-  liborc::TypeKind kind = type->getKind();
-  const int subtype_count = static_cast<int>(type->getSubtypeCount());
-
-  switch (kind) {
-    case liborc::BOOLEAN:
-      *out = boolean();
-      break;
-    case liborc::BYTE:
-      *out = int8();
-      break;
-    case liborc::SHORT:
-      *out = int16();
-      break;
-    case liborc::INT:
-      *out = int32();
-      break;
-    case liborc::LONG:
-      *out = int64();
-      break;
-    case liborc::FLOAT:
-      *out = float32();
-      break;
-    case liborc::DOUBLE:
-      *out = float64();
-      break;
-    case liborc::VARCHAR:
-    case liborc::STRING:
-      *out = utf8();
-      break;
-    case liborc::BINARY:
-      *out = binary();
-      break;
-    case liborc::CHAR:
-      *out = fixed_size_binary(static_cast<int>(type->getMaximumLength()));
-      break;
-    case liborc::TIMESTAMP:
-      *out = timestamp(TimeUnit::NANO);
-      break;
-    case liborc::DATE:
-      *out = date32();
-      break;
-    case liborc::DECIMAL: {
-      const int precision = static_cast<int>(type->getPrecision());
-      const int scale = static_cast<int>(type->getScale());
-      if (precision == 0) {
-        // In HIVE 0.11/0.12 precision is set as 0, but means max precision
-        *out = decimal(38, 6);
-      } else {
-        *out = decimal(precision, scale);
-      }
-      break;
-    }
-    case liborc::LIST: {
-      if (subtype_count != 1) {
-        return Status::Invalid("Invalid Orc List type");
-      }
-      std::shared_ptr<DataType> elemtype;
-      RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &elemtype));
-      *out = list(elemtype);
-      break;
-    }
-    case liborc::MAP: {
-      if (subtype_count != 2) {
-        return Status::Invalid("Invalid Orc Map type");
-      }
-      std::shared_ptr<DataType> keytype;
-      std::shared_ptr<DataType> valtype;
-      RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &keytype));
-      RETURN_NOT_OK(GetArrowType(type->getSubtype(1), &valtype));
-      *out = list(struct_({field("key", keytype), field("value", valtype)}));
-      break;
-    }
-    case liborc::STRUCT: {
-      std::vector<std::shared_ptr<Field>> fields;
-      for (int child = 0; child < subtype_count; ++child) {
-        std::shared_ptr<DataType> elemtype;
-        RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
-        std::string name = type->getFieldName(child);
-        fields.push_back(field(name, elemtype));
-      }
-      *out = struct_(fields);
-      break;
-    }
-    case liborc::UNION: {
-      std::vector<std::shared_ptr<Field>> fields;
-      std::vector<uint8_t> type_codes;
-      for (int child = 0; child < subtype_count; ++child) {
-        std::shared_ptr<DataType> elemtype;
-        RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
-        fields.push_back(field("_union_" + std::to_string(child), elemtype));
-        type_codes.push_back(static_cast<uint8_t>(child));
-      }
-      *out = union_(fields, type_codes);
-      break;
-    }
-    default: { return Status::Invalid("Unknown Orc type kind: ", kind); }
-  }
-  return Status::OK();
-}
 
 // The number of rows to read in a ColumnVectorBatch
 constexpr int64_t kReadRowsBatch = 1000;
 
-// The numer of nanoseconds in a second
-constexpr int64_t kOneSecondNanos = 1000000000LL;
+class ORCStripeReader : public RecordBatchReader {
+public:
+  ORCStripeReader(
+          std::unique_ptr<liborc::RowReader> rowReader,
+          std::shared_ptr<Schema> schema,
+          int64_t readSize,
+          MemoryPool* pool):
+    rowReader_(std::move(rowReader)),
+    schema_(schema),
+    pool_(pool),
+    readSize_{readSize} {}
+
+  virtual std::shared_ptr<Schema> schema() const override {
+    return schema_;
+  }
+
+  virtual Status ReadNext(std::shared_ptr<RecordBatch>* out) override {
+    std::unique_ptr<liborc::ColumnVectorBatch> batch;
+    try {
+      batch = rowReader_->createRowBatch(readSize_);
+    } catch (const liborc::ParseError& e) {
+      return Status::Invalid(e.what());
+    }
+
+    const liborc::Type& type = rowReader_->getSelectedType();
+    if (!rowReader_->next(*batch)) {
+      out->reset();
+      return Status::OK();
+    }
+
+    std::unique_ptr<RecordBatchBuilder> builder;
+    RETURN_NOT_OK(RecordBatchBuilder::Make(schema_, pool_, batch->numElements, &builder));
+
+    // The top-level type must be a struct to read into an arrow table
+    const auto& struct_batch = checked_cast<liborc::StructVectorBatch&>(*batch);
+
+    for (int i = 0; i < builder->num_fields(); i++) {
+      RETURN_NOT_OK(AdapaterUtil::AppendBatch(type.getSubtype(i), struct_batch.fields[i], 0,
+                                              batch->numElements, builder->GetField(i)));
+    }
+
+    RETURN_NOT_OK(builder->Flush(out));
+    return Status::OK();
+  }
+
+private:
+  std::unique_ptr<liborc::RowReader> rowReader_;
+  std::shared_ptr<Schema> schema_;
+  MemoryPool* pool_;
+  int64_t readSize_;
+};
 
 class ORCFileReader::Impl {
  public:
@@ -233,6 +177,7 @@ class ORCFileReader::Impl {
     }
     pool_ = pool;
     reader_ = std::move(liborc_reader);
+    currentRow = 0;
 
     return Init();
   }
@@ -241,10 +186,12 @@ class ORCFileReader::Impl {
     int64_t nstripes = reader_->getNumberOfStripes();
     stripes_.resize(nstripes);
     std::unique_ptr<liborc::StripeInformation> stripe;
+    uint64_t firstRowOfStripe = 0;
     for (int i = 0; i < nstripes; ++i) {
       stripe = reader_->getStripe(i);
       stripes_[i] = StripeInformation(
-          {stripe->getOffset(), stripe->getLength(), stripe->getNumberOfRows()});
+          {stripe->getOffset(), stripe->getLength(), stripe->getNumberOfRows(), firstRowOfStripe});
+      firstRowOfStripe += stripe->getNumberOfRows();
     }
     return Status::OK();
   }
@@ -279,7 +226,7 @@ class ORCFileReader::Impl {
     std::vector<std::shared_ptr<Field>> fields;
     for (int child = 0; child < size; ++child) {
       std::shared_ptr<DataType> elemtype;
-      RETURN_NOT_OK(GetArrowType(type.getSubtype(child), &elemtype));
+      RETURN_NOT_OK(AdapaterUtil::GetArrowType(type.getSubtype(child), &elemtype));
       std::string name = type.getFieldName(child);
       fields.push_back(field(name, elemtype));
     }
@@ -349,6 +296,22 @@ class ORCFileReader::Impl {
     return Status::OK();
   }
 
+  Status SelectStripeWithRowNumber(liborc::RowReaderOptions* opts, int64_t rowNumber, StripeInformation* out) {
+    ARROW_RETURN_IF(rowNumber >= NumberOfRows(),
+                    Status::Invalid("Out of bounds row number: ", rowNumber));
+
+    for (auto it = stripes_.begin(); it != stripes_.end(); it++) {
+      if ( static_cast<uint64_t>(rowNumber) >= it->firstRowOfStripe &&
+            static_cast<uint64_t>(rowNumber) < it->firstRowOfStripe + it->num_rows) {
+        opts->range(it->offset, it->length);
+        *out = *it;
+        return Status::OK();
+      }
+    }
+
+    return Status::Invalid("Invalid row number", rowNumber);
+  }
+
   Status SelectIndices(liborc::RowReaderOptions* opts,
                        const std::vector<int>& include_indices) {
     std::list<uint64_t> include_indices_list;
@@ -391,7 +354,7 @@ class ORCFileReader::Impl {
     const liborc::Type& type = rowreader->getSelectedType();
     while (rowreader->next(*batch)) {
       for (int i = 0; i < builder->num_fields(); i++) {
-        RETURN_NOT_OK(AppendBatch(type.getSubtype(i), struct_batch.fields[i], 0,
+        RETURN_NOT_OK(AdapaterUtil::AppendBatch(type.getSubtype(i), struct_batch.fields[i], 0,
                                   batch->numElements, builder->GetField(i)));
       }
     }
@@ -399,283 +362,51 @@ class ORCFileReader::Impl {
     return Status::OK();
   }
 
-  Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
-                     int64_t offset, int64_t length, ArrayBuilder* builder) {
-    if (type == nullptr) {
-      return Status::OK();
-    }
-    liborc::TypeKind kind = type->getKind();
-    switch (kind) {
-      case liborc::STRUCT:
-        return AppendStructBatch(type, batch, offset, length, builder);
-      case liborc::LIST:
-        return AppendListBatch(type, batch, offset, length, builder);
-      case liborc::MAP:
-        return AppendMapBatch(type, batch, offset, length, builder);
-      case liborc::LONG:
-        return AppendNumericBatch<Int64Builder, liborc::LongVectorBatch, int64_t>(
-            batch, offset, length, builder);
-      case liborc::INT:
-        return AppendNumericBatchCast<Int32Builder, int32_t, liborc::LongVectorBatch,
-                                      int64_t>(batch, offset, length, builder);
-      case liborc::SHORT:
-        return AppendNumericBatchCast<Int16Builder, int16_t, liborc::LongVectorBatch,
-                                      int64_t>(batch, offset, length, builder);
-      case liborc::BYTE:
-        return AppendNumericBatchCast<Int8Builder, int8_t, liborc::LongVectorBatch,
-                                      int64_t>(batch, offset, length, builder);
-      case liborc::DOUBLE:
-        return AppendNumericBatch<DoubleBuilder, liborc::DoubleVectorBatch, double>(
-            batch, offset, length, builder);
-      case liborc::FLOAT:
-        return AppendNumericBatchCast<FloatBuilder, float, liborc::DoubleVectorBatch,
-                                      double>(batch, offset, length, builder);
-      case liborc::BOOLEAN:
-        return AppendBoolBatch(batch, offset, length, builder);
-      case liborc::VARCHAR:
-      case liborc::STRING:
-        return AppendBinaryBatch<StringBuilder>(batch, offset, length, builder);
-      case liborc::BINARY:
-        return AppendBinaryBatch<BinaryBuilder>(batch, offset, length, builder);
-      case liborc::CHAR:
-        return AppendFixedBinaryBatch(batch, offset, length, builder);
-      case liborc::DATE:
-        return AppendNumericBatchCast<Date32Builder, int32_t, liborc::LongVectorBatch,
-                                      int64_t>(batch, offset, length, builder);
-      case liborc::TIMESTAMP:
-        return AppendTimestampBatch(batch, offset, length, builder);
-      case liborc::DECIMAL:
-        return AppendDecimalBatch(type, batch, offset, length, builder);
-      default:
-        return Status::NotImplemented("Not implemented type kind: ", kind);
-    }
-  }
+  Status Seek(int64_t rowNumber) {
+    ARROW_RETURN_IF(rowNumber >= NumberOfRows(),
+          Status::Invalid("Out of bounds row number: ", rowNumber));
 
-  Status AppendStructBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                           int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<StructBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::StructVectorBatch*>(cbatch);
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    RETURN_NOT_OK(builder->AppendValues(length, valid_bytes));
-
-    for (int i = 0; i < builder->num_fields(); i++) {
-      RETURN_NOT_OK(AppendBatch(type->getSubtype(i), batch->fields[i], offset, length,
-                                builder->field_builder(i)));
-    }
+    currentRow = rowNumber;
     return Status::OK();
   }
 
-  Status AppendListBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                         int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<ListBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::ListVectorBatch*>(cbatch);
-    liborc::ColumnVectorBatch* elements = batch->elements.get();
-    const liborc::Type* elemtype = type->getSubtype(0);
-
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      if (!has_nulls || batch->notNull[i]) {
-        int64_t start = batch->offsets[i];
-        int64_t end = batch->offsets[i + 1];
-        RETURN_NOT_OK(builder->Append());
-        RETURN_NOT_OK(AppendBatch(elemtype, elements, start, end - start,
-                                  builder->value_builder()));
-      } else {
-        RETURN_NOT_OK(builder->AppendNull());
-      }
-    }
-    return Status::OK();
-  }
-
-  Status AppendMapBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                        int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto list_builder = checked_cast<ListBuilder*>(abuilder);
-    auto struct_builder = checked_cast<StructBuilder*>(list_builder->value_builder());
-    auto batch = checked_cast<liborc::MapVectorBatch*>(cbatch);
-    liborc::ColumnVectorBatch* keys = batch->keys.get();
-    liborc::ColumnVectorBatch* vals = batch->elements.get();
-    const liborc::Type* keytype = type->getSubtype(0);
-    const liborc::Type* valtype = type->getSubtype(1);
-
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      RETURN_NOT_OK(list_builder->Append());
-      int64_t start = batch->offsets[i];
-      int64_t list_length = batch->offsets[i + 1] - start;
-      if (list_length && (!has_nulls || batch->notNull[i])) {
-        RETURN_NOT_OK(struct_builder->AppendValues(list_length, nullptr));
-        RETURN_NOT_OK(AppendBatch(keytype, keys, start, list_length,
-                                  struct_builder->field_builder(0)));
-        RETURN_NOT_OK(AppendBatch(valtype, vals, start, list_length,
-                                  struct_builder->field_builder(1)));
-      }
-    }
-    return Status::OK();
-  }
-
-  template <class builder_type, class batch_type, class elem_type>
-  Status AppendNumericBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                            int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<builder_type*>(abuilder);
-    auto batch = checked_cast<batch_type*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    const elem_type* source = batch->data.data() + offset;
-    RETURN_NOT_OK(builder->AppendValues(source, length, valid_bytes));
-    return Status::OK();
-  }
-
-  template <class builder_type, class target_type, class batch_type, class source_type>
-  Status AppendNumericBatchCast(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                                int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<builder_type*>(abuilder);
-    auto batch = checked_cast<batch_type*>(cbatch);
-
-    if (length == 0) {
+  Status NextStripeReader(int64_t readSize, const std::vector<int>& include_indices,
+                        std::shared_ptr<RecordBatchReader>* out) {
+    if (currentRow >= NumberOfRows()) {
+      out->reset();
       return Status::OK();
     }
 
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+    liborc::RowReaderOptions opts;
+    if (!include_indices.empty()) {
+      RETURN_NOT_OK(SelectIndices(&opts, include_indices));
     }
-    const source_type* source = batch->data.data() + offset;
-    auto cast_iter = internal::MakeLazyRange(
-        [&source](int64_t index) { return static_cast<target_type>(source[index]); },
-        length);
+    StripeInformation stripeInfo;
+    RETURN_NOT_OK(SelectStripeWithRowNumber(&opts, currentRow, &stripeInfo));
+    std::shared_ptr<Schema> schema;
+    RETURN_NOT_OK(ReadSchema(opts, &schema));
+    std::unique_ptr<liborc::RowReader> rowreader;
+    try {
+      rowreader = reader_->createRowReader(opts);
+      rowreader->seekToRow(currentRow);
+      currentRow = stripeInfo.firstRowOfStripe + stripeInfo.num_rows;
+    } catch (const liborc::ParseError& e) {
+      return Status::Invalid(e.what());
+    }
 
-    RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
-
+    *out = std::shared_ptr<RecordBatchReader>(new ORCStripeReader(std::move(rowreader), schema, readSize, pool_));
     return Status::OK();
   }
 
-  Status AppendBoolBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                         int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<BooleanBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::LongVectorBatch*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    const int64_t* source = batch->data.data() + offset;
-
-    auto cast_iter = internal::MakeLazyRange(
-        [&source](int64_t index) { return static_cast<bool>(source[index]); }, length);
-
-    RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
-
-    return Status::OK();
-  }
-
-  Status AppendTimestampBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                              int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<TimestampBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::TimestampVectorBatch*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-
-    const int64_t* seconds = batch->data.data() + offset;
-    const int64_t* nanos = batch->nanoseconds.data() + offset;
-
-    auto transform_timestamp = [seconds, nanos](int64_t index) {
-      return seconds[index] * kOneSecondNanos + nanos[index];
-    };
-
-    auto transform_range = internal::MakeLazyRange(transform_timestamp, length);
-
-    RETURN_NOT_OK(builder->AppendValues(transform_range.begin(), transform_range.end(),
-                                        valid_bytes));
-    return Status::OK();
-  }
-
-  template <class builder_type>
-  Status AppendBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                           int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<builder_type*>(abuilder);
-    auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
-
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      if (!has_nulls || batch->notNull[i]) {
-        RETURN_NOT_OK(
-            builder->Append(batch->data[i], static_cast<int32_t>(batch->length[i])));
-      } else {
-        RETURN_NOT_OK(builder->AppendNull());
-      }
-    }
-    return Status::OK();
-  }
-
-  Status AppendFixedBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                                int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<FixedSizeBinaryBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
-
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      if (!has_nulls || batch->notNull[i]) {
-        RETURN_NOT_OK(builder->Append(batch->data[i]));
-      } else {
-        RETURN_NOT_OK(builder->AppendNull());
-      }
-    }
-    return Status::OK();
-  }
-
-  Status AppendDecimalBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                            int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<Decimal128Builder*>(abuilder);
-
-    const bool has_nulls = cbatch->hasNulls;
-    if (type->getPrecision() == 0 || type->getPrecision() > 18) {
-      auto batch = checked_cast<liborc::Decimal128VectorBatch*>(cbatch);
-      for (int64_t i = offset; i < length + offset; i++) {
-        if (!has_nulls || batch->notNull[i]) {
-          RETURN_NOT_OK(builder->Append(
-              Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
-        } else {
-          RETURN_NOT_OK(builder->AppendNull());
-        }
-      }
-    } else {
-      auto batch = checked_cast<liborc::Decimal64VectorBatch*>(cbatch);
-      for (int64_t i = offset; i < length + offset; i++) {
-        if (!has_nulls || batch->notNull[i]) {
-          RETURN_NOT_OK(builder->Append(Decimal128(batch->values[i])));
-        } else {
-          RETURN_NOT_OK(builder->AppendNull());
-        }
-      }
-    }
-    return Status::OK();
+  Status NextStripeReader(int64_t readSize, std::shared_ptr<RecordBatchReader>* out) {
+    return NextStripeReader(readSize, {}, out);
   }
 
  private:
   MemoryPool* pool_;
   std::unique_ptr<liborc::Reader> reader_;
   std::vector<StripeInformation> stripes_;
+  int64_t currentRow;
 };
 
 ORCFileReader::ORCFileReader() { impl_.reset(new ORCFileReader::Impl()); }
@@ -719,6 +450,19 @@ Status ORCFileReader::ReadStripe(int64_t stripe, std::shared_ptr<RecordBatch>* o
 Status ORCFileReader::ReadStripe(int64_t stripe, const std::vector<int>& include_indices,
                                  std::shared_ptr<RecordBatch>* out) {
   return impl_->ReadStripe(stripe, include_indices, out);
+}
+
+Status ORCFileReader::Seek(int64_t rowNumber) {
+  return impl_->Seek(rowNumber);
+}
+
+Status ORCFileReader::NextStripeReader(int64_t readSize, std::shared_ptr<RecordBatchReader>* out) {
+  return impl_->NextStripeReader(readSize, out);
+}
+
+Status ORCFileReader::NextStripeReader(int64_t readSize, const std::vector<int>& include_indices,
+                        std::shared_ptr<RecordBatchReader>* out) {
+  return impl_->NextStripeReader(readSize, include_indices, out);
 }
 
 int64_t ORCFileReader::NumberOfStripes() { return impl_->NumberOfStripes(); }

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -105,8 +105,8 @@ class ARROW_EXPORT ORCFileReader {
   /// \brief Seek to designated row. Invoke NextStripeReader() after seek
   ///        will return stripe reader starting from designed row.
   ///
-  /// \param[in] rowNumber the rows number to seek
-  Status Seek(int64_t rowNumber);
+  /// \param[in] row_number the rows number to seek
+  Status Seek(int64_t row_number);
 
   /// \brief Get a stripe level record batch iterator with specified row count
   ///         in each record batch. NextStripeReader serves as an fine grain
@@ -119,7 +119,7 @@ class ARROW_EXPORT ORCFileReader {
   Status NextStripeReader(int64_t batch_size, std::shared_ptr<RecordBatchReader>* out);
 
   /// \brief Get a stripe level record batch iterator with specified row count
-  ///         in each record batch.NextStripeReader serves as an fine grain
+  ///         in each record batch. NextStripeReader serves as an fine grain
   ///         alternative to ReadStripe which may cause OOM issue by loading
   ///         the whole stripes into memory.
   ///

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -41,7 +41,6 @@ class ARROW_EXPORT ORCFileReader {
  public:
   ~ORCFileReader();
 
-
   /// \brief Create a new ORC reader with default read size as 1024
   ///
   /// \param[in] file the data source

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -120,7 +120,7 @@ class ARROW_EXPORT ORCFileReader {
 
   /// \brief Get a stripe level record batch iterator with specified row count
   ///         in each record batch.NextStripeReader serves as an fine grain
-  ///         alternative to ReadStripe which may cause OOM issue by loading 
+  ///         alternative to ReadStripe which may cause OOM issue by loading
   ///         the whole stripes into memory.
   ///
   /// \param[in] batch_size Get a stripe level record batch iterator with specified row

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -92,6 +92,7 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// \param[in] stripe the stripe index
   /// \param[out] out the returned RecordBatch
+  ARROW_DEPRECATED("Use Seek with NextStripeReader")
   Status ReadStripe(int64_t stripe, std::shared_ptr<RecordBatch>* out);
 
   /// \brief Read a single stripe as a RecordBatch
@@ -99,6 +100,7 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[in] stripe the stripe index
   /// \param[in] include_indices the selected field indices to read
   /// \param[out] out the returned RecordBatch
+  ARROW_DEPRECATED("Use Seek with NextStripeReader")
   Status ReadStripe(int64_t stripe, const std::vector<int>& include_indices,
                     std::shared_ptr<RecordBatch>* out);
 
@@ -108,18 +110,23 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[in] rowNumber the rows number to seek
   Status Seek(int64_t rowNumber);
 
-  /// \brief Get stripe reader
+  /// \brief Get a stripe level record batch iterator with specified row count
+  ///         in each record batch.
   ///
-  /// \param[in] readSize the record batch reader default read size
+  /// \param[in] batch_size the number of rows each record batch contains in
+  ///            record batch iteration.
   /// \param[out] out the returned stripe reader
-  Status NextStripeReader(int64_t readSize, std::shared_ptr<RecordBatchReader>* out);
+  Status NextStripeReader(int64_t batch_size, std::shared_ptr<RecordBatchReader>* out);
 
-  /// \brief Get stripe reader
+  /// \brief Get a stripe level record batch iterator with specified row count
+  ///         in each record batch.
   ///
-  /// \param[in] readSize the record batch reader default read size
+  /// \param[in] batch_size Get a stripe level record batch iterator with specified row
+  /// count
+  ///         in each record batch.
   /// \param[in] include_indices the selected field indices to read
   /// \param[out] out the returned stripe reader
-  Status NextStripeReader(int64_t readSize, const std::vector<int>& include_indices,
+  Status NextStripeReader(int64_t batch_size, const std::vector<int>& include_indices,
                           std::shared_ptr<RecordBatchReader>* out);
 
   /// \brief The number of stripes in the file

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -103,7 +103,7 @@ class ARROW_EXPORT ORCFileReader {
                     std::shared_ptr<RecordBatch>* out);
 
   /// \brief Seek to designated row. Invoke NextStripeReader() after seek
-  ///        will return stripe reader starting from designed row.
+  ///        will return stripe reader starting from designated row.
   ///
   /// \param[in] row_number the rows number to seek
   Status Seek(int64_t row_number);

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -41,7 +41,8 @@ class ARROW_EXPORT ORCFileReader {
  public:
   ~ORCFileReader();
 
-  /// \brief Create a new ORC reader
+
+  /// \brief Create a new ORC reader with default read size as 1024
   ///
   /// \param[in] file the data source
   /// \param[in] pool a MemoryPool to use for buffer allocations
@@ -101,6 +102,26 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[out] out the returned RecordBatch
   Status ReadStripe(int64_t stripe, const std::vector<int>& include_indices,
                     std::shared_ptr<RecordBatch>* out);
+
+  /// \brief Seek to designated row. Invoke NextStripeReader() after seek
+  ///        will return stripe reader starting from designed row.
+  ///
+  /// \param[in] rowNumber the rows number to seek
+  Status Seek(int64_t rowNumber);
+
+  /// \brief Get stripe reader
+  ///
+  /// \param[in] readSize the record batch reader default read size
+  /// \param[out] out the returned stripe reader
+  Status NextStripeReader(int64_t readSize, std::shared_ptr<RecordBatchReader>* out);
+
+  /// \brief Get stripe reader
+  ///
+  /// \param[in] readSize the record batch reader default read size
+  /// \param[in] include_indices the selected field indices to read
+  /// \param[out] out the returned stripe reader
+  Status NextStripeReader(int64_t readSize, const std::vector<int>& include_indices,
+                          std::shared_ptr<RecordBatchReader>* out);
 
   /// \brief The number of stripes in the file
   int64_t NumberOfStripes();

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -41,7 +41,7 @@ class ARROW_EXPORT ORCFileReader {
  public:
   ~ORCFileReader();
 
-  /// \brief Create a new ORC reader with default read size as 1024
+  /// \brief Creates a new ORC reader.
   ///
   /// \param[in] file the data source
   /// \param[in] pool a MemoryPool to use for buffer allocations
@@ -92,7 +92,6 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// \param[in] stripe the stripe index
   /// \param[out] out the returned RecordBatch
-  ARROW_DEPRECATED("Use Seek with NextStripeReader")
   Status ReadStripe(int64_t stripe, std::shared_ptr<RecordBatch>* out);
 
   /// \brief Read a single stripe as a RecordBatch
@@ -100,7 +99,6 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[in] stripe the stripe index
   /// \param[in] include_indices the selected field indices to read
   /// \param[out] out the returned RecordBatch
-  ARROW_DEPRECATED("Use Seek with NextStripeReader")
   Status ReadStripe(int64_t stripe, const std::vector<int>& include_indices,
                     std::shared_ptr<RecordBatch>* out);
 
@@ -111,7 +109,9 @@ class ARROW_EXPORT ORCFileReader {
   Status Seek(int64_t rowNumber);
 
   /// \brief Get a stripe level record batch iterator with specified row count
-  ///         in each record batch.
+  ///         in each record batch. NextStripeReader serves as an fine grain
+  ///         alternative to ReadStripe which may cause OOM issue by loading
+  ///         the whole stripes into memory.
   ///
   /// \param[in] batch_size the number of rows each record batch contains in
   ///            record batch iteration.
@@ -119,11 +119,13 @@ class ARROW_EXPORT ORCFileReader {
   Status NextStripeReader(int64_t batch_size, std::shared_ptr<RecordBatchReader>* out);
 
   /// \brief Get a stripe level record batch iterator with specified row count
-  ///         in each record batch.
+  ///         in each record batch.NextStripeReader serves as an fine grain
+  ///         alternative to ReadStripe which may cause OOM issue by loading 
+  ///         the whole stripes into memory.
   ///
   /// \param[in] batch_size Get a stripe level record batch iterator with specified row
-  /// count
-  ///         in each record batch.
+  /// count in each record batch.
+  ///
   /// \param[in] include_indices the selected field indices to read
   /// \param[out] out the returned stripe reader
   Status NextStripeReader(int64_t batch_size, const std::vector<int>& include_indices,

--- a/cpp/src/arrow/adapters/orc/adapter_util.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_util.cc
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "adapter_util.h"
+#include <string>
+#include <vector>
 
+#include "arrow/adapters/orc/adapter_util.h"
 #include "arrow/builder.h"
 #include "arrow/array/builder_base.h"
 #include "arrow/util/checked_cast.h"
@@ -48,8 +50,9 @@ constexpr int64_t kOneSecondNanos = 1000000000LL;
     RETURN_NOT_OK(builder->AppendValues(length, valid_bytes));
 
     for (int i = 0; i < builder->num_fields(); i++) {
-      RETURN_NOT_OK(AdapaterUtil::AppendBatch(type->getSubtype(i), batch->fields[i], offset, length,
-                                builder->field_builder(i)));
+      RETURN_NOT_OK(AdapaterUtil::AppendBatch(
+              type->getSubtype(i), batch->fields[i],
+              offset, length, builder->field_builder(i)));
     }
     return Status::OK();
   }
@@ -160,7 +163,7 @@ constexpr int64_t kOneSecondNanos = 1000000000LL;
     const int64_t* source = batch->data.data() + offset;
 
     auto cast_iter = internal::MakeLazyRange(
-            [&source](int64_t index) { return static_cast<bool>(source[index]); }, length);
+           [&source](int64_t index) { return static_cast<bool>(source[index]); }, length);
 
     RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
 
@@ -239,7 +242,7 @@ constexpr int64_t kOneSecondNanos = 1000000000LL;
       for (int64_t i = offset; i < length + offset; i++) {
         if (!has_nulls || batch->notNull[i]) {
           RETURN_NOT_OK(builder->Append(
-                  Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
+             Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
         } else {
           RETURN_NOT_OK(builder->AppendNull());
         }
@@ -257,8 +260,9 @@ constexpr int64_t kOneSecondNanos = 1000000000LL;
     return Status::OK();
   }
 
-  Status AdapaterUtil::AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
-                     int64_t offset, int64_t length, ArrayBuilder* builder) {
+  Status AdapaterUtil::AppendBatch(
+          const liborc::Type* type, liborc::ColumnVectorBatch* batch,
+          int64_t offset, int64_t length, ArrayBuilder* builder) {
     if (type == nullptr) {
       return Status::OK();
     }
@@ -309,7 +313,8 @@ constexpr int64_t kOneSecondNanos = 1000000000LL;
     }
   }
 
-  Status AdapaterUtil::GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
+  Status AdapaterUtil::GetArrowType(
+          const liborc::Type* type, std::shared_ptr<DataType>* out) {
     // When subselecting fields on read, liborc will set some nodes to nullptr,
     // so we need to check for nullptr before progressing
     if (type == nullptr) {

--- a/cpp/src/arrow/adapters/orc/adapter_util.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_util.cc
@@ -1,0 +1,418 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "adapter_util.h"
+
+#include "arrow/builder.h"
+#include "arrow/array/builder_base.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/decimal.h"
+#include "arrow/util/lazy.h"
+
+#include "orc/Exceptions.hh"
+#include "orc/OrcFile.hh"
+
+// alias to not interfere with nested orc namespace
+namespace liborc = orc;
+
+namespace arrow {
+
+using internal::checked_cast;
+
+// The numer of nanoseconds in a second
+constexpr int64_t kOneSecondNanos = 1000000000LL;
+
+  Status AppendStructBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                           int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<StructBuilder*>(abuilder);
+    auto batch = checked_cast<liborc::StructVectorBatch*>(cbatch);
+
+    const uint8_t* valid_bytes = nullptr;
+    if (batch->hasNulls) {
+      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+    }
+    RETURN_NOT_OK(builder->AppendValues(length, valid_bytes));
+
+    for (int i = 0; i < builder->num_fields(); i++) {
+      RETURN_NOT_OK(AdapaterUtil::AppendBatch(type->getSubtype(i), batch->fields[i], offset, length,
+                                builder->field_builder(i)));
+    }
+    return Status::OK();
+  }
+
+  Status AppendListBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                         int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<ListBuilder*>(abuilder);
+    auto batch = checked_cast<liborc::ListVectorBatch*>(cbatch);
+    liborc::ColumnVectorBatch* elements = batch->elements.get();
+    const liborc::Type* elemtype = type->getSubtype(0);
+
+    const bool has_nulls = batch->hasNulls;
+    for (int64_t i = offset; i < length + offset; i++) {
+      if (!has_nulls || batch->notNull[i]) {
+        int64_t start = batch->offsets[i];
+        int64_t end = batch->offsets[i + 1];
+        RETURN_NOT_OK(builder->Append());
+        RETURN_NOT_OK(AdapaterUtil::AppendBatch(elemtype, elements, start, end - start,
+                                  builder->value_builder()));
+      } else {
+        RETURN_NOT_OK(builder->AppendNull());
+      }
+    }
+    return Status::OK();
+  }
+
+  Status AppendMapBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                        int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+    auto list_builder = checked_cast<ListBuilder*>(abuilder);
+    auto struct_builder = checked_cast<StructBuilder*>(list_builder->value_builder());
+    auto batch = checked_cast<liborc::MapVectorBatch*>(cbatch);
+    liborc::ColumnVectorBatch* keys = batch->keys.get();
+    liborc::ColumnVectorBatch* vals = batch->elements.get();
+    const liborc::Type* keytype = type->getSubtype(0);
+    const liborc::Type* valtype = type->getSubtype(1);
+
+    const bool has_nulls = batch->hasNulls;
+    for (int64_t i = offset; i < length + offset; i++) {
+      RETURN_NOT_OK(list_builder->Append());
+      int64_t start = batch->offsets[i];
+      int64_t list_length = batch->offsets[i + 1] - start;
+      if (list_length && (!has_nulls || batch->notNull[i])) {
+        RETURN_NOT_OK(struct_builder->AppendValues(list_length, nullptr));
+        RETURN_NOT_OK(AdapaterUtil::AppendBatch(keytype, keys, start, list_length,
+                                  struct_builder->field_builder(0)));
+        RETURN_NOT_OK(AdapaterUtil::AppendBatch(valtype, vals, start, list_length,
+                                  struct_builder->field_builder(1)));
+      }
+    }
+    return Status::OK();
+  }
+
+  template <class builder_type, class batch_type, class elem_type>
+  Status AppendNumericBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                            int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<builder_type*>(abuilder);
+    auto batch = checked_cast<batch_type*>(cbatch);
+
+    if (length == 0) {
+      return Status::OK();
+    }
+    const uint8_t* valid_bytes = nullptr;
+    if (batch->hasNulls) {
+      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+    }
+    const elem_type* source = batch->data.data() + offset;
+    RETURN_NOT_OK(builder->AppendValues(source, length, valid_bytes));
+    return Status::OK();
+  }
+
+  template <class builder_type, class target_type, class batch_type, class source_type>
+  Status AppendNumericBatchCast(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                                int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<builder_type*>(abuilder);
+    auto batch = checked_cast<batch_type*>(cbatch);
+
+    if (length == 0) {
+      return Status::OK();
+    }
+
+    const uint8_t* valid_bytes = nullptr;
+    if (batch->hasNulls) {
+      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+    }
+    const source_type* source = batch->data.data() + offset;
+    auto cast_iter = internal::MakeLazyRange(
+            [&source](int64_t index) { return static_cast<target_type>(source[index]); },
+            length);
+
+    RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
+
+    return Status::OK();
+  }
+
+  Status AppendBoolBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                         int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<BooleanBuilder*>(abuilder);
+    auto batch = checked_cast<liborc::LongVectorBatch*>(cbatch);
+
+    if (length == 0) {
+      return Status::OK();
+    }
+
+    const uint8_t* valid_bytes = nullptr;
+    if (batch->hasNulls) {
+      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+    }
+    const int64_t* source = batch->data.data() + offset;
+
+    auto cast_iter = internal::MakeLazyRange(
+            [&source](int64_t index) { return static_cast<bool>(source[index]); }, length);
+
+    RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
+
+    return Status::OK();
+  }
+
+  Status AppendTimestampBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                              int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<TimestampBuilder*>(abuilder);
+    auto batch = checked_cast<liborc::TimestampVectorBatch*>(cbatch);
+
+    if (length == 0) {
+      return Status::OK();
+    }
+
+    const uint8_t* valid_bytes = nullptr;
+    if (batch->hasNulls) {
+      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+    }
+
+    const int64_t* seconds = batch->data.data() + offset;
+    const int64_t* nanos = batch->nanoseconds.data() + offset;
+
+    auto transform_timestamp = [seconds, nanos](int64_t index) {
+      return seconds[index] * kOneSecondNanos + nanos[index];
+    };
+
+    auto transform_range = internal::MakeLazyRange(transform_timestamp, length);
+
+    RETURN_NOT_OK(builder->AppendValues(transform_range.begin(), transform_range.end(),
+                                        valid_bytes));
+    return Status::OK();
+  }
+
+  template <class builder_type>
+  Status AppendBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                           int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<builder_type*>(abuilder);
+    auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
+
+    const bool has_nulls = batch->hasNulls;
+    for (int64_t i = offset; i < length + offset; i++) {
+      if (!has_nulls || batch->notNull[i]) {
+        RETURN_NOT_OK(
+                builder->Append(batch->data[i], static_cast<int32_t>(batch->length[i])));
+      } else {
+        RETURN_NOT_OK(builder->AppendNull());
+      }
+    }
+    return Status::OK();
+  }
+
+  Status AppendFixedBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                                int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<FixedSizeBinaryBuilder*>(abuilder);
+    auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
+
+    const bool has_nulls = batch->hasNulls;
+    for (int64_t i = offset; i < length + offset; i++) {
+      if (!has_nulls || batch->notNull[i]) {
+        RETURN_NOT_OK(builder->Append(batch->data[i]));
+      } else {
+        RETURN_NOT_OK(builder->AppendNull());
+      }
+    }
+    return Status::OK();
+  }
+
+  Status AppendDecimalBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                            int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+    auto builder = checked_cast<Decimal128Builder*>(abuilder);
+
+    const bool has_nulls = cbatch->hasNulls;
+    if (type->getPrecision() == 0 || type->getPrecision() > 18) {
+      auto batch = checked_cast<liborc::Decimal128VectorBatch*>(cbatch);
+      for (int64_t i = offset; i < length + offset; i++) {
+        if (!has_nulls || batch->notNull[i]) {
+          RETURN_NOT_OK(builder->Append(
+                  Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
+        } else {
+          RETURN_NOT_OK(builder->AppendNull());
+        }
+      }
+    } else {
+      auto batch = checked_cast<liborc::Decimal64VectorBatch*>(cbatch);
+      for (int64_t i = offset; i < length + offset; i++) {
+        if (!has_nulls || batch->notNull[i]) {
+          RETURN_NOT_OK(builder->Append(Decimal128(batch->values[i])));
+        } else {
+          RETURN_NOT_OK(builder->AppendNull());
+        }
+      }
+    }
+    return Status::OK();
+  }
+
+  Status AdapaterUtil::AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
+                     int64_t offset, int64_t length, ArrayBuilder* builder) {
+    if (type == nullptr) {
+      return Status::OK();
+    }
+    liborc::TypeKind kind = type->getKind();
+    switch (kind) {
+      case liborc::STRUCT:
+        return AppendStructBatch(type, batch, offset, length, builder);
+      case liborc::LIST:
+        return AppendListBatch(type, batch, offset, length, builder);
+      case liborc::MAP:
+        return AppendMapBatch(type, batch, offset, length, builder);
+      case liborc::LONG:
+        return AppendNumericBatch<Int64Builder, liborc::LongVectorBatch, int64_t>(
+                batch, offset, length, builder);
+      case liborc::INT:
+        return AppendNumericBatchCast<Int32Builder, int32_t, liborc::LongVectorBatch,
+                int64_t>(batch, offset, length, builder);
+      case liborc::SHORT:
+        return AppendNumericBatchCast<Int16Builder, int16_t, liborc::LongVectorBatch,
+                int64_t>(batch, offset, length, builder);
+      case liborc::BYTE:
+        return AppendNumericBatchCast<Int8Builder, int8_t, liborc::LongVectorBatch,
+                int64_t>(batch, offset, length, builder);
+      case liborc::DOUBLE:
+        return AppendNumericBatch<DoubleBuilder, liborc::DoubleVectorBatch, double>(
+                batch, offset, length, builder);
+      case liborc::FLOAT:
+        return AppendNumericBatchCast<FloatBuilder, float, liborc::DoubleVectorBatch,
+                double>(batch, offset, length, builder);
+      case liborc::BOOLEAN:
+        return AppendBoolBatch(batch, offset, length, builder);
+      case liborc::VARCHAR:
+      case liborc::STRING:
+        return AppendBinaryBatch<StringBuilder>(batch, offset, length, builder);
+      case liborc::BINARY:
+        return AppendBinaryBatch<BinaryBuilder>(batch, offset, length, builder);
+      case liborc::CHAR:
+        return AppendFixedBinaryBatch(batch, offset, length, builder);
+      case liborc::DATE:
+        return AppendNumericBatchCast<Date32Builder, int32_t, liborc::LongVectorBatch,
+                int64_t>(batch, offset, length, builder);
+      case liborc::TIMESTAMP:
+        return AppendTimestampBatch(batch, offset, length, builder);
+      case liborc::DECIMAL:
+        return AppendDecimalBatch(type, batch, offset, length, builder);
+      default:
+        return Status::NotImplemented("Not implemented type kind: ", kind);
+    }
+  }
+
+  Status AdapaterUtil::GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out) {
+    // When subselecting fields on read, liborc will set some nodes to nullptr,
+    // so we need to check for nullptr before progressing
+    if (type == nullptr) {
+      *out = null();
+      return Status::OK();
+    }
+    liborc::TypeKind kind = type->getKind();
+    const int subtype_count = static_cast<int>(type->getSubtypeCount());
+
+    switch (kind) {
+      case liborc::BOOLEAN:
+        *out = boolean();
+        break;
+      case liborc::BYTE:
+        *out = int8();
+        break;
+      case liborc::SHORT:
+        *out = int16();
+        break;
+      case liborc::INT:
+        *out = int32();
+        break;
+      case liborc::LONG:
+        *out = int64();
+        break;
+      case liborc::FLOAT:
+        *out = float32();
+        break;
+      case liborc::DOUBLE:
+        *out = float64();
+        break;
+      case liborc::VARCHAR:
+      case liborc::STRING:
+        *out = utf8();
+        break;
+      case liborc::BINARY:
+        *out = binary();
+        break;
+      case liborc::CHAR:
+        *out = fixed_size_binary(static_cast<int>(type->getMaximumLength()));
+        break;
+      case liborc::TIMESTAMP:
+        *out = timestamp(TimeUnit::NANO);
+        break;
+      case liborc::DATE:
+        *out = date32();
+        break;
+      case liborc::DECIMAL: {
+        const int precision = static_cast<int>(type->getPrecision());
+        const int scale = static_cast<int>(type->getScale());
+        if (precision == 0) {
+          // In HIVE 0.11/0.12 precision is set as 0, but means max precision
+          *out = decimal(38, 6);
+        } else {
+          *out = decimal(precision, scale);
+        }
+        break;
+      }
+      case liborc::LIST: {
+        if (subtype_count != 1) {
+          return Status::Invalid("Invalid Orc List type");
+        }
+        std::shared_ptr<DataType> elemtype;
+        RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &elemtype));
+        *out = list(elemtype);
+        break;
+      }
+      case liborc::MAP: {
+        if (subtype_count != 2) {
+          return Status::Invalid("Invalid Orc Map type");
+        }
+        std::shared_ptr<DataType> keytype;
+        std::shared_ptr<DataType> valtype;
+        RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &keytype));
+        RETURN_NOT_OK(GetArrowType(type->getSubtype(1), &valtype));
+        *out = list(struct_({field("key", keytype), field("value", valtype)}));
+        break;
+      }
+      case liborc::STRUCT: {
+        std::vector<std::shared_ptr<Field>> fields;
+        for (int child = 0; child < subtype_count; ++child) {
+          std::shared_ptr<DataType> elemtype;
+          RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
+          std::string name = type->getFieldName(child);
+          fields.push_back(field(name, elemtype));
+        }
+        *out = struct_(fields);
+        break;
+      }
+      case liborc::UNION: {
+        std::vector<std::shared_ptr<Field>> fields;
+        std::vector<uint8_t> type_codes;
+        for (int child = 0; child < subtype_count; ++child) {
+          std::shared_ptr<DataType> elemtype;
+          RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
+          fields.push_back(field("_union_" + std::to_string(child), elemtype));
+          type_codes.push_back(static_cast<uint8_t>(child));
+        }
+        *out = union_(fields, type_codes);
+        break;
+      }
+      default: { return Status::Invalid("Unknown Orc type kind: ", kind); }
+    }
+    return Status::OK();
+  }
+} // namespace arrow

--- a/cpp/src/arrow/adapters/orc/adapter_util.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_util.cc
@@ -19,8 +19,8 @@
 #include <vector>
 
 #include "arrow/adapters/orc/adapter_util.h"
-#include "arrow/builder.h"
 #include "arrow/array/builder_base.h"
+#include "arrow/builder.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/lazy.h"
@@ -38,386 +38,385 @@ using internal::checked_cast;
 // The numer of nanoseconds in a second
 constexpr int64_t kOneSecondNanos = 1000000000LL;
 
-  Status AppendStructBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                           int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<StructBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::StructVectorBatch*>(cbatch);
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    RETURN_NOT_OK(builder->AppendValues(length, valid_bytes));
-
-    for (int i = 0; i < builder->num_fields(); i++) {
-      RETURN_NOT_OK(AdapaterUtil::AppendBatch(
-              type->getSubtype(i), batch->fields[i],
-              offset, length, builder->field_builder(i)));
-    }
-    return Status::OK();
-  }
-
-  Status AppendListBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+Status AppendStructBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
                          int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<ListBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::ListVectorBatch*>(cbatch);
-    liborc::ColumnVectorBatch* elements = batch->elements.get();
-    const liborc::Type* elemtype = type->getSubtype(0);
+  auto builder = checked_cast<StructBuilder*>(abuilder);
+  auto batch = checked_cast<liborc::StructVectorBatch*>(cbatch);
 
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      if (!has_nulls || batch->notNull[i]) {
-        int64_t start = batch->offsets[i];
-        int64_t end = batch->offsets[i + 1];
-        RETURN_NOT_OK(builder->Append());
-        RETURN_NOT_OK(AdapaterUtil::AppendBatch(elemtype, elements, start, end - start,
-                                  builder->value_builder()));
-      } else {
-        RETURN_NOT_OK(builder->AppendNull());
-      }
-    }
-    return Status::OK();
+  const uint8_t* valid_bytes = nullptr;
+  if (batch->hasNulls) {
+    valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
   }
+  RETURN_NOT_OK(builder->AppendValues(length, valid_bytes));
 
-  Status AppendMapBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                        int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto list_builder = checked_cast<ListBuilder*>(abuilder);
-    auto struct_builder = checked_cast<StructBuilder*>(list_builder->value_builder());
-    auto batch = checked_cast<liborc::MapVectorBatch*>(cbatch);
-    liborc::ColumnVectorBatch* keys = batch->keys.get();
-    liborc::ColumnVectorBatch* vals = batch->elements.get();
-    const liborc::Type* keytype = type->getSubtype(0);
-    const liborc::Type* valtype = type->getSubtype(1);
+  for (int i = 0; i < builder->num_fields(); i++) {
+    RETURN_NOT_OK(AdapaterUtil::AppendBatch(type->getSubtype(i), batch->fields[i], offset,
+                                            length, builder->field_builder(i)));
+  }
+  return Status::OK();
+}
 
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      RETURN_NOT_OK(list_builder->Append());
+Status AppendListBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                       int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<ListBuilder*>(abuilder);
+  auto batch = checked_cast<liborc::ListVectorBatch*>(cbatch);
+  liborc::ColumnVectorBatch* elements = batch->elements.get();
+  const liborc::Type* elemtype = type->getSubtype(0);
+
+  const bool has_nulls = batch->hasNulls;
+  for (int64_t i = offset; i < length + offset; i++) {
+    if (!has_nulls || batch->notNull[i]) {
       int64_t start = batch->offsets[i];
-      int64_t list_length = batch->offsets[i + 1] - start;
-      if (list_length && (!has_nulls || batch->notNull[i])) {
-        RETURN_NOT_OK(struct_builder->AppendValues(list_length, nullptr));
-        RETURN_NOT_OK(AdapaterUtil::AppendBatch(keytype, keys, start, list_length,
-                                  struct_builder->field_builder(0)));
-        RETURN_NOT_OK(AdapaterUtil::AppendBatch(valtype, vals, start, list_length,
-                                  struct_builder->field_builder(1)));
-      }
-    }
-    return Status::OK();
-  }
-
-  template <class builder_type, class batch_type, class elem_type>
-  Status AppendNumericBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                            int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<builder_type*>(abuilder);
-    auto batch = checked_cast<batch_type*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    const elem_type* source = batch->data.data() + offset;
-    RETURN_NOT_OK(builder->AppendValues(source, length, valid_bytes));
-    return Status::OK();
-  }
-
-  template <class builder_type, class target_type, class batch_type, class source_type>
-  Status AppendNumericBatchCast(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                                int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<builder_type*>(abuilder);
-    auto batch = checked_cast<batch_type*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    const source_type* source = batch->data.data() + offset;
-    auto cast_iter = internal::MakeLazyRange(
-            [&source](int64_t index) { return static_cast<target_type>(source[index]); },
-            length);
-
-    RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
-
-    return Status::OK();
-  }
-
-  Status AppendBoolBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                         int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<BooleanBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::LongVectorBatch*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-    const int64_t* source = batch->data.data() + offset;
-
-    auto cast_iter = internal::MakeLazyRange(
-           [&source](int64_t index) { return static_cast<bool>(source[index]); }, length);
-
-    RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
-
-    return Status::OK();
-  }
-
-  Status AppendTimestampBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                              int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<TimestampBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::TimestampVectorBatch*>(cbatch);
-
-    if (length == 0) {
-      return Status::OK();
-    }
-
-    const uint8_t* valid_bytes = nullptr;
-    if (batch->hasNulls) {
-      valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
-    }
-
-    const int64_t* seconds = batch->data.data() + offset;
-    const int64_t* nanos = batch->nanoseconds.data() + offset;
-
-    auto transform_timestamp = [seconds, nanos](int64_t index) {
-      return seconds[index] * kOneSecondNanos + nanos[index];
-    };
-
-    auto transform_range = internal::MakeLazyRange(transform_timestamp, length);
-
-    RETURN_NOT_OK(builder->AppendValues(transform_range.begin(), transform_range.end(),
-                                        valid_bytes));
-    return Status::OK();
-  }
-
-  template <class builder_type>
-  Status AppendBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                           int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<builder_type*>(abuilder);
-    auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
-
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      if (!has_nulls || batch->notNull[i]) {
-        RETURN_NOT_OK(
-                builder->Append(batch->data[i], static_cast<int32_t>(batch->length[i])));
-      } else {
-        RETURN_NOT_OK(builder->AppendNull());
-      }
-    }
-    return Status::OK();
-  }
-
-  Status AppendFixedBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
-                                int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<FixedSizeBinaryBuilder*>(abuilder);
-    auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
-
-    const bool has_nulls = batch->hasNulls;
-    for (int64_t i = offset; i < length + offset; i++) {
-      if (!has_nulls || batch->notNull[i]) {
-        RETURN_NOT_OK(builder->Append(batch->data[i]));
-      } else {
-        RETURN_NOT_OK(builder->AppendNull());
-      }
-    }
-    return Status::OK();
-  }
-
-  Status AppendDecimalBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
-                            int64_t offset, int64_t length, ArrayBuilder* abuilder) {
-    auto builder = checked_cast<Decimal128Builder*>(abuilder);
-
-    const bool has_nulls = cbatch->hasNulls;
-    if (type->getPrecision() == 0 || type->getPrecision() > 18) {
-      auto batch = checked_cast<liborc::Decimal128VectorBatch*>(cbatch);
-      for (int64_t i = offset; i < length + offset; i++) {
-        if (!has_nulls || batch->notNull[i]) {
-          RETURN_NOT_OK(builder->Append(
-             Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
-        } else {
-          RETURN_NOT_OK(builder->AppendNull());
-        }
-      }
+      int64_t end = batch->offsets[i + 1];
+      RETURN_NOT_OK(builder->Append());
+      RETURN_NOT_OK(AdapaterUtil::AppendBatch(elemtype, elements, start, end - start,
+                                              builder->value_builder()));
     } else {
-      auto batch = checked_cast<liborc::Decimal64VectorBatch*>(cbatch);
-      for (int64_t i = offset; i < length + offset; i++) {
-        if (!has_nulls || batch->notNull[i]) {
-          RETURN_NOT_OK(builder->Append(Decimal128(batch->values[i])));
-        } else {
-          RETURN_NOT_OK(builder->AppendNull());
-        }
-      }
+      RETURN_NOT_OK(builder->AppendNull());
     }
+  }
+  return Status::OK();
+}
+
+Status AppendMapBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                      int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+  auto list_builder = checked_cast<ListBuilder*>(abuilder);
+  auto struct_builder = checked_cast<StructBuilder*>(list_builder->value_builder());
+  auto batch = checked_cast<liborc::MapVectorBatch*>(cbatch);
+  liborc::ColumnVectorBatch* keys = batch->keys.get();
+  liborc::ColumnVectorBatch* vals = batch->elements.get();
+  const liborc::Type* keytype = type->getSubtype(0);
+  const liborc::Type* valtype = type->getSubtype(1);
+
+  const bool has_nulls = batch->hasNulls;
+  for (int64_t i = offset; i < length + offset; i++) {
+    RETURN_NOT_OK(list_builder->Append());
+    int64_t start = batch->offsets[i];
+    int64_t list_length = batch->offsets[i + 1] - start;
+    if (list_length && (!has_nulls || batch->notNull[i])) {
+      RETURN_NOT_OK(struct_builder->AppendValues(list_length, nullptr));
+      RETURN_NOT_OK(AdapaterUtil::AppendBatch(keytype, keys, start, list_length,
+                                              struct_builder->field_builder(0)));
+      RETURN_NOT_OK(AdapaterUtil::AppendBatch(valtype, vals, start, list_length,
+                                              struct_builder->field_builder(1)));
+    }
+  }
+  return Status::OK();
+}
+
+template <class builder_type, class batch_type, class elem_type>
+Status AppendNumericBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                          int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<builder_type*>(abuilder);
+  auto batch = checked_cast<batch_type*>(cbatch);
+
+  if (length == 0) {
+    return Status::OK();
+  }
+  const uint8_t* valid_bytes = nullptr;
+  if (batch->hasNulls) {
+    valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+  }
+  const elem_type* source = batch->data.data() + offset;
+  RETURN_NOT_OK(builder->AppendValues(source, length, valid_bytes));
+  return Status::OK();
+}
+
+template <class builder_type, class target_type, class batch_type, class source_type>
+Status AppendNumericBatchCast(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                              int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<builder_type*>(abuilder);
+  auto batch = checked_cast<batch_type*>(cbatch);
+
+  if (length == 0) {
     return Status::OK();
   }
 
-  Status AdapaterUtil::AppendBatch(
-          const liborc::Type* type, liborc::ColumnVectorBatch* batch,
-          int64_t offset, int64_t length, ArrayBuilder* builder) {
-    if (type == nullptr) {
-      return Status::OK();
-    }
-    liborc::TypeKind kind = type->getKind();
-    switch (kind) {
-      case liborc::STRUCT:
-        return AppendStructBatch(type, batch, offset, length, builder);
-      case liborc::LIST:
-        return AppendListBatch(type, batch, offset, length, builder);
-      case liborc::MAP:
-        return AppendMapBatch(type, batch, offset, length, builder);
-      case liborc::LONG:
-        return AppendNumericBatch<Int64Builder, liborc::LongVectorBatch, int64_t>(
-                batch, offset, length, builder);
-      case liborc::INT:
-        return AppendNumericBatchCast<Int32Builder, int32_t, liborc::LongVectorBatch,
-                int64_t>(batch, offset, length, builder);
-      case liborc::SHORT:
-        return AppendNumericBatchCast<Int16Builder, int16_t, liborc::LongVectorBatch,
-                int64_t>(batch, offset, length, builder);
-      case liborc::BYTE:
-        return AppendNumericBatchCast<Int8Builder, int8_t, liborc::LongVectorBatch,
-                int64_t>(batch, offset, length, builder);
-      case liborc::DOUBLE:
-        return AppendNumericBatch<DoubleBuilder, liborc::DoubleVectorBatch, double>(
-                batch, offset, length, builder);
-      case liborc::FLOAT:
-        return AppendNumericBatchCast<FloatBuilder, float, liborc::DoubleVectorBatch,
-                double>(batch, offset, length, builder);
-      case liborc::BOOLEAN:
-        return AppendBoolBatch(batch, offset, length, builder);
-      case liborc::VARCHAR:
-      case liborc::STRING:
-        return AppendBinaryBatch<StringBuilder>(batch, offset, length, builder);
-      case liborc::BINARY:
-        return AppendBinaryBatch<BinaryBuilder>(batch, offset, length, builder);
-      case liborc::CHAR:
-        return AppendFixedBinaryBatch(batch, offset, length, builder);
-      case liborc::DATE:
-        return AppendNumericBatchCast<Date32Builder, int32_t, liborc::LongVectorBatch,
-                int64_t>(batch, offset, length, builder);
-      case liborc::TIMESTAMP:
-        return AppendTimestampBatch(batch, offset, length, builder);
-      case liborc::DECIMAL:
-        return AppendDecimalBatch(type, batch, offset, length, builder);
-      default:
-        return Status::NotImplemented("Not implemented type kind: ", kind);
-    }
+  const uint8_t* valid_bytes = nullptr;
+  if (batch->hasNulls) {
+    valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+  }
+  const source_type* source = batch->data.data() + offset;
+  auto cast_iter = internal::MakeLazyRange(
+      [&source](int64_t index) { return static_cast<target_type>(source[index]); },
+      length);
+
+  RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
+
+  return Status::OK();
+}
+
+Status AppendBoolBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset, int64_t length,
+                       ArrayBuilder* abuilder) {
+  auto builder = checked_cast<BooleanBuilder*>(abuilder);
+  auto batch = checked_cast<liborc::LongVectorBatch*>(cbatch);
+
+  if (length == 0) {
+    return Status::OK();
   }
 
-  Status AdapaterUtil::GetArrowType(
-          const liborc::Type* type, std::shared_ptr<DataType>* out) {
-    // When subselecting fields on read, liborc will set some nodes to nullptr,
-    // so we need to check for nullptr before progressing
-    if (type == nullptr) {
-      *out = null();
-      return Status::OK();
-    }
-    liborc::TypeKind kind = type->getKind();
-    const int subtype_count = static_cast<int>(type->getSubtypeCount());
+  const uint8_t* valid_bytes = nullptr;
+  if (batch->hasNulls) {
+    valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+  }
+  const int64_t* source = batch->data.data() + offset;
 
-    switch (kind) {
-      case liborc::BOOLEAN:
-        *out = boolean();
-        break;
-      case liborc::BYTE:
-        *out = int8();
-        break;
-      case liborc::SHORT:
-        *out = int16();
-        break;
-      case liborc::INT:
-        *out = int32();
-        break;
-      case liborc::LONG:
-        *out = int64();
-        break;
-      case liborc::FLOAT:
-        *out = float32();
-        break;
-      case liborc::DOUBLE:
-        *out = float64();
-        break;
-      case liborc::VARCHAR:
-      case liborc::STRING:
-        *out = utf8();
-        break;
-      case liborc::BINARY:
-        *out = binary();
-        break;
-      case liborc::CHAR:
-        *out = fixed_size_binary(static_cast<int>(type->getMaximumLength()));
-        break;
-      case liborc::TIMESTAMP:
-        *out = timestamp(TimeUnit::NANO);
-        break;
-      case liborc::DATE:
-        *out = date32();
-        break;
-      case liborc::DECIMAL: {
-        const int precision = static_cast<int>(type->getPrecision());
-        const int scale = static_cast<int>(type->getScale());
-        if (precision == 0) {
-          // In HIVE 0.11/0.12 precision is set as 0, but means max precision
-          *out = decimal(38, 6);
-        } else {
-          *out = decimal(precision, scale);
-        }
-        break;
+  auto cast_iter = internal::MakeLazyRange(
+      [&source](int64_t index) { return static_cast<bool>(source[index]); }, length);
+
+  RETURN_NOT_OK(builder->AppendValues(cast_iter.begin(), cast_iter.end(), valid_bytes));
+
+  return Status::OK();
+}
+
+Status AppendTimestampBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                            int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<TimestampBuilder*>(abuilder);
+  auto batch = checked_cast<liborc::TimestampVectorBatch*>(cbatch);
+
+  if (length == 0) {
+    return Status::OK();
+  }
+
+  const uint8_t* valid_bytes = nullptr;
+  if (batch->hasNulls) {
+    valid_bytes = reinterpret_cast<const uint8_t*>(batch->notNull.data()) + offset;
+  }
+
+  const int64_t* seconds = batch->data.data() + offset;
+  const int64_t* nanos = batch->nanoseconds.data() + offset;
+
+  auto transform_timestamp = [seconds, nanos](int64_t index) {
+    return seconds[index] * kOneSecondNanos + nanos[index];
+  };
+
+  auto transform_range = internal::MakeLazyRange(transform_timestamp, length);
+
+  RETURN_NOT_OK(
+      builder->AppendValues(transform_range.begin(), transform_range.end(), valid_bytes));
+  return Status::OK();
+}
+
+template <class builder_type>
+Status AppendBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                         int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<builder_type*>(abuilder);
+  auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
+
+  const bool has_nulls = batch->hasNulls;
+  for (int64_t i = offset; i < length + offset; i++) {
+    if (!has_nulls || batch->notNull[i]) {
+      RETURN_NOT_OK(
+          builder->Append(batch->data[i], static_cast<int32_t>(batch->length[i])));
+    } else {
+      RETURN_NOT_OK(builder->AppendNull());
+    }
+  }
+  return Status::OK();
+}
+
+Status AppendFixedBinaryBatch(liborc::ColumnVectorBatch* cbatch, int64_t offset,
+                              int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<FixedSizeBinaryBuilder*>(abuilder);
+  auto batch = checked_cast<liborc::StringVectorBatch*>(cbatch);
+
+  const bool has_nulls = batch->hasNulls;
+  for (int64_t i = offset; i < length + offset; i++) {
+    if (!has_nulls || batch->notNull[i]) {
+      RETURN_NOT_OK(builder->Append(batch->data[i]));
+    } else {
+      RETURN_NOT_OK(builder->AppendNull());
+    }
+  }
+  return Status::OK();
+}
+
+Status AppendDecimalBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,
+                          int64_t offset, int64_t length, ArrayBuilder* abuilder) {
+  auto builder = checked_cast<Decimal128Builder*>(abuilder);
+
+  const bool has_nulls = cbatch->hasNulls;
+  if (type->getPrecision() == 0 || type->getPrecision() > 18) {
+    auto batch = checked_cast<liborc::Decimal128VectorBatch*>(cbatch);
+    for (int64_t i = offset; i < length + offset; i++) {
+      if (!has_nulls || batch->notNull[i]) {
+        RETURN_NOT_OK(builder->Append(
+            Decimal128(batch->values[i].getHighBits(), batch->values[i].getLowBits())));
+      } else {
+        RETURN_NOT_OK(builder->AppendNull());
       }
-      case liborc::LIST: {
-        if (subtype_count != 1) {
-          return Status::Invalid("Invalid Orc List type");
-        }
+    }
+  } else {
+    auto batch = checked_cast<liborc::Decimal64VectorBatch*>(cbatch);
+    for (int64_t i = offset; i < length + offset; i++) {
+      if (!has_nulls || batch->notNull[i]) {
+        RETURN_NOT_OK(builder->Append(Decimal128(batch->values[i])));
+      } else {
+        RETURN_NOT_OK(builder->AppendNull());
+      }
+    }
+  }
+  return Status::OK();
+}
+
+Status AdapaterUtil::AppendBatch(const liborc::Type* type,
+                                 liborc::ColumnVectorBatch* batch, int64_t offset,
+                                 int64_t length, ArrayBuilder* builder) {
+  if (type == nullptr) {
+    return Status::OK();
+  }
+  liborc::TypeKind kind = type->getKind();
+  switch (kind) {
+    case liborc::STRUCT:
+      return AppendStructBatch(type, batch, offset, length, builder);
+    case liborc::LIST:
+      return AppendListBatch(type, batch, offset, length, builder);
+    case liborc::MAP:
+      return AppendMapBatch(type, batch, offset, length, builder);
+    case liborc::LONG:
+      return AppendNumericBatch<Int64Builder, liborc::LongVectorBatch, int64_t>(
+          batch, offset, length, builder);
+    case liborc::INT:
+      return AppendNumericBatchCast<Int32Builder, int32_t, liborc::LongVectorBatch,
+                                    int64_t>(batch, offset, length, builder);
+    case liborc::SHORT:
+      return AppendNumericBatchCast<Int16Builder, int16_t, liborc::LongVectorBatch,
+                                    int64_t>(batch, offset, length, builder);
+    case liborc::BYTE:
+      return AppendNumericBatchCast<Int8Builder, int8_t, liborc::LongVectorBatch,
+                                    int64_t>(batch, offset, length, builder);
+    case liborc::DOUBLE:
+      return AppendNumericBatch<DoubleBuilder, liborc::DoubleVectorBatch, double>(
+          batch, offset, length, builder);
+    case liborc::FLOAT:
+      return AppendNumericBatchCast<FloatBuilder, float, liborc::DoubleVectorBatch,
+                                    double>(batch, offset, length, builder);
+    case liborc::BOOLEAN:
+      return AppendBoolBatch(batch, offset, length, builder);
+    case liborc::VARCHAR:
+    case liborc::STRING:
+      return AppendBinaryBatch<StringBuilder>(batch, offset, length, builder);
+    case liborc::BINARY:
+      return AppendBinaryBatch<BinaryBuilder>(batch, offset, length, builder);
+    case liborc::CHAR:
+      return AppendFixedBinaryBatch(batch, offset, length, builder);
+    case liborc::DATE:
+      return AppendNumericBatchCast<Date32Builder, int32_t, liborc::LongVectorBatch,
+                                    int64_t>(batch, offset, length, builder);
+    case liborc::TIMESTAMP:
+      return AppendTimestampBatch(batch, offset, length, builder);
+    case liborc::DECIMAL:
+      return AppendDecimalBatch(type, batch, offset, length, builder);
+    default:
+      return Status::NotImplemented("Not implemented type kind: ", kind);
+  }
+}
+
+Status AdapaterUtil::GetArrowType(const liborc::Type* type,
+                                  std::shared_ptr<DataType>* out) {
+  // When subselecting fields on read, liborc will set some nodes to nullptr,
+  // so we need to check for nullptr before progressing
+  if (type == nullptr) {
+    *out = null();
+    return Status::OK();
+  }
+  liborc::TypeKind kind = type->getKind();
+  const int subtype_count = static_cast<int>(type->getSubtypeCount());
+
+  switch (kind) {
+    case liborc::BOOLEAN:
+      *out = boolean();
+      break;
+    case liborc::BYTE:
+      *out = int8();
+      break;
+    case liborc::SHORT:
+      *out = int16();
+      break;
+    case liborc::INT:
+      *out = int32();
+      break;
+    case liborc::LONG:
+      *out = int64();
+      break;
+    case liborc::FLOAT:
+      *out = float32();
+      break;
+    case liborc::DOUBLE:
+      *out = float64();
+      break;
+    case liborc::VARCHAR:
+    case liborc::STRING:
+      *out = utf8();
+      break;
+    case liborc::BINARY:
+      *out = binary();
+      break;
+    case liborc::CHAR:
+      *out = fixed_size_binary(static_cast<int>(type->getMaximumLength()));
+      break;
+    case liborc::TIMESTAMP:
+      *out = timestamp(TimeUnit::NANO);
+      break;
+    case liborc::DATE:
+      *out = date32();
+      break;
+    case liborc::DECIMAL: {
+      const int precision = static_cast<int>(type->getPrecision());
+      const int scale = static_cast<int>(type->getScale());
+      if (precision == 0) {
+        // In HIVE 0.11/0.12 precision is set as 0, but means max precision
+        *out = decimal(38, 6);
+      } else {
+        *out = decimal(precision, scale);
+      }
+      break;
+    }
+    case liborc::LIST: {
+      if (subtype_count != 1) {
+        return Status::Invalid("Invalid Orc List type");
+      }
+      std::shared_ptr<DataType> elemtype;
+      RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &elemtype));
+      *out = list(elemtype);
+      break;
+    }
+    case liborc::MAP: {
+      if (subtype_count != 2) {
+        return Status::Invalid("Invalid Orc Map type");
+      }
+      std::shared_ptr<DataType> keytype;
+      std::shared_ptr<DataType> valtype;
+      RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &keytype));
+      RETURN_NOT_OK(GetArrowType(type->getSubtype(1), &valtype));
+      *out = list(struct_({field("key", keytype), field("value", valtype)}));
+      break;
+    }
+    case liborc::STRUCT: {
+      std::vector<std::shared_ptr<Field>> fields;
+      for (int child = 0; child < subtype_count; ++child) {
         std::shared_ptr<DataType> elemtype;
-        RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &elemtype));
-        *out = list(elemtype);
-        break;
+        RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
+        std::string name = type->getFieldName(child);
+        fields.push_back(field(name, elemtype));
       }
-      case liborc::MAP: {
-        if (subtype_count != 2) {
-          return Status::Invalid("Invalid Orc Map type");
-        }
-        std::shared_ptr<DataType> keytype;
-        std::shared_ptr<DataType> valtype;
-        RETURN_NOT_OK(GetArrowType(type->getSubtype(0), &keytype));
-        RETURN_NOT_OK(GetArrowType(type->getSubtype(1), &valtype));
-        *out = list(struct_({field("key", keytype), field("value", valtype)}));
-        break;
-      }
-      case liborc::STRUCT: {
-        std::vector<std::shared_ptr<Field>> fields;
-        for (int child = 0; child < subtype_count; ++child) {
-          std::shared_ptr<DataType> elemtype;
-          RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
-          std::string name = type->getFieldName(child);
-          fields.push_back(field(name, elemtype));
-        }
-        *out = struct_(fields);
-        break;
-      }
-      case liborc::UNION: {
-        std::vector<std::shared_ptr<Field>> fields;
-        std::vector<uint8_t> type_codes;
-        for (int child = 0; child < subtype_count; ++child) {
-          std::shared_ptr<DataType> elemtype;
-          RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
-          fields.push_back(field("_union_" + std::to_string(child), elemtype));
-          type_codes.push_back(static_cast<uint8_t>(child));
-        }
-        *out = union_(fields, type_codes);
-        break;
-      }
-      default: { return Status::Invalid("Unknown Orc type kind: ", kind); }
+      *out = struct_(fields);
+      break;
     }
-    return Status::OK();
+    case liborc::UNION: {
+      std::vector<std::shared_ptr<Field>> fields;
+      std::vector<uint8_t> type_codes;
+      for (int child = 0; child < subtype_count; ++child) {
+        std::shared_ptr<DataType> elemtype;
+        RETURN_NOT_OK(GetArrowType(type->getSubtype(child), &elemtype));
+        fields.push_back(field("_union_" + std::to_string(child), elemtype));
+        type_codes.push_back(static_cast<uint8_t>(child));
+      }
+      *out = union_(fields, type_codes);
+      break;
+    }
+    default: { return Status::Invalid("Unknown Orc type kind: ", kind); }
   }
-} // namespace arrow
+  return Status::OK();
+}
+}  // namespace arrow

--- a/cpp/src/arrow/adapters/orc/adapter_util.h
+++ b/cpp/src/arrow/adapters/orc/adapter_util.h
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_ADAPATER_UTIL_HH
-#define ARROW_ADAPATER_UTIL_HH
+#ifndef ARROW_ADAPATER_UTIL_H
+#define ARROW_ADAPATER_UTIL_H
 
 #include <cstdint>
 #include <memory>
@@ -25,15 +25,20 @@
 #include "arrow/status.h"
 #include "orc/OrcFile.hh"
 
+namespace liborc = orc;
+
 namespace arrow {
 
-class AdapaterUtil {
- public:
-  static Status GetArrowType(const orc::Type* type, std::shared_ptr<DataType>* out);
+namespace adapters {
 
-  static Status AppendBatch(const orc::Type* type, orc::ColumnVectorBatch* batch,
-                            int64_t offset, int64_t length, ArrayBuilder* builder);
-};
+namespace orc {
+
+Status GetArrowType(const liborc::Type* type, std::shared_ptr<DataType>* out);
+
+Status AppendBatch(const liborc::Type* type, liborc::ColumnVectorBatch* batch,
+                   int64_t offset, int64_t length, ArrayBuilder* builder);
+}  // namespace orc
+}  // namespace adapters
 }  // namespace arrow
 
-#endif  // ARROW_ADAPATER_UTIL_HH
+#endif  // ARROW_ADAPATER_UTIL_H

--- a/cpp/src/arrow/adapters/orc/adapter_util.h
+++ b/cpp/src/arrow/adapters/orc/adapter_util.h
@@ -20,6 +20,7 @@
 
 
 #include <cstdint>
+#include <memory>
 
 #include "arrow/array/builder_base.h"
 #include "arrow/status.h"
@@ -28,7 +29,7 @@
 namespace arrow {
 
 class AdapaterUtil {
-public:
+ public:
   static Status GetArrowType(const orc::Type* type, std::shared_ptr<DataType>* out);
 
   static Status AppendBatch(const orc::Type* type, orc::ColumnVectorBatch* batch,

--- a/cpp/src/arrow/adapters/orc/adapter_util.h
+++ b/cpp/src/arrow/adapters/orc/adapter_util.h
@@ -18,7 +18,6 @@
 #ifndef ARROW_ADAPATER_UTIL_HH
 #define ARROW_ADAPATER_UTIL_HH
 
-
 #include <cstdint>
 #include <memory>
 
@@ -35,7 +34,6 @@ class AdapaterUtil {
   static Status AppendBatch(const orc::Type* type, orc::ColumnVectorBatch* batch,
                             int64_t offset, int64_t length, ArrayBuilder* builder);
 };
-}
+}  // namespace arrow
 
-
-#endif //ARROW_ADAPATER_UTIL_HH
+#endif  // ARROW_ADAPATER_UTIL_HH

--- a/cpp/src/arrow/adapters/orc/adapter_util.h
+++ b/cpp/src/arrow/adapters/orc/adapter_util.h
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef ARROW_ADAPATER_UTIL_HH
+#define ARROW_ADAPATER_UTIL_HH
+
+
+#include <cstdint>
+
+#include "arrow/array/builder_base.h"
+#include "arrow/status.h"
+#include "orc/OrcFile.hh"
+
+namespace arrow {
+
+class AdapaterUtil {
+public:
+  static Status GetArrowType(const orc::Type* type, std::shared_ptr<DataType>* out);
+
+  static Status AppendBatch(const orc::Type* type, orc::ColumnVectorBatch* batch,
+                            int64_t offset, int64_t length, ArrayBuilder* builder);
+};
+}
+
+
+#endif //ARROW_ADAPATER_UTIL_HH


### PR DESCRIPTION
Improvemnt of current ORC adapter interface that enable following operation:

- enable seek operation to designated row
- enable iteration over stripe with StripeReader
    - StripeReader is neccesary since ORC support stripe level dictionary
       encoding, for this reason the Arrow Schema could varies between
       stripes if Dictionary Based Type is enabled.
- enable row level iteration with StripeReader