### PR TITLE
ARROW-4825: [Python] Destruct MemoryPool after its buffers.

### DIFF
--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -349,6 +349,7 @@ cdef class Buffer:
         shared_ptr[CBuffer] buffer
         Py_ssize_t shape[1]
         Py_ssize_t strides[1]
+        object allocator
 
     cdef void init(self, const shared_ptr[CBuffer]& buffer)
     cdef getitem(self, int64_t i)

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -83,3 +83,11 @@ def test_set_memory_pool():
         assert pool.bytes_allocated() == allocated_before
     finally:
         pa.set_memory_pool(old_pool)
+
+
+def test_memory_pool_destruction():
+    # see ARROW-4825
+    pool = pa.logging_memory_pool(pa.default_memory_pool())
+    buf = pa.allocate_buffer(512, memory_pool=pool)
+    del pool
+    del buf


### PR DESCRIPTION
This PR introduces `Buffer.set_allocator` method that is used to ensure that memory pool instance is destructed after garbage collecting all its buffers. Resolves [ARROW 4825](https://issues.apache.org/jira/browse/ARROW-4825).