### PR TITLE
ARROW-4834: [R] Feature flag when building parquet

### DIFF
--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -17,7 +17,7 @@
 
 #include <arrow/api.h>
 #include <arrow/io/api.h>
-#ifndef ARROW_R_PARQUET_OFF
+#ifdef ARROW_R_WITH_PARQUET
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/exception.h>
@@ -26,12 +26,7 @@
 
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Table> read_parquet_file(std::string filename) {
-#ifdef ARROW_R_PARQUET_OFF
-  Rcpp::stop("Support for Parquet is not available.");
-
-  std::shared_ptr<arrow::Table> table;
-  return table;
-#else
+#ifdef ARROW_R_WITH_PARQUET
   std::shared_ptr<arrow::io::ReadableFile> infile;
   PARQUET_THROW_NOT_OK(
       arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool(), &infile));
@@ -42,6 +37,11 @@ std::shared_ptr<arrow::Table> read_parquet_file(std::string filename) {
   std::shared_ptr<arrow::Table> table;
   PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
 
+  return table;
+#else
+  Rcpp::stop("Support for Parquet is not available.");
+
+  std::shared_ptr<arrow::Table> table;
   return table;
 #endif
 }

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -17,12 +17,16 @@
 
 #include <arrow/api.h>
 #include <arrow/io/api.h>
+#ifndef ARROW_R_PARQUET_OFF
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/exception.h>
+#endif
+#include <RcppCommon.h>
 
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Table> read_parquet_file(std::string filename) {
+#ifndef ARROW_R_PARQUET_OFF
   std::shared_ptr<arrow::io::ReadableFile> infile;
   PARQUET_THROW_NOT_OK(
       arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool(), &infile));
@@ -34,4 +38,10 @@ std::shared_ptr<arrow::Table> read_parquet_file(std::string filename) {
   PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
 
   return table;
+#else
+  Rcpp::stop("Support for Parquet is not available.");
+
+  std::shared_ptr<arrow::Table> table;
+  return table;
+#endif
 }

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -26,7 +26,12 @@
 
 // [[Rcpp::export]]
 std::shared_ptr<arrow::Table> read_parquet_file(std::string filename) {
-#ifndef ARROW_R_PARQUET_OFF
+#ifdef ARROW_R_PARQUET_OFF
+  Rcpp::stop("Support for Parquet is not available.");
+
+  std::shared_ptr<arrow::Table> table;
+  return table;
+#else
   std::shared_ptr<arrow::io::ReadableFile> infile;
   PARQUET_THROW_NOT_OK(
       arrow::io::ReadableFile::Open(filename, arrow::default_memory_pool(), &infile));
@@ -37,11 +42,6 @@ std::shared_ptr<arrow::Table> read_parquet_file(std::string filename) {
   std::shared_ptr<arrow::Table> table;
   PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
 
-  return table;
-#else
-  Rcpp::stop("Support for Parquet is not available.");
-
-  std::shared_ptr<arrow::Table> table;
   return table;
 #endif
 }


### PR DESCRIPTION
Support `ARROW_R_PARQUET_OFF` build flag to disable Parquet for R builds.

Fix for: https://issues.apache.org/jira/browse/ARROW-4834

CC: @jeroen