### PR TITLE
ARROW-5386: [Java] Making the rounding behavior of the buffer capacity configurable

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -268,7 +268,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Get the expected buffer size after rounding.
+   * Gets the expected buffer size after rounding.
    * @param initialRequestSize the requested buffer size.
    * @param roundingOption the rounding option.
    * @return the buffer size after rounding.

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -59,7 +59,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   private volatile boolean isClosed = false; // the allocator has been closed
 
   /**
-   * Initialize an allocator
+   * Initializes an allocator
    * @param parentAllocator   parent allocator. null if defining a root allocator
    * @param listener          listener callback. Must be non-null -- use
    *                          {@link AllocationListener#NOOP} if no listener desired
@@ -176,7 +176,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Specify an indentation amount when using a StringBuilder.
+   * Specifies the amount of indentation when using a StringBuilder.
    *
    * @param sb StringBuilder to use
    * @param indent Indentation amount
@@ -245,7 +245,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Track when a ChildAllocator of this BaseAllocator is closed. Used for debugging purposes.
+   * Tracks when a ChildAllocator of this BaseAllocator is closed. Used for debugging purposes.
    *
    * @param childAllocator The child allocator that has been closed.
    */
@@ -502,7 +502,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Provide a verbose string of the current allocator state. Includes the state of all child
+   * Provides a verbose string of the current allocator state. Includes the state of all child
    * allocators, along with
    * historical logs of each object and including stacktraces.
    *
@@ -863,7 +863,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     /**
-     * Allocate a buffer of the requested size.
+     * Allocates a buffer of the requested size.
      *
      * <p>The implementation of the allocator's inner class provides this.
      *
@@ -900,7 +900,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     /**
-     * Return the reservation back to the allocator without having used it.
+     * Returns the reservation back to the allocator without having used it.
      *
      * @param nBytes the size of the reservation
      */

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -318,7 +318,9 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     // This happens when the requested buffer size is within a chunk size. In that case, the actual buffer size
     // must be a power of 2, and the specific rounding behavior depends on the rounding option:
     // 1. If rounding up is used as the option, the actual buffer size will be requested size rounded up to the nearest power of 2.
+    // This is the default behavior.
     // 2. If rounding down is used, the actual buffer size will be the requested size rounded down to the nearest power of 2.
+    // This option is used to avoid OutOfMemoryException.
     final int actualRequestSize = getRoundedSize(initialRequestSize, roundingOption);
 
     listener.onPreAllocation(actualRequestSize);

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -59,7 +59,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   private volatile boolean isClosed = false; // the allocator has been closed
 
   /**
-   * Initializes an allocator
+   * Initialize an allocator
    * @param parentAllocator   parent allocator. null if defining a root allocator
    * @param listener          listener callback. Must be non-null -- use
    *                          {@link AllocationListener#NOOP} if no listener desired
@@ -176,7 +176,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Specifies the amount of indentation when using a StringBuilder.
+   * Specify an indentation amount when using a StringBuilder.
    *
    * @param sb StringBuilder to use
    * @param indent Indentation amount
@@ -245,7 +245,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Tracks when a ChildAllocator of this BaseAllocator is closed. Used for debugging purposes.
+   * Track when a ChildAllocator of this BaseAllocator is closed. Used for debugging purposes.
    *
    * @param childAllocator The child allocator that has been closed.
    */
@@ -502,7 +502,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Provides a verbose string of the current allocator state. Includes the state of all child
+   * Provide a verbose string of the current allocator state. Includes the state of all child
    * allocators, along with
    * historical logs of each object and including stacktraces.
    *
