### PR TITLE
PARQUET-1411: [C++] Add parameterized logical annotations to Parquet metadata

### DIFF
--- a/cpp/src/parquet/parquet.thrift
+++ b/cpp/src/parquet/parquet.thrift
@@ -35,7 +35,7 @@ enum Type {
   BOOLEAN = 0;
   INT32 = 1;
   INT64 = 2;
-  INT96 = 3;
+  INT96 = 3;  // deprecated, only used by legacy implementations.
   FLOAT = 4;
   DOUBLE = 5;
   BYTE_ARRAY = 6;
@@ -259,9 +259,11 @@ struct DecimalType {
 /** Time units for logical types */
 struct MilliSeconds {}
 struct MicroSeconds {}
+struct NanoSeconds {}
 union TimeUnit {
   1: MilliSeconds MILLIS
   2: MicroSeconds MICROS
+  3: NanoSeconds NANOS
 }
 
 /**
@@ -277,7 +279,7 @@ struct TimestampType {
 /**
  * Time logical type annotation
  *
- * Allowed for physical types: INT32 (millis), INT64 (micros)
+ * Allowed for physical types: INT32 (millis), INT64 (micros, nanos)
  */
 struct TimeType {
   1: required bool isAdjustedToUTC
@@ -320,19 +322,27 @@ struct BsonType {
  * following table.
  */
 union LogicalType {
-  1:  StringType STRING       // use ConvertedType UTF8 if encoding is UTF-8
+  1:  StringType STRING       // use ConvertedType UTF8
   2:  MapType MAP             // use ConvertedType MAP
   3:  ListType LIST           // use ConvertedType LIST
   4:  EnumType ENUM           // use ConvertedType ENUM
   5:  DecimalType DECIMAL     // use ConvertedType DECIMAL
   6:  DateType DATE           // use ConvertedType DATE
-  7:  TimeType TIME           // use ConvertedType TIME_MICROS or TIME_MILLIS
-  8:  TimestampType TIMESTAMP // use ConvertedType TIMESTAMP_MICROS or TIMESTAMP_MILLIS
+
+  // use ConvertedType TIME_MICROS for TIME(isAdjustedToUTC = true, unit = MICROS)
+  // use ConvertedType TIME_MILLIS for TIME(isAdjustedToUTC = true, unit = MILLIS)
+  7:  TimeType TIME
+
+  // use ConvertedType TIMESTAMP_MICROS for TIMESTAMP(isAdjustedToUTC = true, unit = MICROS)
+  // use ConvertedType TIMESTAMP_MILLIS for TIMESTAMP(isAdjustedToUTC = true, unit = MILLIS)
+  8:  TimestampType TIMESTAMP
+
   // 9: reserved for INTERVAL
   10: IntType INTEGER         // use ConvertedType INT_* or UINT_*
   11: NullType UNKNOWN        // no compatible ConvertedType
   12: JsonType JSON           // use ConvertedType JSON
   13: BsonType BSON           // use ConvertedType BSON
+  14: UUIDType UUID
 }
 
 /**

--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -198,7 +198,9 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
     stream << "     { \"Id\": \"" << i << "\", \"Name\": \"" << descr->name() << "\","
            << " \"PhysicalType\": \"" << TypeToString(descr->physical_type()) << "\","
            << " \"LogicalType\": \"" << LogicalTypeToString(descr->logical_type())
-           << "\" }";
+           << "\","
+           << " \"LogicalAnnotation\": " << (descr->logical_annotation())->ToJSON()
+           << " }";
     c++;
     if (c != static_cast<int>(selected_columns.size())) {
       stream << ",\n";

--- a/cpp/src/parquet/reader-test.cc
+++ b/cpp/src/parquet/reader-test.cc
@@ -265,17 +265,17 @@ TEST(TestJSONWithLocalFile, JSONOutput) {
   "NumberOfRealColumns": "11",
   "NumberOfColumns": "11",
   "Columns": [
-     { "Id": "0", "Name": "id", "PhysicalType": "INT32", "LogicalType": "NONE" },
-     { "Id": "1", "Name": "bool_col", "PhysicalType": "BOOLEAN", "LogicalType": "NONE" },
-     { "Id": "2", "Name": "tinyint_col", "PhysicalType": "INT32", "LogicalType": "NONE" },
-     { "Id": "3", "Name": "smallint_col", "PhysicalType": "INT32", "LogicalType": "NONE" },
-     { "Id": "4", "Name": "int_col", "PhysicalType": "INT32", "LogicalType": "NONE" },
-     { "Id": "5", "Name": "bigint_col", "PhysicalType": "INT64", "LogicalType": "NONE" },
-     { "Id": "6", "Name": "float_col", "PhysicalType": "FLOAT", "LogicalType": "NONE" },
-     { "Id": "7", "Name": "double_col", "PhysicalType": "DOUBLE", "LogicalType": "NONE" },
-     { "Id": "8", "Name": "date_string_col", "PhysicalType": "BYTE_ARRAY", "LogicalType": "NONE" },
-     { "Id": "9", "Name": "string_col", "PhysicalType": "BYTE_ARRAY", "LogicalType": "NONE" },
-     { "Id": "10", "Name": "timestamp_col", "PhysicalType": "INT96", "LogicalType": "NONE" }
+     { "Id": "0", "Name": "id", "PhysicalType": "INT32", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "1", "Name": "bool_col", "PhysicalType": "BOOLEAN", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "2", "Name": "tinyint_col", "PhysicalType": "INT32", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "3", "Name": "smallint_col", "PhysicalType": "INT32", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "4", "Name": "int_col", "PhysicalType": "INT32", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "5", "Name": "bigint_col", "PhysicalType": "INT64", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "6", "Name": "float_col", "PhysicalType": "FLOAT", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "7", "Name": "double_col", "PhysicalType": "DOUBLE", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "8", "Name": "date_string_col", "PhysicalType": "BYTE_ARRAY", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "9", "Name": "string_col", "PhysicalType": "BYTE_ARRAY", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} },
+     { "Id": "10", "Name": "timestamp_col", "PhysicalType": "INT96", "LogicalType": "NONE", "LogicalAnnotation": {"Type": "None"} }
   ],
   "RowGroups": [
      {

--- a/cpp/src/parquet/schema-test.cc
+++ b/cpp/src/parquet/schema-test.cc
@@ -18,16 +18,21 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <cstring>
+#include <functional>
 #include <iosfwd>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "arrow/util/checked_cast.h"
 #include "parquet/exception.h"
 #include "parquet/schema-internal.h"
 #include "parquet/schema.h"
 #include "parquet/thrift.h"
 #include "parquet/types.h"
+
+using ::arrow::internal::checked_cast;
 
 namespace parquet {
 
@@ -509,6 +514,16 @@ TEST_F(TestSchemaFlatten, DecimalMetadata) {
   ASSERT_TRUE(elements_[1].__isset.scale);
 
   elements_.clear();
+  // ... including those created with new logical annotations
+  node = PrimitiveNode::Make("decimal", Repetition::REQUIRED,
+                             DecimalAnnotation::Make(10, 5), Type::INT64, -1);
+  group = GroupNode::Make("group", Repetition::REPEATED, {node}, ListAnnotation::Make());
+  Flatten(reinterpret_cast<GroupNode*>(group.get()));
+  ASSERT_EQ("decimal", elements_[1].name);
+  ASSERT_TRUE(elements_[1].__isset.precision);
+  ASSERT_TRUE(elements_[1].__isset.scale);
+
+  elements_.clear();
   // Not for integers with no logical type
   group =
       GroupNode::Make("group", Repetition::REPEATED, {Int64("int64")}, LogicalType::LIST);
@@ -532,6 +547,10 @@ TEST_F(TestSchemaFlatten, NestedExample) {
   // 3-level list encoding, by hand
   elt = NewGroup("b", FieldRepetitionType::REPEATED, 1, 3);
   elt.__set_converted_type(ConvertedType::LIST);
+  format::ListType ls;
+  format::LogicalType lt;
+  lt.__set_LIST(ls);
+  elt.__set_logicalType(lt);
   elements.push_back(elt);
   elements.push_back(NewPrimitive("item", FieldRepetitionType::OPTIONAL, Type::INT64, 4));
 
@@ -761,22 +780,1381 @@ TEST(TestSchemaPrinter, Examples) {
   fields.push_back(PrimitiveNode::Make("c", Repetition::REQUIRED, Type::INT32,
                                        LogicalType::DECIMAL, -1, 3, 2));
 
+  fields.push_back(PrimitiveNode::Make("d", Repetition::REQUIRED,
+                                       DecimalAnnotation::Make(10, 5), Type::INT64, -1));
+
   NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
 
   std::string result = Print(schema);
   std::string expected = R"(message schema {
   required int32 a;
   optional group bag {
-    repeated group b (LIST) {
+    repeated group b (List) {
       optional int64 item1;
       required boolean item2;
     }
   }
-  required int32 c (DECIMAL(3,2));
+  required int32 c (Decimal(precision=3, scale=2));
+  required int64 d (Decimal(precision=10, scale=5));
 }
 )";
   ASSERT_EQ(expected, result);
 }
 
+static void ConfirmFactoryEquivalence(
+    LogicalType::type converted_type,
+    const std::shared_ptr<const LogicalAnnotation>& from_make,
+    std::function<bool(const std::shared_ptr<const LogicalAnnotation>&)> check_is_type) {
+  std::shared_ptr<const LogicalAnnotation> from_converted_type =
+      LogicalAnnotation::FromConvertedType(converted_type);
+  ASSERT_EQ(from_converted_type->type(), from_make->type())
+      << from_make->ToString() << " annotations unexpectedly do not match on type";
+  ASSERT_TRUE(from_converted_type->Equals(*from_make))
+      << from_make->ToString() << " annotations unexpectedly not equivalent";
+  ASSERT_TRUE(check_is_type(from_converted_type))
+      << from_converted_type->ToString()
+      << " annotation (from converted type) does not have expected type property";
+  ASSERT_TRUE(check_is_type(from_make))
+      << from_make->ToString()
+      << " annotation (from Make()) does not have expected type property";
+  return;
+}
+
+TEST(TestLogicalAnnotationConstruction, FactoryEquivalence) {
+  // For each legacy converted type, ensure that the equivalent annotation object
+  // can be obtained from either the base class's FromConvertedType() factory method or
+  // the annotation type class's Make() method (accessed via convenience methods on the
+  // base class) and that these annotation objects are equivalent
+
+  struct ConfirmFactoryEquivalenceArguments {
+    LogicalType::type converted_type;
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    std::function<bool(const std::shared_ptr<const LogicalAnnotation>&)> check_is_type;
+  };
+
+  auto check_is_string = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_string();
+  };
+  auto check_is_map = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_map();
+  };
+  auto check_is_list = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_list();
+  };
+  auto check_is_enum = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_enum();
+  };
+  auto check_is_date = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_date();
+  };
+  auto check_is_time = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_time();
+  };
+  auto check_is_timestamp =
+      [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+        return annotation->is_timestamp();
+      };
+  auto check_is_int = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_int();
+  };
+  auto check_is_JSON = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_JSON();
+  };
+  auto check_is_BSON = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_BSON();
+  };
+  auto check_is_interval =
+      [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+        return annotation->is_interval();
+      };
+  auto check_is_none = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_none();
+  };
+
+  std::vector<ConfirmFactoryEquivalenceArguments> cases = {
+      {LogicalType::UTF8, LogicalAnnotation::String(), check_is_string},
+      {LogicalType::MAP, LogicalAnnotation::Map(), check_is_map},
+      {LogicalType::MAP_KEY_VALUE, LogicalAnnotation::Map(), check_is_map},
+      {LogicalType::LIST, LogicalAnnotation::List(), check_is_list},
+      {LogicalType::ENUM, LogicalAnnotation::Enum(), check_is_enum},
+      {LogicalType::DATE, LogicalAnnotation::Date(), check_is_date},
+      {LogicalType::TIME_MILLIS,
+       LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS), check_is_time},
+      {LogicalType::TIME_MICROS,
+       LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS), check_is_time},
+      {LogicalType::TIMESTAMP_MILLIS,
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       check_is_timestamp},
+      {LogicalType::TIMESTAMP_MICROS,
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       check_is_timestamp},
+      {LogicalType::UINT_8, LogicalAnnotation::Int(8, false), check_is_int},
+      {LogicalType::UINT_16, LogicalAnnotation::Int(16, false), check_is_int},
+      {LogicalType::UINT_32, LogicalAnnotation::Int(32, false), check_is_int},
+      {LogicalType::UINT_64, LogicalAnnotation::Int(64, false), check_is_int},
+      {LogicalType::INT_8, LogicalAnnotation::Int(8, true), check_is_int},
+      {LogicalType::INT_16, LogicalAnnotation::Int(16, true), check_is_int},
+      {LogicalType::INT_32, LogicalAnnotation::Int(32, true), check_is_int},
+      {LogicalType::INT_64, LogicalAnnotation::Int(64, true), check_is_int},
+      {LogicalType::JSON, LogicalAnnotation::JSON(), check_is_JSON},
+      {LogicalType::BSON, LogicalAnnotation::BSON(), check_is_BSON},
+      {LogicalType::INTERVAL, LogicalAnnotation::Interval(), check_is_interval},
+      {LogicalType::NONE, LogicalAnnotation::None(), check_is_none}};
+
+  for (const ConfirmFactoryEquivalenceArguments& c : cases) {
+    ConfirmFactoryEquivalence(c.converted_type, c.annotation, c.check_is_type);
+  }
+
+  // LogicalType::DECIMAL, LogicalAnnotation::Decimal, is_decimal
+  schema::DecimalMetadata converted_decimal_metadata;
+  converted_decimal_metadata.isset = true;
+  converted_decimal_metadata.precision = 10;
+  converted_decimal_metadata.scale = 4;
+  std::shared_ptr<const LogicalAnnotation> from_converted_type =
+      LogicalAnnotation::FromConvertedType(LogicalType::DECIMAL,
+                                           converted_decimal_metadata);
+  std::shared_ptr<const LogicalAnnotation> from_make = LogicalAnnotation::Decimal(10, 4);
+  ASSERT_EQ(from_converted_type->type(), from_make->type());
+  ASSERT_TRUE(from_converted_type->Equals(*from_make));
+  ASSERT_TRUE(from_converted_type->is_decimal());
+  ASSERT_TRUE(from_make->is_decimal());
+  ASSERT_TRUE(LogicalAnnotation::Decimal(16)->Equals(*LogicalAnnotation::Decimal(16, 0)));
+}
+
+static void ConfirmConvertedTypeCompatibility(
+    const std::shared_ptr<const LogicalAnnotation>& original,
+    LogicalType::type expected_converted_type) {
+  ASSERT_TRUE(original->is_valid())
+      << original->ToString() << " annotation unexpectedly is not valid";
+  schema::DecimalMetadata converted_decimal_metadata;
+  LogicalType::type converted_type =
+      original->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, expected_converted_type)
+      << original->ToString()
+      << " annotation unexpectedly returns incorrect converted type";
+  ASSERT_FALSE(converted_decimal_metadata.isset)
+      << original->ToString()
+      << " annotation unexpectedly returns converted decimal metatdata that is set";
+  ASSERT_TRUE(original->is_compatible(converted_type, converted_decimal_metadata))
+      << original->ToString()
+      << " annotation unexpectedly is incompatible with converted type and decimal "
+         "metadata it returned";
+  ASSERT_FALSE(original->is_compatible(converted_type, {true, 1, 1}))
+      << original->ToString()
+      << " annotation unexpectedly is compatible with converted decimal metadata that is "
+         "set";
+  ASSERT_TRUE(original->is_compatible(converted_type))
+      << original->ToString()
+      << " annotation unexpectedly is incompatible with converted type it returned";
+  std::shared_ptr<const LogicalAnnotation> reconstructed =
+      LogicalAnnotation::FromConvertedType(converted_type, converted_decimal_metadata);
+  ASSERT_TRUE(reconstructed->is_valid()) << "Reconstructed " << reconstructed->ToString()
+                                         << " annotation unexpectedly is not valid";
+  ASSERT_TRUE(reconstructed->Equals(*original))
+      << "Reconstructed annotation (" << reconstructed->ToString()
+      << ") unexpectedly not equivalent to original annotation (" << original->ToString()
+      << ")";
+  return;
+}
+
+TEST(TestLogicalAnnotationConstruction, ConvertedTypeCompatibility) {
+  // For each legacy converted type, ensure that the equivalent logical annotation
+  // emits correct, compatible converted type information and that the emitted
+  // information can be used to reconstruct another equivalent logical annotation.
+
+  struct ExpectedConvertedType {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    LogicalType::type converted_type;
+  };
+
+  std::vector<ExpectedConvertedType> cases = {
+      {LogicalAnnotation::String(), LogicalType::UTF8},
+      {LogicalAnnotation::Map(), LogicalType::MAP},
+      {LogicalAnnotation::List(), LogicalType::LIST},
+      {LogicalAnnotation::Enum(), LogicalType::ENUM},
+      {LogicalAnnotation::Date(), LogicalType::DATE},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS),
+       LogicalType::TIME_MILLIS},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS),
+       LogicalType::TIME_MICROS},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       LogicalType::TIMESTAMP_MILLIS},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       LogicalType::TIMESTAMP_MICROS},
+      {LogicalAnnotation::Int(8, false), LogicalType::UINT_8},
+      {LogicalAnnotation::Int(16, false), LogicalType::UINT_16},
+      {LogicalAnnotation::Int(32, false), LogicalType::UINT_32},
+      {LogicalAnnotation::Int(64, false), LogicalType::UINT_64},
+      {LogicalAnnotation::Int(8, true), LogicalType::INT_8},
+      {LogicalAnnotation::Int(16, true), LogicalType::INT_16},
+      {LogicalAnnotation::Int(32, true), LogicalType::INT_32},
+      {LogicalAnnotation::Int(64, true), LogicalType::INT_64},
+      {LogicalAnnotation::JSON(), LogicalType::JSON},
+      {LogicalAnnotation::BSON(), LogicalType::BSON},
+      {LogicalAnnotation::Interval(), LogicalType::INTERVAL},
+      {LogicalAnnotation::None(), LogicalType::NONE}};
+
+  for (const ExpectedConvertedType& c : cases) {
+    ConfirmConvertedTypeCompatibility(c.annotation, c.converted_type);
+  }
+
+  // Special cases ...
+
+  std::shared_ptr<const LogicalAnnotation> original;
+  LogicalType::type converted_type;
+  schema::DecimalMetadata converted_decimal_metadata;
+  std::shared_ptr<const LogicalAnnotation> reconstructed;
+
+  // DECIMAL
+  std::memset(&converted_decimal_metadata, 0x00, sizeof(converted_decimal_metadata));
+  original = LogicalAnnotation::Decimal(6, 2);
+  ASSERT_TRUE(original->is_valid());
+  converted_type = original->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, LogicalType::DECIMAL);
+  ASSERT_TRUE(converted_decimal_metadata.isset);
+  ASSERT_EQ(converted_decimal_metadata.precision, 6);
+  ASSERT_EQ(converted_decimal_metadata.scale, 2);
+  ASSERT_TRUE(original->is_compatible(converted_type, converted_decimal_metadata));
+  reconstructed =
+      LogicalAnnotation::FromConvertedType(converted_type, converted_decimal_metadata);
+  ASSERT_TRUE(reconstructed->is_valid());
+  ASSERT_TRUE(reconstructed->Equals(*original));
+
+  // Unknown
+  original = LogicalAnnotation::Unknown();
+  ASSERT_TRUE(original->is_invalid());
+  ASSERT_FALSE(original->is_valid());
+  converted_type = original->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, LogicalType::NA);
+  ASSERT_FALSE(converted_decimal_metadata.isset);
+  ASSERT_TRUE(original->is_compatible(converted_type, converted_decimal_metadata));
+  ASSERT_TRUE(original->is_compatible(converted_type));
+  reconstructed =
+      LogicalAnnotation::FromConvertedType(converted_type, converted_decimal_metadata);
+  ASSERT_TRUE(reconstructed->is_invalid());
+  ASSERT_TRUE(reconstructed->Equals(*original));
+}
+
+static void ConfirmNewTypeIncompatibility(
+    const std::shared_ptr<const LogicalAnnotation>& annotation,
+    std::function<bool(const std::shared_ptr<const LogicalAnnotation>&)> check_is_type) {
+  ASSERT_TRUE(annotation->is_valid())
+      << annotation->ToString() << " annotation unexpectedly is not valid";
+  ASSERT_TRUE(check_is_type(annotation))
+      << annotation->ToString() << " annotation is not expected annotation type";
+  schema::DecimalMetadata converted_decimal_metadata;
+  LogicalType::type converted_type =
+      annotation->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, LogicalType::NONE)
+      << annotation->ToString() << " annotation converted type unexpectedly is not NONE";
+  ASSERT_FALSE(converted_decimal_metadata.isset)
+      << annotation->ToString()
+      << " annotation converted decimal metadata unexpectedly is set";
+  return;
+}
+
+TEST(TestLogicalAnnotationConstruction, NewTypeIncompatibility) {
+  // For each new logical annotation type, ensure that the logical annotation
+  // correctly reports that it has no legacy equivalent
+
+  struct ConfirmNewTypeIncompatibilityArguments {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    std::function<bool(const std::shared_ptr<const LogicalAnnotation>&)> check_is_type;
+  };
+
+  auto check_is_UUID = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_UUID();
+  };
+  auto check_is_null = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_null();
+  };
+  auto check_is_time = [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+    return annotation->is_time();
+  };
+  auto check_is_timestamp =
+      [](const std::shared_ptr<const LogicalAnnotation>& annotation) {
+        return annotation->is_timestamp();
+      };
+
+  std::vector<ConfirmNewTypeIncompatibilityArguments> cases = {
+      {LogicalAnnotation::UUID(), check_is_UUID},
+      {LogicalAnnotation::Null(), check_is_null},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS),
+       check_is_time},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS),
+       check_is_time},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS), check_is_time},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS), check_is_time},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       check_is_timestamp},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       check_is_timestamp},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       check_is_timestamp},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       check_is_timestamp},
+  };
+
+  for (const ConfirmNewTypeIncompatibilityArguments& c : cases) {
+    ConfirmNewTypeIncompatibility(c.annotation, c.check_is_type);
+  }
+}
+
+TEST(TestLogicalAnnotationConstruction, FactoryExceptions) {
+  // Ensure that annotation construction catches invalid arguments
+
+  std::vector<std::function<void()>> cases = {
+      []() {
+        TimeAnnotation::Make(true, LogicalAnnotation::TimeUnit::UNKNOWN);
+      },  // Invalid TimeUnit
+      []() {
+        TimestampAnnotation::Make(true, LogicalAnnotation::TimeUnit::UNKNOWN);
+      },                                          // Invalid TimeUnit
+      []() { IntAnnotation::Make(-1, false); },   // Invalid bit width
+      []() { IntAnnotation::Make(0, false); },    // Invalid bit width
+      []() { IntAnnotation::Make(1, false); },    // Invalid bit width
+      []() { IntAnnotation::Make(65, false); },   // Invalid bit width
+      []() { DecimalAnnotation::Make(-1); },      // Invalid precision
+      []() { DecimalAnnotation::Make(0); },       // Invalid precision
+      []() { DecimalAnnotation::Make(0, 0); },    // Invalid precision
+      []() { DecimalAnnotation::Make(10, -1); },  // Invalid scale
+      []() { DecimalAnnotation::Make(10, 11); }   // Invalid scale
+  };
+
+  for (auto f : cases) {
+    ASSERT_ANY_THROW(f());
+  }
+}
+
+static void ConfirmAnnotationProperties(
+    const std::shared_ptr<const LogicalAnnotation>& annotation, bool nested,
+    bool serialized, bool valid) {
+  ASSERT_TRUE(annotation->is_nested() == nested)
+      << annotation->ToString() << " annotation has incorrect nested() property";
+  ASSERT_TRUE(annotation->is_serialized() == serialized)
+      << annotation->ToString() << " annotation has incorrect serialized() property";
+  ASSERT_TRUE(annotation->is_valid() == valid)
+      << annotation->ToString() << " annotation has incorrect valid() property";
+  ASSERT_TRUE(annotation->is_nonnested() != nested)
+      << annotation->ToString() << " annotation has incorrect nonnested() property";
+  ASSERT_TRUE(annotation->is_invalid() != valid)
+      << annotation->ToString() << " annotation has incorrect invalid() property";
+  return;
+}
+
+TEST(TestLogicalAnnotationOperation, AnnotationProperties) {
+  // For each annotation type, ensure that the correct general properties are reported
+
+  struct ExpectedProperties {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    bool nested;
+    bool serialized;
+    bool valid;
+  };
+
+  std::vector<ExpectedProperties> cases = {
+      {StringAnnotation::Make(), false, true, true},
+      {MapAnnotation::Make(), true, true, true},
+      {ListAnnotation::Make(), true, true, true},
+      {EnumAnnotation::Make(), false, true, true},
+      {DecimalAnnotation::Make(16, 6), false, true, true},
+      {DateAnnotation::Make(), false, true, true},
+      {TimeAnnotation::Make(true, LogicalAnnotation::TimeUnit::MICROS), false, true,
+       true},
+      {TimestampAnnotation::Make(true, LogicalAnnotation::TimeUnit::MICROS), false, true,
+       true},
+      {IntervalAnnotation::Make(), false, true, true},
+      {IntAnnotation::Make(8, false), false, true, true},
+      {IntAnnotation::Make(64, true), false, true, true},
+      {NullAnnotation::Make(), false, true, true},
+      {JSONAnnotation::Make(), false, true, true},
+      {BSONAnnotation::Make(), false, true, true},
+      {UUIDAnnotation::Make(), false, true, true},
+      {NoAnnotation::Make(), false, false, true},
+      {UnknownAnnotation::Make(), false, false, false},
+  };
+
+  for (const ExpectedProperties& c : cases) {
+    ConfirmAnnotationProperties(c.annotation, c.nested, c.serialized, c.valid);
+  }
+}
+
+static constexpr int PHYSICAL_TYPE_COUNT = 8;
+
+static Type::type physical_type[PHYSICAL_TYPE_COUNT] = {
+    Type::BOOLEAN, Type::INT32,  Type::INT64,      Type::INT96,
+    Type::FLOAT,   Type::DOUBLE, Type::BYTE_ARRAY, Type::FIXED_LEN_BYTE_ARRAY};
+
+static void ConfirmSinglePrimitiveTypeApplicability(
+    const std::shared_ptr<const LogicalAnnotation>& annotation,
+    Type::type applicable_type) {
+  for (int i = 0; i < PHYSICAL_TYPE_COUNT; ++i) {
+    if (physical_type[i] == applicable_type) {
+      ASSERT_TRUE(annotation->is_applicable(physical_type[i]))
+          << annotation->ToString()
+          << " annotation unexpectedly inapplicable to physical type "
+          << TypeToString(physical_type[i]);
+    } else {
+      ASSERT_FALSE(annotation->is_applicable(physical_type[i]))
+          << annotation->ToString()
+          << " annotation unexpectedly applicable to physical type "
+          << TypeToString(physical_type[i]);
+    }
+  }
+  return;
+}
+
+static void ConfirmAnyPrimitiveTypeApplicability(
+    const std::shared_ptr<const LogicalAnnotation>& annotation) {
+  for (int i = 0; i < PHYSICAL_TYPE_COUNT; ++i) {
+    ASSERT_TRUE(annotation->is_applicable(physical_type[i]))
+        << annotation->ToString()
+        << " annotation unexpectedly inapplicable to physical type "
+        << TypeToString(physical_type[i]);
+  }
+  return;
+}
+
+static void ConfirmNoPrimitiveTypeApplicability(
+    const std::shared_ptr<const LogicalAnnotation>& annotation) {
+  for (int i = 0; i < PHYSICAL_TYPE_COUNT; ++i) {
+    ASSERT_FALSE(annotation->is_applicable(physical_type[i]))
+        << annotation->ToString()
+        << " annotation unexpectedly applicable to physical type "
+        << TypeToString(physical_type[i]);
+  }
+  return;
+}
+
+TEST(TestLogicalAnnotationOperation, AnnotationApplicability) {
+  // Check that each logical annotation type correctly reports which
+  // underlying primitive type(s) it can be applied to
+
+  struct ExpectedApplicability {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    Type::type applicable_type;
+  };
+
+  std::vector<ExpectedApplicability> single_type_cases = {
+      {LogicalAnnotation::String(), Type::BYTE_ARRAY},
+      {LogicalAnnotation::Enum(), Type::BYTE_ARRAY},
+      {LogicalAnnotation::Date(), Type::INT32},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS), Type::INT32},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS), Type::INT64},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS), Type::INT64},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT64},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64},
+      {LogicalAnnotation::Int(8, false), Type::INT32},
+      {LogicalAnnotation::Int(16, false), Type::INT32},
+      {LogicalAnnotation::Int(32, false), Type::INT32},
+      {LogicalAnnotation::Int(64, false), Type::INT64},
+      {LogicalAnnotation::Int(8, true), Type::INT32},
+      {LogicalAnnotation::Int(16, true), Type::INT32},
+      {LogicalAnnotation::Int(32, true), Type::INT32},
+      {LogicalAnnotation::Int(64, true), Type::INT64},
+      {LogicalAnnotation::JSON(), Type::BYTE_ARRAY},
+      {LogicalAnnotation::BSON(), Type::BYTE_ARRAY}};
+
+  for (const ExpectedApplicability& c : single_type_cases) {
+    ConfirmSinglePrimitiveTypeApplicability(c.annotation, c.applicable_type);
+  }
+
+  std::vector<std::shared_ptr<const LogicalAnnotation>> no_type_cases = {
+      LogicalAnnotation::Map(), LogicalAnnotation::List()};
+
+  for (auto c : no_type_cases) {
+    ConfirmNoPrimitiveTypeApplicability(c);
+  }
+
+  std::vector<std::shared_ptr<const LogicalAnnotation>> any_type_cases = {
+      LogicalAnnotation::Null(), LogicalAnnotation::None(), LogicalAnnotation::Unknown()};
+
+  for (auto c : any_type_cases) {
+    ConfirmAnyPrimitiveTypeApplicability(c);
+  }
+
+  // Fixed binary, exact length cases ...
+
+  struct InapplicableType {
+    Type::type physical_type;
+    int physical_length;
+  };
+
+  std::vector<InapplicableType> inapplicable_types = {{Type::FIXED_LEN_BYTE_ARRAY, 8},
+                                                      {Type::FIXED_LEN_BYTE_ARRAY, 20},
+                                                      {Type::BOOLEAN, -1},
+                                                      {Type::INT32, -1},
+                                                      {Type::INT64, -1},
+                                                      {Type::INT96, -1},
+                                                      {Type::FLOAT, -1},
+                                                      {Type::DOUBLE, -1},
+                                                      {Type::BYTE_ARRAY, -1}};
+
+  std::shared_ptr<const LogicalAnnotation> annotation;
+
+  annotation = LogicalAnnotation::Interval();
+  ASSERT_TRUE(annotation->is_applicable(Type::FIXED_LEN_BYTE_ARRAY, 12));
+  for (const InapplicableType& t : inapplicable_types) {
+    ASSERT_FALSE(annotation->is_applicable(t.physical_type, t.physical_length));
+  }
+
+  annotation = LogicalAnnotation::UUID();
+  ASSERT_TRUE(annotation->is_applicable(Type::FIXED_LEN_BYTE_ARRAY, 16));
+  for (const InapplicableType& t : inapplicable_types) {
+    ASSERT_FALSE(annotation->is_applicable(t.physical_type, t.physical_length));
+  }
+}
+
+TEST(TestLogicalAnnotationOperation, DecimalAnnotationApplicability) {
+  // Check that the decimal logical annotation type correctly reports which
+  // underlying primitive type(s) it can be applied to
+
+  std::shared_ptr<const LogicalAnnotation> annotation;
+
+  for (int32_t precision = 1; precision <= 9; ++precision) {
+    annotation = DecimalAnnotation::Make(precision, 0);
+    ASSERT_TRUE(annotation->is_applicable(Type::INT32))
+        << annotation->ToString() << " unexpectedly inapplicable to physical type INT32";
+  }
+  annotation = DecimalAnnotation::Make(10, 0);
+  ASSERT_FALSE(annotation->is_applicable(Type::INT32))
+      << annotation->ToString() << " unexpectedly applicable to physical type INT32";
+
+  for (int32_t precision = 1; precision <= 18; ++precision) {
+    annotation = DecimalAnnotation::Make(precision, 0);
+    ASSERT_TRUE(annotation->is_applicable(Type::INT64))
+        << annotation->ToString() << " unexpectedly inapplicable to physical type INT64";
+  }
+  annotation = DecimalAnnotation::Make(19, 0);
+  ASSERT_FALSE(annotation->is_applicable(Type::INT64))
+      << annotation->ToString() << " unexpectedly applicable to physical type INT64";
+
+  for (int32_t precision = 1; precision <= 36; ++precision) {
+    annotation = DecimalAnnotation::Make(precision, 0);
+    ASSERT_TRUE(annotation->is_applicable(Type::BYTE_ARRAY))
+        << annotation->ToString()
+        << " unexpectedly inapplicable to physical type BYTE_ARRAY";
+  }
+
+  struct PrecisionLimits {
+    int32_t physical_length;
+    int32_t precision_limit;
+  };
+
+  std::vector<PrecisionLimits> cases = {{1, 2},   {2, 4},   {3, 6},   {4, 9},  {8, 18},
+                                        {10, 23}, {16, 38}, {20, 47}, {32, 76}};
+
+  for (const PrecisionLimits& c : cases) {
+    int32_t precision;
+    for (precision = 1; precision <= c.precision_limit; ++precision) {
+      annotation = DecimalAnnotation::Make(precision, 0);
+      ASSERT_TRUE(
+          annotation->is_applicable(Type::FIXED_LEN_BYTE_ARRAY, c.physical_length))
+          << annotation->ToString()
+          << " unexpectedly inapplicable to physical type FIXED_LEN_BYTE_ARRAY with "
+             "length "
+          << c.physical_length;
+    }
+    annotation = DecimalAnnotation::Make(precision, 0);
+    ASSERT_FALSE(annotation->is_applicable(Type::FIXED_LEN_BYTE_ARRAY, c.physical_length))
+        << annotation->ToString()
+        << " unexpectedly applicable to physical type FIXED_LEN_BYTE_ARRAY with length "
+        << c.physical_length;
+  }
+
+  ASSERT_FALSE((DecimalAnnotation::Make(16, 6))->is_applicable(Type::BOOLEAN));
+  ASSERT_FALSE((DecimalAnnotation::Make(16, 6))->is_applicable(Type::FLOAT));
+  ASSERT_FALSE((DecimalAnnotation::Make(16, 6))->is_applicable(Type::DOUBLE));
+}
+
+TEST(TestLogicalAnnotationOperation, AnnotationRepresentation) {
+  // Ensure that each logical annotation type prints a correct string and
+  // JSON representation
+
+  struct ExpectedRepresentation {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    const char* string_representation;
+    const char* JSON_representation;
+  };
+
+  std::vector<ExpectedRepresentation> cases = {
+      {LogicalAnnotation::Unknown(), "Unknown", R"({"Type": "Unknown"})"},
+      {LogicalAnnotation::String(), "String", R"({"Type": "String"})"},
+      {LogicalAnnotation::Map(), "Map", R"({"Type": "Map"})"},
+      {LogicalAnnotation::List(), "List", R"({"Type": "List"})"},
+      {LogicalAnnotation::Enum(), "Enum", R"({"Type": "Enum"})"},
+      {LogicalAnnotation::Decimal(10, 4), "Decimal(precision=10, scale=4)",
+       R"({"Type": "Decimal", "precision": 10, "scale": 4})"},
+      {LogicalAnnotation::Decimal(10), "Decimal(precision=10, scale=0)",
+       R"({"Type": "Decimal", "precision": 10, "scale": 0})"},
+      {LogicalAnnotation::Date(), "Date", R"({"Type": "Date"})"},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS),
+       "Time(isAdjustedToUTC=true, timeUnit=milliseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": true, "timeUnit": "milliseconds"})"},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS),
+       "Time(isAdjustedToUTC=true, timeUnit=microseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": true, "timeUnit": "microseconds"})"},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS),
+       "Time(isAdjustedToUTC=true, timeUnit=nanoseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": true, "timeUnit": "nanoseconds"})"},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS),
+       "Time(isAdjustedToUTC=false, timeUnit=milliseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": false, "timeUnit": "milliseconds"})"},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS),
+       "Time(isAdjustedToUTC=false, timeUnit=microseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": false, "timeUnit": "microseconds"})"},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS),
+       "Time(isAdjustedToUTC=false, timeUnit=nanoseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": false, "timeUnit": "nanoseconds"})"},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       "Timestamp(isAdjustedToUTC=true, timeUnit=milliseconds)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": true, "timeUnit": "milliseconds"})"},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       "Timestamp(isAdjustedToUTC=true, timeUnit=microseconds)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": true, "timeUnit": "microseconds"})"},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       "Timestamp(isAdjustedToUTC=true, timeUnit=nanoseconds)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": true, "timeUnit": "nanoseconds"})"},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       "Timestamp(isAdjustedToUTC=false, timeUnit=milliseconds)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": false, "timeUnit": "milliseconds"})"},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       "Timestamp(isAdjustedToUTC=false, timeUnit=microseconds)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": false, "timeUnit": "microseconds"})"},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       "Timestamp(isAdjustedToUTC=false, timeUnit=nanoseconds)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": false, "timeUnit": "nanoseconds"})"},
+      {LogicalAnnotation::Interval(), "Interval", R"({"Type": "Interval"})"},
+      {LogicalAnnotation::Int(8, false), "Int(bitWidth=8, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 8, "isSigned": false})"},
+      {LogicalAnnotation::Int(16, false), "Int(bitWidth=16, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 16, "isSigned": false})"},
+      {LogicalAnnotation::Int(32, false), "Int(bitWidth=32, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 32, "isSigned": false})"},
+      {LogicalAnnotation::Int(64, false), "Int(bitWidth=64, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 64, "isSigned": false})"},
+      {LogicalAnnotation::Int(8, true), "Int(bitWidth=8, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 8, "isSigned": true})"},
+      {LogicalAnnotation::Int(16, true), "Int(bitWidth=16, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 16, "isSigned": true})"},
+      {LogicalAnnotation::Int(32, true), "Int(bitWidth=32, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 32, "isSigned": true})"},
+      {LogicalAnnotation::Int(64, true), "Int(bitWidth=64, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 64, "isSigned": true})"},
+      {LogicalAnnotation::Null(), "Null", R"({"Type": "Null"})"},
+      {LogicalAnnotation::JSON(), "JSON", R"({"Type": "JSON"})"},
+      {LogicalAnnotation::BSON(), "BSON", R"({"Type": "BSON"})"},
+      {LogicalAnnotation::UUID(), "UUID", R"({"Type": "UUID"})"},
+      {LogicalAnnotation::None(), "None", R"({"Type": "None"})"},
+  };
+
+  for (const ExpectedRepresentation& c : cases) {
+    ASSERT_STREQ(c.annotation->ToString().c_str(), c.string_representation);
+    ASSERT_STREQ(c.annotation->ToJSON().c_str(), c.JSON_representation);
+  }
+}
+
+TEST(TestLogicalAnnotationOperation, AnnotationSortOrder) {
+  // Ensure that each logical annotation type reports the correct sort order
+
+  struct ExpectedSortOrder {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    SortOrder::type sort_order;
+  };
+
+  std::vector<ExpectedSortOrder> cases = {
+      {LogicalAnnotation::Unknown(), SortOrder::UNKNOWN},
+      {LogicalAnnotation::String(), SortOrder::UNSIGNED},
+      {LogicalAnnotation::Map(), SortOrder::UNKNOWN},
+      {LogicalAnnotation::List(), SortOrder::UNKNOWN},
+      {LogicalAnnotation::Enum(), SortOrder::UNSIGNED},
+      {LogicalAnnotation::Decimal(8, 2), SortOrder::SIGNED},
+      {LogicalAnnotation::Date(), SortOrder::SIGNED},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalAnnotation::Interval(), SortOrder::UNKNOWN},
+      {LogicalAnnotation::Int(8, false), SortOrder::UNSIGNED},
+      {LogicalAnnotation::Int(16, false), SortOrder::UNSIGNED},
+      {LogicalAnnotation::Int(32, false), SortOrder::UNSIGNED},
+      {LogicalAnnotation::Int(64, false), SortOrder::UNSIGNED},
+      {LogicalAnnotation::Int(8, true), SortOrder::SIGNED},
+      {LogicalAnnotation::Int(16, true), SortOrder::SIGNED},
+      {LogicalAnnotation::Int(32, true), SortOrder::SIGNED},
+      {LogicalAnnotation::Int(64, true), SortOrder::SIGNED},
+      {LogicalAnnotation::Null(), SortOrder::UNKNOWN},
+      {LogicalAnnotation::JSON(), SortOrder::UNSIGNED},
+      {LogicalAnnotation::BSON(), SortOrder::UNSIGNED},
+      {LogicalAnnotation::UUID(), SortOrder::UNSIGNED},
+      {LogicalAnnotation::None(), SortOrder::UNKNOWN}};
+
+  for (const ExpectedSortOrder& c : cases) {
+    ASSERT_EQ(c.annotation->sort_order(), c.sort_order)
+        << c.annotation->ToString() << " annotation has incorrect sort order";
+  }
+}
+
+static void ConfirmPrimitiveNodeFactoryEquivalence(
+    const std::shared_ptr<const LogicalAnnotation>& logical_annotation,
+    LogicalType::type converted_type, Type::type physical_type, int physical_length,
+    int precision, int scale) {
+  std::string name = "something";
+  Repetition::type repetition = Repetition::REQUIRED;
+  NodePtr from_converted_type = PrimitiveNode::Make(
+      name, repetition, physical_type, converted_type, physical_length, precision, scale);
+  NodePtr from_logical_annotation = PrimitiveNode::Make(
+      name, repetition, logical_annotation, physical_type, physical_length);
+  ASSERT_TRUE(from_converted_type->Equals(from_logical_annotation.get()))
+      << "Primitive node constructed with converted type "
+      << LogicalTypeToString(converted_type)
+      << " unexpectedly not equivalent to primitive node constructed with logical "
+         "annotation "
+      << logical_annotation->ToString();
+  return;
+}
+
+static void ConfirmGroupNodeFactoryEquivalence(
+    std::string name, const std::shared_ptr<const LogicalAnnotation>& logical_annotation,
+    LogicalType::type converted_type) {
+  Repetition::type repetition = Repetition::OPTIONAL;
+  NodePtr from_converted_type = GroupNode::Make(name, repetition, {}, converted_type);
+  NodePtr from_logical_annotation =
+      GroupNode::Make(name, repetition, {}, logical_annotation);
+  ASSERT_TRUE(from_converted_type->Equals(from_logical_annotation.get()))
+      << "Group node constructed with converted type "
+      << LogicalTypeToString(converted_type)
+      << " unexpectedly not equivalent to group node constructed with logical annotation "
+      << logical_annotation->ToString();
+  return;
+}
+
+TEST(TestSchemaNodeCreation, FactoryEquivalence) {
+  // Ensure that the Node factory methods produce equivalent results regardless
+  // of whether they are given a converted type or a logical annotation.
+
+  // Primitive nodes ...
+
+  struct PrimitiveNodeFactoryArguments {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    LogicalType::type converted_type;
+    Type::type physical_type;
+    int physical_length;
+    int precision;
+    int scale;
+  };
+
+  std::vector<PrimitiveNodeFactoryArguments> cases = {
+      {LogicalAnnotation::String(), LogicalType::UTF8, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalAnnotation::Enum(), LogicalType::ENUM, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalAnnotation::Decimal(16, 6), LogicalType::DECIMAL, Type::INT64, -1, 16, 6},
+      {LogicalAnnotation::Date(), LogicalType::DATE, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS),
+       LogicalType::TIME_MILLIS, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS),
+       LogicalType::TIME_MICROS, Type::INT64, -1, -1, -1},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       LogicalType::TIMESTAMP_MILLIS, Type::INT64, -1, -1, -1},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       LogicalType::TIMESTAMP_MICROS, Type::INT64, -1, -1, -1},
+      {LogicalAnnotation::Interval(), LogicalType::INTERVAL, Type::FIXED_LEN_BYTE_ARRAY,
+       12, -1, -1},
+      {LogicalAnnotation::Int(8, false), LogicalType::UINT_8, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Int(8, true), LogicalType::INT_8, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Int(16, false), LogicalType::UINT_16, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Int(16, true), LogicalType::INT_16, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Int(32, false), LogicalType::UINT_32, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Int(32, true), LogicalType::INT_32, Type::INT32, -1, -1, -1},
+      {LogicalAnnotation::Int(64, false), LogicalType::UINT_64, Type::INT64, -1, -1, -1},
+      {LogicalAnnotation::Int(64, true), LogicalType::INT_64, Type::INT64, -1, -1, -1},
+      {LogicalAnnotation::JSON(), LogicalType::JSON, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalAnnotation::BSON(), LogicalType::BSON, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalAnnotation::None(), LogicalType::NONE, Type::INT64, -1, -1, -1}};
+
+  for (const PrimitiveNodeFactoryArguments& c : cases) {
+    ConfirmPrimitiveNodeFactoryEquivalence(c.annotation, c.converted_type,
+                                           c.physical_type, c.physical_length,
+                                           c.precision, c.scale);
+  }
+
+  // Group nodes ...
+  ConfirmGroupNodeFactoryEquivalence("map", LogicalAnnotation::Map(), LogicalType::MAP);
+  ConfirmGroupNodeFactoryEquivalence("list", LogicalAnnotation::List(),
+                                     LogicalType::LIST);
+}
+
+TEST(TestSchemaNodeCreation, FactoryExceptions) {
+  // Ensure that the Node factory method that accepts an annotation refuses to create
+  // an object if compatibility conditions are not met
+
+  // Nested annotation on non-group node ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("map", Repetition::REQUIRED, MapAnnotation::Make(),
+                                       Type::INT64));
+  // Incompatible primitive type ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("string", Repetition::REQUIRED,
+                                       StringAnnotation::Make(), Type::BOOLEAN));
+  // Incompatible primitive length ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("interval", Repetition::REQUIRED,
+                                       IntervalAnnotation::Make(),
+                                       Type::FIXED_LEN_BYTE_ARRAY, 11));
+  // Primitive too small for given precision ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("decimal", Repetition::REQUIRED,
+                                       DecimalAnnotation::Make(16, 6), Type::INT32));
+  // Incompatible primitive length ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("uuid", Repetition::REQUIRED,
+                                       UUIDAnnotation::Make(), Type::FIXED_LEN_BYTE_ARRAY,
+                                       64));
+  // Non-positive length argument for fixed length binary ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("negative_length", Repetition::REQUIRED,
+                                       NoAnnotation::Make(), Type::FIXED_LEN_BYTE_ARRAY,
+                                       -16));
+  // Non-positive length argument for fixed length binary ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make("zero_length", Repetition::REQUIRED,
+                                       NoAnnotation::Make(), Type::FIXED_LEN_BYTE_ARRAY,
+                                       0));
+  // Non-nested annotation on group node ...
+  ASSERT_ANY_THROW(
+      GroupNode::Make("list", Repetition::REPEATED, {}, JSONAnnotation::Make()));
+
+  // nullptr annotation arguments convert to NoAnnotation/LogicalType::NONE
+  std::shared_ptr<const LogicalAnnotation> empty;
+  NodePtr node;
+  ASSERT_NO_THROW(
+      node = PrimitiveNode::Make("value", Repetition::REQUIRED, empty, Type::DOUBLE));
+  ASSERT_TRUE(node->logical_annotation()->is_none());
+  ASSERT_EQ(node->logical_type(), LogicalType::NONE);
+  ASSERT_NO_THROW(node = GroupNode::Make("items", Repetition::REPEATED, {}, empty));
+  ASSERT_TRUE(node->logical_annotation()->is_none());
+  ASSERT_EQ(node->logical_type(), LogicalType::NONE);
+
+  // Invalid LogicalType in deserialized element ...
+  node = PrimitiveNode::Make("string", Repetition::REQUIRED, StringAnnotation::Make(),
+                             Type::BYTE_ARRAY);
+  ASSERT_EQ(node->logical_annotation()->type(), LogicalAnnotation::Type::STRING);
+  ASSERT_TRUE(node->logical_annotation()->is_valid());
+  ASSERT_TRUE(node->logical_annotation()->is_serialized());
+  format::SchemaElement string_intermediary;
+  node->ToParquet(&string_intermediary);
+  // ... corrupt the Thrift intermediary ....
+  string_intermediary.logicalType.__isset.STRING = false;
+  ASSERT_ANY_THROW(node = PrimitiveNode::FromParquet(&string_intermediary, 1));
+
+  // Invalid TimeUnit in deserialized TimeAnnotation ...
+  node = PrimitiveNode::Make(
+      "time", Repetition::REQUIRED,
+      TimeAnnotation::Make(true, LogicalAnnotation::TimeUnit::NANOS), Type::INT64);
+  format::SchemaElement time_intermediary;
+  node->ToParquet(&time_intermediary);
+  // ... corrupt the Thrift intermediary ....
+  time_intermediary.logicalType.TIME.unit.__isset.NANOS = false;
+  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&time_intermediary, 1));
+
+  // Invalid TimeUnit in deserialized TimestampAnnotation ...
+  node = PrimitiveNode::Make(
+      "timestamp", Repetition::REQUIRED,
+      TimestampAnnotation::Make(true, LogicalAnnotation::TimeUnit::NANOS), Type::INT64);
+  format::SchemaElement timestamp_intermediary;
+  node->ToParquet(&timestamp_intermediary);
+  // ... corrupt the Thrift intermediary ....
+  timestamp_intermediary.logicalType.TIMESTAMP.unit.__isset.NANOS = false;
+  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&timestamp_intermediary, 1));
+}
+
+struct SchemaElementConstructionArguments {
+  std::string name;
+  std::shared_ptr<const LogicalAnnotation> annotation;
+  Type::type physical_type;
+  int physical_length;
+  bool expect_converted_type;
+  LogicalType::type converted_type;
+  bool expect_logicalType;
+  std::function<bool()> check_logicalType;
+};
+
+class TestSchemaElementConstruction : public ::testing::Test {
+ public:
+  TestSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    // Make node, create serializable Thrift object from it ...
+    node_ = PrimitiveNode::Make(c.name, Repetition::REQUIRED, c.annotation,
+                                c.physical_type, c.physical_length);
+    element_.reset(new format::SchemaElement);
+    node_->ToParquet(element_.get());
+
+    // ... then set aside some values for later inspection.
+    name_ = c.name;
+    expect_converted_type_ = c.expect_converted_type;
+    converted_type_ = c.converted_type;
+    expect_logicalType_ = c.expect_logicalType;
+    check_logicalType_ = c.check_logicalType;
+    return this;
+  }
+
+  void Inspect() {
+    ASSERT_EQ(element_->name, name_);
+    if (expect_converted_type_) {
+      ASSERT_TRUE(element_->__isset.converted_type)
+          << node_->logical_annotation()->ToString()
+          << " annotation unexpectedly failed to generate a converted type in the Thrift "
+             "intermediate object";
+      ASSERT_EQ(element_->converted_type, ToThrift(converted_type_))
+          << node_->logical_annotation()->ToString()
+          << " annotation unexpectedly failed to generate correct converted type in the "
+             "Thrift intermediate object";
+    } else {
+      ASSERT_FALSE(element_->__isset.converted_type)
+          << node_->logical_annotation()->ToString()
+          << " annotation unexpectedly generated a converted type in the Thrift "
+             "intermediate object";
+    }
+    if (expect_logicalType_) {
+      ASSERT_TRUE(element_->__isset.logicalType)
+          << node_->logical_annotation()->ToString()
+          << " annotation unexpectedly failed to genverate a logicalType in the Thrift "
+             "intermediate object";
+      ASSERT_TRUE(check_logicalType_()) << node_->logical_annotation()->ToString()
+                                        << " annotation generated incorrect logicalType "
+                                           "settings in the Thrift intermediate object";
+    } else {
+      ASSERT_FALSE(element_->__isset.logicalType)
+          << node_->logical_annotation()->ToString()
+          << " annotation unexpectedly generated a logicalType in the Thrift "
+             "intermediate object";
+    }
+    return;
+  }
+
+ protected:
+  NodePtr node_;
+  std::unique_ptr<format::SchemaElement> element_;
+  std::string name_;
+  bool expect_converted_type_;
+  LogicalType::type converted_type_;  // expected converted type in Thrift object
+  bool expect_logicalType_;
+  std::function<bool()> check_logicalType_;  // specialized (by annotation type)
+                                             // logicalType check for Thrift object
+};
+
+/*
+ * The Test*SchemaElementConstruction suites confirm that the logical type
+ * and converted type members of the Thrift intermediate message object
+ * (format::SchemaElement) that is created upon serialization of an annotated
+ * schema node are correctly populated.
+ */
+
+TEST_F(TestSchemaElementConstruction, SimpleCases) {
+  auto check_nothing = []() {
+    return true;
+  };  // used for annotations that don't expect a logicalType to be set
+
+  std::vector<SchemaElementConstructionArguments> cases = {
+      {"string", LogicalAnnotation::String(), Type::BYTE_ARRAY, -1, true,
+       LogicalType::UTF8, true,
+       [this]() { return element_->logicalType.__isset.STRING; }},
+      {"enum", LogicalAnnotation::Enum(), Type::BYTE_ARRAY, -1, true, LogicalType::ENUM,
+       true, [this]() { return element_->logicalType.__isset.ENUM; }},
+      {"date", LogicalAnnotation::Date(), Type::INT32, -1, true, LogicalType::DATE, true,
+       [this]() { return element_->logicalType.__isset.DATE; }},
+      {"interval", LogicalAnnotation::Interval(), Type::FIXED_LEN_BYTE_ARRAY, 12, true,
+       LogicalType::INTERVAL, false, check_nothing},
+      {"null", LogicalAnnotation::Null(), Type::DOUBLE, -1, false, LogicalType::NA, true,
+       [this]() { return element_->logicalType.__isset.UNKNOWN; }},
+      {"json", LogicalAnnotation::JSON(), Type::BYTE_ARRAY, -1, true, LogicalType::JSON,
+       true, [this]() { return element_->logicalType.__isset.JSON; }},
+      {"bson", LogicalAnnotation::BSON(), Type::BYTE_ARRAY, -1, true, LogicalType::BSON,
+       true, [this]() { return element_->logicalType.__isset.BSON; }},
+      {"uuid", LogicalAnnotation::UUID(), Type::FIXED_LEN_BYTE_ARRAY, 16, false,
+       LogicalType::NA, true, [this]() { return element_->logicalType.__isset.UUID; }},
+      {"none", LogicalAnnotation::None(), Type::INT64, -1, false, LogicalType::NA, false,
+       check_nothing},
+      {"unknown", LogicalAnnotation::Unknown(), Type::INT64, -1, true, LogicalType::NA,
+       false, check_nothing}};
+
+  for (const SchemaElementConstructionArguments& c : cases) {
+    this->Reconstruct(c)->Inspect();
+  }
+}
+
+class TestDecimalSchemaElementConstruction : public TestSchemaElementConstruction {
+ public:
+  TestDecimalSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    TestSchemaElementConstruction::Reconstruct(c);
+    const auto& decimal_annotation =
+        checked_cast<const DecimalAnnotation&>(*c.annotation);
+    precision_ = decimal_annotation.precision();
+    scale_ = decimal_annotation.scale();
+    return this;
+  }
+
+  void Inspect() {
+    TestSchemaElementConstruction::Inspect();
+    ASSERT_EQ(element_->precision, precision_);
+    ASSERT_EQ(element_->scale, scale_);
+    ASSERT_EQ(element_->logicalType.DECIMAL.precision, precision_);
+    ASSERT_EQ(element_->logicalType.DECIMAL.scale, scale_);
+    return;
+  }
+
+ protected:
+  int32_t precision_;
+  int32_t scale_;
+};
+
+TEST_F(TestDecimalSchemaElementConstruction, DecimalCases) {
+  auto check_DECIMAL = [this]() { return element_->logicalType.__isset.DECIMAL; };
+
+  std::vector<SchemaElementConstructionArguments> cases = {
+      {"decimal", LogicalAnnotation::Decimal(16, 6), Type::INT64, -1, true,
+       LogicalType::DECIMAL, true, check_DECIMAL},
+      {"decimal", LogicalAnnotation::Decimal(1, 0), Type::INT32, -1, true,
+       LogicalType::DECIMAL, true, check_DECIMAL},
+      {"decimal", LogicalAnnotation::Decimal(10), Type::INT64, -1, true,
+       LogicalType::DECIMAL, true, check_DECIMAL},
+      {"decimal", LogicalAnnotation::Decimal(11, 11), Type::INT64, -1, true,
+       LogicalType::DECIMAL, true, check_DECIMAL},
+  };
+
+  for (const SchemaElementConstructionArguments& c : cases) {
+    this->Reconstruct(c)->Inspect();
+  }
+}
+
+class TestTemporalSchemaElementConstruction : public TestSchemaElementConstruction {
+ public:
+  template <typename T>
+  TestTemporalSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    TestSchemaElementConstruction::Reconstruct(c);
+    const auto& t = checked_cast<const T&>(*c.annotation);
+    adjusted_ = t.is_adjusted_to_utc();
+    unit_ = t.time_unit();
+    return this;
+  }
+
+  template <typename T>
+  void Inspect() {
+    FAIL() << "Invalid typename specified in test suite";
+    return;
+  }
+
+ protected:
+  bool adjusted_;
+  LogicalAnnotation::TimeUnit::unit unit_;
+};
+
+template <>
+void TestTemporalSchemaElementConstruction::Inspect<format::TimeType>() {
+  TestSchemaElementConstruction::Inspect();
+  ASSERT_EQ(element_->logicalType.TIME.isAdjustedToUTC, adjusted_);
+  switch (unit_) {
+    case LogicalAnnotation::TimeUnit::MILLIS:
+      ASSERT_TRUE(element_->logicalType.TIME.unit.__isset.MILLIS);
+      break;
+    case LogicalAnnotation::TimeUnit::MICROS:
+      ASSERT_TRUE(element_->logicalType.TIME.unit.__isset.MICROS);
+      break;
+    case LogicalAnnotation::TimeUnit::NANOS:
+      ASSERT_TRUE(element_->logicalType.TIME.unit.__isset.NANOS);
+      break;
+    case LogicalAnnotation::TimeUnit::UNKNOWN:
+    default:
+      FAIL() << "Invalid time unit in test case";
+  }
+  return;
+}
+
+template <>
+void TestTemporalSchemaElementConstruction::Inspect<format::TimestampType>() {
+  TestSchemaElementConstruction::Inspect();
+  ASSERT_EQ(element_->logicalType.TIMESTAMP.isAdjustedToUTC, adjusted_);
+  switch (unit_) {
+    case LogicalAnnotation::TimeUnit::MILLIS:
+      ASSERT_TRUE(element_->logicalType.TIMESTAMP.unit.__isset.MILLIS);
+      break;
+    case LogicalAnnotation::TimeUnit::MICROS:
+      ASSERT_TRUE(element_->logicalType.TIMESTAMP.unit.__isset.MICROS);
+      break;
+    case LogicalAnnotation::TimeUnit::NANOS:
+      ASSERT_TRUE(element_->logicalType.TIMESTAMP.unit.__isset.NANOS);
+      break;
+    case LogicalAnnotation::TimeUnit::UNKNOWN:
+    default:
+      FAIL() << "Invalid time unit in test case";
+  }
+  return;
+}
+
+TEST_F(TestTemporalSchemaElementConstruction, TemporalCases) {
+  auto check_TIME = [this]() { return element_->logicalType.__isset.TIME; };
+
+  std::vector<SchemaElementConstructionArguments> time_cases = {
+      {"time_T_ms", LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT32, -1, true, LogicalType::TIME_MILLIS, true, check_TIME},
+      {"time_F_ms", LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT32, -1, false, LogicalType::NA, true, check_TIME},
+      {"time_T_us", LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64, -1, true, LogicalType::TIME_MICROS, true, check_TIME},
+      {"time_F_us", LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIME},
+      {"time_T_ns", LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIME},
+      {"time_F_ns", LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIME},
+  };
+
+  for (const SchemaElementConstructionArguments& c : time_cases) {
+    this->Reconstruct<TimeAnnotation>(c)->Inspect<format::TimeType>();
+  }
+
+  auto check_TIMESTAMP = [this]() { return element_->logicalType.__isset.TIMESTAMP; };
+
+  std::vector<SchemaElementConstructionArguments> timestamp_cases = {
+      {"timestamp_T_ms",
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT64, -1, true, LogicalType::TIMESTAMP_MILLIS, true, check_TIMESTAMP},
+      {"timestamp_F_ms",
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIMESTAMP},
+      {"timestamp_T_us",
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64, -1, true, LogicalType::TIMESTAMP_MICROS, true, check_TIMESTAMP},
+      {"timestamp_F_us",
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIMESTAMP},
+      {"timestamp_T_ns",
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIMESTAMP},
+      {"timestamp_F_ns",
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64, -1, false, LogicalType::NA, true, check_TIMESTAMP},
+  };
+
+  for (const SchemaElementConstructionArguments& c : timestamp_cases) {
+    this->Reconstruct<TimestampAnnotation>(c)->Inspect<format::TimestampType>();
+  }
+}
+
+class TestIntegerSchemaElementConstruction : public TestSchemaElementConstruction {
+ public:
+  TestIntegerSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    TestSchemaElementConstruction::Reconstruct(c);
+    const auto& int_annotation = checked_cast<const IntAnnotation&>(*c.annotation);
+    width_ = int_annotation.bit_width();
+    signed_ = int_annotation.is_signed();
+    return this;
+  }
+
+  void Inspect() {
+    TestSchemaElementConstruction::Inspect();
+    ASSERT_EQ(element_->logicalType.INTEGER.bitWidth, width_);
+    ASSERT_EQ(element_->logicalType.INTEGER.isSigned, signed_);
+    return;
+  }
+
+ protected:
+  int width_;
+  bool signed_;
+};
+
+TEST_F(TestIntegerSchemaElementConstruction, IntegerCases) {
+  auto check_INTEGER = [this]() { return element_->logicalType.__isset.INTEGER; };
+
+  std::vector<SchemaElementConstructionArguments> cases = {
+      {"uint8", LogicalAnnotation::Int(8, false), Type::INT32, -1, true,
+       LogicalType::UINT_8, true, check_INTEGER},
+      {"uint16", LogicalAnnotation::Int(16, false), Type::INT32, -1, true,
+       LogicalType::UINT_16, true, check_INTEGER},
+      {"uint32", LogicalAnnotation::Int(32, false), Type::INT32, -1, true,
+       LogicalType::UINT_32, true, check_INTEGER},
+      {"uint64", LogicalAnnotation::Int(64, false), Type::INT64, -1, true,
+       LogicalType::UINT_64, true, check_INTEGER},
+      {"int8", LogicalAnnotation::Int(8, true), Type::INT32, -1, true, LogicalType::INT_8,
+       true, check_INTEGER},
+      {"int16", LogicalAnnotation::Int(16, true), Type::INT32, -1, true,
+       LogicalType::INT_16, true, check_INTEGER},
+      {"int32", LogicalAnnotation::Int(32, true), Type::INT32, -1, true,
+       LogicalType::INT_32, true, check_INTEGER},
+      {"int64", LogicalAnnotation::Int(64, true), Type::INT64, -1, true,
+       LogicalType::INT_64, true, check_INTEGER},
+  };
+
+  for (const SchemaElementConstructionArguments& c : cases) {
+    this->Reconstruct(c)->Inspect();
+  }
+}
+
+TEST(TestLogicalAnnotationSerialization, SchemaElementNestedCases) {
+  // Confirm that the intermediate Thrift objects created during node serialization
+  // contain correct ConvertedType and LogicalType information
+
+  NodePtr string_node = PrimitiveNode::Make("string", Repetition::REQUIRED,
+                                            StringAnnotation::Make(), Type::BYTE_ARRAY);
+  NodePtr date_node = PrimitiveNode::Make("date", Repetition::REQUIRED,
+                                          DateAnnotation::Make(), Type::INT32);
+  NodePtr json_node = PrimitiveNode::Make("json", Repetition::REQUIRED,
+                                          JSONAnnotation::Make(), Type::BYTE_ARRAY);
+  NodePtr uuid_node =
+      PrimitiveNode::Make("uuid", Repetition::REQUIRED, UUIDAnnotation::Make(),
+                          Type::FIXED_LEN_BYTE_ARRAY, 16);
+  NodePtr timestamp_node = PrimitiveNode::Make(
+      "timestamp", Repetition::REQUIRED,
+      TimestampAnnotation::Make(false, LogicalAnnotation::TimeUnit::NANOS), Type::INT64);
+  NodePtr int_node = PrimitiveNode::Make("int", Repetition::REQUIRED,
+                                         IntAnnotation::Make(64, false), Type::INT64);
+  NodePtr decimal_node = PrimitiveNode::Make("decimal", Repetition::REQUIRED,
+                                             DecimalAnnotation::Make(16, 6), Type::INT64);
+
+  NodePtr list_node = GroupNode::Make("list", Repetition::REPEATED,
+                                      {string_node, date_node, json_node, uuid_node,
+                                       timestamp_node, int_node, decimal_node},
+                                      ListAnnotation::Make());
+  std::vector<format::SchemaElement> list_elements;
+  ToParquet(reinterpret_cast<GroupNode*>(list_node.get()), &list_elements);
+  ASSERT_EQ(list_elements[0].name, "list");
+  ASSERT_TRUE(list_elements[0].__isset.converted_type);
+  ASSERT_TRUE(list_elements[0].__isset.logicalType);
+  ASSERT_EQ(list_elements[0].converted_type, ToThrift(LogicalType::LIST));
+  ASSERT_TRUE(list_elements[0].logicalType.__isset.LIST);
+  ASSERT_TRUE(list_elements[1].logicalType.__isset.STRING);
+  ASSERT_TRUE(list_elements[2].logicalType.__isset.DATE);
+  ASSERT_TRUE(list_elements[3].logicalType.__isset.JSON);
+  ASSERT_TRUE(list_elements[4].logicalType.__isset.UUID);
+  ASSERT_TRUE(list_elements[5].logicalType.__isset.TIMESTAMP);
+  ASSERT_TRUE(list_elements[6].logicalType.__isset.INTEGER);
+  ASSERT_TRUE(list_elements[7].logicalType.__isset.DECIMAL);
+
+  NodePtr map_node =
+      GroupNode::Make("map", Repetition::REQUIRED, {}, MapAnnotation::Make());
+  std::vector<format::SchemaElement> map_elements;
+  ToParquet(reinterpret_cast<GroupNode*>(map_node.get()), &map_elements);
+  ASSERT_EQ(map_elements[0].name, "map");
+  ASSERT_TRUE(map_elements[0].__isset.converted_type);
+  ASSERT_TRUE(map_elements[0].__isset.logicalType);
+  ASSERT_EQ(map_elements[0].converted_type, ToThrift(LogicalType::MAP));
+  ASSERT_TRUE(map_elements[0].logicalType.__isset.MAP);
+}
+
+static void ConfirmPrimitiveNodeRoundtrip(
+    const std::shared_ptr<const LogicalAnnotation>& annotation, Type::type physical_type,
+    int physical_length) {
+  std::shared_ptr<Node> original = PrimitiveNode::Make(
+      "something", Repetition::REQUIRED, annotation, physical_type, physical_length);
+  format::SchemaElement intermediary;
+  original->ToParquet(&intermediary);
+  std::unique_ptr<Node> recovered = PrimitiveNode::FromParquet(&intermediary, 1);
+  ASSERT_TRUE(original->Equals(recovered.get()))
+      << "Recovered primitive node unexpectedly not equivalent to original primitive "
+         "node constructed with logical annotation "
+      << annotation->ToString();
+  return;
+}
+
+static void ConfirmGroupNodeRoundtrip(
+    std::string name, const std::shared_ptr<const LogicalAnnotation>& annotation) {
+  NodeVector node_vector;
+  std::shared_ptr<Node> original =
+      GroupNode::Make(name, Repetition::REQUIRED, node_vector, annotation);
+  std::vector<format::SchemaElement> elements;
+  ToParquet(reinterpret_cast<GroupNode*>(original.get()), &elements);
+  std::unique_ptr<Node> recovered =
+      GroupNode::FromParquet(&(elements[0]), 1, node_vector);
+  ASSERT_TRUE(original->Equals(recovered.get()))
+      << "Recovered group node unexpectedly not equivalent to original group node "
+         "constructed with logical annotation "
+      << annotation->ToString();
+  return;
+}
+
+TEST(TestLogicalAnnotationSerialization, Roundtrips) {
+  // Confirm that Thrift serialization-deserialization of nodes with logical
+  // annotations produces equivalent reconstituted nodes
+
+  // Primitive nodes ...
+  struct AnnotatedPrimitiveNodeFactoryArguments {
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    Type::type physical_type;
+    int physical_length;
+  };
+
+  std::vector<AnnotatedPrimitiveNodeFactoryArguments> cases = {
+      {LogicalAnnotation::String(), Type::BYTE_ARRAY, -1},
+      {LogicalAnnotation::Enum(), Type::BYTE_ARRAY, -1},
+      {LogicalAnnotation::Decimal(16, 6), Type::INT64, -1},
+      {LogicalAnnotation::Date(), Type::INT32, -1},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS), Type::INT32,
+       -1},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS), Type::INT64,
+       -1},
+      {LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS), Type::INT64,
+       -1},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS), Type::INT32,
+       -1},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS), Type::INT64,
+       -1},
+      {LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS), Type::INT64,
+       -1},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT64, -1},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64, -1},
+      {LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64, -1},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       Type::INT64, -1},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       Type::INT64, -1},
+      {LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       Type::INT64, -1},
+      {LogicalAnnotation::Interval(), Type::FIXED_LEN_BYTE_ARRAY, 12},
+      {LogicalAnnotation::Int(8, false), Type::INT32, -1},
+      {LogicalAnnotation::Int(16, false), Type::INT32, -1},
+      {LogicalAnnotation::Int(32, false), Type::INT32, -1},
+      {LogicalAnnotation::Int(64, false), Type::INT64, -1},
+      {LogicalAnnotation::Int(8, true), Type::INT32, -1},
+      {LogicalAnnotation::Int(16, true), Type::INT32, -1},
+      {LogicalAnnotation::Int(32, true), Type::INT32, -1},
+      {LogicalAnnotation::Int(64, true), Type::INT64, -1},
+      {LogicalAnnotation::Null(), Type::BOOLEAN, -1},
+      {LogicalAnnotation::JSON(), Type::BYTE_ARRAY, -1},
+      {LogicalAnnotation::BSON(), Type::BYTE_ARRAY, -1},
+      {LogicalAnnotation::UUID(), Type::FIXED_LEN_BYTE_ARRAY, 16},
+      {LogicalAnnotation::None(), Type::BOOLEAN, -1}};
+
+  for (const AnnotatedPrimitiveNodeFactoryArguments& c : cases) {
+    ConfirmPrimitiveNodeRoundtrip(c.annotation, c.physical_type, c.physical_length);
+  }
+
+  // Group nodes ...
+  ConfirmGroupNodeRoundtrip("map", LogicalAnnotation::Map());
+  ConfirmGroupNodeRoundtrip("list", LogicalAnnotation::List());
+}
+
 }  // namespace schema
