### PR TITLE
ARROW-4866: [C++] Fix zstd_ep build for Debug, static CRT builds. Add separate CMake variable for propagating compiler toolchain to ExternalProjects

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -350,29 +350,29 @@ endif()
 # directory. This leads to issues if the variables are exported in a subshell
 # and the invocation of make/ninja is in distinct subshell without the same
 # environment (CC/CXX).
-set(EP_COMMON_CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                         -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+set(EP_COMMON_TOOLCHAIN -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+
+if (CMAKE_AR)
+  set(EP_COMMON_TOOLCHAIN ${EP_COMMON_TOOLCHAIN}
+                           -DCMAKE_AR=${CMAKE_AR})
+endif()
+
+if (CMAKE_RANLIB)
+  set(EP_COMMON_TOOLCHAIN ${EP_COMMON_TOOLCHAIN}
+                           -DCMAKE_RANLIB=${CMAKE_RANLIB})
+endif()
 
 # External projects are still able to override the following declarations.
 # cmake command line will favor the last defined variable when a duplicate is
 # encountered. This requires that `EP_COMMON_CMAKE_ARGS` is always the first
 # argument.
-set(EP_COMMON_CMAKE_ARGS ${EP_COMMON_CMAKE_ARGS}
+set(EP_COMMON_CMAKE_ARGS ${EP_COMMON_TOOLCHAIN}
                          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                          -DCMAKE_C_FLAGS=${EP_C_FLAGS}
                          -DCMAKE_C_FLAGS_${UPPERCASE_BUILD_TYPE}=${EP_C_FLAGS}
                          -DCMAKE_CXX_FLAGS=${EP_CXX_FLAGS}
                          -DCMAKE_CXX_FLAGS_${UPPERCASE_BUILD_TYPE}=${EP_CXX_FLAGS})
-
-if (CMAKE_AR)
-  set(EP_COMMON_CMAKE_ARGS ${EP_COMMON_CMAKE_ARGS}
-                           -DCMAKE_AR=${CMAKE_AR})
-endif()
-
-if (CMAKE_RANLIB)
-  set(EP_COMMON_CMAKE_ARGS ${EP_COMMON_CMAKE_ARGS}
-                           -DCMAKE_RANLIB=${CMAKE_RANLIB})
-endif()
 
 if (NOT ARROW_VERBOSE_THIRDPARTY_BUILD)
   set(EP_LOG_OPTIONS
@@ -1438,7 +1438,7 @@ macro(build_zstd)
   message(STATUS "Building zstd from source")
   set(ZSTD_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/zstd_ep-install")
 
-  set(ZSTD_CMAKE_ARGS ${EP_COMMON_CMAKE_ARGS}
+  set(ZSTD_CMAKE_ARGS ${EP_COMMON_TOOLCHAIN}
     "-DCMAKE_INSTALL_PREFIX=${ZSTD_PREFIX}"
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
zstd sets a bunch of its own compilation flags and they conflict with the CFLAGS/CXXFLAGS that are part of EP_COMMON_CMAKE_ARGS