### PR TITLE
ARROW-5032: [C++] Install headers in vendored/datetime directory

### DIFF
--- a/cpp/src/arrow/vendored/datetime/CMakeLists.txt
+++ b/cpp/src/arrow/vendored/datetime/CMakeLists.txt
@@ -15,7 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-arrow_install_all_headers("arrow/vendored")
-
-add_subdirectory(datetime)
-add_subdirectory(variant)
+arrow_install_all_headers("arrow/vendored/datetime")


### PR DESCRIPTION
I found that header files in `vendored/datetime` directory are not installed even though `vendored/datetime.h` is installed.  `vendored/datetime.h` depends on the files in `vendored/datetime` directory, so they should be installed.