### PR TITLE
ARROW-4996: [Plasma] Enable uninstalling of signal handler and fix log_dir

### DIFF
--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -24,6 +24,7 @@
 #include <iostream>
 
 #ifdef ARROW_USE_GLOG
+#include <vector>
 #include "glog/logging.h"
 #endif
 
@@ -84,6 +85,7 @@ typedef CerrLog LoggingProvider;
 
 ArrowLogLevel ArrowLog::severity_threshold_ = ArrowLogLevel::ARROW_INFO;
 std::unique_ptr<std::string> ArrowLog::app_name_;
+std::unique_ptr<std::string> ArrowLog::log_dir_;
 
 #ifdef ARROW_USE_GLOG
 
@@ -113,10 +115,10 @@ void ArrowLog::StartArrowLog(const std::string& app_name,
                              ArrowLogLevel severity_threshold,
                              const std::string& log_dir) {
   severity_threshold_ = severity_threshold;
-  app_name_.reset(new std::string(app_name.c_str()));
+  app_name_.reset(new std::string(app_name));
+  log_dir_.reset(new std::string(log_dir));
 #ifdef ARROW_USE_GLOG
   int mapped_severity_threshold = GetMappedSeverity(severity_threshold_);
-  google::InitGoogleLogging(app_name_->c_str());
   google::SetStderrLogging(mapped_severity_threshold);
   // Enble log file if log_dir is not empty.
   if (!log_dir.empty()) {
@@ -134,15 +136,39 @@ void ArrowLog::StartArrowLog(const std::string& app_name,
         app_name_without_path = app_name.substr(pos + 1);
       }
     }
+    google::InitGoogleLogging(app_name_->c_str());
     google::SetLogFilenameExtension(app_name_without_path.c_str());
-    google::SetLogDestination(mapped_severity_threshold, log_dir.c_str());
+    for (int i = static_cast<int>(severity_threshold_);
+         i <= static_cast<int>(ArrowLogLevel::ARROW_FATAL); ++i) {
+      int level = GetMappedSeverity(static_cast<ArrowLogLevel>(i));
+      google::SetLogDestination(level, dir_ends_with_slash.c_str());
+    }
+  }
+#endif
+}
+
+void ArrowLog::UninstallSignalAction() {
+#ifdef RAY_USE_GLOG
+  RAY_LOG(DEBUG) << "Uninstall signal handlers.";
+  // This signal list comes from glog's signalhandler.cc.
+  // https://github.com/google/glog/blob/master/src/signalhandler.cc#L58-L70
+  static std::vector<int> installed_signals({SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM});
+  struct sigaction sig_action;
+  memset(&sig_action, 0, sizeof(sig_action));
+  sigemptyset(&sig_action.sa_mask);
+  sig_action.sa_handler = SIG_DFL;
+  for (int signal_num : installed_signals) {
+    sigaction(signal_num, &sig_action, NULL);
   }
 #endif
 }
 
 void ArrowLog::ShutDownArrowLog() {
 #ifdef ARROW_USE_GLOG
-  google::ShutdownGoogleLogging();
+  UninstallSignalAction();
+  if (!log_dir_->empty()) {
+    google::ShutdownGoogleLogging();
+  }
 #endif
 }
 

--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -84,7 +84,8 @@ typedef CerrLog LoggingProvider;
 #endif
 
 ArrowLogLevel ArrowLog::severity_threshold_ = ArrowLogLevel::ARROW_INFO;
-std::unique_ptr<std::string> ArrowLog::log_dir_;
+// Keep the log directory.
+static std::unique_ptr<std::string> log_dir_;
 
 #ifdef ARROW_USE_GLOG
 

