### PR TITLE
ARROW-4969: [C++] Set RPATH in correct order for test executables on OSX

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -515,7 +515,7 @@ function(ADD_TEST_CASE REL_TEST_NAME)
                                      INSTALL_RPATH_USE_LINK_PATH
                                      TRUE
                                      INSTALL_RPATH
-                                     "$ENV{CONDA_PREFIX}/lib;${EXECUTABLE_OUTPUT_PATH}")
+                                     "${EXECUTABLE_OUTPUT_PATH};$ENV{CONDA_PREFIX}/lib")
   endif()
 
   if(ARG_STATIC_LINK_LIBS)


### PR DESCRIPTION
Running `otool -l debug/arrow-scalar-test`:

Before:
```
Load command 17
          cmd LC_RPATH
      cmdsize 56
         path /Users/krisz/.conda/envs/arrow36/lib (offset 12)
Load command 18
          cmd LC_RPATH
      cmdsize 64
         path /Users/krisz/Workspace/arrow/cpp/build/debug/ (offset 12)
```

After:
```
Load command 17
          cmd LC_RPATH
      cmdsize 64
         path /Users/krisz/Workspace/arrow/cpp/build/debug/ (offset 12)
Load command 18
          cmd LC_RPATH
      cmdsize 56
         path /Users/krisz/.conda/envs/arrow36/lib (offset 12)
```