### PR TITLE
ARROW-3962: [Go] Handle null values in CSV

### DIFF
--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -117,6 +117,19 @@ func WithHeader(useHeader bool) Option {
 	}
 }
 
+func WithNullString(null string) Option {
+	return func(cfg config) {
+		switch cfg := cfg.(type) {
+		case *Reader:
+			cfg.null = null
+		case *Writer:
+			cfg.null = null
+		default:
+			panic(fmt.Errorf("arrow/csv: unknown config type %T", cfg))
+		}
+	}
+}
+
 func validate(schema *arrow.Schema) {
 	for i, f := range schema.Fields() {
 		switch ft := f.Type.(type) {

--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -117,13 +117,34 @@ func WithHeader(useHeader bool) Option {
 	}
 }
 
-func WithNullString(null string) Option {
+// WithNullReader sets options for a CSV Reader pertaining to NULL value
+// handling. If stringsCanBeNull is true, then a string that matches one of the
+// nullValues set will be interpreted as NULL. Numeric columns will be checked
+// for nulls in all cases. If no nullValues arguments are passed in, the
+// defaults set in NewReader() will be kept.
+func WithNullReader(stringsCanBeNull bool, nullValues ...string) Option {
 	return func(cfg config) {
 		switch cfg := cfg.(type) {
 		case *Reader:
-			cfg.null = null
+			cfg.stringsCanBeNull = stringsCanBeNull
+
+			// only override defaults if nullValues are passed in
+			if len(nullValues) != 0 {
+				cfg.nullValues = nullValues
+			}
+		default:
+			panic(fmt.Errorf("arrow/csv: unknown config type %T", cfg))
+		}
+	}
+}
+
+// WithNullWriter sets the null string written for NULL values. The default is
+// set in NewWriter().
+func WithNullWriter(null string) Option {
+	return func(cfg config) {
+		switch cfg := cfg.(type) {
 		case *Writer:
-			cfg.null = null
+			cfg.nullValue = null
 		default:
 			panic(fmt.Errorf("arrow/csv: unknown config type %T", cfg))
 		}

--- a/go/arrow/csv/common.go
+++ b/go/arrow/csv/common.go
@@ -104,13 +104,13 @@ func WithCRLF(useCRLF bool) Option {
 	}
 }
 
-func WithHeader() Option {
+func WithHeader(useHeader bool) Option {
 	return func(cfg config) {
 		switch cfg := cfg.(type) {
 		case *Reader:
-			cfg.header = true
+			cfg.header = useHeader
 		case *Writer:
-			cfg.header = true
+			cfg.header = useHeader
 		default:
 			panic(fmt.Errorf("arrow/csv: unknown config type %T", cfg))
 		}

--- a/go/arrow/csv/reader.go
+++ b/go/arrow/csv/reader.go
@@ -269,73 +269,43 @@ func (r *Reader) initFieldConverter(field *arrow.Field) func(array.Builder, stri
 		}
 	case *arrow.Int8Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseInt(field, str, 8)
-			if !null {
-				field.(*array.Int8Builder).Append(int8(v))
-			}
+			r.parseInt8(field, str)
 		}
 	case *arrow.Int16Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseInt(field, str, 16)
-			if !null {
-				field.(*array.Int16Builder).Append(int16(v))
-			}
+			r.parseInt16(field, str)
 		}
 	case *arrow.Int32Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseInt(field, str, 32)
-			if !null {
-				field.(*array.Int32Builder).Append(int32(v))
-			}
+			r.parseInt32(field, str)
 		}
 	case *arrow.Int64Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseInt(field, str, 64)
-			if !null {
-				field.(*array.Int64Builder).Append(int64(v))
-			}
+			r.parseInt64(field, str)
 		}
 	case *arrow.Uint8Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseUint(field, str, 8)
-			if !null {
-				field.(*array.Uint8Builder).Append(uint8(v))
-			}
+			r.parseUint8(field, str)
 		}
 	case *arrow.Uint16Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseUint(field, str, 16)
-			if !null {
-				field.(*array.Uint16Builder).Append(uint16(v))
-			}
+			r.parseUint16(field, str)
 		}
 	case *arrow.Uint32Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseUint(field, str, 32)
-			if !null {
-				field.(*array.Uint32Builder).Append(uint32(v))
-			}
+			r.parseUint32(field, str)
 		}
 	case *arrow.Uint64Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseUint(field, str, 64)
-			if !null {
-				field.(*array.Uint64Builder).Append(uint64(v))
-			}
+			r.parseUint64(field, str)
 		}
 	case *arrow.Float32Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseFloat(field, str, 32)
