### PR TITLE
ARROW-3791: [C++ / Python] Add boolean type inference to the CSV parser

### DIFF
--- a/cpp/src/arrow/csv/column-builder-test.cc
+++ b/cpp/src/arrow/csv/column-builder-test.cc
@@ -189,6 +189,34 @@ TEST(InferringColumnBuilder, MultipleChunkInteger) {
   AssertChunkedEqual(*expected, *actual);
 }
 
+TEST(InferringColumnBuilder, SingleChunkBoolean) {
+  auto tg = TaskGroup::MakeSerial();
+  std::shared_ptr<ColumnBuilder> builder;
+  ASSERT_OK(ColumnBuilder::Make(0, ConvertOptions::Defaults(), tg, &builder));
+
+  std::shared_ptr<ChunkedArray> actual;
+  AssertBuilding(builder, {{"", "0", "FALSE"}}, &actual);
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<BooleanType, bool>({{false, true, true}},
+                                            {{false, false, false}}, &expected);
+  AssertChunkedEqual(*expected, *actual);
+}
+
+TEST(InferringColumnBuilder, MultipleChunkBoolean) {
+  auto tg = TaskGroup::MakeSerial();
+  std::shared_ptr<ColumnBuilder> builder;
+  ASSERT_OK(ColumnBuilder::Make(0, ConvertOptions::Defaults(), tg, &builder));
+
+  std::shared_ptr<ChunkedArray> actual;
+  AssertBuilding(builder, {{""}, {"1", "True", "0"}}, &actual);
+
+  std::shared_ptr<ChunkedArray> expected;
+  ChunkedArrayFromVector<BooleanType, bool>({{false}, {true, true, true}},
+                                            {{false}, {true, true, false}}, &expected);
+  AssertChunkedEqual(*expected, *actual);
+}
+
 TEST(InferringColumnBuilder, SingleChunkReal) {
   auto tg = TaskGroup::MakeSerial();
   std::shared_ptr<ColumnBuilder> builder;
@@ -315,6 +343,9 @@ TEST(InferringColumnBuilder, MultipleChunkBinary) {
       {{true}, {true}, {true, true}}, {{""}, {"008"}, {"NaN", "baré\xff"}}, &expected);
   AssertChunkedEqual(*expected, *actual);
 }
+
+// Parallel parsing is tested more comprehensively on the Python side
+// (see python/pyarrow/tests/test_csv.py)
 
 TEST(InferringColumnBuilder, MultipleChunkIntegerParallel) {
   auto tg = TaskGroup::MakeThreaded(GetCpuThreadPool());

--- a/cpp/src/arrow/csv/column-builder.cc
+++ b/cpp/src/arrow/csv/column-builder.cc
@@ -167,7 +167,7 @@ class InferringColumnBuilder : public ColumnBuilder {
   std::shared_ptr<Converter> converter_;
 
   // Current inference status
-  enum class InferKind { Null, Integer, Real, Timestamp, Text, Binary };
+  enum class InferKind { Null, Integer, Boolean, Real, Timestamp, Text, Binary };
 
   std::shared_ptr<DataType> infer_type_;
   InferKind infer_kind_;
@@ -191,6 +191,9 @@ Status InferringColumnBuilder::LoosenType() {
       infer_kind_ = InferKind::Integer;
       break;
     case InferKind::Integer:
+      infer_kind_ = InferKind::Boolean;
+      break;
+    case InferKind::Boolean:
       infer_kind_ = InferKind::Timestamp;
       break;
     case InferKind::Timestamp:
@@ -218,6 +221,10 @@ Status InferringColumnBuilder::UpdateType() {
       break;
     case InferKind::Integer:
       infer_type_ = int64();
+      can_loosen_type_ = true;
+      break;
+    case InferKind::Boolean:
+      infer_type_ = boolean();
       can_loosen_type_ = true;
       break;
     case InferKind::Timestamp:

--- a/cpp/src/arrow/csv/options.cc
+++ b/cpp/src/arrow/csv/options.cc
@@ -24,10 +24,12 @@ ParseOptions ParseOptions::Defaults() { return ParseOptions(); }
 
 ConvertOptions ConvertOptions::Defaults() {
   auto options = ConvertOptions();
-  // The default list of possible null spellings is taken from Pandas' read_csv().
+  // Same default null / true / false spellings as in Pandas.
   options.null_values = {"",     "#N/A", "#N/A N/A", "#NA",     "-1.#IND", "-1.#QNAN",
                          "-NaN", "-nan", "1.#IND",   "1.#QNAN", "N/A",     "NA",
                          "NULL", "NaN",  "n/a",      "nan",     "null"};
+  options.true_values = {"1", "True", "TRUE", "true"};
+  options.false_values = {"0", "False", "FALSE", "false"};
   return options;
 }
 

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -69,6 +69,9 @@ struct ARROW_EXPORT ConvertOptions {
   std::unordered_map<std::string, std::shared_ptr<DataType>> column_types;
   // Recognized spellings for null values
   std::vector<std::string> null_values;
+  // Recognized spellings for boolean values
+  std::vector<std::string> true_values;
+  std::vector<std::string> false_values;
 
   static ConvertOptions Defaults();
 };

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -255,6 +255,12 @@ cdef class ConvertOptions:
     null_values: list, optional
         A sequence of strings that denote nulls in the data
         (defaults are appropriate in most cases).
+    true_values: list, optional
+        A sequence of strings that denote true booleans in the data
+        (defaults are appropriate in most cases).
+    false_values: list, optional
+        A sequence of strings that denote false booleans in the data
+        (defaults are appropriate in most cases).
     """
     cdef:
         CCSVConvertOptions options
@@ -262,7 +268,8 @@ cdef class ConvertOptions:
     # Avoid mistakingly creating attributes
     __slots__ = ()
 
-    def __init__(self, check_utf8=None, column_types=None, null_values=None):
+    def __init__(self, check_utf8=None, column_types=None, null_values=None,
+                 true_values=None, false_values=None):
         self.options = CCSVConvertOptions.Defaults()
         if check_utf8 is not None:
             self.check_utf8 = check_utf8
@@ -270,6 +277,10 @@ cdef class ConvertOptions:
             self.column_types = column_types
         if null_values is not None:
             self.null_values = null_values
+        if true_values is not None:
+            self.true_values = true_values
+        if false_values is not None:
+            self.false_values = false_values
 
     @property
     def check_utf8(self):
@@ -321,6 +332,28 @@ cdef class ConvertOptions:
     @null_values.setter
     def null_values(self, value):
         self.options.null_values = [tobytes(x) for x in value]
+
+    @property
+    def true_values(self):
+        """
+        A sequence of strings that denote true booleans in the data.
+        """
+        return [frombytes(x) for x in self.options.true_values]
+
+    @true_values.setter
+    def true_values(self, value):
+        self.options.true_values = [tobytes(x) for x in value]
+
+    @property
+    def false_values(self):
+        """
+        A sequence of strings that denote false booleans in the data.
+        """
+        return [frombytes(x) for x in self.options.false_values]
+
+    @false_values.setter
+    def false_values(self, value):
+        self.options.false_values = [tobytes(x) for x in value]
 
 
 cdef _get_reader(input_file, shared_ptr[InputStream]* out):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1008,6 +1008,8 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         c_bool check_utf8
         unordered_map[c_string, shared_ptr[CDataType]] column_types
         vector[c_string] null_values
+        vector[c_string] true_values
+        vector[c_string] false_values
 
         @staticmethod
         CCSVConvertOptions Defaults()


### PR DESCRIPTION
The set of recognized values can be customized using arrow::csv::ConvertOptions.