### PR TITLE
ARROW-3475: [C++] Allow builders to finish to the corresponding array type

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -748,6 +748,26 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendValues) {
   this->Check(this->builder_nn_, false);
 }
 
+TYPED_TEST(TestPrimitiveBuilder, TestTypedFinish) {
+  DECL_T();
+
+  int64_t size = 1000;
+  this->RandomData(size);
+
+  std::vector<T>& draws = this->draws_;
+  std::vector<uint8_t>& valid_bytes = this->valid_bytes_;
+
+  ASSERT_OK(this->builder_->AppendValues(draws.data(), size, valid_bytes.data()));
+  std::shared_ptr<Array> result_untyped;
+  ASSERT_OK(this->builder_->Finish(&result_untyped));
+
+  ASSERT_OK(this->builder_->AppendValues(draws.data(), size, valid_bytes.data()));
+  std::shared_ptr<typename TestFixture::ArrayType> result;
+  ASSERT_OK(this->builder_->Finish(&result));
+
+  AssertArraysEqual(*result_untyped, *result);
+}
+
 TYPED_TEST(TestPrimitiveBuilder, TestAppendValuesIter) {
   int64_t size = 10000;
   this->RandomData(size);

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -177,6 +177,15 @@ class ARROW_EXPORT ArrayBuilder {
 
   static Status TrimBuffer(const int64_t bytes_filled, ResizableBuffer* buffer);
 
+  /// \brief Finish to an array of the specified ArrayType
+  template <typename ArrayType>
+  Status FinishTyped(std::shared_ptr<ArrayType>* out) {
+    std::shared_ptr<Array> out_untyped;
+    ARROW_RETURN_NOT_OK(Finish(&out_untyped));
+    *out = std::static_pointer_cast<ArrayType>(std::move(out_untyped));
+    return Status::OK();
+  }
+
   static Status CheckCapacity(int64_t new_capacity, int64_t old_capacity) {
     if (new_capacity < 0) {
       return Status::Invalid("Resize capacity must be positive");

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -23,6 +23,7 @@
 #include <limits>
 #include <memory>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "arrow/buffer-builder.h"

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -120,6 +120,10 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<BinaryArray>* out) { return FinishTyped(out); }
+
   /// \return size of values buffer so far
   int64_t value_data_length() const { return value_data_builder_.length(); }
   /// \return capacity of values buffer
@@ -186,6 +190,10 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   /// \return Status
   Status AppendValues(const char** values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<StringArray>* out) { return FinishTyped(out); }
 };
 
 // ----------------------------------------------------------------------
@@ -253,6 +261,10 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   void Reset() override;
   Status Resize(int64_t capacity) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<FixedSizeBinaryArray>* out) { return FinishTyped(out); }
 
   /// \return size of values buffer so far
   int64_t value_data_length() const { return byte_builder_.length(); }

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -120,7 +120,9 @@ class ARROW_EXPORT BinaryBuilder : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<BinaryArray>* out) { return FinishTyped(out); }
 
@@ -191,7 +193,9 @@ class ARROW_EXPORT StringBuilder : public BinaryBuilder {
   Status AppendValues(const char** values, int64_t length,
                       const uint8_t* valid_bytes = NULLPTR);
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<StringArray>* out) { return FinishTyped(out); }
 };
@@ -262,7 +266,9 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   Status Resize(int64_t capacity) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<FixedSizeBinaryArray>* out) { return FinishTyped(out); }
 

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -38,6 +38,10 @@ class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
   Status Append(const Decimal128& val);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<Decimal128Array>* out) { return FinishTyped(out); }
 };
 
 using DecimalBuilder = Decimal128Builder;

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -39,7 +39,9 @@ class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<Decimal128Array>* out) { return FinishTyped(out); }
 };

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -106,6 +106,10 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
   Status Resize(int64_t capacity) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
+
   /// is the dictionary builder in the delta building mode
   bool is_building_delta() { return delta_offset_ > 0; }
 
