### PR TITLE
ARROW-4628: [Rust] [DataFusion] Implement type coercion query optimizer rule

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -81,7 +81,10 @@ impl ExecutionContext {
 
                 Ok(self.optimize(&plan)?)
             }
-            _ => unimplemented!(),
+            other => Err(ExecutionError::General(format!(
+                "Cannot create logical plan from {:?}",
+                other
+            ))),
         }
     }
 
@@ -257,7 +260,9 @@ impl ExecutionContext {
                 }
             }
 
-            _ => unimplemented!(),
+            _ => Err(ExecutionError::NotImplemented(
+                "Unsupported logical plan for execution".to_string(),
+            )),
         }
     }
 }
@@ -274,6 +279,6 @@ impl SchemaProvider for ExecutionContextSchemaProvider {
     }
 
     fn get_function_meta(&self, _name: &str) -> Option<Arc<FunctionMeta>> {
-        unimplemented!()
+        None
     }
 }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -81,10 +81,7 @@ impl ExecutionContext {
 
                 Ok(self.optimize(&plan)?)
             }
-            other => Err(ExecutionError::General(format!(
-                "Cannot create logical plan from {:?}",
-                other
-            ))),
+            _ => unimplemented!(),
         }
     }
 
@@ -260,9 +257,7 @@ impl ExecutionContext {
                 }
             }
 
-            _ => Err(ExecutionError::NotImplemented(
-                "Unsupported logical plan for execution".to_string(),
-            )),
+            _ => unimplemented!(),
         }
     }
 }
@@ -279,6 +274,6 @@ impl SchemaProvider for ExecutionContextSchemaProvider {
     }
 
     fn get_function_meta(&self, _name: &str) -> Option<Arc<FunctionMeta>> {
-        None
+        unimplemented!()
     }
 }

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -450,53 +450,54 @@ impl fmt::Debug for LogicalPlan {
     }
 }
 