+
 }  // namespace parquet

--- a/cpp/src/parquet/schema-test.cc
+++ b/cpp/src/parquet/schema-test.cc
@@ -591,6 +591,7 @@ TEST(TestColumnDescriptor, TestAttrs) {
   path: 
   physical_type: BYTE_ARRAY
   logical_type: UTF8
+  logical_annotation: String
   max_definition_level: 4
   max_repetition_level: 1
 })",
@@ -610,6 +611,7 @@ TEST(TestColumnDescriptor, TestAttrs) {
   path: 
   physical_type: FIXED_LEN_BYTE_ARRAY
   logical_type: DECIMAL
+  logical_annotation: Decimal(precision=10, scale=4)
   max_definition_level: 4
   max_repetition_level: 1
   length: 12

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -95,7 +95,8 @@ const std::shared_ptr<ColumnPath> Node::path() const {
 
 bool Node::EqualsInternal(const Node* other) const {
   return type_ == other->type_ && name_ == other->name_ &&
-         repetition_ == other->repetition_ && logical_type_ == other->logical_type_;
+         repetition_ == other->repetition_ && logical_type_ == other->logical_type_ &&
+         logical_annotation_->Equals(*(other->logical_annotation()));
 }
 
 void Node::SetParent(const Node* parent) { parent_ = parent; }
@@ -200,6 +201,12 @@ PrimitiveNode::PrimitiveNode(const std::string& name, Repetition::type repetitio
       ss << " can not be applied to a primitive type";
       throw ParquetException(ss.str());
   }
+  // For forward compatibility, create an equivalent logical annotation
+  logical_annotation_ =
+      LogicalAnnotation::FromConvertedType(logical_type_, decimal_metadata_);
+  DCHECK(logical_annotation_ && !logical_annotation_->is_nested() &&
+         logical_annotation_->is_compatible(logical_type_, decimal_metadata_));
+
   if (type == Type::FIXED_LEN_BYTE_ARRAY) {
     if (length <= 0) {
       ss << "Invalid FIXED_LEN_BYTE_ARRAY length: " << length;
@@ -209,10 +216,51 @@ PrimitiveNode::PrimitiveNode(const std::string& name, Repetition::type repetitio
   }
 }
 
+PrimitiveNode::PrimitiveNode(const std::string& name, Repetition::type repetition,
+                             std::shared_ptr<const LogicalAnnotation> logical_annotation,
+                             Type::type physical_type, int physical_length, int id)
+    : Node(Node::PRIMITIVE, name, repetition, logical_annotation, id),
+      physical_type_(physical_type),
+      type_length_(physical_length) {
+  std::stringstream error;
+  if (logical_annotation_) {
+    // Check for annotation type <=> node type consistency
+    if (!logical_annotation_->is_nested()) {
+      // Check for annotation type <=> physical type consistency
+      if (logical_annotation_->is_applicable(physical_type, physical_length)) {
+        // For backward compatibility, assign equivalent legacy
+        // converted type (if possible)
+        logical_type_ = logical_annotation_->ToConvertedType(&decimal_metadata_);
+      } else {
+        error << logical_annotation_->ToString();
+        error << " can not be applied to primitive type ";
+        error << TypeToString(physical_type);
+        throw ParquetException(error.str());
+      }
+    } else {
+      error << "Nested annotation type ";
+      error << logical_annotation_->ToString();
+      error << " can not be applied to non-group node";
+      throw ParquetException(error.str());
+    }
+  } else {
+    logical_annotation_ = NoAnnotation::Make();
+    logical_type_ = logical_annotation_->ToConvertedType(&decimal_metadata_);
+  }
+  DCHECK(logical_annotation_ && !logical_annotation_->is_nested() &&
+         logical_annotation_->is_compatible(logical_type_, decimal_metadata_));
+
+  if (physical_type == Type::FIXED_LEN_BYTE_ARRAY) {
+    if (physical_length <= 0) {
+      error << "Invalid FIXED_LEN_BYTE_ARRAY length: " << physical_length;
+      throw ParquetException(error.str());
+    }
+  }
+}
+
 bool PrimitiveNode::EqualsInternal(const PrimitiveNode* other) const {
   bool is_equal = true;
-  if ((physical_type_ != other->physical_type_) ||
-      (logical_type_ != other->logical_type_)) {
+  if (physical_type_ != other->physical_type_) {
     return false;
   }
   if (logical_type_ == LogicalType::DECIMAL) {
@@ -240,6 +288,55 @@ void PrimitiveNode::VisitConst(Node::ConstVisitor* visitor) const {
 
 // ----------------------------------------------------------------------
 // Group node
+
+GroupNode::GroupNode(const std::string& name, Repetition::type repetition,
+                     const NodeVector& fields, LogicalType::type logical_type, int id)
+    : Node(Node::GROUP, name, repetition, logical_type, id), fields_(fields) {
+  // For forward compatibility, create an equivalent logical annotation
+  logical_annotation_ = LogicalAnnotation::FromConvertedType(logical_type_);
+  DCHECK(logical_annotation_ &&
+         (logical_annotation_->is_nested() || logical_annotation_->is_none()) &&
+         logical_annotation_->is_compatible(logical_type_));
+
+  field_name_to_idx_.clear();
+  auto field_idx = 0;
+  for (NodePtr& field : fields_) {
+    field->SetParent(this);
+    field_name_to_idx_.emplace(field->name(), field_idx++);
+  }
+}
+
+GroupNode::GroupNode(const std::string& name, Repetition::type repetition,
+                     const NodeVector& fields,
+                     std::shared_ptr<const LogicalAnnotation> logical_annotation, int id)
+    : Node(Node::GROUP, name, repetition, logical_annotation, id), fields_(fields) {
+  if (logical_annotation_) {
+    // Check for annotation type <=> node type consistency
+    if (logical_annotation_->is_nested()) {
+      // For backward compatibility, assign equivalent legacy converted type (if possible)
+      logical_type_ = logical_annotation_->ToConvertedType(nullptr);
+    } else {
+      std::stringstream error;
+      error << "Annotation type ";
+      error << logical_annotation_->ToString();
+      error << " can not be applied to group node";
+      throw ParquetException(error.str());
+    }
+  } else {
+    logical_annotation_ = NoAnnotation::Make();
+    logical_type_ = logical_annotation_->ToConvertedType(nullptr);
+  }
+  DCHECK(logical_annotation_ &&
+         (logical_annotation_->is_nested() || logical_annotation_->is_none()) &&
+         logical_annotation_->is_compatible(logical_type_));
+
+  field_name_to_idx_.clear();
+  auto field_idx = 0;
+  for (NodePtr& field : fields_) {
+    field->SetParent(this);
+    field_name_to_idx_.emplace(field->name(), field_idx++);
+  }
+}
 
 bool GroupNode::EqualsInternal(const GroupNode* other) const {
   if (this == other) {
@@ -290,48 +387,55 @@ void GroupNode::VisitConst(Node::ConstVisitor* visitor) const { visitor->Visit(t
 // ----------------------------------------------------------------------
 // Node construction from Parquet metadata
 
-struct NodeParams {
-  explicit NodeParams(const std::string& name) : name(name) {}
-
-  const std::string& name;
-  Repetition::type repetition;
-  LogicalType::type logical_type;
-};
-
-static inline NodeParams GetNodeParams(const format::SchemaElement* element) {
-  NodeParams params(element->name);
-
-  params.repetition = FromThrift(element->repetition_type);
-  if (element->__isset.converted_type) {
-    params.logical_type = FromThrift(element->converted_type);
-  } else {
-    params.logical_type = LogicalType::NONE;
-  }
-  return params;
-}
-
 std::unique_ptr<Node> GroupNode::FromParquet(const void* opaque_element, int node_id,
                                              const NodeVector& fields) {
   const format::SchemaElement* element =
       static_cast<const format::SchemaElement*>(opaque_element);
-  NodeParams params = GetNodeParams(element);
-  return std::unique_ptr<Node>(new GroupNode(params.name, params.repetition, fields,
-                                             params.logical_type, node_id));
+
+  std::unique_ptr<GroupNode> group_node;
+  if (element->__isset.logicalType) {
+    // updated writer with logical type present
+    group_node = std::unique_ptr<GroupNode>(
+        new GroupNode(element->name, FromThrift(element->repetition_type), fields,
+                      LogicalAnnotation::FromThrift(element->logicalType), node_id));
+  } else {
+    group_node = std::unique_ptr<GroupNode>(new GroupNode(
+        element->name, FromThrift(element->repetition_type), fields,
+        (element->__isset.converted_type ? FromThrift(element->converted_type)
+                                         : LogicalType::NONE),
+        node_id));
+  }
+
+  return std::unique_ptr<Node>(group_node.release());
 }
 
 std::unique_ptr<Node> PrimitiveNode::FromParquet(const void* opaque_element,
                                                  int node_id) {
   const format::SchemaElement* element =
       static_cast<const format::SchemaElement*>(opaque_element);
-  NodeParams params = GetNodeParams(element);
 
-  std::unique_ptr<PrimitiveNode> result =
-      std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
-          params.name, params.repetition, FromThrift(element->type), params.logical_type,
-          element->type_length, element->precision, element->scale, node_id));
+  std::unique_ptr<PrimitiveNode> primitive_node;
+  if (element->__isset.logicalType) {
+    // updated writer with logical type present
+    primitive_node = std::unique_ptr<PrimitiveNode>(
+        new PrimitiveNode(element->name, FromThrift(element->repetition_type),
+                          LogicalAnnotation::FromThrift(element->logicalType),
+                          FromThrift(element->type), element->type_length, node_id));
+  } else if (element->__isset.converted_type) {
+    // legacy writer with logical type present
+    primitive_node = std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
+        element->name, FromThrift(element->repetition_type), FromThrift(element->type),
+        FromThrift(element->converted_type), element->type_length, element->precision,
+        element->scale, node_id));
+  } else {
+    // logical type not present
+    primitive_node = std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
+        element->name, FromThrift(element->repetition_type), NoAnnotation::Make(),
+        FromThrift(element->type), element->type_length, node_id));
+  }
 
   // Return as unique_ptr to the base type
-  return std::unique_ptr<Node>(result.release());
+  return std::unique_ptr<Node>(primitive_node.release());
 }
 
 void GroupNode::ToParquet(void* opaque_element) const {
@@ -342,15 +446,24 @@ void GroupNode::ToParquet(void* opaque_element) const {
   if (logical_type_ != LogicalType::NONE) {
     element->__set_converted_type(ToThrift(logical_type_));
   }
+  if (logical_annotation_ && logical_annotation_->is_serialized()) {
+    element->__set_logicalType(logical_annotation_->ToThrift());
+  }
+  return;
 }
 
 void PrimitiveNode::ToParquet(void* opaque_element) const {
   format::SchemaElement* element = static_cast<format::SchemaElement*>(opaque_element);
-
   element->__set_name(name_);
   element->__set_repetition_type(ToThrift(repetition_));
   if (logical_type_ != LogicalType::NONE) {
     element->__set_converted_type(ToThrift(logical_type_));
+  }
+  if (logical_annotation_ && logical_annotation_->is_serialized() &&
+      // TODO(tpboudreau): remove the following conjunct to enable serialization
+      // of IntervalTypes after parquet.thrift recognizes them
+      !logical_annotation_->is_interval()) {
+    element->__set_logicalType(logical_annotation_->ToThrift());
   }
   element->__set_type(ToThrift(physical_type_));
   if (physical_type_ == Type::FIXED_LEN_BYTE_ARRAY) {
@@ -360,6 +473,7 @@ void PrimitiveNode::ToParquet(void* opaque_element) const {
     element->__set_precision(decimal_metadata_.precision);
     element->__set_scale(decimal_metadata_.scale);
   }
+  return;
 }
 
 // ----------------------------------------------------------------------
@@ -531,7 +645,10 @@ static void PrintType(const PrimitiveNode* node, std::ostream& stream) {
 
 static void PrintLogicalType(const PrimitiveNode* node, std::ostream& stream) {
   auto lt = node->logical_type();
-  if (lt == LogicalType::DECIMAL) {
+  auto la = node->logical_annotation();
+  if (la && la->is_valid() && !la->is_none()) {
+    stream << " (" << la->ToString() << ")";
+  } else if (lt == LogicalType::DECIMAL) {
     stream << " (" << LogicalTypeToString(lt) << "(" << node->decimal_metadata().precision
            << "," << node->decimal_metadata().scale << "))";
   } else if (lt != LogicalType::NONE) {
@@ -555,7 +672,10 @@ void SchemaPrinter::Visit(const GroupNode* node) {
     PrintRepLevel(node->repetition(), stream_);
     stream_ << " group " << node->name();
     auto lt = node->logical_type();
-    if (lt != LogicalType::NONE) {
+    auto la = node->logical_annotation();
+    if (la && la->is_valid() && !la->is_none()) {
+      stream_ << " (" << la->ToString() << ")";
+    } else if (lt != LogicalType::NONE) {
       stream_ << " (" << LogicalTypeToString(lt) << ")";
     }
     stream_ << " {" << std::endl;

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -871,6 +871,7 @@ std::string ColumnDescriptor::ToString() const {
      << "  path: " << path()->ToDotString() << std::endl
      << "  physical_type: " << TypeToString(physical_type()) << std::endl
      << "  logical_type: " << LogicalTypeToString(logical_type()) << std::endl
+     << "  logical_annotation: " << logical_annotation()->ToString() << std::endl
      << "  max_definition_level: " << max_definition_level() << std::endl
      << "  max_repetition_level: " << max_repetition_level() << std::endl;
 

--- a/cpp/src/parquet/types-test.cc
+++ b/cpp/src/parquet/types-test.cc
@@ -37,6 +37,7 @@ TEST(TestTypeToString, PhysicalTypes) {
 TEST(TestLogicalTypeToString, LogicalTypes) {
   ASSERT_STREQ("NONE", LogicalTypeToString(LogicalType::NONE).c_str());
   ASSERT_STREQ("UTF8", LogicalTypeToString(LogicalType::UTF8).c_str());
+  ASSERT_STREQ("MAP", LogicalTypeToString(LogicalType::MAP).c_str());
   ASSERT_STREQ("MAP_KEY_VALUE", LogicalTypeToString(LogicalType::MAP_KEY_VALUE).c_str());
   ASSERT_STREQ("LIST", LogicalTypeToString(LogicalType::LIST).c_str());
   ASSERT_STREQ("ENUM", LogicalTypeToString(LogicalType::ENUM).c_str());

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -553,10 +553,6 @@ class LogicalAnnotation::Impl {
   Impl& operator=(const Impl&) = delete;
   virtual ~Impl() noexcept {}
 
- protected:
-  Impl(LogicalAnnotation::Type::type t, SortOrder::type o) : type_(t), order_(o) {}
-  Impl() = default;
-
   class Compatible;
   class SimpleCompatible;
   class Incompatible;
@@ -583,6 +579,10 @@ class LogicalAnnotation::Impl {
   class UUID;
   class No;
   class Unknown;
+
+ protected:
+  Impl(LogicalAnnotation::Type::type t, SortOrder::type o) : type_(t), order_(o) {}
+  Impl() = default;
 
  private:
   LogicalAnnotation::Type::type type_ = LogicalAnnotation::Type::UNKNOWN;

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -15,12 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iomanip>
+#include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
+
+#include "parquet/exception.h"
+#include "parquet/parquet_types.h"
 #include "parquet/types.h"
+
+using ::arrow::internal::checked_cast;
 
 namespace parquet {
 
@@ -169,6 +180,8 @@ std::string LogicalTypeToString(LogicalType::type t) {
       return "NONE";
     case LogicalType::UTF8:
       return "UTF8";
+    case LogicalType::MAP:
+      return "MAP";
     case LogicalType::MAP_KEY_VALUE:
       return "MAP_KEY_VALUE";
     case LogicalType::LIST:
@@ -291,7 +304,1290 @@ SortOrder::type GetSortOrder(LogicalType::type converted, Type::type primitive) 
   return SortOrder::UNKNOWN;
 }
 
+SortOrder::type GetSortOrder(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                             Type::type primitive) {
+  SortOrder::type o = SortOrder::UNKNOWN;
+  if (annotation && annotation->is_valid()) {
+    o = (annotation->is_none() ? DefaultSortOrder(primitive) : annotation->sort_order());
+  }
+  return o;
+}
+
 ColumnOrder ColumnOrder::undefined_ = ColumnOrder(ColumnOrder::UNDEFINED);
 ColumnOrder ColumnOrder::type_defined_ = ColumnOrder(ColumnOrder::TYPE_DEFINED_ORDER);
+
+// Static methods for LogicalAnnotation class
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::FromConvertedType(
+    const LogicalType::type converted_type,
+    const schema::DecimalMetadata converted_decimal_metadata) {
+  switch (converted_type) {
+    case LogicalType::UTF8:
+      return StringAnnotation::Make();
+    case LogicalType::MAP_KEY_VALUE:
+    case LogicalType::MAP:
+      return MapAnnotation::Make();
+    case LogicalType::LIST:
+      return ListAnnotation::Make();
+    case LogicalType::ENUM:
+      return EnumAnnotation::Make();
+    case LogicalType::DECIMAL:
+      return DecimalAnnotation::Make(converted_decimal_metadata.precision,
+                                     converted_decimal_metadata.scale);
+    case LogicalType::DATE:
+      return DateAnnotation::Make();
+    case LogicalType::TIME_MILLIS:
+      return TimeAnnotation::Make(true, LogicalAnnotation::TimeUnit::MILLIS);
+    case LogicalType::TIME_MICROS:
+      return TimeAnnotation::Make(true, LogicalAnnotation::TimeUnit::MICROS);
+    case LogicalType::TIMESTAMP_MILLIS:
+      return TimestampAnnotation::Make(true, LogicalAnnotation::TimeUnit::MILLIS);
+    case LogicalType::TIMESTAMP_MICROS:
+      return TimestampAnnotation::Make(true, LogicalAnnotation::TimeUnit::MICROS);
+    case LogicalType::INTERVAL:
+      return IntervalAnnotation::Make();
+    case LogicalType::INT_8:
+      return IntAnnotation::Make(8, true);
+    case LogicalType::INT_16:
+      return IntAnnotation::Make(16, true);
+    case LogicalType::INT_32:
+      return IntAnnotation::Make(32, true);
+    case LogicalType::INT_64:
+      return IntAnnotation::Make(64, true);
+    case LogicalType::UINT_8:
+      return IntAnnotation::Make(8, false);
+    case LogicalType::UINT_16:
+      return IntAnnotation::Make(16, false);
+    case LogicalType::UINT_32:
+      return IntAnnotation::Make(32, false);
+    case LogicalType::UINT_64:
+      return IntAnnotation::Make(64, false);
+    case LogicalType::JSON:
+      return JSONAnnotation::Make();
+    case LogicalType::BSON:
+      return BSONAnnotation::Make();
+    case LogicalType::NONE:
+      return NoAnnotation::Make();
+    case LogicalType::NA:
+      return UnknownAnnotation::Make();
+  }
+  return UnknownAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::FromThrift(
+    const format::LogicalType& type) {
+  if (type.__isset.STRING) {
+    return StringAnnotation::Make();
+  } else if (type.__isset.MAP) {
+    return MapAnnotation::Make();
+  } else if (type.__isset.LIST) {
+    return ListAnnotation::Make();
+  } else if (type.__isset.ENUM) {
+    return EnumAnnotation::Make();
+  } else if (type.__isset.DECIMAL) {
+    return DecimalAnnotation::Make(type.DECIMAL.precision, type.DECIMAL.scale);
+  } else if (type.__isset.DATE) {
+    return DateAnnotation::Make();
+  } else if (type.__isset.TIME) {
+    LogicalAnnotation::TimeUnit::unit unit;
+    if (type.TIME.unit.__isset.MILLIS) {
+      unit = LogicalAnnotation::TimeUnit::MILLIS;
+    } else if (type.TIME.unit.__isset.MICROS) {
+      unit = LogicalAnnotation::TimeUnit::MICROS;
+    } else if (type.TIME.unit.__isset.NANOS) {
+      unit = LogicalAnnotation::TimeUnit::NANOS;
+    } else {
+      unit = LogicalAnnotation::TimeUnit::UNKNOWN;
+    }
+    return TimeAnnotation::Make(type.TIME.isAdjustedToUTC, unit);
+  } else if (type.__isset.TIMESTAMP) {
+    LogicalAnnotation::TimeUnit::unit unit;
+    if (type.TIMESTAMP.unit.__isset.MILLIS) {
+      unit = LogicalAnnotation::TimeUnit::MILLIS;
+    } else if (type.TIMESTAMP.unit.__isset.MICROS) {
+      unit = LogicalAnnotation::TimeUnit::MICROS;
+    } else if (type.TIMESTAMP.unit.__isset.NANOS) {
+      unit = LogicalAnnotation::TimeUnit::NANOS;
+    } else {
+      unit = LogicalAnnotation::TimeUnit::UNKNOWN;
+    }
+    return TimestampAnnotation::Make(type.TIMESTAMP.isAdjustedToUTC, unit);
+    // TODO(tpboudreau): activate the commented code after parquet.thrift
+    // recognizes IntervalType as a LogicalType
+    //} else if (type.__isset.INTERVAL) {
+    //  return IntervalAnnotation::Make();
+  } else if (type.__isset.INTEGER) {
+    return IntAnnotation::Make(static_cast<int>(type.INTEGER.bitWidth),
+                               type.INTEGER.isSigned);
+  } else if (type.__isset.UNKNOWN) {
+    return NullAnnotation::Make();
+  } else if (type.__isset.JSON) {
+    return JSONAnnotation::Make();
+  } else if (type.__isset.BSON) {
+    return BSONAnnotation::Make();
+  } else if (type.__isset.UUID) {
+    return UUIDAnnotation::Make();
+  } else {
+    throw ParquetException("Metadata contains Thrift LogicalType that is not recognized");
+  }
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::String() {
+  return StringAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Map() {
+  return MapAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::List() {
+  return ListAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Enum() {
+  return EnumAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Decimal(int32_t precision,
+                                                                    int32_t scale) {
+  return DecimalAnnotation::Make(precision, scale);
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Date() {
+  return DateAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Time(
+    bool is_adjusted_to_utc, LogicalAnnotation::TimeUnit::unit time_unit) {
+  return TimeAnnotation::Make(is_adjusted_to_utc, time_unit);
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Timestamp(
+    bool is_adjusted_to_utc, LogicalAnnotation::TimeUnit::unit time_unit) {
+  return TimestampAnnotation::Make(is_adjusted_to_utc, time_unit);
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Interval() {
+  return IntervalAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Int(int bit_width,
+                                                                bool is_signed) {
+  return IntAnnotation::Make(bit_width, is_signed);
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Null() {
+  return NullAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::JSON() {
+  return JSONAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::BSON() {
+  return BSONAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::UUID() {
+  return UUIDAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::None() {
+  return NoAnnotation::Make();
+}
+
+std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Unknown() {
+  return UnknownAnnotation::Make();
+}
+
+/*
+ * The annotation implementation classes are built in four layers: (1) the base
+ * layer, which establishes the interface and provides generally reusable implementations
+ * for the ToJSON() and Equals() methods; (2) an intermediate derived layer for the
+ * "compatibility" methods, which provides implementations for is_compatible() and
+ * ToConvertedType(); (3) another intermediate layer for the "applicability" methods
+ * that provides several implementations for the is_applicable() method; and (4) the
+ * final derived classes, one for each annotation type, which supply implementations
+ * for those methods that remain virtual (usually just ToString() and ToThrift()) or
+ * otherwise need to be overridden.
+ */
+
+// LogicalAnnotationImpl base class
+
+class LogicalAnnotation::Impl {
+ public:
+  virtual bool is_applicable(parquet::Type::type primitive_type,
+                             int32_t primitive_length = -1) const = 0;
+
+  virtual bool is_compatible(LogicalType::type converted_type,
+                             schema::DecimalMetadata converted_decimal_metadata = {
+                                 false, -1, -1}) const = 0;
+
+  virtual LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const = 0;
+
+  virtual std::string ToString() const = 0;
+
+  virtual std::string ToJSON() const {
+    std::stringstream json;
+    json << R"({"Type": ")" << ToString() << R"("})";
+    return json.str();
+  }
+
+  virtual format::LogicalType ToThrift() const {
+    // annotation types inheriting this method should never be serialized
+    std::stringstream ss;
+    ss << "Annotation type " << ToString() << " should not be serialized";
+    throw ParquetException(ss.str());
+  }
+
+  virtual bool Equals(const LogicalAnnotation& other) const {
+    return other.type() == type_;
+  }
+
+  LogicalAnnotation::Type::type type() const { return type_; }
+
+  SortOrder::type sort_order() const { return order_; }
+
+  Impl(const Impl&) = delete;
+  Impl& operator=(const Impl&) = delete;
+  virtual ~Impl() noexcept {}
+
+ protected:
+  Impl(LogicalAnnotation::Type::type t, SortOrder::type o) : type_(t), order_(o) {}
+  Impl() = default;
+
+  class Compatible;
+  class SimpleCompatible;
+  class Incompatible;
+
+  class Applicable;
+  class SimpleApplicable;
+  class TypeLengthApplicable;
+  class UniversalApplicable;
+  class Inapplicable;
+
+  class String;
+  class Map;
+  class List;
+  class Enum;
+  class Decimal;
+  class Date;
+  class Time;
+  class Timestamp;
+  class Interval;
+  class Int;
+  class Null;
+  class JSON;
+  class BSON;
+  class UUID;
+  class No;
+  class Unknown;
+
+ private:
+  LogicalAnnotation::Type::type type_ = LogicalAnnotation::Type::UNKNOWN;
+  SortOrder::type order_ = SortOrder::UNKNOWN;
+};
+
+// Special methods for public LogicalAnnotation class
+
+LogicalAnnotation::LogicalAnnotation() = default;
+LogicalAnnotation::~LogicalAnnotation() noexcept = default;
+
+// Delegating methods for public LogicalAnnotation class
+
+bool LogicalAnnotation::is_applicable(parquet::Type::type primitive_type,
+                                      int32_t primitive_length) const {
+  return impl_->is_applicable(primitive_type, primitive_length);
+}
+
+bool LogicalAnnotation::is_compatible(
+    LogicalType::type converted_type,
+    schema::DecimalMetadata converted_decimal_metadata) const {
+  return impl_->is_compatible(converted_type, converted_decimal_metadata);
+}
+
+LogicalType::type LogicalAnnotation::ToConvertedType(
+    schema::DecimalMetadata* out_decimal_metadata) const {
+  return impl_->ToConvertedType(out_decimal_metadata);
+}
+
+std::string LogicalAnnotation::ToString() const { return impl_->ToString(); }
+
+std::string LogicalAnnotation::ToJSON() const { return impl_->ToJSON(); }
+
+format::LogicalType LogicalAnnotation::ToThrift() const { return impl_->ToThrift(); }
+
+bool LogicalAnnotation::Equals(const LogicalAnnotation& other) const {
+  return impl_->Equals(other);
+}
+
+LogicalAnnotation::Type::type LogicalAnnotation::type() const { return impl_->type(); }
+
+SortOrder::type LogicalAnnotation::sort_order() const { return impl_->sort_order(); }
+
+// Type checks for public LogicalAnnotation class
+
+bool LogicalAnnotation::is_string() const {
+  return impl_->type() == LogicalAnnotation::Type::STRING;
+}
+bool LogicalAnnotation::is_map() const {
+  return impl_->type() == LogicalAnnotation::Type::MAP;
+}
+bool LogicalAnnotation::is_list() const {
+  return impl_->type() == LogicalAnnotation::Type::LIST;
+}
+bool LogicalAnnotation::is_enum() const {
+  return impl_->type() == LogicalAnnotation::Type::ENUM;
+}
+bool LogicalAnnotation::is_decimal() const {
+  return impl_->type() == LogicalAnnotation::Type::DECIMAL;
+}
+bool LogicalAnnotation::is_date() const {
+  return impl_->type() == LogicalAnnotation::Type::DATE;
+}
+bool LogicalAnnotation::is_time() const {
+  return impl_->type() == LogicalAnnotation::Type::TIME;
+}
+bool LogicalAnnotation::is_timestamp() const {
+  return impl_->type() == LogicalAnnotation::Type::TIMESTAMP;
+}
+bool LogicalAnnotation::is_interval() const {
+  return impl_->type() == LogicalAnnotation::Type::INTERVAL;
+}
+bool LogicalAnnotation::is_int() const {
+  return impl_->type() == LogicalAnnotation::Type::INT;
+}
+bool LogicalAnnotation::is_null() const {
+  return impl_->type() == LogicalAnnotation::Type::NIL;
+}
+bool LogicalAnnotation::is_JSON() const {
+  return impl_->type() == LogicalAnnotation::Type::JSON;
+}
+bool LogicalAnnotation::is_BSON() const {
+  return impl_->type() == LogicalAnnotation::Type::BSON;
+}
+bool LogicalAnnotation::is_UUID() const {
+  return impl_->type() == LogicalAnnotation::Type::UUID;
+}
+bool LogicalAnnotation::is_none() const {
+  return impl_->type() == LogicalAnnotation::Type::NONE;
+}
+bool LogicalAnnotation::is_valid() const {
+  return impl_->type() != LogicalAnnotation::Type::UNKNOWN;
+}
+bool LogicalAnnotation::is_invalid() const { return !is_valid(); }
+bool LogicalAnnotation::is_nested() const {
+  return (impl_->type() == LogicalAnnotation::Type::LIST) ||
+         (impl_->type() == LogicalAnnotation::Type::MAP);
+}
+bool LogicalAnnotation::is_nonnested() const { return !is_nested(); }
+bool LogicalAnnotation::is_serialized() const {
+  return !((impl_->type() == LogicalAnnotation::Type::NONE) ||
+           (impl_->type() == LogicalAnnotation::Type::UNKNOWN));
+}
+
+// LogicalAnnotationImpl intermediate "compatibility" classes
+
+class LogicalAnnotation::Impl::Compatible : public virtual LogicalAnnotation::Impl {
+ protected:
+  Compatible() = default;
+};
+
+#define set_decimal_metadata(m___, i___, p___, s___) \
+  {                                                  \
+    if (m___) {                                      \
+      (m___)->isset = (i___);                        \
+      (m___)->scale = (s___);                        \
+      (m___)->precision = (p___);                    \
+    }                                                \
+  }
+
+#define reset_decimal_metadata(m___) \
+  { set_decimal_metadata(m___, false, -1, -1); }
+
+// For logical annotation types that always translate to the same converted type
+class LogicalAnnotation::Impl::SimpleCompatible
+    : public virtual LogicalAnnotation::Impl::Compatible {
+ public:
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override {
+    return (converted_type == converted_type_) && !converted_decimal_metadata.isset;
+  }
+
+  LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const override {
+    reset_decimal_metadata(out_decimal_metadata);
+    return converted_type_;
+  }
+
+ protected:
+  explicit SimpleCompatible(LogicalType::type c) : converted_type_(c) {}
+
+ private:
+  LogicalType::type converted_type_ = LogicalType::NA;
+};
+
+// For logical annotations that have no corresponding converted type
+class LogicalAnnotation::Impl::Incompatible : public virtual LogicalAnnotation::Impl {
+ public:
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override {
+    return (converted_type == LogicalType::NONE || converted_type == LogicalType::NA) &&
+           !converted_decimal_metadata.isset;
+  }
+
+  LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const override {
+    reset_decimal_metadata(out_decimal_metadata);
+    return LogicalType::NONE;
+  }
+
+ protected:
+  Incompatible() = default;
+};
+
+// LogicalAnnotationImpl intermediate "applicability" classes
+
+class LogicalAnnotation::Impl::Applicable : public virtual LogicalAnnotation::Impl {
+ protected:
+  Applicable() = default;
+};
+
+// For logical annotations that can apply only to a single
+// physical type
+class LogicalAnnotation::Impl::SimpleApplicable
+    : public virtual LogicalAnnotation::Impl::Applicable {
+ public:
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override {
+    return primitive_type == type_;
+  }
+
+ protected:
+  explicit SimpleApplicable(parquet::Type::type t) : type_(t) {}
+
+ private:
+  parquet::Type::type type_;
+};
+
+// For logical annotations that can apply only to a particular
+// physical type and physical length combination
+class LogicalAnnotation::Impl::TypeLengthApplicable
+    : public virtual LogicalAnnotation::Impl::Applicable {
+ public:
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override {
+    return primitive_type == type_ && primitive_length == length_;
+  }
+
+ protected:
+  TypeLengthApplicable(parquet::Type::type t, int32_t l) : type_(t), length_(l) {}
+
+ private:
+  parquet::Type::type type_;
+  int32_t length_;
+};
+
+// For logical annotations that can apply to any physical type
+class LogicalAnnotation::Impl::UniversalApplicable
+    : public virtual LogicalAnnotation::Impl::Applicable {
+ public:
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override {
+    return true;
+  }
+
+ protected:
+  UniversalApplicable() = default;
+};
+
+// For logical annotations that can never apply to any primitive
+// physical type
+class LogicalAnnotation::Impl::Inapplicable : public virtual LogicalAnnotation::Impl {
+ public:
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override {
+    return false;
+  }
+
+ protected:
+  Inapplicable() = default;
+};
+
+// LogicalAnnotation implementation final classes
+
+#define OVERRIDE_TOSTRING(n___) \
+  std::string ToString() const override { return #n___; }
+
+#define OVERRIDE_TOTHRIFT(t___, s___)             \
+  format::LogicalType ToThrift() const override { \
+    format::LogicalType type;                     \
+    format::t___ subtype;                         \
+    type.__set_##s___(subtype);                   \
+    return type;                                  \
+  }
+
+class LogicalAnnotation::Impl::String final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::SimpleApplicable {
+ public:
+  friend class StringAnnotation;
+
+  OVERRIDE_TOSTRING(String)
+  OVERRIDE_TOTHRIFT(StringType, STRING)
+
+ private:
+  String()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::STRING, SortOrder::UNSIGNED),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::UTF8),
+        LogicalAnnotation::Impl::SimpleApplicable(parquet::Type::BYTE_ARRAY) {}
+};
+
+// Each public annotation class's Make() creation method instantiates a corresponding
+// LogicalAnnotation::Impl::* object and installs that implementation in the annotation
+// it returns.
+
+#define GENERATE_MAKE(a___)                                           \
+  std::shared_ptr<const LogicalAnnotation> a___##Annotation::Make() { \
+    auto* annotation = new a___##Annotation();                        \
+    annotation->impl_.reset(new LogicalAnnotation::Impl::a___());     \
+    return std::shared_ptr<const LogicalAnnotation>(annotation);      \
+  }
+
+GENERATE_MAKE(String)
+
+class LogicalAnnotation::Impl::Map final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::Inapplicable {
+ public:
+  friend class MapAnnotation;
+
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override {
+    return (converted_type == LogicalType::MAP ||
+            converted_type == LogicalType::MAP_KEY_VALUE) &&
+           !converted_decimal_metadata.isset;
+  }
+
+  OVERRIDE_TOSTRING(Map)
+  OVERRIDE_TOTHRIFT(MapType, MAP)
+
+ private:
+  Map()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::MAP, SortOrder::UNKNOWN),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::MAP) {}
+};
+
+GENERATE_MAKE(Map)
+
+class LogicalAnnotation::Impl::List final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::Inapplicable {
+ public:
+  friend class ListAnnotation;
+
+  OVERRIDE_TOSTRING(List)
+  OVERRIDE_TOTHRIFT(ListType, LIST)
+
+ private:
+  List()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::LIST, SortOrder::UNKNOWN),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::LIST) {}
+};
+
+GENERATE_MAKE(List)
+
+class LogicalAnnotation::Impl::Enum final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::SimpleApplicable {
+ public:
+  friend class EnumAnnotation;
+
+  OVERRIDE_TOSTRING(Enum)
+  OVERRIDE_TOTHRIFT(EnumType, ENUM)
+
+ private:
+  Enum()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::ENUM, SortOrder::UNSIGNED),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::ENUM),
+        LogicalAnnotation::Impl::SimpleApplicable(parquet::Type::BYTE_ARRAY) {}
+};
+
+GENERATE_MAKE(Enum)
+
+// The parameterized annotation types (currently Decimal, Time, Timestamp, and Int)
+// generally can't reuse the simple method implementations available in the base and
+// intermediate classes and must (re)implement them all
+
+class LogicalAnnotation::Impl::Decimal final
+    : public LogicalAnnotation::Impl::Compatible,
+      public LogicalAnnotation::Impl::Applicable {
+ public:
+  friend class DecimalAnnotation;
+
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override;
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override;
+  LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const override;
+  std::string ToString() const override;
+  std::string ToJSON() const override;
+  format::LogicalType ToThrift() const override;
+  bool Equals(const LogicalAnnotation& other) const override;
+
+  int32_t precision() const { return precision_; }
+  int32_t scale() const { return scale_; }
+
+ private:
+  Decimal(int32_t p, int32_t s)
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::DECIMAL, SortOrder::SIGNED),
+        precision_(p),
+        scale_(s) {}
+  int32_t precision_ = -1;
+  int32_t scale_ = -1;
+};
+
+bool LogicalAnnotation::Impl::Decimal::is_applicable(parquet::Type::type primitive_type,
+                                                     int32_t primitive_length) const {
+  bool ok = false;
+  switch (primitive_type) {
+    case parquet::Type::INT32: {
+      ok = (1 <= precision_) && (precision_ <= 9);
+    } break;
+    case parquet::Type::INT64: {
+      ok = (1 <= precision_) && (precision_ <= 18);
+      if (precision_ < 10) {
+        // FIXME(tpb): warn that INT32 could be used
+      }
+    } break;
+    case parquet::Type::FIXED_LEN_BYTE_ARRAY: {
+      ok = precision_ <= static_cast<int32_t>(std::floor(
+                             std::log10(std::pow(2.0, (8.0 * primitive_length) - 1.0))));
+    } break;
+    case parquet::Type::BYTE_ARRAY: {
+      ok = true;
+    } break;
+    default: { } break; }
+  return ok;
+}
+
+bool LogicalAnnotation::Impl::Decimal::is_compatible(
+    LogicalType::type converted_type,
+    schema::DecimalMetadata converted_decimal_metadata) const {
+  return converted_type == LogicalType::DECIMAL &&
+         (converted_decimal_metadata.isset &&
+          converted_decimal_metadata.scale == scale_ &&
+          converted_decimal_metadata.precision == precision_);
+}
+
+LogicalType::type LogicalAnnotation::Impl::Decimal::ToConvertedType(
+    schema::DecimalMetadata* out_decimal_metadata) const {
+  set_decimal_metadata(out_decimal_metadata, true, precision_, scale_);
+  return LogicalType::DECIMAL;
+}
+
+std::string LogicalAnnotation::Impl::Decimal::ToString() const {
+  std::stringstream type;
+  type << "Decimal(precision=" << precision_ << ", scale=" << scale_ << ")";
+  return type.str();
+}
+
+std::string LogicalAnnotation::Impl::Decimal::ToJSON() const {
+  std::stringstream json;
+  json << R"({"Type": "Decimal", "precision": )" << precision_ << R"(, "scale": )"
+       << scale_ << "}";
+  return json.str();
+}
+
+format::LogicalType LogicalAnnotation::Impl::Decimal::ToThrift() const {
+  format::LogicalType type;
+  format::DecimalType decimal_type;
+  decimal_type.__set_precision(precision_);
+  decimal_type.__set_scale(scale_);
+  type.__set_DECIMAL(decimal_type);
+  return type;
+}
+
+bool LogicalAnnotation::Impl::Decimal::Equals(const LogicalAnnotation& other) const {
+  bool eq = false;
+  if (other.is_decimal()) {
+    const auto& other_decimal = checked_cast<const DecimalAnnotation&>(other);
+    eq = (precision_ == other_decimal.precision() && scale_ == other_decimal.scale());
+  }
+  return eq;
+}
+
+std::shared_ptr<const LogicalAnnotation> DecimalAnnotation::Make(int32_t precision,
+                                                                 int32_t scale) {
+  if (precision < 1) {
+    throw ParquetException(
+        "Precision must be greater than or equal to 1 for Decimal annotation");
+  }
+  if (scale < 0 || scale > precision) {
+    throw ParquetException(
+        "Scale must be a non-negative integer that does not exceed precision for "
+        "Decimal annotation");
+  }
+  auto* annotation = new DecimalAnnotation();
+  annotation->impl_.reset(new LogicalAnnotation::Impl::Decimal(precision, scale));
+  return std::shared_ptr<const LogicalAnnotation>(annotation);
+}
+
+int32_t DecimalAnnotation::precision() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Decimal&>(*impl_)).precision();
+}
+
+int32_t DecimalAnnotation::scale() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Decimal&>(*impl_)).scale();
+}
+
+class LogicalAnnotation::Impl::Date final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::SimpleApplicable {
+ public:
+  friend class DateAnnotation;
+
+  OVERRIDE_TOSTRING(Date)
+  OVERRIDE_TOTHRIFT(DateType, DATE)
+
+ private:
+  Date()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::DATE, SortOrder::SIGNED),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::DATE),
+        LogicalAnnotation::Impl::SimpleApplicable(parquet::Type::INT32) {}
+};
+
+GENERATE_MAKE(Date)
+
+#define time_unit_string(u___)                                                \
+  ((u___) == LogicalAnnotation::TimeUnit::MILLIS                              \
+       ? "milliseconds"                                                       \
+       : ((u___) == LogicalAnnotation::TimeUnit::MICROS                       \
+              ? "microseconds"                                                \
+              : ((u___) == LogicalAnnotation::TimeUnit::NANOS ? "nanoseconds" \
+                                                              : "unknown")))
+
+class LogicalAnnotation::Impl::Time final : public LogicalAnnotation::Impl::Compatible,
+                                            public LogicalAnnotation::Impl::Applicable {
+ public:
+  friend class TimeAnnotation;
+
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override;
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override;
+  LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const override;
+  std::string ToString() const override;
+  std::string ToJSON() const override;
+  format::LogicalType ToThrift() const override;
+  bool Equals(const LogicalAnnotation& other) const override;
+
+  bool is_adjusted_to_utc() const { return adjusted_; }
+  LogicalAnnotation::TimeUnit::unit time_unit() const { return unit_; }
+
+ private:
+  Time(bool a, LogicalAnnotation::TimeUnit::unit u)
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::TIME, SortOrder::SIGNED),
+        adjusted_(a),
+        unit_(u) {}
+  bool adjusted_ = false;
+  LogicalAnnotation::TimeUnit::unit unit_;
+};
+
+bool LogicalAnnotation::Impl::Time::is_applicable(parquet::Type::type primitive_type,
+                                                  int32_t primitive_length) const {
+  return (primitive_type == parquet::Type::INT32 &&
+          unit_ == LogicalAnnotation::TimeUnit::MILLIS) ||
+         (primitive_type == parquet::Type::INT64 &&
+          (unit_ == LogicalAnnotation::TimeUnit::MICROS ||
+           unit_ == LogicalAnnotation::TimeUnit::NANOS));
+}
+
+bool LogicalAnnotation::Impl::Time::is_compatible(
+    LogicalType::type converted_type,
+    schema::DecimalMetadata converted_decimal_metadata) const {
+  if (converted_decimal_metadata.isset) {
+    return false;
+  } else if (adjusted_ && unit_ == LogicalAnnotation::TimeUnit::MILLIS) {
+    return converted_type == LogicalType::TIME_MILLIS;
+  } else if (adjusted_ && unit_ == LogicalAnnotation::TimeUnit::MICROS) {
+    return converted_type == LogicalType::TIME_MICROS;
+  } else {
+    return (converted_type == LogicalType::NONE) || (converted_type == LogicalType::NA);
+  }
+}
+
+LogicalType::type LogicalAnnotation::Impl::Time::ToConvertedType(
+    schema::DecimalMetadata* out_decimal_metadata) const {
+  reset_decimal_metadata(out_decimal_metadata);
+  if (adjusted_) {
+    if (unit_ == LogicalAnnotation::TimeUnit::MILLIS) {
+      return LogicalType::TIME_MILLIS;
+    } else if (unit_ == LogicalAnnotation::TimeUnit::MICROS) {
+      return LogicalType::TIME_MICROS;
+    }
+  }
+  return LogicalType::NONE;
+}
+
+std::string LogicalAnnotation::Impl::Time::ToString() const {
+  std::stringstream type;
+  type << "Time(isAdjustedToUTC=" << std::boolalpha << adjusted_
+       << ", timeUnit=" << time_unit_string(unit_) << ")";
+  return type.str();
+}
+
+std::string LogicalAnnotation::Impl::Time::ToJSON() const {
+  std::stringstream json;
+  json << R"({"Type": "Time", "isAdjustedToUTC": )" << std::boolalpha << adjusted_
+       << R"(, "timeUnit": ")" << time_unit_string(unit_) << R"("})";
+  return json.str();
+}
+
+format::LogicalType LogicalAnnotation::Impl::Time::ToThrift() const {
+  format::LogicalType type;
+  format::TimeType time_type;
+  format::TimeUnit time_unit;
+  DCHECK(unit_ != LogicalAnnotation::TimeUnit::UNKNOWN);
+  if (unit_ == LogicalAnnotation::TimeUnit::MILLIS) {
+    format::MilliSeconds millis;
+    time_unit.__set_MILLIS(millis);
+  } else if (unit_ == LogicalAnnotation::TimeUnit::MICROS) {
+    format::MicroSeconds micros;
+    time_unit.__set_MICROS(micros);
+  } else if (unit_ == LogicalAnnotation::TimeUnit::NANOS) {
+    format::NanoSeconds nanos;
+    time_unit.__set_NANOS(nanos);
+  }
+  time_type.__set_isAdjustedToUTC(adjusted_);
+  time_type.__set_unit(time_unit);
+  type.__set_TIME(time_type);
+  return type;
+}
+
+bool LogicalAnnotation::Impl::Time::Equals(const LogicalAnnotation& other) const {
+  bool eq = false;
+  if (other.is_time()) {
+    const auto& other_time = checked_cast<const TimeAnnotation&>(other);
+    eq =
+        (adjusted_ == other_time.is_adjusted_to_utc() && unit_ == other_time.time_unit());
+  }
+  return eq;
+}
+
+std::shared_ptr<const LogicalAnnotation> TimeAnnotation::Make(
+    bool is_adjusted_to_utc, LogicalAnnotation::TimeUnit::unit time_unit) {
+  if (time_unit == LogicalAnnotation::TimeUnit::MILLIS ||
+      time_unit == LogicalAnnotation::TimeUnit::MICROS ||
+      time_unit == LogicalAnnotation::TimeUnit::NANOS) {
+    auto* annotation = new TimeAnnotation();
+    annotation->impl_.reset(
+        new LogicalAnnotation::Impl::Time(is_adjusted_to_utc, time_unit));
+    return std::shared_ptr<const LogicalAnnotation>(annotation);
+  } else {
+    throw ParquetException(
+        "TimeUnit must be one of MILLIS, MICROS, or NANOS for Time annotation");
+  }
+}
+
+bool TimeAnnotation::is_adjusted_to_utc() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Time&>(*impl_))
+      .is_adjusted_to_utc();
+}
+
+LogicalAnnotation::TimeUnit::unit TimeAnnotation::time_unit() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Time&>(*impl_)).time_unit();
+}
+
+class LogicalAnnotation::Impl::Timestamp final
+    : public LogicalAnnotation::Impl::Compatible,
+      public LogicalAnnotation::Impl::SimpleApplicable {
+ public:
+  friend class TimestampAnnotation;
+
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override;
+  LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const override;
+  std::string ToString() const override;
+  std::string ToJSON() const override;
+  format::LogicalType ToThrift() const override;
+  bool Equals(const LogicalAnnotation& other) const override;
+
+  bool is_adjusted_to_utc() const { return adjusted_; }
+  LogicalAnnotation::TimeUnit::unit time_unit() const { return unit_; }
+
+ private:
+  Timestamp(bool a, LogicalAnnotation::TimeUnit::unit u)
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::TIMESTAMP, SortOrder::SIGNED),
+        LogicalAnnotation::Impl::SimpleApplicable(parquet::Type::INT64),
+        adjusted_(a),
+        unit_(u) {}
+  bool adjusted_ = false;
+  LogicalAnnotation::TimeUnit::unit unit_;
+};
+
+bool LogicalAnnotation::Impl::Timestamp::is_compatible(
+    LogicalType::type converted_type,
+    schema::DecimalMetadata converted_decimal_metadata) const {
+  if (converted_decimal_metadata.isset) {
+    return false;
+  } else if (adjusted_ && unit_ == LogicalAnnotation::TimeUnit::MILLIS) {
+    return converted_type == LogicalType::TIMESTAMP_MILLIS;
+  } else if (adjusted_ && unit_ == LogicalAnnotation::TimeUnit::MICROS) {
+    return converted_type == LogicalType::TIMESTAMP_MICROS;
+  } else {
+    return (converted_type == LogicalType::NONE) || (converted_type == LogicalType::NA);
+  }
+}
+
+LogicalType::type LogicalAnnotation::Impl::Timestamp::ToConvertedType(
+    schema::DecimalMetadata* out_decimal_metadata) const {
+  reset_decimal_metadata(out_decimal_metadata);
+  if (adjusted_) {
+    if (unit_ == LogicalAnnotation::TimeUnit::MILLIS) {
+      return LogicalType::TIMESTAMP_MILLIS;
+    } else if (unit_ == LogicalAnnotation::TimeUnit::MICROS) {
+      return LogicalType::TIMESTAMP_MICROS;
+    }
+  }
+  return LogicalType::NONE;
+}
+
+std::string LogicalAnnotation::Impl::Timestamp::ToString() const {
+  std::stringstream type;
+  type << "Timestamp(isAdjustedToUTC=" << std::boolalpha << adjusted_
+       << ", timeUnit=" << time_unit_string(unit_) << ")";
+  return type.str();
+}
+
+std::string LogicalAnnotation::Impl::Timestamp::ToJSON() const {
+  std::stringstream json;
+  json << R"({"Type": "Timestamp", "isAdjustedToUTC": )" << std::boolalpha << adjusted_
+       << R"(, "timeUnit": ")" << time_unit_string(unit_) << R"("})";
+  return json.str();
+}
+
+format::LogicalType LogicalAnnotation::Impl::Timestamp::ToThrift() const {
+  format::LogicalType type;
+  format::TimestampType timestamp_type;
+  format::TimeUnit time_unit;
+  DCHECK(unit_ != LogicalAnnotation::TimeUnit::UNKNOWN);
+  if (unit_ == LogicalAnnotation::TimeUnit::MILLIS) {
+    format::MilliSeconds millis;
+    time_unit.__set_MILLIS(millis);
+  } else if (unit_ == LogicalAnnotation::TimeUnit::MICROS) {
+    format::MicroSeconds micros;
+    time_unit.__set_MICROS(micros);
+  } else if (unit_ == LogicalAnnotation::TimeUnit::NANOS) {
+    format::NanoSeconds nanos;
+    time_unit.__set_NANOS(nanos);
+  }
+  timestamp_type.__set_isAdjustedToUTC(adjusted_);
+  timestamp_type.__set_unit(time_unit);
+  type.__set_TIMESTAMP(timestamp_type);
+  return type;
+}
+
+bool LogicalAnnotation::Impl::Timestamp::Equals(const LogicalAnnotation& other) const {
+  bool eq = false;
+  if (other.is_timestamp()) {
+    const auto& other_timestamp = checked_cast<const TimestampAnnotation&>(other);
+    eq = (adjusted_ == other_timestamp.is_adjusted_to_utc() &&
+          unit_ == other_timestamp.time_unit());
+  }
+  return eq;
+}
+
+std::shared_ptr<const LogicalAnnotation> TimestampAnnotation::Make(
+    bool is_adjusted_to_utc, LogicalAnnotation::TimeUnit::unit time_unit) {
+  if (time_unit == LogicalAnnotation::TimeUnit::MILLIS ||
+      time_unit == LogicalAnnotation::TimeUnit::MICROS ||
+      time_unit == LogicalAnnotation::TimeUnit::NANOS) {
+    auto* annotation = new TimestampAnnotation();
+    annotation->impl_.reset(
+        new LogicalAnnotation::Impl::Timestamp(is_adjusted_to_utc, time_unit));
+    return std::shared_ptr<const LogicalAnnotation>(annotation);
+  } else {
+    throw ParquetException(
+        "TimeUnit must be one of MILLIS, MICROS, or NANOS for Timestamp annotation");
+  }
+}
+
+bool TimestampAnnotation::is_adjusted_to_utc() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Timestamp&>(*impl_))
+      .is_adjusted_to_utc();
+}
+
+LogicalAnnotation::TimeUnit::unit TimestampAnnotation::time_unit() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Timestamp&>(*impl_)).time_unit();
+}
+
+class LogicalAnnotation::Impl::Interval final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::TypeLengthApplicable {
+ public:
+  friend class IntervalAnnotation;
+
+  OVERRIDE_TOSTRING(Interval)
+  // TODO(tpboudreau): uncomment the following line to enable serialization after
+  // parquet.thrift recognizes IntervalType as a LogicalType
+  // OVERRIDE_TOTHRIFT(IntervalType, INTERVAL)
+
+ private:
+  Interval()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::INTERVAL, SortOrder::UNKNOWN),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::INTERVAL),
+        LogicalAnnotation::Impl::TypeLengthApplicable(parquet::Type::FIXED_LEN_BYTE_ARRAY,
+                                                      12) {}
+};
+
+GENERATE_MAKE(Interval)
+
+class LogicalAnnotation::Impl::Int final : public LogicalAnnotation::Impl::Compatible,
+                                           public LogicalAnnotation::Impl::Applicable {
+ public:
+  friend class IntAnnotation;
+
+  bool is_applicable(parquet::Type::type primitive_type,
+                     int32_t primitive_length = -1) const override;
+  bool is_compatible(LogicalType::type converted_type,
+                     schema::DecimalMetadata converted_decimal_metadata) const override;
+  LogicalType::type ToConvertedType(
+      schema::DecimalMetadata* out_decimal_metadata) const override;
+  std::string ToString() const override;
+  std::string ToJSON() const override;
+  format::LogicalType ToThrift() const override;
+  bool Equals(const LogicalAnnotation& other) const override;
+
+  int bit_width() const { return width_; }
+  bool is_signed() const { return signed_; }
+
+ private:
+  Int(int w, bool s)
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::INT,
+                                (s ? SortOrder::SIGNED : SortOrder::UNSIGNED)),
+        width_(w),
+        signed_(s) {}
+  int width_ = 0;
+  bool signed_ = false;
+};
+
+bool LogicalAnnotation::Impl::Int::is_applicable(parquet::Type::type primitive_type,
+                                                 int32_t primitive_length) const {
+  return (primitive_type == parquet::Type::INT32 && width_ <= 32) ||
+         (primitive_type == parquet::Type::INT64 && width_ == 64);
+}
+
+bool LogicalAnnotation::Impl::Int::is_compatible(
+    LogicalType::type converted_type,
+    schema::DecimalMetadata converted_decimal_metadata) const {
+  if (converted_decimal_metadata.isset) {
+    return false;
+  } else if (signed_ && width_ == 8) {
+    return converted_type == LogicalType::INT_8;
+  } else if (signed_ && width_ == 16) {
+    return converted_type == LogicalType::INT_16;
+  } else if (signed_ && width_ == 32) {
+    return converted_type == LogicalType::INT_32;
+  } else if (signed_ && width_ == 64) {
+    return converted_type == LogicalType::INT_64;
+  } else if (!signed_ && width_ == 8) {
+    return converted_type == LogicalType::UINT_8;
+  } else if (!signed_ && width_ == 16) {
+    return converted_type == LogicalType::UINT_16;
+  } else if (!signed_ && width_ == 32) {
+    return converted_type == LogicalType::UINT_32;
+  } else if (!signed_ && width_ == 64) {
+    return converted_type == LogicalType::UINT_64;
+  } else {
+    return false;
+  }
+}
+
+LogicalType::type LogicalAnnotation::Impl::Int::ToConvertedType(
+    schema::DecimalMetadata* out_decimal_metadata) const {
+  reset_decimal_metadata(out_decimal_metadata);
+  if (signed_) {
+    switch (width_) {
+      case 8:
+        return LogicalType::INT_8;
+      case 16:
+        return LogicalType::INT_16;
+      case 32:
+        return LogicalType::INT_32;
+      case 64:
+        return LogicalType::INT_64;
+    }
+  } else {  // unsigned
+    switch (width_) {
+      case 8:
+        return LogicalType::UINT_8;
+      case 16:
+        return LogicalType::UINT_16;
+      case 32:
+        return LogicalType::UINT_32;
+      case 64:
+        return LogicalType::UINT_64;
+    }
+  }
+  return LogicalType::NONE;
+}
+
+std::string LogicalAnnotation::Impl::Int::ToString() const {
+  std::stringstream type;
+  type << "Int(bitWidth=" << width_ << ", isSigned=" << std::boolalpha << signed_ << ")";
+  return type.str();
+}
+
+std::string LogicalAnnotation::Impl::Int::ToJSON() const {
+  std::stringstream json;
+  json << R"({"Type": "Int", "bitWidth": )" << width_ << R"(, "isSigned": )"
+       << std::boolalpha << signed_ << "}";
+  return json.str();
+}
+
+format::LogicalType LogicalAnnotation::Impl::Int::ToThrift() const {
+  format::LogicalType type;
+  format::IntType int_type;
+  DCHECK(width_ == 64 || width_ == 32 || width_ == 16 || width_ == 8);
+  int_type.__set_bitWidth(static_cast<int8_t>(width_));
+  int_type.__set_isSigned(signed_);
+  type.__set_INTEGER(int_type);
+  return type;
+}
+
+bool LogicalAnnotation::Impl::Int::Equals(const LogicalAnnotation& other) const {
+  bool eq = false;
+  if (other.is_int()) {
+    const auto& other_int = checked_cast<const IntAnnotation&>(other);
+    eq = (width_ == other_int.bit_width() && signed_ == other_int.is_signed());
+  }
+  return eq;
+}
+
+std::shared_ptr<const LogicalAnnotation> IntAnnotation::Make(int bit_width,
+                                                             bool is_signed) {
+  if (bit_width == 8 || bit_width == 16 || bit_width == 32 || bit_width == 64) {
+    auto* annotation = new IntAnnotation();
+    annotation->impl_.reset(new LogicalAnnotation::Impl::Int(bit_width, is_signed));
+    return std::shared_ptr<const LogicalAnnotation>(annotation);
+  } else {
+    throw ParquetException(
+        "Bit width must be exactly 8, 16, 32, or 64 for Int annotation");
+  }
+}
+
+int IntAnnotation::bit_width() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Int&>(*impl_)).bit_width();
+}
+
+bool IntAnnotation::is_signed() const {
+  return (dynamic_cast<const LogicalAnnotation::Impl::Int&>(*impl_)).is_signed();
+}
+
+class LogicalAnnotation::Impl::Null final
+    : public LogicalAnnotation::Impl::Incompatible,
+      public LogicalAnnotation::Impl::UniversalApplicable {
+ public:
+  friend class NullAnnotation;
+
+  OVERRIDE_TOSTRING(Null)
+  OVERRIDE_TOTHRIFT(NullType, UNKNOWN)
+
+ private:
+  Null() : LogicalAnnotation::Impl(LogicalAnnotation::Type::NIL, SortOrder::UNKNOWN) {}
+};
+
+GENERATE_MAKE(Null)
+
+class LogicalAnnotation::Impl::JSON final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::SimpleApplicable {
+ public:
+  friend class JSONAnnotation;
+
+  OVERRIDE_TOSTRING(JSON)
+  OVERRIDE_TOTHRIFT(JsonType, JSON)
+
+ private:
+  JSON()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::JSON, SortOrder::UNSIGNED),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::JSON),
+        LogicalAnnotation::Impl::SimpleApplicable(parquet::Type::BYTE_ARRAY) {}
+};
+
+GENERATE_MAKE(JSON)
+
+class LogicalAnnotation::Impl::BSON final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::SimpleApplicable {
+ public:
+  friend class BSONAnnotation;
+
+  OVERRIDE_TOSTRING(BSON)
+  OVERRIDE_TOTHRIFT(BsonType, BSON)
+
+ private:
+  BSON()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::BSON, SortOrder::UNSIGNED),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::BSON),
+        LogicalAnnotation::Impl::SimpleApplicable(parquet::Type::BYTE_ARRAY) {}
+};
+
+GENERATE_MAKE(BSON)
+
+class LogicalAnnotation::Impl::UUID final
+    : public LogicalAnnotation::Impl::Incompatible,
+      public LogicalAnnotation::Impl::TypeLengthApplicable {
+ public:
+  friend class UUIDAnnotation;
+
+  OVERRIDE_TOSTRING(UUID)
+  OVERRIDE_TOTHRIFT(UUIDType, UUID)
+
+ private:
+  UUID()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::UUID, SortOrder::UNSIGNED),
+        LogicalAnnotation::Impl::TypeLengthApplicable(parquet::Type::FIXED_LEN_BYTE_ARRAY,
+                                                      16) {}
+};
+
+GENERATE_MAKE(UUID)
+
+class LogicalAnnotation::Impl::No final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::UniversalApplicable {
+ public:
+  friend class NoAnnotation;
+
+  OVERRIDE_TOSTRING(None)
+
+ private:
+  No()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::NONE, SortOrder::UNKNOWN),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::NONE) {}
+};
+
+GENERATE_MAKE(No)
+
+class LogicalAnnotation::Impl::Unknown final
+    : public LogicalAnnotation::Impl::SimpleCompatible,
+      public LogicalAnnotation::Impl::UniversalApplicable {
+ public:
+  friend class UnknownAnnotation;
+
+  OVERRIDE_TOSTRING(Unknown)
+
+ private:
+  Unknown()
+      : LogicalAnnotation::Impl(LogicalAnnotation::Type::UNKNOWN, SortOrder::UNKNOWN),
+        LogicalAnnotation::Impl::SimpleCompatible(LogicalType::NA) {}
+};
+
+GENERATE_MAKE(Unknown)
 
 }  // namespace parquet


