### PR TITLE
ARROW-4774: [C++] Fix FileWriter::WriteTable segfault

### DIFF
--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -1153,6 +1153,8 @@ Status WriteFileMetaData(const FileMetaData& file_metadata,
 }
 
 Status FileWriter::WriteTable(const Table& table, int64_t chunk_size) {
+  RETURN_NOT_OK(table.Validate());
+
   if (chunk_size <= 0 && table.num_rows() > 0) {
     return Status::Invalid("chunk size per row_group must be greater than 0");
   } else if (!table.schema()->Equals(*schema_, false)) {

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -257,6 +257,8 @@ cdef api shared_ptr[CTable] pyarrow_unwrap_table(object table):
 
 
 cdef api object pyarrow_wrap_table(const shared_ptr[CTable]& ctable):
+    # Ensure that wrapped table is Valid
+    check_status(ctable.get().Validate())
     cdef Table table = Table.__new__(Table)
     table.init(ctable)
     return table

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1172,7 +1172,6 @@ cdef class Table(_PandasConvertible):
             vector[shared_ptr[CColumn]] columns
             Schema cy_schema
             shared_ptr[CSchema] c_schema
-            shared_ptr[CTable] table
             int i, K = <int> len(arrays)
 
         if schema is None:

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -822,8 +822,8 @@ def test_table_negative_indexing():
     data = [
         pa.array(range(5)),
         pa.array([-10, -5, 0, 5, 10]),
-        pa.array([1.0, 2.0, 3.0]),
-        pa.array(['ab', 'bc', 'cd']),
+        pa.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+        pa.array(['ab', 'bc', 'cd', 'de', 'ef']),
     ]
     table = pa.Table.from_arrays(data, names=tuple('abcd'))
 
@@ -865,16 +865,16 @@ def test_table_safe_casting():
     data = [
         pa.array(range(5), type=pa.int64()),
         pa.array([-10, -5, 0, 5, 10], type=pa.int32()),
-        pa.array([1.0, 2.0, 3.0], type=pa.float64()),
-        pa.array(['ab', 'bc', 'cd'], type=pa.string())
+        pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64()),
+        pa.array(['ab', 'bc', 'cd', 'de', 'ef'], type=pa.string())
     ]
     table = pa.Table.from_arrays(data, names=tuple('abcd'))
 
     expected_data = [
         pa.array(range(5), type=pa.int32()),
         pa.array([-10, -5, 0, 5, 10], type=pa.int16()),
-        pa.array([1, 2, 3], type=pa.int64()),
-        pa.array(['ab', 'bc', 'cd'], type=pa.string())
+        pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+        pa.array(['ab', 'bc', 'cd', 'de' , 'ef'], type=pa.string())
     ]
     expected_table = pa.Table.from_arrays(expected_data, names=tuple('abcd'))
 
@@ -893,16 +893,16 @@ def test_table_unsafe_casting():
     data = [
         pa.array(range(5), type=pa.int64()),
         pa.array([-10, -5, 0, 5, 10], type=pa.int32()),
-        pa.array([1.1, 2.2, 3.3], type=pa.float64()),
-        pa.array(['ab', 'bc', 'cd'], type=pa.string())
+        pa.array([1.1, 2.2, 3.3, 4.4, 5.5], type=pa.float64()),
+        pa.array(['ab', 'bc', 'cd', 'de', 'ef'], type=pa.string())
     ]
     table = pa.Table.from_arrays(data, names=tuple('abcd'))
 
     expected_data = [
         pa.array(range(5), type=pa.int32()),
         pa.array([-10, -5, 0, 5, 10], type=pa.int16()),
-        pa.array([1, 2, 3], type=pa.int64()),
-        pa.array(['ab', 'bc', 'cd'], type=pa.string())
+        pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+        pa.array(['ab', 'bc', 'cd', 'de', 'ef'], type=pa.string())
     ]
     expected_table = pa.Table.from_arrays(expected_data, names=tuple('abcd'))
 
@@ -919,3 +919,12 @@ def test_table_unsafe_casting():
 
     casted_table = table.cast(target_schema, safe=False)
     assert casted_table.equals(expected_table)
+
+
+def test_invalid_table_construct():
+    array = np.array([0, 1], dtype=np.uint8)
+    u8 = pa.uint8()
+    arrays = [pa.array(array, type=u8), pa.array(array[1:], type=u8)]
+
+    with pytest.raises(pa.lib.ArrowInvalid) as e:
+        pa.Table.from_arrays(arrays, names=["a1", "a2"])

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -874,7 +874,7 @@ def test_table_safe_casting():
         pa.array(range(5), type=pa.int32()),
         pa.array([-10, -5, 0, 5, 10], type=pa.int16()),
         pa.array([1, 2, 3, 4, 5], type=pa.int64()),
-        pa.array(['ab', 'bc', 'cd', 'de' , 'ef'], type=pa.string())
+        pa.array(['ab', 'bc', 'cd', 'de', 'ef'], type=pa.string())
     ]
     expected_table = pa.Table.from_arrays(expected_data, names=tuple('abcd'))
 
@@ -926,5 +926,5 @@ def test_invalid_table_construct():
     u8 = pa.uint8()
     arrays = [pa.array(array, type=u8), pa.array(array[1:], type=u8)]
 
-    with pytest.raises(pa.lib.ArrowInvalid) as e:
+    with pytest.raises(pa.lib.ArrowInvalid):
         pa.Table.from_arrays(arrays, names=["a1", "a2"])


### PR DESCRIPTION
FileWriter expects a well-formed Table where all columns are of equal
lengths.

- WriteTable checks if the table is valid
- Python ensure that a table is valid before wrapping it