### PR TITLE
ARROW-4853: [Rust] Array slice doesn't work on ListArray and StructArray

### DIFF
--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -990,6 +990,7 @@ impl From<Vec<(Field, ArrayRef)>> for StructArray {
 
         let data = ArrayData::builder(DataType::Struct(field_types))
             .child_data(field_values.into_iter().map(|a| a.data()).collect())
+            .len(length)
             .build();
         Self::from(data)
     }
@@ -1781,6 +1782,9 @@ mod tests {
         ]);
         assert_eq!(boolean_data, struct_array.column(0).data());
         assert_eq!(int_data, struct_array.column(1).data());
+        assert_eq!(4, struct_array.len());
+        assert_eq!(0, struct_array.null_count());
+        assert_eq!(0, struct_array.offset());
     }
 
     #[test]

--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -1509,25 +1509,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "inconsistent offsets buffer and values array")]
-    fn test_list_array_invalid_value_offset_end() {
-        let value_data = ArrayData::builder(DataType::Int32)
-            .len(8)
-            .add_buffer(Buffer::from(&[0, 1, 2, 3, 4, 5, 6, 7].to_byte_slice()))
-            .build();
-
-        let value_offsets = Buffer::from(&[0, 2, 5, 7].to_byte_slice());
-
-        let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
-            .len(3)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
-            .build();
-        ListArray::from(list_data);
-    }
-
-    #[test]
     fn test_binary_array() {
         let values: [u8; 12] = [
             b'h', b'e', b'l', b'l', b'o', b'p', b'a', b'r', b'q', b'u', b'e', b't',

--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -949,12 +949,11 @@ impl From<ArrayDataRef> for StructArray {
     fn from(data: ArrayDataRef) -> Self {
         let mut boxed_fields = vec![];
         for cd in data.child_data() {
-            let child_data =
-                if data.offset != 0 || data.len != cd.len {
-                    slice_data(cd.clone(), data.offset, data.len)
-                } else {
-                    cd.clone()
-                };
+            let child_data = if data.offset != 0 || data.len != cd.len {
+                slice_data(cd.clone(), data.offset, data.len)
+            } else {
+                cd.clone()
+            };
             boxed_fields.push(make_array(child_data));
         }
         Self { data, boxed_fields }

--- a/rust/arrow/src/builder.rs
+++ b/rust/arrow/src/builder.rs
@@ -686,6 +686,10 @@ impl StructBuilder {
             child_data.push(arr.data());
         }
 
+        if child_data.len() > 0 {
+            self.len = child_data[0].len()
+        }
+
         let null_bit_buffer = self.bitmap_builder.finish();
         let null_count = self.len - bit_util::count_set_bits(null_bit_buffer.data());
         let mut builder = ArrayData::builder(DataType::Struct(self.fields.clone()))
@@ -1357,7 +1361,7 @@ mod tests {
 
         let arr = builder.finish();
         assert_eq!(10, arr.len());
-        assert_eq!(0, builder.len());
+        assert_eq!(10, builder.len());
 
         builder
             .field_builder::<Int32Builder>(0)
@@ -1372,7 +1376,7 @@ mod tests {
 
         let arr = builder.finish();
         assert_eq!(5, arr.len());
-        assert_eq!(0, builder.len());
+        assert_eq!(5, builder.len());
     }
 
     #[test]


### PR DESCRIPTION
This fixes a few issues related to Array offset and slicing:

1. The invariant check in ListArray::from() is no longer valid for the case
  of offset. This removes the check.
2. Both `Array::is_valid` and `Array::is_null` should take into account of offset.
3. `StructArray::len()` should return `data.len()` instead of the length of the
  first child array. In the case of slicing, we'll not modify child array data so
  the previous approach will return wrong result.