### PR TITLE
ARROW-4413: [Python] Fix pa.hdfs.connect() on Python 2

### DIFF
--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -59,10 +59,10 @@ cdef class HadoopFileSystem:
 
     cdef readonly:
         bint is_open
-        str host
-        str user
-        str kerb_ticket
-        str driver
+        object host
+        object user
+        object kerb_ticket
+        object driver
         int port
         dict extra_conf
 


### PR DESCRIPTION
I can't actually test this works on a HDFS filesystem, but this should fix the logical error.