### PR TITLE
ARROW-5189: [Rust] [Parquet] Format / display individual fields within a parquet row

### DIFF
--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -1175,10 +1175,7 @@ mod tests {
         assert_eq!("12.1", format!("{}", row.fmt(11)));
         assert_eq!("\"abc\"", format!("{}", row.fmt(12)));
         assert_eq!("[1, 2, 3, 4, 5]", format!("{}", row.fmt(13)));
-        assert_eq!(
-            convert_date_to_string(14611),
-            format!("{}", row.fmt(14))
-        );
+        assert_eq!(convert_date_to_string(14611), format!("{}", row.fmt(14)));
         assert_eq!(
             convert_timestamp_to_string(1262391174000),
             format!("{}", row.fmt(15))
@@ -1218,10 +1215,7 @@ mod tests {
 
         assert_eq!("{x: null, Y: 2}", format!("{}", row.fmt(0)));
         assert_eq!("[2, 1, null, 12]", format!("{}", row.fmt(1)));
-        assert_eq!(
-            "{1 -> 1.2, 2 -> 4.5, 3 -> 2.3}",
-            format!("{}", row.fmt(2))
-        );
+        assert_eq!("{1 -> 1.2, 2 -> 4.5, 3 -> 2.3}", format!("{}", row.fmt(2)));
     }
 
     #[test]

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -76,7 +76,7 @@ pub trait RowAccessor {
 
 /// Trait for formating fields within a Row.
 pub trait RowFormatter {
-    fn fmt(&self, i: usize) -> Result<&fmt::Display>;
+    fn fmt(&self, i: usize) -> &fmt::Display;
 }
 
 /// Macro to generate type-safe get_xxx methods for primitive types,
@@ -109,11 +109,8 @@ macro_rules! row_complex_accessor {
 
 impl RowFormatter for Row {
     /// Get Display reference for a given field.
-    fn fmt(&self, i: usize) -> Result<&fmt::Display> {
-        match self.fields.get(i) {
-            Some(t) => Ok(&t.1),
-            _ => Err(general_err!("Cannot access field {}", i)),
-        }
+    fn fmt(&self, i: usize) -> &fmt::Display {
+        &self.fields[i].1
     }
 }
 
@@ -1164,29 +1161,29 @@ mod tests {
             ("16".to_string(), Field::Decimal(Decimal::from_i32(4, 7, 2))),
         ]);
 
-        assert_eq!("null", format!("{}", row.fmt(0).unwrap()));
-        assert_eq!("false", format!("{}", row.fmt(1).unwrap()));
-        assert_eq!("3", format!("{}", row.fmt(2).unwrap()));
-        assert_eq!("4", format!("{}", row.fmt(3).unwrap()));
-        assert_eq!("5", format!("{}", row.fmt(4).unwrap()));
-        assert_eq!("6", format!("{}", row.fmt(5).unwrap()));
-        assert_eq!("7", format!("{}", row.fmt(6).unwrap()));
-        assert_eq!("8", format!("{}", row.fmt(7).unwrap()));
-        assert_eq!("9", format!("{}", row.fmt(8).unwrap()));
-        assert_eq!("10", format!("{}", row.fmt(9).unwrap()));
-        assert_eq!("11.1", format!("{}", row.fmt(10).unwrap()));
-        assert_eq!("12.1", format!("{}", row.fmt(11).unwrap()));
-        assert_eq!("\"abc\"", format!("{}", row.fmt(12).unwrap()));
-        assert_eq!("[1, 2, 3, 4, 5]", format!("{}", row.fmt(13).unwrap()));
+        assert_eq!("null", format!("{}", row.fmt(0)));
+        assert_eq!("false", format!("{}", row.fmt(1)));
+        assert_eq!("3", format!("{}", row.fmt(2)));
+        assert_eq!("4", format!("{}", row.fmt(3)));
+        assert_eq!("5", format!("{}", row.fmt(4)));
+        assert_eq!("6", format!("{}", row.fmt(5)));
+        assert_eq!("7", format!("{}", row.fmt(6)));
+        assert_eq!("8", format!("{}", row.fmt(7)));
+        assert_eq!("9", format!("{}", row.fmt(8)));
+        assert_eq!("10", format!("{}", row.fmt(9)));
+        assert_eq!("11.1", format!("{}", row.fmt(10)));
+        assert_eq!("12.1", format!("{}", row.fmt(11)));
+        assert_eq!("\"abc\"", format!("{}", row.fmt(12)));
+        assert_eq!("[1, 2, 3, 4, 5]", format!("{}", row.fmt(13)));
         assert_eq!(
             convert_date_to_string(14611),
-            format!("{}", row.fmt(14).unwrap())
+            format!("{}", row.fmt(14))
         );
         assert_eq!(
             convert_timestamp_to_string(1262391174000),
-            format!("{}", row.fmt(15).unwrap())
+            format!("{}", row.fmt(15))
         );
-        assert_eq!("0.04", format!("{}", row.fmt(16).unwrap()));
+        assert_eq!("0.04", format!("{}", row.fmt(16)));
     }
 
     #[test]
@@ -1219,11 +1216,11 @@ mod tests {
             ),
         ]);
 
-        assert_eq!("{x: null, Y: 2}", format!("{}", row.fmt(0).unwrap()));
-        assert_eq!("[2, 1, null, 12]", format!("{}", row.fmt(1).unwrap()));
+        assert_eq!("{x: null, Y: 2}", format!("{}", row.fmt(0)));
+        assert_eq!("[2, 1, null, 12]", format!("{}", row.fmt(1)));
         assert_eq!(
             "{1 -> 1.2, 2 -> 4.5, 3 -> 2.3}",
-            format!("{}", row.fmt(2).unwrap())
+            format!("{}", row.fmt(2))
         );
     }
 

--- a/rust/parquet/src/record/mod.rs
+++ b/rust/parquet/src/record/mod.rs
@@ -21,4 +21,4 @@ mod api;
 pub mod reader;
 mod triplet;
 
-pub use self::api::{List, ListAccessor, Map, MapAccessor, Row, RowAccessor};
+pub use self::api::{List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowFormatter};

--- a/rust/parquet/src/record/mod.rs
+++ b/rust/parquet/src/record/mod.rs
@@ -21,4 +21,6 @@ mod api;
 pub mod reader;
 mod triplet;
 
-pub use self::api::{List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowFormatter};
+pub use self::api::{
+    List, ListAccessor, Map, MapAccessor, Row, RowAccessor, RowFormatter,
+};


### PR DESCRIPTION
Hi,

I'm working on a simple cli app to sample and analyze parquet files.
And couldn't find simple way to get a simple string representation of each column within a `Row`. 

All `Field`s in a row already implement `fmt::Display` but there is now way to format individual fields.
Since the `Row#fields`  is not exposed by the api. Which i assume is by design.

Having a way to format individual fields seems like a common problem, 
so I came up with a `RowFormatter` which provides a way to access the field as a `fmt::Display`.

```rust
use parquet::record::RowFormatter;

// ...

let row = make_row(vec![
    ("id".to_string(), Field::Int(5)),
    ("name".to_string(), Field::Str("abc".to_string()))
]);

println!("row id   : {}", row.fmt(0).unwrap());
println!("row name : {}", row.fmt(1).unwrap());
```

I'm just getting started with Rust so please let me know if i can do anything better here..