### PR TITLE
ARROW-3578: [Release] Resolve all hard and symbolic links in tar.gz

### DIFF
--- a/ci/travis_release_audit.sh
+++ b/ci/travis_release_audit.sh
@@ -20,5 +20,7 @@
 set -e
 
 # Check licenses according to Apache policy
-git archive HEAD --prefix=apache-arrow/ --output=arrow-src.tar.gz
+git archive HEAD --prefix=apache-arrow-raw/ | tar xf -
+cp -r -L apache-arrow{-raw,}
+tar czf arrow-src.tar.gz apache-arrow
 ./dev/release/run-rat.sh arrow-src.tar.gz

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -68,8 +68,14 @@ rm -rf ${tag}/c_glib
 tar xf ${dist_c_glib_tar_gz} -C ${tag}
 rm -f ${dist_c_glib_tar_gz}
 
+# Resolve all hard and symbolic links
+rm -rf ${tag}.tmp
+mv ${tag} ${tag}.tmp
+cp -r -L ${tag}.tmp ${tag}
+rm -rf ${tag}.tmp
+
 # Create new tarball from modified source directory
-tar czhf ${tarball} ${tag}
+tar czf ${tarball} ${tag}
 rm -rf ${tag}
 
 ${SOURCE_DIR}/run-rat.sh ${tarball}

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -8,7 +8,6 @@
 *.json
 *.snap
 .github/ISSUE_TEMPLATE.md
-cpp/examples/parquet/parquet-arrow/cmake_modules/FindArrow.cmake
 cpp/CHANGELOG_PARQUET.md
 cpp/src/arrow/io/mman.h
 cpp/src/arrow/util/random.h
@@ -19,13 +18,9 @@ cpp/build-support/asan_symbolize.py
 cpp/build-support/cpplint.py
 cpp/build-support/lint_exclusions.txt
 cpp/build-support/iwyu/*
-cpp/cmake_modules/BuildUtils.cmake
 cpp/cmake_modules/FindPythonLibsNew.cmake
-cpp/cmake_modules/FindNumPy.cmake
-cpp/cmake_modules/SetupCxxFlags.cmake
 cpp/cmake_modules/SnappyCMakeLists.txt
 cpp/cmake_modules/SnappyConfig.h
-cpp/cmake_modules/CompilerInfo.cmake
 cpp/src/parquet/.parquetcppversion
 cpp/src/plasma/thirdparty/ae/ae.c
 cpp/src/plasma/thirdparty/ae/ae.h
@@ -125,8 +120,9 @@ go/*.tmpldata
 go/*.s
 js/.npmignore
 js/closure-compiler-scripts/*
-python/cmake_modules
-python/cmake_modules/*
+python/cmake_modules/FindPythonLibsNew.cmake
+python/cmake_modules/SnappyCMakeLists.txt
+python/cmake_modules/SnappyConfig.h
 python/MANIFEST.in
 python/manylinux1/.dockerignore
 python/pyarrow/includes/__init__.pxd


### PR DESCRIPTION
They may cause some problems when we extract the archive on Windows
and we run RAT against the archive.