### PR TITLE
ARROW-5206: [Java] Add APIs in MessageSerializer to directly serialize/deserialize ArrowBuf

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -66,16 +66,21 @@ public class ReadChannel implements AutoCloseable {
     return totalRead;
   }
 
+  public int readFully(ArrowBuf buffer, int l) throws IOException {
+    return readFully(buffer, buffer.writerIndex(), l);
+  }
+
   /**
    * Reads up to len into buffer. Returns bytes read.
    *
    * @param buffer the buffer to read to
-   * @param l      the amount of bytes to read
+   * @param offset the position to start read
+   * @param length the amount of bytes to read
    * @return the number of bytes read
    * @throws IOException if nit enough bytes left to read
    */
-  public int readFully(ArrowBuf buffer, int l) throws IOException {
-    int n = readFully(buffer.nioBuffer(buffer.writerIndex(), l));
+  public int readFully(ArrowBuf buffer, int offset, int length) throws IOException {
+    int n = readFully(buffer.nioBuffer(offset, length));
     buffer.writerIndex(n);
     return n;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -89,9 +89,13 @@ public class WriteChannel implements AutoCloseable {
     return write(outBuffer);
   }
 
-  public void write(ArrowBuf buffer) throws IOException {
-    ByteBuffer nioBuffer = buffer.nioBuffer(buffer.readerIndex(), buffer.readableBytes());
-    write(nioBuffer);
+  public long write(ArrowBuf buffer) throws IOException {
+    return write(buffer, buffer.readerIndex(), buffer.readableBytes());
+  }
+
+  public long write(ArrowBuf buffer, int offset, int length) throws IOException {
+    ByteBuffer nioBuffer = buffer.nioBuffer(offset, length);
+    return write(nioBuffer);
   }
 
   public long write(FBSerializable writer, boolean withSizePrefix) throws IOException {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -576,4 +576,29 @@ public class MessageSerializer {
     }
     return bodyBuffer;
   }
+
+  /**
+   * Serialize an ArrowBuf to WriteChannel.
+   * @param buffer The ArrowBuf to serialize
+   * @param offset The write index in buffer
+   * @param length Length in bytes of the buffer to write
+   * @param channel WriteChannel to write the buffer
+   * @throws IOException if something went wrong
+   */
+  public static void serializeArrowBuf(ArrowBuf buffer, int offset, int length, WriteChannel channel) throws IOException {
+    channel.write(buffer, offset, length);
+  }
+
+  /**
+   * Deserialize an ArrowBuf from ReadChannel.
+   * @param buffer The ArrowBuf to deserialize to
+   * @param offset The read index in buffer
+   * @param length Length in bytes of the buffer to read
+   * @param channel ReadChannel to read the buffer
+   * @throws IOException
+   */
+  public static void deserializeArrowBuf(ArrowBuf buffer, int offset, int length, ReadChannel channel) throws IOException {
+    channel.readFully(buffer, offset, length);
+  }
+
 }


### PR DESCRIPTION
This PR is related to [ARROW-5206](https://issues.apache.org/jira/browse/ARROW-5206), add APIs in MessageSerializer to directly serialize/deserialize ArrowBuf.