-			if !null {
-				field.(*array.Float32Builder).Append(float32(v))
-			}
+			r.parseFloat32(field, str)
 		}
 	case *arrow.Float64Type:
 		return func(field array.Builder, str string) {
-			v, null := r.parseFloat(field, str, 64)
-			if !null {
-				field.(*array.Float64Builder).Append(float64(v))
-			}
+			r.parseFloat64(field, str)
 		}
 	case *arrow.StringType:
 		// specialize the implementation when we know we cannot have nulls
@@ -379,52 +349,163 @@ func (r *Reader) parseBool(field array.Builder, str string) {
 	field.(*array.BooleanBuilder).Append(v)
 }
 
-func (r *Reader) parseInt(field array.Builder, str string, width int) (int64, bool) {
+func (r *Reader) parseInt8(field array.Builder, str string) {
 	if r.isNull(str) {
 		field.AppendNull()
-		return 0, true
+		return
 	}
 
-	v, err := strconv.ParseInt(str, 10, width)
+	v, err := strconv.ParseInt(str, 10, 8)
 	if err != nil && r.err == nil {
 		r.err = err
 		field.AppendNull()
-		return 0, true
+		return
 	}
 
-	return v, false
+	field.(*array.Int8Builder).Append(int8(v))
 }
 
-func (r *Reader) parseUint(field array.Builder, str string, width int) (uint64, bool) {
+func (r *Reader) parseInt16(field array.Builder, str string) {
 	if r.isNull(str) {
 		field.AppendNull()
-		return 0, true
+		return
 	}
 
-	v, err := strconv.ParseUint(str, 10, width)
+	v, err := strconv.ParseInt(str, 10, 16)
 	if err != nil && r.err == nil {
 		r.err = err
 		field.AppendNull()
-		return 0, true
+		return
 	}
 
-	return v, false
+	field.(*array.Int16Builder).Append(int16(v))
 }
 
-func (r *Reader) parseFloat(field array.Builder, str string, width int) (float64, bool) {
+func (r *Reader) parseInt32(field array.Builder, str string) {
 	if r.isNull(str) {
 		field.AppendNull()
-		return 0.0, true
+		return
 	}
 
-	v, err := strconv.ParseFloat(str, width)
+	v, err := strconv.ParseInt(str, 10, 32)
 	if err != nil && r.err == nil {
 		r.err = err
 		field.AppendNull()
-		return 0.0, true
+		return
 	}
 
-	return v, false
+	field.(*array.Int32Builder).Append(int32(v))
+}
+
+func (r *Reader) parseInt64(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseInt(str, 10, 64)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+
+	field.(*array.Int64Builder).Append(v)
+}
+
+func (r *Reader) parseUint8(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseUint(str, 10, 8)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+
+	field.(*array.Uint8Builder).Append(uint8(v))
+}
+
+func (r *Reader) parseUint16(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseUint(str, 10, 16)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+
+	field.(*array.Uint16Builder).Append(uint16(v))
+}
+
+func (r *Reader) parseUint32(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseUint(str, 10, 32)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+
+	field.(*array.Uint32Builder).Append(uint32(v))
+}
+
+func (r *Reader) parseUint64(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseUint(str, 10, 64)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+
+	field.(*array.Uint64Builder).Append(v)
+}
+
+func (r *Reader) parseFloat32(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseFloat(str, 32)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+	field.(*array.Float32Builder).Append(float32(v))
+
+}
+
+func (r *Reader) parseFloat64(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
+	}
+
+	v, err := strconv.ParseFloat(str, 64)
+	if err != nil && r.err == nil {
+		r.err = err
+		field.AppendNull()
+		return
+	}
+	field.(*array.Float64Builder).Append(v)
 }
 
 // Retain increases the reference count by 1.

--- a/go/arrow/csv/reader.go
+++ b/go/arrow/csv/reader.go
@@ -18,6 +18,7 @@ package csv
 
 import (
 	"encoding/csv"
+	"fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -49,7 +50,10 @@ type Reader struct {
 	header bool
 	once   sync.Once
 
-	null string
+	fieldConverter []func(field array.Builder, val string)
+
+	stringsCanBeNull bool
+	nullValues       []string
 }
 
 // NewReader returns a reader that reads from the CSV file and creates
@@ -61,11 +65,12 @@ func NewReader(r io.Reader, schema *arrow.Schema, opts ...Option) *Reader {
 	validate(schema)
 
 	rr := &Reader{
-		r:      csv.NewReader(r),
-		schema: schema,
-		refs:   1,
-		chunk:  1,
-		null:   "NULL",
+		r:                csv.NewReader(r),
+		schema:           schema,
+		refs:             1,
+		chunk:            1,
+		stringsCanBeNull: false,
+		nullValues:       []string{"", "NULL", "null"},
 	}
 	rr.r.ReuseRecord = true
 	for _, opt := range opts {
@@ -86,6 +91,15 @@ func NewReader(r io.Reader, schema *arrow.Schema, opts ...Option) *Reader {
 	default:
 		rr.next = rr.next1
 	}
+
+	// Create a table of functions that will parse columns. This optimization
+	// allows us to specialize the implementation of each column's decoding
+	// and hoist type-based branches outside the inner loop.
+	rr.fieldConverter = make([]func(array.Builder, string), len(schema.Fields()))
+	for idx, field := range schema.Fields() {
+		rr.fieldConverter[idx] = rr.initFieldConverter(&field)
+	}
+
 	return rr
 }
 
@@ -232,146 +246,185 @@ func (r *Reader) validate(recs []string) {
 	}
 }
 
-func (r *Reader) read(recs []string) {
-	for i, str := range recs {
-		if str == r.null {
-			r.bld.Field(i).AppendNull()
-		} else {
-			switch r.schema.Field(i).Type.(type) {
-			case *arrow.BooleanType:
-				var v bool
-				switch str {
-				case "false", "False", "0":
-					v = false
-				case "true", "True", "1":
-					v = true
-				}
-				r.bld.Field(i).(*array.BooleanBuilder).Append(v)
-			case *arrow.Int8Type:
-				v := r.readI8(str)
-				r.bld.Field(i).(*array.Int8Builder).Append(v)
-			case *arrow.Int16Type:
-				v := r.readI16(str)
-				r.bld.Field(i).(*array.Int16Builder).Append(v)
-			case *arrow.Int32Type:
-				v := r.readI32(str)
-				r.bld.Field(i).(*array.Int32Builder).Append(v)
-			case *arrow.Int64Type:
-				v := r.readI64(str)
-				r.bld.Field(i).(*array.Int64Builder).Append(v)
-			case *arrow.Uint8Type:
-				v := r.readU8(str)
-				r.bld.Field(i).(*array.Uint8Builder).Append(v)
-			case *arrow.Uint16Type:
-				v := r.readU16(str)
-				r.bld.Field(i).(*array.Uint16Builder).Append(v)
-			case *arrow.Uint32Type:
-				v := r.readU32(str)
-				r.bld.Field(i).(*array.Uint32Builder).Append(v)
-			case *arrow.Uint64Type:
-				v := r.readU64(str)
-				r.bld.Field(i).(*array.Uint64Builder).Append(v)
-			case *arrow.Float32Type:
-				v := r.readF32(str)
-				r.bld.Field(i).(*array.Float32Builder).Append(v)
-			case *arrow.Float64Type:
-				v := r.readF64(str)
-				r.bld.Field(i).(*array.Float64Builder).Append(v)
-			case *arrow.StringType:
-				r.bld.Field(i).(*array.StringBuilder).Append(str)
-			}
+func (r *Reader) isNull(val string) bool {
+	for _, ns := range r.nullValues {
+		if val == ns {
+			return true
 		}
 	}
+	return false
 }
 
-func (r *Reader) readI8(str string) int8 {
-	v, err := strconv.ParseInt(str, 10, 8)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
+func (r *Reader) read(recs []string) {
+	for i, str := range recs {
+		r.fieldConverter[i](r.bld.Field(i), str)
 	}
-	return int8(v)
 }
 
-func (r *Reader) readI16(str string) int16 {
-	v, err := strconv.ParseInt(str, 10, 16)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
+func (r *Reader) initFieldConverter(field *arrow.Field) func(array.Builder, string) {
+	switch field.Type.(type) {
+	case *arrow.BooleanType:
+		return func(field array.Builder, str string) {
+			r.parseBool(field, str)
+		}
+	case *arrow.Int8Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseInt(field, str, 8)
+			if !null {
+				field.(*array.Int8Builder).Append(int8(v))
+			}
+		}
+	case *arrow.Int16Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseInt(field, str, 16)
+			if !null {
+				field.(*array.Int16Builder).Append(int16(v))
+			}
+		}
+	case *arrow.Int32Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseInt(field, str, 32)
+			if !null {
+				field.(*array.Int32Builder).Append(int32(v))
+			}
+		}
+	case *arrow.Int64Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseInt(field, str, 64)
+			if !null {
+				field.(*array.Int64Builder).Append(int64(v))
+			}
+		}
+	case *arrow.Uint8Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseUint(field, str, 8)
+			if !null {
+				field.(*array.Uint8Builder).Append(uint8(v))
+			}
+		}
+	case *arrow.Uint16Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseUint(field, str, 16)
+			if !null {
+				field.(*array.Uint16Builder).Append(uint16(v))
+			}
+		}
+	case *arrow.Uint32Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseUint(field, str, 32)
+			if !null {
+				field.(*array.Uint32Builder).Append(uint32(v))
+			}
+		}
+	case *arrow.Uint64Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseUint(field, str, 64)
+			if !null {
+				field.(*array.Uint64Builder).Append(uint64(v))
+			}
+		}
+	case *arrow.Float32Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseFloat(field, str, 32)
+			if !null {
+				field.(*array.Float32Builder).Append(float32(v))
+			}
+		}
+	case *arrow.Float64Type:
+		return func(field array.Builder, str string) {
+			v, null := r.parseFloat(field, str, 64)
+			if !null {
+				field.(*array.Float64Builder).Append(float64(v))
+			}
+		}
+	case *arrow.StringType:
+		// specialize the implementation when we know we cannot have nulls
+		if r.stringsCanBeNull {
+			return func(field array.Builder, str string) {
+				if r.isNull(str) {
+					field.AppendNull()
+				} else {
+					field.(*array.StringBuilder).Append(str)
+				}
+			}
+		} else {
+			return func(field array.Builder, str string) {
+				field.(*array.StringBuilder).Append(str)
+			}
+		}
+
+	default:
+		panic(fmt.Errorf("arrow/csv: unhandled field type %T", field.Type))
 	}
