### PR TITLE
ARROW-5437: [Python] Missing pandas pytest marker from parquet tests

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2593,6 +2593,7 @@ def test_write_nested_zero_length_array_chunk_failure():
     _check_roundtrip(tbl)
 
 
+@pytest.mark.pandas
 def test_partitioned_dataset(tempdir):
     # ARROW-3208: Segmentation fault when reading a Parquet partitioned dataset
     # to a Parquet file
@@ -2622,6 +2623,7 @@ def test_read_column_invalid_index():
             f.reader.read_column(index)
 
 
+@pytest.mark.pandas
 def test_dataset_metadata(tempdir):
     path = tempdir / "ARROW-1983-dataset"
 
@@ -2630,7 +2632,7 @@ def test_dataset_metadata(tempdir):
         'one': [1, 2, 3],
         'two': [-1, -2, -3],
         'three': [[1, 2], [2, 3], [3, 4]],
-        })
+    })
     table = pa.Table.from_pandas(df)
 
     metadata_list = []


### PR DESCRIPTION
Previously failing tests: https://travis-ci.org/ursa-labs/crossbow/builds/538694001
Crossbow tests: [ursa-labs/crossbow@build-553](https://github.com/ursa-labs/crossbow/branches/all?utf8=%E2%9C%93&query=build-553)