### PR TITLE
ARROW-5046: [Release][C++] Exclude fragile Plasma test from verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -224,7 +224,12 @@ ${ARROW_CMAKE_OPTIONS}
   git clone https://github.com/apache/parquet-testing.git
   export PARQUET_TEST_DATA=$PWD/parquet-testing/data
 
-  ctest -j$NPROC --output-on-failure -L unittest
+  # TODO: ARROW-5036
+  ctest \
+    --exclude-regex "plasma-serialization_tests" \
+    -j$NPROC \
+    --output-on-failure \
+    -L unittest
   popd
 }
 


### PR DESCRIPTION
We should fix this in 0.14.0.
https://issues.apache.org/jira/browse/ARROW-5036