@@ -863,7 +863,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     /**
-     * Allocates a buffer of the requested size.
+     * Allocate a buffer of the requested size.
      *
      * <p>The implementation of the allocator's inner class provides this.
      *
@@ -900,7 +900,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     /**
-     * Returns the reservation back to the allocator without having used it.
+     * Return the reservation back to the allocator without having used it.
      *
      * @param nBytes the size of the reservation
      */

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -317,10 +317,10 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     // The actual buffer size may not equal the requested buffer size.
     // This happens when the requested buffer size is within a chunk size. In that case, the actual buffer size
     // must be a power of 2, and the specific rounding behavior depends on the rounding option:
-    // 1. If rounding up is used as the option, the actual buffer size will be requested size rounded up to the nearest power of 2.
-    // This is the default behavior.
-    // 2. If rounding down is used, the actual buffer size will be the requested size rounded down to the nearest power of 2.
-    // This option is used to avoid OutOfMemoryException.
+    // 1. If rounding up is used as the option, the actual buffer size will be requested size rounded up to the
+    // nearest power of 2. This is the default behavior.
+    // 2. If rounding down is used, the actual buffer size will be the requested size rounded down to the nearest
+    // power of 2. This option is used to avoid OutOfMemoryException.
     final int actualRequestSize = getRoundedSize(initialRequestSize, roundingOption);
 
     listener.onPreAllocation(actualRequestSize);

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -314,7 +314,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       return empty;
     }
 
-    // round to next largest power of two if we're within a chunk since that is how our allocator
+    // round to a power of two if we're within a chunk since that is how our allocator
     // operates
     final int actualRequestSize = getRoundedSize(initialRequestSize, roundingOption);
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -314,8 +314,11 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       return empty;
     }
 
