### PR TITLE
ARROW-4808: [Java][Vector] More util methods to set decimal vector.

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -270,6 +270,57 @@ public class DecimalVector extends BaseFixedWidthVector {
   }
 
   /**
+   * Sets the element at given index using the buffer whose size maybe <= 16 bytes.
+   * @param index index to write the decimal to
+   * @param start start of value in the buffer
+   * @param buffer contains the decimal in little endian bytes
+   * @param length length of the value in the buffer
+   */
+  public void setSafe(int index, int start, ArrowBuf buffer, int length) {
+    handleSafe(index);
+    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    valueBuffer.setBytes(index * TYPE_WIDTH, buffer, start, length);
+    // sign extend
+    if (length < 16) {
+      byte msb = buffer.getByte(start + length - 1);
+      final byte pad = (byte) (msb < 0 ? 0xFF : 0x00);
+      int startIndex = (index * TYPE_WIDTH) + length;
+      int endIndex = (index * TYPE_WIDTH) + TYPE_WIDTH;
+      for (int i = startIndex; i < endIndex; i++) {
+        valueBuffer.setByte(i, pad);
+      }
+    }
+  }
+
+
+  /**
+   * Sets the element at given index using the buffer whose size maybe <= 16 bytes.
+   * @param index index to write the decimal to
+   * @param start start of value in the buffer
+   * @param buffer contains the decimal in big endian bytes
+   * @param length length of the value in the buffer
+   */
+  public void setBigEndianSafe(int index, int start, ArrowBuf buffer, int length) {
+    handleSafe(index);
+    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    int startIndexInVector = index * TYPE_WIDTH;
+    int startOfInputBuffer = start;
+    for (int i = length - 1; i >= 0; i--) {
+      valueBuffer.setByte(startIndexInVector, buffer.getByte(i));
+      startIndexInVector++;
+    }
+    // sign extend
+    if (length < 16) {
+      byte msb = buffer.getByte(startOfInputBuffer);
+      final byte pad = (byte) (msb < 0 ? 0xFF : 0x00);
+      int endIndex = startIndexInVector + TYPE_WIDTH;
+      for (int i = startIndexInVector; i < endIndex; i++) {
+        valueBuffer.setByte(i, pad);
+      }
+    }
+  }
+
+  /**
    * Set the element at the given index to the given value.
    *
    * @param index   position of element

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -279,13 +279,14 @@ public class DecimalVector extends BaseFixedWidthVector {
   public void setSafe(int index, int start, ArrowBuf buffer, int length) {
     handleSafe(index);
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    valueBuffer.setBytes(index * TYPE_WIDTH, buffer, start, length);
+    int startIndexInVector = index * TYPE_WIDTH;
+    valueBuffer.setBytes(startIndexInVector, buffer, start, length);
     // sign extend
     if (length < 16) {
       byte msb = buffer.getByte(start + length - 1);
       final byte pad = (byte) (msb < 0 ? 0xFF : 0x00);
-      int startIndex = (index * TYPE_WIDTH) + length;
-      int endIndex = (index * TYPE_WIDTH) + TYPE_WIDTH;
+      int startIndex = startIndexInVector + length;
+      int endIndex = startIndexInVector + TYPE_WIDTH;
       for (int i = startIndex; i < endIndex; i++) {
         valueBuffer.setByte(i, pad);
       }
@@ -304,16 +305,15 @@ public class DecimalVector extends BaseFixedWidthVector {
     handleSafe(index);
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
     int startIndexInVector = index * TYPE_WIDTH;
-    int startOfInputBuffer = start;
-    for (int i = length - 1; i >= 0; i--) {
+    for (int i = start + length - 1; i >= start; i--) {
       valueBuffer.setByte(startIndexInVector, buffer.getByte(i));
       startIndexInVector++;
     }
     // sign extend
     if (length < 16) {
-      byte msb = buffer.getByte(startOfInputBuffer);
+      byte msb = buffer.getByte(start);
       final byte pad = (byte) (msb < 0 ? 0xFF : 0x00);
-      int endIndex = startIndexInVector + TYPE_WIDTH;
+      int endIndex = startIndexInVector + TYPE_WIDTH - length;
       for (int i = startIndexInVector; i < endIndex; i++) {
         valueBuffer.setByte(i, pad);
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -255,7 +255,7 @@ public class TestDecimalVector {
   public void setUsingArrowBufOfLEInts() {
     try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
             new ArrowType.Decimal(5, 2), allocator);
-         ArrowBuf buf = allocator.buffer(4);) {
+         ArrowBuf buf = allocator.buffer(8);) {
       decimalVector.allocateNew();
 
       // add a positive value equivalen to 705.32
@@ -265,8 +265,8 @@ public class TestDecimalVector {
 
       // add a -ve value equivalen to -705.32
       val = -70532;
-      buf.setInt(0, val);
-      decimalVector.setSafe(1, 0, buf, 4);
+      buf.setInt(4, val);
+      decimalVector.setSafe(1, 4, buf, 4);
 
       decimalVector.setValueCount(2);
 
@@ -284,7 +284,7 @@ public class TestDecimalVector {
   public void setUsingArrowLongLEBytes() {
     try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
             new ArrowType.Decimal(18, 0), allocator);
-         ArrowBuf buf = allocator.buffer(8);) {
+         ArrowBuf buf = allocator.buffer(16);) {
       decimalVector.allocateNew();
 
       long val = Long.MAX_VALUE;
@@ -292,8 +292,8 @@ public class TestDecimalVector {
       decimalVector.setSafe(0, 0, buf, 8);
 
       val = Long.MIN_VALUE;
-      buf.setLong(0, val);
-      decimalVector.setSafe(1, 0, buf, 8);
+      buf.setLong(8, val);
+      decimalVector.setSafe(1, 8, buf, 8);
 
       decimalVector.setValueCount(2);
 
@@ -310,36 +310,35 @@ public class TestDecimalVector {
   public void setUsingArrowBufOfBEBytes() {
     try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
             new ArrowType.Decimal(5, 2), allocator);
-         ArrowBuf buf = allocator.buffer(4);) {
+         ArrowBuf buf = allocator.buffer(9);) {
       BigDecimal [] expectedValues = new BigDecimal[] {BigDecimal.valueOf(705.32), BigDecimal
-              .valueOf(-705.32)};
-      verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues);
+              .valueOf(-705.32),BigDecimal.valueOf(705.32)};
+      verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues, 3);
     }
 
     try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
             new ArrowType.Decimal(36, 2), allocator);
-         ArrowBuf buf = allocator.buffer(15);) {
+         ArrowBuf buf = allocator.buffer(45);) {
       BigDecimal[] expectedValues = new BigDecimal[] {new BigDecimal("2982346298346289346293467923465345.63"),
-                                                      new BigDecimal("-2982346298346289346293467923465345.63")};
-      verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues);
+                                                      new BigDecimal("-2982346298346289346293467923465345.63"),
+                                                      new BigDecimal("2982346298346289346293467923465345.63")};
+      verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues, 15);
     }
   }
 
   private void verifyWritingArrowBufWithBigEndianBytes(DecimalVector decimalVector,
-                                                       ArrowBuf buf, BigDecimal[] expectedValues) {
+                                                       ArrowBuf buf, BigDecimal[] expectedValues,
+                                                       int length) {
     decimalVector.allocateNew();
-    byte []bigEndianBytes = expectedValues[0].unscaledValue().toByteArray();
-    buf.setBytes(0 , bigEndianBytes, 0 , bigEndianBytes.length);
-    decimalVector.setBigEndianSafe(0, 0, buf, bigEndianBytes.length);
+    for (int i = 0; i < expectedValues.length; i++) {
+      byte []bigEndianBytes = expectedValues[i].unscaledValue().toByteArray();
+      buf.setBytes(length * i , bigEndianBytes, 0 , bigEndianBytes.length);
+      decimalVector.setBigEndianSafe(i, length * i, buf, bigEndianBytes.length);
+    }
 
-    bigEndianBytes = expectedValues[1].unscaledValue().toByteArray();
-    buf.setBytes(0 , bigEndianBytes, 0 , bigEndianBytes.length);
-    decimalVector.setBigEndianSafe(1, 0, buf, bigEndianBytes.length);
+    decimalVector.setValueCount(3);
 
-
-    decimalVector.setValueCount(2);
-
-    for (int i = 0; i < 2; i ++) {
+    for (int i = 0; i < expectedValues.length; i ++) {
       BigDecimal value = decimalVector.getObject(i);
       assertEquals(expectedValues[i], value);
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -32,6 +32,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.netty.buffer.ArrowBuf;
+
 public class TestDecimalVector {
 
   private static long[] intValues;
@@ -246,6 +248,100 @@ public class TestDecimalVector {
       }
       assertTrue(decimalVector.isNull(outputIdx++));
       assertEquals(BigInteger.valueOf(0), decimalVector.getObject(outputIdx).unscaledValue());
+    }
+  }
+
+  @Test
+  public void setUsingArrowBufOfLEInts() {
+    try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
+            new ArrowType.Decimal(5, 2), allocator);
+         ArrowBuf buf = allocator.buffer(4);) {
+      decimalVector.allocateNew();
+
+      // add a positive value equivalen to 705.32
+      int val = 70532;
+      buf.setInt(0, val);
+      decimalVector.setSafe(0, 0, buf, 4);
+
+      // add a -ve value equivalen to -705.32
+      val = -70532;
+      buf.setInt(0, val);
+      decimalVector.setSafe(1, 0, buf, 4);
+
+      decimalVector.setValueCount(2);
+
+      BigDecimal [] expectedValues = new BigDecimal[] {BigDecimal.valueOf(705.32), BigDecimal
+              .valueOf(-705.32)};
+      for (int i = 0; i < 2; i ++) {
+        BigDecimal value = decimalVector.getObject(i);
+        assertEquals(expectedValues[i], value);
+      }
+    }
+
+  }
+
+  @Test
+  public void setUsingArrowLongLEBytes() {
+    try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
+            new ArrowType.Decimal(18, 0), allocator);
+         ArrowBuf buf = allocator.buffer(8);) {
+      decimalVector.allocateNew();
+
+      long val = Long.MAX_VALUE;
+      buf.setLong(0, val);
+      decimalVector.setSafe(0, 0, buf, 8);
+
+      val = Long.MIN_VALUE;
+      buf.setLong(0, val);
+      decimalVector.setSafe(1, 0, buf, 8);
+
+      decimalVector.setValueCount(2);
+
+      BigDecimal [] expectedValues = new BigDecimal[] {BigDecimal.valueOf(Long.MAX_VALUE), BigDecimal
+              .valueOf(Long.MIN_VALUE)};
+      for (int i = 0; i < 2; i ++) {
+        BigDecimal value = decimalVector.getObject(i);
+        assertEquals(expectedValues[i], value);
+      }
+    }
+  }
+
+  @Test
+  public void setUsingArrowBufOfBEBytes() {
+    try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
+            new ArrowType.Decimal(5, 2), allocator);
+         ArrowBuf buf = allocator.buffer(4);) {
+      BigDecimal [] expectedValues = new BigDecimal[] {BigDecimal.valueOf(705.32), BigDecimal
+              .valueOf(-705.32)};
+      verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues);
+    }
+
+    try (DecimalVector decimalVector = TestUtils.newVector(DecimalVector.class, "decimal",
+            new ArrowType.Decimal(36, 2), allocator);
+         ArrowBuf buf = allocator.buffer(15);) {
+      BigDecimal[] expectedValues = new BigDecimal[] {new BigDecimal("2982346298346289346293467923465345.63"),
+                                                      new BigDecimal("-2982346298346289346293467923465345.63")};
+      verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues);
+    }
+  }
+
+  private void verifyWritingArrowBufWithBigEndianBytes(DecimalVector decimalVector,
+                                                       ArrowBuf buf, BigDecimal[] expectedValues) {
+    decimalVector.allocateNew();
+    byte []bigEndianBytes = expectedValues[0].unscaledValue().toByteArray();
+    buf.setBytes(0 , bigEndianBytes, 0 , bigEndianBytes.length);
+    decimalVector.setBigEndianSafe(0, 0, buf, bigEndianBytes.length);
+
+    bigEndianBytes = expectedValues[1].unscaledValue().toByteArray();
+    buf.setBytes(0 , bigEndianBytes, 0 , bigEndianBytes.length);
+    decimalVector.setBigEndianSafe(1, 0, buf, bigEndianBytes.length);
+
+
+    decimalVector.setValueCount(2);
+
+    for (int i = 0; i < 2; i ++) {
+      BigDecimal value = decimalVector.getObject(i);
+      assertEquals(expectedValues[i], value);
     }
   }
 }


### PR DESCRIPTION
- Supports setting using an arrow buf of little endian bytes.
- Supports arrow bufs of size less than 16 bytes.