### PR TITLE
ARROW-4825: [WIP][C++][Python] Transition from MemoryPool* to shared_ptr<MemoryPool>&

### DIFF
--- a/cpp/examples/arrow/row-wise-conversion-example.cc
+++ b/cpp/examples/arrow/row-wise-conversion-example.cc
@@ -58,7 +58,7 @@ arrow::Status VectorToColumnarTable(const std::vector<struct data_row>& rows,
   // arrow::jemalloc::MemoryPool::default_pool() as this can increase the size of
   // the underlying memory regions in-place. At the moment, arrow::jemalloc is only
   // supported on Unix systems, not Windows.
-  arrow::MemoryPool* pool = arrow::default_memory_pool();
+  auto pool = arrow::default_memory_pool();
 
   Int64Builder id_builder(pool);
   DoubleBuilder cost_builder(pool);

--- a/cpp/examples/parquet/parquet-arrow/reader-writer.cc
+++ b/cpp/examples/parquet/parquet-arrow/reader-writer.cc
@@ -54,20 +54,22 @@ void write_parquet_file(const arrow::Table& table) {
   // The last argument to the function call is the size of the RowGroup in
   // the parquet file. Normally you would choose this to be rather large but
   // for the example, we use a small value to have multiple RowGroups.
+  auto pool = arrow::default_memory_pool();
   PARQUET_THROW_NOT_OK(
-      parquet::arrow::WriteTable(table, arrow::default_memory_pool(), outfile, 3));
+      parquet::arrow::WriteTable(table, pool, outfile, 3));
 }
 
 // #2: Fully read in the file
 void read_whole_file() {
   std::cout << "Reading parquet-arrow-example.parquet at once" << std::endl;
   std::shared_ptr<arrow::io::ReadableFile> infile;
+  auto pool = arrow::default_memory_pool();
   PARQUET_THROW_NOT_OK(arrow::io::ReadableFile::Open(
-      "parquet-arrow-example.parquet", arrow::default_memory_pool(), &infile));
+      "parquet-arrow-example.parquet", pool, &infile));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+      parquet::arrow::OpenFile(infile, pool, &reader));
   std::shared_ptr<arrow::Table> table;
   PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
   std::cout << "Loaded " << table->num_rows() << " rows in " << table->num_columns()
@@ -78,12 +80,13 @@ void read_whole_file() {
 void read_single_rowgroup() {
   std::cout << "Reading first RowGroup of parquet-arrow-example.parquet" << std::endl;
   std::shared_ptr<arrow::io::ReadableFile> infile;
+  auto pool = arrow::default_memory_pool();
   PARQUET_THROW_NOT_OK(arrow::io::ReadableFile::Open(
-      "parquet-arrow-example.parquet", arrow::default_memory_pool(), &infile));
+      "parquet-arrow-example.parquet", pool, &infile));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+      parquet::arrow::OpenFile(infile, pool, &reader));
   std::shared_ptr<arrow::Table> table;
   PARQUET_THROW_NOT_OK(reader->RowGroup(0)->ReadTable(&table));
   std::cout << "Loaded " << table->num_rows() << " rows in " << table->num_columns()
@@ -94,12 +97,13 @@ void read_single_rowgroup() {
 void read_single_column() {
   std::cout << "Reading first column of parquet-arrow-example.parquet" << std::endl;
   std::shared_ptr<arrow::io::ReadableFile> infile;
+  auto pool = arrow::default_memory_pool();
   PARQUET_THROW_NOT_OK(arrow::io::ReadableFile::Open(
-      "parquet-arrow-example.parquet", arrow::default_memory_pool(), &infile));
+      "parquet-arrow-example.parquet", pool, &infile));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+      parquet::arrow::OpenFile(infile, pool, &reader));
   std::shared_ptr<arrow::ChunkedArray> array;
   PARQUET_THROW_NOT_OK(reader->ReadColumn(0, &array));
   PARQUET_THROW_NOT_OK(arrow::PrettyPrint(*array, 4, &std::cout));
