### PR TITLE
ARROW-2102: [C++] Implement Take kernel

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -158,6 +158,7 @@ if(ARROW_COMPUTE)
       compute/kernels/hash.cc
       compute/kernels/mean.cc
       compute/kernels/sum.cc
+      compute/kernels/take.cc
       compute/kernels/util-internal.cc
       compute/operations/cast.cc
       compute/operations/literal.cc)

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -232,8 +232,8 @@ Status FixedSizeBinaryBuilder::AppendValues(const uint8_t* data, int64_t length,
 
 Status FixedSizeBinaryBuilder::AppendNull() {
   RETURN_NOT_OK(Reserve(1));
-  UnsafeAppendToBitmap(false);
-  return byte_builder_.Advance(byte_width_);
+  UnsafeAppendNull();
+  return Status::OK();
 }
 
 void FixedSizeBinaryBuilder::Reset() {

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -195,9 +195,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   }
 
   void UnsafeAppend(util::string_view value) {
-#ifndef NDEBUG
-    CheckValueSize(static_cast<int64_t>(value.size()));
-#endif
+    CheckValueSize(value);
     UnsafeAppend(reinterpret_cast<const uint8_t*>(value.data()));
   }
 
@@ -206,16 +204,12 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   }
 
   Status Append(const util::string_view& view) {
-#ifndef NDEBUG
-    CheckValueSize(static_cast<int64_t>(view.size()));
-#endif
+    CheckValueSize(view);
     return Append(reinterpret_cast<const uint8_t*>(view.data()));
   }
 
   Status Append(const std::string& s) {
-#ifndef NDEBUG
-    CheckValueSize(static_cast<int64_t>(s.size()));
-#endif
+    CheckValueSize(s);
     return Append(reinterpret_cast<const uint8_t*>(s.data()));
   }
 
@@ -257,6 +251,13 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
  protected:
   int32_t byte_width_;
   BufferBuilder byte_builder_;
+
+  template <typename Sized>
+  void CheckValueSize(const Sized& s, decltype(s.size())* = nullptr) {
+#ifndef NDEBUG
+    CheckValueSize(static_cast<size_t>(s.size()));
+#endif
+  }
 
 #ifndef NDEBUG
   void CheckValueSize(int64_t size);

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -189,6 +189,18 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
     return byte_builder_.Append(value, byte_width_);
   }
 
+  void UnsafeAppend(const uint8_t* value) {
+    UnsafeAppendToBitmap(true);
+    byte_builder_.UnsafeAppend(value, byte_width_);
+  }
+
+  void UnsafeAppend(util::string_view value) {
+#ifndef NDEBUG
+    CheckValueSize(static_cast<int64_t>(value.size()));
+#endif
+    UnsafeAppend(reinterpret_cast<const uint8_t*>(value.data()));
+  }
+
   Status Append(const char* value) {
     return Append(reinterpret_cast<const uint8_t*>(value));
   }
