### PR TITLE
ARROW-5346:  [C++] Revert changed to vendored datetime library

### DIFF
--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -159,7 +159,7 @@ class ArrayPrinter : public PrettyPrinter {
   enable_if_date<typename T::TypeClass, Status> WriteDataValues(const T& array) {
     const auto data = array.raw_values();
     using unit = typename std::conditional<std::is_same<T, Date32Array>::value,
-                                           arrow_vendored::util::date::days,
+                                           arrow_vendored::date::days,
                                            std::chrono::milliseconds>::type;
     WriteValues(array, [&](int64_t i) { FormatDateTime<unit>("%F", data[i], true); });
     return Status::OK();
@@ -367,9 +367,9 @@ class ArrayPrinter : public PrettyPrinter {
   template <typename Unit>
   void FormatDateTime(const char* fmt, int64_t value, bool add_epoch) {
     if (add_epoch) {
-      (*sink_) << arrow_vendored::util::date::format(fmt, epoch_ + Unit{value});
+      (*sink_) << arrow_vendored::date::format(fmt, epoch_ + Unit{value});
     } else {
-      (*sink_) << arrow_vendored::util::date::format(fmt, Unit{value});
+      (*sink_) << arrow_vendored::date::format(fmt, Unit{value});
     }
   }
 
@@ -391,12 +391,12 @@ class ArrayPrinter : public PrettyPrinter {
     }
   }
 
-  static arrow_vendored::util::date::sys_days epoch_;
+  static arrow_vendored::date::sys_days epoch_;
   std::string null_rep_;
 };
 
-arrow_vendored::util::date::sys_days ArrayPrinter::epoch_ =
-    arrow_vendored::util::date::sys_days{arrow_vendored::util::date::jan / 1 / 1970};
+arrow_vendored::date::sys_days ArrayPrinter::epoch_ =
+    arrow_vendored::date::sys_days{arrow_vendored::date::jan / 1 / 1970};
 
 Status ArrayPrinter::WriteValidityBitmap(const Array& array) {
   Indent();

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -158,9 +158,9 @@ class ArrayPrinter : public PrettyPrinter {
   template <typename T>
   enable_if_date<typename T::TypeClass, Status> WriteDataValues(const T& array) {
     const auto data = array.raw_values();
-    using unit =
-        typename std::conditional<std::is_same<T, Date32Array>::value, arrow_vendored::util::date::days,
-                                  std::chrono::milliseconds>::type;
+    using unit = typename std::conditional<std::is_same<T, Date32Array>::value,
+                                           arrow_vendored::util::date::days,
+                                           std::chrono::milliseconds>::type;
     WriteValues(array, [&](int64_t i) { FormatDateTime<unit>("%F", data[i], true); });
     return Status::OK();
   }

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -159,7 +159,7 @@ class ArrayPrinter : public PrettyPrinter {
   enable_if_date<typename T::TypeClass, Status> WriteDataValues(const T& array) {
     const auto data = array.raw_values();
     using unit =
-        typename std::conditional<std::is_same<T, Date32Array>::value, util::date::days,
+        typename std::conditional<std::is_same<T, Date32Array>::value, arrow_vendored::util::date::days,
                                   std::chrono::milliseconds>::type;
     WriteValues(array, [&](int64_t i) { FormatDateTime<unit>("%F", data[i], true); });
     return Status::OK();
@@ -367,9 +367,9 @@ class ArrayPrinter : public PrettyPrinter {
   template <typename Unit>
   void FormatDateTime(const char* fmt, int64_t value, bool add_epoch) {
     if (add_epoch) {
-      (*sink_) << util::date::format(fmt, epoch_ + Unit{value});
+      (*sink_) << arrow_vendored::util::date::format(fmt, epoch_ + Unit{value});
     } else {
-      (*sink_) << util::date::format(fmt, Unit{value});
+      (*sink_) << arrow_vendored::util::date::format(fmt, Unit{value});
     }
   }
 
@@ -391,12 +391,12 @@ class ArrayPrinter : public PrettyPrinter {
     }
   }
 
-  static util::date::sys_days epoch_;
+  static arrow_vendored::util::date::sys_days epoch_;
   std::string null_rep_;
 };
 
-util::date::sys_days ArrayPrinter::epoch_ =
-    util::date::sys_days{util::date::jan / 1 / 1970};
+arrow_vendored::util::date::sys_days ArrayPrinter::epoch_ =
+    arrow_vendored::util::date::sys_days{arrow_vendored::util::date::jan / 1 / 1970};
 
 Status ArrayPrinter::WriteValidityBitmap(const Array& array) {
   Indent();

--- a/cpp/src/arrow/symbols.map
+++ b/cpp/src/arrow/symbols.map
@@ -23,6 +23,7 @@
       # Unfortunately this will also catch template specializations
       # (from e.g. STL or Flatbuffers) involving Arrow types.
       *arrow::*;
+      *arrow_vendored::*;
     };
     # Also export C-level helpers
     arrow_*;

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -405,7 +405,7 @@ class StringConverter<TimestampType> {
     // - "YYYY-MM-DD[ T]hh:mm:ss"
     // - "YYYY-MM-DD[ T]hh:mm:ssZ"
     // UTC is always assumed, and the DataType's timezone is ignored.
-    arrow_vendored::util::date::year_month_day ymd;
+    arrow_vendored::date::year_month_day ymd;
     if (ARROW_PREDICT_FALSE(length < 10)) {
       return false;
     }
@@ -413,7 +413,7 @@ class StringConverter<TimestampType> {
       if (ARROW_PREDICT_FALSE(!ParseYYYY_MM_DD(s, &ymd))) {
         return false;
       }
-      return ConvertTimePoint(arrow_vendored::util::date::sys_days(ymd), out);
+      return ConvertTimePoint(arrow_vendored::date::sys_days(ymd), out);
     }
     if (ARROW_PREDICT_FALSE(s[10] != ' ') && ARROW_PREDICT_FALSE(s[10] != 'T')) {
       return false;
@@ -429,7 +429,7 @@ class StringConverter<TimestampType> {
       if (ARROW_PREDICT_FALSE(!ParseHH_MM_SS(s + 11, &seconds))) {
         return false;
       }
-      return ConvertTimePoint(arrow_vendored::util::date::sys_days(ymd) + seconds, out);
+      return ConvertTimePoint(arrow_vendored::date::sys_days(ymd) + seconds, out);
     }
     return false;
   }
@@ -458,7 +458,7 @@ class StringConverter<TimestampType> {
     return true;
   }
 
-  bool ParseYYYY_MM_DD(const char* s, arrow_vendored::util::date::year_month_day* out) {
+  bool ParseYYYY_MM_DD(const char* s, arrow_vendored::date::year_month_day* out) {
     uint16_t year;
     uint8_t month, day;
     if (ARROW_PREDICT_FALSE(s[4] != '-') || ARROW_PREDICT_FALSE(s[7] != '-')) {
@@ -473,9 +473,9 @@ class StringConverter<TimestampType> {
     if (ARROW_PREDICT_FALSE(!detail::ParseUnsigned(s + 8, 2, &day))) {
       return false;
     }
-    *out = {arrow_vendored::util::date::year{year},
-            arrow_vendored::util::date::month{month},
-            arrow_vendored::util::date::day{day}};
+    *out = {arrow_vendored::date::year{year},
+            arrow_vendored::date::month{month},
+            arrow_vendored::date::day{day}};
     return out->ok();
   }
 

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -473,8 +473,7 @@ class StringConverter<TimestampType> {
     if (ARROW_PREDICT_FALSE(!detail::ParseUnsigned(s + 8, 2, &day))) {
       return false;
     }
-    *out = {arrow_vendored::date::year{year},
-            arrow_vendored::date::month{month},
+    *out = {arrow_vendored::date::year{year}, arrow_vendored::date::month{month},
             arrow_vendored::date::day{day}};
     return out->ok();
   }

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -473,7 +473,8 @@ class StringConverter<TimestampType> {
     if (ARROW_PREDICT_FALSE(!detail::ParseUnsigned(s + 8, 2, &day))) {
       return false;
     }
-    *out = {arrow_vendored::util::date::year{year}, arrow_vendored::util::date::month{month},
+    *out = {arrow_vendored::util::date::year{year},
+            arrow_vendored::util::date::month{month},
             arrow_vendored::util::date::day{day}};
     return out->ok();
   }

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -405,7 +405,7 @@ class StringConverter<TimestampType> {
     // - "YYYY-MM-DD[ T]hh:mm:ss"
     // - "YYYY-MM-DD[ T]hh:mm:ssZ"
     // UTC is always assumed, and the DataType's timezone is ignored.
-    arrow::util::date::year_month_day ymd;
+    arrow_vendored::util::date::year_month_day ymd;
     if (ARROW_PREDICT_FALSE(length < 10)) {
       return false;
     }
@@ -413,7 +413,7 @@ class StringConverter<TimestampType> {
       if (ARROW_PREDICT_FALSE(!ParseYYYY_MM_DD(s, &ymd))) {
         return false;
       }
-      return ConvertTimePoint(arrow::util::date::sys_days(ymd), out);
+      return ConvertTimePoint(arrow_vendored::util::date::sys_days(ymd), out);
     }
     if (ARROW_PREDICT_FALSE(s[10] != ' ') && ARROW_PREDICT_FALSE(s[10] != 'T')) {
       return false;
@@ -429,7 +429,7 @@ class StringConverter<TimestampType> {
       if (ARROW_PREDICT_FALSE(!ParseHH_MM_SS(s + 11, &seconds))) {
         return false;
       }
-      return ConvertTimePoint(arrow::util::date::sys_days(ymd) + seconds, out);
+      return ConvertTimePoint(arrow_vendored::util::date::sys_days(ymd) + seconds, out);
     }
     return false;
   }
@@ -458,7 +458,7 @@ class StringConverter<TimestampType> {
     return true;
   }
 
-  bool ParseYYYY_MM_DD(const char* s, arrow::util::date::year_month_day* out) {
+  bool ParseYYYY_MM_DD(const char* s, arrow_vendored::util::date::year_month_day* out) {
     uint16_t year;
     uint8_t month, day;
     if (ARROW_PREDICT_FALSE(s[4] != '-') || ARROW_PREDICT_FALSE(s[7] != '-')) {
@@ -473,8 +473,8 @@ class StringConverter<TimestampType> {
     if (ARROW_PREDICT_FALSE(!detail::ParseUnsigned(s + 8, 2, &day))) {
       return false;
     }
-    *out = {arrow::util::date::year{year}, arrow::util::date::month{month},
-            arrow::util::date::day{day}};
+    *out = {arrow_vendored::util::date::year{year}, arrow_vendored::util::date::month{month},
+            arrow_vendored::util::date::day{day}};
     return out->ok();
   }
 

--- a/cpp/src/arrow/vendored/datetime/date.h
+++ b/cpp/src/arrow/vendored/datetime/date.h
@@ -76,7 +76,7 @@
 # endif
 #endif
 
-namespace arrow
+namespace arrow_vendored
 {
 namespace util
 {
@@ -1109,7 +1109,7 @@ trunc(const std::chrono::duration<Rep, Period>& d)
 {
     using namespace std::chrono;
     using rep = typename std::common_type<Rep, typename To::rep>::type;
-    return To{detail::trunc(duration_cast<To>(duration_cast<std::chrono::duration<rep>>(d)).count())};
+    return To{detail::trunc(duration_cast<To>(duration_cast<duration<rep>>(d)).count())};
 }
 
 #ifndef HAS_CHRONO_ROUNDING
@@ -1155,7 +1155,7 @@ floor(const std::chrono::duration<Rep, Period>& d)
 {
     using namespace std::chrono;
     using rep = typename std::common_type<Rep, typename To::rep>::type;
-    return floor<To>(floor<std::chrono::duration<rep>>(d));
+    return floor<To>(floor<duration<rep>>(d));
 }
 
 // round to nearest, to even on tie
@@ -6127,7 +6127,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     {
                         h = hours{H};
                         min = minutes{M};
-                        s = round<Duration>(std::chrono::duration<long double>{S});
+                        s = round<Duration>(duration<long double>{S});
                     }
 #endif
                     command = nullptr;
@@ -6508,7 +6508,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                         long double S;
                         read(is, rld{S, 1, width == -1 ? w : static_cast<unsigned>(width)});
                         if (!is.fail())
-                            s = round<Duration>(std::chrono::duration<long double>{S});
+                            s = round<Duration>(duration<long double>{S});
 #if !ONLY_C_LOCALE
                     }
                     else if (modified == CharT{'O'})
@@ -6545,7 +6545,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                         {
                             h = hours{H};
                             min = minutes{M};
-                            s = round<Duration>(std::chrono::duration<long double>{S});
+                            s = round<Duration>(duration<long double>{S});
                         }
                     }
                     else
@@ -8017,7 +8017,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 
 }  // namespace date
 }  // namespace util
-}  // namespace arrow
+}  // namespace arrow_vendored
 
 
 #ifdef __GNUC__

--- a/cpp/src/arrow/vendored/datetime/date.h
+++ b/cpp/src/arrow/vendored/datetime/date.h
@@ -78,8 +78,6 @@
 
 namespace arrow_vendored
 {
-namespace util
-{
 namespace date
 {
 
@@ -8016,7 +8014,6 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 }
 
 }  // namespace date
-}  // namespace util
 }  // namespace arrow_vendored
 
 

--- a/cpp/src/arrow/vendored/datetime/ios.h
+++ b/cpp/src/arrow/vendored/datetime/ios.h
@@ -34,8 +34,6 @@
 
     namespace arrow_vendored
     {
-    namespace util
-    {
     namespace date
     {
     namespace iOSUtils
@@ -46,7 +44,6 @@
 
     }  // namespace iOSUtils
     }  // namespace date
-    }  // namespace util
     }  // namespace arrow_vendored
 
 # endif  // TARGET_OS_IPHONE

--- a/cpp/src/arrow/vendored/datetime/ios.h
+++ b/cpp/src/arrow/vendored/datetime/ios.h
@@ -32,7 +32,7 @@
 # if TARGET_OS_IPHONE
 #   include <string>
 
-    namespace arrow
+    namespace arrow_vendored
     {
     namespace util
     {
@@ -47,7 +47,7 @@
     }  // namespace iOSUtils
     }  // namespace date
     }  // namespace util
-    }  // namespace arrow
+    }  // namespace arrow_vendored
 
 # endif  // TARGET_OS_IPHONE
 #else   // !__APPLE__

--- a/cpp/src/arrow/vendored/datetime/tz.cpp
+++ b/cpp/src/arrow/vendored/datetime/tz.cpp
@@ -251,8 +251,6 @@ get_download_folder()
 
 namespace arrow_vendored
 {
-namespace util
-{
 namespace date
 {
 // +---------------------+
@@ -3789,7 +3787,6 @@ current_zone()
 }
 
 }  // namespace date
-}  // namespace util
 }  // namespace arrow_vendored
 
 #if defined(__GNUC__) && __GNUC__ < 5

--- a/cpp/src/arrow/vendored/datetime/tz.cpp
+++ b/cpp/src/arrow/vendored/datetime/tz.cpp
@@ -249,7 +249,7 @@ get_download_folder()
 
 #endif  // !USE_OS_TZDB
 
-namespace arrow
+namespace arrow_vendored
 {
 namespace util
 {
@@ -3790,7 +3790,7 @@ current_zone()
 
 }  // namespace date
 }  // namespace util
-}  // namespace arrow
+}  // namespace arrow_vendored
 
 #if defined(__GNUC__) && __GNUC__ < 5
 # pragma GCC diagnostic pop

--- a/cpp/src/arrow/vendored/datetime/tz.h
+++ b/cpp/src/arrow/vendored/datetime/tz.h
@@ -155,7 +155,7 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 #  endif
 #endif
 
-namespace arrow
+namespace arrow_vendored
 {
 namespace util
 {

--- a/cpp/src/arrow/vendored/datetime/tz.h
+++ b/cpp/src/arrow/vendored/datetime/tz.h
@@ -157,8 +157,6 @@ static_assert(HAS_REMOTE_API == 0 ? AUTO_DOWNLOAD == 0 : true,
 
 namespace arrow_vendored
 {
-namespace util
-{
 namespace date
 {
 
@@ -2587,7 +2585,6 @@ to_gps_time(const tai_time<Duration>& t)
 #endif  // !MISSING_LEAP_SECONDS
 
 }  // namespace date
-}  // namespace util
 }  // namespace arrow
 
 #endif  // TZ_H

--- a/cpp/src/arrow/vendored/datetime/tz_private.h
+++ b/cpp/src/arrow/vendored/datetime/tz_private.h
@@ -36,8 +36,6 @@
 
 namespace arrow_vendored
 {
-namespace util
-{
 namespace date
 {
 
@@ -314,7 +312,6 @@ struct transition
 }  // namespace detail
 
 }  // namespace date
-}  // namespace util
 }  // namespace arrow_vendored
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)

--- a/cpp/src/arrow/vendored/datetime/tz_private.h
+++ b/cpp/src/arrow/vendored/datetime/tz_private.h
@@ -34,7 +34,7 @@
 #include <vector>
 #endif
 
-namespace arrow
+namespace arrow_vendored
 {
 namespace util
 {
@@ -315,7 +315,7 @@ struct transition
 
 }  // namespace date
 }  // namespace util
-}  // namespace arrow
+}  // namespace arrow_vendored
 
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 #include "tz.h"

--- a/cpp/src/gandiva/cast_time.cc
+++ b/cpp/src/gandiva/cast_time.cc
@@ -52,12 +52,12 @@ extern "C" {
 // TODO : Do input validation or make sure the callers do that ?
 int gdv_fn_time_with_zone(int* time_fields, const char* zone, int zone_len,
                           int64_t* ret_time) {
-  using arrow_vendored::util::date::day;
-  using arrow_vendored::util::date::local_days;
-  using arrow_vendored::util::date::locate_zone;
-  using arrow_vendored::util::date::month;
-  using arrow_vendored::util::date::time_zone;
-  using arrow_vendored::util::date::year;
+  using arrow_vendored::date::day;
+  using arrow_vendored::date::local_days;
+  using arrow_vendored::date::locate_zone;
+  using arrow_vendored::date::month;
+  using arrow_vendored::date::time_zone;
+  using arrow_vendored::date::year;
   using std::chrono::hours;
   using std::chrono::milliseconds;
   using std::chrono::minutes;

--- a/cpp/src/gandiva/cast_time.cc
+++ b/cpp/src/gandiva/cast_time.cc
@@ -52,12 +52,12 @@ extern "C" {
 // TODO : Do input validation or make sure the callers do that ?
 int gdv_fn_time_with_zone(int* time_fields, const char* zone, int zone_len,
                           int64_t* ret_time) {
-  using arrow::util::date::day;
-  using arrow::util::date::local_days;
-  using arrow::util::date::locate_zone;
-  using arrow::util::date::month;
-  using arrow::util::date::time_zone;
-  using arrow::util::date::year;
+  using arrow_vendored::util::date::day;
+  using arrow_vendored::util::date::local_days;
+  using arrow_vendored::util::date::locate_zone;
+  using arrow_vendored::util::date::month;
+  using arrow_vendored::util::date::time_zone;
+  using arrow_vendored::util::date::year;
   using std::chrono::hours;
   using std::chrono::milliseconds;
   using std::chrono::minutes;

--- a/cpp/src/gandiva/date_utils.h
+++ b/cpp/src/gandiva/date_utils.h
@@ -69,16 +69,16 @@ static inline bool ParseTimestamp(const char* buf, const char* format,
 
   // TODO: date::parse fails parsing when the hour value is 0.
   // eg.1886-12-01 00:00:00
-  arrow::util::date::sys_seconds seconds;
+  arrow_vendored::util::date::sys_seconds seconds;
   if (ignoreTimeInDay) {
-    arrow::util::date::sys_days days;
-    stream >> arrow::util::date::parse(format, days);
+    arrow_vendored::util::date::sys_days days;
+    stream >> arrow_vendored::util::date::parse(format, days);
     if (stream.fail()) {
       return false;
     }
     seconds = days;
   } else {
-    stream >> arrow::util::date::parse(format, seconds);
+    stream >> arrow_vendored::util::date::parse(format, seconds);
     if (stream.fail()) {
       return false;
     }
@@ -93,8 +93,8 @@ static inline bool ParseTimestamp(const char* buf, const char* format,
     return false;
   }
   // ignore the time part
-  arrow::util::date::sys_seconds secs =
-      arrow::util::date::sys_days(arrow::util::date::year(result.tm_year + 1900) /
+  arrow_vendored::util::date::sys_seconds secs =
+      arrow_vendored::util::date::sys_days(arrow_vendored::util::date::year(result.tm_year + 1900) /
                                   (result.tm_mon + 1) / result.tm_mday);
   if (!ignoreTimeInDay) {
     secs += (std::chrono::hours(result.tm_hour) + std::chrono::minutes(result.tm_min) +

--- a/cpp/src/gandiva/date_utils.h
+++ b/cpp/src/gandiva/date_utils.h
@@ -93,9 +93,9 @@ static inline bool ParseTimestamp(const char* buf, const char* format,
     return false;
   }
   // ignore the time part
-  arrow_vendored::util::date::sys_seconds secs =
-      arrow_vendored::util::date::sys_days(arrow_vendored::util::date::year(result.tm_year + 1900) /
-                                  (result.tm_mon + 1) / result.tm_mday);
+  arrow_vendored::util::date::sys_seconds secs = arrow_vendored::util::date::sys_days(
+      arrow_vendored::util::date::year(result.tm_year + 1900) / (result.tm_mon + 1) /
+      result.tm_mday);
   if (!ignoreTimeInDay) {
     secs += (std::chrono::hours(result.tm_hour) + std::chrono::minutes(result.tm_min) +
              std::chrono::seconds(result.tm_sec));

--- a/cpp/src/gandiva/date_utils.h
+++ b/cpp/src/gandiva/date_utils.h
@@ -69,16 +69,16 @@ static inline bool ParseTimestamp(const char* buf, const char* format,
 
   // TODO: date::parse fails parsing when the hour value is 0.
   // eg.1886-12-01 00:00:00
-  arrow_vendored::util::date::sys_seconds seconds;
+  arrow_vendored::date::sys_seconds seconds;
   if (ignoreTimeInDay) {
-    arrow_vendored::util::date::sys_days days;
-    stream >> arrow_vendored::util::date::parse(format, days);
+    arrow_vendored::date::sys_days days;
+    stream >> arrow_vendored::date::parse(format, days);
     if (stream.fail()) {
       return false;
     }
     seconds = days;
   } else {
-    stream >> arrow_vendored::util::date::parse(format, seconds);
+    stream >> arrow_vendored::date::parse(format, seconds);
     if (stream.fail()) {
       return false;
     }
@@ -93,8 +93,8 @@ static inline bool ParseTimestamp(const char* buf, const char* format,
     return false;
   }
   // ignore the time part
-  arrow_vendored::util::date::sys_seconds secs = arrow_vendored::util::date::sys_days(
-      arrow_vendored::util::date::year(result.tm_year + 1900) / (result.tm_mon + 1) /
+  arrow_vendored::date::sys_seconds secs = arrow_vendored::date::sys_days(
+      arrow_vendored::date::year(result.tm_year + 1900) / (result.tm_mon + 1) /
       result.tm_mday);
   if (!ignoreTimeInDay) {
     secs += (std::chrono::hours(result.tm_hour) + std::chrono::minutes(result.tm_min) +

--- a/cpp/src/gandiva/date_utils.h
+++ b/cpp/src/gandiva/date_utils.h
@@ -93,9 +93,9 @@ static inline bool ParseTimestamp(const char* buf, const char* format,
     return false;
   }
   // ignore the time part
-  arrow_vendored::date::sys_seconds secs = arrow_vendored::date::sys_days(
-      arrow_vendored::date::year(result.tm_year + 1900) / (result.tm_mon + 1) /
-      result.tm_mday);
+  arrow_vendored::date::sys_seconds secs =
+      arrow_vendored::date::sys_days(arrow_vendored::date::year(result.tm_year + 1900) /
+                                     (result.tm_mon + 1) / result.tm_mday);
   if (!ignoreTimeInDay) {
     secs += (std::chrono::hours(result.tm_hour) + std::chrono::minutes(result.tm_min) +
              std::chrono::seconds(result.tm_sec));

--- a/cpp/src/gandiva/precompiled/epoch_time_point.h
+++ b/cpp/src/gandiva/precompiled/epoch_time_point.h
@@ -35,17 +35,17 @@ class EpochTimePoint {
   int TmMon() const { return static_cast<unsigned int>(YearMonthDay().month()) - 1; }
 
   int TmYday() const {
-    auto to_days = arrow::util::date::floor<arrow::util::date::days>(tp_);
+    auto to_days = arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
     auto first_day_in_year =
-        arrow::util::date::sys_days{YearMonthDay().year() / arrow::util::date::jan / 1};
+        arrow_vendored::util::date::sys_days{YearMonthDay().year() / arrow_vendored::util::date::jan / 1};
     return (to_days - first_day_in_year).count();
   }
 
   int TmMday() const { return static_cast<unsigned int>(YearMonthDay().day()); }
 
   int TmWday() const {
-    auto to_days = arrow::util::date::floor<arrow::util::date::days>(tp_);
-    return (arrow::util::date::weekday{to_days} - arrow::util::date::Sunday)  // NOLINT
+    auto to_days = arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
+    return (arrow_vendored::util::date::weekday{to_days} - arrow_vendored::util::date::Sunday)  // NOLINT
         .count();                                                             // NOLINT
   }
 
@@ -59,22 +59,22 @@ class EpochTimePoint {
   }
 
   EpochTimePoint AddYears(int num_years) const {
-    auto ymd = YearMonthDay() + arrow::util::date::years(num_years);
-    return EpochTimePoint((arrow::util::date::sys_days{ymd} +  // NOLINT
+    auto ymd = YearMonthDay() + arrow_vendored::util::date::years(num_years);
+    return EpochTimePoint((arrow_vendored::util::date::sys_days{ymd} +  // NOLINT
                            TimeOfDay().to_duration())
                               .time_since_epoch());
   }
 
   EpochTimePoint AddMonths(int num_months) const {
-    auto ymd = YearMonthDay() + arrow::util::date::months(num_months);
-    return EpochTimePoint((arrow::util::date::sys_days{ymd} +  // NOLINT
+    auto ymd = YearMonthDay() + arrow_vendored::util::date::months(num_months);
+    return EpochTimePoint((arrow_vendored::util::date::sys_days{ymd} +  // NOLINT
                            TimeOfDay().to_duration())
                               .time_since_epoch());
   }
 
   EpochTimePoint AddDays(int num_days) const {
-    auto days_since_epoch = arrow::util::date::sys_days{YearMonthDay()}  // NOLINT
-                            + arrow::util::date::days(num_days);
+    auto days_since_epoch = arrow_vendored::util::date::sys_days{YearMonthDay()}  // NOLINT
+                            + arrow_vendored::util::date::days(num_days);
     return EpochTimePoint(
         (days_since_epoch + TimeOfDay().to_duration()).time_since_epoch());
   }
@@ -88,15 +88,15 @@ class EpochTimePoint {
   int64_t MillisSinceEpoch() const { return tp_.time_since_epoch().count(); }
 
  private:
-  arrow::util::date::year_month_day YearMonthDay() const {
-    return arrow::util::date::year_month_day{
-        arrow::util::date::floor<arrow::util::date::days>(tp_)};  // NOLINT
+  arrow_vendored::util::date::year_month_day YearMonthDay() const {
+    return arrow_vendored::util::date::year_month_day{
+        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_)};  // NOLINT
   }
 
-  arrow::util::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {
+  arrow_vendored::util::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {
     auto millis_since_midnight =
-        tp_ - arrow::util::date::floor<arrow::util::date::days>(tp_);
-    return arrow::util::date::time_of_day<std::chrono::milliseconds>(
+        tp_ - arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
+    return arrow_vendored::util::date::time_of_day<std::chrono::milliseconds>(
         millis_since_midnight);
   }
 

--- a/cpp/src/gandiva/precompiled/epoch_time_point.h
+++ b/cpp/src/gandiva/precompiled/epoch_time_point.h
@@ -35,18 +35,21 @@ class EpochTimePoint {
   int TmMon() const { return static_cast<unsigned int>(YearMonthDay().month()) - 1; }
 
   int TmYday() const {
-    auto to_days = arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
-    auto first_day_in_year =
-        arrow_vendored::util::date::sys_days{YearMonthDay().year() / arrow_vendored::util::date::jan / 1};
+    auto to_days =
+        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
+    auto first_day_in_year = arrow_vendored::util::date::sys_days{
+        YearMonthDay().year() / arrow_vendored::util::date::jan / 1};
     return (to_days - first_day_in_year).count();
   }
 
   int TmMday() const { return static_cast<unsigned int>(YearMonthDay().day()); }
 
   int TmWday() const {
-    auto to_days = arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
-    return (arrow_vendored::util::date::weekday{to_days} - arrow_vendored::util::date::Sunday)  // NOLINT
-        .count();                                                             // NOLINT
+    auto to_days =
+        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
+    return (arrow_vendored::util::date::weekday{to_days} -  // NOLINT
+            arrow_vendored::util::date::Sunday)
+        .count();
   }
 
   int TmHour() const { return static_cast<int>(TimeOfDay().hours().count()); }
@@ -73,8 +76,9 @@ class EpochTimePoint {
   }
 
   EpochTimePoint AddDays(int num_days) const {
-    auto days_since_epoch = arrow_vendored::util::date::sys_days{YearMonthDay()}  // NOLINT
-                            + arrow_vendored::util::date::days(num_days);
+    auto days_since_epoch =
+        arrow_vendored::util::date::sys_days{YearMonthDay()} +  // NOLINT
+        arrow_vendored::util::date::days(num_days);
     return EpochTimePoint(
         (days_since_epoch + TimeOfDay().to_duration()).time_since_epoch());
   }
@@ -90,7 +94,8 @@ class EpochTimePoint {
  private:
   arrow_vendored::util::date::year_month_day YearMonthDay() const {
     return arrow_vendored::util::date::year_month_day{
-        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_)};  // NOLINT
+        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(
+            tp_)};  // NOLINT
   }
 
   arrow_vendored::util::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {

--- a/cpp/src/gandiva/precompiled/epoch_time_point.h
+++ b/cpp/src/gandiva/precompiled/epoch_time_point.h
@@ -35,8 +35,7 @@ class EpochTimePoint {
   int TmMon() const { return static_cast<unsigned int>(YearMonthDay().month()) - 1; }
 
   int TmYday() const {
-    auto to_days =
-        arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+    auto to_days = arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
     auto first_day_in_year = arrow_vendored::date::sys_days{
         YearMonthDay().year() / arrow_vendored::date::jan / 1};
     return (to_days - first_day_in_year).count();
@@ -45,8 +44,7 @@ class EpochTimePoint {
   int TmMday() const { return static_cast<unsigned int>(YearMonthDay().day()); }
 
   int TmWday() const {
-    auto to_days =
-        arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+    auto to_days = arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
     return (arrow_vendored::date::weekday{to_days} -  // NOLINT
             arrow_vendored::date::Sunday)
         .count();
@@ -76,9 +74,8 @@ class EpochTimePoint {
   }
 
   EpochTimePoint AddDays(int num_days) const {
-    auto days_since_epoch =
-        arrow_vendored::date::sys_days{YearMonthDay()} +  // NOLINT
-        arrow_vendored::date::days(num_days);
+    auto days_since_epoch = arrow_vendored::date::sys_days{YearMonthDay()} +  // NOLINT
+                            arrow_vendored::date::days(num_days);
     return EpochTimePoint(
         (days_since_epoch + TimeOfDay().to_duration()).time_since_epoch());
   }
@@ -94,8 +91,7 @@ class EpochTimePoint {
  private:
   arrow_vendored::date::year_month_day YearMonthDay() const {
     return arrow_vendored::date::year_month_day{
-        arrow_vendored::date::floor<arrow_vendored::date::days>(
-            tp_)};  // NOLINT
+        arrow_vendored::date::floor<arrow_vendored::date::days>(tp_)};  // NOLINT
   }
 
   arrow_vendored::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {

--- a/cpp/src/gandiva/precompiled/epoch_time_point.h
+++ b/cpp/src/gandiva/precompiled/epoch_time_point.h
@@ -36,9 +36,9 @@ class EpochTimePoint {
 
   int TmYday() const {
     auto to_days =
-        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
-    auto first_day_in_year = arrow_vendored::util::date::sys_days{
-        YearMonthDay().year() / arrow_vendored::util::date::jan / 1};
+        arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+    auto first_day_in_year = arrow_vendored::date::sys_days{
+        YearMonthDay().year() / arrow_vendored::date::jan / 1};
     return (to_days - first_day_in_year).count();
   }
 
@@ -46,9 +46,9 @@ class EpochTimePoint {
 
   int TmWday() const {
     auto to_days =
-        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
-    return (arrow_vendored::util::date::weekday{to_days} -  // NOLINT
-            arrow_vendored::util::date::Sunday)
+        arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+    return (arrow_vendored::date::weekday{to_days} -  // NOLINT
+            arrow_vendored::date::Sunday)
         .count();
   }
 
@@ -62,23 +62,23 @@ class EpochTimePoint {
   }
 
   EpochTimePoint AddYears(int num_years) const {
-    auto ymd = YearMonthDay() + arrow_vendored::util::date::years(num_years);
-    return EpochTimePoint((arrow_vendored::util::date::sys_days{ymd} +  // NOLINT
+    auto ymd = YearMonthDay() + arrow_vendored::date::years(num_years);
+    return EpochTimePoint((arrow_vendored::date::sys_days{ymd} +  // NOLINT
                            TimeOfDay().to_duration())
                               .time_since_epoch());
   }
 
   EpochTimePoint AddMonths(int num_months) const {
-    auto ymd = YearMonthDay() + arrow_vendored::util::date::months(num_months);
-    return EpochTimePoint((arrow_vendored::util::date::sys_days{ymd} +  // NOLINT
+    auto ymd = YearMonthDay() + arrow_vendored::date::months(num_months);
+    return EpochTimePoint((arrow_vendored::date::sys_days{ymd} +  // NOLINT
                            TimeOfDay().to_duration())
                               .time_since_epoch());
   }
 
   EpochTimePoint AddDays(int num_days) const {
     auto days_since_epoch =
-        arrow_vendored::util::date::sys_days{YearMonthDay()} +  // NOLINT
-        arrow_vendored::util::date::days(num_days);
+        arrow_vendored::date::sys_days{YearMonthDay()} +  // NOLINT
+        arrow_vendored::date::days(num_days);
     return EpochTimePoint(
         (days_since_epoch + TimeOfDay().to_duration()).time_since_epoch());
   }
@@ -92,16 +92,16 @@ class EpochTimePoint {
   int64_t MillisSinceEpoch() const { return tp_.time_since_epoch().count(); }
 
  private:
-  arrow_vendored::util::date::year_month_day YearMonthDay() const {
-    return arrow_vendored::util::date::year_month_day{
-        arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(
+  arrow_vendored::date::year_month_day YearMonthDay() const {
+    return arrow_vendored::date::year_month_day{
+        arrow_vendored::date::floor<arrow_vendored::date::days>(
             tp_)};  // NOLINT
   }
 
-  arrow_vendored::util::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {
+  arrow_vendored::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {
     auto millis_since_midnight =
-        tp_ - arrow_vendored::util::date::floor<arrow_vendored::util::date::days>(tp_);
-    return arrow_vendored::util::date::time_of_day<std::chrono::milliseconds>(
+        tp_ - arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+    return arrow_vendored::date::time_of_day<std::chrono::milliseconds>(
         millis_since_midnight);
   }
 

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -519,11 +519,11 @@ void set_error_for_date(int32 length, const char* input, const char* msg,
 }
 
 date64 castDATE_utf8(int64_t context, const char* input, int32 length) {
-  using arrow_vendored::util::date::day;
-  using arrow_vendored::util::date::month;
-  using arrow_vendored::util::date::sys_days;
-  using arrow_vendored::util::date::year;
-  using arrow_vendored::util::date::year_month_day;
+  using arrow_vendored::date::day;
+  using arrow_vendored::date::month;
+  using arrow_vendored::date::sys_days;
+  using arrow_vendored::date::year;
+  using arrow_vendored::date::year_month_day;
   using gandiva::TimeFields;
   // format : 0 is year, 1 is month and 2 is day.
   int dateFields[3];
@@ -583,11 +583,11 @@ date64 castDATE_utf8(int64_t context, const char* input, int32 length) {
  * Format is <year-month-day>[ hours:minutes:seconds][.millis][ displacement|zone]
  */
 timestamp castTIMESTAMP_utf8(int64_t context, const char* input, int32 length) {
-  using arrow_vendored::util::date::day;
-  using arrow_vendored::util::date::month;
-  using arrow_vendored::util::date::sys_days;
-  using arrow_vendored::util::date::year;
-  using arrow_vendored::util::date::year_month_day;
+  using arrow_vendored::date::day;
+  using arrow_vendored::date::month;
+  using arrow_vendored::date::sys_days;
+  using arrow_vendored::date::year;
+  using arrow_vendored::date::year_month_day;
   using gandiva::TimeFields;
   using std::chrono::hours;
   using std::chrono::milliseconds;

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -519,11 +519,11 @@ void set_error_for_date(int32 length, const char* input, const char* msg,
 }
 
 date64 castDATE_utf8(int64_t context, const char* input, int32 length) {
-  using arrow::util::date::day;
-  using arrow::util::date::month;
-  using arrow::util::date::sys_days;
-  using arrow::util::date::year;
-  using arrow::util::date::year_month_day;
+  using arrow_vendored::util::date::day;
+  using arrow_vendored::util::date::month;
+  using arrow_vendored::util::date::sys_days;
+  using arrow_vendored::util::date::year;
+  using arrow_vendored::util::date::year_month_day;
   using gandiva::TimeFields;
   // format : 0 is year, 1 is month and 2 is day.
   int dateFields[3];
@@ -583,11 +583,11 @@ date64 castDATE_utf8(int64_t context, const char* input, int32 length) {
  * Format is <year-month-day>[ hours:minutes:seconds][.millis][ displacement|zone]
  */
 timestamp castTIMESTAMP_utf8(int64_t context, const char* input, int32 length) {
-  using arrow::util::date::day;
-  using arrow::util::date::month;
-  using arrow::util::date::sys_days;
-  using arrow::util::date::year;
-  using arrow::util::date::year_month_day;
+  using arrow_vendored::util::date::day;
+  using arrow_vendored::util::date::month;
+  using arrow_vendored::util::date::sys_days;
+  using arrow_vendored::util::date::year;
+  using arrow_vendored::util::date::year_month_day;
   using gandiva::TimeFields;
   using std::chrono::hours;
   using std::chrono::milliseconds;


### PR DESCRIPTION
The best way I could think of accomplishing this was to introduce another top level namespace arrow_vendored, so "duration" does not conflict between the two.  Other suggestions welcome.