### PR TITLE
ARROW-5250: [Java] Add javadoc comments to public methods, remove style check suppression.

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -141,7 +141,7 @@ public final class JdbcToArrowConfig {
   /**
    * Returns the array sub-type {@link JdbcFieldInfo} defined for the provided column name.
    *
-   * @param index The {@link java.sql.ResultSetMetaData} column name of an {@link java.sql.Types#ARRAY} type.
+   * @param name The {@link java.sql.ResultSetMetaData} column name of an {@link java.sql.Types#ARRAY} type.
    * @return The {@link JdbcFieldInfo} for that array's sub-type, or <code>null</code> if not defined.
    */
   public JdbcFieldInfo getArraySubTypeByColumnName(String name) {

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -237,6 +237,8 @@
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <!-- This seems partially broken under JDK >= 9. -->
+            <property name="suppressLoadErrors" value="true"/>
             <property name="ignoreMethodNamesRegex" value="main"/>
         </module>
         <module name="MethodName">

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -237,6 +237,7 @@
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="ignoreMethodNamesRegex" value="main"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>

--- a/java/dev/checkstyle/suppressions.xml
+++ b/java/dev/checkstyle/suppressions.xml
@@ -23,6 +23,8 @@
   <suppress checks="JavadocPackage" files=".*[\\/]src[\\/]test[\\/].*"/>
   <suppress checks="JavadocPackage" files=".*[\\/]maven-archetypes[\\/].*"/>
   <suppress checks="JavadocPackage" files=".*[\\/]examples[\\/].*"/>
+  <!-- Method javadoc not required in testing directories -->
+  <suppress checks="JavadocMethod" files=".*[\\/]src[\\/]test[\\/].*"/>
 
   <!-- suppress all checks in the generated directories -->
   <suppress checks=".*" files=".+[\\/]generated[\\/].+\.java" />
@@ -31,9 +33,6 @@
 
   <!-- suppress files that include additional lines in license -->
   <suppress checks="Header" files="AutoCloseables.java|Collections2.java" />
-
-  <!-- TODO: Temporarily suppress missing Javadocs -->
-  <suppress checks="JavadocMethod" message="Missing a Javadoc comment." files=".*" />
 
   <!-- Suppress certain checks requiring many code changes, that add little benefit -->
   <suppress checks="NoFinalizer|OverloadMethodsDeclarationOrder|VariableDeclarationUsageDistance" files=".*" />

--- a/java/flight/src/main/java/org/apache/arrow/flight/ActionType.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/ActionType.java
@@ -19,16 +19,28 @@ package org.apache.arrow.flight;
 
 import org.apache.arrow.flight.impl.Flight;
 
+/**
+ * POJO wrapper around protocol specifics for Flight actions.
+ */
 public class ActionType {
   private final String type;
   private final String description;
 
+  /**
+   * Construct a new instance.
+   *
+   * @param type The type of action to perform
+   * @param description The description of the type.
+   */
   public ActionType(String type, String description) {
     super();
     this.type = type;
     this.description = description;
   }
 
+  /**
+   * Constructs a new instance from the corresponding protocol buffer object.
+   */
   ActionType(Flight.ActionType type) {
     this.type = type.getType();
     this.description = type.getDescription();
@@ -38,6 +50,9 @@ public class ActionType {
     return type;
   }
 
+  /**
+   *  Converts the POJO to the corresponding protocol buffer type.
+   */
   Flight.ActionType toProtocol() {
     return Flight.ActionType.newBuilder()
         .setType(type)

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -127,7 +127,7 @@ public class FlightClient implements AutoCloseable {
   }
 
   /**
-   * Authenticates with a username an password.
+   * Authenticates with a username and password.
    */
   public void authenticateBasic(String username, String password) {
     BasicClientAuthHandler basicClient = new BasicClientAuthHandler(username, password);

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -54,6 +54,9 @@ import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 
+/**
+ * Client for flight servers.
+ */
 public class FlightClient implements AutoCloseable {
   private static final int PENDING_REQUESTS = 5;
   /** The maximum number of trace events to keep on the gRPC Channel. This value disables channel tracing. */
@@ -99,7 +102,7 @@ public class FlightClient implements AutoCloseable {
   }
 
   /**
-   * List actions available on the Flight service.
+   * Lists actions available on the Flight service.
    *
    * @param options RPC-layer hints for the call.
    */
@@ -112,7 +115,7 @@ public class FlightClient implements AutoCloseable {
   }
 
   /**
-   * Perform an action on the Flight service.
+   * Performs an action on the Flight service.
    *
    * @param action The action to perform.
    * @param options RPC-layer hints for this call.
@@ -123,13 +126,16 @@ public class FlightClient implements AutoCloseable {
         .transform(CallOptions.wrapStub(blockingStub, options).doAction(action.toProtocol()), Result::new);
   }
 
+  /**
+   * Authenticates with a username an password.
+   */
   public void authenticateBasic(String username, String password) {
     BasicClientAuthHandler basicClient = new BasicClientAuthHandler(username, password);
     authenticate(basicClient);
   }
 
   /**
-   * Authenticate against the Flight service.
+   * Authenticates against the Flight service.
    *
    * @param options RPC-layer hints for this call.
    * @param handler The auth mechanism to use.

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightEndpoint.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightEndpoint.java
@@ -24,16 +24,28 @@ import org.apache.arrow.flight.impl.Flight;
 
 import com.google.common.collect.ImmutableList;
 
+/**
+ * POJO to convert to/from the underlying protobuf FlighEndpoint.
+ */
 public class FlightEndpoint {
   private List<Location> locations;
   private Ticket ticket;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param ticket A ticket that describe the key of a data stream.
+   * @param locations  The possible locations the stream can be retrieved from.
+   */
   public FlightEndpoint(Ticket ticket, Location... locations) {
     super();
     this.locations = ImmutableList.copyOf(locations);
     this.ticket = ticket;
   }
 
+  /**
+   * Constructs from the protocol buffer representation.
+   */
   public FlightEndpoint(Flight.FlightEndpoint flt) {
     locations = flt.getLocationList().stream()
         .map(t -> new Location(t)).collect(Collectors.toList());
@@ -48,6 +60,9 @@ public class FlightEndpoint {
     return ticket;
   }
 
+  /**
+   * Converts to the protocol buffer representation.
+   */
   Flight.FlightEndpoint toProtocol() {
     Flight.FlightEndpoint.Builder b = Flight.FlightEndpoint.newBuilder()
         .setTicket(ticket.toProtocol());

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightInfo.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightInfo.java
@@ -46,7 +46,8 @@ public class FlightInfo {
   private final long records;
 
   /**
-   * Constructs a new instance
+   * Constructs a new instance.
+   *
    * @param schema The schema of the Flight
    * @param descriptor An identifier for the Flight.
    * @param endpoints A list of endpoints that have the flight available.

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightInfo.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightInfo.java
@@ -35,6 +35,9 @@ import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 
+/**
+ * A POJO representation of a FlightInfo, metadata associated with a set of data records.
+ */
 public class FlightInfo {
   private Schema schema;
   private FlightDescriptor descriptor;
@@ -42,6 +45,14 @@ public class FlightInfo {
   private final long bytes;
   private final long records;
 
+  /**
+   * Constructs a new instance
+   * @param schema The schema of the Flight
+   * @param descriptor An identifier for the Flight.
+   * @param endpoints A list of endpoints that have the flight available.
+   * @param bytes The number of bytes in the flight
+   * @param records The number of records in the flight.
+   */
   public FlightInfo(Schema schema, FlightDescriptor descriptor, List<FlightEndpoint> endpoints, long bytes,
       long records) {
     super();
@@ -52,6 +63,9 @@ public class FlightInfo {
     this.records = records;
   }
 
+  /**
+   * Constructs from the protocol buffer representation.
+   */
   FlightInfo(Flight.FlightInfo pbFlightInfo) {
     try {
       final ByteBuffer schemaBuf = pbFlightInfo.getSchema().asReadOnlyByteBuffer();
@@ -88,6 +102,9 @@ public class FlightInfo {
     return endpoints;
   }
 
+  /**
+   * Converts to the protocol buffer representation.
+   */
   Flight.FlightInfo toProtocol() {
     // Encode schema in a Message payload
     ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.flight.auth.ServerAuthInterceptor;
-import org.apache.arrow.flight.impl.Flight.FlightInfo;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
@@ -39,6 +38,14 @@ public class FlightServer implements AutoCloseable {
   /** The maximum size of an individual gRPC message. This effectively disables the limit. */
   static final int MAX_GRPC_MESSAGE_SIZE = Integer.MAX_VALUE;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param allocator The allocator to use for storing/copying arrow data.
+   * @param port The port to bind to.
+   * @param producer The underlying business logic for the server.
+   * @param authHandler The authorization handler for the server.
+   */
   public FlightServer(
       BufferAllocator allocator,
       int port,
@@ -53,6 +60,7 @@ public class FlightServer implements AutoCloseable {
         .build();
   }
 
+  /** Start the server. */
   public FlightServer start() throws IOException {
     server.start();
     return this;
@@ -67,6 +75,7 @@ public class FlightServer implements AutoCloseable {
     server.awaitTermination();
   }
 
+  /** Shutdown the server, waits for up to 6 seconds for successful shutdown before returning. */
   public void close() throws InterruptedException {
     server.shutdown();
     final boolean terminated = server.awaitTermination(3000, TimeUnit.MILLISECONDS);

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -205,7 +205,7 @@ public class FlightStream {
   }
 
   /**
-   * Cancel's sending the stream to a client.
+   * Cancels sending the stream to a client.
    *
    * @throws UnsupportedOperationException on a stream being uploaded from the client.
    */

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -36,6 +36,9 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import io.grpc.stub.StreamObserver;
 
+/**
+ * An adaptor between protobuf streams and flight data streams.
+ */
 public class FlightStream {
 
 
@@ -58,6 +61,14 @@ public class FlightStream {
   private volatile FlightDescriptor descriptor;
   private volatile Schema schema;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param allocator  The allocator to use for creating/reallocating buffers for Vectors.
+   * @param pendingTarget Target number of messages to receive.
+   * @param cancellable Only provided for streams from server to client, used to cancel mid-stream requests.
+   * @param requestor A callback do determine how many pending items there are.
+   */
   public FlightStream(BufferAllocator allocator, int pendingTarget, Cancellable cancellable, Requestor requestor) {
     this.allocator = allocator;
     this.pendingTarget = pendingTarget;
@@ -73,6 +84,11 @@ public class FlightStream {
     return descriptor;
   }
 
+  /**
+   * Closes the stream (freeing any existing resources).
+   *
+   * <p>If the stream is isn't complete and is cancellable this method will cancel the stream first.</p>
+   */
   public void close() throws Exception {
     if (!completed && cancellable != null) {
       cancel("Stream closed before end.", null);
@@ -127,6 +143,7 @@ public class FlightStream {
     }
   }
 
+  /** Get the current vector data from the stream. */
   public VectorSchemaRoot getRoot() {
     try {
       return root.get();
@@ -168,7 +185,7 @@ public class FlightStream {
         case TENSOR:
         default:
           queue.add(DONE_EX);
-          ex = new UnsupportedOperationException("Unable to handle message of type." + msg);
+          ex = new UnsupportedOperationException("Unable to handle message of type: " + msg);
 
       }
 
@@ -187,6 +204,11 @@ public class FlightStream {
     }
   }
 
+  /**
+   * Cancel's sending the stream to a client.
+   *
+   * @throws UnsupportedOperationException on a stream being uploaded from the client.
+   */
   public void cancel(String message, Throwable exception) {
     if (cancellable != null) {
       cancellable.cancel(message, exception);
@@ -205,6 +227,9 @@ public class FlightStream {
   }
 
   public interface Requestor {
+    /**
+     * Requests <code>count</code> more messages from the reuqestor.
+     */
     void request(int count);
   }
 }

--- a/java/flight/src/main/java/org/apache/arrow/flight/Location.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/Location.java
@@ -24,6 +24,12 @@ public class Location {
   private final String host;
   private final int port;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param host the host containing a flight server
+   * @param port the port the server is listening on.
+   */
   public Location(String host, int port) {
     super();
     this.host = host;

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/ClientAuthWrapper.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/ClientAuthWrapper.java
@@ -33,10 +33,10 @@ import io.grpc.stub.StreamObserver;
 public class ClientAuthWrapper {
 
   /**
-   * Do client auth for a client.
+   * Do client auth for a client.  The stub will be authenticated after this method returns.
+   *
    * @param authHandler The handler to use.
    * @param stub The service stub.
-   * @return The token if auth was successful.
    */
   public static void doClientAuth(ClientAuthHandler authHandler, FlightServiceStub stub) {
     AuthObserver observer = new AuthObserver();

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/ExampleFlightServer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/ExampleFlightServer.java
@@ -38,6 +38,10 @@ public class ExampleFlightServer implements AutoCloseable {
   private final BufferAllocator allocator;
   private final InMemoryStore mem;
 
+  /**
+   * Constructs a new instance using Allocator for allocating buffer storage that binds
+   * to the given location.
+   */
   public ExampleFlightServer(BufferAllocator allocator, Location location) {
     this.allocator = allocator.newChildAllocator("flight-server", 0, Long.MAX_VALUE);
     this.location = location;
@@ -66,6 +70,9 @@ public class ExampleFlightServer implements AutoCloseable {
     AutoCloseables.close(mem, flightServer, allocator);
   }
 
+  /**
+   *  Main method starts the server listening to localhost:12233.
+   */
   public static void main(String[] args) throws Exception {
     final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
     final ExampleFlightServer efs = new ExampleFlightServer(a, new Location("localhost", 12233));

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/ExampleTicket.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/ExampleTicket.java
@@ -45,7 +45,8 @@ public class ExampleTicket {
   private final String uuid;
 
   /**
-   * Constructs a new instance
+   * Constructs a new instance.
+   *
    * @param path Path to data
    * @param ordinal A counter for the stream.
    * @param uuid  A unique identifier for this particular stream.

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/ExampleTicket.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/ExampleTicket.java
@@ -30,6 +30,9 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
+/**
+ * POJO object used to demonstrate how an opaque ticket can be generated.
+ */
 @JsonSerialize
 public class ExampleTicket {
 
@@ -41,6 +44,12 @@ public class ExampleTicket {
   // uuid to ensure that a stream from one node is not recreated on another node and mixed up.
   private final String uuid;
 
+  /**
+   * Constructs a new instance
+   * @param path Path to data
+   * @param ordinal A counter for the stream.
+   * @param uuid  A unique identifier for this particular stream.
+   */
   @JsonCreator
   public ExampleTicket(@JsonProperty("path") List<String> path, @JsonProperty("ordinal") int ordinal,
       @JsonProperty("uuid") String uuid) {
@@ -63,6 +72,9 @@ public class ExampleTicket {
     return uuid;
   }
 
+  /**
+   * Deserializes a new instance from the protocol buffer ticket.
+   */
   public static ExampleTicket from(Ticket ticket) {
     try {
       return MAPPER.readValue(ticket.getBytes(), ExampleTicket.class);
@@ -71,6 +83,9 @@ public class ExampleTicket {
     }
   }
 
+  /**
+   *  Creates a new protocol buffer Ticket by serializing to JSON.
+   */
   public Ticket toTicket() {
     try {
       return new Ticket(MAPPER.writeValueAsBytes(this));

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/FlightHolder.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/FlightHolder.java
@@ -34,6 +34,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
+/**
+ * A logical collection of streams sharing the same schema.
+ */
 public class FlightHolder implements AutoCloseable {
 
   private final BufferAllocator allocator;
@@ -41,6 +44,13 @@ public class FlightHolder implements AutoCloseable {
   private final Schema schema;
   private final List<Stream> streams = new CopyOnWriteArrayList<>();
 
+  /**
+   * Creates a new instance.
+   *
+   * @param allocator The allocator to use for allocating buffers to store data.
+   * @param descriptor The descriptor for the streams.
+   * @param schema  The schema for the stream.
+   */
   public FlightHolder(BufferAllocator allocator, FlightDescriptor descriptor, Schema schema) {
     Preconditions.checkArgument(!descriptor.isCommand());
     this.allocator = allocator.newChildAllocator(descriptor.toString(), 0, Long.MAX_VALUE);
@@ -48,6 +58,9 @@ public class FlightHolder implements AutoCloseable {
     this.schema = schema;
   }
 
+  /**
+   * Returns the stream based on the ordinal of ExampleTicket.
+   */
   public Stream getStream(ExampleTicket ticket) {
     Preconditions.checkArgument(ticket.getOrdinal() < streams.size(), "Unknown stream.");
     Stream stream = streams.get(ticket.getOrdinal());
@@ -55,6 +68,9 @@ public class FlightHolder implements AutoCloseable {
     return stream;
   }
 
+  /**
+   * Adds a new streams which clients can populate via the returned object.
+   */
   public Stream.StreamCreator addStream(Schema schema) {
     Preconditions.checkArgument(schema.equals(schema), "Stream schema inconsistent with existing schema.");
     return new Stream.StreamCreator(schema, allocator, t -> {
@@ -64,6 +80,9 @@ public class FlightHolder implements AutoCloseable {
     });
   }
 
+  /**
+   * List all available streams as being available at <code>l</code>.
+   */
   public FlightInfo getFlightInfo(final Location l) {
     final long bytes = allocator.getAllocatedMemory();
     final long records = streams.stream().collect(Collectors.summingLong(t -> t.getRecordCount()));

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/InMemoryStore.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/InMemoryStore.java
@@ -67,7 +67,7 @@ public class InMemoryStore implements FlightProducer, AutoCloseable {
   }
 
   /**
-   * Returns the appropriate stream give the ticket (streams are indexed by path and an ordinal).
+   * Returns the appropriate stream given the ticket (streams are indexed by path and an ordinal).
    */
   public Stream getStream(Ticket t) {
     ExampleTicket example = ExampleTicket.from(t);

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/InMemoryStore.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/InMemoryStore.java
@@ -48,6 +48,12 @@ public class InMemoryStore implements FlightProducer, AutoCloseable {
   private final BufferAllocator allocator;
   private final Location location;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param allocator The allocator for creating new Arrow buffers.
+   * @param location The location of the storage.
+   */
   public InMemoryStore(BufferAllocator allocator, Location location) {
     super();
     this.allocator = allocator;
@@ -60,6 +66,9 @@ public class InMemoryStore implements FlightProducer, AutoCloseable {
     getStream(ticket).sendTo(allocator, listener);
   }
 
+  /**
+   * Returns the appropriate stream give the ticket (streams are indexed by path and an ordinal).
+   */
   public Stream getStream(Ticket t) {
     ExampleTicket example = ExampleTicket.from(t);
     FlightDescriptor d = FlightDescriptor.path(example.getPath());
@@ -71,6 +80,9 @@ public class InMemoryStore implements FlightProducer, AutoCloseable {
     return h.getStream(example);
   }
 
+  /**
+   * Create a new {@link Stream} with the given schema and descriptor.
+   */
   public StreamCreator putStream(final FlightDescriptor descriptor, final Schema schema) {
     final FlightHolder h = holders.computeIfAbsent(
         descriptor,

--- a/java/flight/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/grpc/GetReadableBuffer.java
@@ -53,6 +53,12 @@ public class GetReadableBuffer {
     BUFFER_INPUT_STREAM = tmpClazz;
   }
 
+  /**
+   * Extracts the ReadableBuffer for the given input stream.
+   *
+   * @param is Must be an instance of io.grpc.internal.ReadableBuffers$BufferInputStream or
+   *     null will be returned.
+   */
   public static ReadableBuffer getReadableBuffer(InputStream is) {
 
     if (BUFFER_INPUT_STREAM == null || !is.getClass().equals(BUFFER_INPUT_STREAM)) {

--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -165,6 +165,11 @@ public final class ArrowBuf implements AutoCloseable {
     return length;
   }
 
+  /**
+   * Adjusts the capacity of this buffer.  Size increases are NOT supported.
+   *
+   * @param newCapacity Must be in in the range [0, length).
+   */
   public synchronized ArrowBuf capacity(int newCapacity) {
 
     if (newCapacity == length) {
@@ -181,24 +186,39 @@ public final class ArrowBuf implements AutoCloseable {
     throw new UnsupportedOperationException("Buffers don't support resizing that increases the size.");
   }
 
+  /**
+   * Returns the byte order of elements in this buffer.
+   */
   public ByteOrder order() {
     return ByteOrder.LITTLE_ENDIAN;
   }
 
+  /**
+   * Returns the number of bytes still available to read in this buffer.
+   */
   public int readableBytes() {
     Preconditions.checkState(writerIndex >= readerIndex,
             "Writer index cannot be less than reader index");
     return writerIndex - readerIndex;
   }
 
+  /**
+   * Returns the number of bytes still available to write into this buffer before capacity is reached.
+   */
   public int writableBytes() {
     return capacity() - writerIndex;
   }
 
+  /**
+   * Returns a slice of only the readable bytes in the buffer.
+   */
   public ArrowBuf slice() {
     return slice(readerIndex, readableBytes());
   }
 
+  /**
+   *  Returns a slice (view) starting at <code>index</code> with the given <code>length</code>.
+   */
   public ArrowBuf slice(int index, int length) {
     if (isEmpty) {
       return this;

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -42,6 +42,13 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
   private int length;
   private final long address;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param arrowBuf The buffer to wrap.
+   * @param arrowByteBufAllocator The allocator for the buffer (assumed to be {@link ArrowByteBufAllocator}).
+   * @param length The length of this buffer.
+   */
   public NettyArrowBuf(
       final ArrowBuf arrowBuf,
       final ByteBufAllocator arrowByteBufAllocator,

--- a/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
@@ -31,17 +31,26 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
+/**
+ * Simple server that echoes back data received.
+ */
 public class EchoServer {
   private static final Logger LOGGER = LoggerFactory.getLogger(EchoServer.class);
   private final ServerSocket serverSocket;
   private boolean closed = false;
 
+  /**
+   * Constructs a new instance that binds to the given port.
+   */
   public EchoServer(int port) throws IOException {
     LOGGER.debug("Starting echo server.");
     serverSocket = new ServerSocket(port);
     LOGGER.debug("Running echo server on port: " + port());
   }
 
+  /**
+   * Main method to run the server, the first argument is an optional port number.
+   */
   public static void main(String[] args) throws Exception {
     int port;
     if (args.length > 0) {
@@ -56,6 +65,9 @@ public class EchoServer {
     return serverSocket.getLocalPort();
   }
 
+  /**
+   * Starts the main server event loop.
+   */
   public void run() throws IOException {
     try {
       while (!closed) {
@@ -93,6 +105,9 @@ public class EchoServer {
       this.socket = socket;
     }
 
+    /**
+     * Reads a record batch off the socket and writes it back out.
+     */
     public void run() throws IOException {
       // Read the entire input stream and write it back
       try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
@@ -34,6 +34,7 @@ import org.apache.arrow.vector.ipc.ArrowStreamWriter;
  * first argument and the output is written to standard out.
  */
 public class FileToStream {
+  private FileToStream() {}
 
   public static void convert(FileInputStream in, OutputStream out) throws IOException {
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
@@ -36,6 +36,9 @@ import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 public class FileToStream {
   private FileToStream() {}
 
+  /**
+   * Reads an Arrow file from in and writes it back to out.
+   */
   public static void convert(FileInputStream in, OutputStream out) throws IOException {
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
     try (ArrowFileReader reader = new ArrowFileReader(in.getChannel(), allocator)) {
@@ -57,6 +60,10 @@ public class FileToStream {
     }
   }
 
+  /**
+   * Main method.  The first arg is the file path.  The second, optional argument,
+   * is an output file location (defaults to standard out).
+   */
   public static void main(String[] args) throws IOException {
     if (args.length != 1 && args.length != 2) {
       System.err.println("Usage: FileToStream <input file> [output file]");

--- a/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
@@ -46,6 +46,9 @@ import org.apache.commons.cli.PosixParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Application for cross language integration testing.
+ */
 public class Integration {
   private static final Logger LOGGER = LoggerFactory.getLogger(Integration.class);
   private final Options options;
@@ -58,6 +61,9 @@ public class Integration {
         .values()));
   }
 
+  /**
+   *  Main method.
+   */
   public static void main(String[] args) {
     try {
       new Integration().run(args);

--- a/java/tools/src/main/java/org/apache/arrow/tools/StreamToFile.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/StreamToFile.java
@@ -35,6 +35,9 @@ import org.apache.arrow.vector.ipc.ArrowStreamReader;
  * Converts an Arrow stream to an Arrow file.
  */
 public class StreamToFile {
+  /**
+   *  Reads a record batchs from in and writes them to out.
+   */
   public static void convert(InputStream in, OutputStream out) throws IOException {
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
     try (ArrowStreamReader reader = new ArrowStreamReader(in, allocator)) {
@@ -56,6 +59,11 @@ public class StreamToFile {
     }
   }
 
+  /**
+   * Main method.  Defaults to reading from standard in and standard out.
+   * If there are two arguments the first is interpreted as the input file path,
+   * the second is the output file path.
+   */
   public static void main(String[] args) throws IOException {
     InputStream in = System.in;
     OutputStream out = System.out;

--- a/java/tools/src/main/java/org/apache/arrow/tools/StreamToFile.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/StreamToFile.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.ipc.ArrowStreamReader;
  */
 public class StreamToFile {
   /**
-   *  Reads a record batchs from in and writes them to out.
+   *  Reads an Arrow stream from <code>in</code> and writes it to <code>out</code>.
    */
   public static void convert(InputStream in, OutputStream out) throws IOException {
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);

--- a/java/vector/src/main/java/org/apache/arrow/util/AutoCloseables.java
+++ b/java/vector/src/main/java/org/apache/arrow/util/AutoCloseables.java
@@ -34,6 +34,10 @@ public final class AutoCloseables {
   private AutoCloseables() {
   }
 
+  /**
+   * Returns a new {@link AutoCloseable} that calls {@link #close(Iterable)} on <code>autoCloseables</code>
+   * when close is called.
+   */
   public static AutoCloseable all(final Collection<? extends AutoCloseable> autoCloseables) {
     return new AutoCloseable() {
       @Override
@@ -106,6 +110,9 @@ public final class AutoCloseables {
     }
   }
 
+  /**
+   * Calls {@link #close(Iterable)} on the flattened list of closeables.
+   */
   @SafeVarargs
   public static void close(Iterable<? extends AutoCloseable>...closeables) throws Exception {
     close(Arrays.asList(closeables).stream()
@@ -113,6 +120,9 @@ public final class AutoCloseables {
         .collect(Collectors.toList()));
   }
 
+  /**
+   * Converts <code>ac</code> to a {@link Iterable} filtering out any null values.
+   */
   public static Iterable<AutoCloseable> iter(AutoCloseable... ac) {
     if (ac.length == 0) {
       return Collections.emptyList();
@@ -144,10 +154,16 @@ public final class AutoCloseables {
       return t;
     }
 
+    /**
+     * Add all of <code>list</code> to the rollback list.
+     */
     public void addAll(AutoCloseable... list) {
       closeables.addAll(Arrays.asList(list));
     }
 
+    /**
+     * Add all of <code>list</code> to the rollback list.
+     */
     public void addAll(Iterable<? extends AutoCloseable> list) {
       for (AutoCloseable ac : list) {
         closeables.add(ac);
@@ -167,6 +183,9 @@ public final class AutoCloseables {
 
   }
 
+  /**
+   * Creates an {@link RollbackCloseable} from the given closeables.
+   */
   public static RollbackCloseable rollbackable(AutoCloseable... closeables) {
     return new RollbackCloseable(closeables);
   }

--- a/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
+++ b/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
@@ -32,26 +32,35 @@ import java.util.stream.StreamSupport;
 public class Collections2 {
   private Collections2() {}
 
+  /**
+   * Creates an {@link List} from the elements remaining in iterator.
+   */
   public static <T> List<T> toList(Iterator<T> iterator) {
     List<T> target = new ArrayList<>();
     iterator.forEachRemaining(target::add);
     return target;
   }
 
+  /**
+   * Converts the iterable into a new {@link List}.
+   */
   public static <T> List<T> toList(Iterable<T> iterable) {
     return StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toList());
   }
 
+  /** Copies the elements of <code>map</code> to a new unmodifiable map. */
   public static <K,V> Map<K, V> immutableMapCopy(Map<K, V> map) {
     Map<K,V> newMap = new HashMap<>();
     newMap.putAll(map);
     return java.util.Collections.unmodifiableMap(newMap);
   }
 
+  /** Copies the elements of list to a new unmodifiable list. */
   public static <V> List<V> immutableListCopy(List<V> list) {
     return Collections.unmodifiableList(list.stream().collect(Collectors.toList()));
   }
 
+  /** Copies the values to a new unmodifiable list. */
   public static <V> List<V> asImmutableList(V...values) {
     return Collections.unmodifiableList(Arrays.asList(values));
   }

--- a/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
+++ b/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class Collections2 {
+  private Collections2() {}
 
   public static <T> List<T> toList(Iterator<T> iterator) {
     List<T> target = new ArrayList<>();
@@ -48,7 +49,7 @@ public class Collections2 {
   }
 
   public static <V> List<V> immutableListCopy(List<V> list) {
-    return list.stream().collect(Collectors.toList());
+    return Collections.unmodifiableList(list.stream().collect(Collectors.toList()));
   }
 
   public static <V> List<V> asImmutableList(V...values) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/AddOrGetResult.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AddOrGetResult.java
@@ -19,19 +19,23 @@ package org.apache.arrow.vector;
 
 import org.apache.arrow.util.Preconditions;
 
+/** Tuple class containing a vector and whether is was created. */
 public class AddOrGetResult<V extends ValueVector> {
   private final V vector;
   private final boolean created;
 
+  /** Constructs a new object. */
   public AddOrGetResult(V vector, boolean created) {
     this.vector = Preconditions.checkNotNull(vector);
     this.created = created;
   }
 
+  /** Returns the vector. */
   public V getVector() {
     return vector;
   }
 
+  /** Returns whether the vectos is created. */
   public boolean isCreated() {
     return created;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
@@ -20,13 +20,29 @@ package org.apache.arrow.vector;
 import org.apache.arrow.vector.complex.RepeatedFixedWidthVectorLike;
 import org.apache.arrow.vector.complex.RepeatedVariableWidthVectorLike;
 
+/** Helper utility methods for allocating storage for Vectors. */
 public class AllocationHelper {
   private AllocationHelper() {}
 
+  /**
+   * Allocates the vector
+   * @param v The vector to allocate.
+   * @param valueCount Number of values to allocate.
+   * @param bytesPerValue bytes per value.
+   * @throws org.apache.arrow.memory.OutOfMemoryException if it can't allocate the memory.
+   */
   public static void allocate(ValueVector v, int valueCount, int bytesPerValue) {
     allocate(v, valueCount, bytesPerValue, 5);
   }
 
+  /**
+   * Allocates memory for a vector assuming given number of values and their width.
+   * @param v The vector the allocate.
+   * @param valueCount The number of elements to allocate.
+   * @param bytesPerValue The bytes per value to use for allocating underlying storage
+   * @param childValCount  If <code>v</code> is a repeated vector, this is number of child elements to allocate.
+   * @throws org.apache.arrow.memory.OutOfMemoryException if it can't allocate the memory.
+   */
   public static void allocatePrecomputedChildCount(
       ValueVector v,
       int valueCount,
@@ -45,6 +61,14 @@ public class AllocationHelper {
     }
   }
 
+  /**
+   * Allocates memory for a vector assuming given number of values and their width.
+   * @param v The vector the allocate.
+   * @param valueCount The number of elements to allocate.
+   * @param bytesPerValue The bytes per value to use for allocating underlying storage
+   * @param repeatedPerTop  If <code>v</code> is a repeated vector, this is assumed number of elements per child.
+   * @throws org.apache.arrow.memory.OutOfMemoryException if it can't allocate the memory
+   */
   public static void allocate(ValueVector v, int valueCount, int bytesPerValue, int repeatedPerTop) {
     allocatePrecomputedChildCount(v, valueCount, bytesPerValue, repeatedPerTop * valueCount);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
@@ -21,6 +21,7 @@ import org.apache.arrow.vector.complex.RepeatedFixedWidthVectorLike;
 import org.apache.arrow.vector.complex.RepeatedVariableWidthVectorLike;
 
 public class AllocationHelper {
+  private AllocationHelper() {}
 
   public static void allocate(ValueVector v, int valueCount, int bytesPerValue) {
     allocate(v, valueCount, bytesPerValue, 5);

--- a/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AllocationHelper.java
@@ -25,7 +25,8 @@ public class AllocationHelper {
   private AllocationHelper() {}
 
   /**
-   * Allocates the vector
+   * Allocates the vector.
+   *
    * @param v The vector to allocate.
    * @param valueCount Number of values to allocate.
    * @param bytesPerValue bytes per value.
@@ -37,6 +38,7 @@ public class AllocationHelper {
 
   /**
    * Allocates memory for a vector assuming given number of values and their width.
+   *
    * @param v The vector the allocate.
    * @param valueCount The number of elements to allocate.
    * @param bytesPerValue The bytes per value to use for allocating underlying storage
@@ -63,6 +65,7 @@ public class AllocationHelper {
 
   /**
    * Allocates memory for a vector assuming given number of values and their width.
+   *
    * @param v The vector the allocate.
    * @param valueCount The number of elements to allocate.
    * @param bytesPerValue The bytes per value to use for allocating underlying storage

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -50,6 +50,13 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   protected ArrowBuf valueBuffer;
   protected int valueCount;
 
+  /** Constructs a new instance.
+   *
+   * @param name The name of the vector.
+   * @param allocator The allocator to use for allocating memory for the vector.
+   * @param fieldType The type of the buffer.
+   * @param typeWidth The width in bytes of the type.
+   */
   public BaseFixedWidthVector(final String name, final BufferAllocator allocator,
                                       FieldType fieldType, final int typeWidth) {
     super(name, allocator);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -50,7 +50,8 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   protected ArrowBuf valueBuffer;
   protected int valueCount;
 
-  /** Constructs a new instance.
+  /**
+   * Constructs a new instance.
    *
    * @param name The name of the vector.
    * @param allocator The allocator to use for allocating memory for the vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -80,7 +80,8 @@ public abstract class BaseValueVector implements ValueVector {
     return Collections.emptyIterator();
   }
 
-  /** Checks to ensure that every buffer <code>vv</code> uses
+  /**
+   * Checks to ensure that every buffer <code>vv</code> uses
    * has a positive reference count, throws if this precondition
    * isn't met.  Returns true otherwise.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -30,6 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * Base class for other Arrow Vector Types.  Provides basic functionality around
+ * memory management.
+ */
 public abstract class BaseValueVector implements ValueVector {
   private static final Logger logger = LoggerFactory.getLogger(BaseValueVector.class);
 
@@ -76,6 +80,10 @@ public abstract class BaseValueVector implements ValueVector {
     return Collections.emptyIterator();
   }
 
+  /** Checks to ensure that every buffer <code>vv</code> uses
+   * has a positive reference count, throws if this precondition
+   * isn't met.  Returns true otherwise.
+   */
   public static boolean checkBufRefs(final ValueVector vv) {
     for (final ArrowBuf buffer : vv.getBuffers(false)) {
       if (buffer.refCnt() <= 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -55,7 +55,9 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   protected int lastSet;
   protected final Field field;
 
-  /** Constructs a new instance.
+  /**
+   * Constructs a new instance.
+   *
    * @param name A name for the vector
    * @param allocator The allocator to use for creating/resizing buffers
    * @param fieldType The type of this vector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -34,6 +34,10 @@ import org.apache.arrow.vector.util.TransferPair;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * BaseVariableWidthVector is a base class providing functionality for variable width
+ * types (e.g. Lists, Strings, etc.)
+ */
 public abstract class BaseVariableWidthVector extends BaseValueVector
         implements VariableWidthVector, FieldVector, VectorDefinitionSetter {
   private static final int DEFAULT_RECORD_BYTE_COUNT = 8;
@@ -51,6 +55,11 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   protected int lastSet;
   protected final Field field;
 
+  /** Constructs a new instance.
+   * @param name A name for the vector
+   * @param allocator The allocator to use for creating/resizing buffers
+   * @param fieldType The type of this vector.
+   */
   public BaseVariableWidthVector(final String name, final BufferAllocator allocator,
                                          FieldType fieldType) {
     super(name, allocator);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -163,14 +163,26 @@ public class BitVectorHelper {
     return 8 * sizeInBytes - count;
   }
 
+  /** Returns the byte at index from data right-shifted by offset. */
   public static byte getBitsFromCurrentByte(final ArrowBuf data, final int index, final int offset) {
     return (byte) ((data.getByte(index) & 0xFF) >>> offset);
   }
 
+  /**
+   * Returns the byte at <code>index</code> from left-shifted by (8 - <code>offset</code>).
+   */
   public static byte getBitsFromNextByte(ArrowBuf data, int index, int offset) {
     return (byte) ((data.getByte(index) << (8 - offset)));
   }
 
+  /** Returns a new buffer if the source validity buffer is either all null or all
+   * not-null, otherwise returns a buffer pointing to the same memory as source.
+   * @param fieldNode The fieldNode containing the null count
+   * @param sourceValidityBuffer The source validity buffer that will have its
+   *                             position copied if there is a mix of null and non-null values
+   * @param allocator The allocator to use for creating a new buffer if necessary.
+   * @return A new buffer that is either allocated or points to the same memory as sourceValidityBuffer.
+   */
   public static ArrowBuf loadValidityBuffer(final ArrowFieldNode fieldNode,
                                             final ArrowBuf sourceValidityBuffer,
                                             final BufferAllocator allocator) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -28,6 +28,8 @@ import io.netty.buffer.ArrowBuf;
  */
 public class BitVectorHelper {
 
+  private BitVectorHelper() {}
+
   /**
    * Get the index of byte corresponding to bit index in validity buffer.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -175,11 +175,13 @@ public class BitVectorHelper {
     return (byte) ((data.getByte(index) << (8 - offset)));
   }
 
-  /** Returns a new buffer if the source validity buffer is either all null or all
+  /**
+   * Returns a new buffer if the source validity buffer is either all null or all
    * not-null, otherwise returns a buffer pointing to the same memory as source.
+   *
    * @param fieldNode The fieldNode containing the null count
    * @param sourceValidityBuffer The source validity buffer that will have its
-   *                             position copied if there is a mix of null and non-null values
+   *     position copied if there is a mix of null and non-null values
    * @param allocator The allocator to use for creating a new buffer if necessary.
    * @return A new buffer that is either allocated or points to the same memory as sourceValidityBuffer.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/BufferBacked.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BufferBacked.java
@@ -29,5 +29,4 @@ public interface BufferBacked {
   void load(ArrowFieldNode fieldNode, ArrowBuf data);
 
   ArrowBuf unLoad();
-
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
@@ -19,6 +19,11 @@ package org.apache.arrow.vector;
 
 import org.apache.arrow.util.Preconditions;
 
+/**
+ * Metadata class that captures the "type" of an Arrow buffer.
+ * (e.g. data buffers, offset buffers for variable width types and validity
+ * buffers).
+ */
 public class BufferLayout {
 
   public enum BufferType {
@@ -56,6 +61,10 @@ public class BufferLayout {
     return OFFSET_BUFFER;
   }
 
+  /**
+   * Returns a databuffer for the given bitwidth.  Only supports powers of two between 8 and 128
+   * inclusive.
+   */
   public static BufferLayout dataBuffer(int typeBitWidth) {
     switch (typeBitWidth) {
       case 8:

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -146,6 +146,9 @@ public class DurationVector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Converts the given value and unit to the appropriate {@link Duration}.
+   */
   public static Duration toDuration(long value, TimeUnit unit) {
     switch (unit) {
       case SECOND:

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -185,6 +185,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
    |                                                                |
    *----------------------------------------------------------------*/
 
+  /** Sets the value at index to the provided one. */
   public void set(int index, byte[] value) {
     assert index >= 0;
     assert byteWidth <= value.length;
@@ -192,11 +193,18 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     valueBuffer.setBytes(index * byteWidth, value, 0, byteWidth);
   }
 
+  /**
+   * Same as {@link #set(int, byte[])} but reallocates if <code>index</code>
+   * is larger than capacity.
+   */
   public void setSafe(int index, byte[] value) {
     handleSafe(index);
     set(index, value);
   }
 
+  /**
+   * Sets the value if isSet is positive, otherwise sets the index to null/invalid.
+   */
   public void set(int index, int isSet, byte[] value) {
     if (isSet > 0) {
       set(index, value);

--- a/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
  * with sample data. This class should be used for that purpose.
  */
 public class GenerateSampleData {
+  private GenerateSampleData() {}
 
   public static void generateTestData(final ValueVector vector, final int valueCount) {
     if (vector instanceof IntVector) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/GenerateSampleData.java
@@ -29,6 +29,7 @@ import java.nio.charset.Charset;
 public class GenerateSampleData {
   private GenerateSampleData() {}
 
+  /** Populates <code>vector</code> with <code>valueCount</code> random values. */
   public static void generateTestData(final ValueVector vector, final int valueCount) {
     if (vector instanceof IntVector) {
       writeIntData((IntVector) vector, valueCount);

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -51,6 +51,9 @@ import org.apache.arrow.vector.types.pojo.ArrowType.Utf8;
  */
 public class TypeLayout {
 
+  /**
+   * Constructs a new {@TypeLayout} for the given <code>arrowType</code>.
+   */
   public static TypeLayout getTypeLayout(final ArrowType arrowType) {
     TypeLayout layout = arrowType.accept(new ArrowTypeVisitor<TypeLayout>() {
 
@@ -223,11 +226,16 @@ public class TypeLayout {
     this(asList(bufferLayouts));
   }
 
-
+  /**
+   * Returns the individual {@linkplain BufferLayout}s for the given type.
+   */
   public List<BufferLayout> getBufferLayouts() {
     return bufferLayouts;
   }
 
+  /**
+   * Returns the types of each buffer for in this layout.
+   */
   public List<BufferType> getBufferTypes() {
     List<BufferType> types = new ArrayList<>(bufferLayouts.size());
     for (BufferLayout vector : bufferLayouts) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -234,7 +234,9 @@ public class TypeLayout {
   }
 
   /**
-   * Returns the types of each buffer for in this layout.
+   * Returns the types of each buffer for this layout.  A layout can consist
+   * of multiple buffers for example a validity bitmap buffer, a value buffer or
+   * an offset buffer.
    */
   public List<BufferType> getBufferTypes() {
     List<BufferType> types = new ArrayList<>(bufferLayouts.size());

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -107,12 +107,19 @@ public class UInt1Vector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Copies the value at fromIndex to thisIndex (including validity).
+   */
   public void copyFrom(int fromIndex, int thisIndex, UInt1Vector from) {
     BitVectorHelper.setValidityBit(validityBuffer, thisIndex, from.isSet(fromIndex));
     final byte value = from.valueBuffer.getByte(fromIndex * TYPE_WIDTH);
     valueBuffer.setByte(thisIndex * TYPE_WIDTH, value);
   }
 
+  /**
+   * Identical to {@link #copyFrom()} but reallocates buffer if index is larger
+   * than capacity.
+   */
   public void copyFromSafe(int fromIndex, int thisIndex, UInt1Vector from) {
     handleSafe(thisIndex);
     copyFrom(fromIndex, thisIndex, from);
@@ -250,6 +257,10 @@ public class UInt1Vector extends BaseFixedWidthVector {
     BitVectorHelper.setValidityBit(validityBuffer, index, 0);
   }
 
+  /**
+   * Sets the value at index to value isSet > 0, otherwise sets the index position
+   * to invalid/null.
+   */
   public void set(int index, int isSet, byte value) {
     if (isSet > 0) {
       set(index, value);
@@ -258,6 +269,10 @@ public class UInt1Vector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Same as {@link #set(int, int, byte)} but will reallocate the buffer if index
+   * is larger than current capacity.
+   */
   public void setSafe(int index, int isSet, byte value) {
     handleSafe(index);
     set(index, isSet, value);

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -107,12 +107,17 @@ public class UInt2Vector extends BaseFixedWidthVector {
     }
   }
 
+  /** Copies a value and validity bit from the given vector to this one. */
   public void copyFrom(int fromIndex, int thisIndex, UInt2Vector from) {
     BitVectorHelper.setValidityBit(validityBuffer, thisIndex, from.isSet(fromIndex));
     final char value = from.valueBuffer.getChar(fromIndex * TYPE_WIDTH);
     valueBuffer.setChar(thisIndex * TYPE_WIDTH, value);
   }
 
+  /**
+   * Same as {@link #copyFrom(int, int, UInt2Vector)} but reallocate buffer if
+   * index is larger than capacity.
+   */
   public void copyFromSafe(int fromIndex, int thisIndex, UInt2Vector from) {
     handleSafe(thisIndex);
     copyFrom(fromIndex, thisIndex, from);
@@ -250,6 +255,10 @@ public class UInt2Vector extends BaseFixedWidthVector {
     BitVectorHelper.setValidityBit(validityBuffer, index, 0);
   }
 
+  /**
+   * Sets the given index to value is isSet is positive, otherwise sets
+   * the position as invalid/null.
+   */
   public void set(int index, int isSet, char value) {
     if (isSet > 0) {
       set(index, value);
@@ -258,6 +267,10 @@ public class UInt2Vector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Same as {@link #set(int, int, char)} but will reallocate the buffer if index
+   * is larger than current capacity.
+   */
   public void setSafe(int index, int isSet, char value) {
     handleSafe(index);
     set(index, isSet, value);

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -242,8 +242,10 @@ public class UInt4Vector extends BaseFixedWidthVector {
     }
   }
 
-  /** Same as {@link #set(int, int, int)} but will reallocate if the buffer if index
-   * is larger than the current capacity. */
+  /**
+   * Same as {@link #set(int, int, int)} but will reallocate if the buffer if index
+   * is larger than the current capacity.
+   */
   public void setSafe(int index, int isSet, int value) {
     handleSafe(index);
     set(index, isSet, value);

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -107,12 +107,20 @@ public class UInt4Vector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Copies a value and validity setting to the thisIndex position from the given vector
+   * at fromIndex.
+   */
   public void copyFrom(int fromIndex, int thisIndex, UInt4Vector from) {
     BitVectorHelper.setValidityBit(validityBuffer, thisIndex, from.isSet(fromIndex));
     final int value = from.valueBuffer.getInt(fromIndex * TYPE_WIDTH);
     valueBuffer.setInt(thisIndex * TYPE_WIDTH, value);
   }
 
+  /**
+   * Same as {@link #copyFrom(int, int, UInt4Vector)} but will allocate additional space
+   * if fromIndex is larger than current capacity.
+   */
   public void copyFromSafe(int fromIndex, int thisIndex, UInt4Vector from) {
     handleSafe(thisIndex);
     copyFrom(fromIndex, thisIndex, from);
@@ -222,6 +230,10 @@ public class UInt4Vector extends BaseFixedWidthVector {
     BitVectorHelper.setValidityBit(validityBuffer, index, 0);
   }
 
+  /**
+   * Sets the value at index to value isSet > 0, otherwise sets the index position
+   * to invalid/null.
+   */
   public void set(int index, int isSet, int value) {
     if (isSet > 0) {
       set(index, value);
@@ -230,6 +242,8 @@ public class UInt4Vector extends BaseFixedWidthVector {
     }
   }
 
+  /** Same as {@link #set(int, int, int)} but will reallocate if the buffer if index
+   * is larger than the current capacity. */
   public void setSafe(int index, int isSet, int value) {
     handleSafe(index);
     set(index, isSet, value);

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -107,12 +107,20 @@ public class UInt8Vector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Copy a value and validity setting from fromIndex in <code>from</code> to this
+   * Vector at thisIndex.
+   */
   public void copyFrom(int fromIndex, int thisIndex, UInt8Vector from) {
     BitVectorHelper.setValidityBit(validityBuffer, thisIndex, from.isSet(fromIndex));
     final long value = from.valueBuffer.getLong(fromIndex * TYPE_WIDTH);
     valueBuffer.setLong(thisIndex * TYPE_WIDTH, value);
   }
 
+  /**
+   * Same as {@link #copyFrom(int, int, UInt8Vector)} but reallocates if thisIndex is
+   * larger then current capacity.
+   */
   public void copyFromSafe(int fromIndex, int thisIndex, UInt8Vector from) {
     handleSafe(thisIndex);
     copyFrom(fromIndex, thisIndex, from);
@@ -222,6 +230,7 @@ public class UInt8Vector extends BaseFixedWidthVector {
     BitVectorHelper.setValidityBit(validityBuffer, index, 0);
   }
 
+  /** Sets value at index is isSet is positive otherwise sets the index to invalid/null. */
   public void set(int index, int isSet, long value) {
     if (isSet > 0) {
       set(index, value);
@@ -230,6 +239,9 @@ public class UInt8Vector extends BaseFixedWidthVector {
     }
   }
 
+  /**
+   * Same as {@link #set(int, int, long)} but will reallocate if index is greater than current capacity.
+   */
   public void setSafe(int index, int isSet, long value) {
     handleSafe(index);
     set(index, isSet, value);

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -41,6 +41,9 @@ public class VectorSchemaRoot implements AutoCloseable {
   private final Map<String, FieldVector> fieldVectorsMap = new HashMap<>();
 
 
+  /**
+   * Constructs new instance containing each of the vectors.
+   */
   public VectorSchemaRoot(Iterable<FieldVector> vectors) {
     this(
         StreamSupport.stream(vectors.spliterator(), false).map(t -> t.getField()).collect(Collectors.toList()),
@@ -49,14 +52,31 @@ public class VectorSchemaRoot implements AutoCloseable {
         );
   }
 
+  /**
+   * Constructs a new instance containing the children of parent but not the parent itself.
+   */
   public VectorSchemaRoot(FieldVector parent) {
     this(parent.getField().getChildren(), parent.getChildrenFromFields(), parent.getValueCount());
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param fields The types of each vector.
+   * @param fieldVectors The data vectors (must be equal in size to <code>fields</code>.
+   * @param rowCount The number of rows contained.
+   */
   public VectorSchemaRoot(List<Field> fields, List<FieldVector> fieldVectors, int rowCount) {
     this(new Schema(fields), fieldVectors, rowCount);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param schema The schema for the vectors.
+   * @param fieldVectors The data vectors.
+   * @param rowCount  The number of rows
+   */
   public VectorSchemaRoot(Schema schema, List<FieldVector> fieldVectors, int rowCount) {
     if (schema.getFields().size() != fieldVectors.size()) {
       throw new IllegalArgumentException("Fields must match field vectors. Found " +
@@ -72,6 +92,9 @@ public class VectorSchemaRoot implements AutoCloseable {
     }
   }
 
+  /**
+   * Creates a new set of vectors corresponding to schema that are empty.
+   */
   public static VectorSchemaRoot create(Schema schema, BufferAllocator allocator) {
     List<FieldVector> fieldVectors = new ArrayList<>();
     for (Field field : schema.getFields()) {
@@ -85,6 +108,7 @@ public class VectorSchemaRoot implements AutoCloseable {
     return new VectorSchemaRoot(schema, fieldVectors, 0);
   }
 
+  /** Constructs a new instance from vectors. */
   public static VectorSchemaRoot of(FieldVector... vectors) {
     return new VectorSchemaRoot(Arrays.stream(vectors).collect(Collectors.toList()));
   }
@@ -161,6 +185,9 @@ public class VectorSchemaRoot implements AutoCloseable {
     sb.append("\n");
   }
 
+  /**
+   * Returns a a tab separated value of vectors (based on their java object representation).
+   */
   public String contentToTSVString() {
     StringBuilder sb = new StringBuilder();
     List<Object> row = new ArrayList<>(schema.getFields().size());

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -93,7 +93,7 @@ public class VectorSchemaRoot implements AutoCloseable {
   }
 
   /**
-   * Creates a new set of vectors corresponding to schema that are empty.
+   * Creates a new set of empty vectors corresponding to the given schema.
    */
   public static VectorSchemaRoot create(Schema schema, BufferAllocator allocator) {
     List<FieldVector> fieldVectors = new ArrayList<>();
@@ -186,7 +186,7 @@ public class VectorSchemaRoot implements AutoCloseable {
   }
 
   /**
-   * Returns a a tab separated value of vectors (based on their java object representation).
+   * Returns a tab separated value of vectors (based on their java object representation).
    */
   public String contentToTSVString() {
     StringBuilder sb = new StringBuilder();

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -27,7 +27,7 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import io.netty.buffer.ArrowBuf;
 
 /**
- * Helper class the handles converting a vector the a {@link ArrowRecordBatch}.
+ * Helper class that handles converting a vector the a {@link ArrowRecordBatch}.
  */
 public class VectorUnloader {
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -27,7 +27,8 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import io.netty.buffer.ArrowBuf;
 
 /**
- * Helper class that handles converting a vector the a {@link ArrowRecordBatch}.
+ * Helper class that handles converting a {@link VectorSchemaRoot}
+ * to a {@link ArrowRecordBatch}.
  */
 public class VectorUnloader {
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -26,22 +26,39 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * Helper class the handles converting a vector the a {@link ArrowRecordBatch}.
+ */
 public class VectorUnloader {
 
   private final VectorSchemaRoot root;
   private final boolean includeNullCount;
   private final boolean alignBuffers;
 
+  /**
+   * Constructs a new instance of the given set of vectors.
+   */
   public VectorUnloader(VectorSchemaRoot root) {
     this(root, true, true);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param root  The set of vectors to serialize to an {@link ArrowRecordBatch}.
+   * @param includeNullCount Controls whether null count is copied to the {@link ArrowRecordBatch}
+   * @param alignBuffers Controls if buffers get aligned to 8-byte boundaries.
+   */
   public VectorUnloader(VectorSchemaRoot root, boolean includeNullCount, boolean alignBuffers) {
     this.root = root;
     this.includeNullCount = includeNullCount;
     this.alignBuffers = alignBuffers;
   }
 
+  /**
+   * Performs the depth first traversal of the Vectors to create an {@link ArrowRecordBatch} suitable
+   * for serialization.
+   */
   public ArrowRecordBatch getRecordBatch() {
     List<ArrowFieldNode> nodes = new ArrayList<>();
     List<ArrowBuf> buffers = new ArrayList<>();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -43,6 +43,7 @@ import org.apache.arrow.vector.util.SchemaChangeRuntimeException;
 
 import io.netty.buffer.ArrowBuf;
 
+/** Base class for Vectors that contain repeated values. */
 public abstract class BaseRepeatedValueVector extends BaseValueVector implements RepeatedValueVector {
 
   public static final FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
@@ -262,6 +263,10 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     return vector == DEFAULT_DATA_VECTOR ? 0 : 1;
   }
 
+  /**
+   * Initialize the data vector (and execute callback) if it hasn't already been done,
+   * returns the data vector.
+   */
   public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType fieldType) {
     boolean created = false;
     if (vector instanceof ZeroVector) {
@@ -301,20 +306,23 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
 
-  /* returns the value count for inner data vector at a particular index */
+  /** Returns the value count for inner data vector at a particular index. */
   public int getInnerValueCountAt(int index) {
     return offsetBuffer.getInt((index + 1) * OFFSET_WIDTH) -
             offsetBuffer.getInt(index * OFFSET_WIDTH);
   }
 
+  /** Return if value at index is null (this implementation is always false). */
   public boolean isNull(int index) {
     return false;
   }
 
+  /** Return if value at index is empty (this implementation is always false). */
   public boolean isEmpty(int index) {
     return false;
   }
 
+  /** Starts a new repeated value. */
   public int startNewValue(int index) {
     while (index >= getOffsetBufferValueCapacity()) {
       reallocOffsetBuffer();
@@ -325,6 +333,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     return offset;
   }
 
+  /** Preallocates the number of repeated values. */
   public void setValueCount(int valueCount) {
     this.valueCount = valueCount;
     while (valueCount > getOffsetBufferValueCapacity()) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -53,6 +53,7 @@ import org.apache.arrow.vector.util.TransferPair;
 
 import io.netty.buffer.ArrowBuf;
 
+/** A ListVector where every list value is of the same size. */
 public class FixedSizeListVector extends BaseValueVector implements FieldVector, PromotableVector {
 
   public static FixedSizeListVector empty(String name, int size, BufferAllocator allocator) {
@@ -69,7 +70,9 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
   private int valueCount;
   private int validityAllocationSizeInBytes;
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated use FieldType or static constructor instead.
+   */
   @Deprecated
   public FixedSizeListVector(String name,
                              BufferAllocator allocator,
@@ -79,11 +82,20 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
     this(name, allocator, new FieldType(true, new ArrowType.FixedSizeList(listSize), dictionary), schemaChangeCallback);
   }
 
+  /**
+   * Creates a new instance.
+   *
+   * @param name The name for the vector.
+   * @param allocator The allocator to use for creating/reallocating buffers for the vector.
+   * @param fieldType The underlying data type of the vector.
+   * @param unusedSchemaChangeCallback Currently unused.
+   */
   public FixedSizeListVector(String name,
                              BufferAllocator allocator,
                              FieldType fieldType,
-                             CallBack schemaChangeCallback) {
+                             CallBack unusedSchemaChangeCallback) {
     super(name, allocator);
+
     this.validityBuffer = allocator.getEmpty();
     this.vector = ZeroVector.INSTANCE;
     this.fieldType = fieldType;
@@ -105,6 +117,7 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
     return MinorType.FIXED_SIZE_LIST;
   }
 
+  /** Get the fixed size for each list. */
   public int getListSize() {
     return listSize;
   }
@@ -399,10 +412,16 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
     return vals;
   }
 
+  /**
+   * Returns whether the value at index null.
+   */
   public boolean isNull(int index) {
     return (isSet(index) == 0);
   }
 
+  /**
+   * Returns non-zero when the value at index is non-null.
+   */
   public int isSet(int index) {
     final int byteIndex = index >> 3;
     final byte b = validityBuffer.getByte(byteIndex);
@@ -420,10 +439,17 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
     return valueCount;
   }
 
+  /**
+   * Returns the number of elements the validity buffer can represent with its
+   * current capacity.
+   */
   private int getValidityBufferValueCapacity() {
     return (int) (validityBuffer.capacity() * 8L);
   }
 
+  /**
+   * Sets the value at index to null.  Reallocates if index is larger than capacity.
+   */
   public void setNull(int index) {
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityBuffer();
@@ -431,6 +457,7 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
     BitVectorHelper.setValidityBit(validityBuffer, index, 0);
   }
 
+  /** Sets the value at index to not-null. Reallocates if index is larger than capacity. */
   public void setNotNull(int index) {
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityBuffer();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -544,7 +544,6 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     return reader;
   }
 
-
   /** Initialize the child data vector to field type.  */
   public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType fieldType) {
     AddOrGetResult<T> result = super.addOrGetVector(fieldType);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -52,6 +52,15 @@ import org.apache.arrow.vector.util.TransferPair;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * A list vector contains lists of a specific type of elements.  Its structure contains 3 elements.
+ * <ol>
+ * <li>A validity buffer.</li>
+ * <li> An offset buffer, that denotes lists boundaries. </li>
+ * <li> A child data vector that contains the elements of lists. </li>
+ * </ol>
+ * The latter two are managed by its superclass.
+ */
 public class ListVector extends BaseRepeatedValueVector implements FieldVector, PromotableVector {
 
   public static ListVector empty(String name, BufferAllocator allocator) {
@@ -65,18 +74,30 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
   private int validityAllocationSizeInBytes;
   private int lastSet;
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public ListVector(String name, BufferAllocator allocator, CallBack callBack) {
     this(name, allocator, FieldType.nullable(ArrowType.List.INSTANCE), callBack);
   }
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public ListVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack) {
     this(name, allocator, new FieldType(true, ArrowType.List.INSTANCE, dictionary, null), callBack);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param name The name of the instance.
+   * @param allocator The allocator to use to allocating/reallocating buffers.
+   * @param fieldType The type of this list.
+   * @param callBack A schema change callback.
+   */
   public ListVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, allocator, callBack);
     this.validityBuffer = allocator.getEmpty();
@@ -523,6 +544,8 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     return reader;
   }
 
+
+  /** Initialize the child data vector to field type.  */
   public <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType fieldType) {
     AddOrGetResult<T> result = super.addOrGetVector(fieldType);
     reader = new UnionListReader(this);
@@ -685,6 +708,10 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     return (int) (validityBuffer.capacity() * 8L);
   }
 
+  /**
+   * Sets the list at index to be not-null.  Reallocates validity buffer if index
+   * is larger than current capacity.
+   */
   public void setNotNull(int index) {
     while (index >= getValidityAndOffsetValueCapacity()) {
       reallocValidityAndOffsetBuffers();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -42,6 +42,10 @@ import org.apache.arrow.vector.util.TransferPair;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * A struct vector that has no null values (and no validity buffer).
+ * Child Vectors are handled in {@link AbstractStructVector}.
+ */
 public class NonNullableStructVector extends AbstractStructVector {
 
   public static NonNullableStructVector empty(String name, BufferAllocator allocator) {
@@ -53,12 +57,22 @@ public class NonNullableStructVector extends AbstractStructVector {
   protected final FieldType fieldType;
   public int valueCount;
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public NonNullableStructVector(String name, BufferAllocator allocator, CallBack callBack) {
     this(name, allocator, new FieldType(false, ArrowType.Struct.INSTANCE, null, null), callBack);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param name The name of the instance.
+   * @param allocator The allocator to use to allocating/reallocating buffers.
+   * @param fieldType The type of this list.
+   * @param callBack A schema change callback.
+   */
   public NonNullableStructVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, allocator, callBack);
     this.fieldType = checkNotNull(fieldType);
@@ -72,6 +86,10 @@ public class NonNullableStructVector extends AbstractStructVector {
 
   private transient StructTransferPair ephPair;
 
+  /**
+   * Copies the element at fromIndex in the provided vector to thisIndex.  Reallocates buffers
+   * if thisIndex is larger then current capacity.
+   */
   public void copyFromSafe(int fromIndex, int thisIndex, NonNullableStructVector from) {
     if (ephPair == null || ephPair.from != from) {
       ephPair = (StructTransferPair) from.makeTransferPair(this);
@@ -340,6 +358,7 @@ public class NonNullableStructVector extends AbstractStructVector {
     super.close();
   }
 
+  /** Initializes the struct's members from the given Fields. */
   public void initializeChildrenFromFields(List<Field> children) {
     for (Field field : children) {
       FieldVector vector = (FieldVector) this.add(field.getName(), field.getFieldType());

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
@@ -20,8 +20,14 @@ package org.apache.arrow.vector.complex;
 import java.util.Arrays;
 
 public class StateTool {
+  private StateTool() {}
+
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StateTool.class);
 
+  /**
+   * Verifies <code>currentState</code> is in one of <code>expectedStates</code>,
+   * throws an IllegalArgumentException if it isn't.
+   */
   public static <T extends Enum<?>> void check(T currentState, T... expectedStates) {
     for (T s : expectedStates) {
       if (s == currentState) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
@@ -19,6 +19,9 @@ package org.apache.arrow.vector.complex;
 
 import java.util.Arrays;
 
+/**
+ * Utility methods for state machines based on enums.
+ */
 public class StateTool {
   private StateTool() {}
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -45,6 +45,11 @@ import org.apache.arrow.vector.util.TransferPair;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * A Struct vector consists of nullability/validity buffer and children vectors
+ * that make up the struct's fields.  The children vectors are handled by the
+ * parent class.
+ */
 public class StructVector extends NonNullableStructVector implements FieldVector {
 
   public static StructVector empty(String name, BufferAllocator allocator) {
@@ -58,18 +63,30 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   protected ArrowBuf validityBuffer;
   private int validityAllocationSizeInBytes;
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public StructVector(String name, BufferAllocator allocator, CallBack callBack) {
     this(name, allocator, FieldType.nullable(ArrowType.Struct.INSTANCE), callBack);
   }
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public StructVector(String name, BufferAllocator allocator, DictionaryEncoding dictionary, CallBack callBack) {
     this(name, allocator, new FieldType(true, ArrowType.Struct.INSTANCE, dictionary, null), callBack);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param name The name of the instance.
+   * @param allocator The allocator to use to allocating/reallocating buffers.
+   * @param fieldType The type of this list.
+   * @param callBack A schema change callback.
+   */
   public StructVector(String name, BufferAllocator allocator, FieldType fieldType, CallBack callBack) {
     super(name, checkNotNull(allocator), fieldType, callBack);
     this.validityBuffer = allocator.getEmpty();
@@ -473,14 +490,23 @@ public class StructVector extends NonNullableStructVector implements FieldVector
     super.get(index, holder);
   }
 
+  /**
+   * Return the number of null values in the vector.
+   */
   public int getNullCount() {
     return BitVectorHelper.getNullCount(validityBuffer, valueCount);
   }
 
+  /**
+   * Returns true if the value at the provided index is null.
+   */
   public boolean isNull(int index) {
     return isSet(index) == 0;
   }
 
+  /**
+   * Returns true the value at the given index is set (i.e. not null).
+   */
   public int isSet(int index) {
     final int byteIndex = index >> 3;
     final byte b = validityBuffer.getByte(byteIndex);
@@ -488,6 +514,10 @@ public class StructVector extends NonNullableStructVector implements FieldVector
     return (b >> bitIndex) & 0x01;
   }
 
+  /**
+   * Marks the value at index as being set.  Reallocates the validity buffer
+   * if index is larger than current capacity.
+   */
   public void setIndexDefined(int index) {
     while (index >= getValidityBufferValueCapacity()) {
       /* realloc the inner buffers if needed */
@@ -496,6 +526,9 @@ public class StructVector extends NonNullableStructVector implements FieldVector
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
   }
 
+  /**
+   * Marks the value at index as null/not set.
+   */
   public void setNull(int index) {
     while (index >= getValidityBufferValueCapacity()) {
       /* realloc the inner buffers if needed */

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -25,6 +25,9 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ComplexWriter;
 import org.apache.arrow.vector.types.pojo.Field;
 
+/**
+ * Concrete implementation of {@link ComplexWriter}.
+ */
 public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWriter {
 
   private NullableStructWriter structRoot;
@@ -38,6 +41,14 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
   private enum Mode { INIT, STRUCT, LIST }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param name The name of the writer (for tracking).
+   * @param container A container for the data field to be written.
+   * @param unionEnabled Unused.
+   * @param caseSensitive Whether field names are case sensitive (if false field names will be lowercased.
+   */
   public ComplexWriterImpl(
       String name,
       NonNullableStructVector container,
@@ -130,7 +141,10 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
     }
   }
 
-
+  /**
+   * Returns a StructWriter, initializing it necessary from the constructor this instance
+   * was constructed with.
+   */
   public StructWriter directStruct() {
     Preconditions.checkArgument(name == null);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -41,6 +41,8 @@ import io.netty.buffer.ArrowBuf;
  * can start as a specific type, and this class will promote the writer to a UnionWriter if a call is made that the
  * specifically typed writer cannot handle. A new UnionVector is created, wrapping the original vector, and replaces the
  * original vector in the parent vector, which can be either an AbstractStructVector or a ListVector.
+ *
+ * <p>The writer used can either be for single elements (struct) or  lists.</p>
  */
 public class PromotableWriter extends AbstractPromotableFieldWriter {
 
@@ -61,10 +63,23 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   private State state;
   private FieldWriter writer;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param v The vector to write.
+   * @param parentContainer The parent container for the vector.
+   */
   public PromotableWriter(ValueVector v, AbstractStructVector parentContainer) {
     this(v, parentContainer, NullableStructWriterFactory.getNullableStructWriterFactoryInstance());
   }
 
+  /**
+   * Construcs a new instance.
+   *
+   * @param v The vector to initialize the writer with.
+   * @param parentContainer The parent container for the vector.
+   * @param nullableStructWriterFactory The factory to create the delegate writer.
+   */
   public PromotableWriter(
       ValueVector v,
       AbstractStructVector parentContainer,
@@ -75,10 +90,23 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
     init(v);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param v The vector to initialize the writer with.
+   * @param listVector The vector that serves as a parent of v.
+   */
   public PromotableWriter(ValueVector v, ListVector listVector) {
     this(v, listVector, NullableStructWriterFactory.getNullableStructWriterFactoryInstance());
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param v The vector to initialize the writer with.
+   * @param listVector The vector that serves as a parent of v.
+   * @param nullableStructWriterFactory The factory to create the delegate writer.
+   */
   public PromotableWriter(
       ValueVector v,
       ListVector listVector,

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/SingleListReaderImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/SingleListReaderImpl.java
@@ -24,6 +24,9 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.types.Types.MinorType;
 
+/**
+ * An implementation of {@link AbstractFieldReader} for lists vectors.
+ */
 @SuppressWarnings("unused")
 public class SingleListReaderImpl extends AbstractFieldReader {
 
@@ -31,6 +34,12 @@ public class SingleListReaderImpl extends AbstractFieldReader {
   private final AbstractContainerVector container;
   private FieldReader reader;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param name The name of field to read in container.
+   * @param container The container holding a list.
+   */
   public SingleListReaderImpl(String name, AbstractContainerVector container) {
     super();
     this.name = name;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/StructOrListWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/StructOrListWriterImpl.java
@@ -27,21 +27,35 @@ import org.apache.arrow.vector.complex.writer.IntWriter;
 import org.apache.arrow.vector.complex.writer.VarBinaryWriter;
 import org.apache.arrow.vector.complex.writer.VarCharWriter;
 
+/**
+ * Concrete implementation of {@link StructOrListWriter}.
+ */
 public class StructOrListWriterImpl implements StructOrListWriter {
 
   public final BaseWriter.StructWriter struct;
   public final BaseWriter.ListWriter list;
 
+  /**
+   * Constructs a new instance using a {@link BaseWriter.StructWriter}
+   * (instead of an {@link BaseWriter.ListWriter}).
+   */
   public StructOrListWriterImpl(final BaseWriter.StructWriter writer) {
     this.struct = writer;
     this.list = null;
   }
 
+  /**
+   * Constructs a new instance using a {@link BaseWriter.ListWriter}
+   * (instead of a {@link BaseWriter.StructWriter}).
+   */
   public StructOrListWriterImpl(final BaseWriter.ListWriter writer) {
     this.struct = null;
     this.list = writer;
   }
 
+  /**
+   * Start writing to either the list or the struct.
+   */
   public void start() {
     if (struct != null) {
       struct.start();
@@ -50,6 +64,9 @@ public class StructOrListWriterImpl implements StructOrListWriter {
     }
   }
 
+  /**
+   * Finish writing to the list or struct.
+   */
   public void end() {
     if (struct != null) {
       struct.end();
@@ -58,11 +75,19 @@ public class StructOrListWriterImpl implements StructOrListWriter {
     }
   }
 
+  /**
+   * Creates a new writer for a struct with the given name.
+   */
   public StructOrListWriter struct(final String name) {
     assert struct != null;
     return new StructOrListWriterImpl(struct.struct(name));
   }
 
+  /**
+   * Creates a new writer for a list of structs.
+   *
+   * @param name Unused.
+   */
   public StructOrListWriter listoftstruct(final String name) {
     assert list != null;
     return new StructOrListWriterImpl(list.struct());

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionFixedSizeListReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionFixedSizeListReader.java
@@ -36,6 +36,9 @@ public class UnionFixedSizeListReader extends AbstractFieldReader {
 
   private int currentOffset;
 
+  /**
+   * Constructs a new instance that reads data in <code>vector</code>.
+   */
   public UnionFixedSizeListReader(FixedSizeListVector vector) {
     this.vector = vector;
     this.data = vector.getDataVector();

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/Dictionary.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/Dictionary.java
@@ -23,6 +23,10 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 
+/**
+ * A dictionary (integer to Value mapping) that is used to facilitate
+ * dictionary encoding compression.
+ */
 public class Dictionary {
 
   private final DictionaryEncoding encoding;

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryProvider.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryProvider.java
@@ -21,14 +21,21 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * A manager for association of dictionary IDs to their corresponding {@link Dictionary}.
+ */
 public interface DictionaryProvider {
 
+  /** Return the dictionary for the given ID. */
   public Dictionary lookup(long id);
 
   public static class MapDictionaryProvider implements DictionaryProvider {
 
     private final Map<Long, Dictionary> map;
 
+    /**
+     * Constructs a new instance from the given dictionaries.
+     */
     public MapDictionaryProvider(Dictionary... dictionaries) {
       this.map = new HashMap<>();
       for (Dictionary dictionary : dictionaries) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
@@ -34,6 +34,10 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * An implementation of {@link ArrowReader} that reads the standard arrow binary
+ * file format.
+ */
 public class ArrowFileReader extends ArrowReader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArrowFileReader.class);
@@ -102,7 +106,7 @@ public class ArrowFileReader extends ArrowReader {
     return readDictionaryBatch(in, block, allocator);
   }
 
-  // Returns true if a batch was read, false if no more batches
+  /** Returns true if a batch was read, false if no more batches. */
   @Override
   public boolean loadNextBatch() throws IOException {
     prepareLoadNextBatch();
@@ -123,11 +127,17 @@ public class ArrowFileReader extends ArrowReader {
     return footer.getDictionaries();
   }
 
+  /**
+   * Returns the {@link ArrowBlock} metadata from the file.
+   */
   public List<ArrowBlock> getRecordBlocks() throws IOException {
     ensureInitialized();
     return footer.getRecordBatches();
   }
 
+  /**
+   * Loads record batch for the given block.
+   */
   public boolean loadRecordBatch(ArrowBlock block) throws IOException {
     ensureInitialized();
     int blockIndex = footer.getRecordBatches().indexOf(block);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -98,6 +98,9 @@ public abstract class ArrowWriter implements AutoCloseable {
     ensureStarted();
   }
 
+  /**
+   * Write the vector this vector was constructed with.
+   */
   public void writeBatch() throws IOException {
     ensureStarted();
     try (ArrowRecordBatch batch = unloader.getRecordBatch()) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -99,7 +99,7 @@ public abstract class ArrowWriter implements AutoCloseable {
   }
 
   /**
-   * Write the vector this vector was constructed with.
+   * Writes the record batch currently loaded in this instance's VectorSchemaRoot.
    */
   public void writeBatch() throws IOException {
     ensureStarted();

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -65,8 +65,9 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 import io.netty.buffer.ArrowBuf;
 
 /**
- * A reader for integration test JSON files that converts translates them into Vectors.
- * This class uses a streaming parser API, method naming tends to reflect this implementation
+ * A reader for JSON files that translates them into vectors. This reader is used for integration tests.
+ *
+ * <p>This class uses a streaming parser API, method naming tends to reflect this implementation
  * detail.
  */
 public class JsonFileReader implements AutoCloseable, DictionaryProvider {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -64,6 +64,11 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * A reader for integration test JSON files that converts translates them into Vectors.
+ * This class uses a streaming parser API, method naming tends to reflect this implementation
+ * detail.
+ */
 public class JsonFileReader implements AutoCloseable, DictionaryProvider {
   private final JsonParser parser;
   private final BufferAllocator allocator;
@@ -71,6 +76,11 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
   private Map<Long, Dictionary> dictionaries;
   private Boolean started = false;
 
+  /**
+   * Constructs a new instance.
+   * @param inputFile The file to read.
+   * @param allocator The allocator to use for allocating buffers.
+   */
   public JsonFileReader(File inputFile, BufferAllocator allocator) throws JsonParseException, IOException {
     super();
     this.allocator = allocator;
@@ -89,6 +99,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
     return dictionaries.get(id);
   }
 
+  /** Reads the beginning (schema section) of the json file and returns it. */
   public Schema start() throws JsonParseException, IOException {
     readToken(START_OBJECT);
     {
@@ -146,6 +157,9 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
     }
   }
 
+  /**
+   * Reads the next record batch from the file into <code>root</code>.
+   */
   public boolean read(VectorSchemaRoot root) throws IOException {
     JsonToken t = parser.nextToken();
     if (t == START_OBJECT) {
@@ -172,6 +186,9 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
     }
   }
 
+  /**
+   * Returns the next record batch from the file.
+   */
   public VectorSchemaRoot read() throws IOException {
     JsonToken t = parser.nextToken();
     if (t == START_OBJECT) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -76,6 +76,10 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * A writer that converts binary Vectors into a JSON format suitable
+ * for integration testing.
+ */
 public class JsonFileWriter implements AutoCloseable {
 
   public static final class JSONWriteConfig {
@@ -101,10 +105,16 @@ public class JsonFileWriter implements AutoCloseable {
   private final JsonGenerator generator;
   private Schema schema;
 
+  /**
+   * Constructs a new writer that will output to  <code>outputFile</code>.
+   */
   public JsonFileWriter(File outputFile) throws IOException {
     this(outputFile, config());
   }
 
+  /**
+   * Constructs a new writer that will output to  <code>outputFile</code> with the given options.
+   */
   public JsonFileWriter(File outputFile, JSONWriteConfig config) throws IOException {
     MappingJsonFactory jsonFactory = new MappingJsonFactory();
     this.generator = jsonFactory.createGenerator(outputFile, JsonEncoding.UTF8);
@@ -117,6 +127,9 @@ public class JsonFileWriter implements AutoCloseable {
     this.generator.configure(JsonGenerator.Feature.QUOTE_NON_NUMERIC_NUMBERS, false);
   }
 
+  /**
+   * Writes out the "header" of the file including the schema and any dictionaries required.
+   */
   public void start(Schema schema, DictionaryProvider provider) throws IOException {
     List<Field> fields = new ArrayList<>(schema.getFields().size());
     Set<Long> dictionaryIdsUsed = new HashSet<>();
@@ -160,6 +173,7 @@ public class JsonFileWriter implements AutoCloseable {
     generator.writeEndArray();
   }
 
+  /** Writes the record batch to the JSON file. */
   public void write(VectorSchemaRoot recordBatch) throws IOException {
     if (!recordBatch.getSchema().equals(schema)) {
       throw new IllegalArgumentException("record batches must have the same schema: " + schema);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -62,10 +62,16 @@ public class WriteChannel implements AutoCloseable {
     return write(ByteBuffer.wrap(buffer));
   }
 
+  /**
+   * Writes <zeroCount>zeroCount</zeroCount> zeros the underlying channel.
+   */
   public long writeZeros(int zeroCount) throws IOException {
     return write(new byte[zeroCount]);
   }
 
+  /**
+   * Writes enough bytes to align the channel to an 8-byte bounary.
+   */
   public long align() throws IOException {
     if (currentPosition % 8 != 0) { // align on 8 byte boundaries
       return writeZeros(8 - (int) (currentPosition % 8));
@@ -73,6 +79,9 @@ public class WriteChannel implements AutoCloseable {
     return 0;
   }
 
+  /**
+   * Writes all data from <code>buffer</code> to the underlying channel.
+   */
   public long write(ByteBuffer buffer) throws IOException {
     long length = buffer.remaining();
     LOGGER.debug("Writing buffer with size: {}", length);
@@ -83,17 +92,27 @@ public class WriteChannel implements AutoCloseable {
     return length;
   }
 
+  /**
+   * Writes <code>v</code> in little-endian format to the underlying channel.
+   */
   public long writeIntLittleEndian(int v) throws IOException {
     byte[] outBuffer = new byte[4];
     MessageSerializer.intToBytes(v, outBuffer);
     return write(outBuffer);
   }
 
+  /**
+   * Writes the buffer to the underlying channel.
+   */
   public void write(ArrowBuf buffer) throws IOException {
     ByteBuffer nioBuffer = buffer.nioBuffer(buffer.readerIndex(), buffer.readableBytes());
     write(nioBuffer);
   }
 
+  /**
+   * Writes the serialized flatbuffer to the underlying channel.  If withSizePrefix
+   * is true then the length in bytes of the buffer will first be written in little endian format.
+   */
   public long write(FBSerializable writer, boolean withSizePrefix) throws IOException {
     ByteBuffer buffer = serialize(writer);
     if (withSizePrefix) {
@@ -102,6 +121,9 @@ public class WriteChannel implements AutoCloseable {
     return write(buffer);
   }
 
+  /**
+   * Serializes writer to a ByteBuffer.
+   */
   public static ByteBuffer serialize(FBSerializable writer) {
     FlatBufferBuilder builder = new FlatBufferBuilder();
     int root = writer.writeTo(builder);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBlock.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBlock.java
@@ -21,12 +21,19 @@ import org.apache.arrow.flatbuf.Block;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/** Metadata for an arrow message in a channel. */
 public class ArrowBlock implements FBSerializable {
 
   private final long offset;
   private final int metadataLength;
   private final long bodyLength;
 
+  /**
+   * Constructs a new instance
+   * @param offset The offset into the channel file where the block was written.
+   * @param metadataLength  The length of the flatbuffer metadata in the block.
+   * @param bodyLength The length of data in the block.
+   */
   public ArrowBlock(long offset, int metadataLength, long bodyLength) {
     super();
     this.offset = offset;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBlock.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBlock.java
@@ -29,7 +29,8 @@ public class ArrowBlock implements FBSerializable {
   private final long bodyLength;
 
   /**
-   * Constructs a new instance
+   * Constructs a new instance.
+   *
    * @param offset The offset into the channel file where the block was written.
    * @param metadataLength  The length of the flatbuffer metadata in the block.
    * @param bodyLength The length of data in the block.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBuffer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBuffer.java
@@ -29,6 +29,7 @@ public class ArrowBuffer implements FBSerializable {
 
   /**
    * Constructs a new instance.
+   *
    * @param offset The offset to the start of the buffer in the channel.
    * @param size The size of the buffer.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBuffer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowBuffer.java
@@ -21,11 +21,17 @@ import org.apache.arrow.flatbuf.Buffer;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/** Metadata for a buffer written to a channel. */
 public class ArrowBuffer implements FBSerializable {
 
   private long offset;
   private long size;
 
+  /**
+   * Constructs a new instance.
+   * @param offset The offset to the start of the buffer in the channel.
+   * @param size The size of the buffer.
+   */
   public ArrowBuffer(long offset, long size) {
     super();
     this.offset = offset;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFieldNode.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFieldNode.java
@@ -31,6 +31,7 @@ public class ArrowFieldNode implements FBSerializable {
 
   /**
    * Constructs a new instance.
+   *
    * @param length The number of values written.
    * @param nullCount The number of null values.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFieldNode.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFieldNode.java
@@ -21,11 +21,19 @@ import org.apache.arrow.flatbuf.FieldNode;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/**
+ * Metadata about Vectors/Arrays that is written to a channel.
+ */
 public class ArrowFieldNode implements FBSerializable {
 
   private final int length;
   private final int nullCount;
 
+  /**
+   * Constructs a new instance.
+   * @param length The number of values written.
+   * @param nullCount The number of null values.
+   */
   public ArrowFieldNode(int length, int nullCount) {
     super();
     this.length = length;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFooter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFooter.java
@@ -28,6 +28,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/** Footer metadata for the arrow file format. */
 public class ArrowFooter implements FBSerializable {
 
   private final Schema schema;
@@ -36,12 +37,21 @@ public class ArrowFooter implements FBSerializable {
 
   private final List<ArrowBlock> recordBatches;
 
+  /**
+   * Constructs a new instance.
+   * @param schema The schema for record batches in the file.
+   * @param dictionaries  The dictionaries relevant to the file.
+   * @param recordBatches  The recordBatches written to the file.
+   */
   public ArrowFooter(Schema schema, List<ArrowBlock> dictionaries, List<ArrowBlock> recordBatches) {
     this.schema = schema;
     this.dictionaries = dictionaries;
     this.recordBatches = recordBatches;
   }
 
+  /**
+   * Constructs from the corresponding Flatbuffer message.
+   */
   public ArrowFooter(Footer footer) {
     this(
         Schema.convertSchema(footer.schema()),

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFooter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFooter.java
@@ -39,6 +39,7 @@ public class ArrowFooter implements FBSerializable {
 
   /**
    * Constructs a new instance.
+   *
    * @param schema The schema for record batches in the file.
    * @param dictionaries  The dictionaries relevant to the file.
    * @param recordBatches  The recordBatches written to the file.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializable.java
@@ -19,6 +19,12 @@ package org.apache.arrow.vector.ipc.message;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/**
+ * Interface for serializing to FlatBuffers.
+ */
 public interface FBSerializable {
+  /**
+   * Returns the number of bytes taken to serialize the data in builder after writing to it.
+   */
   int writeTo(FlatBufferBuilder builder);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializables.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializables.java
@@ -24,6 +24,7 @@ import java.util.List;
 import com.google.flatbuffers.FlatBufferBuilder;
 
 public class FBSerializables {
+  private FBSerializables() {}
 
   public static int writeAllStructsToVector(FlatBufferBuilder builder, List<? extends FBSerializable> all) {
     // struct vectors have to be created in reverse order

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializables.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/FBSerializables.java
@@ -23,9 +23,16 @@ import java.util.List;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/**
+ * Utility methods for {@linkplain org.apache.arrow.vector.ipc.message.FBSerializable}s.
+ */
 public class FBSerializables {
   private FBSerializables() {}
 
+  /**
+   * Writes every element of all to builder and calls {@link FlatBufferBuilder#endVector()} afterwards.
+   * Returns the number of result of calling endVector.
+   */
   public static int writeAllStructsToVector(FlatBufferBuilder builder, List<? extends FBSerializable> all) {
     // struct vectors have to be created in reverse order
     List<? extends FBSerializable> reversed = new ArrayList<>(all);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -119,6 +119,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType.Utf8;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 
+/** An enumeration of all logical types supported by this library. */
 public class Types {
 
   public enum MinorType {
@@ -697,6 +698,9 @@ public class Types {
       this.type = type;
     }
 
+    /**
+     * Returns the {@link ArrowType} equivalent of this type.
+     */
     public final ArrowType getType() {
       if (type == null) {
         throw new UnsupportedOperationException("Cannot get simple type for type " + name());
@@ -704,6 +708,7 @@ public class Types {
       return type;
     }
 
+    /** Constructs a new vector for the given type. */
     public abstract FieldVector getNewVector(
         String name,
         FieldType fieldType,
@@ -713,6 +718,9 @@ public class Types {
     public abstract FieldWriter getNewFieldWriter(ValueVector vector);
   }
 
+  /**
+   * Maps the ArrowType to the java implementations MinorType.
+   */
   public static MinorType getMinorTypeForArrowType(ArrowType arrowType) {
     return arrowType.accept(new ArrowTypeVisitor<MinorType>() {
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/DictionaryEncoding.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/DictionaryEncoding.java
@@ -25,12 +25,23 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * A POJO representation of Arrow Dictionary metadata.
+ */
 public class DictionaryEncoding {
 
   private final long id;
   private final boolean ordered;
   private final Int indexType;
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param id The ID of the dictionary to use for iecnoding.
+   * @param ordered Whether the keys in values in the dictionary are ordered.
+   * @param indexType (nullable).  The integer type to use for indexing in the dictionary.  Defaults to a signed
+   *     32 bit integer.
+   */
   @JsonCreator
   public DictionaryEncoding(
       @JsonProperty("id") long id,

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
@@ -36,7 +36,6 @@ import org.apache.arrow.flatbuf.Type;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TypeLayout;
-import org.apache.arrow.vector.types.pojo.ArrowType.Int;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -45,6 +44,9 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/**
+ * A POJO abstraction for the Flatbuffer description of Vector Type.
+ */
 public class Field {
 
   public static Field nullablePrimitive(String name, ArrowType.PrimitiveType type) {
@@ -76,13 +78,17 @@ public class Field {
     this.children = children == null ? Collections.emptyList() : children.stream().collect(Collectors.toList());
   }
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public Field(String name, boolean nullable, ArrowType type, List<Field> children) {
     this(name, new FieldType(nullable, type, null, null), children);
   }
 
-  // deprecated, use FieldType or static constructor instead
+  /**
+   * @deprecated Use FieldType or static constructor instead.
+   */
   @Deprecated
   public Field(String name, boolean nullable, ArrowType type, DictionaryEncoding dictionary, List<Field> children) {
     this(name, new FieldType(nullable, type, dictionary, null), children);
@@ -92,12 +98,18 @@ public class Field {
     this(name, fieldType, children, fieldType == null ? null : TypeLayout.getTypeLayout(fieldType.getType()));
   }
 
+  /**
+   * Construct a new vector of this type using the given allocator.
+   */
   public FieldVector createVector(BufferAllocator allocator) {
     FieldVector vector = fieldType.createNewSingleVector(name, allocator, null);
     vector.initializeChildrenFromFields(children);
     return vector;
   }
 
+  /**
+   * Constructs a new instance from a flatbuffer representation of the field.
+   */
   public static Field convertField(org.apache.arrow.flatbuf.Field field) {
     String name = field.name();
     boolean nullable = field.nullable();
@@ -105,10 +117,10 @@ public class Field {
     DictionaryEncoding dictionary = null;
     org.apache.arrow.flatbuf.DictionaryEncoding dictionaryFB = field.dictionary();
     if (dictionaryFB != null) {
-      Int indexType = null;
+      ArrowType.Int indexType = null;
       org.apache.arrow.flatbuf.Int indexTypeFB = dictionaryFB.indexType();
       if (indexTypeFB != null) {
-        indexType = new Int(indexTypeFB.bitWidth(), indexTypeFB.isSigned());
+        indexType = new ArrowType.Int(indexTypeFB.bitWidth(), indexTypeFB.isSigned());
       }
       dictionary = new DictionaryEncoding(dictionaryFB.id(), dictionaryFB.isOrdered(), indexType);
     }
@@ -151,6 +163,9 @@ public class Field {
     return originalChildField;
   }
 
+  /**
+   * Puts this object into <code>builder</code> and returns the length of the serialized flatbuffer.
+   */
   public int getField(FlatBufferBuilder builder) {
     int nameOffset = name == null ? -1 : builder.createString(name);
     int typeOffset = getType().getType(builder);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
@@ -42,6 +42,14 @@ public class FieldType {
     this(nullable, type, dictionary, null);
   }
 
+  /**
+   * Constructs a new instance.
+   *
+   * @param nullable Whether the Vector is nullable
+   * @param type The logical arrow type of the field.
+   * @param dictionary The dictionary encoding of the field.
+   * @param metadata Custom metadata for the field.
+   */
   public FieldType(boolean nullable, ArrowType type, DictionaryEncoding dictionary, Map<String, String> metadata) {
     super();
     this.nullable = nullable;

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Schema.java
@@ -79,6 +79,7 @@ public class Schema {
     return convertSchema(org.apache.arrow.flatbuf.Schema.getRootAsSchema(buffer));
   }
 
+  /** Converts a flatbuffer schema to its POJO representation. */
   public static Schema convertSchema(org.apache.arrow.flatbuf.Schema schema) {
     List<Field> fields = new ArrayList<>();
     for (int i = 0; i < schema.fieldsLength(); i++) {
@@ -101,6 +102,9 @@ public class Schema {
     this(fields, null);
   }
 
+  /**
+   * Constructor used for JSON deserialization.
+   */
   @JsonCreator
   public Schema(@JsonProperty("fields") Iterable<Field> fields,
                 @JsonProperty("metadata") Map<String, String> metadata) {
@@ -132,6 +136,9 @@ public class Schema {
     return findField(getFields(), name);
   }
 
+  /**
+   * Returns the JSON string representation of this schema.
+   */
   public String toJson() {
     try {
       return writer.writeValueAsString(this);
@@ -141,6 +148,9 @@ public class Schema {
     }
   }
 
+  /**
+   *  Adds this schema to the builder returning the size of the builder after adding.
+   */
   public int getSchema(FlatBufferBuilder builder) {
     int[] fieldOffsets = new int[fields.size()];
     for (int i = 0; i < fields.size(); i++) {
@@ -165,6 +175,9 @@ public class Schema {
     return org.apache.arrow.flatbuf.Schema.endSchema(builder);
   }
 
+  /**
+   * Returns the serialized flatbuffer representation of this schema.
+   */
   public byte[] toByteArray() {
     FlatBufferBuilder builder = new FlatBufferBuilder();
     int schemaOffset = this.getSchema(builder);

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ByteArrayReadableSeekableByteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ByteArrayReadableSeekableByteChannel.java
@@ -21,10 +21,16 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 
+/**
+ * A {@link SeekableByteChannel} backed by a byte array.
+ */
 public class ByteArrayReadableSeekableByteChannel implements SeekableByteChannel {
   private byte[] byteArray;
   private int position = 0;
 
+  /**
+   * Construct a new object using the given byteArray as a backing store.
+   */
   public ByteArrayReadableSeekableByteChannel(byte[] byteArray) {
     if (byteArray == null) {
       throw new NullPointerException();

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DateUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DateUtility.java
@@ -28,7 +28,7 @@ import com.carrotsearch.hppc.ObjectIntHashMap;
 
 // Utility class for Date, DateTime, TimeStamp, Interval data types
 public class DateUtility {
-
+  private DateUtility() {}
 
   /* We have a hashmap that stores the timezone as the key and an index as the value
    * While storing the timezone in value vectors, holders we only use this index. As we

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DateUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DateUtility.java
@@ -26,7 +26,7 @@ import java.time.temporal.ChronoUnit;
 
 import com.carrotsearch.hppc.ObjectIntHashMap;
 
-// Utility class for Date, DateTime, TimeStamp, Interval data types
+/** Utility class for Date, DateTime, TimeStamp, Interval data types. */
 public class DateUtility {
   private DateUtility() {}
 
@@ -643,7 +643,7 @@ public class DateUtility {
     return timezoneList[index];
   }
 
-  // Function returns the date time formatter used to parse date strings
+  /** Returns the date time formatter used to parse date strings. */
   public static DateTimeFormatter getDateTimeFormatter() {
 
     if (dateTimeTZFormat == null) {
@@ -659,7 +659,7 @@ public class DateUtility {
     return dateTimeTZFormat;
   }
 
-  // Function returns time formatter used to parse time strings
+  /** Returns time formatter used to parse time strings. */
   public static DateTimeFormatter getTimeFormatter() {
     if (timeFormat == null) {
       DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import io.netty.buffer.ArrowBuf;
 
 public class DecimalUtility {
+  private DecimalUtility() {}
 
   public static final int DECIMAL_BYTE_LENGTH = 16;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
@@ -51,7 +51,6 @@ import io.netty.util.collection.IntObjectMap;
  * @param <K> key type
  * @param <V> value type
  */
-
 public class MapWithOrdinal<K, V> implements Map<K, V> {
   private static final Logger logger = LoggerFactory.getLogger(MapWithOrdinal.class);
 
@@ -237,6 +236,9 @@ public class MapWithOrdinal<K, V> implements Map<K, V> {
     return delegate.keySet();
   }
 
+  /**
+   * Returns a list of keys in ordinal order.
+   */
   public List<K> keyList() {
     int size = size();
     Set<K> keys = keySet();


### PR DESCRIPTION
Apologies for the large CL.  After this the one last large javadoc fixing of 2019 is to enable checkstyle to types as well and add missing docs to those.

If possible my review preference would be as suggested edits if at all possible but any feedback is welcome.

In addition to javadocs, I also added private constructors to classes containing only static utility methods.

For a small set of test methods I converted them to "private" instead of providing javadocs.

The approach taken was to provide minimal useful javadoc and not necessarily completely formatted with all parameters, etc.  The intent is to enable style checking to "stop" the bleeding so patch authors can provide useful documentation for new API methods going forward.