### PR TITLE
ARROW-5435: [Java] Add test for IntervalYearVector#getAsStringBuilder

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -171,11 +171,17 @@ public class IntervalYearVector extends BaseFixedWidthVector {
   private StringBuilder getAsStringBuilderHelper(int index) {
     int value = valueBuffer.getInt(index * TYPE_WIDTH);
 
-    final String monthString = (Math.abs(value) == 1) ? " month " : " months ";
+    final int years = (value / org.apache.arrow.vector.util.DateUtility.yearsToMonths);
+    final int months = (value % org.apache.arrow.vector.util.DateUtility.yearsToMonths);
+
+    final String yearString = (Math.abs(years) == 1) ? " year " : " years ";
+    final String monthString = (Math.abs(months) == 1) ? " month " : " months ";
 
     return (new StringBuilder()
-      .append(value)
-      .append(monthString));
+        .append(years)
+        .append(yearString)
+        .append(months)
+        .append(monthString));
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -148,8 +148,9 @@ public class IntervalYearVector extends BaseFixedWidthVector {
       return null;
     } else {
       final int interval = valueBuffer.getInt(index * TYPE_WIDTH);
-      // TODO: verify interval is in months
-      return Period.ofMonths(interval);
+      final int years = (interval / org.apache.arrow.vector.util.DateUtility.yearsToMonths);
+      final int months = (interval % org.apache.arrow.vector.util.DateUtility.yearsToMonths);
+      return Period.ofYears(years).plusMonths(months);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -148,9 +148,8 @@ public class IntervalYearVector extends BaseFixedWidthVector {
       return null;
     } else {
       final int interval = valueBuffer.getInt(index * TYPE_WIDTH);
-      final int years = (interval / org.apache.arrow.vector.util.DateUtility.yearsToMonths);
-      final int months = (interval % org.apache.arrow.vector.util.DateUtility.yearsToMonths);
-      return Period.ofYears(years).plusMonths(months);
+      // TODO: verify interval is in months
+      return Period.ofMonths(interval);
     }
   }
 
@@ -172,16 +171,10 @@ public class IntervalYearVector extends BaseFixedWidthVector {
   private StringBuilder getAsStringBuilderHelper(int index) {
     int value = valueBuffer.getInt(index * TYPE_WIDTH);
 
-    final int years = (value / org.apache.arrow.vector.util.DateUtility.yearsToMonths);
-    final int months = (value % org.apache.arrow.vector.util.DateUtility.yearsToMonths);
-
-    final String yearString = (Math.abs(years) == 1) ? " year " : " years ";
-    final String monthString = (Math.abs(months) == 1) ? " month " : " months ";
+    final String monthString = (Math.abs(value) == 1) ? " month " : " months ";
 
     return (new StringBuilder()
-      .append(years)
-      .append(yearString)
-      .append(months)
+      .append(value)
       .append(monthString));
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
@@ -39,7 +39,7 @@ public class TestIntervalYearVector {
   }
 
   @Test
-  public void testGetObject() {
+  public void testGetAsStringBuilder() {
     try (final IntervalYearVector vector = new IntervalYearVector("", allocator)) {
       int valueCount = 100;
       vector.setInitialCapacity(valueCount);
@@ -48,8 +48,9 @@ public class TestIntervalYearVector {
         vector.set(i, i);
       }
 
-      assertEquals("P10M", vector.getObject(10).toString());
-      assertEquals("P2Y10M", vector.getObject(34).toString());
+      assertEquals("1 month ", vector.getAsStringBuilder(1).toString());
+      assertEquals("10 months ", vector.getAsStringBuilder(10).toString());
+      assertEquals("20 months ", vector.getAsStringBuilder(20).toString());
 
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
@@ -48,9 +48,10 @@ public class TestIntervalYearVector {
         vector.set(i, i);
       }
 
-      assertEquals("1 month ", vector.getAsStringBuilder(1).toString());
-      assertEquals("10 months ", vector.getAsStringBuilder(10).toString());
-      assertEquals("20 months ", vector.getAsStringBuilder(20).toString());
+      assertEquals("0 years 1 month ", vector.getAsStringBuilder(1).toString());
+      assertEquals("0 years 10 months ", vector.getAsStringBuilder(10).toString());
+      assertEquals("1 year 8 months ", vector.getAsStringBuilder(20).toString());
+      assertEquals("2 years 6 months ", vector.getAsStringBuilder(30).toString());
 
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestIntervalYearVector {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void init() {
+    allocator = new DirtyRootAllocator(Long.MAX_VALUE, (byte) 100);
+  }
+
+  @After
+  public void terminate() throws Exception {
+    allocator.close();
+  }
+
+  @Test
+  public void testGetObject(){
+    try (final IntervalYearVector vector = new IntervalYearVector("", allocator)) {
+      int valueCount = 100;
+      vector.setInitialCapacity(valueCount);
+      vector.allocateNew();
+      for (int i = 0; i < valueCount; i++) {
+        vector.set(i, i);
+      }
+
+      assertEquals("P10M", vector.getObject(10).toString());
+      assertEquals("P2Y10M", vector.getObject(34).toString());
+
+    }
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestIntervalYearVector.java
@@ -39,7 +39,7 @@ public class TestIntervalYearVector {
   }
 
   @Test
-  public void testGetObject(){
+  public void testGetObject() {
     try (final IntervalYearVector vector = new IntervalYearVector("", allocator)) {
       int valueCount = 100;
       vector.setInitialCapacity(valueCount);


### PR DESCRIPTION
Related to [ARROW-5435](https://issues.apache.org/jira/browse/ARROW-5435).
This adds a test for `IntervalYearVector.getAsStringBuilder`.