-	return int16(v)
 }
 
-func (r *Reader) readI32(str string) int32 {
-	v, err := strconv.ParseInt(str, 10, 32)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
+func (r *Reader) parseBool(field array.Builder, str string) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return
 	}
-	return int32(v)
+
+	var v bool
+	switch str {
+	case "false", "False", "0":
+		v = false
+	case "true", "True", "1":
+		v = true
+	default:
+		r.err = fmt.Errorf("Unrecognized boolean: %s", str)
+		field.AppendNull()
+		return
+	}
+
+	field.(*array.BooleanBuilder).Append(v)
 }
 
-func (r *Reader) readI64(str string) int64 {
-	v, err := strconv.ParseInt(str, 10, 64)
+func (r *Reader) parseInt(field array.Builder, str string, width int) (int64, bool) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return 0, true
+	}
+
+	v, err := strconv.ParseInt(str, 10, width)
 	if err != nil && r.err == nil {
 		r.err = err
-		return 0
+		field.AppendNull()
+		return 0, true
 	}
-	return int64(v)
+
+	return v, false
 }
 
-func (r *Reader) readU8(str string) uint8 {
-	v, err := strconv.ParseUint(str, 10, 8)
+func (r *Reader) parseUint(field array.Builder, str string, width int) (uint64, bool) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return 0, true
+	}
+
+	v, err := strconv.ParseUint(str, 10, width)
 	if err != nil && r.err == nil {
 		r.err = err
-		return 0
+		field.AppendNull()
+		return 0, true
 	}