### PR DESCRIPTION
This PR updates the parquet-cpp implementation to use parameterized logical type annotations as requested in [PARQUET-1411](https://issues.apache.org/jira/browse/PARQUET-1411).  The primary contributions are:

1. Amend the parquet.thrift file consistent with the Parquet format repository to allow Thrift to recognize and serialize a new LogicalType
2. Introduce and integrate a LogicalAnnotation class (and subclasses) in the parquet-cpp library to handle functionality related to this new attribute
3. Expand the public API to include construction functions for GroupNode and PrimitiveNode schema classes that accept the new LogicalAnnotation parameter
4. Add basic unit and integration tests for the new code.

Some (hopefully time saving) notes for reviewers:

- The center of gravity for the PR is the LogicalAnnotation class, so it might be best to start by having a look at it's interface in types.h

- LogicalType would have been a more natural name for this class, but unfortunately that was already in use (in the public API) for the concept Thrift calls "converted type".  Here's a refresher chart of some relevant concepts and their names in the code:

| Concept | Thrift realization | Parquet-CPP realization |
|---------|--------------------|-------------------------|
| Physical storage type | enum Type | enum parquet::Type::type |
| Converted type | enum ConvertedType; struct parquet::format::ConvertedType | enum parquet::LogicalType::type; struct parquet::schema::DecimalMetadata|
| Logical annotation | union LogicalType; struct parquet::format::LogicalType | class parquet::LogicalAnnotation (enum parquet::LogicalAnnotation::Type) |

- After this change, the LogicalAnnotation member (stored in Node.logical_annotation_) is the primary controller of logical typing in the library.  To simplify backward compatibility tasks, the existing converted type/decimal metadata pair is retained and populated at construction with compatible values (where possible).

- While new Make() functions are introduced to accomodate schema node construction with the new annotations, of course the existing corresponding public API functions accepting converted types are retained.  The maintainers might wish to consider deprecating those functions.

- As required by the parquet format specification, after this change, both the converted and logical types are serialized; the new logical type (if present) takes precedence on deserialization, but the legacy converted type is still recognized in the absence of a logical type.

>The existing converted type INTERVAL has no corresponding logical type in the parquet.thrift definition, so it can only be serialized as a converted type.  As with any other element in which only converted type information is present, upon deserialization an equivalent logical annotation is instantiated and it is treated internally as any other type.

- There are several ancillary functions, such as printing and equivalence checking, in which the converted types are still used; in most cases these fallbacks and double-checks are probably redundant.  Note, however, that in the JSON output *both* converted and logical types are intentionally emitted, on the assumption that consumers might be relying on the current format as part of a quasi-public API.  The maintainers may wish to consider deprecating the converted type fields there as well.

I'm far from an expert in the Parquet data format or it's implementing libraries, so I may have misunderstood or omitted things; all corrections or recommendations are obviously welcome.
