### PR TITLE
ARROW-5274: [JavaScript] Wrong array type for countBy

### DIFF
--- a/js/src/compute/dataframe.ts
+++ b/js/src/compute/dataframe.ts
@@ -60,7 +60,7 @@ export class DataFrame<T extends { [key: string]: DataType } = any> extends Tabl
             throw new Error('countBy currently only supports dictionary-encoded columns');
         }
 
-        const countByteLength = Math.ceil(Math.log(vector.dictionary.length) / Math.log(256));
+        const countByteLength = Math.ceil(Math.log(vector.length) / Math.log(256));
         const CountsArrayType = countByteLength == 4 ? Uint32Array :
                                 countByteLength >= 2 ? Uint16Array : Uint8Array;
 
@@ -186,7 +186,7 @@ export class FilteredDataFrame<T extends { [key: string]: DataType } = any> exte
             throw new Error('countBy currently only supports dictionary-encoded columns');
         }
 
-        const countByteLength = Math.ceil(Math.log(vector.dictionary.length) / Math.log(256));
+        const countByteLength = Math.ceil(Math.log(vector.length) / Math.log(256));
         const CountsArrayType = countByteLength == 4 ? Uint32Array :
                                 countByteLength >= 2 ? Uint16Array : Uint8Array;
 


### PR DESCRIPTION
Counting array type by size of indices, not dictionary.

[JIRA link:](https://issues.apache.org/jira/browse/ARROW-5274)