### PR TITLE
ARROW-5232: [Java] Avoid runaway doubling of vector size

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -408,7 +408,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     int targetValueCount = getValueCapacity() * 2;
     if (targetValueCount == 0) {
       if (lastValueCapacity > 0) {
-        targetValueCount = lastValueCapacity * 2;
+        targetValueCount = lastValueCapacity;
       } else {
         targetValueCount = INITIAL_VALUE_ALLOCATION * 2;
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -150,7 +150,7 @@ public abstract class BaseValueVector implements ValueVector {
 
   protected DataAndValidityBuffers allocFixedDataAndValidityBufs(int valueCount, int typeWidth) {
     long bufferSize = computeCombinedBufferSize(valueCount, typeWidth);
-    assert bufferSize < MAX_ALLOCATION_SIZE;
+    assert bufferSize <= MAX_ALLOCATION_SIZE;
 
     int validityBufferSize;
     int dataBufferSize;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -478,14 +478,15 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @throws OutOfMemoryException if the internal memory allocation fails
    */
   public void reallocDataBuffer() {
-    long baseSize = lastValueAllocationSizeInBytes;
     final int currentBufferCapacity = valueBuffer.capacity();
-
-    if (baseSize < (long) currentBufferCapacity) {
-      baseSize = (long) currentBufferCapacity;
+    long newAllocationSize = currentBufferCapacity * 2;
+    if (newAllocationSize == 0) {
+      if (lastValueAllocationSizeInBytes > 0) {
+        newAllocationSize = lastValueAllocationSizeInBytes;
+      } else {
+        newAllocationSize = INITIAL_BYTE_COUNT * 2;
+      }
     }
-
-    long newAllocationSize = baseSize * 2L;
     newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
@@ -525,7 +526,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     int targetOffsetCount = (offsetBuffer.capacity() / OFFSET_WIDTH)  * 2;
     if (targetOffsetCount == 0) {
       if (lastValueCapacity > 0) {
-        targetOffsetCount = 2 * (lastValueCapacity + 1);
+        targetOffsetCount = (lastValueCapacity + 1);
       } else {
         targetOffsetCount = 2 * (INITIAL_VALUE_ALLOCATION + 1);
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -190,4 +190,41 @@ public class TestVectorReAlloc {
       Assert.assertEquals(vector.valueBuffer.capacity(), savedValueBufferSize);
     }
   }
+
+  @Test
+  public void testFixedRepeatedClearAndSet() throws Exception {
+    try (final IntVector vector = new IntVector("", allocator)) {
+      vector.allocateNewSafe(); // Initial allocation
+      vector.clear(); // clear vector.
+      vector.setSafe(0, 10);
+      int savedValueCapacity = vector.getValueCapacity();
+
+      for (int i = 0; i < 1024; ++i) {
+        vector.clear(); // clear vector.
+        vector.setSafe(0, 10);
+      }
+
+      // should be deterministic, and not cause a run-away increase in capacity.
+      Assert.assertEquals(vector.getValueCapacity(), savedValueCapacity);
+    }
+  }
+
+  @Test
+  public void testVariableRepeatedClearAndSet() throws Exception {
+    try (final VarCharVector vector = new VarCharVector("", allocator)) {
+      vector.allocateNewSafe(); // Initial allocation
+
+      vector.clear(); // clear vector.
+      vector.setSafe(0, "hello world".getBytes());
+      int savedValueCapacity = vector.getValueCapacity();
+
+      for (int i = 0; i < 1024; ++i) {
+        vector.clear(); // clear vector.
+        vector.setSafe(0, "hello world".getBytes());
+      }
+
+      // should be deterministic, and not cause a run-away increase in capacity.
+      Assert.assertEquals(vector.getValueCapacity(), savedValueCapacity);
+    }
+  }
 }


### PR DESCRIPTION
In reAlloc, double allocation size only if using the
current buffer capacity or the initial allocation as the base size.