### PR TITLE
ARROW-5011: [Release] Add support in source release script for custom git hash

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -34,7 +34,7 @@ tagrc=${tag}-rc${rc}
 
 echo "Preparing source for tag ${tag}"
 
-release_hash=`git rev-list $tag 2> /dev/null | head -n 1 `
+: ${release_hash=:`git rev-list $tag 2> /dev/null | head -n 1 `}
 
 if [ -z "$release_hash" ]; then
   echo "Cannot continue: unknown git tag: $tag"


### PR DESCRIPTION
This is a minor feature to help debugging said script on a by overriding
the git-archive hash instead of the hash inferred from the release tag.