### PR TITLE
ARROW-4913:[Java][Memory] Add additional methods for observing allocations.

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -30,28 +30,28 @@ public interface AllocationListener {
   /**
    * Called each time a new buffer has been requested.
    *
-   * An exception can be safely thrown by this method to terminate the allocation.
+   * <p>An exception can be safely thrown by this method to terminate the allocation.
    *
-   * @param size
+   * @param size the buffer size being allocated
    */
-  default void onPreAllocation(long size) {};
+  default void onPreAllocation(long size) {}
 
   /**
    * Called each time a new buffer has been allocated.
    *
-   * An exception cannot be thrown by this method.
+   * <p>An exception cannot be thrown by this method.
    *
    * @param size the buffer size being allocated
    */
-  default void onAllocation(long size) {};
+  default void onAllocation(long size) {}
 
   /**
    * Informed each time a buffer is released from allocation.
    *
-   * An exception cannot be thrown by this method.
+   * <p>An exception cannot be thrown by this method.
    * @param size The size of the buffer being released.
    */
-  default void onRelease(long size) {};
+  default void onRelease(long size) {}
 
 
   /**
@@ -73,7 +73,7 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator to which a child was added
    * @param childAllocator  The child allocator that was just added
    */
-  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {};
+  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {}
 
   /**
    * Called immediately after a child allocator was removed from the parent allocator.
@@ -81,5 +81,5 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator from which a child was removed
    * @param childAllocator The child allocator that was just removed
    */
-  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {};
+  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {}
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationListener.java
@@ -25,31 +25,34 @@ package org.apache.arrow.memory;
  */
 public interface AllocationListener {
 
-  public static final AllocationListener NOOP = new AllocationListener() {
-    @Override
-    public void onAllocation(long size) {
-    }
-
-    @Override
-    public boolean onFailedAllocation(long size, AllocationOutcome outcome) {
-      return false;
-    }
-
-    @Override
-    public void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
-    }
-
-    @Override
-    public void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {
-    }
-  };
+  public static final AllocationListener NOOP = new AllocationListener() {};
 
   /**
-   * Called each time a new buffer is allocated.
+   * Called each time a new buffer has been requested.
+   *
+   * An exception can be safely thrown by this method to terminate the allocation.
+   *
+   * @param size
+   */
+  default void onPreAllocation(long size) {};
+
+  /**
+   * Called each time a new buffer has been allocated.
+   *
+   * An exception cannot be thrown by this method.
    *
    * @param size the buffer size being allocated
    */
-  void onAllocation(long size);
+  default void onAllocation(long size) {};
+
+  /**
+   * Informed each time a buffer is released from allocation.
+   *
+   * An exception cannot be thrown by this method.
+   * @param size The size of the buffer being released.
+   */
+  default void onRelease(long size) {};
+
 
   /**
    * Called whenever an allocation failed, giving the caller a chance to create some space in the
@@ -60,7 +63,9 @@ public interface AllocationListener {
    * @param outcome  the outcome of the failed allocation. Carries information of what failed
    * @return true, if the allocation can be retried; false if the allocation should fail
    */
-  boolean onFailedAllocation(long size, AllocationOutcome outcome);
+  default boolean onFailedAllocation(long size, AllocationOutcome outcome) {
+    return false;
+  }
 
   /**
    * Called immediately after a child allocator was added to the parent allocator.
@@ -68,7 +73,7 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator to which a child was added
    * @param childAllocator  The child allocator that was just added
    */
-  void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator);
+  default void onChildAdded(BufferAllocator parentAllocator, BufferAllocator childAllocator) {};
 
   /**
    * Called immediately after a child allocator was removed from the parent allocator.
@@ -76,5 +81,5 @@ public interface AllocationListener {
    * @param parentAllocator The parent allocator from which a child was removed
    * @param childAllocator The child allocator that was just removed
    */
-  void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator);
+  default void onChildRemoved(BufferAllocator parentAllocator, BufferAllocator childAllocator) {};
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -147,6 +147,7 @@ public class AllocationManager {
         // no one else owns, lets release.
         oldLedger.allocator.releaseBytes(size);
         underlying.release();
+        oldLedger.allocator.listener.onRelease(size);
         amDestructionTime = System.nanoTime();
         owningLedger = null;
       } else {

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -49,7 +49,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   final String name;
   final RootAllocator root;
   private final Object DEBUG_LOCK = DEBUG ? new Object() : null;
-  private final AllocationListener listener;
+  final AllocationListener listener;
   private final BaseAllocator parentAllocator;
   private final ArrowByteBufAllocator thisAsByteBufAllocator;
   private final IdentityHashMap<BaseAllocator, Object> childAllocators;
@@ -277,6 +277,9 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     final int actualRequestSize = initialRequestSize < AllocationManager.CHUNK_SIZE ?
         nextPowerOfTwo(initialRequestSize)
         : initialRequestSize;
+
+    listener.onPreAllocation(actualRequestSize);
+
     AllocationOutcome outcome = this.allocateBytes(actualRequestSize);
     if (!outcome.isOk()) {
       if (listener.onFailedAllocation(actualRequestSize, outcome)) {

--- a/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
@@ -26,6 +26,10 @@ import org.apache.arrow.util.VisibleForTesting;
  */
 public class RootAllocator extends BaseAllocator {
 
+  public RootAllocator() {
+    this(AllocationListener.NOOP, Long.MAX_VALUE);
+  }
+
   public RootAllocator(final long limit) {
     this(AllocationListener.NOOP, limit);
   }


### PR DESCRIPTION
- Additional methods for observers to calculate total number of live ledgers and buffers.
- Allows clients to clamp down on heap growth due to these buffers.