@@ -217,6 +229,11 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   Status AppendValues(const uint8_t* data, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
   Status AppendNull();
+
+  void UnsafeAppendNull() {
+    UnsafeAppendToBitmap(false);
+    byte_builder_.UnsafeAdvance(byte_width_);
+  }
 
   void Reset() override;
   Status Resize(int64_t capacity) override;

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -253,7 +253,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   BufferBuilder byte_builder_;
 
   template <typename Sized>
-  void CheckValueSize(const Sized& s, decltype(s.size())* = nullptr) {
+  void CheckValueSize(const Sized& s, decltype(s.size())* = NULLPTR) {
 #ifndef NDEBUG
     CheckValueSize(static_cast<size_t>(s.size()));
 #endif

--- a/cpp/src/arrow/compute/api.h
+++ b/cpp/src/arrow/compute/api.h
@@ -27,5 +27,6 @@
 #include "arrow/compute/kernels/hash.h"     // IWYU pragma: export
 #include "arrow/compute/kernels/mean.h"     // IWYU pragma: export
 #include "arrow/compute/kernels/sum.h"      // IWYU pragma: export
+#include "arrow/compute/kernels/take.h"     // IWYU pragma: export
 
 #endif  // ARROW_COMPUTE_API_H

--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -20,6 +20,7 @@ arrow_install_all_headers("arrow/compute/kernels")
 add_arrow_test(boolean-test PREFIX "arrow-compute")
 add_arrow_test(cast-test PREFIX "arrow-compute")
 add_arrow_test(hash-test PREFIX "arrow-compute")
+add_arrow_test(take-test PREFIX "arrow-compute")
 add_arrow_test(util-internal-test PREFIX "arrow-compute")
 
 # Aggregates

--- a/cpp/src/arrow/compute/kernels/take-test.cc
+++ b/cpp/src/arrow/compute/kernels/take-test.cc
@@ -92,7 +92,7 @@ TEST_F(TestTakeKernelWithBoolean, TakeBoolean) {
   ASSERT_RAISES(Invalid,
                 this->Take(boolean(), "[true, false, true]", "[0, 9, 0]", options, &arr));
 
-  options.out_of_bounds = TakeOptions::TONULL;
+  options.out_of_bounds = TakeOptions::TO_NULL;
   this->AssertTake("[true, false, true]", "[0, 9, 0]", options, "[true, null, true]");
 }
 
@@ -120,7 +120,7 @@ TYPED_TEST(TestTakeKernelWithNumeric, TakeNumeric) {
   ASSERT_RAISES(Invalid, this->Take(this->type_singleton(), "[7, 8, 9]", "[0, 9, 0]",
                                     options, &arr));
 
-  options.out_of_bounds = TakeOptions::TONULL;
+  options.out_of_bounds = TakeOptions::TO_NULL;
   this->AssertTake("[7, 8, 9]", "[0, 9, 0]", options, "[7, null, 7]");
 }
 
@@ -155,7 +155,7 @@ TEST_F(TestTakeKernelWithString, TakeString) {
   ASSERT_RAISES(Invalid,
                 this->Take(utf8(), R"(["a", "b", "c"])", "[0, 9, 0]", options, &arr));
 
-  options.out_of_bounds = TakeOptions::TONULL;
+  options.out_of_bounds = TakeOptions::TO_NULL;
   this->AssertTake(R"(["a", "b", "c"])", "[0, 9, 0]", options, R"(["a", null, "a"])");
 }
 
@@ -167,7 +167,7 @@ TEST_F(TestTakeKernelWithString, TakeDictionary) {
                              "[null, 1, null]");
   this->AssertTakeDictionary(dict, "[0, 1, 4]", "[null, 1, 0]", options, "[null, 1, 0]");
 
-  options.out_of_bounds = TakeOptions::TONULL;
+  options.out_of_bounds = TakeOptions::TO_NULL;
   this->AssertTakeDictionary(dict, "[0, 1, 4]", "[0, 9, 0]", options, "[0, null, 0]");
 }
 

--- a/cpp/src/arrow/compute/kernels/take-test.cc
+++ b/cpp/src/arrow/compute/kernels/take-test.cc
@@ -34,11 +34,11 @@ using util::string_view;
 template <typename ArrowType>
 class TestTakeKernel : public ComputeFixture, public TestBase {
  protected:
-  void AssertTake(const std::shared_ptr<Array>& values,
-                  const std::shared_ptr<Array>& indices, TakeOptions options,
-                  const std::shared_ptr<Array>& expected) {
+  void AssertTakeArrays(const std::shared_ptr<Array>& values,
+                        const std::shared_ptr<Array>& indices, TakeOptions options,
+                        const std::shared_ptr<Array>& expected) {
     std::shared_ptr<Array> actual;
-    ASSERT_OK(arrow::compute::Take(&this->ctx_, *values, *indices, options, actual));
+    ASSERT_OK(arrow::compute::Take(&this->ctx_, *values, *indices, options, &actual));
     AssertArraysEqual(*expected, *actual);
   }
   void AssertTake(const std::shared_ptr<DataType>& type, const std::string& values,
@@ -140,9 +140,8 @@ class TestTakeKernelWithString : public TestTakeKernel<StringType> {
                                           &values));
     ASSERT_OK(DictionaryArray::FromArrays(type, ArrayFromJSON(int8(), expected_indices),
                                           &expected));
-    ASSERT_OK(arrow::compute::Take(&this->ctx_, *values, *ArrayFromJSON(int8(), indices),
-                                   options, &actual));
-    AssertArraysEqual(*expected, *actual);
+    auto take_indices = ArrayFromJSON(int8(), indices);
+    this->AssertTakeArrays(values, take_indices, options, expected);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/take-test.cc
+++ b/cpp/src/arrow/compute/kernels/take-test.cc
@@ -94,9 +94,6 @@ TEST_F(TestTakeKernelWithBoolean, TakeBoolean) {
   std::shared_ptr<Array> arr;
   ASSERT_RAISES(Invalid, this->Take(boolean(), "[true, false, true]", int8(), "[0, 9, 0]",
                                     options, &arr));
-
-  options.out_of_bounds = TakeOptions::TO_NULL;
-  this->AssertTake("[true, false, true]", "[0, 9, 0]", options, "[true, null, true]");
 }
 
 template <typename ArrowType>
@@ -122,9 +119,6 @@ TYPED_TEST(TestTakeKernelWithNumeric, TakeNumeric) {
   std::shared_ptr<Array> arr;
   ASSERT_RAISES(Invalid, this->Take(this->type_singleton(), "[7, 8, 9]", int8(),
                                     "[0, 9, 0]", options, &arr));
-
-  options.out_of_bounds = TakeOptions::TO_NULL;
-  this->AssertTake("[7, 8, 9]", "[0, 9, 0]", options, "[7, null, 7]");
 }
 
 class TestTakeKernelWithString : public TestTakeKernel<StringType> {
@@ -157,9 +151,6 @@ TEST_F(TestTakeKernelWithString, TakeString) {
   std::shared_ptr<Array> arr;
   ASSERT_RAISES(Invalid, this->Take(utf8(), R"(["a", "b", "c"])", int8(), "[0, 9, 0]",
                                     options, &arr));
-
-  options.out_of_bounds = TakeOptions::TO_NULL;
-  this->AssertTake(R"(["a", "b", "c"])", "[0, 9, 0]", options, R"(["a", null, "a"])");
 }
 
 TEST_F(TestTakeKernelWithString, TakeDictionary) {
@@ -169,9 +160,6 @@ TEST_F(TestTakeKernelWithString, TakeDictionary) {
   this->AssertTakeDictionary(dict, "[null, 4, 2]", "[0, 1, 0]", options,
                              "[null, 4, null]");
   this->AssertTakeDictionary(dict, "[3, 4, 2]", "[null, 1, 0]", options, "[null, 4, 3]");
-
-  options.out_of_bounds = TakeOptions::TO_NULL;
-  this->AssertTakeDictionary(dict, "[3, 4, 2]", "[0, 9, 0]", options, "[3, null, 3]");
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/take-test.cc
+++ b/cpp/src/arrow/compute/kernels/take-test.cc
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// returnGegarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <vector>
+
+#include "arrow/compute/context.h"
+#include "arrow/compute/kernels/take.h"
+#include "arrow/compute/test-util.h"
+#include "arrow/testing/gtest_common.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/testing/util.h"
+
+namespace arrow {
+namespace compute {
+
+using util::string_view;
+
+template <typename ArrowType>
+class TestTakeKernel : public ComputeFixture, public TestBase {
+ protected:
+  void AssertTake(const std::shared_ptr<DataType>& type, const std::string& values,
+                  const std::string& indices, TakeOptions options,
+                  const std::string& expected) {
+    std::shared_ptr<Array> actual;
+    ASSERT_OK(this->Take(type, values, indices, options, &actual));
+    AssertArraysEqual(*ArrayFromJSON(type, expected), *actual);
+  }
+  Status Take(const std::shared_ptr<DataType>& type, const std::string& values,
+              const std::string& indices, TakeOptions options,
+              std::shared_ptr<Array>* out) {
+    return arrow::compute::Take(&this->ctx_, *ArrayFromJSON(type, values),
+                                *ArrayFromJSON(int8(), indices), options, out);
+  }
+};
+
+class TestTakeKernelWithNull : public TestTakeKernel<NullType> {
+ protected:
+  void AssertTake(const std::string& values, const std::string& indices,
+                  TakeOptions options, const std::string& expected) {
+    TestTakeKernel<NullType>::AssertTake(utf8(), values, indices, options, expected);
+  }
+};
+
+TEST_F(TestTakeKernelWithNull, TakeNull) {
+  TakeOptions options;
+  this->AssertTake("[null, null, null]", "[0, 1, 0]", options, "[null, null, null]");
+
+  std::shared_ptr<Array> arr;
+  ASSERT_RAISES(Invalid,
+                this->Take(null(), "[null, null, null]", "[0, 9, 0]", options, &arr));
+}
+
+class TestTakeKernelWithBoolean : public TestTakeKernel<BooleanType> {
+ protected:
+  void AssertTake(const std::string& values, const std::string& indices,
+                  TakeOptions options, const std::string& expected) {
+    TestTakeKernel<BooleanType>::AssertTake(boolean(), values, indices, options,
+                                            expected);
+  }
+};
+
+TEST_F(TestTakeKernelWithBoolean, TakeBoolean) {
+  TakeOptions options;
+  this->AssertTake("[true, false, true]", "[0, 1, 0]", options, "[true, false, true]");
+  this->AssertTake("[null, false, true]", "[0, 1, 0]", options, "[null, false, null]");
+  this->AssertTake("[true, false, true]", "[null, 1, 0]", options, "[null, false, true]");
+
+  std::shared_ptr<Array> arr;
+  ASSERT_RAISES(Invalid,
+                this->Take(boolean(), "[true, false, true]", "[0, 9, 0]", options, &arr));
+
+  options.out_of_bounds = TakeOptions::TONULL;
+  this->AssertTake("[true, false, true]", "[0, 9, 0]", options, "[true, null, true]");
+}
+
+template <typename ArrowType>
+class TestTakeKernelWithNumeric : public TestTakeKernel<ArrowType> {
+ protected:
+  void AssertTake(const std::string& values, const std::string& indices,
+                  TakeOptions options, const std::string& expected) {
+    TestTakeKernel<ArrowType>::AssertTake(type_singleton(), values, indices, options,
+                                          expected);
+  }
+  std::shared_ptr<DataType> type_singleton() {
+    return TypeTraits<ArrowType>::type_singleton();
+  }
+};
+
+TYPED_TEST_CASE(TestTakeKernelWithNumeric, NumericArrowTypes);
+TYPED_TEST(TestTakeKernelWithNumeric, TakeNumeric) {
+  TakeOptions options;
+  this->AssertTake("[7, 8, 9]", "[0, 1, 0]", options, "[7, 8, 7]");
+  this->AssertTake("[null, 8, 9]", "[0, 1, 0]", options, "[null, 8, null]");
+  this->AssertTake("[7, 8, 9]", "[null, 1, 0]", options, "[null, 8, 7]");
+
+  std::shared_ptr<Array> arr;
+  ASSERT_RAISES(Invalid, this->Take(this->type_singleton(), "[7, 8, 9]", "[0, 9, 0]",
+                                    options, &arr));
+
+  options.out_of_bounds = TakeOptions::TONULL;
+  this->AssertTake("[7, 8, 9]", "[0, 9, 0]", options, "[7, null, 7]");
+}
+
+class TestTakeKernelWithString : public TestTakeKernel<StringType> {
+ protected:
+  void AssertTake(const std::string& values, const std::string& indices,
+                  TakeOptions options, const std::string& expected) {
+    TestTakeKernel<StringType>::AssertTake(utf8(), values, indices, options, expected);
+  }
+};
+
+TEST_F(TestTakeKernelWithString, TakeString) {
+  TakeOptions options;
+  this->AssertTake(R"(["a", "b", "c"])", "[0, 1, 0]", options, R"(["a", "b", "a"])");
+  this->AssertTake(R"([null, "b", "c"])", "[0, 1, 0]", options, "[null, \"b\", null]");
+  this->AssertTake(R"(["a", "b", "c"])", "[null, 1, 0]", options, R"([null, "b", "a"])");
+
+  std::shared_ptr<Array> arr;
+  ASSERT_RAISES(Invalid,
+                this->Take(utf8(), R"(["a", "b", "c"])", "[0, 9, 0]", options, &arr));
+
+  options.out_of_bounds = TakeOptions::TONULL;
+  this->AssertTake(R"(["a", "b", "c"])", "[0, 9, 0]", options, R"(["a", null, "a"])");
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -21,6 +21,7 @@
 #include "arrow/builder.h"
 #include "arrow/compute/context.h"
 #include "arrow/compute/kernels/take.h"
+#include "arrow/util/logging.h"
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
@@ -31,7 +32,7 @@ Status Take(FunctionContext* context, const Array& values, const Array& indices,
   TakeKernel kernel(values.type(), options);
   Datum out_datum;
   RETURN_NOT_OK(kernel.Call(context, values.data(), indices.data(), &out_datum));
-  *out = MakeArray(out_datum.array());
+  *out = out_datum.make_array();
   return Status::OK();
 }
 
@@ -119,8 +120,8 @@ Status TakeImpl(FunctionContext* context, const ValueArray& values,
     case TakeOptions::UNSAFE:
       return TakeImpl<TakeOptions::UNSAFE>(context, values, indices, builder);
     default:
-      ARROW_LOG(FATAL) << "how did we get here?";
-      return Status::OK();
+      ARROW_LOG(FATAL) << "how did we get here";
+      return Status::NotImplemented("how did we get here");
   }
 }
 
@@ -202,8 +203,8 @@ Status TakeKernel::Call(FunctionContext* ctx, const Datum& values, const Datum& 
   std::shared_ptr<Array> out_array;
   TakeParameters params;
   params.context = ctx;
-  params.values = MakeArray(values.array());
-  params.indices = MakeArray(indices.array());
+  params.values = values.make_array();
+  params.indices = indices.make_array();
   params.options = options_;
   params.out = &out_array;
   UnpackIndices unpack = {params};

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -79,7 +79,7 @@ Status TakeImpl(FunctionContext*, const ValueArray& values, const IndexArray& in
       continue;
     }
     auto index = static_cast<int64_t>(raw_indices[i]);
-    if (B == TakeOptions::ERROR && (index < 0 || index >= values.length())) {
+    if (B == TakeOptions::RAISE && (index < 0 || index >= values.length())) {
       return Status::Invalid("take index out of bounds");
     }
     if (B == TakeOptions::TO_NULL && (index < 0 || index >= values.length())) {
@@ -120,8 +120,8 @@ Status TakeImpl(FunctionContext* context, const ValueArray& values,
                 const IndexArray& indices, const TakeOptions& options,
                 OutBuilder* builder) {
   switch (options.out_of_bounds) {
-    case TakeOptions::ERROR:
-      return TakeImpl<TakeOptions::ERROR>(context, values, indices, builder);
+    case TakeOptions::RAISE:
+      return TakeImpl<TakeOptions::RAISE>(context, values, indices, builder);
     case TakeOptions::TO_NULL:
       return TakeImpl<TakeOptions::TO_NULL>(context, values, indices, builder);
     case TakeOptions::UNSAFE:
@@ -152,7 +152,7 @@ struct UnpackValues {
 
   Status Visit(const NullType& t) {
     auto indices_length = params_.indices->length();
-    if (params_.options.out_of_bounds == TakeOptions::ERROR && indices_length != 0) {
+    if (params_.options.out_of_bounds == TakeOptions::RAISE && indices_length != 0) {
       auto indices = static_cast<IndexArrayRef>(*params_.indices).raw_values();
       auto minmax = std::minmax_element(indices, indices + indices_length);
       auto min = static_cast<int64_t>(*minmax.first);

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -118,6 +118,9 @@ Status TakeImpl(FunctionContext* context, const ValueArray& values,
       return TakeImpl<TakeOptions::TONULL>(context, values, indices, builder);
     case TakeOptions::UNSAFE:
       return TakeImpl<TakeOptions::UNSAFE>(context, values, indices, builder);
+    default:
+      ARROW_LOG(FATAL) << "how did we get here?";
+      return Status::OK();
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -157,7 +157,11 @@ struct UnpackValues {
   }
 
   Status Visit(const DictionaryType& t) {
-    UnpackValues<IndexType> unpack = {params_};
+    auto dictionary_indices = params_.values->data()->Copy();
+    dictionary_indices->type = t.index_type();
+    TakeParameters params = params_;
+    params.values = MakeArray(dictionary_indices);
+    UnpackValues<IndexType> unpack = {params};
     RETURN_NOT_OK(VisitTypeInline(*t.index_type(), &unpack));
     (*params_.out)->data()->type = dictionary(t.index_type(), t.dictionary());
     return Status::OK();

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -1,0 +1,213 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// returnGegarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <utility>
+
+#include "arrow/builder.h"
+#include "arrow/compute/context.h"
+#include "arrow/compute/kernels/take.h"
+#include "arrow/visitor_inline.h"
+
+namespace arrow {
+namespace compute {
+
+Status Take(FunctionContext* context, const Array& values, const Array& indices,
+            const TakeOptions& options, std::shared_ptr<Array>* out) {
+  TakeKernel kernel(values.type(), options);
+  Datum out_datum;
+  RETURN_NOT_OK(kernel.Call(context, values.data(), indices.data(), &out_datum));
+  *out = MakeArray(out_datum.array());
+  return Status::OK();
+}
+
+struct TakeParameters {
+  FunctionContext* context;
+  std::shared_ptr<Array> values, indices;
+  TakeOptions options;
+  std::shared_ptr<Array>* out;
+};
+
+template <typename Builder, typename Scalar>
+Status UnsafeAppend(Builder* builder, Scalar&& value) {
+  builder->UnsafeAppend(std::forward<Scalar>(value));
+  return Status::OK();
+}
+
+Status UnsafeAppend(BinaryBuilder* builder, util::string_view value) {
+  RETURN_NOT_OK(builder->ReserveData(static_cast<int64_t>(value.size())));
+  builder->UnsafeAppend(value);
+  return Status::OK();
+}
+
+Status UnsafeAppend(StringBuilder* builder, util::string_view value) {
+  RETURN_NOT_OK(builder->ReserveData(static_cast<int64_t>(value.size())));
+  builder->UnsafeAppend(value);
+  return Status::OK();
+}
+
+template <int OutOfBounds, bool AllValuesValid, bool AllIndicesValid, typename ValueArray,
+          typename IndexArray, typename OutBuilder>
+Status TakeImpl(FunctionContext*, const ValueArray& values, const IndexArray& indices,
+                OutBuilder* builder) {
+  for (int64_t i = 0; i != indices.length(); ++i) {
+    if (!AllIndicesValid && indices.IsNull(i)) {
+      builder->UnsafeAppendNull();
+      continue;
+    }
+    auto index = indices.raw_values()[i];
+    if (OutOfBounds == TakeOptions::ERROR &&
+        static_cast<int64_t>(index) >= values.length()) {
+      return Status::Invalid("take index out of bounds");
+    }
+    if (OutOfBounds == TakeOptions::TONULL &&
+        static_cast<int64_t>(index) >= values.length()) {
+      builder->UnsafeAppendNull();
+      continue;
+    }
+    if (!AllValuesValid && values.IsNull(index)) {
+      builder->UnsafeAppendNull();
+      continue;
+    }
+    RETURN_NOT_OK(UnsafeAppend(builder, values.GetView(index)));
+  }
+  return Status::OK();
+}
+
+template <int OutOfBounds, bool AllValuesValid, typename ValueArray, typename IndexArray,
+          typename OutBuilder>
+Status TakeImpl(FunctionContext* context, const ValueArray& values,
+                const IndexArray& indices, OutBuilder* builder) {
+  if (indices.null_count() == 0) {
+    return TakeImpl<OutOfBounds, AllValuesValid, true>(context, values, indices, builder);
+  }
+  return TakeImpl<OutOfBounds, AllValuesValid, false>(context, values, indices, builder);
+}
+
+template <int OutOfBounds, typename ValueArray, typename IndexArray, typename OutBuilder>
+Status TakeImpl(FunctionContext* context, const ValueArray& values,
+                const IndexArray& indices, OutBuilder* builder) {
+  if (values.null_count() == 0) {
+    return TakeImpl<OutOfBounds, true>(context, values, indices, builder);
+  }
+  return TakeImpl<OutOfBounds, false>(context, values, indices, builder);
+}
+
+template <typename ValueArray, typename IndexArray, typename OutBuilder>
+Status TakeImpl(FunctionContext* context, const ValueArray& values,
+                const IndexArray& indices, const TakeOptions& options,
+                OutBuilder* builder) {
+  switch (options.out_of_bounds) {
+    case TakeOptions::ERROR:
+      return TakeImpl<TakeOptions::ERROR>(context, values, indices, builder);
+    case TakeOptions::TONULL:
+      return TakeImpl<TakeOptions::TONULL>(context, values, indices, builder);
+    case TakeOptions::UNSAFE:
+      return TakeImpl<TakeOptions::UNSAFE>(context, values, indices, builder);
+  }
+}
+
+template <typename IndexType>
+struct UnpackValues {
+  using IndexArrayRef = const typename TypeTraits<IndexType>::ArrayType&;
+
+  template <typename ValueType>
+  Status Visit(const ValueType&) {
+    using ValueArrayRef = const typename TypeTraits<ValueType>::ArrayType&;
+    using OutBuilder = typename TypeTraits<ValueType>::BuilderType;
+    IndexArrayRef indices = static_cast<IndexArrayRef>(*params_.indices);
+    ValueArrayRef values = static_cast<ValueArrayRef>(*params_.values);
+    std::unique_ptr<ArrayBuilder> builder;
+    RETURN_NOT_OK(MakeBuilder(params_.context->memory_pool(), values.type(), &builder));
+    RETURN_NOT_OK(builder->Reserve(indices.length()));
+    RETURN_NOT_OK(TakeImpl(params_.context, values, indices, params_.options,
+                           static_cast<OutBuilder*>(builder.get())));
+    return builder->Finish(params_.out);
+  }
+
+  Status Visit(const NullType& t) {
+    auto indices_length = params_.indices->length();
+    if (params_.options.out_of_bounds == TakeOptions::ERROR && indices_length != 0) {
+      auto indices = static_cast<IndexArrayRef>(*params_.indices).raw_values();
+      auto max = *std::max_element(indices, indices + indices_length);
+      if (static_cast<int64_t>(max) > params_.values->length()) {
+        return Status::Invalid("out of bounds index");
+      }
+    }
+    params_.out->reset(new NullArray(indices_length));
+    return Status::OK();
+  }
+
+  Status Visit(const DictionaryType& t) {
+    UnpackValues<IndexType> unpack = {params_};
+    RETURN_NOT_OK(VisitTypeInline(*t.index_type(), &unpack));
+    (*params_.out)->data()->type = dictionary(t.index_type(), t.dictionary());
+    return Status::OK();
+  }
+
+  Status Visit(const ExtensionType& t) {
+    // XXX can we just take from its storage?
+    return Status::NotImplemented("gathering values of type ", t);
+  }
+
+  Status Visit(const UnionType& t) {
+    return Status::NotImplemented("gathering values of type ", t);
+  }
+
+  Status Visit(const ListType& t) {
+    return Status::NotImplemented("gathering values of type ", t);
+  }
+
+  Status Visit(const StructType& t) {
+    return Status::NotImplemented("gathering values of type ", t);
+  }
+
+  const TakeParameters& params_;
+};
+
+struct UnpackIndices {
+  template <typename IndexType>
+  enable_if_integer<IndexType, Status> Visit(const IndexType&) {
+    UnpackValues<IndexType> unpack = {params_};
+    return VisitTypeInline(*params_.values->type(), &unpack);
+  }
+  Status Visit(const DataType& other) {
+    return Status::Invalid("index type not supported: ", other);
+  }
+  const TakeParameters& params_;
+};
+
+Status TakeKernel::Call(FunctionContext* ctx, const Datum& values, const Datum& indices,
+                        Datum* out) {
+  if (!values.is_array() || !indices.is_array()) {
+    return Status::Invalid("TakeKernel expects array values and indices");
+  }
+  std::shared_ptr<Array> out_array;
+  TakeParameters params;
+  params.context = ctx;
+  params.values = MakeArray(values.array());
+  params.indices = MakeArray(indices.array());
+  params.options = options_;
+  params.out = &out_array;
+  UnpackIndices unpack = {params};
+  RETURN_NOT_OK(VisitTypeInline(*indices.type(), &unpack));
+  *out = Datum(out_array);
+  return Status::OK();
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/take.h
+++ b/cpp/src/arrow/compute/kernels/take.h
@@ -32,12 +32,14 @@ namespace compute {
 class FunctionContext;
 
 struct ARROW_EXPORT TakeOptions {
-  enum {
-    // indices out of bounds will raise an error
+  enum OutOfBoundsBehavior {
+    // Out of bounds indices will raise an error
     ERROR,
-    // indices out of bounds will result in a null value
-    TONULL,
-    // indices out of bounds is undefined behavior
+    // Out of bounds indices will result in a null value
+    TO_NULL,
+    // Bounds checking will be skipped, which is faster.
+    // Only use this if indices are known to be within bounds;
+    // out of bounds indices will result in undefined behavior
     UNSAFE
   } out_of_bounds = ERROR;
 };
@@ -61,6 +63,17 @@ struct ARROW_EXPORT TakeOptions {
 ARROW_EXPORT
 Status Take(FunctionContext* context, const Array& values, const Array& indices,
             const TakeOptions& options, std::shared_ptr<Array>* out);
+
+/// \brief Take from an array of values at indices in another array
+///
+/// \param[in] context the FunctionContext
+/// \param[in] values datum from which to take
+/// \param[in] indices which values to take
+/// \param[in] options options
+/// \param[out] out resulting datum
+ARROW_EXPORT
+Status Take(FunctionContext* context, const Datum& values, const Datum& indices,
+            const TakeOptions& options, Datum* out);
 
 /// \brief BinaryKernel implementing Take operation
 class ARROW_EXPORT TakeKernel : public BinaryKernel {

--- a/cpp/src/arrow/compute/kernels/take.h
+++ b/cpp/src/arrow/compute/kernels/take.h
@@ -43,6 +43,14 @@ struct ARROW_EXPORT TakeOptions {
 };
 
 /// \brief Take from one array type to another
+///
+/// The output array will be of the same type as the input values
+/// array, with elements taken from the values array at the given
+/// indices.
+///
+/// For example given values ["a", "b", "c"] and indices
+/// [2, 1], the output will be ["c", "b"].
+///
 /// \param[in] context the FunctionContext
 /// \param[in] values array from which to take
 /// \param[in] indices which values to take

--- a/cpp/src/arrow/compute/kernels/take.h
+++ b/cpp/src/arrow/compute/kernels/take.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/compute/kernel.h"
+#include "arrow/status.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class Array;
+
+namespace compute {
+
+class FunctionContext;
+
+struct ARROW_EXPORT TakeOptions {
+  enum {
+    // indices out of bounds will raise an error
+    ERROR,
+    // indices out of bounds will result in a null value
+    TONULL,
+    // indices out of bounds is undefined behavior
+    UNSAFE
+  } out_of_bounds = ERROR;
+};
+
+/// \brief Take from one array type to another
+/// \param[in] context the FunctionContext
+/// \param[in] values array from which to take
+/// \param[in] indices which values to take
+/// \param[in] options options
+/// \param[out] out resulting array
+ARROW_EXPORT
+Status Take(FunctionContext* context, const Array& values, const Array& indices,
+            const TakeOptions& options, std::shared_ptr<Array>* out);
+
+/// \brief BinaryKernel implementing Take operation
+class ARROW_EXPORT TakeKernel : public BinaryKernel {
+ public:
+  explicit TakeKernel(const std::shared_ptr<DataType>& type, TakeOptions options = {})
+      : type_(type), options_(options) {}
+
+  Status Call(FunctionContext* ctx, const Datum& values, const Datum& indices,
+              Datum* out) override;
+
+  std::shared_ptr<DataType> out_type() const override { return type_; }
+
+ private:
+  std::shared_ptr<DataType> type_;
+  TakeOptions options_;
+};
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/take.h
+++ b/cpp/src/arrow/compute/kernels/take.h
@@ -34,14 +34,14 @@ class FunctionContext;
 struct ARROW_EXPORT TakeOptions {
   enum OutOfBoundsBehavior {
     // Out of bounds indices will raise an error
-    ERROR,
+    RAISE,
     // Out of bounds indices will result in a null value
     TO_NULL,
     // Bounds checking will be skipped, which is faster.
     // Only use this if indices are known to be within bounds;
     // out of bounds indices will result in undefined behavior
     UNSAFE
-  } out_of_bounds = ERROR;
+  } out_of_bounds = RAISE;
 };
 
 /// \brief Take from an array of values at indices in another array

--- a/cpp/src/arrow/compute/kernels/take.h
+++ b/cpp/src/arrow/compute/kernels/take.h
@@ -31,18 +31,7 @@ namespace compute {
 
 class FunctionContext;
 
-struct ARROW_EXPORT TakeOptions {
-  enum OutOfBoundsBehavior {
-    // Out of bounds indices will raise an error
-    RAISE,
-    // Out of bounds indices will result in a null value
-    TO_NULL,
-    // Bounds checking will be skipped, which is faster.
-    // Only use this if indices are known to be within bounds;
-    // out of bounds indices will result in undefined behavior
-    UNSAFE
-  } out_of_bounds = RAISE;
-};
+struct ARROW_EXPORT TakeOptions {};
 
 /// \brief Take from an array of values at indices in another array
 ///

--- a/cpp/src/arrow/compute/kernels/take.h
+++ b/cpp/src/arrow/compute/kernels/take.h
@@ -42,14 +42,16 @@ struct ARROW_EXPORT TakeOptions {
   } out_of_bounds = ERROR;
 };
 
-/// \brief Take from one array type to another
+/// \brief Take from an array of values at indices in another array
 ///
 /// The output array will be of the same type as the input values
 /// array, with elements taken from the values array at the given
-/// indices.
+/// indices. If an index is null then the taken element will null.
 ///
-/// For example given values ["a", "b", "c"] and indices
-/// [2, 1], the output will be ["c", "b"].
+/// For example given values = ["a", "b", "c", null, "e", "f"] and
+/// indices = [2, 1, null, 3], the output will be
+/// = [values[2], values[1], null, values[3]]
+/// = ["c", "b", null, null]
 ///
 /// \param[in] context the FunctionContext
 /// \param[in] values array from which to take

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -100,11 +100,6 @@ namespace arrow {
 typedef ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type,
                          Int16Type, Int32Type, Int64Type, FloatType, DoubleType>
     NumericArrowTypes;
-typedef ::testing::Types<NullType, BooleanType, UInt8Type, UInt16Type, UInt32Type,
-                         UInt64Type, Int8Type, Int16Type, Int32Type, Int64Type,
-                         HalfFloatType, FloatType, DoubleType, Date32Type, Date64Type,
-                         StringType, BinaryType>
-    ParameterFreeArrowTypes;
 
 class ChunkedArray;
 class Column;

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -100,6 +100,11 @@ namespace arrow {
 typedef ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type,
                          Int16Type, Int32Type, Int64Type, FloatType, DoubleType>
     NumericArrowTypes;
+typedef ::testing::Types<NullType, BooleanType, UInt8Type, UInt16Type, UInt32Type,
+                         UInt64Type, Int8Type, Int16Type, Int32Type, Int64Type,
+                         HalfFloatType, FloatType, DoubleType, Date32Type, Date64Type,
+                         StringType, BinaryType>
+    ParameterFreeArrowTypes;
 
 class ChunkedArray;
 class Column;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -304,9 +304,9 @@ using enable_if_primitive_ctype =
 template <typename T>
 using enable_if_date = typename std::enable_if<std::is_base_of<DateType, T>::value>::type;
 
-template <typename T>
+template <typename T, typename U = void>
 using enable_if_integer =
-    typename std::enable_if<std::is_base_of<Integer, T>::value>::type;
+    typename std::enable_if<std::is_base_of<Integer, T>::value, U>::type;
 
 template <typename T>
 using enable_if_signed_integer =


### PR DESCRIPTION
This implements take as a `BinaryKernel`

Out of bounds indices raise an error. All integer index types should be supported.

Supported value types are numeric, boolean, null, binary, dictionary, and string (untested: fixed width binary, time/date).

In addition to `TakeKernel`, a convenience function is implemented which takes arrays as its arguments (currently only array inputs are supported).