### PR TITLE
[Packaging][Wheel] Make nightly wheel links available on crossbow's static github page

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -601,10 +601,9 @@ def update_wheel_links(ctx, n, gh_branch, job_prefix, dry_run):
         return '<html><body><ul>{}</ul></body></html>'.format(''.join(links))
 
     queue = ctx.obj['queue']
-    # queue.fetch()
+    queue.fetch()
 
     files = {'nightly': {'wheel': {}}}
-    latest = None
     for job in toolz.take(n, queue.jobs(prefix=job_prefix)):
         wheels = {}
 


### PR DESCRIPTION
`python crossbow.py github-page update-wheel-links -n 30` command generates a static github page like: http://kszucs.me/crossbow/nightly/wheel/

This enables to install nightly wheels via pip: `pip install --no-index --find-links http://kszucs.me/crossbow/nightly/wheel/2019-04-24/ pyarrow`

The urls will change of course.