### PR TITLE
ARROW-4596: [Rust][DataFusion] COUNT aggregation

### DIFF
--- a/rust/arrow/src/compute/array_ops.rs
+++ b/rust/arrow/src/compute/array_ops.rs
@@ -106,10 +106,8 @@ where
 /// Returns the number of not-null values in the array.
 ///
 /// Returns `None` if the array is empty.
-pub fn count<T>(array: &PrimitiveArray<T>) -> Option<usize>
+pub fn count(array: &Array) -> Option<usize>
 where
-    T: ArrowNumericType,
-    T::Native: Add<Output = T::Native>,
 {
     let null_count = array.null_count();
     let n = array.len();

--- a/rust/arrow/src/compute/array_ops.rs
+++ b/rust/arrow/src/compute/array_ops.rs
@@ -103,6 +103,23 @@ where
     }
 }
 
+/// Returns the number of not-null values in the array.
+///
+/// Returns `None` if the array is empty.
+pub fn count<T>(array: &PrimitiveArray<T>) -> Option<usize>
+where
+    T: ArrowNumericType,
+    T::Native: Add<Output = T::Native>,
+{
+    let null_count = array.null_count();
+    let n = array.len();
+    if n == 0 {
+        None
+    } else {
+        Some(n - null_count)
+    }
+}
+
 /// Helper function to perform boolean lambda function on values from two arrays.
 fn bool_op<T, F>(
     left: &PrimitiveArray<T>,

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -53,7 +53,8 @@
 //! let batch = RecordBatch::try_new(
 //!     Arc::new(schema),
 //!     vec![Arc::new(c1), Arc::new(c2), Arc::new(c3), Arc::new(c4)],
-//! ).unwrap();
+//! )
+//! .unwrap();
 //!
 //! let file = get_temp_file("out.csv", &[]);
 //!

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -31,7 +31,8 @@ pub trait Table {
     /// Get a reference to the schema for this table
     fn schema(&self) -> &Arc<Schema>;
 
-    /// Perform a scan of a table and return a sequence of iterators over the data (one iterator per partition)
+    /// Perform a scan of a table and return a sequence of iterators over the data (one
+    /// iterator per partition)
     fn scan(
         &self,
         projection: &Option<Vec<usize>>,

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 //! In-memory data source for presenting a Vec<RecordBatch> as a data source that can be
-//! queried by DataFusion. This allows data to be pre-loaded into memory and then repeatedly
-//! queried without incurring additional file I/O overhead.
+//! queried by DataFusion. This allows data to be pre-loaded into memory and then
+//! repeatedly queried without incurring additional file I/O overhead.
 
 use std::sync::{Arc, Mutex};
 

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -321,20 +321,9 @@ struct CountFunction {
 
 impl CountFunction {
     fn new(data_type: &DataType) -> Self {
-        let value = match data_type {
-            DataType::Int8 => Some(ScalarValue::Int8(0)),
-            DataType::Int16 => Some(ScalarValue::Int16(0)),
-            DataType::Int32 => Some(ScalarValue::Int32(0)),
-            DataType::Int64 => Some(ScalarValue::Int64(0)),
-            DataType::UInt8 => Some(ScalarValue::UInt8(0)),
-            DataType::UInt16 => Some(ScalarValue::UInt16(0)),
-            DataType::UInt32 => Some(ScalarValue::UInt32(0)),
-            DataType::UInt64 => Some(ScalarValue::UInt64(0)),
-            _ => None,
-        };
         Self {
             data_type: data_type.clone(),
-            value,
+            value: None,
         }
     }
 }
@@ -345,6 +334,31 @@ impl AggregateFunction for CountFunction {
     }
 
     fn accumulate_scalar(&mut self, value: &Option<ScalarValue>) -> Result<()> {
+        if self.value.is_none() {
+            self.value = match (data_type, value) {
+                (DataType::Int8, Some(_)) => Some(ScalarValue::Int8(1)),
+                (DataType::Int16, Some(_)) => Some(ScalarValue::Int16(1)),
+                (DataType::Int32, Some(_)) => Some(ScalarValue::Int32(1)),
+                (DataType::Int64, Some(_)) => Some(ScalarValue::Int64(1)),
+                (DataType::UInt8, Some(_)) => Some(ScalarValue::UInt8(1)),
+                (DataType::UInt16, Some(_)) => Some(ScalarValue::UInt16(1)),
+                (DataType::UInt32, Some(_)) => Some(ScalarValue::UInt32(1)),
+                (DataType::UInt64, Some(_)) => Some(ScalarValue::UInt64(1)),
+                (DataType::Int8, None) => Some(ScalarValue::Int8(0)),
+                (DataType::Int16, None) => Some(ScalarValue::Int16(0)),
+                (DataType::Int32, None) => Some(ScalarValue::Int32(0)),
+                (DataType::Int64, None) => Some(ScalarValue::Int64(0)),
+                (DataType::UInt8, None) => Some(ScalarValue::UInt8(0)),
+                (DataType::UInt16, None) => Some(ScalarValue::UInt16(0)),
+                (DataType::UInt32, None) => Some(ScalarValue::UInt32(0)),
+                (DataType::UInt64, None) => Some(ScalarValue::UInt64(0)),
+                _ => {
+                    return Err(ExecutionError::ExecutionError(
+                        "unsupported data type for COUNT".to_string(),
+                    ));
+                }
+            };
+        }
         self.value = match (&self.value, value) {
             (Some(ScalarValue::UInt8(a)), Some(_)) => {
                 Some(ScalarValue::UInt8(*a + 1))

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -19,10 +19,10 @@
 //! functions with optional GROUP BY columns
 
 use std::cell::RefCell;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::str;
 use std::sync::Arc;
-use std::ops::Deref;
 
 use arrow::array::*;
 use arrow::builder::*;
@@ -361,30 +361,14 @@ impl AggregateFunction for CountFunction {
             };
         }
         self.value = match (&self.value, value) {
-            (Some(ScalarValue::UInt8(a)), Some(_)) => {
-                Some(ScalarValue::UInt8(*a + 1))
-            }
-            (Some(ScalarValue::UInt16(a)), Some(_)) => {
-                Some(ScalarValue::UInt16(*a + 1))
-            }
-            (Some(ScalarValue::UInt32(a)), Some(_)) => {
-                Some(ScalarValue::UInt32(*a + 1))
-            }
-            (Some(ScalarValue::UInt64(a)), Some(_)) => {
-                Some(ScalarValue::UInt64(*a + 1))
-            }
-            (Some(ScalarValue::Int8(a)), Some(_)) => {
-                Some(ScalarValue::Int8(*a + 1))
-            }
-            (Some(ScalarValue::Int16(a)), Some(_)) => {
-                Some(ScalarValue::Int16(*a + 1))
-            }
-            (Some(ScalarValue::Int32(a)), Some(_)) => {
-                Some(ScalarValue::Int32(*a + 1))
-            }
-            (Some(ScalarValue::Int64(a)), Some(_)) => {
-                Some(ScalarValue::Int64(*a + 1))
-            }
+            (Some(ScalarValue::UInt8(a)), Some(_)) => Some(ScalarValue::UInt8(*a + 1)),
+            (Some(ScalarValue::UInt16(a)), Some(_)) => Some(ScalarValue::UInt16(*a + 1)),
+            (Some(ScalarValue::UInt32(a)), Some(_)) => Some(ScalarValue::UInt32(*a + 1)),
+            (Some(ScalarValue::UInt64(a)), Some(_)) => Some(ScalarValue::UInt64(*a + 1)),
+            (Some(ScalarValue::Int8(a)), Some(_)) => Some(ScalarValue::Int8(*a + 1)),
+            (Some(ScalarValue::Int16(a)), Some(_)) => Some(ScalarValue::Int16(*a + 1)),
+            (Some(ScalarValue::Int32(a)), Some(_)) => Some(ScalarValue::Int32(*a + 1)),
+            (Some(ScalarValue::Int64(a)), Some(_)) => Some(ScalarValue::Int64(*a + 1)),
             _ => {
                 return Err(ExecutionError::ExecutionError(
                     "unsupported data type for COUNT".to_string(),
@@ -660,60 +644,42 @@ fn array_sum(array: ArrayRef, dt: &DataType) -> Result<Option<ScalarValue>> {
 
 fn array_count(array: ArrayRef, dt: &DataType) -> Result<Option<ScalarValue>> {
     match dt {
-        DataType::UInt8 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::UInt8(n as u8))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt16 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::UInt16(n as u16))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt32 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::UInt32(n as u32))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt64 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int8 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::Int8(n as i8))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int16 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::Int16(n as i16))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int32 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::Int32(n as i32))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int64 => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::Int64(n as i64))),
-                None => Ok(None),
-            }
-        }
-        _ => {
-            match compute::count(array.deref()) {
-                Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
-                None => Ok(None),
-            }
-        }
+        DataType::UInt8 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::UInt8(n as u8))),
+            None => Ok(None),
+        },
+        DataType::UInt16 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::UInt16(n as u16))),
+            None => Ok(None),
+        },
+        DataType::UInt32 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::UInt32(n as u32))),
+            None => Ok(None),
+        },
+        DataType::UInt64 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
+            None => Ok(None),
+        },
+        DataType::Int8 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::Int8(n as i8))),
+            None => Ok(None),
+        },
+        DataType::Int16 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::Int16(n as i16))),
+            None => Ok(None),
+        },
+        DataType::Int32 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::Int32(n as i32))),
+            None => Ok(None),
+        },
+        DataType::Int64 => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::Int64(n as i64))),
+            None => Ok(None),
+        },
+        _ => match compute::count(array.deref()) {
+            Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
+            None => Ok(None),
+        },
     }
 }
 
