### PR TITLE
ARROW-5258: [C++/Python] Collect file metadata of dataset pieces

### DIFF
--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -1058,7 +1058,7 @@ class FileWriter::Impl {
 
   virtual ~Impl() {}
 
-  const std::shared_ptr<FileMetaData> metadata() const { return writer_->metadata(); };
+  const std::shared_ptr<FileMetaData> metadata() const { return writer_->metadata(); }
 
  private:
   friend class FileWriter;
@@ -1093,7 +1093,7 @@ MemoryPool* FileWriter::memory_pool() const { return impl_->memory_pool(); }
 
 const std::shared_ptr<FileMetaData> FileWriter::metadata() const {
   return impl_->metadata();
-};
+}
 
 FileWriter::~FileWriter() {}
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -1058,6 +1058,8 @@ class FileWriter::Impl {
 
   virtual ~Impl() {}
 
+  const std::shared_ptr<FileMetaData> metadata() const { return writer_->metadata(); };
+
  private:
   friend class FileWriter;
 
@@ -1088,6 +1090,10 @@ Status FileWriter::WriteColumnChunk(const std::shared_ptr<::arrow::ChunkedArray>
 Status FileWriter::Close() { return impl_->Close(); }
 
 MemoryPool* FileWriter::memory_pool() const { return impl_->memory_pool(); }
+
+const std::shared_ptr<FileMetaData> FileWriter::metadata() const {
+  return impl_->metadata();
+};
 
 FileWriter::~FileWriter() {}
 

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -181,6 +181,8 @@ class PARQUET_EXPORT FileWriter {
 
   ::arrow::MemoryPool* memory_pool() const;
 
+  const std::shared_ptr<FileMetaData> metadata() const;
+
  private:
   class PARQUET_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -296,7 +296,6 @@ class FileSerializer : public ParquetFileWriter::Contents {
       Close();
     } catch (...) {
     }
-    file_metadata_.reset();
   }
 
  private:
@@ -311,7 +310,6 @@ class FileSerializer : public ParquetFileWriter::Contents {
         num_row_groups_(0),
         num_rows_(0),
         metadata_(FileMetaDataBuilder::Make(&schema_, properties, key_value_metadata)) {
-    file_metadata_.reset();
     StartFile();
   }
 

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -392,8 +392,7 @@ const std::shared_ptr<const KeyValueMetadata>& ParquetFileWriter::key_value_meta
 }
 
 const std::shared_ptr<FileMetaData> ParquetFileWriter::metadata() const {
-  contents_->Close();  // ensure that file metadata is finalized
-  return contents_->metadata();
+  return file_metadata_;
 }
 
 void ParquetFileWriter::Open(std::unique_ptr<ParquetFileWriter::Contents> contents) {
@@ -403,6 +402,7 @@ void ParquetFileWriter::Open(std::unique_ptr<ParquetFileWriter::Contents> conten
 void ParquetFileWriter::Close() {
   if (contents_) {
     contents_->Close();
+    file_metadata_ = contents_->metadata();
     contents_.reset();
   }
 }

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -149,9 +149,8 @@ class PARQUET_EXPORT ParquetFileWriter {
     /// This should be the only place this is stored. Everything else is a const reference
     std::shared_ptr<const KeyValueMetadata> key_value_metadata_;
 
-    // Store finished file metadata:
-    std::shared_ptr<FileMetaData> file_metadata_;
     const std::shared_ptr<FileMetaData> metadata() const { return file_metadata_; }
+    std::shared_ptr<FileMetaData> file_metadata_;
   };
 
   ParquetFileWriter();
@@ -220,12 +219,13 @@ class PARQUET_EXPORT ParquetFileWriter {
   /// Returns the file custom metadata
   const std::shared_ptr<const KeyValueMetadata>& key_value_metadata() const;
 
-  /// Finalizes and returns the file metadata
+  /// Returns the file metadata, only available after calling Close().
   const std::shared_ptr<FileMetaData> metadata() const;
 
  private:
   // Holds a pointer to an instance of Contents implementation
   std::unique_ptr<Contents> contents_;
+  std::shared_ptr<FileMetaData> file_metadata_;
 };
 
 }  // namespace parquet

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -148,6 +148,10 @@ class PARQUET_EXPORT ParquetFileWriter {
 
     /// This should be the only place this is stored. Everything else is a const reference
     std::shared_ptr<const KeyValueMetadata> key_value_metadata_;
+
+    // Store finished file metadata:
+    std::shared_ptr<FileMetaData> file_metadata_;
+    const std::shared_ptr<FileMetaData> metadata() const { return file_metadata_; }
   };
 
   ParquetFileWriter();
@@ -215,6 +219,9 @@ class PARQUET_EXPORT ParquetFileWriter {
 
   /// Returns the file custom metadata
   const std::shared_ptr<const KeyValueMetadata>& key_value_metadata() const;
+
+  /// Finalizes and returns the file metadata
+  const std::shared_ptr<FileMetaData> metadata() const;
 
  private:
   // Holds a pointer to an instance of Contents implementation

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -323,6 +323,8 @@ cdef extern from "parquet/arrow/writer.h" namespace "parquet::arrow" nogil:
         CStatus NewRowGroup(int64_t chunk_size)
         CStatus Close()
 
+        const shared_ptr[CFileMetaData] metadata() const
+
     cdef cppclass ArrowWriterProperties:
         cppclass Builder:
             Builder()


### PR DESCRIPTION
This PR supersedes PR #4166 and provides
- [x] file metadata API (C++)
- [x] ParquetWriter `metadata` property, only available after calling `close` method (Python)
- [x] FileMetaData `to_dict` method for collecting file metadata information to a dictionary (Python)
- [x] support for `metadata_collector` kw argument to `ParquetWriter` and `write_to_dataset` for collecting the file metadata instances of dataset pieces.
- [x] unit-test