### PR TITLE
ARROW-5396: [JS] Support files and streams with no record batches

### DIFF
--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -1031,7 +1031,6 @@ def get_generated_json_files(tempdir=None, flight=False):
 
     file_objs = [
         (generate_primitive_case([], name='primitive_no_batches')
-         .skip_category('JS')
          .skip_category('Java')),
         generate_primitive_case([17, 20], name='primitive'),
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),

--- a/js/src/ipc/message.ts
+++ b/js/src/ipc/message.ts
@@ -165,21 +165,19 @@ export class JSONMessageReader extends MessageReader {
         this._json = source instanceof ArrowJSON ? source : new ArrowJSON(source);
     }
     public next() {
-        const { _json, _batchIndex, _dictionaryIndex } = this;
-        const numBatches = _json.batches.length;
-        const numDictionaries = _json.dictionaries.length;
+        const { _json } = this;
         if (!this._schema) {
             this._schema = true;
             const message = Message.fromJSON(_json.schema, MessageHeader.Schema);
-            return { value: message, done: _batchIndex >= numBatches && _dictionaryIndex >= numDictionaries };
+            return { done: false, value: message };
         }
-        if (_dictionaryIndex < numDictionaries) {
+        if (this._dictionaryIndex < _json.dictionaries.length) {
             const batch = _json.dictionaries[this._dictionaryIndex++];
             this._body = batch['data']['columns'];
             const message = Message.fromJSON(batch, MessageHeader.DictionaryBatch);
             return { done: false, value: message };
         }
-        if (_batchIndex < numBatches) {
+        if (this._batchIndex < _json.batches.length) {
             const batch = _json.batches[this._batchIndex++];
             this._body = batch['columns'];
             const message = Message.fromJSON(batch, MessageHeader.RecordBatch);

--- a/js/src/ipc/reader.ts
+++ b/js/src/ipc/reader.ts
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import { Data } from '../data';
 import { Vector } from '../vector';
 import { DataType } from '../type';
 import { MessageHeader } from '../enum';
@@ -23,12 +22,12 @@ import { Footer } from './metadata/file';
 import { Schema, Field } from '../schema';
 import streamAdapters from '../io/adapters';
 import { Message } from './metadata/message';
-import { RecordBatch } from '../recordbatch';
 import * as metadata from './metadata/message';
 import { ArrayBufferViewInput } from '../util/buffer';
 import { ByteStream, AsyncByteStream } from '../io/stream';
 import { RandomAccessFile, AsyncRandomAccessFile } from '../io/file';
 import { VectorLoader, JSONVectorLoader } from '../visitor/vectorloader';
+import { RecordBatch, _InternalEmptyPlaceholderRecordBatch } from '../recordbatch';
 import {
     FileHandle,
     ArrowJSONLike,
@@ -441,7 +440,7 @@ class RecordBatchStreamReaderImpl<T extends { [key: string]: DataType } = any> e
         }
         if (this.schema && this._recordBatchIndex === 0) {
             this._recordBatchIndex++;
-            return { done: false, value: new RecordBatch<T>(this.schema, 0, this.schema.fields.map((f) => Data.new(f.type, 0, 0))) };
+            return { done: false, value: new _InternalEmptyPlaceholderRecordBatch<T>(this.schema) };
         }
         return this.return();
     }
@@ -515,7 +514,7 @@ class AsyncRecordBatchStreamReaderImpl<T extends { [key: string]: DataType } = a
         }
         if (this.schema && this._recordBatchIndex === 0) {
             this._recordBatchIndex++;
-            return { done: false, value: new RecordBatch<T>(this.schema, 0, this.schema.fields.map((f) => Data.new(f.type, 0, 0))) };
+            return { done: false, value: new _InternalEmptyPlaceholderRecordBatch<T>(this.schema) };
         }
         return await this.return();
     }

--- a/js/src/ipc/reader.ts
+++ b/js/src/ipc/reader.ts
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { Data } from '../data';
 import { Vector } from '../vector';
 import { DataType } from '../type';
 import { MessageHeader } from '../enum';
@@ -438,6 +439,10 @@ class RecordBatchStreamReaderImpl<T extends { [key: string]: DataType } = any> e
                 this.dictionaries.set(header.id, vector);
             }
         }
