### PR TITLE
ARROW-4776: [C++] Add DictionaryBuilder constructor which takes a dictionary array

### DIFF
--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -63,12 +63,36 @@ TYPED_TEST(TestDictionaryBuilder, Basic) {
   ASSERT_EQ(builder.length(), 4);
   ASSERT_EQ(builder.null_count(), 1);
 
+  // Build expected data
+  auto dict_array = ArrayFromJSON(std::make_shared<TypeParam>(), "[1, 2]");
+  auto dict_type = dictionary(int8(), dict_array);
+
   std::shared_ptr<Array> result;
   ASSERT_OK(builder.Finish(&result));
 
-  // Build expected data
+  auto int_array = ArrayFromJSON(int8(), "[0, 1, 0, null]");
+  DictionaryArray expected(dict_type, int_array);
+
+  ASSERT_TRUE(expected.Equals(result));
+}
+
+TYPED_TEST(TestDictionaryBuilder, ArrayInit) {
   auto dict_array = ArrayFromJSON(std::make_shared<TypeParam>(), "[1, 2]");
-  auto dict_type = std::make_shared<DictionaryType>(int8(), dict_array);
+  auto dict_type = dictionary(int8(), dict_array);
+
+  DictionaryBuilder<TypeParam> builder(dict_array, default_memory_pool());
+  ASSERT_OK(builder.Append(static_cast<typename TypeParam::c_type>(1)));
+  ASSERT_OK(builder.Append(static_cast<typename TypeParam::c_type>(2)));
+  ASSERT_OK(builder.Append(static_cast<typename TypeParam::c_type>(1)));
+  ASSERT_OK(builder.AppendNull());
+
+  ASSERT_EQ(builder.length(), 4);
+  ASSERT_EQ(builder.null_count(), 1);
+
+  // Build expected data
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(builder.Finish(&result));
 
   auto int_array = ArrayFromJSON(int8(), "[0, 1, 0, null]");
   DictionaryArray expected(dict_type, int_array);
@@ -87,7 +111,7 @@ TYPED_TEST(TestDictionaryBuilder, ArrayConversion) {
 
   // Build expected data
   auto dict_array = ArrayFromJSON(type, "[1, 2]");
-  auto dict_type = std::make_shared<DictionaryType>(int8(), dict_array);
+  auto dict_type = dictionary(int8(), dict_array);
 
   auto int_array = ArrayFromJSON(int8(), "[0, 1, 0]");
   DictionaryArray expected(dict_type, int_array);
@@ -235,6 +259,25 @@ TEST(TestStringDictionaryBuilder, Basic) {
   auto dtype = dictionary(int8(), ArrayFromJSON(utf8(), "[\"test\", \"test2\"]"));
   auto int_array = ArrayFromJSON(int8(), "[0, 1, 0]");
   DictionaryArray expected(dtype, int_array);
+
+  ASSERT_TRUE(expected.Equals(result));
+}
+
+TEST(TestStringDictionaryBuilder, ArrayInit) {
+  auto dict_array = ArrayFromJSON(utf8(), "[\"test\", \"test2\"]");
+  auto int_array = ArrayFromJSON(int8(), "[0, 1, 0]");
+
+  // Build the dictionary Array
+  StringDictionaryBuilder builder(dict_array, default_memory_pool());
+  ASSERT_OK(builder.Append("test"));
+  ASSERT_OK(builder.Append("test2"));
+  ASSERT_OK(builder.Append("test"));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(builder.Finish(&result));
+
+  // Build expected data
+  DictionaryArray expected(dictionary(int8(), dict_array), int_array);
 
   ASSERT_TRUE(expected.Equals(result));
 }
@@ -440,6 +483,24 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, Basic) {
   ASSERT_OK(int_builder.Finish(&int_array));
 
   DictionaryArray expected(dtype, int_array);
+  ASSERT_TRUE(expected.Equals(result));
+}
+
+TEST(TestFixedSizeBinaryDictionaryBuilder, ArrayInit) {
+  // Build the dictionary Array
+  auto dict_array = ArrayFromJSON(fixed_size_binary(4), R"(["abcd", "wxyz"])");
+  util::string_view test = "abcd", test2 = "wxyz";
+  DictionaryBuilder<FixedSizeBinaryType> builder(dict_array, default_memory_pool());
+  ASSERT_OK(builder.Append(test));
+  ASSERT_OK(builder.Append(test2));
+  ASSERT_OK(builder.Append(test));
+
+  std::shared_ptr<Array> result;
+  FinishAndCheckPadding(&builder, &result);
+
+  // Build expected data
+  auto indices = ArrayFromJSON(int8(), "[0, 1, 0]");
+  DictionaryArray expected(dictionary(int8(), dict_array), indices);
   ASSERT_TRUE(expected.Equals(result));
 }
 

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -52,9 +52,8 @@ struct UnifyDictionaryValues {
   Status Visit(const DataType&, void* = nullptr) {
     // Default implementation for non-dictionary-supported datatypes
     std::stringstream ss;
-    ss << "Unification of " << value_type_->ToString()
-       << " dictionaries is not implemented";
-    return Status::NotImplemented(ss.str());
+    return Status::NotImplemented("Unification of ", value_type_,
+                                  " dictionaries is not implemented");
   }
 
   template <typename T>
@@ -153,10 +152,30 @@ class DictionaryBuilder<T>::MemoTableImpl
  public:
   using MemoTableType = typename internal::HashTraits<T>::MemoTableType;
   using MemoTableType::MemoTableType;
+
+  MemoTableImpl(const std::shared_ptr<Array>& dictionary)
+      : MemoTableImpl(dictionary->length()) {
+    const auto& values =
+        static_cast<const typename TypeTraits<T>::ArrayType&>(*dictionary);
+    for (int64_t i = 0; i < values.length(); ++i) {
+      ARROW_IGNORE_EXPR(this->GetOrInsert(values.GetView(i)));
+    }
+  }
 };
 
 template <typename T>
 DictionaryBuilder<T>::~DictionaryBuilder() {}
+
+template <typename T>
+DictionaryBuilder<T>::DictionaryBuilder(const std::shared_ptr<Array>& dictionary,
+                                        MemoryPool* pool)
+    : ArrayBuilder(dictionary->type(), pool),
+      memo_table_(new MemoTableImpl(dictionary)),
+      delta_offset_(0),
+      byte_width_(-1),
+      values_builder_(pool) {
+  DCHECK_EQ(T::type_id, type_->id()) << "inconsistent type passed to DictionaryBuilder";
+}
 
 template <typename T>
 DictionaryBuilder<T>::DictionaryBuilder(const std::shared_ptr<DataType>& type,
@@ -173,6 +192,12 @@ DictionaryBuilder<NullType>::DictionaryBuilder(const std::shared_ptr<DataType>& 
                                                MemoryPool* pool)
     : ArrayBuilder(type, pool), values_builder_(pool) {
   DCHECK_EQ(Type::NA, type->id()) << "inconsistent type passed to DictionaryBuilder";
+}
+
+DictionaryBuilder<NullType>::DictionaryBuilder(const std::shared_ptr<Array>& dictionary,
+                                               MemoryPool* pool)
+    : ArrayBuilder(dictionary->type(), pool), values_builder_(pool) {
+  DCHECK_EQ(Type::NA, type_->id()) << "inconsistent type passed to DictionaryBuilder";
 }
 
 template <>
@@ -202,7 +227,8 @@ Status DictionaryBuilder<T>::Resize(int64_t capacity) {
     delta_offset_ = 0;
   }
   RETURN_NOT_OK(values_builder_.Resize(capacity));
-  return ArrayBuilder::Resize(capacity);
+  capacity_ = values_builder_.capacity();
+  return Status::OK();
 }
 
 Status DictionaryBuilder<NullType>::Resize(int64_t capacity) {
@@ -210,7 +236,8 @@ Status DictionaryBuilder<NullType>::Resize(int64_t capacity) {
   capacity = std::max(capacity, kMinBuilderCapacity);
 
   RETURN_NOT_OK(values_builder_.Resize(capacity));
-  return ArrayBuilder::Resize(capacity);
+  capacity_ = values_builder_.capacity();
+  return Status::OK();
 }
 
 template <typename T>

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -51,7 +51,6 @@ struct UnifyDictionaryValues {
 
   Status Visit(const DataType&, void* = nullptr) {
     // Default implementation for non-dictionary-supported datatypes
-    std::stringstream ss;
     return Status::NotImplemented("Unification of ", value_type_,
                                   " dictionaries is not implemented");
   }

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -68,6 +68,8 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
   // The DictionaryType is instantiated on the Finish() call.
   DictionaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
 
+  DictionaryBuilder(const std::shared_ptr<Array>& dictionary, MemoryPool* pool);
+
   template <typename T1 = T>
   explicit DictionaryBuilder(
       typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type pool)
@@ -121,6 +123,8 @@ class ARROW_EXPORT DictionaryBuilder<NullType> : public ArrayBuilder {
  public:
   DictionaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
   explicit DictionaryBuilder(MemoryPool* pool);
+
+  DictionaryBuilder(const std::shared_ptr<Array>& dictionary, MemoryPool* pool);
 
   /// \brief Append a scalar null value
   Status AppendNull();

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -25,6 +25,8 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/hashing.h"
+#include "arrow/visitor_inline.h"
 
 namespace arrow {
 
@@ -37,6 +39,35 @@ class MemoryPool;
   case Type::ENUM:                           \
     out->reset(new BuilderType(type, pool)); \
     return Status::OK();
+
+struct DictionaryBuilderCase {
+  template <typename ValueType>
+  Status Visit(const ValueType&, typename ValueType::c_type* = nullptr) {
+    return Create<ValueType>();
+  }
+
+  Status Visit(const BinaryType&) { return Create<BinaryType>(); }
+  Status Visit(const StringType&) { return Create<StringType>(); }
+  Status Visit(const FixedSizeBinaryType&) { return Create<FixedSizeBinaryType>(); }
+
+  Status Visit(const DataType& value_type) { return NotImplemented(value_type); }
+  Status Visit(const HalfFloatType& value_type) { return NotImplemented(value_type); }
+  Status NotImplemented(const DataType& value_type) {
+    return Status::NotImplemented(
+        "MakeBuilder: cannot construct builder for dictionaries with value type ",
+        value_type);
+  }
+
+  template <typename ValueType>
+  Status Create() {
+    out->reset(new DictionaryBuilder<ValueType>(dict_type.dictionary(), pool));
+    return Status::OK();
+  }
+
+  MemoryPool* pool;
+  const DictionaryType& dict_type;
+  std::unique_ptr<ArrayBuilder>* out;
+};
 
 // Initially looked at doing this with vtables, but shared pointers makes it
 // difficult
@@ -70,6 +101,11 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       BUILDER_CASE(BINARY, BinaryBuilder);
       BUILDER_CASE(FIXED_SIZE_BINARY, FixedSizeBinaryBuilder);
       BUILDER_CASE(DECIMAL, Decimal128Builder);
+    case Type::DICTIONARY: {
+      const auto& dict_type = static_cast<const DictionaryType&>(*type);
+      DictionaryBuilderCase visitor = {pool, dict_type, out};
+      return VisitTypeInline(*dict_type.dictionary()->type(), &visitor);
+    }
     case Type::LIST: {
       std::unique_ptr<ArrayBuilder> value_builder;
       std::shared_ptr<DataType> value_type =

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -43,12 +43,12 @@ class MemoryPool;
 struct DictionaryBuilderCase {
   template <typename ValueType>
   Status Visit(const ValueType&, typename ValueType::c_type* = nullptr) {
-    return Create<ValueType>();
+    return CreateFor<ValueType>();
   }
 
-  Status Visit(const BinaryType&) { return Create<BinaryType>(); }
-  Status Visit(const StringType&) { return Create<StringType>(); }
-  Status Visit(const FixedSizeBinaryType&) { return Create<FixedSizeBinaryType>(); }
+  Status Visit(const BinaryType&) { return Create<BinaryDictionaryBuilder>(); }
+  Status Visit(const StringType&) { return Create<StringDictionaryBuilder>(); }
+  Status Visit(const FixedSizeBinaryType&) { return CreateFor<FixedSizeBinaryType>(); }
 
   Status Visit(const DataType& value_type) { return NotImplemented(value_type); }
   Status Visit(const HalfFloatType& value_type) { return NotImplemented(value_type); }
@@ -59,8 +59,13 @@ struct DictionaryBuilderCase {
   }
 
   template <typename ValueType>
+  Status CreateFor() {
+    return Create<DictionaryBuilder<ValueType>>();
+  }
+
+  template <typename BuilderType>
   Status Create() {
-    out->reset(new DictionaryBuilder<ValueType>(dict_type.dictionary(), pool));
+    out->reset(new BuilderType(dict_type.dictionary(), pool));
     return Status::OK();
   }
 


### PR DESCRIPTION
DictionaryBuilder can now be constructed with a user provided dictionary.

This is also available through MakeBuilder