### PR TITLE
ARROW-5179: [Python] Return plain dicts, not OrderedDict, on Python 3.7+

### DIFF
--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -112,6 +112,15 @@ else:
     def unichar(s):
         return chr(s)
 
+
+if sys.version_info >= (3, 7):
+    # Starting with Python 3.7, dicts are guaranteed to be insertion-ordered.
+    ordered_dict = dict
+else:
+    import collections
+    ordered_dict = collections.OrderedDict
+
+
 try:
     import cloudpickle as pickle
 except ImportError:

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -19,14 +19,14 @@
 # distutils: language = c++
 # cython: embedsignature = True
 
-from collections import OrderedDict
 import datetime
 import decimal as _pydecimal
 import json
 import numpy as np
 import os
 import six
-from pyarrow.compat import frombytes, tobytes
+
+from pyarrow.compat import frombytes, tobytes, ordered_dict
 
 from cython.operator cimport dereference as deref
 from pyarrow.includes.libarrow cimport *

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -99,7 +99,7 @@ cdef object pyarrow_wrap_metadata(
     if cmeta == nullptr:
         return None
 
-    result = OrderedDict()
+    result = ordered_dict()
     for i in range(cmeta.size()):
         result[cmeta.key(i)] = cmeta.value(i)
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -813,18 +813,18 @@ cdef class RecordBatch(_PandasConvertible):
 
     def to_pydict(self):
         """
-        Converted the arrow::RecordBatch to an OrderedDict
+        Convert the RecordBatch to a dict or OrderedDict.
 
         Returns
         -------
-        OrderedDict
+        dict
         """
         entries = []
         for i in range(self.batch.num_columns()):
             name = bytes(self.batch.column_name(i)).decode('utf8')
             column = self[i].to_pylist()
             entries.append((name, column))
-        return OrderedDict(entries)
+        return ordered_dict(entries)
 
     def _to_pandas(self, options, **kwargs):
         return Table.from_batches([self])._to_pandas(options, **kwargs)
@@ -1336,11 +1336,11 @@ cdef class Table(_PandasConvertible):
 
     def to_pydict(self):
         """
-        Converted the arrow::Table to an OrderedDict
+        Convert the Table to a dict or OrderedDict.
 
         Returns
         -------
-        OrderedDict
+        dict
         """
         cdef:
             size_t i
@@ -1352,7 +1352,7 @@ cdef class Table(_PandasConvertible):
             column = self.column(i)
             entries.append((column.name, column.to_pylist()))
 
-        return OrderedDict(entries)
+        return ordered_dict(entries)
 
     @property
     def schema(self):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -17,6 +17,7 @@
 
 from collections import OrderedDict, Iterable
 import pickle
+import sys
 
 import numpy as np
 import pytest
@@ -348,10 +349,15 @@ def test_recordbatch_basics():
     assert len(batch) == 5
     assert batch.num_rows == 5
     assert batch.num_columns == len(data)
-    assert batch.to_pydict() == OrderedDict([
+    pydict = batch.to_pydict()
+    assert pydict == OrderedDict([
         ('c0', [0, 1, 2, 3, 4]),
         ('c1', [-10, -5, 0, 5, 10])
     ])
+    if sys.version_info >= (3, 7):
+        assert type(pydict) == dict
+    else:
+        assert type(pydict) == OrderedDict
 
     with pytest.raises(IndexError):
         # bounds checking
@@ -540,10 +546,15 @@ def test_table_basics():
     assert table.num_rows == 5
     assert table.num_columns == 2
     assert table.shape == (5, 2)
-    assert table.to_pydict() == OrderedDict([
+    pydict = table.to_pydict()
+    assert pydict == OrderedDict([
         ('a', [0, 1, 2, 3, 4]),
         ('b', [-10, -5, 0, 5, 10])
     ])
+    if sys.version_info >= (3, 7):
+        assert type(pydict) == dict
+    else:
+        assert type(pydict) == OrderedDict
 
     columns = []
     for col in table.itercolumns():


### PR DESCRIPTION
Starting with Python 3.7, built-in dict is insertion-ordered.
No need to return a slightly heavier and costlier OrderedDict.