### PR TITLE
ARROW-3372: [C++] Add SlicedBuffer class, move parent_ member out of Buffer

### DIFF
--- a/c_glib/arrow-glib/buffer.hpp
+++ b/c_glib/arrow-glib/buffer.hpp
@@ -28,8 +28,8 @@ GArrowBuffer *garrow_buffer_new_raw_bytes(std::shared_ptr<arrow::Buffer> *arrow_
                                           GBytes *data);
 std::shared_ptr<arrow::Buffer> garrow_buffer_get_raw(GArrowBuffer *buffer);
 
-GArrowMutableBuffer *garrow_mutable_buffer_new_raw(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer);
-GArrowMutableBuffer *garrow_mutable_buffer_new_raw_bytes(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer,
+GArrowMutableBuffer *garrow_mutable_buffer_new_raw(std::shared_ptr<arrow::Buffer> *arrow_buffer);
+GArrowMutableBuffer *garrow_mutable_buffer_new_raw_bytes(std::shared_ptr<arrow::Buffer> *arrow_buffer,
                                                          GBytes *data);
 GArrowResizableBuffer *
 garrow_resizable_buffer_new_raw(std::shared_ptr<arrow::ResizableBuffer> *arrow_buffer);

--- a/c_glib/plasma-glib/client.cpp
+++ b/c_glib/plasma-glib/client.cpp
@@ -469,9 +469,7 @@ gplasma_client_create(GPlasmaClient *client,
   if (garrow_error_check(error, status, context)) {
     GArrowBuffer *data = nullptr;
     if (device_number == 0) {
-      auto plasma_mutable_data =
-        std::static_pointer_cast<arrow::MutableBuffer>(plasma_data);
-      data = GARROW_BUFFER(garrow_mutable_buffer_new_raw(&plasma_mutable_data));
+      data = GARROW_BUFFER(garrow_mutable_buffer_new_raw(&plasma_data));
 #ifdef HAVE_ARROW_CUDA
     } else {
       auto plasma_cuda_data =

--- a/cpp/src/arrow/buffer-test.cc
+++ b/cpp/src/arrow/buffer-test.cc
@@ -183,7 +183,7 @@ TEST(TestBuffer, SliceMutableBuffer) {
 
   memcpy(buffer->mutable_data(), data, data_str.size());
 
-  std::shared_ptr<Buffer> slice = SliceMutableBuffer(buffer, 5, 10);
+  std::shared_ptr<Buffer> slice = SliceBuffer(buffer, 5, 10);
   ASSERT_TRUE(slice->is_mutable());
   ASSERT_EQ(10, slice->size());
 

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -149,18 +149,6 @@ class PoolBuffer : public ResizableBuffer {
   MemoryPool* pool_;
 };
 
-std::shared_ptr<Buffer> SliceMutableBuffer(const std::shared_ptr<Buffer>& buffer,
-                                           const int64_t offset, const int64_t length) {
-  return std::make_shared<MutableBuffer>(buffer, offset, length);
-}
-
-MutableBuffer::MutableBuffer(const std::shared_ptr<Buffer>& parent, const int64_t offset,
-                             const int64_t size)
-    : MutableBuffer(parent->mutable_data() + offset, size) {
-  DCHECK(parent->is_mutable()) << "Must pass mutable buffer";
-  parent_ = parent;
-}
-
 namespace {
 // A utility that does most of the work of the `AllocateBuffer` and
 // `AllocateResizableBuffer` methods. The argument `buffer` should be a smart pointer to a

--- a/cpp/src/arrow/gpu/cuda-test.cc
+++ b/cpp/src/arrow/gpu/cuda-test.cc
@@ -106,18 +106,18 @@ TEST_F(TestCudaBuffer, FromBuffer) {
   buffer = SliceBuffer(device_buffer, 0, kSize);
   ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
   ASSERT_EQ(result->size(), kSize);
-  ASSERT_EQ(result->is_mutable(), false);
+  ASSERT_EQ(result->is_mutable(), true);
   AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
 
-  buffer = SliceMutableBuffer(device_buffer, 0, kSize);
+  buffer = SliceBuffer(device_buffer, 0, kSize);
   ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
   ASSERT_EQ(result->size(), kSize);
   ASSERT_EQ(result->is_mutable(), true);
   ASSERT_EQ(result->mutable_data(), buffer->mutable_data());
   AssertCudaBufferEquals(*result, host_buffer->data(), kSize);
 
-  buffer = SliceMutableBuffer(device_buffer, 3, kSize - 10);
-  buffer = SliceMutableBuffer(buffer, 8, kSize - 20);
+  buffer = SliceBuffer(device_buffer, 3, kSize - 10);
+  buffer = SliceBuffer(buffer, 8, kSize - 20);
   ASSERT_OK(CudaBuffer::FromBuffer(buffer, &result));
   ASSERT_EQ(result->size(), kSize - 20);
   ASSERT_EQ(result->is_mutable(), true);

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -114,10 +114,11 @@ Status CudaBuffer::Close() {
 
 CudaBuffer::CudaBuffer(const std::shared_ptr<CudaBuffer>& parent, const int64_t offset,
                        const int64_t size)
-    : Buffer(parent, offset, size),
+    : Buffer(parent->data() + offset, size),
       context_(parent->context()),
       own_data_(false),
-      is_ipc_(false) {
+      is_ipc_(false),
+      parent_(parent) {
   if (parent->is_mutable()) {
     is_mutable_ = true;
     mutable_data_ = const_cast<uint8_t*>(data_);

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -104,6 +104,8 @@ class ARROW_EXPORT CudaBuffer : public Buffer {
   bool own_data_;
   bool is_ipc_;
 
+  std::shared_ptr<CudaBuffer> parent_;
+
   virtual Status Close();
 };
 

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -768,12 +768,9 @@ Status NumPyConverter::Visit(const StructType& type) {
     if (!null_buffer) {
       fixed_null_buffer = null_buffer;
     } else if (null_offset % 8 == 0) {
-      fixed_null_buffer =
-          std::make_shared<Buffer>(null_buffer,
-                                   // byte offset
-                                   null_offset / 8,
-                                   // byte size
-                                   BitUtil::BytesForBits(null_data->length));
+      fixed_null_buffer = SliceBuffer(null_buffer,
+                                      /*offset=*/null_offset / 8,
+                                      /*size=*/BitUtil::BytesForBits(null_data->length));
     } else {
       RETURN_NOT_OK(CopyBitmap(pool_, null_buffer->data(), null_offset, null_data->length,
                                &fixed_null_buffer));

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -106,17 +106,13 @@ static std::mutex gpu_mutex;
 
 /// A Buffer class that automatically releases the backing plasma object
 /// when it goes out of scope. This is returned by Get.
-class ARROW_NO_EXPORT PlasmaBuffer : public Buffer {
+class ARROW_NO_EXPORT PlasmaBuffer : public arrow::SlicedBuffer {
  public:
   ~PlasmaBuffer();
 
   PlasmaBuffer(std::shared_ptr<PlasmaClient::Impl> client, const ObjectID& object_id,
                const std::shared_ptr<Buffer>& buffer)
-      : Buffer(buffer, 0, buffer->size()), client_(client), object_id_(object_id) {
-    if (buffer->is_mutable()) {
-      is_mutable_ = true;
-    }
-  }
+      : SlicedBuffer(buffer, 0, buffer->size()), client_(client), object_id_(object_id) {}
 
  private:
   std::shared_ptr<PlasmaClient::Impl> client_;


### PR DESCRIPTION
The purpose of this patch is to encapsulate buffer slicing in a subclass that can forward virtual functions to a parent buffer. I had found the way that buffer slicing worked previously to be a bit messy, with the `parent_` member being unused unless the buffer is a slice. 

This patch removes a couple of slicing constructors and removes `SliceMutableBuffer`. I would guess that these APIs are only used internally in this library so I'm not sure this will impact users of the C++ library