### PR TITLE
ARROW-4915: [GLib][C++] Add arrow::NullBuilder support for GLib

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -481,7 +481,7 @@ garrow_null_array_builder_append_nulls(GArrowNullArrayBuilder *builder,
     (GARROW_ARRAY_BUILDER(builder),
      n,
      error,
-     "[boolean-array-builder][append-nulls]");
+     "[null-array-builder][append-nulls]");
 }
 
 

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -430,6 +430,8 @@ garrow_null_array_builder_class_init(GArrowNullArrayBuilderClass *klass)
  * garrow_null_array_builder_new:
  *
  * Returns: A newly created #GArrowNullArrayBuilder.
+ *
+ * Since: 0.13.0
  */
 GArrowNullArrayBuilder *
 garrow_null_array_builder_new(void)
@@ -447,7 +449,7 @@ garrow_null_array_builder_new(void)
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
- * Since: 0.14.0
+ * Since: 0.13.0
  */
 gboolean
 garrow_null_array_builder_append_null(GArrowNullArrayBuilder *builder,
@@ -470,7 +472,7 @@ garrow_null_array_builder_append_null(GArrowNullArrayBuilder *builder,
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
- * Since: 0.14.0
+ * Since: 0.13.0
  */
 gboolean
 garrow_null_array_builder_append_nulls(GArrowNullArrayBuilder *builder,

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -153,6 +153,9 @@ G_BEGIN_DECLS
  *
  * You need to use array builder class to create a new array.
  *
+ * #GArrowNullArrayBuilder is the class to create a new
+ * #GArrowNullArray.
+ *
  * #GArrowBooleanArrayBuilder is the class to create a new
  * #GArrowBooleanArray.
  *
@@ -406,6 +409,79 @@ garrow_array_builder_finish(GArrowArrayBuilder *builder, GError **error)
   } else {
     return NULL;
   }
+}
+
+
+G_DEFINE_TYPE(GArrowNullArrayBuilder,
+              garrow_null_array_builder,
+              GARROW_TYPE_ARRAY_BUILDER)
+
+static void
+garrow_null_array_builder_init(GArrowNullArrayBuilder *builder)
+{
+}
+
+static void
+garrow_null_array_builder_class_init(GArrowNullArrayBuilderClass *klass)
+{
+}
+
+/**
+ * garrow_null_array_builder_new:
+ *
+ * Returns: A newly created #GArrowNullArrayBuilder.
+ */
+GArrowNullArrayBuilder *
+garrow_null_array_builder_new(void)
+{
+  auto builder = garrow_array_builder_new(arrow::null(),
+                                          NULL,
+                                          "[null-array-builder][new]");
+  return GARROW_NULL_ARRAY_BUILDER(builder);
+}
+
+/**
+ * garrow_null_array_builder_append_null:
+ * @builder: A #GArrowNullArrayBuilder.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.14.0
+ */
+gboolean
+garrow_null_array_builder_append_null(GArrowNullArrayBuilder *builder,
+                                      GError **error)
+{
+  return garrow_array_builder_append_null<arrow::NullBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     error,
+     "[null-array-builder][append-null]");
+}
+
+/**
+ * garrow_null_array_builder_append_nulls:
+ * @builder: A #GArrowNullArrayBuilder.
+ * @n: The number of null values to be appended.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Append multiple nulls at once. It's more efficient than multiple
+ * `append_null()` calls.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 0.14.0
+ */
+gboolean
+garrow_null_array_builder_append_nulls(GArrowNullArrayBuilder *builder,
+                                       gint64 n,
+                                       GError **error)
+{
+  return garrow_array_builder_append_nulls<arrow::NullBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     n,
+     error,
+     "[boolean-array-builder][append-nulls]");
 }
 
 
