### PR TITLE
ARROW-767: [C++] Filesystem abstraction

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -105,6 +105,9 @@ set(ARROW_SRCS
     csv/options.cc
     csv/parser.cc
     csv/reader.cc
+    filesystem/filesystem.cc
+    filesystem/mockfs.cc
+    filesystem/path-util.cc
     json/options.cc
     json/chunked-builder.cc
     json/chunker.cc
@@ -364,6 +367,7 @@ add_arrow_benchmark(column-benchmark)
 
 add_subdirectory(array)
 add_subdirectory(csv)
+add_subdirectory(filesystem)
 add_subdirectory(json)
 add_subdirectory(io)
 add_subdirectory(util)

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Headers: top level
+arrow_install_all_headers("arrow/filesystem")
+
+add_arrow_test(filesystem-test)

--- a/cpp/src/arrow/filesystem/filesystem-test.cc
+++ b/cpp/src/arrow/filesystem/filesystem-test.cc
@@ -1,0 +1,411 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include "arrow/filesystem/filesystem.h"
+#include "arrow/filesystem/mockfs.h"
+#include "arrow/io/interfaces.h"
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+TEST(FileStats, BaseName) {
+  auto st = FileStats();
+  ASSERT_EQ(st.base_name(), "");
+  st.set_path("foo");
+  ASSERT_EQ(st.base_name(), "foo");
+  st.set_path("foo/bar/baz.qux");
+  ASSERT_EQ(st.base_name(), "baz.qux");
+}
+
+////////////////////////////////////////////////////////////////////////////
+// MockFileSystem tests
+
+class TestMockFS : public ::testing::Test {
+ public:
+  void SetUp() {
+    time_ = TimePoint(TimePoint::duration(42));
+    fs_ = std::make_shared<MockFileSystem>(time_);
+  }
+
+  Status WriteString(io::OutputStream* stream, const std::string& s) {
+    return stream->Write(s.data(), static_cast<int64_t>(s.length()));
+  }
+
+  void CheckDirs(const std::vector<DirInfo>& expected) {
+    ASSERT_EQ(fs_->AllDirs(), expected);
+  }
+
+  void CheckDirPaths(const std::vector<std::string>& expected) {
+    std::vector<DirInfo> infos;
+    infos.reserve(expected.size());
+    for (const auto& s : expected) {
+      infos.push_back({s, time_});
+    }
+    ASSERT_EQ(fs_->AllDirs(), infos);
+  }
+
+  void CheckFiles(const std::vector<FileInfo>& expected) {
+    ASSERT_EQ(fs_->AllFiles(), expected);
+  }
+
+  void CreateFile(const std::string& path, const std::string& data) {
+    std::shared_ptr<io::OutputStream> stream;
+    ASSERT_OK(fs_->OpenAppendStream(path, &stream));
+    ASSERT_OK(WriteString(stream.get(), data));
+    ASSERT_OK(stream->Close());
+  }
+
+ protected:
+  TimePoint time_;
+  std::shared_ptr<MockFileSystem> fs_;
+};
+
+void AssertFileStats(const FileStats& st, const std::string& path, FileType type) {
+  ASSERT_EQ(st.path(), path);
+  ASSERT_EQ(st.type(), type);
+}
+
+void AssertFileStats(const FileStats& st, const std::string& path, FileType type,
+                     TimePoint mtime) {
+  AssertFileStats(st, path, type);
+  ASSERT_EQ(st.mtime(), mtime);
+}
+
+void AssertFileStats(const FileStats& st, const std::string& path, FileType type,
+                     TimePoint mtime, int64_t size) {
+  AssertFileStats(st, path, type, mtime);
+  ASSERT_EQ(st.size(), size);
+}
+
+TEST_F(TestMockFS, Empty) {
+  CheckDirs({});
+  CheckFiles({});
+}
+
+TEST_F(TestMockFS, CreateDir) {
+  ASSERT_OK(fs_->CreateDir("AB"));
+  ASSERT_OK(fs_->CreateDir("AB/CD/EF"));  // Recursive
+  // Non-recursive, parent doesn't exist
+  ASSERT_RAISES(IOError, fs_->CreateDir("AB/GH/IJ", false /* recursive */));
+  ASSERT_OK(fs_->CreateDir("AB/GH", false /* recursive */));
+  ASSERT_OK(fs_->CreateDir("AB/GH/IJ", false /* recursive */));
+  // Idempotency
+  ASSERT_OK(fs_->CreateDir("AB/GH/IJ", false /* recursive */));
+  ASSERT_OK(fs_->CreateDir("XY"));
+  CheckDirs({{"AB", time_},
+             {"AB/CD", time_},
+             {"AB/CD/EF", time_},
+             {"AB/GH", time_},
+             {"AB/GH/IJ", time_},
+             {"XY", time_}});
+  CheckFiles({});
+
+  // Cannot create a directory as child of a file
+  CreateFile("AB/cd", "");
+  auto st = fs_->CreateDir("AB/cd/EF/GH", true /* recursive */);
+  std::string expected_msg =
+      "Cannot create directory 'AB/cd/EF/GH': ancestor 'AB/cd' is a regular file";
+  ASSERT_RAISES(IOError, st);
+  ASSERT_EQ(st.message(), expected_msg);
+  st = fs_->CreateDir("AB/cd/EF", false /* recursive */);
+  expected_msg = "Cannot create directory 'AB/cd/EF': ancestor 'AB/cd' is a regular file";
+  ASSERT_RAISES(IOError, st);
+  ASSERT_EQ(st.message(), expected_msg);
+}
+
+TEST_F(TestMockFS, DeleteDir) {
+  ASSERT_OK(fs_->CreateDir("AB/CD/EF"));
+  ASSERT_OK(fs_->CreateDir("AB/GH/IJ"));
+  ASSERT_OK(fs_->DeleteDir("AB/CD"));
+  ASSERT_OK(fs_->DeleteDir("AB/GH/IJ"));
+  CheckDirs({{"AB", time_}, {"AB/GH", time_}});
+  CheckFiles({});
+  ASSERT_RAISES(IOError, fs_->DeleteDir("AB/CD"));
+  ASSERT_OK(fs_->DeleteDir("AB"));
+  CheckDirs({});
+  CheckFiles({});
+}
+
+TEST_F(TestMockFS, DeleteFile) {
+  ASSERT_OK(fs_->CreateDir("AB"));
+  CreateFile("AB/cd", "data");
+  CheckDirs({{"AB", time_}});
+  CheckFiles({{"AB/cd", time_, "data"}});
+
+  ASSERT_OK(fs_->DeleteFile("AB/cd"));
+  CheckDirs({{"AB", time_}});
+  CheckFiles({});
+
+  CreateFile("ab", "data");
+  CheckDirs({{"AB", time_}});
+  CheckFiles({{"ab", time_, "data"}});
+
+  ASSERT_OK(fs_->DeleteFile("ab"));
+  CheckDirs({{"AB", time_}});
+  CheckFiles({});
+
+  // File doesn't exist
+  ASSERT_RAISES(IOError, fs_->DeleteFile("ab"));
+  ASSERT_RAISES(IOError, fs_->DeleteFile("AB/cd"));
+
+  // Not a file
+  ASSERT_RAISES(IOError, fs_->DeleteFile("AB"));
+  CheckDirs({{"AB", time_}});
+  CheckFiles({});
+}
+
+TEST_F(TestMockFS, GetTargetStatsSingle) {
+  ASSERT_OK(fs_->CreateDir("AB/CD"));
+  CreateFile("AB/CD/ef", "some data");
+
+  FileStats st;
+  ASSERT_OK(fs_->GetTargetStats("AB", &st));
+  AssertFileStats(st, "AB", FileType::Directory, time_);
+  ASSERT_EQ(st.base_name(), "AB");
+  ASSERT_OK(fs_->GetTargetStats("AB/CD", &st));
+  AssertFileStats(st, "AB/CD", FileType::Directory, time_);
+  ASSERT_EQ(st.base_name(), "CD");
+  ASSERT_OK(fs_->GetTargetStats("AB/CD/ef", &st));
+  AssertFileStats(st, "AB/CD/ef", FileType::File, time_, 9);
+  ASSERT_EQ(st.base_name(), "ef");
+  ASSERT_OK(fs_->GetTargetStats("zz", &st));
+  AssertFileStats(st, "zz", FileType::NonExistent);
+  ASSERT_EQ(st.base_name(), "zz");
+
+  // Invalid path
+  ASSERT_RAISES(Invalid, fs_->GetTargetStats("//foo//bar//baz//", &st));
+}
+
+TEST_F(TestMockFS, GetTargetStatsVector) {
+  ASSERT_OK(fs_->CreateDir("AB/CD"));
+  CreateFile("AB/CD/ef", "some data");
+
+  std::vector<FileStats> stats;
+  ASSERT_OK(
+      fs_->GetTargetStats({"AB", "AB/CD", "AB/zz", "zz", "XX/zz", "AB/CD/ef"}, &stats));
+  ASSERT_EQ(stats.size(), 6);
+  AssertFileStats(stats[0], "AB", FileType::Directory, time_);
+  AssertFileStats(stats[1], "AB/CD", FileType::Directory, time_);
+  AssertFileStats(stats[2], "AB/zz", FileType::NonExistent);
+  AssertFileStats(stats[3], "zz", FileType::NonExistent);
+  AssertFileStats(stats[4], "XX/zz", FileType::NonExistent);
+  AssertFileStats(stats[5], "AB/CD/ef", FileType::File, time_, 9);
+
+  // Invalid path
+  ASSERT_RAISES(Invalid,
+                fs_->GetTargetStats({"AB", "AB/CD", "//foo//bar//baz//"}, &stats));
+}
+
+TEST_F(TestMockFS, GetTargetStatsSelector) {
+  // Non-recursive tests for GetTargetStats(Selector, ...).
+  ASSERT_OK(fs_->CreateDir("AB/CD"));
+  CreateFile("ab", "data");
+  CreateFile("AB/cd", "some data");
+  CreateFile("AB/CD/ef", "some other data");
+  CreateFile("AB/CD/gh", "yet other data");
+
+  Selector s;
+  s.base_dir = "";
+  std::vector<FileStats> stats;
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 2);
+  AssertFileStats(stats[0], "AB", FileType::Directory, time_);
+  AssertFileStats(stats[1], "ab", FileType::File, time_, 4);
+
+  s.base_dir = "AB";
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 2);
+  AssertFileStats(stats[0], "AB/CD", FileType::Directory, time_);
+  AssertFileStats(stats[1], "AB/cd", FileType::File, time_, 9);
+
+  s.base_dir = "AB/CD";
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 2);
+  AssertFileStats(stats[0], "AB/CD/ef", FileType::File, time_, 15);
+  AssertFileStats(stats[1], "AB/CD/gh", FileType::File, time_, 14);
+
+  // Doesn't exist
+  s.base_dir = "XX";
+  ASSERT_RAISES(IOError, fs_->GetTargetStats(s, &stats));
+  s.allow_non_existent = true;
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 0);
+  s.allow_non_existent = false;
+
+  // Not a dir
+  s.base_dir = "ab";
+  ASSERT_RAISES(IOError, fs_->GetTargetStats(s, &stats));
+}
+
+TEST_F(TestMockFS, GetTargetStatsSelectorRecursive) {
+  // Recursive tests for GetTargetStats(Selector, ...).
+  ASSERT_OK(fs_->CreateDir("AB/CD"));
+  CreateFile("ab", "data");
+  CreateFile("AB/cd", "some data");
+  CreateFile("AB/CD/ef", "some other data");
+  CreateFile("AB/CD/gh", "yet other data");
+
+  Selector s;
+  s.base_dir = "";
+  s.recursive = true;
+  std::vector<FileStats> stats;
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 6);
+  AssertFileStats(stats[0], "AB", FileType::Directory, time_);
+  AssertFileStats(stats[1], "AB/CD", FileType::Directory, time_);
+  AssertFileStats(stats[2], "AB/CD/ef", FileType::File, time_, 15);
+  AssertFileStats(stats[3], "AB/CD/gh", FileType::File, time_, 14);
+  AssertFileStats(stats[4], "AB/cd", FileType::File, time_, 9);
+  AssertFileStats(stats[5], "ab", FileType::File, time_, 4);
+
+  s.base_dir = "AB";
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 4);
+  AssertFileStats(stats[0], "AB/CD", FileType::Directory, time_);
+  AssertFileStats(stats[1], "AB/CD/ef", FileType::File, time_, 15);
+  AssertFileStats(stats[2], "AB/CD/gh", FileType::File, time_, 14);
+  AssertFileStats(stats[3], "AB/cd", FileType::File, time_, 9);
+
+  // Doesn't exist
+  s.base_dir = "XX";
+  ASSERT_RAISES(IOError, fs_->GetTargetStats(s, &stats));
+  s.allow_non_existent = true;
+  ASSERT_OK(fs_->GetTargetStats(s, &stats));
+  ASSERT_EQ(stats.size(), 0);
+  s.allow_non_existent = false;
+
+  // Not a dir
+  s.base_dir = "ab";
+  ASSERT_RAISES(IOError, fs_->GetTargetStats(s, &stats));
+}
+
+TEST_F(TestMockFS, OpenOutputStream) {
+  std::shared_ptr<io::OutputStream> stream;
+  int64_t position = -1;
+
+  ASSERT_OK(fs_->OpenOutputStream("ab", &stream));
+  ASSERT_OK(stream->Tell(&position));
+  ASSERT_EQ(position, 0);
+  ASSERT_FALSE(stream->closed());
+  ASSERT_OK(stream->Close());
+  ASSERT_TRUE(stream->closed());
+  CheckDirs({});
+  CheckFiles({{"ab", time_, ""}});
+
+  // Parent does not exist
+  ASSERT_RAISES(IOError, fs_->OpenOutputStream("ab/cd", &stream));
+  ASSERT_RAISES(IOError, fs_->OpenOutputStream("ef/gh", &stream));
+  CheckDirs({});
+  CheckFiles({{"ab", time_, ""}});
+
+  ASSERT_OK(fs_->CreateDir("CD"));
+  ASSERT_OK(fs_->OpenOutputStream("CD/ef", &stream));
+  ASSERT_OK(WriteString(stream.get(), "some "));
+  ASSERT_OK(WriteString(stream.get(), "data"));
+  ASSERT_OK(stream->Tell(&position));
+  ASSERT_EQ(position, 9);
+  ASSERT_OK(stream->Close());
+  CheckDirs({{"CD", time_}});
+  CheckFiles({{"CD/ef", time_, "some data"}, {"ab", time_, ""}});
+
+  // Overwrite
+  ASSERT_OK(fs_->OpenOutputStream("CD/ef", &stream));
+  ASSERT_OK(WriteString(stream.get(), "overwritten"));
+  ASSERT_OK(stream->Close());
+  CheckDirs({{"CD", time_}});
+  CheckFiles({{"CD/ef", time_, "overwritten"}, {"ab", time_, ""}});
+
+  // Cannot turn dir into file
+  ASSERT_RAISES(IOError, fs_->OpenOutputStream("CD", &stream));
+  CheckDirs({{"CD", time_}});
+}
+
+TEST_F(TestMockFS, OpenAppendStream) {
+  std::shared_ptr<io::OutputStream> stream;
+  int64_t position = -1;
+
+  ASSERT_OK(fs_->OpenAppendStream("ab", &stream));
+  ASSERT_OK(stream->Tell(&position));
+  ASSERT_EQ(position, 0);
+  ASSERT_OK(WriteString(stream.get(), "some "));
+  ASSERT_OK(WriteString(stream.get(), "data"));
+  ASSERT_OK(stream->Tell(&position));
+  ASSERT_EQ(position, 9);
+  ASSERT_OK(stream->Close());
+  CheckDirs({});
+  CheckFiles({{"ab", time_, "some data"}});
+
+  ASSERT_OK(fs_->OpenAppendStream("ab", &stream));
+  ASSERT_OK(stream->Tell(&position));
+  ASSERT_EQ(position, 9);
+  ASSERT_OK(WriteString(stream.get(), " appended"));
+  ASSERT_OK(stream->Close());
+  CheckDirs({});
+  CheckFiles({{"ab", time_, "some data appended"}});
+}
+
+TEST_F(TestMockFS, OpenInputStream) {
+  ASSERT_OK(fs_->CreateDir("AB"));
+  CreateFile("AB/ab", "some data");
+
+  std::shared_ptr<io::InputStream> stream;
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_OK(fs_->OpenInputStream("AB/ab", &stream));
+  ASSERT_OK(stream->Read(4, &buffer));
+  AssertBufferEqual(*buffer, "some");
+  ASSERT_OK(stream->Read(6, &buffer));
+  AssertBufferEqual(*buffer, " data");
+  ASSERT_OK(stream->Read(1, &buffer));
+  AssertBufferEqual(*buffer, "");
+  ASSERT_OK(stream->Close());
+  ASSERT_RAISES(Invalid, stream->Read(1, &buffer));  // Stream is closed
+
+  // File does not exist
+  ASSERT_RAISES(IOError, fs_->OpenInputStream("AB/cd", &stream));
+  ASSERT_RAISES(IOError, fs_->OpenInputStream("cd", &stream));
+}
+
+TEST_F(TestMockFS, OpenInputFile) {
+  ASSERT_OK(fs_->CreateDir("AB"));
+  CreateFile("AB/ab", "some other data");
+
+  std::shared_ptr<io::RandomAccessFile> file;
+  std::shared_ptr<Buffer> buffer;
+  int64_t size = -1;
+  ASSERT_OK(fs_->OpenInputFile("AB/ab", &file));
+  ASSERT_OK(file->ReadAt(5, 6, &buffer));
+  AssertBufferEqual(*buffer, "other ");
+  ASSERT_OK(file->GetSize(&size));
+  ASSERT_EQ(size, 15);
+  ASSERT_OK(file->Close());
+  ASSERT_RAISES(Invalid, file->ReadAt(1, 1, &buffer));  // Stream is closed
+
+  // File does not exist
+  ASSERT_RAISES(IOError, fs_->OpenInputFile("AB/cd", &file));
+  ASSERT_RAISES(IOError, fs_->OpenInputFile("cd", &file));
+}
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <utility>
+
+#include "arrow/filesystem/filesystem.h"
+#include "arrow/filesystem/path-util.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace fs {
+
+std::string ToString(FileType ftype) {
+  switch (ftype) {
+    case FileType::NonExistent:
+      return "non-existent";
+    case FileType::Unknown:
+      return "unknown";
+    case FileType::File:
+      return "file";
+    case FileType::Directory:
+      return "directory";
+    default:
+      ARROW_LOG(FATAL) << "Invalid FileType value: " << static_cast<int>(ftype);
+      return "???";
+  }
+}
+
+std::string FileStats::base_name() const {
+  return internal::GetAbstractPathParent(path_).second;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// FileSystem default method implementations
+
+FileSystem::~FileSystem() {}
+
+Status FileSystem::GetTargetStats(const std::vector<std::string>& paths,
+                                  std::vector<FileStats>* out) {
+  std::vector<FileStats> res;
+  res.reserve(paths.size());
+  for (const auto& path : paths) {
+    FileStats st;
+    RETURN_NOT_OK(GetTargetStats(path, &st));
+    res.push_back(std::move(st));
+  }
+  *out = std::move(res);
+  return Status::OK();
+}
+
+Status FileSystem::DeleteFiles(const std::vector<std::string>& paths) {
+  Status st = Status::OK();
+  for (const auto& path : paths) {
+    st &= DeleteFile(path);
+  }
+  return st;
+}
+
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/status.h"
+#include "arrow/util/compression.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+namespace io {
+
+class InputStream;
+class OutputStream;
+class RandomAccessFile;
+
+}  // namespace io
+
+namespace fs {
+
+// A system clock time point expressed as a 64-bit (or more) number of
+// nanoseconds since the epoch.
+using TimePoint =
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
+
+/// \brief EXPERIMENTAL: FileSystem entry type
+enum class ARROW_EXPORT FileType {
+  // Target does not exist
+  NonExistent,
+  // Target exists but its type is unknown (could be a special file such
+  // as a Unix socket or character device, or Windows NUL / CON / ...)
+  Unknown,
+  // Target is a regular file
+  File,
+  // Target is a directory
+  Directory
+};
+
+ARROW_EXPORT std::string ToString(FileType);
+
+static const int64_t kNoSize = -1;
+static const TimePoint kNoTime = TimePoint(TimePoint::duration(-1));
+
+/// \brief EXPERIMENTAL: FileSystem entry stats
+struct ARROW_EXPORT FileStats {
+  FileStats() = default;
+  FileStats(FileStats&&) = default;
+  FileStats& operator=(FileStats&&) = default;
+  FileStats(const FileStats&) = default;
+  FileStats& operator=(const FileStats&) = default;
+
+  // The file type.
+  FileType type() const { return type_; }
+  void set_type(FileType type) { type_ = type; }
+
+  // The full file path in the filesystem.
+  std::string path() const { return path_; }
+  void set_path(const std::string& path) { path_ = path; }
+
+  // The file base name (component after the last directory separator or '/').
+  std::string base_name() const;
+
+  // The size in bytes, if available.  Only regular files are guaranteed
+  // to have a size.
+  int64_t size() const { return size_; }
+  void set_size(int64_t size) { size_ = size; }
+
+  // The time of last modification, if available.
+  TimePoint mtime() const { return mtime_; }
+  void set_mtime(TimePoint mtime) { mtime_ = mtime; }
+
+ protected:
+  FileType type_ = FileType::Unknown;
+  std::string path_;
+  int64_t size_ = kNoSize;
+  TimePoint mtime_ = kNoTime;
+};
+
+/// \brief EXPERIMENTAL: file selector
+struct ARROW_EXPORT Selector {
+  // The directory in which to select files.
+  // If the path exists but doesn't point to a directory, this should be an error.
+  std::string base_dir;
+  // The behavior if `base_dir` doesn't exist in the filesystem.  If false,
+  // an error is returned.  If true, an empty selection is returned.
+  bool allow_non_existent = false;
+  // Whether to recurse into subdirectories.
+  bool recursive = false;
+
+  Selector() {}
+};
+
+/// \brief EXPERIMENTAL: abstract file system API
+class ARROW_EXPORT FileSystem {
+ public:
+  virtual ~FileSystem();
+
+  /// Get statistics for the given target.
+  ///
+  /// Any symlink is automatically dereferenced, recursively.
+  /// A non-existing or unreachable file returns an Ok status and
+  /// has a FileType of value NonExistent.  An error status indicates
+  /// a truly exceptional condition (low-level I/O error, etc.).
+  virtual Status GetTargetStats(const std::string& path, FileStats* out) = 0;
+  /// Same, for many targets at once.
+  virtual Status GetTargetStats(const std::vector<std::string>& paths,
+                                std::vector<FileStats>* out);
+  /// Same, according to a selector.
+  ///
+  /// The selector's base directory will not be part of the results, even if
+  /// it exists.
+  /// If it doesn't exist, see `Selector::allow_non_existent`.
+  virtual Status GetTargetStats(const Selector& select, std::vector<FileStats>* out) = 0;
+
+  /// Create a directory and subdirectories.
+  virtual Status CreateDir(const std::string& path, bool recursive = true) = 0;
+
+  /// Delete a directory and contents.
+  virtual Status DeleteDir(const std::string& path) = 0;
+
+  /// Delete a file.
+  virtual Status DeleteFile(const std::string& path) = 0;
+  /// Delete many files.
+  ///
+  /// The default implementation issues individual delete operations in sequence.
+  virtual Status DeleteFiles(const std::vector<std::string>& paths);
+
+  /// Move / rename a file or directory.
+  ///
+  /// The destination will be replaced if it exists.
+  virtual Status Move(const std::string& src, const std::string& dest) = 0;
+
+  /// Copy a file.
+  ///
+  /// The destination will be replaced if it exists.
+  virtual Status Copy(const std::string& src, const std::string& dest) = 0;
+
+  /// Open an input stream for sequential reading.
+  virtual Status OpenInputStream(const std::string& path,
+                                 std::shared_ptr<io::InputStream>* out) = 0;
+
+  /// Open an input file for random access reading.
+  virtual Status OpenInputFile(const std::string& path,
+                               std::shared_ptr<io::RandomAccessFile>* out) = 0;
+
+  /// Open an output stream for sequential writing.
+  ///
+  /// If the target already exists, existing data is truncated.
+  virtual Status OpenOutputStream(const std::string& path,
+                                  std::shared_ptr<io::OutputStream>* out) = 0;
+
+  /// Open an output stream for appending.
+  ///
+  /// If the target doesn't exist, a new empty file is created.
+  virtual Status OpenAppendStream(const std::string& path,
+                                  std::shared_ptr<io::OutputStream>* out) = 0;
+};
+
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -1,0 +1,513 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <iterator>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/buffer.h"
+#include "arrow/filesystem/mockfs.h"
+#include "arrow/filesystem/path-util.h"
+#include "arrow/io/interfaces.h"
+#include "arrow/io/memory.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/variant.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+namespace {
+
+Status PathNotFound(const std::string& path) {
+  return Status::IOError("Path does not exist '", path, "'");
+}
+
+Status NotADir(const std::string& path) {
+  return Status::IOError("Not a directory: '", path, "'");
+}
+
+Status NotAFile(const std::string& path) {
+  return Status::IOError("Not a regular file: '", path, "'");
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Filesystem structure
+
+class Entry;
+
+struct File {
+  TimePoint mtime;
+  std::string name;
+  std::string data;
+
+  File(TimePoint mtime, const std::string& name) : mtime(mtime), name(name) {}
+
+  int64_t size() const { return static_cast<int64_t>(data.length()); }
+};
+
+struct Directory {
+  std::string name;
+  TimePoint mtime;
+  std::map<std::string, std::unique_ptr<Entry>> entries;
+
+  Directory(const std::string& name, TimePoint mtime) : name(name), mtime(mtime) {}
+  Directory(Directory&&) = default;
+
+  Entry* Find(const std::string& s) {
+    auto it = entries.find(s);
+    if (it != entries.end()) {
+      return it->second.get();
+    } else {
+      return nullptr;
+    }
+  }
+
+  bool CreateEntry(const std::string& s, std::unique_ptr<Entry> entry) {
+    DCHECK(!s.empty());
+    auto p = entries.emplace(s, std::move(entry));
+    return p.second;
+  }
+
+  void AssignEntry(const std::string& s, std::unique_ptr<Entry> entry) {
+    DCHECK(!s.empty());
+    entries[s] = std::move(entry);
+  }
+
+  bool DeleteEntry(const std::string& s) { return entries.erase(s) > 0; }
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(Directory);
+};
+
+// A filesystem entry
+using EntryBase = util::variant<File, Directory>;
+
+class Entry : public EntryBase {
+ public:
+  explicit Entry(Directory&& v) : EntryBase(std::move(v)) {}
+  explicit Entry(File&& v) : EntryBase(std::move(v)) {}
+
+  bool is_dir() const { return util::holds_alternative<Directory>(*this); }
+
+  bool is_file() const { return util::holds_alternative<File>(*this); }
+
+  Directory& as_dir() { return util::get<Directory>(*this); }
+
+  File& as_file() { return util::get<File>(*this); }
+
+  // Get stats for this entry.  Note the path() property isn't set.
+  FileStats GetStats() {
+    FileStats st;
+    if (is_dir()) {
+      Directory& dir = as_dir();
+      st.set_type(FileType::Directory);
+      st.set_mtime(dir.mtime);
+    } else {
+      DCHECK(is_file());
+      File& file = as_file();
+      st.set_type(FileType::File);
+      st.set_mtime(file.mtime);
+      st.set_size(file.size());
+    }
+    return st;
+  }
+
+  // Get stats for this entry, knowing the parent path.
+  FileStats GetStats(const std::string& base_path) {
+    FileStats st;
+    if (is_dir()) {
+      Directory& dir = as_dir();
+      st.set_type(FileType::Directory);
+      st.set_mtime(dir.mtime);
+      st.set_path(ConcatAbstractPath(base_path, dir.name));
+    } else {
+      DCHECK(is_file());
+      File& file = as_file();
+      st.set_type(FileType::File);
+      st.set_mtime(file.mtime);
+      st.set_size(file.size());
+      st.set_path(ConcatAbstractPath(base_path, file.name));
+    }
+    return st;
+  }
+
+ private:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(Entry);
+};
+
+////////////////////////////////////////////////////////////////////////////
+// Streams
+
+class MockFSOutputStream : public io::OutputStream {
+ public:
+  explicit MockFSOutputStream(File* file) : file_(file), closed_(false) {}
+
+  ~MockFSOutputStream() override {}
+
+  // Implement the OutputStream interface
+  Status Close() override {
+    closed_ = true;
+    return Status::OK();
+  }
+
+  bool closed() const override { return closed_; }
+
+  Status Tell(int64_t* position) const override {
+    if (closed_) {
+      return Status::Invalid("Invalid operation on closed stream");
+    }
+    *position = file_->size();
+    return Status::OK();
+  }
+
+  Status Write(const void* data, int64_t nbytes) override {
+    if (closed_) {
+      return Status::Invalid("Invalid operation on closed stream");
+    }
+    file_->data.append(reinterpret_cast<const char*>(data), static_cast<size_t>(nbytes));
+    return Status::OK();
+  }
+
+ protected:
+  File* file_;
+  bool closed_;
+};
+
+}  // namespace
+
+std::ostream& operator<<(std::ostream& os, const DirInfo& di) {
+  return os << "'" << di.full_path << "' [mtime=" << di.mtime.time_since_epoch().count()
+            << "]";
+}
+
+std::ostream& operator<<(std::ostream& os, const FileInfo& di) {
+  return os << "'" << di.full_path << "' [mtime=" << di.mtime.time_since_epoch().count()
+            << ", size=" << di.data.length() << "]";
+}
+
+////////////////////////////////////////////////////////////////////////////
+// MockFileSystem implementation
+
+class MockFileSystem::Impl {
+ public:
+  TimePoint current_time;
+  // The root directory
+  Entry root;
+
+  explicit Impl(TimePoint current_time)
+      : current_time(current_time), root(Directory("", current_time)) {}
+
+  template <typename It>
+  Entry* FindEntry(It it, It end, size_t* nconsumed) {
+    size_t consumed = 0;
+    Entry* entry = &root;
+
+    for (; it != end; ++it) {
+      const std::string& part = *it;
+      DCHECK(entry->is_dir());
+      Entry* child = entry->as_dir().Find(part);
+      if (child == nullptr) {
+        // Partial find only
+        break;
+      }
+      ++consumed;
+      entry = child;
+      if (entry->is_file()) {
+        // Cannot go any further
+        break;
+      }
+      // Recurse
+    }
+    *nconsumed = consumed;
+    return entry;
+  }
+
+  // Find an entry, allowing partial matching
+  Entry* FindEntry(const std::vector<std::string>& parts, size_t* nconsumed) {
+    return FindEntry(parts.begin(), parts.end(), nconsumed);
+  }
+
+  // Find an entry, only full matching allowed
+  Entry* FindEntry(const std::vector<std::string>& parts) {
+    size_t consumed;
+    auto entry = FindEntry(parts, &consumed);
+    return (consumed == parts.size()) ? entry : nullptr;
+  }
+
+  // Find the parent entry, only full matching allowed
+  Entry* FindParent(const std::vector<std::string>& parts) {
+    size_t consumed;
+    auto entry = FindEntry(parts.begin(), --parts.end(), &consumed);
+    return (consumed == parts.size() - 1) ? entry : nullptr;
+  }
+
+  void GatherStats(const std::string& base_path, Directory& base_dir, bool recursive,
+                   std::vector<FileStats>* stats) {
+    for (const auto& pair : base_dir.entries) {
+      Entry* child = pair.second.get();
+      stats->push_back(child->GetStats(base_path));
+      if (recursive && child->is_dir()) {
+        Directory& child_dir = child->as_dir();
+        std::string child_path = stats->back().path();
+        GatherStats(std::move(child_path), child_dir, recursive, stats);
+      }
+    }
+  }
+
+  void DumpDirs(const std::string& prefix, Directory& dir, std::vector<DirInfo>* out) {
+    std::string path = prefix + dir.name;
+    if (!path.empty()) {
+      out->push_back({path, dir.mtime});
+      path += "/";
+    }
+    for (const auto& pair : dir.entries) {
+      Entry* child = pair.second.get();
+      if (child->is_dir()) {
+        DumpDirs(path, child->as_dir(), out);
+      }
+    }
+  }
+
+  void DumpFiles(const std::string& prefix, Directory& dir, std::vector<FileInfo>* out) {
+    std::string path = prefix + dir.name;
+    if (!path.empty()) {
+      path += "/";
+    }
+    for (const auto& pair : dir.entries) {
+      Entry* child = pair.second.get();
+      if (child->is_file()) {
+        auto& file = child->as_file();
+        out->push_back({path + file.name, file.mtime, file.data});
+      } else if (child->is_dir()) {
+        DumpFiles(path, child->as_dir(), out);
+      }
+    }
+  }
+
+  Status OpenOutputStream(const std::string& path, bool append,
+                          std::shared_ptr<io::OutputStream>* out) {
+    auto parts = SplitAbstractPath(path);
+    RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+    Entry* parent = FindParent(parts);
+    if (parent == nullptr || !parent->is_dir()) {
+      return PathNotFound(path);
+    }
+    // Find the file in the parent dir, or create it
+    const auto& name = parts.back();
+    Entry* child = parent->as_dir().Find(name);
+    if (child == nullptr) {
+      child = new Entry(File(current_time, name));
+      parent->as_dir().AssignEntry(name, std::unique_ptr<Entry>(child));
+    } else if (child->is_file()) {
+      child->as_file().mtime = current_time;
+      if (!append) {
+        child->as_file().data.clear();
+      }
+    } else {
+      return NotAFile(path);
+    }
+    *out = std::make_shared<MockFSOutputStream>(&child->as_file());
+    return Status::OK();
+  }
+
+  Status OpenInputReader(const std::string& path,
+                         std::shared_ptr<io::BufferReader>* out) {
+    auto parts = SplitAbstractPath(path);
+    RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+    Entry* entry = FindEntry(parts);
+    if (entry == nullptr) {
+      return PathNotFound(path);
+    }
+    if (!entry->is_file()) {
+      return NotAFile(path);
+    }
+    std::shared_ptr<Buffer> buffer;
+    RETURN_NOT_OK(Buffer::FromString(entry->as_file().data, &buffer));
+    *out = std::make_shared<io::BufferReader>(buffer);
+    return Status::OK();
+  }
+};
+
+MockFileSystem::~MockFileSystem() {}
+
+MockFileSystem::MockFileSystem(TimePoint current_time) {
+  impl_ = std::unique_ptr<Impl>(new Impl(current_time));
+}
+
+Status MockFileSystem::CreateDir(const std::string& path, bool recursive) {
+  auto parts = SplitAbstractPath(path);
+  RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+  size_t consumed;
+  Entry* entry = impl_->FindEntry(parts, &consumed);
+  if (!entry->is_dir()) {
+    auto file_path = JoinAbstractPath(parts.begin(), parts.begin() + consumed);
+    return Status::IOError("Cannot create directory '", path, "': ", "ancestor '",
+                           file_path, "' is a regular file");
+  }
+  if (!recursive && (parts.size() - consumed) > 1) {
+    return Status::IOError("Cannot create directory '", path,
+                           "': ", "parent does not exist");
+  }
+  for (size_t i = consumed; i < parts.size(); ++i) {
+    const auto& name = parts[i];
+    std::unique_ptr<Entry> child(new Entry(Directory(name, impl_->current_time)));
+    Entry* child_ptr = child.get();
+    bool inserted = entry->as_dir().CreateEntry(name, std::move(child));
+    DCHECK(inserted);
+    entry = child_ptr;
+  }
+  return Status::OK();
+}
+
+Status MockFileSystem::DeleteDir(const std::string& path) {
+  auto parts = SplitAbstractPath(path);
+  RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+  Entry* parent = impl_->FindParent(parts);
+  if (parent == nullptr || !parent->is_dir()) {
+    return PathNotFound(path);
+  }
+  Directory& parent_dir = parent->as_dir();
+  auto child = parent_dir.Find(parts.back());
+  if (child == nullptr) {
+    return PathNotFound(path);
+  }
+  if (!child->is_dir()) {
+    return NotADir(path);
+  }
+  bool deleted = parent_dir.DeleteEntry(parts.back());
+  DCHECK(deleted);
+  return Status::OK();
+}
+
+Status MockFileSystem::DeleteFile(const std::string& path) {
+  auto parts = SplitAbstractPath(path);
+  RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+  Entry* parent = impl_->FindParent(parts);
+  if (parent == nullptr || !parent->is_dir()) {
+    return PathNotFound(path);
+  }
+  Directory& parent_dir = parent->as_dir();
+  auto child = parent_dir.Find(parts.back());
+  if (child == nullptr) {
+    return PathNotFound(path);
+  }
+  if (!child->is_file()) {
+    return NotAFile(path);
+  }
+  bool deleted = parent_dir.DeleteEntry(parts.back());
+  DCHECK(deleted);
+  return Status::OK();
+}
+
+Status MockFileSystem::GetTargetStats(const std::string& path, FileStats* out) {
+  auto parts = SplitAbstractPath(path);
+  RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+  Entry* entry = impl_->FindEntry(parts);
+  if (entry == nullptr) {
+    FileStats st;
+    st.set_path(path);
+    st.set_type(FileType::NonExistent);
+    *out = std::move(st);
+    return Status::OK();
+  }
+  *out = entry->GetStats();
+  out->set_path(path);
+  return Status::OK();
+}
+
+Status MockFileSystem::GetTargetStats(const Selector& selector,
+                                      std::vector<FileStats>* out) {
+  auto parts = SplitAbstractPath(selector.base_dir);
+  RETURN_NOT_OK(ValidateAbstractPathParts(parts));
+
+  out->clear();
+
+  Entry* base_dir = impl_->FindEntry(parts);
+  if (base_dir == nullptr) {
+    // Base directory does not exist
+    if (selector.allow_non_existent) {
+      return Status::OK();
+    } else {
+      return PathNotFound(selector.base_dir);
+    }
+  }
+  if (!base_dir->is_dir()) {
+    return NotADir(selector.base_dir);
+  }
+
+  impl_->GatherStats(selector.base_dir, base_dir->as_dir(), selector.recursive, out);
+  return Status::OK();
+}
+
+Status MockFileSystem::Move(const std::string& src, const std::string& dest) {
+  return Status::NotImplemented("Move");
+}
+
+Status MockFileSystem::Copy(const std::string& src, const std::string& dest) {
+  return Status::NotImplemented("Copy");
+}
+
+Status MockFileSystem::OpenInputStream(const std::string& path,
+                                       std::shared_ptr<io::InputStream>* out) {
+  std::shared_ptr<io::BufferReader> reader;
+  RETURN_NOT_OK(impl_->OpenInputReader(path, &reader));
+  *out = std::move(reader);
+  return Status::OK();
+}
+
+Status MockFileSystem::OpenInputFile(const std::string& path,
+                                     std::shared_ptr<io::RandomAccessFile>* out) {
+  std::shared_ptr<io::BufferReader> reader;
+  RETURN_NOT_OK(impl_->OpenInputReader(path, &reader));
+  *out = std::move(reader);
+  return Status::OK();
+}
+
+Status MockFileSystem::OpenOutputStream(const std::string& path,
+                                        std::shared_ptr<io::OutputStream>* out) {
+  return impl_->OpenOutputStream(path, false /* append */, out);
+}
+
+Status MockFileSystem::OpenAppendStream(const std::string& path,
+                                        std::shared_ptr<io::OutputStream>* out) {
+  return impl_->OpenOutputStream(path, true /* append */, out);
+}
+
+std::vector<DirInfo> MockFileSystem::AllDirs() {
+  std::vector<DirInfo> result;
+  impl_->DumpDirs("", impl_->root.as_dir(), &result);
+  return result;
+}
+
+std::vector<FileInfo> MockFileSystem::AllFiles() {
+  std::vector<FileInfo> result;
+  impl_->DumpFiles("", impl_->root.as_dir(), &result);
+  return result;
+}
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/filesystem/filesystem.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+struct DirInfo {
+  std::string full_path;
+  TimePoint mtime;
+
+  bool operator==(const DirInfo& other) const {
+    return mtime == other.mtime && full_path == other.full_path;
+  }
+
+  friend ARROW_EXPORT std::ostream& operator<<(std::ostream&, const DirInfo&);
+};
+
+struct FileInfo {
+  std::string full_path;
+  TimePoint mtime;
+  std::string data;
+
+  bool operator==(const FileInfo& other) const {
+    return mtime == other.mtime && full_path == other.full_path && data == other.data;
+  }
+
+  friend ARROW_EXPORT std::ostream& operator<<(std::ostream&, const FileInfo&);
+};
+
+/// A mock FileSystem implementation that holds its contents in memory.
+///
+/// Useful for validating the FileSystem API, writing conformance suite,
+/// and bootstrapping FileSystem-based APIs.
+class ARROW_EXPORT MockFileSystem : public FileSystem {
+ public:
+  explicit MockFileSystem(TimePoint current_time);
+  ~MockFileSystem() override;
+
+  // XXX It's not very practical to have to explicitly declare inheritance
+  // of default overrides.
+  using FileSystem::GetTargetStats;
+  Status GetTargetStats(const std::string& path, FileStats* out) override;
+  Status GetTargetStats(const Selector& select, std::vector<FileStats>* out) override;
+
+  Status CreateDir(const std::string& path, bool recursive = true) override;
+
+  Status DeleteDir(const std::string& path) override;
+
+  Status DeleteFile(const std::string& path) override;
+
+  Status Move(const std::string& src, const std::string& dest) override;
+
+  Status Copy(const std::string& src, const std::string& dest) override;
+
+  Status OpenInputStream(const std::string& path,
+                         std::shared_ptr<io::InputStream>* out) override;
+
+  Status OpenInputFile(const std::string& path,
+                       std::shared_ptr<io::RandomAccessFile>* out) override;
+
+  Status OpenOutputStream(const std::string& path,
+                          std::shared_ptr<io::OutputStream>* out) override;
+
+  Status OpenAppendStream(const std::string& path,
+                          std::shared_ptr<io::OutputStream>* out) override;
+
+  // Contents-dumping helpers to ease testing.
+  // Output is lexicographically-ordered by full path.
+  std::vector<DirInfo> AllDirs();
+  std::vector<FileInfo> AllFiles();
+
+ protected:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/path-util.cc
+++ b/cpp/src/arrow/filesystem/path-util.cc
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/filesystem/path-util.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+// TODO Add unit tests for these functions.
+
+std::vector<std::string> SplitAbstractPath(const std::string& s) {
+  std::vector<std::string> parts;
+  if (s.length() == 0) {
+    return parts;
+  }
+
+  auto append_part = [&parts, &s](size_t start, size_t end) {
+    parts.push_back(s.substr(start, end - start));
+  };
+  // XXX should strip leading and trailing slashes?
+
+  size_t start = 0;
+  while (true) {
+    size_t end = s.find_first_of('/', start);
+    append_part(start, end);
+    if (end == std::string::npos) {
+      break;
+    }
+    start = end + 1;
+  }
+  return parts;
+}
+
+std::pair<std::string, std::string> GetAbstractPathParent(const std::string& s) {
+  // XXX should strip trailing slash?
+
+  auto pos = s.find_last_of('/');
+  if (pos == std::string::npos) {
+    // Empty parent
+    return {{}, s};
+  }
+  return {s.substr(0, pos - 1), s.substr(pos + 1)};
+}
+
+Status ValidateAbstractPathParts(const std::vector<std::string>& parts) {
+  for (const auto& part : parts) {
+    if (part.length() == 0) {
+      return Status::Invalid("Empty path component");
+    }
+  }
+  return Status::OK();
+}
+
+std::string ConcatAbstractPath(const std::string& base, const std::string& stem) {
+  return base.empty() ? stem : base + "/" + stem;
+}
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/filesystem/path-util.h
+++ b/cpp/src/arrow/filesystem/path-util.h
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/status.h"
+
+namespace arrow {
+namespace fs {
+namespace internal {
+
+// Computations on abstract paths (paths that are not local paths with
+// system-dependent behaviour).  Abstract paths are typically used in URIs.
+
+// Split an abstract path into its individual components.
+std::vector<std::string> SplitAbstractPath(const std::string& s);
+
+// Return the parent directory and basename of an abstract path.  Both values may be
+// empty.
+std::pair<std::string, std::string> GetAbstractPathParent(const std::string& s);
+
+// Validate the components of an abstract path.
+Status ValidateAbstractPathParts(const std::vector<std::string>& parts);
+
+// Append an abstract path to another.
+std::string ConcatAbstractPath(const std::string& base, const std::string& stem);
+
+// Join the components of an abstract path.
+template <class StringIt>
+std::string JoinAbstractPath(StringIt it, StringIt end) {
+  std::string path;
+  for (; it != end; ++it) {
+    if (!path.empty()) {
+      path += "/";
+    }
+    path += *it;
+  }
+  return path;
+}
+
+}  // namespace internal
+}  // namespace fs
+}  // namespace arrow

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -282,12 +282,24 @@ Status BufferReader::Close() {
 
 bool BufferReader::closed() const { return !is_open_; }
 
+Status BufferReader::CheckClosed() const {
+  if (!is_open_) {
+    return Status::Invalid("Operation forbidden on closed BufferReader");
+  }
+  return Status::OK();
+}
+
 Status BufferReader::Tell(int64_t* position) const {
+  RETURN_NOT_OK(CheckClosed());
   *position = position_;
   return Status::OK();
 }
 
 util::string_view BufferReader::Peek(int64_t nbytes) const {
+  if (!is_open_) {
+    return {};
+  }
+
   const int64_t bytes_available = std::min(nbytes, size_ - position_);
   return util::string_view(reinterpret_cast<const char*>(data_) + position_,
                            static_cast<size_t>(bytes_available));
@@ -297,6 +309,8 @@ bool BufferReader::supports_zero_copy() const { return true; }
 
 Status BufferReader::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
                             void* buffer) {
+  RETURN_NOT_OK(CheckClosed());
+
   if (nbytes < 0) {
     return Status::IOError("Cannot read a negative number of bytes from BufferReader.");
   }
@@ -309,6 +323,8 @@ Status BufferReader::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_rea
 
 Status BufferReader::ReadAt(int64_t position, int64_t nbytes,
                             std::shared_ptr<Buffer>* out) {
+  RETURN_NOT_OK(CheckClosed());
+
   if (nbytes < 0) {
     return Status::IOError("Cannot read a negative number of bytes from BufferReader.");
   }
@@ -323,23 +339,28 @@ Status BufferReader::ReadAt(int64_t position, int64_t nbytes,
 }
 
 Status BufferReader::Read(int64_t nbytes, int64_t* bytes_read, void* buffer) {
+  RETURN_NOT_OK(CheckClosed());
   RETURN_NOT_OK(ReadAt(position_, nbytes, bytes_read, buffer));
   position_ += *bytes_read;
   return Status::OK();
 }
 
 Status BufferReader::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+  RETURN_NOT_OK(CheckClosed());
   RETURN_NOT_OK(ReadAt(position_, nbytes, out));
   position_ += (*out)->size();
   return Status::OK();
 }
 
 Status BufferReader::GetSize(int64_t* size) {
+  RETURN_NOT_OK(CheckClosed());
   *size = size_;
   return Status::OK();
 }
 
 Status BufferReader::Seek(int64_t position) {
+  RETURN_NOT_OK(CheckClosed());
+
   if (position < 0 || position > size_) {
     return Status::IOError("Seek out of bounds");
   }

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -161,6 +161,8 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
   std::shared_ptr<Buffer> buffer() const { return buffer_; }
 
  protected:
+  inline Status CheckClosed() const;
+
   std::shared_ptr<Buffer> buffer_;
   const uint8_t* data_;
   int64_t size_;

--- a/cpp/src/arrow/io/readahead-test.cc
+++ b/cpp/src/arrow/io/readahead-test.cc
@@ -125,12 +125,6 @@ static void AssertEventualPosition(const FileInterface& file, int64_t expected) 
   ASSERT_EQ(pos, expected) << "File didn't reach expected position";
 }
 
-static void AssertPosition(const FileInterface& file, int64_t expected) {
-  int64_t pos = -1;
-  ABORT_NOT_OK(file.Tell(&pos));
-  ASSERT_EQ(pos, expected) << "File didn't reach expected position";
-}
-
 template <typename Expected>
 static void AssertReadaheadBuffer(const ReadaheadBuffer& buf,
                                   std::set<int64_t> left_paddings,
@@ -199,16 +193,6 @@ TEST(ReadaheadSpooler, Close) {
 
   AssertEventualPosition(*data_reader, 2 * 2);
   ASSERT_OK(spooler.Close());
-
-  // XXX not sure this makes sense
-  ASSERT_OK(spooler.Read(&buf));
-  AssertReadaheadBuffer(buf, {0}, {0}, "01");
-  ASSERT_OK(spooler.Read(&buf));
-  AssertReadaheadBuffer(buf, {0}, {0}, "23");
-  ASSERT_OK(spooler.Read(&buf));
-  AssertReadaheadBufferEOF(buf);
-  AssertPosition(*data_reader, 2 * 2);
-
   // Idempotency
   ASSERT_OK(spooler.Close());
 }

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -48,48 +48,48 @@
 
 #define ASSERT_RAISES(ENUM, expr)                                                     \
   do {                                                                                \
-    ::arrow::Status s = (expr);                                                       \
-    if (!s.Is##ENUM()) {                                                              \
+    ::arrow::Status _st = (expr);                                                     \
+    if (!_st.Is##ENUM()) {                                                            \
       FAIL() << "Expected '" ARROW_STRINGIFY(expr) "' to fail with " ARROW_STRINGIFY( \
                     ENUM) ", but got "                                                \
-             << s.ToString();                                                         \
+             << _st.ToString();                                                       \
     }                                                                                 \
   } while (false)
 
 #define ASSERT_RAISES_WITH_MESSAGE(ENUM, message, expr)                               \
   do {                                                                                \
-    ::arrow::Status s = (expr);                                                       \
-    if (!s.Is##ENUM()) {                                                              \
+    ::arrow::Status _st = (expr);                                                     \
+    if (!_st.Is##ENUM()) {                                                            \
       FAIL() << "Expected '" ARROW_STRINGIFY(expr) "' to fail with " ARROW_STRINGIFY( \
                     ENUM) ", but got "                                                \
-             << s.ToString();                                                         \
+             << _st.ToString();                                                       \
     }                                                                                 \
-    ASSERT_EQ((message), s.ToString());                                               \
+    ASSERT_EQ((message), _st.ToString());                                             \
   } while (false)
 
-#define ASSERT_OK(expr)                                                      \
-  do {                                                                       \
-    ::arrow::Status _s = (expr);                                             \
-    if (!_s.ok()) {                                                          \
-      FAIL() << "'" ARROW_STRINGIFY(expr) "' failed with " << _s.ToString(); \
-    }                                                                        \
+#define ASSERT_OK(expr)                                                       \
+  do {                                                                        \
+    ::arrow::Status _st = (expr);                                             \
+    if (!_st.ok()) {                                                          \
+      FAIL() << "'" ARROW_STRINGIFY(expr) "' failed with " << _st.ToString(); \
+    }                                                                         \
   } while (false)
 
 #define ASSERT_OK_NO_THROW(expr) ASSERT_NO_THROW(ASSERT_OK(expr))
 
-#define ARROW_EXPECT_OK(expr)   \
-  do {                          \
-    ::arrow::Status s = (expr); \
-    EXPECT_TRUE(s.ok());        \
+#define ARROW_EXPECT_OK(expr)     \
+  do {                            \
+    ::arrow::Status _st = (expr); \
+    EXPECT_TRUE(_st.ok());        \
   } while (false)
 
-#define ABORT_NOT_OK(expr)                \
-  do {                                    \
-    ::arrow::Status _s = (expr);          \
-    if (ARROW_PREDICT_FALSE(!_s.ok())) {  \
-      std::cerr << _s.ToString() << "\n"; \
-      std::abort();                       \
-    }                                     \
+#define ABORT_NOT_OK(expr)                 \
+  do {                                     \
+    ::arrow::Status _st = (expr);          \
+    if (ARROW_PREDICT_FALSE(!_st.ok())) {  \
+      std::cerr << _st.ToString() << "\n"; \
+      std::abort();                        \
+    }                                      \
   } while (false);
 
 namespace arrow {

--- a/cpp/src/arrow/util/variant.h
+++ b/cpp/src/arrow/util/variant.h
@@ -26,6 +26,7 @@ namespace util {
 using ::mpark::bad_variant_access;
 using ::mpark::get;
 using ::mpark::get_if;
+using ::mpark::holds_alternative;
 using ::mpark::variant;
 using ::mpark::visit;
 


### PR DESCRIPTION
Add a `FileSystem` interface plus a `MockFileSystem` implementation (only keeping data in memory).