### PR TITLE
ARROW-5204: [C++] Improve builder performance

### DIFF
--- a/cpp/src/arrow/array-binary-test.cc
+++ b/cpp/src/arrow/array-binary-test.cc
@@ -603,7 +603,9 @@ TEST_F(TestBinaryBuilder, TestCapacityReserve) {
   ASSERT_OK(builder_->ReserveData(extra_capacity));
 
   ASSERT_EQ(length, builder_->value_data_length());
-  ASSERT_EQ(expected_capacity, builder_->value_data_capacity());
+  int64_t actual_capacity = builder_->value_data_capacity();
+  ASSERT_GE(actual_capacity, expected_capacity);
+  ASSERT_EQ(actual_capacity & 63, 0);
 
   Done();
 

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -274,10 +274,9 @@ TEST_F(TestBuilder, TestReserve) {
   ASSERT_OK(builder.Resize(1000));
   ASSERT_EQ(1000, builder.capacity());
 
-  // Builder only contains 0 elements, but calling Reserve will result in a round
-  // up to next power of 2
+  // Reserve overallocates for small upsizes.
   ASSERT_OK(builder.Reserve(1030));
-  ASSERT_EQ(BitUtil::NextPower2(1030), builder.capacity());
+  ASSERT_GE(builder.capacity(), 1500);
 }
 
 TEST_F(TestBuilder, TestResizeDownsize) {
@@ -516,9 +515,16 @@ typedef ::testing::Types<PBoolean, PUInt8, PUInt16, PUInt32, PUInt64, PInt8, PIn
 TYPED_TEST_CASE(TestPrimitiveBuilder, Primitives);
 
 TYPED_TEST(TestPrimitiveBuilder, TestInit) {
-  int64_t n = 1000;
-  ASSERT_OK(this->builder_->Reserve(n));
-  ASSERT_EQ(BitUtil::NextPower2(n), this->builder_->capacity());
+  ASSERT_OK(this->builder_->Reserve(1000));
+  ASSERT_EQ(1000, this->builder_->capacity());
+
+  // Small upsize => should overallocate
+  ASSERT_OK(this->builder_->Reserve(1200));
+  ASSERT_GE(1500, this->builder_->capacity());
+
+  // Large upsize => should allocate exactly
+  ASSERT_OK(this->builder_->Reserve(32768));
+  ASSERT_EQ(32768, this->builder_->capacity());
 
   // unsure if this should go in all builder classes
   ASSERT_EQ(0, this->builder_->num_children());
@@ -678,10 +684,10 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {
   ASSERT_EQ(null_count, this->builder_->null_count());
 
   ASSERT_EQ(1000, this->builder_->length());
-  ASSERT_EQ(1024, this->builder_->capacity());
+  ASSERT_EQ(1000, this->builder_->capacity());
 
   ASSERT_EQ(1000, this->builder_nn_->length());
-  ASSERT_EQ(1024, this->builder_nn_->capacity());
+  ASSERT_EQ(1000, this->builder_nn_->capacity());
 
   ASSERT_OK(this->builder_->Reserve(size - 1000));
   ASSERT_OK(this->builder_nn_->Reserve(size - 1000));
@@ -697,10 +703,10 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendScalar) {
   }
 
   ASSERT_EQ(size, this->builder_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   ASSERT_EQ(size, this->builder_nn_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_nn_->capacity());
+  ASSERT_GE(size, this->builder_nn_->capacity());
 
   this->Check(this->builder_, true);
   this->Check(this->builder_nn_, false);
@@ -722,10 +728,10 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValues) {
   ASSERT_OK(this->builder_nn_->AppendValues(draws.data(), K));
 
   ASSERT_EQ(1000, this->builder_->length());
-  ASSERT_EQ(1024, this->builder_->capacity());
+  ASSERT_EQ(1000, this->builder_->capacity());
 
   ASSERT_EQ(1000, this->builder_nn_->length());
-  ASSERT_EQ(1024, this->builder_nn_->capacity());
+  ASSERT_EQ(1000, this->builder_nn_->capacity());
 
   // Append the next 9000
   ASSERT_OK(
@@ -733,10 +739,10 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValues) {
   ASSERT_OK(this->builder_nn_->AppendValues(draws.data() + K, size - K));
 
   ASSERT_EQ(size, this->builder_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   ASSERT_EQ(size, this->builder_nn_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_nn_->capacity());
+  ASSERT_GE(size, this->builder_nn_->capacity());
 
   this->Check(this->builder_, true);
   this->Check(this->builder_nn_, false);
@@ -751,7 +757,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesIter) {
   ASSERT_OK(this->builder_nn_->AppendValues(this->draws_.begin(), this->draws_.end()));
 
   ASSERT_EQ(size, this->builder_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   this->Check(this->builder_, true);
   this->Check(this->builder_nn_, false);
@@ -765,7 +771,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesIterNullValid) {
                                             this->draws_.begin() + size / 2,
                                             static_cast<uint8_t*>(nullptr)));
 
-  ASSERT_EQ(BitUtil::NextPower2(size / 2), this->builder_nn_->capacity());
+  ASSERT_GE(size / 2, this->builder_nn_->capacity());
 
   ASSERT_OK(this->builder_nn_->AppendValues(this->draws_.begin() + size / 2,
                                             this->draws_.end(),
@@ -836,10 +842,10 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesIterConverted) {
   ASSERT_OK(this->builder_nn_->AppendValues(cast_values.begin(), cast_values.end()));
 
   ASSERT_EQ(size, this->builder_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   ASSERT_EQ(size, this->builder_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   this->Check(this->builder_, true);
   this->Check(this->builder_nn_, false);
@@ -884,9 +890,9 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesStdBool) {
   ASSERT_OK(this->builder_nn_->AppendValues(draws.data(), K));
 
   ASSERT_EQ(1000, this->builder_->length());
-  ASSERT_EQ(1024, this->builder_->capacity());
+  ASSERT_EQ(1000, this->builder_->capacity());
   ASSERT_EQ(1000, this->builder_nn_->length());
-  ASSERT_EQ(1024, this->builder_nn_->capacity());
+  ASSERT_EQ(1000, this->builder_nn_->capacity());
 
   // Append the next 9000
   is_valid.clear();
@@ -900,10 +906,10 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesStdBool) {
   ASSERT_OK(this->builder_nn_->AppendValues(partial_draws));
 
   ASSERT_EQ(size, this->builder_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   ASSERT_EQ(size, this->builder_nn_->length());
-  ASSERT_EQ(BitUtil::NextPower2(size), this->builder_->capacity());
+  ASSERT_GE(size, this->builder_->capacity());
 
   this->Check(this->builder_, true);
   this->Check(this->builder_nn_, false);
@@ -934,13 +940,14 @@ TYPED_TEST(TestPrimitiveBuilder, TestReserve) {
   ASSERT_EQ(0, this->builder_->length());
   ASSERT_EQ(kMinBuilderCapacity, this->builder_->capacity());
 
-  ASSERT_OK(this->builder_->Reserve(90));
+  ASSERT_OK(this->builder_->Reserve(100));
+  ASSERT_EQ(0, this->builder_->length());
+  ASSERT_GE(100, this->builder_->capacity());
   ASSERT_OK(this->builder_->Advance(100));
-  ASSERT_OK(this->builder_->Reserve(kMinBuilderCapacity));
+  ASSERT_EQ(100, this->builder_->length());
+  ASSERT_GE(100, this->builder_->capacity());
 
   ASSERT_RAISES(Invalid, this->builder_->Resize(1));
-
-  ASSERT_EQ(BitUtil::NextPower2(kMinBuilderCapacity + 100), this->builder_->capacity());
 }
 
 TEST(TestBooleanBuilder, AppendNullsAdvanceBuilder) {

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -85,17 +85,18 @@ class ARROW_EXPORT ArrayBuilder {
   virtual Status Resize(int64_t capacity);
 
   /// \brief Ensure that there is enough space allocated to add the indicated
-  /// number of elements without any further calls to Resize. The memory
-  /// allocated is rounded up to the next highest power of 2 similar to memory
-  /// allocations in STL containers like std::vector
+  /// number of elements without any further calls to Resize. Overallocation is
+  /// used in order to minimize the impact of incremental Reserve() calls.
+  ///
   /// \param[in] additional_capacity the number of additional array values
   /// \return Status
   Status Reserve(int64_t additional_capacity) {
+    auto current_capacity = capacity();
     auto min_capacity = length() + additional_capacity;
-    if (min_capacity <= capacity()) return Status::OK();
+    if (min_capacity <= current_capacity) return Status::OK();
 
     // leave growth factor up to BufferBuilder
-    auto new_capacity = BufferBuilder::GrowByFactor(min_capacity);
+    auto new_capacity = BufferBuilder::GrowByFactor(current_capacity, min_capacity);
     return Resize(new_capacity);
   }
 


### PR DESCRIPTION
Remove a spurious memset() call that would 0-initialize any additional data area.

Also tweak the overallocation strategy.

This makes PrimitiveBuilder 60+% faster here (4.5 -> 7.4 GB/s).