-	return uint8(v)
+
+	return v, false
 }
 
-func (r *Reader) readU16(str string) uint16 {
-	v, err := strconv.ParseUint(str, 10, 16)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
+func (r *Reader) parseFloat(field array.Builder, str string, width int) (float64, bool) {
+	if r.isNull(str) {
+		field.AppendNull()
+		return 0.0, true
 	}
-	return uint16(v)
-}
 
-func (r *Reader) readU32(str string) uint32 {
-	v, err := strconv.ParseUint(str, 10, 32)
+	v, err := strconv.ParseFloat(str, width)
 	if err != nil && r.err == nil {
 		r.err = err
-		return 0
+		field.AppendNull()
+		return 0.0, true
 	}
-	return uint32(v)
-}
 
-func (r *Reader) readU64(str string) uint64 {
-	v, err := strconv.ParseUint(str, 10, 64)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
-	}
-	return uint64(v)
-}
-
-func (r *Reader) readF32(str string) float32 {
-	v, err := strconv.ParseFloat(str, 32)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
-	}
-	return float32(v)
-}
-
-func (r *Reader) readF64(str string) float64 {
-	v, err := strconv.ParseFloat(str, 64)
-	if err != nil && r.err == nil {
-		r.err = err
-		return 0
-	}
-	return float64(v)
+	return v, false
 }
 
 // Retain increases the reference count by 1.

--- a/go/arrow/csv/reader_test.go
+++ b/go/arrow/csv/reader_test.go
@@ -198,6 +198,7 @@ func testCSVReader(t *testing.T, filepath string, withHeader bool) {
 		csv.WithAllocator(mem),
 		csv.WithComment('#'), csv.WithComma(';'),
 		csv.WithHeader(withHeader),
+		csv.WithNullString("null"),
 	)
 	defer r.Release()
 
@@ -219,7 +220,7 @@ func testCSVReader(t *testing.T, filepath string, withHeader bool) {
 		n++
 	}
 
