### PR TITLE
ARROW-2409: [Rust] Deny warnings in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -348,7 +348,7 @@ matrix:
     - pushd ${TRAVIS_BUILD_DIR}/rust
     # Run coverage for codecov.io
     - mkdir -p target/kcov
-    - RUST_BACKTRACE=1 RUSTUP_TOOLCHAIN=nightly cargo coverage --verbose
+    - RUST_BACKTRACE=1 RUSTUP_TOOLCHAIN=nightly RUSTFLAGS="-D warnings" cargo coverage --verbose
     - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
   - name: Go
     language: go


### PR DESCRIPTION
[ARROW-2409](https://issues.apache.org/jira/browse/ARROW-2409) asks that
we prevent warnings from entering the codebase in order to maintain a
more strict level of hygine.

There are a couple ways to cause rustc to _bail_ when warnings are
encountered, the most straightforward of which might be to put
`#![deny(warnings)]` in each crate root. Still, it struck me as doing
this would cause undue friction on contributors and maintainers.

An alternative, noted by the [rust patterns] guide, is to use
`RUSTFLAGS` to opt-in to this behavior at build time.

For example, with an extraneous import added to a module:

```text
$ RUSTFLAGS="-D warnings" cargo build
   Compiling arrow v0.13.0-SNAPSHOT (/home/owen/projects/arrow/rust/arrow)
error: unused import: `std::io`
  --> arrow/src/datatypes.rs:36:5
   |
36 | use std::io;
   |     ^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`

error: aborting due to previous error

error: Could not compile `arrow`.

To learn more, run the command again with --verbose.
```

Adding this env var to the coverage collection should allow travis to
report warnings as failures in CI while letting developers continue to
work as normal.

This approach is also sort of nice since it will enforce the rule across
all crates in the workspace as new sub-crates are added without having
to remember to annotate the crate root each time.

[rust patterns]: https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md