### PR TITLE
ARROW-5286: [Python] support struct type in from_pandas

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -75,7 +75,7 @@ def get_logical_type(arrow_type):
             return 'datetimetz' if arrow_type.tz is not None else 'datetime'
         elif isinstance(arrow_type, pa.lib.Decimal128Type):
             return 'decimal'
-        raise NotImplementedError(str(arrow_type))
+        return 'object'
 
 
 _numpy_logical_type_map = {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5286

We can infer struct type from dicts, but currently do not allow it in `from_pandas` because getting a "logical pandas type" is not implemented. I opted for now to let this return "object", as that is how pandas stores such data.