### PR TITLE
ARROW-5084: [Website] Add blog post for 0.13.0 release

### DIFF
--- a/site/_posts/2019-04-02-0.13.0-release.md
+++ b/site/_posts/2019-04-02-0.13.0-release.md
@@ -62,138 +62,96 @@ check C++ and Java compatibility, an we have added Python bindings for the C++
 library. We will write a future blog post to go into more detail about how
 Flight works.
 
-## C++ CMake Revamp
+## C++ notes
 
-We have undertaken a significant reworking of our CMake build system for C++ to
-make the third party dependencies more configurable. Read more about this in
-the [C++ developer documentation][18].
+There were 231 issues relating to C++ in this release, far too much to
+summarize in a blog post. Some notable items include:
 
-## Java improvements
+* An experimental `ExtensionType` was developed for creating user-defined data
+  types that can be embedded in the Arrow binary protocol. This is not yet
+  finalized, but [feedback would be welcome][51].
+* We have undertaken a significant reworking of our CMake build system for C++
+  to make the third party dependencies more configurable. Among other things,
+  this eases work on packaging for Linux distributions. Read more about this in
+  the [C++ developer documentation][18].
+* Laying more groundwork for an Arrow-native in-memory query engine
+* We began building a reader for line-delimited JSON files
+* Gandiva can now be compiled on Windows with Visual Studio
+
+## C# Notes
+
+C# .NET development has picked up since the initial code donation last
+fall. 11 issues were resolved this release cycle.
+
+The Arrow C# package is now available via NuGet.
+
+## Go notes
+
+8 Go-related issues were resolved. A notable feature is the addition of a CSV
+file writer.
+
+## Java notes
+
+26 Java issues were resolved. Outside of Flight-related work, some notable
+items include:
 
 * Migration to Java 8 date and time APIs from Joda
+* Array type support in JDBC adapter
 
-## Python developments
+## Python notes
 
-* Improved pandas serialization performance with RangeIndex
+86 Python-related issues were resolved. Some highlights include:
+
 * The Gandiva LLVM expression compiler is now available in the Python wheels
   through the ``pyarrow.gandiva`` module.
+* Flight RPC bindings
+* Improved pandas serialization performance with RangeIndex
+* pyarrow can be used without pandas installed
 
-## Rust developments
+Note that Apache Arrow will continue to support Python 2.7 until January 2020.
 
+## Ruby and C GLib notes
+
+36 C/GLib- and Ruby-related issues were resolved. The work continues to follow
+the upstream work in the C++ project.
+
+## Rust notes
+
+69 Rust-related issues were resolved. Many of these relate to ongoing work in
+the DataFusion query engine. Some notable items include:
+
+* Parallel file scans in DataFusion
+* Prototype DataFrame-style API for DataFusion
 * Writing CSV files
-* Parquet support
+* Continued evolution of Parquet file reader
 
 ## R development progress
 
 The Arrow R developers have expanded the scope of the R language bindings and
 additionally worked on packaging support to be able to submit the package to
-CRAN in the near future.
+CRAN in the near future. 23 issues were resolved for this release.
 
 [We wrote in January about ongoing work][50] to accelerate R work on Apache Spark
 using Arrow.
 
 ## Community Discussions Ongoing
 
+There are a number of active discussions ongoing on the developer
+``dev@arrow.apache.org`` mailing list. We look forward to hearing from the
+community there:
+
 * **Benchmarking**: we are working to create tools for tracking all of our
   benchmark results on a commit-by-commit basis in a centralized database
   schema so that we can monitor for performance regressions over time. We hope
   to develop a publicly viewable benchmark result dashboard.
