### PR TITLE
ARROW-4906: [Format] Write about SparseMatrixIndexCSR format is sorted

### DIFF
--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -49,7 +49,7 @@ table SparseTensorIndexCOO {
   ///    [2, 2, 3, 1, 2, 0],
   ///    [0, 1, 0, 0, 3, 4]]
   ///
-  /// Note that the indices are sorted in lexcographical order.
+  /// Note that the indices are sorted in lexicographical order.
   indicesBuffer: Buffer;
 }
 
@@ -86,6 +86,8 @@ table SparseMatrixIndexCSR {
   /// For example, the indices of the above X is:
   ///
   ///   indices(X) = [1, 2, 2, 1, 3, 0, 2, 3, 1].
+  ///
+  /// Note that the indices are sorted in lexicographical order for each row.
   indicesBuffer: Buffer;
 }
 


### PR DESCRIPTION
Currently, my implementation of SparseCSRIndex assumes indptr is sorted for each row.
So I want to note it in the format documentation just in case.