### PR TITLE
ARROW-3578: [Release] Fix RAT spurious failures

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -34,7 +34,7 @@ tagrc=${tag}-rc${rc}
 
 echo "Preparing source for tag ${tag}"
 
-release_hash=`git rev-list $tag 2> /dev/null | head -n 1 `
+: ${release_hash=:`git rev-list $tag 2> /dev/null | head -n 1 `}
 
 if [ -z "$release_hash" ]; then
   echo "Cannot continue: unknown git tag: $tag"

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -20,6 +20,7 @@ cpp/build-support/cpplint.py
 cpp/build-support/lint_exclusions.txt
 cpp/build-support/iwyu/*
 cpp/cmake_modules/BuildUtils.cmake
+cpp/cmake_modules/FindArrow.cmake
 cpp/cmake_modules/FindPythonLibsNew.cmake
 cpp/cmake_modules/FindNumPy.cmake
 cpp/cmake_modules/SetupCxxFlags.cmake

--- a/dev/release/source/Dockerfile
+++ b/dev/release/source/Dockerfile
@@ -19,12 +19,16 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN \
-  apt update && \
+RUN apt-get update -y -q && \
+  apt-get install -y -q --no-install-recommends wget software-properties-common gpg-agent && \
+  wget --quiet -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+  apt-add-repository -y "deb http://apt.llvm.org/bionic llvm-toolchain-bionic-7 main" && \
+  apt-get -y install clang-7
+
+RUN apt update && \
   apt install -y -V \
     autoconf-archive \
     bison \
-    clang-6.0 \
     cmake \
     flex \
     g++ \


### PR DESCRIPTION
- Adds cpp/cmake_modules/FindArrow.cmake to excludes
- Updates source verify docker image with clang-7 support
- Improve source release script to test any hash