### PR TITLE
ARROW-4717 [C#] Consider exposing ValueTask instead of Task

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Array.cs
@@ -41,7 +41,7 @@ namespace Apache.Arrow
         }
 
         public bool IsValid(int index) =>
-            NullBitmapBuffer.IsEmpty || BitUtility.GetBit(NullBitmapBuffer.Span, index);
+            NullCount == 0 || NullBitmapBuffer.IsEmpty || BitUtility.GetBit(NullBitmapBuffer.Span, index);
 
         public bool IsNull(int index) => !IsValid(index);
 

--- a/csharp/src/Apache.Arrow/Arrays/ArrayData.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrayData.cs
@@ -40,5 +40,18 @@ namespace Apache.Arrow
             Buffers = buffers?.ToArray();
             Children = children?.ToArray();
         }
+
+        public ArrayData(
+            IArrowType dataType,
+            int length, int nullCount = 0, int offset = 0,
+            ArrowBuffer[] buffers = null, ArrayData[] children = null)
+        {
+            DataType = dataType ?? NullType.Default;
+            Length = length;
+            NullCount = nullCount;
+            Offset = offset;
+            Buffers = buffers;
+            Children = children;
+        }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
@@ -18,70 +18,59 @@ using System;
 
 namespace Apache.Arrow
 {
-    public class ArrowArrayFactory
+    public static class ArrowArrayFactory
     {
-        private class FactoryTypeVisitor :
-            IArrowTypeVisitor<Int8Type>,
-            IArrowTypeVisitor<Int16Type>,
-            IArrowTypeVisitor<Int32Type>,
-            IArrowTypeVisitor<Int64Type>,
-            IArrowTypeVisitor<UInt8Type>,
-            IArrowTypeVisitor<UInt16Type>,
-            IArrowTypeVisitor<UInt32Type>,
-            IArrowTypeVisitor<UInt64Type>,
-            IArrowTypeVisitor<BooleanType>,
-            IArrowTypeVisitor<FloatType>,
-            IArrowTypeVisitor<DoubleType>,
-            IArrowTypeVisitor<StructType>,
-            IArrowTypeVisitor<UnionType>,
-            IArrowTypeVisitor<ListType>,
-            IArrowTypeVisitor<TimestampType>,
-            IArrowTypeVisitor<StringType>,
-            IArrowTypeVisitor<BinaryType>
-        {
-            private readonly ArrayData _data;
-            private IArrowArray _array;
-
-            public FactoryTypeVisitor(ArrayData data)
-            {
-                _data = data;
-            }
-
-            public IArrowArray CreateArray()
-            {
-                _data.DataType.Accept(this);
-                return _array;
-            }
-
-            public void Visit(Int8Type type) => _array = new Int8Array(_data);
-            public void Visit(Int16Type type) => _array = new Int16Array(_data);
-            public void Visit(Int32Type type) => _array = new Int32Array(_data);
-            public void Visit(Int64Type type) => _array = new Int64Array(_data);
-            public void Visit(UInt8Type type) => _array = new UInt8Array(_data);
-            public void Visit(UInt16Type type) => _array = new UInt16Array(_data);
-            public void Visit(UInt32Type type) => _array = new UInt32Array(_data);
-            public void Visit(UInt64Type type) => _array = new UInt64Array(_data);
-            public void Visit(BooleanType type) => _array = new BooleanArray(_data);
-            public void Visit(FloatType type) => _array = new FloatArray(_data);
-            public void Visit(DoubleType type) => _array = new DoubleArray(_data);
-            public void Visit(StructType type) => _array = new StructArray(_data);
-            public void Visit(UnionType type) => _array = new UnionArray(_data);
-            public void Visit(ListType type) => _array = new ListArray(_data);
-            public void Visit(TimestampType type) => _array = new TimestampArray(_data);
-            public void Visit(BinaryType type) => _array = new BinaryArray(_data);
-            public void Visit(StringType type) => _array = new StringArray(_data);
-
-            public void Visit(IArrowType type)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
         public static IArrowArray BuildArray(ArrayData data)
         {
-            var visitor = new FactoryTypeVisitor(data);
-            var array = visitor.CreateArray();
-            return array;
+            switch (data.DataType.TypeId)
+            {
+                case ArrowTypeId.Boolean:
+                    return new BooleanArray(data);
+                case ArrowTypeId.UInt8:
+                    return new UInt8Array(data);
+                case ArrowTypeId.Int8:
+                    return new Int8Array(data);
+                case ArrowTypeId.UInt16:
+                    return new UInt16Array(data);
+                case ArrowTypeId.Int16:
+                    return new Int16Array(data);
+                case ArrowTypeId.UInt32:
+                    return new UInt32Array(data);
+                case ArrowTypeId.Int32:
+                    return new Int32Array(data);
+                case ArrowTypeId.UInt64:
+                    return new UInt64Array(data);
+                case ArrowTypeId.Int64:
+                    return new Int64Array(data);
+                case ArrowTypeId.Float:
+                    return new FloatArray(data);
+                case ArrowTypeId.Double:
+                    return new DoubleArray(data);
+                case ArrowTypeId.String:
+                    return new StringArray(data);
+                case ArrowTypeId.Binary:
+                    return new BinaryArray(data);
+                case ArrowTypeId.Timestamp:
+                    return new TimestampArray(data);
+                case ArrowTypeId.List:
+                    return new ListArray(data);
+                case ArrowTypeId.Struct:
+                    return new StructArray(data);
+                case ArrowTypeId.Union:
+                    return new UnionArray(data);
+                case ArrowTypeId.Date64:
+                case ArrowTypeId.Date32:
+                case ArrowTypeId.Decimal:
+                case ArrowTypeId.Dictionary:
+                case ArrowTypeId.FixedSizedBinary:
+                case ArrowTypeId.HalfFloat:
+                case ArrowTypeId.Interval:
+                case ArrowTypeId.Map:
+                case ArrowTypeId.Time32:
+                case ArrowTypeId.Time64:
+                default:
+                    throw new NotSupportedException($"An ArrowArray cannot be built for type {data.DataType.TypeId}.");
+            }
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Extensions/ArrayDataExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/ArrayDataExtensions.cs
@@ -31,21 +31,13 @@ namespace Apache.Arrow
             }
         }
 
-        public static void EnsureDataType(this ArrayData data, params ArrowTypeId[] ids)
+        public static void EnsureDataType(this ArrayData data, ArrowTypeId id)
         {
-            var valid = true;
-
-            foreach (var id in ids)
-            {
-                if (data.DataType.TypeId != id)
-                    valid = false;
-            }
-
-            if (!valid)
+            if (data.DataType.TypeId != id)
             {
                 // TODO: Use localizable string resource
                 throw new ArgumentException(
-                    $"Specified array type <{data.DataType.TypeId}> does not match expected type(s) <{string.Join(",", ids)}>",
+                    $"Specified array type <{data.DataType.TypeId}> does not match expected type(s) <{id}>",
                     nameof(data.DataType.TypeId));
             }
         }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReader.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReader.cs
@@ -45,12 +45,12 @@ namespace Apache.Arrow.Ipc
             return new ArrowFileReader(stream);
         }
 
-        public Task<int> RecordBatchCountAsync()
+        public ValueTask<int> RecordBatchCountAsync()
         {
             return Implementation.RecordBatchCountAsync();
         }
 
-        public Task<RecordBatch> ReadRecordBatchAsync(int index, CancellationToken cancellationToken = default)
+        public ValueTask<RecordBatch> ReadRecordBatchAsync(int index, CancellationToken cancellationToken = default)
         {
             return Implementation.ReadRecordBatchAsync(index, cancellationToken);
         }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
@@ -42,7 +42,7 @@ namespace Apache.Arrow.Ipc
         {
         }
 
-        public async Task<int> RecordBatchCountAsync()
+        public async ValueTask<int> RecordBatchCountAsync()
         {
             if (!HasReadSchema)
             {
@@ -142,7 +142,7 @@ namespace Apache.Arrow.Ipc
             Schema = _footer.Schema;
         }
 
-        public async Task<RecordBatch> ReadRecordBatchAsync(int index, CancellationToken cancellationToken)
+        public async ValueTask<RecordBatch> ReadRecordBatchAsync(int index, CancellationToken cancellationToken)
         {
             await ReadSchemaAsync().ConfigureAwait(false);
 

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -58,7 +58,7 @@ namespace Apache.Arrow.Ipc
             RecordBatchBlocks = new List<Block>();
         }
 
-        public override async Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
             // TODO: Compare record batch schema
 
@@ -101,7 +101,7 @@ namespace Apache.Arrow.Ipc
             _currentRecordBatchOffset = -1;
         }
 
-        public async Task WriteFooterAsync(CancellationToken cancellationToken = default)
+        public async ValueTask WriteFooterAsync(CancellationToken cancellationToken = default)
         {
             if (!HasWrittenFooter)
             {
@@ -114,11 +114,9 @@ namespace Apache.Arrow.Ipc
 
         private async ValueTask WriteHeaderAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
             // Write magic number and empty padding up to the 8-byte boundary
 
-            await WriteMagicAsync().ConfigureAwait(false);
+            await WriteMagicAsync(cancellationToken).ConfigureAwait(false);
             await WritePaddingAsync(CalculatePadding(ArrowFileConstants.Magic.Length))
                 .ConfigureAwait(false);
         }
@@ -182,15 +180,12 @@ namespace Apache.Arrow.Ipc
 
             // Write magic
 
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await WriteMagicAsync().ConfigureAwait(false);
+            await WriteMagicAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private Task WriteMagicAsync()
+        private ValueTask WriteMagicAsync(CancellationToken cancellationToken)
         {
-            return BaseStream.WriteAsync(
-                ArrowFileConstants.Magic, 0, ArrowFileConstants.Magic.Length);
+            return BaseStream.WriteAsync(ArrowFileConstants.Magic, cancellationToken);
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -58,7 +58,7 @@ namespace Apache.Arrow.Ipc
             RecordBatchBlocks = new List<Block>();
         }
 
-        public override async ValueTask WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
+        public override async Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
             // TODO: Compare record batch schema
 
@@ -101,7 +101,7 @@ namespace Apache.Arrow.Ipc
             _currentRecordBatchOffset = -1;
         }
 
-        public async ValueTask WriteFooterAsync(CancellationToken cancellationToken = default)
+        public async Task WriteFooterAsync(CancellationToken cancellationToken = default)
         {
             if (!HasWrittenFooter)
             {
@@ -112,7 +112,7 @@ namespace Apache.Arrow.Ipc
             await BaseStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        private async ValueTask WriteHeaderAsync(CancellationToken cancellationToken)
+        private async Task WriteHeaderAsync(CancellationToken cancellationToken)
         {
             // Write magic number and empty padding up to the 8-byte boundary
 
@@ -121,7 +121,7 @@ namespace Apache.Arrow.Ipc
                 .ConfigureAwait(false);
         }
 
-        private async ValueTask WriteFooterAsync(Schema schema, CancellationToken cancellationToken)
+        private async Task WriteFooterAsync(Schema schema, CancellationToken cancellationToken)
         {
             Builder.Clear();
 

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReader.cs
@@ -66,9 +66,9 @@ namespace Apache.Arrow.Ipc
             }
         }
 
-        public async Task<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
+        public ValueTask<RecordBatch> ReadNextRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            return await _implementation.ReadNextRecordBatchAsync(cancellationToken).ConfigureAwait(false);
+            return _implementation.ReadNextRecordBatchAsync(cancellationToken);
         }
 
         public RecordBatch ReadNextRecordBatch()

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -160,7 +160,7 @@ namespace Apache.Arrow.Ipc
             _fieldTypeBuilder = new ArrowTypeFlatbufferBuilder(Builder);
         }
 
