### PR TITLE
ARROW-4251: [C++][Release] Add option to set ARROW_BOOST_VENDORED environment variable in verify-release-candidate.sh

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -26,7 +26,8 @@
 # - nodejs >= 6.0.0 (best way is to use nvm)
 #
 # If using a non-system Boost, set BOOST_ROOT and add Boost libraries to
-# LD_LIBRARY_PATH
+# LD_LIBRARY_PATH. If your system Boost is too old for the C++ libraries, then
+# set $ARROW_BOOST_VENDORED to "ON" or "1"
 
 case $# in
   3) ARTIFACT="$1"
@@ -48,6 +49,8 @@ set -ex
 set -o pipefail
 
 HERE=$(cd `dirname "${BASH_SOURCE[0]:-$0}"` && pwd)
+
+ARROW_BOOST_VENDORED=${ARROW_BOOST_VENDORED:=OFF}
 
 ARROW_DIST_URL='https://dist.apache.org/repos/dist/dev/arrow'
 
@@ -207,6 +210,7 @@ ${ARROW_CMAKE_OPTIONS}
 -DARROW_GANDIVA=ON
 -DARROW_PARQUET=ON
 -DARROW_BOOST_USE_SHARED=ON
+-DARROW_BOOST_VENDORED=$ARROW_BOOST_VENDORED
 -DCMAKE_BUILD_TYPE=release
 -DARROW_BUILD_TESTS=ON
 -DARROW_CUDA=${ARROW_CUDA}


### PR DESCRIPTION
I'm taking this for a spin on 0.12.1 RC0 on Ubuntu 14.04 (where the system boost does not work -- see ARROW-4868)