### PR TITLE
ARROW-5249: [Java] Add auth capability to Flight async operations

### DIFF
--- a/java/flight/src/test/java/org/apache/arrow/flight/auth/TestAuth.java
+++ b/java/flight/src/test/java/org/apache/arrow/flight/auth/TestAuth.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.flight.auth;
 
+import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -27,16 +28,23 @@ import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.FlightServer;
+import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.FlightTestUtil;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.NoOpFlightProducer;
+import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
 
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -58,6 +66,18 @@ public class TestAuth {
   public void validAuth() {
     client.authenticateBasic(USERNAME, PASSWORD);
     Assert.assertTrue(ImmutableList.copyOf(client.listFlights(Criteria.ALL)).size() >= 0);
+  }
+
+  @Test
+  public void asyncCall() {
+    client.authenticateBasic(USERNAME, PASSWORD);
+    client.listFlights(Criteria.ALL);
+    FlightStream s = client.getStream(new Ticket(new byte[1]));
+
+    while (s.next()) {
+      Assert.assertEquals(4095, s.getRoot().getRowCount());
+      s.getRoot().clear();
+    }
   }
 
   @Test
@@ -113,6 +133,23 @@ public class TestAuth {
               return;
             }
             listener.onCompleted();
+          }
+
+          @Override
+          public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
+            if (!context.peerIdentity().equals(USERNAME)) {
+              listener.error(new IllegalArgumentException("Invalid username"));
+              return;
+            }
+            final Schema pojoSchema = new Schema(ImmutableList.of(Field.nullable("a",
+                    Types.MinorType.BIGINT.getType())));
+            VectorSchemaRoot root = VectorSchemaRoot.create(pojoSchema, allocator);
+            listener.start(root);
+            root.allocateNew();
+            root.setRowCount(4095);
+            listener.putNext();
+            root.clear();
+            listener.completed();
           }
         },
         new BasicServerAuthHandler(validator)));

--- a/java/flight/src/test/java/org/apache/arrow/flight/auth/TestAuth.java
+++ b/java/flight/src/test/java/org/apache/arrow/flight/auth/TestAuth.java
@@ -17,7 +17,6 @@
 
 package org.apache.arrow.flight.auth;
 
-import static io.grpc.stub.ClientCalls.asyncServerStreamingCall;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -44,7 +43,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
auth wasn't being used for most async operations.
This injects auth into the call options