-    // round to a power of two if we're within a chunk since that is how our allocator
-    // operates
+    // The actual buffer size may not equal the requested buffer size.
+    // This happens when the requested buffer size is within a chunk size. In that case, the actual buffer size
+    // must be a power of 2, and the specific rounding behavior depends on the rounding option:
+    // 1. If rounding up is used as the option, the actual buffer size will be requested size rounded up to the nearest power of 2.
+    // 2. If rounding down is used, the actual buffer size will be the requested size rounded down to the nearest power of 2.
     final int actualRequestSize = getRoundedSize(initialRequestSize, roundingOption);
 
     listener.onPreAllocation(actualRequestSize);

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -922,12 +922,12 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   public enum AllocationRoundingOption {
 
     /**
-     * The capacity should be rounded up, if the requested size is below {@link AllocationManager#CHUNK_SIZE}
+     * The capacity should be rounded up, if the requested size is below {@link AllocationManager#CHUNK_SIZE}.
      */
     ROUND_UP,
 
     /**
-     * The capacity should be rounded down, if the requested size is below {@link AllocationManager#CHUNK_SIZE}
+     * The capacity should be rounded down, if the requested size is below {@link AllocationManager#CHUNK_SIZE}.
      */
     ROUND_DOWN
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -144,20 +144,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   /**
-   * Rounds down the provided value to the nearest power of two.
-   *
-   * @param val An integer value.
-   * @return The closest power of two of that value.
-   */
-  public static int prevPowerOfTwo(int val) {
-    if (val == 0) {
-      return val;
-    } else {
-      return Integer.highestOneBit(val);
-    }
-  }
-
-  /**
    * Rounds up the provided value to the nearest power of two.
    *
    * @param val A long value.
@@ -270,21 +256,13 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   /**
    * Gets the expected buffer size after rounding.
    * @param initialRequestSize the requested buffer size.
-   * @param roundingOption the rounding option.
    * @return the buffer size after rounding.
    */
-  public int getRoundedSize(final int initialRequestSize, AllocationRoundingOption roundingOption) {
+  public int getRoundedSize(final int initialRequestSize) {
     if (initialRequestSize >= AllocationManager.CHUNK_SIZE) {
       return initialRequestSize;
-    }
-
-    switch (roundingOption) {
-      case ROUND_UP:
-        return nextPowerOfTwo(initialRequestSize);
-      case ROUND_DOWN:
-        return prevPowerOfTwo(initialRequestSize);
-      default:
-        throw new IllegalArgumentException("Illegal rounding option: " + roundingOption);
+    } else {
+      return nextPowerOfTwo(initialRequestSize);
     }
   }
 
@@ -301,11 +279,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   @Override
   public ArrowBuf buffer(final int initialRequestSize, BufferManager manager) {
-    return buffer(initialRequestSize, manager, AllocationRoundingOption.ROUND_UP);
-  }
-
-  @Override
-  public ArrowBuf buffer(final int initialRequestSize, BufferManager manager, AllocationRoundingOption roundingOption) {
     assertOpen();
 
     Preconditions.checkArgument(initialRequestSize >= 0, "the requested size must be non-negative");
@@ -314,14 +287,11 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       return empty;
     }
 
-    // The actual buffer size may not equal the requested buffer size.
-    // This happens when the requested buffer size is within a chunk size. In that case, the actual buffer size
-    // must be a power of 2, and the specific rounding behavior depends on the rounding option:
-    // 1. If rounding up is used as the option, the actual buffer size will be requested size rounded up to the
-    // nearest power of 2. This is the default behavior.
-    // 2. If rounding down is used, the actual buffer size will be the requested size rounded down to the nearest
-    // power of 2. This option is used to avoid OutOfMemoryException.
-    final int actualRequestSize = getRoundedSize(initialRequestSize, roundingOption);
+    // round to next largest power of two if we're within a chunk since that is how our allocator
+    // operates
+    final int actualRequestSize =
+        initialRequestSize < AllocationManager.CHUNK_SIZE ?
+          nextPowerOfTwo(initialRequestSize) : initialRequestSize;
 
     listener.onPreAllocation(actualRequestSize);
 
@@ -920,21 +890,4 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
   }
-
-  /**
-   * Options for rounding the capacity when allocating an {@link ArrowBuf}.
-   */
-  public enum AllocationRoundingOption {
-
-    /**
-     * The capacity should be rounded up, if the requested size is below {@link AllocationManager#CHUNK_SIZE}.
-     */
-    ROUND_UP,
-
-    /**
-     * The capacity should be rounded down, if the requested size is below {@link AllocationManager#CHUNK_SIZE}.
-     */
-    ROUND_DOWN
-  }
-
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -51,25 +51,11 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf buffer(int size, BufferManager manager);
 
   /**
-   * Allocates a new or reused buffer of the provided size. Note that the buffer may technically
-   * be larger or smaller than the  requested size, depending on the rounding option.
-   * However, the buffer's capacity will be set to the configured size.
-   *
-   * @param size The size in bytes.
-   * @param manager A buffer manager to manage reallocation.
-   * @param roundingOption The rounding option.
-   * @return a new ArrowBuf, or null if the request can't be satisfied
-   * @throws OutOfMemoryException if buffer cannot be allocated
-   */
-  public ArrowBuf buffer(int size, BufferManager manager, BaseAllocator.AllocationRoundingOption roundingOption);
-
-  /**
    * Gets the rounded buffer size.
    * @param size The requested buffer size.
-   * @param roundingOption The rounding option.
    * @return the buffer size after rounding.
    */
-  public int getRoundedSize(final int size, BaseAllocator.AllocationRoundingOption roundingOption);
+  public int getRoundedSize(final int size);
 
   /**
    * Returns the allocator this allocator falls back to when it needs more memory.

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -79,7 +79,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ByteBufAllocator getAsByteBufAllocator();
 
   /**
-   * Create a new child allocator.
+   * Creates a new child allocator.
    *
    * @param name            the name of the allocator.
    * @param initReservation the initial space reservation (obtained from this allocator)
@@ -89,7 +89,7 @@ public interface BufferAllocator extends AutoCloseable {
   public BufferAllocator newChildAllocator(String name, long initReservation, long maxAllocation);
 
   /**
-   * Create a new child allocator.
+   * Creates a new child allocator.
    *
    * @param name            the name of the allocator.
    * @param listener        allocation listener for the newly created child
@@ -104,7 +104,7 @@ public interface BufferAllocator extends AutoCloseable {
       long maxAllocation);
 
   /**
-   * Close and release all buffers generated from this buffer pool.
+   * Closes and releases all buffers generated from this buffer pool.
    *
    * <p>When assertions are on, complains if there are any outstanding buffers; to avoid
    * that, release all buffers before the allocator is closed.</p>
@@ -120,21 +120,21 @@ public interface BufferAllocator extends AutoCloseable {
   public long getAllocatedMemory();
 
   /**
-   * Return the current maximum limit this allocator imposes.
+   * Returns the current maximum limit this allocator imposes.
    *
    * @return Limit in number of bytes.
    */
   public long getLimit();
 
   /**
-   * Return the initial reservation.
+   * Returns the initial reservation.
    *
    * @return reservation in bytes.
    */
   public long getInitReservation();
 
   /**
-   * Set the maximum amount of memory this allocator is allowed to allocate.
+   * Sets the maximum amount of memory this allocator is allowed to allocate.
    *
    * @param newLimit The new Limit to apply to allocations
    */
@@ -156,7 +156,7 @@ public interface BufferAllocator extends AutoCloseable {
   public long getHeadroom();
 
   /**
-   * Create an allocation reservation. A reservation is a way of building up
+   * Creates an allocation reservation. A reservation is a way of building up
    * a request for a buffer whose size is not known in advance. See
    *
    * @return the newly created reservation
@@ -165,7 +165,7 @@ public interface BufferAllocator extends AutoCloseable {
   public AllocationReservation newReservation();
 
   /**
-   * Get a reference to the empty buffer associated with this allocator. Empty buffers are
+   * Gets a reference to the empty buffer associated with this allocator. Empty buffers are
    * special because we don't
    * worry about them leaking or managing reference counts on them since they don't actually
    * point to any memory.
@@ -175,7 +175,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf getEmpty();
 
   /**
-   * Return the name of this allocator. This is a human readable name that can help debugging.
+   * Returns the name of this allocator. This is a human readable name that can help debugging.
    * Typically provides
    * coordinates about where this allocator was created
    *
@@ -184,7 +184,7 @@ public interface BufferAllocator extends AutoCloseable {
   public String getName();
 
   /**
-   * Return whether or not this allocator (or one if its parents) is over its limits. In the case
+   * Returns whether or not this allocator (or one if its parents) is over its limits. In the case
    * that an allocator is
    * over its limit, all consumers of that allocator should aggressively try to addrss the
    * overlimit situation.
@@ -194,7 +194,7 @@ public interface BufferAllocator extends AutoCloseable {
   public boolean isOverLimit();
 
   /**
-   * Return a verbose string describing this allocator. If in DEBUG mode, this will also include
+   * Returns a verbose string describing this allocator. If in DEBUG mode, this will also include
    * relevant stacktraces
    * and historical logs for underlying objects
    *

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -26,7 +26,7 @@ import io.netty.buffer.ByteBufAllocator;
 public interface BufferAllocator extends AutoCloseable {
 
   /**
-   * Allocates a new or reused buffer of the provided size. Note that the buffer may technically
+   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
    * be larger than the
    * requested size for rounding purposes. However, the buffer's capacity will be set to the
    * configured size.
@@ -38,7 +38,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf buffer(int size);
 
   /**
-   * Allocates a new or reused buffer of the provided size. Note that the buffer may technically
+   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
    * be larger than the
    * requested size for rounding purposes. However, the buffer's capacity will be set to the
    * configured size.
@@ -79,7 +79,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ByteBufAllocator getAsByteBufAllocator();
 
   /**
-   * Creates a new child allocator.
+   * Create a new child allocator.
    *
    * @param name            the name of the allocator.
    * @param initReservation the initial space reservation (obtained from this allocator)
@@ -89,7 +89,7 @@ public interface BufferAllocator extends AutoCloseable {
   public BufferAllocator newChildAllocator(String name, long initReservation, long maxAllocation);
 
   /**
-   * Creates a new child allocator.
+   * Create a new child allocator.
    *
    * @param name            the name of the allocator.
    * @param listener        allocation listener for the newly created child
@@ -104,7 +104,7 @@ public interface BufferAllocator extends AutoCloseable {
       long maxAllocation);
 
   /**
-   * Closes and releases all buffers generated from this buffer pool.
+   * Close and release all buffers generated from this buffer pool.
    *
    * <p>When assertions are on, complains if there are any outstanding buffers; to avoid
    * that, release all buffers before the allocator is closed.</p>
@@ -120,21 +120,21 @@ public interface BufferAllocator extends AutoCloseable {
   public long getAllocatedMemory();
 
   /**
-   * Returns the current maximum limit this allocator imposes.
+   * Return the current maximum limit this allocator imposes.
    *
    * @return Limit in number of bytes.
    */
   public long getLimit();
 
   /**
-   * Returns the initial reservation.
+   * Return the initial reservation.
    *
    * @return reservation in bytes.
    */
   public long getInitReservation();
 
   /**
-   * Sets the maximum amount of memory this allocator is allowed to allocate.
+   * Set the maximum amount of memory this allocator is allowed to allocate.
    *
    * @param newLimit The new Limit to apply to allocations
    */
@@ -156,7 +156,7 @@ public interface BufferAllocator extends AutoCloseable {
   public long getHeadroom();
 
   /**
-   * Creates an allocation reservation. A reservation is a way of building up
+   * Create an allocation reservation. A reservation is a way of building up
    * a request for a buffer whose size is not known in advance. See
    *
    * @return the newly created reservation
@@ -165,7 +165,7 @@ public interface BufferAllocator extends AutoCloseable {
   public AllocationReservation newReservation();
 
   /**
-   * Gets a reference to the empty buffer associated with this allocator. Empty buffers are
+   * Get a reference to the empty buffer associated with this allocator. Empty buffers are
    * special because we don't
    * worry about them leaking or managing reference counts on them since they don't actually
    * point to any memory.
@@ -175,7 +175,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf getEmpty();
 
   /**
-   * Returns the name of this allocator. This is a human readable name that can help debugging.
+   * Return the name of this allocator. This is a human readable name that can help debugging.
    * Typically provides
    * coordinates about where this allocator was created
    *
@@ -184,7 +184,7 @@ public interface BufferAllocator extends AutoCloseable {
   public String getName();
 
   /**
-   * Returns whether or not this allocator (or one if its parents) is over its limits. In the case
+   * Return whether or not this allocator (or one if its parents) is over its limits. In the case
    * that an allocator is
    * over its limit, all consumers of that allocator should aggressively try to addrss the
    * overlimit situation.
@@ -194,7 +194,7 @@ public interface BufferAllocator extends AutoCloseable {
   public boolean isOverLimit();
 
   /**
-   * Returns a verbose string describing this allocator. If in DEBUG mode, this will also include
+   * Return a verbose string describing this allocator. If in DEBUG mode, this will also include
    * relevant stacktraces
    * and historical logs for underlying objects
    *

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -26,7 +26,7 @@ import io.netty.buffer.ByteBufAllocator;
 public interface BufferAllocator extends AutoCloseable {
 
   /**
-   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
+   * Allocates a new or reused buffer of the provided size. Note that the buffer may technically
    * be larger than the
    * requested size for rounding purposes. However, the buffer's capacity will be set to the
    * configured size.
@@ -38,7 +38,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf buffer(int size);
 
   /**
-   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
+   * Allocates a new or reused buffer of the provided size. Note that the buffer may technically
    * be larger than the
    * requested size for rounding purposes. However, the buffer's capacity will be set to the
    * configured size.
@@ -51,7 +51,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf buffer(int size, BufferManager manager);
 
   /**
-   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
+   * Allocates a new or reused buffer of the provided size. Note that the buffer may technically
    * be larger or smaller than the  requested size, depending on the rounding option.
    * However, the buffer's capacity will be set to the configured size.
    *
@@ -64,7 +64,7 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf buffer(int size, BufferManager manager, BaseAllocator.AllocationRoundingOption roundingOption);
 
   /**
-   * Get the rounded buffer size.
+   * Gets the rounded buffer size.
    * @param size The requested buffer size.
    * @param roundingOption The rounding option.
    * @return the buffer size after rounding.
@@ -208,5 +208,4 @@ public interface BufferAllocator extends AutoCloseable {
    * a no-op.
    */
   public void assertOpen();
-
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -51,6 +51,27 @@ public interface BufferAllocator extends AutoCloseable {
   public ArrowBuf buffer(int size, BufferManager manager);
 
   /**
+   * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
+   * be larger or smaller than the  requested size, depending on the rounding option.
+   * However, the buffer's capacity will be set to the configured size.
+   *
+   * @param size The size in bytes.
+   * @param manager A buffer manager to manage reallocation.
+   * @param roundingOption The rounding option.
+   * @return a new ArrowBuf, or null if the request can't be satisfied
+   * @throws OutOfMemoryException if buffer cannot be allocated
+   */
+  public ArrowBuf buffer(int size, BufferManager manager, BaseAllocator.AllocationRoundingOption roundingOption);
+
+  /**
+   * Get the rounded buffer size.
+   * @param size The requested buffer size.
+   * @param roundingOption The rounding option.
+   * @return the buffer size after rounding.
+   */
+  public int getRoundedSize(final int size, BaseAllocator.AllocationRoundingOption roundingOption);
+
+  /**
    * Returns the allocator this allocator falls back to when it needs more memory.
    *
    * @return the underlying allocator used by this allocator
@@ -187,4 +208,5 @@ public interface BufferAllocator extends AutoCloseable {
    * a no-op.
    */
   public void assertOpen();
+
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -915,4 +915,36 @@ public class TestBaseAllocator {
 
     allocator.close();
   }
+
+  @Test
+  public void testNextPowerOfTwo() {
+    assertEquals(1, BaseAllocator.nextPowerOfTwo(0));
+    assertEquals(2, BaseAllocator.nextPowerOfTwo(1));
+    assertEquals(2, BaseAllocator.nextPowerOfTwo(2));
+    assertEquals(128, BaseAllocator.nextPowerOfTwo(75));
+    assertEquals(AllocationManager.CHUNK_SIZE, BaseAllocator.nextPowerOfTwo((int) AllocationManager.CHUNK_SIZE));
+    assertEquals(
+            AllocationManager.CHUNK_SIZE * 2, BaseAllocator.nextPowerOfTwo((int) AllocationManager.CHUNK_SIZE + 1));
+  }
+
+  @Test
+  public void testNextPowerOfTwoLong() {
+    assertEquals(1, BaseAllocator.nextPowerOfTwo(0L));
+    assertEquals(2, BaseAllocator.nextPowerOfTwo(1L));
+    assertEquals(2, BaseAllocator.nextPowerOfTwo(2L));
+    assertEquals(128, BaseAllocator.nextPowerOfTwo(75L));
+    assertEquals(AllocationManager.CHUNK_SIZE, BaseAllocator.nextPowerOfTwo(AllocationManager.CHUNK_SIZE));
+    assertEquals(AllocationManager.CHUNK_SIZE * 2, BaseAllocator.nextPowerOfTwo(AllocationManager.CHUNK_SIZE + 1));
+  }
+
+  @Test
+  public void testPrevPowerOfTwo() {
+    assertEquals(0, BaseAllocator.prevPowerOfTwo(0));
+    assertEquals(1, BaseAllocator.prevPowerOfTwo(1));
+    assertEquals(2, BaseAllocator.prevPowerOfTwo(2));
+    assertEquals(64, BaseAllocator.prevPowerOfTwo(75));
+    assertEquals(AllocationManager.CHUNK_SIZE, BaseAllocator.prevPowerOfTwo((int) AllocationManager.CHUNK_SIZE));
+    assertEquals(
+            AllocationManager.CHUNK_SIZE, BaseAllocator.prevPowerOfTwo((int) AllocationManager.CHUNK_SIZE + 1));
+  }
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -857,60 +857,18 @@ public class TestBaseAllocator {
   }
 
   @Test
-  public void testRoundingBehavior() {
-    RootAllocator allocator = new RootAllocator(AllocationManager.CHUNK_SIZE * 2);
-
-    int powerOfTwo = allocator.nextPowerOfTwo((int) AllocationManager.CHUNK_SIZE  / 4);
-
-    // test default rounding option
-    ArrowBuf buf = allocator.buffer(powerOfTwo - 1);
-    assertEquals(powerOfTwo, buf.capacity());
-    buf.close();
-
-    // test rounding up
-    buf = allocator.buffer(powerOfTwo - 1, null, BaseAllocator.AllocationRoundingOption.ROUND_UP);
-    assertEquals(powerOfTwo, buf.capacity());
-    buf.close();
-
-    // test rounding down
-    buf = allocator.buffer(powerOfTwo + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
-    assertEquals(powerOfTwo, buf.capacity());
-    buf.close();
-
-    // test large buffer
-    buf = allocator.buffer(
-            (int) AllocationManager.CHUNK_SIZE  + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_UP);
-    assertEquals(AllocationManager.CHUNK_SIZE  + 1, buf.capacity());
-    buf.close();
-
-    buf = allocator.buffer(
-            (int) AllocationManager.CHUNK_SIZE  + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
-    assertEquals(AllocationManager.CHUNK_SIZE  + 1, buf.capacity());
-    buf.close();
-
-    allocator.close();
-  }
-
-  @Test
   public void testRoundedSize() {
     RootAllocator allocator = new RootAllocator(AllocationManager.CHUNK_SIZE * 2);
 
     int powerOfTwo = allocator.nextPowerOfTwo((int) AllocationManager.CHUNK_SIZE  / 4);
 
-    // test rounding up
-    int roundedSize = allocator.getRoundedSize(powerOfTwo - 1, BaseAllocator.AllocationRoundingOption.ROUND_UP);
-    assertEquals(powerOfTwo, roundedSize);
-
-    // test rounding down
-    roundedSize = allocator.getRoundedSize(powerOfTwo + 1, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
+    // test small buffer
+    int roundedSize = allocator.getRoundedSize(powerOfTwo - 1);
     assertEquals(powerOfTwo, roundedSize);
 
     // test large buffer
     roundedSize = allocator.getRoundedSize(
-            (int) AllocationManager.CHUNK_SIZE  + 1, BaseAllocator.AllocationRoundingOption.ROUND_UP);
-    assertEquals(AllocationManager.CHUNK_SIZE  + 1, roundedSize);
-    roundedSize = allocator.getRoundedSize(
-            (int) AllocationManager.CHUNK_SIZE  + 1, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
+            (int) AllocationManager.CHUNK_SIZE  + 1);
     assertEquals(AllocationManager.CHUNK_SIZE  + 1, roundedSize);
 
     allocator.close();
@@ -935,16 +893,5 @@ public class TestBaseAllocator {
     assertEquals(128, BaseAllocator.nextPowerOfTwo(75L));
     assertEquals(AllocationManager.CHUNK_SIZE, BaseAllocator.nextPowerOfTwo(AllocationManager.CHUNK_SIZE));
     assertEquals(AllocationManager.CHUNK_SIZE * 2, BaseAllocator.nextPowerOfTwo(AllocationManager.CHUNK_SIZE + 1));
-  }
-
-  @Test
-  public void testPrevPowerOfTwo() {
-    assertEquals(0, BaseAllocator.prevPowerOfTwo(0));
-    assertEquals(1, BaseAllocator.prevPowerOfTwo(1));
-    assertEquals(2, BaseAllocator.prevPowerOfTwo(2));
-    assertEquals(64, BaseAllocator.prevPowerOfTwo(75));
-    assertEquals(AllocationManager.CHUNK_SIZE, BaseAllocator.prevPowerOfTwo((int) AllocationManager.CHUNK_SIZE));
-    assertEquals(
-            AllocationManager.CHUNK_SIZE, BaseAllocator.prevPowerOfTwo((int) AllocationManager.CHUNK_SIZE + 1));
   }
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -878,11 +878,13 @@ public class TestBaseAllocator {
     buf.close();
 
     // test large buffer
-    buf = allocator.buffer((int) AllocationManager.CHUNK_SIZE  + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_UP);
+    buf = allocator.buffer(
+            (int) AllocationManager.CHUNK_SIZE  + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_UP);
     assertEquals(AllocationManager.CHUNK_SIZE  + 1, buf.capacity());
     buf.close();
 
-    buf = allocator.buffer((int) AllocationManager.CHUNK_SIZE  + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
+    buf = allocator.buffer(
+            (int) AllocationManager.CHUNK_SIZE  + 1, null, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
     assertEquals(AllocationManager.CHUNK_SIZE  + 1, buf.capacity());
     buf.close();
 
@@ -904,9 +906,11 @@ public class TestBaseAllocator {
     assertEquals(powerOfTwo, roundedSize);
 
     // test large buffer
-    roundedSize = allocator.getRoundedSize((int) AllocationManager.CHUNK_SIZE  + 1, BaseAllocator.AllocationRoundingOption.ROUND_UP);
+    roundedSize = allocator.getRoundedSize(
+            (int) AllocationManager.CHUNK_SIZE  + 1, BaseAllocator.AllocationRoundingOption.ROUND_UP);
     assertEquals(AllocationManager.CHUNK_SIZE  + 1, roundedSize);
-    roundedSize = allocator.getRoundedSize((int) AllocationManager.CHUNK_SIZE  + 1, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
+    roundedSize = allocator.getRoundedSize(
+            (int) AllocationManager.CHUNK_SIZE  + 1, BaseAllocator.AllocationRoundingOption.ROUND_DOWN);
     assertEquals(AllocationManager.CHUNK_SIZE  + 1, roundedSize);
 
     allocator.close();


### PR DESCRIPTION
In our scenario, the following code snippet is frequent in our code base:

int requestSize = ...;
if (requestSize <= allocator.getLimit() - allocator.getAllocatedMemory()){
  ArrowBuf buffer = allocator.buffer(requestSize); 
}
However, it often causes OutOfMemoryException, due to Arrow's rounding behavior.

For example, we have only 12 MB memory left, and we request a buffer with size 10 MB. Appearantly, there is sufficient memory to meet the request. However, the rounding behavior rounds the request size from 10 MB to 16 MB, and there is no 16 MB memory, so an OutOfMemoryException will be thrown.

We propose two ways to solve this problem:

1. We provide a rounding option as an argument to the BaseAllocator#buffer method. There are two possible values for the rounding option: rounding up and rounding down. In the above scenario, the rounding down option can solve the problem.

2. We add a method to the allocator:

int getRoundedSize(final int size, BaseAllocator.AllocationRoundingOption roundingOption)

This method will give the rounded buffer size, given the initial request size. With this method, the user can freely adjust their request size to avoid OOM.

To make it more convenient to use Arrow, we implement both solutions in this PR.