### PR TITLE
ARROW-1983: [C++/Python][WIP] Implement metadata writing support

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -296,6 +296,8 @@ class FileReader::Impl {
       const ::arrow::Schema& old_schema, const std::vector<int>& dict_indices,
       std::vector<std::shared_ptr<::arrow::Column>>& columns);
 
+  std::shared_ptr<FileMetaData> metadata_last() { return reader_.get()->metadata_last(); }
+
  private:
   MemoryPool* pool_;
   std::unique_ptr<ParquetFileReader> reader_;
@@ -377,6 +379,10 @@ FileReader::FileReader(MemoryPool* pool, std::unique_ptr<ParquetFileReader> read
     : impl_(new FileReader::Impl(pool, std::move(reader), properties)) {}
 
 FileReader::~FileReader() {}
+
+std::shared_ptr<FileMetaData> FileReader::metadata_last() {
+  return impl_.get()->metadata_last();
+}
 
 Status FileReader::Impl::GetColumn(int i, FileColumnIteratorFactory iterator_factory,
                                    std::unique_ptr<ColumnReader>* out) {

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -234,6 +234,7 @@ class PARQUET_EXPORT FileReader {
   int num_row_groups() const;
 
   const ParquetFileReader* parquet_reader() const;
+  std::shared_ptr<FileMetaData> metadata_last();
 
   /// Set the number of threads to use during reads of multiple columns. By
   /// default only 1 thread is used

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -1159,8 +1159,9 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
   if (md_sink) {
     auto md_wrapper = std::make_shared<ArrowOutputStream>(md_sink);
     return Open(schema, pool, wrapper, md_wrapper, properties, writer);
-  } else
+  } else {
     return Open(schema, pool, wrapper, properties, writer);
+  }
 }
 
 Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
@@ -1182,8 +1183,9 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
   if (md_sink) {
     auto md_wrapper = std::make_shared<ArrowOutputStream>(md_sink);
     return Open(schema, pool, wrapper, md_wrapper, properties, arrow_properties, writer);
-  } else
+  } else {
     return Open(schema, pool, wrapper, properties, arrow_properties, writer);
+  }
 }
 
 Status WriteFileMetaData(const FileMetaData& file_metadata, OutputStream* sink) {

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -1156,11 +1156,11 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
                         const std::shared_ptr<WriterProperties>& properties,
                         std::unique_ptr<FileWriter>* writer) {
   auto wrapper = std::make_shared<ArrowOutputStream>(sink);
-  if (md_sink) {
+  if (md_sink == nullptr) {
+    return Open(schema, pool, wrapper, properties, writer);
+  } else {
     auto md_wrapper = std::make_shared<ArrowOutputStream>(md_sink);
     return Open(schema, pool, wrapper, md_wrapper, properties, writer);
-  } else {
-    return Open(schema, pool, wrapper, properties, writer);
   }
 }
 
@@ -1180,11 +1180,11 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
                         const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
                         std::unique_ptr<FileWriter>* writer) {
   auto wrapper = std::make_shared<ArrowOutputStream>(sink);
-  if (md_sink) {
+  if (md_sink == nullptr) {
+    return Open(schema, pool, wrapper, properties, arrow_properties, writer);
+  } else {
     auto md_wrapper = std::make_shared<ArrowOutputStream>(md_sink);
     return Open(schema, pool, wrapper, md_wrapper, properties, arrow_properties, writer);
-  } else {
-    return Open(schema, pool, wrapper, properties, arrow_properties, writer);
   }
 }
 

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -146,9 +146,23 @@ class PARQUET_EXPORT FileWriter {
                               const std::shared_ptr<WriterProperties>& properties,
                               std::unique_ptr<FileWriter>* writer);
 
+  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+                              const std::shared_ptr<OutputStream>& sink,
+                              const std::shared_ptr<OutputStream>& md_sink,
+                              const std::shared_ptr<WriterProperties>& properties,
+                              std::unique_ptr<FileWriter>* writer);
+
   static ::arrow::Status Open(
       const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
       const std::shared_ptr<OutputStream>& sink,
+      const std::shared_ptr<WriterProperties>& properties,
+      const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
+      std::unique_ptr<FileWriter>* writer);
+
+  static ::arrow::Status Open(
+      const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+      const std::shared_ptr<OutputStream>& sink,
+      const std::shared_ptr<OutputStream>& md_sink,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
       std::unique_ptr<FileWriter>* writer);
@@ -158,9 +172,23 @@ class PARQUET_EXPORT FileWriter {
                               const std::shared_ptr<WriterProperties>& properties,
                               std::unique_ptr<FileWriter>* writer);
 
+  static ::arrow::Status Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+                              const std::shared_ptr<::arrow::io::OutputStream>& sink,
+                              const std::shared_ptr<::arrow::io::OutputStream>& md_sink,
+                              const std::shared_ptr<WriterProperties>& properties,
+                              std::unique_ptr<FileWriter>* writer);
+
   static ::arrow::Status Open(
       const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
       const std::shared_ptr<::arrow::io::OutputStream>& sink,
+      const std::shared_ptr<WriterProperties>& properties,
+      const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
+      std::unique_ptr<FileWriter>* writer);
+
+  static ::arrow::Status Open(
+      const ::arrow::Schema& schema, ::arrow::MemoryPool* pool,
+      const std::shared_ptr<::arrow::io::OutputStream>& sink,
+      const std::shared_ptr<::arrow::io::OutputStream>& md_sink,
       const std::shared_ptr<WriterProperties>& properties,
       const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
       std::unique_ptr<FileWriter>* writer);
