### PR TITLE
ARROW-5100: [JS] Remove swap while collapsing contiguous buffers

### DIFF
--- a/js/gulp/arrow-task.js
+++ b/js/gulp/arrow-task.js
@@ -40,14 +40,14 @@ const arrowTask = ((cache) => memoizeTask(cache, function copyMain(target) {
     const esnextUmdSourceMapsGlob = `${targetDir(`esnext`, `umd`)}/*.map`;
     return Observable.forkJoin(
         observableFromStreams(gulp.src(dtsGlob),                 gulp.dest(out)), // copy d.ts files
-        observableFromStreams(gulp.src(cjsGlob),                 gulp.dest(out)), // copy es2015 cjs files
-        observableFromStreams(gulp.src(cjsSourceMapsGlob),       gulp.dest(out)), // copy es2015 cjs sourcemaps
-        observableFromStreams(gulp.src(esmSourceMapsGlob),       gulp.dest(out)), // copy es2015 esm sourcemaps
+        observableFromStreams(gulp.src(cjsGlob),                 gulp.dest(out)), // copy esnext cjs files
+        observableFromStreams(gulp.src(cjsSourceMapsGlob),       gulp.dest(out)), // copy esnext cjs sourcemaps
+        observableFromStreams(gulp.src(esmSourceMapsGlob),       gulp.dest(out)), // copy esnext esm sourcemaps
         observableFromStreams(gulp.src(es5UmdSourceMapsGlob),    gulp.dest(out)), // copy es5 umd sourcemap files, but don't rename
-        observableFromStreams(gulp.src(esnextUmdSourceMapsGlob), gulp.dest(out)), // copy es2015 umd sourcemap files, but don't rename
-        observableFromStreams(gulp.src(esmGlob),       gulpRename((p) => { p.extname = '.mjs'; }),          gulp.dest(out)), // copy es2015 esm files and rename to `.mjs`
+        observableFromStreams(gulp.src(esnextUmdSourceMapsGlob), gulp.dest(out)), // copy esnext umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(esmGlob),       gulpRename((p) => { p.extname = '.mjs'; }),          gulp.dest(out)), // copy esnext esm files and rename to `.mjs`
         observableFromStreams(gulp.src(es5UmdGlob),    gulpRename((p) => { p.basename += `.es5.min`; }),    gulp.dest(out)), // copy es5 umd files and add `.min`
-        observableFromStreams(gulp.src(esnextUmdGlob), gulpRename((p) => { p.basename += `.es2015.min`; }), gulp.dest(out)), // copy es2015 umd files and add `.es2015.min`
+        observableFromStreams(gulp.src(esnextUmdGlob), gulpRename((p) => { p.basename += `.esnext.min`; }), gulp.dest(out)), // copy esnext umd files and add `.esnext.min`
     ).publish(new ReplaySubject()).refCount();
 }))({});
 

--- a/js/src/util/buffer.ts
+++ b/js/src/util/buffer.ts
@@ -32,14 +32,10 @@ function collapseContiguousByteRanges(chunks: Uint8Array[]) {
     for (let x, y, i = 0, j = 0, n = chunks.length; ++i < n;) {
         x = result[j];
         y = chunks[i];
-        // continue x and y don't share the same underlying ArrayBuffer
-        if (!x || !y || x.buffer !== y.buffer) {
+        // continue if x and y don't share the same underlying ArrayBuffer, or if x isn't before y
+        if (!x || !y || x.buffer !== y.buffer || y.byteOffset < x.byteOffset) {
             y && (result[++j] = y);
             continue;
-        }
-        // swap if y starts before x
-        if (y.byteOffset < x.byteOffset) {
-            x = chunks[i]; y = result[j];
         }
         ({ byteOffset: xOffset, byteLength: xLen } = x);
         ({ byteOffset: yOffset, byteLength: yLen } = y);


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARROW-5100

Seems like this is a fairly rare edge case, but really perplexing when it happens. I saw it when manually creating Arrow Columns from data sliced out of an ArrayBuffer pool, and just so happened to get an overlapping + out-of-order set of buffers. I added a test case that demonstrates the issue too.

Description from the issue:
> We collapse contiguous Uint8Arrays that share the same underlying ArrayBuffer and have overlapping byte ranges. This was done to maintain true zero-copy behavior when using certain node core streams that use a buffer pool internally, and could write chunks of the same logical Arrow Message at out-of-order byte offsets in the pool.

> Unfortunately this can also lead to a bug where, in rare cases, buffers are swapped while writing Arrow Messages too. We could have a flag to indicate whether we think collapsing out-of-order same-buffer chunks is safe, but I'm not sure if we can always know that, so I'd prefer to take it out and incur the copy cost.
