### PR TITLE
ARROW-4855: [Packaging] Generate default package version based on cpp tags in crossbow.py

### DIFF
--- a/dev/tasks/python-wheels/travis.linux.yml
+++ b/dev/tasks/python-wheels/travis.linux.yml
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 os: linux
-dist: trusty
-sudo: required
-language: cpp
+
 services:
   - docker
 


### PR DESCRIPTION
It picked up wrong version because of the recent JS release.