### PR TITLE
ARROW-4466: [Rust] [DataFusion] Add support for Parquet data source

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -754,7 +754,7 @@ impl Schema {
     }
 
     /// Create a new schema by applying a projection to this schema's fields
-    pub fn projection(&self, projection: &Vec<usize>) -> Result<Arc<Schema>> {
+    pub fn projection(&self, projection: &[usize]) -> Result<Arc<Schema>> {
         let mut fields: Vec<Field> = Vec::with_capacity(projection.len());
         for i in projection {
             if *i < self.fields().len() {

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -26,7 +26,6 @@ use std::mem::size_of;
 use std::ops::{Add, Div, Mul, Sub};
 use std::slice::from_raw_parts;
 use std::str::FromStr;
-use std::sync::Arc;
 
 use packed_simd::*;
 use serde_derive::{Deserialize, Serialize};
@@ -751,22 +750,6 @@ impl Schema {
         json!({
             "fields": self.fields.iter().map(|field| field.to_json()).collect::<Vec<Value>>(),
         })
-    }
-
-    /// Create a new schema by applying a projection to this schema's fields
-    pub fn projection(&self, projection: &[usize]) -> Result<Arc<Schema>> {
-        let mut fields: Vec<Field> = Vec::with_capacity(projection.len());
-        for i in projection {
-            if *i < self.fields().len() {
-                fields.push(self.field(*i).clone());
-            } else {
-                return Err(ArrowError::InvalidArgumentError(format!(
-                    "Invalid column index {} in projection",
-                    i
-                )));
-            }
-        }
-        Ok(Arc::new(Schema::new(fields)))
     }
 }
 

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -754,9 +754,18 @@ impl Schema {
     }
 
     /// Create a new schema by applying a projection to this schema's fields
-    pub fn projection(&self, i: &Vec<usize>) -> Result<Arc<Schema>> {
-        //TODO bounds checks
-        let fields = i.iter().map(|index| self.field(*index).clone()).collect();
+    pub fn projection(&self, projection: &Vec<usize>) -> Result<Arc<Schema>> {
+        let mut fields: Vec<Field> = Vec::with_capacity(projection.len());
+        for i in projection {
+            if *i < self.fields().len() {
+                fields.push(self.field(*i).clone());
+            } else {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "Invalid column index {} in projection",
+                    i
+                )));
+            }
+        }
         Ok(Arc::new(Schema::new(fields)))
     }
 }

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -26,6 +26,7 @@ use std::mem::size_of;
 use std::ops::{Add, Div, Mul, Sub};
 use std::slice::from_raw_parts;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use packed_simd::*;
 use serde_derive::{Deserialize, Serialize};
@@ -750,6 +751,13 @@ impl Schema {
         json!({
             "fields": self.fields.iter().map(|field| field.to_json()).collect::<Vec<Value>>(),
         })
+    }
+
+    /// Create a new schema by applying a projection to this schema's fields
+    pub fn projection(&self, i: &Vec<usize>) -> Result<Arc<Schema>> {
+        //TODO bounds checks
+        let fields = i.iter().map(|index| self.field(*index).clone()).collect();
+        Ok(Arc::new(Schema::new(fields)))
     }
 }
 

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -18,6 +18,7 @@
 pub mod csv;
 pub mod datasource;
 pub mod memory;
