### PR TITLE
ARROW-2119: [IntegrationTest] Add test case with a stream having no record batches

### DIFF
--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -1030,6 +1030,7 @@ def get_generated_json_files(tempdir=None, flight=False):
         return
 
     file_objs = [
+        generate_primitive_case([], name='primitive_no_batches'),
         generate_primitive_case([17, 20], name='primitive'),
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
         generate_decimal_case(),
@@ -1498,6 +1499,8 @@ def write_js_test_json(directory):
     generate_datetime_case().write(os.path.join(directory, 'datetime.json'))
     (generate_dictionary_case()
      .write(os.path.join(directory, 'dictionary.json')))
+    (generate_primitive_case([])
+     .write(os.path.join(directory, 'primitive_no_batches.json')))
     (generate_primitive_case([7, 10])
      .write(os.path.join(directory, 'primitive.json')))
     (generate_primitive_case([0, 0, 0])

--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -1030,7 +1030,9 @@ def get_generated_json_files(tempdir=None, flight=False):
         return
 
     file_objs = [
-        generate_primitive_case([], name='primitive_no_batches'),
+        (generate_primitive_case([], name='primitive_no_batches')
+         .skip_category('JS')
+         .skip_category('Java')),
         generate_primitive_case([17, 20], name='primitive'),
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
         generate_decimal_case(),
@@ -1120,6 +1122,16 @@ class IntegrationRunner(object):
             consumer_file_path = os.path.join(self.temp_dir, file_id + '_' +
                                               name +
                                               '.consumer_stream_as_file')
+
+            if producer.name in test_case.skip:
+                print('-- Skipping test because producer {0} does '
+                      'not support'.format(producer.name))
+                continue
+
+            if consumer.name in test_case.skip:
+                print('-- Skipping test because consumer {0} does '
+                      'not support'.format(consumer.name))
+                continue
 
             if SKIP_ARROW in test_case.skip:
                 print('-- Skipping test')


### PR DESCRIPTION
I think it is not a bad idea to not fail on reading and writing streams that have no record batches, rather than raising an error.

This would require code changes in Java and JS at least, so I will need help from others if this is thought to be a good idea. Might be good to add some unit tests around this also