### PR TITLE
ARROW-4870: [Ruby] Fix msys2_mingw_dependencies

### DIFF
--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -55,5 +55,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("test-unit")
   spec.add_development_dependency("yard")
 
-  spec.metadata["msys2_mingw_dependencies"] = "apache-arrow"
+  spec.metadata["msys2_mingw_dependencies"] = "arrow"
 end


### PR DESCRIPTION
$ pacman -Ss arrow
mingw32/mingw-w64-i686-arrow 0.11.1-1
    Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)
mingw64/mingw-w64-x86_64-arrow 0.11.1-1 [installed]
    Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)