### PR TITLE
ARROW-5188: [Rust] Add temporal types to struct builders

### DIFF
--- a/rust/arrow/src/array.rs
+++ b/rust/arrow/src/array.rs
@@ -146,6 +146,34 @@ pub(crate) fn make_array(data: ArrayDataRef) -> ArrayRef {
         DataType::UInt64 => Arc::new(UInt64Array::from(data)) as ArrayRef,
         DataType::Float32 => Arc::new(Float32Array::from(data)) as ArrayRef,
         DataType::Float64 => Arc::new(Float64Array::from(data)) as ArrayRef,
+        DataType::Date32(DateUnit::Day) => Arc::new(Date32Array::from(data)) as ArrayRef,
+        DataType::Date64(DateUnit::Millisecond) => {
+            Arc::new(Date64Array::from(data)) as ArrayRef
+        }
+        DataType::Time32(TimeUnit::Second) => {
+            Arc::new(Time32SecondArray::from(data)) as ArrayRef
+        }
+        DataType::Time32(TimeUnit::Millisecond) => {
+            Arc::new(Time32MillisecondArray::from(data)) as ArrayRef
+        }
+        DataType::Time64(TimeUnit::Microsecond) => {
+            Arc::new(Time64MicrosecondArray::from(data)) as ArrayRef
+        }
+        DataType::Time64(TimeUnit::Nanosecond) => {
+            Arc::new(Time64NanosecondArray::from(data)) as ArrayRef
+        }
+        DataType::Timestamp(TimeUnit::Second) => {
+            Arc::new(TimestampSecondArray::from(data)) as ArrayRef
+        }
+        DataType::Timestamp(TimeUnit::Millisecond) => {
+            Arc::new(TimestampMillisecondArray::from(data)) as ArrayRef
+        }
+        DataType::Timestamp(TimeUnit::Microsecond) => {
+            Arc::new(TimestampMicrosecondArray::from(data)) as ArrayRef
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond) => {
+            Arc::new(TimestampNanosecondArray::from(data)) as ArrayRef
+        }
         DataType::Utf8 => Arc::new(BinaryArray::from(data)) as ArrayRef,
         DataType::List(_) => Arc::new(ListArray::from(data)) as ArrayRef,
         DataType::Struct(_) => Arc::new(StructArray::from(data)) as ArrayRef,
@@ -935,7 +963,7 @@ impl Array for BinaryArray {
 /// array.
 pub struct StructArray {
     data: ArrayDataRef,
-    boxed_fields: Vec<ArrayRef>,
+    pub(crate) boxed_fields: Vec<ArrayRef>,
 }
 
 impl StructArray {

--- a/rust/arrow/src/builder.rs
+++ b/rust/arrow/src/builder.rs
@@ -645,6 +645,34 @@ impl StructBuilder {
             DataType::Float32 => Box::new(Float32Builder::new(capacity)),
             DataType::Float64 => Box::new(Float64Builder::new(capacity)),
             DataType::Utf8 => Box::new(BinaryBuilder::new(capacity)),
+            DataType::Date32(DateUnit::Day) => Box::new(Date32Builder::new(capacity)),
+            DataType::Date64(DateUnit::Millisecond) => {
+                Box::new(Date64Builder::new(capacity))
+            }
+            DataType::Time32(TimeUnit::Second) => {
+                Box::new(Time32SecondBuilder::new(capacity))
+            }
+            DataType::Time32(TimeUnit::Millisecond) => {
+                Box::new(Time32MillisecondBuilder::new(capacity))
+            }
+            DataType::Time64(TimeUnit::Microsecond) => {
+                Box::new(Time64MicrosecondBuilder::new(capacity))
+            }
+            DataType::Time64(TimeUnit::Nanosecond) => {
+                Box::new(Time64NanosecondBuilder::new(capacity))
+            }
+            DataType::Timestamp(TimeUnit::Second) => {
+                Box::new(TimestampSecondBuilder::new(capacity))
+            }
+            DataType::Timestamp(TimeUnit::Millisecond) => {
+                Box::new(TimestampMillisecondBuilder::new(capacity))
+            }
+            DataType::Timestamp(TimeUnit::Microsecond) => {
+                Box::new(TimestampMicrosecondBuilder::new(capacity))
+            }
+            DataType::Timestamp(TimeUnit::Nanosecond) => {
+                Box::new(TimestampNanosecondBuilder::new(capacity))
+            }
             DataType::Struct(fields) => {
                 let schema = Schema::new(fields.clone());
                 Box::new(Self::from_schema(schema, capacity))


### PR DESCRIPTION
This was an omission when implementing temporal arrays