### PR TITLE
ARROW-4505: [C++] adding pretty print for dates, times, and timestamps

### DIFF
--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -71,12 +71,21 @@ void Check(const T& obj, const PrettyPrintOptions& options, const char* expected
 }
 
 template <typename TYPE, typename C_TYPE>
-void CheckPrimitive(const PrettyPrintOptions& options, const std::vector<bool>& is_valid,
+void CheckPrimitive(const std::shared_ptr<DataType>& type,
+                    const PrettyPrintOptions& options, const std::vector<bool>& is_valid,
                     const std::vector<C_TYPE>& values, const char* expected,
                     bool check_operator = true) {
   std::shared_ptr<Array> array;
-  ArrayFromVector<TYPE, C_TYPE>(is_valid, values, &array);
+  ArrayFromVector<TYPE, C_TYPE>(type, is_valid, values, &array);
   CheckArray(*array, options, expected, check_operator);
+}
+
+template <typename TYPE, typename C_TYPE>
+void CheckPrimitive(const PrettyPrintOptions& options, const std::vector<bool>& is_valid,
+                    const std::vector<C_TYPE>& values, const char* expected,
+                    bool check_operator = true) {
+  CheckPrimitive<TYPE, C_TYPE>(TypeTraits<TYPE>::type_singleton(), options, is_valid,
+                               values, expected, check_operator);
 }
 
 TEST_F(TestPrettyPrint, PrimitiveType) {
@@ -154,6 +163,76 @@ TEST_F(TestPrettyPrint, PrimitiveType) {
     null
   ])expected";
   CheckPrimitive<StringType, std::string>({2, 10}, is_valid, values3, ex3_in2);
+}
+
+TEST_F(TestPrettyPrint, DateTimeTypes) {
+  std::vector<bool> is_valid = {true, true, false, true, false};
+
+  {
+    std::vector<int32_t> values = {0, 1, 2, 31, 4};
+    static const char* expected = R"expected([
+  1970-01-01,
+  1970-01-02,
+  null,
+  1970-02-01,
+  null
+])expected";
+    CheckPrimitive<Date32Type, int32_t>({0, 10}, is_valid, values, expected);
+  }
+
+  {
+    std::vector<int64_t> values = {0, 1, 2,
+                                   678 + 1000 * (5 + 60 * (4 + 60 * (3 + 24 * 1))), 4};
+    static const char* expected = R"expected([
+  1970-01-01 00:00:00.000,
+  1970-01-01 00:00:00.001,
+  null,
+  1970-01-02 03:04:05.678,
+  null
+])expected";
+    CheckPrimitive<Date64Type, int64_t>({0, 10}, is_valid, values, expected);
+  }
+
+  {
+    std::vector<int64_t> values = {
+        0, 1, 2, 678 + 1000000 * (5 + 60 * (4 + 60 * (3 + 24 * int64_t(1)))), 4};
+    static const char* expected = R"expected([
+  1970-01-01 00:00:00.000000Z,
+  1970-01-01 00:00:00.000001Z,
+  null,
+  1970-01-02 03:04:05.000678Z,
+  null
+])expected";
+    CheckPrimitive<TimestampType, int64_t>(timestamp(TimeUnit::MICRO, "Z"), {0, 10},
+                                           is_valid, values, expected);
+  }
+
+  {
+    std::vector<int32_t> values = {1, 62, 2, 3 + 60 * (2 + 60 * 1), 4};
+    static const char* expected = R"expected([
+  00:00:01,
+  00:01:02,
+  null,
+  01:02:03,
+  null
+])expected";
+    CheckPrimitive<Time32Type, int32_t>(time32(TimeUnit::SECOND), {0, 10}, is_valid,
+                                        values, expected);
+  }
+
+  {
+    std::vector<int64_t> values = {
+        0, 1, 2, 678 + int64_t(1000000000) * (5 + 60 * (4 + 60 * 3)), 4};
+    static const char* expected = R"expected([
+  00:00:00.000000000,
+  00:00:00.000000001,
+  null,
+  03:04:05.000000678,
+  null
+])expected";
+    CheckPrimitive<Time64Type, int64_t>(time64(TimeUnit::NANO), {0, 10}, is_valid, values,
+                                        expected);
+  }
 }
 
 TEST_F(TestPrettyPrint, StructTypeBasic) {

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -181,13 +181,14 @@ TEST_F(TestPrettyPrint, DateTimeTypes) {
   }
 
   {
-    std::vector<int64_t> values = {0, 1, 2,
-                                   678 + 1000 * (5 + 60 * (4 + 60 * (3 + 24 * 1))), 4};
+    constexpr int64_t ms_per_day = 24 * 60 * 60 * 1000;
+    std::vector<int64_t> values = {0 * ms_per_day, 1 * ms_per_day, 2 * ms_per_day,
+                                   31 * ms_per_day, 4 * ms_per_day};
     static const char* expected = R"expected([
-  1970-01-01 00:00:00.000,
-  1970-01-01 00:00:00.001,
+  1970-01-01,
+  1970-01-02,
   null,
-  1970-01-02 03:04:05.678,
+  1970-02-01,
   null
 ])expected";
     CheckPrimitive<Date64Type, int64_t>({0, 10}, is_valid, values, expected);

