### PR TITLE
ARROW-4940: [Rust] Enable warnings for missing docs, add docs in datafusion

### DIFF
--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -29,6 +29,7 @@ use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::error::Result;
 
 /// Represents a CSV file with a provided schema
+// TODO: usage example (rather than documenting `new()`)
 pub struct CsvFile {
     filename: String,
     schema: Arc<Schema>,
@@ -36,7 +37,7 @@ pub struct CsvFile {
 }
 
 impl CsvFile {
-    /// Initializer
+    #[allow(missing_docs)]
     pub fn new(filename: &str, schema: &Schema, has_header: bool) -> Self {
         Self {
             filename: String::from(filename),
@@ -67,13 +68,14 @@ impl Table for CsvFile {
 }
 
 /// Iterator over CSV batches
+// TODO: usage example (rather than documenting `new()`)
 pub struct CsvBatchIterator {
     schema: Arc<Schema>,
     reader: csv::Reader<File>,
 }
 
 impl CsvBatchIterator {
-    /// Initializer
+    #[allow(missing_docs)]
     pub fn new(
         filename: &str,
         schema: Arc<Schema>,

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -36,6 +36,7 @@ pub struct CsvFile {
 }
 
 impl CsvFile {
+    /// Initializer
     pub fn new(filename: &str, schema: &Schema, has_header: bool) -> Self {
         Self {
             filename: String::from(filename),
@@ -72,6 +73,7 @@ pub struct CsvBatchIterator {
 }
 
 impl CsvBatchIterator {
+    /// Initializer
     pub fn new(
         filename: &str,
         schema: Arc<Schema>,

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -24,7 +24,8 @@ use arrow::record_batch::RecordBatch;
 
 use crate::error::Result;
 
-/// Iterator of record batches, wrapped in a mutex
+/// Returned by implementors of `Table#scan`, this `RecordBatchIterator` is wrapped with an `Arc`
+/// and `Mutex` so that it can be shared across threads as it is used.
 pub type ScanResult = Arc<Mutex<RecordBatchIterator>>;
 
 /// Source table

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -24,6 +24,7 @@ use arrow::record_batch::RecordBatch;
 
 use crate::error::Result;
 
+/// Iterator of record batches, wrapped in a mutex
 pub type ScanResult = Arc<Mutex<RecordBatchIterator>>;
 
 /// Source table

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -34,12 +34,14 @@ use parquet::reader::schema::parquet_to_arrow_schema;
 use crate::datasource::{RecordBatchIterator, ScanResult, Table};
 use crate::error::{ExecutionError, Result};
 
+/// Table-based representation of a `ParquetFile`
 pub struct ParquetTable {
     filename: String,
     schema: Arc<Schema>,
 }
 
 impl ParquetTable {
+    /// Attempt to initialize a new `ParquetTable` from a file path
     pub fn try_new(filename: &str) -> Result<Self> {
         let file = File::open(filename)?;
         let parquet_file = ParquetFile::open(file, None, 0)?;
@@ -67,6 +69,7 @@ impl Table for ParquetTable {
     }
 }
 
+/// Loader and reader for parquet data
 pub struct ParquetFile {
     reader: SerializedFileReader<File>,
     /// Projection expressed as column indices into underlying parquet reader
@@ -172,6 +175,7 @@ where
 }
 
 impl ParquetFile {
+    /// Read parquet data from a `File`
     pub fn open(
         file: File,
         projection: Option<Vec<usize>>,

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -25,10 +25,12 @@ use parquet::errors::ParquetError;
 
 use sqlparser::sqlparser::ParserError;
 
+/// Result type for operations that could result in an `ExecutionError`
 pub type Result<T> = result::Result<T, ExecutionError>;
 
 /// DataFusion error
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub enum ExecutionError {
     /// Wraps an error from the Arrow crate
     ArrowError(ArrowError),

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -32,9 +32,11 @@ use crate::logicalplan::{Expr, Operator, ScalarValue};
 /// Compiled Expression (basically just a closure to evaluate the expression at runtime)
 pub type CompiledExpr = Rc<Fn(&RecordBatch) -> Result<ArrayRef>>;
 
+/// Like to `CompiledExpr` but the closure transforms `ArrayRef` to another `ArrayRef`
 pub type CompiledCastFunction = Rc<Fn(&ArrayRef) -> Result<ArrayRef>>;
 
 /// Enumeration of supported aggregate functions
+#[allow(missing_docs)] // seems like these variants are self-evident
 pub enum AggregateType {
     Min,
     Max,

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -32,7 +32,7 @@ use crate::logicalplan::{Expr, Operator, ScalarValue};
 /// Compiled Expression (basically just a closure to evaluate the expression at runtime)
 pub type CompiledExpr = Rc<Fn(&RecordBatch) -> Result<ArrayRef>>;
 
-/// Like to `CompiledExpr` but the closure transforms `ArrayRef` to another `ArrayRef`
+/// Similar to `CompiledExpr` but the closure transforms `ArrayRef` to another `ArrayRef`
 pub type CompiledCastFunction = Rc<Fn(&ArrayRef) -> Result<ArrayRef>>;
 
 /// Enumeration of supported aggregate functions

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -30,6 +30,7 @@ use crate::error::Result;
 /// trait for all relations (a relation is essentially just an iterator over batches
 /// of data, with a known schema)
 pub trait Relation {
+    /// Get the next `RecordBatch`, or `None` if the iterator is exhausted
     fn next(&mut self) -> Result<Option<RecordBatch>>;
 
     /// get the schema for this relation

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -18,6 +18,8 @@
 //! DataFusion is a modern distributed compute platform implemented in Rust that uses
 //! Apache Arrow as the memory model
 
+#![warn(missing_docs)]
+
 extern crate arrow;
 #[macro_use]
 extern crate serde_derive;

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -48,7 +48,7 @@ pub struct FunctionMeta {
 }
 
 impl FunctionMeta {
-    /// Initializer
+    #[allow(missing_docs)]
     pub fn new(
         name: String,
         args: Vec<Field>,

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -28,11 +28,13 @@ use crate::optimizer::utils;
 /// Enumeration of supported function types (Scalar and Aggregate)
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum FunctionType {
+    /// Simple function returning a value per DataFrame
     Scalar,
+    /// Aggregate functions produce a value by sampling multiple DataFrames
     Aggregate,
 }
 
-/// Logical representation of a UDF
+/// Logical representation of a UDF (user-defined function)
 #[derive(Debug, Clone)]
 pub struct FunctionMeta {
     /// Function name
@@ -46,6 +48,7 @@ pub struct FunctionMeta {
 }
 
 impl FunctionMeta {
+    /// Initializer
     pub fn new(
         name: String,
         args: Vec<Field>,
@@ -59,60 +62,96 @@ impl FunctionMeta {
             function_type,
         }
     }
+    /// Getter for the function name
     pub fn name(&self) -> &String {
         &self.name
     }
+    /// Getter for the arg list
     pub fn args(&self) -> &Vec<Field> {
         &self.args
     }
+    /// Getter for the `DataType` the function returns
     pub fn return_type(&self) -> &DataType {
         &self.return_type
     }
+    /// Getter for the `FunctionType`
     pub fn function_type(&self) -> &FunctionType {
         &self.function_type
     }
 }
 
+/// Operators applied to expressions
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum Operator {
+    /// Expressions are equal
     Eq,
+    /// Expressions are not equal
     NotEq,
+    /// Left side is smaller than right side
     Lt,
+    /// Left side is smaller or equal to right side
     LtEq,
+    /// Left side is greater than right side
     Gt,
+    /// Left side is greater or equal to right side
     GtEq,
+    /// Addition
     Plus,
+    /// Subtraction
     Minus,
+    /// Multiplication operator, like `*`
     Multiply,
+    /// Division operator, like `/`
     Divide,
+    /// Remainder operator, like `%`
     Modulus,
+    /// Logical AND, like `&&`
     And,
+    /// Logical OR, like `||`
     Or,
+    /// Logical NOT, like `!`
     Not,
+    /// Matches a wildcard pattern
     Like,
+    /// Does not match a wildcard pattern
     NotLike,
 }
 
 /// ScalarValue enumeration
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum ScalarValue {
+    /// null value
     Null,
+    /// true or false value
     Boolean(bool),
+    /// 32bit float
     Float32(f32),
+    /// 64bit float
     Float64(f64),
+    /// signed 8bit int
     Int8(i8),
+    /// signed 16bit int
     Int16(i16),
+    /// signed 32bit int
     Int32(i32),
+    /// signed 64bit int
     Int64(i64),
+    /// unsigned 8bit int
     UInt8(u8),
+    /// unsigned 16bit int
     UInt16(u16),
+    /// unsigned 32bit int
     UInt32(u32),
+    /// unsigned 64bit int
     UInt64(u64),
+    /// utf-8 encoded string
     Utf8(Arc<String>),
+    /// List of scalars packed as a struct
     Struct(Vec<ScalarValue>),
 }
 
 impl ScalarValue {
+    /// Getter for the `DataType` of the value
     pub fn get_datatype(&self) -> DataType {
         match *self {
             ScalarValue::Boolean(_) => DataType::Boolean,
@@ -141,8 +180,11 @@ pub enum Expr {
     Literal(ScalarValue),
     /// binary expression e.g. "age > 21"
     BinaryExpr {
+        /// Left-hand side of the expression
         left: Arc<Expr>,
+        /// The comparison operator
         op: Operator,
+        /// Right-hand side of the expression
         right: Arc<Expr>,
     },
     /// unary IS NOT NULL
@@ -151,26 +193,40 @@ pub enum Expr {
     IsNull(Arc<Expr>),
     /// cast a value to a different type
     Cast {
+        /// The expression being cast
         expr: Arc<Expr>,
+        /// The `DataType` the expression will yield
         data_type: DataType,
     },
     /// sort expression
-    Sort { expr: Arc<Expr>, asc: bool },
+    Sort {
+        /// The expression to sort on
+        expr: Arc<Expr>,
+        /// The direction of the sort
+        asc: bool,
+    },
     /// scalar function
     ScalarFunction {
+        /// Name of the function
         name: String,
+        /// List of expressions to feed to the functions as arguments
         args: Vec<Expr>,
+        /// The `DataType` the expression will yield
         return_type: DataType,
     },
     /// aggregate function
     AggregateFunction {
+        /// Name of the function
         name: String,
+        /// List of expressions to feed to the functions as arguments
         args: Vec<Expr>,
+        /// The `DataType` the expression will yield
         return_type: DataType,
     },
 }
 
 impl Expr {
+    /// Find the `DataType` for the expression
     pub fn get_type(&self, schema: &Schema) -> DataType {
         match self {
             Expr::Column(n) => schema.field(*n).data_type().clone(),
@@ -199,6 +255,9 @@ impl Expr {
         }
     }
 
+    /// Perform a type cast on the expression value.
+    ///
+    /// Will `Err` if the type cast cannot be performed.
     pub fn cast_to(&self, cast_to_type: &DataType, schema: &Schema) -> Result<Expr> {
         let this_type = self.get_type(schema);
         if this_type == *cast_to_type {
@@ -216,6 +275,7 @@ impl Expr {
         }
     }
 
+    /// Equal
     pub fn eq(&self, other: &Expr) -> Expr {
         Expr::BinaryExpr {
             left: Arc::new(self.clone()),
@@ -224,6 +284,7 @@ impl Expr {
         }
     }
 
+    /// Not equal
     pub fn not_eq(&self, other: &Expr) -> Expr {
         Expr::BinaryExpr {
             left: Arc::new(self.clone()),
@@ -232,6 +293,7 @@ impl Expr {
         }
     }
 
+    /// Greater than
     pub fn gt(&self, other: &Expr) -> Expr {
         Expr::BinaryExpr {
             left: Arc::new(self.clone()),
@@ -240,6 +302,7 @@ impl Expr {
         }
     }
 
+    /// Greater than or equal to
     pub fn gt_eq(&self, other: &Expr) -> Expr {
         Expr::BinaryExpr {
             left: Arc::new(self.clone()),
@@ -248,6 +311,7 @@ impl Expr {
         }
     }
 
+    /// Less than
     pub fn lt(&self, other: &Expr) -> Expr {
         Expr::BinaryExpr {
             left: Arc::new(self.clone()),
@@ -256,6 +320,7 @@ impl Expr {
         }
     }
 
+    /// Less than or equal to
     pub fn lt_eq(&self, other: &Expr) -> Expr {
         Expr::BinaryExpr {
             left: Arc::new(self.clone()),
@@ -317,38 +382,63 @@ impl fmt::Debug for Expr {
 pub enum LogicalPlan {
     /// A Projection (essentially a SELECT with an expression list)
     Projection {
+        /// The list of expressions
         expr: Vec<Expr>,
+        /// The incoming logic plan
         input: Arc<LogicalPlan>,
+        /// The schema description
         schema: Arc<Schema>,
     },
     /// A Selection (essentially a WHERE clause with a predicate expression)
-    Selection { expr: Expr, input: Arc<LogicalPlan> },
+    Selection {
+        /// The expression
+        expr: Expr,
+        /// The incoming logic plan
+        input: Arc<LogicalPlan>,
+    },
     /// Represents a list of aggregate expressions with optional grouping expressions
     Aggregate {
+        /// The incoming logic plan
         input: Arc<LogicalPlan>,
+        /// Grouping expressions
         group_expr: Vec<Expr>,
+        /// Aggregate expressions
         aggr_expr: Vec<Expr>,
+        /// The schema description
         schema: Arc<Schema>,
     },
     /// Represents a list of sort expressions to be applied to a relation
     Sort {
+        /// The sort expressions
         expr: Vec<Expr>,
+        /// The incoming logic plan
         input: Arc<LogicalPlan>,
+        /// The schema description
         schema: Arc<Schema>,
     },
     /// A table scan against a table that has been registered on a context
     TableScan {
+        /// The name of the schema
         schema_name: String,
+        /// The name of the table
         table_name: String,
+        /// The schema description
         schema: Arc<Schema>,
+        /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
     },
     /// An empty relation with an empty schema
-    EmptyRelation { schema: Arc<Schema> },
-    // Represents the maximum number of records to return
+    EmptyRelation {
+        /// The schema description
+        schema: Arc<Schema>,
+    },
+    /// Represents the maximum number of records to return
     Limit {
+        /// The expression
         expr: Expr,
+        /// The logical plan
         input: Arc<LogicalPlan>,
+        /// The schema description
         schema: Arc<Schema>,
     },
 }
@@ -450,6 +540,7 @@ impl fmt::Debug for LogicalPlan {
     }
 }
 
+/// Verify a given type cast can be performed
 pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
     use self::DataType::*;
     match type_into {

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -23,5 +23,6 @@ use std::sync::Arc;
 
 /// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.
 pub trait OptimizerRule {
+    /// Perform optimizations on the plan
     fn optimize(&mut self, plan: &LogicalPlan) -> Result<Arc<LogicalPlan>>;
 }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -40,7 +40,7 @@ impl OptimizerRule for ProjectionPushDown {
 }
 
 impl ProjectionPushDown {
-    /// Initialize a new `ProjectionPushDown`
+    #[allow(missing_docs)]
     pub fn new() -> Self {
         Self {}
     }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -40,6 +40,7 @@ impl OptimizerRule for ProjectionPushDown {
 }
 
 impl ProjectionPushDown {
+    /// Initialize a new `ProjectionPushDown`
     pub fn new() -> Self {
         Self {}
     }

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -83,6 +83,7 @@ impl OptimizerRule for TypeCoercionRule {
 }
 
 impl TypeCoercionRule {
+    #[allow(missing_docs)]
     pub fn new() -> Self {
         Self {}
     }

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -31,13 +31,20 @@ macro_rules! parser_err {
     };
 }
 
+/// Types of files to parse as DataFrames
 #[derive(Debug, Clone)]
 pub enum FileType {
+    /// Newline-delimited JSON
     NdJson,
+    /// Apache Parquet columnar storage
     Parquet,
+    /// Comma separated values
     CSV,
 }
 
+/// DataFrame AST Node representations.
+///
+/// Tokens parsed by `DFParser` are converted into these values.
 #[derive(Debug, Clone)]
 pub enum DFASTNode {
     /// ANSI SQL AST node
@@ -210,6 +217,7 @@ impl DFParser {
         }
     }
 
+    /// Parse an infix operator
     pub fn parse_infix(
         &mut self,
         _expr: DFASTNode,

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -31,7 +31,9 @@ use sqlparser::sqlast::*;
 /// The SchemaProvider trait allows the query planner to obtain meta-data about tables and
 /// functions referenced in SQL statements
 pub trait SchemaProvider {
+    /// Getter for a field description
     fn get_table_meta(&self, name: &str) -> Option<Arc<Schema>>;
+    /// Getter for a UDF description
     fn get_function_meta(&self, name: &str) -> Option<Arc<FunctionMeta>>;
 }
 


### PR DESCRIPTION
This is the datafusion part of [ARROW-4683].

Adds a warn lint to the crate root for missing docs, and attempts to add
docs for anything missing at the time of writing.

Overall, I felt like I was delivering a weak product here. Most of the stuff that didn't have docs really didn't seem to need them. I'm not sure how much value is being added here. Notably, I actually opted to allow missing docs on one enum for aggregate function types since the only thing I could think to add in a docstring would be virtually identical to the name of the variant.

I'd welcome suggestions for rephrasing, etc.

[ARROW-4683]: https://issues.apache.org/jira/browse/ARROW-4683