### PR TITLE
ARROW-4895: [Rust] [DataFusion] Move error.rs to root of crate

### DIFF
--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
-use crate::execution::error::Result;
+use crate::error::Result;
 
 /// Represents a CSV file with a provided schema
 pub struct CsvFile {

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-use crate::execution::error::Result;
+use crate::error::Result;
 
 pub type ScanResult = Arc<Mutex<RecordBatchIterator>>;
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
-use crate::execution::error::{ExecutionError, Result};
+use crate::error::{ExecutionError, Result};
 
 /// In-memory table
 pub struct MemTable {

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -32,7 +32,7 @@ use parquet::file::reader::*;
 use parquet::reader::schema::parquet_to_arrow_schema;
 
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
-use crate::execution::error::{ExecutionError, Result};
+use crate::error::{ExecutionError, Result};
 
 pub struct ParquetTable {
     filename: String,

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Error types
+//! DataFusion error types
 
 use std::io::Error;
 use std::result;
@@ -27,17 +27,26 @@ use sqlparser::sqlparser::ParserError;
 
 pub type Result<T> = result::Result<T, ExecutionError>;
 
-/// DataFusion execution error
+/// DataFusion error
 #[derive(Debug)]
 pub enum ExecutionError {
-    IoError(Error),
-    ParserError(ParserError),
-    General(String),
-    InvalidColumn(String),
-    NotImplemented(String),
-    InternalError(String),
+    /// Wraps an error from the Arrow crate
     ArrowError(ArrowError),
+    /// Wraps an error from the Parquet crate
     ParquetError(ParquetError),
+    /// I/O error
+    IoError(Error),
+    /// SQL parser error
+    ParserError(ParserError),
+    /// General error
+    General(String),
+    /// Invalid column error
+    InvalidColumn(String),
+    /// Missing functionality
+    NotImplemented(String),
+    /// Internal error
+    InternalError(String),
+    /// Query engine execution error
     ExecutionError(String),
 }
 

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -29,7 +29,7 @@ use arrow::compute;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::execution::error::{ExecutionError, Result};
+use crate::error::{ExecutionError, Result};
 use crate::execution::expression::{AggregateType, RuntimeExpr};
 use crate::execution::relation::Relation;
 use crate::logicalplan::ScalarValue;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -27,8 +27,8 @@ use arrow::datatypes::*;
 
 use crate::datasource::csv::CsvFile;
 use crate::datasource::datasource::Table;
-use crate::execution::aggregate::AggregateRelation;
 use crate::error::{ExecutionError, Result};
+use crate::execution::aggregate::AggregateRelation;
 use crate::execution::expression::*;
 use crate::execution::filter::FilterRelation;
 use crate::execution::limit::LimitRelation;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -28,7 +28,7 @@ use arrow::datatypes::*;
 use crate::datasource::csv::CsvFile;
 use crate::datasource::datasource::Table;
 use crate::execution::aggregate::AggregateRelation;
-use crate::execution::error::{ExecutionError, Result};
+use crate::error::{ExecutionError, Result};
 use crate::execution::expression::*;
 use crate::execution::filter::FilterRelation;
 use crate::execution::limit::LimitRelation;

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -25,9 +25,9 @@ use arrow::compute;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
-use super::super::logicalplan::{Expr, Operator, ScalarValue};
-use super::context::ExecutionContext;
-use super::error::{ExecutionError, Result};
+use crate::logicalplan::{Expr, Operator, ScalarValue};
+use crate::error::{ExecutionError, Result};
+use crate::execution::context::ExecutionContext;
 
 /// Compiled Expression (basically just a closure to evaluate the expression at runtime)
 pub type CompiledExpr = Rc<Fn(&RecordBatch) -> Result<ArrayRef>>;

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -25,9 +25,9 @@ use arrow::compute;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::logicalplan::{Expr, Operator, ScalarValue};
 use crate::error::{ExecutionError, Result};
 use crate::execution::context::ExecutionContext;
+use crate::logicalplan::{Expr, Operator, ScalarValue};
 
 /// Compiled Expression (basically just a closure to evaluate the expression at runtime)
 pub type CompiledExpr = Rc<Fn(&RecordBatch) -> Result<ArrayRef>>;

--- a/rust/datafusion/src/execution/filter.rs
+++ b/rust/datafusion/src/execution/filter.rs
@@ -26,9 +26,9 @@ use arrow::compute::array_ops::filter;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-use super::error::{ExecutionError, Result};
-use super::expression::RuntimeExpr;
-use super::relation::Relation;
+use crate::error::{ExecutionError, Result};
+use crate::execution::expression::RuntimeExpr;
+use crate::execution::relation::Relation;
 
 /// Implementation of a filter relation
 pub(super) struct FilterRelation {

--- a/rust/datafusion/src/execution/limit.rs
+++ b/rust/datafusion/src/execution/limit.rs
@@ -26,8 +26,8 @@ use arrow::compute::array_ops::limit;
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-use super::error::{ExecutionError, Result};
-use super::relation::Relation;
+use crate::error::{ExecutionError, Result};
+use crate::execution::relation::Relation;
 
 /// Implementation of a LIMIT relation
 pub(super) struct LimitRelation {

--- a/rust/datafusion/src/execution/mod.rs
+++ b/rust/datafusion/src/execution/mod.rs
@@ -19,7 +19,6 @@
 
 pub mod aggregate;
 pub mod context;
-pub mod error;
 pub mod expression;
 pub mod filter;
 pub mod limit;

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -28,7 +28,7 @@ use arrow::array::ArrayRef;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::execution::error::Result;
+use crate::error::Result;
 use crate::execution::expression::RuntimeExpr;
 use crate::execution::relation::Relation;
 

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::RecordBatchIterator;
-use crate::execution::error::Result;
+use crate::error::Result;
 
 /// trait for all relations (a relation is essentially just an iterator over batches
 /// of data, with a known schema)

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -25,6 +25,7 @@ extern crate serde_json;
 extern crate sqlparser;
 
 pub mod datasource;
+pub mod error;
 pub mod execution;
 pub mod logicalplan;
 pub mod optimizer;

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -20,7 +20,7 @@
 use std::string::String;
 use std::sync::Arc;
 
-use crate::execution::error::*;
+use crate::error::*;
 use crate::logicalplan::*;
 
 use arrow::datatypes::*;


### PR DESCRIPTION
The `error.rs` file was under the `execution` module even though this is the error type used across the crate, so I moved it to the top level.