### PR TITLE
ARROW-5159: [Rust] Unable to build benches in arrow crate.

### DIFF
--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -25,8 +25,8 @@ extern crate arrow;
 
 use arrow::array::*;
 use arrow::builder::*;
-use arrow::compute::arithmetic_kernels::*;
 use arrow::compute::array_ops::{limit, sum};
+use arrow::compute::kernels::arithmetic::*;
 use arrow::error::Result;
 
 fn create_array(size: usize) -> Float32Array {

--- a/rust/arrow/benches/boolean_kernels.rs
+++ b/rust/arrow/benches/boolean_kernels.rs
@@ -23,7 +23,7 @@ extern crate arrow;
 
 use arrow::array::*;
 use arrow::builder::*;
-use arrow::compute::boolean_kernels;
+use arrow::compute::kernels::boolean as boolean_kernels;
 use arrow::error::{ArrowError, Result};
 
 ///  Helper function to create arrays


### PR DESCRIPTION
After the refactor of kernel related files in ARROW-5116, the files in `bench` folder won't compile.

eg. 
```
error[E0432]: unresolved import `arrow::compute::boolean_kernels`
 --> arrow/benches/boolean_kernels.rs:26:5
 |
26 | use arrow::compute::boolean_kernels;
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `boolean_kernels` in `compute`
```
This pr fixes these import errors.