### PR TITLE
ARROW-4086: [Java] Add apis to debug memory alloc failures

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcome.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcome.java
@@ -17,38 +17,81 @@
 
 package org.apache.arrow.memory;
 
+import java.util.Optional;
+
 /**
  * Describes the type of outcome that occurred when trying to account for allocation of memory.
  */
-public enum AllocationOutcome {
+public class AllocationOutcome {
+  private final Status status;
+  private final AllocationOutcomeDetails details;
+  static final AllocationOutcome SUCCESS_INSTANCE = new AllocationOutcome(Status.SUCCESS);
 
-  /**
-   * Allocation succeeded.
-   */
-  SUCCESS(true),
-
-  /**
-   * Allocation succeeded but only because the allocator was forced to move beyond a limit.
-   */
-  FORCED_SUCCESS(true),
-
-  /**
-   * Allocation failed because the local allocator's limits were exceeded.
-   */
-  FAILED_LOCAL(false),
-
-  /**
-   * Allocation failed because a parent allocator's limits were exceeded.
-   */
-  FAILED_PARENT(false);
-
-  private final boolean ok;
-
-  AllocationOutcome(boolean ok) {
-    this.ok = ok;
+  AllocationOutcome(Status status, AllocationOutcomeDetails details) {
+    this.status = status;
+    this.details = details;
   }
 
+  AllocationOutcome(Status status) {
+    this(status, null);
+  }
+
+  /**
+   * Get the status of the allocation.
+   * @return status code.
+   */
+  public Status getStatus() {
+    return status;
+  }
+
+  /**
+   * Get additional details of the allocation (like the status at each allocator in the hierarchy).
+   * @return details of allocation
+   */
+  public Optional<AllocationOutcomeDetails> getDetails() {
+    return Optional.ofNullable(details);
+  }
+
+  /**
+   * Returns true if the allocation was a success.
+   * @return true if allocation was successful, false otherwise.
+   */
   public boolean isOk() {
-    return ok;
+    return status.isOk();
+  }
+
+  /**
+   * Allocation status code.
+   */
+  public enum Status {
+    /**
+     * Allocation succeeded.
+     */
+    SUCCESS(true),
+
+    /**
+     * Allocation succeeded but only because the allocator was forced to move beyond a limit.
+     */
+    FORCED_SUCCESS(true),
+
+    /**
+     * Allocation failed because the local allocator's limits were exceeded.
+     */
+    FAILED_LOCAL(false),
+
+    /**
+     * Allocation failed because a parent allocator's limits were exceeded.
+     */
+    FAILED_PARENT(false);
+
+    private final boolean ok;
+
+    Status(boolean ok) {
+      this.ok = ok;
+    }
+
+    public boolean isOk() {
+      return ok;
+    }
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Captures details of allocation for each accountant in the hierarchical chain.
+ */
+public class AllocationOutcomeDetails {
+  Deque<Entry> allocEntries;
+
+  AllocationOutcomeDetails() {
+    allocEntries = new ArrayDeque<>();
+  }
+
+  void pushEntry(Accountant accountant, long totalUsedBeforeAllocation, long requestedSize,
+      long allocatedSize, boolean allocationFailed) {
+
+    Entry top = allocEntries.peekLast();
+    if (top != null && top.allocationFailed) {
+      // if the allocation has already failed, stop saving the entries.
+      return;
+    }
+
+    allocEntries.addLast(new Entry(accountant, totalUsedBeforeAllocation, requestedSize,
+        allocatedSize, allocationFailed));
+  }
+
+  /**
+   * Get the allocator that caused the failure.
+   * @return the allocator that caused failure, null if there was no failure.
+   */
+  public BufferAllocator getFailedAllocator() {
+    Entry top = allocEntries.peekLast();
+    if (top != null && top.allocationFailed && (top.accountant instanceof BufferAllocator)) {
+      return (BufferAllocator)top.accountant;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Allocation outcome details:\n");
+    allocEntries.forEach(sb::append);
+    return sb.toString();
+  }
+
+  /**
+   * Outcome of the allocation request at one accountant in the hierarchy.
+   */
+  public static class Entry {
+    private final Accountant accountant;
+
+    // Remember allocator attributes at the time of the request.
+    private final long limit;
+    private final long used;
+
+    // allocation outcome
+    private final long requestedSize;
+    private final long allocatedSize;
+    private final boolean allocationFailed;
+
+    Entry(Accountant accountant, long totalUsedBeforeAllocation, long requestedSize,
+        long allocatedSize, boolean allocationFailed) {
+      this.accountant = accountant;
+      this.limit = accountant.getLimit();
+      this.used = totalUsedBeforeAllocation;
+
+      this.requestedSize = requestedSize;
+      this.allocatedSize = allocatedSize;
+      this.allocationFailed = allocationFailed;
+    }
+
+    public Accountant getAccountant() {
+      return accountant;
+    }
+
+    public long getLimit() {
+      return limit;
+    }
+
+    public long getUsed() {
+      return used;
+    }
+
+    public long getRequestedSize() {
+      return requestedSize;
+    }
+
+    public long getAllocatedSize() {
+      return allocatedSize;
+    }
+
+    public boolean isAllocationFailed() {
+      return allocationFailed;
+    }
+
+    @Override
+    public String toString() {
+      return new StringBuilder()
+          .append("allocator[" + accountant.getName() + "]")
+          .append(" reservation: " + accountant.getInitReservation())
+          .append(" limit: " + limit)
+          .append(" used: " + used)
+          .append(" requestedSize: " + requestedSize)
+          .append(" allocatedSize: " + allocatedSize)
+          .append(" localAllocationStatus: " + (allocationFailed ? "success" : "fail"))
+          .append("\n")
+          .toString();
+    }
+  }
+
+}

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -18,7 +18,11 @@
 package org.apache.arrow.memory;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.arrow.memory.util.AssertionUtil;
@@ -49,7 +53,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   final AllocationListener listener;
   private final BaseAllocator parentAllocator;
   private final ArrowByteBufAllocator thisAsByteBufAllocator;
-  private final IdentityHashMap<BaseAllocator, Object> childAllocators;
+  private final Map<BaseAllocator, Object> childAllocators;
   private final ArrowBuf empty;
   // members used purely for debugging
   private final IdentityHashMap<BufferLedger, Object> childLedgers;
@@ -73,7 +77,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       final String name,
       final long initReservation,
       final long maxAllocation) throws OutOfMemoryException {
-    super(parentAllocator, initReservation, maxAllocation);
+    super(parentAllocator, name, initReservation, maxAllocation);
 
     this.listener = listener;
 
@@ -92,15 +96,14 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     this.name = name;
 
     this.thisAsByteBufAllocator = new ArrowByteBufAllocator(this);
+    this.childAllocators = Collections.synchronizedMap(new IdentityHashMap<>());
 
     if (DEBUG) {
-      childAllocators = new IdentityHashMap<>();
       reservations = new IdentityHashMap<>();
       childLedgers = new IdentityHashMap<>();
       historicalLog = new HistoricalLog(DEBUG_LOG_LENGTH, "allocator[%s]", name);
       hist("created by \"%s\", owned = %d", name, this.getAllocatedMemory());
     } else {
-      childAllocators = null;
       reservations = null;
       historicalLog = null;
       childLedgers = null;
@@ -110,6 +113,16 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   AllocationListener getListener() {
     return listener;
+  }
+
+  @Override
+  public BufferAllocator getParentAllocator() {
+    return parentAllocator;
+  }
+
+  @Override
+  public Collection<BufferAllocator> getChildAllocators() {
+    return new HashSet<>(childAllocators.keySet());
   }
 
   private static String createErrorMsg(final BufferAllocator allocator, final int rounded, final int requested) {
@@ -248,6 +261,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
             "] not found in parent allocator[" + name + "]'s childAllocators");
         }
       }
+    } else {
+      childAllocators.remove(childAllocator);
     }
     listener.onChildRemoved(this, childAllocator);
   }
@@ -288,7 +303,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         outcome = this.allocateBytes(actualRequestSize);
       }
       if (!outcome.isOk()) {
-        throw new OutOfMemoryException(createErrorMsg(this, actualRequestSize, initialRequestSize));
+        throw new OutOfMemoryException(createErrorMsg(this, actualRequestSize,
+            initialRequestSize), outcome.getDetails());
       }
     }
 