@@ -3890,6 +3966,9 @@ garrow_array_builder_new_raw(arrow::ArrayBuilder *arrow_builder,
 {
   if (type == G_TYPE_INVALID) {
     switch (arrow_builder->type()->id()) {
+    case arrow::Type::type::NA:
+      type = GARROW_TYPE_NULL_ARRAY_BUILDER;
+      break;
     case arrow::Type::type::BOOL:
       type = GARROW_TYPE_BOOLEAN_ARRAY_BUILDER;
       break;

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -56,10 +56,13 @@ struct _GArrowNullArrayBuilderClass
   GArrowArrayBuilderClass parent_class;
 };
 
+GARROW_AVAILABLE_IN_0_13
 GArrowNullArrayBuilder *garrow_null_array_builder_new(void);
 
+GARROW_AVAILABLE_IN_0_13
 gboolean garrow_null_array_builder_append_null(GArrowNullArrayBuilder *builder,
                                                GError **error);
+GARROW_AVAILABLE_IN_0_13
 gboolean garrow_null_array_builder_append_nulls(GArrowNullArrayBuilder *builder,
                                                 gint64 n,
                                                 GError **error);

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -45,6 +45,59 @@ GArrowArray        *garrow_array_builder_finish   (GArrowArrayBuilder *builder,
                                                    GError **error);
 
 
+#define GARROW_TYPE_NULL_ARRAY_BUILDER       \
+  (garrow_null_array_builder_get_type())
+#define GARROW_NULL_ARRAY_BUILDER(obj)                                  \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                    \
+                              GARROW_TYPE_NULL_ARRAY_BUILDER,           \
+                              GArrowNullArrayBuilder))
+#define GARROW_NULL_ARRAY_BUILDER_CLASS(klass)                  \
+  (G_TYPE_CHECK_CLASS_CAST((klass),                             \
+                           GARROW_TYPE_NULL_ARRAY_BUILDER,      \
+                           GArrowNullArrayBuilderClass))
+#define GARROW_IS_NULL_ARRAY_BUILDER(obj)                               \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),                                    \
+                              GARROW_TYPE_NULL_ARRAY_BUILDER))
+#define GARROW_IS_NULL_ARRAY_BUILDER_CLASS(klass)               \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),                             \
+                           GARROW_TYPE_NULL_ARRAY_BUILDER))
+#define GARROW_NULL_ARRAY_BUILDER_GET_CLASS(obj)                \
+  (G_TYPE_INSTANCE_GET_CLASS((obj),                             \
+                             GARROW_TYPE_NULL_ARRAY_BUILDER,    \
+                             GArrowNullArrayBuilderClass))
+
+typedef struct _GArrowNullArrayBuilder         GArrowNullArrayBuilder;
+typedef struct _GArrowNullArrayBuilderClass    GArrowNullArrayBuilderClass;
+
+/**
+ * GArrowNullArrayBuilder:
+ *
+ * It wraps `arrow::NullBuilder`.
+ */
+struct _GArrowNullArrayBuilder
+{
+  /*< private >*/
+  GArrowArrayBuilder parent_instance;
+};
+
+struct _GArrowNullArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
+
+GType garrow_null_array_builder_get_type(void) G_GNUC_CONST;
+
+GArrowNullArrayBuilder *garrow_null_array_builder_new(void);
+
+/* TODO: should wrap AppendValue? */
+
+gboolean garrow_null_array_builder_append_null(GArrowNullArrayBuilder *builder,
+                                               GError **error);
+gboolean garrow_null_array_builder_append_nulls(GArrowNullArrayBuilder *builder,
+                                                gint64 n,
+                                                GError **error);
+
+
 #define GARROW_TYPE_BOOLEAN_ARRAY_BUILDER       \
   (garrow_boolean_array_builder_get_type())
 #define GARROW_BOOLEAN_ARRAY_BUILDER(obj)                               \

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -89,8 +89,6 @@ GType garrow_null_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowNullArrayBuilder *garrow_null_array_builder_new(void);
 
