### PR TITLE
ARROW-4971: [Go] Add type equality test function

### DIFF
--- a/go/arrow/compare.go
+++ b/go/arrow/compare.go
@@ -30,34 +30,3 @@ func TypeEquals(left DataType, right DataType) bool {
 
 	return reflect.DeepEqual(left, right)
 }
-
-/*
-func TypeEquals(left DataType, right DataType) bool {
-	switch {
-	case left == nil || right == nil:
-		return false
-	case left.ID() != right.ID():
-		return false
-	}
-
-	switch l := left.(type) {
-	case *FixedSizeBinaryType:
-		r := right.(*FixedSizeBinaryType)
-		return l.ByteWidth == r.ByteWidth
-	case *Time32Type:
-		r := right.(*Time32Type)
-		return l.Unit == r.Unit
-	case *Time64Type:
-		r := right.(*Time64Type)
-		return l.Unit == r.Unit
-	case *TimestampType:
-		r := right.(*TimestampType)
-		return l.Unit == r.Unit && l.TimeZone == r.TimeZone
-	case *ListType:
-		r := right.(*ListType)
-		return TypeEquals(l.elem, r.elem)
-	default:
-		return true
-	}
-}
-*/

--- a/go/arrow/compare.go
+++ b/go/arrow/compare.go
@@ -43,7 +43,7 @@ func TypeEquals(left DataType, right DataType, checkMetadata bool) bool {
 	case !reflect.DeepEqual(l.index, r.index):
 		return false
 	}