-        private protected async ValueTask WriteRecordBatchInternalAsync(RecordBatch recordBatch,
+        private protected async Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
             CancellationToken cancellationToken = default)
         {
             // TODO: Truncate buffers with extraneous padding / unused capacity
@@ -253,12 +253,12 @@ namespace Apache.Arrow.Ipc
         {
         }
 
-        public virtual ValueTask WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
+        public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
             return WriteRecordBatchInternalAsync(recordBatch, cancellationToken);
         }
 
-        public ValueTask WriteBufferAsync(ArrowBuffer arrowBuffer, CancellationToken cancellationToken = default)
+        private ValueTask WriteBufferAsync(ArrowBuffer arrowBuffer, CancellationToken cancellationToken = default)
         {
             return BaseStream.WriteAsync(arrowBuffer.Memory, cancellationToken);
         }
@@ -363,7 +363,7 @@ namespace Apache.Arrow.Ipc
             }
         }
 
-        protected ValueTask WritePaddingAsync(int length)
+        private protected ValueTask WritePaddingAsync(int length)
         {
             if (length > 0)
             {

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -200,13 +200,12 @@ namespace Apache.Arrow.Ipc
             }
 
             var buffers = recordBatchBuilder.Buffers;
-            var bufferOffsets = new Offset<Flatbuf.Buffer>[buffers.Count];
 
             Flatbuf.RecordBatch.StartBuffersVector(Builder, buffers.Count);
 
             for (var i = buffers.Count - 1; i >= 0; i--)
             {
-                bufferOffsets[i] = Flatbuf.Buffer.CreateBuffer(Builder,
+                Flatbuf.Buffer.CreateBuffer(Builder,
                     buffers[i].Offset, buffers[i].Length);
             }
 

--- a/csharp/src/Apache.Arrow/Ipc/IArrowReader.cs
+++ b/csharp/src/Apache.Arrow/Ipc/IArrowReader.cs
@@ -20,7 +20,7 @@ namespace Apache.Arrow.Ipc
 {
     public interface IArrowReader
     {
-        Task<RecordBatch> ReadNextRecordBatchAsync(
+        ValueTask<RecordBatch> ReadNextRecordBatchAsync(
             CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Eliminating allocations in the C# Arrow library:

1. Use ValueTask instead of Task in the public APIs.
2. Eliminate allocations in ArrayData constructor by taking an array directly instead of calling `ToArray()` every time.
3. Remove some other minor allocations that provide no benefit.
4. Also, add a simple `NullCount == 0` check to optimize the case where there are no nulls in the data, but the null bitmap is filled with 0s instead of being empty.

With this change the `ArrowReaderWithMemory` benchmark in the repo goes from:


## Before
|                      Method |      Allocated Memory/Op |
|---------------------------- |--------------------:|
|       ArrowReaderWithMemory |  5.84 KB |

## After
|                      Method |      Allocated Memory/Op |
|---------------------------- |--------------------:|
|       ArrowReaderWithMemory |  4.48 KB |


@stephentoub @pgovind @chutchinson 