--- a/cpp/src/arrow/pretty_print-test.cc
+++ b/cpp/src/arrow/pretty_print-test.cc
@@ -198,14 +198,14 @@ TEST_F(TestPrettyPrint, DateTimeTypes) {
     std::vector<int64_t> values = {
         0, 1, 2, 678 + 1000000 * (5 + 60 * (4 + 60 * (3 + 24 * int64_t(1)))), 4};
     static const char* expected = R"expected([
-  1970-01-01 00:00:00.000000Z,
-  1970-01-01 00:00:00.000001Z,
+  1970-01-01 00:00:00.000000,
+  1970-01-01 00:00:00.000001,
   null,
-  1970-01-02 03:04:05.000678Z,
+  1970-01-02 03:04:05.000678,
   null
 ])expected";
-    CheckPrimitive<TimestampType, int64_t>(timestamp(TimeUnit::MICRO, "Z"), {0, 10},
-                                           is_valid, values, expected);
+    CheckPrimitive<TimestampType, int64_t>(timestamp(TimeUnit::MICRO, "Transylvania"),
+                                           {0, 10}, is_valid, values, expected);
   }
 
   {

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -146,10 +146,7 @@ class ArrayPrinter : public PrettyPrinter {
 
   template <typename T>
   inline typename std::enable_if<
-      IsInteger<T>::value && !is_date<typename T::TypeClass>::value &&
-          !is_time<typename T::TypeClass>::value &&
-          !std::is_same<TimestampType, typename T::TypeClass>::value,
-      Status>::type
+      IsInteger<T>::value && !is_time<typename T::TypeClass>::value, Status>::type
   WriteDataValues(const T& array) {
     const auto data = array.raw_values();
     WriteValues(array, [&](int64_t i) { (*sink_) << static_cast<int64_t>(data[i]); });

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -33,6 +34,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/string.h"
+#include "arrow/vendored/datetime.h"
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
@@ -143,10 +145,48 @@ class ArrayPrinter : public PrettyPrinter {
   }
 
   template <typename T>
-  inline typename std::enable_if<IsInteger<T>::value, Status>::type WriteDataValues(
-      const T& array) {
+  inline typename std::enable_if<
+      IsInteger<T>::value && !is_date<typename T::TypeClass>::value &&
+          !is_time<typename T::TypeClass>::value &&
+          !std::is_same<TimestampType, typename T::TypeClass>::value,
+      Status>::type
+  WriteDataValues(const T& array) {
     const auto data = array.raw_values();
     WriteValues(array, [&](int64_t i) { (*sink_) << static_cast<int64_t>(data[i]); });
+    return Status::OK();
+  }
+
+  Status WriteDataValues(const Date32Array& array) {
+    const int32_t* data = array.raw_values();
+    WriteValues(
+        array, [&](int64_t i) { FormatDateTime<util::date::days>("%F", data[i], true); });
+    return Status::OK();
+  }
+
+  Status WriteDataValues(const Date64Array& array) {
+    const int64_t* data = array.raw_values();
+    WriteValues(array, [&](int64_t i) {
+      FormatDateTime<std::chrono::milliseconds>("%F %T", data[i], true);
+    });
+    return Status::OK();
+  }
+
+  Status WriteDataValues(const TimestampArray& array) {
+    const int64_t* data = array.raw_values();
+    const auto type = static_cast<const TimestampType*>(array.type().get());
+    const auto fmt = "%F %T" + type->timezone();
+    WriteValues(array, [&](int64_t i) {
+      FormatDateTime(type->unit(), fmt.c_str(), data[i], true);
+    });
+    return Status::OK();
+  }
+
+  template <typename T>
+  enable_if_time<typename T::TypeClass, Status> WriteDataValues(const T& array) {
+    const auto data = array.raw_values();
+    const auto type = static_cast<const TimeType*>(array.type().get());
+    WriteValues(array,
+                [&](int64_t i) { FormatDateTime(type->unit(), "%T", data[i], false); });
     return Status::OK();
   }
 
@@ -320,8 +360,39 @@ class ArrayPrinter : public PrettyPrinter {
   }
 
  private:
+  template <typename Unit>
+  void FormatDateTime(const char* fmt, int64_t value, bool add_epoch) {
+    if (add_epoch) {
+      (*sink_) << util::date::format(fmt, epoch_ + Unit{value});
+    } else {
+      (*sink_) << util::date::format(fmt, Unit{value});
+    }
+  }
+
+  void FormatDateTime(TimeUnit::type unit, const char* fmt, int64_t value,
+                      bool add_epoch) {
+    switch (unit) {
+      case TimeUnit::NANO:
+        FormatDateTime<std::chrono::nanoseconds>(fmt, value, add_epoch);
+        break;
+      case TimeUnit::MICRO:
+        FormatDateTime<std::chrono::microseconds>(fmt, value, add_epoch);
+        break;
+      case TimeUnit::MILLI:
+        FormatDateTime<std::chrono::milliseconds>(fmt, value, add_epoch);
+        break;
+      case TimeUnit::SECOND:
+        FormatDateTime<std::chrono::seconds>(fmt, value, add_epoch);
+        break;
+    }
+  }
+
+  static util::date::sys_days epoch_;
   std::string null_rep_;
 };
+
+util::date::sys_days ArrayPrinter::epoch_ =
+    util::date::sys_days{util::date::jan / 1 / 1970};
 
 Status ArrayPrinter::WriteValidityBitmap(const Array& array) {
   Indent();

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -168,10 +168,8 @@ class ArrayPrinter : public PrettyPrinter {
   Status WriteDataValues(const TimestampArray& array) {
     const int64_t* data = array.raw_values();
     const auto type = static_cast<const TimestampType*>(array.type().get());
-    const auto fmt = "%F %T" + type->timezone();
-    WriteValues(array, [&](int64_t i) {
-      FormatDateTime(type->unit(), fmt.c_str(), data[i], true);
-    });
+    WriteValues(array,
+                [&](int64_t i) { FormatDateTime(type->unit(), "%F %T", data[i], true); });
     return Status::OK();
   }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -691,7 +691,7 @@ class ARROW_EXPORT Time64Type : public TimeType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  explicit Time64Type(TimeUnit::type unit = TimeUnit::MICRO);
+  explicit Time64Type(TimeUnit::type unit = TimeUnit::NANO);
 
   std::string ToString() const override;
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -691,7 +691,7 @@ class ARROW_EXPORT Time64Type : public TimeType {
 
   int bit_width() const override { return static_cast<int>(sizeof(c_type) * CHAR_BIT); }
 
-  explicit Time64Type(TimeUnit::type unit = TimeUnit::MILLI);
+  explicit Time64Type(TimeUnit::type unit = TimeUnit::MICRO);
 
   std::string ToString() const override;
 


### PR DESCRIPTION
| type | fmt |
|---|---|
| DATE32 (days since epoch) | YYYY-MM-DD |
| DATE64 (days since epoch, measured in ms) | YYYY-MM-DD |
| TIMESTAMP (`<TimeUnit>` since epoch) | YYYY-MM-DD HH:mm:ss.xxx<timezone> |
| TIME32 (`<TimeUnit>` since midnight) | HH:mm:ss.xxx |
| TIME64 (`<TimeUnit>` since midnight) | HH:mm:ss.xxx |