+pub mod parquet;
 
 pub use self::csv::{CsvBatchIterator, CsvFile};
 pub use self::datasource::{RecordBatchIterator, ScanResult, Table};

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -54,6 +54,7 @@ impl ParquetTable {
 }
 
 impl Table for ParquetTable {
+
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -142,11 +142,7 @@ where
     fn read(&mut self, batch_size: usize, is_nullable: bool) -> Result<Arc<PrimitiveArray<A>>> {
 
         // create read buffer
-        let mut read_buffer: Vec<P::T> = Vec::with_capacity(batch_size);
-
-        for _ in 0..batch_size {
-            read_buffer.push(A::default_value().into());
-        }
+        let mut read_buffer: Vec<P::T> = vec![A::default_value().into(); batch_size];
 
         if is_nullable {
             let mut def_levels: Vec<i16> = Vec::with_capacity(batch_size);

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -561,10 +561,6 @@ mod tests {
         let testdata = env::var("PARQUET_TEST_DATA").unwrap();
         let filename = format!("{}/{}", testdata, name);
         let table = ParquetTable::try_new(&filename).unwrap();
-        println!("Loading file {} with schema:", name);
-        for field in table.schema().fields() {
-            println!("\t{:?}", field);
-        }
         Box::new(table)
     }
 }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -407,6 +407,25 @@ mod tests {
     use std::env;
 
     #[test]
+    fn read_small_batches() {
+        let table = load_table("alltypes_plain.parquet");
+
+        let projection = None;
+        let scan = table.scan(&projection, 2).unwrap();
+        let mut it = scan[0].lock().unwrap();
+
+        let mut count = 0;
+        while let Some(batch) = it.next().unwrap() {
+            assert_eq!(11, batch.num_columns());
+            assert_eq!(2, batch.num_rows());
+            count += 1;
+        }
+
+        // we should have seen 4 batches of 2 rows
+        assert_eq!(4, count);
+    }
+
+    #[test]
     fn read_alltypes_plain_parquet() {
         let table = load_table("alltypes_plain.parquet");
 

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -22,7 +22,7 @@ use std::string::String;
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, PrimitiveArray};
-use arrow::builder::{BinaryBuilder, PrimitiveBuilder};
+use arrow::builder::{BinaryBuilder, PrimitiveBuilder, TimestampNanosecondBuilder};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 
@@ -33,7 +33,6 @@ use parquet::reader::schema::parquet_to_arrow_schema;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::execution::error::{ExecutionError, Result};
-use arrow::builder::TimestampNanosecondBuilder;
 
 pub struct ParquetTable {
     filename: String,
@@ -338,7 +337,7 @@ impl ParquetFile {
     }
 }
 
-/// convert a parquet timestamp in nanoseconds to a timestamp with milliseconds
+/// convert a Parquet INT96 to an Arrow timestamp in nanoseconds
 fn convert_int96_timestamp(v: &[u32]) -> i64 {
     const JULIAN_DAY_OF_EPOCH: i64 = 2_440_588;
     const SECONDS_PER_DAY: i64 = 86_400;
@@ -347,7 +346,7 @@ fn convert_int96_timestamp(v: &[u32]) -> i64 {
     let day = v[2] as i64;
     let nanoseconds = ((v[1] as i64) << 32) + v[0] as i64;
     let seconds = (day - JULIAN_DAY_OF_EPOCH) * SECONDS_PER_DAY;
-    seconds * MILLIS_PER_SECOND + nanoseconds / 1_000_000
+    seconds * MILLIS_PER_SECOND * 1_000_000 + nanoseconds
 }
 
 impl RecordBatchIterator for ParquetFile {
@@ -474,7 +473,7 @@ mod tests {
             values.push(array.value(i));
         }
 
-        assert_eq!("[1235865600000, 1235865660000, 1238544000000, 1238544060000, 1233446400000, 1233446460000, 1230768000000, 1230768060000]", format!("{:?}", values));
+        assert_eq!("[1235865600000000000, 1235865660000000000, 1238544000000000000, 1238544060000000000, 1233446400000000000, 1233446460000000000, 1230768000000000000, 1230768060000000000]", format!("{:?}", values));
     }
 
     #[test]

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -22,7 +22,7 @@ use std::string::String;
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, PrimitiveArray};
-use arrow::builder::{BinaryBuilder, Int64Builder, PrimitiveBuilder};
+use arrow::builder::{BinaryBuilder, PrimitiveBuilder};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 
@@ -33,6 +33,7 @@ use parquet::reader::schema::parquet_to_arrow_schema;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::execution::error::{ExecutionError, Result};
+use arrow::builder::TimestampNanosecondBuilder;
 
 pub struct ParquetTable {
     filename: String,
@@ -283,7 +284,8 @@ impl ParquetFile {
                                 &mut read_buffer,
                             )?;
 
-                            let mut builder = Int64Builder::new(levels_read);
+                            let mut builder =
+                                TimestampNanosecondBuilder::new(levels_read);
                             let mut value_index = 0;
                             for i in 0..levels_read {
                                 if def_levels[i] > 0 {
@@ -378,11 +380,10 @@ impl RecordBatchIterator for ParquetFile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::BooleanArray;
-    use arrow::array::Float32Array;
-    use arrow::array::Float64Array;
-    use arrow::array::Int64Array;
-    use arrow::array::{BinaryArray, Int32Array};
+    use arrow::array::{
+        BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,
+        TimestampNanosecondArray,
+    };
     use std::env;
 
     #[test]
@@ -466,7 +467,7 @@ mod tests {
         let array = batch
             .column(0)
             .as_any()
-            .downcast_ref::<Int64Array>()
+            .downcast_ref::<TimestampNanosecondArray>()
             .unwrap();
         let mut values: Vec<i64> = vec![];
         for i in 0..batch.num_rows() {

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -22,7 +22,7 @@ use std::string::String;
 use std::sync::{Arc, Mutex};
 
 use arrow::array::Array;
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
 use parquet::column::reader::*;
@@ -31,6 +31,7 @@ use parquet::file::reader::*;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::execution::error::{ExecutionError, Result};
+use arrow::array::BinaryArray;
 use arrow::builder::BooleanBuilder;
 use arrow::builder::Int64Builder;
 use arrow::builder::{BinaryBuilder, Float32Builder, Float64Builder, Int32Builder};
@@ -81,6 +82,94 @@ pub struct ParquetFile {
     column_readers: Vec<ColumnReader>,
 }
 
+fn create_binary_array(b: &Vec<ByteArray>, row_count: usize) -> Result<Arc<BinaryArray>> {
+    let mut builder = BinaryBuilder::new(b.len());
+    for j in 0..row_count {
+        let slice = b[j].slice(0, b[j].len());
+        builder.append_string(&String::from_utf8(slice.data().to_vec()).unwrap())?;
+    }
+    Ok(Arc::new(builder.finish()))
+}
+
+macro_rules! read_column {
+    ($SELF:ident, $R:ident, $INDEX:expr, $BUILDER:ident, $TY:ident, $DEFAULT:expr) => {{
+        //TODO: should be able to get num_rows in row group instead of defaulting to batch size
+        let mut read_buffer: Vec<$TY> = Vec::with_capacity($SELF.batch_size);
+        for _ in 0..$SELF.batch_size {
+            read_buffer.push($DEFAULT);
+        }
+        if $SELF.schema.field($INDEX).is_nullable() {
+
+            let mut def_levels: Vec<i16> = Vec::with_capacity($SELF.batch_size);
+            for _ in 0..$SELF.batch_size {
+                def_levels.push(0);
+            }
+
+            let (values_read, levels_read) = $R.read_batch(
+                    $SELF.batch_size,
+                    Some(&mut def_levels),
+                    None,
+                    &mut read_buffer,
+            )?;
+            let mut builder = $BUILDER::new(levels_read);
+            if values_read == levels_read {
+                builder.append_slice(&read_buffer[0..values_read])?;
+            } else {
+                return Err(ExecutionError::NotImplemented("Parquet datasource does not support null values".to_string()))
+            }
+            Arc::new(builder.finish())
+        } else {
+            let (values_read, _) = $R.read_batch(
+                    $SELF.batch_size,
+                    None,
+                    None,
+                    &mut read_buffer,
+            )?;
+            let mut builder = $BUILDER::new(values_read);
+            builder.append_slice(&read_buffer[0..values_read])?;
+            Arc::new(builder.finish())
+        }
+    }}
+}
+
+macro_rules! read_binary_column {
+    ($SELF:ident, $R:ident, $INDEX:expr) => {{
+        //TODO: should be able to get num_rows in row group instead of defaulting to batch size
+        let mut read_buffer: Vec<ByteArray> =
+            Vec::with_capacity($SELF.batch_size);
+        for _ in 0..$SELF.batch_size {
+            read_buffer.push(ByteArray::default());
+        }
+        if $SELF.schema.field($INDEX).is_nullable() {
+
+            let mut def_levels: Vec<i16> = Vec::with_capacity($SELF.batch_size);
+            for _ in 0..$SELF.batch_size {
+                def_levels.push(0);
+            }
+
+            let (values_read, levels_read) = $R.read_batch(
+                    $SELF.batch_size,
+                    Some(&mut def_levels),
+                    None,
+                    &mut read_buffer,
+            )?;
+            if values_read == levels_read {
+                create_binary_array(&read_buffer, values_read)?
+            } else {
+                return Err(ExecutionError::NotImplemented("Parquet datasource does not support null values".to_string()))
+            }
+        } else {
+            let (values_read, _) = $R.read_batch(
+                    $SELF.batch_size,
+                    None,
+                    None,
+                    &mut read_buffer,
+            )?;
+            create_binary_array(&read_buffer, values_read)?
+        }
+    }}
+}
+
 impl ParquetFile {
     pub fn open(file: File, projection: Option<Vec<usize>>) -> Result<Self> {
         let reader = SerializedFileReader::new(file)?;
@@ -100,12 +189,7 @@ impl ParquetFile {
             }
         };
 
-        let projected_fields: Vec<Field> = projection
-            .iter()
-            .map(|i| schema.fields()[*i].clone())
-            .collect();
-
-        let projected_schema = Arc::new(Schema::new(projected_fields));
+        let projected_schema = schema.projection(&projection)?;
 
         Ok(ParquetFile {
             reader: reader,
@@ -124,8 +208,23 @@ impl ParquetFile {
 
             self.column_readers = Vec::with_capacity(self.projection.len());
 
-            for i in &self.projection {
-                self.column_readers.push(reader.get_column_reader(*i)?);
+            for i in 0..self.projection.len() {
+                match self.schema().field(i).data_type() {
+                    DataType::List(_) => {
+                        return Err(ExecutionError::NotImplemented(
+                            "Parquet datasource does not support LIST".to_string(),
+                        ));
+                    }
+                    DataType::Struct(_) => {
+                        return Err(ExecutionError::NotImplemented(
+                            "Parquet datasource does not support STRUCT".to_string(),
+                        ));
+                    }
+                    _ => {}
+                }
+
+                self.column_readers
+                    .push(reader.get_column_reader(self.projection[i])?);
             }
 
             self.current_row_group = Some(reader);
@@ -143,92 +242,16 @@ impl ParquetFile {
         match &self.current_row_group {
             Some(reader) => {
                 let mut batch: Vec<Arc<Array>> = Vec::with_capacity(reader.num_columns());
-                let mut row_count = 0;
                 for i in 0..self.column_readers.len() {
                     let array: Arc<Array> = match self.column_readers[i] {
                         ColumnReader::BoolColumnReader(ref mut r) => {
-                            let mut read_buffer: Vec<bool> =
-                                Vec::with_capacity(self.batch_size);
-
-                            for _ in 0..self.batch_size {
-                                read_buffer.push(false);
-                            }
-
-                            match r.read_batch(
-                                self.batch_size,
-                                None,
-                                None,
-                                &mut read_buffer,
-                            ) {
-                                Ok((count, _)) => {
-                                    let mut builder = BooleanBuilder::new(count);
-                                    builder.append_slice(&read_buffer[0..count])?;
-                                    row_count = count;
-                                    Arc::new(builder.finish())
-                                }
-                                Err(e) => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {}): {:?}",
-                                        i, e
-                                    )));
-                                }
-                            }
+                            read_column!(self, r, i, BooleanBuilder, bool, false)
                         }
                         ColumnReader::Int32ColumnReader(ref mut r) => {
-                            let mut read_buffer: Vec<i32> =
-                                Vec::with_capacity(self.batch_size);
-
-                            for _ in 0..self.batch_size {
-                                read_buffer.push(0);
-                            }
-
-                            match r.read_batch(
-                                self.batch_size,
-                                None,
-                                None,
-                                &mut read_buffer,
-                            ) {
-                                Ok((count, _)) => {
-                                    let mut builder = Int32Builder::new(count);
-                                    builder.append_slice(&read_buffer[0..count])?;
-                                    row_count = count;
-                                    Arc::new(builder.finish())
-                                }
-                                Err(e) => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {}): {:?}",
-                                        i, e
-                                    )));
-                                }
-                            }
+                            read_column!(self, r, i, Int32Builder, i32, 0)
                         }
                         ColumnReader::Int64ColumnReader(ref mut r) => {
-                            let mut read_buffer: Vec<i64> =
-                                Vec::with_capacity(self.batch_size);
-
-                            for _ in 0..self.batch_size {
-                                read_buffer.push(0);
-                            }
-
-                            match r.read_batch(
-                                self.batch_size,
-                                None,
-                                None,
-                                &mut read_buffer,
-                            ) {
-                                Ok((count, _)) => {
-                                    let mut builder = Int64Builder::new(count);
-                                    builder.append_slice(&read_buffer[0..count])?;
-                                    row_count = count;
-                                    Arc::new(builder.finish())
-                                }
-                                Err(e) => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {}): {:?}",
-                                        i, e
-                                    )));
-                                }
-                            }
+                            read_column!(self, r, i, Int64Builder, i64, 0)
                         }
                         ColumnReader::Int96ColumnReader(ref mut r) => {
                             let mut read_buffer: Vec<Int96> =
@@ -238,16 +261,23 @@ impl ParquetFile {
                                 read_buffer.push(Int96::new());
                             }
 
-                            match r.read_batch(
-                                self.batch_size,
-                                None,
-                                None,
-                                &mut read_buffer,
-                            ) {
-                                Ok((count, _)) => {
-                                    let mut builder = Int64Builder::new(count);
+                            if self.schema.field(i).is_nullable() {
+                                let mut def_levels: Vec<i16> =
+                                    Vec::with_capacity(self.batch_size);
+                                for _ in 0..self.batch_size {
+                                    def_levels.push(0);
+                                }
+                                let (values_read, levels_read) = r.read_batch(
+                                    self.batch_size,
+                                    Some(&mut def_levels),
+                                    None,
+                                    &mut read_buffer,
+                                )?;
 
-                                    for i in 0..count {
+                                if values_read == levels_read {
+                                    let mut builder = Int64Builder::new(values_read);
+
+                                    for i in 0..values_read {
                                         let v = read_buffer[i].data();
                                         let value: u128 = (v[0] as u128) << 64
                                             | (v[1] as u128) << 32
@@ -255,129 +285,52 @@ impl ParquetFile {
                                         let ms: i64 = (value / 1000000) as i64;
                                         builder.append_value(ms)?;
                                     }
-                                    row_count = count;
                                     Arc::new(builder.finish())
+                                } else {
+                                    return Err(ExecutionError::NotImplemented(
+                                        "Parquet datasource does not support null values"
+                                            .to_string(),
+                                    ));
                                 }
-                                Err(e) => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {}): {:?}",
-                                        i, e
-                                    )));
+                            } else {
+                                let (values_read, _) = r.read_batch(
+                                    self.batch_size,
+                                    None,
+                                    None,
+                                    &mut read_buffer,
+                                )?;
+
+                                let mut builder = Int64Builder::new(values_read);
+
+                                for i in 0..values_read {
+                                    let v = read_buffer[i].data();
+                                    let value: u128 = (v[0] as u128) << 64
+                                        | (v[1] as u128) << 32
+                                        | (v[2] as u128);
+                                    let ms: i64 = (value / 1000000) as i64;
+                                    builder.append_value(ms)?;
                                 }
+                                Arc::new(builder.finish())
                             }
                         }
                         ColumnReader::FloatColumnReader(ref mut r) => {
-                            let mut builder = Float32Builder::new(self.batch_size);
-                            let mut read_buffer: Vec<f32> =
-                                Vec::with_capacity(self.batch_size);
-                            for _ in 0..self.batch_size {
-                                read_buffer.push(0.0);
-                            }
-                            match r.read_batch(
-                                self.batch_size,
-                                None,
-                                None,
-                                &mut read_buffer,
-                            ) {
-                                Ok((count, _)) => {
-                                    builder.append_slice(&read_buffer[0..count])?;
-                                    row_count = count;
-                                    Arc::new(builder.finish())
-                                }
-                                Err(e) => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {}): {:?}",
-                                        i, e
-                                    )));
-                                }
-                            }
+                            read_column!(self, r, i, Float32Builder, f32, 0_f32)
                         }
                         ColumnReader::DoubleColumnReader(ref mut r) => {
-                            let mut builder = Float64Builder::new(self.batch_size);
-                            let mut read_buffer: Vec<f64> =
-                                Vec::with_capacity(self.batch_size);
-                            for _ in 0..self.batch_size {
-                                read_buffer.push(0.0);
-                            }
-                            match r.read_batch(
-                                self.batch_size,
-                                None,
-                                None,
-                                &mut read_buffer,
-                            ) {
-                                Ok((count, _)) => {
-                                    builder.append_slice(&read_buffer[0..count])?;
-                                    row_count = count;
-                                    Arc::new(builder.finish())
-                                }
-                                Err(e) => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {}): {:?}",
-                                        i, e
-                                    )));
-                                }
-                            }
+                            read_column!(self, r, i, Float64Builder, f64, 0_f64)
                         }
                         ColumnReader::FixedLenByteArrayColumnReader(ref mut r) => {
-                            let mut b: Vec<ByteArray> =
-                                Vec::with_capacity(self.batch_size);
-                            for _ in 0..self.batch_size {
-                                b.push(ByteArray::default());
-                            }
-                            match r.read_batch(self.batch_size, None, None, &mut b) {
-                                Ok((count, _)) => {
-                                    row_count = count;
-                                    let mut builder = BinaryBuilder::new(row_count);
-                                    for j in 0..row_count {
-                                        let slice = b[j].slice(0, b[j].len());
-                                        builder.append_string(
-                                            &String::from_utf8(slice.data().to_vec())
-                                                .unwrap(),
-                                        )?;
-                                    }
-                                    Arc::new(builder.finish())
-                                }
-                                _ => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {})",
-                                        i
-                                    )));
-                                }
-                            }
+                            read_binary_column!(self, r, i)
                         }
                         ColumnReader::ByteArrayColumnReader(ref mut r) => {
-                            let mut b: Vec<ByteArray> =
-                                Vec::with_capacity(self.batch_size);
-                            for _ in 0..self.batch_size {
-                                b.push(ByteArray::default());
-                            }
-                            match r.read_batch(self.batch_size, None, None, &mut b) {
-                                Ok((count, _)) => {
-                                    row_count = count;
-                                    let mut builder = BinaryBuilder::new(row_count);
-                                    for j in 0..row_count {
-                                        let slice = b[j].slice(0, b[j].len());
-                                        builder.append_string(
-                                            &String::from_utf8(slice.data().to_vec())
-                                                .unwrap(),
-                                        )?;
-                                    }
-                                    Arc::new(builder.finish())
-                                }
-                                _ => {
-                                    return Err(ExecutionError::NotImplemented(format!(
-                                        "Error reading parquet batch (column {})",
-                                        i
-                                    )));
-                                }
-                            }
+                            read_binary_column!(self, r, i)
                         }
                     };
 
                     batch.push(array);
                 }
 
