### PR TITLE
ARROW-4948: [JS] Nightly test failure 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -86,8 +86,8 @@ js/.lock-wscript
 js/build/Release
 js/dist
 js/targets
-js/test/data
-js/test/__snapshots__
+js/test/data/**/*.json
+js/test/data/**/*.arrow
 
 # Rust
 rust/target


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARROW-4948. Updates dockerignore to only ignore test data, not test files. Built and ran JS Dockerfile locally after this change and verified all tests pass.