-
-## C++ notes
-
-* Beginning to lay more groundwork for an Arrow-native in-memory query engine
-
-Much of the C++ development work the last 3 months concerned internal code
-refactoring and performance improvements. Some user-visible highlights of note:
-
-* Experimental support for [in-memory sparse tensors (or ndarrays)][21], with
-  support for zero-copy IPC
-* Support for building on Alpine Linux
-* Significantly improved hash table utilities, with improved hash table
-  performance in many parts of the library
-* IO library improvements for both read and write buffering
-* A fast [trie implementation][20] for string searching
-* Many improvements to the parallel CSV reader in performance and features. See
-  the changelog
-
-Since the LLVM-based Gandiva expression compiler was donated to Apache Arrow
-during the last release cycle, development there has been moving along. We
-expect to have Windows support for Gandiva and to ship this in downstream
-packages (like Python) in the 0.13 release time frame.
-
-## Go notes
-
-The Arrow Go development team has been expanding. The Go library has gained
-support for many missing features from the columnar format as well as semantic
-constructs like chunked arrays and tables that are used heavily in the C++
-project.
-
-## GLib and Ruby notes
-
-Development of the GLib-based C bindings and corresponding Ruby interfaces have
-advanced in lock-step with the C++, Python, and R libraries. In this release,
-there are many new features in C and Ruby:
-
-* Compressed file read/write support
-* Support for using the C++ parallel CSV reader
-* Feather file support
-* Gandiva bindings
-* Plasma bindings
-
-## Python notes
-
-We fixed a ton of bugs and made many improvements throughout the Python
-project. Some highlights from the Python side include:
-
-* Python 3.7 support: wheels and conda packages are now available for Python
-  3.7
-* Substantially improved memory use when converting strings types to pandas
-  format, including when reading Parquet files. Parquet users should notice
-  significantly lower memory use in common use cases
-* Support for reading and writing compressed files, can be used for CSV files,
-  IPC, or any other form of IO
-* The new `pyarrow.input_stream` and `pyarrow.output_stream` functions support
-  read and write buffering. This is analogous to `BufferedIOBase` from the
-  Python standard library, but the internals are implemented natively in C++.
-* Gandiva (LLVM expression compiler) bindings, though not yet available in
-  pip/conda yet. Look for this in 0.13.0.
-* Many improvements to Arrow CUDA integration, including interoperability with
-  Numba
-
-## R notes
-
-The R library made huge progress in 0.12, with work led by new committer Romain
-Francois. The R project's features are not far behind the Python library, and
-we are hoping to be able to make the R library available to CRAN users for use
-with Apache Spark or for reading and writing Parquet files over the next
-quarter.
-
-Users of the `feather` R library will see significant speed increases in many
-cases when reading Feather files with the new Arrow R library.
-
-## Rust notes
-
-Rust development had an active last 3 months; see the changelog for details.
-
-A native Rust implementation was just donated to the project, and the community
-intends to provide a similar level of functionality for reading and writing
-Parquet files using the Arrow in-memory columnar format as an intermediary.
-
-## Upcoming Roadmap, Outlook for 2019
-
-Apache Arrow has become a large, diverse open source project. It is now being
-used in dozens of downstream open source and commercial projects. Work will be
-proceeding in many areas in 2019:
-
-* Development of in-memory query execution engines (e.g. in C++, Rust)
-* Expanded support for reading and writing the Apache Parquet format, and other
-  common data formats like Apache Avro, CSV, JSON, and Apache ORC.
-* New Flight RPC system for fast messaging of Arrow datasets
-* Expanded support in existing programming languages
-* New programming language bindings or native implementations
-
-It promises to be an exciting 2019. We look forward to having you involved in
-the development community.
+* **C++ Datasets**: development of a unified API for reading and writing
+  datasets stored in various common formats like Parquet, JSON, and CSV.
+* **C++ Query Engine**: architecture of a parallel Arrow-native query engine
+  for C++
+* **Arrow Flight Evolution**: adding features to support different real-world
+  data messaging use cases
+* **Arrow Columnar Format evolution**: we are discussing a new "duration" or
+  "time interval" type and some other additions to the Arrow columnar format.
 
 [1]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20ARROW%20AND%20status%20%3D%20Resolved%20AND%20fixVersion%20%3D%200.13.0
 [2]: https://arrow.apache.org/install
@@ -208,3 +166,4 @@ the development community.
 [22]: https://arrow.apache.org/release/0.13.0.html#contributors
 [23]: https://arrow.apache.org/install/
 [50]: http://arrow.apache.org/blog/2019/01/25/r-spark-improvements/