@@ -1266,7 +1232,7 @@ mod tests {
             },
             &schema,
         )
-            .unwrap()];
+        .unwrap()];
 
         let aggr_schema = Arc::new(Schema::new(vec![Field::new(
             "count",

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -643,6 +643,62 @@ fn array_sum(array: ArrayRef, dt: &DataType) -> Result<Option<ScalarValue>> {
     }
 }
 
+fn array_count(array: ArrayRef, dt: &DataType) -> Result<Option<ScalarValue>> {
+    match dt {
+        DataType::UInt8 => {
+            match compute::count(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt8(n as u8))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt16 => {
+            match compute::count(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt16(n as u16))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt32 => {
+            match compute::count(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt32(n as u32))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt64 => {
+            match compute::count(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int8 => {
+            match compute::count(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int8(n as i8))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int16 => {
+            match compute::count(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int16(n as i16))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int32 => {
+            match compute::count(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int32(n as i32))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int64 => {
+            match compute::count(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int64(n as i64))),
+                None => Ok(None),
+            }
+        }
+        _ => Err(ExecutionError::ExecutionError(
+            "Unsupported data type for SUM".to_string(),
+        )),
+    }
+}
+
 fn update_accumulators(
     batch: &RecordBatch,
     row: usize,

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -312,6 +312,46 @@ impl AggregateFunction for SumFunction {
     }
 }
 
+/// Implemntation of COUNT aggregate function
+#[derive(Debug)]
+struct CountFunction {
+    data_type: DataType,
+    value: Option<ScalarValue>,
+}
+
+impl CountFunction {
+    fn new(data_type: &DataType) -> Self {
+        Self {
+            data_type: data_type.clone(),
+            value: Some(ScalarValue::UInt64(0)),
+        }
+    }
+}
+
+impl AggregateFunction for CountFunction {
+    fn name(&self) -> &str {
+        "count"
+    }
+
+    fn accumulate_scalar(&mut self, value: &Option<ScalarValue>) -> Result<()> {
+        if value.is_some() {
+            // Always true
+            if let Some(ScalarValue::UInt64(current_count)) = self.value {
+                self.value = Some(ScalarValue::UInt64(current_count + 1))
+            }
+        }
+        Ok(())
+    }
+
+    fn result(&self) -> &Option<ScalarValue> {
+        &self.value
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}
+
 struct AccumulatorSet {
     aggr_values: Vec<Rc<RefCell<AggregateFunction>>>,
 }

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -22,6 +22,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::str;
 use std::sync::Arc;
+use std::ops::Deref;
 
 use arrow::array::*;
 use arrow::builder::*;
@@ -660,56 +661,59 @@ fn array_sum(array: ArrayRef, dt: &DataType) -> Result<Option<ScalarValue>> {
 fn array_count(array: ArrayRef, dt: &DataType) -> Result<Option<ScalarValue>> {
     match dt {
         DataType::UInt8 => {
-            match compute::count(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::UInt8(n as u8))),
                 None => Ok(None),
             }
         }
         DataType::UInt16 => {
-            match compute::count(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::UInt16(n as u16))),
                 None => Ok(None),
             }
         }
         DataType::UInt32 => {
-            match compute::count(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::UInt32(n as u32))),
                 None => Ok(None),
             }
         }
         DataType::UInt64 => {
-            match compute::count(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
                 None => Ok(None),
             }
         }
         DataType::Int8 => {
-            match compute::count(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::Int8(n as i8))),
                 None => Ok(None),
             }
         }
         DataType::Int16 => {
-            match compute::count(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::Int16(n as i16))),
                 None => Ok(None),
             }
         }
         DataType::Int32 => {
-            match compute::count(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::Int32(n as i32))),
                 None => Ok(None),
             }
         }
         DataType::Int64 => {
-            match compute::count(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+            match compute::count(array.deref()) {
                 Some(n) => Ok(Some(ScalarValue::Int64(n as i64))),
                 None => Ok(None),
             }
         }
-        _ => Err(ExecutionError::ExecutionError(
-            "Unsupported data type for SUM".to_string(),
-        )),
+        _ => {
+            match compute::count(array.deref()) {
+                Some(n) => Ok(Some(ScalarValue::UInt64(n as u64))),
+                None => Ok(None),
+            }
+        }
     }
 }
 
