### PR TITLE
ARROW-4962: [C++] Fix gcc warnings in CHECKIN

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -164,7 +164,7 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option -Werror")
   elseif("${COMPILER_FAMILY}" STREQUAL "gcc")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall \
--Wno-conversion -Wno-sign-conversion")
+-Wno-conversion -Wno-sign-conversion -Wno-unused-variable")
 
     # Treat all compiler warnings as errors
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror")

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -170,9 +170,14 @@ class ARROW_EXPORT ArrayBuilder {
     if (new_capacity < 0) {
       return Status::Invalid("Resize capacity must be positive");
     }
+// gcc is aggressively complaining about overflows (due to Resize and
+// GrowByFactor). Overflowing int64_t is an indication of other problems.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-overflow"
     if (new_capacity < old_capacity) {
       return Status::Invalid("Resize cannot downsize");
     }
+#pragma GCC diagnostic pop
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -170,14 +170,11 @@ class ARROW_EXPORT ArrayBuilder {
     if (new_capacity < 0) {
       return Status::Invalid("Resize capacity must be positive");
     }
-// gcc is aggressively complaining about overflows (due to Resize and
-// GrowByFactor). Overflowing int64_t is an indication of other problems.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-overflow"
+
     if (new_capacity < old_capacity) {
       return Status::Invalid("Resize cannot downsize");
     }
-#pragma GCC diagnostic pop
+
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -34,20 +34,14 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
   /// \brief Append the specified number of null elements
   Status AppendNulls(int64_t length) {
-    auto new_length = length_ + length;
-    ARROW_RETURN_NOT_OK(CheckCapacity(new_length, length_));
+    if (length < 0) return Status::Invalid("length must be positive");
     null_count_ += length;
-    length_ = new_length;
+    length_ += length;
     return Status::OK();
   }
 
   /// \brief Append a single null element
-  Status AppendNull() {
-    ARROW_RETURN_NOT_OK(CheckCapacity(length_ + 1, length_));
-    ++null_count_;
-    ++length_;
-    return Status::OK();
-  }
+  Status AppendNull() { return AppendNulls(1); }
 
   Status Append(std::nullptr_t) { return AppendNull(); }
 

--- a/cpp/src/plasma/test-util.h
+++ b/cpp/src/plasma/test-util.h
@@ -37,6 +37,13 @@ ObjectID random_object_id() {
   return result;
 }
 
+#define PLASMA_CHECK_SYSTEM(expr)        \
+  do {                                   \
+    int status__ = (expr);               \
+    EXPECT_TRUE(WIFEXITED(status__));    \
+    EXPECT_EQ(WEXITSTATUS(status__), 0); \
+  } while (false);
+
 }  // namespace plasma
 
 #endif  // PLASMA_TEST_UTIL_H

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -73,11 +73,11 @@ class TestPlasmaStore : public ::testing::Test {
 #ifdef COVERAGE_BUILD
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
-    std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid`";
+    std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_term_command.c_str()));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
-    std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid`";
+    std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_kill_command.c_str()));
   }
 

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -73,11 +73,13 @@ class TestPlasmaStore : public ::testing::Test {
 #ifdef COVERAGE_BUILD
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
-    std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid` || exit 0";
+    std::string plasma_term_command =
+        "kill -TERM `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_term_command.c_str()));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
-    std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid` || exit 0";
+    std::string plasma_kill_command =
+        "kill -KILL `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_kill_command.c_str()));
   }
 

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -62,7 +62,7 @@ class TestPlasmaStore : public ::testing::Test {
     std::string plasma_command =
         plasma_directory + "/plasma_store_server -m 10000000 -s " + store_socket_name_ +
         " 1> /dev/null 2> /dev/null & " + "echo $! > " + store_socket_name_ + ".pid";
-    system(plasma_command.c_str());
+    DCHECK_EQ(system(plasma_command.c_str()), 0);
     ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));
     ARROW_CHECK_OK(client2_.Connect(store_socket_name_, ""));
   }
@@ -74,11 +74,11 @@ class TestPlasmaStore : public ::testing::Test {
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
     std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid`";
-    system(plasma_term_command.c_str());
+    DCHECK_EQ(system(plasma_term_command.c_str()), 0);
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
     std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid`";
-    system(plasma_kill_command.c_str());
+    DCHECK_EQ(system(plasma_kill_command.c_str()), 0);
   }
 
   void CreateObject(PlasmaClient& client, const ObjectID& object_id,

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -62,7 +62,7 @@ class TestPlasmaStore : public ::testing::Test {
     std::string plasma_command =
         plasma_directory + "/plasma_store_server -m 10000000 -s " + store_socket_name_ +
         " 1> /dev/null 2> /dev/null & " + "echo $! > " + store_socket_name_ + ".pid";
-    DCHECK_EQ(system(plasma_command.c_str()), 0);
+    PLASMA_CHECK_SYSTEM(system(plasma_command.c_str()));
     ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));
     ARROW_CHECK_OK(client2_.Connect(store_socket_name_, ""));
   }
