### PR TITLE
ARROW-5037: [Rust] [DataFusion] Refactor aggregate functions

### DIFF
--- a/rust/datafusion/src/execution/aggregate.rs
+++ b/rust/datafusion/src/execution/aggregate.rs
@@ -84,6 +84,7 @@ enum GroupByScalar {
 trait AggregateFunction {
     /// Get the function name (used for debugging)
     fn name(&self) -> &str;
+
     /// Update the current aggregate value based on a new value. If rollup is false, then
     /// this aggregate function instance is being used to aggregate individual values within
     /// a RecordBatch. If rollup is true then the aggregate function instance is being used
@@ -97,9 +98,17 @@ trait AggregateFunction {
         value: &Option<ScalarValue>,
         rollup: bool,
     ) -> Result<()>;
+
+    fn accumulate_array(
+        &mut self,
+        value: &Option<ScalarValue>,
+        rollup: bool,
+    ) -> Result<()>;
+
     /// Return the result of the aggregate function after all values have been processed
     /// by calls to `acccumulate_scalar`.
     fn result(&self) -> Option<ScalarValue>;
+
     /// Get the data type of the result of the aggregate function. For some operations,
     /// such as `min`, `max`, and `sum`, the data type will be the same as the data type
     /// of the argument. For other aggregates, such as `count`, the data type is independent
@@ -107,7 +116,7 @@ trait AggregateFunction {
     fn data_type(&self) -> &DataType;
 }
 
-/// Implemntation of MIN aggregate function
+/// Implementation of MIN aggregate function
 #[derive(Debug)]
 struct MinFunction {
     data_type: DataType,
@@ -186,7 +195,7 @@ impl AggregateFunction for MinFunction {
     }
 }
 
-/// Implemntation of MAX aggregate function
+/// Implementation of MAX aggregate function
 #[derive(Debug)]
 struct MaxFunction {
     data_type: DataType,
@@ -265,7 +274,7 @@ impl AggregateFunction for MaxFunction {
     }
 }
 
-/// Implemntation of SUM aggregate function
+/// Implementation of SUM aggregate function
 #[derive(Debug)]
 struct SumFunction {
     data_type: DataType,
@@ -344,7 +353,7 @@ impl AggregateFunction for SumFunction {
     }
 }
 
-/// Implemntation of COUNT aggregate function
+/// Implementation of COUNT aggregate function
 #[derive(Debug)]
 struct CountFunction {
     value: Option<u64>,

--- a/rust/datafusion/src/execution/aggregate/count.rs
+++ b/rust/datafusion/src/execution/aggregate/count.rs
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! COUNT aggregate function. Counts the number of non-null values for an expression.
+
+use crate::arrow::array::*;
+use crate::arrow::datatypes::DataType;
+
+use crate::error::Result;
+use crate::execution::aggregate::AggregateFunction;
+use crate::logicalplan::ScalarValue;
+
+/// Implementation of COUNT aggregate function
+#[derive(Debug)]
+pub(super) struct CountFunction {
+    value: Option<u64>,
+}
+
+impl CountFunction {
+    pub fn new() -> Self {
+        Self { value: None }
+    }
+}
+
+impl AggregateFunction for CountFunction {
+    fn name(&self) -> &str {
+        "count"
+    }
+
+    fn accumulate_scalar(
+        &mut self,
+        value: &Option<ScalarValue>,
+        rollup: bool,
+    ) -> Result<()> {
+        if rollup {
+            if let Some(ScalarValue::UInt64(n)) = value {
+                if self.value.is_none() {
+                    self.value = Some(*n);
+                } else {
+                    self.value = Some(self.value.unwrap() + *n);
+                }
+            }
+        } else {
+            if value.is_some() {
+                if self.value.is_none() {
+                    self.value = Some(1);
+                } else {
+                    self.value = Some(self.value.unwrap() + 1);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn accumulate_array(&mut self, array: ArrayRef) -> Result<()> {
+        self.accumulate_scalar(
+            &Some(ScalarValue::UInt64(
+                (array.len() - array.null_count()) as u64,
+            )),
+            true,
+        )
+    }
+
+    fn result(&self) -> Option<ScalarValue> {
+        match self.value {
+            Some(n) => Some(ScalarValue::UInt64(n)),
+            None => None,
+        }
+    }
+
+    fn data_type(&self) -> &DataType {
+        &DataType::UInt64
+    }
+}

--- a/rust/datafusion/src/execution/aggregate/max.rs
+++ b/rust/datafusion/src/execution/aggregate/max.rs
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! MAX aggregate function
+
+use crate::arrow::array::*;
+use crate::arrow::compute;
+use crate::arrow::datatypes::DataType;
+
+use crate::error::{ExecutionError, Result};
+use crate::execution::aggregate::AggregateFunction;
+use crate::logicalplan::ScalarValue;
+
+/// Implementation of MAX aggregate function
+#[derive(Debug)]
+pub(super) struct MaxFunction {
+    data_type: DataType,
+    value: Option<ScalarValue>,
+}
+
+impl MaxFunction {
+    pub fn new(data_type: &DataType) -> Self {
+        Self {
+            data_type: data_type.clone(),
+            value: None,
+        }
+    }
+}
+
+impl AggregateFunction for MaxFunction {
+    fn name(&self) -> &str {
+        "max"
+    }
+
+    fn accumulate_scalar(
+        &mut self,
+        value: &Option<ScalarValue>,
+        _rollup: bool,
+    ) -> Result<()> {
+        if self.value.is_none() {
+            self.value = value.clone();
+        } else if value.is_some() {
+            self.value = match (&self.value, value) {
+                (Some(ScalarValue::UInt8(a)), Some(ScalarValue::UInt8(b))) => {
+                    Some(ScalarValue::UInt8(*a.max(b)))
+                }
+                (Some(ScalarValue::UInt16(a)), Some(ScalarValue::UInt16(b))) => {
+                    Some(ScalarValue::UInt16(*a.max(b)))
+                }
+                (Some(ScalarValue::UInt32(a)), Some(ScalarValue::UInt32(b))) => {
+                    Some(ScalarValue::UInt32(*a.max(b)))
+                }
+                (Some(ScalarValue::UInt64(a)), Some(ScalarValue::UInt64(b))) => {
+                    Some(ScalarValue::UInt64(*a.max(b)))
+                }
+                (Some(ScalarValue::Int8(a)), Some(ScalarValue::Int8(b))) => {
+                    Some(ScalarValue::Int8(*a.max(b)))
+                }
+                (Some(ScalarValue::Int16(a)), Some(ScalarValue::Int16(b))) => {
+                    Some(ScalarValue::Int16(*a.max(b)))
+                }
+                (Some(ScalarValue::Int32(a)), Some(ScalarValue::Int32(b))) => {
+                    Some(ScalarValue::Int32(*a.max(b)))
+                }
+                (Some(ScalarValue::Int64(a)), Some(ScalarValue::Int64(b))) => {
+                    Some(ScalarValue::Int64(*a.max(b)))
+                }
+                (Some(ScalarValue::Float32(a)), Some(ScalarValue::Float32(b))) => {
+                    Some(ScalarValue::Float32(a.max(*b)))
+                }
+                (Some(ScalarValue::Float64(a)), Some(ScalarValue::Float64(b))) => {
+                    Some(ScalarValue::Float64(a.max(*b)))
+                }
+                _ => {
+                    return Err(ExecutionError::ExecutionError(
+                        "unsupported data type for MAX".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn accumulate_array(&mut self, array: ArrayRef) -> Result<()> {
+        let scalar = match array.data_type() {
+            DataType::UInt8 => {
+                match compute::max(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt16 => {
+                match compute::max(array.as_any().downcast_ref::<UInt16Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt32 => {
+                match compute::max(array.as_any().downcast_ref::<UInt32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt64 => {
+                match compute::max(array.as_any().downcast_ref::<UInt64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int8 => {
+                match compute::max(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int16 => {
+                match compute::max(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int32 => {
+                match compute::max(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int64 => {
+                match compute::max(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float32 => {
+                match compute::max(array.as_any().downcast_ref::<Float32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float64 => {
+                match compute::max(array.as_any().downcast_ref::<Float64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                    None => Ok(None),
+                }
+            }
+            _ => Err(ExecutionError::ExecutionError(
+                "Unsupported data type for MAX".to_string(),
+            )),
+        }?;
+        self.accumulate_scalar(&scalar, true)
+    }
+
+    fn result(&self) -> Option<ScalarValue> {
+        self.value.clone()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}

--- a/rust/datafusion/src/execution/aggregate/min.rs
+++ b/rust/datafusion/src/execution/aggregate/min.rs
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! MIN aggregate function
+
+use crate::arrow::array::*;
+use crate::arrow::compute;
+use crate::arrow::datatypes::DataType;
+
+use crate::error::{ExecutionError, Result};
+use crate::execution::aggregate::AggregateFunction;
+use crate::logicalplan::ScalarValue;
+
+/// Implementation of MIN aggregate function
+#[derive(Debug)]
+pub(super) struct MinFunction {
+    data_type: DataType,
+    value: Option<ScalarValue>,
+}
+
+impl MinFunction {
+    pub fn new(data_type: &DataType) -> Self {
+        Self {
+            data_type: data_type.clone(),
+            value: None,
+        }
+    }
+}
+
+impl AggregateFunction for MinFunction {
+    fn name(&self) -> &str {
+        "min"
+    }
+
+    fn accumulate_scalar(
+        &mut self,
+        value: &Option<ScalarValue>,
+        _rollup: bool,
+    ) -> Result<()> {
+        if self.value.is_none() {
+            self.value = value.clone();
+        } else if value.is_some() {
+            self.value = match (&self.value, value) {
+                (Some(ScalarValue::UInt8(a)), Some(ScalarValue::UInt8(b))) => {
+                    Some(ScalarValue::UInt8(*a.min(b)))
+                }
+                (Some(ScalarValue::UInt16(a)), Some(ScalarValue::UInt16(b))) => {
+                    Some(ScalarValue::UInt16(*a.min(b)))
+                }
+                (Some(ScalarValue::UInt32(a)), Some(ScalarValue::UInt32(b))) => {
+                    Some(ScalarValue::UInt32(*a.min(b)))
+                }
+                (Some(ScalarValue::UInt64(a)), Some(ScalarValue::UInt64(b))) => {
+                    Some(ScalarValue::UInt64(*a.min(b)))
+                }
+                (Some(ScalarValue::Int8(a)), Some(ScalarValue::Int8(b))) => {
+                    Some(ScalarValue::Int8(*a.min(b)))
+                }
+                (Some(ScalarValue::Int16(a)), Some(ScalarValue::Int16(b))) => {
+                    Some(ScalarValue::Int16(*a.min(b)))
+                }
+                (Some(ScalarValue::Int32(a)), Some(ScalarValue::Int32(b))) => {
+                    Some(ScalarValue::Int32(*a.min(b)))
+                }
+                (Some(ScalarValue::Int64(a)), Some(ScalarValue::Int64(b))) => {
+                    Some(ScalarValue::Int64(*a.min(b)))
+                }
+                (Some(ScalarValue::Float32(a)), Some(ScalarValue::Float32(b))) => {
+                    Some(ScalarValue::Float32(a.min(*b)))
+                }
+                (Some(ScalarValue::Float64(a)), Some(ScalarValue::Float64(b))) => {
+                    Some(ScalarValue::Float64(a.min(*b)))
+                }
+                _ => {
+                    return Err(ExecutionError::ExecutionError(
+                        "unsupported data type for MIN".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn accumulate_array(&mut self, array: ArrayRef) -> Result<()> {
+        let scalar = match array.data_type() {
+            DataType::UInt8 => {
+                match compute::min(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt16 => {
+                match compute::min(array.as_any().downcast_ref::<UInt16Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt32 => {
+                match compute::min(array.as_any().downcast_ref::<UInt32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt64 => {
+                match compute::min(array.as_any().downcast_ref::<UInt64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int8 => {
+                match compute::min(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int16 => {
+                match compute::min(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int32 => {
+                match compute::min(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int64 => {
+                match compute::min(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float32 => {
+                match compute::min(array.as_any().downcast_ref::<Float32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float64 => {
+                match compute::min(array.as_any().downcast_ref::<Float64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                    None => Ok(None),
+                }
+            }
+            _ => Err(ExecutionError::ExecutionError(
+                "Unsupported data type for MIN".to_string(),
+            )),
+        }?;
+        self.accumulate_scalar(&scalar, true)
+    }
+
+    fn result(&self) -> Option<ScalarValue> {
+        self.value.clone()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}

--- a/rust/datafusion/src/execution/aggregate/mod.rs
+++ b/rust/datafusion/src/execution/aggregate/mod.rs
@@ -107,6 +107,7 @@ trait AggregateFunction {
         rollup: bool,
     ) -> Result<()>;
 
+    /// Update the current aggregate value based on an array of values.
     fn accumulate_array(&mut self, array: ArrayRef) -> Result<()>;
 
     /// Return the result of the aggregate function after all values have been processed

--- a/rust/datafusion/src/execution/aggregate/sum.rs
+++ b/rust/datafusion/src/execution/aggregate/sum.rs
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! SUM aggregate function
+
+use crate::arrow::array::*;
+use crate::arrow::compute;
+use crate::arrow::datatypes::DataType;
+
+use crate::error::{ExecutionError, Result};
+use crate::execution::aggregate::AggregateFunction;
+use crate::logicalplan::ScalarValue;
+
+/// Implementation of SUM aggregate function
+#[derive(Debug)]
+pub(super) struct SumFunction {
+    data_type: DataType,
+    value: Option<ScalarValue>,
+}
+
+impl SumFunction {
+    pub fn new(data_type: &DataType) -> Self {
+        Self {
+            data_type: data_type.clone(),
+            value: None,
+        }
+    }
+}
+
+impl AggregateFunction for SumFunction {
+    fn name(&self) -> &str {
+        "sum"
+    }
+
+    fn accumulate_scalar(
+        &mut self,
+        value: &Option<ScalarValue>,
+        _rollup: bool,
+    ) -> Result<()> {
+        if self.value.is_none() {
+            self.value = value.clone();
+        } else if value.is_some() {
+            self.value = match (&self.value, value) {
+                (Some(ScalarValue::UInt8(a)), Some(ScalarValue::UInt8(b))) => {
+                    Some(ScalarValue::UInt8(*a + b))
+                }
+                (Some(ScalarValue::UInt16(a)), Some(ScalarValue::UInt16(b))) => {
+                    Some(ScalarValue::UInt16(*a + b))
+                }
+                (Some(ScalarValue::UInt32(a)), Some(ScalarValue::UInt32(b))) => {
+                    Some(ScalarValue::UInt32(*a + b))
+                }
+                (Some(ScalarValue::UInt64(a)), Some(ScalarValue::UInt64(b))) => {
+                    Some(ScalarValue::UInt64(*a + b))
+                }
+                (Some(ScalarValue::Int8(a)), Some(ScalarValue::Int8(b))) => {
+                    Some(ScalarValue::Int8(*a + b))
+                }
+                (Some(ScalarValue::Int16(a)), Some(ScalarValue::Int16(b))) => {
+                    Some(ScalarValue::Int16(*a + b))
+                }
+                (Some(ScalarValue::Int32(a)), Some(ScalarValue::Int32(b))) => {
+                    Some(ScalarValue::Int32(*a + b))
+                }
+                (Some(ScalarValue::Int64(a)), Some(ScalarValue::Int64(b))) => {
+                    Some(ScalarValue::Int64(*a + b))
+                }
+                (Some(ScalarValue::Float32(a)), Some(ScalarValue::Float32(b))) => {
+                    Some(ScalarValue::Float32(a + *b))
+                }
+                (Some(ScalarValue::Float64(a)), Some(ScalarValue::Float64(b))) => {
+                    Some(ScalarValue::Float64(a + *b))
+                }
+                _ => {
+                    return Err(ExecutionError::ExecutionError(
+                        "unsupported data type for SUM".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn accumulate_array(&mut self, array: ArrayRef) -> Result<()> {
+        let scalar = match array.data_type() {
+            DataType::UInt8 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt16 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt16Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt32 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt64 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int8 => {
+                match compute::sum(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int16 => {
+                match compute::sum(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int32 => {
+                match compute::sum(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int64 => {
+                match compute::sum(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float32 => {
+                match compute::sum(array.as_any().downcast_ref::<Float32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float64 => {
+                match compute::sum(array.as_any().downcast_ref::<Float64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                    None => Ok(None),
+                }
+            }
+            _ => Err(ExecutionError::ExecutionError(
+                "Unsupported data type for SUM".to_string(),
+            )),
+        }?;
+        self.accumulate_scalar(&scalar, true)
+    }
+
+    fn result(&self) -> Option<ScalarValue> {
+        self.value.clone()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -91,8 +91,8 @@ impl CompiledAggregateExpression {
         &self.t
     }
 
-    /// invoke the compiled expression
-    pub fn invoke(&self, batch: &RecordBatch) -> Result<ArrayRef> {
+    /// invoke the compiled expression for the input to the aggregate function
+    pub fn evaluate_arg(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         self.args[0].invoke(batch)
     }
 }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -315,12 +315,12 @@ impl SqlToRel {
                         let rex_args = args
                             .iter()
                             .map(|a| match a {
-                                // this feels hacky but translate COUNT(1)/COUNT(*) to
-                                // COUNT(first_column)
-                                ASTNode::SQLValue(sqlparser::sqlast::Value::Long(1)) => {
-                                    Ok(Expr::Column(0))
+                                ASTNode::SQLValue(sqlparser::sqlast::Value::Long(_)) => {
+                                    Ok(Expr::Literal(ScalarValue::UInt8(1)))
                                 }
-                                ASTNode::SQLWildcard => Ok(Expr::Column(0)),
+                                ASTNode::SQLWildcard => {
+                                    Ok(Expr::Literal(ScalarValue::UInt8(1)))
+                                },
                                 _ => self.sql_to_rex(a, schema),
                             })
                             .collect::<Result<Vec<Expr>>>()?;
@@ -482,6 +482,14 @@ mod tests {
     #[test]
     fn select_count_one() {
         let sql = "SELECT COUNT(1) FROM person";
+        let expected = "Aggregate: groupBy=[[]], aggr=[[COUNT(UInt8(1))]]\
+                        \n  TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn select_count_column() {
+        let sql = "SELECT COUNT(id) FROM person";
         let expected = "Aggregate: groupBy=[[]], aggr=[[COUNT(#0)]]\
                         \n  TableScan: person projection=None";
         quick_test(sql, expected);

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -47,6 +47,16 @@ fn parquet_query() {
 }
 
 #[test]
+fn csv_count_star() {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx);
+    let sql = "SELECT COUNT(*), COUNT(1), COUNT(c1) FROM aggregate_test_100";
+    let actual = execute(&mut ctx, sql);
+    let expected = "100\t100\t100\n".to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn csv_query_with_predicate() {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv(&mut ctx);


### PR DESCRIPTION
This PR splits out the various aggregate functions into separate files and adds a new `aggregate_array` method to the aggregate function trait, allowing more logic to be delegated to each function.

This PR builds on https://github.com/apache/arrow/pull/4036 and I will rebase once that one is merged.