-/* TODO: should wrap AppendValue? */
-
 gboolean garrow_null_array_builder_append_null(GArrowNullArrayBuilder *builder,
                                                GError **error);
 gboolean garrow_null_array_builder_append_nulls(GArrowNullArrayBuilder *builder,

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -45,47 +45,16 @@ GArrowArray        *garrow_array_builder_finish   (GArrowArrayBuilder *builder,
                                                    GError **error);
 
 
-#define GARROW_TYPE_NULL_ARRAY_BUILDER       \
-  (garrow_null_array_builder_get_type())
-#define GARROW_NULL_ARRAY_BUILDER(obj)                                  \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                    \
-                              GARROW_TYPE_NULL_ARRAY_BUILDER,           \
-                              GArrowNullArrayBuilder))
-#define GARROW_NULL_ARRAY_BUILDER_CLASS(klass)                  \
-  (G_TYPE_CHECK_CLASS_CAST((klass),                             \
-                           GARROW_TYPE_NULL_ARRAY_BUILDER,      \
-                           GArrowNullArrayBuilderClass))
-#define GARROW_IS_NULL_ARRAY_BUILDER(obj)                               \
-  (G_TYPE_CHECK_INSTANCE_TYPE((obj),                                    \
-                              GARROW_TYPE_NULL_ARRAY_BUILDER))
-#define GARROW_IS_NULL_ARRAY_BUILDER_CLASS(klass)               \
-  (G_TYPE_CHECK_CLASS_TYPE((klass),                             \
-                           GARROW_TYPE_NULL_ARRAY_BUILDER))
-#define GARROW_NULL_ARRAY_BUILDER_GET_CLASS(obj)                \
-  (G_TYPE_INSTANCE_GET_CLASS((obj),                             \
-                             GARROW_TYPE_NULL_ARRAY_BUILDER,    \
-                             GArrowNullArrayBuilderClass))
-
-typedef struct _GArrowNullArrayBuilder         GArrowNullArrayBuilder;
-typedef struct _GArrowNullArrayBuilderClass    GArrowNullArrayBuilderClass;
-
-/**
- * GArrowNullArrayBuilder:
- *
- * It wraps `arrow::NullBuilder`.
- */
-struct _GArrowNullArrayBuilder
-{
-  /*< private >*/
-  GArrowArrayBuilder parent_instance;
-};
-
+#define GARROW_TYPE_NULL_ARRAY_BUILDER (garrow_null_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowNullArrayBuilder,
+                         garrow_null_array_builder,
+                         GARROW,
+                         NULL_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
 struct _GArrowNullArrayBuilderClass
 {
   GArrowArrayBuilderClass parent_class;
 };
-
-GType garrow_null_array_builder_get_type(void) G_GNUC_CONST;
 
 GArrowNullArrayBuilder *garrow_null_array_builder_new(void);
 

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -17,6 +17,10 @@
 
 module Helper
   module Buildable
+    def build_null_array(values)
+      build_array(Arrow::NullArrayBuilder.new, values)
+    end
+
     def build_boolean_array(values)
       build_array(Arrow::BooleanArrayBuilder.new, values)
     end

--- a/c_glib/test/test-array-builder.rb
+++ b/c_glib/test/test-array-builder.rb
@@ -113,6 +113,39 @@ class TestArrayBuilder < Test::Unit::TestCase
     super(create_builder, values)
   end
 
+  sub_test_case("NullArrayBuilder") do
+    def create_builder
+      Arrow::NullArrayBuilder.new
+    end
+
+    def value_data_type
+      Arrow::NullDataType.new
+    end
+
+    def builder_class_name
+      "null-array-builder"
+    end
+
+    def sample_values
+      [nil, nil, nil]
+    end
+
+    sub_test_case("value type") do
+      include ArrayBuilderValueTypeTests
+    end
+
+    test("#append_null") do
+      builder = create_builder
+      builder.append_null
+      assert_equal(build_array([nil]),
+                   builder.finish)
+    end
+
+    sub_test_case("#append_nulls") do
+      include ArrayBuilderAppendNullsTests
+    end
+  end
+
   sub_test_case("BooleanArrayBuilder") do
     def create_builder
       Arrow::BooleanArrayBuilder.new

--- a/c_glib/test/test-null-array.rb
+++ b/c_glib/test/test-null-array.rb
@@ -16,18 +16,37 @@
 # under the License.
 
 class TestNullArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def test_new
+    assert_equal(build_null_array([nil, nil, nil]),
+                 Arrow::NullArray.new(3))
+  end
+
   def test_length
-    array = Arrow::NullArray.new(3)
+    builder = Arrow::NullArrayBuilder.new
+    builder.append_null
+    builder.append_null
+    builder.append_null
+    array = builder.finish
     assert_equal(3, array.length)
   end
 
   def test_n_nulls
-    array = Arrow::NullArray.new(3)
+    builder = Arrow::NullArrayBuilder.new
+    builder.append_null
+    builder.append_null
+    builder.append_null
+    array = builder.finish
     assert_equal(3, array.n_nulls)
   end
 
   def test_slice
-    array = Arrow::NullArray.new(3)
+    builder = Arrow::NullArrayBuilder.new
+    builder.append_null
+    builder.append_null
+    builder.append_null
+    array = builder.finish
     assert_equal(2, array.slice(1, 2).length)
   end
 end