@@ -1277,7 +1281,7 @@ mod tests {
         let count = batch
             .column(0)
             .as_any()
-            .downcast_ref::<UInt16Array>()
+            .downcast_ref::<UInt64Array>()
             .unwrap();
         assert_eq!(100, count.value(0));
     }

--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -896,6 +896,8 @@ impl AggregateRelation {
                                     .accumulate_scalar(i, array_max(array, &t)?)?,
                                 AggregateType::Sum => accumulator_set
                                     .accumulate_scalar(i, array_sum(array, &t)?)?,
+                                AggregateType::Count => accumlator_set
+                                    .accumulate_scalar(i, array_count(array, &t)?)?,
                                 _ => {
                                     return Err(ExecutionError::NotImplemented(
                                         "Unsupported aggregate function".to_string(),

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! ExecutionContext contains methods for registering data sources and executing SQL queries
+//! ExecutionContext contains methods for registering data sources and executing SQL
+//! queries
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -107,8 +108,8 @@ impl ExecutionContext {
         Ok(rule.optimize(plan)?)
     }
 
-    /// Execute a logical plan and produce a Relation (a schema-aware iterator over a series
-    /// of RecordBatch instances)
+    /// Execute a logical plan and produce a Relation (a schema-aware iterator over a
+    /// series of RecordBatch instances)
     pub fn execute(
         &mut self,
         plan: &LogicalPlan,

--- a/rust/datafusion/src/execution/filter.rs
+++ b/rust/datafusion/src/execution/filter.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Execution of a filter (predicate) relation. The SQL clause `WHERE expr` represents a filter.
+//! Execution of a filter (predicate) relation. The SQL clause `WHERE expr` represents a
+//! filter.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -32,7 +33,8 @@ use crate::execution::relation::Relation;
 
 /// Implementation of a filter relation
 pub(super) struct FilterRelation {
-    /// The schema for the filter relation. This is always the same as the schema of the input relation.
+    /// The schema for the filter relation. This is always the same as the schema of the
+    /// input relation.
     schema: Arc<Schema>,
     /// Relation that is  being filtered
     input: Rc<RefCell<Relation>>,

--- a/rust/datafusion/src/execution/limit.rs
+++ b/rust/datafusion/src/execution/limit.rs
@@ -33,7 +33,8 @@ use crate::execution::relation::Relation;
 pub(super) struct LimitRelation {
     /// The relation which the limit is being applied to
     input: Rc<RefCell<Relation>>,
-    /// The schema for the limit relation, which is always the same as the schema of the input relation
+    /// The schema for the limit relation, which is always the same as the schema of the
+    /// input relation
     schema: Arc<Schema>,
     /// The number of rows returned by this relation
     limit: usize,

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -15,10 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines the projection relation. A projection determines which columns or expressions are
-//! returned from a query. The SQL statement `SELECT a, b, a+b FROM t1` is an example of a
-//! projection on table `t1` where the expressions `a`, `b`, and `a+b` are the projection
-//! expressions.
+//! Defines the projection relation. A projection determines which columns or expressions
+//! are returned from a query. The SQL statement `SELECT a, b, a+b FROM t1` is an example
+//! of a projection on table `t1` where the expressions `a`, `b`, and `a+b` are the
+//! projection expressions.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 //! A relation is a representation of a set of tuples. A database table is a
-//! type of relation. During query execution, each operation on a relation (such as projection,
-//! selection, aggregation) results in a new relation.
+//! type of relation. During query execution, each operation on a relation (such as
+//! projection, selection, aggregation) results in a new relation.
 
 use std::sync::{Arc, Mutex};
 

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -21,7 +21,8 @@ use crate::logicalplan::LogicalPlan;
 use arrow::error::Result;
 use std::sync::Arc;
 
-/// An optimizer rules performs a transformation on a logical plan to produce an optimized logical plan.
+/// An optimizer rules performs a transformation on a logical plan to produce an optimized
+/// logical plan.
 pub trait OptimizerRule {
     fn optimize(&mut self, plan: &LogicalPlan) -> Result<Arc<LogicalPlan>>;
 }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -140,8 +140,8 @@ impl ProjectionPushDown {
                 schema,
                 ..
             } => {
-                // once we reach the table scan, we can use the accumulated set of column indexes as
-                // the projection in the table scan
+                // once we reach the table scan, we can use the accumulated set of column
+                // indexes as the projection in the table scan
                 let mut projection: Vec<usize> = Vec::with_capacity(accum.len());
                 accum.iter().for_each(|i| projection.push(*i));
 
@@ -156,9 +156,10 @@ impl ProjectionPushDown {
                 }
                 let projected_schema = Schema::new(projected_fields);
 
-                // now that the table scan is returning a different schema we need to create a
-                // mapping from the original column index to the new column index so that we
-                // can rewrite expressions as we walk back up the tree
+                // now that the table scan is returning a different schema we need to
+                // create a mapping from the original column index to the
+                // new column index so that we can rewrite expressions as
+                // we walk back up the tree
 
                 if mapping.len() != 0 {
                     return Err(ArrowError::ComputeError("illegal state".to_string()));

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -431,8 +431,8 @@ pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Field {
     }
 }
 
-/// Derive field meta-data for a list of expressions, for use in creating schemas that result from
-/// evaluating expressions against an input schema.
+/// Derive field meta-data for a list of expressions, for use in creating schemas that
+/// result from evaluating expressions against an input schema.
 pub fn exprlist_to_fields(expr: &Vec<Expr>, input_schema: &Schema) -> Vec<Field> {
     expr.iter()
         .map(|e| expr_to_field(e, input_schema))

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -129,7 +129,8 @@ fn csv_query_limit_zero() {
     assert_eq!(expected, actual);
 }
 
-//TODO Uncomment the following test when ORDER BY is implemented to be able to test ORDER BY + LIMIT
+//TODO Uncomment the following test when ORDER BY is implemented to be able to test ORDER
+// BY + LIMIT
 /*
 #[test]
 fn csv_query_limit_with_order_by() {


### PR DESCRIPTION
I have started to work on this ticket, but I have some doubts that are preventing me from moving forward.
The major one concerns how aggregation currently works - for each struct implementing `AggregateFunction` there are two main "calling sites":
- `AggregateRelation.without_group_by`: for each aggregation we precompute its output on a batch of records using bulk functions (`array_min`, `array_max`, `array_sum`, `array_count`) and then we update the accumulator using their output value, using (after a bit of indirection) `AggregateFunction.accumulate_scalar`;
- `AggregateRelation.with_group_by`: the aggregation value is built one value at a time, using `AggregateFunction.accumulate_scalar`.

This patterns works for `sum`, `min` and `max` because:
```
sum([x, sum([y, w, ..., z])]) = sum([x, y, w, ..., z])
min([x, min([y, w, ..., z])]) = min([x, y, w, ..., z])
max([x, max([y, w, ..., z])]) = max([x, y, w, ..., z])
```
but the same is not true for `count`
```
count([x, count([y, w, ..., z])]) != count([x, y, w, ..., z])
```
as it can be seen from the currently failing test (100 != 2).
How should I address this issue? Should I change `AggregateFunction` to provide an additional accumulation method specifically for bulk computation?

The other doubt concerns the data type: so far I have worked under the assumption that we want the result of a COUNT aggregation to be either `None` (if the array is empty) or an integer (either signed or unsigned, all bit counts are allowed). Is that correct?