### PR TITLE
ARROW-2796: [C++] Simplify version script used for linking

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -239,8 +239,9 @@ if(NOT APPLE AND NOT MSVC)
   # Localize thirdparty symbols using a linker version script. This hides them
   # from the client application. The OS X linker does not support the
   # version-script option.
-  set(ARROW_SHARED_LINK_FLAGS
+  set(ARROW_VERSION_SCRIPT_FLAGS
       "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  set(ARROW_SHARED_LINK_FLAGS ${ARROW_VERSION_SCRIPT_FLAGS})
 endif()
 
 set(ARROW_ALL_SRCS ${ARROW_SRCS})

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -90,6 +90,8 @@ add_arrow_lib(arrow_flight
               DEPENDENCIES
               flight_grpc_gen
               metadata_fbs
+              SHARED_LINK_FLAGS
+              ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
               arrow_shared
               ${ARROW_FLIGHT_STATIC_LINK_LIBS}

--- a/cpp/src/arrow/gpu/CMakeLists.txt
+++ b/cpp/src/arrow/gpu/CMakeLists.txt
@@ -46,7 +46,7 @@ add_arrow_lib(arrow_cuda
               DEPENDENCIES
               metadata_fbs
               SHARED_LINK_FLAGS
-              ""
+              ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
               arrow_shared
               ${ARROW_CUDA_SHARED_LINK_LIBS}

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -80,7 +80,7 @@ add_arrow_lib(arrow_python
               DEPENDENCIES
               ${ARROW_PYTHON_DEPENDENCIES}
               SHARED_LINK_FLAGS
-              ""
+              ${ARROW_VERSION_SCRIPT_FLAGS} # Defined in cpp/arrow/CMakeLists.txt
               SHARED_LINK_LIBS
               ${ARROW_PYTHON_SHARED_LINK_LIBS}
               STATIC_LINK_LIBS

--- a/cpp/src/arrow/symbols.map
+++ b/cpp/src/arrow/symbols.map
@@ -23,71 +23,20 @@
       # those symbols.
       # See https://github.com/apache/arrow/pull/1953#issuecomment-386057063
       std::__once*;
+      # The leading asterisk is required for symbols such as
+      # "typeinfo for arrow::SomeClass".
+      # Unfortunately this will also catch template specializations
+      # (from e.g. STL or Flatbuffers) involving Arrow types.
+      *arrow::*;
     };
+    # Also export C-level helpers
+    arrow_*;
+    pyarrow_*;
 
   # Symbols marked as 'local' are not exported by the DSO and thus may not
-  # be used by client applications.
+  # be used by client applications.  Everything except the above falls here.
+  # This ensures we hide symbols of static dependencies.
   local:
-    # devtoolset / static-libstdc++ symbols
-    __cxa_*;
-    __once_proxy;
+    *;
 
-    # Static libraries that are linked in e.g. the manylinux1 build
-    # Brotli compression library
-    Brotli*;
-    # zlib
-    adler32*;
-    crc32*;
-    deflate*;
-    inflate*;
-    get_crc_table;
-    zcalloc;
-    zcfree;
-    zError;
-    zlibCompileFlags;
-    zlibVersion;
-    _tr_*;
-    # bz2
-    BZ2_*;
-    # lz4
-    LZ4_*;
-    LZ4F_*;
-    # zstandard
-    ZSTD_*;
-    ZSTDv*;
-    HUF_*;
-    HUFv*;
-    FSE_*;
-    FSEv*;
-    ZBUFFv*;
-    ZSTDMT*;
-    POOL_*;
-    HIST_*;
-    ERR_getErrorString;
-    # jemalloc
-    je_arrow_*;
-    # uriparser
-    uri*;
-    # ORC destructors
-    _ZThn8_N3orc*;
-    # Protobuf symbols that aren't hidden by the C++ section below
-    # (destructors, vtables, other stuff)
-    *N6google8protobuf*;
-
-    extern "C++" {
-      # devtoolset or -static-libstdc++ - the Red Hat devtoolset statically
-      # links c++11 symbols into binaries so that the result may be executed on
-      # a system with an older libstdc++ which doesn't include the necessary
-      # c++11 symbols.
-      std::*;
-
-      # Statically linked C++ dependencies
-      boost::*;
-      double_conversion::*;
-      google::*;
-      # glog
-      *MakeCheckOpValueString*;
-      orc::*;
-      snappy::*;
-    };
 };


### PR DESCRIPTION
Also use it for Arrow sublibraries: libarrow_flight.so, libarrow_python.so, libarrow_cuda.so.