--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -173,7 +173,6 @@ void ArrowLog::UninstallSignalAction() {
 
 void ArrowLog::ShutDownArrowLog() {
 #ifdef ARROW_USE_GLOG
-  UninstallSignalAction();
   if (!log_dir_->empty()) {
     google::ShutdownGoogleLogging();
   }

--- a/cpp/src/arrow/util/logging.cc
+++ b/cpp/src/arrow/util/logging.cc
@@ -84,7 +84,6 @@ typedef CerrLog LoggingProvider;
 #endif
 
 ArrowLogLevel ArrowLog::severity_threshold_ = ArrowLogLevel::ARROW_INFO;
-std::unique_ptr<std::string> ArrowLog::app_name_;
 std::unique_ptr<std::string> ArrowLog::log_dir_;
 
 #ifdef ARROW_USE_GLOG
@@ -115,6 +114,10 @@ void ArrowLog::StartArrowLog(const std::string& app_name,
                              ArrowLogLevel severity_threshold,
                              const std::string& log_dir) {
   severity_threshold_ = severity_threshold;
+  // In InitGoogleLogging, it simply keeps the pointer.
+  // We need to make sure the app name passed to InitGoogleLogging exist.
+  // We should avoid using static string is a dynamic lib.
+  static std::unique_ptr<std::string> app_name_;
   app_name_.reset(new std::string(app_name));
   log_dir_.reset(new std::string(log_dir));
 #ifdef ARROW_USE_GLOG

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -167,6 +167,9 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   /// If glog is not installed, this function won't do anything.
   static void InstallFailureSignalHandler();
 
+  /// Uninstall the signal actions installed by InstallFailureSignalHandler.
+  static void UninstallSignalAction();
+
   /// Return whether or not the log level is enabled in current setting.
   ///
   /// \param log_level The input log level to test.
@@ -175,9 +178,6 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowLog);
-
-  /// Uninstall the signal actions installed by InstallFailureSignalHandler.
-  static void UninstallSignalAction();
 
   // Hide the implementation of log provider by void *.
   // Otherwise, lib user may define the same macro to use the correct header file.

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -186,8 +186,6 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   bool is_enabled_;
 
   static ArrowLogLevel severity_threshold_;
-  // Keep the log directory.
-  static std::unique_ptr<std::string> log_dir_;
 
  protected:
   virtual std::ostream& Stream();

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -163,6 +163,9 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   /// The shutdown function of arrow log, it should be used with StartArrowLog as a pair.
   static void ShutDownArrowLog();
 
+  /// Uninstall the signal actions installed by InstallFailureSignalHandler.
+  static void UninstallSignalAction();
+
   /// Install the failure signal handler to output call stack when crash.
   /// If glog is not installed, this function won't do anything.
   static void InstallFailureSignalHandler();
@@ -186,6 +189,8 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   // In InitGoogleLogging, it simply keeps the pointer.
   // We need to make sure the app name passed to InitGoogleLogging exist.
   static std::unique_ptr<std::string> app_name_;
+  // Keep the log directory.
+  static std::unique_ptr<std::string> log_dir_;
 
  protected:
   virtual std::ostream& Stream();

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -163,9 +163,6 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   /// The shutdown function of arrow log, it should be used with StartArrowLog as a pair.
   static void ShutDownArrowLog();
 
-  /// Uninstall the signal actions installed by InstallFailureSignalHandler.
-  static void UninstallSignalAction();
-
   /// Install the failure signal handler to output call stack when crash.
   /// If glog is not installed, this function won't do anything.
   static void InstallFailureSignalHandler();
@@ -178,6 +175,9 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowLog);
+
+  /// Uninstall the signal actions installed by InstallFailureSignalHandler.
+  static void UninstallSignalAction();
 
   // Hide the implementation of log provider by void *.
   // Otherwise, lib user may define the same macro to use the correct header file.

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -186,9 +186,6 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   bool is_enabled_;
 
   static ArrowLogLevel severity_threshold_;
-  // In InitGoogleLogging, it simply keeps the pointer.
-  // We need to make sure the app name passed to InitGoogleLogging exist.
-  static std::unique_ptr<std::string> app_name_;
   // Keep the log directory.
   static std::unique_ptr<std::string> log_dir_;
 

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -1173,6 +1173,7 @@ int main(int argc, char* argv[]) {
   plasma::g_runner->Shutdown();
   plasma::g_runner = nullptr;
 
+  ArrowLog::UninstallSignalAction();
   ArrowLog::ShutDownArrowLog();
   return 0;
 }


### PR DESCRIPTION
1. `UninstallSignalAction` is added at exiting time.
2. When `log_dir` is empty, we should not call InitGoogleLogging, which means there should be not log files. If `log_dir` is not empty, we should call `SetLogDestination` for different log levels.