### PR TITLE
ARROW-5219: [C++] Build protobuf_ep in parallel when using Ninja build

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1047,6 +1047,9 @@ macro(build_protobuf)
                       CONFIGURE_COMMAND
                       "./configure"
                       ${PROTOBUF_CONFIGURE_ARGS}
+                      BUILD_COMMAND
+                      ${MAKE}
+                      ${MAKE_BUILD_ARGS}
                       BUILD_IN_SOURCE
                       1
                       URL


### PR DESCRIPTION
I noticed this when looking at ARROW-5192