-	for i, _ := range l.fields {
+	for i := range l.fields {
 		leftField, rightField := l.fields[i], r.fields[i]
 		switch {
 		case leftField.Name != rightField.Name:

--- a/go/arrow/compare.go
+++ b/go/arrow/compare.go
@@ -24,8 +24,12 @@ type typeEqualsConfig struct {
 	metadata bool
 }
 
+// TypeEqualsOption is a functional option type used for configuring type
+// equality checks.
 type TypeEqualsOption func(*typeEqualsConfig)
 
+// CheckMetadata is an option for TypeEquals that allows checking for metadata
+// equality besides type equality. It only makes sense for STRUCT type.
 func CheckMetadata() TypeEqualsOption {
 	return func(cfg *typeEqualsConfig) {
 		cfg.metadata = true

--- a/go/arrow/compare.go
+++ b/go/arrow/compare.go
@@ -34,7 +34,7 @@ func CheckMetadata() TypeEqualsOption {
 
 // TypeEquals checks if two DataType are the same, optionally checking metadata
 // equality for STRUCT types.
-func TypeEquals(left DataType, right DataType, opts ...TypeEqualsOption) bool {
+func TypeEquals(left, right DataType, opts ...TypeEqualsOption) bool {
 	var cfg typeEqualsConfig
 	for _, opt := range opts {
 		opt(&cfg)

--- a/go/arrow/compare.go
+++ b/go/arrow/compare.go
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrow
+
+import (
+	"reflect"
+)
+
+func TypeEquals(left DataType, right DataType) bool {
+	switch {
+	case left == nil || right == nil:
+		return false
+	case left.ID() != right.ID():
+		return false
+	}
+
+	return reflect.DeepEqual(left, right)
+}
+
+/*
+func TypeEquals(left DataType, right DataType) bool {
+	switch {
+	case left == nil || right == nil:
+		return false
+	case left.ID() != right.ID():
+		return false
+	}
+
+	switch l := left.(type) {
+	case *FixedSizeBinaryType:
+		r := right.(*FixedSizeBinaryType)
+		return l.ByteWidth == r.ByteWidth
+	case *Time32Type:
+		r := right.(*Time32Type)
+		return l.Unit == r.Unit
+	case *Time64Type:
+		r := right.(*Time64Type)
+		return l.Unit == r.Unit
+	case *TimestampType:
+		r := right.(*TimestampType)
+		return l.Unit == r.Unit && l.TimeZone == r.TimeZone
+	case *ListType:
+		r := right.(*ListType)
+		return TypeEquals(l.elem, r.elem)
+	default:
+		return true
+	}
+}
+*/

--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -238,7 +238,12 @@ func TestTypeEquals(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			got := TypeEquals(test.left, test.right, test.checkMetadata)
+			var got bool
+			if test.checkMetadata {
+				got = TypeEquals(test.left, test.right, CheckMetadata())
+			} else {
+				got = TypeEquals(test.left, test.right)
+			}
 			if got != test.want {
 				t.Fatalf("TypeEquals(%v, %v, %v): got=%v, want=%v", test.left, test.right, test.checkMetadata, got, test.want)
 			}

--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arrow
+
+import (
+	"testing"
+)
+
+func TestTypeEquals(t *testing.T) {
+	tests := []struct {
+		left, right DataType
+		want        bool
+	}{
+		{
+			nil, nil, false,
+		},
+		{
+			nil, PrimitiveTypes.Uint8, false,
+		},
+		{
+			PrimitiveTypes.Float32, nil, false,
+		},
+		{
+			PrimitiveTypes.Float64, PrimitiveTypes.Int32, false,
+		},
+		{
+			Null, Null, true,
+		},
+		{
+			&Time32Type{Unit: Second}, &Time32Type{Unit: Second}, true,
+		},
+		{
+			&Time32Type{Unit: Millisecond}, &Time32Type{Unit: Second}, false,
+		},
+		{
+			&Time64Type{Unit: Nanosecond}, &Time64Type{Unit: Nanosecond}, true,
+		},
+		{
+			&Time64Type{Unit: Nanosecond}, &Time64Type{Unit: Microsecond}, false,
+		},
+		{
+			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Second, TimeZone: "UTC"}, true,
+		},
+		{
+			&TimestampType{Unit: Microsecond, TimeZone: "UTC"}, &TimestampType{Unit: Millisecond, TimeZone: "UTC"}, false,
+		},
+		{
+			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Second, TimeZone: "CET"}, false,
+		},
+		{
+			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Nanosecond, TimeZone: "CET"}, false,
+		},
+		{
+			&ListType{PrimitiveTypes.Uint64}, &ListType{PrimitiveTypes.Uint64}, true,
+		},
+		{
+			&ListType{PrimitiveTypes.Uint64}, &ListType{PrimitiveTypes.Uint32}, false,
+		},
+		{
+			&ListType{&Time32Type{Unit: Millisecond}}, &ListType{&Time32Type{Unit: Millisecond}}, true,
+		},
+		{
+			&ListType{&Time32Type{Unit: Millisecond}}, &ListType{&Time32Type{Unit: Second}}, false,
+		},
+		{
+			&ListType{&ListType{PrimitiveTypes.Uint16}}, &ListType{&ListType{PrimitiveTypes.Uint16}}, true,
+		},
+		{
+			&ListType{&ListType{PrimitiveTypes.Uint16}}, &ListType{&ListType{PrimitiveTypes.Uint8}}, false,
+		},
+		{
+			&ListType{&ListType{&ListType{PrimitiveTypes.Uint16}}}, &ListType{&ListType{PrimitiveTypes.Uint8}}, false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+			},
+			false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+			},
+			false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f0", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f0": 0},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+			},
+			false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0, "f2": 0},
+			},
+			false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint32, Nullable: true},
+				},
+				index: map[string]int{"f1": 0},
+				meta:  MetadataFrom(map[string]string{"k1": "v2"}),
+			},
+			false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+			},
+			true,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
+			},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		got := TypeEquals(test.left, test.right)
+		if got != test.want {
+			t.Errorf("TypeEquals(%v, %v): got=%v, want=%v", test.left, test.right, got, test.want)
+		}
+	}
+}