@@ -138,6 +142,10 @@ class ARROW_EXPORT DictionaryBuilder<NullType> : public ArrayBuilder {
 
   Status Resize(int64_t capacity) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
  protected:
   AdaptiveIntBuilder values_builder_;

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -106,7 +106,9 @@ class ARROW_EXPORT DictionaryBuilder : public ArrayBuilder {
   Status Resize(int64_t capacity) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
@@ -143,7 +145,9 @@ class ARROW_EXPORT DictionaryBuilder<NullType> : public ArrayBuilder {
   Status Resize(int64_t capacity) override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -52,6 +52,10 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
   void Reset() override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<ListArray>* out) { return FinishTyped(out); }
+
   /// \brief Vector append
   ///
   /// If passed, valid_bytes is of equal length to values, and any zero byte
@@ -95,6 +99,10 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
                 std::vector<std::shared_ptr<ArrayBuilder>>&& field_builders);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<StructArray>* out) { return FinishTyped(out); }
 
   /// Null bitmap is of equal length to every child field, and any zero byte
   /// will be considered as a null for that field, but users must using app-

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -52,7 +52,9 @@ class ARROW_EXPORT ListBuilder : public ArrayBuilder {
   void Reset() override;
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<ListArray>* out) { return FinishTyped(out); }
 
@@ -100,7 +102,9 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<StructArray>* out) { return FinishTyped(out); }
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -46,6 +46,10 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
   Status Append(std::nullptr_t) { return AppendNull(); }
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<NullArray>* out) { return FinishTyped(out); }
 };
 
 /// Base class for all Builders that emit an Array of a scalar numerical type.
@@ -53,6 +57,7 @@ template <typename T>
 class NumericBuilder : public ArrayBuilder {
  public:
   using value_type = typename T::c_type;
+  using ArrayType = typename TypeTraits<T>::ArrayType;
   using ArrayBuilder::ArrayBuilder;
 
   template <typename T1 = T>
@@ -158,6 +163,10 @@ class NumericBuilder : public ArrayBuilder {
     capacity_ = length_ = null_count_ = 0;
     return Status::OK();
   }
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<ArrayType>* out) { return FinishTyped(out); }
 
   /// \brief Append a sequence of elements in one shot
   /// \param[in] values_begin InputIterator to the beginning of the values
@@ -402,6 +411,11 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   }
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
+
+  using ArrayBuilder::Finish;
+
+  Status Finish(std::shared_ptr<BooleanArray>* out) { return FinishTyped(out); }
+
   void Reset() override;
   Status Resize(int64_t capacity) override;
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -47,7 +47,9 @@ class ARROW_EXPORT NullBuilder : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<NullArray>* out) { return FinishTyped(out); }
 };
@@ -164,7 +166,9 @@ class NumericBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<ArrayType>* out) { return FinishTyped(out); }
 
@@ -412,7 +416,9 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
   using ArrayBuilder::Finish;
+  /// \endcond
 
   Status Finish(std::shared_ptr<BooleanArray>* out) { return FinishTyped(out); }
 

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -76,6 +76,12 @@ class ARROW_EXPORT DenseUnionBuilder : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  /// \cond FALSE
+  using ArrayBuilder::Finish;
+  /// \endcond
+
+  Status Finish(std::shared_ptr<UnionArray>* out) { return FinishTyped(out); }
+
   /// \brief Make a new child builder available to the UnionArray
   ///
   /// \param[in] child the child builder

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <memory>
-#include <utility>
 
 #include "arrow/array/builder_adaptive.h"   // IWYU pragma: export
 #include "arrow/array/builder_base.h"       // IWYU pragma: export
@@ -28,7 +27,6 @@
 #include "arrow/array/builder_nested.h"     // IWYU pragma: export
 #include "arrow/array/builder_primitive.h"  // IWYU pragma: export
 #include "arrow/status.h"
-#include "arrow/type_traits.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {

--- a/cpp/src/arrow/builder.h
+++ b/cpp/src/arrow/builder.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
 #include "arrow/array/builder_adaptive.h"   // IWYU pragma: export
 #include "arrow/array/builder_base.h"       // IWYU pragma: export
@@ -27,6 +28,7 @@
 #include "arrow/array/builder_nested.h"     // IWYU pragma: export
 #include "arrow/array/builder_primitive.h"  // IWYU pragma: export
 #include "arrow/status.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {


### PR DESCRIPTION
Allows `Int64Builder` to finish into `shared_ptr<Int64Array>`, `ListBuilder` to finish into `shared_ptr<ListArray>`, etc.