### PR TITLE
ARROW-4724: [C++][CI] Enable Python build and test in MinGW build

### DIFF
--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -24,6 +24,10 @@ set INSTALL_DIR=%HOMEDRIVE%%HOMEPATH%\install
 set PATH=%INSTALL_DIR%\bin;%PATH%
 set PKG_CONFIG_PATH=%INSTALL_DIR%\lib\pkgconfig
 
+for /f "usebackq" %%v in (`python3 -c "import sys; print('.'.join(map(str, sys.version_info[0:2])))"`) do (
+  set PYTHON_VERSION=%%v
+)
+
 set CPP_BUILD_DIR=cpp\build
 mkdir %CPP_BUILD_DIR%
 pushd %CPP_BUILD_DIR%
@@ -45,14 +49,19 @@ cmake ^
     -DPythonInterp_FIND_VERSION=ON ^
     -DPythonInterp_FIND_VERSION_MAJOR=3 ^
     -DARROW_BUILD_TESTS=ON ^
-    -DARROW_PYTHON=OFF ^
     .. || exit /B
 make -j4 || exit /B
+setlocal
+set PYTHONHOME=%MINGW_PREFIX%\lib\python%PYTHON_VERSION%
+set PYTHONPATH=%PYTHONHOME%
+set PYTHONPATH=%PYTHONPATH%;%MINGW_PREFIX%\lib\python%PYTHON_VERSION%\lib-dynload
+set PYTHONPATH=%PYTHONPATH%;%MINGW_PREFIX%\lib\python%PYTHON_VERSION%\site-packages
 @rem TODO(ARROW-4784): Run all tests
 ctest ^
   --exclude-regex "arrow-array-test|arrow-thread-pool-test" ^
   --output-on-failure ^
   --parallel 2 || exit /B
+endlocal
 make install || exit /B
 popd
 


### PR DESCRIPTION
We don't need to set PYTHONHOME and PHTHONPATH when we use
libpython.dll from MSYS2 through python.exe but we need to set them
when we use libpython.dll directly.