### PR TITLE
ARROW-4954: [Python] Fix test failure with Flight enabled

### DIFF
--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -68,15 +68,18 @@ class EchoStreamFlightServer(EchoFlightServer):
 
 class InvalidStreamFlightServer(flight.FlightServerBase):
     """A Flight server that tries to return messages with differing schemas."""
-    data1 = [pa.array([-10, -5, 0, 5, 10])]
-    data2 = [pa.array([-10.0, -5.0, 0.0, 5.0, 10.0])]
-    table1 = pa.Table.from_arrays(data1, names=['a'])
-    table2 = pa.Table.from_arrays(data2, names=['a'])
 
-    schema = table1.schema
+    schema = pa.schema([('a', pa.int32())])
 
     def do_get(self, ticket):
-        return flight.GeneratorStream(self.schema, [self.table1, self.table2])
+        data1 = [pa.array([-10, -5, 0, 5, 10], type=pa.int32())]
+        data2 = [pa.array([-10.0, -5.0, 0.0, 5.0, 10.0], type=pa.float64())]
+        assert data1.type != data2.type
+        table1 = pa.Table.from_arrays(data1, names=['a'])
+        table2 = pa.Table.from_arrays(data2, names=['a'])
+        assert table1.schema == self.schema
+
+        return flight.GeneratorStream(self.schema, [table1, table2])
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Avoid allocating static test data.