### PR TITLE
ARROW-5242: [C++] Fixes compiler warning in recent VS updates

### DIFF
--- a/cpp/src/arrow/vendored/datetime/tz.cpp
+++ b/cpp/src/arrow/vendored/datetime/tz.cpp
@@ -202,7 +202,12 @@ get_known_folder(const GUID& folderid)
     if (SUCCEEDED(hr))
     {
         co_task_mem_ptr folder_ptr(pfolder);
-        folder = std::string(folder_ptr.get(), folder_ptr.get() + wcslen(folder_ptr.get()));
+        folder.clear();
+        folder.reserve(wcslen(folder_ptr.get()));
+        for (std::size_t idx = 0; idx != wcslen(folder_ptr.get()); ++idx)
+        {
+            folder.push_back(static_cast<char>(folder_ptr[idx]));
+        }
     }
     return folder;
 }

--- a/cpp/src/arrow/vendored/datetime/tz.cpp
+++ b/cpp/src/arrow/vendored/datetime/tz.cpp
@@ -202,12 +202,10 @@ get_known_folder(const GUID& folderid)
     if (SUCCEEDED(hr))
     {
         co_task_mem_ptr folder_ptr(pfolder);
-        folder.clear();
-        folder.reserve(wcslen(folder_ptr.get()));
-        for (std::size_t idx = 0; idx != wcslen(folder_ptr.get()); ++idx)
-        {
-            folder.push_back(static_cast<char>(folder_ptr[idx]));
-        }
+        #pragma warning(push)
+        #pragma warning(disable : 4244)
+        folder = std::string(folder_ptr.get(), folder_ptr.get() + wcslen(folder_ptr.get()));
+        #pragma warning(pop)
     }
     return folder;
 }


### PR DESCRIPTION
Resolve narrowing from wchar_t -> char warning in recent VS updates, this code will cause a C++ compiler warning C4244, so add the fix in your port. Thanks!

warning info: 
~\include\xstring(2308): warning C4244: 'argument': conversion from '_Ty' to 'const _Elem', possible loss of data

