### PR TITLE
ARROW-5165: [Python] update dev installation docs for --build-type + validate in setup.py

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -285,7 +285,7 @@ Now, build pyarrow:
    export PYARROW_WITH_GANDIVA=1
    export PYARROW_WITH_ORC=1
    export PYARROW_WITH_PARQUET=1
-   python setup.py build_ext --build-type=$ARROW_BUILD_TYPE --inplace
+   python setup.py build_ext --inplace
    popd
 
 If you did not build one of the optional components, set the corresponding

--- a/python/setup.py
+++ b/python/setup.py
@@ -172,7 +172,7 @@ class build_ext(_build_ext):
 
     def _run_cmake(self):
         # check if build_type is correctly passed / set
-        if self.build_type not in ('release', 'debug'):
+        if self.build_type.lower() not in ('release', 'debug'):
             raise ValueError("--build-type (or PYARROW_BUILD_TYPE) needs to "
                              "be 'release' or 'debug'")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -171,6 +171,11 @@ class build_ext(_build_ext):
         'gandiva']
 
     def _run_cmake(self):
+        # check if build_type is correctly passed / set
+        if self.build_type not in ('release', 'debug'):
+            raise ValueError("--build-type (or PYARROW_BUILD_TYPE) needs to "
+                             "be 'release' or 'debug'")
+
         # The directory containing this setup.py
         source = osp.dirname(osp.abspath(__file__))
 


### PR DESCRIPTION
- Remove the mention of ``--build-type=$ARROW_BUILD_TYPE`` in the docs, since `ARROW_BUILD_TYPE` is not set, and 'release' is already the default.
- Validate the value of `self.build_type` so that doing ``--build-type=$ARROW_BUILD_TYPE`` without having the env variable set gives a helpful error message instead of failing when bundling includes