-	if got, want := n, 2; got != want {
+	if got, want := n, 3; got != want {
 		t.Fatalf("invalid number of rows: got=%d, want=%d", got, want)
 	}
 
@@ -247,6 +248,18 @@ rec[1]["u64"]: [2]
 rec[1]["f32"]: [2.2]
 rec[1]["f64"]: [2.2]
 rec[1]["str"]: ["str-2"]
+rec[2]["bool"]: [(null)]
+rec[2]["i8"]: [(null)]
+rec[2]["i16"]: [(null)]
+rec[2]["i32"]: [(null)]
+rec[2]["i64"]: [(null)]
+rec[2]["u8"]: [(null)]
+rec[2]["u16"]: [(null)]
+rec[2]["u32"]: [(null)]
+rec[2]["u64"]: [(null)]
+rec[2]["f32"]: [(null)]
+rec[2]["f64"]: [(null)]
+rec[2]["str"]: [(null)]
 `
 
 	if got, want := out.String(), want; got != want {

--- a/go/arrow/csv/reader_test.go
+++ b/go/arrow/csv/reader_test.go
@@ -198,7 +198,7 @@ func testCSVReader(t *testing.T, filepath string, withHeader bool) {
 		csv.WithAllocator(mem),
 		csv.WithComment('#'), csv.WithComma(';'),
 		csv.WithHeader(withHeader),
-		csv.WithNullString("null"),
+		csv.WithNullReader(true),
 	)
 	defer r.Release()
 
@@ -275,6 +275,8 @@ rec[2]["str"]: [(null)]
 		r := csv.NewReader(bytes.NewReader(raw), schema,
 			csv.WithAllocator(mem),
 			csv.WithComment('#'), csv.WithComma(';'),
+			csv.WithHeader(withHeader),
+			csv.WithNullReader(true),
 		)
 
 		r.Next()

--- a/go/arrow/csv/reader_test.go
+++ b/go/arrow/csv/reader_test.go
@@ -148,10 +148,31 @@ func Example_withChunk() {
 }
 
 func TestCSVReader(t *testing.T) {
+	tests := []struct {
+		Name   string
+		File   string
+		Header bool
+	}{{
+		Name:   "NoHeader",
+		File:   "testdata/types.csv",
+		Header: false,
+	}, {
+		Name:   "Header",
+		File:   "testdata/header.csv",
+		Header: true,
+	}}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			testCSVReader(t, test.File, test.Header)
+		})
+	}
+}
+
+func testCSVReader(t *testing.T, filepath string, withHeader bool) {
 	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
 	defer mem.AssertSize(t, 0)
 
-	raw, err := ioutil.ReadFile("testdata/types.csv")
+	raw, err := ioutil.ReadFile(filepath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,6 +197,7 @@ func TestCSVReader(t *testing.T) {
 	r := csv.NewReader(bytes.NewReader(raw), schema,
 		csv.WithAllocator(mem),
 		csv.WithComment('#'), csv.WithComma(';'),
+		csv.WithHeader(withHeader),
 	)
 	defer r.Release()
 
@@ -246,93 +268,6 @@ rec[1]["str"]: ["str-2"]
 		r.Record()
 
 		r.Release()
-	}
-}
-
-func TestCSVReaderWithHeader(t *testing.T) {
-	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	defer mem.AssertSize(t, 0)
-
-	raw, err := ioutil.ReadFile("testdata/header.csv")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	schema := arrow.NewSchema(
-		[]arrow.Field{
-			arrow.Field{Name: "0", Type: arrow.FixedWidthTypes.Boolean},
-			arrow.Field{Name: "1", Type: arrow.PrimitiveTypes.Int8},
-			arrow.Field{Name: "2", Type: arrow.PrimitiveTypes.Int16},
-			arrow.Field{Name: "3", Type: arrow.PrimitiveTypes.Int32},
-			arrow.Field{Name: "4", Type: arrow.PrimitiveTypes.Int64},
-			arrow.Field{Name: "5", Type: arrow.PrimitiveTypes.Uint8},
-			arrow.Field{Name: "6", Type: arrow.PrimitiveTypes.Uint16},
-			arrow.Field{Name: "7", Type: arrow.PrimitiveTypes.Uint32},
-			arrow.Field{Name: "8", Type: arrow.PrimitiveTypes.Uint64},
-			arrow.Field{Name: "9", Type: arrow.PrimitiveTypes.Float32},
-			arrow.Field{Name: "10", Type: arrow.PrimitiveTypes.Float64},
-			arrow.Field{Name: "11", Type: arrow.BinaryTypes.String},
-		},
-		nil,
-	)
-
-	r := csv.NewReader(bytes.NewReader(raw), schema,
-		csv.WithAllocator(mem),
-		csv.WithComment('#'), csv.WithComma(';'),
-		csv.WithHeader(),
-	)
-	defer r.Release()
-
-	r.Retain()
-	r.Release()
-
-	out := new(bytes.Buffer)
-
-	n := 0
-	for r.Next() {
-		rec := r.Record()
-		for i, col := range rec.Columns() {
-			fmt.Fprintf(out, "rec[%d][%q]: %v\n", n, rec.ColumnName(i), col)
-		}
-		n++
-	}
-
-	if got, want := n, 2; got != want {
-		t.Fatalf("invalid number of rows: got=%d, want=%d", got, want)
-	}
-
-	want := `rec[0]["bool"]: [true]
-rec[0]["i8"]: [-1]
-rec[0]["i16"]: [-1]
-rec[0]["i32"]: [-1]
-rec[0]["i64"]: [-1]
-rec[0]["u8"]: [1]
-rec[0]["u16"]: [1]
-rec[0]["u32"]: [1]
-rec[0]["u64"]: [1]
-rec[0]["f32"]: [1.1]
-rec[0]["f64"]: [1.1]
-rec[0]["str"]: ["str-1"]
-rec[1]["bool"]: [false]
-rec[1]["i8"]: [-2]
-rec[1]["i16"]: [-2]
-rec[1]["i32"]: [-2]
-rec[1]["i64"]: [-2]
-rec[1]["u8"]: [2]
-rec[1]["u16"]: [2]
-rec[1]["u32"]: [2]
-rec[1]["u64"]: [2]
-rec[1]["f32"]: [2.2]
-rec[1]["f64"]: [2.2]
-rec[1]["str"]: ["str-2"]
-`
-
-	if got, want := out.String(), want; got != want {
-		t.Fatalf("invalid output:\ngot= %s\nwant=%s\n", got, want)
-	}
-
-	if r.Err() != nil {
-		t.Fatalf("unexpected error: %v", r.Err())
 	}
 }
 

--- a/go/arrow/csv/testdata/header.csv
+++ b/go/arrow/csv/testdata/header.csv
@@ -18,3 +18,4 @@
 bool;i8;i16;i32;i64;u8;u16;u32;u64;f32;f64;str
 true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;str-1
 false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;str-2
+null;null;null;null;null;null;null;null;null;null;null;null

--- a/go/arrow/csv/testdata/types.csv
+++ b/go/arrow/csv/testdata/types.csv
@@ -18,3 +18,4 @@
 ## supported types: bool;int8;int16;int32;int64;uint8;uint16;uint32;uint64;float32;float64;string
 true;-1;-1;-1;-1;1;1;1;1;1.1;1.1;str-1
 false;-2;-2;-2;-2;2;2;2;2;2.2;2.2;str-2
+null;null;null;null;null;null;null;null;null;null;null;null

--- a/go/arrow/csv/writer.go
+++ b/go/arrow/csv/writer.go
@@ -28,11 +28,11 @@ import (
 
 // Writer wraps encoding/csv.Writer and writes array.Record based on a schema.
 type Writer struct {
-	w      *csv.Writer
-	schema *arrow.Schema
-	header bool
-	once   sync.Once
-	null   string
+	w         *csv.Writer
+	schema    *arrow.Schema
+	header    bool
+	once      sync.Once
+	nullValue string
 }
 
 // NewWriter returns a writer that writes array.Records to the CSV file
@@ -43,7 +43,11 @@ type Writer struct {
 func NewWriter(w io.Writer, schema *arrow.Schema, opts ...Option) *Writer {
 	validate(schema)
 
-	ww := &Writer{w: csv.NewWriter(w), schema: schema}
+	ww := &Writer{
+		w:         csv.NewWriter(w),
+		schema:    schema,
+		nullValue: "NULL", // override by passing WithNullWriter() as an option
+	}
 	for _, opt := range opts {
 		opt(ww)
 	}
@@ -82,7 +86,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatBool(arr.Value(i))
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Int8Type:
@@ -91,7 +95,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Int16Type:
@@ -100,7 +104,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Int32Type:
@@ -109,7 +113,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Int64Type:
@@ -118,7 +122,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Uint8Type:
@@ -127,7 +131,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Uint16Type:
@@ -136,7 +140,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Uint32Type:
@@ -145,7 +149,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Uint64Type:
@@ -154,7 +158,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Float32Type:
@@ -163,7 +167,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatFloat(float64(arr.Value(i)), 'g', -1, 32)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.Float64Type:
@@ -172,7 +176,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = strconv.FormatFloat(float64(arr.Value(i)), 'g', -1, 64)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		case *arrow.StringType:
@@ -181,7 +185,7 @@ func (w *Writer) Write(record array.Record) error {
 				if arr.IsValid(i) {
 					recs[i][j] = arr.Value(i)
 				} else {
-					recs[i][j] = w.null
+					recs[i][j] = w.nullValue
 				}
 			}
 		}

--- a/go/arrow/csv/writer.go
+++ b/go/arrow/csv/writer.go
@@ -32,6 +32,7 @@ type Writer struct {
 	schema *arrow.Schema
 	header bool
 	once   sync.Once
+	null   string
 }
 
 // NewWriter returns a writer that writes array.Records to the CSV file
@@ -78,62 +79,110 @@ func (w *Writer) Write(record array.Record) error {
 		case *arrow.BooleanType:
 			arr := col.(*array.Boolean)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatBool(arr.Value(i))
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatBool(arr.Value(i))
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Int8Type:
 			arr := col.(*array.Int8)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Int16Type:
 			arr := col.(*array.Int16)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Int32Type:
 			arr := col.(*array.Int32)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Int64Type:
 			arr := col.(*array.Int64)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatInt(int64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Uint8Type:
 			arr := col.(*array.Uint8)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Uint16Type:
 			arr := col.(*array.Uint16)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Uint32Type:
 			arr := col.(*array.Uint32)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Uint64Type:
 			arr := col.(*array.Uint64)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatUint(uint64(arr.Value(i)), 10)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Float32Type:
 			arr := col.(*array.Float32)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatFloat(float64(arr.Value(i)), 'g', -1, 32)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatFloat(float64(arr.Value(i)), 'g', -1, 32)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.Float64Type:
 			arr := col.(*array.Float64)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = strconv.FormatFloat(float64(arr.Value(i)), 'g', -1, 64)
+				if arr.IsValid(i) {
+					recs[i][j] = strconv.FormatFloat(float64(arr.Value(i)), 'g', -1, 64)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		case *arrow.StringType:
 			arr := col.(*array.String)
 			for i := 0; i < arr.Len(); i++ {
-				recs[i][j] = arr.Value(i)
+				if arr.IsValid(i) {
+					recs[i][j] = arr.Value(i)
+				} else {
+					recs[i][j] = w.null
+				}
 			}
 		}
 	}

--- a/go/arrow/csv/writer_test.go
+++ b/go/arrow/csv/writer_test.go
@@ -182,7 +182,7 @@ func testCSVWriter(t *testing.T, writeHeader bool) {
 		csv.WithComma(';'),
 		csv.WithCRLF(false),
 		csv.WithHeader(writeHeader),
-		csv.WithNullString("null"),
+		csv.WithNullWriter("null"),
 	)
 	err := w.Write(rec)
 	if err != nil {

--- a/go/arrow/csv/writer_test.go
+++ b/go/arrow/csv/writer_test.go
@@ -115,6 +115,24 @@ func Example_writer() {
 }
 
 func TestCSVWriter(t *testing.T) {
+	tests := []struct {
+		name   string
+		header bool
+	}{{
+		name:   "Noheader",
+		header: false,
+	}, {
+		name:   "Header",
+		header: true,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testCSVWriter(t, test.header)
+		})
+	}
+}
+
+func testCSVWriter(t *testing.T, writeHeader bool) {
 	f := new(bytes.Buffer)
 
 	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
@@ -156,7 +174,11 @@ func TestCSVWriter(t *testing.T) {
 	rec := b.NewRecord()
 	defer rec.Release()
 
-	w := csv.NewWriter(f, schema, csv.WithComma(';'), csv.WithCRLF(false))
+	w := csv.NewWriter(f, schema,
+		csv.WithComma(';'),
+		csv.WithCRLF(false),
+		csv.WithHeader(writeHeader),
+	)
 	err := w.Write(rec)
 	if err != nil {
 		t.Fatal(err)
@@ -177,64 +199,9 @@ false;0;0;0;0;1;1;1;1;0.1;0.1;str-1
 true;1;1;1;1;2;2;2;2;0.2;0.2;str-2
 `
 
-	if got, want := f.String(), want; strings.Compare(got, want) != 0 {
-		t.Fatalf("invalid output:\ngot=%s\nwant=%s\n", got, want)
+	if writeHeader {
+		want = "bool;i8;i16;i32;i64;u8;u16;u32;u64;f32;f64;str\n" + want
 	}
-}
-
-func TestCSVWriterWithHeader(t *testing.T) {
-	f := new(bytes.Buffer)
-
-	pool := memory.NewCheckedAllocator(memory.NewGoAllocator())
-	defer pool.AssertSize(t, 0)
-	schema := arrow.NewSchema(
-		[]arrow.Field{
-			{Name: "bool", Type: arrow.FixedWidthTypes.Boolean},
-			{Name: "i8", Type: arrow.PrimitiveTypes.Int8},
-			{Name: "i16", Type: arrow.PrimitiveTypes.Int16},
-			{Name: "i32", Type: arrow.PrimitiveTypes.Int32},
-			{Name: "i64", Type: arrow.PrimitiveTypes.Int64},
-			{Name: "u8", Type: arrow.PrimitiveTypes.Uint8},
-			{Name: "u16", Type: arrow.PrimitiveTypes.Uint16},
-			{Name: "u32", Type: arrow.PrimitiveTypes.Uint32},
-			{Name: "u64", Type: arrow.PrimitiveTypes.Uint64},
-			{Name: "f32", Type: arrow.PrimitiveTypes.Float32},
-			{Name: "f64", Type: arrow.PrimitiveTypes.Float64},
-			{Name: "str", Type: arrow.BinaryTypes.String},
-		},
-		nil,
-	)
-
-	b := array.NewRecordBuilder(pool, schema)
-	defer b.Release()
-
-	b.Field(0).(*array.BooleanBuilder).AppendValues([]bool{true, false, true}, nil)
-	b.Field(1).(*array.Int8Builder).AppendValues([]int8{-1, 0, 1}, nil)
-	b.Field(2).(*array.Int16Builder).AppendValues([]int16{-1, 0, 1}, nil)
-	b.Field(3).(*array.Int32Builder).AppendValues([]int32{-1, 0, 1}, nil)
-	b.Field(4).(*array.Int64Builder).AppendValues([]int64{-1, 0, 1}, nil)
-	b.Field(5).(*array.Uint8Builder).AppendValues([]uint8{0, 1, 2}, nil)
-	b.Field(6).(*array.Uint16Builder).AppendValues([]uint16{0, 1, 2}, nil)
-	b.Field(7).(*array.Uint32Builder).AppendValues([]uint32{0, 1, 2}, nil)
-	b.Field(8).(*array.Uint64Builder).AppendValues([]uint64{0, 1, 2}, nil)
-	b.Field(9).(*array.Float32Builder).AppendValues([]float32{0.0, 0.1, 0.2}, nil)
-	b.Field(10).(*array.Float64Builder).AppendValues([]float64{0.0, 0.1, 0.2}, nil)
-	b.Field(11).(*array.StringBuilder).AppendValues([]string{"str-0", "str-1", "str-2"}, nil)
-
-	rec := b.NewRecord()
-	defer rec.Release()
-
-	w := csv.NewWriter(f, schema, csv.WithComma(';'), csv.WithCRLF(false), csv.WithHeader())
-	err := w.Write(rec)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := `bool;i8;i16;i32;i64;u8;u16;u32;u64;f32;f64;str
-true;-1;-1;-1;-1;0;0;0;0;0;0;str-0
-false;0;0;0;0;1;1;1;1;0.1;0.1;str-1
-true;1;1;1;1;2;2;2;2;0.2;0.2;str-2
-`
 
 	if got, want := f.String(), want; strings.Compare(got, want) != 0 {
 		t.Fatalf("invalid output:\ngot=%s\nwant=%s\n", got, want)

--- a/go/arrow/csv/writer_test.go
+++ b/go/arrow/csv/writer_test.go
@@ -171,6 +171,10 @@ func testCSVWriter(t *testing.T, writeHeader bool) {
 	b.Field(10).(*array.Float64Builder).AppendValues([]float64{0.0, 0.1, 0.2}, nil)
 	b.Field(11).(*array.StringBuilder).AppendValues([]string{"str-0", "str-1", "str-2"}, nil)
 
+	for _, field := range b.Fields() {
+		field.AppendNull()
+	}
+
 	rec := b.NewRecord()
 	defer rec.Release()
 
@@ -178,6 +182,7 @@ func testCSVWriter(t *testing.T, writeHeader bool) {
 		csv.WithComma(';'),
 		csv.WithCRLF(false),
 		csv.WithHeader(writeHeader),
+		csv.WithNullString("null"),
 	)
 	err := w.Write(rec)
 	if err != nil {
@@ -197,6 +202,7 @@ func testCSVWriter(t *testing.T, writeHeader bool) {
 	want := `true;-1;-1;-1;-1;0;0;0;0;0;0;str-0
 false;0;0;0;0;1;1;1;1;0.1;0.1;str-1
 true;1;1;1;1;2;2;2;2;0.2;0.2;str-2
+null;null;null;null;null;null;null;null;null;null;null;null
 `
 
 	if writeHeader {


### PR DESCRIPTION
This patch-set extends the support for nulls in Arrow's CSV reader and writer. The string used for nulls is added as an option for the Reader and Writer structs. 

Also included in the PR is a commit that refactors the test code to avoid repetition between with-header and non-header tests. If preferred, I can create a separate PR and corresponding JIRA. 

See #3129 for a prior (abandoned) attempt at this, but with useful discussion. This current PR explicitly passes the string for null values to the reader or writer. We could generalize the reader further by using a slice of valid NULLs; this is roughly what the C++ interface provides from what I can tell.