### PR TITLE
ARROW-4824: [Python] Fix error checking in read_csv()

### DIFF
--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -26,7 +26,7 @@ import sys
 import threading
 import time
 import warnings
-from io import BufferedIOBase, IOBase, UnsupportedOperation
+from io import BufferedIOBase, IOBase, TextIOBase, UnsupportedOperation
 
 from pyarrow.util import _stringify_path
 from pyarrow.compat import (
@@ -626,6 +626,10 @@ cdef class PythonFile(NativeFile):
                     if 'w' not in handle.mode and '+' not in handle.mode:
                         raise TypeError("writable file expected")
             # (other duck-typed file-like objects are possible)
+
+        # If possible, check the file is a binary file
+        if isinstance(handle, TextIOBase):
+            raise TypeError("binary file expected, got text file")
 
         if kind == 'r':
             self.set_random_access_file(

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -184,6 +184,17 @@ class BaseTestCSVRead:
         assert table.num_columns == len(names)
         assert [c.name for c in table.columns] == names
 
+    def test_file_object(self):
+        data = b"a,b\n1,2\n"
+        expected_data = {'a': [1], 'b': [2]}
+        bio = io.BytesIO(data)
+        table = self.read_csv(bio)
+        assert table.to_pydict() == expected_data
+        # Text files not allowed
+        sio = io.StringIO(data.decode())
+        with pytest.raises(TypeError):
+            self.read_csv(sio)
+
     def test_header(self):
         rows = b"abc,def,gh\n"
         table = self.read_bytes(rows)

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -83,6 +83,9 @@ def test_python_file_write():
     f.close()
     assert f.closed
 
+    with pytest.raises(TypeError, match="binary file expected"):
+        pa.PythonFile(StringIO())
+
 
 def test_python_file_read():
     data = b'some sample data'
@@ -112,6 +115,9 @@ def test_python_file_read():
     assert not f.closed
     f.close()
     assert f.closed
+
+    with pytest.raises(TypeError, match="binary file expected"):
+        pa.PythonFile(StringIO(), mode='r')
 
 
 def test_python_file_readall():


### PR DESCRIPTION
Raise a TypeError when a text file is given to read_csv(), as only binary files are allowed.

Also fix a systemic issue where Python exceptions could be swallowed by C++ destructors that could call back into Python and clear the current error status.  The solution is to define a "safe" facility to call into Python code from C++ without clobbering the current error status.
