### PR TITLE
ARROW-4664: [C++] Do not execute expressions inside DCHECK macros in release builds

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -190,10 +190,9 @@ else()
     # /wdnnnn disables a warning where "nnnn" is a warning number
     string(REPLACE "/W3" "" CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS}")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /W3")
-  elseif ("${COMPILER_FAMILY}" STREQUAL "clang")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
-  elseif ("${COMPILER_FAMILY}" STREQUAL "gcc")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
+  elseif (("${COMPILER_FAMILY}" STREQUAL "clang") OR
+          ("${COMPILER_FAMILY}" STREQUAL "gcc"))
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall -Wno-unused-variable")
   else()
     message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
   endif()

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -193,11 +193,6 @@ else()
   elseif (("${COMPILER_FAMILY}" STREQUAL "clang") OR
           ("${COMPILER_FAMILY}" STREQUAL "gcc"))
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
-    if ("${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
-      # Quiet some warnings that show up due to variables only used in DCHECK
-      # expressions
-      set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-variable")
-    endif()
   else()
     message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
   endif()

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -192,7 +192,12 @@ else()
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /W3")
   elseif (("${COMPILER_FAMILY}" STREQUAL "clang") OR
           ("${COMPILER_FAMILY}" STREQUAL "gcc"))
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall -Wno-unused-variable")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall")
+    if ("${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
+      # Quiet some warnings that show up due to variables only used in DCHECK
+      # expressions
+      set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-variable")
+    endif()
   else()
     message(FATAL_ERROR "Unknown compiler. Version info:\n${COMPILER_VERSION_FULL}")
   endif()

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -149,7 +149,8 @@ std::shared_ptr<Array> Array::Slice(int64_t offset) const {
 
 std::string Array::ToString() const {
   std::stringstream ss;
-  DCHECK(PrettyPrint(*this, 0, &ss).ok());
+  Status s = PrettyPrint(*this, 0, &ss);
+  DCHECK_OK(s);
   return ss.str();
 }
 

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -77,6 +77,10 @@ class FlightMessageReaderImpl : public FlightMessageReader {
 
     internal::FlightData data;
     // Pretend to be pb::FlightData and intercept in SerializationTraits
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
     if (reader_->Read(reinterpret_cast<pb::FlightData*>(&data))) {
 #ifndef _WIN32
 #pragma GCC diagnostic pop

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -78,6 +78,9 @@ class FlightMessageReaderImpl : public FlightMessageReader {
     internal::FlightData data;
     // Pretend to be pb::FlightData and intercept in SerializationTraits
     if (reader_->Read(reinterpret_cast<pb::FlightData*>(&data))) {
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
       std::unique_ptr<ipc::Message> message;
 
       // Validate IPC message
@@ -207,6 +210,10 @@ class FlightServiceImpl : public FlightService::Service {
 
     // Pretend to be pb::FlightData, we cast back to FlightPayload in
     // SerializationTraits
+#ifndef _WIN32
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
     writer->Write(*reinterpret_cast<const pb::FlightData*>(&schema_payload),
                   grpc::WriteOptions());
 
@@ -221,6 +228,9 @@ class FlightServiceImpl : public FlightService::Service {
         break;
       }
     }
+#ifndef _WIN32
+#pragma GCC diagnostic pop
+#endif
     return grpc::Status::OK;
   }
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -226,7 +226,7 @@ class ReadableFile::ReadableFileImpl : public OSFile {
 
 ReadableFile::ReadableFile(MemoryPool* pool) { impl_.reset(new ReadableFileImpl(pool)); }
 
-ReadableFile::~ReadableFile() { DCHECK(impl_->Close().ok()); }
+ReadableFile::~ReadableFile() { DCHECK_OK(impl_->Close()); }
 
 Status ReadableFile::Open(const std::string& path, std::shared_ptr<ReadableFile>* file) {
   return Open(path, default_memory_pool(), file);
@@ -299,7 +299,7 @@ FileOutputStream::FileOutputStream() { impl_.reset(new FileOutputStreamImpl()); 
 
 FileOutputStream::~FileOutputStream() {
   // This can fail; better to explicitly call close
-  DCHECK(impl_->Close().ok());
+  DCHECK_OK(impl_->Close());
 }
 
 Status FileOutputStream::Open(const std::string& path,

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -357,7 +357,9 @@ class MemoryMappedFile::MemoryMap : public MutableBuffer {
   ~MemoryMap() {
     DCHECK_OK(Close());
     if (mutable_data_ != nullptr) {
-      DCHECK_EQ(munmap(mutable_data_, static_cast<size_t>(size_)), 0);
+      int result = munmap(mutable_data_, static_cast<size_t>(size_));
+      DCHECK_EQ(result, 0);
+      ARROW_UNUSED(result);
     }
   }
 

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -65,7 +65,7 @@ Status BufferOutputStream::Reset(int64_t initial_capacity, MemoryPool* pool) {
 BufferOutputStream::~BufferOutputStream() {
   // This can fail, better to explicitly call close
   if (buffer_) {
-    DCHECK(Close().ok());
+    DCHECK_OK(Close());
   }
 }
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -141,7 +141,8 @@ void MakeSparseTensorFromTensor(const Tensor& tensor,
                                 std::shared_ptr<Buffer>* data) {
   NumericTensor<TYPE> numeric_tensor(tensor.data(), tensor.shape(), tensor.strides());
   SparseTensorConverter<TYPE, SparseIndexType> converter(numeric_tensor);
-  DCHECK_OK(converter.Convert());
+  Status s = converter.Convert();
+  DCHECK_OK(s);
   *sparse_index = converter.sparse_index;
   *data = converter.data;
 }
@@ -319,7 +320,8 @@ SparseTensorImpl<SparseIndexType>::SparseTensorImpl(const NumericTensor<TYPE>& t
     : SparseTensorImpl(nullptr, tensor.type(), nullptr, tensor.shape(),
                        tensor.dim_names_) {
   SparseTensorConverter<TYPE, SparseIndexType> converter(tensor);
-  DCHECK_OK(converter.Convert());
+  Status s = converter.Convert();
+  DCHECK_OK(s);
   sparse_index_ = converter.sparse_index;
   data_ = converter.data;
 }

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -648,7 +648,8 @@ void BasicDecimal128::GetWholeAndFraction(int scale, BasicDecimal128* whole,
   DCHECK_LE(scale, 38);
 
   BasicDecimal128 multiplier(ScaleMultipliers[scale]);
-  DCHECK_EQ(Divide(multiplier, whole, fraction), DecimalStatus::kSuccess);
+  auto s = Divide(multiplier, whole, fraction);
+  DCHECK_EQ(s, DecimalStatus::kSuccess);
 }
 
 const BasicDecimal128& BasicDecimal128::GetScaleMultiplier(int32_t scale) {
@@ -678,7 +679,8 @@ BasicDecimal128 BasicDecimal128::ReduceScaleBy(int32_t reduce_by, bool round) co
   BasicDecimal128 divisor(ScaleMultipliers[reduce_by]);
   BasicDecimal128 result;
   BasicDecimal128 remainder;
-  DCHECK_EQ(Divide(divisor, &result, &remainder), DecimalStatus::kSuccess);
+  auto s = Divide(divisor, &result, &remainder);
+  DCHECK_EQ(s, DecimalStatus::kSuccess);
   if (round) {
     auto divisor_half = ScaleMultipliersHalf[reduce_by];
     if (remainder.Abs() >= divisor_half) {

--- a/cpp/src/arrow/util/logging-test.cc
+++ b/cpp/src/arrow/util/logging-test.cc
@@ -18,12 +18,10 @@
 #include <chrono>
 #include <cstdint>
 #include <iostream>
-#include <thread>
 
 #include <gtest/gtest.h>
 
 #include "arrow/util/logging.h"
-#include "arrow/util/stopwatch.h"
 
 // This code is adapted from
 // https://github.com/ray-project/ray/blob/master/src/ray/util/logging_test.cc.
@@ -107,19 +105,28 @@ TEST(LogPerfTest, PerfTest) {
 
 }  // namespace util
 
-static inline void sleep_for(double seconds) {
-  std::this_thread::sleep_for(
-      std::chrono::nanoseconds(static_cast<int64_t>(seconds * 1e9)));
-}
-
 TEST(DcheckMacros, DoNotEvaluateReleaseMode) {
 #ifdef NDEBUG
-  internal::StopWatch watch;
-  watch.Start();
-  auto Function = [&]() { sleep_for(1.); };
-  DCHECK(Function());
-  auto time = watch.Stop();
-  ASSERT_LT(time, 1000000000ULL);
+  int i = 0;
+  auto f1 = [&]() {
+    ++i;
+    return true;
+  };
+  DCHECK(f1());
+  ASSERT_EQ(0, i);
+  auto f2 = [&]() {
+    ++i;
+    return i;
+  };
+  DCHECK_EQ(f2(), 0);
+  DCHECK_NE(f2(), 0);
+  DCHECK_LT(f2(), 0);
+  DCHECK_LE(f2(), 0);
+  DCHECK_GE(f2(), 0);
+  DCHECK_GT(f2(), 0);
+  ASSERT_EQ(0, i);
+  ARROW_UNUSED(f1);
+  ARROW_UNUSED(f2);
 #endif
 }
 

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -83,8 +83,8 @@ enum class ArrowLogLevel : int {
 
 #define DCHECK(condition) \
   while (false) ::arrow::util::detail::NullLog()
-#define DCHECK_OK(s)   \
-  ARROW_IGNORE_EXPR(s) \
+#define DCHECK_OK(s)    \
+  ARROW_IGNORE_EXPR(s); \
   while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_EQ(val1, val2) \
   while (false) ::arrow::util::detail::NullLog()

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -81,36 +81,23 @@ enum class ArrowLogLevel : int {
 #ifdef NDEBUG
 #define ARROW_DFATAL ::arrow::util::ArrowLogLevel::ARROW_WARNING
 
-#define DCHECK(condition)       \
-  ARROW_IGNORE_EXPR(condition); \
-  ARROW_CHECK(true)
-#define DCHECK_OK(status)    \
-  ARROW_IGNORE_EXPR(status); \
-  ARROW_CHECK(true)
+#define DCHECK(condition) \
+  while (false) ::arrow::util::detail::NullLog()
+#define DCHECK_OK(s)   \
+  ARROW_IGNORE_EXPR(s) \
+  while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_EQ(val1, val2) \
-  ARROW_IGNORE_EXPR(val1);    \
-  ARROW_IGNORE_EXPR(val2);    \
-  ARROW_CHECK(true)
+  while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_NE(val1, val2) \
-  ARROW_IGNORE_EXPR(val1);    \
-  ARROW_IGNORE_EXPR(val2);    \
-  ARROW_CHECK(true)
+  while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_LE(val1, val2) \
-  ARROW_IGNORE_EXPR(val1);    \
-  ARROW_IGNORE_EXPR(val2);    \
-  ARROW_CHECK(true)
+  while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_LT(val1, val2) \
-  ARROW_IGNORE_EXPR(val1);    \
-  ARROW_IGNORE_EXPR(val2);    \
-  ARROW_CHECK(true)
+  while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_GE(val1, val2) \
-  ARROW_IGNORE_EXPR(val1);    \
-  ARROW_IGNORE_EXPR(val2);    \
-  ARROW_CHECK(true)
+  while (false) ::arrow::util::detail::NullLog()
 #define DCHECK_GT(val1, val2) \
-  ARROW_IGNORE_EXPR(val1);    \
-  ARROW_IGNORE_EXPR(val2);    \
-  ARROW_CHECK(true)
+  while (false) ::arrow::util::detail::NullLog()
 
 #else
 #define ARROW_DFATAL ::arrow::util::ArrowLogLevel::ARROW_FATAL
@@ -214,8 +201,29 @@ class ARROW_EXPORT Voidify {
   void operator&(ArrowLogBase&) {}
 };
 
+namespace detail {
+
+/// @brief A helper for the nil log sink.
+///
+/// Using this helper is analogous to sending log messages to /dev/null:
+/// nothing gets logged.
+class NullLog {
+ public:
+  /// The no-op output operator.
+  ///
+  /// @param [in] t
+  ///   The object to send into the nil sink.
+  /// @return Reference to the updated object.
+  template <class T>
+  NullLog& operator<<(const T& t) {
+    return *this;
+  }
+};
+
+}  // namespace detail
 }  // namespace util
 }  // namespace arrow
+
 #endif  // GANDIVA_IR
 
 #endif  // ARROW_UTIL_LOGGING_H

--- a/cpp/src/gandiva/precompiled/testing.h
+++ b/cpp/src/gandiva/precompiled/testing.h
@@ -30,7 +30,9 @@ namespace gandiva {
 
 timestamp StringToTimestamp(const char* buf) {
   int64_t out = 0;
-  DCHECK(internal::ParseTimestamp(buf, "%Y-%m-%d %H:%M:%S", false, &out));
+  bool success = internal::ParseTimestamp(buf, "%Y-%m-%d %H:%M:%S", false, &out);
+  DCHECK(success);
+  ARROW_UNUSED(success);
   return out * 1000;
 }
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -305,7 +305,8 @@ class PARQUET_NO_EXPORT PrimitiveImpl : public ColumnReader::ColumnReaderImpl {
   PrimitiveImpl(MemoryPool* pool, std::unique_ptr<FileColumnIterator> input)
       : pool_(pool), input_(std::move(input)), descr_(input_->descr()) {
     record_reader_ = RecordReader::Make(descr_, pool_);
-    DCHECK(NodeToField(*input_->descr()->schema_node(), &field_).ok());
+    Status s = NodeToField(*input_->descr()->schema_node(), &field_);
+    DCHECK_OK(s);
     NextRowGroup();
   }
 


### PR DESCRIPTION
This hard-suppresses expressions passed to DCHECK macros. IMHO the intent of these macros is to only execute their contents in debug builds, so we are assured of zero cost in release builds. This is currently not the case and I regard it as a regression from prior releases of the project. 

I think that `DCHECK_OK` still executes the code within. For the sake of avoiding time-wasting discussions I request that we address the behavior of DCHECK_OK in a separate issue.