### PR TITLE
ARROW-4708: [C++] refactoring JSON parser to prepare for multithreaded impl

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -138,8 +138,8 @@ endmacro()
 if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
   # Pre-checkin builds
   if("${COMPILER_FAMILY}" STREQUAL "msvc")
-    string(REPLACE "/W3" "" CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS}")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /W3")
+    # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-by-compiler-version
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /W3 /wd4365 /wd4267 /wd4838")
   elseif("${COMPILER_FAMILY}" STREQUAL "clang")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Weverything -Wno-c++98-compat \
 -Wno-c++98-compat-pedantic -Wno-deprecated -Wno-weak-vtables -Wno-padded \

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -29,6 +29,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -62,14 +63,14 @@ class ARROW_EXPORT Buffer {
         size_(size),
         capacity_(size) {}
 
-  /// \brief Construct from std::string without copying memory
+  /// \brief Construct from string_view without copying memory
   ///
-  /// \param[in] data a std::string object
+  /// \param[in] data a string_view object
   ///
-  /// \note The std::string must stay alive for the lifetime of the Buffer, so
-  /// temporary rvalue strings must be stored in an lvalue somewhere
-  explicit Buffer(const std::string& data)
-      : Buffer(reinterpret_cast<const uint8_t*>(data.c_str()),
+  /// \note The memory viewed by data must not be deallocated in the lifetime of the
+  /// Buffer; temporary rvalue strings must be stored in an lvalue somewhere
+  explicit Buffer(util::string_view data)
+      : Buffer(reinterpret_cast<const uint8_t*>(data.data()),
                static_cast<int64_t>(data.size())) {}
 
   virtual ~Buffer() = default;
@@ -229,6 +230,16 @@ static inline std::shared_ptr<Buffer> SliceBuffer(const std::shared_ptr<Buffer>&
 ARROW_EXPORT
 std::shared_ptr<Buffer> SliceMutableBuffer(const std::shared_ptr<Buffer>& buffer,
                                            const int64_t offset, const int64_t length);
+
+/// \brief Like SliceBuffer, but construct a mutable buffer slice.
+///
+/// If the parent buffer is not mutable, behavior is undefined (it may abort
+/// in debug builds).
+static inline std::shared_ptr<Buffer> SliceMutableBuffer(
+    const std::shared_ptr<Buffer>& buffer, const int64_t offset) {
+  int64_t length = buffer->size() - offset;
+  return SliceMutableBuffer(buffer, offset, length);
+}
 
 /// @}
 

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -162,6 +162,12 @@ class ARROW_EXPORT Buffer {
   /// \note Can throw std::bad_alloc if buffer is large
   std::string ToString() const;
 
+  /// \brief View buffer contents as a util::string_view
+  /// \return util::string_view
+  explicit operator util::string_view() const {
+    return util::string_view(reinterpret_cast<const char*>(data_), size_);
+  }
+
   /// \brief Return a pointer to the buffer's data
   const uint8_t* data() const { return data_; }
   /// \brief Return a writable pointer to the buffer's data

--- a/cpp/src/arrow/ipc/json-internal.h
+++ b/cpp/src/arrow/ipc/json-internal.h
@@ -18,22 +18,11 @@
 #ifndef ARROW_IPC_JSON_INTERNAL_H
 #define ARROW_IPC_JSON_INTERNAL_H
 
-#define RAPIDJSON_HAS_STDSTRING 1
-#define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
-#define RAPIDJSON_HAS_CXX11_RANGE_FOR 1
-
-#define RAPIDJSON_NAMESPACE arrow::rapidjson
-#define RAPIDJSON_NAMESPACE_BEGIN \
-  namespace arrow {               \
-  namespace rapidjson {
-#define RAPIDJSON_NAMESPACE_END \
-  }                             \
-  }
-
 #include <memory>
 #include <sstream>
 #include <string>
 
+#include "arrow/json/rapidjson-defs.h"
 #include "rapidjson/document.h"      // IWYU pragma: export
 #include "rapidjson/encodings.h"     // IWYU pragma: export
 #include "rapidjson/error/en.h"      // IWYU pragma: export

--- a/cpp/src/arrow/ipc/json-simple-test.cc
+++ b/cpp/src/arrow/ipc/json-simple-test.cc
@@ -315,6 +315,46 @@ TEST(TestString, Basics) {
   s = '\x00';
   s += "\x1f";
   AssertJSONArray<BinaryType, std::string>(type, "[\"\\u0000\\u001f\"]", {s});
+
+  // Timestamp type
+  type = timestamp(TimeUnit::SECOND);
+  AssertJSONArray<TimestampType, int64_t>(
+      type, R"(["1970-01-01","2000-02-29","3989-07-14","1900-02-28"])",
+      {0, 951782400, 63730281600LL, -2203977600LL});
+
+  type = timestamp(TimeUnit::NANO);
+  AssertJSONArray<TimestampType, int64_t>(
+      type, R"(["1970-01-01","2000-02-29","1900-02-28"])",
+      {0, 951782400000000000LL, -2203977600000000000LL});
+}
+
+TEST(TestTimestamp, Basics) {
+  // Timestamp type
+  std::shared_ptr<DataType> type = utf8();
+  std::shared_ptr<Array> expected, actual;
+
+  AssertJSONArray<StringType, std::string>(type, "[]", {});
+  AssertJSONArray<StringType, std::string>(type, "[\"\", \"foo\"]", {"", "foo"});
+  AssertJSONArray<StringType, std::string>(type, "[\"\", null]", {true, false}, {"", ""});
+  // NUL character in string
+  std::string s = "some";
+  s += '\x00';
+  s += "char";
+  AssertJSONArray<StringType, std::string>(type, "[\"\", \"some\\u0000char\"]", {"", s});
+  // UTF8 sequence in string
+  AssertJSONArray<StringType, std::string>(type, "[\"\xc3\xa9\"]", {"\xc3\xa9"});
+
+  // Binary type
+  type = binary();
+  AssertJSONArray<BinaryType, std::string>(type, "[\"\", \"foo\", null]",
+                                           {true, true, false}, {"", "foo", ""});
+  // Arbitrary binary (non-UTF8) sequence in string
+  s = "\xff\x9f";
+  AssertJSONArray<BinaryType, std::string>(type, "[\"" + s + "\"]", {s});
+  // Bytes < 0x20 can be represented as JSON unicode escapes
+  s = '\x00';
+  s += "\x1f";
+  AssertJSONArray<BinaryType, std::string>(type, "[\"\\u0000\\u001f\"]", {s});
 }
 
 TEST(TestString, Errors) {

--- a/cpp/src/arrow/ipc/json-simple-test.cc
+++ b/cpp/src/arrow/ipc/json-simple-test.cc
@@ -315,9 +315,11 @@ TEST(TestString, Basics) {
   s = '\x00';
   s += "\x1f";
   AssertJSONArray<BinaryType, std::string>(type, "[\"\\u0000\\u001f\"]", {s});
+}
 
+TEST(TestTimestamp, Basics) {
   // Timestamp type
-  type = timestamp(TimeUnit::SECOND);
+  auto type = timestamp(TimeUnit::SECOND);
   AssertJSONArray<TimestampType, int64_t>(
       type, R"(["1970-01-01","2000-02-29","3989-07-14","1900-02-28"])",
       {0, 951782400, 63730281600LL, -2203977600LL});
@@ -326,35 +328,6 @@ TEST(TestString, Basics) {
   AssertJSONArray<TimestampType, int64_t>(
       type, R"(["1970-01-01","2000-02-29","1900-02-28"])",
       {0, 951782400000000000LL, -2203977600000000000LL});
-}
-
-TEST(TestTimestamp, Basics) {
-  // Timestamp type
-  std::shared_ptr<DataType> type = utf8();
-  std::shared_ptr<Array> expected, actual;
-
-  AssertJSONArray<StringType, std::string>(type, "[]", {});
-  AssertJSONArray<StringType, std::string>(type, "[\"\", \"foo\"]", {"", "foo"});
-  AssertJSONArray<StringType, std::string>(type, "[\"\", null]", {true, false}, {"", ""});
-  // NUL character in string
-  std::string s = "some";
-  s += '\x00';
-  s += "char";
-  AssertJSONArray<StringType, std::string>(type, "[\"\", \"some\\u0000char\"]", {"", s});
-  // UTF8 sequence in string
-  AssertJSONArray<StringType, std::string>(type, "[\"\xc3\xa9\"]", {"\xc3\xa9"});
-
-  // Binary type
-  type = binary();
-  AssertJSONArray<BinaryType, std::string>(type, "[\"\", \"foo\", null]",
-                                           {true, true, false}, {"", "foo", ""});
-  // Arbitrary binary (non-UTF8) sequence in string
-  s = "\xff\x9f";
-  AssertJSONArray<BinaryType, std::string>(type, "[\"" + s + "\"]", {s});
-  // Bytes < 0x20 can be represented as JSON unicode escapes
-  s = '\x00';
-  s += "\x1f";
-  AssertJSONArray<BinaryType, std::string>(type, "[\"\\u0000\\u001f\"]", {s});
 }
 
 TEST(TestString, Errors) {

--- a/cpp/src/arrow/ipc/json-simple.cc
+++ b/cpp/src/arrow/ipc/json-simple.cc
@@ -149,12 +149,14 @@ class BooleanConverter final : public ConcreteConverter<BooleanConverter> {
 // Helpers for numeric converters
 
 // Convert single signed integer value (also {Date,Time}{32,64} and Timestamp)
-template <typename T, typename CType = typename TypeTraits<T>::CType>
-enable_if_signed_integer<typename CTypeTraits<CType>::ArrowType, Status> ConvertNumber(
-    const rj::Value& json_obj, CType* out) {
+template <typename T>
+typename std::enable_if<is_signed_integer<T>::value || is_date<T>::value ||
+                            is_time<T>::value || is_timestamp<T>::value,
+                        Status>::type
+ConvertNumber(const rj::Value& json_obj, typename T::c_type* out) {
   if (json_obj.IsInt64()) {
     int64_t v64 = json_obj.GetInt64();
-    *out = static_cast<CType>(v64);
+    *out = static_cast<typename T::c_type>(v64);
     if (*out == v64) {
       return Status::OK();
     } else {

--- a/cpp/src/arrow/ipc/json-simple.cc
+++ b/cpp/src/arrow/ipc/json-simple.cc
@@ -164,17 +164,18 @@ ConvertNumber(const rj::Value& json_obj, typename T::c_type* out) {
                              TypeTraits<T>::type_singleton());
     }
   } else {
+    *out = static_cast<typename T::c_type>(0);
     return JSONTypeError("signed int", json_obj.GetType());
   }
 }
 
 // Convert single unsigned integer value
-template <typename T, typename CType = typename TypeTraits<T>::CType>
+template <typename T>
 enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                                    CType* out) {
+                                                    typename T::c_type* out) {
   if (json_obj.IsUint64()) {
     uint64_t v64 = json_obj.GetUint64();
-    *out = static_cast<CType>(v64);
+    *out = static_cast<typename T::c_type>(v64);
     if (*out == v64) {
       return Status::OK();
     } else {
@@ -182,17 +183,20 @@ enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
                              TypeTraits<T>::type_singleton());
     }
   } else {
+    *out = static_cast<typename T::c_type>(0);
     return JSONTypeError("unsigned int", json_obj.GetType());
   }
 }
 
 // Convert single floating point value
-template <typename T, typename CType = typename TypeTraits<T>::CType>
-enable_if_floating_point<T, Status> ConvertNumber(const rj::Value& json_obj, CType* out) {
+template <typename T>
+enable_if_floating_point<T, Status> ConvertNumber(const rj::Value& json_obj,
+                                                  typename T::c_type* out) {
   if (json_obj.IsNumber()) {
-    *out = static_cast<CType>(json_obj.GetDouble());
+    *out = static_cast<typename T::c_type>(json_obj.GetDouble());
     return Status::OK();
   } else {
+    *out = static_cast<typename T::c_type>(0);
     return JSONTypeError("number", json_obj.GetType());
   }
 }

--- a/cpp/src/arrow/ipc/json-simple.cc
+++ b/cpp/src/arrow/ipc/json-simple.cc
@@ -29,6 +29,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/parsing.h"
 #include "arrow/util/string_view.h"
 
 namespace arrow {
@@ -91,8 +92,6 @@ class ConcreteConverter : public Converter {
   }
 };
 
-// TODO : dates and times?
-
 // ------------------------------------------------------------------------
 // Converter for null arrays
 
@@ -114,7 +113,7 @@ class NullConverter final : public ConcreteConverter<NullConverter> {
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<NullBuilder> builder_;
 };
 
@@ -142,9 +141,59 @@ class BooleanConverter final : public ConcreteConverter<BooleanConverter> {
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<BooleanBuilder> builder_;
 };
+
+// ------------------------------------------------------------------------
+// Helpers for numeric converters
+
+// Convert single signed integer value (also {Date,Time}{32,64} and Timestamp)
+template <typename T, typename CType = typename TypeTraits<T>::CType>
+enable_if_signed_integer<typename CTypeTraits<CType>::ArrowType, Status> ConvertNumber(
+    const rj::Value& json_obj, CType* out) {
+  if (json_obj.IsInt64()) {
+    int64_t v64 = json_obj.GetInt64();
+    *out = static_cast<CType>(v64);
+    if (*out == v64) {
+      return Status::OK();
+    } else {
+      return Status::Invalid("Value ", v64, " out of bounds for ",
+                             TypeTraits<T>::type_singleton());
+    }
+  } else {
+    return JSONTypeError("signed int", json_obj.GetType());
+  }
+}
+
+// Convert single unsigned integer value
+template <typename T, typename CType = typename TypeTraits<T>::CType>
+enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
+                                                    CType* out) {
+  if (json_obj.IsUint64()) {
+    uint64_t v64 = json_obj.GetUint64();
+    *out = static_cast<CType>(v64);
+    if (*out == v64) {
+      return Status::OK();
+    } else {
+      return Status::Invalid("Value ", v64, " out of bounds for ",
+                             TypeTraits<T>::type_singleton());
+    }
+  } else {
+    return JSONTypeError("unsigned int", json_obj.GetType());
+  }
+}
+
+// Convert single floating point value
+template <typename T, typename CType = typename TypeTraits<T>::CType>
+enable_if_floating_point<T, Status> ConvertNumber(const rj::Value& json_obj, CType* out) {
+  if (json_obj.IsNumber()) {
+    *out = static_cast<CType>(json_obj.GetDouble());
+    return Status::OK();
+  } else {
+    return JSONTypeError("number", json_obj.GetType());
+  }
+}
 
 // ------------------------------------------------------------------------
 // Converter for int arrays
@@ -166,49 +215,14 @@ class IntegerConverter final : public ConcreteConverter<IntegerConverter<Type>> 
     if (json_obj.IsNull()) {
       return AppendNull();
     }
-    return AppendNumber(json_obj);
+    c_type value;
+    RETURN_NOT_OK(ConvertNumber<Type>(json_obj, &value));
+    return builder_->Append(value);
   }
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
-  // Append signed integer value
-  template <typename Integer = c_type>
-  typename std::enable_if<std::is_signed<Integer>::value, Status>::type AppendNumber(
-      const rj::Value& json_obj) {
-    if (json_obj.IsInt64()) {
-      int64_t v64 = json_obj.GetInt64();
-      c_type v = static_cast<c_type>(v64);
-      if (v == v64) {
-        return builder_->Append(v);
-      } else {
-        return Status::Invalid("Value ", v64, " out of bounds for ",
-                               this->type_->ToString());
-      }
-    } else {
-      return JSONTypeError("signed int", json_obj.GetType());
-    }
-  }
-
-  // Append unsigned integer value
-  template <typename Integer = c_type>
-  typename std::enable_if<std::is_unsigned<Integer>::value, Status>::type AppendNumber(
-      const rj::Value& json_obj) {
-    if (json_obj.IsUint64()) {
-      uint64_t v64 = json_obj.GetUint64();
-      c_type v = static_cast<c_type>(v64);
-      if (v == v64) {
-        return builder_->Append(v);
-      } else {
-        return Status::Invalid("Value ", v64, " out of bounds for ",
-                               this->type_->ToString());
-      }
-      return builder_->Append(v);
-    } else {
-      return JSONTypeError("unsigned int", json_obj.GetType());
-    }
-  }
-
+ private:
   std::shared_ptr<NumericBuilder<Type>> builder_;
 };
 
@@ -231,17 +245,14 @@ class FloatConverter final : public ConcreteConverter<FloatConverter<Type>> {
     if (json_obj.IsNull()) {
       return AppendNull();
     }
-    if (json_obj.IsNumber()) {
-      c_type v = static_cast<c_type>(json_obj.GetDouble());
-      return builder_->Append(v);
-    } else {
-      return JSONTypeError("number", json_obj.GetType());
-    }
+    c_type value;
+    RETURN_NOT_OK(ConvertNumber<Type>(json_obj, &value));
+    return builder_->Append(value);
   }
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<NumericBuilder<Type>> builder_;
 };
 
@@ -278,9 +289,47 @@ class DecimalConverter final : public ConcreteConverter<DecimalConverter> {
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<DecimalBuilder> builder_;
   Decimal128Type* decimal_type_;
+};
+
+// ------------------------------------------------------------------------
+// Converter for timestamp arrays
+
+class TimestampConverter final : public ConcreteConverter<TimestampConverter> {
+ public:
+  explicit TimestampConverter(const std::shared_ptr<DataType>& type)
+      : from_string_(type) {
+    this->type_ = type;
+    builder_ = std::make_shared<TimestampBuilder>(type, default_memory_pool());
+  }
+
+  Status AppendNull() override { return builder_->AppendNull(); }
+
+  Status AppendValue(const rj::Value& json_obj) override {
+    if (json_obj.IsNull()) {
+      return AppendNull();
+    }
+    int64_t value;
+    if (json_obj.IsNumber()) {
+      RETURN_NOT_OK(ConvertNumber<Int64Type>(json_obj, &value));
+    } else if (json_obj.IsString()) {
+      auto view = util::string_view(json_obj.GetString(), json_obj.GetStringLength());
+      if (!from_string_(view.data(), view.size(), &value)) {
+        return Status::Invalid("couldn't parse timestamp from ", view);
+      }
+    } else {
+      return JSONTypeError("timestamp", json_obj.GetType());
+    }
+    return builder_->Append(value);
+  }
+
+  std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
+
+ private:
+  ::arrow::internal::StringConverter<TimestampType> from_string_;
+  std::shared_ptr<TimestampBuilder> builder_;
 };
 
 // ------------------------------------------------------------------------
@@ -309,7 +358,7 @@ class StringConverter final : public ConcreteConverter<StringConverter> {
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<BinaryBuilder> builder_;
 };
 
@@ -346,7 +395,7 @@ class FixedSizeBinaryConverter final
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<FixedSizeBinaryBuilder> builder_;
 };
 
@@ -378,7 +427,7 @@ class ListConverter final : public ConcreteConverter<ListConverter> {
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<ListBuilder> builder_;
   std::shared_ptr<Converter> child_converter_;
 };
@@ -453,7 +502,7 @@ class StructConverter final : public ConcreteConverter<StructConverter> {
 
   std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
 
- protected:
+ private:
   std::shared_ptr<StructBuilder> builder_;
   std::vector<std::shared_ptr<Converter>> child_converters_;
 };
@@ -478,7 +527,7 @@ Status GetConverter(const std::shared_ptr<DataType>& type,
     SIMPLE_CONVERTER_CASE(Type::DATE32, IntegerConverter<Date32Type>)
     SIMPLE_CONVERTER_CASE(Type::INT64, IntegerConverter<Int64Type>)
     SIMPLE_CONVERTER_CASE(Type::TIME64, IntegerConverter<Int64Type>)
-    SIMPLE_CONVERTER_CASE(Type::TIMESTAMP, IntegerConverter<Int64Type>)
+    SIMPLE_CONVERTER_CASE(Type::TIMESTAMP, TimestampConverter)
     SIMPLE_CONVERTER_CASE(Type::DATE64, IntegerConverter<Date64Type>)
     SIMPLE_CONVERTER_CASE(Type::UINT8, IntegerConverter<UInt8Type>)
     SIMPLE_CONVERTER_CASE(Type::UINT16, IntegerConverter<UInt16Type>)

--- a/cpp/src/arrow/json/api.h
+++ b/cpp/src/arrow/json/api.h
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_JSON_API_H
-#define ARROW_JSON_API_H
+#pragma once
 
 #include "arrow/json/options.h"
 #include "arrow/json/reader.h"
-
-#endif  // ARROW_JSON_API_H

--- a/cpp/src/arrow/json/chunker-test.cc
+++ b/cpp/src/arrow/json/chunker-test.cc
@@ -37,7 +37,7 @@ namespace json {
 using util::string_view;
 
 template <typename Lines>
-std::shared_ptr<Buffer> join(Lines&& lines, std::string delimiter) {
+static std::shared_ptr<Buffer> join(Lines&& lines, std::string delimiter) {
   std::shared_ptr<Buffer> joined;
   BufferVector line_buffers;
   auto delimiter_buffer = std::make_shared<Buffer>(delimiter);
@@ -49,17 +49,19 @@ std::shared_ptr<Buffer> join(Lines&& lines, std::string delimiter) {
   return joined;
 }
 
-string_view View(const std::shared_ptr<Buffer>& buffer) {
+static string_view View(const std::shared_ptr<Buffer>& buffer) {
   return string_view(reinterpret_cast<const char*>(buffer->data()), buffer->size());
 }
 
-bool WhitespaceOnly(string_view s) {
+static bool WhitespaceOnly(string_view s) {
   return s.find_first_not_of(" \t\r\n") == string_view::npos;
 }
 
-bool WhitespaceOnly(const std::shared_ptr<Buffer>& b) { return WhitespaceOnly(View(b)); }
+static bool WhitespaceOnly(const std::shared_ptr<Buffer>& b) {
+  return WhitespaceOnly(View(b));
+}
 
-std::size_t ConsumeWholeObject(std::shared_ptr<Buffer>* buf) {
+static std::size_t ConsumeWholeObject(std::shared_ptr<Buffer>* buf) {
   auto str = View(*buf);
   auto fail = [buf] {
     *buf = nullptr;
@@ -144,7 +146,7 @@ INSTANTIATE_TEST_CASE_P(NoNewlineChunkerTest, BaseChunkerTest, ::testing::Values
 INSTANTIATE_TEST_CASE_P(ChunkerTest, BaseChunkerTest, ::testing::Values(true));
 
 constexpr auto object_count = 3;
-const std::vector<std::string>& lines() {
+static const std::vector<std::string>& lines() {
   static const std::vector<std::string> l = {R"({"0":"ab","1":"c","2":""})",
                                              R"({"0":"def","1":"","2":"gh"})",
                                              R"({"0":"","1":"ij","2":"kl"})"};

--- a/cpp/src/arrow/json/chunker-test.cc
+++ b/cpp/src/arrow/json/chunker-test.cc
@@ -15,20 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cstdint>
 #include <memory>
 #include <numeric>
 #include <string>
 
 #include <gtest/gtest.h>
-#include <rapidjson/document.h>
-#include <rapidjson/prettywriter.h>
-#include <rapidjson/reader.h>
 
+#include "arrow/buffer.h"
 #include "arrow/json/chunker.h"
-#include "arrow/json/options.h"
-#include "arrow/testing/gtest_common.h"
-#include "arrow/testing/util.h"
+#include "arrow/json/test-common.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/util/string_view.h"
 
 namespace arrow {
@@ -41,89 +37,90 @@ namespace json {
 using util::string_view;
 
 template <typename Lines>
-std::string join(Lines&& lines, std::string delimiter) {
-  std::string joined;
+std::shared_ptr<Buffer> join(Lines&& lines, std::string delimiter) {
+  std::shared_ptr<Buffer> joined;
+  BufferVector line_buffers;
+  auto delimiter_buffer = std::make_shared<Buffer>(delimiter);
   for (const auto& line : lines) {
-    joined += line + delimiter;
+    line_buffers.push_back(std::make_shared<Buffer>(line));
+    line_buffers.push_back(delimiter_buffer);
   }
+  ABORT_NOT_OK(ConcatenateBuffers(line_buffers, default_memory_pool(), &joined));
   return joined;
 }
 
-std::string PrettyPrint(string_view one_line) {
-  rapidjson::Document document;
-  document.Parse(one_line.data());
-  rapidjson::StringBuffer sb;
-  rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
-  document.Accept(writer);
-  return sb.GetString();
+string_view View(const std::shared_ptr<Buffer>& buffer) {
+  return string_view(reinterpret_cast<const char*>(buffer->data()), buffer->size());
 }
 
 bool WhitespaceOnly(string_view s) {
   return s.find_first_not_of(" \t\r\n") == string_view::npos;
 }
 
-std::size_t ConsumeWholeObject(string_view* str) {
-  auto fail = [str] {
-    *str = string_view();
+bool WhitespaceOnly(const std::shared_ptr<Buffer>& b) { return WhitespaceOnly(View(b)); }
+
+std::size_t ConsumeWholeObject(std::shared_ptr<Buffer>* buf) {
+  auto str = View(*buf);
+  auto fail = [buf] {
+    *buf = nullptr;
     return string_view::npos;
   };
-  if (WhitespaceOnly(*str)) return fail();
-  auto open_brace = str->find_first_not_of(" \t\r\n");
-  if (str->at(open_brace) != '{') return fail();
-  auto close_brace = str->find_first_of("}");
+  if (WhitespaceOnly(str)) return fail();
+  auto open_brace = str.find_first_not_of(" \t\r\n");
+  if (str.at(open_brace) != '{') return fail();
+  auto close_brace = str.find_first_of("}");
   if (close_brace == string_view::npos) return fail();
-  if (str->at(close_brace) != '}') return fail();
+  if (str.at(close_brace) != '}') return fail();
   auto length = close_brace + 1;
-  *str = str->substr(length);
+  *buf = SliceBuffer(*buf, length);
   return length;
 }
 
-void AssertWholeObjects(Chunker& chunker, string_view block, int expected_count) {
-  string_view whole;
-  ASSERT_OK(chunker.Process(block, &whole));
+void AssertWholeObjects(Chunker& chunker, const std::shared_ptr<Buffer>& block,
+                        int expected_count) {
+  std::shared_ptr<Buffer> whole, partial;
+  ASSERT_OK(chunker.Process(block, &whole, &partial));
   int count = 0;
-  while (!WhitespaceOnly(whole)) {
+  while (whole && !WhitespaceOnly(whole)) {
     if (ConsumeWholeObject(&whole) == string_view::npos) FAIL();
     ++count;
   }
   ASSERT_EQ(count, expected_count);
 }
 
-void AssertChunking(Chunker& chunker, std::string str, int total_count) {
+void AssertChunking(Chunker& chunker, std::shared_ptr<Buffer> buf, int total_count) {
   // First chunkize whole JSON block
-  AssertWholeObjects(chunker, str, total_count);
+  AssertWholeObjects(chunker, buf, total_count);
 
   // Then chunkize incomplete substrings of the block
-  for (int i = 0; i != total_count; ++i) {
+  for (int i = 0; i < total_count; ++i) {
     // ensure shearing the closing brace off the last object causes it to be chunked out
-    string_view str_view(str);
-    auto last_brace = str_view.find_last_of('}');
-    AssertWholeObjects(chunker, str.substr(0, last_brace), total_count - i - 1);
+    auto last_brace = View(buf).find_last_of('}');
+    AssertWholeObjects(chunker, SliceBuffer(buf, 0, last_brace), total_count - i - 1);
 
     // ensure skipping one object reduces the count by one
-    ASSERT_NE(ConsumeWholeObject(&str_view), string_view::npos);
-    str = str_view.to_string();
-    AssertWholeObjects(chunker, str, total_count - i - 1);
+    ASSERT_NE(ConsumeWholeObject(&buf), string_view::npos);
+    AssertWholeObjects(chunker, buf, total_count - i - 1);
   }
 }
 
-void AssertStraddledChunking(Chunker& chunker, string_view str) {
-  auto first_half = str.substr(0, str.size() / 2).to_string();
-  auto second_half = str.substr(str.size() / 2);
+void AssertStraddledChunking(Chunker& chunker, const std::shared_ptr<Buffer>& buf) {
+  auto first_half = SliceBuffer(buf, 0, buf->size() / 2);
+  auto second_half = SliceBuffer(buf, buf->size() / 2);
   AssertChunking(chunker, first_half, 1);
-  string_view first_whole;
-  ASSERT_OK(chunker.Process(first_half, &first_whole));
-  ASSERT_TRUE(string_view(first_half).starts_with(first_whole));
-  auto partial = string_view(first_half).substr(first_whole.size());
-  string_view completion;
-  ASSERT_OK(chunker.Process(partial, second_half, &completion));
-  ASSERT_TRUE(second_half.starts_with(completion));
-  auto straddling = partial.to_string() + completion.to_string();
-  string_view straddling_view(straddling);
-  auto length = ConsumeWholeObject(&straddling_view);
+  std::shared_ptr<Buffer> first_whole, partial;
+  ASSERT_OK(chunker.Process(first_half, &first_whole, &partial));
+  ASSERT_TRUE(View(first_half).starts_with(View(first_whole)));
+  std::shared_ptr<Buffer> completion, rest;
+  ASSERT_OK(chunker.Process(partial, second_half, &completion, &rest));
+  ASSERT_TRUE(View(second_half).starts_with(View(completion)));
+  std::shared_ptr<Buffer> straddling;
+  ASSERT_OK(
+      ConcatenateBuffers({partial, completion}, default_memory_pool(), &straddling));
+  auto length = ConsumeWholeObject(&straddling);
   ASSERT_NE(length, string_view::npos);
   ASSERT_NE(length, 0);
-  auto final_whole = second_half.substr(completion.size());
+  auto final_whole = SliceBuffer(second_half, completion->size());
   length = ConsumeWholeObject(&final_whole);
   ASSERT_NE(length, string_view::npos);
   ASSERT_NE(length, 0);
@@ -142,9 +139,9 @@ class BaseChunkerTest : public ::testing::TestWithParam<bool> {
   std::unique_ptr<Chunker> chunker_;
 };
 
-INSTANTIATE_TEST_CASE_P(ChunkerTest, BaseChunkerTest, ::testing::Values(true));
-
 INSTANTIATE_TEST_CASE_P(NoNewlineChunkerTest, BaseChunkerTest, ::testing::Values(false));
+
+INSTANTIATE_TEST_CASE_P(ChunkerTest, BaseChunkerTest, ::testing::Values(true));
 
 constexpr auto object_count = 3;
 const std::vector<std::string>& lines() {
@@ -159,8 +156,10 @@ TEST_P(BaseChunkerTest, Basics) {
 }
 
 TEST_P(BaseChunkerTest, Empty) {
-  AssertChunking(*chunker_, "\n", 0);
-  AssertChunking(*chunker_, "\n\n", 0);
+  auto empty = std::make_shared<Buffer>("\n");
+  AssertChunking(*chunker_, empty, 0);
+  empty = std::make_shared<Buffer>("\n\n");
+  AssertChunking(*chunker_, empty, 0);
 }
 
 TEST(ChunkerTest, PrettyPrinted) {
@@ -193,15 +192,18 @@ TEST(ChunkerTest, StraddlingSingleLine) {
 }
 
 TEST_P(BaseChunkerTest, StraddlingEmpty) {
-  auto joined = join(lines(), "\n");
-  auto first = string_view(joined).substr(0, lines()[0].size() + 1);
-  auto rest = string_view(joined).substr(first.size());
-  string_view first_whole;
-  ASSERT_OK(chunker_->Process(first, &first_whole));
-  auto partial = first.substr(first_whole.size());
-  string_view completion;
-  ASSERT_OK(chunker_->Process(partial, rest, &completion));
-  ASSERT_EQ(completion.size(), 0);
+  auto all = join(lines(), "\n");
+
+  auto first = SliceBuffer(all, 0, lines()[0].size() + 1);
+  std::shared_ptr<Buffer> first_whole, partial;
+  ASSERT_OK(chunker_->Process(first, &first_whole, &partial));
+  ASSERT_TRUE(WhitespaceOnly(partial));
+
+  auto others = SliceBuffer(all, first->size());
+  std::shared_ptr<Buffer> completion, rest;
+  ASSERT_OK(chunker_->Process(partial, others, &completion, &rest));
+  ASSERT_EQ(completion->size(), 0);
+  ASSERT_TRUE(rest->Equals(*others));
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -18,12 +18,10 @@
 #include "arrow/json/chunker.h"
 
 #include <algorithm>
-#include <cstdint>
-#include <memory>
-#include <string>
 #include <utility>
 #include <vector>
 
+#include "arrow/util/sse-util.h"
 #if defined(ARROW_HAVE_SSE4_2)
 #define RAPIDJSON_SSE42 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
@@ -32,11 +30,10 @@
 #define RAPIDJSON_SSE2 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
 #endif
-#include <rapidjson/error/en.h>
 #include <rapidjson/reader.h>
 
-#include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/buffer.h"
+#include "arrow/json/options.h"
 #include "arrow/util/stl.h"
 #include "arrow/util/string_view.h"
 
@@ -46,53 +43,65 @@ namespace json {
 using internal::make_unique;
 using util::string_view;
 
+string_view View(const std::shared_ptr<Buffer>& buffer) {
+  return string_view(reinterpret_cast<const char*>(buffer->data()), buffer->size());
+}
+
 Status StraddlingTooLarge() {
   return Status::Invalid("straddling object straddles two block boundaries");
 }
 
-std::size_t ConsumeWhitespace(string_view* str) {
+size_t ConsumeWhitespace(std::shared_ptr<Buffer>* buf) {
 #if defined(ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD)
-  auto nonws_begin =
-      rapidjson::SkipWhitespace_SIMD(str->data(), str->data() + str->size());
-  auto ws_count = nonws_begin - str->data();
-  *str = str->substr(ws_count);
-  return static_cast<std::size_t>(ws_count);
+  auto data = reinterpret_cast<const char*>((*buf)->data());
+  auto nonws_begin = rapidjson::SkipWhitespace_SIMD(data, data + (*buf)->size());
+  auto ws_count = nonws_begin - data;
+  *buf = SliceBuffer(*buf, ws_count);
+  return static_cast<size_t>(ws_count);
 #undef ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD
 #else
-  auto ws_count = str->find_first_not_of(" \t\r\n");
-  *str = str->substr(ws_count);
+  auto ws_count = View(*buf).find_first_not_of(" \t\r\n");
+  *buf = SliceBuffer(*buf, ws_count);
   return ws_count;
 #endif
 }
 
 class NewlinesStrictlyDelimitChunker : public Chunker {
  public:
-  Status Process(string_view block, string_view* chunked) override {
-    auto last_newline = block.find_last_of("\n\r");
+  Status Process(const std::shared_ptr<Buffer>& block, std::shared_ptr<Buffer>* whole,
+                 std::shared_ptr<Buffer>* partial) override {
+    auto last_newline = View(block).find_last_of("\n\r");
     if (last_newline == string_view::npos) {
       // no newlines in this block, return empty chunk
-      *chunked = string_view();
+      *whole = SliceBuffer(block, 0, 0);
+      *partial = block;
     } else {
-      *chunked = block.substr(0, last_newline + 1);
+      *whole = SliceBuffer(block, 0, last_newline + 1);
+      *partial = SliceBuffer(block, last_newline + 1);
     }
     return Status::OK();
   }
 
-  Status Process(string_view partial, string_view block,
-                 string_view* completion) override {
+  Status Process(const std::shared_ptr<Buffer>& partial_original,
+                 const std::shared_ptr<Buffer>& block,
+                 std::shared_ptr<Buffer>* completion,
+                 std::shared_ptr<Buffer>* rest) override {
+    auto partial = partial_original;
     ConsumeWhitespace(&partial);
-    if (partial.size() == 0) {
+    if (partial->size() == 0) {
       // if partial is empty, don't bother looking for completion
-      *completion = string_view();
+      *completion = SliceBuffer(block, 0, 0);
+      *rest = block;
       return Status::OK();
     }
-    auto first_newline = block.find_first_of("\n\r");
+    auto first_newline = View(block).find_first_of("\n\r");
     if (first_newline == string_view::npos) {
       // no newlines in this block; straddling object straddles *two* block boundaries.
       // retry with larger buffer
       return StraddlingTooLarge();
     }
-    *completion = block.substr(0, first_newline + 1);
+    *completion = SliceBuffer(block, 0, first_newline + 1);
+    *rest = SliceBuffer(block, first_newline + 1);
     return Status::OK();
   }
 };
@@ -104,7 +113,12 @@ class MultiStringStream {
   using Ch = char;
   explicit MultiStringStream(std::vector<string_view> strings)
       : strings_(std::move(strings)) {
-    std::remove(strings_.begin(), strings_.end(), string_view(""));
+    std::reverse(strings_.begin(), strings_.end());
+  }
+  explicit MultiStringStream(const BufferVector& buffers) : strings_(buffers.size()) {
+    for (size_t i = 0; i < buffers.size(); ++i) {
+      strings_[i] = View(buffers[i]);
+    }
     std::reverse(strings_.begin(), strings_.end());
   }
   char Peek() const {
@@ -122,25 +136,25 @@ class MultiStringStream {
     ++index_;
     return taken;
   }
-  std::size_t Tell() { return index_; }
+  size_t Tell() { return index_; }
   void Put(char) { ARROW_LOG(FATAL) << "not implemented"; }
   void Flush() { ARROW_LOG(FATAL) << "not implemented"; }
   char* PutBegin() {
     ARROW_LOG(FATAL) << "not implemented";
     return nullptr;
   }
-  std::size_t PutEnd(char*) {
+  size_t PutEnd(char*) {
     ARROW_LOG(FATAL) << "not implemented";
     return 0;
   }
 
  private:
-  std::size_t index_ = 0;
+  size_t index_ = 0;
   std::vector<string_view> strings_;
 };
 
 template <typename Stream>
-std::size_t ConsumeWholeObject(Stream&& stream) {
+size_t ConsumeWholeObject(Stream&& stream) {
   static constexpr unsigned parse_flags = rapidjson::kParseIterativeFlag |
                                           rapidjson::kParseStopWhenDoneFlag |
                                           rapidjson::kParseNumbersAsStringsFlag;
@@ -160,37 +174,44 @@ std::size_t ConsumeWholeObject(Stream&& stream) {
 
 class ParsingChunker : public Chunker {
  public:
-  Status Process(string_view block, string_view* chunked) override {
-    if (block.size() == 0) {
-      *chunked = string_view();
+  Status Process(const std::shared_ptr<Buffer>& block, std::shared_ptr<Buffer>* whole,
+                 std::shared_ptr<Buffer>* partial) override {
+    if (block->size() == 0) {
+      *whole = SliceBuffer(block, 0, 0);
+      *partial = block;
       return Status::OK();
     }
-    std::size_t total_length = 0;
-    for (auto consumed = block;; consumed = block.substr(total_length)) {
+    size_t total_length = 0;
+    for (auto consumed = block;; consumed = SliceBuffer(block, total_length)) {
       using rapidjson::MemoryStream;
-      MemoryStream ms(consumed.data(), consumed.size());
+      MemoryStream ms(reinterpret_cast<const char*>(consumed->data()), consumed->size());
       using InputStream = rapidjson::EncodedInputStream<rapidjson::UTF8<>, MemoryStream>;
       auto length = ConsumeWholeObject(InputStream(ms));
       if (length == string_view::npos || length == 0) {
         // found incomplete object or consumed is empty
         break;
       }
-      if (length > consumed.size()) {
-        total_length += consumed.size();
+      if (static_cast<int64_t>(length) > consumed->size()) {
+        total_length += consumed->size();
         break;
       }
       total_length += length;
     }
-    *chunked = block.substr(0, total_length);
+    *whole = SliceBuffer(block, 0, total_length);
+    *partial = SliceBuffer(block, total_length);
     return Status::OK();
   }
 
-  Status Process(string_view partial, string_view block,
-                 string_view* completion) override {
+  Status Process(const std::shared_ptr<Buffer>& partial_original,
+                 const std::shared_ptr<Buffer>& block,
+                 std::shared_ptr<Buffer>* completion,
+                 std::shared_ptr<Buffer>* rest) override {
+    auto partial = partial_original;
     ConsumeWhitespace(&partial);
-    if (partial.size() == 0) {
+    if (partial->size() == 0) {
       // if partial is empty, don't bother looking for completion
-      *completion = string_view();
+      *completion = SliceBuffer(block, 0, 0);
+      *rest = block;
       return Status::OK();
     }
     auto length = ConsumeWholeObject(MultiStringStream({partial, block}));
@@ -199,12 +220,14 @@ class ParsingChunker : public Chunker {
       // retry with larger buffer
       return StraddlingTooLarge();
     }
-    *completion = block.substr(0, length - partial.size());
+    auto completion_length = length - partial->size();
+    *completion = SliceBuffer(block, 0, completion_length);
+    *rest = SliceBuffer(block, completion_length);
     return Status::OK();
   }
 };
 
-std::unique_ptr<Chunker> Chunker::Make(ParseOptions options) {
+std::unique_ptr<Chunker> Chunker::Make(const ParseOptions& options) {
   if (!options.newlines_in_values) {
     return make_unique<NewlinesStrictlyDelimitChunker>();
   }

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -43,15 +43,15 @@ namespace json {
 using internal::make_unique;
 using util::string_view;
 
-string_view View(const std::shared_ptr<Buffer>& buffer) {
+static string_view View(const std::shared_ptr<Buffer>& buffer) {
   return string_view(reinterpret_cast<const char*>(buffer->data()), buffer->size());
 }
 
-Status StraddlingTooLarge() {
+static Status StraddlingTooLarge() {
   return Status::Invalid("straddling object straddles two block boundaries");
 }
 
-size_t ConsumeWhitespace(std::shared_ptr<Buffer>* buf) {
+static size_t ConsumeWhitespace(std::shared_ptr<Buffer>* buf) {
 #if defined(ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD)
   auto data = reinterpret_cast<const char*>((*buf)->data());
   auto nonws_begin = rapidjson::SkipWhitespace_SIMD(data, data + (*buf)->size());
@@ -154,7 +154,7 @@ class MultiStringStream {
 };
 
 template <typename Stream>
-size_t ConsumeWholeObject(Stream&& stream) {
+static size_t ConsumeWholeObject(Stream&& stream) {
   static constexpr unsigned parse_flags = rapidjson::kParseIterativeFlag |
                                           rapidjson::kParseStopWhenDoneFlag |
                                           rapidjson::kParseNumbersAsStringsFlag;

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -48,7 +48,6 @@ static size_t ConsumeWhitespace(std::shared_ptr<Buffer>* buf) {
   auto ws_count = nonws_begin - data;
   *buf = SliceBuffer(*buf, ws_count);
   return static_cast<size_t>(ws_count);
-#undef ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD
 #else
   auto ws_count = string_view(**buf).find_first_not_of(" \t\r\n");
   if (ws_count == string_view::npos) {

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -51,6 +51,9 @@ static size_t ConsumeWhitespace(std::shared_ptr<Buffer>* buf) {
 #undef ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD
 #else
   auto ws_count = string_view(**buf).find_first_not_of(" \t\r\n");
+  if (ws_count == string_view::npos) {
+    ws_count = (*buf)->size();
+  }
   *buf = SliceBuffer(*buf, ws_count);
   return ws_count;
 #endif

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -82,10 +82,10 @@ class NewlinesStrictlyDelimitChunker : public Chunker {
     return Status::OK();
   }
 
-  Status Process(const std::shared_ptr<Buffer>& partial_original,
-                 const std::shared_ptr<Buffer>& block,
-                 std::shared_ptr<Buffer>* completion,
-                 std::shared_ptr<Buffer>* rest) override {
+  Status ProcessWithPartial(const std::shared_ptr<Buffer>& partial_original,
+                            const std::shared_ptr<Buffer>& block,
+                            std::shared_ptr<Buffer>* completion,
+                            std::shared_ptr<Buffer>* rest) override {
     auto partial = partial_original;
     ConsumeWhitespace(&partial);
     if (partial->size() == 0) {
@@ -202,10 +202,10 @@ class ParsingChunker : public Chunker {
     return Status::OK();
   }
 
-  Status Process(const std::shared_ptr<Buffer>& partial_original,
-                 const std::shared_ptr<Buffer>& block,
-                 std::shared_ptr<Buffer>* completion,
-                 std::shared_ptr<Buffer>* rest) override {
+  Status ProcessWithPartial(const std::shared_ptr<Buffer>& partial_original,
+                            const std::shared_ptr<Buffer>& block,
+                            std::shared_ptr<Buffer>* completion,
+                            std::shared_ptr<Buffer>* rest) override {
     auto partial = partial_original;
     ConsumeWhitespace(&partial);
     if (partial->size() == 0) {

--- a/cpp/src/arrow/json/chunker.h
+++ b/cpp/src/arrow/json/chunker.h
@@ -53,10 +53,10 @@ class ARROW_EXPORT Chunker {
   /// \param[in] block json data
   /// \param[out] completion subrange of block containing the completion of partial
   /// \param[out] rest subrange of block containing what completion does not cover
-  virtual Status Process(const std::shared_ptr<Buffer>& partial,
-                         const std::shared_ptr<Buffer>& block,
-                         std::shared_ptr<Buffer>* completion,
-                         std::shared_ptr<Buffer>* rest) = 0;
+  virtual Status ProcessWithPartial(const std::shared_ptr<Buffer>& partial,
+                                    const std::shared_ptr<Buffer>& block,
+                                    std::shared_ptr<Buffer>* completion,
+                                    std::shared_ptr<Buffer>* rest) = 0;
 
   static std::unique_ptr<Chunker> Make(const ParseOptions& options);
 

--- a/cpp/src/arrow/json/chunker.h
+++ b/cpp/src/arrow/json/chunker.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_JSON_CHUNKER_H
-#define ARROW_JSON_CHUNKER_H
+#pragma once
 
 #include <memory>
 
@@ -68,5 +67,3 @@ class ARROW_EXPORT Chunker {
 
 }  // namespace json
 }  // namespace arrow
-
-#endif  // ARROW_JSON_CHUNKER_H

--- a/cpp/src/arrow/json/chunker.h
+++ b/cpp/src/arrow/json/chunker.h
@@ -20,15 +20,17 @@
 
 #include <memory>
 
-#include "arrow/json/options.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
-#include "arrow/util/sse-util.h"
-#include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+
+class Buffer;
+
 namespace json {
+
+struct ParseOptions;
 
 /// \class Chunker
 /// \brief A reusable block-based chunker for JSON data
@@ -41,17 +43,23 @@ class ARROW_EXPORT Chunker {
 
   /// \brief Carve up a chunk in a block of data to contain only whole objects
   /// \param[in] block json data to be chunked
-  /// \param[out] chunked subrange of block containing whole json objects
-  virtual Status Process(util::string_view block, util::string_view* chunked) = 0;
+  /// \param[out] whole subrange of block containing whole json objects
+  /// \param[out] partial subrange of block a partial json object
+  virtual Status Process(const std::shared_ptr<Buffer>& block,
+                         std::shared_ptr<Buffer>* whole,
+                         std::shared_ptr<Buffer>* partial) = 0;
 
   /// \brief Carve the completion of a partial object out of a block
   /// \param[in] partial incomplete json object
   /// \param[in] block json data
-  /// \param[out] completion subrange of block contining the completion of partial
-  virtual Status Process(util::string_view partial, util::string_view block,
-                         util::string_view* completion) = 0;
+  /// \param[out] completion subrange of block containing the completion of partial
+  /// \param[out] rest subrange of block containing what completion does not cover
+  virtual Status Process(const std::shared_ptr<Buffer>& partial,
+                         const std::shared_ptr<Buffer>& block,
+                         std::shared_ptr<Buffer>* completion,
+                         std::shared_ptr<Buffer>* rest) = 0;
 
-  static std::unique_ptr<Chunker> Make(ParseOptions options);
+  static std::unique_ptr<Chunker> Make(const ParseOptions& options);
 
  protected:
   Chunker() = default;

--- a/cpp/src/arrow/json/options.h
+++ b/cpp/src/arrow/json/options.h
@@ -20,15 +20,13 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
-#include <unordered_map>
 
-#include "arrow/type.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
 class DataType;
+class Schema;
 
 namespace json {
 

--- a/cpp/src/arrow/json/options.h
+++ b/cpp/src/arrow/json/options.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_JSON_OPTIONS_H
-#define ARROW_JSON_OPTIONS_H
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -62,5 +61,3 @@ struct ARROW_EXPORT ReadOptions {
 
 }  // namespace json
 }  // namespace arrow
-
-#endif  // ARROW_JSON_OPTIONS_H

--- a/cpp/src/arrow/json/parser-benchmark.cc
+++ b/cpp/src/arrow/json/parser-benchmark.cc
@@ -17,9 +17,9 @@
 
 #include "benchmark/benchmark.h"
 
-#include <iostream>
 #include <string>
 
+#include "arrow/json/chunker.h"
 #include "arrow/json/options.h"
 #include "arrow/json/parser.h"
 #include "arrow/json/test-common.h"
@@ -28,14 +28,65 @@
 namespace arrow {
 namespace json {
 
-static void BenchmarkJSONParsing(benchmark::State& state,  // NOLINT non-const reference
-                                 const std::string& json, int32_t num_rows,
-                                 ParseOptions options) {
+static void BenchmarkJSONChunking(benchmark::State& state,  // NOLINT non-const reference
+                                  const std::shared_ptr<Buffer>& json,
+                                  ParseOptions options) {
+  auto chunker = Chunker::Make(options);
   for (auto _ : state) {
-    std::shared_ptr<Buffer> src;
-    ABORT_NOT_OK(MakeBuffer(json, &src));
-    BlockParser parser(options, src);
-    ABORT_NOT_OK(parser.Parse(src));
+    std::shared_ptr<Buffer> chunked, partial;
+    ABORT_NOT_OK(chunker->Process(json, &chunked, &partial));
+  }
+  state.SetBytesProcessed(state.iterations() * json->size());
+}
+
+static void BM_ChunkJSONPrettyPrinted(
+    benchmark::State& state) {  // NOLINT non-const reference
+  const int32_t num_rows = 5000;
+  auto options = ParseOptions::Defaults();
+  options.newlines_in_values = true;
+  options.explicit_schema = schema({field("int", int32()), field("str", utf8())});
+  std::default_random_engine engine;
+  std::string json;
+  for (int i = 0; i < num_rows; ++i) {
+    StringBuffer sb;
+    Writer writer(sb);
+    ABORT_NOT_OK(Generate(options.explicit_schema, engine, &writer));
+    json += PrettyPrint(sb.GetString());
+    json += "\n";
+  }
+  BenchmarkJSONChunking(state, std::make_shared<Buffer>(json), options);
+}
+
+BENCHMARK(BM_ChunkJSONPrettyPrinted)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
+
+static void BM_ChunkJSONLineDelimited(
+    benchmark::State& state) {  // NOLINT non-const reference
+  const int32_t num_rows = 5000;
+  auto options = ParseOptions::Defaults();
+  options.newlines_in_values = false;
+  options.explicit_schema = schema({field("int", int32()), field("str", utf8())});
+  std::default_random_engine engine;
+  std::string json;
+  for (int i = 0; i < num_rows; ++i) {
+    StringBuffer sb;
+    Writer writer(sb);
+    ABORT_NOT_OK(Generate(options.explicit_schema, engine, &writer));
+    json += sb.GetString();
+    json += "\n";
+  }
+  BenchmarkJSONChunking(state, std::make_shared<Buffer>(json), options);
+}
+
+BENCHMARK(BM_ChunkJSONLineDelimited)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
+
+static void BenchmarkJSONParsing(benchmark::State& state,  // NOLINT non-const reference
+                                 const std::shared_ptr<Buffer>& json, int32_t num_rows,
+                                 ParseOptions options) {
+  std::shared_ptr<ResizableBuffer> storage;
+  ABORT_NOT_OK(AllocateResizableBuffer(json->size(), &storage));
+  for (auto _ : state) {
+    BlockParser parser(options, storage);
+    ABORT_NOT_OK(parser.Parse(json));
     if (parser.num_rows() != num_rows) {
       std::cerr << "Parsing incomplete\n";
       std::abort();
@@ -43,7 +94,7 @@ static void BenchmarkJSONParsing(benchmark::State& state,  // NOLINT non-const r
     std::shared_ptr<Array> parsed;
     ABORT_NOT_OK(parser.Finish(&parsed));
   }
-  state.SetBytesProcessed(state.iterations() * json.size());
+  state.SetBytesProcessed(state.iterations() * json->size());
 }
 
 static void BM_ParseJSONBlockWithSchema(
@@ -52,16 +103,16 @@ static void BM_ParseJSONBlockWithSchema(
   auto options = ParseOptions::Defaults();
   options.unexpected_field_behavior = UnexpectedFieldBehavior::Error;
   options.explicit_schema = schema({field("int", int32()), field("str", utf8())});
-  std::mt19937_64 engine;
+  std::default_random_engine engine;
   std::string json;
-  for (int i = 0; i != num_rows; ++i) {
+  for (int i = 0; i < num_rows; ++i) {
     StringBuffer sb;
     Writer writer(sb);
     ABORT_NOT_OK(Generate(options.explicit_schema, engine, &writer));
     json += sb.GetString();
     json += "\n";
   }
-  BenchmarkJSONParsing(state, json, num_rows, options);
+  BenchmarkJSONParsing(state, std::make_shared<Buffer>(json), num_rows, options);
 }
 
 BENCHMARK(BM_ParseJSONBlockWithSchema)->MinTime(1.0)->Unit(benchmark::kMicrosecond);

--- a/cpp/src/arrow/json/parser-test.cc
+++ b/cpp/src/arrow/json/parser-test.cc
@@ -15,33 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cstdint>
-#include <iomanip>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
-#include <rapidjson/error/en.h>
-#include <rapidjson/reader.h>
 
-#include "arrow/ipc/json-simple.h"
 #include "arrow/json/options.h"
 #include "arrow/json/parser.h"
-#include "arrow/json/reader.h"
 #include "arrow/json/test-common.h"
 #include "arrow/status.h"
-#include "arrow/testing/util.h"
-#include "arrow/util/logging.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/util/string_view.h"
 
 namespace arrow {
+namespace json {
 
 using util::string_view;
 
-namespace json {
-
-std::string scalars_only_src() {
+static std::string scalars_only_src() {
   return R"(
     { "hello": 3.5, "world": false, "yo": "thing" }
     { "hello": 3.2, "world": null }
@@ -50,7 +42,7 @@ std::string scalars_only_src() {
   )";
 }
 
-std::string nested_src() {
+static std::string nested_src() {
   return R"(
     { "hello": 3.5, "world": false, "yo": "thing", "arr": [1, 2, 3], "nuf": {} }
     { "hello": 3.2, "world": null, "arr": [2], "nuf": null }
@@ -59,9 +51,10 @@ std::string nested_src() {
   )";
 }
 
-void AssertRawStructArraysEqual(const StructArray& expected, const StructArray& actual);
+void AssertUnconvertedStructArraysEqual(const StructArray& expected,
+                                        const StructArray& actual);
 
-void AssertRawArraysEqual(const Array& expected, const Array& actual) {
+void AssertUnconvertedArraysEqual(const Array& expected, const Array& actual) {
   switch (actual.type_id()) {
     case Type::BOOL:
     case Type::NA:
@@ -81,43 +74,38 @@ void AssertRawArraysEqual(const Array& expected, const Array& actual) {
       AssertBufferEqual(*expected_offsets, *actual_offsets);
       auto expected_values = static_cast<const ListArray&>(expected).values();
       auto actual_values = static_cast<const ListArray&>(actual).values();
-      return AssertRawArraysEqual(*expected_values, *actual_values);
+      return AssertUnconvertedArraysEqual(*expected_values, *actual_values);
     }
     case Type::STRUCT:
       ASSERT_EQ(expected.type_id(), Type::STRUCT);
-      return AssertRawStructArraysEqual(static_cast<const StructArray&>(expected),
-                                        static_cast<const StructArray&>(actual));
+      return AssertUnconvertedStructArraysEqual(static_cast<const StructArray&>(expected),
+                                                static_cast<const StructArray&>(actual));
     default:
       FAIL();
   }
 }
 
-void AssertRawStructArraysEqual(const StructArray& expected, const StructArray& actual) {
+void AssertUnconvertedStructArraysEqual(const StructArray& expected,
+                                        const StructArray& actual) {
   ASSERT_EQ(expected.num_fields(), actual.num_fields());
-  for (int i = 0; i != expected.num_fields(); ++i) {
+  for (int i = 0; i < expected.num_fields(); ++i) {
     auto expected_name = expected.type()->child(i)->name();
     auto actual_name = actual.type()->child(i)->name();
     ASSERT_EQ(expected_name, actual_name);
-    AssertRawArraysEqual(*expected.field(i), *actual.field(i));
+    AssertUnconvertedArraysEqual(*expected.field(i), *actual.field(i));
   }
 }
 
 void AssertParseColumns(ParseOptions options, string_view src_str,
                         const std::vector<std::shared_ptr<Field>>& fields,
                         const std::vector<std::string>& columns_json) {
-  std::shared_ptr<Buffer> src;
-  ASSERT_OK(MakeBuffer(src_str, &src));
-  BlockParser parser(options, src);
-  ASSERT_OK(parser.Parse(src));
   std::shared_ptr<Array> parsed;
-  ASSERT_OK(parser.Finish(&parsed));
+  ASSERT_OK(ParseFromString(options, src_str, &parsed));
   auto struct_array = std::static_pointer_cast<StructArray>(parsed);
-  for (size_t i = 0; i != fields.size(); ++i) {
-    // std::shared_ptr<Array> column_expected;
-    // ASSERT_OK(ArrayFromJSON(fields[i]->type(), columns_json[i], &column_expected));
+  for (size_t i = 0; i < fields.size(); ++i) {
     auto column_expected = ArrayFromJSON(fields[i]->type(), columns_json[i]);
     auto column = struct_array->GetFieldByName(fields[i]->name());
-    AssertRawArraysEqual(*column_expected, *column);
+    AssertUnconvertedArraysEqual(*column_expected, *column);
   }
 }
 
@@ -160,10 +148,8 @@ TEST(BlockParserWithSchema, FailOnInconvertible) {
   auto options = ParseOptions::Defaults();
   options.explicit_schema = schema({field("a", int32())});
   options.unexpected_field_behavior = UnexpectedFieldBehavior::Ignore;
-  std::shared_ptr<Buffer> src;
-  ASSERT_OK(MakeBuffer("{\"a\":0}\n{\"a\":true}", &src));
-  BlockParser parser(options, src);
-  ASSERT_RAISES(Invalid, parser.Parse(src));
+  std::shared_ptr<Array> parsed;
+  ASSERT_RAISES(Invalid, ParseFromString(options, "{\"a\":0}\n{\"a\":true}", &parsed));
 }
 
 TEST(BlockParserWithSchema, Nested) {
@@ -183,10 +169,8 @@ TEST(BlockParserWithSchema, FailOnIncompleteJson) {
   auto options = ParseOptions::Defaults();
   options.explicit_schema = schema({field("a", int32())});
   options.unexpected_field_behavior = UnexpectedFieldBehavior::Ignore;
-  std::shared_ptr<Buffer> src;
-  ASSERT_OK(MakeBuffer("{\"a\":0, \"b\"", &src));
-  BlockParser parser(options, src);
-  ASSERT_RAISES(Invalid, parser.Parse(src));
+  std::shared_ptr<Array> parsed;
+  ASSERT_RAISES(Invalid, ParseFromString(options, "{\"a\":0, \"b\"", &parsed));
 }
 
 TEST(BlockParser, Basics) {
@@ -208,41 +192,6 @@ TEST(BlockParser, Nested) {
                      {"[\"thing\", null, \"\xe5\xbf\x8d\", null]",
                       R"([["1", "2", "3"], ["2"], [], null])",
                       R"([{"ps":null}, null, {"ps":"78"}, {"ps":"90"}])"});
-}
-
-void AssertParseOne(ParseOptions options, string_view src_str,
-                    const std::vector<std::shared_ptr<Field>>& fields,
-                    const std::vector<std::string>& columns_json) {
-  std::shared_ptr<Buffer> src;
-  ASSERT_OK(MakeBuffer(src_str, &src));
-  std::shared_ptr<RecordBatch> parsed;
-  ASSERT_OK(ParseOne(options, src, &parsed));
-  for (size_t i = 0; i != fields.size(); ++i) {
-    auto column_expected = ArrayFromJSON(fields[i]->type(), columns_json[i]);
-    auto column = parsed->GetColumnByName(fields[i]->name());
-    AssertArraysEqual(*column_expected, *column);
-  }
-}
-
-TEST(ParseOne, Basics) {
-  auto options = ParseOptions::Defaults();
-  options.unexpected_field_behavior = UnexpectedFieldBehavior::InferType;
-  AssertParseOne(
-      options, scalars_only_src(),
-      {field("hello", float64()), field("world", boolean()), field("yo", utf8())},
-      {"[3.5, 3.2, 3.4, 0.0]", "[false, null, null, true]",
-       "[\"thing\", null, \"\xe5\xbf\x8d\", null]"});
-}
-
-TEST(ParseOne, Nested) {
-  auto options = ParseOptions::Defaults();
-  options.unexpected_field_behavior = UnexpectedFieldBehavior::InferType;
-  AssertParseOne(
-      options, nested_src(),
-      {field("yo", utf8()), field("arr", list(int64())),
-       field("nuf", struct_({field("ps", int64())}))},
-      {"[\"thing\", null, \"\xe5\xbf\x8d\", null]", R"([[1, 2, 3], [2], [], null])",
-       R"([{"ps":null}, null, {"ps":78}, {"ps":90}])"});
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -54,11 +54,11 @@ using internal::checked_cast;
 using util::string_view;
 
 template <typename... T>
-Status ParseError(T&&... t) {
+static Status ParseError(T&&... t) {
   return Status::Invalid("JSON parse error: ", std::forward<T>(t)...);
 }
 
-Status KindChangeError(Kind::type from, Kind::type to) {
+static Status KindChangeError(Kind::type from, Kind::type to) {
   return ParseError("A column changed from ", Kind::Name(from), " to ", Kind::Name(to));
 }
 
@@ -81,7 +81,7 @@ const std::shared_ptr<const KeyValueMetadata>& Kind::Tag(Kind::type kind) {
   return tags[kind];
 }
 
-internal::Trie MakeFromTagTrie() {
+static internal::Trie MakeFromTagTrie() {
   internal::TrieBuilder builder;
   for (auto kind : {Kind::kNull, Kind::kBoolean, Kind::kNumber, Kind::kString,
                     Kind::kArray, Kind::kObject}) {

--- a/cpp/src/arrow/json/parser.h
+++ b/cpp/src/arrow/json/parser.h
@@ -18,69 +18,35 @@
 #ifndef ARROW_JSON_PARSER_H
 #define ARROW_JSON_PARSER_H
 
-#include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
 
-#include "arrow/builder.h"
 #include "arrow/json/options.h"
-#include "arrow/record_batch.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
-#include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
-#include "arrow/visitor_inline.h"
 
 namespace arrow {
 
+class Array;
+class Buffer;
 class MemoryPool;
-class RecordBatch;
+class KeyValueMetadata;
+class ResizableBuffer;
 
 namespace json {
 
 struct Kind {
   enum type : uint8_t { kNull, kBoolean, kNumber, kString, kArray, kObject };
+
+  static const std::string& Name(Kind::type);
+
+  static const std::shared_ptr<const KeyValueMetadata>& Tag(Kind::type);
+
+  static Kind::type FromTag(const std::shared_ptr<const KeyValueMetadata>& tag);
+
+  static Status ForType(const DataType& type, Kind::type* kind);
 };
-
-inline static const std::shared_ptr<const KeyValueMetadata>& Tag(Kind::type k) {
-  static std::shared_ptr<const KeyValueMetadata> tags[] = {
-      key_value_metadata({{"json_kind", "null"}}),
-      key_value_metadata({{"json_kind", "boolean"}}),
-      key_value_metadata({{"json_kind", "number"}}),
-      key_value_metadata({{"json_kind", "string"}}),
-      key_value_metadata({{"json_kind", "array"}}),
-      key_value_metadata({{"json_kind", "object"}})};
-  return tags[static_cast<uint8_t>(k)];
-}
-
-inline static Status KindForType(const DataType& type, Kind::type* kind) {
-  struct {
-    Status Visit(const NullType&) { return SetKind(Kind::kNull); }
-    Status Visit(const BooleanType&) { return SetKind(Kind::kBoolean); }
-    Status Visit(const Number&) { return SetKind(Kind::kNumber); }
-    // XXX should TimeType & DateType be Kind::kNumber or Kind::kString?
-    Status Visit(const TimeType&) { return SetKind(Kind::kNumber); }
-    Status Visit(const DateType&) { return SetKind(Kind::kNumber); }
-    Status Visit(const BinaryType&) { return SetKind(Kind::kString); }
-    // XXX should Decimal128Type be Kind::kNumber or Kind::kString?
-    Status Visit(const FixedSizeBinaryType&) { return SetKind(Kind::kString); }
-    Status Visit(const DictionaryType& dict_type) {
-      return KindForType(*dict_type.dictionary()->type(), kind_);
-    }
-    Status Visit(const ListType&) { return SetKind(Kind::kArray); }
-    Status Visit(const StructType&) { return SetKind(Kind::kObject); }
-    Status Visit(const DataType& not_impl) {
-      return Status::NotImplemented("JSON parsing of ", not_impl);
-    }
-    Status SetKind(Kind::type kind) {
-      *kind_ = kind;
-      return Status::OK();
-    }
-    Kind::type* kind_;
-  } visitor = {kind};
-  return VisitTypeInline(type, &visitor);
-}
 
 constexpr int32_t kMaxParserNumRows = 100000;
 
@@ -93,12 +59,12 @@ constexpr int32_t kMaxParserNumRows = 100000;
 /// parser, so the original buffer can be discarded after Parse() returns.
 class ARROW_EXPORT BlockParser {
  public:
-  BlockParser(MemoryPool* pool, ParseOptions options,
-              const std::shared_ptr<Buffer>& scalar_storage);
-  BlockParser(ParseOptions options, const std::shared_ptr<Buffer>& scalar_storage);
+  BlockParser(MemoryPool* pool, const ParseOptions& options,
+              const std::shared_ptr<ResizableBuffer>& scalar_storage);
+  BlockParser(ParseOptions options,
+              const std::shared_ptr<ResizableBuffer>& scalar_storage);
 
-  /// \brief Parse a block of data insitu (destructively)
-  /// \warning The input must be null terminated
+  /// \brief Parse a block of data
   Status Parse(const std::shared_ptr<Buffer>& json) { return impl_->Parse(json); }
 
   /// \brief Extract parsed data

--- a/cpp/src/arrow/json/parser.h
+++ b/cpp/src/arrow/json/parser.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_JSON_PARSER_H
-#define ARROW_JSON_PARSER_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -90,5 +89,3 @@ class ARROW_EXPORT BlockParser {
 
 }  // namespace json
 }  // namespace arrow
-
-#endif  // ARROW_JSON_PARSER_H

--- a/cpp/src/arrow/json/parser.h
+++ b/cpp/src/arrow/json/parser.h
@@ -75,7 +75,7 @@ class ARROW_EXPORT BlockParser {
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(BlockParser);
 
-  BlockParser(MemoryPool* pool) : pool_(pool) {}
+  explicit BlockParser(MemoryPool* pool) : pool_(pool) {}
 
   MemoryPool* pool_;
   int32_t num_rows_ = 0;

--- a/cpp/src/arrow/json/rapidjson-defs.h
+++ b/cpp/src/arrow/json/rapidjson-defs.h
@@ -30,6 +30,8 @@
   }                             \
   }
 
+#include "arrow/util/sse-util.h"
+
 // enable SIMD whitespace skipping, if available
 #if defined(ARROW_HAVE_SSE2)
 #define RAPIDJSON_SSE2 1

--- a/cpp/src/arrow/json/rapidjson-defs.h
+++ b/cpp/src/arrow/json/rapidjson-defs.h
@@ -31,12 +31,12 @@
   }
 
 // enable SIMD whitespace skipping, if available
-#if defined(__SSE4_2__)
-#define RAPIDJSON_SSE42 1
+#if defined(ARROW_HAVE_SSE2)
+#define RAPIDJSON_SSE2 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
 #endif
 
-#if (defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64))
-#define RAPIDJSON_SSE2 1
+#if defined(ARROW_HAVE_SSE4_2)
+#define RAPIDJSON_SSE42 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
 #endif

--- a/cpp/src/arrow/json/rapidjson-defs.h
+++ b/cpp/src/arrow/json/rapidjson-defs.h
@@ -30,16 +30,13 @@
   }                             \
   }
 
-#include "arrow/util/sse-util.h"
-
 // enable SIMD whitespace skipping, if available
-
-#if defined(ARROW_HAVE_SSE4_2)
+#if defined(__SSE4_2__)
 #define RAPIDJSON_SSE42 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
 #endif
 
-#if defined(ARROW_HAVE_SSE2)
+#if (defined(__SSE2__) || defined(_M_AMD64) || defined(_M_X64))
 #define RAPIDJSON_SSE2 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
 #endif

--- a/cpp/src/arrow/json/rapidjson-defs.h
+++ b/cpp/src/arrow/json/rapidjson-defs.h
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Include this file before including any RapidJSON headers.
+
+#define RAPIDJSON_HAS_STDSTRING 1
+#define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
+#define RAPIDJSON_HAS_CXX11_RANGE_FOR 1
+
+// rapidjson will be defined in namespace arrow::rapidjson
+#define RAPIDJSON_NAMESPACE arrow::rapidjson
+#define RAPIDJSON_NAMESPACE_BEGIN \
+  namespace arrow {               \
+  namespace rapidjson {
+#define RAPIDJSON_NAMESPACE_END \
+  }                             \
+  }
+
+#include "arrow/util/sse-util.h"
+
+// enable SIMD whitespace skipping, if available
+
+#if defined(ARROW_HAVE_SSE4_2)
+#define RAPIDJSON_SSE42 1
+#define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
+#endif
+
+#if defined(ARROW_HAVE_SSE2)
+#define RAPIDJSON_SSE2 1
+#define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
+#endif

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -21,6 +21,7 @@
 
 #include "arrow/array.h"
 #include "arrow/builder.h"
+#include "arrow/json/parser.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/parsing.h"

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -18,6 +18,8 @@
 #include "arrow/json/reader.h"
 
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "arrow/array.h"
 #include "arrow/builder.h"

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -33,29 +33,6 @@ namespace json {
 
 using internal::StringConverter;
 
-Kind::type KindFromTag(const std::shared_ptr<const KeyValueMetadata>& tag) {
-  std::string kind_name = tag->value(0);
-  switch (kind_name[0]) {
-    case 'n':
-      if (kind_name[2] == 'l') {
-        return Kind::kNull;
-      } else {
-        return Kind::kNumber;
-      }
-    case 'b':
-      return Kind::kBoolean;
-    case 's':
-      return Kind::kString;
-    case 'o':
-      return Kind::kObject;
-    case 'a':
-      return Kind::kArray;
-    default:
-      ARROW_LOG(FATAL);
-      return Kind::kNull;
-  }
-}
-
 struct ConvertImpl {
   Status Visit(const NullType&) {
     *out = in;
@@ -187,7 +164,7 @@ static Status InferAndConvert(std::shared_ptr<DataType> expected,
                               const std::shared_ptr<const KeyValueMetadata>& tag,
                               const std::shared_ptr<Array>& in,
                               std::shared_ptr<Array>* out) {
-  Kind::type kind = KindFromTag(tag);
+  Kind::type kind = Kind::FromTag(tag);
   switch (kind) {
     case Kind::kObject: {
       // FIXME(bkietz) in general expected fields may not be an exact prefix of parsed's

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -19,19 +19,18 @@
 #define ARROW_JSON_READER_H
 
 #include <memory>
-#include <string>
-#include <utility>
-#include <vector>
 
-#include "arrow/json/options.h"  // IWYU pragma: keep
-#include "arrow/json/parser.h"   // IWYU pragma: keep
+#include "arrow/json/options.h"
 #include "arrow/status.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
+class Buffer;
 class MemoryPool;
 class Table;
+class RecordBatch;
 
 namespace io {
 class InputStream;
@@ -45,12 +44,12 @@ class ARROW_EXPORT TableReader {
 
   virtual Status Read(std::shared_ptr<Table>* out) = 0;
 
-  // XXX pass optional schema?
   static Status Make(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
                      const ReadOptions&, const ParseOptions&,
                      std::shared_ptr<TableReader>* out);
 };
 
+ARROW_DEPRECATED("Use TableReader")
 ARROW_EXPORT Status ParseOne(ParseOptions options, std::shared_ptr<Buffer> json,
                              std::shared_ptr<RecordBatch>* out);
 

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -53,8 +53,10 @@ class ARROW_EXPORT TableReader {
 ARROW_EXPORT Status ParseOne(ParseOptions options, std::shared_ptr<Buffer> json,
                              std::shared_ptr<RecordBatch>* out);
 
-Status Convert(const std::shared_ptr<DataType>& out_type, std::shared_ptr<Array> in,
-               std::shared_ptr<Array>* out);
+/// \brief convert an Array produced by BlockParser into an Array of out_type
+ARROW_EXPORT Status Convert(const std::shared_ptr<DataType>& out_type,
+                            const std::shared_ptr<Array>& in,
+                            std::shared_ptr<Array>* out);
 
 }  // namespace json
 }  // namespace arrow

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_JSON_READER_H
-#define ARROW_JSON_READER_H
+#pragma once
 
 #include <memory>
 
@@ -59,5 +58,3 @@ Status Convert(const std::shared_ptr<DataType>& out_type, std::shared_ptr<Array>
 
 }  // namespace json
 }  // namespace arrow
-
-#endif  // ARROW_JSON_READER_H

--- a/cpp/src/arrow/json/reader.h
+++ b/cpp/src/arrow/json/reader.h
@@ -31,6 +31,8 @@ class Buffer;
 class MemoryPool;
 class Table;
 class RecordBatch;
+class Array;
+class DataType;
 
 namespace io {
 class InputStream;
@@ -49,9 +51,11 @@ class ARROW_EXPORT TableReader {
                      std::shared_ptr<TableReader>* out);
 };
 
-ARROW_DEPRECATED("Use TableReader")
 ARROW_EXPORT Status ParseOne(ParseOptions options, std::shared_ptr<Buffer> json,
                              std::shared_ptr<RecordBatch>* out);
+
+Status Convert(const std::shared_ptr<DataType>& out_type, std::shared_ptr<Array> in,
+               std::shared_ptr<Array>* out);
 
 }  // namespace json
 }  // namespace arrow

--- a/cpp/src/arrow/json/test-common.h
+++ b/cpp/src/arrow/json/test-common.h
@@ -26,7 +26,6 @@
 #include <rapidjson/writer.h>
 
 #include "arrow/io/memory.h"
-#include "arrow/json/converter.h"
 #include "arrow/json/options.h"
 #include "arrow/json/parser.h"
 #include "arrow/testing/gtest_util.h"
@@ -164,47 +163,6 @@ inline static Status ParseFromString(ParseOptions options, string_view src_str,
   BlockParser parser(options, storage);
   RETURN_NOT_OK(parser.Parse(src));
   return parser.Finish(parsed);
-}
-
-inline static Status Convert(MemoryPool* pool,
-                             const std::shared_ptr<DataType>& target_type,
-                             const std::shared_ptr<Array>& parsed,
-                             std::shared_ptr<ArrayData>* converted_data);
-
-inline static Status Convert(MemoryPool* pool,
-                             const std::shared_ptr<DataType>& target_type,
-                             const std::shared_ptr<Array>& parsed,
-                             std::shared_ptr<Array>* converted) {
-  auto converted_data = parsed->data()->Copy();
-  converted_data->type = target_type;
-  if (target_type->id() == Type::LIST) {
-    auto list_array = static_cast<const ListArray*>(parsed.get());
-    RETURN_NOT_OK(Convert(pool, target_type->child(0)->type(), list_array->values(),
-                          &converted_data->child_data[0]));
-    *converted = MakeArray(converted_data);
-    return Status::OK();
-  }
-  if (target_type->id() == Type::STRUCT) {
-    auto struct_array = static_cast<const StructArray*>(parsed.get());
-    for (int i = 0; i < target_type->num_children(); ++i) {
-      RETURN_NOT_OK(Convert(pool, target_type->child(i)->type(), struct_array->field(i),
-                            &converted_data->child_data[i]));
-    }
-    *converted = MakeArray(converted_data);
-    return Status::OK();
-  }
-  std::shared_ptr<Converter> converter;
-  RETURN_NOT_OK(MakeConverter(target_type, pool, &converter));
-  return converter->Convert(parsed, converted);
-}
-
-Status Convert(MemoryPool* pool, const std::shared_ptr<DataType>& target_type,
-               const std::shared_ptr<Array>& parsed,
-               std::shared_ptr<ArrayData>* converted_data) {
-  std::shared_ptr<Array> converted;
-  RETURN_NOT_OK(Convert(pool, target_type, parsed, &converted));
-  *converted_data = converted->data();
-  return Status::OK();
 }
 
 std::string PrettyPrint(string_view one_line) {

--- a/cpp/src/arrow/json/test-common.h
+++ b/cpp/src/arrow/json/test-common.h
@@ -158,11 +158,10 @@ inline static Status DecodeStringDictionary(const DictionaryArray& dict_array,
 inline static Status ParseFromString(ParseOptions options, string_view src_str,
                                      std::shared_ptr<Array>* parsed) {
   auto src = std::make_shared<Buffer>(src_str);
-  std::shared_ptr<ResizableBuffer> storage;
-  RETURN_NOT_OK(AllocateResizableBuffer(src->size(), &storage));
-  BlockParser parser(options, storage);
-  RETURN_NOT_OK(parser.Parse(src));
-  return parser.Finish(parsed);
+  std::unique_ptr<BlockParser> parser;
+  RETURN_NOT_OK(BlockParser::Make(options, &parser));
+  RETURN_NOT_OK(parser->Parse(src));
+  return parser->Finish(parsed);
 }
 
 std::string PrettyPrint(string_view one_line) {

--- a/cpp/src/arrow/json/test-common.h
+++ b/cpp/src/arrow/json/test-common.h
@@ -20,10 +20,11 @@
 #include <string>
 #include <vector>
 
-#include <rapidjson/document.h>
-#include <rapidjson/prettywriter.h>
-#include <rapidjson/reader.h>
-#include <rapidjson/writer.h>
+#include "arrow/json/rapidjson-defs.h"
+#include "rapidjson/document.h"
+#include "rapidjson/prettywriter.h"
+#include "rapidjson/reader.h"
+#include "rapidjson/writer.h"
 
 #include "arrow/io/memory.h"
 #include "arrow/json/options.h"
@@ -36,9 +37,11 @@
 namespace arrow {
 namespace json {
 
-using rapidjson::StringBuffer;
+namespace rj = arrow::rapidjson;
+
+using rj::StringBuffer;
 using util::string_view;
-using Writer = rapidjson::Writer<StringBuffer>;
+using Writer = rj::Writer<StringBuffer>;
 
 inline static Status OK(bool ok) { return ok ? Status::OK() : Status::Invalid(""); }
 
@@ -102,7 +105,7 @@ struct GenerateImpl {
   }
   Status Visit(const StructType& t) { return Generate(t.children(), e, &writer); }
   Engine& e;
-  rapidjson::Writer<rapidjson::StringBuffer>& writer;
+  rj::Writer<rj::StringBuffer>& writer;
 };
 
 template <typename Engine>
@@ -165,10 +168,10 @@ inline static Status ParseFromString(ParseOptions options, string_view src_str,
 }
 
 std::string PrettyPrint(string_view one_line) {
-  rapidjson::Document document;
+  rj::Document document;
   document.Parse(one_line.data());
-  rapidjson::StringBuffer sb;
-  rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
+  rj::StringBuffer sb;
+  rj::PrettyWriter<rj::StringBuffer> writer(sb);
   document.Accept(writer);
   return sb.GetString();
 }

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -294,69 +294,75 @@ struct is_8bit_int {
       (std::is_same<UInt8Type, T>::value || std::is_same<Int8Type, T>::value);
 };
 
-template <typename T>
-using enable_if_8bit_int = typename std::enable_if<is_8bit_int<T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_8bit_int = typename std::enable_if<is_8bit_int<T>::value, R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_primitive_ctype =
-    typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value>::type;
+    typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value, R>::type;
 
-template <typename T>
-using enable_if_date = typename std::enable_if<std::is_base_of<DateType, T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_date =
+    typename std::enable_if<std::is_base_of<DateType, T>::value, R>::type;
 
-template <typename T, typename U = void>
+template <typename T, typename R = void>
 using enable_if_integer =
-    typename std::enable_if<std::is_base_of<Integer, T>::value, U>::type;
+    typename std::enable_if<std::is_base_of<Integer, T>::value, R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_signed_integer =
     typename std::enable_if<std::is_base_of<Integer, T>::value &&
-                            std::is_signed<typename T::c_type>::value>::type;
+                                std::is_signed<typename T::c_type>::value,
+                            R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_unsigned_integer =
     typename std::enable_if<std::is_base_of<Integer, T>::value &&
-                            std::is_unsigned<typename T::c_type>::value>::type;
+                                std::is_unsigned<typename T::c_type>::value,
+                            R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_floating_point =
-    typename std::enable_if<std::is_base_of<FloatingPoint, T>::value>::type;
+    typename std::enable_if<std::is_base_of<FloatingPoint, T>::value, R>::type;
 
-template <typename T>
-using enable_if_time = typename std::enable_if<std::is_base_of<TimeType, T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_time =
+    typename std::enable_if<std::is_base_of<TimeType, T>::value, R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_timestamp =
-    typename std::enable_if<std::is_base_of<TimestampType, T>::value>::type;
+    typename std::enable_if<std::is_base_of<TimestampType, T>::value, R>::type;
 
-template <typename T>
-using enable_if_has_c_type = typename std::enable_if<has_c_type<T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_has_c_type = typename std::enable_if<has_c_type<T>::value, R>::type;
 
-template <typename T>
-using enable_if_null = typename std::enable_if<std::is_same<NullType, T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_null = typename std::enable_if<std::is_same<NullType, T>::value, R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_binary =
-    typename std::enable_if<std::is_base_of<BinaryType, T>::value>::type;
+    typename std::enable_if<std::is_base_of<BinaryType, T>::value, R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_boolean =
-    typename std::enable_if<std::is_same<BooleanType, T>::value>::type;
+    typename std::enable_if<std::is_same<BooleanType, T>::value, R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_binary_like =
     typename std::enable_if<std::is_base_of<BinaryType, T>::value ||
-                            std::is_base_of<FixedSizeBinaryType, T>::value>::type;
+                                std::is_base_of<FixedSizeBinaryType, T>::value,
+                            R>::type;
 
-template <typename T>
+template <typename T, typename R = void>
 using enable_if_fixed_size_binary =
-    typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value>::type;
+    typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value, R>::type;
 
-template <typename T>
-using enable_if_list = typename std::enable_if<std::is_base_of<ListType, T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_list =
+    typename std::enable_if<std::is_base_of<ListType, T>::value, R>::type;
 
-template <typename T>
-using enable_if_number = typename std::enable_if<is_number<T>::value>::type;
+template <typename T, typename R = void>
+using enable_if_number = typename std::enable_if<is_number<T>::value, R>::type;
 
 namespace detail {
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -302,18 +302,17 @@ using enable_if_primitive_ctype =
     typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value, R>::type;
 
 template <typename T, typename R = void>
-using enable_if_date =
-    typename std::enable_if<std::is_base_of<DateType, T>::value, R>::type;
-
-template <typename T, typename R = void>
 using enable_if_integer =
     typename std::enable_if<std::is_base_of<Integer, T>::value, R>::type;
 
+template <typename T>
+using is_signed_integer =
+    std::integral_constant<bool, std::is_base_of<Integer, T>::value &&
+                                     std::is_signed<typename T::c_type>::value>;
+
 template <typename T, typename R = void>
 using enable_if_signed_integer =
-    typename std::enable_if<std::is_base_of<Integer, T>::value &&
-                                std::is_signed<typename T::c_type>::value,
-                            R>::type;
+    typename std::enable_if<is_signed_integer<T>::value, R>::type;
 
 template <typename T, typename R = void>
 using enable_if_unsigned_integer =
@@ -325,13 +324,23 @@ template <typename T, typename R = void>
 using enable_if_floating_point =
     typename std::enable_if<std::is_base_of<FloatingPoint, T>::value, R>::type;
 
-template <typename T, typename R = void>
-using enable_if_time =
-    typename std::enable_if<std::is_base_of<TimeType, T>::value, R>::type;
+template <typename T>
+using is_date = std::is_base_of<DateType, T>;
 
 template <typename T, typename R = void>
-using enable_if_timestamp =
-    typename std::enable_if<std::is_base_of<TimestampType, T>::value, R>::type;
+using enable_if_date = typename std::enable_if<is_date<T>::value, R>::type;
+
+template <typename T>
+using is_time = std::is_base_of<TimeType, T>;
+
+template <typename T, typename R = void>
+using enable_if_time = typename std::enable_if<is_time<T>::value, R>::type;
+
+template <typename T>
+using is_timestamp = std::is_base_of<TimestampType, T>;
+
+template <typename T, typename R = void>
+using enable_if_timestamp = typename std::enable_if<is_timestamp<T>::value, R>::type;
 
 template <typename T, typename R = void>
 using enable_if_has_c_type = typename std::enable_if<has_c_type<T>::value, R>::type;

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -55,6 +55,8 @@ class StringConverter;
 template <>
 class StringConverter<BooleanType> {
  public:
+  explicit StringConverter(const std::shared_ptr<DataType>& = NULLPTR) {}
+
   using value_type = bool;
 
   bool operator()(const char* s, size_t length, value_type* out) {
@@ -97,7 +99,7 @@ class StringToFloatConverterMixin {
  public:
   using value_type = typename ARROW_TYPE::c_type;
 
-  StringToFloatConverterMixin()
+  explicit StringToFloatConverterMixin(const std::shared_ptr<DataType>& = NULLPTR)
       : main_converter_(flags_, main_junk_value_, main_junk_value_, "inf", "nan"),
         fallback_converter_(flags_, fallback_junk_value_, fallback_junk_value_, "inf",
                             "nan") {}
@@ -148,10 +150,14 @@ class StringToFloatConverterMixin {
 };
 
 template <>
-class StringConverter<FloatType> : public StringToFloatConverterMixin<FloatType> {};
+class StringConverter<FloatType> : public StringToFloatConverterMixin<FloatType> {
+  using StringToFloatConverterMixin<FloatType>::StringToFloatConverterMixin;
+};
 
 template <>
-class StringConverter<DoubleType> : public StringToFloatConverterMixin<DoubleType> {};
+class StringConverter<DoubleType> : public StringToFloatConverterMixin<DoubleType> {
+  using StringToFloatConverterMixin<DoubleType>::StringToFloatConverterMixin;
+};
 
 // NOTE: HalfFloatType would require a half<->float conversion library
 
@@ -277,6 +283,9 @@ class StringToUnsignedIntConverterMixin {
  public:
   using value_type = typename ARROW_TYPE::c_type;
 
+  explicit StringToUnsignedIntConverterMixin(const std::shared_ptr<DataType>& = NULLPTR) {
+  }
+
   bool operator()(const char* s, size_t length, value_type* out) {
     if (ARROW_PREDICT_FALSE(length == 0)) {
       return false;
@@ -291,18 +300,23 @@ class StringToUnsignedIntConverterMixin {
 };
 
 template <>
-class StringConverter<UInt8Type> : public StringToUnsignedIntConverterMixin<UInt8Type> {};
+class StringConverter<UInt8Type> : public StringToUnsignedIntConverterMixin<UInt8Type> {
+  using StringToUnsignedIntConverterMixin<UInt8Type>::StringToUnsignedIntConverterMixin;
+};
 
 template <>
 class StringConverter<UInt16Type> : public StringToUnsignedIntConverterMixin<UInt16Type> {
+  using StringToUnsignedIntConverterMixin<UInt16Type>::StringToUnsignedIntConverterMixin;
 };
 
 template <>
 class StringConverter<UInt32Type> : public StringToUnsignedIntConverterMixin<UInt32Type> {
+  using StringToUnsignedIntConverterMixin<UInt32Type>::StringToUnsignedIntConverterMixin;
 };
 
 template <>
 class StringConverter<UInt64Type> : public StringToUnsignedIntConverterMixin<UInt64Type> {
+  using StringToUnsignedIntConverterMixin<UInt64Type>::StringToUnsignedIntConverterMixin;
 };
 
 template <class ARROW_TYPE>
@@ -310,6 +324,8 @@ class StringToSignedIntConverterMixin {
  public:
   using value_type = typename ARROW_TYPE::c_type;
   using unsigned_type = typename std::make_unsigned<value_type>::type;
+
+  explicit StringToSignedIntConverterMixin(const std::shared_ptr<DataType>& = NULLPTR) {}
 
   bool operator()(const char* s, size_t length, value_type* out) {
     static constexpr unsigned_type max_positive =
@@ -356,16 +372,24 @@ class StringToSignedIntConverterMixin {
 };
 
 template <>
-class StringConverter<Int8Type> : public StringToSignedIntConverterMixin<Int8Type> {};
+class StringConverter<Int8Type> : public StringToSignedIntConverterMixin<Int8Type> {
+  using StringToSignedIntConverterMixin<Int8Type>::StringToSignedIntConverterMixin;
+};
 
 template <>
-class StringConverter<Int16Type> : public StringToSignedIntConverterMixin<Int16Type> {};
+class StringConverter<Int16Type> : public StringToSignedIntConverterMixin<Int16Type> {
+  using StringToSignedIntConverterMixin<Int16Type>::StringToSignedIntConverterMixin;
+};
 
 template <>
-class StringConverter<Int32Type> : public StringToSignedIntConverterMixin<Int32Type> {};
+class StringConverter<Int32Type> : public StringToSignedIntConverterMixin<Int32Type> {
+  using StringToSignedIntConverterMixin<Int32Type>::StringToSignedIntConverterMixin;
+};
 
 template <>
-class StringConverter<Int64Type> : public StringToSignedIntConverterMixin<Int64Type> {};
+class StringConverter<Int64Type> : public StringToSignedIntConverterMixin<Int64Type> {
+  using StringToSignedIntConverterMixin<Int64Type>::StringToSignedIntConverterMixin;
+};
 
 template <>
 class StringConverter<TimestampType> {

--- a/cpp/src/arrow/util/sse-util.h
+++ b/cpp/src/arrow/util/sse-util.h
@@ -36,7 +36,7 @@
 
 // gcc/clang (possibly others)
 
-#if defined(__SSE4_2__)
+#if defined(__SSE2__)
 #define ARROW_HAVE_SSE2 1
 #include <emmintrin.h>
 #endif

--- a/cpp/src/arrow/util/sse-util.h
+++ b/cpp/src/arrow/util/sse-util.h
@@ -18,11 +18,9 @@
 // From Apache Impala as of 2016-01-29. Pared down to a minimal set of
 // functions needed for parquet-cpp
 
-#ifndef ARROW_UTIL_SSE_UTIL_H
-#define ARROW_UTIL_SSE_UTIL_H
+#pragma once
 
-#undef ARROW_HAVE_SSE2
-#undef ARROW_HAVE_SSE4_2
+#include "arrow/util/macros.h"
 
 #ifdef ARROW_USE_SIMD
 
@@ -46,7 +44,9 @@
 #include <nmmintrin.h>
 #endif
 
-#endif
+#endif  // ARROW_USE_SIMD
+
+// MSVC x86-64
 
 namespace arrow {
 
@@ -155,5 +155,3 @@ static inline uint32_t SSE4_crc32_u64(uint32_t, uint64_t) {
 #endif  // ARROW_HAVE_SSE4_2
 
 }  // namespace arrow
-
-#endif  //  ARROW_UTIL_SSE_UTIL_H


### PR DESCRIPTION
- don't use in-situ parsing
- remove UnsafeStringBuilder (which was only useful when parsing in-situ)
- don't require null termination of parsed buffers
- resize parser's scalar storage when it might overflow
- rewrite chunker to use Buffer instead of string_view
  to represent memory ranges
- iwyu + lint cleanup
- add test for parsing JSON with a partial schema
- add test for inferring timestamp type in an unexpected
  field of strings
- refactor rapidjson defines into a single header
- correct SSE detection
- disable MSVC conversion errors (to match GCC and Clang options)
- allow ArrayFromJSON to parse timestamps from strings
