### PR TITLE
ARROW-4806: [Rust] Temporal array casts

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.80", features = ["rc"] }
 serde_derive = "1.0.80"
 serde_json = { version = "1.0.13", features = ["preserve_order"] }
 indexmap = "1.0"
-rand = "0.5"
+rand = "0.6"
 csv = "1.0"
 num = "0.2"
 regex = "1.1"
@@ -67,6 +67,10 @@ harness = false
 
 [[bench]]
 name = "arithmetic_kernels"
+harness = false
+
+[[bench]]
+name = "cast_kernels"
 harness = false
 
 [[bench]]

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+use rand::prelude::random;
+
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::array::*;
+use arrow::compute::cast;
+use arrow::datatypes::{DataType, DateUnit};
+
+fn create_date32_array(size: usize) -> Date32Array {
+    let data: Vec<i32> = vec![random(); size];
+    Date32Array::from(data)
+}
+
+fn cast_date32_to_date64(size: usize) {
+    let arr_a = Arc::new(create_date32_array(size)) as ArrayRef;
+    criterion::black_box(cast(&arr_a, &DataType::Date64(DateUnit::Millisecond)).unwrap());
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    c.bench_function("cast date32 to date64 512", |b| {
+        b.iter(|| cast_date32_to_date64(512))
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -18,6 +18,7 @@
 #[macro_use]
 extern crate criterion;
 use criterion::Criterion;
+use rand::distributions::{Distribution, Standard};
 use rand::prelude::random;
 
 use std::sync::Arc;
@@ -26,107 +27,89 @@ extern crate arrow;
 
 use arrow::array::*;
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, DateUnit, TimeUnit};
+use arrow::datatypes::*;
 
-// this is the best possible scenario, use this as the baseline when reading the numbers
-fn cast_int32_to_int32(size: usize) {
-    let arr_a = Arc::new(Int32Array::from(vec![random::<i32>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Int32).unwrap());
-}
-
-fn cast_int32_to_int64(size: usize) {
-    let arr_a = Arc::new(Int32Array::from(vec![random::<i32>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Int64).unwrap());
-}
-
-fn cast_int64_to_int32(size: usize) {
-    let arr_a = Arc::new(Int64Array::from(vec![random::<i64>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Int32).unwrap());
-}
-
-fn cast_date64_to_date32(size: usize) {
-    let arr_a = Arc::new(Date64Array::from(vec![random::<i64>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Date32(DateUnit::Day)).unwrap());
-}
-
-fn cast_date32_to_date64(size: usize) {
-    let arr_a = Arc::new(Date32Array::from(vec![random::<i32>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Date64(DateUnit::Millisecond)).unwrap());
-}
-
-fn cast_time32_s_to_time32_ms(size: usize) {
-    let arr_a =
-        Arc::new(Time32SecondArray::from(vec![random::<i32>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Time32(TimeUnit::Millisecond)).unwrap());
-}
-
-fn cast_time32_s_to_time64_us(size: usize) {
-    let arr_a =
-        Arc::new(Time32SecondArray::from(vec![random::<i32>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Time64(TimeUnit::Microsecond)).unwrap());
-}
-
-fn cast_time64_ns_to_time32_s(size: usize) {
-    let arr_a =
-        Arc::new(Time64NanosecondArray::from(vec![random::<i64>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Time32(TimeUnit::Second)).unwrap());
-}
-
-// uses divide to reduce time resolution
-fn cast_timestamp_ns_to_timestamp_s(size: usize) {
-    let arr_a =
-        Arc::new(TimestampNanosecondArray::from(vec![random::<i64>(); size])) as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Timestamp(TimeUnit::Second)).unwrap());
-}
-
-// uses multiply to increase time resolution
-fn cast_timestamp_ms_to_timestamp_ns(size: usize) {
-    let arr_a = Arc::new(TimestampMillisecondArray::from(vec![random::<i64>(); size]))
-        as ArrayRef;
-    criterion::black_box(
-        cast(&arr_a, &DataType::Timestamp(TimeUnit::Nanosecond)).unwrap(),
-    );
-}
-
-fn cast_timestamp_ms_to_i64(size: usize) {
-    let arr_a = Arc::new(TimestampMillisecondArray::from(vec![random::<i64>(); size]))
-        as ArrayRef;
-    criterion::black_box(cast(&arr_a, &DataType::Int64).unwrap());
+// cast array from specified primitive array type to desired data type
+fn cast_array<FROM>(size: usize, to_type: DataType) -> ()
+where
+    FROM: ArrowNumericType,
+    Standard: Distribution<FROM::Native>,
+    PrimitiveArray<FROM>: std::convert::From<Vec<FROM::Native>>,
+{
+    let array = Arc::new(PrimitiveArray::<FROM>::from(vec![
+        random::<FROM::Native>();
+        size
+    ])) as ArrayRef;
+    criterion::black_box(cast(&array, &to_type).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast int32 to int32 512", |b| {
-        b.iter(|| cast_int32_to_int32(512))
+        b.iter(|| cast_array::<Int32Type>(512, DataType::Int32))
     });
-    c.bench_function("cast int64 to int32 512", |b| {
-        b.iter(|| cast_int64_to_int32(512))
+    c.bench_function("cast int32 to uint32 512", |b| {
+        b.iter(|| cast_array::<Int32Type>(512, DataType::UInt32))
+    });
+    c.bench_function("cast int32 to float32 512", |b| {
+        b.iter(|| cast_array::<Int32Type>(512, DataType::Float32))
+    });
+    c.bench_function("cast int32 to float64 512", |b| {
+        b.iter(|| cast_array::<Int32Type>(512, DataType::Float64))
     });
     c.bench_function("cast int32 to int64 512", |b| {
-        b.iter(|| cast_int32_to_int64(512))
+        b.iter(|| cast_array::<Int32Type>(512, DataType::Int64))
+    });
+    c.bench_function("cast float32 to int32 512", |b| {
+        b.iter(|| cast_array::<Float32Type>(512, DataType::Int32))
+    });
+    c.bench_function("cast float64 to float32 512", |b| {
+        b.iter(|| cast_array::<Float64Type>(512, DataType::Float32))
+    });
+    c.bench_function("cast float64 to uint64 512", |b| {
+        b.iter(|| cast_array::<Float64Type>(512, DataType::UInt64))
+    });
+    c.bench_function("cast int64 to int32 512", |b| {
+        b.iter(|| cast_array::<Int64Type>(512, DataType::Int32))
     });
     c.bench_function("cast date64 to date32 512", |b| {
-        b.iter(|| cast_date64_to_date32(512))
+        b.iter(|| cast_array::<Date64Type>(512, DataType::Date32(DateUnit::Day)))
     });
     c.bench_function("cast date32 to date64 512", |b| {
-        b.iter(|| cast_date32_to_date64(512))
+        b.iter(|| cast_array::<Date32Type>(512, DataType::Date64(DateUnit::Millisecond)))
     });
     c.bench_function("cast time32s to time32ms 512", |b| {
-        b.iter(|| cast_time32_s_to_time32_ms(512))
+        b.iter(|| {
+            cast_array::<Time32SecondType>(512, DataType::Time32(TimeUnit::Millisecond))
+        })
     });
     c.bench_function("cast time32s to time64us 512", |b| {
-        b.iter(|| cast_time32_s_to_time64_us(512))
+        b.iter(|| {
+            cast_array::<Time32SecondType>(512, DataType::Time64(TimeUnit::Microsecond))
+        })
     });
     c.bench_function("cast time64ns to time32s 512", |b| {
-        b.iter(|| cast_time64_ns_to_time32_s(512))
+        b.iter(|| {
+            cast_array::<Time64NanosecondType>(512, DataType::Time32(TimeUnit::Second))
+        })
     });
     c.bench_function("cast timestamp_ns to timestamp_s 512", |b| {
-        b.iter(|| cast_timestamp_ns_to_timestamp_s(512))
+        b.iter(|| {
+            cast_array::<TimestampNanosecondType>(
+                512,
+                DataType::Timestamp(TimeUnit::Nanosecond),
+            )
+        })
     });
     c.bench_function("cast timestamp_ms to timestamp_ns 512", |b| {
-        b.iter(|| cast_timestamp_ms_to_timestamp_ns(512))
+        b.iter(|| {
+            cast_array::<TimestampMillisecondType>(
+                512,
+                DataType::Timestamp(TimeUnit::Nanosecond),
+            )
+        })
     });
     c.bench_function("cast timestamp_ms to i64 512", |b| {
-        b.iter(|| cast_timestamp_ms_to_i64(512))
+        b.iter(|| cast_array::<TimestampMillisecondType>(512, DataType::Int64))
     });
 }
 

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -26,21 +26,33 @@ extern crate arrow;
 
 use arrow::array::*;
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, DateUnit};
+use arrow::datatypes::{DataType, DateUnit, TimeUnit};
 
-fn create_date32_array(size: usize) -> Date32Array {
-    let data: Vec<i32> = vec![random(); size];
-    Date32Array::from(data)
+fn cast_date64_to_date32(size: usize) {
+    let arr_a = Arc::new(Date64Array::from(vec![random::<i64>(); size])) as ArrayRef;
+    criterion::black_box(cast(&arr_a, &DataType::Date32(DateUnit::Day)).unwrap());
 }
 
 fn cast_date32_to_date64(size: usize) {
-    let arr_a = Arc::new(create_date32_array(size)) as ArrayRef;
+    let arr_a = Arc::new(Date32Array::from(vec![random::<i32>(); size])) as ArrayRef;
     criterion::black_box(cast(&arr_a, &DataType::Date64(DateUnit::Millisecond)).unwrap());
 }
 
+fn cast_time32_s_to_time32_ms(size: usize) {
+    let arr_a =
+        Arc::new(Time32SecondArray::from(vec![random::<i32>(); size])) as ArrayRef;
+    criterion::black_box(cast(&arr_a, &DataType::Time32(TimeUnit::Millisecond)).unwrap());
+}
+
 fn add_benchmark(c: &mut Criterion) {
+    c.bench_function("cast date64 to date32 512", |b| {
+        b.iter(|| cast_date64_to_date32(512))
+    });
     c.bench_function("cast date32 to date64 512", |b| {
         b.iter(|| cast_date32_to_date64(512))
+    });
+    c.bench_function("cast time32s to time32ms 512", |b| {
+        b.iter(|| cast_time32_s_to_time32_ms(512))
     });
 }
 

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -88,6 +88,12 @@ fn cast_timestamp_ms_to_timestamp_ns(size: usize) {
     );
 }
 
+fn cast_timestamp_ms_to_i64(size: usize) {
+    let arr_a = Arc::new(TimestampMillisecondArray::from(vec![random::<i64>(); size]))
+        as ArrayRef;
+    criterion::black_box(cast(&arr_a, &DataType::Int64).unwrap());
+}
+
 fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast int32 to int32 512", |b| {
         b.iter(|| cast_int32_to_int32(512))
@@ -118,6 +124,9 @@ fn add_benchmark(c: &mut Criterion) {
     });
     c.bench_function("cast timestamp_ms to timestamp_ns 512", |b| {
         b.iter(|| cast_timestamp_ms_to_timestamp_ns(512))
+    });
+    c.bench_function("cast timestamp_ms to i64 512", |b| {
+        b.iter(|| cast_timestamp_ms_to_i64(512))
     });
 }
 

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -28,6 +28,12 @@ use arrow::array::*;
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, DateUnit, TimeUnit};
 
+// this is the best possible scenario, use this as the baseline when reading the numbers
+fn cast_int32_to_int32(size: usize) {
+    let arr_a = Arc::new(Int32Array::from(vec![random::<i32>(); size])) as ArrayRef;
+    criterion::black_box(cast(&arr_a, &DataType::Int32).unwrap());
+}
+
 fn cast_int32_to_int64(size: usize) {
     let arr_a = Arc::new(Int32Array::from(vec![random::<i32>(); size])) as ArrayRef;
     criterion::black_box(cast(&arr_a, &DataType::Int64).unwrap());
@@ -83,6 +89,9 @@ fn cast_timestamp_ms_to_timestamp_ns(size: usize) {
 }
 
 fn add_benchmark(c: &mut Criterion) {
+    c.bench_function("cast int32 to int32 512", |b| {
+        b.iter(|| cast_int32_to_int32(512))
+    });
     c.bench_function("cast int64 to int32 512", |b| {
         b.iter(|| cast_int64_to_int32(512))
     });

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -1037,74 +1037,42 @@ mod tests {
     #[test]
     fn test_cast_date32_to_date64() {
         let a = Date32Array::from(vec![10000, 17890]);
-        assert_eq!(
-            "PrimitiveArray<Date32(Day)>\n[\n  1997-05-19,\n  2018-12-25,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date64(DateUnit::Millisecond)).unwrap();
         let c = b.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(864000000000, c.value(0));
         assert_eq!(1545696000000, c.value(1));
-        assert_eq!(
-            "PrimitiveArray<Date64(Millisecond)>\n[\n  1997-05-19,\n  2018-12-25,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
     fn test_cast_date64_to_date32() {
         let a = Date64Array::from(vec![Some(864000000005), Some(1545696000001), None]);
-        assert_eq!(
-            "PrimitiveArray<Date64(Millisecond)>\n[\n  1997-05-19,\n  2018-12-25,\n  null,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date32(DateUnit::Day)).unwrap();
         let c = b.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(10000, c.value(0));
         assert_eq!(17890, c.value(1));
         assert!(c.is_null(2));
-        assert_eq!(
-            "PrimitiveArray<Date32(Day)>\n[\n  1997-05-19,\n  2018-12-25,\n  null,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
     fn test_cast_date32_to_int32() {
         let a = Date32Array::from(vec![10000, 17890]);
-        assert_eq!(
-            "PrimitiveArray<Date32(Day)>\n[\n  1997-05-19,\n  2018-12-25,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Int32).unwrap();
         let c = b.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(10000, c.value(0));
         assert_eq!(17890, c.value(1));
-        assert_eq!(
-            "PrimitiveArray<Int32>\n[\n  10000,\n  17890,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
     fn test_cast_int32_to_date32() {
         let a = Int32Array::from(vec![10000, 17890]);
-        assert_eq!(
-            "PrimitiveArray<Int32>\n[\n  10000,\n  17890,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date32(DateUnit::Day)).unwrap();
         let c = b.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(10000, c.value(0));
         assert_eq!(17890, c.value(1));
-        assert_eq!(
-            "PrimitiveArray<Date32(Day)>\n[\n  1997-05-19,\n  2018-12-25,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
@@ -1114,20 +1082,12 @@ mod tests {
             Some(1545696000001),
             None,
         ]);
-        assert_eq!(
-            "PrimitiveArray<Timestamp(Millisecond)>\n[\n  1997-05-19T00:00:00.005,\n  2018-12-25T00:00:00.001,\n  null,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date32(DateUnit::Day)).unwrap();
         let c = b.as_any().downcast_ref::<Date32Array>().unwrap();
         assert_eq!(10000, c.value(0));
         assert_eq!(17890, c.value(1));
         assert!(c.is_null(2));
-        assert_eq!(
-            "PrimitiveArray<Date32(Day)>\n[\n  1997-05-19,\n  2018-12-25,\n  null,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
@@ -1137,20 +1097,12 @@ mod tests {
             Some(1545696000001),
             None,
         ]);
-        assert_eq!(
-            "PrimitiveArray<Timestamp(Millisecond)>\n[\n  1997-05-19T00:00:00.005,\n  2018-12-25T00:00:00.001,\n  null,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date64(DateUnit::Millisecond)).unwrap();
         let c = b.as_any().downcast_ref::<Date64Array>().unwrap();
         assert_eq!(864000000005, c.value(0));
         assert_eq!(1545696000001, c.value(1));
         assert!(c.is_null(2));
-        assert_eq!(
-            "PrimitiveArray<Date64(Millisecond)>\n[\n  1997-05-19,\n  2018-12-25,\n  null,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
@@ -1160,10 +1112,6 @@ mod tests {
             Some(1545696000001),
             None,
         ]);
-        assert_eq!(
-            "PrimitiveArray<Timestamp(Millisecond)>\n[\n  1997-05-19T00:00:00.005,\n  2018-12-25T00:00:00.001,\n  null,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Int64).unwrap();
         let c = b.as_any().downcast_ref::<Int64Array>().unwrap();
@@ -1171,10 +1119,6 @@ mod tests {
         assert_eq!(864000000005, c.value(0));
         assert_eq!(1545696000001, c.value(1));
         assert!(c.is_null(2));
-        assert_eq!(
-            "PrimitiveArray<Int64>\n[\n  864000000005,\n  1545696000001,\n  null,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]
@@ -1184,20 +1128,12 @@ mod tests {
             Some(1545696002001),
             None,
         ]);
-        assert_eq!(
-            "PrimitiveArray<Timestamp(Millisecond)>\n[\n  1997-05-19T00:00:03.005,\n  2018-12-25T00:00:02.001,\n  null,\n]",
-            format!("{:?}", a)
-        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Timestamp(TimeUnit::Second)).unwrap();
         let c = b.as_any().downcast_ref::<TimestampSecondArray>().unwrap();
         assert_eq!(864000003, c.value(0));
         assert_eq!(1545696002, c.value(1));
         assert!(c.is_null(2));
-        assert_eq!(
-            "PrimitiveArray<Timestamp(Second)>\n[\n  1997-05-19T00:00:03,\n  2018-12-25T00:00:02,\n  null,\n]",
-            format!("{:?}", c)
-        );
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -367,7 +367,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
         }
         (Time32(from_unit), Time64(to_unit)) => {
             let time_array = Int32Array::from(array.data());
-            // cast up to i64 so we can multiply
+            // note: (numeric_cast + SIMD multiply) is faster than (cast & multiply)
             let c: Int64Array = numeric_cast(&time_array)?;
             let from_size = time_unit_multiple(&from_unit);
             let to_size = time_unit_multiple(&to_unit);


### PR DESCRIPTION
This PR enables support for temporal casts, mostly taking advantage of the `divide` and `multiply` arithmetic kernels.