### PR TITLE
ARROW-4956: [C#] Allow ArrowBuffers to wrap external Memory

### DIFF
--- a/csharp/src/Apache.Arrow/ArrowBuffer.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.cs
@@ -21,13 +21,9 @@ namespace Apache.Arrow
 {
     public readonly partial struct ArrowBuffer: IEquatable<ArrowBuffer>
     {
-        public static ArrowBuffer WrapExternalMemoryAsAnArrowBuffer(Memory<byte> externalMemory)
-        {
-            return new ArrowBuffer(externalMemory);
-        }
         public static ArrowBuffer Empty => new ArrowBuffer(Memory<byte>.Empty);
 
-        internal ArrowBuffer(ReadOnlyMemory<byte> data)
+        public ArrowBuffer(ReadOnlyMemory<byte> data)
         {
             Memory = data;
         }

--- a/csharp/src/Apache.Arrow/ArrowBuffer.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.cs
@@ -21,6 +21,10 @@ namespace Apache.Arrow
 {
     public readonly partial struct ArrowBuffer: IEquatable<ArrowBuffer>
     {
+        public static ArrowBuffer WrapExternalMemoryAsAnArrowBuffer(Memory<byte> externalMemory)
+        {
+            return new ArrowBuffer(externalMemory);
+        }
         public static ArrowBuffer Empty => new ArrowBuffer(Memory<byte>.Empty);
 
         internal ArrowBuffer(ReadOnlyMemory<byte> data)

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferTests.cs
@@ -86,7 +86,7 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void TestExternalMemoryWrappedAsArrowBuffer()
         {
-            Memory<byte> memory = new byte[4 * 3];
+            Memory<byte> memory = new byte[sizeof(int) * 3];
             Span<byte> spanOfBytes = memory.Span;
             var span = spanOfBytes.CastTo<int>();
             span[0] = 0;

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferTests.cs
@@ -15,6 +15,7 @@
 
 using Apache.Arrow.Tests.Fixtures;
 using System;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Apache.Arrow.Tests
@@ -80,6 +81,23 @@ namespace Apache.Arrow.Tests
                 }
             }
 
+        }
+
+        [Fact]
+        public void TestExternalMemoryWrappedAsArrowBuffer()
+        {
+            Memory<byte> memory = new byte[4 * 3];
+            Span<byte> spanOfBytes = memory.Span;
+            var span = spanOfBytes.CastTo<int>();
+            span[0] = 0;
+            span[1] = 1;
+            span[2] = 2;
+
+            ArrowBuffer buffer = ArrowBuffer.WrapExternalMemoryAsAnArrowBuffer(memory);
+            Assert.Equal(2, buffer.Span.CastTo<int>()[2]);
+
+            span[2] = 10;
+            Assert.Equal(10, buffer.Span.CastTo<int>()[2]);
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferTests.cs
@@ -93,7 +93,7 @@ namespace Apache.Arrow.Tests
             span[1] = 1;
             span[2] = 2;
 
-            ArrowBuffer buffer = ArrowBuffer.WrapExternalMemoryAsAnArrowBuffer(memory);
+            ArrowBuffer buffer = new ArrowBuffer(memory);
             Assert.Equal(2, buffer.Span.CastTo<int>()[2]);
 
             span[2] = 10;


### PR DESCRIPTION
Allow ArrowBuffer to wrap external memory

@eerhardt @chutchinson 