### PR TITLE
ARROW-5354: [C++] adding support for simple, allocation-free null arrays

### DIFF
--- a/cpp/src/arrow/array-list-test.cc
+++ b/cpp/src/arrow/array-list-test.cc
@@ -201,14 +201,10 @@ TEST_F(TestListArray, TestAppendNull) {
   ASSERT_TRUE(result_->IsNull(0));
   ASSERT_TRUE(result_->IsNull(1));
 
-  ASSERT_EQ(0, result_->raw_value_offsets()[0]);
-  ASSERT_EQ(0, result_->value_offset(1));
-  ASSERT_EQ(0, result_->value_offset(2));
+  ASSERT_EQ(result_->value_offsets(), nullptr);
 
   auto values = result_->values();
   ASSERT_EQ(0, values->length());
-  // Values buffer should be non-null
-  ASSERT_NE(nullptr, values->data()->buffers[1]);
 }
 
 TEST_F(TestListArray, TestAppendNulls) {
@@ -223,15 +219,8 @@ TEST_F(TestListArray, TestAppendNulls) {
   ASSERT_TRUE(result_->IsNull(1));
   ASSERT_TRUE(result_->IsNull(2));
 
-  ASSERT_EQ(0, result_->raw_value_offsets()[0]);
-  ASSERT_EQ(0, result_->value_offset(1));
-  ASSERT_EQ(0, result_->value_offset(2));
-  ASSERT_EQ(0, result_->value_offset(3));
-
   auto values = result_->values();
   ASSERT_EQ(0, values->length());
-  // Values buffer should be non-null
-  ASSERT_NE(nullptr, values->data()->buffers[1]);
 }
 
 void ValidateBasicListArray(const ListArray* result, const std::vector<int32_t>& values,

--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -514,7 +514,9 @@ void TestPrimitiveBuilder<PBoolean>::Check(const std::unique_ptr<BooleanBuilder>
   AssertArraysEqual(*result, *expected);
 
   // buffers are correctly sized
-  ASSERT_EQ(result->data()->buffers[0]->size(), BitUtil::BytesForBits(size));
+  if (result->data()->buffers[0] != nullptr) {
+    ASSERT_EQ(result->data()->buffers[0]->size(), BitUtil::BytesForBits(size));
+  }
   ASSERT_EQ(result->data()->buffers[1]->size(), BitUtil::BytesForBits(size));
 
   // Builder is now reset

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -86,6 +86,12 @@ Status ArrayBuilder::Advance(int64_t elements) {
 Status ArrayBuilder::Finish(std::shared_ptr<Array>* out) {
   std::shared_ptr<ArrayData> internal_data;
   RETURN_NOT_OK(FinishInternal(&internal_data));
+  if (internal_data->null_count == 0) {
+    internal_data->buffers[0] = nullptr;
+  } else if (internal_data->null_count == internal_data->length) {
+    *out = MakeArrayOfNull(internal_data->type, internal_data->length);
+    return Status::OK();
+  }
   *out = MakeArray(internal_data);
   return Status::OK();
 }

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -236,7 +236,9 @@ Status ConcatenateBuffers(const std::vector<std::shared_ptr<Buffer>>& buffers,
   RETURN_NOT_OK(AllocateBuffer(pool, out_length, out));
   auto out_data = (*out)->mutable_data();
   for (const auto& buffer : buffers) {
-    std::memcpy(out_data, buffer->data(), buffer->size());
+    if (buffer->data()) {
+      std::memcpy(out_data, buffer->data(), buffer->size());
+    }
     out_data += buffer->size();
   }
   return Status::OK();

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -83,7 +83,7 @@ class ARROW_EXPORT Buffer {
   /// in general we expected buffers to be aligned and padded to 64 bytes.  In the future
   /// we might add utility methods to help determine if a buffer satisfies this contract.
   Buffer(const std::shared_ptr<Buffer>& parent, const int64_t offset, const int64_t size)
-      : Buffer(parent->data() + offset, size) {
+      : Buffer(parent->data() ? parent->data() + offset : NULLPTR, size) {
     parent_ = parent;
   }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -887,6 +887,8 @@ class ScalarEqualsVisitor {
     return Status::NotImplemented("extension");
   }
 
+  Status Visit(const Scalar& left) { return Status::NotImplemented(*left.type); }
+
   bool result() const { return result_; }
 
  protected:

--- a/cpp/src/arrow/compute/kernels/aggregate-test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate-test.cc
@@ -56,16 +56,13 @@ static SumResult<ArrowType> NaiveSumPartial(const Array& array) {
   ResultType result;
 
   auto data = array.data();
-  internal::BitmapReader reader(array.null_bitmap_data(), array.offset(), array.length());
+
   const auto& array_numeric = reinterpret_cast<const ArrayType&>(array);
-  const auto values = array_numeric.raw_values();
   for (int64_t i = 0; i < array.length(); i++) {
-    if (reader.IsSet()) {
-      result.first += values[i];
+    if (array_numeric.IsValid(i)) {
+      result.first += array_numeric.raw_values()[i];
       result.second++;
     }
-
-    reader.Next();
   }
 
   return result;

--- a/cpp/src/arrow/compute/kernels/compare.cc
+++ b/cpp/src/arrow/compute/kernels/compare.cc
@@ -64,9 +64,10 @@ class CompareFunction final : public FilterFunction {
     // Output must be of same length
     DCHECK_EQ(output->length, input.length);
 
-    // Scalar is null, all comparisons are null.
-    if (!scalar.is_valid) {
-      return detail::SetAllNulls(ctx_, input, output);
+    // Scalar is null or input is all nulls, all comparisons are null.
+    if (!scalar.is_valid || input.GetNullCount() == input.length) {
+      *output = *MakeArrayOfNull(boolean(), input.length)->data();
+      return Status::OK();
     }
 
     // Copy null_bitmap

--- a/cpp/src/arrow/compute/kernels/sum-internal.h
+++ b/cpp/src/arrow/compute/kernels/sum-internal.h
@@ -72,6 +72,8 @@ class SumAggregateFunction final : public AggregateFunctionStaticState<StateType
 
     if (input.null_count() == 0) {
       *state = ConsumeDense(array);
+    } else if (input.null_count() == input.length()) {
+      *state = StateType();
     } else if (input.length() <= kTinyThreshold) {
       // In order to simplify ConsumeSparse implementation (requires at least 3
       // bytes of bitmap data), small arrays are handled differently.

--- a/cpp/src/arrow/compute/kernels/take.cc
+++ b/cpp/src/arrow/compute/kernels/take.cc
@@ -208,6 +208,11 @@ Status TakeKernel::Call(FunctionContext* ctx, const Datum& values, const Datum& 
   params.context = ctx;
   params.values = values.make_array();
   params.indices = indices.make_array();
+  if (params.values->null_count() == params.values->length() ||
+      params.indices->null_count() == params.indices->length()) {
+    *out = MakeArrayOfNull(params.values->type(), params.indices->length());
+    return Status::OK();
+  }
   params.options = options_;
   params.out = &out_array;
   UnpackIndices unpack = {params};

--- a/cpp/src/arrow/compute/kernels/util-internal-test.cc
+++ b/cpp/src/arrow/compute/kernels/util-internal-test.cc
@@ -96,21 +96,6 @@ TEST(PropagateNulls, OffsetAndHasNulls) {
               Each(0));
 }
 
-TEST(SetAllNulls, Basic) {
-  const int64_t length = 16;
-  ArrayData input(boolean(), length);
-  FunctionContext ctx(default_memory_pool());
-  ArrayData output;
-
-  ASSERT_OK(SetAllNulls(&ctx, input, &output));
-  ASSERT_THAT(output.null_count, Eq(length));
-
-  const auto& output_buffer = *output.buffers[0];
-  ASSERT_THAT(std::vector<uint8_t>(output_buffer.data(),
-                                   output_buffer.data() + output_buffer.size()),
-              Each(0));
-}
-
 TEST(AssignNullIntersection, ZeroCopyWhenZeroNullsOnOneInput) {
   ArrayData some_nulls(boolean(), /* length= */ 16, kUnknownNullCount);
   constexpr uint8_t validity_bitmap[8] = {254, 0, 0, 0, 0, 0, 0, 0};

--- a/cpp/src/arrow/compute/kernels/util-internal.h
+++ b/cpp/src/arrow/compute/kernels/util-internal.h
@@ -72,14 +72,6 @@ Status InvokeBinaryArrayKernel(FunctionContext* ctx, BinaryKernel* kernel,
 ARROW_EXPORT
 Status PropagateNulls(FunctionContext* ctx, const ArrayData& input, ArrayData* output);
 
-/// \brief Set validity bitmap in output with all null values.
-///
-/// \param[in] ctx the kernel FunctionContext
-/// \param[in] input the input array
-/// \param[out] output the output array.  Must have length and buffer set correctly.
-ARROW_EXPORT
-Status SetAllNulls(FunctionContext* ctx, const ArrayData& input, ArrayData* output);
-
 /// \brief Assign validity bitmap to output, taking the intersection of left and right
 /// null bitmaps if necessary, but zero-copy otherwise.
 ///

--- a/cpp/src/arrow/util/concatenate.h
+++ b/cpp/src/arrow/util/concatenate.h
@@ -20,11 +20,15 @@
 #include <memory>
 #include <vector>
 
-#include "arrow/array.h"
-#include "arrow/memory_pool.h"
+#include "arrow/status.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+
+class Array;
+struct ArrayData;
+using ArrayVector = std::vector<std::shared_ptr<Array>>;
+class MemoryPool;
 
 /// \brief Concatenate arrays
 ///
@@ -35,5 +39,15 @@ namespace arrow {
 ARROW_EXPORT
 Status Concatenate(const ArrayVector& arrays, MemoryPool* pool,
                    std::shared_ptr<Array>* out);
+
+/// \brief Concatenate array data
+///
+/// \param[in] data a vector of array data to be concatenated
+/// \param[in] pool memory to store the result will be allocated from this memory pool
+/// \param[out] out the resulting concatenated array data
+/// \return Status
+ARROW_EXPORT
+Status ConcatenateArrayData(const std::vector<ArrayData>& data, MemoryPool* pool,
+                            ArrayData* out);
 
 }  // namespace arrow


### PR DESCRIPTION
In the case of all elements of an array being null, no buffers whatsoever need to be allocated (similar to NullArray). This is a more extreme case of the optimization which allows the null bitmap buffer to be null if all elements are valid.

This pull also adds a factory for producing lightweight arrays with all null elements.