### PR TITLE
ARROW-5225: [Java] Improve performance of BaseValueVector#getValidityBufferSizeFromCount

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -104,7 +104,7 @@ public abstract class BaseValueVector implements ValueVector {
 
   /* number of bytes for the validity buffer for the given valueCount */
   protected static int getValidityBufferSizeFromCount(final int valueCount) {
-    return valueCount % 8 > 0 ? valueCount / 8 + 1 : valueCount / 8;
+    return (valueCount + 7) >> 3;
   }
 
   /* round up to the next multiple of 8 */

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -104,7 +104,7 @@ public abstract class BaseValueVector implements ValueVector {
 
   /* number of bytes for the validity buffer for the given valueCount */
   protected static int getValidityBufferSizeFromCount(final int valueCount) {
-    return (int) Math.ceil(valueCount / 8.0);
+    return valueCount % 8 > 0 ? valueCount / 8 + 1 : valueCount / 8;
   }
 
   /* round up to the next multiple of 8 */

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -123,7 +123,7 @@ public class BitVectorHelper {
    * @return buffer size
    */
   public static int getValidityBufferSize(int valueCount) {
-    return ((int) Math.ceil(valueCount / 8.0));
+    return valueCount % 8 > 0 ? valueCount / 8 + 1 : valueCount / 8;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -123,7 +123,7 @@ public class BitVectorHelper {
    * @return buffer size
    */
   public static int getValidityBufferSize(int valueCount) {
-    return valueCount % 8 > 0 ? valueCount / 8 + 1 : valueCount / 8;
+    return (valueCount + 7) >> 3;
   }
 
   /**


### PR DESCRIPTION
Now in BaseValueVector#getValidityBufferSizeFromCount  and BitVectorHelper#getValidityBufferSize, it uses Math.ceil to calculate size which is not efficient (lots of unnecessary logic in StrictMath#floorOrCeil) . Since the valueCount is always not less than 0, we could simply replace Math.ceil with the following code:

return valueCount % 8 > 0 ? valueCount / 8 + 1 : valueCount / 8;