### PR TITLE
ARROW-5262: [Python] Fix typo

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -51,7 +51,7 @@ like so:
    pytest pyarrow
 
 Package requirements to run the unit tests are found in
-``requirements-test.txt`` and can be installed if needed with ``pip -r
+``requirements-test.txt`` and can be installed if needed with ``pip install -r
 requirements-test.txt``.
 
 The project has a number of custom command line options for its test


### PR DESCRIPTION
`install` is necessary to install the libraries with a requirements file.
Thank you for your review.