### PR TITLE
ARROW-5434: [Memory][Java] Introduce wrappers for backward compatibility.

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -1204,4 +1204,45 @@ public final class ArrowBuf implements AutoCloseable {
               "Realloc is only available in the context of operator's UDFs");
     }
   }
+
+  /**
+   * Following are wrapper methods to keep this backward compatible.
+   */
+  public void release() {
+    referenceManager.release();
+  }
+
+  public void release(int decrement) {
+    referenceManager.release(decrement);
+  }
+
+  public void retain() {
+    referenceManager.retain();
+  }
+
+  public void retain(int increment) {
+    referenceManager.retain(increment);
+  }
+
+  public ArrowBuf clear() {
+    this.readerIndex = this.writerIndex = 0;
+    return this;
+  }
+
+  /**
+   * Initialize the reader and writer index.
+   * @param readerIndex index to read from
+   * @param writerIndex index to write to
+   * @return this
+   */
+  public ArrowBuf setIndex(int readerIndex, int writerIndex) {
+    if (readerIndex >= 0 && readerIndex <= writerIndex && writerIndex <= this.capacity()) {
+      this.readerIndex = readerIndex;
+      this.writerIndex = writerIndex;
+      return this;
+    } else {
+      throw new IndexOutOfBoundsException(String.format("readerIndex: %d, writerIndex: %d " +
+              "(expected: 0 <= readerIndex <= writerIndex <= capacity(%d))", readerIndex, writerIndex, this.capacity()));
+    }
+  }
 }

--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -77,7 +77,7 @@ public final class ArrowBuf implements AutoCloseable {
   private int readerIndex;
   private int writerIndex;
   private final HistoricalLog historicalLog = BaseAllocator.DEBUG ?
-      new HistoricalLog(BaseAllocator.DEBUG_LOG_LENGTH, "ArrowBuf[%d]", id) : null;
+          new HistoricalLog(BaseAllocator.DEBUG_LOG_LENGTH, "ArrowBuf[%d]", id) : null;
   private volatile int length;
 
   /**
@@ -1208,22 +1208,27 @@ public final class ArrowBuf implements AutoCloseable {
   /**
    * Following are wrapper methods to keep this backward compatible.
    */
+  @Deprecated
   public void release() {
     referenceManager.release();
   }
 
+  @Deprecated
   public void release(int decrement) {
     referenceManager.release(decrement);
   }
 
+  @Deprecated
   public void retain() {
     referenceManager.retain();
   }
 
+  @Deprecated
   public void retain(int increment) {
     referenceManager.retain(increment);
   }
 
+  @Deprecated
   public ArrowBuf clear() {
     this.readerIndex = this.writerIndex = 0;
     return this;
@@ -1235,6 +1240,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param writerIndex index to write to
    * @return this
    */
+  @Deprecated
   public ArrowBuf setIndex(int readerIndex, int writerIndex) {
     if (readerIndex >= 0 && readerIndex <= writerIndex && writerIndex <= this.capacity()) {
       this.readerIndex = readerIndex;
@@ -1242,7 +1248,7 @@ public final class ArrowBuf implements AutoCloseable {
       return this;
     } else {
       throw new IndexOutOfBoundsException(String.format("readerIndex: %d, writerIndex: %d " +
-              "(expected: 0 <= readerIndex <= writerIndex <= capacity(%d))", readerIndex, writerIndex, this.capacity()));
+       "(expected:0 <= readerIndex <= writerIndex <= capacity(%d))", readerIndex, writerIndex, this.capacity()));
     }
   }
 }

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -355,12 +355,12 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
 
   @Override
   public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
-    throw new UnsupportedOperationException("Operation not supported");
+    return (int) in.read(nioBuffers(index, length));
   }
 
   @Override
   public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
-    throw new UnsupportedOperationException("Operation not supported");
+    return (int) in.read(nioBuffers(index, length));
   }
 
   @Override

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -76,6 +76,10 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
     return this;
   }
 
+  public ArrowBuf arrowBuf() {
+    return arrowBuf;
+  }
+
   @Override
   public ByteBuf retain(final int increment) {
     arrowBuf.getReferenceManager().retain(increment);


### PR DESCRIPTION
- Introduce some wrapper methods to reduce amount of client changes.
- Changes were introduced as part of patch to support arrow buffers on random memory.