### PR TITLE
ARROW-5311: [C++] use more specific error status types in take

### DIFF
--- a/c_glib/arrow-glib/error.cpp
+++ b/c_glib/arrow-glib/error.cpp
@@ -57,8 +57,6 @@ static GArrowError garrow_error_code(const arrow::Status& status) {
       return GARROW_ERROR_CAPACITY;
     case arrow::StatusCode::IndexError:
       return GARROW_ERROR_INDEX;
-    case arrow::StatusCode::IndexError:
-      return GARROW_ERROR_INDEX;
     case arrow::StatusCode::UnknownError:
       return GARROW_ERROR_UNKNOWN;
     case arrow::StatusCode::NotImplemented:

--- a/c_glib/arrow-glib/error.cpp
+++ b/c_glib/arrow-glib/error.cpp
@@ -18,7 +18,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#  include <config.h>
+#include <config.h>
 #endif
 
 #include <arrow-glib/error.hpp>
@@ -37,78 +37,70 @@ G_BEGIN_DECLS
  * values.
  */
 
-G_DEFINE_QUARK(garrow-error-quark, garrow_error)
+G_DEFINE_QUARK(garrow - error - quark, garrow_error)
 
-static GArrowError
-garrow_error_code(const arrow::Status &status)
-{
+static GArrowError garrow_error_code(const arrow::Status& status) {
   switch (status.code()) {
-  case arrow::StatusCode::OK:
-    return GARROW_ERROR_UNKNOWN;
-  case arrow::StatusCode::OutOfMemory:
-    return GARROW_ERROR_OUT_OF_MEMORY;
-  case arrow::StatusCode::KeyError:
-    return GARROW_ERROR_KEY;
-  case arrow::StatusCode::TypeError:
-    return GARROW_ERROR_TYPE;
-  case arrow::StatusCode::Invalid:
-    return GARROW_ERROR_INVALID;
-  case arrow::StatusCode::IOError:
-    return GARROW_ERROR_IO;
-  case arrow::StatusCode::CapacityError:
-    return GARROW_ERROR_CAPACITY;
-  case arrow::StatusCode::UnknownError:
-    return GARROW_ERROR_UNKNOWN;
-  case arrow::StatusCode::NotImplemented:
-    return GARROW_ERROR_NOT_IMPLEMENTED;
-  case arrow::StatusCode::SerializationError:
-    return GARROW_ERROR_SERIALIZATION;
-  case arrow::StatusCode::PythonError:
-    return GARROW_ERROR_PYTHON;
-  case arrow::StatusCode::PlasmaObjectExists:
-    return GARROW_ERROR_PLASMA_OBJECT_EXISTS;
-  case arrow::StatusCode::PlasmaObjectNonexistent:
-    return GARROW_ERROR_PLASMA_OBJECT_NONEXISTENT;
-  case arrow::StatusCode::PlasmaStoreFull:
-    return GARROW_ERROR_PLASMA_STORE_FULL;
-  case arrow::StatusCode::PlasmaObjectAlreadySealed:
-    return GARROW_ERROR_PLASMA_OBJECT_ALREADY_SEALED;
-  case arrow::StatusCode::CodeGenError:
-    return GARROW_ERROR_CODE_GENERATION;
-  case arrow::StatusCode::ExpressionValidationError:
-    return GARROW_ERROR_EXPRESSION_VALIDATION;
-  case arrow::StatusCode::ExecutionError:
-    return GARROW_ERROR_EXECUTION;
-  default:
-    return GARROW_ERROR_UNKNOWN;
+    case arrow::StatusCode::OK:
+      return GARROW_ERROR_UNKNOWN;
+    case arrow::StatusCode::OutOfMemory:
+      return GARROW_ERROR_OUT_OF_MEMORY;
+    case arrow::StatusCode::KeyError:
+      return GARROW_ERROR_KEY;
+    case arrow::StatusCode::TypeError:
+      return GARROW_ERROR_TYPE;
+    case arrow::StatusCode::Invalid:
+      return GARROW_ERROR_INVALID;
+    case arrow::StatusCode::IOError:
+      return GARROW_ERROR_IO;
+    case arrow::StatusCode::CapacityError:
+      return GARROW_ERROR_CAPACITY;
+    case arrow::StatusCode::IndexError:
+      return GARROW_ERROR_INDEX;
+    case arrow::StatusCode::IndexError:
+      return GARROW_ERROR_INDEX;
+    case arrow::StatusCode::UnknownError:
+      return GARROW_ERROR_UNKNOWN;
+    case arrow::StatusCode::NotImplemented:
+      return GARROW_ERROR_NOT_IMPLEMENTED;
+    case arrow::StatusCode::SerializationError:
+      return GARROW_ERROR_SERIALIZATION;
+    case arrow::StatusCode::PythonError:
+      return GARROW_ERROR_PYTHON;
+    case arrow::StatusCode::PlasmaObjectExists:
+      return GARROW_ERROR_PLASMA_OBJECT_EXISTS;
+    case arrow::StatusCode::PlasmaObjectNonexistent:
+      return GARROW_ERROR_PLASMA_OBJECT_NONEXISTENT;
+    case arrow::StatusCode::PlasmaStoreFull:
+      return GARROW_ERROR_PLASMA_STORE_FULL;
+    case arrow::StatusCode::PlasmaObjectAlreadySealed:
+      return GARROW_ERROR_PLASMA_OBJECT_ALREADY_SEALED;
+    case arrow::StatusCode::CodeGenError:
+      return GARROW_ERROR_CODE_GENERATION;
+    case arrow::StatusCode::ExpressionValidationError:
+      return GARROW_ERROR_EXPRESSION_VALIDATION;
+    case arrow::StatusCode::ExecutionError:
+      return GARROW_ERROR_EXECUTION;
+    default:
+      return GARROW_ERROR_UNKNOWN;
   }
 }
 
 G_END_DECLS
 
-gboolean
-garrow_error_check(GError **error,
-                   const arrow::Status &status,
-                   const char *context)
-{
+gboolean garrow_error_check(GError** error, const arrow::Status& status,
+                            const char* context) {
   if (status.ok()) {
     return TRUE;
   } else {
-    g_set_error(error,
-                GARROW_ERROR,
-                garrow_error_code(status),
-                "%s: %s",
-                context,
+    g_set_error(error, GARROW_ERROR, garrow_error_code(status), "%s: %s", context,
                 status.ToString().c_str());
     return FALSE;
   }
 }
 
-arrow::Status
-garrow_error_to_status(GError *error,
-                       arrow::StatusCode code,
-                       const char *context)
-{
+arrow::Status garrow_error_to_status(GError* error, arrow::StatusCode code,
+                                     const char* context) {
   std::stringstream message;
   message << context << ": " << g_quark_to_string(error->domain);
   message << "(" << error->code << "): ";

--- a/c_glib/arrow-glib/error.h
+++ b/c_glib/arrow-glib/error.h
@@ -31,6 +31,7 @@ G_BEGIN_DECLS
  * @GARROW_ERROR_INVALID: Invalid value error.
  * @GARROW_ERROR_IO: IO error.
  * @GARROW_ERROR_CAPACITY: Capacity error.
+ * @GARROW_ERROR_INDEX: Index error.
  * @GARROW_ERROR_UNKNOWN: Unknown error.
  * @GARROW_ERROR_NOT_IMPLEMENTED: The feature is not implemented.
  * @GARROW_ERROR_SERIALIZATION: Serialization error.
@@ -41,8 +42,10 @@ G_BEGIN_DECLS
  * @GARROW_ERROR_PLASMA_OBJECT_ALREADY_SEALED: Object already sealed on Plasma.
  * @GARROW_ERROR_CODE_GENERATION: Error generating code for expression evaluation
  *   in Gandiva.
- * @GARROW_ERROR_EXPRESSION_VALIDATION: Validation errors in expression given for code generation.
- * @GARROW_ERROR_EXECUTION: Execution error while evaluating the expression against a record batch.
+ * @GARROW_ERROR_EXPRESSION_VALIDATION: Validation errors in expression given for code
+ * generation.
+ * @GARROW_ERROR_EXECUTION: Execution error while evaluating the expression against a
+ * record batch.
  *
  * The error codes are used by all arrow-glib functions.
  *
@@ -55,6 +58,7 @@ typedef enum {
   GARROW_ERROR_INVALID,
   GARROW_ERROR_IO,
   GARROW_ERROR_CAPACITY,
+  GARROW_ERROR_INDEX,
   GARROW_ERROR_UNKNOWN = 9,
   GARROW_ERROR_NOT_IMPLEMENTED,
   GARROW_ERROR_SERIALIZATION,

--- a/c_glib/test/test-take.rb
+++ b/c_glib/test/test-take.rb
@@ -36,7 +36,7 @@ class TestTake < Test::Unit::TestCase
   def test_out_of_index
     require_gi(1, 42, 0)
     indices = build_int16_array([1, 2, 3])
-    assert_raise(Arrow::Error::Invalid) do
+    assert_raise(Arrow::Error::KeyError) do
       build_int16_array([0, 1, 2]).take(indices)
     end
   end

--- a/c_glib/test/test-take.rb
+++ b/c_glib/test/test-take.rb
@@ -36,7 +36,7 @@ class TestTake < Test::Unit::TestCase
   def test_out_of_index
     require_gi(1, 42, 0)
     indices = build_int16_array([1, 2, 3])
-    assert_raise(Arrow::Error::KeyError) do
+    assert_raise(Arrow::Error::Index) do
       build_int16_array([0, 1, 2]).take(indices)
     end
   end

--- a/cpp/src/arrow/compute/kernels/take-test.cc
+++ b/cpp/src/arrow/compute/kernels/take-test.cc
@@ -72,8 +72,8 @@ TEST_F(TestTakeKernelWithNull, TakeNull) {
   this->AssertTake("[null, null, null]", "[0, 1, 0]", options, "[null, null, null]");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(KeyError, this->Take(null(), "[null, null, null]", int8(), "[0, 9, 0]",
-                                     options, &arr));
+  ASSERT_RAISES(IndexError, this->Take(null(), "[null, null, null]", int8(), "[0, 9, 0]",
+                                       options, &arr));
 }
 
 TEST_F(TestTakeKernelWithNull, InvalidIndexType) {
@@ -99,8 +99,8 @@ TEST_F(TestTakeKernelWithBoolean, TakeBoolean) {
   this->AssertTake("[true, false, true]", "[null, 1, 0]", options, "[null, false, true]");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(KeyError, this->Take(boolean(), "[true, false, true]", int8(),
-                                     "[0, 9, 0]", options, &arr));
+  ASSERT_RAISES(IndexError, this->Take(boolean(), "[true, false, true]", int8(),
+                                       "[0, 9, 0]", options, &arr));
 }
 
 template <typename ArrowType>
@@ -124,8 +124,8 @@ TYPED_TEST(TestTakeKernelWithNumeric, TakeNumeric) {
   this->AssertTake("[7, 8, 9]", "[null, 1, 0]", options, "[null, 8, 7]");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(KeyError, this->Take(this->type_singleton(), "[7, 8, 9]", int8(),
-                                     "[0, 9, 0]", options, &arr));
+  ASSERT_RAISES(IndexError, this->Take(this->type_singleton(), "[7, 8, 9]", int8(),
+                                       "[0, 9, 0]", options, &arr));
 }
 
 class TestTakeKernelWithString : public TestTakeKernel<StringType> {
@@ -156,8 +156,8 @@ TEST_F(TestTakeKernelWithString, TakeString) {
   this->AssertTake(R"(["a", "b", "c"])", "[null, 1, 0]", options, R"([null, "b", "a"])");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(KeyError, this->Take(utf8(), R"(["a", "b", "c"])", int8(), "[0, 9, 0]",
-                                     options, &arr));
+  ASSERT_RAISES(IndexError, this->Take(utf8(), R"(["a", "b", "c"])", int8(), "[0, 9, 0]",
+                                       options, &arr));
 }
 
 TEST_F(TestTakeKernelWithString, TakeDictionary) {

--- a/cpp/src/arrow/compute/kernels/take-test.cc
+++ b/cpp/src/arrow/compute/kernels/take-test.cc
@@ -72,8 +72,15 @@ TEST_F(TestTakeKernelWithNull, TakeNull) {
   this->AssertTake("[null, null, null]", "[0, 1, 0]", options, "[null, null, null]");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(Invalid, this->Take(null(), "[null, null, null]", int8(), "[0, 9, 0]",
-                                    options, &arr));
+  ASSERT_RAISES(KeyError, this->Take(null(), "[null, null, null]", int8(), "[0, 9, 0]",
+                                     options, &arr));
+}
+
+TEST_F(TestTakeKernelWithNull, InvalidIndexType) {
+  TakeOptions options;
+  std::shared_ptr<Array> arr;
+  ASSERT_RAISES(TypeError, this->Take(null(), "[null, null, null]", float32(),
+                                      "[0.0, 1.0, 0.1]", options, &arr));
 }
 
 class TestTakeKernelWithBoolean : public TestTakeKernel<BooleanType> {
@@ -92,8 +99,8 @@ TEST_F(TestTakeKernelWithBoolean, TakeBoolean) {
   this->AssertTake("[true, false, true]", "[null, 1, 0]", options, "[null, false, true]");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(Invalid, this->Take(boolean(), "[true, false, true]", int8(), "[0, 9, 0]",
-                                    options, &arr));
+  ASSERT_RAISES(KeyError, this->Take(boolean(), "[true, false, true]", int8(),
+                                     "[0, 9, 0]", options, &arr));
 }
 
 template <typename ArrowType>
@@ -117,8 +124,8 @@ TYPED_TEST(TestTakeKernelWithNumeric, TakeNumeric) {
   this->AssertTake("[7, 8, 9]", "[null, 1, 0]", options, "[null, 8, 7]");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(Invalid, this->Take(this->type_singleton(), "[7, 8, 9]", int8(),
-                                    "[0, 9, 0]", options, &arr));
+  ASSERT_RAISES(KeyError, this->Take(this->type_singleton(), "[7, 8, 9]", int8(),
+                                     "[0, 9, 0]", options, &arr));
 }
 
 class TestTakeKernelWithString : public TestTakeKernel<StringType> {
@@ -149,8 +156,8 @@ TEST_F(TestTakeKernelWithString, TakeString) {
   this->AssertTake(R"(["a", "b", "c"])", "[null, 1, 0]", options, R"([null, "b", "a"])");
 
   std::shared_ptr<Array> arr;
-  ASSERT_RAISES(Invalid, this->Take(utf8(), R"(["a", "b", "c"])", int8(), "[0, 9, 0]",
-                                    options, &arr));
+  ASSERT_RAISES(KeyError, this->Take(utf8(), R"(["a", "b", "c"])", int8(), "[0, 9, 0]",
+                                     options, &arr));
 }
 
 TEST_F(TestTakeKernelWithString, TakeDictionary) {

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -80,7 +80,7 @@ Status TakeImpl(FunctionContext*, const ValueArray& values, const IndexArray& in
     }
     auto index = static_cast<int64_t>(raw_indices[i]);
     if (index < 0 || index >= values.length()) {
-      return Status::KeyError("take index out of bounds");
+      return Status::IndexError("take index out of bounds");
     }
     if (!AllValuesValid && values.IsNull(index)) {
       builder->UnsafeAppendNull();
@@ -136,7 +136,7 @@ struct UnpackValues {
       auto min = static_cast<int64_t>(*minmax.first);
       auto max = static_cast<int64_t>(*minmax.second);
       if (min < 0 || max >= params_.values->length()) {
-        return Status::KeyError("take index out of bounds");
+        return Status::IndexError("take index out of bounds");
       }
     }
     params_.out->reset(new NullArray(indices_length));

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -80,7 +80,7 @@ Status TakeImpl(FunctionContext*, const ValueArray& values, const IndexArray& in
     }
     auto index = static_cast<int64_t>(raw_indices[i]);
     if (index < 0 || index >= values.length()) {
-      return Status::Invalid("take index out of bounds");
+      return Status::KeyError("take index out of bounds");
     }
     if (!AllValuesValid && values.IsNull(index)) {
       builder->UnsafeAppendNull();
@@ -136,7 +136,7 @@ struct UnpackValues {
       auto min = static_cast<int64_t>(*minmax.first);
       auto max = static_cast<int64_t>(*minmax.second);
       if (min < 0 || max >= params_.values->length()) {
-        return Status::Invalid("out of bounds index");
+        return Status::KeyError("take index out of bounds");
       }
     }
     params_.out->reset(new NullArray(indices_length));
@@ -192,7 +192,7 @@ struct UnpackIndices {
   }
 
   Status Visit(const DataType& other) {
-    return Status::Invalid("index type not supported: ", other);
+    return Status::TypeError("index type not supported: ", other);
   }
 
   const TakeParameters& params_;

--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -107,6 +107,8 @@ Status ConvertPyError(StatusCode code) {
     // Try to match the Python exception type with an appropriate Status code
     if (PyErr_GivenExceptionMatches(exc_type, PyExc_MemoryError)) {
       code = StatusCode::OutOfMemory;
+    } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_IndexError)) {
+      code = StatusCode::IndexError;
     } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_KeyError)) {
       code = StatusCode::KeyError;
     } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_TypeError)) {

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -61,6 +61,9 @@ std::string Status::CodeAsString() const {
     case StatusCode::CapacityError:
       type = "Capacity error";
       break;
+    case StatusCode::IndexError:
+      type = "Index error";
+      break;
     case StatusCode::UnknownError:
       type = "Unknown error";
       break;

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -86,6 +86,7 @@ enum class StatusCode : char {
   Invalid = 4,
   IOError = 5,
   CapacityError = 6,
+  IndexError = 7,
   UnknownError = 9,
   NotImplemented = 10,
   SerializationError = 11,
@@ -195,6 +196,13 @@ class ARROW_EXPORT Status {
 
   /// Return an error status when a container's capacity would exceed its limits
   template <typename... Args>
+  static Status IndexError(Args&&... args) {
+    return Status(StatusCode::IndexError,
+                  util::StringBuilder(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status when a container's capacity would exceed its limits
+  template <typename... Args>
   static Status CapacityError(Args&&... args) {
     return Status(StatusCode::CapacityError,
                   util::StringBuilder(std::forward<Args>(args)...));
@@ -275,6 +283,8 @@ class ARROW_EXPORT Status {
   bool IsIOError() const { return code() == StatusCode::IOError; }
   /// Return true iff the status indicates a container reaching capacity limits.
   bool IsCapacityError() const { return code() == StatusCode::CapacityError; }
+  /// Return true iff the status indicates a container reaching capacity limits.
+  bool IsIndexError() const { return code() == StatusCode::IndexError; }
   /// Return true iff the status indicates a type error.
   bool IsTypeError() const { return code() == StatusCode::TypeError; }
   /// Return true iff the status indicates an unknown error.

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -194,7 +194,7 @@ class ARROW_EXPORT Status {
     return Status(StatusCode::Invalid, util::StringBuilder(std::forward<Args>(args)...));
   }
 
-  /// Return an error status when a container's capacity would exceed its limits
+  /// Return an error status when an index is out of bounds
   template <typename... Args>
   static Status IndexError(Args&&... args) {
     return Status(StatusCode::IndexError,
@@ -283,7 +283,7 @@ class ARROW_EXPORT Status {
   bool IsIOError() const { return code() == StatusCode::IOError; }
   /// Return true iff the status indicates a container reaching capacity limits.
   bool IsCapacityError() const { return code() == StatusCode::CapacityError; }
-  /// Return true iff the status indicates a container reaching capacity limits.
+  /// Return true iff the status indicates an out of bounds index.
   bool IsIndexError() const { return code() == StatusCode::IndexError; }
   /// Return true iff the status indicates a type error.
   bool IsTypeError() const { return code() == StatusCode::TypeError; }

--- a/cpp/src/arrow/util/trie.cc
+++ b/cpp/src/arrow/util/trie.cc
@@ -81,7 +81,9 @@ Status TrieBuilder::AppendChildNode(Trie::Node* parent, uint8_t ch, Trie::Node&&
 
   DCHECK_EQ(trie_.lookup_table_[parent_lookup], -1);
   if (trie_.nodes_.size() >= static_cast<size_t>(kMaxIndex)) {
-    return Status::CapacityError("Trie out of bounds");
+    auto max_capacity = kMaxIndex;
+    return Status::CapacityError("TrieBuilder cannot contain more than ", max_capacity,
+                                 " child nodes");
   }
   trie_.nodes_.push_back(std::move(node));
   trie_.lookup_table_[parent_lookup] = static_cast<index_type>(trie_.nodes_.size() - 1);
@@ -118,7 +120,7 @@ Status TrieBuilder::ExtendLookupTable(index_type* out_index) {
   auto cur_size = trie_.lookup_table_.size();
   auto cur_index = cur_size / 256;
   if (cur_index > static_cast<size_t>(kMaxIndex)) {
-    return Status::CapacityError("Trie out of bounds");
+    return Status::CapacityError("TrieBuilder cannot extend lookup table further");
   }
   trie_.lookup_table_.resize(cur_size + 256, -1);
   *out_index = static_cast<index_type>(cur_index);

--- a/matlab/src/util/handle_status.cc
+++ b/matlab/src/util/handle_status.cc
@@ -59,6 +59,11 @@ void HandleStatus(const arrow::Status& status) {
                         status.ToString().c_str());
       break;
     }
+    case arrow::StatusCode::IndexError: {
+      mexErrMsgIdAndTxt("MATLAB:arrow:status:IndexError", arrow_error_message,
+                        status.ToString().c_str());
+      break;
+    }
     case arrow::StatusCode::UnknownError: {
       mexErrMsgIdAndTxt("MATLAB:arrow:status:UnknownError", arrow_error_message,
                         status.ToString().c_str());

--- a/python/pyarrow/error.pxi
+++ b/python/pyarrow/error.pxi
@@ -52,6 +52,10 @@ class ArrowCapacityError(ArrowException):
     pass
 
 
+class ArrowIndexError(IndexError, ArrowException):
+    pass
+
+
 class PlasmaObjectExists(ArrowException):
     pass
 
@@ -91,6 +95,8 @@ cdef int check_status(const CStatus& status) nogil except -1:
             raise ArrowTypeError(message)
         elif status.IsCapacityError():
             raise ArrowCapacityError(message)
+        elif status.IsIndexError():
+            raise ArrowIndexError(message)
         elif status.IsPlasmaObjectExists():
             raise PlasmaObjectExists(message)
         elif status.IsPlasmaObjectNonexistent():

--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -62,6 +62,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool IsNotImplemented()
         c_bool IsTypeError()
         c_bool IsCapacityError()
+        c_bool IsIndexError()
         c_bool IsSerializationError()
         c_bool IsPythonError()
         c_bool IsPlasmaObjectExists()

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -68,13 +68,11 @@ def test_take(ty, values):
         assert result.equals(expected)
 
     indices = pa.array([2, 5])
-    with pytest.raises(ValueError):
-        # TODO should be IndexError ?
+    with pytest.raises(KeyError):
         arr.take(indices)
 
     indices = pa.array([2, -1])
-    with pytest.raises(ValueError):
-        # TODO should be IndexError ?
+    with pytest.raises(KeyError):
         arr.take(indices)
 
 
@@ -90,7 +88,7 @@ def test_take_indices_types():
 
     for indices_type in [pa.float32(), pa.float64()]:
         indices = pa.array([0, 4, 2], type=indices_type)
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             arr.take(indices)
 
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -68,11 +68,11 @@ def test_take(ty, values):
         assert result.equals(expected)
 
     indices = pa.array([2, 5])
-    with pytest.raises(KeyError):
+    with pytest.raises(IndexError):
         arr.take(indices)
 
     indices = pa.array([2, -1])
-    with pytest.raises(KeyError):
+    with pytest.raises(IndexError):
         arr.take(indices)
 
 

--- a/r/R/enums.R
+++ b/r/R/enums.R
@@ -52,7 +52,7 @@ Type <- enum("arrow::Type::type",
 #' @export
 StatusCode <- enum("arrow::StatusCode",
   OK = 0L, OutOfMemory = 1L, KeyError = 2L, TypeError = 3L,
-  Invalid = 4L, IOError = 5L, CapacityError = 6L,
+  Invalid = 4L, IOError = 5L, CapacityError = 6L, IndexError = 7L,
   UnknownError = 9L, NotImplemented = 10L, SerializationError = 11L,
   PythonError = 12L, RError = 13L,
   PlasmaObjectExists = 20L, PlasmaObjectNonexistent = 21L,


### PR DESCRIPTION
Now emits

- TypeError when indices are not integral
- KeyError when an index is out of bounds