### PR TITLE
ARROW-5612: [Python][Doc] Add prominent note that date_as_object option changed with Arrow 0.13

### DIFF
--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -71,11 +71,6 @@ convert a pandas Series to an Arrow Array using :meth:`pyarrow.Array.from_pandas
 As Arrow Arrays are always nullable, you can supply an optional mask using
 the ``mask`` parameter to mark all null-entries.
 
-.. note::
-   Arrow is the default engine used by pandas to read and write parquet files. Underneath :meth:`pyarrow.Table.to_pandas`
-   and :meth:`pyarrow.Table.from_pandas` are used to perform the necessary conversions. Options to these methods can be passed through
-   ``pandas.read_parquet`` and ``pandas.to_parquet`` using the ``**kwargs`` argument.
-
 Type differences
 ----------------
 
@@ -189,9 +184,11 @@ If you want to use NumPy's ``datetime64`` dtype instead, pass
    s2 = pd.Series(arr.to_pandas(date_as_object=False))
    s2.dtype
 
-
 .. warning::
-   In Arrow versions < ``0.13`` the parameter ``date_as_object`` is ``False`` by default.
+
+   As of Arrow ``0.13`` the parameter ``date_as_object`` is ``True``
+   by default. Older versions must pass ``date_as_object=True`` to
+   obtain this behavior
 
 Time types
 ~~~~~~~~~~

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -191,7 +191,7 @@ If you want to use NumPy's ``datetime64`` dtype instead, pass
 
 
 .. warning::
-   In Arrow versions < ``0.13`` the parameter ``date_as_object`` was ``False`` by default.
+   In Arrow versions < ``0.13`` the parameter ``date_as_object`` is ``False`` by default.
 
 Time types
 ~~~~~~~~~~

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -71,6 +71,11 @@ convert a pandas Series to an Arrow Array using :meth:`pyarrow.Array.from_pandas
 As Arrow Arrays are always nullable, you can supply an optional mask using
 the ``mask`` parameter to mark all null-entries.
 
+.. note::
+   Arrow is the default engine used by pandas to read and write parquet files. Underneath :meth:`pyarrow.Table.to_pandas`
+   and :meth:`pyarrow.Table.from_pandas` are used to perform the necessary conversions. Options to these methods can be passed through
+   ``pandas.read_parquet`` and ``pandas.to_parquet`` using the ``**kwargs`` argument.
+
 Type differences
 ----------------
 
@@ -183,6 +188,10 @@ If you want to use NumPy's ``datetime64`` dtype instead, pass
 
    s2 = pd.Series(arr.to_pandas(date_as_object=False))
    s2.dtype
+
+
+.. warning::
+   In Arrow versions < ``0.13`` the parameter ``date_as_object`` was ``False`` by default.
 
 Time types
 ~~~~~~~~~~


### PR DESCRIPTION
Adding small documentation on bits on the pandas integration documentation. It relates to #4363 
Not sure if the wording is correct. 