### PR TITLE
ARROW-4865: [Rust] Support list casts

### DIFF
--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -131,7 +131,7 @@ pub type ArrayRef = Arc<Array>;
 
 /// Constructs an array using the input `data`. Returns a reference-counted `Array`
 /// instance.
-pub fn make_array(data: ArrayDataRef) -> ArrayRef {
+pub(crate) fn make_array(data: ArrayDataRef) -> ArrayRef {
     // TODO: here data_type() needs to clone the type - maybe add a type tag enum to
     // avoid the cloning.
     match data.data_type().clone() {

--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -131,7 +131,7 @@ pub type ArrayRef = Arc<Array>;
 
 /// Constructs an array using the input `data`. Returns a reference-counted `Array`
 /// instance.
-fn make_array(data: ArrayDataRef) -> ArrayRef {
+pub fn make_array(data: ArrayDataRef) -> ArrayRef {
     // TODO: here data_type() needs to clone the type - maybe add a type tag enum to
     // avoid the cloning.
     match data.data_type().clone() {

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -97,7 +97,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             "Cannot cast list to non-list data types".to_string(),
         )),
         (_, List(ref to)) => {
-            // converts item to
+            // cast primitive to list's primitive
             let cast_array = cast(array, &*to)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
             let offsets: Vec<i32> = (0..array.len() as i32 + 1).collect();


### PR DESCRIPTION
This is a follow up from the initial cast kernel PR, and adds support for:

* List<Primitive> to List<Primitive>
* Primitive to List<Primitive>

The only remaining expansion to the cast kernel will be temporal casts, then I think we'll be able to cover all cast use-cases.