-                if row_count == 0 {
+                if batch.len() == 0 || batch[0].data().len() == 0 {
                     Ok(None)
                 } else {
                     Ok(Some(RecordBatch::try_new(self.schema.clone(), batch)?))
@@ -604,8 +557,8 @@ mod tests {
     #[test]
     fn read_int64_nullable_impala_parquet() {
         let table = load_table("nullable.impala.parquet");
-
         let projection = Some(vec![0]);
+
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
         let batch = it.next().unwrap().unwrap();
@@ -624,6 +577,20 @@ mod tests {
         }
 
         assert_eq!("[1, 2, 3, 4, 5, 6, 7]", format!("{:?}", values));
+    }
+
+    #[test]
+    fn read_array_nullable_impala_parquet() {
+        let table = load_table("nullable.impala.parquet");
+        let projection = Some(vec![1]);
+        let scan = table.scan(&projection, 1024).unwrap();
+        let mut it = scan[0].lock().unwrap();
+        let batch = it.next();
+
+        assert_eq!(
+            "NotImplemented(\"Parquet datasource does not support LIST\")",
+            format!("{:?}", batch.err().unwrap())
+        );
     }
 
     fn load_table(name: &str) -> Box<Table> {

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -1,0 +1,310 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Parquet Data source
+
+use std::cell::RefCell;
+use std::fs::File;
+use std::rc::Rc;
+use std::string::String;
+use std::sync::Arc;
+
+use arrow::array::Array;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+
+use parquet::basic;
+use parquet::column::reader::*;
+use parquet::data_type::ByteArray;
+use parquet::file::reader::*;
+use parquet::schema::types::Type;
+
+use crate::datasource::{RecordBatchIterator, Table};
+use crate::execution::error::{ExecutionError, Result};
+use arrow::builder::{BinaryBuilder, Float64Builder, Int32Builder};
+
+pub struct ParquetTable {
+    filename: String,
+    schema: Arc<Schema>,
+}
+
+impl ParquetTable {
+    pub fn new(filename: &str) -> Self {
+        let file = File::open(filename).unwrap();
+        let parquet_file = ParquetFile::open(file, None).unwrap();
+        let schema = parquet_file.schema.clone();
+        Self {
+            filename: filename.to_string(),
+            schema,
+        }
+    }
+}
+
+impl Table for ParquetTable {
+    fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
+
+    fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        _batch_size: usize,
+    ) -> Result<Rc<RefCell<RecordBatchIterator>>> {
+        let file = File::open(self.filename.clone()).unwrap();
+        let parquet_file = ParquetFile::open(file, projection.clone()).unwrap();
+        Ok(Rc::new(RefCell::new(parquet_file)))
+    }
+}
+
+pub struct ParquetFile {
+    reader: SerializedFileReader<File>,
+    row_group_index: usize,
+    schema: Arc<Schema>,
+    projection: Option<Vec<usize>>,
+    batch_size: usize,
+    current_row_group: Option<Box<RowGroupReader>>,
+    column_readers: Vec<ColumnReader>,
+}
+
+impl ParquetFile {
+    pub fn open(file: File, projection: Option<Vec<usize>>) -> Result<Self> {
+        let reader = SerializedFileReader::new(file).unwrap();
+
+        let metadata = reader.metadata();
+        let file_type = to_arrow(metadata.file_metadata().schema())?;
+
+        match file_type.data_type() {
+            DataType::Struct(fields) => {
+                let schema = Schema::new(fields.clone());
+                //println!("Parquet schema: {:?}", schema);
+                Ok(ParquetFile {
+                    reader: reader,
+                    row_group_index: 0,
+                    schema: Arc::new(schema),
+                    projection,
+                    batch_size: 64 * 1024,
+                    current_row_group: None,
+                    column_readers: vec![],
+                })
+            }
+            _ => Err(ExecutionError::General(
+                "Failed to read Parquet schema".to_string(),
+            )),
+        }
+    }
+
+    fn load_next_row_group(&mut self) {
+        if self.row_group_index < self.reader.num_row_groups() {
+            //println!("Loading row group {} of {}", self.row_group_index, self.reader.num_row_groups());
+            let reader = self.reader.get_row_group(self.row_group_index).unwrap();
+
+            self.column_readers = vec![];
+
+            match &self.projection {
+                None => {
+                    for i in 0..reader.num_columns() {
+                        self.column_readers
+                            .push(reader.get_column_reader(i).unwrap());
+                    }
+                }
+                Some(proj) => {
+                    for i in proj {
+                        //TODO validate index in bounds
+                        self.column_readers
+                            .push(reader.get_column_reader(*i).unwrap());
+                    }
+                }
+            }
+
+            self.current_row_group = Some(reader);
+            self.row_group_index += 1;
+        } else {
+            panic!()
+        }
+    }
+
+    fn load_batch(&mut self) -> Result<Option<RecordBatch>> {
+        match &self.current_row_group {
+            Some(reader) => {
+                let mut batch: Vec<Arc<Array>> = Vec::with_capacity(reader.num_columns());
+                let mut row_count = 0;
+                for i in 0..self.column_readers.len() {
+                    let array: Arc<Array> = match self.column_readers[i] {
+                        ColumnReader::Int32ColumnReader(ref mut r) => {
+                            let mut builder = Int32Builder::new(self.batch_size);
+                            let mut read_buffer: Vec<i32> =
+                                Vec::with_capacity(self.batch_size);
+                            match r.read_batch(
+                                self.batch_size,
+                                None,
+                                None,
+                                &mut read_buffer,
+                            ) {
+                                //TODO this isn't handling null values
+                                Ok((count, _)) => {
+                                    builder.append_slice(&read_buffer).unwrap();
+                                    row_count = count;
+                                    Arc::new(builder.finish())
+                                }
+                                _ => {
+                                    return Err(ExecutionError::NotImplemented(format!(
+                                        "Error reading parquet batch (column {})",
+                                        i
+                                    )));
+                                }
+                            }
+                        }
+                        ColumnReader::DoubleColumnReader(ref mut r) => {
+                            let mut builder = Float64Builder::new(self.batch_size);
+                            let mut read_buffer: Vec<f64> =
+                                Vec::with_capacity(self.batch_size);
+                            match r.read_batch(
+                                self.batch_size,
+                                None,
+                                None,
+                                &mut read_buffer,
+                            ) {
+                                //TODO this isn't handling null values
+                                Ok((count, _)) => {
+                                    builder.append_slice(&read_buffer).unwrap();
+                                    row_count = count;
+                                    Arc::new(builder.finish())
+                                }
+                                _ => {
+                                    return Err(ExecutionError::NotImplemented(format!(
+                                        "Error reading parquet batch (column {})",
+                                        i
+                                    )));
+                                }
+                            }
+                        }
+                        ColumnReader::ByteArrayColumnReader(ref mut r) => {
+                            let mut b: Vec<ByteArray> =
+                                Vec::with_capacity(self.batch_size);
+                            for _ in 0..self.batch_size {
+                                b.push(ByteArray::default());
+                            }
+                            match r.read_batch(self.batch_size, None, None, &mut b) {
+                                //TODO this isn't handling null values
+                                Ok((count, _)) => {
+                                    row_count = count;
+                                    //TODO this is horribly inefficient
+                                    let mut builder = BinaryBuilder::new(row_count);
+                                    for j in 0..row_count {
+                                        let foo = b[j].slice(0, b[j].len());
+                                        let bytes: &[u8] = foo.data();
+                                        let str =
+                                            String::from_utf8(bytes.to_vec()).unwrap();
+                                        builder.append_string(&str).unwrap();
+                                    }
+                                    Arc::new(builder.finish())
+                                }
+                                _ => {
+                                    return Err(ExecutionError::NotImplemented(format!(
+                                        "Error reading parquet batch (column {})",
+                                        i
+                                    )));
+                                }
+                            }
+                        }
+                        _ => {
+                            return Err(ExecutionError::NotImplemented(
+                                "unsupported column reader type".to_string(),
+                            ));
+                        }
+                    };
+
+                    batch.push(array);
+                }
+
+                //                println!("Loaded batch of {} rows", row_count);
+
+                if row_count == 0 {
+                    Ok(None)
+                } else {
+                    Ok(Some(RecordBatch::try_new(self.schema.clone(), batch)?))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+fn to_arrow(t: &Type) -> Result<Field> {
+    match t {
+        Type::PrimitiveType {
+            basic_info,
+            physical_type,
+            ..
+        } => {
+            let arrow_type = match physical_type {
+                basic::Type::BOOLEAN => DataType::Boolean,
+                basic::Type::INT32 => DataType::Int32,
+                basic::Type::INT64 => DataType::Int64,
+                basic::Type::INT96 => DataType::Int64, //TODO ???
+                basic::Type::FLOAT => DataType::Float32,
+                basic::Type::DOUBLE => DataType::Float64,
+                basic::Type::BYTE_ARRAY => DataType::Utf8, /*match basic_info.logical_type() {
+                basic::LogicalType::UTF8 => DataType::Utf8,
+                _ => unimplemented!("No support for Parquet BYTE_ARRAY yet"),
+                }*/
+                basic::Type::FIXED_LEN_BYTE_ARRAY => {
+                    unimplemented!("No support for Parquet FIXED_LEN_BYTE_ARRAY yet")
+                }
+            };
+
+            Ok(Field::new(basic_info.name(), arrow_type, false))
+        }
+        Type::GroupType { basic_info, fields } => Ok(Field::new(
+            basic_info.name(),
+            DataType::Struct(
+                fields
+                    .iter()
+                    .map(|f| to_arrow(f))
+                    .collect::<Result<Vec<Field>>>()?,
+            ),
+            false,
+        )),
+    }
+}
+
+impl RecordBatchIterator for ParquetFile {
+    fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
+
+    fn next(&mut self) -> Result<Option<RecordBatch>> {
+        // advance the row group reader if necessary
+        if self.current_row_group.is_none() {
+            self.load_next_row_group();
+            self.load_batch()
+        } else {
+            match self.load_batch() {
+                Ok(Some(b)) => Ok(Some(b)),
+                Ok(None) => {
+                    if self.row_group_index < self.reader.num_row_groups() {
+                        self.load_next_row_group();
+                        self.load_batch()
+                    } else {
+                        Ok(None)
+                    }
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+}

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -22,19 +22,17 @@ use std::string::String;
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, PrimitiveArray};
-use arrow::builder::PrimitiveBuilder;
+use arrow::builder::{BinaryBuilder, Int64Builder, PrimitiveBuilder};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 
 use parquet::column::reader::*;
-use parquet::data_type::ByteArray;
+use parquet::data_type::{ByteArray, Int96};
 use parquet::file::reader::*;
+use parquet::reader::schema::parquet_to_arrow_schema;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::execution::error::{ExecutionError, Result};
-use arrow::builder::{BinaryBuilder, Int64Builder};
-use parquet::data_type::Int96;
-use parquet::reader::schema::parquet_to_arrow_schema;
 
 pub struct ParquetTable {
     filename: String,

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -139,7 +139,6 @@ impl ParquetFile {
             self.column_readers = vec![];
 
             for i in &self.projection {
-                //TODO validate index in bounds
                 self.column_readers
                     .push(reader.get_column_reader(*i).unwrap());
             }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -128,19 +128,29 @@ macro_rules! read_binary_column {
     }}
 }
 
-trait ArrowReader<T> where T: ArrowPrimitiveType {
-    fn read(&mut self, batch_size: usize, is_nullable: bool) -> Result<Arc<PrimitiveArray<T>>>;
+trait ArrowReader<T>
+where
+    T: ArrowPrimitiveType,
+{
+    fn read(
+        &mut self,
+        batch_size: usize,
+        is_nullable: bool,
+    ) -> Result<Arc<PrimitiveArray<T>>>;
 }
 
-impl<A,P> ArrowReader<A> for ColumnReaderImpl<P> 
+impl<A, P> ArrowReader<A> for ColumnReaderImpl<P>
 where
-    A: ArrowPrimitiveType, 
+    A: ArrowPrimitiveType,
     P: parquet::data_type::DataType,
     P::T: std::convert::From<A::Native>,
     A::Native: std::convert::From<P::T>,
 {
-    fn read(&mut self, batch_size: usize, is_nullable: bool) -> Result<Arc<PrimitiveArray<A>>> {
-
+    fn read(
+        &mut self,
+        batch_size: usize,
+        is_nullable: bool,
+    ) -> Result<Arc<PrimitiveArray<A>>> {
         // create read buffer
         let mut read_buffer: Vec<P::T> = vec![A::default_value().into(); batch_size];
 
@@ -151,14 +161,15 @@ where
             }
 
             let (values_read, levels_read) = self.read_batch(
-                    batch_size,
-                    Some(&mut def_levels),
-                    None,
-                    &mut read_buffer,
+                batch_size,
+                Some(&mut def_levels),
+                None,
+                &mut read_buffer,
             )?;
             let mut builder = PrimitiveBuilder::<A>::new(levels_read);
             if values_read == levels_read {
-                let converted_buffer: Vec<A::Native> = read_buffer.into_iter().map(|v| v.into()).collect();
+                let converted_buffer: Vec<A::Native> =
+                    read_buffer.into_iter().map(|v| v.into()).collect();
                 builder.append_slice(&converted_buffer[0..values_read])?;
             } else {
                 for (v, l) in read_buffer.into_iter().zip(def_levels) {
@@ -171,15 +182,12 @@ where
             }
             Ok(Arc::new(builder.finish()))
         } else {
-            let (values_read, _) = self.read_batch(
-                batch_size,
-                None,
-                None,
-                &mut read_buffer,
-            )?;
+            let (values_read, _) =
+                self.read_batch(batch_size, None, None, &mut read_buffer)?;
 
             let mut builder = PrimitiveBuilder::<A>::new(values_read);
-            let converted_buffer: Vec<A::Native> = read_buffer.into_iter().map(|v| v.into()).collect();
+            let converted_buffer: Vec<A::Native> =
+                read_buffer.into_iter().map(|v| v.into()).collect();
             builder.append_slice(&converted_buffer[0..values_read])?;
             Ok(Arc::new(builder.finish()))
         }
@@ -262,21 +270,33 @@ impl ParquetFile {
                     let is_nullable = self.schema().field(i).is_nullable();
                     let array: Arc<Array> = match self.column_readers[i] {
                         ColumnReader::BoolColumnReader(ref mut r) => {
-                            match ArrowReader::<BooleanType>::read(r, self.batch_size, is_nullable) {
+                            match ArrowReader::<BooleanType>::read(
+                                r,
+                                self.batch_size,
+                                is_nullable,
+                            ) {
                                 Ok(array) => array,
-                                Err(e) => return Err(e)
+                                Err(e) => return Err(e),
                             }
                         }
                         ColumnReader::Int32ColumnReader(ref mut r) => {
-                            match ArrowReader::<Int32Type>::read(r, self.batch_size, is_nullable) {
+                            match ArrowReader::<Int32Type>::read(
+                                r,
+                                self.batch_size,
+                                is_nullable,
+                            ) {
                                 Ok(array) => array,
-                                Err(e) => return Err(e)
+                                Err(e) => return Err(e),
                             }
                         }
                         ColumnReader::Int64ColumnReader(ref mut r) => {
-                            match ArrowReader::<Int64Type>::read(r, self.batch_size, is_nullable) {
+                            match ArrowReader::<Int64Type>::read(
+                                r,
+                                self.batch_size,
+                                is_nullable,
+                            ) {
                                 Ok(array) => array,
-                                Err(e) => return Err(e)
+                                Err(e) => return Err(e),
                             }
                         }
                         ColumnReader::Int96ColumnReader(ref mut r) => {
@@ -340,15 +360,23 @@ impl ParquetFile {
                             }
                         }
                         ColumnReader::FloatColumnReader(ref mut r) => {
-                            match ArrowReader::<Float32Type>::read(r, self.batch_size, is_nullable) {
+                            match ArrowReader::<Float32Type>::read(
+                                r,
+                                self.batch_size,
+                                is_nullable,
+                            ) {
                                 Ok(array) => array,
-                                Err(e) => return Err(e)
+                                Err(e) => return Err(e),
                             }
                         }
                         ColumnReader::DoubleColumnReader(ref mut r) => {
-                            match ArrowReader::<Float64Type>::read(r, self.batch_size, is_nullable) {
+                            match ArrowReader::<Float64Type>::read(
+                                r,
+                                self.batch_size,
+                                is_nullable,
+                            ) {
                                 Ok(array) => array,
-                                Err(e) => return Err(e)
+                                Err(e) => return Err(e),
                             }
                         }
                         ColumnReader::FixedLenByteArrayColumnReader(ref mut r) => {

--- a/rust/datafusion/src/execution/error.rs
+++ b/rust/datafusion/src/execution/error.rs
@@ -21,6 +21,7 @@ use std::io::Error;
 use std::result;
 
 use arrow::error::ArrowError;
+use parquet::errors::ParquetError;
 
 use sqlparser::sqlparser::ParserError;
 
@@ -35,6 +36,7 @@ pub enum ExecutionError {
     NotImplemented(String),
     InternalError(String),
     ArrowError(ArrowError),
+    ParquetError(ParquetError),
     ExecutionError(String),
 }
 
@@ -59,6 +61,12 @@ impl From<&'static str> for ExecutionError {
 impl From<ArrowError> for ExecutionError {
     fn from(e: ArrowError) -> Self {
         ExecutionError::ArrowError(e)
+    }
+}
+
+impl From<ParquetError> for ExecutionError {
+    fn from(e: ParquetError) -> Self {
+        ExecutionError::ParquetError(e)
     }
 }
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -183,14 +183,12 @@ fn load_parquet_table(name: &str) -> Rc<Table> {
     let testdata = env::var("PARQUET_TEST_DATA").unwrap();
     let filename = format!("{}/{}", testdata, name);
     let table = ParquetTable::try_new(&filename).unwrap();
-    println!("{:?}", table.schema());
     Rc::new(table)
 }
 
 /// Execute query and return result set as tab delimited string
 fn execute(ctx: &mut ExecutionContext, sql: &str) -> String {
     let plan = ctx.create_logical_plan(&sql).unwrap();
-    println!("Plan: {:?}", plan);
     let results = ctx.execute(&plan, DEFAULT_BATCH_SIZE).unwrap();
     result_str(&results)
 }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -182,7 +182,7 @@ fn register_csv(
 fn load_parquet_table(name: &str) -> Rc<Table> {
     let testdata = env::var("PARQUET_TEST_DATA").unwrap();
     let filename = format!("{}/{}", testdata, name);
-    let table = ParquetTable::new(&filename);
+    let table = ParquetTable::try_new(&filename).unwrap();
     println!("{:?}", table.schema());
     Rc::new(table)
 }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -26,21 +26,23 @@ extern crate datafusion;
 use arrow::array::*;
 use arrow::datatypes::{DataType, Field, Schema};
 
+use datafusion::datasource::parquet::ParquetTable;
+use datafusion::datasource::Table;
 use datafusion::execution::context::ExecutionContext;
 use datafusion::execution::relation::Relation;
-use datafusion::datasource::parquet::ParquetFile;
-use datafusion::datasource::parquet::ParquetTable;
-use datafusion::datasource::{RecordBatchIterator, Table};
 
 const DEFAULT_BATCH_SIZE: usize = 1024 * 1024;
 
 #[test]
 fn parquet_query() {
     let mut ctx = ExecutionContext::new();
-    ctx.register_table("alltypes_plain", load_parquet_table("alltypes_plain.parquet"));
+    ctx.register_table(
+        "alltypes_plain",
+        load_parquet_table("alltypes_plain.parquet"),
+    );
     let sql = "SELECT id, string_col FROM alltypes_plain";
     let actual = execute(&mut ctx, sql);
-    let expected = "tbd".to_string();
+    let expected = "4\t\"0\"\n5\t\"1\"\n6\t\"0\"\n7\t\"1\"\n2\t\"0\"\n3\t\"1\"\n0\t\"0\"\n1\t\"1\"\n".to_string();
     assert_eq!(expected, actual);
 }
 
@@ -187,7 +189,9 @@ fn load_parquet_table(name: &str) -> Rc<Table> {
 
 /// Execute query and return result set as tab delimited string
 fn execute(ctx: &mut ExecutionContext, sql: &str) -> String {
-    let results = ctx.sql(&sql, DEFAULT_BATCH_SIZE).unwrap();
+    let plan = ctx.create_logical_plan(&sql).unwrap();
+    println!("Plan: {:?}", plan);
+    let results = ctx.execute(&plan, DEFAULT_BATCH_SIZE).unwrap();
     result_str(&results)
 }
 

--- a/rust/parquet/src/reader/schema.rs
+++ b/rust/parquet/src/reader/schema.rs
@@ -177,11 +177,12 @@ impl ParquetTypeConverter {
             PhysicalType::BOOLEAN => Ok(DataType::Boolean),
             PhysicalType::INT32 => self.to_int32(),
             PhysicalType::INT64 => self.to_int64(),
+            PhysicalType::INT96 => self.to_int64(),
             PhysicalType::FLOAT => Ok(DataType::Float32),
             PhysicalType::DOUBLE => Ok(DataType::Float64),
             PhysicalType::BYTE_ARRAY => self.to_byte_array(),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet type {}",
+                "Unable to convert parquet type d {}",
                 other
             ))),
         }
@@ -197,7 +198,7 @@ impl ParquetTypeConverter {
             LogicalType::INT_16 => Ok(DataType::Int16),
             LogicalType::INT_32 => Ok(DataType::Int32),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type {}",
+                "Unable to convert parquet logical type a {}",
                 other
             ))),
         }
@@ -209,7 +210,7 @@ impl ParquetTypeConverter {
             LogicalType::INT_64 => Ok(DataType::Int64),
             LogicalType::UINT_64 => Ok(DataType::UInt64),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type {}",
+                "Unable to convert parquet logical type b {}",
                 other
             ))),
         }
@@ -217,9 +218,10 @@ impl ParquetTypeConverter {
 
     fn to_byte_array(&self) -> Result<DataType> {
         match self.schema.get_basic_info().logical_type() {
+            LogicalType::NONE => Ok(DataType::Utf8),
             LogicalType::UTF8 => Ok(DataType::Utf8),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type {}",
+                "Unable to convert parquet logical type c {}",
                 other
             ))),
         }

--- a/rust/parquet/src/reader/schema.rs
+++ b/rust/parquet/src/reader/schema.rs
@@ -182,7 +182,7 @@ impl ParquetTypeConverter {
             PhysicalType::DOUBLE => Ok(DataType::Float64),
             PhysicalType::BYTE_ARRAY => self.to_byte_array(),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet type d {}",
+                "Unable to convert parquet type {}",
                 other
             ))),
         }
@@ -198,7 +198,7 @@ impl ParquetTypeConverter {
             LogicalType::INT_16 => Ok(DataType::Int16),
             LogicalType::INT_32 => Ok(DataType::Int32),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type a {}",
+                "Unable to convert parquet logical type {}",
                 other
             ))),
         }
@@ -210,7 +210,7 @@ impl ParquetTypeConverter {
             LogicalType::INT_64 => Ok(DataType::Int64),
             LogicalType::UINT_64 => Ok(DataType::UInt64),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type b {}",
+                "Unable to convert parquet logical type {}",
                 other
             ))),
         }
@@ -221,7 +221,7 @@ impl ParquetTypeConverter {
             LogicalType::NONE => Ok(DataType::Utf8),
             LogicalType::UTF8 => Ok(DataType::Utf8),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type c {}",
+                "Unable to convert parquet logical type {}",
                 other
             ))),
         }

--- a/rust/parquet/src/reader/schema.rs
+++ b/rust/parquet/src/reader/schema.rs
@@ -28,7 +28,7 @@ use crate::basic::{LogicalType, Repetition, Type as PhysicalType};
 use crate::errors::{ParquetError::ArrowError, Result};
 use crate::schema::types::{SchemaDescPtr, Type, TypePtr};
 
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, DateUnit, Field, Schema};
 
 /// Convert parquet schema to arrow schema.
 pub fn parquet_to_arrow_schema(parquet_schema: SchemaDescPtr) -> Result<Schema> {
@@ -197,6 +197,7 @@ impl ParquetTypeConverter {
             LogicalType::INT_8 => Ok(DataType::Int8),
             LogicalType::INT_16 => Ok(DataType::Int16),
             LogicalType::INT_32 => Ok(DataType::Int32),
+            LogicalType::DATE => Ok(DataType::Date32(DateUnit::Millisecond)),
             other => Err(ArrowError(format!(
                 "Unable to convert parquet logical type {}",
                 other
@@ -209,6 +210,7 @@ impl ParquetTypeConverter {
             LogicalType::NONE => Ok(DataType::Int64),
             LogicalType::INT_64 => Ok(DataType::Int64),
             LogicalType::UINT_64 => Ok(DataType::UInt64),
+            LogicalType::DATE => Ok(DataType::Date64(DateUnit::Millisecond)),
             other => Err(ArrowError(format!(
                 "Unable to convert parquet logical type {}",
                 other

--- a/rust/parquet/src/reader/schema.rs
+++ b/rust/parquet/src/reader/schema.rs
@@ -176,12 +176,12 @@ impl ParquetTypeConverter {
     fn to_primitive_type_inner(&self) -> Result<DataType> {
         match self.schema.get_physical_type() {
             PhysicalType::BOOLEAN => Ok(DataType::Boolean),
-            PhysicalType::INT32 => self.to_int32(),
-            PhysicalType::INT64 => self.to_int64(),
-            PhysicalType::INT96 => self.to_int96(),
+            PhysicalType::INT32 => self.from_int32(),
+            PhysicalType::INT64 => self.from_int64(),
+            PhysicalType::INT96 => Ok(DataType::Timestamp(TimeUnit::Nanosecond)),
             PhysicalType::FLOAT => Ok(DataType::Float32),
             PhysicalType::DOUBLE => Ok(DataType::Float64),
-            PhysicalType::BYTE_ARRAY => self.to_byte_array(),
+            PhysicalType::BYTE_ARRAY => self.from_byte_array(),
             other => Err(ArrowError(format!(
                 "Unable to convert parquet physical type {}",
                 other
@@ -189,7 +189,7 @@ impl ParquetTypeConverter {
         }
     }
 
-    fn to_int32(&self) -> Result<DataType> {
+    fn from_int32(&self) -> Result<DataType> {
         match self.schema.get_basic_info().logical_type() {
             LogicalType::NONE => Ok(DataType::Int32),
             LogicalType::UINT_8 => Ok(DataType::UInt8),
@@ -199,7 +199,6 @@ impl ParquetTypeConverter {
             LogicalType::INT_16 => Ok(DataType::Int16),
             LogicalType::INT_32 => Ok(DataType::Int32),
             LogicalType::DATE => Ok(DataType::Date32(DateUnit::Millisecond)),
-            LogicalType::TIME_MICROS => Ok(DataType::Time32(TimeUnit::Microsecond)),
             LogicalType::TIME_MILLIS => Ok(DataType::Time32(TimeUnit::Millisecond)),
             other => Err(ArrowError(format!(
                 "Unable to convert parquet INT32 logical type {}",
@@ -208,14 +207,12 @@ impl ParquetTypeConverter {
         }
     }
 
-    fn to_int64(&self) -> Result<DataType> {
+    fn from_int64(&self) -> Result<DataType> {
         match self.schema.get_basic_info().logical_type() {
             LogicalType::NONE => Ok(DataType::Int64),
             LogicalType::INT_64 => Ok(DataType::Int64),
             LogicalType::UINT_64 => Ok(DataType::UInt64),
-            LogicalType::DATE => Ok(DataType::Date64(DateUnit::Millisecond)),
             LogicalType::TIME_MICROS => Ok(DataType::Time64(TimeUnit::Microsecond)),
-            LogicalType::TIME_MILLIS => Ok(DataType::Time64(TimeUnit::Millisecond)),
             LogicalType::TIMESTAMP_MICROS => {
                 Ok(DataType::Timestamp(TimeUnit::Microsecond))
             }
@@ -229,31 +226,12 @@ impl ParquetTypeConverter {
         }
     }
 
-    fn to_int96(&self) -> Result<DataType> {
-        match self.schema.get_basic_info().logical_type() {
-            LogicalType::NONE => Ok(DataType::Int64),
-            LogicalType::DATE => Ok(DataType::Date64(DateUnit::Millisecond)),
-            LogicalType::TIME_MICROS => Ok(DataType::Time64(TimeUnit::Microsecond)),
-            LogicalType::TIME_MILLIS => Ok(DataType::Time64(TimeUnit::Millisecond)),
-            LogicalType::TIMESTAMP_MICROS => {
-                Ok(DataType::Timestamp(TimeUnit::Microsecond))
-            }
-            LogicalType::TIMESTAMP_MILLIS => {
-                Ok(DataType::Timestamp(TimeUnit::Millisecond))
-            }
-            other => Err(ArrowError(format!(
-                "Unable to convert parquet INT96 logical type {}",
-                other
-            ))),
-        }
-    }
-
-    fn to_byte_array(&self) -> Result<DataType> {
+    fn from_byte_array(&self) -> Result<DataType> {
         match self.schema.get_basic_info().logical_type() {
             LogicalType::NONE => Ok(DataType::Utf8),
             LogicalType::UTF8 => Ok(DataType::Utf8),
             other => Err(ArrowError(format!(
-                "Unable to convert parquet logical type {}",
+                "Unable to convert parquet BYTE_ARRAY logical type {}",
                 other
             ))),
         }


### PR DESCRIPTION
I'm sure I'll need some guidance on this one from @sunchao or @liurenjie1024 but I am keen to get parquet support added for primitive types so that I can actually use DataFusion and Arrow in production at some point.