### PR TITLE
PARQUET-1571: [C++] Fix BufferedInputStream when buffer exactly exhausted

### DIFF
--- a/cpp/src/parquet/util/memory-test.cc
+++ b/cpp/src/parquet/util/memory-test.cc
@@ -32,68 +32,157 @@ using arrow::MemoryPool;
 
 namespace parquet {
 
-class TestBuffer : public ::testing::Test {};
-
-TEST(TestBufferedInputStream, Basics) {
-  int64_t source_size = 256;
-  int64_t stream_offset = 10;
-  int64_t stream_size = source_size - stream_offset;
-  int64_t chunk_size = 50;
-  std::shared_ptr<ResizableBuffer> buf =
-      AllocateBuffer(default_memory_pool(), source_size);
-  ASSERT_EQ(source_size, buf->size());
-  for (int i = 0; i < source_size; i++) {
-    buf->mutable_data()[i] = static_cast<uint8_t>(i);
+class TestBufferedInputStream : public ::testing::Test {
+ public:
+  void SetUp() {
+    // Create a buffer larger than source size, to check that the stream end is upholded.
+    std::shared_ptr<ResizableBuffer> buf =
+        AllocateBuffer(default_memory_pool(), source_size_ + 10);
+    ASSERT_LT(source_size_, buf->size());
+    for (int i = 0; i < source_size_; i++) {
+      buf->mutable_data()[i] = static_cast<uint8_t>(i);
+    }
+    source_ = std::make_shared<ArrowInputFile>(
+        std::make_shared<::arrow::io::BufferReader>(buf));
+    stream_.reset(new BufferedInputStream(default_memory_pool(), chunk_size_,
+                                          source_.get(), stream_offset_, stream_size_));
   }
 
-  auto wrapper =
-      std::make_shared<ArrowInputFile>(std::make_shared<::arrow::io::BufferReader>(buf));
+ protected:
+  int64_t source_size_ = 256;
+  int64_t stream_offset_ = 10;
+  int64_t stream_size_ = source_size_ - stream_offset_;
+  int64_t chunk_size_ = 50;
+  std::shared_ptr<RandomAccessSource> source_;
+  std::unique_ptr<BufferedInputStream> stream_;
+};
 
-  std::unique_ptr<BufferedInputStream> stream(new BufferedInputStream(
-      default_memory_pool(), chunk_size, wrapper.get(), stream_offset, stream_size));
-
+TEST_F(TestBufferedInputStream, Basics) {
   const uint8_t* output;
   int64_t bytes_read;
 
   // source is at offset 10
-  output = stream->Peek(10, &bytes_read);
+  output = stream_->Peek(10, &bytes_read);
   ASSERT_EQ(10, bytes_read);
   for (int i = 0; i < 10; i++) {
     ASSERT_EQ(10 + i, output[i]) << i;
   }
-  output = stream->Read(10, &bytes_read);
+  output = stream_->Read(10, &bytes_read);
   ASSERT_EQ(10, bytes_read);
   for (int i = 0; i < 10; i++) {
     ASSERT_EQ(10 + i, output[i]) << i;
   }
-  output = stream->Read(10, &bytes_read);
+  output = stream_->Read(10, &bytes_read);
   ASSERT_EQ(10, bytes_read);
   for (int i = 0; i < 10; i++) {
     ASSERT_EQ(20 + i, output[i]) << i;
   }
-  stream->Advance(5);
-  stream->Advance(5);
+  stream_->Advance(5);
+  stream_->Advance(5);
   // source is at offset 40
   // read across buffer boundary. buffer size is 50
-  output = stream->Read(20, &bytes_read);
+  output = stream_->Read(20, &bytes_read);
   ASSERT_EQ(20, bytes_read);
   for (int i = 0; i < 20; i++) {
     ASSERT_EQ(40 + i, output[i]) << i;
   }
-  // read more than original chunk_size
-  output = stream->Read(60, &bytes_read);
+  // read more than original chunk size
+  output = stream_->Read(60, &bytes_read);
   ASSERT_EQ(60, bytes_read);
   for (int i = 0; i < 60; i++) {
     ASSERT_EQ(60 + i, output[i]) << i;
   }
 
-  stream->Advance(120);
+  stream_->Advance(120);
   // source is at offset 240
   // read outside of source boundary. source size is 256
-  output = stream->Read(30, &bytes_read);
+  output = stream_->Read(30, &bytes_read);
   ASSERT_EQ(16, bytes_read);
   for (int i = 0; i < 16; i++) {
     ASSERT_EQ(240 + i, output[i]) << i;
+  }
+  // Stream exhausted
+  output = stream_->Read(1, &bytes_read);
+  ASSERT_EQ(bytes_read, 0);
+}
+
+TEST_F(TestBufferedInputStream, LargeFirstPeek) {
+  // Test a first peek larger than chunk size
+  const uint8_t* output;
+  int64_t bytes_read;
+  int64_t n = 70;
+  ASSERT_GT(n, chunk_size_);
+
+  // source is at offset 10
+  output = stream_->Peek(n, &bytes_read);
+  ASSERT_EQ(n, bytes_read);
+  for (int i = 0; i < n; i++) {
+    ASSERT_EQ(10 + i, output[i]) << i;
+  }
+  output = stream_->Peek(n, &bytes_read);
+  ASSERT_EQ(n, bytes_read);
+  for (int i = 0; i < n; i++) {
+    ASSERT_EQ(10 + i, output[i]) << i;
+  }
+  output = stream_->Read(n, &bytes_read);
+  ASSERT_EQ(n, bytes_read);
+  for (int i = 0; i < n; i++) {
+    ASSERT_EQ(10 + i, output[i]) << i;
+  }
+  // source is at offset 10 + n
+  output = stream_->Read(20, &bytes_read);
+  ASSERT_EQ(20, bytes_read);
+  for (int i = 0; i < 20; i++) {
+    ASSERT_EQ(10 + n + i, output[i]) << i;
+  }
+}
+
+TEST_F(TestBufferedInputStream, OneByteReads) {
+  const uint8_t* output;
+  int64_t bytes_read;
+
+  for (int i = 0; i < stream_size_; ++i) {
+    output = stream_->Read(1, &bytes_read);
+    ASSERT_EQ(bytes_read, 1);
+    ASSERT_EQ(10 + i, output[0]) << i;
+  }
+  // Stream exhausted
+  output = stream_->Read(1, &bytes_read);
+  ASSERT_EQ(bytes_read, 0);
+}
+
+TEST_F(TestBufferedInputStream, BufferExactlyExhausted) {
+  // Test exhausting the buffer exactly then issuing further reads (PARQUET-1571).
+  const uint8_t* output;
+  int64_t bytes_read;
+
+  // source is at offset 10
+  int64_t n = 10;
+  output = stream_->Read(n, &bytes_read);
+  ASSERT_EQ(n, bytes_read);
+  for (int i = 0; i < n; i++) {
+    ASSERT_EQ(10 + i, output[i]) << i;
+  }
+  // source is at offset 20
+  // Exhaust buffer exactly
+  n = stream_->remaining_in_buffer();
+  output = stream_->Read(n, &bytes_read);
+  ASSERT_EQ(n, bytes_read);
+  for (int i = 0; i < n; i++) {
+    ASSERT_EQ(20 + i, output[i]) << i;
+  }
+  // source is at offset 20 + n
+  // Read new buffer
+  output = stream_->Read(10, &bytes_read);
+  ASSERT_EQ(10, bytes_read);
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ(20 + n + i, output[i]) << i;
+  }
+  // source is at offset 30 + n
+  output = stream_->Read(10, &bytes_read);
+  ASSERT_EQ(10, bytes_read);
+  for (int i = 0; i < 10; i++) {
+    ASSERT_EQ(30 + n + i, output[i]) << i;
   }
 }
 

--- a/cpp/src/parquet/util/memory.h
+++ b/cpp/src/parquet/util/memory.h
@@ -276,13 +276,16 @@ class PARQUET_EXPORT BufferedInputStream : public InputStream {
 
   virtual void Advance(int64_t num_bytes);
 
+  // Return the number of bytes remaining in buffer (i.e. without reading from source).
+  int64_t remaining_in_buffer() const;
+
  private:
   std::shared_ptr<ResizableBuffer> buffer_;
   RandomAccessSource* source_;
   int64_t stream_offset_;
   int64_t stream_end_;
   int64_t buffer_offset_;
-  int64_t buffer_size_;
+  int64_t buffer_end_;
 };
 
 std::shared_ptr<ResizableBuffer> PARQUET_EXPORT AllocateBuffer(

--- a/python/requirements-wheel.txt
+++ b/python/requirements-wheel.txt
@@ -1,5 +1,5 @@
 wheel==0.31.1
-setuptools_scm
+setuptools_scm==3.2.0
 six>=1.0.0
 numpy==1.14.5
 futures; python_version < "3.2"

--- a/python/requirements-wheel.txt
+++ b/python/requirements-wheel.txt
@@ -1,5 +1,5 @@
 wheel==0.31.1
-setuptools_scm==3.2.0
+setuptools_scm
 six>=1.0.0
 numpy==1.14.5
 futures; python_version < "3.2"


### PR DESCRIPTION
Rework the BufferedInputStream implementation to make internal semantics more apparent.