@@ -74,11 +74,11 @@ class TestPlasmaStore : public ::testing::Test {
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
     std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid`";
-    DCHECK_EQ(system(plasma_term_command.c_str()), 0);
+    PLASMA_CHECK_SYSTEM(system(plasma_term_command.c_str()));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
     std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid`";
-    DCHECK_EQ(system(plasma_kill_command.c_str()), 0);
+    PLASMA_CHECK_SYSTEM(system(plasma_kill_command.c_str()));
   }
 
   void CreateObject(PlasmaClient& client, const ObjectID& object_id,

--- a/cpp/src/plasma/test/external_store_tests.cc
+++ b/cpp/src/plasma/test/external_store_tests.cc
@@ -64,7 +64,7 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
                                  "hashtable://test -s " + store_socket_name_ +
                                  " 1> /tmp/log.stdout 2> /tmp/log.stderr & " +
                                  "echo $! > " + store_socket_name_ + ".pid";
-    system(plasma_command.c_str());
+    EXPECT_EQ(system(plasma_command.c_str()), 0);
     ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));
   }
   void TearDown() override {
@@ -74,11 +74,11 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
     std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid`";
-    system(plasma_term_command.c_str());
+    EXPECT_EQ(system(plasma_term_command.c_str()), 0);
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
     std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid`";
-    system(plasma_kill_command.c_str());
+    EXPECT_EQ(system(plasma_kill_command.c_str()), 0);
   }
 
  protected:

--- a/cpp/src/plasma/test/external_store_tests.cc
+++ b/cpp/src/plasma/test/external_store_tests.cc
@@ -73,11 +73,11 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
 #ifdef COVERAGE_BUILD
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
-    std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid`";
+    std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_term_command.c_str()));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
-    std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid`";
+    std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_kill_command.c_str()));
   }
 

--- a/cpp/src/plasma/test/external_store_tests.cc
+++ b/cpp/src/plasma/test/external_store_tests.cc
@@ -64,7 +64,7 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
                                  "hashtable://test -s " + store_socket_name_ +
                                  " 1> /tmp/log.stdout 2> /tmp/log.stderr & " +
                                  "echo $! > " + store_socket_name_ + ".pid";
-    EXPECT_EQ(system(plasma_command.c_str()), 0);
+    PLASMA_CHECK_SYSTEM(system(plasma_command.c_str()));
     ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));
   }
   void TearDown() override {
@@ -74,11 +74,11 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
     std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid`";
-    EXPECT_EQ(system(plasma_term_command.c_str()), 0);
+    PLASMA_CHECK_SYSTEM(system(plasma_term_command.c_str()));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
     std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid`";
-    EXPECT_EQ(system(plasma_kill_command.c_str()), 0);
+    PLASMA_CHECK_SYSTEM(system(plasma_kill_command.c_str()));
   }
 
  protected:

--- a/cpp/src/plasma/test/external_store_tests.cc
+++ b/cpp/src/plasma/test/external_store_tests.cc
@@ -73,11 +73,13 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
 #ifdef COVERAGE_BUILD
     // Ask plasma_store to exit gracefully and give it time to write out
     // coverage files
-    std::string plasma_term_command = "kill -TERM `cat " + store_socket_name_ + ".pid` || exit 0";
+    std::string plasma_term_command =
+        "kill -TERM `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_term_command.c_str()));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
-    std::string plasma_kill_command = "kill -KILL `cat " + store_socket_name_ + ".pid` || exit 0";
+    std::string plasma_kill_command =
+        "kill -KILL `cat " + store_socket_name_ + ".pid` || exit 0";
     PLASMA_CHECK_SYSTEM(system(plasma_kill_command.c_str()));
   }
 


### PR DESCRIPTION
- The recent change in DCHECK* (removing the ARROW_IGNORE_EXPR) added
new compilation warnings. The simplest way to disable this is to
disable unused variables or sprinkle ARROW_IGNORE_EXPR in a lot of
places. I went for the first.
- Added some checks to `system` return code in plasma tests
- Disable `-Wstrict-overflow` for ArrayBuilder::CheckCapacity