@@ -210,7 +238,23 @@ PARQUET_EXPORT
 
 ::arrow::Status PARQUET_EXPORT WriteTable(
     const ::arrow::Table& table, ::arrow::MemoryPool* pool,
+    const std::shared_ptr<OutputStream>& sink,
+    const std::shared_ptr<OutputStream>& md_sink, int64_t chunk_size,
+    const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
+    const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
+        default_arrow_writer_properties());
+
+::arrow::Status PARQUET_EXPORT WriteTable(
+    const ::arrow::Table& table, ::arrow::MemoryPool* pool,
     const std::shared_ptr<::arrow::io::OutputStream>& sink, int64_t chunk_size,
+    const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
+    const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
+        default_arrow_writer_properties());
+
+::arrow::Status PARQUET_EXPORT WriteTable(
+    const ::arrow::Table& table, ::arrow::MemoryPool* pool,
+    const std::shared_ptr<::arrow::io::OutputStream>& sink,
+    const std::shared_ptr<::arrow::io::OutputStream>& md_sink, int64_t chunk_size,
     const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
     const std::shared_ptr<ArrowWriterProperties>& arrow_properties =
         default_arrow_writer_properties());

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -135,7 +135,7 @@ class SerializedFile : public ParquetFileReader::Contents {
  public:
   SerializedFile(std::unique_ptr<RandomAccessSource> source,
                  const ReaderProperties& props = default_reader_properties())
-    : source_(std::move(source)), properties_(props), next_metadata_pos_(-1) {}
+      : source_(std::move(source)), properties_(props), next_metadata_pos_(-1) {}
 
   ~SerializedFile() override {
     try {
@@ -158,9 +158,7 @@ class SerializedFile : public ParquetFileReader::Contents {
     file_metadata_ = metadata;
   }
 
-  void ParseMetaData() {
-    parse_metadata(source_->Size());
-  }
+  void ParseMetaData() { parse_metadata(source_->Size()); }
 
   int64_t parse_metadata(int64_t file_size) {
     if (file_size < FOOTER_SIZE) {
@@ -214,15 +212,15 @@ class SerializedFile : public ParquetFileReader::Contents {
         return next_metadata_pos;
       }
     }
-    return 0; // no more metadata
+    return 0;  // no more metadata
   }
 
   std::shared_ptr<FileMetaData> metadata_last() override {
-    if (next_metadata_pos_ == -1)
-      next_metadata_pos_ = source_->Size();
+    if (next_metadata_pos_ == -1) next_metadata_pos_ = source_->Size();
     if (next_metadata_pos_ > 0) {
       next_metadata_pos_ = parse_metadata(next_metadata_pos_);
     } else {
+      next_metadata_pos_ = -1;
       file_metadata_.reset();
     }
     return file_metadata_;

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -82,6 +82,7 @@ class PARQUET_EXPORT ParquetFileReader {
     virtual void Close() = 0;
     virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
     virtual std::shared_ptr<FileMetaData> metadata() const = 0;
+    virtual std::shared_ptr<FileMetaData> metadata_last() = 0;
   };
 
   ParquetFileReader();
@@ -119,6 +120,9 @@ class PARQUET_EXPORT ParquetFileReader {
 
   // Returns the file metadata. Only one instance is ever created
   std::shared_ptr<FileMetaData> metadata() const;
+
+  // Returns the last file metadata of a dataset metadata file.
+  std::shared_ptr<FileMetaData> metadata_last();
 
  private:
   // Holds a pointer to an instance of Contents implementation

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -165,6 +165,20 @@ class PARQUET_EXPORT ParquetFileWriter {
       const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = NULLPTR);
 
+  static std::unique_ptr<ParquetFileWriter> Open(
+      const std::shared_ptr<::arrow::io::OutputStream>& sink,
+      const std::shared_ptr<::arrow::io::OutputStream>& md_sink,
+      const std::shared_ptr<schema::GroupNode>& schema,
+      const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
+      const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = NULLPTR);
+
+  static std::unique_ptr<ParquetFileWriter> Open(
+      const std::shared_ptr<OutputStream>& sink,
+      const std::shared_ptr<OutputStream>& md_sink,
+      const std::shared_ptr<schema::GroupNode>& schema,
+      const std::shared_ptr<WriterProperties>& properties = default_writer_properties(),
+      const std::shared_ptr<const KeyValueMetadata>& key_value_metadata = NULLPTR);
+
   void Open(std::unique_ptr<Contents> contents);
   void Close();
 

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -292,6 +292,8 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
 
         void set_use_threads(c_bool use_threads)
 
+        shared_ptr[CFileMetaData] metadata_last()
+
 
 cdef extern from "parquet/arrow/schema.h" namespace "parquet::arrow" nogil:
     CStatus FromParquetSchema(

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -206,6 +206,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         int64_t index_page_offset() const
         int64_t total_compressed_size() const
         int64_t total_uncompressed_size() const
+        c_bool has_index_page() const
 
     cdef cppclass CRowGroupMetaData" parquet::RowGroupMetaData":
         int num_columns()
@@ -310,6 +311,7 @@ cdef extern from "parquet/arrow/writer.h" namespace "parquet::arrow" nogil:
         @staticmethod
         CStatus Open(const CSchema& schema, CMemoryPool* pool,
                      const shared_ptr[OutputStream]& sink,
+                     const shared_ptr[OutputStream]& md_sink,
                      const shared_ptr[WriterProperties]& properties,
                      const shared_ptr[ArrowWriterProperties]& arrow_properties,
                      unique_ptr[FileWriter]* writer)

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -687,6 +687,23 @@ cdef class ParquetReader:
         return result
 
     @property
+    def iter_metadata(self):
+        cdef:
+            shared_ptr[CFileMetaData] metadata
+            FileMetaData result
+
+        while 1:
+            with nogil:
+                metadata = self.reader.get().metadata_last()
+
+            if metadata:
+                result = FileMetaData()
+                result.init(metadata)
+                yield result
+            else:
+                break
+
+    @property
     def num_row_groups(self):
         return self.reader.get().num_row_groups()
 

--- a/python/pyarrow/tests/test_parquet_dataset.py
+++ b/python/pyarrow/tests/test_parquet_dataset.py
@@ -1,0 +1,68 @@
+
+import pyarrow as pa
+import pandas as pd
+import pyarrow.parquet as pq
+
+
+def get_props(obj):
+    """Collect properties of object in a dictionary.
+    """
+    import inspect
+    d = {}
+    for n in dir(obj):
+        if n.startswith('_'):
+            continue
+        a = inspect.getattr_static(obj, n)
+        if inspect.isdatadescriptor(a):
+            try:
+                v = getattr(obj, n)
+            except Exception as msg:
+                v = str(msg)
+            if n == 'statistics':
+                v = get_props(v)
+            elif n == 'schema':
+                v = v.to_arrow_schema()
+            d[n] = v
+    return d
+
+
+def test_dataset_metadata(tempdir):
+    path = tempdir / "ARROW-1983-dataset"
+
+    # create and write a test dataset
+    df = pd.DataFrame({
+        'one': [1, 2, 3],
+        'two': [-1, -2, -3],
+        'three': [[1, 2], [2, 3], [3, 4]],
+        })
+    table = pa.Table.from_pandas(df)
+    pq.write_to_dataset(table, root_path=str(path),
+                        write_metadata=True,
+                        partition_cols=['one', 'two'])
+
+    # open the dataset and collect metadata from pieces:
+    dataset = pq.ParquetDataset(path)
+    metadata_list = [p.get_metadata() for p in dataset.pieces]
+
+    # read dataset metadata only:
+    md_path = str(path) + "_metadata.parquet"
+    metadata_list2 = pq.read_metadata_list(md_path)
+
+    # compare metadata list content:
+    for md, md2 in zip(metadata_list, metadata_list2):
+        assert get_props(md) == get_props(md2)
+        for r in range(md.num_row_groups):
+            rg = md.row_group(r)
+            rg2 = md2.row_group(r)
+            assert get_props(rg) == get_props(rg2)
+            for c in range(rg.num_columns):
+                col = rg.column(c)
+                col2 = rg2.column(c)
+                assert get_props(col) == get_props(col2)
+
+    path = tempdir / "ARROW-1983-single.parquet"
+    pq.write_table(table, str(path))
+
+    # make sure read_metadata_list works on a single file
+    metadata_list3 = pq.read_metadata_list(path)
+    assert len(metadata_list3) == 1

--- a/python/pyarrow/tests/test_parquet_dataset.py
+++ b/python/pyarrow/tests/test_parquet_dataset.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 import pyarrow as pa
 import pandas as pd
@@ -5,14 +21,14 @@ import pyarrow.parquet as pq
 
 
 def get_props(obj):
-    """Collect properties of object in a dictionary.
+    """Collect properties of an object into a dictionary.
     """
     import inspect
     d = {}
     for n in dir(obj):
         if n.startswith('_'):
             continue
-        a = inspect.getattr_static(obj, n)
+        a = getattr(type(obj), n)
         if inspect.isdatadescriptor(a):
             try:
                 v = getattr(obj, n)
@@ -49,6 +65,7 @@ def test_dataset_metadata(tempdir):
     metadata_list2 = pq.read_metadata_list(md_path)
 
     # compare metadata list content:
+    assert len(metadata_list) == len(metadata_list2)
     for md, md2 in zip(metadata_list, metadata_list2):
         assert get_props(md) == get_props(md2)
         for r in range(md.num_row_groups):


### PR DESCRIPTION
This PR adds another sink to parquet writers for collecting metadata of datasets.

- [x] Implement reader for the metadata file of a dataset
- [x] Implement tests
