### PR TITLE
ARROW-5404: [C++] force usage of nonstd::sv_lite::string_view instead of std::string_view

### DIFF
--- a/cpp/src/arrow/util/string_view.h
+++ b/cpp/src/arrow/util/string_view.h
@@ -18,6 +18,8 @@
 #ifndef ARROW_UTIL_STRING_VIEW_H
 #define ARROW_UTIL_STRING_VIEW_H
 
+#define nssv_CONFIG_SELECT_STRING_VIEW nssv_STRING_VIEW_NONSTD
+
 #include "arrow/vendored/string_view.hpp"  // IWYU pragma: export
 
 namespace arrow {


### PR DESCRIPTION
Otherwise libraries built with C++11 enabled can have ABI conflicts when built against applications built with C++ >= 17