### PR TITLE
ARROW-4837: [C++] Support c++filt on a custom path in the run-test.sh script

### DIFF
--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -56,4 +56,4 @@ ENV CC=gcc \
 
 # build and test
 CMD arrow/ci/docker_build_cpp.sh && \
-    cd /build/cpp && ctest -j2 --output-on-failure -L unittest
+    cd /build/cpp && ninja test

--- a/cpp/Dockerfile.alpine
+++ b/cpp/Dockerfile.alpine
@@ -45,4 +45,4 @@ ENV CC=gcc \
 
 # build and test
 CMD arrow/ci/docker_build_cpp.sh && \
-    cd /build/cpp && ctest -j2 --output-on-failure -L unittest
+    cd /build/cpp && ninja test

--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -103,7 +103,7 @@ function run_test() {
 
   $TEST_EXECUTABLE "$@" 2>&1 \
     | $ROOT/build-support/asan_symbolize.py \
-    | c++filt \
+    | ${CXXFILT:-c++filt} \
     | $ROOT/build-support/stacktrace_addr2line.pl $TEST_EXECUTABLE \
     | $pipe_cmd 2>&1 | tee $LOGFILE
   STATUS=$?


### PR DESCRIPTION
On conda this is `CXXFILT=/opt/conda/bin/x86_64-conda_cos6-linux-gnu-c++filt`