### PR TITLE
ARROW-5102: [C++] Reduce header dependencies

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -21,6 +21,8 @@
 #  include <config.h>
 #endif
 
+#include <sstream>
+
 #include <arrow-glib/array.hpp>
 #include <arrow-glib/compute.hpp>
 #include <arrow-glib/data-type.hpp>

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -132,6 +132,7 @@ set(ARROW_SRCS
     util/logging.cc
     util/key_value_metadata.cc
     util/memory.cc
+    util/string_builder.cc
     util/task-group.cc
     util/thread-pool.cc
     util/trie.cc
@@ -283,6 +284,7 @@ if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS)
   # that depend on gtest
   add_arrow_lib(arrow_testing
                 SOURCES
+                io/test-common.cc
                 ipc/test-common.cc
                 filesystem/test-util.cc
                 testing/gtest_util.cc

--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -40,6 +40,7 @@
 #include "arrow/util/bit-util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/lazy.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"

--- a/cpp/src/arrow/adapters/orc/adapter_util.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_util.cc
@@ -21,6 +21,7 @@
 #include "arrow/adapters/orc/adapter_util.h"
 #include "arrow/array/builder_base.h"
 #include "arrow/builder.h"
+#include "arrow/status.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/lazy.h"

--- a/cpp/src/arrow/api.h
+++ b/cpp/src/arrow/api.h
@@ -20,21 +20,22 @@
 #ifndef ARROW_API_H
 #define ARROW_API_H
 
-#include "arrow/array.h"           // IYWU pragma: export
-#include "arrow/buffer.h"          // IYWU pragma: export
-#include "arrow/builder.h"         // IYWU pragma: export
-#include "arrow/compare.h"         // IYWU pragma: export
-#include "arrow/extension_type.h"  // IYWU pragma: export
-#include "arrow/memory_pool.h"     // IYWU pragma: export
-#include "arrow/pretty_print.h"    // IYWU pragma: export
-#include "arrow/record_batch.h"    // IYWU pragma: export
-#include "arrow/status.h"          // IYWU pragma: export
-#include "arrow/table.h"           // IYWU pragma: export
-#include "arrow/table_builder.h"   // IYWU pragma: export
-#include "arrow/tensor.h"          // IYWU pragma: export
-#include "arrow/type.h"            // IYWU pragma: export
-#include "arrow/util/config.h"     // IYWU pragma: export
-#include "arrow/visitor.h"         // IYWU pragma: export
+#include "arrow/array.h"                    // IYWU pragma: export
+#include "arrow/buffer.h"                   // IYWU pragma: export
+#include "arrow/builder.h"                  // IYWU pragma: export
+#include "arrow/compare.h"                  // IYWU pragma: export
+#include "arrow/extension_type.h"           // IYWU pragma: export
+#include "arrow/memory_pool.h"              // IYWU pragma: export
+#include "arrow/pretty_print.h"             // IYWU pragma: export
+#include "arrow/record_batch.h"             // IYWU pragma: export
+#include "arrow/status.h"                   // IYWU pragma: export
+#include "arrow/table.h"                    // IYWU pragma: export
+#include "arrow/table_builder.h"            // IYWU pragma: export
+#include "arrow/tensor.h"                   // IYWU pragma: export
+#include "arrow/type.h"                     // IYWU pragma: export
+#include "arrow/util/config.h"              // IYWU pragma: export
+#include "arrow/util/key_value_metadata.h"  // IWYU pragma: export
+#include "arrow/visitor.h"                  // IYWU pragma: export
 
 /// \brief Top-level namespace for Apache Arrow C++ API
 namespace arrow {}

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -38,6 +38,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_common.h"
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -22,7 +22,6 @@
 #include <cstdint>
 #include <cstring>
 #include <numeric>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -19,7 +19,6 @@
 
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -23,7 +23,6 @@
 #include <cstring>
 #include <memory>
 #include <numeric>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <limits>
-#include <sstream>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <sstream>
 #include <utility>
 #include <vector>
 

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -19,7 +19,6 @@
 #define ARROW_BUFFER_BUILDER_H
 
 #include <algorithm>
-#include <array>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -107,18 +106,6 @@ class ARROW_EXPORT BufferBuilder {
   Status Append(const int64_t num_copies, uint8_t value) {
     ARROW_RETURN_NOT_OK(Reserve(num_copies));
     UnsafeAppend(num_copies, value);
-    return Status::OK();
-  }
-
-  /// \brief Append the given data to the buffer
-  ///
-  /// The buffer is automatically expanded if necessary.
-  template <size_t NBYTES>
-  Status Append(const std::array<uint8_t, NBYTES>& data) {
-    constexpr auto nbytes = static_cast<int64_t>(NBYTES);
-    ARROW_RETURN_NOT_OK(Reserve(NBYTES));
-    std::copy(data.cbegin(), data.cend(), data_ + size_);
-    size_ += nbytes;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/buffer.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <utility>
 

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -18,7 +18,6 @@
 #ifndef ARROW_BUFFER_H
 #define ARROW_BUFFER_H
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <memory>

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -17,7 +17,6 @@
 
 #include "arrow/builder.h"
 
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/compute/compute-benchmark.cc
+++ b/cpp/src/arrow/compute/compute-benchmark.cc
@@ -22,6 +22,7 @@
 #include "arrow/builder.h"
 #include "arrow/memory_pool.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 
 #include "arrow/compute/context.h"

--- a/cpp/src/arrow/compute/kernels/boolean-test.cc
+++ b/cpp/src/arrow/compute/kernels/boolean-test.cc
@@ -122,7 +122,7 @@ TEST_F(TestBooleanKernel, Invert) {
   ASSERT_OK(Invert(&this->ctx_, ca1, &result));
   ASSERT_EQ(Datum::CHUNKED_ARRAY, result.kind());
   std::shared_ptr<ChunkedArray> result_ca = result.chunked_array();
-  ASSERT_ARRAYS_EQUAL(*ca2, *result_ca);
+  AssertChunkedEqual(*ca2, *result_ca);
 }
 
 TEST_F(TestBooleanKernel, InvertEmptyArray) {

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <sstream>
 #include <utility>
 
 #include "arrow/memory_pool.h"

--- a/cpp/src/arrow/csv/test-common.h
+++ b/cpp/src/arrow/csv/test-common.h
@@ -19,7 +19,6 @@
 #define ARROW_CSV_TEST_COMMON_H
 
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -30,11 +29,11 @@ namespace arrow {
 namespace csv {
 
 std::string MakeCSVData(std::vector<std::string> lines) {
-  std::stringstream ss;
+  std::string s;
   for (const auto& line : lines) {
-    ss << line;
+    s += line;
   }
-  return ss.str();
+  return s;
 }
 
 // Make a BlockParser from a vector of lines representing a CSV file

--- a/cpp/src/arrow/extension_type-test.cc
+++ b/cpp/src/arrow/extension_type-test.cc
@@ -42,6 +42,7 @@
 #include "arrow/testing/gtest_common.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
+#include "arrow/util/key_value_metadata.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/extension_type.cc
+++ b/cpp/src/arrow/extension_type.cc
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "arrow/array.h"
+#include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/visibility.h"
 

--- a/cpp/src/arrow/flight/perf-server.cc
+++ b/cpp/src/arrow/flight/perf-server.cc
@@ -29,7 +29,9 @@
 #include "arrow/io/test-common.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
+#include "arrow/util/logging.h"
 
 #include "arrow/flight/api.h"
 #include "arrow/flight/internal.h"
@@ -125,8 +127,10 @@ Status GetPerfBatches(const perf::Token& token, const std::shared_ptr<Schema>& s
   const int32_t length = token.definition().records_per_batch();
   const int32_t ncolumns = 4;
   for (int i = 0; i < ncolumns; ++i) {
-    RETURN_NOT_OK(MakeRandomBuffer<int64_t>(length, default_memory_pool(), &buffer));
+    RETURN_NOT_OK(MakeRandomByteBuffer(length * sizeof(int64_t), default_memory_pool(),
+                                       &buffer, static_cast<int32_t>(i) /* seed */));
     arrays.push_back(std::make_shared<Int64Array>(length, buffer));
+    RETURN_NOT_OK(ValidateArray(*arrays.back()));
   }
 
   *data_stream = std::unique_ptr<FlightDataStream>(

--- a/cpp/src/arrow/flight/test-integration-client.cc
+++ b/cpp/src/arrow/flight/test-integration-client.cc
@@ -27,12 +27,14 @@
 
 #include <gflags/gflags.h>
 
+#include "arrow/io/file.h"
 #include "arrow/io/test-common.h"
 #include "arrow/ipc/dictionary.h"
 #include "arrow/ipc/json-integration.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/util/logging.h"
 
 #include "arrow/flight/api.h"

--- a/cpp/src/arrow/flight/test-server.cc
+++ b/cpp/src/arrow/flight/test-server.cc
@@ -25,6 +25,7 @@
 
 #include <gflags/gflags.h>
 
+#include "arrow/buffer.h"
 #include "arrow/io/test-common.h"
 #include "arrow/record_batch.h"
 #include "arrow/util/logging.h"

--- a/cpp/src/arrow/io/compressed-test.cc
+++ b/cpp/src/arrow/io/compressed-test.cc
@@ -27,6 +27,7 @@
 #include "arrow/io/memory.h"
 #include "arrow/io/test-common.h"
 #include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/compression.h"
 

--- a/cpp/src/arrow/io/file-test.cc
+++ b/cpp/src/arrow/io/file-test.cc
@@ -25,8 +25,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <memory>
-#include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <thread>
 #include <vector>
@@ -39,6 +39,7 @@
 #include "arrow/io/test-common.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/io-util.h"
 
@@ -95,7 +96,7 @@ class TestFileOutputStream : public FileTestFixture {
 #if defined(_MSC_VER)
 TEST_F(TestFileOutputStream, FileNameWideCharConversionRangeException) {
   std::shared_ptr<FileOutputStream> file;
-  // Form literal string with non-ASCII symbol(127 + 1)
+  // Invalid utf-8 filename
   std::string file_name = "\x80";
   ASSERT_RAISES(Invalid, FileOutputStream::Open(file_name, &file));
 
@@ -105,6 +106,8 @@ TEST_F(TestFileOutputStream, FileNameWideCharConversionRangeException) {
   std::shared_ptr<ReadableFile> rd_file;
   ASSERT_RAISES(Invalid, ReadableFile::Open(file_name, &rd_file));
 }
+
+// TODO add a test with a valid utf-8 filename
 #endif
 
 TEST_F(TestFileOutputStream, DestructorClosesFile) {

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -275,6 +275,10 @@ BufferReader::BufferReader(const uint8_t* data, int64_t size)
 BufferReader::BufferReader(const Buffer& buffer)
     : BufferReader(buffer.data(), buffer.size()) {}
 
+BufferReader::BufferReader(const util::string_view& data)
+    : BufferReader(reinterpret_cast<const uint8_t*>(data.data()),
+                   static_cast<int64_t>(data.size())) {}
+
 Status BufferReader::Close() {
   is_open_ = false;
   return Status::OK();

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -136,9 +136,7 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
 
   /// \brief Instantiate from std::string or arrow::util::string_view. Does not
   /// own data
-  explicit BufferReader(const util::string_view& data)
-      : BufferReader(reinterpret_cast<const uint8_t*>(data.data()),
-                     static_cast<int64_t>(data.size())) {}
+  explicit BufferReader(const util::string_view& data);
 
   Status Close() override;
   bool closed() const override;

--- a/cpp/src/arrow/io/test-common.cc
+++ b/cpp/src/arrow/io/test-common.cc
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/io/test-common.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>  // IWYU pragma: keep
+
+#ifdef _WIN32
+#include <crtdbg.h>
+#include <io.h>
+#else
+#include <fcntl.h>
+#endif
+
+#include "arrow/buffer.h"
+#include "arrow/io/file.h"
+#include "arrow/io/memory.h"
+#include "arrow/memory_pool.h"
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow {
+namespace io {
+
+void AssertFileContents(const std::string& path, const std::string& contents) {
+  std::shared_ptr<ReadableFile> rf;
+  int64_t size;
+
+  ASSERT_OK(ReadableFile::Open(path, &rf));
+  ASSERT_OK(rf->GetSize(&size));
+  ASSERT_EQ(size, contents.size());
+
+  std::shared_ptr<Buffer> actual_data;
+  ASSERT_OK(rf->Read(size, &actual_data));
+  ASSERT_TRUE(actual_data->Equals(Buffer(contents)));
+}
+
+bool FileExists(const std::string& path) { return std::ifstream(path.c_str()).good(); }
+
+#if defined(_WIN32)
+static void InvalidParamHandler(const wchar_t* expr, const wchar_t* func,
+                                const wchar_t* source_file, unsigned int source_line,
+                                uintptr_t reserved) {
+  wprintf(L"Invalid parameter in function '%s'. Source: '%s' line %d expression '%s'\n",
+          func, source_file, source_line, expr);
+}
+#endif
+
+bool FileIsClosed(int fd) {
+#if defined(_WIN32)
+  // Disables default behavior on wrong params which causes the application to crash
+  // https://msdn.microsoft.com/en-us/library/ksazx244.aspx
+  _set_invalid_parameter_handler(InvalidParamHandler);
+
+  // Disables possible assertion alert box on invalid input arguments
+  _CrtSetReportMode(_CRT_ASSERT, 0);
+
+  int new_fd = _dup(fd);
+  if (new_fd == -1) {
+    return errno == EBADF;
+  }
+  _close(new_fd);
+  return false;
+#else
+  if (-1 != fcntl(fd, F_GETFD)) {
+    return false;
+  }
+  return errno == EBADF;
+#endif
+}
+
+Status ZeroMemoryMap(MemoryMappedFile* file) {
+  constexpr int64_t kBufferSize = 512;
+  static constexpr uint8_t kZeroBytes[kBufferSize] = {0};
+
+  RETURN_NOT_OK(file->Seek(0));
+  int64_t position = 0;
+  int64_t file_size;
+  RETURN_NOT_OK(file->GetSize(&file_size));
+
+  int64_t chunksize;
+  while (position < file_size) {
+    chunksize = std::min(kBufferSize, file_size - position);
+    RETURN_NOT_OK(file->Write(kZeroBytes, chunksize));
+    position += chunksize;
+  }
+  return Status::OK();
+}
+
+void MemoryMapFixture::TearDown() {
+  for (auto path : tmp_files_) {
+    ARROW_UNUSED(std::remove(path.c_str()));
+  }
+}
+
+void MemoryMapFixture::CreateFile(const std::string& path, int64_t size) {
+  std::shared_ptr<MemoryMappedFile> file;
+  ASSERT_OK(MemoryMappedFile::Create(path, size, &file));
+  tmp_files_.push_back(path);
+}
+
+Status MemoryMapFixture::InitMemoryMap(int64_t size, const std::string& path,
+                                       std::shared_ptr<MemoryMappedFile>* mmap) {
+  RETURN_NOT_OK(MemoryMappedFile::Create(path, size, mmap));
+  tmp_files_.push_back(path);
+  return Status::OK();
+}
+
+void MemoryMapFixture::AppendFile(const std::string& path) { tmp_files_.push_back(path); }
+
+}  // namespace io
+}  // namespace arrow

--- a/cpp/src/arrow/ipc/json-internal.h
+++ b/cpp/src/arrow/ipc/json-internal.h
@@ -19,7 +19,6 @@
 #define ARROW_IPC_JSON_INTERNAL_H
 
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include "arrow/json/rapidjson-defs.h"

--- a/cpp/src/arrow/ipc/json-test.cc
+++ b/cpp/src/arrow/ipc/json-test.cc
@@ -296,7 +296,7 @@ TEST(TestJsonFileReadWrite, BasicRoundTrip) {
   for (int i = 0; i < nbatches; ++i) {
     std::shared_ptr<RecordBatch> batch;
     ASSERT_OK(reader->ReadRecordBatch(i, &batch));
-    ASSERT_RECORD_BATCHES_EQUAL(*batch, *batches[i]);
+    ASSERT_BATCHES_EQUAL(*batch, *batches[i]);
   }
 }
 

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -39,6 +39,7 @@
 #include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/visitor_inline.h"
 

--- a/cpp/src/arrow/ipc/read-write-test.cc
+++ b/cpp/src/arrow/ipc/read-write-test.cc
@@ -41,10 +41,13 @@
 #include "arrow/sparse_tensor.h"
 #include "arrow/status.h"
 #include "arrow/tensor.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/util/bit-util.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/key_value_metadata.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/json/parser.h
+++ b/cpp/src/arrow/json/parser.h
@@ -22,6 +22,7 @@
 
 #include "arrow/json/options.h"
 #include "arrow/status.h"
+#include "arrow/util/key_value_metadata.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -23,7 +23,6 @@
 #include <iostream>   // IWYU pragma: keep
 #include <limits>
 #include <memory>
-#include <sstream>  // IWYU pragma: keep
 
 #include "arrow/status.h"
 #include "arrow/util/logging.h"  // IWYU pragma: keep

--- a/cpp/src/arrow/pretty_print.h
+++ b/cpp/src/arrow/pretty_print.h
@@ -18,7 +18,7 @@
 #ifndef ARROW_PRETTY_PRINT_H
 #define ARROW_PRETTY_PRINT_H
 
-#include <ostream>
+#include <iosfwd>
 #include <string>
 
 #include "arrow/util/visibility.h"

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -24,7 +24,6 @@
 #include <cmath>
 #include <cstdint>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -19,7 +19,7 @@
 
 #include <cstdlib>
 #include <mutex>
-#include <sstream>
+#include <string>
 
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"

--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -19,8 +19,6 @@
 #define ARROW_PYTHON_COMMON_H
 
 #include <memory>
-#include <sstream>
-#include <string>
 #include <utility>
 
 #include "arrow/python/config.h"

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/python/inference.cc
+++ b/cpp/src/arrow/python/inference.cc
@@ -23,7 +23,6 @@
 #include <algorithm>
 #include <limits>
 #include <map>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/python/inference.h
+++ b/cpp/src/arrow/python/inference.h
@@ -24,8 +24,6 @@
 #include "arrow/python/platform.h"
 
 #include <memory>
-#include <ostream>
-#include <string>
 
 #include "arrow/python/visibility.h"
 #include "arrow/type.h"

--- a/cpp/src/arrow/python/numpy-internal.h
+++ b/cpp/src/arrow/python/numpy-internal.h
@@ -27,6 +27,7 @@
 #include "arrow/python/platform.h"
 
 #include <cstdint>
+#include <sstream>
 #include <string>
 
 namespace arrow {

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <vector>
 

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -28,7 +28,6 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/python/platform.h
+++ b/cpp/src/arrow/python/platform.h
@@ -21,7 +21,6 @@
 #ifndef ARROW_PYTHON_PLATFORM_H
 #define ARROW_PYTHON_PLATFORM_H
 
-#include <iostream>
 #include <Python.h> // IWYU pragma: export
 #include <datetime.h>
 

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -19,7 +19,6 @@
 #define PYARROW_UTIL_DATETIME_H
 
 #include <algorithm>
-#include <sstream>
 
 #include <datetime.h>
 #include "arrow/python/platform.h"

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <cstdlib>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <utility>
 
@@ -39,6 +38,13 @@ Status RecordBatch::AddColumn(int i, const std::string& field_name,
   auto field = ::arrow::field(field_name, column->type());
   return AddColumn(i, field, column, out);
 }
+
+std::shared_ptr<Array> RecordBatch::GetColumnByName(const std::string& name) const {
+  auto i = schema_->GetFieldIndex(name);
+  return i == -1 ? NULLPTR : column(i);
+}
+
+int RecordBatch::num_columns() const { return schema_->num_fields(); }
 
 /// \class SimpleRecordBatch
 /// \brief A basic, non-lazy in-memory record batch

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -23,16 +23,11 @@
 #include <string>
 #include <vector>
 
-#include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-
-class Array;
-struct ArrayData;
-class Status;
-class Table;
 
 /// \class RecordBatch
 /// \brief Collection of equal-length arrays matching a particular Schema
@@ -95,10 +90,7 @@ class ARROW_EXPORT RecordBatch {
   /// \brief Retrieve an array from the record batch
   /// \param[in] name field name
   /// \return an Array or null if no field was found
-  std::shared_ptr<Array> GetColumnByName(const std::string& name) const {
-    auto i = schema_->GetFieldIndex(name);
-    return i == -1 ? NULLPTR : column(i);
-  }
+  std::shared_ptr<Array> GetColumnByName(const std::string& name) const;
 
   /// \brief Retrieve an array's internaldata from the record batch
   /// \param[in] i field index, does not boundscheck
@@ -141,7 +133,7 @@ class ARROW_EXPORT RecordBatch {
   const std::string& column_name(int i) const;
 
   /// \return the number of columns in the table
-  int num_columns() const { return schema_->num_fields(); }
+  int num_columns() const;
 
   /// \return the number of rows (the corresponding length of each column)
   int64_t num_rows() const { return num_rows_; }

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -12,8 +12,9 @@
 
 #include "arrow/status.h"
 
-#include <assert.h>
-#include <sstream>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
 
 namespace arrow {
 
@@ -112,6 +113,17 @@ std::string Status::ToString() const {
   result += ": ";
   result += state_->msg;
   return result;
+}
+
+void Status::Abort() const { Abort(std::string()); }
+
+void Status::Abort(const std::string& message) const {
+  std::cerr << "-- Arrow Fatal Error --\n";
+  if (!message.empty()) {
+    std::cerr << message << "\n";
+  }
+  std::cerr << ToString() << std::endl;
+  std::abort();
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -335,6 +335,9 @@ class ARROW_EXPORT Status {
   /// \brief Return the specific error message attached to this status.
   std::string message() const { return ok() ? "" : state_->msg; }
 
+  [[noreturn]] void Abort() const;
+  [[noreturn]] void Abort(const std::string& message) const;
+
  private:
   struct State {
     StatusCode code;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -21,7 +21,6 @@
 #include <cstdlib>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <utility>
 
 #include "arrow/array.h"

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "arrow/compare.h"
+#include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <random>
+#include <vector>
 
 #include "arrow/type.h"
 #include "arrow/util/visibility.h"
@@ -235,4 +238,35 @@ class ARROW_EXPORT RandomArrayGenerator {
 };
 
 }  // namespace random
+
+//
+// Assorted functions
+//
+
+template <typename T, typename U>
+void randint(int64_t N, T lower, T upper, std::vector<U>* out) {
+  const int random_seed = 0;
+  std::default_random_engine gen(random_seed);
+  std::uniform_int_distribution<T> d(lower, upper);
+  out->resize(N, static_cast<T>(0));
+  std::generate(out->begin(), out->end(), [&d, &gen] { return static_cast<U>(d(gen)); });
+}
+
+template <typename T, typename U>
+void random_real(int64_t n, uint32_t seed, T min_value, T max_value,
+                 std::vector<U>* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_real_distribution<T> d(min_value, max_value);
+  out->resize(n, static_cast<T>(0));
+  std::generate(out->begin(), out->end(), [&d, &gen] { return static_cast<U>(d(gen)); });
+}
+
+template <typename T, typename U>
+void rand_uniform_int(int64_t n, uint32_t seed, T min_value, T max_value, U* out) {
+  assert(out || (n == 0));
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<T> d(min_value, max_value);
+  std::generate(out, out + n, [&d, &gen] { return static_cast<U>(d(gen)); });
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -17,6 +17,9 @@
 
 #include "arrow/testing/util.h"
 
+#include <chrono>
+#include <random>
+
 #ifndef _WIN32
 #include <sys/stat.h>  // IWYU pragma: keep
 #include <sys/wait.h>  // IWYU pragma: keep
@@ -24,8 +27,14 @@
 #endif
 
 #include "arrow/table.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/logging.h"
 
 namespace arrow {
+
+uint64_t random_seed() {
+  return std::chrono::high_resolution_clock::now().time_since_epoch().count();
+}
 
 void random_null_bytes(int64_t n, double pct_null, uint8_t* null_bytes) {
   const int random_seed = 0;

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -18,62 +18,36 @@
 #pragma once
 
 #include <algorithm>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <limits>
 #include <memory>
-#include <random>
-#include <sstream>
 #include <string>
 #include <type_traits>
 #include <vector>
 
-#include "arrow/array.h"
 #include "arrow/buffer.h"
-#include "arrow/builder.h"
-#include "arrow/memory_pool.h"
-#include "arrow/pretty_print.h"
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
-#include "arrow/type.h"
-#include "arrow/type_traits.h"
-#include "arrow/util/bit-util.h"
-#include "arrow/util/logging.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
+class Array;
 class ChunkedArray;
 class Column;
+class MemoryPool;
+class RecordBatch;
 class Table;
 
 using ArrayVector = std::vector<std::shared_ptr<Array>>;
 
-template <typename T, typename U>
-void randint(int64_t N, T lower, T upper, std::vector<U>* out) {
-  const int random_seed = 0;
-  std::default_random_engine gen(random_seed);
-  std::uniform_int_distribution<T> d(lower, upper);
-  out->resize(N, static_cast<T>(0));
-  std::generate(out->begin(), out->end(), [&d, &gen] { return static_cast<U>(d(gen)); });
-}
-
-template <typename T, typename U>
-void random_real(int64_t n, uint32_t seed, T min_value, T max_value,
-                 std::vector<U>* out) {
-  std::default_random_engine gen(seed);
-  std::uniform_real_distribution<T> d(min_value, max_value);
-  out->resize(n, static_cast<T>(0));
-  std::generate(out->begin(), out->end(), [&d, &gen] { return static_cast<U>(d(gen)); });
-}
-
 template <typename T>
-inline Status CopyBufferFromVector(const std::vector<T>& values, MemoryPool* pool,
-                                   std::shared_ptr<Buffer>* result) {
+Status CopyBufferFromVector(const std::vector<T>& values, MemoryPool* pool,
+                            std::shared_ptr<Buffer>* result) {
   int64_t nbytes = static_cast<int>(values.size()) * sizeof(T);
 
   std::shared_ptr<Buffer> buffer;
@@ -103,39 +77,7 @@ ARROW_EXPORT Status MakeRandomByteBuffer(int64_t length, MemoryPool* pool,
                                          std::shared_ptr<ResizableBuffer>* out,
                                          uint32_t seed = 0);
 
-static inline uint64_t random_seed() {
-  return std::chrono::high_resolution_clock::now().time_since_epoch().count();
-}
-
-template <typename T, typename U>
-void rand_uniform_int(int64_t n, uint32_t seed, T min_value, T max_value, U* out) {
-  DCHECK(out || (n == 0));
-  std::default_random_engine gen(seed);
-  std::uniform_int_distribution<T> d(min_value, max_value);
-  std::generate(out, out + n, [&d, &gen] { return static_cast<U>(d(gen)); });
-}
-
-template <typename T, typename Enable = void>
-struct GenerateRandom {};
-
-template <typename T>
-struct GenerateRandom<T, typename std::enable_if<std::is_integral<T>::value>::type> {
-  static void Gen(int64_t length, uint32_t seed, void* out) {
-    rand_uniform_int(length, seed, std::numeric_limits<T>::min(),
-                     std::numeric_limits<T>::max(), reinterpret_cast<T*>(out));
-  }
-};
-
-template <typename T>
-Status MakeRandomBuffer(int64_t length, MemoryPool* pool,
-                        std::shared_ptr<ResizableBuffer>* out, uint32_t seed = 0) {
-  DCHECK(pool);
-  std::shared_ptr<ResizableBuffer> result;
-  RETURN_NOT_OK(AllocateResizableBuffer(pool, sizeof(T) * length, &result));
-  GenerateRandom<T>::Gen(length, seed, result->mutable_data());
-  *out = result;
-  return Status::OK();
-}
+ARROW_EXPORT uint64_t random_seed();
 
 template <class T, class Builder>
 Status MakeArray(const std::vector<uint8_t>& valid_bytes, const std::vector<T>& values,

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -30,6 +30,7 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/key_value_metadata.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -19,8 +19,10 @@
 
 #include <climits>
 #include <cstddef>
+#include <ostream>
 #include <sstream>  // IWYU pragma: keep
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -118,6 +120,11 @@ bool DataType::Equals(const std::shared_ptr<DataType>& other) const {
   return Equals(*other.get());
 }
 
+std::ostream& operator<<(std::ostream& os, const DataType& type) {
+  os << type.ToString();
+  return os;
+}
+
 std::string BooleanType::ToString() const { return name(); }
 
 FloatingPoint::Precision HalfFloatType::precision() const { return FloatingPoint::HALF; }
@@ -189,6 +196,24 @@ std::string Time64Type::ToString() const {
   std::stringstream ss;
   ss << "time64[" << this->unit_ << "]";
   return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& os, TimeUnit::type unit) {
+  switch (unit) {
+    case TimeUnit::SECOND:
+      os << "s";
+      break;
+    case TimeUnit::MILLI:
+      os << "ms";
+      break;
+    case TimeUnit::MICRO:
+      os << "us";
+      break;
+    case TimeUnit::NANO:
+      os << "ns";
+      break;
+  }
+  return os;
 }
 
 // ----------------------------------------------------------------------
@@ -271,10 +296,20 @@ int LookupNameIndex(const std::unordered_multimap<std::string, int>& name_to_ind
 
 }  // namespace
 
+class StructType::Impl {
+ public:
+  explicit Impl(const std::vector<std::shared_ptr<Field>>& fields)
+      : name_to_index_(CreateNameToIndexMap(fields)) {}
+
+  const std::unordered_multimap<std::string, int> name_to_index_;
+};
+
 StructType::StructType(const std::vector<std::shared_ptr<Field>>& fields)
-    : NestedType(Type::STRUCT), name_to_index_(CreateNameToIndexMap(fields)) {
+    : NestedType(Type::STRUCT), impl_(new Impl(fields)) {
   children_ = fields;
 }
+
+StructType::~StructType() {}
 
 std::string StructType::ToString() const {
   std::stringstream s;
@@ -296,12 +331,12 @@ std::shared_ptr<Field> StructType::GetFieldByName(const std::string& name) const
 }
 
 int StructType::GetFieldIndex(const std::string& name) const {
-  return LookupNameIndex(name_to_index_, name);
+  return LookupNameIndex(impl_->name_to_index_, name);
 }
 
 std::vector<int> StructType::GetAllFieldIndices(const std::string& name) const {
   std::vector<int> result;
-  auto p = name_to_index_.equal_range(name);
+  auto p = impl_->name_to_index_.equal_range(name);
   for (auto it = p.first; it != p.second; ++it) {
     result.push_back(it->second);
   }
@@ -311,7 +346,7 @@ std::vector<int> StructType::GetAllFieldIndices(const std::string& name) const {
 std::vector<std::shared_ptr<Field>> StructType::GetAllFieldsByName(
     const std::string& name) const {
   std::vector<std::shared_ptr<Field>> result;
-  auto p = name_to_index_.equal_range(name);
+  auto p = impl_->name_to_index_.equal_range(name);
   for (auto it = p.first; it != p.second; ++it) {
     result.push_back(children_[it->second]);
   }
@@ -371,17 +406,44 @@ std::string NullType::ToString() const { return name(); }
 // ----------------------------------------------------------------------
 // Schema implementation
 
+class Schema::Impl {
+ public:
+  Impl(const std::vector<std::shared_ptr<Field>>& fields,
+       const std::shared_ptr<const KeyValueMetadata>& metadata)
+      : fields_(fields),
+        name_to_index_(CreateNameToIndexMap(fields_)),
+        metadata_(metadata) {}
+
+  Impl(std::vector<std::shared_ptr<Field>>&& fields,
+       const std::shared_ptr<const KeyValueMetadata>& metadata)
+      : fields_(std::move(fields)),
+        name_to_index_(CreateNameToIndexMap(fields_)),
+        metadata_(metadata) {}
+
+  std::vector<std::shared_ptr<Field>> fields_;
+  std::unordered_multimap<std::string, int> name_to_index_;
+  std::shared_ptr<const KeyValueMetadata> metadata_;
+};
+
 Schema::Schema(const std::vector<std::shared_ptr<Field>>& fields,
                const std::shared_ptr<const KeyValueMetadata>& metadata)
-    : fields_(fields),
-      name_to_index_(CreateNameToIndexMap(fields_)),
-      metadata_(metadata) {}
+    : impl_(new Impl(fields, metadata)) {}
 
 Schema::Schema(std::vector<std::shared_ptr<Field>>&& fields,
                const std::shared_ptr<const KeyValueMetadata>& metadata)
-    : fields_(std::move(fields)),
-      name_to_index_(CreateNameToIndexMap(fields_)),
-      metadata_(metadata) {}
+    : impl_(new Impl(std::move(fields), metadata)) {}
+
+Schema::Schema(const Schema& schema) : impl_(new Impl(*schema.impl_)) {}
+
+Schema::~Schema() {}
+
+int Schema::num_fields() const { return static_cast<int>(impl_->fields_.size()); }
+
+std::shared_ptr<Field> Schema::field(int i) const { return impl_->fields_[i]; }
+
+const std::vector<std::shared_ptr<Field>>& Schema::fields() const {
+  return impl_->fields_;
+}
 
 bool Schema::Equals(const Schema& other, bool check_metadata) const {
   if (this == &other) {
@@ -402,7 +464,7 @@ bool Schema::Equals(const Schema& other, bool check_metadata) const {
   if (!check_metadata) {
     return true;
   } else if (this->HasMetadata() && other.HasMetadata()) {
-    return metadata_->Equals(*other.metadata_);
+    return impl_->metadata_->Equals(*other.impl_->metadata_);
   } else if (!this->HasMetadata() && !other.HasMetadata()) {
     return true;
   } else {
@@ -412,16 +474,16 @@ bool Schema::Equals(const Schema& other, bool check_metadata) const {
 
 std::shared_ptr<Field> Schema::GetFieldByName(const std::string& name) const {
   int i = GetFieldIndex(name);
-  return i == -1 ? nullptr : fields_[i];
+  return i == -1 ? nullptr : impl_->fields_[i];
 }
 
 int Schema::GetFieldIndex(const std::string& name) const {
-  return LookupNameIndex(name_to_index_, name);
+  return LookupNameIndex(impl_->name_to_index_, name);
 }
 
 std::vector<int> Schema::GetAllFieldIndices(const std::string& name) const {
   std::vector<int> result;
-  auto p = name_to_index_.equal_range(name);
+  auto p = impl_->name_to_index_.equal_range(name);
   for (auto it = p.first; it != p.second; ++it) {
     result.push_back(it->second);
   }
@@ -431,9 +493,9 @@ std::vector<int> Schema::GetAllFieldIndices(const std::string& name) const {
 std::vector<std::shared_ptr<Field>> Schema::GetAllFieldsByName(
     const std::string& name) const {
   std::vector<std::shared_ptr<Field>> result;
-  auto p = name_to_index_.equal_range(name);
+  auto p = impl_->name_to_index_.equal_range(name);
   for (auto it = p.first; it != p.second; ++it) {
-    result.push_back(fields_[it->second]);
+    result.push_back(impl_->fields_[it->second]);
   }
   return result;
 }
@@ -444,8 +506,8 @@ Status Schema::AddField(int i, const std::shared_ptr<Field>& field,
     return Status::Invalid("Invalid column index to add field.");
   }
 
-  *out =
-      std::make_shared<Schema>(internal::AddVectorElement(fields_, i, field), metadata_);
+  *out = std::make_shared<Schema>(internal::AddVectorElement(impl_->fields_, i, field),
+                                  impl_->metadata_);
   return Status::OK();
 }
 
@@ -455,24 +517,26 @@ Status Schema::SetField(int i, const std::shared_ptr<Field>& field,
     return Status::Invalid("Invalid column index to add field.");
   }
 
-  *out = std::make_shared<Schema>(internal::ReplaceVectorElement(fields_, i, field),
-                                  metadata_);
+  *out = std::make_shared<Schema>(
+      internal::ReplaceVectorElement(impl_->fields_, i, field), impl_->metadata_);
   return Status::OK();
 }
 
 bool Schema::HasMetadata() const {
-  return (metadata_ != nullptr) && (metadata_->size() > 0);
+  return (impl_->metadata_ != nullptr) && (impl_->metadata_->size() > 0);
 }
 
 std::shared_ptr<Schema> Schema::AddMetadata(
     const std::shared_ptr<const KeyValueMetadata>& metadata) const {
-  return std::make_shared<Schema>(fields_, metadata);
+  return std::make_shared<Schema>(impl_->fields_, metadata);
 }
 
-std::shared_ptr<const KeyValueMetadata> Schema::metadata() const { return metadata_; }
+std::shared_ptr<const KeyValueMetadata> Schema::metadata() const {
+  return impl_->metadata_;
+}
 
 std::shared_ptr<Schema> Schema::RemoveMetadata() const {
-  return std::make_shared<Schema>(fields_);
+  return std::make_shared<Schema>(impl_->fields_);
 }
 
 Status Schema::RemoveField(int i, std::shared_ptr<Schema>* out) const {
@@ -480,7 +544,8 @@ Status Schema::RemoveField(int i, std::shared_ptr<Schema>* out) const {
     return Status::Invalid("Invalid column index to remove field.");
   }
 
-  *out = std::make_shared<Schema>(internal::DeleteVectorElement(fields_, i), metadata_);
+  *out = std::make_shared<Schema>(internal::DeleteVectorElement(impl_->fields_, i),
+                                  impl_->metadata_);
   return Status::OK();
 }
 
@@ -488,7 +553,7 @@ std::string Schema::ToString() const {
   std::stringstream buffer;
 
   int i = 0;
-  for (auto field : fields_) {
+  for (const auto& field : impl_->fields_) {
     if (i > 0) {
       buffer << std::endl;
     }
@@ -496,8 +561,8 @@ std::string Schema::ToString() const {
     ++i;
   }
 
-  if (metadata_) {
-    buffer << metadata_->ToString();
+  if (impl_->metadata_) {
+    buffer << impl_->metadata_->ToString();
   }
 
   return buffer.str();
@@ -505,7 +570,7 @@ std::string Schema::ToString() const {
 
 std::vector<std::string> Schema::field_names() const {
   std::vector<std::string> names;
-  for (auto& field : fields_) {
+  for (const auto& field : impl_->fields_) {
     names.push_back(field->name());
   }
   return names;

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -27,6 +27,7 @@ namespace arrow {
 class Status;
 
 class DataType;
+class KeyValueMetadata;
 class Array;
 struct ArrayData;
 class ArrayBuilder;

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <sstream>
 
 #include <brotli/decode.h>
 #include <brotli/encode.h>

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <sstream>
 
 #include <lz4.h>
 #include <lz4frame.h>

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <sstream>
 
 #include <snappy.h>
 

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <string>
 
 #include <zconf.h>

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -19,7 +19,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <sstream>
 
 #include <zstd.h>
 

--- a/cpp/src/arrow/util/concatenate.cc
+++ b/cpp/src/arrow/util/concatenate.cc
@@ -25,6 +25,7 @@
 
 #include "arrow/array.h"
 #include "arrow/memory_pool.h"
+#include "arrow/status.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/visibility.h"
 #include "arrow/visitor_inline.h"

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <iomanip>
 #include <limits>
+#include <ostream>
 #include <sstream>
 #include <string>
 
@@ -432,6 +433,11 @@ Status Decimal128::ToArrowStatus(DecimalStatus dstatus) const {
       break;
   }
   return status;
+}
+
+std::ostream& operator<<(std::ostream& os, const Decimal128& decimal) {
+  os << decimal.ToIntegerString();
+  return os;
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -17,10 +17,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstdint>
+#include <iosfwd>
 #include <limits>
-#include <sstream>
 #include <string>
 #include <type_traits>
 
@@ -123,10 +122,8 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
     return Status::OK();
   }
 
-  friend std::ostream& operator<<(std::ostream& os, const Decimal128& decimal) {
-    os << decimal.ToIntegerString();
-    return os;
-  }
+  friend ARROW_EXPORT std::ostream& operator<<(std::ostream& os,
+                                               const Decimal128& decimal);
 
  private:
   /// Converts internal error code to Status

--- a/cpp/src/arrow/util/io-util.h
+++ b/cpp/src/arrow/util/io-util.h
@@ -18,40 +18,30 @@
 #ifndef ARROW_UTIL_IO_UTIL_H
 #define ARROW_UTIL_IO_UTIL_H
 
-#include <iostream>
 #include <memory>
 #include <string>
 
-#include "arrow/buffer.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/status.h"
 
-#if defined(_MSC_VER)
-#include <boost/filesystem.hpp>  // NOLINT
-#endif
-
 namespace arrow {
+
+class Buffer;
+
 namespace io {
 
 // Output stream that just writes to stdout.
 class ARROW_EXPORT StdoutStream : public OutputStream {
  public:
-  StdoutStream() : pos_(0) { set_mode(FileMode::WRITE); }
+  StdoutStream();
   ~StdoutStream() override {}
 
-  Status Close() override { return Status::OK(); }
-  bool closed() const override { return false; }
+  Status Close() override;
+  bool closed() const override;
 
-  Status Tell(int64_t* position) const override {
-    *position = pos_;
-    return Status::OK();
-  }
+  Status Tell(int64_t* position) const override;
 
-  Status Write(const void* data, int64_t nbytes) override {
-    pos_ += nbytes;
-    std::cout.write(reinterpret_cast<const char*>(data), nbytes);
-    return Status::OK();
-  }
+  Status Write(const void* data, int64_t nbytes) override;
 
  private:
   int64_t pos_;
@@ -60,22 +50,15 @@ class ARROW_EXPORT StdoutStream : public OutputStream {
 // Output stream that just writes to stderr.
 class ARROW_EXPORT StderrStream : public OutputStream {
  public:
-  StderrStream() : pos_(0) { set_mode(FileMode::WRITE); }
+  StderrStream();
   ~StderrStream() override {}
 
-  Status Close() override { return Status::OK(); }
-  bool closed() const override { return false; }
+  Status Close() override;
+  bool closed() const override;
 
-  Status Tell(int64_t* position) const override {
-    *position = pos_;
-    return Status::OK();
-  }
+  Status Tell(int64_t* position) const override;
 
-  Status Write(const void* data, int64_t nbytes) override {
-    pos_ += nbytes;
-    std::cerr.write(reinterpret_cast<const char*>(data), nbytes);
-    return Status::OK();
-  }
+  Status Write(const void* data, int64_t nbytes) override;
 
  private:
   int64_t pos_;
@@ -84,38 +67,17 @@ class ARROW_EXPORT StderrStream : public OutputStream {
 // Input stream that just reads from stdin.
 class ARROW_EXPORT StdinStream : public InputStream {
  public:
-  StdinStream() : pos_(0) { set_mode(FileMode::READ); }
+  StdinStream();
   ~StdinStream() override {}
 
-  Status Close() override { return Status::OK(); }
-  bool closed() const override { return false; }
+  Status Close() override;
+  bool closed() const override;
 
-  Status Tell(int64_t* position) const override {
-    *position = pos_;
-    return Status::OK();
-  }
+  Status Tell(int64_t* position) const override;
 
-  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override {
-    std::cin.read(reinterpret_cast<char*>(out), nbytes);
-    if (std::cin) {
-      *bytes_read = nbytes;
-      pos_ += nbytes;
-    } else {
-      *bytes_read = 0;
-    }
-    return Status::OK();
-  }
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
 
-  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override {
-    std::shared_ptr<ResizableBuffer> buffer;
-    ARROW_RETURN_NOT_OK(AllocateResizableBuffer(nbytes, &buffer));
-    int64_t bytes_read;
-    ARROW_RETURN_NOT_OK(Read(nbytes, &bytes_read, buffer->mutable_data()));
-    ARROW_RETURN_NOT_OK(buffer->Resize(bytes_read, false));
-    buffer->ZeroPadding();
-    *out = buffer;
-    return Status::OK();
-  }
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
  private:
   int64_t pos_;
@@ -125,26 +87,34 @@ class ARROW_EXPORT StdinStream : public InputStream {
 
 namespace internal {
 
+class ARROW_EXPORT PlatformFilename {
+ public:
+  ~PlatformFilename();
+  PlatformFilename();
+  PlatformFilename(const PlatformFilename&);
+  PlatformFilename(PlatformFilename&&);
+  PlatformFilename& operator=(const PlatformFilename&);
+  PlatformFilename& operator=(PlatformFilename&&);
+
 #if defined(_MSC_VER)
-// namespace fs = boost::filesystem;
-// #define PlatformFilename fs::path
-typedef ::boost::filesystem::path PlatformFilename;
-
+  const std::wstring& ToNative() const;
 #else
-
-struct PlatformFilename {
-  PlatformFilename() {}
-  explicit PlatformFilename(const std::string& path) { utf8_path = path; }
-
-  const char* c_str() const { return utf8_path.c_str(); }
-
-  const std::string& string() const { return utf8_path; }
-
-  size_t length() const { return utf8_path.size(); }
-
-  std::string utf8_path;
-};
+  const std::string& ToNative() const;
 #endif
+  std::string ToString() const;
+
+  static Status FromString(const std::string& file_name, PlatformFilename* out);
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+
+#if defined(_MSC_VER)
+  explicit PlatformFilename(const std::wstring& path);
+#else
+  explicit PlatformFilename(const std::string& path);
+#endif
+};
 
 ARROW_EXPORT
 Status FileNameFromString(const std::string& file_name, PlatformFilename* out);

--- a/cpp/src/arrow/util/lazy-benchmark.cc
+++ b/cpp/src/arrow/util/lazy-benchmark.cc
@@ -21,6 +21,7 @@
 
 #include <benchmark/benchmark.h>
 
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/lazy.h"
 

--- a/cpp/src/arrow/util/lazy-test.cc
+++ b/cpp/src/arrow/util/lazy-test.cc
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/lazy.h"
 

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -36,8 +36,8 @@
 
 #else  // !GANDIVA_IR
 
-#include <iostream>
 #include <memory>
+#include <ostream>
 #include <string>
 
 #include "arrow/util/macros.h"
@@ -153,19 +153,18 @@ class ARROW_EXPORT ArrowLogBase {
   }
 
  protected:
-  virtual std::ostream& Stream() { return std::cerr; }
+  virtual std::ostream& Stream() = 0;
 };
 
 class ARROW_EXPORT ArrowLog : public ArrowLogBase {
  public:
   ArrowLog(const char* file_name, int line_number, ArrowLogLevel severity);
-
-  virtual ~ArrowLog();
+  ~ArrowLog() override;
 
   /// Return whether or not current logging instance is enabled.
   ///
   /// \return True if logging is enabled and false otherwise.
-  virtual bool IsEnabled() const;
+  bool IsEnabled() const override;
 
   /// The init function of arrow log for a program which should be called only once.
   ///
@@ -204,7 +203,7 @@ class ARROW_EXPORT ArrowLog : public ArrowLogBase {
   static ArrowLogLevel severity_threshold_;
 
  protected:
-  virtual std::ostream& Stream();
+  std::ostream& Stream() override;
 };
 
 // This class make ARROW_CHECK compilation pass to change the << operator to void.

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -23,9 +23,7 @@
 #include <cassert>
 #include <chrono>
 #include <limits>
-#include <locale>
 #include <memory>
-#include <sstream>
 #include <string>
 #include <type_traits>
 

--- a/cpp/src/arrow/util/string_builder.cc
+++ b/cpp/src/arrow/util/string_builder.cc
@@ -15,26 +15,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Non-public header
+#include "arrow/util/string_builder.h"
 
-#ifndef ARROW_GPU_CUDA_COMMON_H
-#define ARROW_GPU_CUDA_COMMON_H
+#include <sstream>
 
-#include <cuda.h>
+#include "arrow/util/stl.h"
 
 namespace arrow {
-namespace cuda {
 
-#define CU_RETURN_NOT_OK(STMT)                                                  \
-  do {                                                                          \
-    CUresult ret = (STMT);                                                      \
-    if (ret != CUDA_SUCCESS) {                                                  \
-      return Status::IOError("Cuda Driver API call in ", __FILE__, " at line ", \
-                             __LINE__, " failed with code ", ret, ": ", #STMT); \
-    }                                                                           \
-  } while (0)
+using internal::make_unique;
 
-}  // namespace cuda
+namespace util {
+namespace detail {
+
+StringStreamWrapper::StringStreamWrapper()
+    : sstream_(make_unique<std::ostringstream>()), ostream_(*sstream_) {}
+
+StringStreamWrapper::~StringStreamWrapper() {}
+
+std::string StringStreamWrapper::str() { return sstream_->str(); }
+
+}  // namespace detail
+}  // namespace util
 }  // namespace arrow
-
-#endif  // ARROW_GPU_CUDA_COMMON_H

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -18,31 +18,49 @@
 #ifndef ARROW_UTIL_STRING_BUILDER_H
 #define ARROW_UTIL_STRING_BUILDER_H
 
-#include <sstream>
+#include <memory>
+#include <ostream>
 #include <string>
 #include <utility>
+
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace util {
 
+namespace detail {
+
+class ARROW_EXPORT StringStreamWrapper {
+ public:
+  StringStreamWrapper();
+  ~StringStreamWrapper();
+
+  std::ostream& stream() { return ostream_; }
+  std::string str();
+
+ protected:
+  std::unique_ptr<std::ostringstream> sstream_;
+  std::ostream& ostream_;
+};
+
+}  // namespace detail
+
 template <typename Head>
-void StringBuilderRecursive(std::stringstream& stream, Head&& head) {
+void StringBuilderRecursive(std::ostream& stream, Head&& head) {
   stream << head;
 }
 
 template <typename Head, typename... Tail>
-void StringBuilderRecursive(std::stringstream& stream, Head&& head, Tail&&... tail) {
+void StringBuilderRecursive(std::ostream& stream, Head&& head, Tail&&... tail) {
   StringBuilderRecursive(stream, std::forward<Head>(head));
   StringBuilderRecursive(stream, std::forward<Tail>(tail)...);
 }
 
 template <typename... Args>
 std::string StringBuilder(Args&&... args) {
-  std::stringstream stream;
-
-  StringBuilderRecursive(stream, std::forward<Args>(args)...);
-
-  return stream.str();
+  detail::StringStreamWrapper ss;
+  StringBuilderRecursive(ss.stream(), std::forward<Args>(args)...);
+  return ss.str();
 }
 
 }  // namespace util

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -24,7 +24,6 @@
 #include "arrow/extension_type.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
-#include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/util/bit-util.h"
 #include "arrow/util/checked_cast.h"

--- a/cpp/src/gandiva/tests/literal_test.cc
+++ b/cpp/src/gandiva/tests/literal_test.cc
@@ -197,7 +197,7 @@ TEST_F(TestLiteral, TestNullLiteralInIf) {
   auto res = field("res", float64());
 
   auto node_a = TreeExprBuilder::MakeField(field_a);
-  auto literal_5 = TreeExprBuilder::MakeLiteral((double_t)5);
+  auto literal_5 = TreeExprBuilder::MakeLiteral(5.0);
   auto a_gt_5 = TreeExprBuilder::MakeFunction("greater_than", {node_a, literal_5},
                                               arrow::boolean());
   auto literal_null = TreeExprBuilder::MakeNull(arrow::float64());

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -15,9 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "gandiva/projector.h"
+#include <cmath>
+
 #include <gtest/gtest.h>
+
 #include "arrow/memory_pool.h"
+
+#include "gandiva/projector.h"
 #include "gandiva/tests/test_util.h"
 #include "gandiva/tree_expr_builder.h"
 

--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -354,16 +354,6 @@ void AssertChunkedEqual(const ChunkedArray& expected, const ChunkedArray& actual
   }
 }
 
-void PrintColumn(const Column& col, std::stringstream* ss) {
-  const ChunkedArray& carr = *col.data();
-  for (int i = 0; i < carr.num_chunks(); ++i) {
-    auto c1 = carr.chunk(i);
-    *ss << "Chunk " << i << std::endl;
-    ARROW_EXPECT_OK(::arrow::PrettyPrint(*c1, 0, ss));
-    *ss << std::endl;
-  }
-}
-
 void DoSimpleRoundtrip(const std::shared_ptr<Table>& table, bool use_threads,
                        int64_t row_group_size, const std::vector<int>& column_subset,
                        std::shared_ptr<Table>* out,

--- a/cpp/src/parquet/arrow/test-util.h
+++ b/cpp/src/parquet/arrow/test-util.h
@@ -26,6 +26,7 @@
 
 #include "arrow/api.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"
 


### PR DESCRIPTION
This is a first attempt at making our headers lighter-weight.

The benefits are currently meagre: I get a 4% speedup when compiling Arrow + Parquet.