### PR TITLE
ARROW-5013: [Rust] [DataFusion] Refactor runtime expression support

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -155,12 +155,8 @@ impl ExecutionContext {
             } => {
                 let input_rel = self.execute(input, batch_size)?;
                 let input_schema = input_rel.as_ref().borrow().schema().clone();
-                let runtime_expr = compile_scalar_expr(&self, expr, &input_schema)?;
-                let rel = FilterRelation::new(
-                    input_rel,
-                    runtime_expr, /* .get_func()?.clone() */
-                    input_schema,
-                );
+                let runtime_expr = compile_expr(&self, expr, &input_schema)?;
+                let rel = FilterRelation::new(input_rel, runtime_expr, input_schema);
                 Ok(Rc::new(RefCell::new(rel)))
             }
             LogicalPlan::Projection {
@@ -177,9 +173,9 @@ impl ExecutionContext {
 
                 let project_schema = Arc::new(Schema::new(project_columns));
 
-                let compiled_expr: Result<Vec<RuntimeExpr>> = expr
+                let compiled_expr: Result<Vec<CompiledExpr>> = expr
                     .iter()
-                    .map(|e| compile_scalar_expr(&self, e, &input_schema))
+                    .map(|e| compile_expr(&self, e, &input_schema))
                     .collect();
 
                 let rel = ProjectRelation::new(input_rel, compiled_expr?, project_schema);
@@ -196,16 +192,17 @@ impl ExecutionContext {
 
                 let input_schema = input_rel.as_ref().borrow().schema().clone();
 
-                let compiled_group_expr_result: Result<Vec<RuntimeExpr>> = group_expr
-                    .iter()
-                    .map(|e| compile_scalar_expr(&self, e, &input_schema))
-                    .collect();
-                let compiled_group_expr = compiled_group_expr_result?;
-
-                let compiled_aggr_expr_result: Result<Vec<RuntimeExpr>> = aggr_expr
+                let compiled_group_expr_result: Result<Vec<CompiledExpr>> = group_expr
                     .iter()
                     .map(|e| compile_expr(&self, e, &input_schema))
                     .collect();
+                let compiled_group_expr = compiled_group_expr_result?;
+
+                let compiled_aggr_expr_result: Result<Vec<CompiledAggregateExpression>> =
+                    aggr_expr
+                        .iter()
+                        .map(|e| compile_aggregate_expr(&self, e, &input_schema))
+                        .collect();
                 let compiled_aggr_expr = compiled_aggr_expr_result?;
 
                 let mut output_fields: Vec<Field> = vec![];

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -29,7 +29,7 @@ use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 use crate::error::Result;
-use crate::execution::expression::RuntimeExpr;
+use crate::execution::expression::CompiledExpr;
 use crate::execution::relation::Relation;
 
 /// Projection relation
@@ -39,13 +39,13 @@ pub(super) struct ProjectRelation {
     /// The relation that the projection is being applied to
     input: Rc<RefCell<Relation>>,
     /// Projection expressions
-    expr: Vec<RuntimeExpr>,
+    expr: Vec<CompiledExpr>,
 }
 
 impl ProjectRelation {
     pub fn new(
         input: Rc<RefCell<Relation>>,
-        expr: Vec<RuntimeExpr>,
+        expr: Vec<CompiledExpr>,
         schema: Arc<Schema>,
     ) -> Self {
         ProjectRelation {
@@ -61,12 +61,12 @@ impl Relation for ProjectRelation {
         match self.input.borrow_mut().next()? {
             Some(batch) => {
                 let projected_columns: Result<Vec<ArrayRef>> =
-                    self.expr.iter().map(|e| e.get_func()?(&batch)).collect();
+                    self.expr.iter().map(|e| e.invoke(&batch)).collect();
 
                 let schema = Schema::new(
                     self.expr
                         .iter()
-                        .map(|e| Field::new(&e.get_name(), e.get_type(), true))
+                        .map(|e| Field::new(&e.name(), e.data_type().clone(), true))
                         .collect(),
                 );
 


### PR DESCRIPTION
This refactors to remove the redundant `RuntimeExpr` enum in favor of having concrete `CompiledExpr` and `CompiledAggregateExpr` types.