--- a/c_glib/test/test-null-array.rb
+++ b/c_glib/test/test-null-array.rb
@@ -16,37 +16,18 @@
 # under the License.
 
 class TestNullArray < Test::Unit::TestCase
-  include Helper::Buildable
-
-  def test_new
-    assert_equal(build_null_array([nil, nil, nil]),
-                 Arrow::NullArray.new(3))
-  end
-
   def test_length
-    builder = Arrow::NullArrayBuilder.new
-    builder.append_null
-    builder.append_null
-    builder.append_null
-    array = builder.finish
+    array = Arrow::NullArray.new(3)
     assert_equal(3, array.length)
   end
 
   def test_n_nulls
-    builder = Arrow::NullArrayBuilder.new
-    builder.append_null
-    builder.append_null
-    builder.append_null
-    array = builder.finish
+    array = Arrow::NullArray.new(3)
     assert_equal(3, array.n_nulls)
   end
 
   def test_slice
-    builder = Arrow::NullArrayBuilder.new
-    builder.append_null
-    builder.append_null
-    builder.append_null
-    array = builder.finish
+    array = Arrow::NullArray.new(3)
     assert_equal(2, array.slice(1, 2).length)
   end
 end

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -259,11 +259,12 @@ TEST(TestNullBuilder, Basics) {
   ASSERT_OK(builder.AppendNull());
   ASSERT_OK(builder.Append(nullptr));
   ASSERT_OK(builder.AppendNull());
+  ASSERT_OK(builder.AppendNulls(2));
   ASSERT_OK(builder.Finish(&array));
 
   const auto& null_array = checked_cast<NullArray&>(*array);
-  ASSERT_EQ(null_array.length(), 3);
-  ASSERT_EQ(null_array.null_count(), 3);
+  ASSERT_EQ(null_array.length(), 5);
+  ASSERT_EQ(null_array.null_count(), 5);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -34,8 +34,10 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
   /// \brief Append the specified number of null elements
   Status AppendNulls(int64_t length) {
+    auto new_length = length_ + length;
+    ARROW_RETURN_NOT_OK(CheckCapacity(new_length, length_));
     null_count_ += length;
-    length_ += length;
+    length_ = new_length;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -32,6 +32,14 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
   explicit NullBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(null(), pool) {}
 
+  /// \brief Append the specified number of null elements
+  Status AppendNulls(int64_t length) {
+    null_count_ += length;
+    length_ += length;
+    return Status::OK();
+  }
+
+  /// \brief Append a single null element
   Status AppendNull() {
     ++null_count_;
     ++length_;

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -43,6 +43,7 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
   /// \brief Append a single null element
   Status AppendNull() {
+    ARROW_RETURN_NOT_OK(CheckCapacity(length_ + 1, length_));
     ++null_count_;
     ++length_;
     return Status::OK();

--- a/ruby/red-arrow/lib/arrow/array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/array-builder.rb
@@ -62,6 +62,10 @@ module Arrow
           Arrow::StringArray.new(values)
         end
       end
+
+      def buildable?(args)
+        args.size == method(:build).arity
+      end
     end
 
     def build(values)

--- a/ruby/red-arrow/lib/arrow/array.rb
+++ b/ruby/red-arrow/lib/arrow/array.rb
@@ -24,7 +24,7 @@ module Arrow
         builder_class_name = "#{name}Builder"
         if const_defined?(builder_class_name)
           builder_class = const_get(builder_class_name)
-          if args.size == builder_class.method(:build).arity
+          if builder_class.buildable?(args)
             builder_class.build(*args)
           else
             super

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -53,6 +53,7 @@ module Arrow
       require "arrow/file-output-stream"
       require "arrow/list-array-builder"
       require "arrow/list-data-type"
+      require "arrow/null-array-builder"
       require "arrow/path-extension"
       require "arrow/record"
       require "arrow/record-batch"

--- a/ruby/red-arrow/lib/arrow/null-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/null-array-builder.rb
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class NullArrayBuilder
+    class << self
+      def buildable?(args)
+        super and args.collect(&:class) != [Integer]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request add two things:

1. `arrow::NullBuilder::AppendNulls()` function
2. `GArrowNullArrayBuilder` class