### PR TITLE
ARROW-5214: [C++] Fix thirdparty download script

### DIFF
--- a/cpp/thirdparty/download_dependencies.sh
+++ b/cpp/thirdparty/download_dependencies.sh
@@ -36,9 +36,8 @@ download_dependency() {
   local url=$1
   local out=$2
 
-  # --show-progress will not output to stdout, it is safe to pipe the result of
-  # the script into eval.
-  wget --no-verbose --continue --output-document="${out}" "${url}"
+  wget --quiet --continue --output-document="${out}" "${url}" || \
+    (echo "Failed downloading ${url}"; exit 1)
 }
 
 main() {

--- a/cpp/thirdparty/download_dependencies.sh
+++ b/cpp/thirdparty/download_dependencies.sh
@@ -37,7 +37,7 @@ download_dependency() {
   local out=$2
 
   wget --quiet --continue --output-document="${out}" "${url}" || \
-    (echo "Failed downloading ${url}"; exit 1)
+    (echo "Failed downloading ${url}" 1>&2; exit 1)
 }
 
 main() {

--- a/cpp/thirdparty/download_dependencies.sh
+++ b/cpp/thirdparty/download_dependencies.sh
@@ -38,7 +38,7 @@ download_dependency() {
 
   # --show-progress will not output to stdout, it is safe to pipe the result of
   # the script into eval.
-  wget --quiet --continue --output-document="${out}" "${url}"
+  wget --no-verbose --continue --output-document="${out}" "${url}"
 }
 
 main() {

--- a/cpp/thirdparty/versions.txt
+++ b/cpp/thirdparty/versions.txt
@@ -69,9 +69,9 @@ DEPENDENCIES=(
   "ARROW_PROTOBUF_URL protobuf-${PROTOBUF_VERSION}.tar.gz https://github.com/google/protobuf/releases/download/${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION:1}.tar.gz"
   "ARROW_RAPIDJSON_URL rapidjson-${RAPIDJSON_VERSION}.tar.gz https://github.com/miloyip/rapidjson/archive/${RAPIDJSON_VERSION}.tar.gz"
   "ARROW_RE2_URL re2-${RE2_VERSION}.tar.gz https://github.com/google/re2/archive/${RE2_VERSION}.tar.gz"
-  "ARROW_SNAPPY_URL snappy-${SNAPPY_VERSION}.tar.gz https://github.com/google/snappy/releases/download/${SNAPPY_VERSION}/snappy-${SNAPPY_VERSION}.tar.gz"
+  "ARROW_SNAPPY_URL snappy-${SNAPPY_VERSION}.tar.gz https://github.com/google/snappy/archive/${SNAPPY_VERSION}.tar.gz"
   "ARROW_THRIFT_URL thrift-${THRIFT_VERSION}.tar.gz http://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
-  "ARROW_URIPARSER_URL uriparser-${URIPARSER_VERSION}.tar.gz https://github.com/uriparser/uriparser/archive/${URIPARSER_VERSION}.tar.gz"
+  "ARROW_URIPARSER_URL uriparser-${URIPARSER_VERSION}.tar.gz https://github.com/uriparser/uriparser/archive/uriparser-${URIPARSER_VERSION}.tar.gz"
   "ARROW_ZLIB_URL zlib-${ZLIB_VERSION}.tar.gz http://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
   "ARROW_ZSTD_URL zstd-${ZSTD_VERSION}.tar.gz https://github.com/facebook/zstd/archive/${ZSTD_VERSION}.tar.gz"
 )


### PR DESCRIPTION
- Some URI changed
- Switched wget option from `--quiet` to `--no-verbose` for improved
  error messages. Sadly this will clutter stderr sometimes with non
  failure error, thus manual copy-paste will be hindered, but not inline
  eval, e.g. `eval $(download.. )`.