+[51]: https://github.com/apache/arrow/blob/master/cpp/src/arrow/extension_type.h

--- a/site/_posts/2019-04-02-0.13.0-release.md
+++ b/site/_posts/2019-04-02-0.13.0-release.md
@@ -1,0 +1,210 @@
+---
+layout: post
+title: "Apache Arrow 0.13.0 Release"
+date: "2019-04-01 07:00:00 -0600"
+author: wesm
+categories: [release]
+---
+<!--
+{% comment %}
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+The Apache Arrow team is pleased to announce the 0.13.0 release. This is the
+covers more than 2 months of development work and includes [**550 resolved
+issues**][1] from [**81 distinct contributors**][22].
+
+See the [Install Page][2] to learn how to get the libraries for your
+platform. The [complete changelog][3] is also available.
+
+While it's a large release, this post will give some brief highlights in the
+project since the 0.12.0 release from January.
+
+## New committer and PMC member
+
+The Arrow team is growing! Since the 0.12.0 release we have increased the size
+of our committer and PMC rosters.
+
+* [Andy Grove][13] was promoted to PMC member
+* [Micah Kornfield][14] was added as a committer
+
+Thank you for all your contributions!
+
+## Rust DataFusion Query Engine donation
+
+Since the last release, we received a donation of [DataFusion][17], a
+Rust-native query engine for the Arrow columnar format, whose development had
+been led prior by Andy grove. [Read more about DataFusion][19] in our February
+blog post.
+
+This is an exciting development for the Rust community, and we look forward to
+developing more analytical query processing within the Apache Arrow project.
+
+## Arrow Flight gRPC progress
+
+Over the last couple months, we have made significant progress on Arrow Flight,
+an Arrow-native data messaging framework. We have have integration tests to
+check C++ and Java compatibility, an we have added Python bindings for the C++
+library. We will write a future blog post to go into more detail about how
+Flight works.
+
+## C++ CMake Revamp
+
+We have undertaken a significant reworking of our CMake build system for C++ to
+make the third party dependencies more configurable. Read more about this in
+the [C++ developer documentation][18].
+
+## Java improvements
+
+* Migration to Java 8 date and time APIs from Joda
+
+## Python developments
+
+* Improved pandas serialization performance with RangeIndex
+* The Gandiva LLVM expression compiler is now available in the Python wheels
+  through the ``pyarrow.gandiva`` module.
+
+## Rust developments
+
+* Writing CSV files
+* Parquet support
+
+## R development progress
+
+The Arrow R developers have expanded the scope of the R language bindings and
+additionally worked on packaging support to be able to submit the package to
+CRAN in the near future.
+
+[We wrote in January about ongoing work][50] to accelerate R work on Apache Spark
+using Arrow.
+
+## Community Discussions Ongoing
+
+* **Benchmarking**: we are working to create tools for tracking all of our
+  benchmark results on a commit-by-commit basis in a centralized database
+  schema so that we can monitor for performance regressions over time. We hope
+  to develop a publicly viewable benchmark result dashboard.
+
+## C++ notes
+
+* Beginning to lay more groundwork for an Arrow-native in-memory query engine
+
+Much of the C++ development work the last 3 months concerned internal code
+refactoring and performance improvements. Some user-visible highlights of note:
+
+* Experimental support for [in-memory sparse tensors (or ndarrays)][21], with
+  support for zero-copy IPC
+* Support for building on Alpine Linux
+* Significantly improved hash table utilities, with improved hash table
+  performance in many parts of the library
+* IO library improvements for both read and write buffering
+* A fast [trie implementation][20] for string searching
+* Many improvements to the parallel CSV reader in performance and features. See
+  the changelog
+
+Since the LLVM-based Gandiva expression compiler was donated to Apache Arrow
+during the last release cycle, development there has been moving along. We
+expect to have Windows support for Gandiva and to ship this in downstream
+packages (like Python) in the 0.13 release time frame.
+
+## Go notes
+
+The Arrow Go development team has been expanding. The Go library has gained
+support for many missing features from the columnar format as well as semantic
+constructs like chunked arrays and tables that are used heavily in the C++
+project.
+
+## GLib and Ruby notes
+
+Development of the GLib-based C bindings and corresponding Ruby interfaces have
+advanced in lock-step with the C++, Python, and R libraries. In this release,
+there are many new features in C and Ruby:
+
+* Compressed file read/write support
+* Support for using the C++ parallel CSV reader
+* Feather file support
+* Gandiva bindings
+* Plasma bindings
+
+## Python notes
+
+We fixed a ton of bugs and made many improvements throughout the Python
+project. Some highlights from the Python side include:
+
+* Python 3.7 support: wheels and conda packages are now available for Python
+  3.7
+* Substantially improved memory use when converting strings types to pandas
+  format, including when reading Parquet files. Parquet users should notice
+  significantly lower memory use in common use cases
+* Support for reading and writing compressed files, can be used for CSV files,
+  IPC, or any other form of IO
+* The new `pyarrow.input_stream` and `pyarrow.output_stream` functions support
+  read and write buffering. This is analogous to `BufferedIOBase` from the
+  Python standard library, but the internals are implemented natively in C++.
+* Gandiva (LLVM expression compiler) bindings, though not yet available in
+  pip/conda yet. Look for this in 0.13.0.
+* Many improvements to Arrow CUDA integration, including interoperability with
+  Numba
+
+## R notes
+
+The R library made huge progress in 0.12, with work led by new committer Romain
+Francois. The R project's features are not far behind the Python library, and
+we are hoping to be able to make the R library available to CRAN users for use
+with Apache Spark or for reading and writing Parquet files over the next
+quarter.
+
+Users of the `feather` R library will see significant speed increases in many
+cases when reading Feather files with the new Arrow R library.
+
+## Rust notes
+
+Rust development had an active last 3 months; see the changelog for details.
+
+A native Rust implementation was just donated to the project, and the community
+intends to provide a similar level of functionality for reading and writing
+Parquet files using the Arrow in-memory columnar format as an intermediary.
+
+## Upcoming Roadmap, Outlook for 2019
+
+Apache Arrow has become a large, diverse open source project. It is now being
+used in dozens of downstream open source and commercial projects. Work will be
+proceeding in many areas in 2019:
+
+* Development of in-memory query execution engines (e.g. in C++, Rust)
+* Expanded support for reading and writing the Apache Parquet format, and other
+  common data formats like Apache Avro, CSV, JSON, and Apache ORC.
+* New Flight RPC system for fast messaging of Arrow datasets
+* Expanded support in existing programming languages
+* New programming language bindings or native implementations
+
+It promises to be an exciting 2019. We look forward to having you involved in
+the development community.
+
+[1]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20ARROW%20AND%20status%20%3D%20Resolved%20AND%20fixVersion%20%3D%200.13.0
+[2]: https://arrow.apache.org/install
+[3]: https://arrow.apache.org/release/0.13.0.html
+[13]: https://github.com/andygrove
+[14]: https://github.com/emkornfield
+[17]: http://incubator.apache.org/ip-clearance/arrow-rust-datafusion.html
+[18]: https://github.com/apache/arrow/blob/master/docs/source/developers/cpp.rst#build-dependency-management
+[19]: http://arrow.apache.org/blog/2019/02/04/datafusion-donation/
+[20]: https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/trie.h
+[21]: https://github.com/apache/arrow/blob/master/cpp/src/arrow/sparse_tensor.h
+[22]: https://arrow.apache.org/release/0.13.0.html#contributors
+[23]: https://arrow.apache.org/install/
+[50]: http://arrow.apache.org/blog/2019/01/25/r-spark-improvements/

