### PR TITLE
ARROW-4942: [Ruby] Remove needless omits in tests

### DIFF
--- a/ruby/red-arrow/test/raw-records/record-batch/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/record-batch/test-dense-union-array.rb
@@ -84,7 +84,6 @@ class RawRecordsRecordBatchDenseUnionArrayTest < Test::Unit::TestCase
   end
 
   test("NullArray") do
-    omit("Need to add support for NullArrayBuilder")
     records = [
       [{"0" => nil}],
       [nil],

--- a/ruby/red-arrow/test/raw-records/record-batch/test-list-array.rb
+++ b/ruby/red-arrow/test/raw-records/record-batch/test-list-array.rb
@@ -34,7 +34,6 @@ class RawRecordsRecordBatchListArrayTest < Test::Unit::TestCase
   end
 
   test("NullArray") do
-    omit("Need to add support for NullArrayBuilder")
     records = [
       [[nil, nil, nil]],
       [nil],

--- a/ruby/red-arrow/test/raw-records/record-batch/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/record-batch/test-sparse-union-array.rb
@@ -72,7 +72,6 @@ class RawRecordsRecordBatchSparseUnionArrayTest < Test::Unit::TestCase
   end
 
   test("NullArray") do
-    omit("Need to add support for NullArrayBuilder")
     records = [
       [{"0" => nil}],
       [nil],

--- a/ruby/red-arrow/test/raw-records/record-batch/test-struct-array.rb
+++ b/ruby/red-arrow/test/raw-records/record-batch/test-struct-array.rb
@@ -36,7 +36,6 @@ class RawRecordsRecordBatchStructArrayTest < Test::Unit::TestCase
   end
 
   test("NullArray") do
-    omit("Need to add support for NullArrayBuilder")
     records = [
       [{"field" => nil}],
       [nil],


### PR DESCRIPTION
@kou I forgot to remove `omit("Need to add support for NullArrayBuilder")` in the previous pull-request.