### PR TITLE
ARROW-4908: [Rust] [DataFusion] Add support for date/time parquet types encoded as INT32/INT64

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -196,6 +196,13 @@ make_type!(
 );
 make_type!(Date32Type, i32, DataType::Date32(DateUnit::Day), 32, 0i32);
 make_type!(
+    Date32MillisecondType,
+    i32,
+    DataType::Date32(DateUnit::Millisecond),
+    32,
+    0i32
+);
+make_type!(
     Date64Type,
     i64,
     DataType::Date64(DateUnit::Millisecond),

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -196,13 +196,6 @@ make_type!(
 );
 make_type!(Date32Type, i32, DataType::Date32(DateUnit::Day), 32, 0i32);
 make_type!(
-    Date32MillisecondType,
-    i32,
-    DataType::Date32(DateUnit::Millisecond),
-    32,
-    0i32
-);
-make_type!(
     Date64Type,
     i64,
     DataType::Date64(DateUnit::Millisecond),

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -479,20 +479,27 @@ mod tests {
     fn read_alltypes_plain_parquet() {
         let table = load_table("alltypes_plain.parquet");
 
-        let x: Vec<String> = table.schema().fields().iter().map(|f| format!("{}: {:?}", f.name(), f.data_type())).collect();
-        let y =  x.join("\n");
+        let x: Vec<String> = table
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| format!("{}: {:?}", f.name(), f.data_type()))
+            .collect();
+        let y = x.join("\n");
         assert_eq!(
-        "id: Int32\n\
-        bool_col: Boolean\n\
-        tinyint_col: Int32\n\
-        smallint_col: Int32\n\
-        int_col: Int32\n\
-        bigint_col: Int64\n\
-        float_col: Float32\n\
-        double_col: Float64\n\
-        date_string_col: Utf8\n\
-        string_col: Utf8\n\
-        timestamp_col: Timestamp(Nanosecond)", y);
+            "id: Int32\n\
+             bool_col: Boolean\n\
+             tinyint_col: Int32\n\
+             smallint_col: Int32\n\
+             int_col: Int32\n\
+             bigint_col: Int64\n\
+             float_col: Float32\n\
+             double_col: Float64\n\
+             date_string_col: Utf8\n\
+             string_col: Utf8\n\
+             timestamp_col: Timestamp(Nanosecond)",
+            y
+        );
 
         let projection = None;
         let scan = table.scan(&projection, 1024).unwrap();

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -264,8 +264,8 @@ impl ParquetFile {
                             )?
                         }
                         ColumnReader::Int32ColumnReader(ref mut r) => match dt {
-                            DataType::Date32(DateUnit::Millisecond) => {
-                                ArrowReader::<Date32MillisecondType>::read(
+                            DataType::Date32(DateUnit::Day) => {
+                                ArrowReader::<Date32Type>::read(
                                     r,
                                     self.batch_size,
                                     is_nullable,
@@ -292,8 +292,8 @@ impl ParquetFile {
                                     is_nullable,
                                 )?
                             }
-                            DataType::Timestamp(TimeUnit::Microsecond) => {
-                                ArrowReader::<TimestampMicrosecondType>::read(
+                            DataType::Time64(TimeUnit::Nanosecond) => {
+                                ArrowReader::<Time64NanosecondType>::read(
                                     r,
                                     self.batch_size,
                                     is_nullable,
@@ -301,6 +301,20 @@ impl ParquetFile {
                             }
                             DataType::Timestamp(TimeUnit::Millisecond) => {
                                 ArrowReader::<TimestampMillisecondType>::read(
+                                    r,
+                                    self.batch_size,
+                                    is_nullable,
+                                )?
+                            }
+                            DataType::Timestamp(TimeUnit::Microsecond) => {
+                                ArrowReader::<TimestampMicrosecondType>::read(
+                                    r,
+                                    self.batch_size,
+                                    is_nullable,
+                                )?
+                            }
+                            DataType::Timestamp(TimeUnit::Nanosecond) => {
+                                ArrowReader::<TimestampMicrosecondType>::read(
                                     r,
                                     self.batch_size,
                                     is_nullable,
@@ -464,6 +478,21 @@ mod tests {
     #[test]
     fn read_alltypes_plain_parquet() {
         let table = load_table("alltypes_plain.parquet");
+
+        let x: Vec<String> = table.schema().fields().iter().map(|f| format!("{}: {:?}", f.name(), f.data_type())).collect();
+        let y =  x.join("\n");
+        assert_eq!(
+        "id: Int32\n\
+        bool_col: Boolean\n\
+        tinyint_col: Int32\n\
+        smallint_col: Int32\n\
+        int_col: Int32\n\
+        bigint_col: Int64\n\
+        float_col: Float32\n\
+        double_col: Float64\n\
+        date_string_col: Utf8\n\
+        string_col: Utf8\n\
+        timestamp_col: Timestamp(Nanosecond)", y);
 
         let projection = None;
         let scan = table.scan(&projection, 1024).unwrap();

--- a/rust/parquet/src/reader/schema.rs
+++ b/rust/parquet/src/reader/schema.rs
@@ -198,7 +198,7 @@ impl ParquetTypeConverter {
             LogicalType::INT_8 => Ok(DataType::Int8),
             LogicalType::INT_16 => Ok(DataType::Int16),
             LogicalType::INT_32 => Ok(DataType::Int32),
-            LogicalType::DATE => Ok(DataType::Date32(DateUnit::Millisecond)),
+            LogicalType::DATE => Ok(DataType::Date32(DateUnit::Day)),
             LogicalType::TIME_MILLIS => Ok(DataType::Time32(TimeUnit::Millisecond)),
             other => Err(ArrowError(format!(
                 "Unable to convert parquet INT32 logical type {}",
@@ -213,11 +213,11 @@ impl ParquetTypeConverter {
             LogicalType::INT_64 => Ok(DataType::Int64),
             LogicalType::UINT_64 => Ok(DataType::UInt64),
             LogicalType::TIME_MICROS => Ok(DataType::Time64(TimeUnit::Microsecond)),
-            LogicalType::TIMESTAMP_MICROS => {
-                Ok(DataType::Timestamp(TimeUnit::Microsecond))
-            }
             LogicalType::TIMESTAMP_MILLIS => {
                 Ok(DataType::Timestamp(TimeUnit::Millisecond))
+            }
+            LogicalType::TIMESTAMP_MICROS => {
+                Ok(DataType::Timestamp(TimeUnit::Microsecond))
             }
             other => Err(ArrowError(format!(
                 "Unable to convert parquet INT64 logical type {}",


### PR DESCRIPTION
This PR adds support for the date/time parquet types that can be encoded in INT32/INT64 physical types. 