--- a/site/_posts/2019-04-02-0.13.0-release.md
+++ b/site/_posts/2019-04-02-0.13.0-release.md
@@ -24,8 +24,8 @@ limitations under the License.
 {% endcomment %}
 -->
 
-The Apache Arrow team is pleased to announce the 0.13.0 release. This is the
-covers more than 2 months of development work and includes [**550 resolved
+The Apache Arrow team is pleased to announce the 0.13.0 release. This covers
+more than 2 months of development work and includes [**550 resolved
 issues**][1] from [**81 distinct contributors**][22].
 
 See the [Install Page][2] to learn how to get the libraries for your
@@ -48,7 +48,7 @@ Thank you for all your contributions!
 
 Since the last release, we received a donation of [DataFusion][17], a
 Rust-native query engine for the Arrow columnar format, whose development had
-been led prior by Andy grove. [Read more about DataFusion][19] in our February
+been led prior by Andy Grove. [Read more about DataFusion][19] in our February
 blog post.
 
 This is an exciting development for the Rust community, and we look forward to
@@ -57,8 +57,8 @@ developing more analytical query processing within the Apache Arrow project.
 ## Arrow Flight gRPC progress
 
 Over the last couple months, we have made significant progress on Arrow Flight,
-an Arrow-native data messaging framework. We have have integration tests to
-check C++ and Java compatibility, an we have added Python bindings for the C++
+an Arrow-native data messaging framework. We have integration tests to check
+C++ and Java compatibility, and we have added Python bindings for the C++
 library. We will write a future blog post to go into more detail about how
 Flight works.
 
@@ -83,7 +83,7 @@ summarize in a blog post. Some notable items include:
 C# .NET development has picked up since the initial code donation last
 fall. 11 issues were resolved this release cycle.
 
-The Arrow C# package is now available via NuGet.
+The Arrow C# package is [now available via NuGet][244].
 
 ## Go notes
 
@@ -97,6 +97,13 @@ items include:
 
 * Migration to Java 8 date and time APIs from Joda
 * Array type support in JDBC adapter
+
+## Javascript Notes
+
+The recent [JavaScript 0.4.1 release][243] is the last JavaScript-only release
+of Apache Arrow. Starting with 0.13 the Javascript implementation is now
+included in mainline Arrow releases! The version number of the released
+JavaScript packages will now be in sync with the mainline version number.
 
 ## Python notes
 
@@ -115,14 +122,20 @@ Note that Apache Arrow will continue to support Python 2.7 until January 2020.
 36 C/GLib- and Ruby-related issues were resolved. The work continues to follow
 the upstream work in the C++ project.
 
+* `Arrow::RecordBatch#raw_records` was added. It can convert a record batch to
+  a Ruby's array in 10x-200x faster than the same conversion by a pure-Ruby
+  implementation.
+
 ## Rust notes
 
 69 Rust-related issues were resolved. Many of these relate to ongoing work in
 the DataFusion query engine. Some notable items include:
 
-* Parallel file scans in DataFusion
+* Date/time support
+* SIMD for arithmetic operations
+* Writing CSV and reading line-delimited JSON
+* Parquet data source support for DataFusion
 * Prototype DataFrame-style API for DataFusion
-* Writing CSV files
 * Continued evolution of Parquet file reader
 
 ## R development progress
@@ -161,9 +174,8 @@ community there:
 [17]: http://incubator.apache.org/ip-clearance/arrow-rust-datafusion.html
 [18]: https://github.com/apache/arrow/blob/master/docs/source/developers/cpp.rst#build-dependency-management
 [19]: http://arrow.apache.org/blog/2019/02/04/datafusion-donation/
-[20]: https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/trie.h
-[21]: https://github.com/apache/arrow/blob/master/cpp/src/arrow/sparse_tensor.h
 [22]: https://arrow.apache.org/release/0.13.0.html#contributors
-[23]: https://arrow.apache.org/install/
 [50]: http://arrow.apache.org/blog/2019/01/25/r-spark-improvements/
 [51]: https://github.com/apache/arrow/blob/master/cpp/src/arrow/extension_type.h
+[243]: https://www.npmjs.com/package/apache-arrow/v/0.4.1
+[244]: https://www.nuget.org/packages/Apache.Arrow/0.13.0


### PR DESCRIPTION
This post is fairly brief; the releases are getting harder and harder to summarize in a short blog post, so I don't think we can go into too much detail.

If anyone from the other PLs would like to post a blurb for me to add (GLib, Ruby, Rust, Go, Java, JavaScript, C#) please write here and I'll incorporate.

I will plan to publish this and send out on social media tomorrow (April 2) morning in the USA.