### PR TITLE
[C#] Fix copyright, company and authors metadata in assembly and nuget.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Arrow
-Copyright 2016 The Apache Software Foundation
+Copyright 2016-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -10,8 +10,8 @@
   <!-- AssemblyInfo properties -->
   <PropertyGroup>
     <Product>Apache Arrow library</Product>
-    <Copyright>2018 Apache Software Foundation</Copyright>
-    <Company>Apache</Company>
+    <Copyright>Copyright 2016-2019 The Apache Software Foundation</Copyright>
+    <Company>The Apache Software Foundation</Company>
     <Version>0.13.0-SNAPSHOT</Version>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
 
   <!-- NuGet properties -->
   <PropertyGroup>
-    <Authors>Apache</Authors>
+    <Authors>The Apache Software Foundation</Authors>
     <PackageIconUrl>https://www.apache.org/images/feather.png</PackageIconUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageProjectUrl>https://arrow.apache.org/</PackageProjectUrl>


### PR DESCRIPTION
Follow up from #3891 to fix up references to `The Apache Software Foundation` in the C# assembly and NuGet metadata.

I also updated the `Copyright` to match 

https://github.com/apache/arrow/blob/686c44ca6472a86f6908debc21330270c4c01c90/NOTICE.txt#L1-L2

@wesm @kou 