### PR TITLE
ARROW-4741: [Java] Add missing type javadoc and enable checkstyle

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/Constants.java
@@ -17,7 +17,11 @@
 
 package org.apache.arrow.adapter.jdbc;
 
+/**
+ * String constants used for metadata returned on Vectors.
+ */
 public class Constants {
+  private Constants() {}
 
   public static final String SQL_CATALOG_NAME_KEY = "SQL_CATALOG_NAME";
   public static final String SQL_TABLE_NAME_KEY = "SQL_TABLE_NAME";

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -241,6 +241,15 @@
             <property name="suppressLoadErrors" value="true"/>
             <property name="ignoreMethodNamesRegex" value="main"/>
         </module>
+        <module name="JavadocType">
+            <property name="scope" value="public"/>
+        </module>
+        <module name="JavadocType">
+            <property name="scope" value="protected"/>
+        </module>
+        <module name="JavadocType">
+            <property name="scope" value="package"/>
+        </module>
         <module name="MethodName">
             <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
             <message key="name.invalidPattern"

--- a/java/dev/checkstyle/suppressions.xml
+++ b/java/dev/checkstyle/suppressions.xml
@@ -25,6 +25,8 @@
   <suppress checks="JavadocPackage" files=".*[\\/]examples[\\/].*"/>
   <!-- Method javadoc not required in testing directories -->
   <suppress checks="JavadocMethod" files=".*[\\/]src[\\/]test[\\/].*"/>
+  <!-- Class javadoc not required in testing directories -->
+  <suppress checks="JavadocType" files=".*[\\/]src[\\/]test[\\/].*"/>
 
   <!-- suppress all checks in the generated directories -->
   <suppress checks=".*" files=".+[\\/]generated[\\/].+\.java" />

--- a/java/flight/src/main/java/org/apache/arrow/flight/Action.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/Action.java
@@ -21,6 +21,11 @@ import org.apache.arrow.flight.impl.Flight;
 
 import com.google.protobuf.ByteString;
 
+/**
+ * An opaque action for the service to perform.
+ *
+ * <p>This is a POJO wrapper around the message of the same name in Flight.proto.
+ */
 public class Action {
 
   private final String type;

--- a/java/flight/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -77,6 +77,7 @@ class ArrowMessage implements AutoCloseable {
 
   private static Marshaller<FlightData> NO_BODY_MARSHALLER = ProtoUtils.marshaller(FlightData.getDefaultInstance());
 
+  /** Types of messages that can be sent. */
   public static enum HeaderType {
     NONE,
     SCHEMA,

--- a/java/flight/src/main/java/org/apache/arrow/flight/CallOptions.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/CallOptions.java
@@ -53,6 +53,9 @@ public class CallOptions {
     }
   }
 
+  /**
+   * CallOPtions specific to GRPC stubs.
+   */
   interface GrpcCallOption extends CallOption {
     <T extends AbstractStub<T>> T wrapStub(T stub);
   }

--- a/java/flight/src/main/java/org/apache/arrow/flight/CallOptions.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/CallOptions.java
@@ -54,7 +54,7 @@ public class CallOptions {
   }
 
   /**
-   * CallOPtions specific to GRPC stubs.
+   * CallOptions specific to GRPC stubs.
    */
   interface GrpcCallOption extends CallOption {
     <T extends AbstractStub<T>> T wrapStub(T stub);

--- a/java/flight/src/main/java/org/apache/arrow/flight/Criteria.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/Criteria.java
@@ -21,6 +21,11 @@ import org.apache.arrow.flight.impl.Flight;
 
 import com.google.protobuf.ByteString;
 
+/**
+ * An opaque object that can be used to filter a list of streams available from a server.
+ *
+ * <p>This is a POJO wrapper around the protobuf Criteria message.
+ */
 public class Criteria {
 
   public static Criteria ALL = new Criteria((byte[]) null);

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -306,6 +306,9 @@ public class FlightClient implements AutoCloseable {
     }
   }
 
+  /**
+   * Interface for subscribers to a stream returned by the server.
+   */
   public interface ClientStreamListener {
 
     public void putNext();

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightConstants.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightConstants.java
@@ -17,8 +17,11 @@
 
 package org.apache.arrow.flight;
 
+/**
+ * String constants relevant to flight implementations.
+ */
 public interface FlightConstants {
 
-  public static final String SERVICE = "arrow.flight.protocol.FlightService";
+  String SERVICE = "arrow.flight.protocol.FlightService";
 
 }

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
@@ -27,6 +27,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 
+/**
+ * An identifier for a particular set of data.  This can either be an opaque command that generates
+ * the data or a static "path" to the data.  This is a POJO wrapper around the protobuf message with
+ * the same name.
+ */
 public class FlightDescriptor {
 
   private boolean isCmd;

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightProducer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightProducer.java
@@ -27,25 +27,28 @@ import org.apache.arrow.vector.VectorSchemaRoot;
  */
 public interface FlightProducer {
 
-  public void getStream(CallContext context, Ticket ticket,
+  void getStream(CallContext context, Ticket ticket,
       ServerStreamListener listener);
 
-  public void listFlights(CallContext context, Criteria criteria,
+  void listFlights(CallContext context, Criteria criteria,
       StreamListener<FlightInfo> listener);
 
-  public FlightInfo getFlightInfo(CallContext context,
+  FlightInfo getFlightInfo(CallContext context,
       FlightDescriptor descriptor);
 
-  public Callable<PutResult> acceptPut(CallContext context,
+  Callable<PutResult> acceptPut(CallContext context,
       FlightStream flightStream);
 
-  public void doAction(CallContext context, Action action,
+  void doAction(CallContext context, Action action,
       StreamListener<Result> listener);
 
-  public void listActions(CallContext context,
+  void listActions(CallContext context,
       StreamListener<ActionType> listener);
 
-  public interface ServerStreamListener {
+  /**
+   * Listener for creating a stream on the server side.
+   */
+  interface ServerStreamListener {
 
     boolean isCancelled();
 
@@ -61,7 +64,12 @@ public interface FlightProducer {
 
   }
 
-  public interface StreamListener<T> {
+  /**
+   * Callbacks for pushing objects to a receiver.
+   *
+   * @param <T> Type of the values in the stream.
+   */
+  interface StreamListener<T> {
 
     void onNext(T val);
 

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -39,6 +39,10 @@ import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 
+/**
+ * Generic server of flight data that is customized via construction with delegate classes for the
+ * actual logic.  The server currently uses GRPC as its transport mechanism.
+ */
 public class FlightServer implements AutoCloseable {
 
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(FlightServer.class);

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -43,6 +43,9 @@ import com.google.common.base.Preconditions;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
+/**
+ * GRPC service implementation for a fligh server.
+ */
 class FlightService extends FlightServiceImplBase {
 
   private static final Logger logger = LoggerFactory.getLogger(FlightService.class);
@@ -188,6 +191,9 @@ class FlightService extends FlightServiceImplBase {
     }
   }
 
+  /**
+   * Call context for the service.
+   */
   static class CallContext implements FlightProducer.CallContext {
 
     private final String peerIdentity;

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -44,7 +44,7 @@ import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 
 /**
- * GRPC service implementation for a fligh server.
+ * GRPC service implementation for a flight server.
  */
 class FlightService extends FlightServiceImplBase {
 

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -222,13 +222,19 @@ public class FlightStream {
     return new Observer();
   }
 
+  /**
+   * Provides a callback to cancel a process that is in progress.
+   */
   public interface Cancellable {
     void cancel(String message, Throwable exception);
   }
 
+  /**
+   * Provides a interface to request more items from a stream producer.
+   */
   public interface Requestor {
     /**
-     * Requests <code>count</code> more messages from the reuqestor.
+     * Requests <code>count</code> more messages from the instance of this object.
      */
     void request(int count);
   }

--- a/java/flight/src/main/java/org/apache/arrow/flight/GenericOperation.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/GenericOperation.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.flight;
 
+/**
+ * Unused?.
+ */
 class GenericOperation {
 
   private final String type;

--- a/java/flight/src/main/java/org/apache/arrow/flight/NoOpFlightProducer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/NoOpFlightProducer.java
@@ -21,6 +21,9 @@ import java.util.concurrent.Callable;
 
 import org.apache.arrow.flight.impl.Flight.PutResult;
 
+/**
+ * A {@link FlightProducer} that throws on all operations.
+ */
 public class NoOpFlightProducer implements FlightProducer {
 
   @Override

--- a/java/flight/src/main/java/org/apache/arrow/flight/Result.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/Result.java
@@ -24,7 +24,7 @@ import com.google.protobuf.ByteString;
 /**
  * Opaque result returned after executing an action.
  *
- * <p>POJO wrapper around the Fligh procol buffer message sharing the same name.
+ * <p>POJO wrapper around the Flight protocol buffer message sharing the same name.
  */
 public class Result {
 

--- a/java/flight/src/main/java/org/apache/arrow/flight/Result.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/Result.java
@@ -21,6 +21,11 @@ import org.apache.arrow.flight.impl.Flight;
 
 import com.google.protobuf.ByteString;
 
+/**
+ * Opaque result returned after executing an action.
+ *
+ * <p>POJO wrapper around the Fligh procol buffer message sharing the same name.
+ */
 public class Result {
 
   private final byte[] body;

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/AuthConstants.java
@@ -24,6 +24,9 @@ import io.grpc.Metadata.BinaryMarshaller;
 import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;
 
+/**
+ * Constants used in authorization of flight connections.
+ */
 public final class AuthConstants {
 
   public static final String HANDSHAKE_DESCRIPTOR_NAME = MethodDescriptor

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/BasicServerAuthHandler.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/BasicServerAuthHandler.java
@@ -40,6 +40,9 @@ public class BasicServerAuthHandler implements ServerAuthHandler {
     this.authValidator = authValidator;
   }
 
+  /**
+   * Interface that this handler delegates for determining if credentials are valid.
+   */
   public interface BasicAuthValidator {
 
     public byte[] getToken(String username, String password) throws Exception;

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/ClientAuthInterceptor.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/ClientAuthInterceptor.java
@@ -25,6 +25,9 @@ import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 
+/**
+ * GRPC client intercepter that handles authentication with the server.
+ */
 public class ClientAuthInterceptor implements ClientInterceptor {
   private volatile ClientAuthHandler authHandler = null;
 

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/ClientAuthWrapper.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/ClientAuthWrapper.java
@@ -30,6 +30,9 @@ import com.google.protobuf.ByteString;
 
 import io.grpc.stub.StreamObserver;
 
+/**
+ * Utility class for performing authorization over using a GRPC stub.
+ */
 public class ClientAuthWrapper {
 
   /**

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/ServerAuthHandler.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/ServerAuthHandler.java
@@ -20,6 +20,9 @@ package org.apache.arrow.flight.auth;
 import java.util.Iterator;
 import java.util.Optional;
 
+/**
+ * Interface for Server side authentication handlers.
+ */
 public interface ServerAuthHandler {
 
   /**
@@ -37,11 +40,15 @@ public interface ServerAuthHandler {
    */
   boolean authenticate(ServerAuthSender outgoing, Iterator<byte[]> incoming);
 
-  public interface ServerAuthSender {
+  /**
+   * Interface for an server implementations to send back authentication messages
+   * back to the client.
+   */
+  interface ServerAuthSender {
 
-    public void send(byte[] payload);
+    void send(byte[] payload);
 
-    public void onError(String message, Throwable cause);
+    void onError(String message, Throwable cause);
 
   }
 

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/ServerAuthInterceptor.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/ServerAuthInterceptor.java
@@ -28,6 +28,9 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 
+/**
+ * GRPC Interceptor for performing authentication.
+ */
 public class ServerAuthInterceptor implements ServerInterceptor {
 
   private final ServerAuthHandler authHandler;

--- a/java/flight/src/main/java/org/apache/arrow/flight/auth/ServerAuthWrapper.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/auth/ServerAuthWrapper.java
@@ -31,6 +31,9 @@ import com.google.protobuf.ByteString;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
+/**
+ * Contains utility methods for integrating authorization into a GRPC stream.
+ */
 public class ServerAuthWrapper {
 
   /**

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/integration/IntegrationTestServer.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/integration/IntegrationTestServer.java
@@ -28,6 +28,9 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+/**
+ * Flight server for integration testing.
+ */
 class IntegrationTestServer {
   private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(IntegrationTestServer.class);
   private final Options options;

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java
@@ -19,7 +19,9 @@ package org.apache.arrow.gandiva.evaluator;
 
 import org.apache.arrow.vector.types.pojo.ArrowType.Decimal;
 
+/** Utility methods for working with {@link Decimal} values. */
 public class DecimalTypeUtil {
+  private DecimalTypeUtil() {}
 
   public enum OperationType {
     ADD,

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/DecimalTypeUtil.java
@@ -19,10 +19,15 @@ package org.apache.arrow.gandiva.evaluator;
 
 import org.apache.arrow.vector.types.pojo.ArrowType.Decimal;
 
-/** Utility methods for working with {@link Decimal} values. */
+/**
+ * Utility methods for working with {@link Decimal} values.
+ */
 public class DecimalTypeUtil {
   private DecimalTypeUtil() {}
 
+  /**
+   * Enum for supported mathematical operations.
+   */
   public enum OperationType {
     ADD,
     SUBTRACT,

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt16.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt16.java
@@ -21,7 +21,7 @@ import org.apache.arrow.gandiva.ipc.GandivaTypes.SelectionVectorType;
 
 import io.netty.buffer.ArrowBuf;
 
-/*
+/**
  * Selection vector with records of arrow type INT16.
  */
 public class SelectionVectorInt16 extends SelectionVector {

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt32.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt32.java
@@ -21,7 +21,7 @@ import org.apache.arrow.gandiva.ipc.GandivaTypes.SelectionVectorType;
 
 import io.netty.buffer.ArrowBuf;
 
-/*
+/**
  * Selection vector with records of arrow type INT32.
  */
 public class SelectionVectorInt32 extends SelectionVector {

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/exceptions/EvaluatorClosedException.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/exceptions/EvaluatorClosedException.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.gandiva.exceptions;
 
+/** Indicates an attempted call to methods on a closed evaluator. */
 public class EvaluatorClosedException extends GandivaException {
   public EvaluatorClosedException() {
     super("Cannot invoke methods on evaluator after closing it");

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/exceptions/GandivaException.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/exceptions/GandivaException.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.gandiva.exceptions;
 
+/** Base class for all specialized exceptions this package uses. */
 public class GandivaException extends Exception {
 
   public GandivaException(String msg) {

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/AndNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/AndNode.java
@@ -22,6 +22,9 @@ import java.util.List;
 import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
 
+/**
+ * Node representing a logical And expression.
+ */
 class AndNode implements TreeNode {
   private final List<TreeNode> children;
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
@@ -27,7 +27,12 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+/**
+ * Utility methods to convert between Arrow and Gandiva types.
+ */
 public class ArrowTypeHelper {
+  private ArrowTypeHelper() {}
+
   static final int WIDTH_8 = 8;
   static final int WIDTH_16 = 16;
   static final int WIDTH_32 = 32;

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/FunctionNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/FunctionNode.java
@@ -23,6 +23,9 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
+/**
+ * Node representing an arbitrary function in an expression.
+ */
 class FunctionNode implements TreeNode {
   private final String function;
   private final List<TreeNode> children;

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/IfNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/IfNode.java
@@ -21,6 +21,9 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
+/**
+ * Node representing a if-then-else block expression.
+ */
 class IfNode implements TreeNode {
   private final TreeNode condition;
   private final TreeNode thenNode;

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/NullNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/NullNode.java
@@ -21,6 +21,7 @@ import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
+/** An expression indicating a null value. */
 class NullNode implements TreeNode {
   private final ArrowType type;
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/OrNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/OrNode.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
 
+/** Represents a logical OR Node */
 class OrNode implements TreeNode {
   private final List<TreeNode> children;
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/OrNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/OrNode.java
@@ -22,7 +22,9 @@ import java.util.List;
 import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
 
-/** Represents a logical OR Node */
+/**
+ * Represents a logical OR Node.
+ */
 class OrNode implements TreeNode {
   private final List<TreeNode> children;
 

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/TreeBuilder.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/TreeBuilder.java
@@ -23,7 +23,12 @@ import java.util.List;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 
+/**
+ * Contains helper functions for constructing expression trees.
+ */
 public class TreeBuilder {
+  private TreeBuilder() {}
+
   /**
    * Helper functions to create literal constants.
    */

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -20,7 +20,6 @@ package org.apache.arrow.memory;
 import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.arrow.memory.util.AssertionUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
@@ -681,6 +680,9 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
   }
 
+  /**
+   * Enum for logging verbosity.
+   */
   public static enum Verbosity {
     BASIC(false, false), // only include basic information
     LOG(true, false), // include basic

--- a/java/memory/src/main/java/org/apache/arrow/memory/OwnershipTransferNOOP.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/OwnershipTransferNOOP.java
@@ -19,6 +19,9 @@ package org.apache.arrow.memory;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * An {@link OwnershipTransferResult} indicating no transfer needed.
+ */
 public class OwnershipTransferNOOP implements OwnershipTransferResult {
   private final ArrowBuf buffer;
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/OwnershipTransferResult.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/OwnershipTransferResult.java
@@ -19,6 +19,9 @@ package org.apache.arrow.memory;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * The result of transferring an {@link ArrowBuf} between {@linkplain BufferAllocator}s.
+ */
 public interface OwnershipTransferResult {
 
   boolean getAllocationFit();

--- a/java/memory/src/main/java/org/apache/arrow/memory/ValueWithKeyIncluded.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ValueWithKeyIncluded.java
@@ -20,6 +20,8 @@ package org.apache.arrow.memory;
 /**
  * Helper Iface to generify a value to be included in the map where
  * key is part of the value.
+ *
+ * @param <K> The type of the key.
  */
 public interface ValueWithKeyIncluded<K> {
   K getKey();

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/AssertionUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/AssertionUtil.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.memory.util;
 
+/**
+ * Utility class to that provides {@link #ASSERT_ENABLED} constant to determine if assertions are enabled.
+ */
 public class AssertionUtil {
 
   public static final boolean ASSERT_ENABLED;

--- a/java/memory/src/main/java/org/apache/arrow/util/VisibleForTesting.java
+++ b/java/memory/src/main/java/org/apache/arrow/util/VisibleForTesting.java
@@ -17,5 +17,10 @@
 
 package org.apache.arrow.util;
 
+/**
+ * Annotation to indicate an class member or class is visible
+ * only for the purposes of testing and otherwise should not
+ * be referenced by other classes.
+ */
 public @interface VisibleForTesting {
 }

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/ObjectStoreLink.java
@@ -27,6 +27,9 @@ import org.apache.arrow.plasma.exceptions.PlasmaOutOfMemoryException;
  */
 public interface ObjectStoreLink {
 
+  /**
+   * Tuple for data and metadata stored in Plasma.
+   */
   class ObjectStoreData {
 
     public ObjectStoreData(byte[] metadata, byte[] data) {

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/DuplicateObjectException.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/DuplicateObjectException.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.plasma.exceptions;
 
+/**
+ * Thrown when attempting to place an object into the store for an ID that already exists.
+ */
 public class DuplicateObjectException extends RuntimeException {
 
   public DuplicateObjectException(String objectId) {

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaClientException.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaClientException.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.plasma.exceptions;
 
+/**
+ * Generic exception thrown by the plasma client (for example on failure to connect).
+ */
 public class PlasmaClientException extends RuntimeException {
 
   public PlasmaClientException(String message) {

--- a/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaOutOfMemoryException.java
+++ b/java/plasma/src/main/java/org/apache/arrow/plasma/exceptions/PlasmaOutOfMemoryException.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.plasma.exceptions;
 
+/**
+ * Indicates no more memory is available in Plasma.
+ */
 public class PlasmaOutOfMemoryException extends RuntimeException {
 
   public PlasmaOutOfMemoryException() {

--- a/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/EchoServer.java
@@ -98,6 +98,9 @@ public class EchoServer {
     serverSocket.close();
   }
 
+  /**
+   * Handler for each client connection to the server.
+   */
   public static class ClientConnection implements AutoCloseable {
     public final Socket socket;
 

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileRoundtrip.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileRoundtrip.java
@@ -37,6 +37,9 @@ import org.apache.commons.cli.PosixParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Application that verifies data can be round-tripped through a file.
+ */
 public class FileRoundtrip {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileRoundtrip.class);
   private final Options options;

--- a/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/Integration.java
@@ -127,6 +127,9 @@ public class Integration {
     }
   }
 
+  /**
+   * Commands (actions) the application can perform.
+   */
   enum Command {
     ARROW_TO_JSON(true, false) {
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
+++ b/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+/**
+ * Utility methods for manipulating {@link java.util.Collections} and their subclasses/implementations.
+ */
 public class Collections2 {
   private Collections2() {}
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/AddOrGetResult.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/AddOrGetResult.java
@@ -19,7 +19,11 @@ package org.apache.arrow.vector;
 
 import org.apache.arrow.util.Preconditions;
 
-/** Tuple class containing a vector and whether is was created. */
+/**
+ * Tuple class containing a vector and whether is was created.
+ *
+ * @param <V> The type of vector the result is for.
+ */
 public class AddOrGetResult<V extends ValueVector> {
   private final V vector;
   private final boolean created;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -139,6 +139,9 @@ public abstract class BaseValueVector implements ValueVector {
     return BaseAllocator.nextPowerOfTwo(bufferSize);
   }
 
+  /**
+   * Container for primitive vectors (1 for the validity bit-mask and one to hold the values).
+   */
   class DataAndValidityBuffers {
     private ArrowBuf dataBuf;
     private ArrowBuf validityBuf;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
@@ -26,6 +26,9 @@ import org.apache.arrow.util.Preconditions;
  */
 public class BufferLayout {
 
+  /**
+   * Enumeration of the different logical types a buffer can have.
+   */
   public enum BufferType {
     DATA("DATA"),
     OFFSET("OFFSET"),

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedWidthVector.java
@@ -18,6 +18,9 @@
 package org.apache.arrow.vector;
 
 
+/**
+ * Interface for all fixed width {@link ValueVector} (e.g. integer, fixed size binary, etc).
+ */
 public interface FixedWidthVector extends ValueVector {
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/SchemaChangeCallBack.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SchemaChangeCallBack.java
@@ -20,6 +20,10 @@ package org.apache.arrow.vector;
 import org.apache.arrow.vector.util.CallBack;
 
 
+/**
+ * Callback for when the Schema for the Vector changes (generally happens when a vector is promoted to a union type
+ * from a single value type).
+ */
 public class SchemaChangeCallBack implements CallBack {
   private boolean schemaChanged = false;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
@@ -193,6 +193,9 @@ public abstract class TimeStampVector extends BaseFixedWidthVector {
    *----------------------------------------------------------------*/
 
 
+  /**
+   * {@link TransferPair} for {@link TimeStampVector}.
+   */
   public class TransferImpl implements TransferPair {
     TimeStampVector to;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector;
 
+/**
+ * Interface vectors that contain variable width members (e.g. Strings, Lists, etc).
+ */
 public interface VariableWidthVector extends ValueVector, DensityAwareVector {
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorDefinitionSetter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorDefinitionSetter.java
@@ -17,7 +17,10 @@
 
 package org.apache.arrow.vector;
 
+/**
+ * Interface for setting a specific index values as defined/valid on a vector.
+ */
 public interface VectorDefinitionSetter {
 
-  public void setIndexDefined(int index);
+  void setIndexDefined(int index);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -37,6 +37,9 @@ import org.apache.arrow.vector.util.TransferPair;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * A zero length vector of any type.
+ */
 public class ZeroVector implements FieldVector {
   public static final ZeroVector INSTANCE = new ZeroVector();
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -186,6 +186,9 @@ public class NonNullableStructVector extends AbstractStructVector {
     return new StructTransferPair(this, new NonNullableStructVector(ref, allocator, fieldType, callBack), false);
   }
 
+  /**
+   * {@link TransferPair} for this this class.
+   */
   protected static class StructTransferPair implements TransferPair {
     private final TransferPair[] pairs;
     private final NonNullableStructVector from;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/Positionable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/Positionable.java
@@ -17,6 +17,11 @@
 
 package org.apache.arrow.vector.complex;
 
+/**
+ * Get and set position in a particular data structure.
+ *
+ */
+@SuppressWarnings("unused") // Used in when instantiating freemarker templates.
 public interface Positionable {
   public int getPosition();
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/PromotableVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/PromotableVector.java
@@ -23,6 +23,9 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.FieldType;
 
+/**
+ * Vector that can store multiple {@linkplain FieldType} vectors as children.
+ */
 public interface PromotableVector {
 
   <T extends ValueVector> AddOrGetResult<T> addOrGetVector(FieldType type);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedVariableWidthVectorLike.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedVariableWidthVectorLike.java
@@ -17,6 +17,10 @@
 
 package org.apache.arrow.vector.complex;
 
+/**
+ * A {@link org.apache.arrow.vector.ValueVector} mix-in that can be used in conjunction with
+ * variable {@link RepeatedValueVector} subtypes (e.g. Strings, Lists, etc).
+ */
 public interface RepeatedVariableWidthVectorLike {
   /**
    * Allocate a new memory space for this vector.  Must be called prior to using the ValueVector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -164,6 +164,9 @@ public class StructVector extends NonNullableStructVector implements FieldVector
     return new NullableStructTransferPair(this, new StructVector(ref, allocator, fieldType, callBack), false);
   }
 
+  /**
+   * {@link TransferPair} for this (nullable) {@link StructVector}.
+   */
   protected class NullableStructTransferPair extends StructTransferPair {
 
     private StructVector target;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/VectorWithOrdinal.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/VectorWithOrdinal.java
@@ -19,6 +19,10 @@ package org.apache.arrow.vector.complex;
 
 import org.apache.arrow.vector.ValueVector;
 
+/**
+ * Tuple of a {@link ValueVector} and an index into a data structure containing the {@link ValueVector}.
+ * Useful for composite types to determine the index of a child.
+ */
 public class VectorWithOrdinal {
   public final ValueVector vector;
   public final int ordinal;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
@@ -24,7 +24,11 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.holders.UnionHolder;
 
-
+/**
+ * Base class providing common functionality for {@link FieldReader} implementations.
+ *
+ * <p>This includes tracking the current index and throwing implementations of optional methods.
+ */
 abstract class AbstractBaseReader implements FieldReader {
 
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractBaseReader.class);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseWriter.java
@@ -20,6 +20,11 @@ package org.apache.arrow.vector.complex.impl;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 
 
+/**
+ * Base class providing common functionality for {@link FieldWriter} implementations.
+ *
+ * <p>Currently this only includes index tracking.
+ */
 abstract class AbstractBaseWriter implements FieldWriter {
   //private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractBaseWriter.class);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableStructReaderImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableStructReaderImpl.java
@@ -22,6 +22,10 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.types.pojo.Field;
 
+/**
+ * An {@link org.apache.arrow.vector.complex.reader.FieldReader} for
+ * reading nullable struct vectors.
+ */
 public class NullableStructReaderImpl extends SingleStructReaderImpl {
 
   private StructVector nullableStructVector;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableStructWriterFactory.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/NullableStructWriterFactory.java
@@ -19,6 +19,10 @@ package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.vector.complex.StructVector;
 
+/**
+ * A factory for {@link NullableStructWriter} instances.  The factory allows for configuring if field
+ * names should be considered case sensitive.
+ */
 public class NullableStructWriterFactory {
   private final boolean caseSensitive;
   private static final NullableStructWriterFactory nullableStructWriterFactory =

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/SingleStructReaderImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/SingleStructReaderImpl.java
@@ -28,6 +28,9 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 
+/**
+ * {@link FieldReader} for a single {@link org.apache.arrow.vector.complex.NonNullableStructVector}.
+ */
 @SuppressWarnings("unused")
 public class SingleStructReaderImpl extends AbstractFieldReader {
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionListReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionListReader.java
@@ -26,6 +26,9 @@ import org.apache.arrow.vector.holders.UnionHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
 
+/**
+ * {@link FieldReader} for list of union types.
+ */
 public class UnionListReader extends AbstractFieldReader {
 
   private ListVector vector;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/reader/FieldReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/reader/FieldReader.java
@@ -24,5 +24,9 @@ import org.apache.arrow.vector.complex.reader.BaseReader.ScalarReader;
 import org.apache.arrow.vector.complex.reader.BaseReader.StructReader;
 
 
+/**
+ * Composite of all Reader types (e.g. {@link StructReader}, {@link ScalarReader}, etc).  Each reader type
+ * is in essence a way of iterating over a {@link ValueVector}.
+ */
 public interface FieldReader extends StructReader, ListReader, ScalarReader, RepeatedStructReader, RepeatedListReader {
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/writer/FieldWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/writer/FieldWriter.java
@@ -21,6 +21,10 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
 import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
 
+/**
+ * Composite of all writer types.  Writers are convenience classes for incrementally
+ * adding values to {@linkplain org.apache.arrow.vector.ValueVector}s.
+ */
 public interface FieldWriter extends StructWriter, ListWriter, ScalarWriter {
   void allocate();
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -30,6 +30,11 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
+/**
+ * Encoder/decoder for Dictionary encoded {@link ValueVector}. Dictionary encoding produces an
+ * integer {@link ValueVector}. Each entry in the Vector is index into the dictionary which can hold
+ * values of any type.
+ */
 public class DictionaryEncoder {
 
   // TODO recursively examine fields?

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryProvider.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryProvider.java
@@ -29,6 +29,9 @@ public interface DictionaryProvider {
   /** Return the dictionary for the given ID. */
   public Dictionary lookup(long id);
 
+  /**
+   * Implementation of {@link DictionaryProvider} that is backed by a hash-map.
+   */
   public static class MapDictionaryProvider implements DictionaryProvider {
 
     private final Map<Long, Dictionary> map;

--- a/java/vector/src/main/java/org/apache/arrow/vector/holders/ComplexHolder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/holders/ComplexHolder.java
@@ -19,6 +19,9 @@ package org.apache.arrow.vector.holders;
 
 import org.apache.arrow.vector.complex.reader.FieldReader;
 
+/**
+ * Represents a single value of a complex type (e.g. Union, Struct).
+ */
 public class ComplexHolder implements ValueHolder {
   public FieldReader reader;
   public int isSet;

--- a/java/vector/src/main/java/org/apache/arrow/vector/holders/RepeatedListHolder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/holders/RepeatedListHolder.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector.holders;
 
+/**
+ * {@link ValueHolder} for a nested {@link org.apache.arrow.vector.complex.ListVector}.
+ */
 public final class RepeatedListHolder implements ValueHolder {
   public int start;
   public int end;

--- a/java/vector/src/main/java/org/apache/arrow/vector/holders/RepeatedStructHolder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/holders/RepeatedStructHolder.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector.holders;
 
+/**
+ * {@link ValueHolder} for a list of structs.
+ */
 public final class RepeatedStructHolder implements ValueHolder {
   public int start;
   public int end;

--- a/java/vector/src/main/java/org/apache/arrow/vector/holders/UnionHolder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/holders/UnionHolder.java
@@ -20,6 +20,9 @@ package org.apache.arrow.vector.holders;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types.MinorType;
 
+/**
+ * {@link ValueHolder} for Union Vectors.
+ */
 public class UnionHolder implements ValueHolder {
   public FieldReader reader;
   public int isSet;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -32,6 +32,9 @@ import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * {@link ArrowWriter} that writes out a Arrow files (https://arrow.apache.org/docs/format/IPC.html#file-format).
+ */
 public class ArrowFileWriter extends ArrowWriter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArrowFileWriter.class);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowMagic.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowMagic.java
@@ -21,7 +21,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+/**
+ * Magic header/footer helpers for {@link ArrowFileWriter} and {@link ArrowFileReader} formatted files.
+ */
 class ArrowMagic {
+  private ArrowMagic(){}
 
   private static final byte[] MAGIC = "ARROW1".getBytes(StandardCharsets.UTF_8);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/InvalidArrowFileException.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/InvalidArrowFileException.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector.ipc;
 
+/**
+ * Exception indicating a problem with an Arrow File (https://arrow.apache.org/docs/format/IPC.html#file-format).
+ */
 public class InvalidArrowFileException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -82,6 +82,9 @@ import io.netty.buffer.ArrowBuf;
  */
 public class JsonFileWriter implements AutoCloseable {
 
+  /**
+   * Configuration POJO for writing JSON files.
+   */
   public static final class JSONWriteConfig {
     private final boolean pretty;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -26,6 +26,9 @@ import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * Adapter around {@link ReadableByteChannel} that reads into {@linkplain ArrowBuf}s.
+ */
 public class ReadChannel implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ReadChannel.class);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/SeekableReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/SeekableReadChannel.java
@@ -20,6 +20,10 @@ package org.apache.arrow.vector.ipc;
 import java.io.IOException;
 import java.nio.channels.SeekableByteChannel;
 
+/**
+ * An {@link ReadChannel} that supports seeking to a
+ * random position.
+ */
 public class SeekableReadChannel extends ReadChannel {
 
   private final SeekableByteChannel in;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
@@ -21,6 +21,10 @@ import org.apache.arrow.flatbuf.DictionaryBatch;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 
+/**
+ * POJO wrapper around a Dictionary Batch IPC messages
+ * (https://arrow.apache.org/docs/format/IPC.html#dictionary-batches)
+ */
 public class ArrowDictionaryBatch implements ArrowMessage {
 
   private final long dictionaryId;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowMessage.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowMessage.java
@@ -17,15 +17,23 @@
 
 package org.apache.arrow.vector.ipc.message;
 
+/**
+ * Interface for Arrow IPC messages (https://arrow.apache.org/docs/format/IPC.html).
+ */
 public interface ArrowMessage extends FBSerializable, AutoCloseable {
 
-  public int computeBodyLength();
+  int computeBodyLength();
 
-  public <T> T accepts(ArrowMessageVisitor<T> visitor);
+  <T> T accepts(ArrowMessageVisitor<T> visitor);
 
-  public static interface ArrowMessageVisitor<T> {
-    public T visit(ArrowDictionaryBatch message);
+  /**
+   * Visitor interface for implementations of {@link ArrowMessage}.
+   *
+   * @param <T> The type of value to return after visiting.
+   */
+  static interface ArrowMessageVisitor<T> {
+    T visit(ArrowDictionaryBatch message);
 
-    public T visit(ArrowRecordBatch message);
+    T visit(ArrowRecordBatch message);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -32,6 +32,9 @@ import com.google.flatbuffers.FlatBufferBuilder;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * POJO representation of an RecordBatch IPC message (https://arrow.apache.org/docs/format/IPC.html).
+ */
 public class ArrowRecordBatch implements ArrowMessage {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArrowRecordBatch.class);

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/DateUnit.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/DateUnit.java
@@ -17,8 +17,13 @@
 
 package org.apache.arrow.vector.types;
 
+/**
+ * Resolutions that dates can be stored at.
+ */
 public enum DateUnit {
+  /** Days since epoch. */
   DAY(org.apache.arrow.flatbuf.DateUnit.DAY),
+  /** Milliseconds since epoch. */
   MILLISECOND(org.apache.arrow.flatbuf.DateUnit.MILLISECOND);
 
   private static final DateUnit[] valuesByFlatbufId = new DateUnit[DateUnit.values().length];

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/FloatingPointPrecision.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/FloatingPointPrecision.java
@@ -19,9 +19,15 @@ package org.apache.arrow.vector.types;
 
 import org.apache.arrow.flatbuf.Precision;
 
+/**
+ * Precisions of primitive floating point numbers.
+ */
 public enum FloatingPointPrecision {
+  /** 16-bit (not a standard java type). */
   HALF(Precision.HALF),
+  /** 32-bit (i.e. float in java). */
   SINGLE(Precision.SINGLE),
+  /** 64-bit (i.e. double in java). */
   DOUBLE(Precision.DOUBLE);
 
   private static final FloatingPointPrecision[] valuesByFlatbufId =

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/IntervalUnit.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/IntervalUnit.java
@@ -18,7 +18,7 @@
 package org.apache.arrow.vector.types;
 
 /**
- * Resolutions that intervals (periods can be stored in).
+ * Resolutions for Interval Vectors.
  */
 public enum IntervalUnit {
   /** Values are stored as number of months (which can be converted into years and months via division). */

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/IntervalUnit.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/IntervalUnit.java
@@ -17,8 +17,13 @@
 
 package org.apache.arrow.vector.types;
 
+/**
+ * Resolutions that intervals (periods can be stored in).
+ */
 public enum IntervalUnit {
+  /** Values are stored as number of months (which can be converted into years and months via division). */
   YEAR_MONTH(org.apache.arrow.flatbuf.IntervalUnit.YEAR_MONTH),
+  /** Values are stored as some number of days and some number of milliseconds within that day. */
   DAY_TIME(org.apache.arrow.flatbuf.IntervalUnit.DAY_TIME);
 
   private static final IntervalUnit[] valuesByFlatbufId = new IntervalUnit[IntervalUnit.values().length];

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/TimeUnit.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/TimeUnit.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector.types;
 
+/**
+ * Resolutions that times can be stored with.
+ */
 public enum TimeUnit {
   SECOND(org.apache.arrow.flatbuf.TimeUnit.SECOND),
   MILLISECOND(org.apache.arrow.flatbuf.TimeUnit.MILLISECOND),

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -122,6 +122,9 @@ import org.apache.arrow.vector.util.CallBack;
 /** An enumeration of all logical types supported by this library. */
 public class Types {
 
+  /**
+   * The actual enumeration of types.
+   */
   public enum MinorType {
     NULL(Null.INSTANCE) {
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/UnionMode.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/UnionMode.java
@@ -17,8 +17,20 @@
 
 package org.apache.arrow.vector.types;
 
+/**
+ * Different memory layouts for Union Vectors.
+ */
 public enum UnionMode {
+  /**
+   * Each child vector is the same length as the overall vector, and there is one 8-bit integer buffer to indicate
+   * the index of a child vector to use at any given position.
+   */
   Sparse(org.apache.arrow.flatbuf.UnionMode.Sparse),
+  /**
+   * Each child vector is of variable width.  The parent vector contains both an child index vector (like in
+   * {@link #Sparse}) and in addition a slot index buffer to determine the offset into the child vector indicated
+   * by the index vector.
+   */
   Dense(org.apache.arrow.flatbuf.UnionMode.Dense);
 
   private static final UnionMode[] valuesByFlatbufId = new UnionMode[UnionMode.values().length];

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
@@ -27,6 +27,10 @@ import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.util.CallBack;
 
+/**
+ * POJO representation of an Arrow field type.  It consists of a logical type, nullability and whether the field
+ * (column) is dictionary encoded.
+ */
 public class FieldType {
 
   public static FieldType nullable(ArrowType type) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ByteFunctionHelpers.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ByteFunctionHelpers.java
@@ -22,8 +22,13 @@ import org.apache.arrow.memory.BoundsChecking;
 import io.netty.buffer.ArrowBuf;
 import io.netty.util.internal.PlatformDependent;
 
+/**
+ * Utility methods for memory comparison at a byte level.
+ */
 public class ByteFunctionHelpers {
   static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ByteFunctionHelpers.class);
+
+  private ByteFunctionHelpers() {}
 
   /**
    * Helper function to check for equality of bytes in two ArrowBufs.

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/CallBack.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/CallBack.java
@@ -17,7 +17,9 @@
 
 package org.apache.arrow.vector.util;
 
-
+/**
+ * Generic callback interface to be notified of events on value vectors.
+ */
 public interface CallBack {
-  public void doWork();
+  void doWork();
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
@@ -23,6 +23,9 @@ import java.nio.ByteBuffer;
 
 import io.netty.buffer.ArrowBuf;
 
+/**
+ * Utility methods for configurable precision Decimal values (e.g. {@link BigDecimal}).
+ */
 public class DecimalUtility {
   private DecimalUtility() {}
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DictionaryUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DictionaryUtility.java
@@ -31,8 +31,11 @@ import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 
-
+/**
+ * Utility methods for working with Dictionaries used in Dictionary encodings.
+ */
 public class DictionaryUtility {
+  private DictionaryUtility() {}
 
   /**
    * Convert field and child fields that have a dictionary encoding to message format, so fields

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringArrayList.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringArrayList.java
@@ -22,6 +22,12 @@ import java.util.ArrayList;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * Extension of {@link ArrayList} that {@link #toString()} method returns the serialized JSON
+ * version of its members (or throws an exception if they can't be converted to JSON).
+ *
+ * @param <E> Type of value held in the list.
+ */
 public class JsonStringArrayList<E> extends ArrayList<E> {
 
   private static ObjectMapper mapper;

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringHashMap.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/JsonStringHashMap.java
@@ -22,9 +22,12 @@ import java.util.LinkedHashMap;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/*
+/**
  * Simple class that extends the regular java.util.HashMap but overrides the
  * toString() method of the HashMap class to produce a JSON string instead
+ *
+ * @param <K> The type of the key for the map.
+ * @param <V> The type of the value for the map.
  */
 public class JsonStringHashMap<K, V> extends LinkedHashMap<K, V> {
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/SchemaChangeRuntimeException.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/SchemaChangeRuntimeException.java
@@ -18,6 +18,9 @@
 package org.apache.arrow.vector.util;
 
 
+/**
+ * Thrown when child vectors (e.g. in lists) don't match the expected type.
+ */
 public class SchemaChangeRuntimeException extends RuntimeException {
   public SchemaChangeRuntimeException() {
     super();

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
@@ -668,6 +668,9 @@ public class Text {
     return size;
   }
 
+  /**
+   * JSON serializer for {@link Text}.
+   */
   public static class TextSerializer extends StdSerializer<Text> {
 
     public TextSerializer() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/TransferPair.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/TransferPair.java
@@ -19,12 +19,15 @@ package org.apache.arrow.vector.util;
 
 import org.apache.arrow.vector.ValueVector;
 
+/**
+ * Interface for copying values between a pair of two vectors of the same type.
+ */
 public interface TransferPair {
-  public void transfer();
+  void transfer();
 
-  public void splitAndTransfer(int startIndex, int length);
+  void splitAndTransfer(int startIndex, int length);
 
-  public ValueVector getTo();
+  ValueVector getTo();
 
-  public void copyValueSafe(int from, int to);
+  void copyValueSafe(int from, int to);
 }


### PR DESCRIPTION
This change:
1.   Enables a check style rule on all public, protected and package visible classes/enums.
2.   Adds missing javadocs to make the rule pass
3.   Adds some private constructors to static method utility classes (some of these are  little bit short, and in some cases especially flight some of the purposes of classes was a littler hard to infer).
4.   Cleans up redundant public qualifier on interfaces when found.