### PR TITLE
ARROW-5009: [C++] Remove using std::.* where I could find them

### DIFF
--- a/cpp/src/arrow/array-binary-test.cc
+++ b/cpp/src/arrow/array-binary-test.cc
@@ -37,9 +37,6 @@
 
 namespace arrow {
 
-using std::string;
-using std::vector;
-
 using internal::checked_cast;
 
 // ----------------------------------------------------------------------
@@ -68,11 +65,11 @@ class TestStringArray : public ::testing::Test {
   }
 
  protected:
-  vector<int32_t> offsets_;
-  vector<char> chars_;
-  vector<uint8_t> valid_bytes_;
+  std::vector<int32_t> offsets_;
+  std::vector<char> chars_;
+  std::vector<uint8_t> valid_bytes_;
 
-  vector<string> expected_;
+  std::vector<std::string> expected_;
 
   std::shared_ptr<Buffer> value_buf_;
   std::shared_ptr<Buffer> offsets_buf_;
@@ -212,8 +209,8 @@ class TestStringBuilder : public TestBuilder {
 };
 
 TEST_F(TestStringBuilder, TestScalarAppend) {
-  vector<string> strings = {"", "bb", "a", "", "ccc"};
-  vector<uint8_t> is_null = {0, 0, 0, 1, 0};
+  std::vector<std::string> strings = {"", "bb", "a", "", "ccc"};
+  std::vector<uint8_t> is_null = {0, 0, 0, 1, 0};
 
   int N = static_cast<int>(strings.size());
   int reps = 1000;
@@ -251,8 +248,8 @@ TEST_F(TestStringBuilder, TestScalarAppend) {
 }
 
 TEST_F(TestStringBuilder, TestAppendVector) {
-  vector<string> strings = {"", "bb", "a", "", "ccc"};
-  vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
+  std::vector<std::string> strings = {"", "bb", "a", "", "ccc"};
+  std::vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
 
   int N = static_cast<int>(strings.size());
   int reps = 1000;
@@ -285,7 +282,7 @@ TEST_F(TestStringBuilder, TestAppendVector) {
 
 TEST_F(TestStringBuilder, TestAppendCStringsWithValidBytes) {
   const char* strings[] = {nullptr, "aaa", nullptr, "ignored", ""};
-  vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
+  std::vector<uint8_t> valid_bytes = {1, 1, 1, 0, 1};
 
   int N = static_cast<int>(sizeof(strings) / sizeof(strings[0]));
   int reps = 1000;
@@ -381,11 +378,11 @@ class TestBinaryArray : public ::testing::Test {
   }
 
  protected:
-  vector<int32_t> offsets_;
-  vector<char> chars_;
-  vector<uint8_t> valid_bytes_;
+  std::vector<int32_t> offsets_;
+  std::vector<char> chars_;
+  std::vector<uint8_t> valid_bytes_;
 
-  vector<string> expected_;
+  std::vector<std::string> expected_;
 
   std::shared_ptr<Buffer> value_buf_;
   std::shared_ptr<Buffer> offsets_buf_;
@@ -463,7 +460,7 @@ TEST_F(TestBinaryArray, TestGetString) {
 TEST_F(TestBinaryArray, TestEqualsEmptyStrings) {
   BinaryBuilder builder;
 
-  string empty_string("");
+  std::string empty_string("");
   for (int i = 0; i < 5; ++i) {
     ASSERT_OK(builder.Append(empty_string));
   }
@@ -501,8 +498,8 @@ class TestBinaryBuilder : public TestBuilder {
 };
 
 TEST_F(TestBinaryBuilder, TestScalarAppend) {
-  vector<string> strings = {"", "bb", "a", "", "ccc"};
-  vector<uint8_t> is_null = {0, 0, 0, 1, 0};
+  std::vector<std::string> strings = {"", "bb", "a", "", "ccc"};
+  std::vector<uint8_t> is_null = {0, 0, 0, 1, 0};
 
   int N = static_cast<int>(strings.size());
   int reps = 10;
@@ -536,8 +533,8 @@ TEST_F(TestBinaryBuilder, TestScalarAppend) {
 }
 
 TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
-  vector<string> strings = {"", "bb", "a", "", "ccc"};
-  vector<uint8_t> is_null = {0, 0, 0, 1, 0};
+  std::vector<std::string> strings = {"", "bb", "a", "", "ccc"};
+  std::vector<uint8_t> is_null = {0, 0, 0, 1, 0};
 
   int N = static_cast<int>(strings.size());
   int reps = 13;
@@ -577,7 +574,8 @@ TEST_F(TestBinaryBuilder, TestScalarAppendUnsafe) {
 }
 
 TEST_F(TestBinaryBuilder, TestCapacityReserve) {
-  vector<string> strings = {"aaaaa", "bbbbbbbbbb", "ccccccccccccccc", "dddddddddd"};
+  std::vector<std::string> strings = {"aaaaa", "bbbbbbbbbb", "ccccccccccccccc",
+                                      "dddddddddd"};
   int N = static_cast<int>(strings.size());
   int reps = 15;
   int64_t length = 0;
@@ -632,8 +630,8 @@ void CheckSliceEquality() {
 
   BuilderType builder;
 
-  vector<string> strings = {"foo", "", "bar", "baz", "qux", ""};
-  vector<uint8_t> is_null = {0, 1, 0, 1, 0, 0};
+  std::vector<std::string> strings = {"foo", "", "bar", "baz", "qux", ""};
+  std::vector<uint8_t> is_null = {0, 1, 0, 1, 0, 0};
 
   int N = static_cast<int>(strings.size());
   int reps = 10;

--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -36,9 +36,6 @@
 
 namespace arrow {
 
-using std::string;
-using std::vector;
-
 using internal::checked_cast;
 
 // ----------------------------------------------------------------------
@@ -764,7 +761,7 @@ TEST(TestDecimalDictionaryBuilder, DoubleTableSize) {
 // DictionaryArray tests
 
 TEST(TestDictionary, Basics) {
-  vector<int32_t> values = {100, 1000, 10000, 100000};
+  std::vector<int32_t> values = {100, 1000, 10000, 100000};
   std::shared_ptr<Array> dict;
   ArrayFromVector<Int32Type, int32_t>(values, &dict);
 
@@ -785,7 +782,7 @@ TEST(TestDictionary, Basics) {
 }
 
 TEST(TestDictionary, Equals) {
-  vector<bool> is_valid = {true, true, false, true, true, true};
+  std::vector<bool> is_valid = {true, true, false, true, true, true};
   std::shared_ptr<Array> dict, dict2, indices, indices2, indices3;
 
   dict = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\"]");
@@ -794,13 +791,13 @@ TEST(TestDictionary, Equals) {
   dict2 = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\", \"qux\"]");
   std::shared_ptr<DataType> dict2_type = dictionary(int16(), dict2);
 
-  vector<int16_t> indices_values = {1, 2, -1, 0, 2, 0};
+  std::vector<int16_t> indices_values = {1, 2, -1, 0, 2, 0};
   ArrayFromVector<Int16Type, int16_t>(is_valid, indices_values, &indices);
 
-  vector<int16_t> indices2_values = {1, 2, 0, 0, 2, 0};
+  std::vector<int16_t> indices2_values = {1, 2, 0, 0, 2, 0};
   ArrayFromVector<Int16Type, int16_t>(is_valid, indices2_values, &indices2);
 
-  vector<int16_t> indices3_values = {1, 1, 0, 0, 2, 0};
+  std::vector<int16_t> indices3_values = {1, 1, 0, 0, 2, 0};
   ArrayFromVector<Int16Type, int16_t>(is_valid, indices3_values, &indices3);
 
   auto array = std::make_shared<DictionaryArray>(dict_type, indices);
@@ -880,8 +877,8 @@ TEST(TestDictionary, FromArray) {
 
   // Invalid index is masked by null
   std::shared_ptr<Array> indices3;
-  vector<bool> is_valid3 = {true, true, false, true, true, true};
-  vector<int16_t> indices_values3 = {1, 2, -1, 0, 2, 0};
+  std::vector<bool> is_valid3 = {true, true, false, true, true, true};
+  std::vector<int16_t> indices_values3 = {1, 2, -1, 0, 2, 0};
   ArrayFromVector<Int16Type, int16_t>(is_valid3, indices_values3, &indices3);
 
   // Index out of bounds

--- a/cpp/src/arrow/array-list-test.cc
+++ b/cpp/src/arrow/array-list-test.cc
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -34,9 +33,6 @@
 #include "arrow/util/checked_cast.h"
 
 namespace arrow {
-
-using std::string;
-using std::vector;
 
 using internal::checked_cast;
 
@@ -73,10 +69,10 @@ TEST_F(TestListArray, Equality) {
   Int32Builder* vb = checked_cast<Int32Builder*>(builder_->value_builder());
 
   std::shared_ptr<Array> array, equal_array, unequal_array;
-  vector<int32_t> equal_offsets = {0, 1, 2, 5, 6, 7, 8, 10};
-  vector<int32_t> equal_values = {1, 2, 3, 4, 5, 2, 2, 2, 5, 6};
-  vector<int32_t> unequal_offsets = {0, 1, 4, 7};
-  vector<int32_t> unequal_values = {1, 2, 2, 2, 3, 4, 5};
+  std::vector<int32_t> equal_offsets = {0, 1, 2, 5, 6, 7, 8, 10};
+  std::vector<int32_t> equal_values = {1, 2, 3, 4, 5, 2, 2, 2, 5, 6};
+  std::vector<int32_t> unequal_offsets = {0, 1, 4, 7};
+  std::vector<int32_t> unequal_values = {1, 2, 2, 2, 3, 4, 5};
 
   // setup two equal arrays
   ASSERT_OK(builder_->AppendValues(equal_offsets.data(), equal_offsets.size()));
@@ -207,14 +203,14 @@ TEST_F(TestListArray, TestAppendNull) {
   ASSERT_NE(nullptr, values->data()->buffers[1]);
 }
 
-void ValidateBasicListArray(const ListArray* result, const vector<int32_t>& values,
-                            const vector<uint8_t>& is_valid) {
+void ValidateBasicListArray(const ListArray* result, const std::vector<int32_t>& values,
+                            const std::vector<uint8_t>& is_valid) {
   ASSERT_OK(ValidateArray(*result));
   ASSERT_EQ(1, result->null_count());
   ASSERT_EQ(0, result->values()->null_count());
 
   ASSERT_EQ(3, result->length());
-  vector<int32_t> ex_offsets = {0, 3, 3, 7};
+  std::vector<int32_t> ex_offsets = {0, 3, 3, 7};
   for (size_t i = 0; i < ex_offsets.size(); ++i) {
     ASSERT_EQ(ex_offsets[i], result->value_offset(i));
   }
@@ -232,9 +228,9 @@ void ValidateBasicListArray(const ListArray* result, const vector<int32_t>& valu
 }
 
 TEST_F(TestListArray, TestBasics) {
-  vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6};
-  vector<int> lengths = {3, 0, 4};
-  vector<uint8_t> is_valid = {1, 0, 1};
+  std::vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6};
+  std::vector<int> lengths = {3, 0, 4};
+  std::vector<uint8_t> is_valid = {1, 0, 1};
 
   Int32Builder* vb = checked_cast<Int32Builder*>(builder_->value_builder());
 
@@ -254,10 +250,10 @@ TEST_F(TestListArray, TestBasics) {
 }
 
 TEST_F(TestListArray, BulkAppend) {
-  vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6};
-  vector<int> lengths = {3, 0, 4};
-  vector<uint8_t> is_valid = {1, 0, 1};
-  vector<int32_t> offsets = {0, 3, 3};
+  std::vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6};
+  std::vector<int> lengths = {3, 0, 4};
+  std::vector<uint8_t> is_valid = {1, 0, 1};
+  std::vector<int32_t> offsets = {0, 3, 3};
 
   Int32Builder* vb = checked_cast<Int32Builder*>(builder_->value_builder());
   ASSERT_OK(vb->Reserve(values.size()));
@@ -271,11 +267,11 @@ TEST_F(TestListArray, BulkAppend) {
 }
 
 TEST_F(TestListArray, BulkAppendInvalid) {
-  vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6};
-  vector<int> lengths = {3, 0, 4};
-  vector<uint8_t> is_null = {0, 1, 0};
-  vector<uint8_t> is_valid = {1, 0, 1};
-  vector<int32_t> offsets = {0, 2, 4};  // should be 0, 3, 3 given the is_null array
+  std::vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6};
+  std::vector<int> lengths = {3, 0, 4};
+  std::vector<uint8_t> is_null = {0, 1, 0};
+  std::vector<uint8_t> is_valid = {1, 0, 1};
+  std::vector<int32_t> offsets = {0, 2, 4};  // should be 0, 3, 3 given the is_null array
 
   Int32Builder* vb = checked_cast<Int32Builder*>(builder_->value_builder());
   ASSERT_OK(vb->Reserve(values.size()));
@@ -303,7 +299,7 @@ TEST_F(TestListArray, TestBuilderPreserveFieleName) {
   ASSERT_OK(MakeBuilder(pool_, list_type_with_name, &tmp));
   builder_.reset(checked_cast<ListBuilder*>(tmp.release()));
 
-  vector<int32_t> values = {1, 2, 4, 8};
+  std::vector<int32_t> values = {1, 2, 4, 8};
   ASSERT_OK(builder_->AppendValues(values.data(), values.size()));
 
   std::shared_ptr<Array> list_array;

--- a/cpp/src/arrow/array-struct-test.cc
+++ b/cpp/src/arrow/array-struct-test.cc
@@ -18,7 +18,6 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -33,21 +32,18 @@
 
 namespace arrow {
 
-using std::string;
-using std::vector;
-
 using internal::checked_cast;
 
 // ----------------------------------------------------------------------
 // Struct tests
 
 void ValidateBasicStructArray(const StructArray* result,
-                              const vector<uint8_t>& struct_is_valid,
-                              const vector<char>& list_values,
-                              const vector<uint8_t>& list_is_valid,
-                              const vector<int>& list_lengths,
-                              const vector<int>& list_offsets,
-                              const vector<int32_t>& int_values) {
+                              const std::vector<uint8_t>& struct_is_valid,
+                              const std::vector<char>& list_values,
+                              const std::vector<uint8_t>& list_is_valid,
+                              const std::vector<int>& list_lengths,
+                              const std::vector<int>& list_offsets,
+                              const std::vector<int32_t>& int_values) {
   ASSERT_EQ(4, result->length());
   ASSERT_OK(ValidateArray(*result));
 
@@ -91,8 +87,8 @@ class TestStructBuilder : public TestBuilder {
     auto char_type = int8();
     auto list_type = list(char_type);
 
-    vector<std::shared_ptr<DataType>> types = {list_type, int32_type};
-    vector<std::shared_ptr<Field>> fields;
+    std::vector<std::shared_ptr<DataType>> types = {list_type, int32_type};
+    std::vector<std::shared_ptr<Field>> fields;
     fields.push_back(field("list", list_type));
     fields.push_back(field("int", int32_type));
 
@@ -112,7 +108,7 @@ class TestStructBuilder : public TestBuilder {
   }
 
  protected:
-  vector<std::shared_ptr<Field>> value_fields_;
+  std::vector<std::shared_ptr<Field>> value_fields_;
 
   std::shared_ptr<StructBuilder> builder_;
   std::shared_ptr<StructArray> result_;
@@ -153,12 +149,12 @@ TEST_F(TestStructBuilder, TestAppendNull) {
 }
 
 TEST_F(TestStructBuilder, TestBasics) {
-  vector<int32_t> int_values = {1, 2, 3, 4};
-  vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
-  vector<int> list_lengths = {3, 0, 3, 4};
-  vector<int> list_offsets = {0, 3, 3, 6, 10};
-  vector<uint8_t> list_is_valid = {1, 0, 1, 1};
-  vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
+  std::vector<int32_t> int_values = {1, 2, 3, 4};
+  std::vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
+  std::vector<int> list_lengths = {3, 0, 3, 4};
+  std::vector<int> list_offsets = {0, 3, 3, 6, 10};
+  std::vector<uint8_t> list_is_valid = {1, 0, 1, 1};
+  std::vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
 
   ListBuilder* list_vb = checked_cast<ListBuilder*>(builder_->field_builder(0));
   Int8Builder* char_vb = checked_cast<Int8Builder*>(list_vb->value_builder());
@@ -189,12 +185,12 @@ TEST_F(TestStructBuilder, TestBasics) {
 }
 
 TEST_F(TestStructBuilder, BulkAppend) {
-  vector<int32_t> int_values = {1, 2, 3, 4};
-  vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
-  vector<int> list_lengths = {3, 0, 3, 4};
-  vector<int> list_offsets = {0, 3, 3, 6};
-  vector<uint8_t> list_is_valid = {1, 0, 1, 1};
-  vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
+  std::vector<int32_t> int_values = {1, 2, 3, 4};
+  std::vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
+  std::vector<int> list_lengths = {3, 0, 3, 4};
+  std::vector<int> list_offsets = {0, 3, 3, 6};
+  std::vector<uint8_t> list_is_valid = {1, 0, 1, 1};
+  std::vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
 
   ListBuilder* list_vb = checked_cast<ListBuilder*>(builder_->field_builder(0));
   Int8Builder* char_vb = checked_cast<Int8Builder*>(list_vb->value_builder());
@@ -221,12 +217,12 @@ TEST_F(TestStructBuilder, BulkAppend) {
 }
 
 TEST_F(TestStructBuilder, BulkAppendInvalid) {
-  vector<int32_t> int_values = {1, 2, 3, 4};
-  vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
-  vector<int> list_lengths = {3, 0, 3, 4};
-  vector<int> list_offsets = {0, 3, 3, 6};
-  vector<uint8_t> list_is_valid = {1, 0, 1, 1};
-  vector<uint8_t> struct_is_valid = {1, 0, 1, 1};  // should be 1, 1, 1, 1
+  std::vector<int32_t> int_values = {1, 2, 3, 4};
+  std::vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
+  std::vector<int> list_lengths = {3, 0, 3, 4};
+  std::vector<int> list_offsets = {0, 3, 3, 6};
+  std::vector<uint8_t> list_is_valid = {1, 0, 1, 1};
+  std::vector<uint8_t> struct_is_valid = {1, 0, 1, 1};  // should be 1, 1, 1, 1
 
   ListBuilder* list_vb = checked_cast<ListBuilder*>(builder_->field_builder(0));
   Int8Builder* char_vb = checked_cast<Int8Builder*>(list_vb->value_builder());
@@ -257,18 +253,19 @@ TEST_F(TestStructBuilder, TestEquality) {
   std::shared_ptr<Array> unequal_bitmap_array, unequal_offsets_array,
       unequal_values_array;
 
-  vector<int32_t> int_values = {101, 102, 103, 104};
-  vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
-  vector<int> list_lengths = {3, 0, 3, 4};
-  vector<int> list_offsets = {0, 3, 3, 6};
-  vector<uint8_t> list_is_valid = {1, 0, 1, 1};
-  vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
+  std::vector<int32_t> int_values = {101, 102, 103, 104};
+  std::vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
+  std::vector<int> list_lengths = {3, 0, 3, 4};
+  std::vector<int> list_offsets = {0, 3, 3, 6};
+  std::vector<uint8_t> list_is_valid = {1, 0, 1, 1};
+  std::vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
 
-  vector<int32_t> unequal_int_values = {104, 102, 103, 101};
-  vector<char> unequal_list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'l', 'u', 'c', 'y'};
-  vector<int> unequal_list_offsets = {0, 3, 4, 6};
-  vector<uint8_t> unequal_list_is_valid = {1, 1, 1, 1};
-  vector<uint8_t> unequal_struct_is_valid = {1, 0, 0, 1};
+  std::vector<int32_t> unequal_int_values = {104, 102, 103, 101};
+  std::vector<char> unequal_list_values = {'j', 'o', 'e', 'b', 'o',
+                                           'b', 'l', 'u', 'c', 'y'};
+  std::vector<int> unequal_list_offsets = {0, 3, 4, 6};
+  std::vector<uint8_t> unequal_list_is_valid = {1, 1, 1, 1};
+  std::vector<uint8_t> unequal_struct_is_valid = {1, 0, 0, 1};
 
   ListBuilder* list_vb = checked_cast<ListBuilder*>(builder_->field_builder(0));
   Int8Builder* char_vb = checked_cast<Int8Builder*>(list_vb->value_builder());
@@ -392,12 +389,12 @@ TEST_F(TestStructBuilder, TestSlice) {
   std::shared_ptr<Array> unequal_bitmap_array, unequal_offsets_array,
       unequal_values_array;
 
-  vector<int32_t> int_values = {101, 102, 103, 104};
-  vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
-  vector<int> list_lengths = {3, 0, 3, 4};
-  vector<int> list_offsets = {0, 3, 3, 6};
-  vector<uint8_t> list_is_valid = {1, 0, 1, 1};
-  vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
+  std::vector<int32_t> int_values = {101, 102, 103, 104};
+  std::vector<char> list_values = {'j', 'o', 'e', 'b', 'o', 'b', 'm', 'a', 'r', 'k'};
+  std::vector<int> list_lengths = {3, 0, 3, 4};
+  std::vector<int> list_offsets = {0, 3, 3, 6};
+  std::vector<uint8_t> list_is_valid = {1, 0, 1, 1};
+  std::vector<uint8_t> struct_is_valid = {1, 1, 1, 1};
 
   ListBuilder* list_vb = checked_cast<ListBuilder*>(builder_->field_builder(0));
   Int8Builder* char_vb = checked_cast<Int8Builder*>(list_vb->value_builder());

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -50,9 +50,6 @@
 
 namespace arrow {
 
-using std::string;
-using std::vector;
-
 using internal::checked_cast;
 
 class TestArray : public ::testing::Test {
@@ -87,7 +84,7 @@ TEST_F(TestArray, TestLength) {
   ASSERT_EQ(arr->length(), 100);
 }
 
-Status MakeArrayFromValidBytes(const vector<uint8_t>& v, MemoryPool* pool,
+Status MakeArrayFromValidBytes(const std::vector<uint8_t>& v, MemoryPool* pool,
                                std::shared_ptr<Array>* out) {
   int64_t null_count = v.size() - std::accumulate(v.begin(), v.end(), 0);
 
@@ -145,7 +142,7 @@ TEST_F(TestArray, TestNullArrayEquality) {
 }
 
 TEST_F(TestArray, SliceRecomputeNullCount) {
-  vector<uint8_t> valid_bytes = {1, 0, 1, 1, 0, 1, 0, 0, 0};
+  std::vector<uint8_t> valid_bytes = {1, 0, 1, 1, 0, 1, 0, 0, 0};
 
   std::shared_ptr<Array> array;
   ASSERT_OK(MakeArrayFromValidBytes(valid_bytes, pool_, &array));
@@ -183,11 +180,11 @@ TEST_F(TestArray, NullArraySliceNullCount) {
 
 TEST_F(TestArray, TestIsNullIsValid) {
   // clang-format off
-  vector<uint8_t> null_bitmap = {1, 0, 1, 1, 0, 1, 0, 0,
-                                 1, 0, 1, 1, 0, 1, 0, 0,
-                                 1, 0, 1, 1, 0, 1, 0, 0,
-                                 1, 0, 1, 1, 0, 1, 0, 0,
-                                 1, 0, 0, 1};
+  std::vector<uint8_t> null_bitmap = {1, 0, 1, 1, 0, 1, 0, 0,
+                                      1, 0, 1, 1, 0, 1, 0, 0,
+                                      1, 0, 1, 1, 0, 1, 0, 0,
+                                      1, 0, 1, 1, 0, 1, 0, 0,
+                                      1, 0, 0, 1};
   // clang-format on
   int64_t null_count = 0;
   for (uint8_t x : null_bitmap) {
@@ -361,8 +358,8 @@ class TestPrimitiveBuilder : public TestBuilder {
   std::unique_ptr<BuilderType> builder_;
   std::unique_ptr<BuilderType> builder_nn_;
 
-  vector<T> draws_;
-  vector<uint8_t> valid_bytes_;
+  std::vector<T> draws_;
+  std::vector<uint8_t> valid_bytes_;
 };
 
 /// \brief uint8_t isn't a valid template parameter to uniform_int_distribution, so
@@ -394,7 +391,7 @@ struct UniformIntSampleType<int8_t> {
 #define PINT_DECL(CapType, c_type)                                                 \
   struct P##CapType {                                                              \
     PTYPE_DECL(CapType, c_type)                                                    \
-    static void draw(int64_t N, vector<T>* draws) {                                \
+    static void draw(int64_t N, std::vector<T>* draws) {                           \
       using sample_type = typename UniformIntSampleType<c_type>::type;             \
       const T lower = std::numeric_limits<T>::min();                               \
       const T upper = std::numeric_limits<T>::max();                               \
@@ -403,12 +400,12 @@ struct UniformIntSampleType<int8_t> {
     }                                                                              \
   }
 
-#define PFLOAT_DECL(CapType, c_type, LOWER, UPPER)  \
-  struct P##CapType {                               \
-    PTYPE_DECL(CapType, c_type)                     \
-    static void draw(int64_t N, vector<T>* draws) { \
-      random_real(N, 0, LOWER, UPPER, draws);       \
-    }                                               \
+#define PFLOAT_DECL(CapType, c_type, LOWER, UPPER)       \
+  struct P##CapType {                                    \
+    PTYPE_DECL(CapType, c_type)                          \
+    static void draw(int64_t N, std::vector<T>* draws) { \
+      random_real(N, 0, LOWER, UPPER, draws);            \
+    }                                                    \
   }
 
 PINT_DECL(UInt8, uint8_t);
@@ -558,8 +555,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestArrayDtorDealloc) {
 
   int64_t size = 1000;
 
-  vector<T>& draws = this->draws_;
-  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
 
   int64_t memory_before = this->pool_->bytes_allocated();
 
@@ -588,8 +585,8 @@ TYPED_TEST(TestPrimitiveBuilder, Equality) {
 
   const int64_t size = 1000;
   this->RandomData(size);
-  vector<T>& draws = this->draws_;
-  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
   std::shared_ptr<Array> array, equal_array, unequal_array;
   auto builder = this->builder_.get();
   ASSERT_OK(MakeArray(valid_bytes, draws, size, builder, &array));
@@ -624,8 +621,8 @@ TYPED_TEST(TestPrimitiveBuilder, SliceEquality) {
 
   const int64_t size = 1000;
   this->RandomData(size);
-  vector<T>& draws = this->draws_;
-  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
   auto builder = this->builder_.get();
 
   std::shared_ptr<Array> array;
@@ -657,8 +654,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {
 
   const int64_t size = 10000;
 
-  vector<T>& draws = this->draws_;
-  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
 
   this->RandomData(size);
 
@@ -714,8 +711,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValues) {
   int64_t size = 10000;
   this->RandomData(size);
 
-  vector<T>& draws = this->draws_;
-  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
 
   // first slug
   int64_t K = 1000;
@@ -818,9 +815,9 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesIterConverted) {
   this->RandomData(size);
 
   // append convertible values
-  vector<conversion_type> draws_converted(this->draws_.begin(), this->draws_.end());
-  vector<int32_t> valid_bytes_converted(this->valid_bytes_.begin(),
-                                        this->valid_bytes_.end());
+  std::vector<conversion_type> draws_converted(this->draws_.begin(), this->draws_.end());
+  std::vector<int32_t> valid_bytes_converted(this->valid_bytes_.begin(),
+                                             this->valid_bytes_.end());
 
   auto cast_values = internal::MakeLazyRange(
       [&draws_converted](int64_t index) {
@@ -853,8 +850,8 @@ TYPED_TEST(TestPrimitiveBuilder, TestZeroPadded) {
   int64_t size = 10000;
   this->RandomData(size);
 
-  vector<T>& draws = this->draws_;
-  vector<uint8_t>& valid_bytes = this->valid_bytes_;
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
 
   // first slug
   int64_t K = 1000;
@@ -872,7 +869,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesStdBool) {
   int64_t size = 10000;
   this->RandomData(size);
 
-  vector<T>& draws = this->draws_;
+  std::vector<T>& draws = this->draws_;
 
   std::vector<bool> is_valid;
 
@@ -1009,8 +1006,8 @@ void CheckSliceApproxEquals() {
   using T = typename TYPE::c_type;
 
   const int64_t kSize = 50;
-  vector<T> draws1;
-  vector<T> draws2;
+  std::vector<T> draws1;
+  std::vector<T> draws2;
 
   const uint32_t kSeed = 0;
   random_real(kSize, kSeed, 0.0, 100.0, &draws1);
@@ -1022,7 +1019,7 @@ void CheckSliceApproxEquals() {
     draws2[i] = draws1[i];
   }
 
-  vector<bool> is_valid;
+  std::vector<bool> is_valid;
   random_is_valid(kSize, 0.1, &is_valid);
 
   std::shared_ptr<Array> array1, array2;
@@ -1062,10 +1059,10 @@ TEST_F(TestFWBinaryArray, Builder) {
 
   int64_t nbytes = length * byte_width;
 
-  vector<uint8_t> data(nbytes);
+  std::vector<uint8_t> data(nbytes);
   random_bytes(nbytes, 0, data.data());
 
-  vector<uint8_t> is_valid(length);
+  std::vector<uint8_t> is_valid(length);
   random_null_bytes(length, 0.1, is_valid.data());
 
   const uint8_t* raw_data = data.data();
@@ -1117,8 +1114,8 @@ TEST_F(TestFWBinaryArray, Builder) {
   InitBuilder(byte_width);
   for (int64_t i = 0; i < length; ++i) {
     if (is_valid[i]) {
-      ASSERT_OK(builder_->Append(
-          string(reinterpret_cast<const char*>(raw_data + byte_width * i), byte_width)));
+      ASSERT_OK(builder_->Append(std::string(
+          reinterpret_cast<const char*>(raw_data + byte_width * i), byte_width)));
     } else {
       ASSERT_OK(builder_->AppendNull());
     }
@@ -1197,8 +1194,8 @@ TEST_F(TestFWBinaryArray, Slice) {
   auto type = fixed_size_binary(4);
   FixedSizeBinaryBuilder builder(type);
 
-  vector<string> strings = {"foo1", "foo2", "foo3", "foo4", "foo5"};
-  vector<uint8_t> is_null = {0, 1, 0, 0, 0};
+  std::vector<std::string> strings = {"foo1", "foo2", "foo3", "foo4", "foo5"};
+  std::vector<uint8_t> is_null = {0, 1, 0, 0, 0};
 
   for (int i = 0; i < 5; ++i) {
     if (is_null[i]) {

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -32,8 +32,6 @@
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 
-using std::string;
-
 namespace arrow {
 
 TEST(TestAllocate, Bitmap) {

--- a/cpp/src/arrow/compute/compute-test.cc
+++ b/cpp/src/arrow/compute/compute-test.cc
@@ -42,9 +42,6 @@
 #include "arrow/compute/kernels/util-internal.h"
 #include "arrow/compute/test-util.h"
 
-using std::shared_ptr;
-using std::vector;
-
 namespace arrow {
 namespace compute {
 
@@ -78,8 +75,8 @@ TEST_F(TestInvokeBinaryKernel, Exceptions) {
   MockBinaryKernel kernel;
   std::vector<Datum> outputs;
   std::shared_ptr<Table> table;
-  vector<bool> values1 = {true, false, true};
-  vector<bool> values2 = {false, true, false};
+  std::vector<bool> values1 = {true, false, true};
+  std::vector<bool> values2 = {false, true, false};
 
   auto type = boolean();
   auto a1 = _MakeArray<BooleanType, bool>(type, values1, {});

--- a/cpp/src/arrow/compute/kernels/aggregate-test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate-test.cc
@@ -17,7 +17,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -37,9 +36,6 @@
 #include "arrow/testing/gtest_common.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
-
-using std::shared_ptr;
-using std::vector;
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/boolean-test.cc
+++ b/cpp/src/arrow/compute/kernels/boolean-test.cc
@@ -31,9 +31,6 @@
 #include "arrow/compute/kernels/util-internal.h"
 #include "arrow/compute/test-util.h"
 
-using std::shared_ptr;
-using std::vector;
-
 namespace arrow {
 namespace compute {
 
@@ -99,8 +96,8 @@ class TestBooleanKernel : public ComputeFixture, public TestBase {
 };
 
 TEST_F(TestBooleanKernel, Invert) {
-  vector<bool> values1 = {true, false, true, false};
-  vector<bool> values2 = {false, true, false, true};
+  std::vector<bool> values1 = {true, false, true, false};
+  std::vector<bool> values2 = {false, true, false, true};
 
   auto type = boolean();
   auto a1 = _MakeArray<BooleanType, bool>(type, values1, {true, true, true, false});
@@ -153,25 +150,25 @@ TEST_F(TestBooleanKernel, BinaryOpOnEmptyArray) {
 }
 
 TEST_F(TestBooleanKernel, And) {
-  vector<bool> values1 = {true, false, true, false, true, true};
-  vector<bool> values2 = {true, true, false, false, true, false};
-  vector<bool> values3 = {true, false, false, false, true, false};
+  std::vector<bool> values1 = {true, false, true, false, true, true};
+  std::vector<bool> values2 = {true, true, false, false, true, false};
+  std::vector<bool> values3 = {true, false, false, false, true, false};
   TestBinaryKernel(And, values1, values2, values3, values3);
 }
 
 TEST_F(TestBooleanKernel, Or) {
-  vector<bool> values1 = {true, false, true, false, true, true};
-  vector<bool> values2 = {true, true, false, false, true, false};
-  vector<bool> values3 = {true, true, true, false, true, true};
-  vector<bool> values3_nulls = {true, false, false, false, true, false};
+  std::vector<bool> values1 = {true, false, true, false, true, true};
+  std::vector<bool> values2 = {true, true, false, false, true, false};
+  std::vector<bool> values3 = {true, true, true, false, true, true};
+  std::vector<bool> values3_nulls = {true, false, false, false, true, false};
   TestBinaryKernel(Or, values1, values2, values3, values3_nulls);
 }
 
 TEST_F(TestBooleanKernel, Xor) {
-  vector<bool> values1 = {true, false, true, false, true, true};
-  vector<bool> values2 = {true, true, false, false, true, false};
-  vector<bool> values3 = {false, true, true, false, false, true};
-  vector<bool> values3_nulls = {true, false, false, false, true, false};
+  std::vector<bool> values1 = {true, false, true, false, true, true};
+  std::vector<bool> values2 = {true, true, false, false, true, false};
+  std::vector<bool> values3 = {false, true, true, false, false, true};
+  std::vector<bool> values3_nulls = {true, false, false, false, true, false};
   TestBinaryKernel(Xor, values1, values2, values3, values3_nulls);
 }
 

--- a/cpp/src/arrow/compute/kernels/cast-test.cc
+++ b/cpp/src/arrow/compute/kernels/cast-test.cc
@@ -46,9 +46,6 @@
 #include "arrow/compute/kernels/util-internal.h"
 #include "arrow/compute/test-util.h"
 
-using std::shared_ptr;
-using std::vector;
-
 namespace arrow {
 namespace compute {
 
@@ -64,17 +61,17 @@ static void AssertBufferSame(const Array& left, const Array& right, int buffer_i
 class TestCast : public ComputeFixture, public TestBase {
  public:
   void CheckPass(const Array& input, const Array& expected,
-                 const shared_ptr<DataType>& out_type, const CastOptions& options) {
-    shared_ptr<Array> result;
+                 const std::shared_ptr<DataType>& out_type, const CastOptions& options) {
+    std::shared_ptr<Array> result;
     ASSERT_OK(Cast(&ctx_, input, out_type, options, &result));
     ASSERT_ARRAYS_EQUAL(expected, *result);
   }
 
   template <typename InType, typename I_TYPE>
-  void CheckFails(const shared_ptr<DataType>& in_type, const vector<I_TYPE>& in_values,
-                  const vector<bool>& is_valid, const shared_ptr<DataType>& out_type,
-                  const CastOptions& options) {
-    shared_ptr<Array> input, result;
+  void CheckFails(const std::shared_ptr<DataType>& in_type,
+                  const std::vector<I_TYPE>& in_values, const std::vector<bool>& is_valid,
+                  const std::shared_ptr<DataType>& out_type, const CastOptions& options) {
+    std::shared_ptr<Array> input, result;
     if (is_valid.size() > 0) {
       ArrayFromVector<InType, I_TYPE>(in_type, is_valid, in_values, &input);
     } else {
@@ -83,8 +80,8 @@ class TestCast : public ComputeFixture, public TestBase {
     ASSERT_RAISES(Invalid, Cast(&ctx_, *input, out_type, options, &result));
   }
 
-  void CheckZeroCopy(const Array& input, const shared_ptr<DataType>& out_type) {
-    shared_ptr<Array> result;
+  void CheckZeroCopy(const Array& input, const std::shared_ptr<DataType>& out_type) {
+    std::shared_ptr<Array> result;
     ASSERT_OK(Cast(&ctx_, input, out_type, {}, &result));
     ASSERT_EQ(input.data()->buffers.size(), result->data()->buffers.size());
     for (size_t i = 0; i < input.data()->buffers.size(); ++i) {
@@ -93,11 +90,12 @@ class TestCast : public ComputeFixture, public TestBase {
   }
 
   template <typename InType, typename I_TYPE, typename OutType, typename O_TYPE>
-  void CheckCase(const shared_ptr<DataType>& in_type, const vector<I_TYPE>& in_values,
-                 const vector<bool>& is_valid, const shared_ptr<DataType>& out_type,
-                 const vector<O_TYPE>& out_values, const CastOptions& options) {
+  void CheckCase(const std::shared_ptr<DataType>& in_type,
+                 const std::vector<I_TYPE>& in_values, const std::vector<bool>& is_valid,
+                 const std::shared_ptr<DataType>& out_type,
+                 const std::vector<O_TYPE>& out_values, const CastOptions& options) {
     DCHECK_EQ(in_values.size(), out_values.size());
-    shared_ptr<Array> input, expected;
+    std::shared_ptr<Array> input, expected;
     if (is_valid.size() > 0) {
       DCHECK_EQ(is_valid.size(), out_values.size());
       ArrayFromVector<InType, I_TYPE>(in_type, is_valid, in_values, &input);
@@ -114,12 +112,12 @@ class TestCast : public ComputeFixture, public TestBase {
     }
   }
 
-  void CheckCaseJSON(const shared_ptr<DataType>& in_type,
-                     const shared_ptr<DataType>& out_type, const std::string& in_json,
-                     const std::string& expected_json,
+  void CheckCaseJSON(const std::shared_ptr<DataType>& in_type,
+                     const std::shared_ptr<DataType>& out_type,
+                     const std::string& in_json, const std::string& expected_json,
                      const CastOptions& options = CastOptions()) {
-    shared_ptr<Array> input = ArrayFromJSON(in_type, in_json);
-    shared_ptr<Array> expected = ArrayFromJSON(out_type, expected_json);
+    std::shared_ptr<Array> input = ArrayFromJSON(in_type, in_json);
+    std::shared_ptr<Array> expected = ArrayFromJSON(out_type, expected_json);
     DCHECK_EQ(input->length(), expected->length());
     CheckPass(*input, *expected, out_type, options);
 
@@ -131,8 +129,8 @@ class TestCast : public ComputeFixture, public TestBase {
 };
 
 TEST_F(TestCast, SameTypeZeroCopy) {
-  shared_ptr<Array> arr = ArrayFromJSON(int32(), "[0, null, 2, 3, 4]");
-  shared_ptr<Array> result;
+  std::shared_ptr<Array> arr = ArrayFromJSON(int32(), "[0, null, 2, 3, 4]");
+  std::shared_ptr<Array> result;
   ASSERT_OK(Cast(&this->ctx_, *arr, int32(), {}, &result));
 
   AssertBufferSame(*arr, *result, 0);
@@ -142,11 +140,11 @@ TEST_F(TestCast, SameTypeZeroCopy) {
 TEST_F(TestCast, FromBoolean) {
   CastOptions options;
 
-  vector<bool> is_valid(20, true);
+  std::vector<bool> is_valid(20, true);
   is_valid[3] = false;
 
-  vector<bool> v1(is_valid.size(), true);
-  vector<int32_t> e1(is_valid.size(), 1);
+  std::vector<bool> v1(is_valid.size(), true);
+  std::vector<int32_t> e1(is_valid.size(), 1);
   for (size_t i = 0; i < v1.size(); ++i) {
     if (i % 3 == 1) {
       v1[i] = false;
@@ -176,23 +174,23 @@ TEST_F(TestCast, ToIntUpcast) {
   CastOptions options;
   options.allow_int_overflow = false;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // int8 to int32
-  vector<int8_t> v1 = {0, 1, 127, -1, 0};
-  vector<int32_t> e1 = {0, 1, 127, -1, 0};
+  std::vector<int8_t> v1 = {0, 1, 127, -1, 0};
+  std::vector<int32_t> e1 = {0, 1, 127, -1, 0};
   CheckCase<Int8Type, int8_t, Int32Type, int32_t>(int8(), v1, is_valid, int32(), e1,
                                                   options);
 
   // bool to int8
-  vector<bool> v2 = {false, true, false, true, true};
-  vector<int8_t> e2 = {0, 1, 0, 1, 1};
+  std::vector<bool> v2 = {false, true, false, true, true};
+  std::vector<int8_t> e2 = {0, 1, 0, 1, 1};
   CheckCase<BooleanType, bool, Int8Type, int8_t>(boolean(), v2, is_valid, int8(), e2,
                                                  options);
 
   // uint8 to int16, no overflow/underrun
-  vector<uint8_t> v3 = {0, 100, 200, 255, 0};
-  vector<int16_t> e3 = {0, 100, 200, 255, 0};
+  std::vector<uint8_t> v3 = {0, 100, 200, 255, 0};
+  std::vector<int16_t> e3 = {0, 100, 200, 255, 0};
   CheckCase<UInt8Type, uint8_t, Int16Type, int16_t>(uint8(), v3, is_valid, int16(), e3,
                                                     options);
 }
@@ -201,12 +199,12 @@ TEST_F(TestCast, OverflowInNullSlot) {
   CastOptions options;
   options.allow_int_overflow = false;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
-  vector<int32_t> v11 = {0, 70000, 2000, 1000, 0};
-  vector<int16_t> e11 = {0, 0, 2000, 1000, 0};
+  std::vector<int32_t> v11 = {0, 70000, 2000, 1000, 0};
+  std::vector<int16_t> e11 = {0, 0, 2000, 1000, 0};
 
-  shared_ptr<Array> expected;
+  std::shared_ptr<Array> expected;
   ArrayFromVector<Int16Type, int16_t>(int16(), is_valid, e11, &expected);
 
   auto buf = Buffer::Wrap(v11.data(), v11.size());
@@ -219,37 +217,37 @@ TEST_F(TestCast, ToIntDowncastSafe) {
   CastOptions options;
   options.allow_int_overflow = false;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // int16 to uint8, no overflow/underrun
-  vector<int16_t> v1 = {0, 100, 200, 1, 2};
-  vector<uint8_t> e1 = {0, 100, 200, 1, 2};
+  std::vector<int16_t> v1 = {0, 100, 200, 1, 2};
+  std::vector<uint8_t> e1 = {0, 100, 200, 1, 2};
   CheckCase<Int16Type, int16_t, UInt8Type, uint8_t>(int16(), v1, is_valid, uint8(), e1,
                                                     options);
 
   // int16 to uint8, with overflow
-  vector<int16_t> v2 = {0, 100, 256, 0, 0};
+  std::vector<int16_t> v2 = {0, 100, 256, 0, 0};
   CheckFails<Int16Type>(int16(), v2, is_valid, uint8(), options);
 
   // underflow
-  vector<int16_t> v3 = {0, 100, -1, 0, 0};
+  std::vector<int16_t> v3 = {0, 100, -1, 0, 0};
   CheckFails<Int16Type>(int16(), v3, is_valid, uint8(), options);
 
   // int32 to int16, no overflow
-  vector<int32_t> v4 = {0, 1000, 2000, 1, 2};
-  vector<int16_t> e4 = {0, 1000, 2000, 1, 2};
+  std::vector<int32_t> v4 = {0, 1000, 2000, 1, 2};
+  std::vector<int16_t> e4 = {0, 1000, 2000, 1, 2};
   CheckCase<Int32Type, int32_t, Int16Type, int16_t>(int32(), v4, is_valid, int16(), e4,
                                                     options);
 
   // int32 to int16, overflow
-  vector<int32_t> v5 = {0, 1000, 2000, 70000, 0};
+  std::vector<int32_t> v5 = {0, 1000, 2000, 70000, 0};
   CheckFails<Int32Type>(int32(), v5, is_valid, int16(), options);
 
   // underflow
-  vector<int32_t> v6 = {0, 1000, 2000, -70000, 0};
+  std::vector<int32_t> v6 = {0, 1000, 2000, -70000, 0};
   CheckFails<Int32Type>(int32(), v6, is_valid, int16(), options);
 
-  vector<int32_t> v7 = {0, 1000, 2000, -70000, 0};
+  std::vector<int32_t> v7 = {0, 1000, 2000, -70000, 0};
   CheckFails<Int32Type>(int32(), v7, is_valid, uint8(), options);
 }
 
@@ -267,9 +265,9 @@ TEST_F(TestCast, IntegerSignedToUnsigned) {
   CastOptions options;
   options.allow_int_overflow = false;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
-  vector<int32_t> v1 = {INT32_MIN, 100, -1, UINT16_MAX, INT32_MAX};
+  std::vector<int32_t> v1 = {INT32_MIN, 100, -1, UINT16_MAX, INT32_MAX};
 
   // Same width
   CheckFails<Int32Type>(int32(), v1, is_valid, uint32(), options);
@@ -278,7 +276,7 @@ TEST_F(TestCast, IntegerSignedToUnsigned) {
   // Narrower
   CheckFails<Int32Type>(int32(), v1, is_valid, uint16(), options);
   // Fail because of overflow (instead of underflow).
-  vector<int32_t> over = {0, -11, 0, UINT16_MAX + 1, INT32_MAX};
+  std::vector<int32_t> over = {0, -11, 0, UINT16_MAX + 1, INT32_MAX};
   CheckFails<Int32Type>(int32(), over, is_valid, uint16(), options);
 
   options.allow_int_overflow = true;
@@ -298,10 +296,10 @@ TEST_F(TestCast, IntegerUnsignedToSigned) {
   CastOptions options;
   options.allow_int_overflow = false;
 
-  vector<bool> is_valid = {true, true, true};
+  std::vector<bool> is_valid = {true, true, true};
 
-  vector<uint32_t> v1 = {0, INT16_MAX + 1, UINT32_MAX};
-  vector<uint32_t> v2 = {0, INT16_MAX + 1, 2};
+  std::vector<uint32_t> v1 = {0, INT16_MAX + 1, UINT32_MAX};
+  std::vector<uint32_t> v2 = {0, INT16_MAX + 1, 2};
   // Same width
   CheckFails<UInt32Type>(uint32(), v1, is_valid, int32(), options);
   // Narrower
@@ -324,43 +322,43 @@ TEST_F(TestCast, ToIntDowncastUnsafe) {
   CastOptions options;
   options.allow_int_overflow = true;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // int16 to uint8, no overflow/underrun
-  vector<int16_t> v1 = {0, 100, 200, 1, 2};
-  vector<uint8_t> e1 = {0, 100, 200, 1, 2};
+  std::vector<int16_t> v1 = {0, 100, 200, 1, 2};
+  std::vector<uint8_t> e1 = {0, 100, 200, 1, 2};
   CheckCase<Int16Type, int16_t, UInt8Type, uint8_t>(int16(), v1, is_valid, uint8(), e1,
                                                     options);
 
   // int16 to uint8, with overflow
-  vector<int16_t> v2 = {0, 100, 256, 0, 0};
-  vector<uint8_t> e2 = {0, 100, 0, 0, 0};
+  std::vector<int16_t> v2 = {0, 100, 256, 0, 0};
+  std::vector<uint8_t> e2 = {0, 100, 0, 0, 0};
   CheckCase<Int16Type, int16_t, UInt8Type, uint8_t>(int16(), v2, is_valid, uint8(), e2,
                                                     options);
 
   // underflow
-  vector<int16_t> v3 = {0, 100, -1, 0, 0};
-  vector<uint8_t> e3 = {0, 100, 255, 0, 0};
+  std::vector<int16_t> v3 = {0, 100, -1, 0, 0};
+  std::vector<uint8_t> e3 = {0, 100, 255, 0, 0};
   CheckCase<Int16Type, int16_t, UInt8Type, uint8_t>(int16(), v3, is_valid, uint8(), e3,
                                                     options);
 
   // int32 to int16, no overflow
-  vector<int32_t> v4 = {0, 1000, 2000, 1, 2};
-  vector<int16_t> e4 = {0, 1000, 2000, 1, 2};
+  std::vector<int32_t> v4 = {0, 1000, 2000, 1, 2};
+  std::vector<int16_t> e4 = {0, 1000, 2000, 1, 2};
   CheckCase<Int32Type, int32_t, Int16Type, int16_t>(int32(), v4, is_valid, int16(), e4,
                                                     options);
 
   // int32 to int16, overflow
   // TODO(wesm): do we want to allow this? we could set to null
-  vector<int32_t> v5 = {0, 1000, 2000, 70000, 0};
-  vector<int16_t> e5 = {0, 1000, 2000, 4464, 0};
+  std::vector<int32_t> v5 = {0, 1000, 2000, 70000, 0};
+  std::vector<int16_t> e5 = {0, 1000, 2000, 4464, 0};
   CheckCase<Int32Type, int32_t, Int16Type, int16_t>(int32(), v5, is_valid, int16(), e5,
                                                     options);
 
   // underflow
   // TODO(wesm): do we want to allow this? we could set overflow to null
-  vector<int32_t> v6 = {0, 1000, 2000, -70000, 0};
-  vector<int16_t> e6 = {0, 1000, 2000, -4464, 0};
+  std::vector<int32_t> v6 = {0, 1000, 2000, -70000, 0};
+  std::vector<int16_t> e6 = {0, 1000, 2000, -4464, 0};
   CheckCase<Int32Type, int32_t, Int16Type, int16_t>(int32(), v6, is_valid, int16(), e6,
                                                     options);
 }
@@ -369,36 +367,36 @@ TEST_F(TestCast, FloatingPointToInt) {
   // which means allow_float_truncate == false
   auto options = CastOptions::Safe();
 
-  vector<bool> is_valid = {true, false, true, true, true};
-  vector<bool> all_valid = {true, true, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> all_valid = {true, true, true, true, true};
 
   // float32 to int32 no truncation
-  vector<float> v1 = {1.0, 0, 0.0, -1.0, 5.0};
-  vector<int32_t> e1 = {1, 0, 0, -1, 5};
+  std::vector<float> v1 = {1.0, 0, 0.0, -1.0, 5.0};
+  std::vector<int32_t> e1 = {1, 0, 0, -1, 5};
   CheckCase<FloatType, float, Int32Type, int32_t>(float32(), v1, is_valid, int32(), e1,
                                                   options);
   CheckCase<FloatType, float, Int32Type, int32_t>(float32(), v1, all_valid, int32(), e1,
                                                   options);
 
   // float64 to int32 no truncation
-  vector<double> v2 = {1.0, 0, 0.0, -1.0, 5.0};
-  vector<int32_t> e2 = {1, 0, 0, -1, 5};
+  std::vector<double> v2 = {1.0, 0, 0.0, -1.0, 5.0};
+  std::vector<int32_t> e2 = {1, 0, 0, -1, 5};
   CheckCase<DoubleType, double, Int32Type, int32_t>(float64(), v2, is_valid, int32(), e2,
                                                     options);
   CheckCase<DoubleType, double, Int32Type, int32_t>(float64(), v2, all_valid, int32(), e2,
                                                     options);
 
   // float64 to int64 no truncation
-  vector<double> v3 = {1.0, 0, 0.0, -1.0, 5.0};
-  vector<int64_t> e3 = {1, 0, 0, -1, 5};
+  std::vector<double> v3 = {1.0, 0, 0.0, -1.0, 5.0};
+  std::vector<int64_t> e3 = {1, 0, 0, -1, 5};
   CheckCase<DoubleType, double, Int64Type, int64_t>(float64(), v3, is_valid, int64(), e3,
                                                     options);
   CheckCase<DoubleType, double, Int64Type, int64_t>(float64(), v3, all_valid, int64(), e3,
                                                     options);
 
   // float64 to int32 truncate
-  vector<double> v4 = {1.5, 0, 0.5, -1.5, 5.5};
-  vector<int32_t> e4 = {1, 0, 0, -1, 5};
+  std::vector<double> v4 = {1.5, 0, 0.5, -1.5, 5.5};
+  std::vector<int32_t> e4 = {1, 0, 0, -1, 5};
 
   options.allow_float_truncate = false;
   CheckFails<DoubleType>(float64(), v4, is_valid, int32(), options);
@@ -411,8 +409,8 @@ TEST_F(TestCast, FloatingPointToInt) {
                                                     options);
 
   // float64 to int64 truncate
-  vector<double> v5 = {1.5, 0, 0.5, -1.5, 5.5};
-  vector<int64_t> e5 = {1, 0, 0, -1, 5};
+  std::vector<double> v5 = {1.5, 0, 0.5, -1.5, 5.5};
+  std::vector<int64_t> e5 = {1, 0, 0, -1, 5};
 
   options.allow_float_truncate = false;
   CheckFails<DoubleType>(float64(), v5, is_valid, int64(), options);
@@ -429,10 +427,10 @@ TEST_F(TestCast, FloatingPointToInt) {
 TEST_F(TestCast, IntToFloatingPoint) {
   auto options = CastOptions::Safe();
 
-  vector<bool> all_valid = {true, true, true, true, true};
-  vector<bool> all_invalid = {false, false, false, false, false};
+  std::vector<bool> all_valid = {true, true, true, true, true};
+  std::vector<bool> all_invalid = {false, false, false, false, false};
 
-  vector<int64_t> v1 = {INT64_MIN, INT64_MIN + 1, 0, INT64_MAX - 1, INT64_MAX};
+  std::vector<int64_t> v1 = {INT64_MIN, INT64_MIN + 1, 0, INT64_MAX - 1, INT64_MAX};
   CheckFails<Int64Type>(int64(), v1, all_valid, float32(), options);
 
   // While it's not safe to convert, all values are null.
@@ -447,43 +445,43 @@ TEST_F(TestCast, TimestampToTimestamp) {
 
   auto CheckTimestampCast =
       [this](const CastOptions& options, TimeUnit::type from_unit, TimeUnit::type to_unit,
-             const vector<int64_t>& from_values, const vector<int64_t>& to_values,
-             const vector<bool>& is_valid) {
+             const std::vector<int64_t>& from_values,
+             const std::vector<int64_t>& to_values, const std::vector<bool>& is_valid) {
         CheckCase<TimestampType, int64_t, TimestampType, int64_t>(
             timestamp(from_unit), from_values, is_valid, timestamp(to_unit), to_values,
             options);
       };
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // Multiply promotions
-  vector<int64_t> v1 = {0, 100, 200, 1, 2};
-  vector<int64_t> e1 = {0, 100000, 200000, 1000, 2000};
+  std::vector<int64_t> v1 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e1 = {0, 100000, 200000, 1000, 2000};
   CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::MILLI, v1, e1, is_valid);
 
-  vector<int64_t> v2 = {0, 100, 200, 1, 2};
-  vector<int64_t> e2 = {0, 100000000L, 200000000L, 1000000, 2000000};
+  std::vector<int64_t> v2 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e2 = {0, 100000000L, 200000000L, 1000000, 2000000};
   CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::MICRO, v2, e2, is_valid);
 
-  vector<int64_t> v3 = {0, 100, 200, 1, 2};
-  vector<int64_t> e3 = {0, 100000000000L, 200000000000L, 1000000000L, 2000000000L};
+  std::vector<int64_t> v3 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e3 = {0, 100000000000L, 200000000000L, 1000000000L, 2000000000L};
   CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::NANO, v3, e3, is_valid);
 
-  vector<int64_t> v4 = {0, 100, 200, 1, 2};
-  vector<int64_t> e4 = {0, 100000, 200000, 1000, 2000};
+  std::vector<int64_t> v4 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e4 = {0, 100000, 200000, 1000, 2000};
   CheckTimestampCast(options, TimeUnit::MILLI, TimeUnit::MICRO, v4, e4, is_valid);
 
-  vector<int64_t> v5 = {0, 100, 200, 1, 2};
-  vector<int64_t> e5 = {0, 100000000L, 200000000L, 1000000, 2000000};
+  std::vector<int64_t> v5 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e5 = {0, 100000000L, 200000000L, 1000000, 2000000};
   CheckTimestampCast(options, TimeUnit::MILLI, TimeUnit::NANO, v5, e5, is_valid);
 
-  vector<int64_t> v6 = {0, 100, 200, 1, 2};
-  vector<int64_t> e6 = {0, 100000, 200000, 1000, 2000};
+  std::vector<int64_t> v6 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e6 = {0, 100000, 200000, 1000, 2000};
   CheckTimestampCast(options, TimeUnit::MICRO, TimeUnit::NANO, v6, e6, is_valid);
 
   // Zero copy
-  vector<int64_t> v7 = {0, 70000, 2000, 1000, 0};
-  shared_ptr<Array> arr;
+  std::vector<int64_t> v7 = {0, 70000, 2000, 1000, 0};
+  std::shared_ptr<Array> arr;
   ArrayFromVector<TimestampType, int64_t>(timestamp(TimeUnit::SECOND), is_valid, v7,
                                           &arr);
   CheckZeroCopy(*arr, timestamp(TimeUnit::SECOND));
@@ -492,21 +490,21 @@ TEST_F(TestCast, TimestampToTimestamp) {
   CheckZeroCopy(*arr, int64());
 
   // Divide, truncate
-  vector<int64_t> v8 = {0, 100123, 200456, 1123, 2456};
-  vector<int64_t> e8 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> v8 = {0, 100123, 200456, 1123, 2456};
+  std::vector<int64_t> e8 = {0, 100, 200, 1, 2};
 
   options.allow_time_truncate = true;
   CheckTimestampCast(options, TimeUnit::MILLI, TimeUnit::SECOND, v8, e8, is_valid);
   CheckTimestampCast(options, TimeUnit::MICRO, TimeUnit::MILLI, v8, e8, is_valid);
   CheckTimestampCast(options, TimeUnit::NANO, TimeUnit::MICRO, v8, e8, is_valid);
 
-  vector<int64_t> v9 = {0, 100123000, 200456000, 1123000, 2456000};
-  vector<int64_t> e9 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> v9 = {0, 100123000, 200456000, 1123000, 2456000};
+  std::vector<int64_t> e9 = {0, 100, 200, 1, 2};
   CheckTimestampCast(options, TimeUnit::MICRO, TimeUnit::SECOND, v9, e9, is_valid);
   CheckTimestampCast(options, TimeUnit::NANO, TimeUnit::MILLI, v9, e9, is_valid);
 
-  vector<int64_t> v10 = {0, 100123000000L, 200456000000L, 1123000000L, 2456000000};
-  vector<int64_t> e10 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> v10 = {0, 100123000000L, 200456000000L, 1123000000L, 2456000000};
+  std::vector<int64_t> e10 = {0, 100, 200, 1, 2};
   CheckTimestampCast(options, TimeUnit::NANO, TimeUnit::SECOND, v10, e10, is_valid);
 
   // Disallow truncate, failures
@@ -528,14 +526,14 @@ TEST_F(TestCast, TimestampToTimestamp) {
 TEST_F(TestCast, TimestampToDate32_Date64) {
   CastOptions options;
 
-  vector<bool> is_valid = {true, true, false};
+  std::vector<bool> is_valid = {true, true, false};
 
   // 2000-01-01, 2000-01-02, null
-  vector<int64_t> v_nano = {946684800000000000, 946771200000000000, 0};
-  vector<int64_t> v_micro = {946684800000000, 946771200000000, 0};
-  vector<int64_t> v_milli = {946684800000, 946771200000, 0};
-  vector<int64_t> v_second = {946684800, 946771200, 0};
-  vector<int32_t> v_day = {10957, 10958, 0};
+  std::vector<int64_t> v_nano = {946684800000000000, 946771200000000000, 0};
+  std::vector<int64_t> v_micro = {946684800000000, 946771200000000, 0};
+  std::vector<int64_t> v_milli = {946684800000, 946771200000, 0};
+  std::vector<int64_t> v_second = {946684800, 946771200, 0};
+  std::vector<int32_t> v_day = {10957, 10958, 0};
 
   // Simple conversions
   CheckCase<TimestampType, int64_t, Date64Type, int64_t>(
@@ -557,10 +555,10 @@ TEST_F(TestCast, TimestampToDate32_Date64) {
       timestamp(TimeUnit::SECOND), v_second, is_valid, date32(), v_day, options);
 
   // Disallow truncate, failures
-  vector<int64_t> v_nano_fail = {946684800000000001, 946771200000000001, 0};
-  vector<int64_t> v_micro_fail = {946684800000001, 946771200000001, 0};
-  vector<int64_t> v_milli_fail = {946684800001, 946771200001, 0};
-  vector<int64_t> v_second_fail = {946684801, 946771201, 0};
+  std::vector<int64_t> v_nano_fail = {946684800000000001, 946771200000000001, 0};
+  std::vector<int64_t> v_micro_fail = {946684800000001, 946771200000001, 0};
+  std::vector<int64_t> v_milli_fail = {946684800001, 946771200001, 0};
+  std::vector<int64_t> v_second_fail = {946684801, 946771201, 0};
 
   options.allow_time_truncate = false;
   CheckFails<TimestampType>(timestamp(TimeUnit::NANO), v_nano_fail, is_valid, date64(),
@@ -582,7 +580,7 @@ TEST_F(TestCast, TimestampToDate32_Date64) {
                             date32(), options);
 
   // Make sure that nulls are excluded from the truncation checks
-  vector<int64_t> v_second_nofail = {946684800, 946771200, 1};
+  std::vector<int64_t> v_second_nofail = {946684800, 946771200, 1};
   CheckCase<TimestampType, int64_t, Date64Type, int64_t>(
       timestamp(TimeUnit::SECOND), v_second_nofail, is_valid, date64(), v_milli, options);
   CheckCase<TimestampType, int64_t, Date32Type, int32_t>(
@@ -592,49 +590,49 @@ TEST_F(TestCast, TimestampToDate32_Date64) {
 TEST_F(TestCast, TimeToCompatible) {
   CastOptions options;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // Multiply promotions
-  vector<int32_t> v1 = {0, 100, 200, 1, 2};
-  vector<int32_t> e1 = {0, 100000, 200000, 1000, 2000};
+  std::vector<int32_t> v1 = {0, 100, 200, 1, 2};
+  std::vector<int32_t> e1 = {0, 100000, 200000, 1000, 2000};
   CheckCase<Time32Type, int32_t, Time32Type, int32_t>(
       time32(TimeUnit::SECOND), v1, is_valid, time32(TimeUnit::MILLI), e1, options);
 
-  vector<int32_t> v2 = {0, 100, 200, 1, 2};
-  vector<int64_t> e2 = {0, 100000000L, 200000000L, 1000000, 2000000};
+  std::vector<int32_t> v2 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e2 = {0, 100000000L, 200000000L, 1000000, 2000000};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
       time32(TimeUnit::SECOND), v2, is_valid, time64(TimeUnit::MICRO), e2, options);
 
-  vector<int32_t> v3 = {0, 100, 200, 1, 2};
-  vector<int64_t> e3 = {0, 100000000000L, 200000000000L, 1000000000L, 2000000000L};
+  std::vector<int32_t> v3 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e3 = {0, 100000000000L, 200000000000L, 1000000000L, 2000000000L};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
       time32(TimeUnit::SECOND), v3, is_valid, time64(TimeUnit::NANO), e3, options);
 
-  vector<int32_t> v4 = {0, 100, 200, 1, 2};
-  vector<int64_t> e4 = {0, 100000, 200000, 1000, 2000};
+  std::vector<int32_t> v4 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e4 = {0, 100000, 200000, 1000, 2000};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
       time32(TimeUnit::MILLI), v4, is_valid, time64(TimeUnit::MICRO), e4, options);
 
-  vector<int32_t> v5 = {0, 100, 200, 1, 2};
-  vector<int64_t> e5 = {0, 100000000L, 200000000L, 1000000, 2000000};
+  std::vector<int32_t> v5 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e5 = {0, 100000000L, 200000000L, 1000000, 2000000};
   CheckCase<Time32Type, int32_t, Time64Type, int64_t>(
       time32(TimeUnit::MILLI), v5, is_valid, time64(TimeUnit::NANO), e5, options);
 
-  vector<int64_t> v6 = {0, 100, 200, 1, 2};
-  vector<int64_t> e6 = {0, 100000, 200000, 1000, 2000};
+  std::vector<int64_t> v6 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e6 = {0, 100000, 200000, 1000, 2000};
   CheckCase<Time64Type, int64_t, Time64Type, int64_t>(
       time64(TimeUnit::MICRO), v6, is_valid, time64(TimeUnit::NANO), e6, options);
 
   // Zero copy
-  vector<int64_t> v7 = {0, 70000, 2000, 1000, 0};
-  shared_ptr<Array> arr;
+  std::vector<int64_t> v7 = {0, 70000, 2000, 1000, 0};
+  std::shared_ptr<Array> arr;
   ArrayFromVector<Time64Type, int64_t>(time64(TimeUnit::MICRO), is_valid, v7, &arr);
   CheckZeroCopy(*arr, time64(TimeUnit::MICRO));
 
   // ARROW-1773: cast to int64
   CheckZeroCopy(*arr, int64());
 
-  vector<int32_t> v7_2 = {0, 70000, 2000, 1000, 0};
+  std::vector<int32_t> v7_2 = {0, 70000, 2000, 1000, 0};
   ArrayFromVector<Time32Type, int32_t>(time32(TimeUnit::SECOND), is_valid, v7_2, &arr);
   CheckZeroCopy(*arr, time32(TimeUnit::SECOND));
 
@@ -642,8 +640,8 @@ TEST_F(TestCast, TimeToCompatible) {
   CheckZeroCopy(*arr, int32());
 
   // Divide, truncate
-  vector<int32_t> v8 = {0, 100123, 200456, 1123, 2456};
-  vector<int32_t> e8 = {0, 100, 200, 1, 2};
+  std::vector<int32_t> v8 = {0, 100123, 200456, 1123, 2456};
+  std::vector<int32_t> e8 = {0, 100, 200, 1, 2};
 
   options.allow_time_truncate = true;
   CheckCase<Time32Type, int32_t, Time32Type, int32_t>(
@@ -653,15 +651,15 @@ TEST_F(TestCast, TimeToCompatible) {
   CheckCase<Time64Type, int32_t, Time64Type, int32_t>(
       time64(TimeUnit::NANO), v8, is_valid, time64(TimeUnit::MICRO), e8, options);
 
-  vector<int64_t> v9 = {0, 100123000, 200456000, 1123000, 2456000};
-  vector<int32_t> e9 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> v9 = {0, 100123000, 200456000, 1123000, 2456000};
+  std::vector<int32_t> e9 = {0, 100, 200, 1, 2};
   CheckCase<Time64Type, int64_t, Time32Type, int32_t>(
       time64(TimeUnit::MICRO), v9, is_valid, time32(TimeUnit::SECOND), e9, options);
   CheckCase<Time64Type, int64_t, Time32Type, int32_t>(
       time64(TimeUnit::NANO), v9, is_valid, time32(TimeUnit::MILLI), e9, options);
 
-  vector<int64_t> v10 = {0, 100123000000L, 200456000000L, 1123000000L, 2456000000};
-  vector<int32_t> e10 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> v10 = {0, 100123000000L, 200456000000L, 1123000000L, 2456000000};
+  std::vector<int32_t> e10 = {0, 100, 200, 1, 2};
   CheckCase<Time64Type, int64_t, Time32Type, int32_t>(
       time64(TimeUnit::NANO), v10, is_valid, time32(TimeUnit::SECOND), e10, options);
 
@@ -685,20 +683,20 @@ TEST_F(TestCast, TimeToCompatible) {
 TEST_F(TestCast, DateToCompatible) {
   CastOptions options;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   constexpr int64_t F = 86400000;
 
   // Multiply promotion
-  vector<int32_t> v1 = {0, 100, 200, 1, 2};
-  vector<int64_t> e1 = {0, 100 * F, 200 * F, F, 2 * F};
+  std::vector<int32_t> v1 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> e1 = {0, 100 * F, 200 * F, F, 2 * F};
   CheckCase<Date32Type, int32_t, Date64Type, int64_t>(date32(), v1, is_valid, date64(),
                                                       e1, options);
 
   // Zero copy
-  vector<int32_t> v2 = {0, 70000, 2000, 1000, 0};
-  vector<int64_t> v3 = {0, 70000, 2000, 1000, 0};
-  shared_ptr<Array> arr;
+  std::vector<int32_t> v2 = {0, 70000, 2000, 1000, 0};
+  std::vector<int64_t> v3 = {0, 70000, 2000, 1000, 0};
+  std::shared_ptr<Array> arr;
   ArrayFromVector<Date32Type, int32_t>(date32(), is_valid, v2, &arr);
   CheckZeroCopy(*arr, date32());
 
@@ -712,8 +710,8 @@ TEST_F(TestCast, DateToCompatible) {
   CheckZeroCopy(*arr, int64());
 
   // Divide, truncate
-  vector<int64_t> v8 = {0, 100 * F + 123, 200 * F + 456, F + 123, 2 * F + 456};
-  vector<int32_t> e8 = {0, 100, 200, 1, 2};
+  std::vector<int64_t> v8 = {0, 100 * F + 123, 200 * F + 456, F + 123, 2 * F + 456};
+  std::vector<int32_t> e8 = {0, 100, 200, 1, 2};
 
   options.allow_time_truncate = true;
   CheckCase<Date64Type, int64_t, Date32Type, int32_t>(date64(), v8, is_valid, date32(),
@@ -726,30 +724,30 @@ TEST_F(TestCast, DateToCompatible) {
 
 TEST_F(TestCast, ToDouble) {
   CastOptions options;
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // int16 to double
-  vector<int16_t> v1 = {0, 100, 200, 1, 2};
-  vector<double> e1 = {0, 100, 200, 1, 2};
+  std::vector<int16_t> v1 = {0, 100, 200, 1, 2};
+  std::vector<double> e1 = {0, 100, 200, 1, 2};
   CheckCase<Int16Type, int16_t, DoubleType, double>(int16(), v1, is_valid, float64(), e1,
                                                     options);
 
   // float to double
-  vector<float> v2 = {0, 100, 200, 1, 2};
-  vector<double> e2 = {0, 100, 200, 1, 2};
+  std::vector<float> v2 = {0, 100, 200, 1, 2};
+  std::vector<double> e2 = {0, 100, 200, 1, 2};
   CheckCase<FloatType, float, DoubleType, double>(float32(), v2, is_valid, float64(), e2,
                                                   options);
 
   // bool to double
-  vector<bool> v3 = {true, true, false, false, true};
-  vector<double> e3 = {1, 1, 0, 0, 1};
+  std::vector<bool> v3 = {true, true, false, false, true};
+  std::vector<double> e3 = {1, 1, 0, 0, 1};
   CheckCase<BooleanType, bool, DoubleType, double>(boolean(), v3, is_valid, float64(), e3,
                                                    options);
 }
 
 TEST_F(TestCast, ChunkedArray) {
-  vector<int16_t> values1 = {0, 1, 2};
-  vector<int16_t> values2 = {3, 4, 5};
+  std::vector<int16_t> values1 = {0, 1, 2};
+  std::vector<int16_t> values2 = {3, 4, 5};
 
   auto type = int16();
   auto out_type = int64();
@@ -768,8 +766,8 @@ TEST_F(TestCast, ChunkedArray) {
 
   auto out_carr = out.chunked_array();
 
-  vector<int64_t> ex_values1 = {0, 1, 2};
-  vector<int64_t> ex_values2 = {3, 4, 5};
+  std::vector<int64_t> ex_values1 = {0, 1, 2};
+  std::vector<int64_t> ex_values2 = {3, 4, 5};
   auto a3 = _MakeArray<Int64Type, int64_t>(out_type, ex_values1, {});
   auto a4 = _MakeArray<Int64Type, int64_t>(out_type, ex_values2, {});
 
@@ -780,27 +778,27 @@ TEST_F(TestCast, ChunkedArray) {
 }
 
 TEST_F(TestCast, UnsupportedTarget) {
-  vector<bool> is_valid = {true, false, true, true, true};
-  vector<int32_t> v1 = {0, 1, 2, 3, 4};
+  std::vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<int32_t> v1 = {0, 1, 2, 3, 4};
 
-  shared_ptr<Array> arr;
+  std::shared_ptr<Array> arr;
   ArrayFromVector<Int32Type, int32_t>(int32(), is_valid, v1, &arr);
 
-  shared_ptr<Array> result;
+  std::shared_ptr<Array> result;
   ASSERT_RAISES(NotImplemented, Cast(&this->ctx_, *arr, utf8(), {}, &result));
 }
 
 TEST_F(TestCast, DateTimeZeroCopy) {
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
-  vector<int32_t> v1 = {0, 70000, 2000, 1000, 0};
-  shared_ptr<Array> arr;
+  std::vector<int32_t> v1 = {0, 70000, 2000, 1000, 0};
+  std::shared_ptr<Array> arr;
   ArrayFromVector<Int32Type, int32_t>(int32(), is_valid, v1, &arr);
 
   CheckZeroCopy(*arr, time32(TimeUnit::SECOND));
   CheckZeroCopy(*arr, date32());
 
-  vector<int64_t> v2 = {0, 70000, 2000, 1000, 0};
+  std::vector<int64_t> v2 = {0, 70000, 2000, 1000, 0};
   ArrayFromVector<Int64Type, int64_t>(int64(), is_valid, v2, &arr);
 
   CheckZeroCopy(*arr, time64(TimeUnit::MICRO));
@@ -814,7 +812,7 @@ TEST_F(TestCast, FromNull) {
 
   NullArray arr(length);
 
-  shared_ptr<Array> result;
+  std::shared_ptr<Array> result;
   ASSERT_OK(Cast(&ctx_, arr, int32(), {}, &result));
 
   ASSERT_EQ(length, result->length());
@@ -828,13 +826,13 @@ TEST_F(TestCast, PreallocatedMemory) {
   CastOptions options;
   options.allow_int_overflow = false;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   const int64_t length = 5;
 
-  shared_ptr<Array> arr;
-  vector<int32_t> v1 = {0, 70000, 2000, 1000, 0};
-  vector<int64_t> e1 = {0, 70000, 2000, 1000, 0};
+  std::shared_ptr<Array> arr;
+  std::vector<int32_t> v1 = {0, 70000, 2000, 1000, 0};
+  std::vector<int64_t> e1 = {0, 70000, 2000, 1000, 0};
   ArrayFromVector<Int32Type, int32_t>(int32(), is_valid, v1, &arr);
 
   auto out_type = int64();
@@ -844,7 +842,7 @@ TEST_F(TestCast, PreallocatedMemory) {
 
   auto out_data = ArrayData::Make(out_type, length);
 
-  shared_ptr<Buffer> out_values;
+  std::shared_ptr<Buffer> out_values;
   ASSERT_OK(this->ctx_.Allocate(length * sizeof(int64_t), &out_values));
 
   out_data->buffers.push_back(arr->data()->buffers[0]);
@@ -856,8 +854,8 @@ TEST_F(TestCast, PreallocatedMemory) {
   // Buffer address unchanged
   ASSERT_EQ(out_values.get(), out_data->buffers[1].get());
 
-  shared_ptr<Array> result = MakeArray(out_data);
-  shared_ptr<Array> expected;
+  std::shared_ptr<Array> result = MakeArray(out_data);
+  std::shared_ptr<Array> expected;
   ArrayFromVector<Int64Type, int64_t>(int64(), is_valid, e1, &expected);
 
   ASSERT_ARRAYS_EQUAL(*expected, *result);
@@ -865,20 +863,20 @@ TEST_F(TestCast, PreallocatedMemory) {
 
 template <typename InType, typename InT, typename OutType, typename OutT>
 void CheckOffsetOutputCase(FunctionContext* ctx, const std::shared_ptr<DataType>& in_type,
-                           const vector<InT>& in_values,
+                           const std::vector<InT>& in_values,
                            const std::shared_ptr<DataType>& out_type,
-                           const vector<OutT>& out_values) {
+                           const std::vector<OutT>& out_values) {
   using OutTraits = TypeTraits<OutType>;
 
   CastOptions options;
 
   const int64_t length = static_cast<int64_t>(in_values.size());
 
-  shared_ptr<Array> arr, expected;
+  std::shared_ptr<Array> arr, expected;
   ArrayFromVector<InType, InT>(in_type, in_values, &arr);
   ArrayFromVector<OutType, OutT>(out_type, out_values, &expected);
 
-  shared_ptr<Buffer> out_buffer;
+  std::shared_ptr<Buffer> out_buffer;
   ASSERT_OK(ctx->Allocate(OutTraits::bytes_required(length), &out_buffer));
 
   std::unique_ptr<UnaryKernel> kernel;
@@ -897,28 +895,28 @@ void CheckOffsetOutputCase(FunctionContext* ctx, const std::shared_ptr<DataType>
   ASSERT_OK(kernel->Call(ctx, arr->Slice(0, first_half), &out_first));
   ASSERT_OK(kernel->Call(ctx, arr->Slice(first_half), &out_second));
 
-  shared_ptr<Array> result = MakeArray(out_data);
+  std::shared_ptr<Array> result = MakeArray(out_data);
 
   ASSERT_ARRAYS_EQUAL(*expected, *result);
 }
 
 TEST_F(TestCast, OffsetOutputBuffer) {
   // ARROW-1735
-  vector<int32_t> v1 = {0, 10000, 2000, 1000, 0};
-  vector<int64_t> e1 = {0, 10000, 2000, 1000, 0};
+  std::vector<int32_t> v1 = {0, 10000, 2000, 1000, 0};
+  std::vector<int64_t> e1 = {0, 10000, 2000, 1000, 0};
 
   auto in_type = int32();
   auto out_type = int64();
   CheckOffsetOutputCase<Int32Type, int32_t, Int64Type, int64_t>(&this->ctx_, in_type, v1,
                                                                 out_type, e1);
 
-  vector<bool> e2 = {false, true, true, true, false};
+  std::vector<bool> e2 = {false, true, true, true, false};
 
   out_type = boolean();
   CheckOffsetOutputCase<Int32Type, int32_t, BooleanType, bool>(&this->ctx_, in_type, v1,
                                                                boolean(), e2);
 
-  vector<int16_t> e3 = {0, 10000, 2000, 1000, 0};
+  std::vector<int16_t> e3 = {0, 10000, 2000, 1000, 0};
   CheckOffsetOutputCase<Int32Type, int32_t, Int16Type, int16_t>(&this->ctx_, in_type, v1,
                                                                 int16(), e3);
 }
@@ -926,11 +924,11 @@ TEST_F(TestCast, OffsetOutputBuffer) {
 TEST_F(TestCast, StringToBoolean) {
   CastOptions options;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
-  vector<std::string> v1 = {"False", "true", "true", "True", "false"};
-  vector<std::string> v2 = {"0", "1", "1", "1", "0"};
-  vector<bool> e = {false, true, true, true, false};
+  std::vector<std::string> v1 = {"False", "true", "true", "True", "false"};
+  std::vector<std::string> v2 = {"0", "1", "1", "1", "0"};
+  std::vector<bool> e = {false, true, true, true, false};
   CheckCase<StringType, std::string, BooleanType, bool>(utf8(), v1, is_valid, boolean(),
                                                         e, options);
   CheckCase<StringType, std::string, BooleanType, bool>(utf8(), v2, is_valid, boolean(),
@@ -940,7 +938,7 @@ TEST_F(TestCast, StringToBoolean) {
 TEST_F(TestCast, StringToBooleanErrors) {
   CastOptions options;
 
-  vector<bool> is_valid = {true};
+  std::vector<bool> is_valid = {true};
 
   CheckFails<StringType, std::string>(utf8(), {"false "}, is_valid, boolean(), options);
   CheckFails<StringType, std::string>(utf8(), {"T"}, is_valid, boolean(), options);
@@ -949,14 +947,14 @@ TEST_F(TestCast, StringToBooleanErrors) {
 TEST_F(TestCast, StringToNumber) {
   CastOptions options;
 
-  vector<bool> is_valid = {true, false, true, true, true};
+  std::vector<bool> is_valid = {true, false, true, true, true};
 
   // string to int
-  vector<std::string> v_int = {"0", "1", "127", "-1", "0"};
-  vector<int8_t> e_int8 = {0, 1, 127, -1, 0};
-  vector<int16_t> e_int16 = {0, 1, 127, -1, 0};
-  vector<int32_t> e_int32 = {0, 1, 127, -1, 0};
-  vector<int64_t> e_int64 = {0, 1, 127, -1, 0};
+  std::vector<std::string> v_int = {"0", "1", "127", "-1", "0"};
+  std::vector<int8_t> e_int8 = {0, 1, 127, -1, 0};
+  std::vector<int16_t> e_int16 = {0, 1, 127, -1, 0};
+  std::vector<int32_t> e_int32 = {0, 1, 127, -1, 0};
+  std::vector<int64_t> e_int64 = {0, 1, 127, -1, 0};
   CheckCase<StringType, std::string, Int8Type, int8_t>(utf8(), v_int, is_valid, int8(),
                                                        e_int8, options);
   CheckCase<StringType, std::string, Int16Type, int16_t>(utf8(), v_int, is_valid, int16(),
@@ -976,11 +974,11 @@ TEST_F(TestCast, StringToNumber) {
                                                          e_int64, options);
 
   // string to uint
-  vector<std::string> v_uint = {"0", "1", "127", "255", "0"};
-  vector<uint8_t> e_uint8 = {0, 1, 127, 255, 0};
-  vector<uint16_t> e_uint16 = {0, 1, 127, 255, 0};
-  vector<uint32_t> e_uint32 = {0, 1, 127, 255, 0};
-  vector<uint64_t> e_uint64 = {0, 1, 127, 255, 0};
+  std::vector<std::string> v_uint = {"0", "1", "127", "255", "0"};
+  std::vector<uint8_t> e_uint8 = {0, 1, 127, 255, 0};
+  std::vector<uint16_t> e_uint16 = {0, 1, 127, 255, 0};
+  std::vector<uint32_t> e_uint32 = {0, 1, 127, 255, 0};
+  std::vector<uint64_t> e_uint64 = {0, 1, 127, 255, 0};
   CheckCase<StringType, std::string, UInt8Type, uint8_t>(utf8(), v_uint, is_valid,
                                                          uint8(), e_uint8, options);
   CheckCase<StringType, std::string, UInt16Type, uint16_t>(utf8(), v_uint, is_valid,
@@ -1000,9 +998,9 @@ TEST_F(TestCast, StringToNumber) {
                                                            uint64(), e_uint64, options);
 
   // string to float
-  vector<std::string> v_float = {"0.1", "1.2", "127.3", "200.4", "0.5"};
-  vector<float> e_float = {0.1f, 1.2f, 127.3f, 200.4f, 0.5f};
-  vector<double> e_double = {0.1, 1.2, 127.3, 200.4, 0.5};
+  std::vector<std::string> v_float = {"0.1", "1.2", "127.3", "200.4", "0.5"};
+  std::vector<float> e_float = {0.1f, 1.2f, 127.3f, 200.4f, 0.5f};
+  std::vector<double> e_double = {0.1, 1.2, 127.3, 200.4, 0.5};
   CheckCase<StringType, std::string, FloatType, float>(utf8(), v_float, is_valid,
                                                        float32(), e_float, options);
   CheckCase<StringType, std::string, DoubleType, double>(utf8(), v_float, is_valid,
@@ -1026,7 +1024,7 @@ TEST_F(TestCast, StringToNumber) {
 TEST_F(TestCast, StringToNumberErrors) {
   CastOptions options;
 
-  vector<bool> is_valid = {true};
+  std::vector<bool> is_valid = {true};
 
   CheckFails<StringType, std::string>(utf8(), {"z"}, is_valid, int8(), options);
   CheckFails<StringType, std::string>(utf8(), {"12 z"}, is_valid, int8(), options);
@@ -1043,11 +1041,11 @@ TEST_F(TestCast, StringToNumberErrors) {
 TEST_F(TestCast, StringToTimestamp) {
   CastOptions options;
 
-  vector<bool> is_valid = {true, false, true};
-  vector<std::string> strings = {"1970-01-01", "xxx", "2000-02-29"};
+  std::vector<bool> is_valid = {true, false, true};
+  std::vector<std::string> strings = {"1970-01-01", "xxx", "2000-02-29"};
 
   auto type = timestamp(TimeUnit::SECOND);
-  vector<int64_t> e = {0, 0, 951782400};
+  std::vector<int64_t> e = {0, 0, 951782400};
   CheckCase<StringType, std::string, TimestampType, int64_t>(utf8(), strings, is_valid,
                                                              type, e, options);
 
@@ -1062,7 +1060,7 @@ TEST_F(TestCast, StringToTimestamp) {
 TEST_F(TestCast, StringToTimestampErrors) {
   CastOptions options;
 
-  vector<bool> is_valid = {true};
+  std::vector<bool> is_valid = {true};
 
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
     auto type = timestamp(unit);
@@ -1077,9 +1075,9 @@ TEST_F(TestCast, BinaryToString) {
   CastOptions options;
 
   // All valid except the last one
-  vector<bool> all = {1, 1, 1, 1, 1};
-  vector<bool> valid = {1, 1, 1, 1, 0};
-  vector<std::string> strings = {"Hi", "olá mundo", "你好世界", "", kInvalidUtf8};
+  std::vector<bool> all = {1, 1, 1, 1, 1};
+  std::vector<bool> valid = {1, 1, 1, 1, 0};
+  std::vector<std::string> strings = {"Hi", "olá mundo", "你好世界", "", kInvalidUtf8};
 
   std::shared_ptr<Array> array;
 
@@ -1108,7 +1106,7 @@ TYPED_TEST_CASE(TestDictionaryCast, TestTypes);
 
 TYPED_TEST(TestDictionaryCast, Basic) {
   CastOptions options;
-  shared_ptr<Array> plain_array =
+  std::shared_ptr<Array> plain_array =
       TestBase::MakeRandomArray<typename TypeTraits<TypeParam>::ArrayType>(10, 2);
 
   Datum out;
@@ -1134,7 +1132,7 @@ TEST_F(TestCast, DictToNumericNoNulls) {
 }
 
 TEST_F(TestCast, DictToNonDictNoNulls) {
-  vector<std::string> dict_values = {"foo", "bar", "baz"};
+  std::vector<std::string> dict_values = {"foo", "bar", "baz"};
   auto ex_dict = _MakeArray<StringType, std::string>(utf8(), dict_values, {});
   auto dict_type = dictionary(int32(), ex_dict);
 
@@ -1167,10 +1165,10 @@ TEST_F(TestCast, DictToNonDictNoNulls) {
 
 /*TYPED_TEST(TestDictionaryCast, Reverse) {
   CastOptions options;
-  shared_ptr<Array> plain_array =
+  std::shared_ptr<Array> plain_array =
       TestBase::MakeRandomArray<typename TypeTraits<TypeParam>::ArrayType>(10, 2);
 
-  shared_ptr<Array> dict_array;
+  std::shared_ptr<Array> dict_array;
   ASSERT_OK(EncodeArrayToDictionary(*plain_array, this->pool_, &dict_array));
 
   this->CheckPass(*plain_array, *dict_array, dict_array->type(), options);
@@ -1180,11 +1178,11 @@ TEST_F(TestCast, ListToList) {
   CastOptions options;
   std::shared_ptr<Array> offsets;
 
-  vector<int32_t> offsets_values = {0, 1, 2, 5, 7, 7, 8, 10};
+  std::vector<int32_t> offsets_values = {0, 1, 2, 5, 7, 7, 8, 10};
   std::vector<bool> offsets_is_valid = {true, true, true, true, false, true, true, true};
   ArrayFromVector<Int32Type, int32_t>(offsets_is_valid, offsets_values, &offsets);
 
-  shared_ptr<Array> int32_plain_array =
+  std::shared_ptr<Array> int32_plain_array =
       TestBase::MakeRandomArray<typename TypeTraits<Int32Type>::ArrayType>(10, 2);
   std::shared_ptr<Array> int32_list_array;
   ASSERT_OK(

--- a/cpp/src/arrow/dbi/hiveserver2/sample-usage.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/sample-usage.cc
@@ -25,8 +25,6 @@
 namespace hs2 = arrow::hiveserver2;
 
 using arrow::Status;
-using std::string;
-using std::unique_ptr;
 
 using hs2::Operation;
 using hs2::Service;
@@ -43,11 +41,11 @@ using hs2::Session;
 
 int main(int argc, char** argv) {
   // Connect to the server.
-  string host = "localhost";
+  std::string host = "localhost";
   int port = 21050;
   int conn_timeout = 0;
   hs2::ProtocolVersion protocol = hs2::ProtocolVersion::PROTOCOL_V7;
-  unique_ptr<Service> service;
+  std::unique_ptr<Service> service;
   Status status = Service::Connect(host, port, conn_timeout, protocol, &service);
   if (!status.ok()) {
     std::cout << "Failed to connect to service: " << status.ToString();
@@ -56,9 +54,9 @@ int main(int argc, char** argv) {
   }
 
   // Open a session.
-  string user = "user";
+  std::string user = "user";
   hs2::HS2ClientConfig config;
-  unique_ptr<Session> session;
+  std::unique_ptr<Session> session;
   status = service->OpenSession(user, config, &session);
   if (!status.ok()) {
     std::cout << "Failed to open session: " << status.ToString();
@@ -68,8 +66,8 @@ int main(int argc, char** argv) {
   }
 
   // Execute a statement.
-  string statement = "SELECT int_col, string_col FROM test order by int_col";
-  unique_ptr<hs2::Operation> execute_op;
+  std::string statement = "SELECT int_col, string_col FROM test order by int_col";
+  std::unique_ptr<hs2::Operation> execute_op;
   status = session->ExecuteStatement(statement, &execute_op);
   if (!status.ok()) {
     std::cout << "Failed to execute select: " << status.ToString();
@@ -79,7 +77,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  unique_ptr<hs2::ColumnarRowSet> execute_results;
+  std::unique_ptr<hs2::ColumnarRowSet> execute_results;
   bool has_more_rows = true;
   int64_t total_retrieved = 0;
   std::cout << "Contents of test:\n";
@@ -93,8 +91,8 @@ int main(int argc, char** argv) {
       return 1;
     }
 
-    unique_ptr<hs2::Int32Column> int_col = execute_results->GetInt32Col(0);
-    unique_ptr<hs2::StringColumn> string_col = execute_results->GetStringCol(1);
+    std::unique_ptr<hs2::Int32Column> int_col = execute_results->GetInt32Col(0);
+    std::unique_ptr<hs2::StringColumn> string_col = execute_results->GetStringCol(1);
     assert(int_col->length() == string_col->length());
     total_retrieved += int_col->length();
     for (int64_t i = 0; i < int_col->length(); ++i) {
@@ -117,7 +115,7 @@ int main(int argc, char** argv) {
   std::cout << "\n";
   ABORT_NOT_OK(execute_op->Close());
 
-  unique_ptr<Operation> show_tables_op;
+  std::unique_ptr<Operation> show_tables_op;
   status = session->ExecuteStatement("show tables", &show_tables_op);
   if (!status.ok()) {
     std::cout << "Failed to execute GetTables: " << status.ToString();

--- a/cpp/src/arrow/dbi/hiveserver2/service.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/service.cc
@@ -39,8 +39,6 @@ using apache::thrift::protocol::TProtocol;
 using apache::thrift::transport::TBufferedTransport;
 using apache::thrift::transport::TSocket;
 using apache::thrift::transport::TTransport;
-using std::string;
-using std::unique_ptr;
 
 namespace arrow {
 namespace hiveserver2 {
@@ -52,8 +50,9 @@ struct Service::ServiceImpl {
   std::shared_ptr<TProtocol> protocol;
 };
 
-Status Service::Connect(const string& host, int port, int conn_timeout,
-                        ProtocolVersion protocol_version, unique_ptr<Service>* service) {
+Status Service::Connect(const std::string& host, int port, int conn_timeout,
+                        ProtocolVersion protocol_version,
+                        std::unique_ptr<Service>* service) {
   service->reset(new Service(host, port, conn_timeout, protocol_version));
   return (*service)->Open();
 }
@@ -74,13 +73,13 @@ void Service::SetRecvTimeout(int timeout) { impl_->socket->setRecvTimeout(timeou
 
 void Service::SetSendTimeout(int timeout) { impl_->socket->setSendTimeout(timeout); }
 
-Status Service::OpenSession(const string& user, const HS2ClientConfig& config,
-                            unique_ptr<Session>* session) const {
+Status Service::OpenSession(const std::string& user, const HS2ClientConfig& config,
+                            std::unique_ptr<Session>* session) const {
   session->reset(new Session(rpc_));
   return (*session)->Open(config, user);
 }
 
-Service::Service(const string& host, int port, int conn_timeout,
+Service::Service(const std::string& host, int port, int conn_timeout,
                  ProtocolVersion protocol_version)
     : host_(host),
       port_(port),

--- a/cpp/src/arrow/dbi/hiveserver2/session.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/session.cc
@@ -25,8 +25,6 @@
 
 namespace hs2 = apache::hive::service::cli::thrift;
 using apache::thrift::TException;
-using std::string;
-using std::unique_ptr;
 
 namespace arrow {
 namespace hiveserver2 {
@@ -53,7 +51,7 @@ Status Session::Close() {
   return TStatusToStatus(resp.status);
 }
 
-Status Session::Open(const HS2ClientConfig& config, const string& user) {
+Status Session::Open(const HS2ClientConfig& config, const std::string& user) {
   hs2::TOpenSessionReq req;
   req.__set_configuration(config.GetConfig());
   req.__set_username(user);
@@ -71,7 +69,7 @@ class ExecuteStatementOperation : public Operation {
   explicit ExecuteStatementOperation(const std::shared_ptr<ThriftRPC>& rpc)
       : Operation(rpc) {}
 
-  Status Open(hs2::TSessionHandle session_handle, const string& statement,
+  Status Open(hs2::TSessionHandle session_handle, const std::string& statement,
               const HS2ClientConfig& config) {
     hs2::TExecuteStatementReq req;
     req.__set_sessionHandle(session_handle);
@@ -88,14 +86,14 @@ class ExecuteStatementOperation : public Operation {
   }
 };
 
-Status Session::ExecuteStatement(const string& statement,
-                                 unique_ptr<Operation>* operation) const {
+Status Session::ExecuteStatement(const std::string& statement,
+                                 std::unique_ptr<Operation>* operation) const {
   return ExecuteStatement(statement, HS2ClientConfig(), operation);
 }
 
-Status Session::ExecuteStatement(const string& statement,
+Status Session::ExecuteStatement(const std::string& statement,
                                  const HS2ClientConfig& conf_overlay,
-                                 unique_ptr<Operation>* operation) const {
+                                 std::unique_ptr<Operation>* operation) const {
   ExecuteStatementOperation* op = new ExecuteStatementOperation(rpc_);
   operation->reset(op);
   return op->Open(impl_->handle, statement, conf_overlay);

--- a/cpp/src/arrow/dbi/hiveserver2/util.cc
+++ b/cpp/src/arrow/dbi/hiveserver2/util.cc
@@ -31,7 +31,6 @@
 #include "arrow/status.h"
 
 namespace hs2 = apache::hive::service::cli::thrift;
-using std::string;
 using std::unique_ptr;
 
 namespace arrow {

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -29,9 +29,6 @@
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 
-using std::shared_ptr;
-using std::vector;
-
 namespace arrow {
 
 std::shared_ptr<Column> column(const std::shared_ptr<Field>& field,
@@ -246,7 +243,7 @@ class TestTable : public TestBase {
     auto f1 = field("f1", uint8());
     auto f2 = field("f2", int16());
 
-    vector<shared_ptr<Field>> fields = {f0, f1, f2};
+    std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
     schema_ = std::make_shared<Schema>(fields);
 
     arrays_ = {MakeRandomArray<Int32Array>(length), MakeRandomArray<UInt8Array>(length),
@@ -259,7 +256,7 @@ class TestTable : public TestBase {
 
  protected:
   std::shared_ptr<Table> table_;
-  shared_ptr<Schema> schema_;
+  std::shared_ptr<Schema> schema_;
 
   std::vector<std::shared_ptr<Array>> arrays_;
   std::vector<std::shared_ptr<Column>> columns_;
@@ -343,7 +340,7 @@ TEST_F(TestTable, Equals) {
   auto f0 = field("f3", int32());
   auto f1 = field("f4", uint8());
   auto f2 = field("f5", int16());
-  vector<shared_ptr<Field>> fields = {f0, f1, f2};
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
   auto other_schema = std::make_shared<Schema>(fields);
   auto other = Table::Make(other_schema, columns_);
   ASSERT_FALSE(table_->Equals(*other));
@@ -567,7 +564,7 @@ TEST_F(TestRecordBatch, Equals) {
   auto f1 = field("f1", uint8());
   auto f2 = field("f2", int16());
 
-  vector<shared_ptr<Field>> fields = {f0, f1, f2};
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
   auto schema = ::arrow::schema({f0, f1, f2});
   auto schema2 = ::arrow::schema({f0, f1});
 
@@ -617,7 +614,7 @@ TEST_F(TestRecordBatch, Slice) {
   auto f0 = field("f0", int32());
   auto f1 = field("f1", uint8());
 
-  vector<shared_ptr<Field>> fields = {f0, f1};
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1};
   auto schema = ::arrow::schema(fields);
 
   auto a0 = MakeRandomArray<Int32Array>(length);

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -31,9 +31,6 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 
-using std::shared_ptr;
-using std::vector;
-
 namespace arrow {
 
 using internal::checked_cast;
@@ -144,7 +141,7 @@ TEST_F(TestSchema, Basics) {
 
   auto schema2 = ::arrow::schema({f0, f1, f2});
 
-  vector<shared_ptr<Field>> fields3 = {f0, f1_optional, f2};
+  std::vector<std::shared_ptr<Field>> fields3 = {f0, f1_optional, f2};
   auto schema3 = std::make_shared<Schema>(fields3);
   ASSERT_TRUE(schema->Equals(*schema2));
   ASSERT_FALSE(schema->Equals(*schema3));
@@ -269,7 +266,7 @@ TEST_F(TestSchema, TestAddMetadata) {
   auto f0 = field("f0", int32());
   auto f1 = field("f1", uint8(), false);
   auto f2 = field("f2", utf8());
-  vector<shared_ptr<Field>> fields = {f0, f1, f2};
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
   auto metadata = std::shared_ptr<KeyValueMetadata>(
       new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
   auto schema = std::make_shared<Schema>(fields);
@@ -284,7 +281,7 @@ TEST_F(TestSchema, TestRemoveMetadata) {
   auto f0 = field("f0", int32());
   auto f1 = field("f1", uint8(), false);
   auto f2 = field("f2", utf8());
-  vector<shared_ptr<Field>> fields = {f0, f1, f2};
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
   KeyValueMetadata metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto schema = std::make_shared<Schema>(fields);
   std::shared_ptr<Schema> new_schema = schema->RemoveMetadata();
@@ -438,18 +435,18 @@ TEST(TestTimestampType, ToString) {
 
 TEST(TestNestedType, Equals) {
   auto create_struct = [](std::string inner_name,
-                          std::string struct_name) -> shared_ptr<Field> {
+                          std::string struct_name) -> std::shared_ptr<Field> {
     auto f_type = field(inner_name, int32());
-    vector<shared_ptr<Field>> fields = {f_type};
+    std::vector<std::shared_ptr<Field>> fields = {f_type};
     auto s_type = std::make_shared<StructType>(fields);
     return field(struct_name, s_type);
   };
 
   auto create_union = [](std::string inner_name,
-                         std::string union_name) -> shared_ptr<Field> {
+                         std::string union_name) -> std::shared_ptr<Field> {
     auto f_type = field(inner_name, int32());
-    vector<shared_ptr<Field>> fields = {f_type};
-    vector<uint8_t> codes = {Type::INT32};
+    std::vector<std::shared_ptr<Field>> fields = {f_type};
+    std::vector<uint8_t> codes = {Type::INT32};
     auto u_type = std::make_shared<UnionType>(fields, codes, UnionMode::SPARSE);
     return field(union_name, u_type);
   };
@@ -483,7 +480,7 @@ TEST(TestStructType, Basics) {
   auto f2_type = uint8();
   auto f2 = field("f2", f2_type);
 
-  vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
+  std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
 
   StructType struct_type(fields);
 

--- a/cpp/src/arrow/util/compression-test.cc
+++ b/cpp/src/arrow/util/compression-test.cc
@@ -38,7 +38,7 @@ std::vector<uint8_t> MakeRandomData(int data_size) {
   return data;
 }
 
-vector<uint8_t> MakeCompressibleData(int data_size) {
+std::vector<uint8_t> MakeCompressibleData(int data_size) {
   std::string base_data =
       "Apache Arrow is a cross-language development platform for in-memory data";
   int nrepeats = static_cast<int>(1 + data_size / base_data.size());

--- a/cpp/src/arrow/util/compression-test.cc
+++ b/cpp/src/arrow/util/compression-test.cc
@@ -29,14 +29,11 @@
 #include "arrow/testing/util.h"
 #include "arrow/util/compression.h"
 
-using std::string;
-using std::vector;
-
 namespace arrow {
 namespace util {
 
-vector<uint8_t> MakeRandomData(int data_size) {
-  vector<uint8_t> data(data_size);
+std::vector<uint8_t> MakeRandomData(int data_size) {
+  std::vector<uint8_t> data(data_size);
   random_bytes(data_size, 1234, data.data());
   return data;
 }
@@ -46,7 +43,7 @@ vector<uint8_t> MakeCompressibleData(int data_size) {
       "Apache Arrow is a cross-language development platform for in-memory data";
   int nrepeats = static_cast<int>(1 + data_size / base_data.size());
 
-  vector<uint8_t> data(base_data.size() * nrepeats);
+  std::vector<uint8_t> data(base_data.size() * nrepeats);
   for (int i = 0; i < nrepeats; ++i) {
     std::memcpy(data.data() + i * base_data.size(), base_data.data(), base_data.size());
   }
@@ -56,7 +53,7 @@ vector<uint8_t> MakeCompressibleData(int data_size) {
 
 // Check roundtrip of one-shot compression and decompression functions.
 
-void CheckCodecRoundtrip(Compression::type ctype, const vector<uint8_t>& data) {
+void CheckCodecRoundtrip(Compression::type ctype, const std::vector<uint8_t>& data) {
   // create multiple compressors to try to break them
   std::unique_ptr<Codec> c1, c2;
 
@@ -111,7 +108,7 @@ void CheckCodecRoundtrip(Compression::type ctype, const vector<uint8_t>& data) {
 
 // Check the streaming compressor against one-shot decompression
 
-void CheckStreamingCompressor(Codec* codec, const vector<uint8_t>& data) {
+void CheckStreamingCompressor(Codec* codec, const std::vector<uint8_t>& data) {
   std::shared_ptr<Compressor> compressor;
   ASSERT_OK(codec->MakeCompressor(&compressor));
 
@@ -180,7 +177,7 @@ void CheckStreamingCompressor(Codec* codec, const vector<uint8_t>& data) {
 
 // Check the streaming decompressor against one-shot compression
 
-void CheckStreamingDecompressor(Codec* codec, const vector<uint8_t>& data) {
+void CheckStreamingDecompressor(Codec* codec, const std::vector<uint8_t>& data) {
   // Create compressed data
   int64_t max_compressed_len = codec->MaxCompressedLen(data.size(), data.data());
   std::vector<uint8_t> compressed(max_compressed_len);
@@ -230,7 +227,7 @@ void CheckStreamingDecompressor(Codec* codec, const vector<uint8_t>& data) {
 
 // Check the streaming compressor and decompressor together
 
-void CheckStreamingRoundtrip(Codec* codec, const vector<uint8_t>& data) {
+void CheckStreamingRoundtrip(Codec* codec, const std::vector<uint8_t>& data) {
   std::shared_ptr<Compressor> compressor;
   std::shared_ptr<Decompressor> decompressor;
   ASSERT_OK(codec->MakeCompressor(&compressor));
@@ -338,7 +335,7 @@ TEST_P(CodecTest, CodecRoundtrip) {
 
   int sizes[] = {0, 10000, 100000};
   for (int data_size : sizes) {
-    vector<uint8_t> data = MakeRandomData(data_size);
+    std::vector<uint8_t> data = MakeRandomData(data_size);
     CheckCodecRoundtrip(GetCompression(), data);
 
     data = MakeCompressibleData(data_size);
@@ -355,7 +352,7 @@ TEST_P(CodecTest, OutputBufferIsSmall) {
   std::unique_ptr<Codec> codec;
   ASSERT_OK(Codec::Create(type, &codec));
 
-  vector<uint8_t> data = MakeRandomData(10);
+  std::vector<uint8_t> data = MakeRandomData(10);
   auto max_compressed_len = codec->MaxCompressedLen(data.size(), data.data());
   std::vector<uint8_t> compressed(max_compressed_len);
   std::vector<uint8_t> decompressed(data.size() - 1);
@@ -394,7 +391,7 @@ TEST_P(CodecTest, StreamingCompressor) {
   for (int data_size : sizes) {
     auto codec = MakeCodec();
 
-    vector<uint8_t> data = MakeRandomData(data_size);
+    std::vector<uint8_t> data = MakeRandomData(data_size);
     CheckStreamingCompressor(codec.get(), data);
 
     data = MakeCompressibleData(data_size);
@@ -421,7 +418,7 @@ TEST_P(CodecTest, StreamingDecompressor) {
   for (int data_size : sizes) {
     auto codec = MakeCodec();
 
-    vector<uint8_t> data = MakeRandomData(data_size);
+    std::vector<uint8_t> data = MakeRandomData(data_size);
     CheckStreamingDecompressor(codec.get(), data);
 
     data = MakeCompressibleData(data_size);
@@ -439,7 +436,7 @@ TEST_P(CodecTest, StreamingRoundtrip) {
   for (int data_size : sizes) {
     auto codec = MakeCodec();
 
-    vector<uint8_t> data = MakeRandomData(data_size);
+    std::vector<uint8_t> data = MakeRandomData(data_size);
     CheckStreamingRoundtrip(codec.get(), data);
 
     data = MakeCompressibleData(data_size);

--- a/cpp/src/arrow/util/rle-encoding-test.cc
+++ b/cpp/src/arrow/util/rle-encoding-test.cc
@@ -30,8 +30,6 @@
 #include "arrow/util/bit-util.h"
 #include "arrow/util/rle-encoding.h"
 
-using std::vector;
-
 namespace arrow {
 namespace util {
 
@@ -176,8 +174,8 @@ TEST(BitArray, TestMixed) {
 // expected_encoding != NULL, also validates that the encoded buffer is
 // exactly 'expected_encoding'.
 // if expected_len is not -1, it will validate the encoded size is correct.
-void ValidateRle(const vector<int>& values, int bit_width, uint8_t* expected_encoding,
-                 int expected_len) {
+void ValidateRle(const std::vector<int>& values, int bit_width,
+                 uint8_t* expected_encoding, int expected_len) {
   const int len = 64 * 1024;
   uint8_t buffer[len];
   EXPECT_LE(expected_len, len);
@@ -210,7 +208,7 @@ void ValidateRle(const vector<int>& values, int bit_width, uint8_t* expected_enc
   // Verify batch read
   {
     RleDecoder decoder(buffer, len, bit_width);
-    vector<int> values_read(values.size());
+    std::vector<int> values_read(values.size());
     ASSERT_EQ(values.size(),
               decoder.GetBatch(values_read.data(), static_cast<int>(values.size())));
     EXPECT_EQ(values, values_read);
@@ -219,7 +217,7 @@ void ValidateRle(const vector<int>& values, int bit_width, uint8_t* expected_enc
 
 // A version of ValidateRle that round-trips the values and returns false if
 // the returned values are not all the same
-bool CheckRoundTrip(const vector<int>& values, int bit_width) {
+bool CheckRoundTrip(const std::vector<int>& values, int bit_width) {
   const int len = 64 * 1024;
   uint8_t buffer[len];
   RleEncoder encoder(buffer, len, bit_width);
@@ -245,7 +243,7 @@ bool CheckRoundTrip(const vector<int>& values, int bit_width) {
   // Verify batch read
   {
     RleDecoder decoder(buffer, len, bit_width);
-    vector<int> values_read(values.size());
+    std::vector<int> values_read(values.size());
     if (static_cast<int>(values.size()) !=
         decoder.GetBatch(values_read.data(), static_cast<int>(values.size()))) {
       return false;
@@ -261,7 +259,7 @@ bool CheckRoundTrip(const vector<int>& values, int bit_width) {
 TEST(Rle, SpecificSequences) {
   const int len = 1024;
   uint8_t expected_buffer[len];
-  vector<int> values;
+  std::vector<int> values;
 
   // Test 50 0' followed by 50 1's
   values.resize(100);
@@ -311,7 +309,7 @@ TEST(Rle, SpecificSequences) {
 // is used, otherwise alternating values are used.
 void TestRleValues(int bit_width, int num_vals, int value = -1) {
   const uint64_t mod = (bit_width == 64) ? 1 : 1LL << bit_width;
-  vector<int> values;
+  std::vector<int> values;
   for (int v = 0; v < num_vals; ++v) {
     values.push_back((value != -1) ? value : static_cast<int>(v % mod));
   }
@@ -359,7 +357,7 @@ TEST(Rle, BitWidthZeroLiteral) {
 // Test that writes out a repeated group and then a literal
 // group but flush before finishing.
 TEST(BitRle, Flush) {
-  vector<int> values;
+  std::vector<int> values;
   for (int i = 0; i < 16; ++i) values.push_back(1);
   values.push_back(0);
   ValidateRle(values, 1, NULL, -1);
@@ -376,7 +374,7 @@ TEST(BitRle, Random) {
   int niters = 50;
   int ngroups = 1000;
   int max_group_size = 16;
-  vector<int> values(ngroups + max_group_size);
+  std::vector<int> values(ngroups + max_group_size);
 
   // prng setup
   std::random_device rd;
@@ -409,7 +407,7 @@ TEST(BitRle, Random) {
 // Test a sequence of 1 0's, 2 1's, 3 0's. etc
 // e.g. 011000111100000
 TEST(BitRle, RepeatedPattern) {
-  vector<int> values;
+  std::vector<int> values;
   const int min_run = 1;
   const int max_run = 32;
 

--- a/cpp/src/gandiva/function_registry_common.h
+++ b/cpp/src/gandiva/function_registry_common.h
@@ -46,7 +46,6 @@ using arrow::uint32;
 using arrow::uint64;
 using arrow::uint8;
 using arrow::utf8;
-using std::vector;
 
 inline DataTypePtr time32() { return arrow::time32(arrow::TimeUnit::MILLI); }
 

--- a/cpp/src/parquet/column_reader-test.cc
+++ b/cpp/src/parquet/column_reader-test.cc
@@ -32,10 +32,6 @@
 #include "parquet/types.h"
 #include "parquet/util/test-common.h"
 
-using std::shared_ptr;
-using std::string;
-using std::vector;
-
 namespace parquet {
 
 using schema::NodePtr;
@@ -43,11 +39,11 @@ using schema::NodePtr;
 namespace test {
 
 template <typename T>
-static inline bool vector_equal_with_def_levels(const vector<T>& left,
-                                                const vector<int16_t>& def_levels,
+static inline bool vector_equal_with_def_levels(const std::vector<T>& left,
+                                                const std::vector<int16_t>& def_levels,
                                                 int16_t max_def_levels,
                                                 int16_t max_rep_levels,
-                                                const vector<T>& right) {
+                                                const std::vector<T>& right) {
   size_t i_left = 0;
   size_t i_right = 0;
   for (size_t i = 0; i < def_levels.size(); i++) {
@@ -83,9 +79,9 @@ class TestPrimitiveReader : public ::testing::Test {
   }
 
   void CheckResults() {
-    vector<int32_t> vresult(num_values_, -1);
-    vector<int16_t> dresult(num_levels_, -1);
-    vector<int16_t> rresult(num_levels_, -1);
+    std::vector<int32_t> vresult(num_values_, -1);
+    std::vector<int16_t> dresult(num_levels_, -1);
+    std::vector<int16_t> rresult(num_levels_, -1);
     int64_t values_read = 0;
     int total_values_read = 0;
     int batch_actual = 0;
@@ -122,10 +118,10 @@ class TestPrimitiveReader : public ::testing::Test {
   }
 
   void CheckResultsSpaced() {
-    vector<int32_t> vresult(num_levels_, -1);
-    vector<int16_t> dresult(num_levels_, -1);
-    vector<int16_t> rresult(num_levels_, -1);
-    vector<uint8_t> valid_bits(num_levels_, 255);
+    std::vector<int32_t> vresult(num_levels_, -1);
+    std::vector<int16_t> dresult(num_levels_, -1);
+    std::vector<int16_t> rresult(num_levels_, -1);
+    std::vector<uint8_t> valid_bits(num_levels_, 255);
     int total_values_read = 0;
     int batch_actual = 0;
     int levels_actual = 0;
@@ -219,12 +215,12 @@ class TestPrimitiveReader : public ::testing::Test {
   int num_values_;
   int16_t max_def_level_;
   int16_t max_rep_level_;
-  vector<shared_ptr<Page>> pages_;
+  std::vector<std::shared_ptr<Page>> pages_;
   std::shared_ptr<ColumnReader> reader_;
-  vector<int32_t> values_;
-  vector<int16_t> def_levels_;
-  vector<int16_t> rep_levels_;
-  vector<uint8_t> data_buffer_;  // For BA and FLBA
+  std::vector<int32_t> values_;
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  std::vector<uint8_t> data_buffer_;  // For BA and FLBA
 };
 
 TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
@@ -270,9 +266,9 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequiredSkip) {
   MakePages<Int32Type>(&descr, num_pages, levels_per_page, def_levels_, rep_levels_,
                        values_, data_buffer_, pages_, Encoding::PLAIN);
   InitReader(&descr);
-  vector<int32_t> vresult(levels_per_page / 2, -1);
-  vector<int16_t> dresult(levels_per_page / 2, -1);
-  vector<int16_t> rresult(levels_per_page / 2, -1);
+  std::vector<int32_t> vresult(levels_per_page / 2, -1);
+  std::vector<int16_t> dresult(levels_per_page / 2, -1);
+  std::vector<int16_t> rresult(levels_per_page / 2, -1);
 
   Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
   int64_t values_read = 0;
@@ -284,7 +280,7 @@ TEST_F(TestPrimitiveReader, TestInt32FlatRequiredSkip) {
   // Read half a page
   reader->ReadBatch(levels_per_page / 2, dresult.data(), rresult.data(), vresult.data(),
                     &values_read);
-  vector<int32_t> sub_values(
+  std::vector<int32_t> sub_values(
       values_.begin() + 2 * levels_per_page,
       values_.begin() + static_cast<int>(2.5 * static_cast<double>(levels_per_page)));
   ASSERT_TRUE(vector_equal(sub_values, vresult));
@@ -328,11 +324,11 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
   max_rep_level_ = 0;
   NodePtr type = schema::Int32("a", Repetition::REQUIRED);
   const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
-  shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
+  std::shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
 
-  shared_ptr<DictionaryPage> dict_page =
+  std::shared_ptr<DictionaryPage> dict_page =
       std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
-  shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
+  std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
       &descr, {}, 0, Encoding::RLE_DICTIONARY, {}, 0, {}, 0, {}, 0);
   pages_.push_back(dict_page);
   pages_.push_back(data_page);
@@ -366,9 +362,9 @@ TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
   ASSERT_THROW(reader_->HasNext(), ParquetException);
   pages_.clear();
 
-  shared_ptr<DictionaryPage> dict_page1 =
+  std::shared_ptr<DictionaryPage> dict_page1 =
       std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN_DICTIONARY);
-  shared_ptr<DictionaryPage> dict_page2 =
+  std::shared_ptr<DictionaryPage> dict_page2 =
       std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
   pages_.push_back(dict_page1);
   pages_.push_back(dict_page2);

--- a/cpp/src/parquet/column_scanner-test.cc
+++ b/cpp/src/parquet/column_scanner-test.cc
@@ -32,10 +32,6 @@
 #include "parquet/types.h"
 #include "parquet/util/test-common.h"
 
-using std::shared_ptr;
-using std::string;
-using std::vector;
-
 namespace parquet {
 
 using schema::NodePtr;
@@ -43,8 +39,8 @@ using schema::NodePtr;
 namespace test {
 
 template <>
-void InitDictValues<bool>(int num_values, int dict_per_page, vector<bool>& values,
-                          vector<uint8_t>& buffer) {
+void InitDictValues<bool>(int num_values, int dict_per_page, std::vector<bool>& values,
+                          std::vector<uint8_t>& buffer) {
   // No op for bool
 }
 
@@ -132,12 +128,12 @@ class TestFlatScanner : public ::testing::Test {
  protected:
   int num_levels_;
   int num_values_;
-  vector<shared_ptr<Page>> pages_;
+  std::vector<std::shared_ptr<Page>> pages_;
   std::shared_ptr<Scanner> scanner_;
-  vector<T> values_;
-  vector<int16_t> def_levels_;
-  vector<int16_t> rep_levels_;
-  vector<uint8_t> data_buffer_;  // For BA and FLBA
+  std::vector<T> values_;
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  std::vector<uint8_t> data_buffer_;  // For BA and FLBA
 };
 
 static int num_levels_per_page = 100;

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -19,7 +19,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <string>
 #include <vector>
 
 #include "arrow/array.h"
@@ -39,9 +38,6 @@
 using arrow::default_memory_pool;
 using arrow::MemoryPool;
 
-using std::string;
-using std::vector;
-
 // TODO(hatemhelal): investigate whether this can be replaced with GTEST_SKIP in a future
 // gtest release that contains https://github.com/google/googletest/pull/1544
 #define SKIP_TEST_IF(condition) \
@@ -59,7 +55,7 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
   int nbytes = static_cast<int>(::arrow::BitUtil::BytesForBits(nvalues));
 
   // seed the prng so failure is deterministic
-  vector<bool> draws = flip_coins_seed(nvalues, 0.5, 0);
+  std::vector<bool> draws = flip_coins_seed(nvalues, 0.5, 0);
 
   std::unique_ptr<BooleanEncoder> encoder =
       MakeTypedEncoder<BooleanType>(Encoding::PLAIN);
@@ -71,7 +67,7 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
   std::shared_ptr<Buffer> encode_buffer = encoder->FlushValues();
   ASSERT_EQ(nbytes, encode_buffer->size());
 
-  vector<uint8_t> decode_buffer(nbytes);
+  std::vector<uint8_t> decode_buffer(nbytes);
   const uint8_t* decode_data = &decode_buffer[0];
 
   decoder->SetData(nvalues, encode_buffer->data(),
@@ -88,27 +84,27 @@ TEST(VectorBooleanTest, TestEncodeDecode) {
 // test data generation
 
 template <typename T>
-void GenerateData(int num_values, T* out, vector<uint8_t>* heap) {
+void GenerateData(int num_values, T* out, std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   random_numbers(num_values, 0, std::numeric_limits<T>::min(),
                  std::numeric_limits<T>::max(), out);
 }
 
 template <>
-void GenerateData<bool>(int num_values, bool* out, vector<uint8_t>* heap) {
+void GenerateData<bool>(int num_values, bool* out, std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   random_bools(num_values, 0.5, 0, out);
 }
 
 template <>
-void GenerateData<Int96>(int num_values, Int96* out, vector<uint8_t>* heap) {
+void GenerateData<Int96>(int num_values, Int96* out, std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
                        std::numeric_limits<int32_t>::max(), out);
 }
 
 template <>
-void GenerateData<ByteArray>(int num_values, ByteArray* out, vector<uint8_t>* heap) {
+void GenerateData<ByteArray>(int num_values, ByteArray* out, std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   int max_byte_array_len = 12;
   heap->resize(num_values * max_byte_array_len);
@@ -118,7 +114,7 @@ void GenerateData<ByteArray>(int num_values, ByteArray* out, vector<uint8_t>* he
 static int flba_length = 8;
 
 template <>
-void GenerateData<FLBA>(int num_values, FLBA* out, vector<uint8_t>* heap) {
+void GenerateData<FLBA>(int num_values, FLBA* out, std::vector<uint8_t>* heap) {
   // seed the prng so failure is deterministic
   heap->resize(num_values * flba_length);
   random_fixed_byte_array(num_values, 0, heap->data(), flba_length, out);
@@ -202,9 +198,9 @@ class TestEncodingBase : public ::testing::Test {
   int type_length_;
   T* draws_;
   T* decode_buf_;
-  vector<uint8_t> input_bytes_;
-  vector<uint8_t> output_bytes_;
-  vector<uint8_t> data_buffer_;
+  std::vector<uint8_t> input_bytes_;
+  std::vector<uint8_t> output_bytes_;
+  std::vector<uint8_t> data_buffer_;
 
   std::shared_ptr<Buffer> encode_buffer_;
   std::shared_ptr<ColumnDescriptor> descr_;
@@ -473,7 +469,7 @@ class TestArrowBuilderDecoding : public ::testing::Test {
   std::shared_ptr<::arrow::Array> expected_dense_;
   int num_values_;
   int null_count_;
-  vector<ByteArray> input_data_;
+  std::vector<ByteArray> input_data_;
   const uint8_t* valid_bits_;
   std::unique_ptr<ByteArrayEncoder> encoder_;
   std::unique_ptr<ByteArrayDecoder> decoder_;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -38,8 +38,6 @@
 #include "parquet/types.h"
 #include "parquet/util/memory.h"
 
-using std::string;
-
 namespace parquet {
 
 // PARQUET-978: Minimize footer reads by reading 64 KB from the end of the file

--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -34,9 +34,6 @@
 #include "parquet/statistics.h"
 #include "parquet/types.h"
 
-using std::string;
-using std::vector;
-
 namespace parquet {
 
 class ColumnReader;
@@ -136,7 +133,7 @@ void ParquetFilePrinter::DebugPrint(std::ostream& stream, std::list<int> selecte
     char buffer[bufsize];
 
     // Create readers for selected columns and print contents
-    vector<std::shared_ptr<Scanner>> scanners(selected_columns.size(), nullptr);
+    std::vector<std::shared_ptr<Scanner>> scanners(selected_columns.size(), nullptr);
     int j = 0;
     for (auto i : selected_columns) {
       std::shared_ptr<ColumnReader> col_reader = group_reader->Column(i);

--- a/cpp/src/parquet/reader-test.cc
+++ b/cpp/src/parquet/reader-test.cc
@@ -33,8 +33,6 @@
 #include "parquet/util/memory.h"
 #include "parquet/util/test-common.h"
 
-using std::string;
-
 namespace parquet {
 
 using ReadableFile = ::arrow::io::ReadableFile;

--- a/cpp/src/parquet/schema-test.cc
+++ b/cpp/src/parquet/schema-test.cc
@@ -29,9 +29,6 @@
 #include "parquet/thrift.h"
 #include "parquet/types.h"
 
-using std::string;
-using std::vector;
-
 namespace parquet {
 
 using format::ConvertedType;

--- a/cpp/src/parquet/test-specialization.h
+++ b/cpp/src/parquet/test-specialization.h
@@ -34,14 +34,14 @@ namespace parquet {
 namespace test {
 
 template <>
-void inline InitValues<bool>(int num_values, vector<bool>& values,
-                             vector<uint8_t>& buffer) {
+void inline InitValues<bool>(int num_values, std::vector<bool>& values,
+                             std::vector<uint8_t>& buffer) {
   values = flip_coins(num_values, 0);
 }
 
 template <>
-void inline InitValues<ByteArray>(int num_values, vector<ByteArray>& values,
-                                  vector<uint8_t>& buffer) {
+void inline InitValues<ByteArray>(int num_values, std::vector<ByteArray>& values,
+                                  std::vector<uint8_t>& buffer) {
   int max_byte_array_len = 12;
   int num_bytes = static_cast<int>(max_byte_array_len + sizeof(uint32_t));
   size_t nbytes = num_values * num_bytes;
@@ -49,8 +49,9 @@ void inline InitValues<ByteArray>(int num_values, vector<ByteArray>& values,
   random_byte_array(num_values, 0, buffer.data(), values.data(), max_byte_array_len);
 }
 
-void inline InitWideByteArrayValues(int num_values, vector<ByteArray>& values,
-                                    vector<uint8_t>& buffer, int min_len, int max_len) {
+void inline InitWideByteArrayValues(int num_values, std::vector<ByteArray>& values,
+                                    std::vector<uint8_t>& buffer, int min_len,
+                                    int max_len) {
   int num_bytes = static_cast<int>(max_len + sizeof(uint32_t));
   size_t nbytes = num_values * num_bytes;
   buffer.resize(nbytes);
@@ -58,16 +59,16 @@ void inline InitWideByteArrayValues(int num_values, vector<ByteArray>& values,
 }
 
 template <>
-void inline InitValues<FLBA>(int num_values, vector<FLBA>& values,
-                             vector<uint8_t>& buffer) {
+void inline InitValues<FLBA>(int num_values, std::vector<FLBA>& values,
+                             std::vector<uint8_t>& buffer) {
   size_t nbytes = num_values * FLBA_LENGTH;
   buffer.resize(nbytes);
   random_fixed_byte_array(num_values, 0, buffer.data(), FLBA_LENGTH, values.data());
 }
 
 template <>
-void inline InitValues<Int96>(int num_values, vector<Int96>& values,
-                              vector<uint8_t>& buffer) {
+void inline InitValues<Int96>(int num_values, std::vector<Int96>& values,
+                              std::vector<uint8_t>& buffer) {
   random_Int96_numbers(num_values, 0, std::numeric_limits<int32_t>::min(),
                        std::numeric_limits<int32_t>::max(), values.data());
 }
@@ -110,7 +111,7 @@ class PrimitiveTypedTest : public ::testing::Test {
   std::vector<int16_t> def_levels_;
 
   std::vector<uint8_t> buffer_;
-  // Pointer to the values, needed as we cannot use vector<bool>::data()
+  // Pointer to the values, needed as we cannot use std::vector<bool>::data()
   T* values_ptr_;
   std::vector<uint8_t> bool_buffer_;
 

--- a/cpp/src/parquet/util/test-common.h
+++ b/cpp/src/parquet/util/test-common.h
@@ -27,8 +27,6 @@
 #include "parquet/exception.h"
 #include "parquet/types.h"
 
-using std::vector;
-
 namespace parquet {
 
 namespace test {
@@ -52,7 +50,8 @@ const char* get_data_dir() {
 }
 
 template <typename T>
-static inline void assert_vector_equal(const vector<T>& left, const vector<T>& right) {
+static inline void assert_vector_equal(const std::vector<T>& left,
+                                       const std::vector<T>& right) {
   ASSERT_EQ(left.size(), right.size());
 
   for (size_t i = 0; i < left.size(); ++i) {
@@ -61,7 +60,7 @@ static inline void assert_vector_equal(const vector<T>& left, const vector<T>& r
 }
 
 template <typename T>
-static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
+static inline bool vector_equal(const std::vector<T>& left, const std::vector<T>& right) {
   if (left.size() != right.size()) {
     return false;
   }
@@ -78,30 +77,30 @@ static inline bool vector_equal(const vector<T>& left, const vector<T>& right) {
 }
 
 template <typename T>
-static vector<T> slice(const vector<T>& values, int start, int end) {
+static std::vector<T> slice(const std::vector<T>& values, int start, int end) {
   if (end < start) {
-    return vector<T>(0);
+    return std::vector<T>(0);
   }
 
-  vector<T> out(end - start);
+  std::vector<T> out(end - start);
   for (int i = start; i < end; ++i) {
     out[i - start] = values[i];
   }
   return out;
 }
 
-static inline vector<bool> flip_coins_seed(int n, double p, uint32_t seed) {
+static inline std::vector<bool> flip_coins_seed(int n, double p, uint32_t seed) {
   std::default_random_engine gen(seed);
   std::bernoulli_distribution d(p);
 
-  vector<bool> draws(n);
+  std::vector<bool> draws(n);
   for (int i = 0; i < n; ++i) {
     draws[i] = d(gen);
   }
   return draws;
 }
 
-static inline vector<bool> flip_coins(int n, double p) {
+static inline std::vector<bool> flip_coins(int n, double p) {
   uint64_t seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
   return flip_coins_seed(n, p, static_cast<uint32_t>(seed));
 }


### PR DESCRIPTION
This is more of a proposal to see if people are okay with it, I'm okay closing the PR.  I also am touching parquet files, please let me know if I should open a separate JIRA for those.

We seem to pretty consistently use std:: in most places and sometimes inconsistently within files, this fixes those style issues.