### PR TITLE
ARROW-5130: [C++][Python] Limit exporting of std::* symbols

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -209,8 +209,8 @@ if(NOT APPLE AND NOT MSVC)
   # Localize thirdparty symbols using a linker version script. This hides them
   # from the client application. The OS X linker does not support the
   # version-script option.
-  set(SHARED_LINK_FLAGS
-      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/parquet/symbols.map")
+  set(PARQUET_SHARED_LINK_FLAGS
+      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
 endif()
 
 # Because of PARQUET-1420 (Thrift-generated symbols not exported in DLL),

--- a/cpp/src/parquet/symbols.map
+++ b/cpp/src/parquet/symbols.map
@@ -21,6 +21,7 @@
   local:
     # devtoolset / static-libstdc++ symbols
     __cxa_*;
+    __once_proxy;
 
     extern "C++" {
       # boost

--- a/cpp/src/parquet/symbols.map
+++ b/cpp/src/parquet/symbols.map
@@ -35,5 +35,6 @@
       # a system with an older libstdc++ which doesn't include the necessary
       # c++11 symbols.
       std::*;
+      *std::__once_call*;
     };
 };

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -80,6 +80,14 @@ if(ARROW_CUDA)
   add_definitions(-DPLASMA_CUDA)
 endif()
 
+if(NOT APPLE AND NOT MSVC)
+  # Localize thirdparty symbols using a linker version script. This hides them
+  # from the client application. The OS X linker does not support the
+  # version-script option.
+  set(PLASMA_SHARED_LINK_FLAGS
+      "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+endif()
+
 add_arrow_lib(plasma
               SOURCES
               ${PLASMA_SRCS}
@@ -87,6 +95,8 @@ add_arrow_lib(plasma
               PLASMA_LIBRARIES
               DEPENDENCIES
               gen_plasma_fbs
+              SHARED_LINK_FLAGS
+              ${PLASMA_SHARED_LINK_FLAGS}
               SHARED_LINK_LIBS
               ${PLASMA_LINK_LIBS}
               STATIC_LINK_LIBS

--- a/cpp/src/plasma/symbols.map
+++ b/cpp/src/plasma/symbols.map
@@ -16,22 +16,17 @@
 # under the License.
 
 {
-  global:
-    extern "C++" {
-      # The leading asterisk is required for symbols such as
-      # "typeinfo for arrow::SomeClass".
-      # Unfortunately this will also catch template specializations
-      # (from e.g. STL or Flatbuffers) involving Arrow types.
-      *arrow::*;
-    };
-    # Also export C-level helpers
-    arrow_*;
-    pyarrow_*;
-
   # Symbols marked as 'local' are not exported by the DSO and thus may not
-  # be used by client applications.  Everything except the above falls here.
-  # This ensures we hide symbols of static dependencies.
+  # be used by client applications.
   local:
-    *;
+    # devtoolset / static-libstdc++ symbols
+    __cxa_*;
 
+    extern "C++" {
+      # devtoolset or -static-libstdc++ - the Red Hat devtoolset statically
+      # links c++11 symbols into binaries so that the result may be executed on
+      # a system with an older libstdc++ which doesn't include the necessary
+      # c++11 symbols.
+      std::*;
+    };
 };

--- a/cpp/src/plasma/symbols.map
+++ b/cpp/src/plasma/symbols.map
@@ -21,6 +21,7 @@
   local:
     # devtoolset / static-libstdc++ symbols
     __cxa_*;
+    __once_proxy;
 
     extern "C++" {
       # devtoolset or -static-libstdc++ - the Red Hat devtoolset statically

--- a/cpp/src/plasma/symbols.map
+++ b/cpp/src/plasma/symbols.map
@@ -29,5 +29,6 @@
       # a system with an older libstdc++ which doesn't include the necessary
       # c++11 symbols.
       std::*;
+      *std::__once_call*;
     };
 };


### PR DESCRIPTION
This patch addresses the incompatibility of `pyarrow` and `tensorflow` wheels provided by Google.

It has been tested with:

```python
import pyarrow
import tensorflow
```

As well as more complicated examples such as https://github.com/horovod/horovod/blob/master/examples/keras_spark_rossmann.py which uses PyArrow + Petastorm to read the data.

Fixes https://issues.apache.org/jira/browse/ARROW-5130