+        if (this.schema && this._recordBatchIndex === 0) {
+            this._recordBatchIndex++;
+            return { done: false, value: new RecordBatch<T>(this.schema, 0, this.schema.fields.map((f) => Data.new(f.type, 0, 0))) };
+        }
         return this.return();
     }
     protected _readNextMessageAndValidate<T extends MessageHeader>(type?: T | null) {
@@ -507,6 +512,10 @@ class AsyncRecordBatchStreamReaderImpl<T extends { [key: string]: DataType } = a
                 const vector = this._loadDictionaryBatch(header, buffer);
                 this.dictionaries.set(header.id, vector);
             }
+        }
+        if (this.schema && this._recordBatchIndex === 0) {
+            this._recordBatchIndex++;
+            return { done: false, value: new RecordBatch<T>(this.schema, 0, this.schema.fields.map((f) => Data.new(f.type, 0, 0))) };
         }
         return await this.return();
     }

--- a/js/src/ipc/writer.ts
+++ b/js/src/ipc/writer.ts
@@ -162,7 +162,9 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
         }
 
         if (payload instanceof RecordBatch) {
-            this._writeRecordBatch(payload);
+            if (payload.length > 0) {
+                this._writeRecordBatch(payload);
+            }
         } else if (payload instanceof Table) {
             this.writeAll(payload.chunks);
         } else if (isIterable(payload)) {

--- a/js/src/ipc/writer.ts
+++ b/js/src/ipc/writer.ts
@@ -22,7 +22,6 @@ import { Column } from '../column';
 import { Schema, Field } from '../schema';
 import { Chunked } from '../vector/chunked';
 import { Message } from './metadata/message';
-import { RecordBatch } from '../recordbatch';
 import * as metadata from './metadata/message';
 import { DataType, Dictionary } from '../type';
 import { FileBlock, Footer } from './metadata/file';
@@ -32,6 +31,7 @@ import { VectorAssembler } from '../visitor/vectorassembler';
 import { JSONTypeAssembler } from '../visitor/jsontypeassembler';
 import { JSONVectorAssembler } from '../visitor/jsonvectorassembler';
 import { ArrayBufferViewInput, toUint8Array } from '../util/buffer';
+import { RecordBatch, _InternalEmptyPlaceholderRecordBatch } from '../recordbatch';
 import { Writable, ReadableInterop, ReadableDOMStreamOptions } from '../io/interfaces';
 import { isPromise, isAsyncIterable, isWritableDOMStream, isWritableNodeStream, isIterable } from '../util/compat';
 
@@ -162,7 +162,7 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
         }
 
         if (payload instanceof RecordBatch) {
-            if (payload.length > 0) {
+            if (!(payload instanceof _InternalEmptyPlaceholderRecordBatch)) {
                 this._writeRecordBatch(payload);
             }
         } else if (payload instanceof Table) {

--- a/js/src/recordbatch.ts
+++ b/js/src/recordbatch.ts
@@ -99,3 +99,14 @@ export class RecordBatch<T extends { [key: string]: DataType } = any>
         return new RecordBatch<{ [key: string]: K }>(schema, this.length, childData);
     }
 }
+
+/**
+ * @ignore
+ * @private
+ */
+/* tslint:disable:class-name */
+export class _InternalEmptyPlaceholderRecordBatch<T extends { [key: string]: DataType } = any> extends RecordBatch<T> {
+    constructor(schema: Schema<T>) {
+        super(schema, 0, schema.fields.map((f) => Data.new(f.type, 0, 0, 0)));
+    }
+}


### PR DESCRIPTION
Re: #3871, [ARROW-2119](https://issues.apache.org/jira/browse/ARROW-2119), and closes [ARROW-5396](https://issues.apache.org/jira/browse/ARROW-5396).

This PR updates the JS Readers and Writers to support files and streams with no RecordBatches. The approach here is two-fold:

1. If the Readers' source message stream terminates after reading the Schema message, the Reader will yield a dummy zero-length RecordBatch with the schema.
2. The Writer always writes the schema for any RecordBatch, but skips writing the RecordBatch field metadata if it's empty.

This is necessary because the reader and writer don't know about each other when they're communicating via the Node and DOM stream i/o primitives; they only know about the values pushed through the streams. Since the RecordBatchReader and Writer don't yield the Schema message as a standalone value, we pump the stream with a zero-length RecordBatch that contains the schema instead.