### PR TITLE
ARROW-4820: [Python] hadoop class path derived not correct

### DIFF
--- a/integration/hdfs/Dockerfile
+++ b/integration/hdfs/Dockerfile
@@ -17,10 +17,6 @@
 
 FROM arrow:python-3.6
 
-# installing libhdfs3, it needs to be pinned, see ARROW-1465 and ARROW-1445
-RUN conda install -y -c conda-forge hdfs3 libhdfs3=2.2.31 && \
-    conda clean --all
-
 # installing libhdfs (JNI)
 ARG HADOOP_VERSION=2.6.5
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
@@ -34,6 +30,12 @@ RUN apt-get update -y && \
     rm /hadoop-$HADOOP_VERSION.tar.gz && \
     mv /hadoop-$HADOOP_VERSION /usr/local/hadoop
 ADD integration/hdfs/hdfs-site.xml $HADOOP_HOME/etc/hadoop/
+
+# installing libhdfs3, it needs to be pinned, see ARROW-1465 and ARROW-1445
+# after the conda-forge migration it's failing with abi incompatibilities, so
+# turning it off for now
+# RUN conda install -y -c conda-forge libhdfs3=2.2.31 && \
+#     conda clean --all
 
 # build cpp with tests
 ENV CC=gcc \

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -146,8 +146,12 @@ def _derive_hadoop_classpath():
     xargs_echo = subprocess.Popen(('xargs', 'echo'),
                                   stdin=find.stdout,
                                   stdout=subprocess.PIPE)
-    return subprocess.check_output(('tr', "' '", "':'"),
+    jars = subprocess.check_output(('tr', "' '", "':'"),
                                    stdin=xargs_echo.stdout)
+    hadoop_conf = os.environ["HADOOP_CONF_DIR"] \
+        if "HADOOP_CONF_DIR" in os.environ \
+        else os.environ["HADOOP_HOME"] + "/etc/hadoop"
+    return (hadoop_conf + ":").encode("utf-8") + jars
 
 
 def _hadoop_classpath_glob(hadoop_bin):


### PR DESCRIPTION
> hdfs.py method _derive_hadoop_classpath add hadoop config dir to hadoop classpath

Fix for  https://issues.apache.org/jira/browse/ARROW-4820