### PR TITLE
ARROW-5402: [Plasma] add support to pin objects in plasma store

### DIFF
--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -209,10 +209,10 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
 
   Status Create(const ObjectID& object_id, int64_t data_size, const uint8_t* metadata,
                 int64_t metadata_size, std::shared_ptr<Buffer>* data, int device_num = 0,
-                bool is_pinned = true);
+                bool is_pinned = false);
 
   Status CreateAndSeal(const ObjectID& object_id, const std::string& data,
-                       const std::string& metadata, bool is_pinned = true);
+                       const std::string& metadata, bool is_pinned = false);
 
   Status Get(const std::vector<ObjectID>& object_ids, int64_t timeout_ms,
              std::vector<ObjectBuffer>* object_buffers);

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -83,7 +83,7 @@ class ARROW_EXPORT PlasmaClient {
   ///        device_num = 0 corresponds to the host,
   ///        device_num = 1 corresponds to GPU0,
   ///        device_num = 2 corresponds to GPU1, etc.
-  /// \param is_pinned Whether the object can be deleted when it's no longer
+  /// \param is_pinned Whether the object can be evicted when it's no longer
   ///        referenced. A pinned object isn't managed by LRU cache in store,
   ///        and won't be evicted even after its reference count is 0, it can only
   ///        be deleted by calling Delete().

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -102,7 +102,7 @@ class ARROW_EXPORT PlasmaClient {
   /// \param object_id The ID of the object to create.
   /// \param data The data for the object to create.
   /// \param metadata The metadata for the object to create.
-  /// \param is_pinned Whether the object can be deleted when it's no longer
+  /// \param is_pinned Whether the object can be evicted when it's no longer
   ///        referenced. A pinned object isn't managed by LRU cache in store,
   ///        and won't be evicted even after its reference count is 0, it can only
   ///        be deleted by calling Delete().

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -83,12 +83,17 @@ class ARROW_EXPORT PlasmaClient {
   ///        device_num = 0 corresponds to the host,
   ///        device_num = 1 corresponds to GPU0,
   ///        device_num = 2 corresponds to GPU1, etc.
+  /// \param is_pinned Whether the object can be deleted when it's no longer
+  ///        referenced. A pinned object isn't managed by LRU cache in store,
+  ///        and won't be evicted even after its reference count is 0, it can only
+  ///        be deleted by calling Delete().
   /// \return The return status.
   ///
   /// The returned object must be released once it is done with.  It must also
   /// be either sealed or aborted.
   Status Create(const ObjectID& object_id, int64_t data_size, const uint8_t* metadata,
-                int64_t metadata_size, std::shared_ptr<Buffer>* data, int device_num = 0);
+                int64_t metadata_size, std::shared_ptr<Buffer>* data, int device_num = 0,
+                bool is_pinned = false);
 
   /// Create and seal an object in the object store. This is an optimization
   /// which allows small objects to be created quickly with fewer messages to
@@ -97,9 +102,13 @@ class ARROW_EXPORT PlasmaClient {
   /// \param object_id The ID of the object to create.
   /// \param data The data for the object to create.
   /// \param metadata The metadata for the object to create.
+  /// \param is_pinned Whether the object can be deleted when it's no longer
+  ///        referenced. A pinned object isn't managed by LRU cache in store,
+  ///        and won't be evicted even after its reference count is 0, it can only
+  ///        be deleted by calling Delete().
   /// \return The return status.
   Status CreateAndSeal(const ObjectID& object_id, const std::string& data,
-                       const std::string& metadata);
+                       const std::string& metadata, bool is_pinned = false);
 
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -107,7 +107,8 @@ struct ObjectTableEntry {
   int64_t create_time;
   /// How long creation of this object took.
   int64_t construct_duration;
-
+  /// Whether this object is included in LRU cache.
+  bool is_pinned;
   /// The state of the object, e.g., whether it is open or sealed.
   ObjectState state;
   /// The digest of the object. Used to see if two objects are the same.

--- a/cpp/src/plasma/common.h
+++ b/cpp/src/plasma/common.h
@@ -107,7 +107,7 @@ struct ObjectTableEntry {
   int64_t create_time;
   /// How long creation of this object took.
   int64_t construct_duration;
-  /// Whether this object is included in LRU cache.
+  /// Whether this object is excluded in LRU cache.
   bool is_pinned;
   /// The state of the object, e.g., whether it is open or sealed.
   ObjectState state;

--- a/cpp/src/plasma/format/plasma.fbs
+++ b/cpp/src/plasma/format/plasma.fbs
@@ -112,6 +112,8 @@ table PlasmaCreateRequest {
   metadata_size: ulong;
   // Device to create buffer on.
   device_num: int;
+  // Whether to pin this object.
+  is_pinned: bool;
 }
 
 table CudaHandle {
@@ -144,6 +146,8 @@ table PlasmaCreateAndSealRequest {
   metadata: string;
   // Hash of the object data.
   digest: string;
+  // Whether to pin this object.
+  is_pinned: bool;
 }
 
 table PlasmaCreateAndSealReply {

--- a/cpp/src/plasma/plasma.cc
+++ b/cpp/src/plasma/plasma.cc
@@ -29,7 +29,7 @@ namespace fb = plasma::flatbuf;
 
 namespace plasma {
 
-ObjectTableEntry::ObjectTableEntry() : pointer(nullptr), ref_count(0) {}
+ObjectTableEntry::ObjectTableEntry() : pointer(nullptr), ref_count(0), is_pinned(true) {}
 
 ObjectTableEntry::~ObjectTableEntry() { pointer = nullptr; }
 

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -47,10 +47,11 @@ Status PlasmaReceive(int sock, MessageType message_type, std::vector<uint8_t>* b
 /* Plasma Create message functions. */
 
 Status SendCreateRequest(int sock, ObjectID object_id, int64_t data_size,
-                         int64_t metadata_size, int device_num);
+                         int64_t metadata_size, int device_num, bool is_pinned);
 
 Status ReadCreateRequest(uint8_t* data, size_t size, ObjectID* object_id,
-                         int64_t* data_size, int64_t* metadata_size, int* device_num);
+                         int64_t* data_size, int64_t* metadata_size, int* device_num,
+                         bool* is_pinned);
 
 Status SendCreateReply(int sock, ObjectID object_id, PlasmaObject* object,
                        PlasmaError error, int64_t mmap_size);
@@ -60,11 +61,11 @@ Status ReadCreateReply(uint8_t* data, size_t size, ObjectID* object_id,
 
 Status SendCreateAndSealRequest(int sock, const ObjectID& object_id,
                                 const std::string& data, const std::string& metadata,
-                                unsigned char* digest);
+                                unsigned char* digest, bool is_pinned);
 
 Status ReadCreateAndSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
                                 std::string* object_data, std::string* metadata,
-                                unsigned char* digest);
+                                unsigned char* digest, bool* is_pinned);
 
 Status SendCreateAndSealReply(int sock, PlasmaError error);
 

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -231,11 +231,13 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
     auto st = AllocateCudaMemory(device_num, total_size, &pointer, &entry->ipc_handle);
     if (!st.ok()) {
       ARROW_LOG(ERROR) << "Failed to allocate CUDA memory: " << st.ToString();
+      store_info_.objects.erase(object_id);
       return PlasmaError::OutOfMemory;
     }
     result->ipc_handle = entry->ipc_handle;
 #else
     ARROW_LOG(ERROR) << "device_num != 0 but CUDA not enabled";
+    store_info_.objects.erase(object_id);
     return PlasmaError::OutOfMemory;
 #endif
   } else {
@@ -245,6 +247,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
                        << ", data_size=" << data_size
                        << ", metadata_size=" << metadata_size
                        << ", will send a reply of PlasmaError::OutOfMemory";
+      store_info_.objects.erase(object_id);
       return PlasmaError::OutOfMemory;
     }
   }

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -97,6 +97,8 @@ class PlasmaStore {
   ///        device_num = 0 corresponds to the host,
   ///        device_num = 1 corresponds to GPU0,
   ///        device_num = 2 corresponds to GPU1, etc.
+  /// @param is_pinned Whether the object is pinned. A pinned object is not managed
+  ///        by LRU cache, and can only be evicted explicitly by calling Delete().
   /// @param client The client that created the object.
   /// @param result The object that has been created.
   /// @return One of the following error codes:
@@ -108,8 +110,8 @@ class PlasmaStore {
   ///    cannot create the object. In this case, the client should not call
   ///    plasma_release.
   PlasmaError CreateObject(const ObjectID& object_id, int64_t data_size,
-                           int64_t metadata_size, int device_num, Client* client,
-                           PlasmaObject* result);
+                           int64_t metadata_size, int device_num, bool is_pinned,
+                           Client* client, PlasmaObject* result);
 
   /// Abort a created but unsealed object. If the client is not the
   /// creator, then the abort will fail.

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -485,7 +485,6 @@ using TestSmallMemoryPlasmaStore = TestPlasmaStoreBase<3000>;
 TEST_F(TestSmallMemoryPlasmaStore, LRUCacheTest) {
   ObjectID object_id1 = random_object_id();
   ObjectID object_id2 = random_object_id();
-  ObjectID object_id3 = random_object_id();
   bool has_object = false;
   // only one object can be put in the store
   int64_t data_size = 2000;
@@ -528,14 +527,15 @@ TEST_F(TestSmallMemoryPlasmaStore, LRUCacheTest) {
   // We have to invoke Delete to evict an object not in LRU
   auto status = client_.Create(object_id2, data_size, nullptr, 0, &data);
   ARROW_CHECK(!status.ok());
-  // Have to abort create, otherwise the object will be in the entry
+
   ARROW_CHECK_OK(client_.Delete({object_id1}));
   ARROW_CHECK_OK(client_.Contains(object_id1, &has_object));
   ARROW_CHECK(has_object == false);
 
-  ARROW_CHECK_OK(client_.Create(object_id3, data_size, nullptr, 0, &data));
-  ARROW_CHECK_OK(client_.Seal(object_id3));
-  ARROW_CHECK_OK(client_.Contains(object_id3, &has_object));
+  ARROW_CHECK_OK(client_.Delete(object_id2));
+  ARROW_CHECK_OK(client_.Create(object_id2, data_size, nullptr, 0, &data));
+  ARROW_CHECK_OK(client_.Seal(object_id2));
+  ARROW_CHECK_OK(client_.Contains(object_id2, &has_object));
   ARROW_CHECK(has_object == true);
 }
 

--- a/cpp/src/plasma/test/serialization_tests.cc
+++ b/cpp/src/plasma/test/serialization_tests.cc
@@ -97,15 +97,17 @@ TEST_F(TestPlasmaSerialization, CreateRequest) {
   int64_t data_size1 = 42;
   int64_t metadata_size1 = 11;
   int device_num1 = 0;
-  ASSERT_OK(SendCreateRequest(fd, object_id1, data_size1, metadata_size1, device_num1));
+  bool is_pinned1 = false;
+  ASSERT_OK(SendCreateRequest(fd, object_id1, data_size1, metadata_size1, device_num1, is_pinned1));
   std::vector<uint8_t> data =
       read_message_from_file(fd, MessageType::PlasmaCreateRequest);
   ObjectID object_id2;
   int64_t data_size2;
   int64_t metadata_size2;
   int device_num2;
+  bool is_pinned2;
   ASSERT_OK(ReadCreateRequest(data.data(), data.size(), &object_id2, &data_size2,
-                              &metadata_size2, &device_num2));
+                              &metadata_size2, &device_num2, &is_pinned2));
   ASSERT_EQ(data_size1, data_size2);
   ASSERT_EQ(metadata_size1, metadata_size2);
   ASSERT_EQ(object_id1, object_id2);


### PR DESCRIPTION
This adds support to pin an object in plasma store, which is useful in some scenarios (e.g. we want to ensure the actor creation task arguments won't be evicted from plasma so that actor can be re-constructed when it crashes).  

This is done by specifying a flag when creating an object, if the flag is set, then the object won't be managed by LRU cache in plasma, and thus won't be evicted even when its reference count drops to zero, it can only be removed by an explicit `Delete()` call.

@pcmoritz @robertnishihara @guoyuhong  could you please help take a look? thanks.