@@ -367,6 +383,8 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         historicalLog.recordEvent("allocator[%s] created new child allocator[%s]", name,
             childAllocator.name);
       }
+    } else {
+      childAllocators.put(childAllocator, childAllocator);
     }
     this.listener.onChildAdded(this, childAllocator);
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.memory;
 
+import java.util.Collection;
+
 import io.netty.buffer.ArrowBuf;
 import io.netty.buffer.ByteBufAllocator;
 
@@ -133,6 +135,20 @@ public interface BufferAllocator extends AutoCloseable {
    * @return Headroom in bytes
    */
   public long getHeadroom();
+
+  /**
+   * Returns the parent allocator.
+   *
+   * @return parent allocator
+   */
+  public BufferAllocator getParentAllocator();
+
+  /**
+   * Returns the set of child allocators.
+   *
+   * @return set of child allocators
+   */
+  public Collection<BufferAllocator> getChildAllocators();
 
   /**
    * Create an allocation reservation. A reservation is a way of building up

--- a/java/memory/src/main/java/org/apache/arrow/memory/OutOfMemoryException.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/OutOfMemoryException.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.memory;
 
+import java.util.Optional;
+
 /**
  * Indicates memory could not be allocated for Arrow buffers.
  *
@@ -29,6 +31,7 @@ public class OutOfMemoryException extends RuntimeException {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OutOfMemoryException
       .class);
   private static final long serialVersionUID = -6858052345185793382L;
+  private Optional<AllocationOutcomeDetails> outcomeDetails = Optional.empty();
 
   public OutOfMemoryException() {
     super();
@@ -46,7 +49,11 @@ public class OutOfMemoryException extends RuntimeException {
 
   public OutOfMemoryException(String message) {
     super(message);
+  }
 
+  public OutOfMemoryException(String message, Optional<AllocationOutcomeDetails> details) {
+    super(message);
+    this.outcomeDetails = details;
   }
 
   public OutOfMemoryException(Throwable cause) {
@@ -54,5 +61,7 @@ public class OutOfMemoryException extends RuntimeException {
 
   }
 
-
+  public Optional<AllocationOutcomeDetails> getOutcomeDetails() {
+    return outcomeDetails;
+  }
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestAccountant.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestAccountant.java
@@ -31,7 +31,7 @@ public class TestAccountant {
 
   @Test
   public void nested() {
-    final Accountant parent = new Accountant(null, 0, Long.MAX_VALUE);
+    final Accountant parent = new Accountant(null,  "test", 0, Long.MAX_VALUE);
     ensureAccurateReservations(parent);
     assertEquals(0, parent.getAllocatedMemory());
     assertEquals(parent.getLimit() - parent.getAllocatedMemory(), parent.getHeadroom());
@@ -39,7 +39,7 @@ public class TestAccountant {
 
   @Test
   public void multiThread() throws InterruptedException {
-    final Accountant parent = new Accountant(null, 0, Long.MAX_VALUE);
+    final Accountant parent = new Accountant(null,  "test", 0, Long.MAX_VALUE);
 
     final int numberOfThreads = 32;
     final int loops = 100;
@@ -74,15 +74,15 @@ public class TestAccountant {
   }
 
   private void ensureAccurateReservations(Accountant outsideParent) {
-    final Accountant parent = new Accountant(outsideParent, 0, 10);
+    final Accountant parent = new Accountant(outsideParent, "test",  0, 10);
     assertEquals(0, parent.getAllocatedMemory());
 
-    final Accountant child = new Accountant(parent, 2, Long.MAX_VALUE);
+    final Accountant child = new Accountant(parent, "test",  2, Long.MAX_VALUE);
     assertEquals(2, parent.getAllocatedMemory());
     assertEquals(10, child.getHeadroom());
     {
       AllocationOutcome first = child.allocateBytes(1);
-      assertEquals(AllocationOutcome.SUCCESS, first);
+      assertEquals(AllocationOutcome.Status.SUCCESS, first.getStatus());
     }
 
     // child will have new allocation
@@ -93,7 +93,7 @@ public class TestAccountant {
 
     {
       AllocationOutcome first = child.allocateBytes(1);
-      assertEquals(AllocationOutcome.SUCCESS, first);
+      assertEquals(AllocationOutcome.Status.SUCCESS, first.getStatus());
     }
 
     // child will have new allocation
@@ -112,7 +112,7 @@ public class TestAccountant {
 
     {
       AllocationOutcome first = child.allocateBytes(2);
-      assertEquals(AllocationOutcome.SUCCESS, first);
+      assertEquals(AllocationOutcome.Status.SUCCESS, first.getStatus());
     }
 
     // child will have new allocation
@@ -126,7 +126,7 @@ public class TestAccountant {
 
     {
       AllocationOutcome first = child.allocateBytes(7);
-      assertEquals(AllocationOutcome.SUCCESS, first);
+      assertEquals(AllocationOutcome.Status.SUCCESS, first.getStatus());
     }
 
     // child will have new allocation
@@ -145,7 +145,7 @@ public class TestAccountant {
     assertEquals(8, parent.getHeadroom());
 
     AllocationOutcome first = child.allocateBytes(10);
-    assertEquals(AllocationOutcome.FAILED_PARENT, first);
+    assertEquals(AllocationOutcome.Status.FAILED_PARENT, first.getStatus());
 
     // unchanged
     assertEquals(1, child.getAllocatedMemory());

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -247,9 +246,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public void allocateNew() {
-    if (!allocateNewSafe()) {
-      throw new OutOfMemoryException("Failure while allocating memory.");
-    }
+    allocateNew(lastValueCapacity);
   }
 
   /**
@@ -262,19 +259,12 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public boolean allocateNewSafe() {
-    computeAndCheckBufferSize(lastValueCapacity);
-
-    /* we are doing a new allocation -- release the current buffers */
-    clear();
-
     try {
-      allocateBytes(lastValueCapacity);
+      allocateNew(lastValueCapacity);
+      return true;
     } catch (Exception e) {
-      clear();
       return false;
     }
-
-    return true;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -355,9 +354,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   @Override
   public void allocateNew() {
-    if (!allocateNewSafe()) {
-      throw new OutOfMemoryException("Failure while allocating memory.");
-    }
+    allocateNew(lastValueAllocationSizeInBytes, lastValueCapacity);
   }
 
   /**
@@ -370,20 +367,12 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   @Override
   public boolean allocateNewSafe() {
-    checkDataBufferSize(lastValueAllocationSizeInBytes);
-    computeAndCheckOffsetsBufferSize(lastValueCapacity);
-
-    /* we are doing a new allocation -- release the current buffers */
-    clear();
-
     try {
-      allocateBytes(lastValueAllocationSizeInBytes, lastValueCapacity);
+      allocateNew(lastValueAllocationSizeInBytes, lastValueCapacity);
+      return true;
     } catch (Exception e) {
-      clear();
       return false;
     }
-
-    return true;
   }
 
   /**


### PR DESCRIPTION
- On failures, capture state for each allocator in chain and add the
  details to the exception.
- add APIs to get parent/child allocators
- Do not mask the original exception when allocating from vectors