### PR TITLE
ARROW-5317: [Rust] [Parquet] impl IntoIterator for SerializedFileReader

### DIFF
--- a/rust/parquet/src/file/mod.rs
+++ b/rust/parquet/src/file/mod.rs
@@ -77,7 +77,25 @@
 //!     assert_eq!(row_group_reader.num_columns(), 1);
 //! }
 //! ```
-
+//! # Example of reading multiple files
+//!
+//! ```rust,no_run
+//! use parquet::file::reader::SerializedFileReader;
+//! use std::convert::TryFrom;
+//!
+//! let paths = vec![
+//!     "/path/to/sample.parquet/part-1.snappy.parquet",
+//!     "/path/to/sample.parquet/part-2.snappy.parquet"
+//! ];
+//! // Create a reader for each file and flat map rows
+//! let rows = paths.iter()
+//!     .map(|p| SerializedFileReader::try_from(*p).unwrap())
+//!     .flat_map(|r| r.into_iter());
+//!
+//! for row in rows {
+//!     println!("{}", row);
+//! }
+//! ```
 pub mod metadata;
 pub mod properties;
 pub mod reader;

--- a/rust/parquet/src/file/reader.rs
+++ b/rust/parquet/src/file/reader.rs
@@ -810,16 +810,16 @@ mod tests {
     #[test]
     fn test_file_reader_into_iter() -> Result<()> {
         let path = get_test_path("alltypes_plain.parquet");
-        let mut vec = vec![path.clone(), path.clone()]
+        let vec = vec![path.clone(), path.clone()]
             .iter()
             .map(|p| SerializedFileReader::try_from(p.as_path()).unwrap())
             .flat_map(|r| r.into_iter())
             .flat_map(|r| r.get_int(0))
             .collect::<Vec<_>>();
 
-        vec.sort();
-
-        assert_eq!(vec, vec![0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7]);
+        // rows in the parquet file are not sorted by "id"
+        // each file contains [id:4, id:5, id:6, id:7, id:2, id:3, id:0, id:1]
+        assert_eq!(vec, vec![4, 5, 6, 7, 2, 3, 0, 1, 4, 5, 6, 7, 2, 3, 0, 1]);
 
         Ok(())
     }

--- a/rust/parquet/src/record/reader.rs
+++ b/rust/parquet/src/record/reader.rs
@@ -1541,16 +1541,14 @@ mod tests {
     #[test]
     fn test_file_reader_iter() -> Result<()> {
         let path = get_test_path("alltypes_plain.parquet");
-        let mut vec = vec![path]
+        let vec = vec![path]
             .iter()
             .map(|p| SerializedFileReader::try_from(p.as_path()).unwrap())
             .flat_map(|r| Iter::from(r))
             .flat_map(|r| r.get_int(0))
             .collect::<Vec<_>>();
 
-        vec.sort();
-
-        assert_eq!(vec, vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(vec, vec![4, 5, 6, 7, 2, 3, 0, 1]);
 
         Ok(())
     }


### PR DESCRIPTION
This patch adds a row iterator that takes ownership of the reader
and implements IntoIterator for SerializedFileReader

See :
https://github.com/apache/arrow/issues/4301, https://issues.apache.org/jira/browse/ARROW-5317