### PR TITLE
ARROW-4820:[python]hadoop class path derived not correct #3829

### DIFF
--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -138,7 +138,7 @@ def _maybe_set_hadoop_classpath():
     os.environ['CLASSPATH'] = classpath.decode('utf-8')
 
 
-def _derive_hadoop_classpath():
+def _derive_hadoop_clsspath():
     import subprocess
 
     find_args = ('find', os.environ['HADOOP_HOME'], '-name', '*.jar')
@@ -146,8 +146,13 @@ def _derive_hadoop_classpath():
     xargs_echo = subprocess.Popen(('xargs', 'echo'),
                                   stdin=find.stdout,
                                   stdout=subprocess.PIPE)
-    return subprocess.check_output(('tr', "' '", "':'"),
+    classpath_jars = subprocess.check_output(('tr', "' '", "':'"),
                                    stdin=xargs_echo.stdout)
+    classpath_conf = os.environ["HADOOP_CONF_DIR"] \
+        if "HADOOP_CONF_DIR" in os.environ else os.environ['HADOOP_HOME'] + "/etc/hadoop"
+    return (classpath_conf + ":").encode('utf-8') + classpath_jars
+
+
 
 
 def _hadoop_classpath_glob(hadoop_bin):

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -147,10 +147,10 @@ def _derive_hadoop_classpath():
                                   stdin=find.stdout,
                                   stdout=subprocess.PIPE)
     classpath_jars = subprocess.check_output(('tr', "' '", "':'"),
-                                  stdin=xargs_echo.stdout)
+                                             stdin=xargs_echo.stdout)
     classpath_conf = os.environ["HADOOP_CONF_DIR"] \
-                     if "HADOOP_CONF_DIR" in os.environ \
-                     else os.environ['HADOOP_HOME'] + "/etc/hadoop"
+        if "HADOOP_CONF_DIR" in os.environ \
+        else os.environ['HADOOP_HOME'] + "/etc/hadoop"
     return (classpath_conf + ":").encode('utf-8') + classpath_jars
 
 

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -146,8 +146,12 @@ def _derive_hadoop_classpath():
     xargs_echo = subprocess.Popen(('xargs', 'echo'),
                                   stdin=find.stdout,
                                   stdout=subprocess.PIPE)
-    return subprocess.check_output(('tr', "' '", "':'"),
-                                   stdin=xargs_echo.stdout)
+    classpath_jars = subprocess.check_output(('tr', "' '", "':'"),
+                                  stdin=xargs_echo.stdout)
+    classpath_conf = os.environ["HADOOP_CONF_DIR"] \
+                     if "HADOOP_CONF_DIR" in os.environ \
+                     else os.environ['HADOOP_HOME'] + "/etc/hadoop"
+    return (classpath_conf + ":").encode('utf-8') + classpath_jars
 
 
 def _hadoop_classpath_glob(hadoop_bin):


### PR DESCRIPTION
add hadoop conf dir to classpath,if HADOOP_CONF_DIR set, add $HADOOP_CONF_DIR to classpath,
if HADOOP_CONF_DIR not set,add $HADOOP_HOME/etc/hadoop to classpath