### PR TITLE
ARROW-5205: [Python] Improved error messages when user erroneously uses a non-local resource URI to open a file

### DIFF
--- a/ci/detect-changes.py
+++ b/ci/detect-changes.py
@@ -20,11 +20,22 @@ from __future__ import print_function
 import functools
 import os
 import pprint
+import re
 import sys
 import subprocess
 
 
 perr = functools.partial(print, file=sys.stderr)
+
+
+def dump_env_vars(prefix, pattern=None):
+    if pattern is not None:
+        match = lambda s: re.search(pattern, s)
+    else:
+        match = lambda s: True
+    for name in sorted(os.environ):
+        if name.startswith(prefix) and match(name):
+            perr("- {0}: {1!r}".format(name, os.environ[name]))
 
 
 def run_cmd(cmdline):
@@ -198,6 +209,8 @@ def get_windows_shell_eval(env):
 
 
 def run_from_travis():
+    perr("Environment variables (excerpt):")
+    dump_env_vars('TRAVIS_', '(BRANCH|COMMIT|PULL)')
     if (os.environ['TRAVIS_REPO_SLUG'] == 'apache/arrow' and
             os.environ['TRAVIS_BRANCH'] == 'master' and
             os.environ['TRAVIS_EVENT_TYPE'] != 'pull_request'):
@@ -224,6 +237,8 @@ def run_from_travis():
 
 
 def run_from_appveyor():
+    perr("Environment variables (excerpt):")
+    dump_env_vars('APPVEYOR_', '(PULL|REPO)')
     if not os.environ.get('APPVEYOR_PULL_REQUEST_HEAD_COMMIT'):
         # Not a PR build, test everything
         affected = dict.fromkeys(ALL_TOPICS, True)

--- a/python/pyarrow/error.pxi
+++ b/python/pyarrow/error.pxi
@@ -80,6 +80,12 @@ cdef int check_status(const CStatus& status) nogil except -1:
         if status.IsInvalid():
             raise ArrowInvalid(message)
         elif status.IsIOError():
+            # Give a helpful hint if someone passes a hdfs or s3 path
+            if "No such file or directory" in message:
+                if "hdfs:" in message:
+                    message += " Try using HadoopFileSystem."
+                elif "s3:" in message:
+                    message += " Try using S3FSWrapper."
             raise ArrowIOError(message)
         elif status.IsOutOfMemory():
             raise ArrowMemoryError(message)

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -59,6 +59,13 @@ def make_random_csv(num_cols=2, num_rows=10, linesep=u'\r\n'):
     return csv, expected
 
 
+def test_nonlocal_file_errors_nicely():
+    with pytest.raises(pa.lib.ArrowIOError, match="Try using HadoopFileSystem"):
+        read_csv("hdfs://does-not-exist.csv")
+    with pytest.raises(pa.lib.ArrowIOError, match="Try using S3FSWrapper"):
+        read_csv("s3://does-not-exist.csv")
+
+
 def test_read_options():
     cls = ReadOptions
     opts = cls()


### PR DESCRIPTION
Here's a solution for [the issue](https://issues.apache.org/jira/browse/ARROW-5205) that addresses not just the [original report](https://stackoverflow.com/questions/55704943/what-could-be-the-explanation-of-this-pyarrow-lib-arrowioerror/55707311#55707311) about `read_csv` but presumably any other way you could try to load a non-local file. 

I could think of a few other ways to solve this, and we can certainly debate what the better error messages should say, but figured it's easier to discuss in the context of a patch. I also wonder whether pyarrow should just try to do itself what the more helpful error message suggests (i.e. if you get a hdfs path string and it fails, try to connect with HadoopFileSystem and retry rather than tell the user to retry) but maybe that's too clever.