### PR TITLE
ARROW-5049: [Python] org/apache/hadoop/fs/FileSystem class not found  when pyarrow FileSystem used in spark

### DIFF
--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -125,7 +125,7 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 def _maybe_set_hadoop_classpath():
     import re
 
-    if re.match('.*/hadoop-common[^/]+.jar', os.environ.get('CLASSPATH', '')):
+    if re.search(r'hadoop-common[^/]+.jar', os.environ.get('CLASSPATH', '')):
         return
 
     if 'HADOOP_HOME' in os.environ:

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -123,7 +123,9 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
 
 def _maybe_set_hadoop_classpath():
-    if 'hadoop' in os.environ.get('CLASSPATH', ''):
+    import re
+
+    if re.match('.*/hadoop-common[^/]+.jar', os.environ.get('CLASSPATH', '')):
         return
 
     if 'HADOOP_HOME' in os.environ:


### PR DESCRIPTION
ensure hadoop-common*.jar in classpath