@@ -113,12 +117,13 @@ void read_single_column_chunk() {
                "parquet-arrow-example.parquet"
             << std::endl;
   std::shared_ptr<arrow::io::ReadableFile> infile;
+  auto pool = arrow::default_memory_pool();
   PARQUET_THROW_NOT_OK(arrow::io::ReadableFile::Open(
-      "parquet-arrow-example.parquet", arrow::default_memory_pool(), &infile));
+      "parquet-arrow-example.parquet", pool, &infile));
 
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+      parquet::arrow::OpenFile(infile, pool, &reader));
   std::shared_ptr<arrow::ChunkedArray> array;
   PARQUET_THROW_NOT_OK(reader->RowGroup(0)->Column(0)->Read(&array));
   PARQUET_THROW_NOT_OK(arrow::PrettyPrint(*array, 4, &std::cout));

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -222,7 +222,7 @@ class ORCFileReader::Impl {
   Impl() {}
   ~Impl() {}
 
-  Status Open(const std::shared_ptr<io::ReadableFileInterface>& file, MemoryPool* pool) {
+  Status Open(const std::shared_ptr<io::ReadableFileInterface>& file, std::shared_ptr<MemoryPool>& pool) {
     std::unique_ptr<ArrowInputFile> io_wrapper(new ArrowInputFile(file));
     liborc::ReaderOptions options;
     std::unique_ptr<liborc::Reader> liborc_reader;
@@ -673,7 +673,7 @@ class ORCFileReader::Impl {
   }
 
  private:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::unique_ptr<liborc::Reader> reader_;
   std::vector<StripeInformation> stripes_;
 };
@@ -683,7 +683,7 @@ ORCFileReader::ORCFileReader() { impl_.reset(new ORCFileReader::Impl()); }
 ORCFileReader::~ORCFileReader() {}
 
 Status ORCFileReader::Open(const std::shared_ptr<io::ReadableFileInterface>& file,
-                           MemoryPool* pool, std::unique_ptr<ORCFileReader>* reader) {
+                           std::shared_ptr<MemoryPool>& pool, std::unique_ptr<ORCFileReader>* reader) {
   auto result = std::unique_ptr<ORCFileReader>(new ORCFileReader());
   RETURN_NOT_OK(result->impl_->Open(file, pool));
   *reader = std::move(result);

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -48,7 +48,7 @@ class ARROW_EXPORT ORCFileReader {
   /// \param[out] reader the returned reader object
   /// \return Status
   static Status Open(const std::shared_ptr<io::ReadableFileInterface>& file,
-                     MemoryPool* pool, std::unique_ptr<ORCFileReader>* reader);
+                     std::shared_ptr<MemoryPool>& pool, std::unique_ptr<ORCFileReader>* reader);
 
   /// \brief Return the schema read from the ORC file
   ///

--- a/cpp/src/arrow/array-binary-test.cc
+++ b/cpp/src/arrow/array-binary-test.cc
@@ -60,7 +60,8 @@ class TestStringArray : public ::testing::Test {
     length_ = static_cast<int64_t>(offsets_.size()) - 1;
     value_buf_ = Buffer::Wrap(chars_);
     offsets_buf_ = Buffer::Wrap(offsets_);
-    ASSERT_OK(BitUtil::BytesToBits(valid_bytes_, default_memory_pool(), &null_bitmap_));
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    ASSERT_OK(BitUtil::BytesToBits(valid_bytes_, pool, &null_bitmap_));
     null_count_ = CountNulls(valid_bytes_);
 
     strings_ = std::make_shared<StringArray>(length_, offsets_buf_, value_buf_,
@@ -373,7 +374,8 @@ class TestBinaryArray : public ::testing::Test {
     value_buf_ = Buffer::Wrap(chars_);
     offsets_buf_ = Buffer::Wrap(offsets_);
 
-    ASSERT_OK(BitUtil::BytesToBits(valid_bytes_, default_memory_pool(), &null_bitmap_));
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    ASSERT_OK(BitUtil::BytesToBits(valid_bytes_, pool, &null_bitmap_));
     null_count_ = CountNulls(valid_bytes_);
 
     strings_ = std::make_shared<BinaryArray>(length_, offsets_buf_, value_buf_,

--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -54,7 +54,8 @@ typedef ::testing::Types<Int8Type, UInt8Type, Int16Type, UInt16Type, Int32Type,
 TYPED_TEST_CASE(TestDictionaryBuilder, PrimitiveDictionaries);
 
 TYPED_TEST(TestDictionaryBuilder, Basic) {
-  DictionaryBuilder<TypeParam> builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  DictionaryBuilder<TypeParam> builder(pool);
   ASSERT_OK(builder.Append(static_cast<typename TypeParam::c_type>(1)));
   ASSERT_OK(builder.Append(static_cast<typename TypeParam::c_type>(2)));
   ASSERT_OK(builder.Append(static_cast<typename TypeParam::c_type>(1)));
@@ -80,7 +81,8 @@ TYPED_TEST(TestDictionaryBuilder, ArrayConversion) {
   auto type = std::make_shared<TypeParam>();
 
   auto intermediate_result = ArrayFromJSON(type, "[1, 2, 1]");
-  DictionaryBuilder<TypeParam> dictionary_builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  DictionaryBuilder<TypeParam> dictionary_builder(pool);
   ASSERT_OK(dictionary_builder.AppendArray(*intermediate_result));
   std::shared_ptr<Array> result;
   ASSERT_OK(dictionary_builder.Finish(&result));
@@ -100,7 +102,8 @@ TYPED_TEST(TestDictionaryBuilder, DoubleTableSize) {
   // Skip this test for (u)int8
   if (sizeof(Scalar) > 1) {
     // Build the dictionary Array
-    DictionaryBuilder<TypeParam> builder(default_memory_pool());
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    DictionaryBuilder<TypeParam> builder(pool);
     // Build expected data
     NumericBuilder<TypeParam> dict_builder;
     Int16Builder int_builder;
@@ -137,7 +140,8 @@ TYPED_TEST(TestDictionaryBuilder, DeltaDictionary) {
   using c_type = typename TypeParam::c_type;
   auto type = std::make_shared<TypeParam>();
 
-  DictionaryBuilder<TypeParam> builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  DictionaryBuilder<TypeParam> builder(pool);
 
   ASSERT_OK(builder.Append(static_cast<c_type>(1)));
   ASSERT_OK(builder.Append(static_cast<c_type>(2)));
@@ -173,7 +177,8 @@ TYPED_TEST(TestDictionaryBuilder, DoubleDeltaDictionary) {
   using c_type = typename TypeParam::c_type;
   auto type = std::make_shared<TypeParam>();
 
-  DictionaryBuilder<TypeParam> builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  DictionaryBuilder<TypeParam> builder(pool);
 
   ASSERT_OK(builder.Append(static_cast<c_type>(1)));
   ASSERT_OK(builder.Append(static_cast<c_type>(2)));
@@ -223,7 +228,8 @@ TYPED_TEST(TestDictionaryBuilder, DoubleDeltaDictionary) {
 
 TEST(TestStringDictionaryBuilder, Basic) {
   // Build the dictionary Array
-  StringDictionaryBuilder builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  StringDictionaryBuilder builder(pool);
   ASSERT_OK(builder.Append("test"));
   ASSERT_OK(builder.Append("test2"));
   ASSERT_OK(builder.Append("test"));
@@ -242,7 +248,8 @@ TEST(TestStringDictionaryBuilder, Basic) {
 // ARROW-4367
 TEST(TestStringDictionaryBuilder, OnlyNull) {
   // Build the dictionary Array
-  StringDictionaryBuilder builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  StringDictionaryBuilder builder(pool);
   ASSERT_OK(builder.AppendNull());
 
   std::shared_ptr<Array> result;
@@ -258,7 +265,8 @@ TEST(TestStringDictionaryBuilder, OnlyNull) {
 
 TEST(TestStringDictionaryBuilder, DoubleTableSize) {
   // Build the dictionary Array
-  StringDictionaryBuilder builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  StringDictionaryBuilder builder(pool);
   // Build expected data
   StringBuilder str_builder;
   Int16Builder int_builder;
@@ -294,7 +302,8 @@ TEST(TestStringDictionaryBuilder, DoubleTableSize) {
 
 TEST(TestStringDictionaryBuilder, DeltaDictionary) {
   // Build the dictionary Array
-  StringDictionaryBuilder builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  StringDictionaryBuilder builder(pool);
   ASSERT_OK(builder.Append("test"));
   ASSERT_OK(builder.Append("test2"));
   ASSERT_OK(builder.Append("test"));
@@ -328,7 +337,8 @@ TEST(TestStringDictionaryBuilder, DeltaDictionary) {
 TEST(TestStringDictionaryBuilder, BigDeltaDictionary) {
   constexpr int16_t kTestLength = 2048;
   // Build the dictionary Array
-  StringDictionaryBuilder builder(default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  StringDictionaryBuilder builder(pool);
 
   StringBuilder str_builder1;
   Int16Builder int_builder1;
@@ -413,8 +423,9 @@ TEST(TestStringDictionaryBuilder, BigDeltaDictionary) {
 
 TEST(TestFixedSizeBinaryDictionaryBuilder, Basic) {
   // Build the dictionary Array
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   DictionaryBuilder<FixedSizeBinaryType> builder(arrow::fixed_size_binary(4),
-                                                 default_memory_pool());
+                                                 pool);
   std::vector<uint8_t> test{12, 12, 11, 12};
   std::vector<uint8_t> test2{12, 12, 11, 11};
   ASSERT_OK(builder.Append(test.data()));
@@ -445,8 +456,9 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, Basic) {
 
 TEST(TestFixedSizeBinaryDictionaryBuilder, DeltaDictionary) {
   // Build the dictionary Array
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   DictionaryBuilder<FixedSizeBinaryType> builder(arrow::fixed_size_binary(4),
-                                                 default_memory_pool());
+                                                 pool);
   std::vector<uint8_t> test{12, 12, 11, 12};
   std::vector<uint8_t> test2{12, 12, 11, 11};
   std::vector<uint8_t> test3{12, 12, 11, 10};
@@ -504,8 +516,9 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, DeltaDictionary) {
 
 TEST(TestFixedSizeBinaryDictionaryBuilder, DoubleTableSize) {
   // Build the dictionary Array
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   DictionaryBuilder<FixedSizeBinaryType> builder(arrow::fixed_size_binary(4),
-                                                 default_memory_pool());
+                                                 pool);
   // Build expected data
   FixedSizeBinaryBuilder fsb_builder(arrow::fixed_size_binary(4));
   Int16Builder int_builder;
@@ -542,8 +555,9 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, DoubleTableSize) {
 
 TEST(TestFixedSizeBinaryDictionaryBuilder, InvalidTypeAppend) {
   // Build the dictionary Array
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   DictionaryBuilder<FixedSizeBinaryType> builder(arrow::fixed_size_binary(4),
-                                                 default_memory_pool());
+                                                 pool);
   // Build an array with different byte width
   FixedSizeBinaryBuilder fsb_builder(arrow::fixed_size_binary(5));
   std::vector<uint8_t> value{100, 1, 1, 1, 1};
@@ -557,7 +571,8 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, InvalidTypeAppend) {
 TEST(TestDecimalDictionaryBuilder, Basic) {
   // Build the dictionary Array
   auto decimal_type = arrow::decimal(2, 0);
-  DictionaryBuilder<FixedSizeBinaryType> builder(decimal_type, default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  DictionaryBuilder<FixedSizeBinaryType> builder(decimal_type, pool);
 
   // Test data
   std::vector<Decimal128> test{12, 12, 11, 12};
@@ -579,7 +594,8 @@ TEST(TestDecimalDictionaryBuilder, DoubleTableSize) {
   const auto& decimal_type = arrow::decimal(21, 0);
 
   // Build the dictionary Array
-  DictionaryBuilder<FixedSizeBinaryType> builder(decimal_type, default_memory_pool());
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  DictionaryBuilder<FixedSizeBinaryType> builder(decimal_type, pool);
 
   // Build expected data
   FixedSizeBinaryBuilder fsb_builder(decimal_type);
@@ -779,8 +795,9 @@ TEST(TestDictionary, TransposeBasic) {
     auto out_dict_type = dictionary(int16(), out_dict);
 
     const std::vector<int32_t> transpose_map{1, 3, 2};
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
     ASSERT_OK(internal::checked_cast<const DictionaryArray&>(*arr).Transpose(
-        default_memory_pool(), out_dict_type, transpose_map, &out));
+        pool, out_dict_type, transpose_map, &out));
 
     auto expected_indices = ArrayFromJSON(int16(), "[3, 2, 1, 1]");
     ASSERT_OK(DictionaryArray::FromArrays(out_dict_type, expected_indices, &expected));
@@ -793,8 +810,9 @@ TEST(TestDictionary, TransposeBasic) {
     auto out_dict_type = dictionary(int8(), out_dict);
 
     const std::vector<int32_t> transpose_map{1, 3, 2};
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
     ASSERT_OK(internal::checked_cast<const DictionaryArray&>(*arr).Transpose(
-        default_memory_pool(), out_dict_type, transpose_map, &out));
+        pool, out_dict_type, transpose_map, &out));
 
     auto expected_indices = ArrayFromJSON(int8(), "[3, 2, 1, 1]");
     ASSERT_OK(DictionaryArray::FromArrays(out_dict_type, expected_indices, &expected));
@@ -815,8 +833,9 @@ TEST(TestDictionary, TransposeNulls) {
   auto out_dict_type = dictionary(int16(), out_dict);
 
   const std::vector<int32_t> transpose_map{1, 3, 2};
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   ASSERT_OK(internal::checked_cast<const DictionaryArray&>(*arr).Transpose(
-      default_memory_pool(), out_dict_type, transpose_map, &out));
+      pool, out_dict_type, transpose_map, &out));
 
   auto expected_indices = ArrayFromJSON(int16(), "[3, 2, null, 1]");
   ASSERT_OK(DictionaryArray::FromArrays(out_dict_type, expected_indices, &expected));

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -199,7 +199,7 @@ ListArray::ListArray(const std::shared_ptr<DataType>& type, int64_t length,
   SetData(internal_data);
 }
 
-Status ListArray::FromArrays(const Array& offsets, const Array& values, MemoryPool* pool,
+Status ListArray::FromArrays(const Array& offsets, const Array& values, std::shared_ptr<MemoryPool>& pool,
                              std::shared_ptr<Array>* out) {
   if (offsets.length() == 0) {
     return Status::Invalid("List offsets must have non-zero length");
@@ -399,7 +399,7 @@ std::shared_ptr<Array> StructArray::GetFieldByName(const std::string& name) cons
   return i == -1 ? nullptr : field(i);
 }
 
-Status StructArray::Flatten(MemoryPool* pool, ArrayVector* out) const {
+Status StructArray::Flatten(std::shared_ptr<MemoryPool>& pool, ArrayVector* out) const {
   ArrayVector flattened;
   std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
 
@@ -664,7 +664,7 @@ std::shared_ptr<Array> DictionaryArray::dictionary() const {
 }
 
 template <typename InType, typename OutType>
-static Status TransposeDictIndices(MemoryPool* pool, const ArrayData& in_data,
+static Status TransposeDictIndices(std::shared_ptr<MemoryPool>& pool, const ArrayData& in_data,
                                    const std::shared_ptr<DataType>& type,
                                    const std::vector<int32_t>& transpose_map,
                                    std::shared_ptr<Array>* out) {
@@ -683,7 +683,7 @@ static Status TransposeDictIndices(MemoryPool* pool, const ArrayData& in_data,
   return Status::OK();
 }
 
-Status DictionaryArray::Transpose(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+Status DictionaryArray::Transpose(std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<DataType>& type,
                                   const std::vector<int32_t>& transpose_map,
                                   std::shared_ptr<Array>* out) const {
   DCHECK_EQ(type->id(), Type::DICTIONARY);

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -483,7 +483,7 @@ class ARROW_EXPORT ListArray : public Array {
   /// \param[in] pool MemoryPool in case new offsets array needs to be
   /// allocated because of null values
   /// \param[out] out Will have length equal to offsets.length() - 1
-  static Status FromArrays(const Array& offsets, const Array& values, MemoryPool* pool,
+  static Status FromArrays(const Array& offsets, const Array& values, std::shared_ptr<MemoryPool>& pool,
                            std::shared_ptr<Array>* out);
 
   const ListType* list_type() const;
@@ -690,7 +690,7 @@ class ARROW_EXPORT StructArray : public Array {
   ///
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
   /// \param[out] out The resulting vector of arrays
-  Status Flatten(MemoryPool* pool, ArrayVector* out) const;
+  Status Flatten(std::shared_ptr<MemoryPool>& pool, ArrayVector* out) const;
 
  private:
   // For caching boxed child data
@@ -832,7 +832,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   /// \param[in] transpose_map a vector transposing this array's indices
   /// into the target array's indices
   /// \param[out] out the resulting DictionaryArray instance
-  Status Transpose(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+  Status Transpose(std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<DataType>& type,
                    const std::vector<int32_t>& transpose_map,
                    std::shared_ptr<Array>* out) const;
   // XXX Do we also want an unsafe in-place Transpose?

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -35,7 +35,7 @@ namespace arrow {
 
 using internal::AdaptiveIntBuilderBase;
 
-AdaptiveIntBuilderBase::AdaptiveIntBuilderBase(MemoryPool* pool)
+AdaptiveIntBuilderBase::AdaptiveIntBuilderBase(std::shared_ptr<MemoryPool>& pool)
     : ArrayBuilder(int64(), pool),
       data_(nullptr),
       raw_data_(nullptr),
@@ -66,7 +66,7 @@ Status AdaptiveIntBuilderBase::Resize(int64_t capacity) {
   return ArrayBuilder::Resize(capacity);
 }
 
-AdaptiveIntBuilder::AdaptiveIntBuilder(MemoryPool* pool) : AdaptiveIntBuilderBase(pool) {}
+AdaptiveIntBuilder::AdaptiveIntBuilder(std::shared_ptr<MemoryPool> pool) : AdaptiveIntBuilderBase(pool) {}
 
 Status AdaptiveIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(CommitPendingData());
@@ -251,7 +251,7 @@ Status AdaptiveIntBuilder::ExpandIntSize(uint8_t new_int_size) {
   return Status::OK();
 }
 
-AdaptiveUIntBuilder::AdaptiveUIntBuilder(MemoryPool* pool)
+AdaptiveUIntBuilder::AdaptiveUIntBuilder(std::shared_ptr<MemoryPool> pool)
     : AdaptiveIntBuilderBase(pool) {}
 
 Status AdaptiveUIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -27,7 +27,7 @@ namespace internal {
 
 class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
  public:
-  explicit AdaptiveIntBuilderBase(MemoryPool* pool);
+  explicit AdaptiveIntBuilderBase(std::shared_ptr<MemoryPool>& pool);
 
   /// \brief Append multiple nulls
   /// \param[in] length the number of nulls to append
@@ -72,7 +72,7 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
 
 class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveUIntBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit AdaptiveUIntBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
   using ArrayBuilder::Advance;
   using internal::AdaptiveIntBuilderBase::Reset;
@@ -122,7 +122,7 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
 class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveIntBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit AdaptiveIntBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
   using ArrayBuilder::Advance;
   using internal::AdaptiveIntBuilderBase::Reset;

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -58,7 +58,7 @@ constexpr int64_t kListMaximumElements = std::numeric_limits<int32_t>::max() - 1
 /// For example, ArrayBuilder* pointing to BinaryBuilder should be downcast before use.
 class ARROW_EXPORT ArrayBuilder {
  public:
-  explicit ArrayBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
+  explicit ArrayBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool)
       : type_(type), pool_(pool), null_bitmap_builder_(pool) {}
 
   virtual ~ArrayBuilder() = default;
@@ -177,7 +177,7 @@ class ARROW_EXPORT ArrayBuilder {
   }
 
   std::shared_ptr<DataType> type_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
 
   TypedBufferBuilder<bool> null_bitmap_builder_;
   int64_t null_count_ = 0;

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -44,10 +44,10 @@ using internal::checked_cast;
 // ----------------------------------------------------------------------
 // String and binary
 
-BinaryBuilder::BinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
+BinaryBuilder::BinaryBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool)
     : ArrayBuilder(type, pool), offsets_builder_(pool), value_data_builder_(pool) {}
 
-BinaryBuilder::BinaryBuilder(MemoryPool* pool) : BinaryBuilder(binary(), pool) {}
+BinaryBuilder::BinaryBuilder(std::shared_ptr<MemoryPool> pool) : BinaryBuilder(binary(), pool) {}
 
 Status BinaryBuilder::Resize(int64_t capacity) {
   DCHECK_LE(capacity, kListMaximumElements);
@@ -119,7 +119,7 @@ util::string_view BinaryBuilder::GetView(int64_t i) const {
       reinterpret_cast<const char*>(value_data_builder_.data() + offset), value_length);
 }
 
-StringBuilder::StringBuilder(MemoryPool* pool) : BinaryBuilder(utf8(), pool) {}
+StringBuilder::StringBuilder(std::shared_ptr<MemoryPool> pool) : BinaryBuilder(utf8(), pool) {}
 
 Status StringBuilder::AppendValues(const std::vector<std::string>& values,
                                    const uint8_t* valid_bytes) {
@@ -212,7 +212,7 @@ Status StringBuilder::AppendValues(const char** values, int64_t length,
 // Fixed width binary
 
 FixedSizeBinaryBuilder::FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& type,
-                                               MemoryPool* pool)
+                                               std::shared_ptr<MemoryPool> pool)
     : ArrayBuilder(type, pool),
       byte_width_(checked_cast<const FixedSizeBinaryType&>(*type).byte_width()),
       byte_builder_(pool) {}
@@ -275,7 +275,7 @@ util::string_view FixedSizeBinaryBuilder::GetView(int64_t i) const {
 
 namespace internal {
 
-ChunkedBinaryBuilder::ChunkedBinaryBuilder(int32_t max_chunk_size, MemoryPool* pool)
+ChunkedBinaryBuilder::ChunkedBinaryBuilder(int32_t max_chunk_size, std::shared_ptr<MemoryPool> pool)
     : max_chunk_size_(max_chunk_size),
       chunk_data_size_(0),
       builder_(new BinaryBuilder(pool)) {}

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -42,9 +42,9 @@ constexpr int64_t kBinaryMemoryLimit = std::numeric_limits<int32_t>::max() - 1;
 /// \brief Builder class for variable-length binary data
 class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
  public:
-  explicit BinaryBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit BinaryBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
-  BinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
+  BinaryBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool);
 
   Status Append(const uint8_t* value, int32_t length) {
     ARROW_RETURN_NOT_OK(Reserve(1));
@@ -147,7 +147,7 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
 class ARROW_EXPORT StringBuilder : public BinaryBuilder {
  public:
   using BinaryBuilder::BinaryBuilder;
-  explicit StringBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit StringBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
   using BinaryBuilder::Append;
   using BinaryBuilder::Reset;
@@ -181,7 +181,7 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
 class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
  public:
   FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& type,
-                         MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                         std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
   Status Append(const uint8_t* value) {
     ARROW_RETURN_NOT_OK(Reserve(1));
@@ -255,7 +255,7 @@ namespace internal {
 class ARROW_EXPORT ChunkedBinaryBuilder {
  public:
   ChunkedBinaryBuilder(int32_t max_chunk_size,
-                       MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                       std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
   virtual ~ChunkedBinaryBuilder() = default;
 

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -44,7 +44,7 @@ namespace arrow {
 // Decimal128Builder
 
 Decimal128Builder::Decimal128Builder(const std::shared_ptr<DataType>& type,
-                                     MemoryPool* pool)
+                                     std::shared_ptr<MemoryPool> pool)
     : FixedSizeBinaryBuilder(type, pool) {}
 
 Status Decimal128Builder::Append(const Decimal128& value) {

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -29,7 +29,7 @@ class Decimal128;
 class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
  public:
   explicit Decimal128Builder(const std::shared_ptr<DataType>& type,
-                             MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                             std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
   using FixedSizeBinaryBuilder::Append;
   using FixedSizeBinaryBuilder::AppendValues;

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -43,7 +43,7 @@ using internal::checked_cast;
 // DictionaryType unification
 
 struct UnifyDictionaryValues {
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool>& pool_;
   std::shared_ptr<DataType> value_type_;
   const std::vector<const DictionaryType*>& types_;
   std::shared_ptr<Array>* out_values_;
@@ -95,7 +95,7 @@ struct UnifyDictionaryValues {
   }
 };
 
-Status DictionaryType::Unify(MemoryPool* pool, const std::vector<const DataType*>& types,
+Status DictionaryType::Unify(std::shared_ptr<MemoryPool>& pool, const std::vector<const DataType*>& types,
                              std::shared_ptr<DataType>* out_type,
                              std::vector<std::vector<int32_t>>* out_transpose_maps) {
   if (types.size() == 0) {
@@ -160,7 +160,7 @@ DictionaryBuilder<T>::~DictionaryBuilder() {}
 
 template <typename T>
 DictionaryBuilder<T>::DictionaryBuilder(const std::shared_ptr<DataType>& type,
-                                        MemoryPool* pool)
+                                        std::shared_ptr<MemoryPool>& pool)
     : ArrayBuilder(type, pool),
       memo_table_(new MemoTableImpl(0)),
       delta_offset_(0),
@@ -170,14 +170,14 @@ DictionaryBuilder<T>::DictionaryBuilder(const std::shared_ptr<DataType>& type,
 }
 
 DictionaryBuilder<NullType>::DictionaryBuilder(const std::shared_ptr<DataType>& type,
-                                               MemoryPool* pool)
+                                               std::shared_ptr<MemoryPool>& pool)
     : ArrayBuilder(type, pool), values_builder_(pool) {
   DCHECK_EQ(Type::NA, type->id()) << "inconsistent type passed to DictionaryBuilder";
 }
 
 template <>
 DictionaryBuilder<FixedSizeBinaryType>::DictionaryBuilder(
-    const std::shared_ptr<DataType>& type, MemoryPool* pool)
+    const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool)
     : ArrayBuilder(type, pool),
       memo_table_(new MemoTableImpl(0)),
       delta_offset_(0),

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -66,11 +66,11 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
 
   // WARNING: the type given below is the value type, not the DictionaryType.
   // The DictionaryType is instantiated on the Finish() call.
-  DictionaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
+  DictionaryBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool);
 
   template <typename T1 = T>
   explicit DictionaryBuilder(
-      typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type pool)
+      typename std::enable_if<TypeTraits<T1>::is_parameter_free, std::shared_ptr<MemoryPool>&>::type pool)
       : DictionaryBuilder<T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
   ~DictionaryBuilder() override;
@@ -119,8 +119,8 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
 template <>
 class ARROW_EXPORT DictionaryBuilder<NullType> : public ArrayBuilder {
  public:
-  DictionaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
-  explicit DictionaryBuilder(MemoryPool* pool);
+  DictionaryBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool);
+  explicit DictionaryBuilder(std::shared_ptr<MemoryPool>& pool);
 
   /// \brief Append a scalar null value
   Status AppendNull();

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -39,7 +39,7 @@ namespace arrow {
 // ----------------------------------------------------------------------
 // ListBuilder
 
-ListBuilder::ListBuilder(MemoryPool* pool,
+ListBuilder::ListBuilder(std::shared_ptr<MemoryPool>& pool,
                          std::shared_ptr<ArrayBuilder> const& value_builder,
                          const std::shared_ptr<DataType>& type)
     : ArrayBuilder(type ? type
@@ -128,7 +128,7 @@ ArrayBuilder* ListBuilder::value_builder() const {
 // ----------------------------------------------------------------------
 // Struct
 
-StructBuilder::StructBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool,
+StructBuilder::StructBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool,
                              std::vector<std::shared_ptr<ArrayBuilder>>&& field_builders)
     : ArrayBuilder(type, pool) {
   children_ = std::move(field_builders);

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -45,7 +45,7 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
  public:
   /// Use this constructor to incrementally build the value array along with offsets and
   /// null bitmap.
-  ListBuilder(MemoryPool* pool, std::shared_ptr<ArrayBuilder> const& value_builder,
+  ListBuilder(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<ArrayBuilder> const& value_builder,
               const std::shared_ptr<DataType>& type = NULLPTR);
 
   Status Resize(int64_t capacity) override;
@@ -87,7 +87,7 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
 /// called to maintain data-structure consistency.
 class ARROW_EXPORT StructBuilder : public ArrayBuilder {
  public:
-  StructBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool,
+  StructBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool,
                 std::vector<std::shared_ptr<ArrayBuilder>>&& field_builders);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;

--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -45,10 +45,10 @@ Status NullBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-BooleanBuilder::BooleanBuilder(MemoryPool* pool)
+BooleanBuilder::BooleanBuilder(std::shared_ptr<MemoryPool> pool)
     : ArrayBuilder(boolean(), pool), data_builder_(pool) {}
 
-BooleanBuilder::BooleanBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
+BooleanBuilder::BooleanBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool)
     : BooleanBuilder(pool) {
   DCHECK_EQ(Type::BOOL, type->id());
 }

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -29,7 +29,7 @@ namespace arrow {
 
 class ARROW_EXPORT NullBuilder : public ArrayBuilder {
  public:
-  explicit NullBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit NullBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(null(), pool) {}
 
   Status AppendNull() {
@@ -52,7 +52,7 @@ class NumericBuilder : public ArrayBuilder {
 
   template <typename T1 = T>
   explicit NumericBuilder(
-      typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type pool
+      typename std::enable_if<TypeTraits<T1>::is_parameter_free, std::shared_ptr<MemoryPool>>::type pool
           ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(TypeTraits<T1>::type_singleton(), pool) {}
 
@@ -247,9 +247,9 @@ using DoubleBuilder = NumericBuilder<DoubleType>;
 class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
  public:
   using value_type = bool;
-  explicit BooleanBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit BooleanBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
 
-  explicit BooleanBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
+  explicit BooleanBuilder(const std::shared_ptr<DataType>& type, std::shared_ptr<MemoryPool>& pool);
 
   /// Write nulls as uint8_t* (0 value indicates null) into pre-allocated memory
   Status AppendNulls(int64_t length) {

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -23,7 +23,7 @@
 
 namespace arrow {
 
-DenseUnionBuilder::DenseUnionBuilder(MemoryPool* pool,
+DenseUnionBuilder::DenseUnionBuilder(std::shared_ptr<MemoryPool>& pool,
                                      const std::shared_ptr<DataType>& type)
     : ArrayBuilder(type, pool), types_builder_(pool), offsets_builder_(pool) {}
 

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -44,7 +44,7 @@ class ARROW_EXPORT DenseUnionBuilder : public ArrayBuilder {
  public:
   /// Use this constructor to incrementally build the union array along
   /// with types, offsets, and null bitmap.
-  explicit DenseUnionBuilder(MemoryPool* pool,
+  explicit DenseUnionBuilder(std::shared_ptr<MemoryPool>& pool,
                              const std::shared_ptr<DataType>& type = NULLPTR);
 
   Status AppendNull() {

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -42,7 +42,7 @@ namespace arrow {
 /// data
 class ARROW_EXPORT BufferBuilder {
  public:
-  explicit BufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit BufferBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT)
       : pool_(pool), data_(NULLPTR), capacity_(0), size_(0) {}
 
   /// \brief Resize the buffer to the nearest multiple of 64 bytes
@@ -174,7 +174,7 @@ class ARROW_EXPORT BufferBuilder {
 
  private:
   std::shared_ptr<ResizableBuffer> buffer_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   uint8_t* data_;
   int64_t capacity_;
   int64_t size_;
@@ -187,7 +187,7 @@ class TypedBufferBuilder;
 template <typename T>
 class TypedBufferBuilder<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
  public:
-  explicit TypedBufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit TypedBufferBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT)
       : bytes_builder_(pool) {}
 
   Status Append(T value) {
@@ -262,7 +262,7 @@ class TypedBufferBuilder<T, typename std::enable_if<std::is_arithmetic<T>::value
 template <>
 class TypedBufferBuilder<bool> {
  public:
-  explicit TypedBufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit TypedBufferBuilder(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT)
       : bytes_builder_(pool) {}
 
   Status Append(bool value) {

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -96,7 +96,7 @@ class ARROW_EXPORT Buffer {
   bool Equals(const Buffer& other) const;
 
   /// Copy a section of the buffer into a new Buffer.
-  Status Copy(const int64_t start, const int64_t nbytes, MemoryPool* pool,
+  Status Copy(const int64_t start, const int64_t nbytes, std::shared_ptr<MemoryPool>& pool,
               std::shared_ptr<Buffer>* out) const;
 
   /// Copy a section of the buffer using the default memory pool into a new Buffer.
@@ -121,7 +121,7 @@ class ARROW_EXPORT Buffer {
   /// \param[out] out the created buffer
   ///
   /// \return Status message
-  static Status FromString(const std::string& data, MemoryPool* pool,
+  static Status FromString(const std::string& data, std::shared_ptr<MemoryPool>& pool,
                            std::shared_ptr<Buffer>* out);
 
   /// \brief Construct a new buffer that owns its memory from a std::string
@@ -301,7 +301,7 @@ class ARROW_EXPORT ResizableBuffer : public MutableBuffer {
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::shared_ptr<Buffer>* out);
+Status AllocateBuffer(std::shared_ptr<MemoryPool>& pool, const int64_t size, std::shared_ptr<Buffer>* out);
 
 /// \brief Allocate a fixed size mutable buffer from a memory pool, zero its padding.
 ///
@@ -311,7 +311,7 @@ Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::shared_ptr<Buff
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateBuffer(MemoryPool* pool, const int64_t size, std::unique_ptr<Buffer>* out);
+Status AllocateBuffer(std::shared_ptr<MemoryPool>& pool, const int64_t size, std::unique_ptr<Buffer>* out);
 
 /// \brief Allocate a fixed-size mutable buffer from the default memory pool
 ///
@@ -339,7 +339,7 @@ Status AllocateBuffer(const int64_t size, std::unique_ptr<Buffer>* out);
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
+Status AllocateResizableBuffer(std::shared_ptr<MemoryPool>& pool, const int64_t size,
                                std::shared_ptr<ResizableBuffer>* out);
 
 /// \brief Allocate a resizeable buffer from a memory pool, zero its padding.
@@ -350,7 +350,7 @@ Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateResizableBuffer(MemoryPool* pool, const int64_t size,
+Status AllocateResizableBuffer(std::shared_ptr<MemoryPool>& pool, const int64_t size,
                                std::unique_ptr<ResizableBuffer>* out);
 
 /// \brief Allocate a resizeable buffer from the default memory pool
@@ -380,7 +380,7 @@ Status AllocateResizableBuffer(const int64_t size, std::unique_ptr<ResizableBuff
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>* out);
+Status AllocateBitmap(std::shared_ptr<MemoryPool>& pool, int64_t length, std::shared_ptr<Buffer>* out);
 
 /// \brief Allocate a zero-initialized bitmap buffer from a memory pool
 ///
@@ -390,7 +390,7 @@ Status AllocateBitmap(MemoryPool* pool, int64_t length, std::shared_ptr<Buffer>*
 ///
 /// \return Status message
 ARROW_EXPORT
-Status AllocateEmptyBitmap(MemoryPool* pool, int64_t length,
+Status AllocateEmptyBitmap(std::shared_ptr<MemoryPool>& pool, int64_t length,
                            std::shared_ptr<Buffer>* out);
 
 /// \brief Allocate a zero-initialized bitmap buffer from the default memory pool

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -316,8 +316,9 @@ template <class DictionaryBuilderType, class Scalar>
 static void BenchmarkScalarDictionaryArray(
     benchmark::State& state,  // NOLINT non-const reference
     const std::vector<Scalar>& fodder) {
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   while (state.KeepRunning()) {
-    DictionaryBuilder<Int64Type> builder(default_memory_pool());
+    DictionaryBuilder<Int64Type> builder(pool);
     for (const auto value : fodder) {
       ABORT_NOT_OK(builder.Append(value));
     }
@@ -352,9 +353,9 @@ static void BM_BuildStringDictionaryArray(
   auto fodder_size =
       std::accumulate(fodder.begin(), fodder.end(), static_cast<size_t>(0),
                       [&](size_t acc, const std::string& s) { return acc + s.size(); });
-
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   while (state.KeepRunning()) {
-    BinaryDictionaryBuilder builder(default_memory_pool());
+    BinaryDictionaryBuilder builder(pool);
     for (const auto& value : fodder) {
       ABORT_NOT_OK(builder.Append(value));
     }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -42,7 +42,7 @@ class MemoryPool;
 // difficult
 //
 // TODO(wesm): come up with a less monolithic strategy
-Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+Status MakeBuilder(std::shared_ptr<MemoryPool> pool, const std::shared_ptr<DataType>& type,
                    std::unique_ptr<ArrayBuilder>* out) {
   switch (type->id()) {
     case Type::NA: {

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -35,7 +35,7 @@ class DataType;
 class MemoryPool;
 
 ARROW_EXPORT
-Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+Status MakeBuilder(std::shared_ptr<MemoryPool> pool, const std::shared_ptr<DataType>& type,
                    std::unique_ptr<ArrayBuilder>* out);
 
 }  // namespace arrow

--- a/cpp/src/arrow/compute/context.cc
+++ b/cpp/src/arrow/compute/context.cc
@@ -25,10 +25,10 @@
 namespace arrow {
 namespace compute {
 
-FunctionContext::FunctionContext(MemoryPool* pool)
+FunctionContext::FunctionContext(std::shared_ptr<MemoryPool> pool)
     : pool_(pool), cpu_info_(internal::CpuInfo::GetInstance()) {}
 
-MemoryPool* FunctionContext::memory_pool() const { return pool_; }
+std::shared_ptr<MemoryPool> FunctionContext::memory_pool() const { return pool_; }
 
 Status FunctionContext::Allocate(const int64_t nbytes, std::shared_ptr<Buffer>* out) {
   return AllocateBuffer(pool_, nbytes, out);

--- a/cpp/src/arrow/compute/context.h
+++ b/cpp/src/arrow/compute/context.h
@@ -46,8 +46,8 @@ namespace compute {
 /// \brief Container for variables and options used by function evaluation
 class ARROW_EXPORT FunctionContext {
  public:
-  explicit FunctionContext(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
-  MemoryPool* memory_pool() const;
+  explicit FunctionContext(std::shared_ptr<MemoryPool> pool ARROW_MEMORY_POOL_DEFAULT);
+  std::shared_ptr<MemoryPool> memory_pool() const;
 
   /// \brief Allocate buffer from the context's memory pool
   Status Allocate(const int64_t nbytes, std::shared_ptr<Buffer>* out);
@@ -72,7 +72,7 @@ class ARROW_EXPORT FunctionContext {
 
  private:
   Status status_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   internal::CpuInfo* cpu_info_;
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate.cc
@@ -37,7 +37,7 @@ class ManagedAggregateState {
   void* mutable_data() { return state_->mutable_data(); }
 
   static std::shared_ptr<ManagedAggregateState> Make(
-      std::shared_ptr<AggregateFunction>& desc, MemoryPool* pool) {
+      std::shared_ptr<AggregateFunction>& desc, std::shared_ptr<MemoryPool>& pool) {
     std::shared_ptr<Buffer> buf;
     if (!AllocateBuffer(pool, desc->Size(), &buf).ok()) return nullptr;
 
@@ -51,8 +51,8 @@ class ManagedAggregateState {
 
 Status AggregateUnaryKernel::Call(FunctionContext* ctx, const Datum& input, Datum* out) {
   if (!input.is_array()) return Status::Invalid("AggregateKernel expects Array datum");
-
-  auto state = ManagedAggregateState::Make(aggregate_function_, ctx->memory_pool());
+  std::shared_ptr<MemoryPool> pool = ctx->memory_pool();
+  auto state = ManagedAggregateState::Make(aggregate_function_, pool);
   if (!state) return Status::OutOfMemory("AggregateState allocation failed");
 
   auto array = input.make_array();

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -766,7 +766,8 @@ Status UnpackBinaryDictionary(FunctionContext* ctx, const Array& indices,
                               const BinaryArray& dictionary, ArrayData* output) {
   using index_c_type = typename IndexType::c_type;
   std::unique_ptr<ArrayBuilder> builder;
-  RETURN_NOT_OK(MakeBuilder(ctx->memory_pool(), output->type, &builder));
+  std::shared_ptr<MemoryPool> pool = ctx->memory_pool();
+  RETURN_NOT_OK(MakeBuilder(pool, output->type, &builder));
   BinaryBuilder* binary_builder = checked_cast<BinaryBuilder*>(builder.get());
 
   const index_c_type* in = indices.data()->GetValues<index_c_type>(1);

--- a/cpp/src/arrow/compute/kernels/util-internal.cc
+++ b/cpp/src/arrow/compute/kernels/util-internal.cc
@@ -244,7 +244,8 @@ Status AssignNullIntersection(FunctionContext* ctx, const ArrayData& left,
   }
 
   if (left.GetNullCount() > 0 && right.GetNullCount() > 0) {
-    RETURN_NOT_OK(BitmapAnd(ctx->memory_pool(), left.buffers[0]->data(), left.offset,
+    std::shared_ptr<MemoryPool> pool = ctx->memory_pool();
+    RETURN_NOT_OK(BitmapAnd(pool, left.buffers[0]->data(), left.offset,
                             right.buffers[0]->data(), right.offset, right.length, 0,
                             &(output->buffers[0])));
     // Force computation of null count.

--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -284,11 +284,11 @@ class TimestampConverter : public ConcreteConverter {
 // Base Converter class implementation
 
 Converter::Converter(const std::shared_ptr<DataType>& type, const ConvertOptions& options,
-                     MemoryPool* pool)
+                     std::shared_ptr<MemoryPool>& pool)
     : options_(options), pool_(pool), type_(type) {}
 
 Status Converter::Make(const std::shared_ptr<DataType>& type,
-                       const ConvertOptions& options, MemoryPool* pool,
+                       const ConvertOptions& options, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<Converter>* out) {
   Converter* result;
 
@@ -335,7 +335,8 @@ Status Converter::Make(const std::shared_ptr<DataType>& type,
 
 Status Converter::Make(const std::shared_ptr<DataType>& type,
                        const ConvertOptions& options, std::shared_ptr<Converter>* out) {
-  return Make(type, options, default_memory_pool(), out);
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  return Make(type, options, pool, out);
 }
 
 }  // namespace csv

--- a/cpp/src/arrow/csv/converter.h
+++ b/cpp/src/arrow/csv/converter.h
@@ -39,7 +39,7 @@ class BlockParser;
 class ARROW_EXPORT Converter {
  public:
   Converter(const std::shared_ptr<DataType>& type, const ConvertOptions& options,
-            MemoryPool* pool);
+            std::shared_ptr<MemoryPool>& pool);
   virtual ~Converter() = default;
 
   virtual Status Convert(const BlockParser& parser, int32_t col_index,
@@ -50,7 +50,7 @@ class ARROW_EXPORT Converter {
   static Status Make(const std::shared_ptr<DataType>& type, const ConvertOptions& options,
                      std::shared_ptr<Converter>* out);
   static Status Make(const std::shared_ptr<DataType>& type, const ConvertOptions& options,
-                     MemoryPool* pool, std::shared_ptr<Converter>* out);
+                     std::shared_ptr<MemoryPool>& pool, std::shared_ptr<Converter>* out);
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Converter);
@@ -58,7 +58,7 @@ class ARROW_EXPORT Converter {
   virtual Status Initialize() = 0;
 
   const ConvertOptions options_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<DataType> type_;
 };
 

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -52,7 +52,7 @@ class SpecializedOptions {
 // without any further resizes, except at the end.
 class BlockParser::PresizedParsedWriter {
  public:
-  PresizedParsedWriter(MemoryPool* pool, uint32_t size)
+  PresizedParsedWriter(std::shared_ptr<MemoryPool>& pool, uint32_t size)
       : parsed_size_(0), parsed_capacity_(size) {
     ARROW_CHECK_OK(AllocateResizableBuffer(pool, parsed_capacity_, &parsed_buffer_));
     parsed_ = parsed_buffer_->mutable_data();
@@ -89,7 +89,7 @@ class BlockParser::PresizedParsedWriter {
 // efficiently presize the target area for a given number of rows.
 class BlockParser::ResizableValuesWriter {
  public:
-  explicit ResizableValuesWriter(MemoryPool* pool)
+  explicit ResizableValuesWriter(std::shared_ptr<MemoryPool>& pool)
       : values_size_(0), values_capacity_(256) {
     ARROW_CHECK_OK(AllocateResizableBuffer(pool, values_capacity_ * sizeof(*values_),
                                            &values_buffer_));
@@ -143,7 +143,7 @@ class BlockParser::ResizableValuesWriter {
 // faster CSV parsing code.
 class BlockParser::PresizedValuesWriter {
  public:
-  PresizedValuesWriter(MemoryPool* pool, int32_t num_rows, int32_t num_cols)
+  PresizedValuesWriter(std::shared_ptr<MemoryPool>& pool, int32_t num_rows, int32_t num_cols)
       : values_size_(0), values_capacity_(1 + num_rows * num_cols) {
     ARROW_CHECK_OK(AllocateResizableBuffer(pool, values_capacity_ * sizeof(*values_),
                                            &values_buffer_));
@@ -472,7 +472,7 @@ Status BlockParser::ParseFinal(const char* data, uint32_t size, uint32_t* out_si
   return DoParse(data, size, true /* is_final */, out_size);
 }
 
-BlockParser::BlockParser(MemoryPool* pool, ParseOptions options, int32_t num_cols,
+BlockParser::BlockParser(std::shared_ptr<MemoryPool> pool, ParseOptions options, int32_t num_cols,
                          int32_t max_num_rows)
     : pool_(pool), options_(options), num_cols_(num_cols), max_num_rows_(max_num_rows) {}
 

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -53,7 +53,7 @@ class ARROW_EXPORT BlockParser {
  public:
   explicit BlockParser(ParseOptions options, int32_t num_cols = -1,
                        int32_t max_num_rows = kMaxParserNumRows);
-  explicit BlockParser(MemoryPool* pool, ParseOptions options, int32_t num_cols = -1,
+  explicit BlockParser(std::shared_ptr<MemoryPool> pool, ParseOptions options, int32_t num_cols = -1,
                        int32_t max_num_rows = kMaxParserNumRows);
 
   /// \brief Parse a block of data
@@ -115,7 +115,7 @@ class ARROW_EXPORT BlockParser {
                    const char* data, const char* data_end, bool is_final,
                    const char** out_data);
 
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   const ParseOptions options_;
   // The number of rows parsed from the block
   int32_t num_rows_;

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -66,7 +66,7 @@ static constexpr int64_t kDefaultRightPadding = 16;
 
 class BaseTableReader : public csv::TableReader {
  public:
-  BaseTableReader(MemoryPool* pool, const ReadOptions& read_options,
+  BaseTableReader(std::shared_ptr<MemoryPool>& pool, const ReadOptions& read_options,
                   const ParseOptions& parse_options,
                   const ConvertOptions& convert_options)
       : pool_(pool),
@@ -208,7 +208,7 @@ class BaseTableReader : public csv::TableReader {
     return Status::OK();
   }
 
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   ReadOptions read_options_;
   ParseOptions parse_options_;
   ConvertOptions convert_options_;
@@ -238,7 +238,7 @@ class BaseTableReader : public csv::TableReader {
 
 class SerialTableReader : public BaseTableReader {
  public:
-  SerialTableReader(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+  SerialTableReader(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<io::InputStream> input,
                     const ReadOptions& read_options, const ParseOptions& parse_options,
                     const ConvertOptions& convert_options)
       : BaseTableReader(pool, read_options, parse_options, convert_options) {
@@ -302,7 +302,7 @@ class SerialTableReader : public BaseTableReader {
 
 class ThreadedTableReader : public BaseTableReader {
  public:
-  ThreadedTableReader(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+  ThreadedTableReader(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<io::InputStream> input,
                       ThreadPool* thread_pool, const ReadOptions& read_options,
                       const ParseOptions& parse_options,
                       const ConvertOptions& convert_options)
@@ -403,7 +403,7 @@ class ThreadedTableReader : public BaseTableReader {
 /////////////////////////////////////////////////////////////////////////
 // TableReader factory function
 
-Status TableReader::Make(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+Status TableReader::Make(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<io::InputStream> input,
                          const ReadOptions& read_options,
                          const ParseOptions& parse_options,
                          const ConvertOptions& convert_options,

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -42,7 +42,7 @@ class ARROW_EXPORT TableReader {
   virtual Status Read(std::shared_ptr<Table>* out) = 0;
 
   // XXX pass optional schema?
-  static Status Make(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+  static Status Make(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<io::InputStream> input,
                      const ReadOptions&, const ParseOptions&, const ConvertOptions&,
                      std::shared_ptr<TableReader>* out);
 };

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -115,7 +115,7 @@ class FlightPutWriter::FlightPutWriterImpl : public ipc::RecordBatchWriter {
   explicit FlightPutWriterImpl(std::unique_ptr<ClientRpc> rpc,
                                const FlightDescriptor& descriptor,
                                const std::shared_ptr<Schema>& schema,
-                               MemoryPool* pool = default_memory_pool())
+                               std::shared_ptr<MemoryPool> pool = default_memory_pool())
       : rpc_(std::move(rpc)), descriptor_(descriptor), schema_(schema), pool_(pool) {}
 
   Status WriteRecordBatch(const RecordBatch& batch, bool allow_64bit = false) override {
@@ -150,7 +150,7 @@ class FlightPutWriter::FlightPutWriterImpl : public ipc::RecordBatchWriter {
     return Status::OK();
   }
 
-  void set_memory_pool(MemoryPool* pool) override { pool_ = pool; }
+  void set_memory_pool(std::shared_ptr<MemoryPool>& pool) override { pool_ = pool; }
 
  private:
   /// \brief Set the gRPC writer backing this Flight stream.
@@ -165,7 +165,7 @@ class FlightPutWriter::FlightPutWriterImpl : public ipc::RecordBatchWriter {
   FlightDescriptor descriptor_;
   std::shared_ptr<Schema> schema_;
   std::unique_ptr<grpc::ClientWriter<pb::FlightData>> writer_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
 
   // We need to reference some fields
   friend class FlightClient;
@@ -183,7 +183,7 @@ Status FlightPutWriter::WriteRecordBatch(const RecordBatch& batch, bool allow_64
 
 Status FlightPutWriter::Close() { return impl_->Close(); }
 
-void FlightPutWriter::set_memory_pool(MemoryPool* pool) {
+void FlightPutWriter::set_memory_pool(std::shared_ptr<MemoryPool>& pool) {
   return impl_->set_memory_pool(pool);
 }
 

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -119,7 +119,7 @@ class ARROW_EXPORT FlightPutWriter : public ipc::RecordBatchWriter {
 
   Status WriteRecordBatch(const RecordBatch& batch, bool allow_64bit = false) override;
   Status Close() override;
-  void set_memory_pool(MemoryPool* pool) override;
+  void set_memory_pool(std::shared_ptr<MemoryPool>& pool) override;
 
  private:
   class FlightPutWriterImpl;

--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -221,7 +221,8 @@ Status FromProto(const pb::FlightGetInfo& pb_info, FlightInfo::Data* info) {
 Status SchemaToString(const Schema& schema, std::string* out) {
   // TODO(wesm): Do we care about better memory efficiency here?
   std::shared_ptr<Buffer> serialized_schema;
-  RETURN_NOT_OK(ipc::SerializeSchema(schema, default_memory_pool(), &serialized_schema));
+  auto pool = default_memory_pool();
+  RETURN_NOT_OK(ipc::SerializeSchema(schema, pool, &serialized_schema));
   *out = std::string(reinterpret_cast<const char*>(serialized_schema->data()),
                      static_cast<size_t>(serialized_schema->size()));
   return Status::OK();

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -200,7 +200,7 @@ class FlightServiceImpl : public FlightService::Service {
 
     // Write the schema as the first message in the stream
     FlightPayload schema_payload;
-    MemoryPool* pool = default_memory_pool();
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
     ipc::DictionaryMemo dictionary_memo;
     GRPC_RETURN_NOT_OK(ipc::internal::GetSchemaPayload(
         *data_stream->schema(), pool, &dictionary_memo, &schema_payload.ipc_message));

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -61,7 +61,7 @@ class ARROW_EXPORT RecordBatchStream : public FlightDataStream {
   Status Next(FlightPayload* payload) override;
 
  private:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<RecordBatchReader> reader_;
 };
 

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -315,7 +315,7 @@ class TestCudaArrowIpc : public TestCudaBufferBase {
   }
 
  protected:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
 };
 
 TEST_F(TestCudaArrowIpc, BasicWriteRead) {

--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
@@ -60,7 +60,7 @@ Status SerializeRecordBatch(const RecordBatch& batch, CudaContext* ctx,
   return Status::OK();
 }
 
-Status ReadMessage(CudaBufferReader* reader, MemoryPool* pool,
+Status ReadMessage(CudaBufferReader* reader, std::shared_ptr<MemoryPool>& pool,
                    std::unique_ptr<ipc::Message>* out) {
   int32_t message_length = 0;
   int64_t bytes_read = 0;
@@ -90,7 +90,7 @@ Status ReadMessage(CudaBufferReader* reader, MemoryPool* pool,
 }
 
 Status ReadRecordBatch(const std::shared_ptr<Schema>& schema,
-                       const std::shared_ptr<CudaBuffer>& buffer, MemoryPool* pool,
+                       const std::shared_ptr<CudaBuffer>& buffer, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<RecordBatch>* out) {
   CudaBufferReader cuda_reader(buffer);
 

--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.h
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.h
@@ -58,7 +58,7 @@ Status SerializeRecordBatch(const RecordBatch& batch, CudaContext* ctx,
 /// This function reads the message metadata into host memory, but leaves the
 /// message body on the device
 ARROW_EXPORT
-Status ReadMessage(CudaBufferReader* reader, MemoryPool* pool,
+Status ReadMessage(CudaBufferReader* reader, std::shared_ptr<MemoryPool>& pool,
                    std::unique_ptr<ipc::Message>* message);
 
 /// \brief ReadRecordBatch specialized to handle metadata on CUDA device
@@ -68,7 +68,7 @@ Status ReadMessage(CudaBufferReader* reader, MemoryPool* pool,
 /// \param[out] out the reconstructed RecordBatch, with device pointers
 ARROW_EXPORT
 Status ReadRecordBatch(const std::shared_ptr<Schema>& schema,
-                       const std::shared_ptr<CudaBuffer>& buffer, MemoryPool* pool,
+                       const std::shared_ptr<CudaBuffer>& buffer, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<RecordBatch>* out);
 
 }  // namespace cuda

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -71,7 +71,7 @@ Status CudaIpcMemHandle::FromBuffer(const void* opaque_handle,
   return Status::OK();
 }
 
-Status CudaIpcMemHandle::Serialize(MemoryPool* pool, std::shared_ptr<Buffer>* out) const {
+Status CudaIpcMemHandle::Serialize(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<Buffer>* out) const {
   std::shared_ptr<Buffer> buffer;
   int64_t size = impl_->memory_size;
   size_t kHandleSize =

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -132,7 +132,7 @@ class ARROW_EXPORT CudaIpcMemHandle {
   /// \param[in] pool a MemoryPool to allocate memory from
   /// \param[out] out the serialized buffer
   /// \return Status
-  Status Serialize(MemoryPool* pool, std::shared_ptr<Buffer>* out) const;
+  Status Serialize(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<Buffer>* out) const;
 
  private:
   explicit CudaIpcMemHandle(const void* handle);

--- a/cpp/src/arrow/io/buffered-test.cc
+++ b/cpp/src/arrow/io/buffered-test.cc
@@ -96,6 +96,7 @@ class TestBufferedOutputStream : public FileTestFixture<BufferedOutputStream> {
 
     std::shared_ptr<FileOutputStream> file;
     ASSERT_OK(FileOutputStream::Open(path_, append, &file));
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
     fd_ = file->file_descriptor();
     if (append) {
       // Workaround for ARROW-2466 ("append" flag doesn't set file pos)
@@ -105,7 +106,7 @@ class TestBufferedOutputStream : public FileTestFixture<BufferedOutputStream> {
       lseek(fd_, 0, SEEK_END);
 #endif
     }
-    ASSERT_OK(BufferedOutputStream::Create(buffer_size, default_memory_pool(), file,
+    ASSERT_OK(BufferedOutputStream::Create(buffer_size, pool, file,
                                            &buffered_));
   }
 
@@ -311,7 +312,7 @@ class TestBufferedInputStream : public FileTestFixture<BufferedInputStream> {
     local_pool_ = MemoryPool::CreateDefault();
   }
 
-  void MakeExample1(int64_t buffer_size, MemoryPool* pool = default_memory_pool()) {
+  void MakeExample1(int64_t buffer_size, std::shared_ptr<MemoryPool> pool = default_memory_pool()) {
     test_data_ = kExample1;
 
     std::shared_ptr<FileOutputStream> file_out;

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -37,7 +37,7 @@ namespace io {
 
 class BufferedBase {
  public:
-  explicit BufferedBase(MemoryPool* pool)
+  explicit BufferedBase(std::shared_ptr<MemoryPool>& pool)
       : pool_(pool),
         is_open_(true),
         buffer_data_(nullptr),
@@ -77,7 +77,7 @@ class BufferedBase {
   int64_t buffer_size() const { return buffer_size_; }
 
  protected:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   bool is_open_;
 
   std::shared_ptr<ResizableBuffer> buffer_;
@@ -91,7 +91,7 @@ class BufferedBase {
 
 class BufferedOutputStream::Impl : public BufferedBase {
  public:
-  explicit Impl(std::shared_ptr<OutputStream> raw, MemoryPool* pool)
+  explicit Impl(std::shared_ptr<OutputStream> raw, std::shared_ptr<MemoryPool>& pool)
       : BufferedBase(pool), raw_(std::move(raw)) {}
 
   Status Close() {
@@ -174,11 +174,11 @@ class BufferedOutputStream::Impl : public BufferedBase {
 };
 
 BufferedOutputStream::BufferedOutputStream(std::shared_ptr<OutputStream> raw,
-                                           MemoryPool* pool) {
+                                           std::shared_ptr<MemoryPool>& pool) {
   impl_.reset(new Impl(std::move(raw), pool));
 }
 
-Status BufferedOutputStream::Create(int64_t buffer_size, MemoryPool* pool,
+Status BufferedOutputStream::Create(int64_t buffer_size, std::shared_ptr<MemoryPool>& pool,
                                     std::shared_ptr<OutputStream> raw,
                                     std::shared_ptr<BufferedOutputStream>* out) {
   auto result = std::shared_ptr<BufferedOutputStream>(
@@ -221,7 +221,7 @@ std::shared_ptr<OutputStream> BufferedOutputStream::raw() const { return impl_->
 
 class BufferedInputStream::Impl : public BufferedBase {
  public:
-  Impl(std::shared_ptr<InputStream> raw, MemoryPool* pool)
+  Impl(std::shared_ptr<InputStream> raw, std::shared_ptr<MemoryPool>& pool)
       : BufferedBase(pool), raw_(std::move(raw)), bytes_buffered_(0) {}
 
   ~Impl() { DCHECK_OK(Close()); }
@@ -351,13 +351,13 @@ class BufferedInputStream::Impl : public BufferedBase {
 };
 
 BufferedInputStream::BufferedInputStream(std::shared_ptr<InputStream> raw,
-                                         MemoryPool* pool) {
+                                         std::shared_ptr<MemoryPool>& pool) {
   impl_.reset(new Impl(std::move(raw), pool));
 }
 
 BufferedInputStream::~BufferedInputStream() { DCHECK_OK(impl_->Close()); }
 
-Status BufferedInputStream::Create(int64_t buffer_size, MemoryPool* pool,
+Status BufferedInputStream::Create(int64_t buffer_size, std::shared_ptr<MemoryPool>& pool,
                                    std::shared_ptr<InputStream> raw,
                                    std::shared_ptr<BufferedInputStream>* out) {
   auto result =

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -45,7 +45,7 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   /// \param[in] raw another OutputStream
   /// \param[out] out the created BufferedOutputStream
   /// \return Status
-  static Status Create(int64_t buffer_size, MemoryPool* pool,
+  static Status Create(int64_t buffer_size, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<OutputStream> raw,
                        std::shared_ptr<BufferedOutputStream>* out);
 
@@ -80,7 +80,7 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   std::shared_ptr<OutputStream> raw() const;
 
  private:
-  explicit BufferedOutputStream(std::shared_ptr<OutputStream> raw, MemoryPool* pool);
+  explicit BufferedOutputStream(std::shared_ptr<OutputStream> raw, std::shared_ptr<MemoryPool>& pool);
 
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;
@@ -99,7 +99,7 @@ class ARROW_EXPORT BufferedInputStream : public InputStream {
   /// \param[in] pool a MemoryPool to use for allocations
   /// \param[in] raw a raw InputStream
   /// \param[out] out the created BufferedInputStream
-  static Status Create(int64_t buffer_size, MemoryPool* pool,
+  static Status Create(int64_t buffer_size, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<InputStream> raw,
                        std::shared_ptr<BufferedInputStream>* out);
 
@@ -138,7 +138,7 @@ class ARROW_EXPORT BufferedInputStream : public InputStream {
   Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
  private:
-  explicit BufferedInputStream(std::shared_ptr<InputStream> raw, MemoryPool* pool);
+  explicit BufferedInputStream(std::shared_ptr<InputStream> raw, std::shared_ptr<MemoryPool>& pool);
 
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;

--- a/cpp/src/arrow/io/compressed-test.cc
+++ b/cpp/src/arrow/io/compressed-test.cc
@@ -116,7 +116,8 @@ void CheckCompressedOutputStream(Codec* codec, const std::vector<uint8_t>& data,
                                  bool do_flush) {
   // Create compressed output stream
   std::shared_ptr<BufferOutputStream> buffer_writer;
-  ASSERT_OK(BufferOutputStream::Create(1024, default_memory_pool(), &buffer_writer));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  ASSERT_OK(BufferOutputStream::Create(1024, pool, &buffer_writer));
   std::shared_ptr<CompressedOutputStream> stream;
   ASSERT_OK(CompressedOutputStream::Make(codec, buffer_writer, &stream));
 

--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -43,7 +43,7 @@ namespace io {
 
 class CompressedOutputStream::Impl {
  public:
-  Impl(MemoryPool* pool, Codec* codec, const std::shared_ptr<OutputStream>& raw)
+  Impl(std::shared_ptr<MemoryPool>& pool, Codec* codec, const std::shared_ptr<OutputStream>& raw)
       : pool_(pool), raw_(raw), codec_(codec), is_open_(true), compressed_pos_(0) {}
 
   ~Impl() { DCHECK(Close().ok()); }
@@ -178,7 +178,7 @@ class CompressedOutputStream::Impl {
   // Write 64 KB compressed data at a time
   static const int64_t kChunkSize = 64 * 1024;
 
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<OutputStream> raw_;
   Codec* codec_;
   bool is_open_;
@@ -192,10 +192,11 @@ class CompressedOutputStream::Impl {
 Status CompressedOutputStream::Make(util::Codec* codec,
                                     const std::shared_ptr<OutputStream>& raw,
                                     std::shared_ptr<CompressedOutputStream>* out) {
-  return Make(default_memory_pool(), codec, raw, out);
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  return Make(pool, codec, raw, out);
 }
 
-Status CompressedOutputStream::Make(MemoryPool* pool, util::Codec* codec,
+Status CompressedOutputStream::Make(std::shared_ptr<MemoryPool>& pool, util::Codec* codec,
                                     const std::shared_ptr<OutputStream>& raw,
                                     std::shared_ptr<CompressedOutputStream>* out) {
   std::shared_ptr<CompressedOutputStream> res(new CompressedOutputStream);
@@ -228,7 +229,7 @@ std::shared_ptr<OutputStream> CompressedOutputStream::raw() const { return impl_
 
 class CompressedInputStream::Impl {
  public:
-  Impl(MemoryPool* pool, Codec* codec, const std::shared_ptr<InputStream>& raw)
+  Impl(std::shared_ptr<MemoryPool>& pool, Codec* codec, const std::shared_ptr<InputStream>& raw)
       : pool_(pool), raw_(raw), codec_(codec), is_open_(true) {}
 
   Status Init() {
@@ -363,7 +364,7 @@ class CompressedInputStream::Impl {
   // Decompress 1 MB at a time
   static const int64_t kDecompressSize = 1024 * 1024;
 
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<InputStream> raw_;
   Codec* codec_;
   bool is_open_;
@@ -378,10 +379,11 @@ class CompressedInputStream::Impl {
 
 Status CompressedInputStream::Make(Codec* codec, const std::shared_ptr<InputStream>& raw,
                                    std::shared_ptr<CompressedInputStream>* out) {
-  return Make(default_memory_pool(), codec, raw, out);
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  return Make(pool, codec, raw, out);
 }
 
-Status CompressedInputStream::Make(MemoryPool* pool, Codec* codec,
+Status CompressedInputStream::Make(std::shared_ptr<MemoryPool>& pool, Codec* codec,
                                    const std::shared_ptr<InputStream>& raw,
                                    std::shared_ptr<CompressedInputStream>* out) {
   std::shared_ptr<CompressedInputStream> res(new CompressedInputStream);

--- a/cpp/src/arrow/io/compressed.h
+++ b/cpp/src/arrow/io/compressed.h
@@ -46,7 +46,7 @@ class ARROW_EXPORT CompressedOutputStream : public OutputStream {
   /// \brief Create a compressed output stream wrapping the given output stream.
   static Status Make(util::Codec* codec, const std::shared_ptr<OutputStream>& raw,
                      std::shared_ptr<CompressedOutputStream>* out);
-  static Status Make(MemoryPool* pool, util::Codec* codec,
+  static Status Make(std::shared_ptr<MemoryPool>& pool, util::Codec* codec,
                      const std::shared_ptr<OutputStream>& raw,
                      std::shared_ptr<CompressedOutputStream>* out);
 
@@ -81,7 +81,7 @@ class ARROW_EXPORT CompressedInputStream : public InputStream {
   /// \brief Create a compressed input stream wrapping the given input stream.
   static Status Make(util::Codec* codec, const std::shared_ptr<InputStream>& raw,
                      std::shared_ptr<CompressedInputStream>* out);
-  static Status Make(MemoryPool* pool, util::Codec* codec,
+  static Status Make(std::shared_ptr<MemoryPool>& pool, util::Codec* codec,
                      const std::shared_ptr<InputStream>& raw,
                      std::shared_ptr<CompressedInputStream>* out);
 

--- a/cpp/src/arrow/io/file-benchmark.cc
+++ b/cpp/src/arrow/io/file-benchmark.cc
@@ -169,7 +169,8 @@ static void BM_BufferedOutputStreamSmallWritesToNull(
   ABORT_NOT_OK(io::FileOutputStream::Open(GetNullFile(), &file));
 
   std::shared_ptr<io::BufferedOutputStream> buffered_file;
-  ABORT_NOT_OK(io::BufferedOutputStream::Create(kBufferSize, default_memory_pool(), file,
+  auto pool = default_memory_pool();
+  ABORT_NOT_OK(io::BufferedOutputStream::Create(kBufferSize, pool, file,
                                                 &buffered_file));
   BenchmarkStreamingWrites(state, small_sizes, buffered_file.get());
 }
@@ -203,7 +204,8 @@ static void BM_BufferedOutputStreamSmallWritesToPipe(
   SetupPipeWriter(&stream, &reader);
 
   std::shared_ptr<io::BufferedOutputStream> buffered_stream;
-  ABORT_NOT_OK(io::BufferedOutputStream::Create(kBufferSize, default_memory_pool(),
+  auto pool = default_memory_pool();
+  ABORT_NOT_OK(io::BufferedOutputStream::Create(kBufferSize, pool,
                                                 stream, &buffered_stream));
   BenchmarkStreamingWrites(state, small_sizes, buffered_stream.get(), reader.get());
 }
@@ -215,7 +217,8 @@ static void BM_BufferedOutputStreamLargeWritesToPipe(
   SetupPipeWriter(&stream, &reader);
 
   std::shared_ptr<io::BufferedOutputStream> buffered_stream;
-  ABORT_NOT_OK(io::BufferedOutputStream::Create(kBufferSize, default_memory_pool(),
+  auto pool = default_memory_pool();
+  ABORT_NOT_OK(io::BufferedOutputStream::Create(kBufferSize, pool,
                                                 stream, &buffered_stream));
 
   BenchmarkStreamingWrites(state, large_sizes, buffered_stream.get(), reader.get());

--- a/cpp/src/arrow/io/file-test.cc
+++ b/cpp/src/arrow/io/file-test.cc
@@ -477,14 +477,15 @@ class MyMemoryPool : public MemoryPool {
 TEST_F(TestReadableFile, CustomMemoryPool) {
   MakeTestFile();
 
-  MyMemoryPool pool;
-  ASSERT_OK(ReadableFile::Open(path_, &pool, &file_));
+  std::shared_ptr<MyMemoryPool> pool = std::make_shared<MyMemoryPool>();
+  std::shared_ptr<MemoryPool> pool_ = std::static_pointer_cast<MemoryPool>(pool);
+  ASSERT_OK(ReadableFile::Open(path_, pool_, &file_));
 
   std::shared_ptr<Buffer> buffer;
   ASSERT_OK(file_->ReadAt(0, 4, &buffer));
   ASSERT_OK(file_->ReadAt(4, 8, &buffer));
 
-  ASSERT_EQ(2, pool.num_allocations());
+  ASSERT_EQ(2, pool.get()->num_allocations());
 }
 
 TEST_F(TestReadableFile, ThreadSafety) {
@@ -494,9 +495,9 @@ TEST_F(TestReadableFile, ThreadSafety) {
     stream.open(path_.c_str());
     stream << data;
   }
-
-  MyMemoryPool pool;
-  ASSERT_OK(ReadableFile::Open(path_, &pool, &file_));
+  std::shared_ptr<MyMemoryPool> pool = std::make_shared<MyMemoryPool>();
+  std::shared_ptr<MemoryPool> pool_ = std::static_pointer_cast<MemoryPool>(pool);
+  ASSERT_OK(ReadableFile::Open(path_, pool_, &file_));
 
   std::atomic<int> correct_count(0);
   int niter = 30000;

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -122,7 +122,7 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   /// \param[in] pool a MemoryPool for memory allocations
   /// \param[out] file ReadableFile instance
   /// Open file with one's own memory pool for memory allocations
-  static Status Open(const std::string& path, MemoryPool* pool,
+  static Status Open(const std::string& path, std::shared_ptr<MemoryPool>& pool,
                      std::shared_ptr<ReadableFile>* file);
 
   /// \brief Open a local file for reading
@@ -142,7 +142,7 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   ///
   /// The file descriptor becomes owned by the ReadableFile, and will be closed
   /// on Close() or destruction.
-  static Status Open(int fd, MemoryPool* pool, std::shared_ptr<ReadableFile>* file);
+  static Status Open(int fd, std::shared_ptr<MemoryPool>& pool, std::shared_ptr<ReadableFile>* file);
 
   Status Close() override;
   bool closed() const override;
@@ -165,7 +165,7 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   int file_descriptor() const;
 
  private:
-  explicit ReadableFile(MemoryPool* pool);
+  explicit ReadableFile(std::shared_ptr<MemoryPool>& pool);
 
   class ARROW_NO_EXPORT ReadableFileImpl;
   std::unique_ptr<ReadableFileImpl> impl_;

--- a/cpp/src/arrow/io/hdfs-test.cc
+++ b/cpp/src/arrow/io/hdfs-test.cc
@@ -398,7 +398,8 @@ TYPED_TEST(TestHadoopFileSystem, LargeFile) {
   ASSERT_FALSE(file->closed());
 
   std::shared_ptr<Buffer> buffer;
-  ASSERT_OK(AllocateBuffer(nullptr, size, &buffer));
+  std::shared_ptr<MemoryPool> pool;
+  ASSERT_OK(AllocateBuffer(pool, size, &buffer));
 
   int64_t bytes_read = 0;
 
@@ -411,7 +412,7 @@ TYPED_TEST(TestHadoopFileSystem, LargeFile) {
   ASSERT_OK(this->client_->OpenReadable(path, 1 << 18, &file2));
 
   std::shared_ptr<Buffer> buffer2;
-  ASSERT_OK(AllocateBuffer(nullptr, size, &buffer2));
+  ASSERT_OK(AllocateBuffer(pool, size, &buffer2));
 
   ASSERT_OK(file2->Read(size, &bytes_read, buffer2->mutable_data()));
   ASSERT_EQ(0, std::memcmp(buffer2->data(), data.data(), size));

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -123,7 +123,7 @@ Status GetPathInfoFailed(const std::string& path) {
 // Private implementation for read-only files
 class HdfsReadableFile::HdfsReadableFileImpl : public HdfsAnyFileImpl {
  public:
-  explicit HdfsReadableFileImpl(MemoryPool* pool) : pool_(pool) {}
+  explicit HdfsReadableFileImpl(std::shared_ptr<MemoryPool>& pool) : pool_(pool) {}
 
   Status Close() {
     if (is_open_) {
@@ -209,19 +209,16 @@ class HdfsReadableFile::HdfsReadableFileImpl : public HdfsAnyFileImpl {
     return Status::OK();
   }
 
-  void set_memory_pool(MemoryPool* pool) { pool_ = pool; }
+  void set_memory_pool(std::shared_ptr<MemoryPool>& pool) { pool_ = pool; }
 
   void set_buffer_size(int32_t buffer_size) { buffer_size_ = buffer_size; }
 
  private:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   int32_t buffer_size_;
 };
 
-HdfsReadableFile::HdfsReadableFile(MemoryPool* pool) {
-  if (pool == nullptr) {
-    pool = default_memory_pool();
-  }
+HdfsReadableFile::HdfsReadableFile(std::shared_ptr<MemoryPool> pool) {
   impl_.reset(new HdfsReadableFileImpl(pool));
 }
 

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -207,10 +207,10 @@ class ARROW_EXPORT HdfsReadableFile : public RandomAccessFile {
   Status Seek(int64_t position) override;
   Status Tell(int64_t* position) const override;
 
-  void set_memory_pool(MemoryPool* pool);
+  void set_memory_pool(std::shared_ptr<MemoryPool>& pool);
 
  private:
-  explicit HdfsReadableFile(MemoryPool* pool = NULLPTR);
+  explicit HdfsReadableFile(std::shared_ptr<MemoryPool> pool = default_memory_pool());
 
   class ARROW_NO_EXPORT HdfsReadableFileImpl;
   std::unique_ptr<HdfsReadableFileImpl> impl_;

--- a/cpp/src/arrow/io/memory-test.cc
+++ b/cpp/src/arrow/io/memory-test.cc
@@ -203,7 +203,8 @@ TEST(TestBufferReader, RetainParentReference) {
   std::shared_ptr<Buffer> slice2;
   {
     std::shared_ptr<Buffer> buffer;
-    ASSERT_OK(AllocateBuffer(nullptr, static_cast<int64_t>(data.size()), &buffer));
+    std::shared_ptr<MemoryPool> pool;
+    ASSERT_OK(AllocateBuffer(pool, static_cast<int64_t>(data.size()), &buffer));
     std::memcpy(buffer->mutable_data(), data.c_str(), data.size());
     BufferReader reader(buffer);
     ASSERT_OK(reader.Read(4, &slice1));

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -46,14 +46,14 @@ BufferOutputStream::BufferOutputStream(const std::shared_ptr<ResizableBuffer>& b
       position_(0),
       mutable_data_(buffer->mutable_data()) {}
 
-Status BufferOutputStream::Create(int64_t initial_capacity, MemoryPool* pool,
+Status BufferOutputStream::Create(int64_t initial_capacity, std::shared_ptr<MemoryPool>& pool,
                                   std::shared_ptr<BufferOutputStream>* out) {
   // ctor is private, so cannot use make_shared
   *out = std::shared_ptr<BufferOutputStream>(new BufferOutputStream);
   return (*out)->Reset(initial_capacity, pool);
 }
 
-Status BufferOutputStream::Reset(int64_t initial_capacity, MemoryPool* pool) {
+Status BufferOutputStream::Reset(int64_t initial_capacity, std::shared_ptr<MemoryPool> pool) {
   RETURN_NOT_OK(AllocateResizableBuffer(pool, initial_capacity, &buffer_));
   is_open_ = true;
   capacity_ = initial_capacity;

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -47,7 +47,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   /// the OutputStream
   /// \param[in,out] pool a MemoryPool to use for allocations
   /// \param[out] out the created stream
-  static Status Create(int64_t initial_capacity, MemoryPool* pool,
+  static Status Create(int64_t initial_capacity, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<BufferOutputStream>* out);
 
   ~BufferOutputStream() override;
@@ -68,7 +68,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   /// \param[in] initial_capacity the starting allocated capacity
   /// \param[in,out] pool the memory pool to use for allocations
   /// \return Status
-  Status Reset(int64_t initial_capacity = 1024, MemoryPool* pool = default_memory_pool());
+  Status Reset(int64_t initial_capacity = 1024, std::shared_ptr<MemoryPool> pool = default_memory_pool());
 
   int64_t capacity() const { return capacity_; }
 

--- a/cpp/src/arrow/io/readahead-test.cc
+++ b/cpp/src/arrow/io/readahead-test.cc
@@ -252,7 +252,8 @@ TEST(ReadaheadSpooler, StressReads) {
   const int64_t READ_SIZE = 2;
 
   std::shared_ptr<ResizableBuffer> data;
-  ASSERT_OK(MakeRandomByteBuffer(NBYTES, default_memory_pool(), &data));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  ASSERT_OK(MakeRandomByteBuffer(NBYTES, pool, &data));
   auto data_reader = std::make_shared<BufferReader>(data);
 
   ReadaheadSpooler spooler(data_reader, READ_SIZE, 7);

--- a/cpp/src/arrow/io/readahead.cc
+++ b/cpp/src/arrow/io/readahead.cc
@@ -41,7 +41,7 @@ namespace internal {
 
 class ReadaheadSpooler::Impl {
  public:
-  Impl(MemoryPool* pool, std::shared_ptr<InputStream> raw, int64_t read_size,
+  Impl(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<InputStream> raw, int64_t read_size,
        int32_t readahead_queue_size, int64_t left_padding, int64_t right_padding)
       : pool_(pool),
         raw_(raw),
@@ -178,7 +178,7 @@ class ReadaheadSpooler::Impl {
     return Status::OK();
   }
 
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<InputStream> raw_;
   int64_t read_size_;
   int32_t readahead_queue_size_;
@@ -195,7 +195,7 @@ class ReadaheadSpooler::Impl {
   Status read_status_;
 };
 
-ReadaheadSpooler::ReadaheadSpooler(MemoryPool* pool, std::shared_ptr<InputStream> raw,
+ReadaheadSpooler::ReadaheadSpooler(std::shared_ptr<MemoryPool> pool, std::shared_ptr<InputStream> raw,
                                    int64_t read_size, int32_t readahead_queue_size,
                                    int64_t left_padding, int64_t right_padding)
     : impl_(new ReadaheadSpooler::Impl(pool, raw, read_size, readahead_queue_size,

--- a/cpp/src/arrow/io/readahead.h
+++ b/cpp/src/arrow/io/readahead.h
@@ -49,7 +49,7 @@ class ARROW_EXPORT ReadaheadSpooler {
   /// of fixed-size blocks in advance from the underlying stream.
   /// The buffers returned by Read() will be padded at the beginning and the end
   /// with the configured amount of (zeroed) bytes.
-  ReadaheadSpooler(MemoryPool* pool, std::shared_ptr<InputStream> raw,
+  ReadaheadSpooler(std::shared_ptr<MemoryPool> pool, std::shared_ptr<InputStream> raw,
                    int64_t read_size = kDefaultReadSize, int32_t readahead_queue_size = 1,
                    int64_t left_padding = 0, int64_t right_padding = 0);
 

--- a/cpp/src/arrow/ipc/feather-test.cc
+++ b/cpp/src/arrow/ipc/feather-test.cc
@@ -280,7 +280,8 @@ void CheckBatches(const RecordBatch& expected, const RecordBatch& result) {
 class TestTableReader : public ::testing::Test {
  public:
   void SetUp() {
-    ASSERT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &stream_));
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    ASSERT_OK(io::BufferOutputStream::Create(1024, pool, &stream_));
     ASSERT_OK(TableWriter::Open(stream_, &writer_));
   }
 
@@ -355,7 +356,8 @@ TEST_F(TestTableReader, ReadNames) {
 class TestTableWriter : public ::testing::Test {
  public:
   void SetUp() {
-    ASSERT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &stream_));
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    ASSERT_OK(io::BufferOutputStream::Create(1024, pool, &stream_));
     ASSERT_OK(TableWriter::Open(stream_, &writer_));
   }
 

--- a/cpp/src/arrow/ipc/json-integration.h
+++ b/cpp/src/arrow/ipc/json-integration.h
@@ -87,7 +87,7 @@ class ARROW_EXPORT JsonReader {
   /// \param[in] data a Buffer containing the JSON data
   /// \param[out] reader the returned reader object
   /// \return Status
-  static Status Open(MemoryPool* pool, const std::shared_ptr<Buffer>& data,
+  static Status Open(std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<Buffer>& data,
                      std::unique_ptr<JsonReader>* reader);
 
   /// \brief Create a new JSON reader that uses the default memory pool
@@ -104,7 +104,7 @@ class ARROW_EXPORT JsonReader {
   /// \param[in] in_file a ReadableFile containing JSON data
   /// \param[out] reader the returned reader object
   /// \return Status
-  static Status Open(MemoryPool* pool, const std::shared_ptr<io::ReadableFile>& in_file,
+  static Status Open(std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<io::ReadableFile>& in_file,
                      std::unique_ptr<JsonReader>* reader);
 
   /// \brief Return the schema read from the JSON
@@ -120,7 +120,7 @@ class ARROW_EXPORT JsonReader {
   Status ReadRecordBatch(int i, std::shared_ptr<RecordBatch>* batch) const;
 
  private:
-  JsonReader(MemoryPool* pool, const std::shared_ptr<Buffer>& data);
+  JsonReader(std::shared_ptr<MemoryPool>& pool, const std::shared_ptr<Buffer>& data);
 
   // Hide RapidJSON details from public API
   class JsonReaderImpl;

--- a/cpp/src/arrow/ipc/json-internal.h
+++ b/cpp/src/arrow/ipc/json-internal.h
@@ -94,19 +94,19 @@ ARROW_EXPORT Status WriteRecordBatch(const RecordBatch& batch, RjWriter* writer)
 ARROW_EXPORT Status WriteArray(const std::string& name, const Array& array,
                                RjWriter* writer);
 
-ARROW_EXPORT Status ReadSchema(const rj::Value& json_obj, MemoryPool* pool,
+ARROW_EXPORT Status ReadSchema(const rj::Value& json_obj, std::shared_ptr<MemoryPool>& pool,
                                std::shared_ptr<Schema>* schema);
 
 ARROW_EXPORT Status ReadRecordBatch(const rj::Value& json_obj,
                                     const std::shared_ptr<Schema>& schema,
-                                    MemoryPool* pool,
+                                    std::shared_ptr<MemoryPool>& pool,
                                     std::shared_ptr<RecordBatch>* batch);
 
-ARROW_EXPORT Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
+ARROW_EXPORT Status ReadArray(std::shared_ptr<MemoryPool>& pool, const rj::Value& json_obj,
                               const std::shared_ptr<DataType>& type,
                               std::shared_ptr<Array>* array);
 
-ARROW_EXPORT Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
+ARROW_EXPORT Status ReadArray(std::shared_ptr<MemoryPool>& pool, const rj::Value& json_obj,
                               const Schema& schema, std::shared_ptr<Array>* array);
 
 }  // namespace json

--- a/cpp/src/arrow/ipc/json-simple.cc
+++ b/cpp/src/arrow/ipc/json-simple.cc
@@ -290,7 +290,8 @@ class StringConverter final : public ConcreteConverter<StringConverter> {
  public:
   explicit StringConverter(const std::shared_ptr<DataType>& type) {
     this->type_ = type;
-    builder_ = std::make_shared<BinaryBuilder>(type, default_memory_pool());
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    builder_ = std::make_shared<BinaryBuilder>(type, pool);
   }
 
   Status AppendNull() override { return builder_->AppendNull(); }
@@ -321,7 +322,8 @@ class FixedSizeBinaryConverter final
  public:
   explicit FixedSizeBinaryConverter(const std::shared_ptr<DataType>& type) {
     this->type_ = type;
-    builder_ = std::make_shared<FixedSizeBinaryBuilder>(type, default_memory_pool());
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    builder_ = std::make_shared<FixedSizeBinaryBuilder>(type, pool);
   }
 
   Status AppendNull() override { return builder_->AppendNull(); }
@@ -361,7 +363,8 @@ class ListConverter final : public ConcreteConverter<ListConverter> {
     const auto& list_type = checked_cast<const ListType&>(*type_);
     RETURN_NOT_OK(GetConverter(list_type.value_type(), &child_converter_));
     auto child_builder = child_converter_->builder();
-    builder_ = std::make_shared<ListBuilder>(default_memory_pool(), child_builder, type_);
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    builder_ = std::make_shared<ListBuilder>(pool, child_builder, type_);
     return Status::OK();
   }
 
@@ -398,7 +401,8 @@ class StructConverter final : public ConcreteConverter<StructConverter> {
       child_converters_.push_back(child_converter);
       child_builders.push_back(child_converter->builder());
     }
-    builder_ = std::make_shared<StructBuilder>(type_, default_memory_pool(),
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    builder_ = std::make_shared<StructBuilder>(type_, pool,
                                                std::move(child_builders));
     return Status::OK();
   }

--- a/cpp/src/arrow/ipc/json-test.cc
+++ b/cpp/src/arrow/ipc/json-test.cc
@@ -56,7 +56,8 @@ void TestSchemaRoundTrip(const Schema& schema) {
   d.Parse(json_schema);
 
   std::shared_ptr<Schema> out;
-  if (!ReadSchema(d, default_memory_pool(), &out).ok()) {
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  if (!ReadSchema(d, pool, &out).ok()) {
     FAIL() << "Unable to read JSON schema: " << json_schema;
   }
 
@@ -83,7 +84,8 @@ void TestArrayRoundTrip(const Array& array) {
   }
 
   std::shared_ptr<Array> out;
-  ASSERT_OK(ReadArray(default_memory_pool(), d, array.type(), &out));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  ASSERT_OK(ReadArray(pool, d, array.type(), &out));
 
   // std::cout << array_as_json << std::endl;
   CompareArraysDetailed(0, *out, array);
@@ -93,7 +95,7 @@ template <typename T, typename ValueType>
 void CheckPrimitive(const std::shared_ptr<DataType>& type,
                     const std::vector<bool>& is_valid,
                     const std::vector<ValueType>& values) {
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   typename TypeTraits<T>::BuilderType builder(pool);
 
   for (size_t i = 0; i < values.size(); ++i) {

--- a/cpp/src/arrow/ipc/metadata-internal.h
+++ b/cpp/src/arrow/ipc/metadata-internal.h
@@ -164,7 +164,8 @@ static inline Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
   int32_t size = fbb.GetSize();
 
   std::shared_ptr<Buffer> result;
-  RETURN_NOT_OK(AllocateBuffer(default_memory_pool(), size, &result));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  RETURN_NOT_OK(AllocateBuffer(pool, size, &result));
 
   uint8_t* dst = result->mutable_data();
   memcpy(dst, fbb.GetBufferPointer(), size);

--- a/cpp/src/arrow/ipc/read-write-benchmark.cc
+++ b/cpp/src/arrow/ipc/read-write-benchmark.cc
@@ -54,13 +54,13 @@ static void BM_WriteRecordBatch(benchmark::State& state) {  // NOLINT non-const 
   std::shared_ptr<ResizableBuffer> buffer;
   ABORT_NOT_OK(AllocateResizableBuffer(kTotalSize & 2, &buffer));
   auto record_batch = MakeRecordBatch(kTotalSize, state.range(0));
-
+  auto pool = default_memory_pool();
   while (state.KeepRunning()) {
     io::BufferOutputStream stream(buffer);
     int32_t metadata_length;
     int64_t body_length;
     if (!ipc::WriteRecordBatch(*record_batch, 0, &stream, &metadata_length, &body_length,
-                               default_memory_pool())
+                               pool)
              .ok()) {
       state.SkipWithError("Failed to write!");
     }
@@ -80,8 +80,9 @@ static void BM_ReadRecordBatch(benchmark::State& state) {  // NOLINT non-const r
 
   int32_t metadata_length;
   int64_t body_length;
+  auto pool = default_memory_pool();
   if (!ipc::WriteRecordBatch(*record_batch, 0, &stream, &metadata_length, &body_length,
-                             default_memory_pool())
+                             pool)
            .ok()) {
     state.SkipWithError("Failed to write!");
   }

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -82,7 +82,7 @@ class ARROW_EXPORT RecordBatchWriter {
   /// memory pool, but provide the option to override
   ///
   /// \param pool the memory pool to use for required allocations
-  virtual void set_memory_pool(MemoryPool* pool) = 0;
+  virtual void set_memory_pool(std::shared_ptr<MemoryPool>& pool) = 0;
 };
 
 /// \class RecordBatchStreamWriter
@@ -113,7 +113,7 @@ class ARROW_EXPORT RecordBatchStreamWriter : public RecordBatchWriter {
   /// \return Status
   Status Close() override;
 
-  void set_memory_pool(MemoryPool* pool) override;
+  void set_memory_pool(std::shared_ptr<MemoryPool>& pool) override;
 
  protected:
   RecordBatchStreamWriter();
@@ -188,7 +188,7 @@ class ARROW_EXPORT RecordBatchFileWriter : public RecordBatchStreamWriter {
 ARROW_EXPORT
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
                         io::OutputStream* dst, int32_t* metadata_length,
-                        int64_t* body_length, MemoryPool* pool,
+                        int64_t* body_length, std::shared_ptr<MemoryPool>& pool,
                         int max_recursion_depth = kMaxNestingDepth,
                         bool allow_64bit = false);
 
@@ -199,7 +199,7 @@ Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
 /// \param[out] out the serialized message
 /// \return Status
 ARROW_EXPORT
-Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
+Status SerializeRecordBatch(const RecordBatch& batch, std::shared_ptr<MemoryPool>& pool,
                             std::shared_ptr<Buffer>* out);
 
 /// \brief Write record batch to OutputStream
@@ -212,7 +212,7 @@ Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
 /// If writing to pre-allocated memory, you can use
 /// arrow::ipc::GetRecordBatchSize to compute how much space is required
 ARROW_EXPORT
-Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
+Status SerializeRecordBatch(const RecordBatch& batch, std::shared_ptr<MemoryPool>& pool,
                             io::OutputStream* out);
 
 /// \brief Serialize schema using stream writer as a sequence of one or more
@@ -223,7 +223,7 @@ Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
 /// \param[out] out the serialized schema
 /// \return Status
 ARROW_EXPORT
-Status SerializeSchema(const Schema& schema, MemoryPool* pool,
+Status SerializeSchema(const Schema& schema, std::shared_ptr<MemoryPool>& pool,
                        std::shared_ptr<Buffer>* out);
 
 /// \brief Write multiple record batches to OutputStream, including schema
@@ -258,7 +258,7 @@ Status GetTensorSize(const Tensor& tensor, int64_t* size);
 /// \param[out] out the resulting Message
 /// \return Status
 ARROW_EXPORT
-Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
+Status GetTensorMessage(const Tensor& tensor, std::shared_ptr<MemoryPool>& pool,
                         std::unique_ptr<Message>* out);
 
 /// \brief Write arrow::Tensor as a contiguous message.
@@ -293,7 +293,7 @@ Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadat
 ARROW_EXPORT
 Status WriteSparseTensor(const SparseTensor& sparse_tensor, io::OutputStream* dst,
                          int32_t* metadata_length, int64_t* body_length,
-                         MemoryPool* pool);
+                         std::shared_ptr<MemoryPool>& pool);
 
 namespace internal {
 
@@ -322,7 +322,7 @@ Status GetDictionaryPayloads(const Schema& schema,
 /// \param[out] out the returned IpcPayload
 /// \return Status
 ARROW_EXPORT
-Status GetSchemaPayload(const Schema& schema, MemoryPool* pool,
+Status GetSchemaPayload(const Schema& schema, std::shared_ptr<MemoryPool>& pool,
                         DictionaryMemo* dictionary_memo, IpcPayload* out);
 
 /// \brief Compute IpcPayload for the given record batch
@@ -331,7 +331,7 @@ Status GetSchemaPayload(const Schema& schema, MemoryPool* pool,
 /// \param[out] out the returned IpcPayload
 /// \return Status
 ARROW_EXPORT
-Status GetRecordBatchPayload(const RecordBatch& batch, MemoryPool* pool, IpcPayload* out);
+Status GetRecordBatchPayload(const RecordBatch& batch, std::shared_ptr<MemoryPool>& pool, IpcPayload* out);
 
 }  // namespace internal
 

--- a/cpp/src/arrow/json/parser.h
+++ b/cpp/src/arrow/json/parser.h
@@ -93,7 +93,7 @@ constexpr int32_t kMaxParserNumRows = 100000;
 /// parser, so the original buffer can be discarded after Parse() returns.
 class ARROW_EXPORT BlockParser {
  public:
-  BlockParser(MemoryPool* pool, ParseOptions options,
+  BlockParser(std::shared_ptr<MemoryPool> pool, ParseOptions options,
               const std::shared_ptr<Buffer>& scalar_storage);
   BlockParser(ParseOptions options, const std::shared_ptr<Buffer>& scalar_storage);
 
@@ -117,7 +117,7 @@ class ARROW_EXPORT BlockParser {
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(BlockParser);
 
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   const ParseOptions options_;
   std::unique_ptr<Impl> impl_;
 };

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -72,7 +72,8 @@ struct ConvertImpl {
     const StringArray& dict = static_cast<const StringArray&>(*dict_array->dictionary());
     const Int32Array& indices = static_cast<const Int32Array&>(*dict_array->indices());
     using Builder = typename TypeTraits<T>::BuilderType;
-    Builder builder(out_type, default_memory_pool());
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    Builder builder(out_type, pool);
     RETURN_NOT_OK(builder.Resize(indices.length()));
     for (int64_t i = 0; i != indices.length(); ++i) {
       if (indices.IsNull(i)) {
@@ -125,7 +126,8 @@ struct ConvertImpl {
     const StringArray& dict = static_cast<const StringArray&>(*dict_array->dictionary());
     const Int32Array& indices = static_cast<const Int32Array&>(*dict_array->indices());
     using Builder = typename TypeTraits<T>::BuilderType;
-    Builder builder(out_type, default_memory_pool());
+    std::shared_ptr<MemoryPool> pool = default_memory_pool();
+    Builder builder(out_type, pool);
     RETURN_NOT_OK(builder.Resize(indices.length()));
     int64_t values_length = 0;
     for (int64_t i = 0; i != indices.length(); ++i) {

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -46,7 +46,7 @@ class ARROW_EXPORT TableReader {
   virtual Status Read(std::shared_ptr<Table>* out) = 0;
 
   // XXX pass optional schema?
-  static Status Make(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
+  static Status Make(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<io::InputStream> input,
                      const ReadOptions&, const ParseOptions&,
                      std::shared_ptr<TableReader>* out);
 };

--- a/cpp/src/arrow/json/test-common.h
+++ b/cpp/src/arrow/json/test-common.h
@@ -120,7 +120,8 @@ static Status Generate(const std::vector<std::shared_ptr<Field>>& fields, Engine
 }
 
 Status MakeBuffer(util::string_view data, std::shared_ptr<Buffer>* out) {
-  RETURN_NOT_OK(AllocateBuffer(default_memory_pool(), data.size(), out));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  RETURN_NOT_OK(AllocateBuffer(pool, data.size(), out));
   std::copy(std::begin(data), std::end(data), (*out)->mutable_data());
   return Status::OK();
 }

--- a/cpp/src/arrow/memory_pool-test.cc
+++ b/cpp/src/arrow/memory_pool-test.cc
@@ -28,7 +28,7 @@ namespace arrow {
 
 class TestDefaultMemoryPool : public ::arrow::TestMemoryPoolBase {
  public:
-  ::arrow::MemoryPool* memory_pool() override { return ::arrow::default_memory_pool(); }
+  std::shared_ptr<::arrow::MemoryPool> memory_pool() override { return ::arrow::default_memory_pool(); }
 };
 
 TEST_F(TestDefaultMemoryPool, MemoryTracking) { this->TestMemoryTracking(); }
@@ -46,7 +46,7 @@ TEST_F(TestDefaultMemoryPool, Reallocate) { this->TestReallocate(); }
 #if !(defined(ARROW_VALGRIND) || defined(ADDRESS_SANITIZER))
 
 TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
-  MemoryPool* pool = default_memory_pool();
+  MemoryPool* pool = default_memory_pool().get();
   uint8_t* data1;
   uint8_t* data2;
 
@@ -63,9 +63,10 @@ TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
 #endif  // ARROW_VALGRIND
 
 TEST(LoggingMemoryPool, Logging) {
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool_ = default_memory_pool();
+  MemoryPool* pool = pool_.get();
 
-  LoggingMemoryPool lp(pool);
+  LoggingMemoryPool lp(pool_);
 
   uint8_t* data;
   ASSERT_OK(pool->Allocate(100, &data));
@@ -80,9 +81,10 @@ TEST(LoggingMemoryPool, Logging) {
 }
 
 TEST(ProxyMemoryPool, Logging) {
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool_ = default_memory_pool();
+  MemoryPool* pool = pool_.get();
 
-  ProxyMemoryPool pp(pool);
+  ProxyMemoryPool pp(pool_);
 
   uint8_t* data;
   ASSERT_OK(pool->Allocate(100, &data));

--- a/cpp/src/arrow/memory_pool-test.h
+++ b/cpp/src/arrow/memory_pool-test.h
@@ -30,7 +30,7 @@ namespace arrow {
 
 class TestMemoryPoolBase : public ::testing::Test {
  public:
-  virtual ::arrow::MemoryPool* memory_pool() = 0;
+  virtual std::shared_ptr<::arrow::MemoryPool> memory_pool() = 0;
 
   void TestMemoryTracking() {
     auto pool = memory_pool();

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -102,7 +102,7 @@ class ARROW_EXPORT MemoryPool {
 
 class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
  public:
-  explicit LoggingMemoryPool(MemoryPool* pool);
+  explicit LoggingMemoryPool(std::shared_ptr<MemoryPool>& pool);
   ~LoggingMemoryPool() override = default;
 
   Status Allocate(int64_t size, uint8_t** out) override;
@@ -115,7 +115,7 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
   int64_t max_memory() const override;
 
  private:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
 };
 
 /// Derived class for memory allocation.
@@ -124,7 +124,7 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
 /// calls. Actual allocation is delegated to MemoryPool class.
 class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
  public:
-  explicit ProxyMemoryPool(MemoryPool* pool);
+  explicit ProxyMemoryPool(std::shared_ptr<MemoryPool>& pool);
   ~ProxyMemoryPool() override;
 
   Status Allocate(int64_t size, uint8_t** out) override;
@@ -142,7 +142,7 @@ class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
 };
 
 /// Return the process-wide default memory pool.
-ARROW_EXPORT MemoryPool* default_memory_pool();
+ARROW_EXPORT std::shared_ptr<MemoryPool> default_memory_pool();
 
 #ifdef ARROW_NO_DEFAULT_MEMORY_POOL
 #define ARROW_MEMORY_POOL_DEFAULT

--- a/cpp/src/arrow/python/arrow_to_pandas.h
+++ b/cpp/src/arrow/python/arrow_to_pandas.h
@@ -78,7 +78,7 @@ Status ConvertColumnToPandas(const PandasOptions& options,
 // tuple item: (indices: ndarray[int32], block: ndarray[TYPE, ndim=2])
 ARROW_PYTHON_EXPORT
 Status ConvertTableToPandas(const PandasOptions& options,
-                            const std::shared_ptr<Table>& table, MemoryPool* pool,
+                            const std::shared_ptr<Table>& table, std::shared_ptr<MemoryPool>& pool,
                             PyObject** out);
 
 /// Convert a whole table as efficiently as possible to a pandas.DataFrame.
@@ -88,7 +88,7 @@ Status ConvertTableToPandas(const PandasOptions& options,
 ARROW_PYTHON_EXPORT
 Status ConvertTableToPandas(const PandasOptions& options,
                             const std::unordered_set<std::string>& categorical_columns,
-                            const std::shared_ptr<Table>& table, MemoryPool* pool,
+                            const std::shared_ptr<Table>& table, std::shared_ptr<MemoryPool>& pool,
                             PyObject** out);
 
 }  // namespace py

--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -31,16 +31,16 @@ namespace arrow {
 namespace py {
 
 static std::mutex memory_pool_mutex;
-static MemoryPool* default_python_pool = nullptr;
+static std::shared_ptr<MemoryPool> default_python_pool;  // null initialized
 
-void set_default_memory_pool(MemoryPool* pool) {
+void set_default_memory_pool(std::shared_ptr<MemoryPool>& pool) {
   std::lock_guard<std::mutex> guard(memory_pool_mutex);
   default_python_pool = pool;
 }
 
-MemoryPool* get_memory_pool() {
+std::shared_ptr<MemoryPool> get_memory_pool() {
   std::lock_guard<std::mutex> guard(memory_pool_mutex);
-  if (default_python_pool) {
+  if (!(default_python_pool == nullptr)) {
     return default_python_pool;
   } else {
     return default_memory_pool();

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -224,8 +224,8 @@ struct PyBytesView {
 };
 
 // Return the common PyArrow memory pool
-ARROW_PYTHON_EXPORT void set_default_memory_pool(MemoryPool* pool);
-ARROW_PYTHON_EXPORT MemoryPool* get_memory_pool();
+ARROW_PYTHON_EXPORT void set_default_memory_pool(std::shared_ptr<MemoryPool>& pool);
+ARROW_PYTHON_EXPORT std::shared_ptr<MemoryPool> get_memory_pool();
 
 class ARROW_PYTHON_EXPORT PyBuffer : public Buffer {
  public:

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -187,7 +187,7 @@ Status NumPyDtypeToArrow(PyArray_Descr* descr, std::shared_ptr<DataType>* out) {
 
 #undef TO_ARROW_TYPE_CASE
 
-Status NdarrayToTensor(MemoryPool* pool, PyObject* ao, std::shared_ptr<Tensor>* out) {
+Status NdarrayToTensor(std::shared_ptr<MemoryPool>& pool, PyObject* ao, std::shared_ptr<Tensor>* out) {
   if (!PyArray_Check(ao)) {
     return Status::TypeError("Did not pass ndarray object");
   }

--- a/cpp/src/arrow/python/numpy_convert.h
+++ b/cpp/src/arrow/python/numpy_convert.h
@@ -62,7 +62,7 @@ Status NumPyDtypeToArrow(PyArray_Descr* descr, std::shared_ptr<DataType>* out);
 Status GetTensorType(PyObject* dtype, std::shared_ptr<DataType>* out);
 Status GetNumPyType(const DataType& type, int* type_num);
 
-ARROW_PYTHON_EXPORT Status NdarrayToTensor(MemoryPool* pool, PyObject* ao,
+ARROW_PYTHON_EXPORT Status NdarrayToTensor(std::shared_ptr<MemoryPool>& pool, PyObject* ao,
                                            std::shared_ptr<Tensor>* out);
 
 ARROW_PYTHON_EXPORT Status TensorToNdarray(const std::shared_ptr<Tensor>& tensor,

--- a/cpp/src/arrow/python/numpy_to_arrow.h
+++ b/cpp/src/arrow/python/numpy_to_arrow.h
@@ -49,7 +49,7 @@ namespace py {
 /// \param[in] cast_options casting options
 /// \param[out] out a ChunkedArray, to accommodate chunked output
 ARROW_PYTHON_EXPORT
-Status NdarrayToArrow(MemoryPool* pool, PyObject* ao, PyObject* mo, bool from_pandas,
+Status NdarrayToArrow(std::shared_ptr<MemoryPool>& pool, PyObject* ao, PyObject* mo, bool from_pandas,
                       const std::shared_ptr<DataType>& type,
                       const compute::CastOptions& cast_options,
                       std::shared_ptr<ChunkedArray>* out);
@@ -65,7 +65,7 @@ Status NdarrayToArrow(MemoryPool* pool, PyObject* ao, PyObject* mo, bool from_pa
 /// \param[in] type a specific type to cast to, may be null
 /// \param[out] out a ChunkedArray, to accommodate chunked output
 ARROW_PYTHON_EXPORT
-Status NdarrayToArrow(MemoryPool* pool, PyObject* ao, PyObject* mo, bool from_pandas,
+Status NdarrayToArrow(std::shared_ptr<MemoryPool>& pool, PyObject* ao, PyObject* mo, bool from_pandas,
                       const std::shared_ptr<DataType>& type,
                       std::shared_ptr<ChunkedArray>* out);
 

--- a/cpp/src/arrow/python/python-test.cc
+++ b/cpp/src/arrow/python/python-test.cc
@@ -243,7 +243,7 @@ TEST(PandasConversionTest, TestObjectBlockWriteFails) {
   Py_BEGIN_ALLOW_THREADS;
   PandasOptions options;
   options.use_threads = true;
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   ASSERT_RAISES(UnknownError, ConvertTableToPandas(options, table, pool, &out));
   Py_END_ALLOW_THREADS;
 }

--- a/cpp/src/arrow/python/python_to_arrow.h
+++ b/cpp/src/arrow/python/python_to_arrow.h
@@ -43,7 +43,7 @@ struct PyConversionOptions {
   PyConversionOptions() : type(NULLPTR), size(-1), pool(NULLPTR), from_pandas(false) {}
 
   PyConversionOptions(const std::shared_ptr<DataType>& type, int64_t size,
-                      MemoryPool* pool, bool from_pandas)
+                      std::shared_ptr<MemoryPool>& pool, bool from_pandas)
       : type(type), size(size), pool(default_memory_pool()), from_pandas(from_pandas) {}
 
   // Set to null if to be inferred
@@ -53,7 +53,7 @@ struct PyConversionOptions {
   int64_t size;
 
   // Memory pool to use for allocations
-  MemoryPool* pool;
+  std::shared_ptr<MemoryPool> pool;
 
   // Default false
   bool from_pandas;

--- a/cpp/src/arrow/python/serialize.h
+++ b/cpp/src/arrow/python/serialize.h
@@ -71,7 +71,7 @@ struct ARROW_PYTHON_EXPORT SerializedPyObject {
   /// the body. Therefore, the number of buffers in 'data' is 2 * N + K + 1,
   /// with the first buffer containing the serialized record batch containing
   /// the UnionArray that describes the whole object
-  Status GetComponents(MemoryPool* pool, PyObject** out);
+  Status GetComponents(std::shared_ptr<MemoryPool>& pool, PyObject** out);
 };
 
 /// \brief Serialize Python sequence as a SerializedPyObject.

--- a/cpp/src/arrow/stl-test.cc
+++ b/cpp/src/arrow/stl-test.cc
@@ -85,7 +85,8 @@ TEST(TestTableFromTupleVector, PrimitiveTypes) {
       primitive_types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, "Tests"),
       primitive_types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false, "Other")};
   std::shared_ptr<Table> table;
-  ASSERT_OK(TableFromTupleRange(default_memory_pool(), rows, names, &table));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  ASSERT_OK(TableFromTupleRange(pool, rows, names, &table));
 
   std::shared_ptr<Schema> expected_schema =
       schema({field("column1", int8(), false), field("column2", int16(), false),
@@ -127,7 +128,8 @@ TEST(TestTableFromTupleVector, ListType) {
   std::vector<std::string> names{"column1"};
 
   std::shared_ptr<Table> table;
-  ASSERT_OK(TableFromTupleRange(default_memory_pool(), rows, names, &table));
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  ASSERT_OK(TableFromTupleRange(pool, rows, names, &table));
   ASSERT_TRUE(expected_table->Equals(*table));
 }
 

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -201,7 +201,7 @@ struct SchemaFromTuple<Tuple, 0> {
 namespace internal {
 template <typename Tuple, std::size_t N = std::tuple_size<Tuple>::value>
 struct CreateBuildersRecursive {
-  static Status Make(MemoryPool* pool,
+  static Status Make(std::shared_ptr<MemoryPool>& pool,
                      std::vector<std::unique_ptr<ArrayBuilder>>* builders) {
     using Element = typename std::tuple_element<N - 1, Tuple>::type;
     std::shared_ptr<DataType> type = ConversionTraits<Element>::type_singleton();
@@ -213,7 +213,7 @@ struct CreateBuildersRecursive {
 
 template <typename Tuple>
 struct CreateBuildersRecursive<Tuple, 0> {
-  static Status Make(MemoryPool*, std::vector<std::unique_ptr<ArrayBuilder>>*) {
+  static Status Make(std::shared_ptr<MemoryPool>&, std::vector<std::unique_ptr<ArrayBuilder>>*) {
     return Status::OK();
   }
 };
@@ -307,7 +307,7 @@ struct TupleSetter<Range, Tuple, 0> {
 }  // namespace internal
 
 template <typename Range>
-Status TableFromTupleRange(MemoryPool* pool, const Range& rows,
+Status TableFromTupleRange(std::shared_ptr<MemoryPool>& pool, const Range& rows,
                            const std::vector<std::string>& names,
                            std::shared_ptr<Table>* table) {
   using row_type = typename std::iterator_traits<decltype(std::begin(rows))>::value_type;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -145,7 +145,7 @@ std::shared_ptr<ChunkedArray> ChunkedArray::Slice(int64_t offset) const {
   return Slice(offset, length_);
 }
 
-Status ChunkedArray::Flatten(MemoryPool* pool,
+Status ChunkedArray::Flatten(std::shared_ptr<MemoryPool>& pool,
                              std::vector<std::shared_ptr<ChunkedArray>>* out) const {
   std::vector<std::shared_ptr<ChunkedArray>> flattened;
   if (type()->id() != Type::STRUCT) {
@@ -201,7 +201,7 @@ Column::Column(const std::shared_ptr<Field>& field,
                const std::shared_ptr<ChunkedArray>& data)
     : field_(field), data_(data) {}
 
-Status Column::Flatten(MemoryPool* pool,
+Status Column::Flatten(std::shared_ptr<MemoryPool>& pool,
                        std::vector<std::shared_ptr<Column>>* out) const {
   std::vector<std::shared_ptr<Column>> flattened;
   std::vector<std::shared_ptr<Field>> flattened_fields = field_->Flatten();
@@ -337,7 +337,7 @@ class SimpleTable : public Table {
     return Table::Make(new_schema, columns_);
   }
 
-  Status Flatten(MemoryPool* pool, std::shared_ptr<Table>* out) const override {
+  Status Flatten(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<Table>* out) const override {
     std::vector<std::shared_ptr<Field>> flattened_fields;
     std::vector<std::shared_ptr<Column>> flattened_columns;
     for (const auto& column : columns_) {

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -86,7 +86,7 @@ class ARROW_EXPORT ChunkedArray {
   ///
   /// \param[in] pool The pool for buffer allocations, if any
   /// \param[out] out The resulting vector of arrays
-  Status Flatten(MemoryPool* pool, std::vector<std::shared_ptr<ChunkedArray>>* out) const;
+  Status Flatten(std::shared_ptr<MemoryPool>& pool, std::vector<std::shared_ptr<ChunkedArray>>* out) const;
 
   std::shared_ptr<DataType> type() const { return type_; }
 
@@ -175,7 +175,7 @@ class ARROW_EXPORT Column {
   ///
   /// \param[in] pool The pool for buffer allocations, if any
   /// \param[out] out The resulting vector of arrays
-  Status Flatten(MemoryPool* pool, std::vector<std::shared_ptr<Column>>* out) const;
+  Status Flatten(std::shared_ptr<MemoryPool>& pool, std::vector<std::shared_ptr<Column>>* out) const;
 
   /// \brief Determine if two columns are equal.
   ///
@@ -280,7 +280,7 @@ class ARROW_EXPORT Table {
   ///
   /// \param[in] pool The pool for buffer allocations, if any
   /// \param[out] out The returned table
-  virtual Status Flatten(MemoryPool* pool, std::shared_ptr<Table>* out) const = 0;
+  virtual Status Flatten(std::shared_ptr<MemoryPool>& pool, std::shared_ptr<Table>* out) const = 0;
 
   /// \brief Perform any checks to validate the input arguments
   virtual Status Validate() const = 0;

--- a/cpp/src/arrow/table_builder.cc
+++ b/cpp/src/arrow/table_builder.cc
@@ -33,15 +33,15 @@ namespace arrow {
 // RecordBatchBuilder
 
 RecordBatchBuilder::RecordBatchBuilder(const std::shared_ptr<Schema>& schema,
-                                       MemoryPool* pool, int64_t initial_capacity)
+                                       std::shared_ptr<MemoryPool>& pool, int64_t initial_capacity)
     : schema_(schema), initial_capacity_(initial_capacity), pool_(pool) {}
 
-Status RecordBatchBuilder::Make(const std::shared_ptr<Schema>& schema, MemoryPool* pool,
+Status RecordBatchBuilder::Make(const std::shared_ptr<Schema>& schema, std::shared_ptr<MemoryPool>& pool,
                                 std::unique_ptr<RecordBatchBuilder>* builder) {
   return Make(schema, pool, kMinBuilderCapacity, builder);
 }
 
-Status RecordBatchBuilder::Make(const std::shared_ptr<Schema>& schema, MemoryPool* pool,
+Status RecordBatchBuilder::Make(const std::shared_ptr<Schema>& schema, std::shared_ptr<MemoryPool>& pool,
                                 int64_t initial_capacity,
                                 std::unique_ptr<RecordBatchBuilder>* builder) {
   builder->reset(new RecordBatchBuilder(schema, pool, initial_capacity));

--- a/cpp/src/arrow/table_builder.h
+++ b/cpp/src/arrow/table_builder.h
@@ -43,7 +43,7 @@ class ARROW_EXPORT RecordBatchBuilder {
   /// \param[in] schema The schema for the record batch
   /// \param[in] pool A MemoryPool to use for allocations
   /// \param[in] builder the created builder instance
-  static Status Make(const std::shared_ptr<Schema>& schema, MemoryPool* pool,
+  static Status Make(const std::shared_ptr<Schema>& schema, std::shared_ptr<MemoryPool>& pool,
                      std::unique_ptr<RecordBatchBuilder>* builder);
 
   /// \brief Create an initialize a RecordBatchBuilder
@@ -51,7 +51,7 @@ class ARROW_EXPORT RecordBatchBuilder {
   /// \param[in] pool A MemoryPool to use for allocations
   /// \param[in] initial_capacity The initial capacity for the builders
   /// \param[in] builder the created builder instance
-  static Status Make(const std::shared_ptr<Schema>& schema, MemoryPool* pool,
+  static Status Make(const std::shared_ptr<Schema>& schema, std::shared_ptr<MemoryPool>& pool,
                      int64_t initial_capacity,
                      std::unique_ptr<RecordBatchBuilder>* builder);
 
@@ -94,7 +94,7 @@ class ARROW_EXPORT RecordBatchBuilder {
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(RecordBatchBuilder);
 
-  RecordBatchBuilder(const std::shared_ptr<Schema>& schema, MemoryPool* pool,
+  RecordBatchBuilder(const std::shared_ptr<Schema>& schema, std::shared_ptr<MemoryPool>& pool,
                      int64_t initial_capacity);
 
   Status CreateBuilders();
@@ -102,7 +102,7 @@ class ARROW_EXPORT RecordBatchBuilder {
 
   std::shared_ptr<Schema> schema_;
   int64_t initial_capacity_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
 
   std::vector<std::unique_ptr<ArrayBuilder>> field_builders_;
   std::vector<ArrayBuilder*> raw_field_builders_;

--- a/cpp/src/arrow/testing/gtest_common.h
+++ b/cpp/src/arrow/testing/gtest_common.h
@@ -59,7 +59,7 @@ class TestBase : public ::testing::Test {
 
  protected:
   uint32_t random_seed_;
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
 };
 
 template <typename ArrayType>
@@ -124,7 +124,7 @@ class TestBuilder : public ::testing::Test {
   void SetUp() { pool_ = default_memory_pool(); }
 
  protected:
-  MemoryPool* pool_;
+  std::shared_ptr<MemoryPool> pool_;
   std::shared_ptr<DataType> type_;
 };
 

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -145,7 +145,7 @@ int64_t CountNulls(const std::vector<uint8_t>& valid_bytes) {
   return static_cast<int64_t>(std::count(valid_bytes.cbegin(), valid_bytes.cend(), '\0'));
 }
 
-Status MakeRandomByteBuffer(int64_t length, MemoryPool* pool,
+Status MakeRandomByteBuffer(int64_t length, std::shared_ptr<MemoryPool>& pool,
                             std::shared_ptr<ResizableBuffer>* out, uint32_t seed) {
   std::shared_ptr<ResizableBuffer> result;
   RETURN_NOT_OK(AllocateResizableBuffer(pool, length, &result));

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -71,7 +71,7 @@ void random_real(int64_t n, uint32_t seed, T min_value, T max_value,
 }
 
 template <typename T>
-inline Status CopyBufferFromVector(const std::vector<T>& values, MemoryPool* pool,
+inline Status CopyBufferFromVector(const std::vector<T>& values, std::shared_ptr<MemoryPool>& pool,
                                    std::shared_ptr<Buffer>* result) {
   int64_t nbytes = static_cast<int>(values.size()) * sizeof(T);
 
@@ -98,7 +98,7 @@ ARROW_EXPORT void random_decimals(int64_t n, uint32_t seed, int32_t precision,
 ARROW_EXPORT void random_ascii(int64_t n, uint32_t seed, uint8_t* out);
 ARROW_EXPORT int64_t CountNulls(const std::vector<uint8_t>& valid_bytes);
 
-ARROW_EXPORT Status MakeRandomByteBuffer(int64_t length, MemoryPool* pool,
+ARROW_EXPORT Status MakeRandomByteBuffer(int64_t length, std::shared_ptr<MemoryPool>& pool,
                                          std::shared_ptr<ResizableBuffer>* out,
                                          uint32_t seed = 0);
 
@@ -122,7 +122,7 @@ struct GenerateRandom<T, typename std::enable_if<std::is_integral<T>::value>::ty
 };
 
 template <typename T>
-Status MakeRandomBuffer(int64_t length, MemoryPool* pool,
+Status MakeRandomBuffer(int64_t length, std::shared_ptr<MemoryPool>& pool,
                         std::shared_ptr<ResizableBuffer>* out, uint32_t seed = 0) {
   DCHECK(pool);
   std::shared_ptr<ResizableBuffer> result;

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -585,12 +585,13 @@ TEST(TestDictionaryType, UnifyNumeric) {
   auto expected = dictionary(int8(), ArrayFromJSON(int64(), "[3, 4, 7, 1, 8, -200]"));
 
   std::shared_ptr<DataType> dict_type;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get(), t3.get()},
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
+  ASSERT_OK(DictionaryType::Unify(pool, {t1.get(), t2.get(), t3.get()},
                                   &dict_type));
   ASSERT_TRUE(dict_type->Equals(expected));
 
   std::vector<std::vector<int32_t>> transpose_maps;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get(), t3.get()},
+  ASSERT_OK(DictionaryType::Unify(pool, {t1.get(), t2.get(), t3.get()},
                                   &dict_type, &transpose_maps));
   ASSERT_TRUE(dict_type->Equals(expected));
   ASSERT_EQ(transpose_maps.size(), 3);
@@ -607,12 +608,13 @@ TEST(TestDictionaryType, UnifyString) {
       dictionary(int8(), ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"quux\"]"));
 
   std::shared_ptr<DataType> dict_type;
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   ASSERT_OK(
-      DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()}, &dict_type));
+      DictionaryType::Unify(pool, {t1.get(), t2.get()}, &dict_type));
   ASSERT_TRUE(dict_type->Equals(expected));
 
   std::vector<std::vector<int32_t>> transpose_maps;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()}, &dict_type,
+  ASSERT_OK(DictionaryType::Unify(pool, {t1.get(), t2.get()}, &dict_type,
                                   &transpose_maps));
   ASSERT_TRUE(dict_type->Equals(expected));
 
@@ -638,12 +640,13 @@ TEST(TestDictionaryType, UnifyFixedSizeBinary) {
   auto expected = dictionary(int8(), expected_dict);
 
   std::shared_ptr<DataType> dict_type;
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   ASSERT_OK(
-      DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()}, &dict_type));
+      DictionaryType::Unify(pool, {t1.get(), t2.get()}, &dict_type));
   ASSERT_TRUE(dict_type->Equals(expected));
 
   std::vector<std::vector<int32_t>> transpose_maps;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()}, &dict_type,
+  ASSERT_OK(DictionaryType::Unify(pool, {t1.get(), t2.get()}, &dict_type,
                                   &transpose_maps));
   ASSERT_TRUE(dict_type->Equals(expected));
   ASSERT_EQ(transpose_maps.size(), 2);
@@ -682,8 +685,9 @@ TEST(TestDictionaryType, UnifyLarge) {
   auto expected = dictionary(int16(), expected_dict);
 
   std::shared_ptr<DataType> dict_type;
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   ASSERT_OK(
-      DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()}, &dict_type));
+      DictionaryType::Unify(pool, {t1.get(), t2.get()}, &dict_type));
   ASSERT_TRUE(dict_type->Equals(expected));
 }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -780,7 +780,7 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
   ///     of input type indices into unified type indices.
   // XXX Should we return something special (an empty transpose map?) when
   // the transposition is the identity function?
-  static Status Unify(MemoryPool* pool, const std::vector<const DataType*>& types,
+  static Status Unify(std::shared_ptr<MemoryPool>& pool, const std::vector<const DataType*>& types,
                       std::shared_ptr<DataType>* out_type,
                       std::vector<std::vector<int32_t>>* out_transpose_maps = NULLPTR);
 

--- a/cpp/src/arrow/util/bit-util-benchmark.cc
+++ b/cpp/src/arrow/util/bit-util-benchmark.cc
@@ -224,8 +224,9 @@ static void BM_CopyBitmap(benchmark::State& state) {  // NOLINT non-const refere
   const uint8_t* src = buffer->data();
 
   std::shared_ptr<Buffer> copy;
+  auto pool = default_memory_pool();
   while (state.KeepRunning()) {
-    ABORT_NOT_OK(CopyBitmap(default_memory_pool(), src, state.range(1), num_bits, &copy));
+    ABORT_NOT_OK(CopyBitmap(pool, src, state.range(1), num_bits, &copy));
   }
   state.SetBytesProcessed(state.iterations() * kBufferSize * sizeof(int8_t));
 }

--- a/cpp/src/arrow/util/bit-util.cc
+++ b/cpp/src/arrow/util/bit-util.cc
@@ -52,7 +52,7 @@ void FillBitsFromBytes(const std::vector<uint8_t>& bytes, uint8_t* bits) {
 
 }  // namespace
 
-Status BytesToBits(const std::vector<uint8_t>& bytes, MemoryPool* pool,
+Status BytesToBits(const std::vector<uint8_t>& bytes, std::shared_ptr<MemoryPool>& pool,
                    std::shared_ptr<Buffer>* out) {
   int64_t bit_length = BytesForBits(bytes.size());
 
@@ -188,7 +188,7 @@ void TransferBitmap(const uint8_t* data, int64_t offset, int64_t length,
 }
 
 template <bool invert_bits>
-Status TransferBitmap(MemoryPool* pool, const uint8_t* data, int64_t offset,
+Status TransferBitmap(std::shared_ptr<MemoryPool>& pool, const uint8_t* data, int64_t offset,
                       int64_t length, std::shared_ptr<Buffer>* out) {
   std::shared_ptr<Buffer> buffer;
   RETURN_NOT_OK(AllocateEmptyBitmap(pool, length, &buffer));
@@ -219,12 +219,12 @@ void InvertBitmap(const uint8_t* data, int64_t offset, int64_t length, uint8_t* 
   TransferBitmap<true, true>(data, offset, length, dest_offset, dest);
 }
 
-Status CopyBitmap(MemoryPool* pool, const uint8_t* data, int64_t offset, int64_t length,
+Status CopyBitmap(std::shared_ptr<MemoryPool>& pool, const uint8_t* data, int64_t offset, int64_t length,
                   std::shared_ptr<Buffer>* out) {
   return TransferBitmap<false>(pool, data, offset, length, out);
 }
 
-Status InvertBitmap(MemoryPool* pool, const uint8_t* data, int64_t offset, int64_t length,
+Status InvertBitmap(std::shared_ptr<MemoryPool>& pool, const uint8_t* data, int64_t offset, int64_t length,
                     std::shared_ptr<Buffer>* out) {
   return TransferBitmap<true>(pool, data, offset, length, out);
 }
@@ -310,7 +310,7 @@ void BitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
 }
 
 template <typename BitOp, typename LogicalOp>
-Status BitmapOp(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapOp(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
   const int64_t phys_bits = length + out_offset;
@@ -323,7 +323,7 @@ Status BitmapOp(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
 
 }  // namespace
 
-Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapAnd(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
   return BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
@@ -336,7 +336,7 @@ void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
       left, left_offset, right, right_offset, length, out_offset, out);
 }
 
-Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapOr(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
   return BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
@@ -349,7 +349,7 @@ void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
       left, left_offset, right, right_offset, length, out_offset, out);
 }
 
-Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapXor(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer) {
   return BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(

--- a/cpp/src/arrow/util/bit-util.h
+++ b/cpp/src/arrow/util/bit-util.h
@@ -461,7 +461,7 @@ static inline void SetBitsTo(uint8_t* bits, int64_t start_offset, int64_t length
 
 /// \brief Convert vector of bytes to bitmap buffer
 ARROW_EXPORT
-Status BytesToBits(const std::vector<uint8_t>&, MemoryPool*, std::shared_ptr<Buffer>*);
+Status BytesToBits(const std::vector<uint8_t>&, std::shared_ptr<MemoryPool>&, std::shared_ptr<Buffer>*);
 
 }  // namespace BitUtil
 
@@ -699,7 +699,7 @@ void GenerateBitsUnrolled(uint8_t* bitmap, int64_t start_offset, int64_t length,
 ///
 /// \return Status message
 ARROW_EXPORT
-Status CopyBitmap(MemoryPool* pool, const uint8_t* bitmap, int64_t offset, int64_t length,
+Status CopyBitmap(std::shared_ptr<MemoryPool>& pool, const uint8_t* bitmap, int64_t offset, int64_t length,
                   std::shared_ptr<Buffer>* out);
 
 /// Copy a bit range of an existing bitmap into an existing bitmap
@@ -736,7 +736,7 @@ void InvertBitmap(const uint8_t* bitmap, int64_t offset, int64_t length, uint8_t
 ///
 /// \return Status message
 ARROW_EXPORT
-Status InvertBitmap(MemoryPool* pool, const uint8_t* bitmap, int64_t offset,
+Status InvertBitmap(std::shared_ptr<MemoryPool>& pool, const uint8_t* bitmap, int64_t offset,
                     int64_t length, std::shared_ptr<Buffer>* out);
 
 /// Compute the number of 1's in the given data array
@@ -761,7 +761,7 @@ bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.
 ARROW_EXPORT
-Status BitmapAnd(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapAnd(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 
@@ -779,7 +779,7 @@ void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.
 ARROW_EXPORT
-Status BitmapOr(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapOr(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                 const uint8_t* right, int64_t right_offset, int64_t length,
                 int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 
@@ -797,7 +797,7 @@ void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.
 ARROW_EXPORT
-Status BitmapXor(MemoryPool* pool, const uint8_t* left, int64_t left_offset,
+Status BitmapXor(std::shared_ptr<MemoryPool>& pool, const uint8_t* left, int64_t left_offset,
                  const uint8_t* right, int64_t right_offset, int64_t length,
                  int64_t out_offset, std::shared_ptr<Buffer>* out_buffer);
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -693,7 +693,7 @@ struct DictionaryTraits<BooleanType> {
   using T = BooleanType;
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Status GetDictionaryArrayData(MemoryPool* pool,
+  static Status GetDictionaryArrayData(std::shared_ptr<MemoryPool>& pool,
                                        const std::shared_ptr<DataType>& type,
                                        const MemoTableType& memo_table,
                                        int64_t start_offset,
@@ -713,7 +713,7 @@ struct DictionaryTraits<T, enable_if_has_c_type<T>> {
   using c_type = typename T::c_type;
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Status GetDictionaryArrayData(MemoryPool* pool,
+  static Status GetDictionaryArrayData(std::shared_ptr<MemoryPool>& pool,
                                        const std::shared_ptr<DataType>& type,
                                        const MemoTableType& memo_table,
                                        int64_t start_offset,
@@ -737,7 +737,7 @@ template <typename T>
 struct DictionaryTraits<T, enable_if_binary<T>> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Status GetDictionaryArrayData(MemoryPool* pool,
+  static Status GetDictionaryArrayData(std::shared_ptr<MemoryPool>& pool,
                                        const std::shared_ptr<DataType>& type,
                                        const MemoTableType& memo_table,
                                        int64_t start_offset,
@@ -768,7 +768,7 @@ template <typename T>
 struct DictionaryTraits<T, enable_if_fixed_size_binary<T>> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
-  static Status GetDictionaryArrayData(MemoryPool* pool,
+  static Status GetDictionaryArrayData(std::shared_ptr<MemoryPool>& pool,
                                        const std::shared_ptr<DataType>& type,
                                        const MemoTableType& memo_table,
                                        int64_t start_offset,

--- a/cpp/src/gandiva/annotator_test.cc
+++ b/cpp/src/gandiva/annotator_test.cc
@@ -34,12 +34,13 @@ ArrayPtr TestAnnotator::MakeInt32Array(int length) {
   arrow::Status status;
 
   std::shared_ptr<arrow::Buffer> validity;
+  auto pool = arrow::default_memory_pool();
   status =
-      arrow::AllocateBuffer(arrow::default_memory_pool(), (length + 63) / 8, &validity);
+      arrow::AllocateBuffer(pool, (length + 63) / 8, &validity);
   DCHECK_EQ(status.ok(), true);
 
   std::shared_ptr<arrow::Buffer> value;
-  status = AllocateBuffer(arrow::default_memory_pool(), length * sizeof(int32_t), &value);
+  status = AllocateBuffer(pool, length * sizeof(int32_t), &value);
   DCHECK_EQ(status.ok(), true);
 
   auto array_data = arrow::ArrayData::Make(arrow::int32(), length, {validity, value});

--- a/cpp/src/gandiva/execution_context.h
+++ b/cpp/src/gandiva/execution_context.h
@@ -27,7 +27,7 @@ namespace gandiva {
 /// Execution context during llvm evaluation
 class ExecutionContext {
  public:
-  explicit ExecutionContext(arrow::MemoryPool* pool = arrow::default_memory_pool())
+  explicit ExecutionContext(std::shared_ptr<::arrow::MemoryPool> pool = arrow::default_memory_pool())
       : arena_(pool) {}
   std::string get_error() const { return error_msg_; }
 

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -125,14 +125,14 @@ Status Projector::Evaluate(const arrow::RecordBatch& batch,
   return llvm_generator_->Execute(batch, selection_vector, output_data_vecs);
 }
 
-Status Projector::Evaluate(const arrow::RecordBatch& batch, arrow::MemoryPool* pool,
+Status Projector::Evaluate(const arrow::RecordBatch& batch, std::shared_ptr<::arrow::MemoryPool>& pool,
                            arrow::ArrayVector* output) {
   return Evaluate(batch, nullptr, pool, output);
 }
 
 Status Projector::Evaluate(const arrow::RecordBatch& batch,
                            const SelectionVector* selection_vector,
-                           arrow::MemoryPool* pool, arrow::ArrayVector* output) {
+                           std::shared_ptr<::arrow::MemoryPool>& pool, arrow::ArrayVector* output) {
   ARROW_RETURN_NOT_OK(ValidateEvaluateArgsCommon(batch));
   ARROW_RETURN_IF(output == nullptr, Status::Invalid("Output must be non-null."));
   ARROW_RETURN_IF(pool == nullptr, Status::Invalid("Memory pool must be non-null."));
@@ -162,7 +162,7 @@ Status Projector::Evaluate(const arrow::RecordBatch& batch,
 
 // TODO : handle variable-len vectors
 Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
-                                 arrow::MemoryPool* pool, ArrayDataPtr* array_data) {
+                                 std::shared_ptr<::arrow::MemoryPool>& pool, ArrayDataPtr* array_data) {
   const auto* fw_type = dynamic_cast<const arrow::FixedWidthType*>(type.get());
   ARROW_RETURN_IF(fw_type == nullptr,
                   Status::Invalid("Unsupported output data type ", type));

--- a/cpp/src/gandiva/projector.h
+++ b/cpp/src/gandiva/projector.h
@@ -71,7 +71,7 @@ class GANDIVA_EXPORT Projector {
   /// \param[in] batch the record batch. schema should be the same as the one in 'Make'
   /// \param[in] pool memory pool used to allocate output arrays (if required).
   /// \param[out] output the vector of allocated/populated arrays.
-  Status Evaluate(const arrow::RecordBatch& batch, arrow::MemoryPool* pool,
+  Status Evaluate(const arrow::RecordBatch& batch, std::shared_ptr<::arrow::MemoryPool>& pool,
                   arrow::ArrayVector* output);
 
   /// Evaluate the specified record batch, and populate the output arrays. The output
@@ -91,7 +91,7 @@ class GANDIVA_EXPORT Projector {
   /// \param[in] pool memory pool used to allocate output arrays (if required).
   /// \param[out] output the vector of allocated/populated arrays.
   Status Evaluate(const arrow::RecordBatch& batch,
-                  const SelectionVector* selection_vector, arrow::MemoryPool* pool,
+                  const SelectionVector* selection_vector, std::shared_ptr<::arrow::MemoryPool>& pool,
                   arrow::ArrayVector* output);
 
   /// Evaluate the specified record batch, and populate the output arrays at the filtered
@@ -109,7 +109,7 @@ class GANDIVA_EXPORT Projector {
             const FieldVector& output_fields, std::shared_ptr<Configuration>);
 
   /// Allocate an ArrowData of length 'length'.
-  Status AllocArrayData(const DataTypePtr& type, int64_t length, arrow::MemoryPool* pool,
+  Status AllocArrayData(const DataTypePtr& type, int64_t length, std::shared_ptr<::arrow::MemoryPool>& pool,
                         ArrayDataPtr* array_data);
 
   /// Validate that the ArrayData has sufficient capacity to accomodate 'num_records'.

--- a/cpp/src/gandiva/selection_vector.cc
+++ b/cpp/src/gandiva/selection_vector.cc
@@ -93,7 +93,7 @@ Status SelectionVector::MakeInt16(int64_t max_slots,
   return Status::OK();
 }
 
-Status SelectionVector::MakeInt16(int64_t max_slots, arrow::MemoryPool* pool,
+Status SelectionVector::MakeInt16(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                                   std::shared_ptr<SelectionVector>* selection_vector) {
   std::shared_ptr<arrow::Buffer> buffer;
   ARROW_RETURN_NOT_OK(SelectionVectorInt16::AllocateBuffer(max_slots, pool, &buffer));
@@ -118,7 +118,7 @@ Status SelectionVector::MakeInt32(int64_t max_slots,
   return Status::OK();
 }
 
-Status SelectionVector::MakeInt32(int64_t max_slots, arrow::MemoryPool* pool,
+Status SelectionVector::MakeInt32(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                                   std::shared_ptr<SelectionVector>* selection_vector) {
   std::shared_ptr<arrow::Buffer> buffer;
   ARROW_RETURN_NOT_OK(SelectionVectorInt32::AllocateBuffer(max_slots, pool, &buffer));
@@ -144,7 +144,7 @@ Status SelectionVector::MakeInt64(int64_t max_slots,
   return Status::OK();
 }
 
-Status SelectionVector::MakeInt64(int64_t max_slots, arrow::MemoryPool* pool,
+Status SelectionVector::MakeInt64(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                                   std::shared_ptr<SelectionVector>* selection_vector) {
   std::shared_ptr<arrow::Buffer> buffer;
   ARROW_RETURN_NOT_OK(SelectionVectorInt64::AllocateBuffer(max_slots, pool, &buffer));
@@ -155,7 +155,7 @@ Status SelectionVector::MakeInt64(int64_t max_slots, arrow::MemoryPool* pool,
 
 template <typename C_TYPE, typename A_TYPE, SelectionVector::Mode mode>
 Status SelectionVectorImpl<C_TYPE, A_TYPE, mode>::AllocateBuffer(
-    int64_t max_slots, arrow::MemoryPool* pool, std::shared_ptr<arrow::Buffer>* buffer) {
+    int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool, std::shared_ptr<arrow::Buffer>* buffer) {
   auto buffer_len = max_slots * sizeof(C_TYPE);
   ARROW_RETURN_NOT_OK(arrow::AllocateBuffer(pool, buffer_len, buffer));
 

--- a/cpp/src/gandiva/selection_vector.h
+++ b/cpp/src/gandiva/selection_vector.h
@@ -93,7 +93,7 @@ class GANDIVA_EXPORT SelectionVector {
   /// \param[in] pool memory pool to allocate buffer
   /// \param[out] selection_vector selection vector backed by a buffer allocated from the
   ///              pool.
-  static Status MakeInt16(int64_t max_slots, arrow::MemoryPool* pool,
+  static Status MakeInt16(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                           std::shared_ptr<SelectionVector>* selection_vector);
 
   /// \brief creates a selection vector with pre populated buffer.
@@ -119,7 +119,7 @@ class GANDIVA_EXPORT SelectionVector {
   /// \param[in] pool memory pool to allocate buffer
   /// \param[out] selection_vector selection vector backed by a buffer allocated from the
   ///             pool.
-  static Status MakeInt32(int64_t max_slots, arrow::MemoryPool* pool,
+  static Status MakeInt32(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                           std::shared_ptr<SelectionVector>* selection_vector);
 
   /// \brief creates a selection vector with pre populated buffer.
@@ -145,7 +145,7 @@ class GANDIVA_EXPORT SelectionVector {
   /// \param[in] pool memory pool to allocate buffer
   /// \param[out] selection_vector selection vector backed by a buffer allocated from the
   ///             pool.
-  static Status MakeInt64(int64_t max_slots, arrow::MemoryPool* pool,
+  static Status MakeInt64(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                           std::shared_ptr<SelectionVector>* selection_vector);
 };
 

--- a/cpp/src/gandiva/selection_vector_impl.h
+++ b/cpp/src/gandiva/selection_vector_impl.h
@@ -73,7 +73,7 @@ class SelectionVectorImpl : public SelectionVector {
 
   arrow::Buffer& GetBuffer() const override { return *buffer_; }
 
-  static Status AllocateBuffer(int64_t max_slots, arrow::MemoryPool* pool,
+  static Status AllocateBuffer(int64_t max_slots, std::shared_ptr<::arrow::MemoryPool>& pool,
                                std::shared_ptr<arrow::Buffer>* buffer);
 
   static Status ValidateBuffer(int64_t max_slots, std::shared_ptr<arrow::Buffer> buffer);

--- a/cpp/src/gandiva/selection_vector_test.cc
+++ b/cpp/src/gandiva/selection_vector_test.cc
@@ -28,7 +28,7 @@ class TestSelectionVector : public ::testing::Test {
  protected:
   virtual void SetUp() { pool_ = arrow::default_memory_pool(); }
 
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
 };
 
 static inline uint32_t RoundUpNumi64(uint32_t value) { return (value + 63) >> 6; }

--- a/cpp/src/gandiva/simple_arena.h
+++ b/cpp/src/gandiva/simple_arena.h
@@ -42,7 +42,7 @@ namespace gandiva {
 ///
 class SimpleArena {
  public:
-  explicit SimpleArena(arrow::MemoryPool* pool, int64_t min_chunk_size = 4096);
+  explicit SimpleArena(std::shared_ptr<::arrow::MemoryPool>& pool, int64_t min_chunk_size = 4096);
 
   ~SimpleArena();
 
@@ -73,7 +73,7 @@ class SimpleArena {
   void ReleaseChunks(bool retain_first);
 
   // Memory pool used for allocs.
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
 
   // The chunk-size used for allocations from system.
   int64_t min_chunk_size_;
@@ -91,7 +91,7 @@ class SimpleArena {
   std::vector<Chunk> chunks_;
 };
 
-inline SimpleArena::SimpleArena(arrow::MemoryPool* pool, int64_t min_chunk_size)
+inline SimpleArena::SimpleArena(std::shared_ptr<::arrow::MemoryPool>& pool, int64_t min_chunk_size)
     : pool_(pool),
       min_chunk_size_(min_chunk_size),
       total_bytes_(0),

--- a/cpp/src/gandiva/simple_arena_test.cc
+++ b/cpp/src/gandiva/simple_arena_test.cc
@@ -27,7 +27,8 @@ class TestSimpleArena : public ::testing::Test {};
 
 TEST_F(TestSimpleArena, TestAlloc) {
   int64_t chunk_size = 4096;
-  SimpleArena arena(arrow::default_memory_pool(), chunk_size);
+  auto pool = arrow::default_memory_pool();
+  SimpleArena arena(pool, chunk_size);
 
   // Small allocations should come from the same chunk.
   int64_t small_size = 100;
@@ -50,7 +51,8 @@ TEST_F(TestSimpleArena, TestAlloc) {
 // small followed by big, then reset
 TEST_F(TestSimpleArena, TestReset1) {
   int64_t chunk_size = 4096;
-  SimpleArena arena(arrow::default_memory_pool(), chunk_size);
+  auto pool = arrow::default_memory_pool();
+  SimpleArena arena(pool, chunk_size);
 
   int64_t small_size = 100;
   auto p = arena.Allocate(small_size);
@@ -76,7 +78,8 @@ TEST_F(TestSimpleArena, TestReset1) {
 // big followed by small, then reset
 TEST_F(TestSimpleArena, TestReset2) {
   int64_t chunk_size = 4096;
-  SimpleArena arena(arrow::default_memory_pool(), chunk_size);
+  auto pool = arrow::default_memory_pool();
+  SimpleArena arena(pool, chunk_size);
 
   int64_t large_size = 100 * chunk_size;
   auto p = arena.Allocate(large_size);

--- a/cpp/src/gandiva/tests/binary_test.cc
+++ b/cpp/src/gandiva/tests/binary_test.cc
@@ -34,7 +34,7 @@ class TestBinary : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestBinary, TestSimple) {

--- a/cpp/src/gandiva/tests/boolean_expr_test.cc
+++ b/cpp/src/gandiva/tests/boolean_expr_test.cc
@@ -33,7 +33,7 @@ class TestBooleanExpr : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestBooleanExpr, SimpleAnd) {

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -36,7 +36,7 @@ class TestProjector : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 int32_t MillisInDay(int32_t hh, int32_t mm, int32_t ss, int32_t millis) {

--- a/cpp/src/gandiva/tests/decimal_single_test.cc
+++ b/cpp/src/gandiva/tests/decimal_single_test.cc
@@ -67,7 +67,7 @@ class TestDecimalOps : public ::testing::Test {
   }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 ArrayPtr TestDecimalOps::MakeDecimalVector(const DecimalScalar128& in) {

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -39,7 +39,7 @@ class TestDecimal : public ::testing::Test {
                                             int32_t scale);
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 std::vector<Decimal128> TestDecimal::MakeDecimalVector(std::vector<std::string> values,

--- a/cpp/src/gandiva/tests/filter_project_test.cc
+++ b/cpp/src/gandiva/tests/filter_project_test.cc
@@ -34,7 +34,7 @@ class TestFilterProject : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestFilterProject, TestSimple16) {

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -32,7 +32,7 @@ class TestFilter : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestFilter, TestFilterCache) {

--- a/cpp/src/gandiva/tests/hash_test.cc
+++ b/cpp/src/gandiva/tests/hash_test.cc
@@ -37,7 +37,7 @@ class TestHash : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestHash, TestSimple) {

--- a/cpp/src/gandiva/tests/huge_table_test.cc
+++ b/cpp/src/gandiva/tests/huge_table_test.cc
@@ -33,7 +33,7 @@ class DISABLED_TestHugeProjector : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 class DISABLED_TestHugeFilter : public ::testing::Test {
@@ -41,7 +41,7 @@ class DISABLED_TestHugeFilter : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(DISABLED_TestHugeProjector, SimpleTestSumHuge) {

--- a/cpp/src/gandiva/tests/if_expr_test.cc
+++ b/cpp/src/gandiva/tests/if_expr_test.cc
@@ -34,7 +34,7 @@ class TestIfExpr : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestIfExpr, TestSimple) {

--- a/cpp/src/gandiva/tests/in_expr_test.cc
+++ b/cpp/src/gandiva/tests/in_expr_test.cc
@@ -32,7 +32,7 @@ class TestIn : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestIn, TestInSimple) {

--- a/cpp/src/gandiva/tests/literal_test.cc
+++ b/cpp/src/gandiva/tests/literal_test.cc
@@ -36,7 +36,7 @@ class TestLiteral : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestLiteral, TestSimpleArithmetic) {

--- a/cpp/src/gandiva/tests/micro_benchmarks.cc
+++ b/cpp/src/gandiva/tests/micro_benchmarks.cc
@@ -312,9 +312,9 @@ static void DoDecimalAdd3(benchmark::State& state, int32_t precision, int32_t sc
 
   Decimal128DataGenerator data_generator(large);
   ProjectEvaluator evaluator(projector);
-
+  auto pool = ::arrow::default_memory_pool();
   status = TimedEvaluate<arrow::Decimal128Type, arrow::Decimal128>(
-      schema, evaluator, data_generator, arrow::default_memory_pool(), 1 * MILLION,
+      schema, evaluator, data_generator, pool, 1 * MILLION,
       16 * THOUSAND, state);
   ASSERT_OK(status);
 }
@@ -343,9 +343,9 @@ static void DoDecimalAdd2(benchmark::State& state, int32_t precision, int32_t sc
 
   Decimal128DataGenerator data_generator(large);
   ProjectEvaluator evaluator(projector);
-
+  auto pool = ::arrow::default_memory_pool();
   status = TimedEvaluate<arrow::Decimal128Type, arrow::Decimal128>(
-      schema, evaluator, data_generator, arrow::default_memory_pool(), 1 * MILLION,
+      schema, evaluator, data_generator, pool, 1 * MILLION,
       16 * THOUSAND, state);
   ASSERT_OK(status);
 }

--- a/cpp/src/gandiva/tests/null_validity_test.cc
+++ b/cpp/src/gandiva/tests/null_validity_test.cc
@@ -33,7 +33,7 @@ class TestNullValidity : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 // Create an array without a validity buffer.

--- a/cpp/src/gandiva/tests/projector_build_validation_test.cc
+++ b/cpp/src/gandiva/tests/projector_build_validation_test.cc
@@ -32,7 +32,7 @@ class TestProjector : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestProjector, TestNonExistentFunction) {

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -32,7 +32,7 @@ class TestProjector : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestProjector, TestProjectCache) {
@@ -200,7 +200,7 @@ TEST_F(TestProjector, TestIntSumSub) {
 }
 
 template <typename TYPE, typename C_TYPE>
-static void TestArithmeticOpsForType(arrow::MemoryPool* pool) {
+static void TestArithmeticOpsForType(std::shared_ptr<arrow::MemoryPool>& pool) {
   auto atype = arrow::TypeTraits<TYPE>::type_singleton();
 
   // schema for input fields

--- a/cpp/src/gandiva/tests/to_string_test.cc
+++ b/cpp/src/gandiva/tests/to_string_test.cc
@@ -35,7 +35,7 @@ class TestToString : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 #define CHECK_EXPR_TO_STRING(e, str) EXPECT_STREQ(e->ToString().c_str(), str)

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -36,7 +36,7 @@ class TestUtf8 : public ::testing::Test {
   void SetUp() { pool_ = arrow::default_memory_pool(); }
 
  protected:
-  arrow::MemoryPool* pool_;
+  std::shared_ptr<arrow::MemoryPool> pool_;
 };
 
 TEST_F(TestUtf8, TestSimple) {

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -109,7 +109,7 @@ class RowGroupReader;
 // arrays
 class PARQUET_EXPORT FileReader {
  public:
-  FileReader(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader);
+  FileReader(std::shared_ptr<::arrow::MemoryPool>& pool, std::unique_ptr<ParquetFileReader> reader);
 
   // Since the distribution of columns amongst a Parquet file's row groups may
   // be uneven (the number of values in each column chunk can be different), we
@@ -296,14 +296,14 @@ class PARQUET_EXPORT ColumnReader {
 // metadata : separately-computed file metadata, can be nullptr
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
-                         ::arrow::MemoryPool* allocator,
+                         std::shared_ptr<::arrow::MemoryPool>& allocator,
                          const ReaderProperties& properties,
                          const std::shared_ptr<FileMetaData>& metadata,
                          std::unique_ptr<FileReader>* reader);
 
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::ReadableFileInterface>& file,
-                         ::arrow::MemoryPool* allocator,
+                         std::shared_ptr<::arrow::MemoryPool>& allocator,
                          std::unique_ptr<FileReader>* reader);
 
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/record_reader.cc
+++ b/cpp/src/parquet/arrow/record_reader.cc
@@ -58,7 +58,7 @@ constexpr int64_t kMinLevelBatchSize = 1024;
 
 class RecordReader::RecordReaderImpl {
  public:
-  RecordReaderImpl(const ColumnDescriptor* descr, MemoryPool* pool)
+  RecordReaderImpl(const ColumnDescriptor* descr, std::shared_ptr<MemoryPool>& pool)
       : descr_(descr),
         pool_(pool),
         num_buffered_values_(0),
@@ -394,7 +394,7 @@ class RecordReader::RecordReaderImpl {
   virtual bool ReadNewPage() = 0;
 
   const ColumnDescriptor* descr_;
-  ::arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
 
   std::unique_ptr<PageReader> pager_;
   std::shared_ptr<Page> current_page_;
@@ -470,7 +470,7 @@ class TypedRecordReader : public RecordReader::RecordReaderImpl {
 
   using BuilderType = typename RecordReaderTraits<DType>::BuilderType;
 
-  TypedRecordReader(const ColumnDescriptor* descr, ::arrow::MemoryPool* pool)
+  TypedRecordReader(const ColumnDescriptor* descr, std::shared_ptr<::arrow::MemoryPool>& pool)
       : RecordReader::RecordReaderImpl(descr, pool), current_decoder_(nullptr) {
     InitializeBuilder();
   }
@@ -846,7 +846,7 @@ bool TypedRecordReader<DType>::ReadNewPage() {
 }
 
 std::shared_ptr<RecordReader> RecordReader::Make(const ColumnDescriptor* descr,
-                                                 MemoryPool* pool) {
+                                                 std::shared_ptr<MemoryPool> pool) {
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::shared_ptr<RecordReader>(

--- a/cpp/src/parquet/arrow/record_reader.h
+++ b/cpp/src/parquet/arrow/record_reader.h
@@ -51,7 +51,7 @@ class RecordReader {
 
   static std::shared_ptr<RecordReader> Make(
       const ColumnDescriptor* descr,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+      std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool());
 
   virtual ~RecordReader();
 

--- a/cpp/src/parquet/arrow/test-util.h
+++ b/cpp/src/parquet/arrow/test-util.h
@@ -90,8 +90,9 @@ NonNullArray(size_t size, std::shared_ptr<Array>* out) {
   ::arrow::randint(size, 0, 64, &values);
 
   // Passing data type so this will work with TimestampType too
+  auto pool = ::arrow::default_memory_pool();
   ::arrow::NumericBuilder<ArrowType> builder(std::make_shared<ArrowType>(),
-                                             ::arrow::default_memory_pool());
+                                             pool);
   RETURN_NOT_OK(builder.AppendValues(values.data(), values.size()));
   return builder.Finish(out);
 }
@@ -106,8 +107,9 @@ typename std::enable_if<is_arrow_date<ArrowType>::value, Status>::type NonNullAr
   }
 
   // Passing data type so this will work with TimestampType too
+  auto pool = ::arrow::default_memory_pool();
   ::arrow::NumericBuilder<ArrowType> builder(std::make_shared<ArrowType>(),
-                                             ::arrow::default_memory_pool());
+                                             pool);
   builder.AppendValues(values.data(), values.size());
   return builder.Finish(out);
 }
@@ -172,7 +174,8 @@ NonNullArray(size_t size, std::shared_ptr<Array>* out) {
   constexpr int32_t seed = 0;
 
   std::shared_ptr<Buffer> out_buf;
-  RETURN_NOT_OK(::arrow::AllocateBuffer(::arrow::default_memory_pool(), size * byte_width,
+  auto pool = ::arrow::default_memory_pool();
+  RETURN_NOT_OK(::arrow::AllocateBuffer(pool, size * byte_width,
                                         &out_buf));
   random_decimals(size, seed, kDecimalPrecision, out_buf->mutable_data());
 
@@ -226,8 +229,9 @@ NullableArray(size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Arra
   }
 
   // Passing data type so this will work with TimestampType too
+  auto pool = ::arrow::default_memory_pool();
   ::arrow::NumericBuilder<ArrowType> builder(std::make_shared<ArrowType>(),
-                                             ::arrow::default_memory_pool());
+                                             pool);
   RETURN_NOT_OK(builder.AppendValues(values.data(), values.size(), valid_bytes.data()));
   return builder.Finish(out);
 }
@@ -250,8 +254,9 @@ typename std::enable_if<is_arrow_date<ArrowType>::value, Status>::type NullableA
   }
 
   // Passing data type so this will work with TimestampType too
+  auto pool = ::arrow::default_memory_pool();
   ::arrow::NumericBuilder<ArrowType> builder(std::make_shared<ArrowType>(),
-                                             ::arrow::default_memory_pool());
+                                             pool);
   builder.AppendValues(values.data(), values.size(), valid_bytes.data());
   return builder.Finish(out);
 }
@@ -331,7 +336,8 @@ NullableArray(size_t size, size_t num_nulls, uint32_t seed,
       static_cast<const ::arrow::Decimal128Type&>(*type).byte_width();
 
   std::shared_ptr<::arrow::Buffer> out_buf;
-  RETURN_NOT_OK(::arrow::AllocateBuffer(::arrow::default_memory_pool(), size * byte_width,
+  auto pool = ::arrow::default_memory_pool();
+  RETURN_NOT_OK(::arrow::AllocateBuffer(pool, size * byte_width,
                                         &out_buf));
 
   random_decimals(size, seed, precision, out_buf->mutable_data());
@@ -407,7 +413,8 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
   // Allocate an offsets buffer containing only zeroes
   std::shared_ptr<Buffer> offsets_buffer;
   const int64_t offsets_nbytes = (size + 1) * sizeof(int32_t);
-  RETURN_NOT_OK(::arrow::AllocateBuffer(::arrow::default_memory_pool(), offsets_nbytes,
+  auto pool = ::arrow::default_memory_pool();
+  RETURN_NOT_OK(::arrow::AllocateBuffer(pool, offsets_nbytes,
                                         &offsets_buffer));
   memset(offsets_buffer->mutable_data(), 0, offsets_nbytes);
 

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -136,30 +136,30 @@ std::shared_ptr<ArrowWriterProperties> PARQUET_EXPORT default_arrow_writer_prope
  */
 class PARQUET_EXPORT FileWriter {
  public:
-  FileWriter(::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileWriter> writer,
+  FileWriter(std::shared_ptr<::arrow::MemoryPool>& pool, std::unique_ptr<ParquetFileWriter> writer,
              const std::shared_ptr<::arrow::Schema>& schema,
              const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
                  default_arrow_writer_properties());
 
-  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+  static ::arrow::Status Open(const ::arrow::Schema& schema, std::shared_ptr<::arrow::MemoryPool>& pool,
                               const std::shared_ptr<OutputStream>& sink,
                               const std::shared_ptr<WriterProperties>& properties,
                               std::unique_ptr<FileWriter>* writer);
 
   static ::arrow::Status Open(
-      const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+      const ::arrow::Schema& schema, std::shared_ptr<::arrow::MemoryPool>& pool,
       const std::shared_ptr<OutputStream>& sink,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
       std::unique_ptr<FileWriter>* writer);
 
-  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+  static ::arrow::Status Open(const ::arrow::Schema& schema, std::shared_ptr<::arrow::MemoryPool>& pool,
                               const std::shared_ptr<::arrow::io::OutputStream>& sink,
                               const std::shared_ptr<WriterProperties>& properties,
                               std::unique_ptr<FileWriter>* writer);
 
   static ::arrow::Status Open(
-      const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+      const ::arrow::Schema& schema, std::shared_ptr<::arrow::MemoryPool>& pool,
       const std::shared_ptr<::arrow::io::OutputStream>& sink,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
@@ -179,7 +179,7 @@ class PARQUET_EXPORT FileWriter {
 
   virtual ~FileWriter();
 
-  ::arrow::MemoryPool* memory_pool() const;
+  std::shared_ptr<::arrow::MemoryPool> memory_pool() const;
 
  private:
   class PARQUET_NO_EXPORT Impl;
@@ -202,14 +202,14 @@ PARQUET_EXPORT
  * The table shall only consist of columns of primitive type or of primitive lists.
  */
 ::arrow::Status PARQUET_EXPORT WriteTable(
-    const ::arrow::Table& table, ::arrow::MemoryPool* pool,
+    const ::arrow::Table& table, std::shared_ptr<::arrow::MemoryPool>& pool,
     const std::shared_ptr<OutputStream>& sink, int64_t chunk_size,
     const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
     const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
         default_arrow_writer_properties());
 
 ::arrow::Status PARQUET_EXPORT WriteTable(
-    const ::arrow::Table& table, ::arrow::MemoryPool* pool,
+    const ::arrow::Table& table, std::shared_ptr<::arrow::MemoryPool>& pool,
     const std::shared_ptr<::arrow::io::OutputStream>& sink, int64_t chunk_size,
     const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
     const std::shared_ptr<ArrowWriterProperties>& arrow_properties =

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -234,7 +234,7 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   void SetMask(uint32_t key, BlockMask& mask) const;
 
   // Memory pool to allocate aligned buffer for bitset
-  ::arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
 
   // The underlying buffer of bitset.
   std::shared_ptr<Buffer> data_;

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -90,7 +90,7 @@ class PARQUET_EXPORT PageReader {
   static std::unique_ptr<PageReader> Open(
       std::unique_ptr<InputStream> stream, int64_t total_num_rows,
       Compression::type codec,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+      std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool());
 
   // @returns: shared_ptr<Page>(nullptr) on EOS, std::shared_ptr<Page>
   // containing new Page otherwise
@@ -105,7 +105,7 @@ class PARQUET_EXPORT ColumnReader {
 
   static std::shared_ptr<ColumnReader> Make(
       const ColumnDescriptor* descr, std::unique_ptr<PageReader> pager,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+      std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool());
 
   // Returns true if there are still values in this column.
   virtual bool HasNext() = 0;

--- a/cpp/src/parquet/column_scanner.cc
+++ b/cpp/src/parquet/column_scanner.cc
@@ -27,7 +27,7 @@ using arrow::MemoryPool;
 namespace parquet {
 
 std::shared_ptr<Scanner> Scanner::Make(std::shared_ptr<ColumnReader> col_reader,
-                                       int64_t batch_size, MemoryPool* pool) {
+                                       int64_t batch_size, std::shared_ptr<MemoryPool> pool) {
   switch (col_reader->type()) {
     case Type::BOOLEAN:
       return std::make_shared<BoolScanner>(col_reader, batch_size, pool);

--- a/cpp/src/parquet/column_scanner.h
+++ b/cpp/src/parquet/column_scanner.h
@@ -43,7 +43,7 @@ class PARQUET_EXPORT Scanner {
  public:
   explicit Scanner(std::shared_ptr<ColumnReader> reader,
                    int64_t batch_size = DEFAULT_SCANNER_BATCH_SIZE,
-                   ::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+                   std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool())
       : batch_size_(batch_size),
         level_offset_(0),
         levels_buffered_(0),
@@ -60,7 +60,7 @@ class PARQUET_EXPORT Scanner {
   static std::shared_ptr<Scanner> Make(
       std::shared_ptr<ColumnReader> col_reader,
       int64_t batch_size = DEFAULT_SCANNER_BATCH_SIZE,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+      std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool());
 
   virtual void PrintNext(std::ostream& out, int width) = 0;
 
@@ -95,7 +95,7 @@ class PARQUET_TEMPLATE_CLASS_EXPORT TypedScanner : public Scanner {
 
   explicit TypedScanner(std::shared_ptr<ColumnReader> reader,
                         int64_t batch_size = DEFAULT_SCANNER_BATCH_SIZE,
-                        ::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+                        std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool())
       : Scanner(reader, batch_size, pool) {
     typed_reader_ = static_cast<TypedColumnReader<DType>*>(reader.get());
     int value_byte_size = type_traits<DType::type_num>::value_byte_size;

--- a/cpp/src/parquet/column_writer-test.cc
+++ b/cpp/src/parquet/column_writer-test.cc
@@ -660,8 +660,9 @@ TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {
   auto values_data = reinterpret_cast<const int32_t*>(values_buffer->data());
 
   std::shared_ptr<Buffer> valid_bits;
+  auto pool = ::arrow::default_memory_pool();
   ASSERT_OK(::arrow::BitUtil::BytesToBits({1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1},
-                                          ::arrow::default_memory_pool(), &valid_bits));
+                                          pool, &valid_bits));
 
   // valgrind will warn about out of bounds access into def_levels_data
   typed_writer->WriteBatchSpaced(14, def_levels.data(), rep_levels.data(),

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -140,7 +140,7 @@ class SerializedPageWriter : public PageWriter {
  public:
   SerializedPageWriter(OutputStream* sink, Compression::type codec,
                        ColumnChunkMetaDataBuilder* metadata,
-                       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+                       std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool())
       : sink_(sink),
         metadata_(metadata),
         pool_(pool),
@@ -271,7 +271,7 @@ class SerializedPageWriter : public PageWriter {
  private:
   OutputStream* sink_;
   ColumnChunkMetaDataBuilder* metadata_;
-  ::arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
   int64_t num_values_;
   int64_t dictionary_page_offset_;
   int64_t data_page_offset_;
@@ -289,7 +289,7 @@ class BufferedPageWriter : public PageWriter {
  public:
   BufferedPageWriter(OutputStream* sink, Compression::type codec,
                      ColumnChunkMetaDataBuilder* metadata,
-                     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+                     std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool())
       : final_sink_(sink),
         metadata_(metadata),
         in_memory_sink_(new InMemoryOutputStream(pool)),
@@ -333,7 +333,7 @@ class BufferedPageWriter : public PageWriter {
 
 std::unique_ptr<PageWriter> PageWriter::Open(OutputStream* sink, Compression::type codec,
                                              ColumnChunkMetaDataBuilder* metadata,
-                                             ::arrow::MemoryPool* pool,
+                                             std::shared_ptr<::arrow::MemoryPool> pool,
                                              bool buffered_row_group) {
   if (buffered_row_group) {
     return std::unique_ptr<PageWriter>(
@@ -444,7 +444,7 @@ class ColumnWriterImpl {
 
   LevelEncoder level_encoder_;
 
-  ::arrow::MemoryPool* allocator_;
+  std::shared_ptr<::arrow::MemoryPool> allocator_;
 
   // The total number of values stored in the data page. This is the maximum of
   // the number of encoded definition levels or encoded values. For

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -85,7 +85,7 @@ class PARQUET_EXPORT PageWriter {
 
   static std::unique_ptr<PageWriter> Open(
       OutputStream* sink, Compression::type codec, ColumnChunkMetaDataBuilder* metadata,
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
+      std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool(),
       bool buffered_row_group = false);
 
   // The Column Writer decides if dictionary encoding is used if set and

--- a/cpp/src/parquet/encoding-benchmark.cc
+++ b/cpp/src/parquet/encoding-benchmark.cc
@@ -104,7 +104,7 @@ static void DecodeDict(std::vector<typename Type::c_type>& values,
   typedef typename Type::c_type T;
   int num_values = static_cast<int>(values.size());
 
-  MemoryPool* allocator = default_memory_pool();
+  std::shared_ptr<MemoryPool> allocator = default_memory_pool();
   std::shared_ptr<ColumnDescriptor> descr = Int64Schema(Repetition::REQUIRED);
 
   auto base_encoder =

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -183,7 +183,7 @@ class TestEncodingBase : public ::testing::Test {
   }
 
  protected:
-  MemoryPool* allocator_;
+  std::shared_ptr<MemoryPool> allocator_;
 
   int num_values_;
   int type_length_;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -272,8 +272,9 @@ std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
     source = handle;
   } else {
     std::shared_ptr<::arrow::io::ReadableFile> handle;
+    std::shared_ptr<::arrow::MemoryPool> pool = props.memory_pool();
     PARQUET_THROW_NOT_OK(
-        ::arrow::io::ReadableFile::Open(path, props.memory_pool(), &handle));
+        ::arrow::io::ReadableFile::Open(path, pool, &handle));
     source = handle;
   }
 

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -41,13 +41,13 @@ static bool DEFAULT_USE_BUFFERED_STREAM = false;
 
 class PARQUET_EXPORT ReaderProperties {
  public:
-  explicit ReaderProperties(::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+  explicit ReaderProperties(std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool())
       : pool_(pool) {
     buffered_stream_enabled_ = DEFAULT_USE_BUFFERED_STREAM;
     buffer_size_ = DEFAULT_BUFFER_SIZE;
   }
 
-  ::arrow::MemoryPool* memory_pool() const { return pool_; }
+  std::shared_ptr<::arrow::MemoryPool> memory_pool() const { return pool_; }
 
   std::unique_ptr<InputStream> GetStream(RandomAccessSource* source, int64_t start,
                                          int64_t num_bytes) {
@@ -72,7 +72,7 @@ class PARQUET_EXPORT ReaderProperties {
   int64_t buffer_size() const { return buffer_size_; }
 
  private:
-  ::arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
   int64_t buffer_size_;
   bool buffered_stream_enabled_;
 };
@@ -153,7 +153,7 @@ class PARQUET_EXPORT WriterProperties {
           created_by_(DEFAULT_CREATED_BY) {}
     virtual ~Builder() {}
 
-    Builder* memory_pool(::arrow::MemoryPool* pool) {
+    Builder* memory_pool(std::shared_ptr<::arrow::MemoryPool>& pool) {
       pool_ = pool;
       return this;
     }
@@ -331,7 +331,7 @@ class PARQUET_EXPORT WriterProperties {
     }
 
    private:
-    ::arrow::MemoryPool* pool_;
+    std::shared_ptr<::arrow::MemoryPool> pool_;
     int64_t dictionary_pagesize_limit_;
     int64_t write_batch_size_;
     int64_t max_row_group_length_;
@@ -347,7 +347,7 @@ class PARQUET_EXPORT WriterProperties {
     std::unordered_map<std::string, bool> statistics_enabled_;
   };
 
-  inline ::arrow::MemoryPool* memory_pool() const { return pool_; }
+  inline std::shared_ptr<::arrow::MemoryPool> memory_pool() const { return pool_; }
 
   inline int64_t dictionary_pagesize_limit() const { return dictionary_pagesize_limit_; }
 
@@ -406,7 +406,7 @@ class PARQUET_EXPORT WriterProperties {
 
  private:
   explicit WriterProperties(
-      ::arrow::MemoryPool* pool, int64_t dictionary_pagesize_limit,
+      std::shared_ptr<::arrow::MemoryPool>& pool, int64_t dictionary_pagesize_limit,
       int64_t write_batch_size, int64_t max_row_group_length, int64_t pagesize,
       ParquetVersion::type version, const std::string& created_by,
       const ColumnProperties& default_column_properties,
@@ -421,7 +421,7 @@ class PARQUET_EXPORT WriterProperties {
         default_column_properties_(default_column_properties),
         column_properties_(column_properties) {}
 
-  ::arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
   int64_t dictionary_pagesize_limit_;
   int64_t write_batch_size_;
   int64_t max_row_group_length_;

--- a/cpp/src/parquet/statistics-test.cc
+++ b/cpp/src/parquet/statistics-test.cc
@@ -204,10 +204,10 @@ template <>
 std::vector<FLBA> TestRowGroupStatistics<FLBAType>::GetDeepCopy(
     const std::vector<FLBA>& values) {
   std::vector<FLBA> copy;
-  MemoryPool* pool = ::arrow::default_memory_pool();
+  std::shared_ptr<MemoryPool> pool = ::arrow::default_memory_pool();
   for (const FLBA& flba : values) {
     uint8_t* ptr;
-    PARQUET_THROW_NOT_OK(pool->Allocate(FLBA_LENGTH, &ptr));
+    PARQUET_THROW_NOT_OK(pool.get()->Allocate(FLBA_LENGTH, &ptr));
     memcpy(ptr, flba.ptr, FLBA_LENGTH);
     copy.emplace_back(ptr);
   }
@@ -218,10 +218,10 @@ template <>
 std::vector<ByteArray> TestRowGroupStatistics<ByteArrayType>::GetDeepCopy(
     const std::vector<ByteArray>& values) {
   std::vector<ByteArray> copy;
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   for (const ByteArray& ba : values) {
     uint8_t* ptr;
-    PARQUET_THROW_NOT_OK(pool->Allocate(ba.len, &ptr));
+    PARQUET_THROW_NOT_OK(pool.get()->Allocate(ba.len, &ptr));
     memcpy(ptr, ba.ptr, ba.len);
     copy.emplace_back(ba.len, ptr);
   }
@@ -234,21 +234,21 @@ void TestRowGroupStatistics<TestType>::DeepFree(
 
 template <>
 void TestRowGroupStatistics<FLBAType>::DeepFree(std::vector<FLBA>& values) {
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   for (FLBA& flba : values) {
     auto ptr = const_cast<uint8_t*>(flba.ptr);
     memset(ptr, 0, FLBA_LENGTH);
-    pool->Free(ptr, FLBA_LENGTH);
+    pool.get()->Free(ptr, FLBA_LENGTH);
   }
 }
 
 template <>
 void TestRowGroupStatistics<ByteArrayType>::DeepFree(std::vector<ByteArray>& values) {
-  MemoryPool* pool = default_memory_pool();
+  std::shared_ptr<MemoryPool> pool = default_memory_pool();
   for (ByteArray& ba : values) {
     auto ptr = const_cast<uint8_t*>(ba.ptr);
     memset(ptr, 0, ba.len);
-    pool->Free(ptr, ba.len);
+    pool.get()->Free(ptr, ba.len);
   }
 }
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -34,7 +34,7 @@ namespace parquet {
 
 template <typename DType>
 TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(const ColumnDescriptor* schema,
-                                                        MemoryPool* pool)
+                                                        std::shared_ptr<MemoryPool> pool)
     : pool_(pool),
       min_buffer_(AllocateBuffer(pool_, 0)),
       max_buffer_(AllocateBuffer(pool_, 0)) {
@@ -64,7 +64,7 @@ template <typename DType>
 TypedRowGroupStatistics<DType>::TypedRowGroupStatistics(
     const ColumnDescriptor* schema, const std::string& encoded_min,
     const std::string& encoded_max, int64_t num_values, int64_t null_count,
-    int64_t distinct_count, bool has_min_max, MemoryPool* pool)
+    int64_t distinct_count, bool has_min_max, std::shared_ptr<MemoryPool> pool)
     : pool_(pool),
       min_buffer_(AllocateBuffer(pool_, 0)),
       max_buffer_(AllocateBuffer(pool_, 0)) {

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -146,7 +146,7 @@ class PARQUET_TEMPLATE_CLASS_EXPORT TypedRowGroupStatistics : public RowGroupSta
   using T = typename DType::c_type;
 
   TypedRowGroupStatistics(const ColumnDescriptor* schema,
-                          ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+                          std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool());
 
   TypedRowGroupStatistics(const T& min, const T& max, int64_t num_values,
                           int64_t null_count, int64_t distinct_count);
@@ -154,7 +154,7 @@ class PARQUET_TEMPLATE_CLASS_EXPORT TypedRowGroupStatistics : public RowGroupSta
   TypedRowGroupStatistics(const ColumnDescriptor* schema, const std::string& encoded_min,
                           const std::string& encoded_max, int64_t num_values,
                           int64_t null_count, int64_t distinct_count, bool has_min_max,
-                          ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+                          std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool());
 
   bool HasMinMax() const override;
   void Reset() override;
@@ -177,7 +177,7 @@ class PARQUET_TEMPLATE_CLASS_EXPORT TypedRowGroupStatistics : public RowGroupSta
   bool has_min_max_ = false;
   T min_;
   T max_;
-  ::arrow::MemoryPool* pool_;
+  std::shared_ptr<::arrow::MemoryPool> pool_;
   std::shared_ptr<CompareDefault<DType> > comparator_;
 
   void PlainEncode(const T& src, std::string* dst);

--- a/cpp/src/parquet/util/memory-test.cc
+++ b/cpp/src/parquet/util/memory-test.cc
@@ -39,8 +39,9 @@ TEST(TestBufferedInputStream, Basics) {
   int64_t stream_offset = 10;
   int64_t stream_size = source_size - stream_offset;
   int64_t chunk_size = 50;
+  auto pool = ::arrow::default_memory_pool();
   std::shared_ptr<ResizableBuffer> buf =
-      AllocateBuffer(default_memory_pool(), source_size);
+      AllocateBuffer(pool, source_size);
   ASSERT_EQ(source_size, buf->size());
   for (int i = 0; i < source_size; i++) {
     buf->mutable_data()[i] = static_cast<uint8_t>(i);
@@ -50,7 +51,7 @@ TEST(TestBufferedInputStream, Basics) {
       std::make_shared<ArrowInputFile>(std::make_shared<::arrow::io::BufferReader>(buf));
 
   std::unique_ptr<BufferedInputStream> stream(new BufferedInputStream(
-      default_memory_pool(), chunk_size, wrapper.get(), stream_offset, stream_size));
+      pool, chunk_size, wrapper.get(), stream_offset, stream_size));
 
   const uint8_t* output;
   int64_t bytes_read;

--- a/cpp/src/parquet/util/memory.cc
+++ b/cpp/src/parquet/util/memory.cc
@@ -66,7 +66,7 @@ std::unique_ptr<Codec> GetCodecFromArrow(Compression::type codec) {
 }
 
 template <class T>
-Vector<T>::Vector(int64_t size, MemoryPool* pool)
+Vector<T>::Vector(int64_t size, std::shared_ptr<MemoryPool>& pool)
     : buffer_(AllocateBuffer(pool, size * sizeof(T))), size_(size), capacity_(size) {
   if (size > 0) {
     data_ = reinterpret_cast<T*>(buffer_->mutable_data());
@@ -212,7 +212,7 @@ void InMemoryInputStream::Advance(int64_t num_bytes) { offset_ += num_bytes; }
 // ----------------------------------------------------------------------
 // In-memory output stream
 
-InMemoryOutputStream::InMemoryOutputStream(MemoryPool* pool, int64_t initial_capacity)
+InMemoryOutputStream::InMemoryOutputStream(std::shared_ptr<MemoryPool> pool, int64_t initial_capacity)
     : size_(0), capacity_(initial_capacity) {
   if (initial_capacity == 0) {
     initial_capacity = kInMemoryDefaultCapacity;
@@ -252,7 +252,7 @@ std::shared_ptr<Buffer> InMemoryOutputStream::GetBuffer() {
 // ----------------------------------------------------------------------
 // BufferedInputStream
 
-BufferedInputStream::BufferedInputStream(MemoryPool* pool, int64_t buffer_size,
+BufferedInputStream::BufferedInputStream(std::shared_ptr<MemoryPool>& pool, int64_t buffer_size,
                                          RandomAccessSource* source, int64_t start,
                                          int64_t num_bytes)
     : source_(source), stream_offset_(start), stream_end_(start + num_bytes) {
@@ -295,7 +295,7 @@ void BufferedInputStream::Advance(int64_t num_bytes) {
   buffer_offset_ += num_bytes;
 }
 
-std::shared_ptr<ResizableBuffer> AllocateBuffer(MemoryPool* pool, int64_t size) {
+std::shared_ptr<ResizableBuffer> AllocateBuffer(std::shared_ptr<MemoryPool> pool, int64_t size) {
   std::shared_ptr<ResizableBuffer> result;
   PARQUET_THROW_NOT_OK(arrow::AllocateResizableBuffer(pool, size, &result));
   return result;

--- a/cpp/src/parquet/util/memory.h
+++ b/cpp/src/parquet/util/memory.h
@@ -59,7 +59,7 @@ using ResizableBuffer = ::arrow::ResizableBuffer;
 template <class T>
 class PARQUET_EXPORT Vector {
  public:
-  explicit Vector(int64_t size, ::arrow::MemoryPool* pool);
+  explicit Vector(int64_t size, std::shared_ptr<::arrow::MemoryPool>& pool);
   void Resize(int64_t new_size);
   void Reserve(int64_t new_capacity);
   void Assign(int64_t size, const T val);
@@ -190,8 +190,8 @@ class PARQUET_EXPORT ArrowOutputStream : public ArrowFileMethods, public OutputS
 class PARQUET_EXPORT InMemoryOutputStream : public OutputStream {
  public:
   explicit InMemoryOutputStream(
-      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
-      int64_t initial_capacity = kInMemoryDefaultCapacity);
+     std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool(),
+     int64_t initial_capacity = kInMemoryDefaultCapacity);
 
   virtual ~InMemoryOutputStream();
 
@@ -270,7 +270,7 @@ class PARQUET_EXPORT InMemoryInputStream : public InputStream {
 // Implementation of an InputStream when only some of the bytes are in memory.
 class PARQUET_EXPORT BufferedInputStream : public InputStream {
  public:
-  BufferedInputStream(::arrow::MemoryPool* pool, int64_t buffer_size,
+  BufferedInputStream(std::shared_ptr<::arrow::MemoryPool>& pool, int64_t buffer_size,
                       RandomAccessSource* source, int64_t start, int64_t end);
   virtual const uint8_t* Peek(int64_t num_to_peek, int64_t* num_bytes);
   virtual const uint8_t* Read(int64_t num_to_read, int64_t* num_bytes);
@@ -287,7 +287,7 @@ class PARQUET_EXPORT BufferedInputStream : public InputStream {
 };
 
 std::shared_ptr<ResizableBuffer> PARQUET_EXPORT AllocateBuffer(
-    ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(), int64_t size = 0);
+    std::shared_ptr<::arrow::MemoryPool> pool = ::arrow::default_memory_pool(), int64_t size = 0);
 
 }  // namespace parquet
 

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -384,13 +384,13 @@ def read_csv(input_file, read_options=None, parse_options=None,
         CCSVConvertOptions c_convert_options
         shared_ptr[CCSVReader] reader
         shared_ptr[CTable] table
-
+        shared_ptr[CMemoryPool] pool = maybe_unbox_memory_pool(memory_pool)
     _get_reader(input_file, &stream)
     _get_read_options(read_options, &c_read_options)
     _get_parse_options(parse_options, &c_parse_options)
     _get_convert_options(convert_options, &c_convert_options)
 
-    check_status(CCSVReader.Make(maybe_unbox_memory_pool(memory_pool),
+    check_status(CCSVReader.Make(pool,
                                  stream, c_read_options, c_parse_options,
                                  c_convert_options, &reader))
     with nogil:

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -366,7 +366,7 @@ cdef class IpcMemHandle:
         buf : Buffer
           The serialized buffer.
         """
-        cdef CMemoryPool* pool_ = maybe_unbox_memory_pool(pool)
+        cdef shared_ptr[CMemoryPool] pool_ = maybe_unbox_memory_pool(pool)
         cdef shared_ptr[CBuffer] buf
         cdef CCudaIpcMemHandle* h = self.handle.get()
         check_status(h.Serialize(pool_, &buf))
@@ -900,7 +900,7 @@ def read_message(object source, pool=None):
     """
     cdef:
         Message result = Message.__new__(Message)
-    cdef CMemoryPool* pool_ = maybe_unbox_memory_pool(pool)
+    cdef shared_ptr[CMemoryPool] pool_ = maybe_unbox_memory_pool(pool)
     if not isinstance(source, BufferReader):
         reader = BufferReader(source)
     check_status(CudaReadMessage(reader.reader, pool_, &result.message))
@@ -930,7 +930,7 @@ def read_record_batch(object buffer, object schema, pool=None):
     """
     cdef shared_ptr[CSchema] schema_ = pyarrow_unwrap_schema(schema)
     cdef shared_ptr[CCudaBuffer] buffer_ = pyarrow_unwrap_cudabuffer(buffer)
-    cdef CMemoryPool* pool_ = maybe_unbox_memory_pool(pool)
+    cdef shared_ptr[CMemoryPool] pool_ = maybe_unbox_memory_pool(pool)
     cdef shared_ptr[CRecordBatch] batch
     check_status(CudaReadRecordBatch(schema_, buffer_, pool_, &batch))
     return pyarrow_wrap_batch(batch)

--- a/python/pyarrow/_orc.pxd
+++ b/python/pyarrow/_orc.pxd
@@ -36,7 +36,7 @@ cdef extern from "arrow/adapters/orc/adapter.h" \
     cdef cppclass ORCFileReader:
         @staticmethod
         CStatus Open(const shared_ptr[RandomAccessFile]& file,
-                     CMemoryPool* pool,
+                     shared_ptr[CMemoryPool]& pool,
                      unique_ptr[ORCFileReader]* reader)
 
         CStatus ReadSchema(shared_ptr[CSchema]* out)

--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -36,7 +36,7 @@ import six
 cdef class ORCReader:
     cdef:
         object source
-        CMemoryPool* allocator
+        shared_ptr[CMemoryPool] allocator
         unique_ptr[ORCFileReader] reader
 
     def __cinit__(self, MemoryPool memory_pool=None):

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -265,13 +265,13 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
 
 cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
     CStatus OpenFile(const shared_ptr[RandomAccessFile]& file,
-                     CMemoryPool* allocator,
+                     shared_ptr[CMemoryPool]& allocator,
                      const ReaderProperties& properties,
                      const shared_ptr[CFileMetaData]& metadata,
                      unique_ptr[FileReader]* reader)
 
     cdef cppclass FileReader:
-        FileReader(CMemoryPool* pool, unique_ptr[ParquetFileReader] reader)
+        FileReader(shared_ptr[CMemoryPool]& pool, unique_ptr[ParquetFileReader] reader)
         CStatus ReadColumn(int i, shared_ptr[CChunkedArray]* out)
         CStatus ReadSchemaField(int i, shared_ptr[CChunkedArray]* out)
 
@@ -308,7 +308,7 @@ cdef extern from "parquet/arrow/writer.h" namespace "parquet::arrow" nogil:
     cdef cppclass FileWriter:
 
         @staticmethod
-        CStatus Open(const CSchema& schema, CMemoryPool* pool,
+        CStatus Open(const CSchema& schema, shared_ptr[CMemoryPool]& pool,
                      const shared_ptr[OutputStream]& sink,
                      const shared_ptr[WriterProperties]& properties,
                      const shared_ptr[ArrowWriterProperties]& arrow_properties,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -611,7 +611,7 @@ cdef ParquetCompression compression_from_name(name):
 cdef class ParquetReader:
     cdef:
         object source
-        CMemoryPool* allocator
+        shared_ptr[CMemoryPool] allocator
         unique_ptr[FileReader] reader
         FileMetaData _metadata
 
@@ -809,7 +809,7 @@ cdef class ParquetWriter:
         cdef:
             shared_ptr[WriterProperties] properties
             c_string c_where
-            CMemoryPool* pool
+            shared_ptr[CMemoryPool] pool
 
         try:
             where = _stringify_path(where)

--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -30,7 +30,7 @@ cdef class StringBuilder:
         unique_ptr[CStringBuilder] builder
 
     def __cinit__(self, MemoryPool memory_pool=None):
-        cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+        cdef shared_ptr[CMemoryPool] pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CStringBuilder(pool))
 
     def append(self, value):

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -52,7 +52,7 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
         @staticmethod
         CStatus FromBuffer(const void* opaque_handle,
                            shared_ptr[CCudaIpcMemHandle]* handle)
-        CStatus Serialize(CMemoryPool* pool, shared_ptr[CBuffer]* out) const
+        CStatus Serialize(shared_ptr[CMemoryPool]& pool, shared_ptr[CBuffer]* out) const
 
     cdef cppclass CCudaBuffer" arrow::cuda::CudaBuffer"(CBuffer):
         CCudaBuffer(uint8_t* data, int64_t size,
@@ -111,9 +111,9 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
          shared_ptr[CCudaBuffer]* out)
     CStatus CudaReadMessage" arrow::cuda::ReadMessage"\
         (CCudaBufferReader* reader,
-         CMemoryPool* pool,
+         shared_ptr[CMemoryPool]& pool,
          unique_ptr[CMessage]* message)
     CStatus CudaReadRecordBatch" arrow::cuda::ReadRecordBatch"\
         (const shared_ptr[CSchema]& schema,
          const shared_ptr[CCudaBuffer]& buffer,
-         CMemoryPool* pool, shared_ptr[CRecordBatch]* out)
+         shared_ptr[CMemoryPool]& pool, shared_ptr[CRecordBatch]* out)

--- a/python/pyarrow/includes/libgandiva.pxd
+++ b/python/pyarrow/includes/libgandiva.pxd
@@ -45,17 +45,17 @@ cdef extern from "gandiva/selection_vector.h" namespace "gandiva" nogil:
 
     cdef CStatus SelectionVector_MakeInt16\
         "gandiva::SelectionVector::MakeInt16"(
-            int64_t max_slots, CMemoryPool* pool,
+            int64_t max_slots, shared_ptr[CMemoryPool]& pool,
             shared_ptr[CSelectionVector]* selection_vector)
 
     cdef CStatus SelectionVector_MakeInt32\
         "gandiva::SelectionVector::MakeInt32"(
-            int64_t max_slots, CMemoryPool* pool,
+            int64_t max_slots, shared_ptr[CMemoryPool]& pool,
             shared_ptr[CSelectionVector]* selection_vector)
 
     cdef CStatus SelectionVector_MakeInt64\
         "gandiva::SelectionVector::MakeInt64"(
-            int64_t max_slots, CMemoryPool* pool,
+            int64_t max_slots, shared_ptr[CMemoryPool]& pool,
             shared_ptr[CSelectionVector]* selection_vector)
 
 cdef extern from "gandiva/condition.h" namespace "gandiva" nogil:
@@ -182,7 +182,7 @@ cdef extern from "gandiva/projector.h" namespace "gandiva" nogil:
     cdef cppclass CProjector" gandiva::Projector":
 
         CStatus Evaluate(
-            const CRecordBatch& batch, CMemoryPool* pool,
+            const CRecordBatch& batch, shared_ptr[CMemoryPool]& pool,
             const CArrayVector* output)
 
 cdef extern from "gandiva/filter.h" namespace "gandiva" nogil:

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -38,12 +38,12 @@ cdef class Message:
 
 cdef class MemoryPool:
     cdef:
-        CMemoryPool* pool
+        shared_ptr[CMemoryPool] pool
 
-    cdef void init(self, CMemoryPool* pool)
+    cdef void init(self, shared_ptr[CMemoryPool]& pool)
 
 
-cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool)
+cdef shared_ptr[CMemoryPool] maybe_unbox_memory_pool(MemoryPool memory_pool)
 
 
 cdef class DataType:

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -312,7 +312,7 @@ cdef class SerializedPyObject:
 
         """
         cdef PyObject* result
-        cdef CMemoryPool* c_pool = maybe_unbox_memory_pool(memory_pool)
+        cdef shared_ptr[CMemoryPool] c_pool = maybe_unbox_memory_pool(memory_pool)
 
         with nogil:
             check_status(self.data.GetComponents(c_pool, &result))

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -464,7 +464,7 @@ cdef class Column(_PandasConvertible):
         """
         cdef:
             vector[shared_ptr[CColumn]] flattened
-            CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+            shared_ptr[CMemoryPool] pool = maybe_unbox_memory_pool(memory_pool)
 
         with nogil:
             check_status(self.column.Flatten(pool, &flattened))
@@ -778,7 +778,7 @@ cdef class RecordBatch(_PandasConvertible):
         """
         cdef:
             shared_ptr[CBuffer] buffer
-            CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+            shared_ptr[CMemoryPool] pool = maybe_unbox_memory_pool(memory_pool)
 
         with nogil:
             check_status(SerializeRecordBatch(deref(self.batch),
@@ -929,7 +929,7 @@ def table_to_blocks(PandasOptions options, Table table,
     cdef:
         PyObject* result_obj
         shared_ptr[CTable] c_table = table.sp_table
-        CMemoryPool* pool
+        shared_ptr[CMemoryPool] pool
         unordered_set[c_string] categorical_columns
 
     if categories is not None:
@@ -1026,7 +1026,7 @@ cdef class Table(_PandasConvertible):
         """
         cdef:
             shared_ptr[CTable] flattened
-            CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+            shared_ptr[CMemoryPool] pool = maybe_unbox_memory_pool(memory_pool)
 
         with nogil:
             check_status(self.table.Flatten(pool, &flattened))

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -83,3 +83,9 @@ def test_set_memory_pool():
         assert pool.bytes_allocated() == allocated_before
     finally:
         pa.set_memory_pool(old_pool)
+
+
+def test_memory_pool_destruction():
+    pool = pa.logging_memory_pool(pa.default_memory_pool())
+    buf = pa.allocate_buffer(512, memory_pool=pool)
+    del pool

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -891,7 +891,7 @@ cdef class Schema:
         """
         cdef:
             shared_ptr[CBuffer] buffer
-            CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+            shared_ptr[CMemoryPool] pool = maybe_unbox_memory_pool(memory_pool)
 
         with nogil:
             check_status(SerializeSchema(deref(self.schema),


### PR DESCRIPTION
This PR implements MemoryPool storage using shared_ptr to ensure that MemoryPool will be kept alive until all its Buffers are deallocated.

Fixes [ARROW-4825](https://issues.apache.org/jira/browse/ARROW-4825).
