### PR TITLE
ARROW-412: [Format][Documentation] Clarify that Buffer.size in Flatbuffers should reflect the actual memory size rather than the padded size

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -940,7 +940,14 @@ table above): ::
 
 The ``Buffer`` Flatbuffers value describes the location and size of a
 piece of memory. Generally these are interpreted relative to the
-**encapsulated message format** defined next.
+**encapsulated message format** defined below.
+
+The ``size`` field of ``Buffer`` may or may not include padding bytes to round
+up to a multiple or 8 or 64. Implementations may set ``size`` to reflect the
+intent of the transmitted piece of memory to the receiver. For example, a 1
+byte buffer in-memory may have ``size`` set to either 1 or 8 or 64. Either 7 or
+63 padding bytes must be written after the 1 byte of data to comply with the
+padding and alignment requirements of the format.
 
 Byte Order (`Endianness`_)
 ---------------------------

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -942,12 +942,10 @@ The ``Buffer`` Flatbuffers value describes the location and size of a
 piece of memory. Generally these are interpreted relative to the
 **encapsulated message format** defined below.
 
-The ``size`` field of ``Buffer`` may or may not include padding bytes to round
-up to a multiple or 8 or 64. Implementations may set ``size`` to reflect the
-intent of the transmitted piece of memory to the receiver. For example, a 1
-byte buffer in-memory may have ``size`` set to either 1 or 8 or 64. Either 7 or
-63 padding bytes must be written after the 1 byte of data to comply with the
-padding and alignment requirements of the format.
+The ``size`` field of ``Buffer`` is not required to account for padding
+bytes. Since this metadata can be used to communicate in-memory pointer
+addresses between libraries, it is recommended to set ``size`` to the actual
+memory size rather than the padded size.
 
 Byte Order (`Endianness`_)
 ---------------------------

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -323,12 +323,10 @@ struct Buffer {
   offset: long;
 
   /// The absolute length (in bytes) of the memory buffer. The memory is found
-  /// from offset (inclusive) to offset + length (non-inclusive). In record
-  /// batch bodies following the IPC protocol, buffer lengths are always padded
-  /// to a minimum size multiple of 8, but the length here is the Buffer size
-  /// that the writer intends the reader to receive. For example, a buffer of
-  /// size 1 may go on the wire with 1 byte plus 7 bytes of padding, though the
-  /// length here can either be 1 or 8
+  /// from offset (inclusive) to offset + length (non-inclusive). When building
+  /// messages using the encapsulated IPC message, padding bytes may be written
+  /// after a buffer, but such padding bytes do not need to be accounted for in
+  /// the size here.
   length: long;
 }
 

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -202,8 +202,8 @@ enum IntervalUnit: short { YEAR_MONTH, DAY_TIME}
 // A "calendar" interval which models types that don't necessarily
 // have a precise duration without the context of a base timestamp (e.g.
 // days can differ in length during day light savings time transitions).
-// YEAR_MONTH - Indicates the number of elapsed whole months, stored as 
-//   4-byte integers. 
+// YEAR_MONTH - Indicates the number of elapsed whole months, stored as
+//   4-byte integers.
 // DAY_TIME - Indicates the number of elapsed days and milliseconds,
 //   stored as 2 contiguous 32-bit integers (8-bytes in total).  Support
 //   of this IntervalUnit is not required for full arrow compatibility.
@@ -211,7 +211,7 @@ table Interval {
   unit: IntervalUnit;
 }
 
-// An absolute length of time unrelated to any calendar artifacts.  
+// An absolute length of time unrelated to any calendar artifacts.
 //
 // For the purposes of Arrow Implementations, adding this value to a Timestamp
 // ("t1") naively (i.e. simply summing the two number) is acceptable even
@@ -323,7 +323,12 @@ struct Buffer {
   offset: long;
 
   /// The absolute length (in bytes) of the memory buffer. The memory is found
-  /// from offset (inclusive) to offset + length (non-inclusive).
+  /// from offset (inclusive) to offset + length (non-inclusive). In record
+  /// batch bodies following the IPC protocol, buffer lengths are always padded
+  /// to a minimum size multiple of 8, but the length here is the Buffer size
+  /// that the writer intends the reader to receive. For example, a buffer of
+  /// size 1 may go on the wire with 1 byte plus 7 bytes of padding, though the
+  /// length here can either be 1 or 8
   length: long;
 }
 


### PR DESCRIPTION
There had previously been some questions about whether the `Buffer` Flatbuffers struct should include padding bytes in its `length` or not. This adds documentation that the "length" need not be prescriptive about this -- if the writer intends the reader to receive a padded Buffer, then the padding bytes can be included, but it is not a requirement. The protocol requires that padding bytes to a minimum multiple of 8 be written nonetheless. 