-pub fn can_coerce_from(left: &DataType, other: &DataType) -> bool {
+pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
     use self::DataType::*;
-    match left {
-        Int8 => match other {
+    match type_into {
+        Int8 => match type_from {
             Int8 => true,
             _ => false,
         },
-        Int16 => match other {
+        Int16 => match type_from {
             Int8 | Int16 => true,
             _ => false,
         },
-        Int32 => match other {
+        Int32 => match type_from {
             Int8 | Int16 | Int32 => true,
             _ => false,
         },
-        Int64 => match other {
+        Int64 => match type_from {
             Int8 | Int16 | Int32 | Int64 => true,
             _ => false,
         },
-        UInt8 => match other {
+        UInt8 => match type_from {
             UInt8 => true,
             _ => false,
         },
-        UInt16 => match other {
+        UInt16 => match type_from {
             UInt8 | UInt16 => true,
             _ => false,
         },
-        UInt32 => match other {
+        UInt32 => match type_from {
             UInt8 | UInt16 | UInt32 => true,
             _ => false,
         },
-        UInt64 => match other {
+        UInt64 => match type_from {
             UInt8 | UInt16 | UInt32 | UInt64 => true,
             _ => false,
         },
-        Float32 => match other {
+        Float32 => match type_from {
             Int8 | Int16 | Int32 | Int64 => true,
             UInt8 | UInt16 | UInt32 | UInt64 => true,
             Float32 => true,
             _ => false,
         },
-        Float64 => match other {
+        Float64 => match type_from {
             Int8 | Int16 | Int32 | Int64 => true,
             UInt8 | UInt16 | UInt32 | UInt64 => true,
             Float32 | Float64 => true,
             _ => false,
         },
+        Utf8 => true,
         _ => false,
     }
 }

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -93,14 +93,6 @@ pub enum Operator {
     NotLike,
 }
 
-impl Operator {
-    /// Get the result type of applying this operation to its left and right inputs
-    pub fn get_datatype(&self, l: &Expr, _r: &Expr, schema: &Schema) -> DataType {
-        //TODO: implement correctly, just go with left side for now
-        l.get_type(schema).clone()
-    }
-}
-
 /// ScalarValue enumeration
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum ScalarValue {

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -18,11 +18,11 @@
 //! Logical query plan
 
 use std::fmt;
-use std::fmt::{Error, Formatter};
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema};
 
+use crate::error::{ExecutionError, Result};
 use crate::optimizer::utils;
 
 /// Enumeration of supported function types (Scalar and Aggregate)
@@ -192,7 +192,6 @@ impl Expr {
                 ref left,
                 ref right,
                 ref op,
-<<<<<<< HEAD
             } => match op {
                 Operator::Eq | Operator::NotEq => DataType::Boolean,
                 Operator::Lt | Operator::LtEq => DataType::Boolean,
@@ -202,27 +201,12 @@ impl Expr {
                     let left_type = left.get_type(schema);
                     let right_type = right.get_type(schema);
                     utils::get_supertype(&left_type, &right_type).unwrap()
-=======
-            } => {
-                match op {
-                    Operator::Eq | Operator::NotEq => DataType::Boolean,
-                    Operator::Lt | Operator::LtEq => DataType::Boolean,
-                    Operator::Gt | Operator::GtEq => DataType::Boolean,
-                    Operator::And | Operator::Or => DataType::Boolean,
-                    _ => {
-                        let left_type = left.get_type(schema);
-                        let right_type = right.get_type(schema);
-                        utils::get_supertype(&left_type, &right_type)
-                            .unwrap_or(DataType::Utf8) //TODO ???
-                    }
->>>>>>> Roll back some changes to reduce scope of PR
                 }
-            }
+            },
             Expr::Sort { ref expr, .. } => expr.get_type(schema),
         }
     }
 
-<<<<<<< HEAD
     pub fn cast_to(&self, cast_to_type: &DataType, schema: &Schema) -> Result<Expr> {
         let this_type = self.get_type(schema);
         if this_type == *cast_to_type {
@@ -237,17 +221,6 @@ impl Expr {
                 "Cannot automatically convert {:?} to {:?}",
                 this_type, cast_to_type
             )))
-=======
-    pub fn cast_to(&self, cast_to_type: &DataType, schema: &Schema) -> Expr {
-        let this_type = self.get_type(schema);
-        if this_type == *cast_to_type {
-            self.clone()
-        } else {
-            Expr::Cast {
-                expr: Arc::new(self.clone()),
-                data_type: cast_to_type.clone(),
-            }
->>>>>>> Roll back some changes to reduce scope of PR
         }
     }
 
@@ -301,7 +274,7 @@ impl Expr {
 }
 
 impl fmt::Debug for Expr {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Expr::Column(i) => write!(f, "#{}", i),
             Expr::Literal(v) => write!(f, "{:?}", v),
@@ -404,7 +377,7 @@ impl LogicalPlan {
 }
 
 impl LogicalPlan {
-    fn fmt_with_indent(&self, f: &mut Formatter, indent: usize) -> Result<(), Error> {
+    fn fmt_with_indent(&self, f: &mut fmt::Formatter, indent: usize) -> fmt::Result {
         if indent > 0 {
             writeln!(f)?;
             for _ in 0..indent {
@@ -480,7 +453,7 @@ impl LogicalPlan {
 }
 
 impl fmt::Debug for LogicalPlan {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.fmt_with_indent(f, 0)
     }
 }

--- a/rust/datafusion/src/optimizer/mod.rs
+++ b/rust/datafusion/src/optimizer/mod.rs
@@ -19,4 +19,5 @@
 
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod type_coercion;
 pub mod utils;

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -17,8 +17,8 @@
 
 //! Query optimizer traits
 
+use crate::error::Result;
 use crate::logicalplan::LogicalPlan;
-use arrow::error::Result;
 use std::sync::Arc;
 
 /// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -17,8 +17,8 @@
 
 //! Query optimizer traits
 
-use crate::error::Result;
 use crate::logicalplan::LogicalPlan;
+use arrow::error::Result;
 use std::sync::Arc;
 
 /// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -1,0 +1,211 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! The type_coercion optimizer rule ensures that all binary operators are operating on
+//! compatible types by adding explicit cast operations to expressions. For example,
+//! the operation `c_float + c_int` would be rewritten as `c_float + CAST(c_int AS float)`.
+//! This keeps the runtime query execution code much simpler.
+
+use std::sync::Arc;
+
+use arrow::datatypes::Schema;
+
+use crate::error::{ExecutionError, Result};
+use crate::logicalplan::Expr;
+use crate::logicalplan::LogicalPlan;
+use crate::optimizer::optimizer::OptimizerRule;
+use crate::optimizer::utils;
+
+/// Implementation of type coercion optimizer rule
+pub struct TypeCoercionRule {}
+
+impl OptimizerRule for TypeCoercionRule {
+    fn optimize(&mut self, plan: &LogicalPlan) -> Result<Arc<LogicalPlan>> {
+        match plan {
+            LogicalPlan::Projection {
+                expr,
+                input,
+                schema,
+            } => Ok(Arc::new(LogicalPlan::Projection {
+                expr: expr
+                    .iter()
+                    .map(|e| rewrite_expr(e, &schema))
+                    .collect::<Result<Vec<_>>>()?,
+                input: self.optimize(input)?,
+                schema: schema.clone(),
+            })),
+            LogicalPlan::Selection { expr, input } => {
+                Ok(Arc::new(LogicalPlan::Selection {
+                    expr: rewrite_expr(expr, input.schema())?,
+                    input: self.optimize(input)?,
+                }))
+            }
+            LogicalPlan::Aggregate {
+                input,
+                group_expr,
+                aggr_expr,
+                schema,
+            } => Ok(Arc::new(LogicalPlan::Aggregate {
+                group_expr: group_expr
+                    .iter()
+                    .map(|e| rewrite_expr(e, &schema))
+                    .collect::<Result<Vec<_>>>()?,
+                aggr_expr: aggr_expr
+                    .iter()
+                    .map(|e| rewrite_expr(e, &schema))
+                    .collect::<Result<Vec<_>>>()?,
+                input: self.optimize(input)?,
+                schema: schema.clone(),
+            })),
+            LogicalPlan::TableScan { .. } => Ok(Arc::new(plan.clone())),
+            LogicalPlan::EmptyRelation { .. } => Ok(Arc::new(plan.clone())),
+            LogicalPlan::Limit { .. } => Ok(Arc::new(plan.clone())),
+            other => Err(ExecutionError::NotImplemented(format!(
+                "Type coercion optimizer rule does not support relation: {:?}",
+                other
+            ))),
+        }
+    }
+}
+
+impl TypeCoercionRule {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Rewrite an expression to include explicit CAST operations when required
+fn rewrite_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
+    match expr {
+        Expr::BinaryExpr { left, op, right } => {
+            let left = rewrite_expr(left, schema)?;
+            let right = rewrite_expr(right, schema)?;
+            let left_type = left.get_type(schema);
+            let right_type = right.get_type(schema);
+            if left_type == right_type {
+                Ok(expr.clone())
+            } else {
+                let super_type = utils::get_supertype(&left_type, &right_type)?;
+                Ok(Expr::BinaryExpr {
+                    left: Arc::new(left.cast_to(&super_type, schema)?),
+                    op: op.clone(),
+                    right: Arc::new(right.cast_to(&super_type, schema)?),
+                })
+            }
+        }
+        Expr::IsNull(e) => Ok(Expr::IsNull(Arc::new(rewrite_expr(e, schema)?))),
+        Expr::IsNotNull(e) => Ok(Expr::IsNotNull(Arc::new(rewrite_expr(e, schema)?))),
+        Expr::ScalarFunction {
+            name,
+            args,
+            return_type,
+        } => Ok(Expr::ScalarFunction {
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| rewrite_expr(a, schema))
+                .collect::<Result<Vec<_>>>()?,
+            return_type: return_type.clone(),
+        }),
+        Expr::AggregateFunction {
+            name,
+            args,
+            return_type,
+        } => Ok(Expr::AggregateFunction {
+            name: name.clone(),
+            args: args
+                .iter()
+                .map(|a| rewrite_expr(a, schema))
+                .collect::<Result<Vec<_>>>()?,
+            return_type: return_type.clone(),
+        }),
+        Expr::Cast { .. } => Ok(expr.clone()),
+        Expr::Column(_) => Ok(expr.clone()),
+        Expr::Literal(_) => Ok(expr.clone()),
+        other => Err(ExecutionError::NotImplemented(format!(
+            "Type coercion optimizer rule does not support expression: {:?}",
+            other
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logicalplan::Expr::*;
+    use crate::logicalplan::Operator;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    #[test]
+    fn test_add_i32_i64() {
+        binary_cast_test(
+            DataType::Int32,
+            DataType::Int64,
+            "CAST(#0 AS Int64) Plus #1",
+        );
+        binary_cast_test(
+            DataType::Int64,
+            DataType::Int32,
+            "#0 Plus CAST(#1 AS Int64)",
+        );
+    }
+
+    #[test]
+    fn test_add_f32_f64() {
+        binary_cast_test(
+            DataType::Float32,
+            DataType::Float64,
+            "CAST(#0 AS Float64) Plus #1",
+        );
+        binary_cast_test(
+            DataType::Float64,
+            DataType::Float32,
+            "#0 Plus CAST(#1 AS Float64)",
+        );
+    }
+
+    #[test]
+    fn test_add_i32_f32() {
+        binary_cast_test(
+            DataType::Int32,
+            DataType::Float32,
+            "CAST(#0 AS Float32) Plus #1",
+        );
+        binary_cast_test(
+            DataType::Float32,
+            DataType::Int32,
+            "#0 Plus CAST(#1 AS Float32)",
+        );
+    }
+
+    fn binary_cast_test(left_type: DataType, right_type: DataType, expected: &str) {
+        let schema = Schema::new(vec![
+            Field::new("c0", left_type, true),
+            Field::new("c1", right_type, true),
+        ]);
+
+        let expr = Expr::BinaryExpr {
+            left: Arc::new(Column(0)),
+            op: Operator::Plus,
+            right: Arc::new(Column(1)),
+        };
+
+        let expr2 = rewrite_expr(&expr, &schema).unwrap();
+
+        assert_eq!(expected, format!("{:?}", expr2));
+    }
+}

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -101,9 +101,9 @@ fn rewrite_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
             } else {
                 let super_type = utils::get_supertype(&left_type, &right_type)?;
                 Ok(Expr::BinaryExpr {
-                    left: Arc::new(left.cast_to(&super_type, schema)?),
+                    left: Arc::new(left.cast_to(&super_type, schema)),
                     op: op.clone(),
-                    right: Arc::new(right.cast_to(&super_type, schema)?),
+                    right: Arc::new(right.cast_to(&super_type, schema)),
                 })
             }
         }

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -101,9 +101,9 @@ fn rewrite_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
             } else {
                 let super_type = utils::get_supertype(&left_type, &right_type)?;
                 Ok(Expr::BinaryExpr {
-                    left: Arc::new(left.cast_to(&super_type, schema)),
+                    left: Arc::new(left.cast_to(&super_type, schema)?),
                     op: op.clone(),
-                    right: Arc::new(right.cast_to(&super_type, schema)),
+                    right: Arc::new(right.cast_to(&super_type, schema)?),
                 })
             }
         }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-///! Collection of utility functions that are leveraged by the query optimizer rules
+//! Collection of utility functions that are leveraged by the query optimizer rules
+
 use std::collections::HashSet;
 
 use arrow::datatypes::{DataType, Field, Schema};

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -15,12 +15,40 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Collection of utility functions that are leveraged by the query optimizer rules
+///! Collection of utility functions that are leveraged by the query optimizer rules
+use std::collections::HashSet;
 
 use arrow::datatypes::{DataType, Field, Schema};
 
 use crate::error::{ExecutionError, Result};
 use crate::logicalplan::Expr;
+
+/// Recursively walk a list of expression trees, collecting the unique set of column indexes
+/// referenced in the expression
+pub fn exprlist_to_column_indices(expr: &Vec<Expr>, accum: &mut HashSet<usize>) {
+    expr.iter().for_each(|e| expr_to_column_indices(e, accum));
+}
+
+/// Recursively walk an expression tree, collecting the unique set of column indexes
+/// referenced in the expression
+pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) {
+    match expr {
+        Expr::Column(i) => {
+            accum.insert(*i);
+        }
+        Expr::Literal(_) => { /* not needed */ }
+        Expr::IsNull(e) => expr_to_column_indices(e, accum),
+        Expr::IsNotNull(e) => expr_to_column_indices(e, accum),
+        Expr::BinaryExpr { left, right, .. } => {
+            expr_to_column_indices(left, accum);
+            expr_to_column_indices(right, accum);
+        }
+        Expr::Cast { expr, .. } => expr_to_column_indices(expr, accum),
+        Expr::Sort { expr, .. } => expr_to_column_indices(expr, accum),
+        Expr::AggregateFunction { args, .. } => exprlist_to_column_indices(args, accum),
+        Expr::ScalarFunction { args, .. } => exprlist_to_column_indices(args, accum),
+    }
+}
 
 /// Create field meta-data from an expression, for use in a result set schema
 pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
@@ -180,5 +208,35 @@ fn _get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
         (Boolean, Boolean) => Some(Boolean),
 
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logicalplan::Expr;
+    use arrow::datatypes::DataType;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_collect_expr() {
+        let mut accum: HashSet<usize> = HashSet::new();
+        expr_to_column_indices(
+            &Expr::Cast {
+                expr: Arc::new(Expr::Column(3)),
+                data_type: DataType::Float64,
+            },
+            &mut accum,
+        );
+        expr_to_column_indices(
+            &Expr::Cast {
+                expr: Arc::new(Expr::Column(3)),
+                data_type: DataType::Float64,
+            },
+            &mut accum,
+        );
+        assert_eq!(1, accum.len());
+        assert!(accum.contains(&3));
     }
 }

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -215,6 +215,6 @@ impl DFParser {
         _expr: DFASTNode,
         _precedence: u8,
     ) -> Result<Option<DFASTNode>, ParserError> {
-        Ok(None)
+        unimplemented!()
     }
 }

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -215,6 +215,6 @@ impl DFParser {
         _expr: DFASTNode,
         _precedence: u8,
     ) -> Result<Option<DFASTNode>, ParserError> {
-        unimplemented!()
+        Ok(None)
     }
 }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -340,7 +340,7 @@ impl SqlToRel {
                             for i in 0..rex_args.len() {
                                 safe_args.push(
                                     rex_args[i]
-                                        .cast_to(fm.args()[i].data_type(), schema),
+                                        .cast_to(fm.args()[i].data_type(), schema)?,
                                 );
                             }
 

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -340,7 +340,7 @@ impl SqlToRel {
                             for i in 0..rex_args.len() {
                                 safe_args.push(
                                     rex_args[i]
-                                        .cast_to(fm.args()[i].data_type(), schema)?,
+                                        .cast_to(fm.args()[i].data_type(), schema),
                                 );
                             }
 


### PR DESCRIPTION
This PR refactors the existing type coercion logic, to remove it from the SQL query planner and into an optimizer rule and also makes it more complete, with improved unit tests.

It also converts more functions to return Result instead of using unwrap and removes some dead code and removes some duplicated code by introducing a new `utils` file in `optimizer` module.