### PR TITLE
ARROW-4910: [Rust] [DataFusion] Remove all uses of unimplemented!

### DIFF
--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -113,24 +113,24 @@ pub enum ScalarValue {
 }
 
 impl ScalarValue {
-    pub fn get_datatype(&self) -> Result<DataType> {
+    pub fn get_datatype(&self) -> DataType {
         match *self {
-            ScalarValue::Boolean(_) => Ok(DataType::Boolean),
-            ScalarValue::UInt8(_) => Ok(DataType::UInt8),
-            ScalarValue::UInt16(_) => Ok(DataType::UInt16),
-            ScalarValue::UInt32(_) => Ok(DataType::UInt32),
-            ScalarValue::UInt64(_) => Ok(DataType::UInt64),
-            ScalarValue::Int8(_) => Ok(DataType::Int8),
-            ScalarValue::Int16(_) => Ok(DataType::Int16),
-            ScalarValue::Int32(_) => Ok(DataType::Int32),
-            ScalarValue::Int64(_) => Ok(DataType::Int64),
-            ScalarValue::Float32(_) => Ok(DataType::Float32),
-            ScalarValue::Float64(_) => Ok(DataType::Float64),
-            ScalarValue::Utf8(_) => Ok(DataType::Utf8),
-            _ => Err(ExecutionError::General(format!(
+            ScalarValue::Boolean(_) => DataType::Boolean,
+            ScalarValue::UInt8(_) => DataType::UInt8,
+            ScalarValue::UInt16(_) => DataType::UInt16,
+            ScalarValue::UInt32(_) => DataType::UInt32,
+            ScalarValue::UInt64(_) => DataType::UInt64,
+            ScalarValue::Int8(_) => DataType::Int8,
+            ScalarValue::Int16(_) => DataType::Int16,
+            ScalarValue::Int32(_) => DataType::Int32,
+            ScalarValue::Int64(_) => DataType::Int64,
+            ScalarValue::Float32(_) => DataType::Float32,
+            ScalarValue::Float64(_) => DataType::Float64,
+            ScalarValue::Utf8(_) => DataType::Utf8,
+            _ => panic!(
                 "Cannot treat {:?} as scalar value",
                 self
-            ))),
+            ),
         }
     }
 }
@@ -174,28 +174,28 @@ pub enum Expr {
 }
 
 impl Expr {
-    pub fn get_type(&self, schema: &Schema) -> Result<DataType> {
+    pub fn get_type(&self, schema: &Schema) -> DataType {
         match self {
-            Expr::Column(n) => Ok(schema.field(*n).data_type().clone()),
+            Expr::Column(n) => schema.field(*n).data_type().clone(),
             Expr::Literal(l) => l.get_datatype(),
-            Expr::Cast { data_type, .. } => Ok(data_type.clone()),
-            Expr::ScalarFunction { return_type, .. } => Ok(return_type.clone()),
-            Expr::AggregateFunction { return_type, .. } => Ok(return_type.clone()),
-            Expr::IsNull(_) => Ok(DataType::Boolean),
-            Expr::IsNotNull(_) => Ok(DataType::Boolean),
+            Expr::Cast { data_type, .. } => data_type.clone(),
+            Expr::ScalarFunction { return_type, .. } => return_type.clone(),
+            Expr::AggregateFunction { return_type, .. } => return_type.clone(),
+            Expr::IsNull(_) => DataType::Boolean,
+            Expr::IsNotNull(_) => DataType::Boolean,
             Expr::BinaryExpr {
                 ref left,
                 ref right,
                 ref op,
             } => match op {
-                Operator::Eq | Operator::NotEq => Ok(DataType::Boolean),
-                Operator::Lt | Operator::LtEq => Ok(DataType::Boolean),
-                Operator::Gt | Operator::GtEq => Ok(DataType::Boolean),
-                Operator::And | Operator::Or => Ok(DataType::Boolean),
+                Operator::Eq | Operator::NotEq => DataType::Boolean,
+                Operator::Lt | Operator::LtEq => DataType::Boolean,
+                Operator::Gt | Operator::GtEq => DataType::Boolean,
+                Operator::And | Operator::Or => DataType::Boolean,
                 _ => {
-                    let left_type = left.get_type(schema)?;
-                    let right_type = right.get_type(schema)?;
-                    utils::get_supertype(&left_type, &right_type)
+                    let left_type = left.get_type(schema);
+                    let right_type = right.get_type(schema);
+                    utils::get_supertype(&left_type, &right_type).unwrap()
                 }
             },
             Expr::Sort { ref expr, .. } => expr.get_type(schema),
@@ -203,7 +203,7 @@ impl Expr {
     }
 
     pub fn cast_to(&self, cast_to_type: &DataType, schema: &Schema) -> Result<Expr> {
-        let this_type = self.get_type(schema)?;
+        let this_type = self.get_type(schema);
         if this_type == *cast_to_type {
             Ok(self.clone())
         } else if can_coerce_from(cast_to_type, &this_type) {

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -127,10 +127,7 @@ impl ScalarValue {
             ScalarValue::Float32(_) => DataType::Float32,
             ScalarValue::Float64(_) => DataType::Float64,
             ScalarValue::Utf8(_) => DataType::Utf8,
-            _ => panic!(
-                "Cannot treat {:?} as scalar value",
-                self
-            ),
+            _ => panic!("Cannot treat {:?} as scalar value", self),
         }
     }
 }

--- a/rust/datafusion/src/optimizer/mod.rs
+++ b/rust/datafusion/src/optimizer/mod.rs
@@ -19,3 +19,4 @@
 
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod utils;

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Collection of utility functions that are leveraged by the query optimizer rules
+
+use arrow::datatypes::{DataType, Field, Schema};
+
+use crate::error::{ExecutionError, Result};
+use crate::logicalplan::Expr;
+
+/// Create field meta-data from an expression, for use in a result set schema
+pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
+    match e {
+        Expr::Column(i) => Ok(input_schema.fields()[*i].clone()),
+        Expr::Literal(ref lit) => Ok(Field::new("lit", lit.get_datatype()?, true)),
+        Expr::ScalarFunction {
+            ref name,
+            ref return_type,
+            ..
+        } => Ok(Field::new(&name, return_type.clone(), true)),
+        Expr::AggregateFunction {
+            ref name,
+            ref return_type,
+            ..
+        } => Ok(Field::new(&name, return_type.clone(), true)),
+        Expr::Cast { ref data_type, .. } => {
+            Ok(Field::new("cast", data_type.clone(), true))
+        }
+        Expr::BinaryExpr {
+            ref left,
+            ref right,
+            ..
+        } => {
+            let left_type = left.get_type(input_schema)?;
+            let right_type = right.get_type(input_schema)?;
+            Ok(Field::new(
+                "binary_expr",
+                get_supertype(&left_type, &right_type).unwrap(),
+                true,
+            ))
+        }
+        _ => Err(ExecutionError::NotImplemented(format!(
+            "Cannot determine schema type for expression {:?}",
+            e
+        ))),
+    }
+}
+
+/// Create field meta-data from an expression, for use in a result set schema
+pub fn exprlist_to_fields(expr: &Vec<Expr>, input_schema: &Schema) -> Result<Vec<Field>> {
+    expr.iter()
+        .map(|e| expr_to_field(e, input_schema))
+        .collect()
+}
+
+/// Given two datatypes, determine the supertype that both types can safely be cast to
+pub fn get_supertype(l: &DataType, r: &DataType) -> Result<DataType> {
+    match _get_supertype(l, r) {
+        Some(dt) => Ok(dt),
+        None => match _get_supertype(r, l) {
+            Some(dt) => Ok(dt),
+            None => Err(ExecutionError::InternalError(format!(
+                "Failed to determine supertype of {:?} and {:?}",
+                l, r
+            ))),
+        },
+    }
+}
+
+/// Given two datatypes, determine the supertype that both types can safely be cast to
+fn _get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
+    use arrow::datatypes::DataType::*;
+    match (l, r) {
+        (UInt8, Int8) => Some(Int8),
+        (UInt8, Int16) => Some(Int16),
+        (UInt8, Int32) => Some(Int32),
+        (UInt8, Int64) => Some(Int64),
+
+        (UInt16, Int16) => Some(Int16),
+        (UInt16, Int32) => Some(Int32),
+        (UInt16, Int64) => Some(Int64),
+
+        (UInt32, Int32) => Some(Int32),
+        (UInt32, Int64) => Some(Int64),
+
+        (UInt64, Int64) => Some(Int64),
+
+        (Int8, UInt8) => Some(Int8),
+
+        (Int16, UInt8) => Some(Int16),
+        (Int16, UInt16) => Some(Int16),
+
+        (Int32, UInt8) => Some(Int32),
+        (Int32, UInt16) => Some(Int32),
+        (Int32, UInt32) => Some(Int32),
+
+        (Int64, UInt8) => Some(Int64),
+        (Int64, UInt16) => Some(Int64),
+        (Int64, UInt32) => Some(Int64),
+        (Int64, UInt64) => Some(Int64),
+
+        (UInt8, UInt8) => Some(UInt8),
+        (UInt8, UInt16) => Some(UInt16),
+        (UInt8, UInt32) => Some(UInt32),
+        (UInt8, UInt64) => Some(UInt64),
+        (UInt8, Float32) => Some(Float32),
+        (UInt8, Float64) => Some(Float64),
+
+        (UInt16, UInt8) => Some(UInt16),
+        (UInt16, UInt16) => Some(UInt16),
+        (UInt16, UInt32) => Some(UInt32),
+        (UInt16, UInt64) => Some(UInt64),
+        (UInt16, Float32) => Some(Float32),
+        (UInt16, Float64) => Some(Float64),
+
+        (UInt32, UInt8) => Some(UInt32),
+        (UInt32, UInt16) => Some(UInt32),
+        (UInt32, UInt32) => Some(UInt32),
+        (UInt32, UInt64) => Some(UInt64),
+        (UInt32, Float32) => Some(Float32),
+        (UInt32, Float64) => Some(Float64),
+
+        (UInt64, UInt8) => Some(UInt64),
+        (UInt64, UInt16) => Some(UInt64),
+        (UInt64, UInt32) => Some(UInt64),
+        (UInt64, UInt64) => Some(UInt64),
+        (UInt64, Float32) => Some(Float32),
+        (UInt64, Float64) => Some(Float64),
+
+        (Int8, Int8) => Some(Int8),
+        (Int8, Int16) => Some(Int16),
+        (Int8, Int32) => Some(Int32),
+        (Int8, Int64) => Some(Int64),
+        (Int8, Float32) => Some(Float32),
+        (Int8, Float64) => Some(Float64),
+
+        (Int16, Int8) => Some(Int16),
+        (Int16, Int16) => Some(Int16),
+        (Int16, Int32) => Some(Int32),
+        (Int16, Int64) => Some(Int64),
+        (Int16, Float32) => Some(Float32),
+        (Int16, Float64) => Some(Float64),
+
+        (Int32, Int8) => Some(Int32),
+        (Int32, Int16) => Some(Int32),
+        (Int32, Int32) => Some(Int32),
+        (Int32, Int64) => Some(Int64),
+        (Int32, Float32) => Some(Float32),
+        (Int32, Float64) => Some(Float64),
+
+        (Int64, Int8) => Some(Int64),
+        (Int64, Int16) => Some(Int64),
+        (Int64, Int32) => Some(Int64),
+        (Int64, Int64) => Some(Int64),
+        (Int64, Float32) => Some(Float32),
+        (Int64, Float64) => Some(Float64),
+
+        (Float32, Float32) => Some(Float32),
+        (Float32, Float64) => Some(Float64),
+        (Float64, Float32) => Some(Float64),
+        (Float64, Float64) => Some(Float64),
+
+        (Utf8, _) => Some(Utf8),
+        (_, Utf8) => Some(Utf8),
+
+        (Boolean, Boolean) => Some(Boolean),
+
+        _ => None,
+    }
+}

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -26,7 +26,7 @@ use crate::logicalplan::Expr;
 pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
     match e {
         Expr::Column(i) => Ok(input_schema.fields()[*i].clone()),
-        Expr::Literal(ref lit) => Ok(Field::new("lit", lit.get_datatype()?, true)),
+        Expr::Literal(ref lit) => Ok(Field::new("lit", lit.get_datatype(), true)),
         Expr::ScalarFunction {
             ref name,
             ref return_type,
@@ -45,8 +45,8 @@ pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
             ref right,
             ..
         } => {
-            let left_type = left.get_type(input_schema)?;
-            let right_type = right.get_type(input_schema)?;
+            let left_type = left.get_type(input_schema);
+            let right_type = right.get_type(input_schema);
             Ok(Field::new(
                 "binary_expr",
                 get_supertype(&left_type, &right_type).unwrap(),

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use crate::error::*;
 use crate::logicalplan::*;
+use crate::optimizer::utils;
 
 use arrow::datatypes::*;
 
@@ -110,8 +111,10 @@ impl SqlToRel {
                     let mut all_fields: Vec<Expr> = group_expr.clone();
                     aggr_expr.iter().for_each(|x| all_fields.push(x.clone()));
 
-                    let aggr_schema =
-                        Schema::new(exprlist_to_fields(&all_fields, input_schema));
+                    let aggr_schema = Schema::new(utils::exprlist_to_fields(
+                        &all_fields,
+                        input_schema,
+                    )?);
 
                     //TODO: selection, projection, everything else
                     Ok(Arc::new(LogicalPlan::Aggregate {
@@ -126,10 +129,9 @@ impl SqlToRel {
                         _ => input.clone(),
                     };
 
-                    let projection_schema = Arc::new(Schema::new(exprlist_to_fields(
-                        &expr,
-                        input_schema.as_ref(),
-                    )));
+                    let projection_schema = Arc::new(Schema::new(
+                        utils::exprlist_to_fields(&expr, input_schema.as_ref())?,
+                    ));
 
                     let projection = LogicalPlan::Projection {
                         expr: expr,
@@ -234,9 +236,7 @@ impl SqlToRel {
             }
 
             &ASTNode::SQLWildcard => {
-                //                schema.columns().iter().enumerate()
-                //                    .map(|(i,c)| Ok(Expr::Column(i))).collect()
-                unimplemented!("SQL wildcard operator is not supported in projection - please use explicit column names")
+                Err(ExecutionError::NotImplemented("SQL wildcard operator is not supported in projection - please use explicit column names".to_string()))
             }
 
             &ASTNode::SQLCast {
@@ -281,16 +281,16 @@ impl SqlToRel {
 
                 let left_expr = self.sql_to_rex(&left, &schema)?;
                 let right_expr = self.sql_to_rex(&right, &schema)?;
-                let left_type = left_expr.get_type(schema);
-                let right_type = right_expr.get_type(schema);
+                let left_type = left_expr.get_type(schema)?;
+                let right_type = right_expr.get_type(schema)?;
 
-                match get_supertype(&left_type, &right_type) {
-                    Some(supertype) => Ok(Expr::BinaryExpr {
+                match utils::get_supertype(&left_type, &right_type) {
+                    Ok(supertype) => Ok(Expr::BinaryExpr {
                         left: Arc::new(left_expr.cast_to(&supertype, schema)?),
                         op: operator,
                         right: Arc::new(right_expr.cast_to(&supertype, schema)?),
                     }),
-                    None => {
+                    Err(_) => {
                         return Err(ExecutionError::General(format!(
                             "No common supertype found for binary operator {:?} \
                              with input types {:?} and {:?}",
@@ -315,7 +315,7 @@ impl SqlToRel {
 
                         // return type is same as the argument type for these aggregate
                         // functions
-                        let return_type = rex_args[0].get_type(schema).clone();
+                        let return_type = rex_args[0].get_type(schema)?.clone();
 
                         Ok(Expr::AggregateFunction {
                             name: id.clone(),
@@ -395,48 +395,6 @@ pub fn convert_data_type(sql: &SQLType) -> Result<DataType> {
             other
         ))),
     }
-}
-
-/// Derive field meta-data for an expression, for use in creating schemas that result from
-/// evaluating expressions against an input schema.
-pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Field {
-    match e {
-        Expr::Column(i) => input_schema.fields()[*i].clone(),
-        Expr::Literal(ref lit) => Field::new("lit", lit.get_datatype(), true),
-        Expr::ScalarFunction {
-            ref name,
-            ref return_type,
-            ..
-        } => Field::new(name, return_type.clone(), true),
-        Expr::AggregateFunction {
-            ref name,
-            ref return_type,
-            ..
-        } => Field::new(name, return_type.clone(), true),
-        Expr::Cast { ref data_type, .. } => Field::new("cast", data_type.clone(), true),
-        Expr::BinaryExpr {
-            ref left,
-            ref right,
-            ..
-        } => {
-            let left_type = left.get_type(input_schema);
-            let right_type = right.get_type(input_schema);
-            Field::new(
-                "binary_expr",
-                get_supertype(&left_type, &right_type).unwrap(),
-                true,
-            )
-        }
-        _ => unimplemented!("Cannot determine schema type for expression {:?}", e),
-    }
-}
-
-/// Derive field meta-data for a list of expressions, for use in creating schemas that result from
-/// evaluating expressions against an input schema.
-pub fn exprlist_to_fields(expr: &Vec<Expr>, input_schema: &Schema) -> Vec<Field> {
-    expr.iter()
-        .map(|e| expr_to_field(e, input_schema))
-        .collect()
 }
 
 #[cfg(test)]

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -281,8 +281,8 @@ impl SqlToRel {
 
                 let left_expr = self.sql_to_rex(&left, &schema)?;
                 let right_expr = self.sql_to_rex(&right, &schema)?;
-                let left_type = left_expr.get_type(schema)?;
-                let right_type = right_expr.get_type(schema)?;
+                let left_type = left_expr.get_type(schema);
+                let right_type = right_expr.get_type(schema);
 
                 match utils::get_supertype(&left_type, &right_type) {
                     Ok(supertype) => Ok(Expr::BinaryExpr {
@@ -315,7 +315,7 @@ impl SqlToRel {
 
                         // return type is same as the argument type for these aggregate
                         // functions
-                        let return_type = rex_args[0].get_type(schema)?.clone();
+                        let return_type = rex_args[0].get_type(schema).clone();
 
                         Ok(Expr::AggregateFunction {
                             name: id.clone(),


### PR DESCRIPTION
This PR removes all uses of `unimplemented!` in DataFusion.

It also refactors to replace two copies of `expr_to_field` and `exprlist_to_fields` with one copy in a new file `optimizer::utils` and also removes some dead code.

There are no functional changes in this PR.

Note that I had already made these changes under the larger PR https://github.com/apache/arrow/pull/3939 but I felt it would be better to break this up into smaller PRs.