### PR TITLE
PARQUET-1565: [C++]  Add default case to catch all unhandled physical types

### DIFF
--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -2362,7 +2362,7 @@ TEST(TestArrowReaderAdHoc, Int96BadMemoryAccess) {
 
 TEST(TestArrowReaderAdHoc, CorruptedSchema) {
   // PARQUET-1481
-  auto path = test::get_data_file("PARQUET-1481.parquet", /*is_good=*/ false);
+  auto path = test::get_data_file("PARQUET-1481.parquet", /*is_good=*/false);
   TryReadDataFile(path, false /* should_succeed */);
 }
 

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -2362,7 +2362,7 @@ TEST(TestArrowReaderAdHoc, Int96BadMemoryAccess) {
 
 TEST(TestArrowReaderAdHoc, CorruptedSchema) {
   // PARQUET-1481
-  auto path = test::get_data_file("PARQUET-1481.parquet", false /*is_good*/);
+  auto path = test::get_data_file("PARQUET-1481.parquet", /*is_good=*/ false);
   TryReadDataFile(path, false /* should_succeed */);
 }
 

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -2346,7 +2346,13 @@ void TryReadDataFile(const std::string& testing_file_path, bool should_succeed =
   try {
     arrow_reader.reset(new FileReader(pool, ParquetFileReader::OpenFile(path, false)));
     std::shared_ptr<::arrow::Table> table;
-    ASSERT_OK(arrow_reader->ReadTable(&table));
+    auto status = arrow_reader->ReadTable(&table);
+
+    if (should_succeed) {
+      ASSERT_OK(status);
+    } else {
+      ASSERT_FALSE(status.ok()) << "Expected reading file to fail.";
+    }
   } catch (const ParquetException& e) {
     if (should_succeed) {
       FAIL() << "Exception thrown when reading file: " << e.what();
@@ -2361,7 +2367,7 @@ TEST(TestArrowReaderAdHoc, Int96BadMemoryAccess) {
 
 TEST(TestArrowReaderAdHoc, CorruptedSchema) {
   // PARQUET-1481
-  TryReadDataFile("bad_data/PARQUET-1481.parquet", false /* should_succeed */);
+  TryReadDataFile("/../bad_data/PARQUET-1481.parquet", false /* should_succeed */);
 }
 
 class TestArrowReaderAdHocSparkAndHvr

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -2334,12 +2334,7 @@ TEST(TestImpalaConversion, ArrowTimestampToImpalaTimestamp) {
   ASSERT_EQ(expected, calculated);
 }
 
-void TryReadDataFile(const std::string& testing_file_path, bool should_succeed = true) {
-  std::string dir_string(test::get_data_dir());
-  std::stringstream ss;
-  ss << dir_string << "/" << testing_file_path;
-  auto path = ss.str();
-
+void TryReadDataFile(const std::string& path, bool should_succeed = true) {
   auto pool = ::arrow::default_memory_pool();
 
   std::unique_ptr<FileReader> arrow_reader;
@@ -2362,12 +2357,13 @@ void TryReadDataFile(const std::string& testing_file_path, bool should_succeed =
 
 TEST(TestArrowReaderAdHoc, Int96BadMemoryAccess) {
   // PARQUET-995
-  TryReadDataFile("alltypes_plain.parquet");
+  TryReadDataFile(test::get_data_file("alltypes_plain.parquet"));
 }
 
 TEST(TestArrowReaderAdHoc, CorruptedSchema) {
   // PARQUET-1481
-  TryReadDataFile("/../bad_data/PARQUET-1481.parquet", false /* should_succeed */);
+  auto path = test::get_data_file("PARQUET-1481.parquet", false /*is_good*/);
+  TryReadDataFile(path, false /* should_succeed */);
 }
 
 class TestArrowReaderAdHocSparkAndHvr

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -856,15 +856,11 @@ TEST(TestFromParquetSchema, CorruptMetadata) {
   // corrupted metadata.
   auto path = test::get_data_file("PARQUET-1481.parquet", /*is_good=*/false);
 
-  try {
-    std::unique_ptr<parquet::ParquetFileReader> reader =
-        parquet::ParquetFileReader::OpenFile(path);
-    const auto parquet_schema = reader->metadata()->schema();
-    std::shared_ptr<::arrow::Schema> arrow_schema;
-    ASSERT_RAISES(IOError, FromParquetSchema(parquet_schema, &arrow_schema));
-  } catch (const ParquetException& e) {
-    FAIL() << "Exception thrown while reading file: " << e.what();
-  }
+  std::unique_ptr<parquet::ParquetFileReader> reader =
+      parquet::ParquetFileReader::OpenFile(path);
+  const auto parquet_schema = reader->metadata()->schema();
+  std::shared_ptr<::arrow::Schema> arrow_schema;
+  ASSERT_RAISES(IOError, FromParquetSchema(parquet_schema, &arrow_schema));
 }
 
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -854,10 +854,7 @@ TEST(InvalidSchema, ParquetNegativeDecimalScale) {
 TEST(TestFromParquetSchema, CorruptMetadata) {
   // PARQUET-1565: ensure that an IOError is returned when the parquet file contains
   // corrupted metadata.
-  std::string dir_string(test::get_data_dir());
-  std::stringstream ss;
-  ss << dir_string << "/../bad_data/PARQUET-1481.parquet";
-  auto path = ss.str();
+  auto path = test::get_data_file("PARQUET-1481.parquet", false /*is_good*/);
 
   try {
     std::unique_ptr<parquet::ParquetFileReader> reader =

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -854,7 +854,7 @@ TEST(InvalidSchema, ParquetNegativeDecimalScale) {
 TEST(TestFromParquetSchema, CorruptMetadata) {
   // PARQUET-1565: ensure that an IOError is returned when the parquet file contains
   // corrupted metadata.
-  auto path = test::get_data_file("PARQUET-1481.parquet", false /*is_good*/);
+  auto path = test::get_data_file("PARQUET-1481.parquet",  /*is_good=*/ false);
 
   try {
     std::unique_ptr<parquet::ParquetFileReader> reader =

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -854,7 +854,7 @@ TEST(InvalidSchema, ParquetNegativeDecimalScale) {
 TEST(TestFromParquetSchema, CorruptMetadata) {
   // PARQUET-1565: ensure that an IOError is returned when the parquet file contains
   // corrupted metadata.
-  auto path = test::get_data_file("PARQUET-1481.parquet",  /*is_good=*/ false);
+  auto path = test::get_data_file("PARQUET-1481.parquet", /*is_good=*/false);
 
   try {
     std::unique_ptr<parquet::ParquetFileReader> reader =

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -196,6 +196,11 @@ Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>*
     case ParquetType::FIXED_LEN_BYTE_ARRAY:
       RETURN_NOT_OK(FromFLBA(primitive, out));
       break;
+    default: {
+      // PARQUET-1565: This can occur if the file is corrupt
+      return Status::IOError("Invalid physical column type: ",
+                             TypeToString(primitive.physical_type()));
+    }
   }
   return Status::OK();
 }

--- a/cpp/src/parquet/util/test-common.h
+++ b/cpp/src/parquet/util/test-common.h
@@ -49,6 +49,28 @@ const char* get_data_dir() {
   return result;
 }
 
+std::string get_bad_data_dir() {
+  // PARQUET_TEST_DATA should point to ARROW_HOME/cpp/submodules/parquet-testing/data
+  // so need to reach one folder up to access the "bad_data" folder.
+  std::string data_dir(get_data_dir());
+  std::stringstream ss;
+  ss << data_dir << "/../bad_data";
+  return ss.str();
+}
+
+std::string get_data_file(const std::string& testing_file_path, bool is_good = true) {
+  std::stringstream ss;
+
+  if (is_good) {
+    ss << get_data_dir();
+  } else {
+    ss << get_bad_data_dir();
+  }
+
+  ss << "/" << testing_file_path;
+  return ss.str();
+}
+
 template <typename T>
 static inline void assert_vector_equal(const std::vector<T>& left,
                                        const std::vector<T>& right) {

--- a/cpp/src/parquet/util/test-common.h
+++ b/cpp/src/parquet/util/test-common.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <limits>
 #include <random>
+#include <string>
 #include <vector>
 
 #include "parquet/exception.h"

--- a/cpp/src/parquet/util/test-common.h
+++ b/cpp/src/parquet/util/test-common.h
@@ -59,7 +59,7 @@ std::string get_bad_data_dir() {
   return ss.str();
 }
 
-std::string get_data_file(const std::string& testing_file_path, bool is_good = true) {
+std::string get_data_file(const std::string& filename, bool is_good = true) {
   std::stringstream ss;
 
   if (is_good) {
@@ -68,7 +68,7 @@ std::string get_data_file(const std::string& testing_file_path, bool is_good = t
     ss << get_bad_data_dir();
   }
 
-  ss << "/" << testing_file_path;
+  ss << "/" << filename;
   return ss.str();
 }
 


### PR DESCRIPTION
This should prevent the SEGV observed when calling `FromParquetSchema` while reading the corrupt file [PARQUET-1481](https://github.com/apache/parquet-testing/blob/master/bad_data/PARQUET-1481.parquet)