--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -22,68 +22,69 @@ import (
 
 func TestTypeEquals(t *testing.T) {
 	tests := []struct {
-		left, right DataType
-		want        bool
+		left, right   DataType
+		want          bool
+		checkMetadata bool
 	}{
 		{
-			nil, nil, false,
+			nil, nil, false, false,
 		},
 		{
-			nil, PrimitiveTypes.Uint8, false,
+			nil, PrimitiveTypes.Uint8, false, false,
 		},
 		{
-			PrimitiveTypes.Float32, nil, false,
+			PrimitiveTypes.Float32, nil, false, false,
 		},
 		{
-			PrimitiveTypes.Float64, PrimitiveTypes.Int32, false,
+			PrimitiveTypes.Float64, PrimitiveTypes.Int32, false, false,
 		},
 		{
-			Null, Null, true,
+			Null, Null, true, false,
 		},
 		{
-			&Time32Type{Unit: Second}, &Time32Type{Unit: Second}, true,
+			&Time32Type{Unit: Second}, &Time32Type{Unit: Second}, true, false,
 		},
 		{
-			&Time32Type{Unit: Millisecond}, &Time32Type{Unit: Second}, false,
+			&Time32Type{Unit: Millisecond}, &Time32Type{Unit: Second}, false, false,
 		},
 		{
-			&Time64Type{Unit: Nanosecond}, &Time64Type{Unit: Nanosecond}, true,
+			&Time64Type{Unit: Nanosecond}, &Time64Type{Unit: Nanosecond}, true, false,
 		},
 		{
-			&Time64Type{Unit: Nanosecond}, &Time64Type{Unit: Microsecond}, false,
+			&Time64Type{Unit: Nanosecond}, &Time64Type{Unit: Microsecond}, false, false,
 		},
 		{
-			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Second, TimeZone: "UTC"}, true,
+			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Second, TimeZone: "UTC"}, true, false,
 		},
 		{
-			&TimestampType{Unit: Microsecond, TimeZone: "UTC"}, &TimestampType{Unit: Millisecond, TimeZone: "UTC"}, false,
+			&TimestampType{Unit: Microsecond, TimeZone: "UTC"}, &TimestampType{Unit: Millisecond, TimeZone: "UTC"}, false, false,
 		},
 		{
-			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Second, TimeZone: "CET"}, false,
+			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Second, TimeZone: "CET"}, false, false,
 		},
 		{
-			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Nanosecond, TimeZone: "CET"}, false,
+			&TimestampType{Unit: Second, TimeZone: "UTC"}, &TimestampType{Unit: Nanosecond, TimeZone: "CET"}, false, false,
 		},
 		{
-			&ListType{PrimitiveTypes.Uint64}, &ListType{PrimitiveTypes.Uint64}, true,
+			&ListType{PrimitiveTypes.Uint64}, &ListType{PrimitiveTypes.Uint64}, true, false,
 		},
 		{
-			&ListType{PrimitiveTypes.Uint64}, &ListType{PrimitiveTypes.Uint32}, false,
+			&ListType{PrimitiveTypes.Uint64}, &ListType{PrimitiveTypes.Uint32}, false, false,
 		},
 		{
-			&ListType{&Time32Type{Unit: Millisecond}}, &ListType{&Time32Type{Unit: Millisecond}}, true,
+			&ListType{&Time32Type{Unit: Millisecond}}, &ListType{&Time32Type{Unit: Millisecond}}, true, false,
 		},
 		{
-			&ListType{&Time32Type{Unit: Millisecond}}, &ListType{&Time32Type{Unit: Second}}, false,
+			&ListType{&Time32Type{Unit: Millisecond}}, &ListType{&Time32Type{Unit: Second}}, false, false,
 		},
 		{
-			&ListType{&ListType{PrimitiveTypes.Uint16}}, &ListType{&ListType{PrimitiveTypes.Uint16}}, true,
+			&ListType{&ListType{PrimitiveTypes.Uint16}}, &ListType{&ListType{PrimitiveTypes.Uint16}}, true, false,
 		},
 		{
-			&ListType{&ListType{PrimitiveTypes.Uint16}}, &ListType{&ListType{PrimitiveTypes.Uint8}}, false,
+			&ListType{&ListType{PrimitiveTypes.Uint16}}, &ListType{&ListType{PrimitiveTypes.Uint8}}, false, false,
 		},
 		{
-			&ListType{&ListType{&ListType{PrimitiveTypes.Uint16}}}, &ListType{&ListType{PrimitiveTypes.Uint8}}, false,
+			&ListType{&ListType{&ListType{PrimitiveTypes.Uint16}}}, &ListType{&ListType{PrimitiveTypes.Uint8}}, false, false,
 		},
 		{
 			&StructType{
@@ -98,7 +99,7 @@ func TestTypeEquals(t *testing.T) {
 				},
 				index: map[string]int{"f1": 0},
 			},
-			false,
+			false, true,
 		},
 		{
 			&StructType{
@@ -113,7 +114,7 @@ func TestTypeEquals(t *testing.T) {
 				},
 				index: map[string]int{"f1": 0},
 			},
-			false,
+			false, false,
 		},
 		{
 			&StructType{
@@ -128,7 +129,7 @@ func TestTypeEquals(t *testing.T) {
 				},
 				index: map[string]int{"f1": 0},
 			},
-			false,
+			false, false,
 		},
 		{
 			&StructType{
@@ -144,7 +145,60 @@ func TestTypeEquals(t *testing.T) {
 				},
 				index: map[string]int{"f1": 0, "f2": 0},
 			},
-			false,
+			false, true,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+			},
+			true, false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+			},
+			true, false,
+		},
+		{
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
+			},
+			&StructType{
+				fields: []Field{
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
+				},
+				index: map[string]int{"f1": 0, "f2": 1},
+				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
+			},
+			true, true,
 		},
 		{
 			&StructType{
@@ -161,50 +215,31 @@ func TestTypeEquals(t *testing.T) {
 				index: map[string]int{"f1": 0},
 				meta:  MetadataFrom(map[string]string{"k1": "v2"}),
 			},
-			false,
+			true, false,
 		},
 		{
 			&StructType{
 				fields: []Field{
-					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true, Metadata: MetadataFrom(map[string]string{"k1": "v1"})},
 					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
 				index: map[string]int{"f1": 0, "f2": 1},
 			},
 			&StructType{
 				fields: []Field{
-					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
+					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true, Metadata: MetadataFrom(map[string]string{"k1": "v2"})},
 					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
 				},
 				index: map[string]int{"f1": 0, "f2": 1},
 			},
-			true,
-		},
-		{
-			&StructType{
-				fields: []Field{
-					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
-					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
-				},
-				index: map[string]int{"f1": 0, "f2": 1},
-				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
-			},
-			&StructType{
-				fields: []Field{
-					Field{Name: "f1", Type: PrimitiveTypes.Uint16, Nullable: true},
-					Field{Name: "f2", Type: PrimitiveTypes.Float32, Nullable: false},
-				},
-				index: map[string]int{"f1": 0, "f2": 1},
-				meta:  MetadataFrom(map[string]string{"k1": "v1"}),
-			},
-			true,
+			false, true,
 		},
 	}
 
 	for _, test := range tests {
-		got := TypeEquals(test.left, test.right)
+		got := TypeEquals(test.left, test.right, test.checkMetadata)
 		if got != test.want {
-			t.Errorf("TypeEquals(%v, %v): got=%v, want=%v", test.left, test.right, got, test.want)
+			t.Errorf("TypeEquals(%v, %v, %v): got=%v, want=%v", test.left, test.right, test.checkMetadata, got, test.want)
 		}
 	}
 }

--- a/go/arrow/compare_test.go
+++ b/go/arrow/compare_test.go
@@ -237,9 +237,11 @@ func TestTypeEquals(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := TypeEquals(test.left, test.right, test.checkMetadata)
-		if got != test.want {
-			t.Errorf("TypeEquals(%v, %v, %v): got=%v, want=%v", test.left, test.right, test.checkMetadata, got, test.want)
-		}
+		t.Run("", func(t *testing.T) {
+			got := TypeEquals(test.left, test.right, test.checkMetadata)
+			if got != test.want {
+				t.Fatalf("TypeEquals(%v, %v, %v): got=%v, want=%v", test.left, test.right, test.checkMetadata, got, test.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Hello,

In the quest for adding support for array comparison (equality) I just added type comparison.

For the moment it considers metadata (only applies to STRUCT type) in the comparison. In the C++ implementation they have a flag to ignore metadata. Do you think we should have it too?

Feel free to give me your feedback!

A