### PR TITLE
ARROW-2905: [C++] Remove raw_data_ member from BufferBuilder, adaptive int builders

### DIFF
--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -58,7 +58,6 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
   virtual Status CommitPendingData() = 0;
 
   std::shared_ptr<ResizableBuffer> data_;
-  uint8_t* raw_data_;
   uint8_t int_size_;
 
   static constexpr int32_t pending_size_ = 1024;

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -56,8 +56,11 @@ class ARROW_EXPORT BufferBuilder {
   /// \return Status
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
     // Resize(0) is a no-op
-    if (new_capacity == 0) {
+    if (ARROW_UNLIKELY(new_capacity == 0)) {
       return Status::OK();
+    }
+    if (ARROW_UNLIKELY(buffer_ == NULLPTR)) {
+      return Status::Invalid("memory pool failed to allocate empty resizable buffer");
     }
     int64_t old_capacity = capacity_;
     ARROW_RETURN_NOT_OK(buffer_->Resize(new_capacity, shrink_to_fit));

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -29,7 +29,6 @@
 #include "arrow/buffer.h"
 #include "arrow/status.h"
 #include "arrow/util/bit-util.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
@@ -45,7 +44,7 @@ class ARROW_EXPORT BufferBuilder {
  public:
   explicit BufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : pool_(pool), capacity_(0), size_(0) {
-    ARROW_IGNORE_EXPR(AllocateResizableBuffer(pool_, 0, &buffer_));
+    static_cast<void>(AllocateResizableBuffer(pool_, 0, &buffer_));
   }
 
   /// \brief Resize the buffer to the nearest multiple of 64 bytes
@@ -128,7 +127,6 @@ class ARROW_EXPORT BufferBuilder {
 
   // Advance pointer and zero out memory
   Status Advance(const int64_t length) { return Append(length, 0); }
-
   // Advance pointer, but don't allocate or zero memory
   void UnsafeAdvance(const int64_t length) { size_ += length; }
 
@@ -162,7 +160,7 @@ class ARROW_EXPORT BufferBuilder {
 
   void Reset() {
     buffer_ = NULLPTR;
-    ARROW_IGNORE_EXPR(AllocateResizableBuffer(pool_, 0, &buffer_));
+    static_cast<void>(AllocateResizableBuffer(pool_, 0, &buffer_));
     capacity_ = size_ = 0;
   }
 

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -43,7 +43,7 @@ namespace arrow {
 class ARROW_EXPORT BufferBuilder {
  public:
   explicit BufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
-      : pool_(pool), data_(NULLPTR), capacity_(0), size_(0) {}
+      : pool_(pool), capacity_(0), size_(0) {}
 
   /// \brief Resize the buffer to the nearest multiple of 64 bytes
   ///
@@ -64,9 +64,8 @@ class ARROW_EXPORT BufferBuilder {
       ARROW_RETURN_NOT_OK(buffer_->Resize(new_capacity, shrink_to_fit));
     }
     capacity_ = buffer_->capacity();
-    data_ = buffer_->mutable_data();
     if (capacity_ > old_capacity) {
-      memset(data_ + old_capacity, 0, capacity_ - old_capacity);
+      memset(mutable_data() + old_capacity, 0, capacity_ - old_capacity);
     }
     return Status::OK();
   }
@@ -123,7 +122,7 @@ class ARROW_EXPORT BufferBuilder {
   Status Append(const std::array<uint8_t, NBYTES>& data) {
     constexpr auto nbytes = static_cast<int64_t>(NBYTES);
     ARROW_RETURN_NOT_OK(Reserve(NBYTES, true));
-    std::copy(data.cbegin(), data.cend(), data_ + size_);
+    std::copy(data.cbegin(), data.cend(), mutable_data() + size_);
     size_ += nbytes;
     return Status::OK();
   }
@@ -136,12 +135,12 @@ class ARROW_EXPORT BufferBuilder {
 
   // Unsafe methods don't check existing size
   void UnsafeAppend(const void* data, const int64_t length) {
-    memcpy(data_ + size_, data, static_cast<size_t>(length));
+    memcpy(mutable_data() + size_, data, static_cast<size_t>(length));
     size_ += length;
   }
 
   void UnsafeAppend(const int64_t num_copies, uint8_t value) {
-    memset(data_ + size_, value, static_cast<size_t>(num_copies));
+    memset(mutable_data() + size_, value, static_cast<size_t>(num_copies));
     size_ += num_copies;
   }
 
@@ -169,13 +168,15 @@ class ARROW_EXPORT BufferBuilder {
 
   int64_t capacity() const { return capacity_; }
   int64_t length() const { return size_; }
-  const uint8_t* data() const { return data_; }
-  uint8_t* mutable_data() { return data_; }
+  const uint8_t* data() const { return buffer_->data(); }
+  uint8_t* mutable_data() {
+    return buffer_->mutable_data();
+    ;
+  }
 
  private:
   std::shared_ptr<ResizableBuffer> buffer_;
   MemoryPool* pool_;
-  uint8_t* data_;
   int64_t capacity_;
   int64_t size_;
 };

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -56,10 +56,10 @@ class ARROW_EXPORT BufferBuilder {
   /// \return Status
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
     // Resize(0) is a no-op
-    if (ARROW_UNLIKELY(new_capacity == 0)) {
+    if (ARROW_PREDICT_FALSE(new_capacity == 0)) {
       return Status::OK();
     }
-    if (ARROW_UNLIKELY(buffer_ == NULLPTR)) {
+    if (ARROW_PREDICT_FALSE(buffer_ == NULLPTR)) {
       return Status::Invalid("memory pool failed to allocate empty resizable buffer");
     }
     int64_t old_capacity = capacity_;

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -169,10 +169,7 @@ class ARROW_EXPORT BufferBuilder {
   int64_t capacity() const { return capacity_; }
   int64_t length() const { return size_; }
   const uint8_t* data() const { return buffer_->data(); }
-  uint8_t* mutable_data() {
-    return buffer_->mutable_data();
-    ;
-  }
+  uint8_t* mutable_data() { return buffer_->mutable_data(); }
 
  private:
   std::shared_ptr<ResizableBuffer> buffer_;

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -227,6 +227,9 @@ TEST(TestAllocateResizableBuffer, ZeroSize) {
     return Status::OK();
   };
   TestZeroSizeAllocateBuffer(pool, allocate_func);
+  std::shared_ptr<ResizableBuffer> buffer;
+  ASSERT_OK(AllocateResizableBuffer(pool, 0, &buffer));
+  ASSERT_OK(buffer->Resize(64));
 }
 
 TEST(TestAllocateResizableBuffer, ZeroResize) {


### PR DESCRIPTION
Removing this member had no appreciable effect on performance in the builder benchmark:

```
Before
-----------------------------------------------------------------------------------------------
Benchmark                                                        Time           CPU Iterations
-----------------------------------------------------------------------------------------------
BM_BuildAdaptiveIntNoNulls/repeats:2_mean                     7910 us       7910 us         89   7.90159GB/s
BM_BuildAdaptiveIntNoNulls/repeats:2_stddev                     93 us         93 us         89   95.2444MB/s
BM_BuildAdaptiveIntNoNullsScalarAppend/repeats:3_mean        16794 us      16794 us         42   3.72172GB/s
BM_BuildAdaptiveIntNoNullsScalarAppend/repeats:3_stddev        144 us        144 us         42   32.5893MB/s

After
-----------------------------------------------------------------------------------------------
Benchmark                                                        Time           CPU Iterations
-----------------------------------------------------------------------------------------------
BM_BuildAdaptiveIntNoNulls/repeats:2_mean                     7782 us       7781 us         89   8.03249GB/s
BM_BuildAdaptiveIntNoNulls/repeats:2_stddev                     54 us         53 us         89    55.593MB/s
BM_BuildAdaptiveIntNoNullsScalarAppend/repeats:3_mean        16589 us      16588 us         42   3.76803GB/s
BM_BuildAdaptiveIntNoNullsScalarAppend/repeats:3_stddev        195 us        194 us         42   45.0538MB/s
```

