### PR TITLE
ARROW-5026: [Python][Packaging] Fix gandiva.dll detection on non Windows

### DIFF
--- a/cpp/cmake_modules/FindGandiva.cmake
+++ b/cpp/cmake_modules/FindGandiva.cmake
@@ -48,8 +48,13 @@ else()
 
   # TODO: ARROW-5021
   set(GANDIVA_SEARCH_LIB_PATH "${GANDIVA_HOME}/lib")
-  # TODO: ARROW-5025
-  set(GANDIVA_SEARCH_SHARED_LIB_PATH "${GANDIVA_HOME}/bin")
+  if(WIN32)
+    # TODO: ARROW-5025
+    set(GANDIVA_SEARCH_SHARED_LIB_PATH "${GANDIVA_HOME}/bin")
+  else()
+    # TODO: ARROW-5026
+    set(GANDIVA_SEARCH_SHARED_LIB_PATH "${GANDIVA_HOME}/lib")
+  endif()
 
   find_path(GANDIVA_INCLUDE_DIR gandiva/expression_registry.h
             PATHS ${GANDIVA_SEARCH_HEADER_PATHS}


### PR DESCRIPTION
This is a workaround for 0.13.0 release. We should do real fix after
0.13.0 release.