### PR TITLE
PARQUET-1405: Fix writing statistics into DataPageHeader

### DIFF
--- a/cpp/src/parquet/thrift.h
+++ b/cpp/src/parquet/thrift.h
@@ -118,7 +118,7 @@ static inline format::Statistics ToThrift(const EncodedStatistics& stats) {
     // If the order is SIGNED, then the old max value must be set too.
     // This for backward compatibility
     if (stats.is_signed()) {
-      statistics.__set_max(stats.min());
+      statistics.__set_max(stats.max());
     }
   }
   if (stats.has_null_count) {


### PR DESCRIPTION
This patch fixes backwards compatibility for statistics (for which we don't currently have tests), issue introduced in prior patch for PARQUET-1405