### PR TITLE
ARROW-5131: [Python] Support Azure Data Lake Filesystem

### DIFF
--- a/python/pip-wheel-metadata/pyarrow.dist-info/LICENSE.txt
+++ b/python/pip-wheel-metadata/pyarrow.dist-info/LICENSE.txt
@@ -1,0 +1,88 @@
+## 3rd-party licenses for code that has been adapted for the Arrow Python
+   library
+
+-------------------------------------------------------------------------------
+Some code from pandas has been adapted for this codebase. pandas is available
+under the 3-clause BSD license, which follows:
+
+pandas license
+==============
+
+Copyright (c) 2011-2012, Lambda Foundry, Inc. and PyData Development Team
+All rights reserved.
+
+Copyright (c) 2008-2011 AQR Capital Management, LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the copyright holder nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-------------------------------------------------------------------------------
+
+Some bits from DyND, in particular aspects of the build system, have been
+adapted from libdynd and dynd-python under the terms of the BSD 2-clause
+license
+
+The BSD 2-Clause License
+
+    Copyright (C) 2011-12, Dynamic NDArray Developers
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+           notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above
+           copyright notice, this list of conditions and the following
+           disclaimer in the documentation and/or other materials provided
+           with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Dynamic NDArray Developers list:
+
+ * Mark Wiebe
+ * Continuum Analytics
+
+-------------------------------------------------------------------------------
+
+Some source code from Ibis (https://github.com/cloudera/ibis) has been adapted
+for Arrow. Ibis is released under the Apache License, Version 2.0.

--- a/python/pip-wheel-metadata/pyarrow.dist-info/LICENSE.txt
+++ b/python/pip-wheel-metadata/pyarrow.dist-info/LICENSE.txt
@@ -1,5 +1,4 @@
-## 3rd-party licenses for code that has been adapted for the Arrow Python
-   library
+
 
 -------------------------------------------------------------------------------
 Some code from pandas has been adapted for this codebase. pandas is available

--- a/python/pip-wheel-metadata/pyarrow.dist-info/METADATA
+++ b/python/pip-wheel-metadata/pyarrow.dist-info/METADATA
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: pyarrow
-Version: 0.12.1.dev204+g0bc43c9f
+Version: 0.12.1.dev205+g085022ab
 Summary: Python library for Apache Arrow
 Home-page: https://arrow.apache.org/
 Maintainer: Apache Arrow Developers

--- a/python/pip-wheel-metadata/pyarrow.dist-info/METADATA
+++ b/python/pip-wheel-metadata/pyarrow.dist-info/METADATA
@@ -1,0 +1,113 @@
+Metadata-Version: 2.1
+Name: pyarrow
+Version: 0.12.1.dev204+g0bc43c9f
+Summary: Python library for Apache Arrow
+Home-page: https://arrow.apache.org/
+Maintainer: Apache Arrow Developers
+Maintainer-email: dev@arrow.apache.org
+License: Apache License, Version 2.0
+Platform: UNKNOWN
+Classifier: License :: OSI Approved :: Apache Software License
+Classifier: Programming Language :: Python :: 2.7
+Classifier: Programming Language :: Python :: 3.5
+Classifier: Programming Language :: Python :: 3.6
+Classifier: Programming Language :: Python :: 3.7
+Description-Content-Type: text/markdown
+Requires-Dist: numpy (>=1.14)
+Requires-Dist: six (>=1.0.0)
+Requires-Dist: futures ; python_version < "3.2"
+Requires-Dist: enum34 (>=1.1.6) ; python_version < "3.4"
+
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+## Python library for Apache Arrow
+
+This library provides a Python API for functionality provided by the Arrow C++
+libraries, along with tools for Arrow integration and interoperability with
+pandas, NumPy, and other software in the Python ecosystem.
+
+## Installing
+
+Across platforms, you can install a recent version of pyarrow with the conda
+package manager:
+
+```shell
+conda install pyarrow -c conda-forge
+```
+
+On Linux/macOS and Windows, you can also install binary wheels from PyPI with pip:
+
+```shell
+pip install pyarrow
+```
+
+## Development
+
+### Coding Style
+
+We follow a similar PEP8-like coding style to the [pandas project][3].
+
+The code must pass `flake8` (available from pip or conda) or it will fail the
+build. Check for style errors before submitting your pull request with:
+
+```
+flake8 .
+flake8 --config=.flake8.cython .
+```
+
+### Building from Source
+
+See the [Development][2] page in the documentation.
+
+### Running the unit tests
+
+We are using [pytest][4] to develop our unit test suite. After building the
+project using `setup.py build_ext --inplace`, you can run its unit tests like
+so:
+
+```bash
+pytest pyarrow
+```
+
+The project has a number of custom command line options for its test
+suite. Some tests are disabled by default, for example. To see all the options,
+run
+
+```bash
+pytest pyarrow --help
+```
+
+and look for the "custom options" section.
+
+For running the benchmarks, see the [Sphinx documentation][5].
+
+### Building the documentation
+
+```bash
+pip install -r ../docs/requirements.txt
+python setup.py build_sphinx -s ../docs/source
+```
+
+[2]: https://github.com/apache/arrow/blob/master/docs/source/python/development.rst
+[3]: https://github.com/pandas-dev/pandas
+[4]: https://docs.pytest.org/en/latest/
+[5]: https://arrow.apache.org/docs/latest/python/benchmarks.html
+
+

--- a/python/pip-wheel-metadata/pyarrow.dist-info/entry_points.txt
+++ b/python/pip-wheel-metadata/pyarrow.dist-info/entry_points.txt
@@ -1,0 +1,3 @@
+[console_scripts]
+plasma_store = pyarrow:_plasma_store_entry_point
+

--- a/python/pip-wheel-metadata/pyarrow.dist-info/top_level.txt
+++ b/python/pip-wheel-metadata/pyarrow.dist-info/top_level.txt
@@ -1,0 +1,2 @@
+__dummy__
+pyarrow

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -438,8 +438,8 @@ def _sanitize_remote_path(path):
     elif path.startswith('adl://'):
         newpath = path.replace('adl://', '')
         path_parts = newpath.split('/')
-        path_parts = [p for p in path_parts if not
-        'azuredatalakestore.net' in p]
+        path_parts = [p for p in path_parts if 'azuredatalakestore.net' not
+                      in p]
         outpath = "/".join(path_parts)
         return outpath
     elif path.startswith('/'):

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -385,8 +385,8 @@ class ADLFSWrapper(DaskFileSystem):
             else:
                 if not any(ftype in path for ftype in
                            ['parquet', 'parq', 'metadata']):
-                    raise ValueError('Directory is not a partition of *.parquet. \
-                        Try passing a globstring.')
+                    raise ValueError('Directory is not a partition of'
+                                     ' *.parquet. Try passing a globstring.')
                 return True
         except OSError:
             return False
@@ -403,9 +403,8 @@ class ADLFSWrapper(DaskFileSystem):
     def walk(self, path, invalidate_cache=True, refresh=False):
         """
         Directory tree generator, like os.walk
-
-        Generator version of what is in ADLFSClient, which yields a flattened list of
-        files
+        Generator version of what is in ADLFSClient, which yields a
+        flattened list of files
         """
         path = _sanitize_remote_path(_stringify_path(path))
         directories = set()
@@ -439,8 +438,8 @@ def _sanitize_remote_path(path):
     elif path.startswith('adl://'):
         newpath = path.replace('adl://', '')
         path_parts = newpath.split('/')
-        path_parts = [p for p in path_parts if p
-                      not in 'azuredatalakestore.net']
+        path_parts = [p for p in path_parts if not
+        'azuredatalakestore.net' in p]
         outpath = "/".join(path_parts)
         return outpath
     elif path.startswith('/'):

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -378,7 +378,7 @@ class ADLFSWrapper(DaskFileSystem):
     def isdir(self, path):
         path = _sanitize_remote_path(_stringify_path(path))
         try:
-            contents = self.ls(path)
+            contents = self.fs.ls(path)
             if len(contents) == 1 and contents[0] == path:
                 return False
             else:
@@ -390,7 +390,7 @@ class ADLFSWrapper(DaskFileSystem):
     def isfile(self, path):
         path = _sanitize_remote_path(_stringify_path(path))
         try:
-            contents = self.ls(path)
+            contents = self.fs.ls(path)
             return len(contents) == 1 and contents[0] == path
         except OSError:
             return False
@@ -406,7 +406,7 @@ class ADLFSWrapper(DaskFileSystem):
         directories = set()
         files = set()
 
-        for key in list(self._ls(path, invalidate_cache=invalidate_cache)):
+        for key in list(self.fs._ls(path, invalidate_cache=invalidate_cache)):
             path = key['name']
             if key['type'] == 'DIRECTORY':
                 directories.add(path)

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -479,7 +479,7 @@ def _ensure_filesystem(fs):
         for mro in inspect.getmro(fs_type):
             if mro.__name__ == 'S3FileSystem':
                 return S3FSWrapper(fs)
-            # In case its an Azure Datalake Gen1 Filesystem, use the 
+            # In case its an Azure Datalake Gen1 Filesystem, use the
             # AzureDatalakeFilesystem wrapper
             elif mro.__name__ == 'AzureDatalakeFileSystem':
                 return AzureDatalakeFileSystemWrapper(fs)

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -372,8 +372,9 @@ class S3FSWrapper(DaskFileSystem):
             for tup in self.walk(directory, refresh=refresh):
                 yield tup
 
+
 class ADLFSWrapper(DaskFileSystem):
-    
+
     @implements(FileSystem.isdir)
     def isdir(self, path):
         path = _sanitize_remote_path(_stringify_path(path))
@@ -382,8 +383,10 @@ class ADLFSWrapper(DaskFileSystem):
             if len(contents) == 1 and contents[0] == path:
                 return False
             else:
-                if not any(ftype in path for ftype in ['parquet', 'parq', 'metadata']):
-                    raise ValueError('Directory is not a partition of *.parquet.  Try passing a globstring.')
+                if not any(ftype in path for ftype in
+                           ['parquet', 'parq', 'metadata']):
+                    raise ValueError('Directory is not a partition of *.parquet. \
+                        Try passing a globstring.')
                 return True
         except OSError:
             return False
@@ -397,7 +400,7 @@ class ADLFSWrapper(DaskFileSystem):
         except OSError:
             return False
 
-    def walk(self, path, invalidate_cache=True):
+    def walk(self, path, invalidate_cache=True, refresh=False):
         """
         Directory tree generator, like os.walk
 
@@ -436,12 +439,15 @@ def _sanitize_remote_path(path):
     elif path.startswith('adl://'):
         newpath = path.replace('adl://', '')
         path_parts = newpath.split('/')
-        path_parts = [p for p in path_parts if not 'azuredatalakestore.net' in p]
+        path_parts = [p for p in path_parts if p
+                      not in 'azuredatalakestore.net']
         outpath = "/".join(path_parts)
         return outpath
     elif path.startswith('/'):
-        # This is a shim.  When an individual file is passed to the adlfilesystemclient, it returns
-        # a leading "/" that has to be removed to make the path and sanitized paths match.
+        # This is a shim.  When an individual file is passed to the
+        #  adlfilesystemclient, it returns
+        # a leading "/" that has to be removed to make the path and
+        # sanitized paths match.
         return path[1:]
     else:
         return path

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1144,6 +1144,8 @@ def _make_manifest(path_or_paths, fs, pathsep='/', metadata_nthreads=1,
         path_or_paths = path_or_paths[0]
 
     if _is_path_like(path_or_paths) and fs.isdir(path_or_paths):
+        print('...This is a directory... checking fs.pathsep')
+        print(fs.pathsep)
         manifest = ParquetManifest(path_or_paths, filesystem=fs,
                                    open_file_func=open_file_func,
                                    pathsep=fs.pathsep,

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1144,8 +1144,6 @@ def _make_manifest(path_or_paths, fs, pathsep='/', metadata_nthreads=1,
         path_or_paths = path_or_paths[0]
 
     if _is_path_like(path_or_paths) and fs.isdir(path_or_paths):
-        print('...This is a directory... checking fs.pathsep')
-        print(fs.pathsep)
         manifest = ParquetManifest(path_or_paths, filesystem=fs,
                                    open_file_func=open_file_func,
                                    pathsep=fs.pathsep,

--- a/python/pyarrow/tests/test_filesystem.py
+++ b/python/pyarrow/tests/test_filesystem.py
@@ -35,3 +35,17 @@ def test_resolve_local_path():
         fs, path = filesystem.resolve_filesystem_and_path(uri)
         assert isinstance(fs, filesystem.LocalFileSystem)
         assert path == uri
+
+
+def test_resolve_azuredatalakefilesystem_uri():
+        uri = "adl://home/folder/myfile.parquet"
+        fs, path = filesystem.resolve_filesystem_and_path(uri)
+        assert isinstance(fs, filesystem.AzureDatalakeFileSystemWrapper)
+        assert path == '/folder/myfile.parquet'
+
+
+def test_resolve_azuredatalakefilesystem_file():
+        uri = "adl://home/myfile.parquet"
+        fs, path = filesystem.resolve_filesystem_and_path(uri)
+        assert isinstance(fs, filesystem.AzureDatalakeFileSystemWrapper)
+        assert path == "/myfile.parquet"

--- a/python/pyarrow/tests/test_filesystem.py
+++ b/python/pyarrow/tests/test_filesystem.py
@@ -38,14 +38,14 @@ def test_resolve_local_path():
 
 
 def test_resolve_azuredatalakefilesystem_uri():
-        uri = "adl://home/folder/myfile.parquet"
-        fs, path = filesystem.resolve_filesystem_and_path(uri)
-        assert isinstance(fs, filesystem.AzureDatalakeFileSystemWrapper)
-        assert path == '/folder/myfile.parquet'
+    uri = "adl://home/folder/myfile.parquet"
+    fs, path = filesystem.resolve_filesystem_and_path(uri)
+    assert isinstance(fs, filesystem.AzureDatalakeFileSystemWrapper)
+    assert path == '/folder/myfile.parquet'
 
 
 def test_resolve_azuredatalakefilesystem_file():
-        uri = "adl://home/myfile.parquet"
-        fs, path = filesystem.resolve_filesystem_and_path(uri)
-        assert isinstance(fs, filesystem.AzureDatalakeFileSystemWrapper)
-        assert path == "/myfile.parquet"
+    uri = "adl://home/myfile.parquet"
+    fs, path = filesystem.resolve_filesystem_and_path(uri)
+    assert isinstance(fs, filesystem.AzureDatalakeFileSystemWrapper)
+    assert path == "/myfile.parquet"


### PR DESCRIPTION
This PR adds a Gen1 Azure Datalake Filesystem Wrapper, in filesystem.py, which enables the ability read parquet files written to Azure Datalake using the pyarrow engine.  To work, this also requires explicitly importing the dask-adlfs package, as found [here](https://github.com/dask/dask-adlfs).