### PR TITLE
ARROW-5313: [Format] Comments on Field table are a bit confusing

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -245,23 +245,23 @@ table DictionaryEncoding {
 /// nested type.
 
 table Field {
-  // Name is not required, in i.e. a List
+  /// Name is not required, in i.e. a List
   name: string;
 
-  // Whether or not this field can contain nulls. Should be true in general.
+  /// Whether or not this field can contain nulls. Should be true in general.
   nullable: bool;
 
-  // This is the type of the decoded value if the field is dictionary encoded.
+  /// This is the type of the decoded value if the field is dictionary encoded.
   type: Type;
 
-  // Present only if the field is dictionary encoded.
+  /// Present only if the field is dictionary encoded.
   dictionary: DictionaryEncoding;
 
-  // children apply only to nested data types like Struct, List and Union. For
-  // primitive types children will have length 0.
+  /// children apply only to nested data types like Struct, List and Union. For
+  /// primitive types children will have length 0.
   children: [ Field ];
 
-  // User-defined metadata
+  /// User-defined metadata
   custom_metadata: [ KeyValue ];
 }
 

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -243,23 +243,23 @@ table DictionaryEncoding {
 /// ----------------------------------------------------------------------
 /// A field represents a named column in a record / row batch or child of a
 /// nested type.
-///
-/// - children is only for nested Arrow arrays
-/// - For primitive types, children will have length 0
-/// - nullable should default to true in general
 
 table Field {
   // Name is not required, in i.e. a List
   name: string;
+
+  // Whether or not this field can contain nulls. Should be true in general.
   nullable: bool;
-  // This is the type of the decoded value if the field is dictionary encoded
+
+  // This is the type of the decoded value if the field is dictionary encoded.
   type: Type;
 
-  // Present only if the field is dictionary encoded
+  // Present only if the field is dictionary encoded.
   dictionary: DictionaryEncoding;
 
-  // children apply only to Nested data types like Struct, List and Union
-  children: [Field];
+  // children apply only to nested data types like Struct, List and Union. For
+  // primitive types children will have length 0.
+  children: [ Field ];
 
   // User-defined metadata
   custom_metadata: [ KeyValue ];


### PR DESCRIPTION
Move comments about specific attributes of `Field` into the definition to avoid confusion.