### PR TITLE
ARROW-3729: [C++][Parquet] Use logical annotations in Arrow Parquet reader/writer

### DIFF
--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -115,7 +115,7 @@ std::shared_ptr<const LogicalAnnotation> get_logical_annotation(const ::DataType
       return LogicalAnnotation::Date();
     case ArrowId::TIMESTAMP: {
       const auto& ts_type = static_cast<const ::arrow::TimestampType&>(type);
-      const bool adjusted_to_utc = (ts_type.timezone() == "UTC");
+      const bool adjusted_to_utc = !(ts_type.timezone().empty());
       switch (ts_type.unit()) {
         case TimeUnit::MILLI:
           return LogicalAnnotation::Timestamp(adjusted_to_utc,

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -885,13 +885,13 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
        ParquetType::INT64, -1},
       {"timestamp(millisecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"),
-       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
        ParquetType::INT64, -1},
       {"timestamp(microsecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::MICRO, "CET"),
-       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"timestamp(nanosecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::NANO, "CET"),
-       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
        ParquetType::INT64, -1},
       {"null", ::arrow::null(), LogicalAnnotation::Null(), ParquetType::INT32, -1}};
 

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -89,7 +89,16 @@ class TestConvertParquetSchema : public ::testing::Test {
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata) {
     NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, nodes);
     descr_.Init(schema);
-    return FromParquetSchema(&descr_, {}, key_value_metadata, &result_schema_);
+    return FromParquetSchema(&descr_, key_value_metadata, &result_schema_);
+  }
+
+  ::arrow::Status ConvertSchema(
+      const std::vector<NodePtr>& nodes, const std::vector<int>& column_indices,
+      const std::shared_ptr<const KeyValueMetadata>& key_value_metadata) {
+    NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, nodes);
+    descr_.Init(schema);
+    return FromParquetSchema(&descr_, column_indices, key_value_metadata,
+                             &result_schema_);
   }
 
  protected:
@@ -311,7 +320,7 @@ TEST_F(TestConvertParquetSchema, ParquetKeyValueMetadata) {
   auto key_value_metadata = std::make_shared<KeyValueMetadata>();
   key_value_metadata->Append("foo", "bar");
   key_value_metadata->Append("biz", "baz");
-  ASSERT_OK(ConvertSchema(parquet_fields, key_value_metadata));
+  ASSERT_OK(ConvertSchema(parquet_fields, {}, key_value_metadata));
 
   auto arrow_metadata = result_schema_->metadata();
   ASSERT_EQ("foo", arrow_metadata->key(0));
@@ -329,10 +338,176 @@ TEST_F(TestConvertParquetSchema, ParquetEmptyKeyValueMetadata) {
   arrow_fields.push_back(std::make_shared<Field>("int32", INT32, false));
 
   std::shared_ptr<KeyValueMetadata> key_value_metadata = nullptr;
-  ASSERT_OK(ConvertSchema(parquet_fields, key_value_metadata));
+  ASSERT_OK(ConvertSchema(parquet_fields, {}, key_value_metadata));
 
   auto arrow_metadata = result_schema_->metadata();
   ASSERT_EQ(arrow_metadata, nullptr);
+}
+
+TEST_F(TestConvertParquetSchema, ParquetSimpleTimezoneNodes) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+  auto parquet_file_metadata = std::make_shared<KeyValueMetadata>();
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "ts", Repetition::REQUIRED,
+      LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+      ParquetType::INT64));
+  arrow_fields.push_back(
+      std::make_shared<Field>("ts", ::arrow::timestamp(TimeUnit::MILLI), false));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "ts:UTC", Repetition::REQUIRED,
+      LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+      ParquetType::INT64));
+  arrow_fields.push_back(std::make_shared<Field>(
+      "ts:UTC", ::arrow::timestamp(TimeUnit::MILLI, "UTC"), false));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "ts:CET", Repetition::REQUIRED,
+      LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+      ParquetType::INT64));
+  parquet_file_metadata->Append("org.apache.arrow.field[ts:CET].timestamp.timezone",
+                                "CET");
+  arrow_fields.push_back(std::make_shared<Field>(
+      "ts:CET", ::arrow::timestamp(TimeUnit::MILLI, "CET"), false));
+
+  parquet_file_metadata->Append("application.key", "application.value");
+
+  ASSERT_OK(ConvertSchema(parquet_fields, parquet_file_metadata));
+  ASSERT_NO_FATAL_FAILURE(
+      CheckFlatSchema(std::make_shared<::arrow::Schema>(arrow_fields)));
+  // Confirm arrow timezone metadata removed, application metadata retained
+  auto arrow_metadata = result_schema_->metadata();
+  ASSERT_EQ(1, arrow_metadata->size());
+  ASSERT_EQ("application.key", arrow_metadata->key(0));
+  ASSERT_EQ("application.value", arrow_metadata->value(0));
+}
+
+static void MakeNestedTimezoneSchemas(std::vector<std::shared_ptr<Field>>& arrow_fields,
+                                      std::vector<NodePtr>& parquet_fields,
+                                      std::shared_ptr<KeyValueMetadata>& parquet_metadata,
+                                      bool unpacked_dictionaries = false) {
+  {
+    auto arrow_element = std::make_shared<Field>(
+        "timestamp:CET", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"), false);
+    auto arrow_list = std::make_shared<::arrow::ListType>(arrow_element);
+    arrow_fields.push_back(std::make_shared<Field>("some_list", arrow_list, false));
+
+    auto parquet_element = PrimitiveNode::Make(
+        "timestamp:CET", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64);
+    auto parquet_list = GroupNode::Make("list", Repetition::REPEATED, {parquet_element});
+    parquet_fields.push_back(GroupNode::Make("some_list", Repetition::REQUIRED,
+                                             {parquet_list}, LogicalType::LIST));
+    parquet_metadata->Append(
+        "org.apache.arrow.field[some_list.list.timestamp:CET].timestamp.timezone", "CET");
+  }
+
+  {
+    auto arrow_element_1 = std::make_shared<Field>(
+        "timestamp", ::arrow::timestamp(::arrow::TimeUnit::MILLI), false);
+    auto arrow_element_2 = std::make_shared<Field>(
+        "timestamp:UTC", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "UTC"), false);
+    auto arrow_element_3 = std::make_shared<Field>(
+        "timestamp:CET", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"), false);
+    auto arrow_elements = {arrow_element_1, arrow_element_2, arrow_element_3};
+    auto arrow_struct = std::make_shared<::arrow::StructType>(arrow_elements);
+    auto arrow_group = std::make_shared<Field>("some_struct", arrow_struct, false);
+    auto arrow_field = std::make_shared<Field>(
+        "timestamp:NZST", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "NZST"), false);
+    arrow_fields.push_back(arrow_group);
+    arrow_fields.push_back(arrow_field);
+
+    auto parquet_element_1 = PrimitiveNode::Make(
+        "timestamp", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64);
+    auto parquet_element_2 = PrimitiveNode::Make(
+        "timestamp:UTC", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64);
+    auto parquet_element_3 = PrimitiveNode::Make(
+        "timestamp:CET", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64);
+    auto parquet_group =
+        GroupNode::Make("some_struct", Repetition::REQUIRED,
+                        {parquet_element_1, parquet_element_2, parquet_element_3});
+    auto parquet_field = PrimitiveNode::Make(
+        "timestamp:NZST", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64);
+    parquet_fields.push_back(parquet_group);
+    parquet_fields.push_back(parquet_field);
+    parquet_metadata->Append(
+        "org.apache.arrow.field[some_struct.timestamp:CET].timestamp.timezone", "CET");
+    parquet_metadata->Append("org.apache.arrow.field[timestamp:NZST].timestamp.timezone",
+                             "NZST");
+  }
+
+  {
+    if (unpacked_dictionaries) {
+      // The Parquet nodes immediately below are converted to these non-dictionary Arrow
+      // fields
+      arrow_fields.push_back(std::make_shared<Field>(
+          "dictionary_timestamp", ::arrow::timestamp(::arrow::TimeUnit::MILLI), false));
+      arrow_fields.push_back(std::make_shared<Field>(
+          "dictionary_timestamp:UTC", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "UTC"),
+          false));
+      arrow_fields.push_back(std::make_shared<Field>(
+          "dictionary_timestamp:CET", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"),
+          false));
+    } else {
+      // When converted, these Arrow dictionaries are unpacked and stored as the Parquet
+      // nodes immediately below
+      arrow_fields.push_back(std::make_shared<Field>(
+          "dictionary_timestamp",
+          ::arrow::dictionary(::arrow::int16(), ::arrow::timestamp(TimeUnit::MILLI)),
+          false));
+      arrow_fields.push_back(std::make_shared<Field>(
+          "dictionary_timestamp:UTC",
+          ::arrow::dictionary(::arrow::int16(),
+                              ::arrow::timestamp(TimeUnit::MILLI, "UTC")),
+          false));
+      arrow_fields.push_back(std::make_shared<Field>(
+          "dictionary_timestamp:CET",
+          ::arrow::dictionary(::arrow::int16(),
+                              ::arrow::timestamp(TimeUnit::MILLI, "CET")),
+          false));
+    }
+
+    parquet_fields.push_back(PrimitiveNode::Make(
+        "dictionary_timestamp", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        "dictionary_timestamp:UTC", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        "dictionary_timestamp:CET", Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64));
+    parquet_metadata->Append(
+        "org.apache.arrow.field[dictionary_timestamp:CET].timestamp.timezone", "CET");
+  }
+
+  return;
+}
+
+TEST_F(TestConvertParquetSchema, ParquetNestedTimezoneNodes) {
+  std::vector<NodePtr> parquet_fields;
+  std::shared_ptr<KeyValueMetadata> parquet_metadata =
+      std::make_shared<KeyValueMetadata>();
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  MakeNestedTimezoneSchemas(arrow_fields, parquet_fields, parquet_metadata, true);
+
+  ASSERT_OK(ConvertSchema(parquet_fields, parquet_metadata));
+  ASSERT_NO_FATAL_FAILURE(
+      CheckFlatSchema(std::make_shared<::arrow::Schema>(arrow_fields)));
 }
 
 TEST_F(TestConvertParquetSchema, ParquetFlatDecimals) {
@@ -733,7 +908,10 @@ class TestConvertArrowSchema : public ::testing::Test {
  public:
   virtual void SetUp() {}
 
-  void CheckFlatSchema(const std::vector<NodePtr>& nodes) {
+  void CheckFlatSchema(
+      const std::vector<NodePtr>& nodes,
+      const std::shared_ptr<const KeyValueMetadata>& expected_metadata = nullptr,
+      bool expect_strict_metadata_equality = true) {
     NodePtr schema_node = GroupNode::Make("schema", Repetition::REPEATED, nodes);
     const GroupNode* expected_schema_node =
         static_cast<const GroupNode*>(schema_node.get());
@@ -746,18 +924,35 @@ class TestConvertArrowSchema : public ::testing::Test {
       auto rhs = expected_schema_node->field(i);
       EXPECT_TRUE(lhs->Equals(rhs.get()));
     }
+
+    if (expected_metadata) {
+      if (expect_strict_metadata_equality) {
+        ASSERT_TRUE(result_metadata_->Equals(*expected_metadata));
+      } else {
+        // check for expected keys and values, indifferent to order in container
+        ASSERT_EQ(result_metadata_->size(), expected_metadata->size());
+        for (int i = 0; i < expected_metadata->size(); ++i) {
+          int index = result_metadata_->FindKey(expected_metadata->key(i));
+          ASSERT_NE(index, -1) << "key '" << expected_metadata->key(i)
+                               << "' unexpectedly missing from result metadata";
+          ASSERT_EQ(result_metadata_->value(index), expected_metadata->value(i));
+        }
+      }
+    }
   }
 
   ::arrow::Status ConvertSchema(const std::vector<std::shared_ptr<Field>>& fields) {
     arrow_schema_ = std::make_shared<::arrow::Schema>(fields);
     std::shared_ptr<::parquet::WriterProperties> properties =
         ::parquet::default_writer_properties();
-    return ToParquetSchema(arrow_schema_.get(), *properties.get(), &result_schema_);
+    return ToParquetSchema(arrow_schema_.get(), *properties.get(), &result_metadata_,
+                           &result_schema_);
   }
 
  protected:
   std::shared_ptr<::arrow::Schema> arrow_schema_;
   std::shared_ptr<SchemaDescriptor> result_schema_;
+  std::shared_ptr<const KeyValueMetadata> result_metadata_;
 };
 
 TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
@@ -924,6 +1119,72 @@ TEST_F(TestConvertArrowSchema, ArrowNonconvertibleFields) {
   }
 }
 
+TEST_F(TestConvertArrowSchema, ArrowSimpleTimezoneFields) {
+  struct TimezoneFieldConstructionArguments {
+    std::string name;
+    std::shared_ptr<::arrow::DataType> datatype;
+    bool is_adjusted_to_utc;
+    bool inserts_metadata;
+    std::pair<std::string, std::string> key_value_metadata;
+  };
+
+  std::vector<TimezoneFieldConstructionArguments> cases = {
+      {"timestamp", ::arrow::timestamp(::arrow::TimeUnit::MILLI), false, false, {"", ""}},
+      {"timestamp:UTC",
+       ::arrow::timestamp(::arrow::TimeUnit::MILLI, "UTC"),
+       true,
+       false,
+       {"", ""}},
+      {"timestamp:utc",
+       ::arrow::timestamp(::arrow::TimeUnit::MILLI, "utc"),
+       true,
+       false,
+       {"", ""}},
+      {"timestamp:CET",
+       ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"),
+       false,
+       true,
+       {"org.apache.arrow.field[timestamp:CET].timestamp.timezone", "CET"}},
+      {"timestamp:NZST",
+       ::arrow::timestamp(::arrow::TimeUnit::MILLI, "NZST"),
+       false,
+       true,
+       {"org.apache.arrow.field[timestamp:NZST].timestamp.timezone", "NZST"}},
+  };
+
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+  std::vector<NodePtr> parquet_fields;
+  auto parquet_file_metadata = std::make_shared<KeyValueMetadata>();
+
+  for (const TimezoneFieldConstructionArguments& c : cases) {
+    arrow_fields.push_back(std::make_shared<Field>(c.name, c.datatype, false));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        c.name, Repetition::REQUIRED,
+        LogicalAnnotation::Timestamp(c.is_adjusted_to_utc,
+                                     LogicalAnnotation::TimeUnit::MILLIS),
+        ParquetType::INT64));
+    if (c.inserts_metadata) {
+      parquet_file_metadata->Append(c.key_value_metadata.first,
+                                    c.key_value_metadata.second);
+    }
+  }
+
+  ASSERT_OK(ConvertSchema(arrow_fields));
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields, parquet_file_metadata, false));
+}
+
+TEST_F(TestConvertArrowSchema, ArrowNestedTimezoneFields) {
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+  std::vector<NodePtr> parquet_fields;
+  std::shared_ptr<KeyValueMetadata> parquet_metadata =
+      std::make_shared<KeyValueMetadata>();
+
+  MakeNestedTimezoneSchemas(arrow_fields, parquet_fields, parquet_metadata);
+
+  ASSERT_OK(ConvertSchema(arrow_fields));
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields, parquet_metadata, false));
+}
+
 TEST_F(TestConvertArrowSchema, ParquetFlatPrimitivesAsDictionaries) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;
@@ -948,6 +1209,15 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitivesAsDictionaries) {
                                                ParquetType::INT32, LogicalType::DATE));
   arrow_fields.push_back(std::make_shared<Field>(
       "date64", ::arrow::dictionary(::arrow::int8(), ::arrow::date64()), false));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "timestamp", Repetition::REQUIRED,
+      LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+      ParquetType::INT64));
+  arrow_fields.push_back(std::make_shared<Field>(
+      "timestamp",
+      ::arrow::dictionary(::arrow::int8(), ::arrow::timestamp(TimeUnit::MILLI, "UTC")),
+      false));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("float", Repetition::OPTIONAL, ParquetType::FLOAT));

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -33,6 +33,7 @@ using arrow::Field;
 using arrow::TimeUnit;
 
 using ParquetType = parquet::Type;
+using parquet::LogicalAnnotation;
 using parquet::LogicalType;
 using parquet::Repetition;
 using parquet::schema::GroupNode;
@@ -115,12 +116,14 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
   parquet_fields.push_back(PrimitiveNode::Make("timestamp", Repetition::REQUIRED,
                                                ParquetType::INT64,
                                                LogicalType::TIMESTAMP_MILLIS));
-  arrow_fields.push_back(std::make_shared<Field>("timestamp", TIMESTAMP_MS, false));
+  arrow_fields.push_back(std::make_shared<Field>(
+      "timestamp", ::arrow::timestamp(TimeUnit::MILLI, "UTC"), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp[us]", Repetition::REQUIRED,
                                                ParquetType::INT64,
                                                LogicalType::TIMESTAMP_MICROS));
-  arrow_fields.push_back(std::make_shared<Field>("timestamp[us]", TIMESTAMP_US, false));
+  arrow_fields.push_back(std::make_shared<Field>(
+      "timestamp[us]", ::arrow::timestamp(TimeUnit::MICRO, "UTC"), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("date", Repetition::REQUIRED,
                                                ParquetType::INT32, LogicalType::DATE));
@@ -165,6 +168,103 @@ TEST_F(TestConvertParquetSchema, ParquetFlatPrimitives) {
   auto arrow_schema = std::make_shared<::arrow::Schema>(arrow_fields);
   ASSERT_OK(ConvertSchema(parquet_fields));
 
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(arrow_schema));
+}
+
+TEST_F(TestConvertParquetSchema, ParquetAnnotatedFields) {
+  struct FieldConstructionArguments {
+    std::string name;
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    parquet::Type::type physical_type;
+    int physical_length;
+    std::shared_ptr<::arrow::DataType> datatype;
+  };
+
+  std::vector<FieldConstructionArguments> cases = {
+      {"string", LogicalAnnotation::String(), ParquetType::BYTE_ARRAY, -1,
+       ::arrow::utf8()},
+      {"enum", LogicalAnnotation::Enum(), ParquetType::BYTE_ARRAY, -1, ::arrow::binary()},
+      {"decimal(8, 2)", LogicalAnnotation::Decimal(8, 2), ParquetType::INT32, -1,
+       ::arrow::decimal(8, 2)},
+      {"decimal(16, 4)", LogicalAnnotation::Decimal(16, 4), ParquetType::INT64, -1,
+       ::arrow::decimal(16, 4)},
+      {"decimal(32, 8)", LogicalAnnotation::Decimal(32, 8),
+       ParquetType::FIXED_LEN_BYTE_ARRAY, 16, ::arrow::decimal(32, 8)},
+      {"date", LogicalAnnotation::Date(), ParquetType::INT32, -1, ::arrow::date32()},
+      {"time(ms)", LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT32, -1, ::arrow::time32(::arrow::TimeUnit::MILLI)},
+      {"time(us)", LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1, ::arrow::time64(::arrow::TimeUnit::MICRO)},
+      {"time(ns)", LogicalAnnotation::Time(true, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1, ::arrow::time64(::arrow::TimeUnit::NANO)},
+      {"time(ms)", LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT32, -1, ::arrow::time32(::arrow::TimeUnit::MILLI)},
+      {"time(us)", LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1, ::arrow::time64(::arrow::TimeUnit::MICRO)},
+      {"time(ns)", LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1, ::arrow::time64(::arrow::TimeUnit::NANO)},
+      {"timestamp(true, ms)",
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT64, -1, ::arrow::timestamp(::arrow::TimeUnit::MILLI, "UTC")},
+      {"timestamp(true, us)",
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1, ::arrow::timestamp(::arrow::TimeUnit::MICRO, "UTC")},
+      {"timestamp(true, ns)",
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1, ::arrow::timestamp(::arrow::TimeUnit::NANO, "UTC")},
+      {"timestamp(false, ms)",
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT64, -1, ::arrow::timestamp(::arrow::TimeUnit::MILLI)},
+      {"timestamp(false, us)",
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1, ::arrow::timestamp(::arrow::TimeUnit::MICRO)},
+      {"timestamp(false, ns)",
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1, ::arrow::timestamp(::arrow::TimeUnit::NANO)},
+      {"int(8, false)", LogicalAnnotation::Int(8, false), ParquetType::INT32, -1,
+       ::arrow::uint8()},
+      {"int(8, true)", LogicalAnnotation::Int(8, true), ParquetType::INT32, -1,
+       ::arrow::int8()},
+      {"int(16, false)", LogicalAnnotation::Int(16, false), ParquetType::INT32, -1,
+       ::arrow::uint16()},
+      {"int(16, true)", LogicalAnnotation::Int(16, true), ParquetType::INT32, -1,
+       ::arrow::int16()},
+      {"int(32, false)", LogicalAnnotation::Int(32, false), ParquetType::INT32, -1,
+       ::arrow::uint32()},
+      {"int(32, true)", LogicalAnnotation::Int(32, true), ParquetType::INT32, -1,
+       ::arrow::int32()},
+      {"int(64, false)", LogicalAnnotation::Int(64, false), ParquetType::INT64, -1,
+       ::arrow::uint64()},
+      {"int(64, true)", LogicalAnnotation::Int(64, true), ParquetType::INT64, -1,
+       ::arrow::int64()},
+      {"json", LogicalAnnotation::JSON(), ParquetType::BYTE_ARRAY, -1, ::arrow::binary()},
+      {"bson", LogicalAnnotation::BSON(), ParquetType::BYTE_ARRAY, -1, ::arrow::binary()},
+      {"interval", LogicalAnnotation::Interval(), ParquetType::FIXED_LEN_BYTE_ARRAY, 12,
+       ::arrow::fixed_size_binary(12)},
+      {"uuid", LogicalAnnotation::UUID(), ParquetType::FIXED_LEN_BYTE_ARRAY, 16,
+       ::arrow::fixed_size_binary(16)},
+      {"none", LogicalAnnotation::None(), ParquetType::BOOLEAN, -1, ::arrow::boolean()},
+      {"none", LogicalAnnotation::None(), ParquetType::INT32, -1, ::arrow::int32()},
+      {"none", LogicalAnnotation::None(), ParquetType::INT64, -1, ::arrow::int64()},
+      {"none", LogicalAnnotation::None(), ParquetType::FLOAT, -1, ::arrow::float32()},
+      {"none", LogicalAnnotation::None(), ParquetType::DOUBLE, -1, ::arrow::float64()},
+      {"none", LogicalAnnotation::None(), ParquetType::BYTE_ARRAY, -1, ::arrow::binary()},
+      {"none", LogicalAnnotation::None(), ParquetType::FIXED_LEN_BYTE_ARRAY, 64,
+       ::arrow::fixed_size_binary(64)},
+      {"null", LogicalAnnotation::Null(), ParquetType::BYTE_ARRAY, -1, ::arrow::null()},
+  };
+
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  for (const FieldConstructionArguments& c : cases) {
+    parquet_fields.push_back(PrimitiveNode::Make(
+        c.name, Repetition::OPTIONAL, c.annotation, c.physical_type, c.physical_length));
+    arrow_fields.push_back(std::make_shared<Field>(c.name, c.datatype));
+  }
+
+  ASSERT_OK(ConvertSchema(parquet_fields));
+  auto arrow_schema = std::make_shared<::arrow::Schema>(arrow_fields);
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(arrow_schema));
 }
 
@@ -586,6 +686,7 @@ TEST_F(TestConvertParquetSchema, ParquetNestedSchemaPartialOrdering) {
 
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(arrow_schema));
 }
+
 TEST_F(TestConvertParquetSchema, ParquetRepeatedNestedSchema) {
   std::vector<NodePtr> parquet_fields;
   std::vector<std::shared_ptr<Field>> arrow_fields;
@@ -686,12 +787,14 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
   parquet_fields.push_back(PrimitiveNode::Make("timestamp", Repetition::REQUIRED,
                                                ParquetType::INT64,
                                                LogicalType::TIMESTAMP_MILLIS));
-  arrow_fields.push_back(std::make_shared<Field>("timestamp", TIMESTAMP_MS, false));
+  arrow_fields.push_back(std::make_shared<Field>(
+      "timestamp", ::arrow::timestamp(TimeUnit::MILLI, "UTC"), false));
 
   parquet_fields.push_back(PrimitiveNode::Make("timestamp[us]", Repetition::REQUIRED,
                                                ParquetType::INT64,
                                                LogicalType::TIMESTAMP_MICROS));
-  arrow_fields.push_back(std::make_shared<Field>("timestamp[us]", TIMESTAMP_US, false));
+  arrow_fields.push_back(std::make_shared<Field>(
+      "timestamp[us]", ::arrow::timestamp(TimeUnit::MICRO, "UTC"), false));
 
   parquet_fields.push_back(
       PrimitiveNode::Make("float", Repetition::OPTIONAL, ParquetType::FLOAT));
@@ -712,6 +815,113 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
   ASSERT_OK(ConvertSchema(arrow_fields));
 
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
+TEST_F(TestConvertArrowSchema, ArrowFields) {
+  struct FieldConstructionArguments {
+    std::string name;
+    std::shared_ptr<::arrow::DataType> datatype;
+    std::shared_ptr<const LogicalAnnotation> annotation;
+    parquet::Type::type physical_type;
+    int physical_length;
+  };
+
+  std::vector<FieldConstructionArguments> cases = {
+      {"boolean", ::arrow::boolean(), LogicalAnnotation::None(), ParquetType::BOOLEAN,
+       -1},
+      {"binary", ::arrow::binary(), LogicalAnnotation::None(), ParquetType::BYTE_ARRAY,
+       -1},
+      {"fixed_size_binary", ::arrow::fixed_size_binary(64), LogicalAnnotation::None(),
+       ParquetType::FIXED_LEN_BYTE_ARRAY, 64},
+      {"uint8", ::arrow::uint8(), LogicalAnnotation::Int(8, false), ParquetType::INT32,
+       -1},
+      {"int8", ::arrow::int8(), LogicalAnnotation::Int(8, true), ParquetType::INT32, -1},
+      {"uint16", ::arrow::uint16(), LogicalAnnotation::Int(16, false), ParquetType::INT32,
+       -1},
+      {"int16", ::arrow::int16(), LogicalAnnotation::Int(16, true), ParquetType::INT32,
+       -1},
+      {"uint32", ::arrow::uint32(), LogicalAnnotation::None(), ParquetType::INT64,
+       -1},  // Parquet 1.0
+      {"int32", ::arrow::int32(), LogicalAnnotation::None(), ParquetType::INT32, -1},
+      {"uint64", ::arrow::uint64(), LogicalAnnotation::Int(64, false), ParquetType::INT64,
+       -1},
+      {"int64", ::arrow::int64(), LogicalAnnotation::None(), ParquetType::INT64, -1},
+      {"float32", ::arrow::float32(), LogicalAnnotation::None(), ParquetType::FLOAT, -1},
+      {"float64", ::arrow::float64(), LogicalAnnotation::None(), ParquetType::DOUBLE, -1},
+      {"utf8", ::arrow::utf8(), LogicalAnnotation::String(), ParquetType::BYTE_ARRAY, -1},
+      {"decimal(1, 0)", ::arrow::decimal(1, 0), LogicalAnnotation::Decimal(1, 0),
+       ParquetType::FIXED_LEN_BYTE_ARRAY, 1},
+      {"decimal(8, 2)", ::arrow::decimal(8, 2), LogicalAnnotation::Decimal(8, 2),
+       ParquetType::FIXED_LEN_BYTE_ARRAY, 4},
+      {"decimal(16, 4)", ::arrow::decimal(16, 4), LogicalAnnotation::Decimal(16, 4),
+       ParquetType::FIXED_LEN_BYTE_ARRAY, 7},
+      {"decimal(32, 8)", ::arrow::decimal(32, 8), LogicalAnnotation::Decimal(32, 8),
+       ParquetType::FIXED_LEN_BYTE_ARRAY, 14},
+      {"time32", ::arrow::time32(::arrow::TimeUnit::MILLI),
+       LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT32, -1},
+      {"time64(microsecond)", ::arrow::time64(::arrow::TimeUnit::MICRO),
+       LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1},
+      {"time64(nanosecond)", ::arrow::time64(::arrow::TimeUnit::NANO),
+       LogicalAnnotation::Time(false, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1},
+      {"timestamp(millisecond)", ::arrow::timestamp(::arrow::TimeUnit::MILLI),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT64, -1},
+      {"timestamp(microsecond)", ::arrow::timestamp(::arrow::TimeUnit::MICRO),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1},
+      {"timestamp(nanosecond)", ::arrow::timestamp(::arrow::TimeUnit::NANO),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1},
+      {"timestamp(millisecond, UTC)", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "UTC"),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT64, -1},
+      {"timestamp(microsecond, UTC)", ::arrow::timestamp(::arrow::TimeUnit::MICRO, "UTC"),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1},
+      {"timestamp(nanosecond, UTC)", ::arrow::timestamp(::arrow::TimeUnit::NANO, "UTC"),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1},
+      {"timestamp(millisecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MILLIS),
+       ParquetType::INT64, -1},
+      {"timestamp(microsecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::MICRO, "CET"),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
+       ParquetType::INT64, -1},
+      {"timestamp(nanosecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::NANO, "CET"),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       ParquetType::INT64, -1},
+      {"null", ::arrow::null(), LogicalAnnotation::Null(), ParquetType::INT32, -1}};
+
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+  std::vector<NodePtr> parquet_fields;
+
+  for (const FieldConstructionArguments& c : cases) {
+    arrow_fields.push_back(std::make_shared<Field>(c.name, c.datatype, false));
+    parquet_fields.push_back(PrimitiveNode::Make(
+        c.name, Repetition::REQUIRED, c.annotation, c.physical_type, c.physical_length));
+  }
+
+  ASSERT_OK(ConvertSchema(arrow_fields));
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
+TEST_F(TestConvertArrowSchema, ArrowNonconvertibleFields) {
+  struct FieldConstructionArguments {
+    std::string name;
+    std::shared_ptr<::arrow::DataType> datatype;
+  };
+
+  std::vector<FieldConstructionArguments> cases = {
+      {"float16", ::arrow::float16()},
+  };
+
+  for (const FieldConstructionArguments& c : cases) {
+    auto field = std::make_shared<Field>(c.name, c.datatype);
+    ASSERT_RAISES(NotImplemented, ConvertSchema({field}));
+  }
 }
 
 TEST_F(TestConvertArrowSchema, ParquetFlatPrimitivesAsDictionaries) {
@@ -807,15 +1017,6 @@ TEST_F(TestConvertArrowSchema, ParquetLists) {
   ASSERT_OK(ConvertSchema(arrow_fields));
 
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
-}
-
-TEST_F(TestConvertArrowSchema, UnsupportedTypes) {
-  std::vector<std::shared_ptr<Field>> unsupported_fields = {
-      ::arrow::field("f0", ::arrow::time64(TimeUnit::NANO))};
-
-  for (const auto& field : unsupported_fields) {
-    ASSERT_RAISES(NotImplemented, ConvertSchema({field}));
-  }
 }
 
 TEST_F(TestConvertArrowSchema, ParquetFlatDecimals) {

--- a/cpp/src/parquet/arrow/arrow-schema-test.cc
+++ b/cpp/src/parquet/arrow/arrow-schema-test.cc
@@ -873,7 +873,7 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
        LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"timestamp(nanosecond)", ::arrow::timestamp(::arrow::TimeUnit::NANO),
-       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::NANOS),
+       LogicalAnnotation::Timestamp(false, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"timestamp(millisecond, UTC)", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "UTC"),
        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
@@ -882,7 +882,7 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"timestamp(nanosecond, UTC)", ::arrow::timestamp(::arrow::TimeUnit::NANO, "UTC"),
-       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"timestamp(millisecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::MILLI, "CET"),
        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MILLIS),
@@ -891,7 +891,7 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
        LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"timestamp(nanosecond, CET)", ::arrow::timestamp(::arrow::TimeUnit::NANO, "CET"),
-       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::NANOS),
+       LogicalAnnotation::Timestamp(true, LogicalAnnotation::TimeUnit::MICROS),
        ParquetType::INT64, -1},
       {"null", ::arrow::null(), LogicalAnnotation::Null(), ParquetType::INT32, -1}};
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1613,7 +1613,11 @@ Status PrimitiveImpl::NextBatch(int64_t records_to_read,
           TRANSFER_DATA(::arrow::TimestampType, Int64Type);
         } break;
         case ::arrow::TimeUnit::NANO: {
-          TRANSFER_DATA(::arrow::TimestampType, Int96Type);
+          if (descr_->physical_type() == ::parquet::Type::INT96) {
+            TRANSFER_DATA(::arrow::TimestampType, Int96Type);
+          } else {
+            TRANSFER_DATA(::arrow::TimestampType, Int64Type);
+          }
         } break;
         default:
           return Status::NotImplemented("TimeUnit not supported");

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -135,7 +135,7 @@ static Status MakeArrowTime64(const std::shared_ptr<const LogicalAnnotation>& an
 static Status MakeArrowTimestamp(
     const std::shared_ptr<const LogicalAnnotation>& annotation,
     std::shared_ptr<ArrowType>* out) {
-  static constexpr auto utc = "UTC";
+  static const char* utc = "UTC";
   const auto& timestamp = checked_cast<const TimestampAnnotation&>(*annotation);
   switch (timestamp.time_unit()) {
     case LogicalAnnotation::TimeUnit::MILLIS:
@@ -520,15 +520,9 @@ Status StructToNode(const std::shared_ptr<::arrow::StructType>& type,
   return Status::OK();
 }
 
-static bool HasUTCTimezone(const std::string& timezone) {
-  static const std::vector<std::string> utczones{"UTC", "utc"};
-  return std::any_of(utczones.begin(), utczones.end(),
-                     [timezone](const std::string& utc) { return timezone == utc; });
-}
-
 static std::shared_ptr<const LogicalAnnotation> TimestampAnnotationFromArrowTimestamp(
     const ::arrow::TimestampType& timestamp_type, ::arrow::TimeUnit::type time_unit) {
-  const bool utc = HasUTCTimezone(timestamp_type.timezone());
+  const bool utc = !(timestamp_type.timezone().empty());
   switch (time_unit) {
     case ::arrow::TimeUnit::MILLI:
       return LogicalAnnotation::Timestamp(utc, LogicalAnnotation::TimeUnit::MILLIS);

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -18,6 +18,8 @@
 #include "parquet/arrow/schema.h"
 
 #include <algorithm>
+#include <deque>
+#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -33,6 +35,7 @@
 #include "parquet/exception.h"
 #include "parquet/properties.h"
 #include "parquet/schema-internal.h"
+#include "parquet/schema.h"
 #include "parquet/types.h"
 
 using arrow::Field;
@@ -43,6 +46,7 @@ using ArrowType = arrow::DataType;
 using ArrowTypeId = arrow::Type;
 
 using parquet::Repetition;
+using parquet::schema::ColumnPath;
 using parquet::schema::GroupNode;
 using parquet::schema::Node;
 using parquet::schema::NodePtr;
@@ -55,6 +59,9 @@ using parquet::LogicalType;
 namespace parquet {
 
 namespace arrow {
+
+static const char* key_prefix = "org.apache.arrow.field[";
+static const char* key_suffix = "].timestamp.timezone";
 
 const auto TIMESTAMP_MS = ::arrow::timestamp(::arrow::TimeUnit::MILLI);
 const auto TIMESTAMP_US = ::arrow::timestamp(::arrow::TimeUnit::MICRO);
@@ -132,31 +139,46 @@ static Status MakeArrowTime64(const std::shared_ptr<const LogicalAnnotation>& an
   return Status::OK();
 }
 
+static int FetchMetadataTimezoneIndex(
+    const std::string& path, const std::shared_ptr<const KeyValueMetadata>& metadata) {
+  int index = -1;
+  if (metadata) {
+    const std::string key(key_prefix + path + key_suffix);
+    index = metadata->FindKey(key);
+  }
+  return index;
+}
+
 static Status MakeArrowTimestamp(
-    const std::shared_ptr<const LogicalAnnotation>& annotation,
+    const std::shared_ptr<const LogicalAnnotation>& annotation, const std::string& path,
+    const std::shared_ptr<const KeyValueMetadata>& metadata,
     std::shared_ptr<ArrowType>* out) {
-  static constexpr auto utc = "UTC";
   const auto& timestamp = checked_cast<const TimestampAnnotation&>(*annotation);
+  ::arrow::TimeUnit::type time_unit;
+
   switch (timestamp.time_unit()) {
     case LogicalAnnotation::TimeUnit::MILLIS:
-      *out = (timestamp.is_adjusted_to_utc()
-                  ? ::arrow::timestamp(::arrow::TimeUnit::MILLI, utc)
-                  : ::arrow::timestamp(::arrow::TimeUnit::MILLI));
+      time_unit = ::arrow::TimeUnit::MILLI;
       break;
     case LogicalAnnotation::TimeUnit::MICROS:
-      *out = (timestamp.is_adjusted_to_utc()
-                  ? ::arrow::timestamp(::arrow::TimeUnit::MICRO, utc)
-                  : ::arrow::timestamp(::arrow::TimeUnit::MICRO));
+      time_unit = ::arrow::TimeUnit::MICRO;
       break;
     case LogicalAnnotation::TimeUnit::NANOS:
-      *out = (timestamp.is_adjusted_to_utc()
-                  ? ::arrow::timestamp(::arrow::TimeUnit::NANO, utc)
-                  : ::arrow::timestamp(::arrow::TimeUnit::NANO));
+      time_unit = ::arrow::TimeUnit::NANO;
       break;
     default:
       return Status::TypeError("Unrecognized time unit in timestamp annotation: ",
                                annotation->ToString());
   }
+
+  // Attempt to recover optional timezone for this field from file metadata
+  int index = FetchMetadataTimezoneIndex(path, metadata);
+
+  *out = (timestamp.is_adjusted_to_utc()
+              ? ::arrow::timestamp(time_unit, "UTC")
+              : (index == -1 ? ::arrow::timestamp(time_unit)
+                             : ::arrow::timestamp(time_unit, metadata->value(index))));
+
   return Status::OK();
 }
 
@@ -228,6 +250,8 @@ static Status FromInt32(const std::shared_ptr<const LogicalAnnotation>& annotati
 }
 
 static Status FromInt64(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                        const std::string& path,
+                        const std::shared_ptr<const KeyValueMetadata>& metadata,
                         std::shared_ptr<ArrowType>* out) {
   switch (annotation->type()) {
     case LogicalAnnotation::Type::INT:
@@ -237,7 +261,7 @@ static Status FromInt64(const std::shared_ptr<const LogicalAnnotation>& annotati
       RETURN_NOT_OK(MakeArrowDecimal(annotation, out));
       break;
     case LogicalAnnotation::Type::TIMESTAMP:
-      RETURN_NOT_OK(MakeArrowTimestamp(annotation, out));
+      RETURN_NOT_OK(MakeArrowTimestamp(annotation, path, metadata, out));
       break;
     case LogicalAnnotation::Type::TIME:
       RETURN_NOT_OK(MakeArrowTime64(annotation, out));
@@ -252,7 +276,9 @@ static Status FromInt64(const std::shared_ptr<const LogicalAnnotation>& annotati
   return Status::OK();
 }
 
-Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>* out) {
+Status FromPrimitive(const PrimitiveNode& primitive,
+                     const std::shared_ptr<const KeyValueMetadata>& metadata,
+                     std::shared_ptr<ArrowType>* out) {
   const std::shared_ptr<const LogicalAnnotation>& annotation =
       primitive.logical_annotation();
   if (annotation->is_invalid() || annotation->is_null()) {
@@ -268,7 +294,8 @@ Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>*
       RETURN_NOT_OK(FromInt32(annotation, out));
       break;
     case ParquetType::INT64:
-      RETURN_NOT_OK(FromInt64(annotation, out));
+      RETURN_NOT_OK(FromInt64(annotation, ColumnPath::FromNode(primitive)->ToDotString(),
+                              metadata, out));
       break;
     case ParquetType::INT96:
       *out = TIMESTAMP_NS;
@@ -297,6 +324,7 @@ Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>*
 // Forward declaration
 Status NodeToFieldInternal(const Node& node,
                            const std::unordered_set<const Node*>* included_leaf_nodes,
+                           const std::shared_ptr<const KeyValueMetadata>& metadata,
                            std::shared_ptr<Field>* out);
 
 /*
@@ -314,6 +342,7 @@ inline bool IsIncludedLeaf(const Node& node,
 
 Status StructFromGroup(const GroupNode& group,
                        const std::unordered_set<const Node*>* included_leaf_nodes,
+                       const std::shared_ptr<const KeyValueMetadata>& metadata,
                        std::shared_ptr<ArrowType>* out) {
   std::vector<std::shared_ptr<Field>> fields;
   std::shared_ptr<Field> field;
@@ -321,7 +350,8 @@ Status StructFromGroup(const GroupNode& group,
   *out = nullptr;
 
   for (int i = 0; i < group.field_count(); i++) {
-    RETURN_NOT_OK(NodeToFieldInternal(*group.field(i), included_leaf_nodes, &field));
+    RETURN_NOT_OK(
+        NodeToFieldInternal(*group.field(i), included_leaf_nodes, metadata, &field));
     if (field != nullptr) {
       fields.push_back(field);
     }
@@ -334,6 +364,7 @@ Status StructFromGroup(const GroupNode& group,
 
 Status NodeToList(const GroupNode& group,
                   const std::unordered_set<const Node*>* included_leaf_nodes,
+                  const std::shared_ptr<const KeyValueMetadata>& metadata,
                   std::shared_ptr<ArrowType>* out) {
   *out = nullptr;
   if (group.field_count() == 1) {
@@ -347,8 +378,8 @@ Status NodeToList(const GroupNode& group,
       if (list_group.field_count() == 1 && !schema::HasStructListName(list_group)) {
         // List of primitive type
         std::shared_ptr<Field> item_field;
-        RETURN_NOT_OK(
-            NodeToFieldInternal(*list_group.field(0), included_leaf_nodes, &item_field));
+        RETURN_NOT_OK(NodeToFieldInternal(*list_group.field(0), included_leaf_nodes,
+                                          metadata, &item_field));
 
         if (item_field != nullptr) {
           *out = ::arrow::list(item_field);
@@ -356,7 +387,8 @@ Status NodeToList(const GroupNode& group,
       } else {
         // List of struct
         std::shared_ptr<ArrowType> inner_type;
-        RETURN_NOT_OK(StructFromGroup(list_group, included_leaf_nodes, &inner_type));
+        RETURN_NOT_OK(
+            StructFromGroup(list_group, included_leaf_nodes, metadata, &inner_type));
         if (inner_type != nullptr) {
           auto item_field = std::make_shared<Field>(list_node.name(), inner_type, false);
           *out = ::arrow::list(item_field);
@@ -366,8 +398,8 @@ Status NodeToList(const GroupNode& group,
       // repeated primitive node
       std::shared_ptr<ArrowType> inner_type;
       if (IsIncludedLeaf(static_cast<const Node&>(list_node), included_leaf_nodes)) {
-        RETURN_NOT_OK(
-            FromPrimitive(static_cast<const PrimitiveNode&>(list_node), &inner_type));
+        RETURN_NOT_OK(FromPrimitive(static_cast<const PrimitiveNode&>(list_node),
+                                    metadata, &inner_type));
         auto item_field = std::make_shared<Field>(list_node.name(), inner_type, false);
         *out = ::arrow::list(item_field);
       }
@@ -383,11 +415,12 @@ Status NodeToList(const GroupNode& group,
 }
 
 Status NodeToField(const Node& node, std::shared_ptr<Field>* out) {
-  return NodeToFieldInternal(node, nullptr, out);
+  return NodeToFieldInternal(node, nullptr, nullptr, out);
 }
 
 Status NodeToFieldInternal(const Node& node,
                            const std::unordered_set<const Node*>* included_leaf_nodes,
+                           const std::shared_ptr<const KeyValueMetadata>& metadata,
                            std::shared_ptr<Field>* out) {
   std::shared_ptr<ArrowType> type = nullptr;
   bool nullable = !node.is_required();
@@ -399,9 +432,10 @@ Status NodeToFieldInternal(const Node& node,
     std::shared_ptr<ArrowType> inner_type;
     if (node.is_group()) {
       RETURN_NOT_OK(StructFromGroup(static_cast<const GroupNode&>(node),
-                                    included_leaf_nodes, &inner_type));
+                                    included_leaf_nodes, metadata, &inner_type));
     } else if (IsIncludedLeaf(node, included_leaf_nodes)) {
-      RETURN_NOT_OK(FromPrimitive(static_cast<const PrimitiveNode&>(node), &inner_type));
+      RETURN_NOT_OK(
+          FromPrimitive(static_cast<const PrimitiveNode&>(node), metadata, &inner_type));
     }
     if (inner_type != nullptr) {
       auto item_field = std::make_shared<Field>(node.name(), inner_type, false);
@@ -411,14 +445,15 @@ Status NodeToFieldInternal(const Node& node,
   } else if (node.is_group()) {
     const auto& group = static_cast<const GroupNode&>(node);
     if (node.logical_annotation()->is_list()) {
-      RETURN_NOT_OK(NodeToList(group, included_leaf_nodes, &type));
+      RETURN_NOT_OK(NodeToList(group, included_leaf_nodes, metadata, &type));
     } else {
-      RETURN_NOT_OK(StructFromGroup(group, included_leaf_nodes, &type));
+      RETURN_NOT_OK(StructFromGroup(group, included_leaf_nodes, metadata, &type));
     }
   } else {
     // Primitive (leaf) node
     if (IsIncludedLeaf(node, included_leaf_nodes)) {
-      RETURN_NOT_OK(FromPrimitive(static_cast<const PrimitiveNode&>(node), &type));
+      RETURN_NOT_OK(
+          FromPrimitive(static_cast<const PrimitiveNode&>(node), metadata, &type));
     }
   }
   if (type != nullptr) {
@@ -427,26 +462,56 @@ Status NodeToFieldInternal(const Node& node,
   return Status::OK();
 }
 
-Status FromParquetSchema(
-    const SchemaDescriptor* parquet_schema,
-    const std::shared_ptr<const KeyValueMetadata>& key_value_metadata,
-    std::shared_ptr<::arrow::Schema>* out) {
+static std::shared_ptr<const KeyValueMetadata> FilterParquetMetadata(
+    const std::shared_ptr<const KeyValueMetadata>& metadata) {
+  // Return a copy of the input metadata stripped of any key-values pairs
+  // that held Arrow/Parquet storage specific information
+  std::shared_ptr<KeyValueMetadata> filtered_metadata =
+      std::make_shared<KeyValueMetadata>();
+  if (metadata) {
+    for (int i = 0; i < metadata->size(); ++i) {
+      const std::string& key = metadata->key(i);
+      const std::string& value = metadata->value(i);
+      // Discard keys like "org.apache.arrow.field[*].timestamp.timezone"
+      size_t key_size = key.size();
+      size_t key_prefix_size = strlen(key_prefix);
+      size_t key_suffix_size = strlen(key_suffix);
+      bool timezone_storage_key =
+          (key_size >= (key_prefix_size + key_suffix_size)) &&
+          (key.compare(0, key_prefix_size, key_prefix) == 0) &&
+          (key.compare(key_size - key_suffix_size, key_suffix_size, key_suffix) == 0);
+      if (!timezone_storage_key) {
+        filtered_metadata->Append(key, value);
+      }
+    }
+  }
+  if (filtered_metadata->size() == 0) {
+    filtered_metadata.reset();
+  }
+  return filtered_metadata;
+}
+
+Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                         const std::shared_ptr<const KeyValueMetadata>& parquet_metadata,
+                         std::shared_ptr<::arrow::Schema>* out) {
   const GroupNode& schema_node = *parquet_schema->group_node();
 
   int num_fields = static_cast<int>(schema_node.field_count());
   std::vector<std::shared_ptr<Field>> fields(num_fields);
   for (int i = 0; i < num_fields; i++) {
-    RETURN_NOT_OK(NodeToField(*schema_node.field(i), &fields[i]));
+    RETURN_NOT_OK(NodeToFieldInternal(*schema_node.field(i), nullptr, parquet_metadata,
+                                      &fields[i]));
   }
 
-  *out = std::make_shared<::arrow::Schema>(fields, key_value_metadata);
+  *out =
+      std::make_shared<::arrow::Schema>(fields, FilterParquetMetadata(parquet_metadata));
   return Status::OK();
 }
 
-Status FromParquetSchema(
-    const SchemaDescriptor* parquet_schema, const std::vector<int>& column_indices,
-    const std::shared_ptr<const KeyValueMetadata>& key_value_metadata,
-    std::shared_ptr<::arrow::Schema>* out) {
+Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                         const std::vector<int>& column_indices,
+                         const std::shared_ptr<const KeyValueMetadata>& parquet_metadata,
+                         std::shared_ptr<::arrow::Schema>* out) {
   // TODO(wesm): Consider adding an arrow::Schema name attribute, which comes
   // from the root Parquet node
 
@@ -470,13 +535,15 @@ Status FromParquetSchema(
   std::vector<std::shared_ptr<Field>> fields;
   std::shared_ptr<Field> field;
   for (auto node : base_nodes) {
-    RETURN_NOT_OK(NodeToFieldInternal(*node, &included_leaf_nodes, &field));
+    RETURN_NOT_OK(
+        NodeToFieldInternal(*node, &included_leaf_nodes, parquet_metadata, &field));
     if (field != nullptr) {
       fields.push_back(field);
     }
   }
 
-  *out = std::make_shared<::arrow::Schema>(fields, key_value_metadata);
+  *out =
+      std::make_shared<::arrow::Schema>(fields, FilterParquetMetadata(parquet_metadata));
   return Status::OK();
 }
 
@@ -491,13 +558,73 @@ Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
   return FromParquetSchema(parquet_schema, nullptr, out);
 }
 
+class PresumedColumnPath {
+  // Pre-constructs the eventual column path dot string for a Parquet node
+  // before it is fully constructed from Arrow fields
+ public:
+  PresumedColumnPath() = default;
+
+  void Extend(const std::shared_ptr<Field>& field) {
+    switch (field->type()->id()) {
+      case ArrowTypeId::DICTIONARY:
+        path_.push_back({false, ""});
+        break;
+      case ArrowTypeId::LIST:
+        path_.push_back({true, field->name() + ".list"});
+        break;
+      default:
+        path_.push_back({true, field->name()});
+        break;
+    }
+    return;
+  }
+
+  void Retract() {
+    DCHECK(!path_.empty());
+    path_.pop_back();
+    return;
+  }
+
+  std::string ToDotString() const {
+    std::stringstream ss;
+    int i = 0;
+    for (auto c = path_.cbegin(); c != path_.cend(); ++c) {
+      if (c->include) {
+        if (i > 0) {
+          ss << ".";
+        }
+        ss << c->component;
+        ++i;
+      }
+    }
+    return ss.str();
+  }
+
+ private:
+  struct Component {
+    bool include;
+    std::string component;
+  };
+  std::deque<Component> path_;
+};
+
+Status FieldToNodeInternal(const std::shared_ptr<Field>& field,
+                           const WriterProperties& properties,
+                           const ArrowWriterProperties& arrow_properties,
+                           PresumedColumnPath& path,
+                           std::unordered_map<std::string, std::string>& metadata,
+                           NodePtr* out);
+
 Status ListToNode(const std::shared_ptr<::arrow::ListType>& type, const std::string& name,
                   bool nullable, const WriterProperties& properties,
-                  const ArrowWriterProperties& arrow_properties, NodePtr* out) {
-  Repetition::type repetition = nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
+                  const ArrowWriterProperties& arrow_properties, PresumedColumnPath& path,
+                  std::unordered_map<std::string, std::string>& metadata, NodePtr* out) {
+  const Repetition::type repetition =
+      nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
 
   NodePtr element;
-  RETURN_NOT_OK(FieldToNode(type->value_field(), properties, arrow_properties, &element));
+  RETURN_NOT_OK(FieldToNodeInternal(type->value_field(), properties, arrow_properties,
+                                    path, metadata, &element));
 
   NodePtr list = GroupNode::Make("list", Repetition::REPEATED, {element});
   *out = GroupNode::Make(name, repetition, {list}, LogicalAnnotation::List());
@@ -507,13 +634,17 @@ Status ListToNode(const std::shared_ptr<::arrow::ListType>& type, const std::str
 Status StructToNode(const std::shared_ptr<::arrow::StructType>& type,
                     const std::string& name, bool nullable,
                     const WriterProperties& properties,
-                    const ArrowWriterProperties& arrow_properties, NodePtr* out) {
-  Repetition::type repetition = nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
+                    const ArrowWriterProperties& arrow_properties,
+                    PresumedColumnPath& path,
+                    std::unordered_map<std::string, std::string>& metadata,
+                    NodePtr* out) {
+  const Repetition::type repetition =
+      nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
 
   std::vector<NodePtr> children(type->num_children());
   for (int i = 0; i < type->num_children(); i++) {
-    RETURN_NOT_OK(
-        FieldToNode(type->child(i), properties, arrow_properties, &children[i]));
+    RETURN_NOT_OK(FieldToNodeInternal(type->child(i), properties, arrow_properties, path,
+                                      metadata, &children[i]));
   }
 
   *out = GroupNode::Make(name, repetition, children);
@@ -526,9 +657,32 @@ static bool HasUTCTimezone(const std::string& timezone) {
                      [timezone](const std::string& utc) { return timezone == utc; });
 }
 
+static void StoreMetadataTimezone(const std::string& path,
+                                  std::unordered_map<std::string, std::string>& metadata,
+                                  const std::string& timezone) {
+  const std::string key(key_prefix + path + key_suffix);
+  if (metadata.find(key) != metadata.end()) {
+    std::stringstream ms;
+    ms << "Duplicate field name '" << path
+       << "' for timestamp with timezone field in Arrow schema.";
+    throw ParquetException(ms.str());
+  }
+  metadata.insert(std::make_pair(key, timezone));
+  return;
+}
+
 static std::shared_ptr<const LogicalAnnotation> TimestampAnnotationFromArrowTimestamp(
-    const ::arrow::TimestampType& timestamp_type, ::arrow::TimeUnit::type time_unit) {
-  const bool utc = HasUTCTimezone(timestamp_type.timezone());
+    const std::string& path, const ::arrow::TimestampType& timestamp_type,
+    ::arrow::TimeUnit::type time_unit,
+    std::unordered_map<std::string, std::string>& metadata) {
+  const std::string& timezone = timestamp_type.timezone();
+  const bool utc = HasUTCTimezone(timezone);
+
+  if (!utc && !timezone.empty()) {
+    // Attempt to preserve timezone for this field as file metadata
+    StoreMetadataTimezone(path, metadata, timezone);
+  }
+
   switch (time_unit) {
     case ::arrow::TimeUnit::MILLI:
       return LogicalAnnotation::Timestamp(utc, LogicalAnnotation::TimeUnit::MILLIS);
@@ -544,7 +698,10 @@ static std::shared_ptr<const LogicalAnnotation> TimestampAnnotationFromArrowTime
 }
 
 static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
+                                   const std::string& name,
                                    const ArrowWriterProperties& properties,
+                                   const std::string& path,
+                                   std::unordered_map<std::string, std::string>& metadata,
                                    ParquetType::type* physical_type,
                                    std::shared_ptr<const LogicalAnnotation>* annotation) {
   const bool coerce = properties.coerce_timestamps_enabled();
@@ -558,8 +715,8 @@ static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
   }
 
   *physical_type = ParquetType::INT64;
-  PARQUET_CATCH_NOT_OK(*annotation =
-                           TimestampAnnotationFromArrowTimestamp(type, target_unit));
+  PARQUET_CATCH_NOT_OK(*annotation = TimestampAnnotationFromArrowTimestamp(
+                           path, type, target_unit, metadata));
 
   // The user is explicitly asking for timestamp data to be converted to the
   // specified units (target_unit).
@@ -587,17 +744,22 @@ static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
   return Status::OK();
 }
 
-Status FieldToNode(const std::shared_ptr<Field>& field,
-                   const WriterProperties& properties,
-                   const ArrowWriterProperties& arrow_properties, NodePtr* out) {
+Status FieldToNodeInternal(const std::shared_ptr<Field>& field,
+                           const WriterProperties& properties,
+                           const ArrowWriterProperties& arrow_properties,
+                           PresumedColumnPath& path,
+                           std::unordered_map<std::string, std::string>& metadata,
+                           NodePtr* out) {
+  const Repetition::type repetition =
+      field->nullable() ? Repetition::OPTIONAL : Repetition::REQUIRED;
   std::shared_ptr<const LogicalAnnotation> annotation = LogicalAnnotation::None();
   ParquetType::type type;
-  Repetition::type repetition =
-      field->nullable() ? Repetition::OPTIONAL : Repetition::REQUIRED;
 
   int length = -1;
   int precision = -1;
   int scale = -1;
+
+  path.Extend(field);
 
   switch (field->type()->id()) {
     case ArrowTypeId::NA:
@@ -678,9 +840,9 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       annotation = LogicalAnnotation::Date();
       break;
     case ArrowTypeId::TIMESTAMP:
-      RETURN_NOT_OK(
-          GetTimestampMetadata(static_cast<::arrow::TimestampType&>(*field->type()),
-                               arrow_properties, &type, &annotation));
+      RETURN_NOT_OK(GetTimestampMetadata(
+          static_cast<::arrow::TimestampType&>(*field->type()), field->name(),
+          arrow_properties, path.ToDotString(), metadata, &type, &annotation));
       break;
     case ArrowTypeId::TIME32:
       type = ParquetType::INT32;
@@ -701,12 +863,12 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     case ArrowTypeId::STRUCT: {
       auto struct_type = std::static_pointer_cast<::arrow::StructType>(field->type());
       return StructToNode(struct_type, field->name(), field->nullable(), properties,
-                          arrow_properties, out);
+                          arrow_properties, path, metadata, out);
     }
     case ArrowTypeId::LIST: {
       auto list_type = std::static_pointer_cast<::arrow::ListType>(field->type());
       return ListToNode(list_type, field->name(), field->nullable(), properties,
-                        arrow_properties, out);
+                        arrow_properties, path, metadata, out);
     }
     case ArrowTypeId::DICTIONARY: {
       // Parquet has no Dictionary type, dictionary-encoded is handled on
@@ -715,7 +877,8 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
           static_cast<const ::arrow::DictionaryType&>(*field->type());
       std::shared_ptr<::arrow::Field> unpacked_field = ::arrow::field(
           field->name(), dict_type.value_type(), field->nullable(), field->metadata());
-      return FieldToNode(unpacked_field, properties, arrow_properties, out);
+      return FieldToNodeInternal(unpacked_field, properties, arrow_properties, path,
+                                 metadata, out);
     }
     default: {
       // TODO: DENSE_UNION, SPARE_UNION, JSON_SCALAR, DECIMAL_TEXT, VARCHAR
@@ -725,34 +888,92 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     }
   }
 
+  path.Retract();
+
   PARQUET_CATCH_NOT_OK(*out = PrimitiveNode::Make(field->name(), repetition, annotation,
                                                   type, length));
 
   return Status::OK();
 }
 
+Status FieldToNode(const std::shared_ptr<Field>& field,
+                   const WriterProperties& properties,
+                   const ArrowWriterProperties& arrow_properties,
+                   std::unordered_map<std::string, std::string>& parquet_metadata_map,
+                   NodePtr* out) {
+  PresumedColumnPath parquet_column_path;
+  return FieldToNodeInternal(field, properties, arrow_properties, parquet_column_path,
+                             parquet_metadata_map, out);
+}
+
+Status FieldToNode(const std::shared_ptr<Field>& field,
+                   const WriterProperties& properties,
+                   const ArrowWriterProperties& arrow_properties, NodePtr* out) {
+  PresumedColumnPath parquet_column_path;
+  std::unordered_map<std::string, std::string> dummy_metadata_map;
+  return FieldToNodeInternal(field, properties, arrow_properties, parquet_column_path,
+                             dummy_metadata_map, out);
+}
+
 Status ToParquetSchema(const ::arrow::Schema* arrow_schema,
                        const WriterProperties& properties,
                        const ArrowWriterProperties& arrow_properties,
-                       std::shared_ptr<SchemaDescriptor>* out) {
-  std::vector<NodePtr> nodes(arrow_schema->num_fields());
+                       std::shared_ptr<const KeyValueMetadata>* parquet_metadata_out,
+                       std::shared_ptr<SchemaDescriptor>* parquet_schema_out) {
+  std::unordered_map<std::string, std::string> parquet_metadata_map;
+  std::vector<NodePtr> parquet_nodes(arrow_schema->num_fields());
+
+  // TODO(tpboudreau): consider making construction of metadata map in
+  // FieldToNodeInternal() conditional on whether caller asked for metadata
+  // (parquet_metadata_out != NULL); metadata construction (even if
+  // unnecessary) can cause FieldToNodeInternal() to fail
   for (int i = 0; i < arrow_schema->num_fields(); i++) {
-    RETURN_NOT_OK(
-        FieldToNode(arrow_schema->field(i), properties, arrow_properties, &nodes[i]));
+    PresumedColumnPath parquet_column_path;
+    RETURN_NOT_OK(FieldToNodeInternal(arrow_schema->field(i), properties,
+                                      arrow_properties, parquet_column_path,
+                                      parquet_metadata_map, &parquet_nodes[i]));
   }
 
-  NodePtr schema = GroupNode::Make("schema", Repetition::REQUIRED, nodes);
-  *out = std::make_shared<::parquet::SchemaDescriptor>();
-  PARQUET_CATCH_NOT_OK((*out)->Init(schema));
+  if (parquet_metadata_out) {
+    if (arrow_schema->HasMetadata()) {
+      // merge Arrow application metadata with Arrow/Parquet storage specific metadata
+      auto arrow_metadata = arrow_schema->metadata();
+      std::unordered_map<std::string, std::string> arrow_metadata_map;
+      arrow_metadata->ToUnorderedMap(&arrow_metadata_map);
+      parquet_metadata_map.insert(arrow_metadata_map.cbegin(), arrow_metadata_map.cend());
+    }
+    *parquet_metadata_out =
+        std::make_shared<const KeyValueMetadata>(parquet_metadata_map);
+  }
+
+  NodePtr parquet_schema = GroupNode::Make("schema", Repetition::REQUIRED, parquet_nodes);
+  *parquet_schema_out = std::make_shared<::parquet::SchemaDescriptor>();
+  PARQUET_CATCH_NOT_OK((*parquet_schema_out)->Init(parquet_schema));
 
   return Status::OK();
 }
 
 Status ToParquetSchema(const ::arrow::Schema* arrow_schema,
                        const WriterProperties& properties,
-                       std::shared_ptr<SchemaDescriptor>* out) {
+                       std::shared_ptr<const KeyValueMetadata>* parquet_metadata_out,
+                       std::shared_ptr<SchemaDescriptor>* parquet_schema_out) {
   return ToParquetSchema(arrow_schema, properties, *default_arrow_writer_properties(),
-                         out);
+                         parquet_metadata_out, parquet_schema_out);
+}
+
+Status ToParquetSchema(const ::arrow::Schema* arrow_schema,
+                       const WriterProperties& properties,
+                       const ArrowWriterProperties& arrow_properties,
+                       std::shared_ptr<SchemaDescriptor>* parquet_schema_out) {
+  return ToParquetSchema(arrow_schema, properties, arrow_properties, nullptr,
+                         parquet_schema_out);
+}
+
+Status ToParquetSchema(const ::arrow::Schema* arrow_schema,
+                       const WriterProperties& properties,
+                       std::shared_ptr<SchemaDescriptor>* parquet_schema_out) {
+  return ToParquetSchema(arrow_schema, properties, *default_arrow_writer_properties(),
+                         nullptr, parquet_schema_out);
 }
 
 /// \brief Compute the number of bytes required to represent a decimal of a

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -17,6 +17,7 @@
 
 #include "parquet/arrow/schema.h"
 
+#include <algorithm>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -25,6 +26,7 @@
 #include "arrow/array.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 
 #include "parquet/arrow/writer.h"
@@ -35,6 +37,7 @@
 
 using arrow::Field;
 using arrow::Status;
+using arrow::internal::checked_cast;
 
 using ArrowType = arrow::DataType;
 using ArrowTypeId = arrow::Type;
@@ -46,6 +49,7 @@ using parquet::schema::NodePtr;
 using parquet::schema::PrimitiveNode;
 
 using ParquetType = parquet::Type;
+using parquet::LogicalAnnotation;
 using parquet::LogicalType;
 
 namespace parquet {
@@ -56,117 +60,202 @@ const auto TIMESTAMP_MS = ::arrow::timestamp(::arrow::TimeUnit::MILLI);
 const auto TIMESTAMP_US = ::arrow::timestamp(::arrow::TimeUnit::MICRO);
 const auto TIMESTAMP_NS = ::arrow::timestamp(::arrow::TimeUnit::NANO);
 
-std::shared_ptr<ArrowType> MakeDecimal128Type(const PrimitiveNode& node) {
-  const auto& metadata = node.decimal_metadata();
-  return ::arrow::decimal(metadata.precision, metadata.scale);
+static Status MakeArrowDecimal(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                               std::shared_ptr<ArrowType>* out) {
+  const auto& decimal = checked_cast<const DecimalAnnotation&>(*annotation);
+  *out = ::arrow::decimal(decimal.precision(), decimal.scale());
+  return Status::OK();
 }
 
-static Status FromByteArray(const PrimitiveNode& node, std::shared_ptr<ArrowType>* out) {
-  switch (node.logical_type()) {
-    case LogicalType::UTF8:
-      *out = ::arrow::utf8();
+static Status MakeArrowInt(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                           std::shared_ptr<ArrowType>* out) {
+  const auto& integer = checked_cast<const IntAnnotation&>(*annotation);
+  switch (integer.bit_width()) {
+    case 8:
+      *out = integer.is_signed() ? ::arrow::int8() : ::arrow::uint8();
       break;
-    case LogicalType::DECIMAL:
-      *out = MakeDecimal128Type(node);
+    case 16:
+      *out = integer.is_signed() ? ::arrow::int16() : ::arrow::uint16();
+      break;
+    case 32:
+      *out = integer.is_signed() ? ::arrow::int32() : ::arrow::uint32();
       break;
     default:
-      // BINARY
-      *out = ::arrow::binary();
-      break;
+      return Status::TypeError(annotation->ToString(),
+                               " can not annotate physical type Int32");
   }
   return Status::OK();
 }
 
-static Status FromFLBA(const PrimitiveNode& node, std::shared_ptr<ArrowType>* out) {
-  switch (node.logical_type()) {
-    case LogicalType::NONE:
-      *out = ::arrow::fixed_size_binary(node.type_length());
-      break;
-    case LogicalType::DECIMAL:
-      *out = MakeDecimal128Type(node);
+static Status MakeArrowInt64(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                             std::shared_ptr<ArrowType>* out) {
+  const auto& integer = checked_cast<const IntAnnotation&>(*annotation);
+  switch (integer.bit_width()) {
+    case 64:
+      *out = integer.is_signed() ? ::arrow::int64() : ::arrow::uint64();
       break;
     default:
-      return Status::NotImplemented("Unhandled logical type ",
-                                    LogicalTypeToString(node.logical_type()),
+      return Status::TypeError(annotation->ToString(),
+                               " can not annotate physical type Int64");
+  }
+  return Status::OK();
+}
+
+static Status MakeArrowTime32(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                              std::shared_ptr<ArrowType>* out) {
+  const auto& time = checked_cast<const TimeAnnotation&>(*annotation);
+  switch (time.time_unit()) {
+    case LogicalAnnotation::TimeUnit::MILLIS:
+      *out = ::arrow::time32(::arrow::TimeUnit::MILLI);
+      break;
+    default:
+      return Status::TypeError(annotation->ToString(),
+                               " can not annotate physical type Time32");
+  }
+  return Status::OK();
+}
+
+static Status MakeArrowTime64(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                              std::shared_ptr<ArrowType>* out) {
+  const auto& time = checked_cast<const TimeAnnotation&>(*annotation);
+  switch (time.time_unit()) {
+    case LogicalAnnotation::TimeUnit::MICROS:
+      *out = ::arrow::time64(::arrow::TimeUnit::MICRO);
+      break;
+    case LogicalAnnotation::TimeUnit::NANOS:
+      *out = ::arrow::time64(::arrow::TimeUnit::NANO);
+      break;
+    default:
+      return Status::TypeError(annotation->ToString(),
+                               " can not annotate physical type Time64");
+  }
+  return Status::OK();
+}
+
+static Status MakeArrowTimestamp(
+    const std::shared_ptr<const LogicalAnnotation>& annotation,
+    std::shared_ptr<ArrowType>* out) {
+  static constexpr auto utc = "UTC";
+  const auto& timestamp = checked_cast<const TimestampAnnotation&>(*annotation);
+  switch (timestamp.time_unit()) {
+    case LogicalAnnotation::TimeUnit::MILLIS:
+      *out = (timestamp.is_adjusted_to_utc()
+                  ? ::arrow::timestamp(::arrow::TimeUnit::MILLI, utc)
+                  : ::arrow::timestamp(::arrow::TimeUnit::MILLI));
+      break;
+    case LogicalAnnotation::TimeUnit::MICROS:
+      *out = (timestamp.is_adjusted_to_utc()
+                  ? ::arrow::timestamp(::arrow::TimeUnit::MICRO, utc)
+                  : ::arrow::timestamp(::arrow::TimeUnit::MICRO));
+      break;
+    case LogicalAnnotation::TimeUnit::NANOS:
+      *out = (timestamp.is_adjusted_to_utc()
+                  ? ::arrow::timestamp(::arrow::TimeUnit::NANO, utc)
+                  : ::arrow::timestamp(::arrow::TimeUnit::NANO));
+      break;
+    default:
+      return Status::TypeError("Unrecognized time unit in timestamp annotation: ",
+                               annotation->ToString());
+  }
+  return Status::OK();
+}
+
+static Status FromByteArray(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                            std::shared_ptr<ArrowType>* out) {
+  switch (annotation->type()) {
+    case LogicalAnnotation::Type::STRING:
+      *out = ::arrow::utf8();
+      break;
+    case LogicalAnnotation::Type::DECIMAL:
+      RETURN_NOT_OK(MakeArrowDecimal(annotation, out));
+      break;
+    case LogicalAnnotation::Type::NONE:
+    case LogicalAnnotation::Type::ENUM:
+    case LogicalAnnotation::Type::JSON:
+    case LogicalAnnotation::Type::BSON:
+      *out = ::arrow::binary();
+      break;
+    default:
+      return Status::NotImplemented("Unhandled logical annotation ",
+                                    annotation->ToString(), " for binary array");
+  }
+  return Status::OK();
+}
+
+static Status FromFLBA(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                       int32_t physical_length, std::shared_ptr<ArrowType>* out) {
+  switch (annotation->type()) {
+    case LogicalAnnotation::Type::DECIMAL:
+      RETURN_NOT_OK(MakeArrowDecimal(annotation, out));
+      break;
+    case LogicalAnnotation::Type::NONE:
+    case LogicalAnnotation::Type::INTERVAL:
+    case LogicalAnnotation::Type::UUID:
+      *out = ::arrow::fixed_size_binary(physical_length);
+      break;
+    default:
+      return Status::NotImplemented("Unhandled logical annotation ",
+                                    annotation->ToString(),
                                     " for fixed-length binary array");
   }
 
   return Status::OK();
 }
 
-static Status FromInt32(const PrimitiveNode& node, std::shared_ptr<ArrowType>* out) {
-  switch (node.logical_type()) {
-    case LogicalType::NONE:
-      *out = ::arrow::int32();
+static Status FromInt32(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                        std::shared_ptr<ArrowType>* out) {
+  switch (annotation->type()) {
+    case LogicalAnnotation::Type::INT:
+      RETURN_NOT_OK(MakeArrowInt(annotation, out));
       break;
-    case LogicalType::UINT_8:
-      *out = ::arrow::uint8();
-      break;
-    case LogicalType::INT_8:
-      *out = ::arrow::int8();
-      break;
-    case LogicalType::UINT_16:
-      *out = ::arrow::uint16();
-      break;
-    case LogicalType::INT_16:
-      *out = ::arrow::int16();
-      break;
-    case LogicalType::INT_32:
-      *out = ::arrow::int32();
-      break;
-    case LogicalType::UINT_32:
-      *out = ::arrow::uint32();
-      break;
-    case LogicalType::DATE:
+    case LogicalAnnotation::Type::DATE:
       *out = ::arrow::date32();
       break;
-    case LogicalType::TIME_MILLIS:
-      *out = ::arrow::time32(::arrow::TimeUnit::MILLI);
+    case LogicalAnnotation::Type::TIME:
+      RETURN_NOT_OK(MakeArrowTime32(annotation, out));
       break;
-    case LogicalType::DECIMAL:
-      *out = MakeDecimal128Type(node);
+    case LogicalAnnotation::Type::DECIMAL:
+      RETURN_NOT_OK(MakeArrowDecimal(annotation, out));
+      break;
+    case LogicalAnnotation::Type::NONE:
+      *out = ::arrow::int32();
       break;
     default:
-      return Status::NotImplemented("Unhandled logical type ",
-                                    LogicalTypeToString(node.logical_type()),
+      return Status::NotImplemented("Unhandled logical type ", annotation->ToString(),
                                     " for INT32");
   }
   return Status::OK();
 }
 
-static Status FromInt64(const PrimitiveNode& node, std::shared_ptr<ArrowType>* out) {
-  switch (node.logical_type()) {
-    case LogicalType::NONE:
+static Status FromInt64(const std::shared_ptr<const LogicalAnnotation>& annotation,
+                        std::shared_ptr<ArrowType>* out) {
+  switch (annotation->type()) {
+    case LogicalAnnotation::Type::INT:
+      RETURN_NOT_OK(MakeArrowInt64(annotation, out));
+      break;
+    case LogicalAnnotation::Type::DECIMAL:
+      RETURN_NOT_OK(MakeArrowDecimal(annotation, out));
+      break;
+    case LogicalAnnotation::Type::TIMESTAMP:
+      RETURN_NOT_OK(MakeArrowTimestamp(annotation, out));
+      break;
+    case LogicalAnnotation::Type::TIME:
+      RETURN_NOT_OK(MakeArrowTime64(annotation, out));
+      break;
+    case LogicalAnnotation::Type::NONE:
       *out = ::arrow::int64();
-      break;
-    case LogicalType::INT_64:
-      *out = ::arrow::int64();
-      break;
-    case LogicalType::UINT_64:
-      *out = ::arrow::uint64();
-      break;
-    case LogicalType::DECIMAL:
-      *out = MakeDecimal128Type(node);
-      break;
-    case LogicalType::TIMESTAMP_MILLIS:
-      *out = TIMESTAMP_MS;
-      break;
-    case LogicalType::TIMESTAMP_MICROS:
-      *out = TIMESTAMP_US;
-      break;
-    case LogicalType::TIME_MICROS:
-      *out = ::arrow::time64(::arrow::TimeUnit::MICRO);
       break;
     default:
-      return Status::NotImplemented("Unhandled logical type ",
-                                    LogicalTypeToString(node.logical_type()),
+      return Status::NotImplemented("Unhandled logical type ", annotation->ToString(),
                                     " for INT64");
   }
   return Status::OK();
 }
 
 Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>* out) {
-  if (primitive.logical_type() == LogicalType::NA) {
+  const std::shared_ptr<const LogicalAnnotation>& annotation =
+      primitive.logical_annotation();
+  if (annotation->is_invalid() || annotation->is_null()) {
     *out = ::arrow::null();
     return Status::OK();
   }
@@ -176,10 +265,10 @@ Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>*
       *out = ::arrow::boolean();
       break;
     case ParquetType::INT32:
-      RETURN_NOT_OK(FromInt32(primitive, out));
+      RETURN_NOT_OK(FromInt32(annotation, out));
       break;
     case ParquetType::INT64:
-      RETURN_NOT_OK(FromInt64(primitive, out));
+      RETURN_NOT_OK(FromInt64(annotation, out));
       break;
     case ParquetType::INT96:
       *out = TIMESTAMP_NS;
@@ -191,10 +280,10 @@ Status FromPrimitive(const PrimitiveNode& primitive, std::shared_ptr<ArrowType>*
       *out = ::arrow::float64();
       break;
     case ParquetType::BYTE_ARRAY:
-      RETURN_NOT_OK(FromByteArray(primitive, out));
+      RETURN_NOT_OK(FromByteArray(annotation, out));
       break;
     case ParquetType::FIXED_LEN_BYTE_ARRAY:
-      RETURN_NOT_OK(FromFLBA(primitive, out));
+      RETURN_NOT_OK(FromFLBA(annotation, primitive.type_length(), out));
       break;
     default: {
       // PARQUET-1565: This can occur if the file is corrupt
@@ -321,7 +410,7 @@ Status NodeToFieldInternal(const Node& node,
     }
   } else if (node.is_group()) {
     const auto& group = static_cast<const GroupNode&>(node);
-    if (node.logical_type() == LogicalType::LIST) {
+    if (node.logical_annotation()->is_list()) {
       RETURN_NOT_OK(NodeToList(group, included_leaf_nodes, &type));
     } else {
       RETURN_NOT_OK(StructFromGroup(group, included_leaf_nodes, &type));
@@ -411,7 +500,7 @@ Status ListToNode(const std::shared_ptr<::arrow::ListType>& type, const std::str
   RETURN_NOT_OK(FieldToNode(type->value_field(), properties, arrow_properties, &element));
 
   NodePtr list = GroupNode::Make("list", Repetition::REPEATED, {element});
-  *out = GroupNode::Make(name, repetition, {list}, LogicalType::LIST);
+  *out = GroupNode::Make(name, repetition, {list}, LogicalAnnotation::List());
   return Status::OK();
 }
 
@@ -431,27 +520,35 @@ Status StructToNode(const std::shared_ptr<::arrow::StructType>& type,
   return Status::OK();
 }
 
-static LogicalType::type LogicalTypeFromArrowTimeUnit(::arrow::TimeUnit::type time_unit) {
+static bool HasUTCTimezone(const std::string& timezone) {
+  static const std::vector<std::string> utczones{"UTC", "utc"};
+  return std::any_of(utczones.begin(), utczones.end(),
+                     [timezone](const std::string& utc) { return timezone == utc; });
+}
+
+static std::shared_ptr<const LogicalAnnotation> TimestampAnnotationFromArrowTimestamp(
+    const ::arrow::TimestampType& timestamp_type, ::arrow::TimeUnit::type time_unit) {
+  const bool utc = HasUTCTimezone(timestamp_type.timezone());
   switch (time_unit) {
     case ::arrow::TimeUnit::MILLI:
-      return LogicalType::TIMESTAMP_MILLIS;
+      return LogicalAnnotation::Timestamp(utc, LogicalAnnotation::TimeUnit::MILLIS);
     case ::arrow::TimeUnit::MICRO:
-      return LogicalType::TIMESTAMP_MICROS;
-    case ::arrow::TimeUnit::SECOND:
+      return LogicalAnnotation::Timestamp(utc, LogicalAnnotation::TimeUnit::MICROS);
     case ::arrow::TimeUnit::NANO:
+      return LogicalAnnotation::Timestamp(utc, LogicalAnnotation::TimeUnit::NANOS);
+    case ::arrow::TimeUnit::SECOND:
       // No equivalent parquet logical type.
       break;
   }
-
-  return LogicalType::NONE;
+  return LogicalAnnotation::None();
 }
 
 static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
                                    const ArrowWriterProperties& properties,
                                    ParquetType::type* physical_type,
-                                   LogicalType::type* logical_type) {
+                                   std::shared_ptr<const LogicalAnnotation>* annotation) {
   const bool coerce = properties.coerce_timestamps_enabled();
-  const auto unit = coerce ? properties.coerce_timestamps_unit() : type.unit();
+  const auto target_unit = coerce ? properties.coerce_timestamps_unit() : type.unit();
 
   // The user is explicitly asking for Impala int96 encoding, there is no
   // logical type.
@@ -461,41 +558,39 @@ static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
   }
 
   *physical_type = ParquetType::INT64;
-  *logical_type = LogicalTypeFromArrowTimeUnit(unit);
+  PARQUET_CATCH_NOT_OK(*annotation =
+                           TimestampAnnotationFromArrowTimestamp(type, target_unit));
 
-  // The user is requesting that all timestamp columns are casted to a specific
-  // type. Only 2 TimeUnit are supported by arrow-parquet.
+  // The user is explicitly asking for timestamp data to be converted to the
+  // specified units (target_unit).
   if (coerce) {
-    switch (unit) {
+    switch (target_unit) {
       case ::arrow::TimeUnit::MILLI:
       case ::arrow::TimeUnit::MICRO:
-        break;
       case ::arrow::TimeUnit::NANO:
+        break;
       case ::arrow::TimeUnit::SECOND:
         return Status::NotImplemented(
-            "Can only coerce Arrow timestamps to milliseconds"
-            " or microseconds");
+            "Can only coerce Arrow timestamps to milliseconds, microseconds, or "
+            "nanoseconds");
     }
-
     return Status::OK();
   }
 
-  // Until ARROW-3729 is resolved, nanoseconds are explicitly converted to
-  // int64 microseconds when deprecated int96 is not requested.
-  if (type.unit() == ::arrow::TimeUnit::NANO)
-    *logical_type = LogicalType::TIMESTAMP_MICROS;
-  else if (type.unit() == ::arrow::TimeUnit::SECOND)
+  // The user implicitly wants timestamp data to retain its original time units,
+  // however the Arrow seconds time unit can not be represented (annotated) in Parquet.
+  if (type.unit() == ::arrow::TimeUnit::SECOND) {
     return Status::NotImplemented(
-        "Only MILLI, MICRO, and NANOS units supported for Arrow timestamps with "
-        "Parquet.");
+        "Only MILLI, MICRO, and NANO units supported for Arrow timestamps with Parquet.");
+  }
 
   return Status::OK();
-}  // namespace arrow
+}
 
 Status FieldToNode(const std::shared_ptr<Field>& field,
                    const WriterProperties& properties,
                    const ArrowWriterProperties& arrow_properties, NodePtr* out) {
-  LogicalType::type logical_type = LogicalType::NONE;
+  std::shared_ptr<const LogicalAnnotation> annotation = LogicalAnnotation::None();
   ParquetType::type type;
   Repetition::type repetition =
       field->nullable() ? Repetition::OPTIONAL : Repetition::REQUIRED;
@@ -507,33 +602,33 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
   switch (field->type()->id()) {
     case ArrowTypeId::NA:
       type = ParquetType::INT32;
-      logical_type = LogicalType::NA;
+      annotation = LogicalAnnotation::Null();
       break;
     case ArrowTypeId::BOOL:
       type = ParquetType::BOOLEAN;
       break;
     case ArrowTypeId::UINT8:
       type = ParquetType::INT32;
-      logical_type = LogicalType::UINT_8;
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Int(8, false));
       break;
     case ArrowTypeId::INT8:
       type = ParquetType::INT32;
-      logical_type = LogicalType::INT_8;
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Int(8, true));
       break;
     case ArrowTypeId::UINT16:
       type = ParquetType::INT32;
-      logical_type = LogicalType::UINT_16;
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Int(16, false));
       break;
     case ArrowTypeId::INT16:
       type = ParquetType::INT32;
-      logical_type = LogicalType::INT_16;
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Int(16, true));
       break;
     case ArrowTypeId::UINT32:
       if (properties.version() == ::parquet::ParquetVersion::PARQUET_1_0) {
         type = ParquetType::INT64;
       } else {
         type = ParquetType::INT32;
-        logical_type = LogicalType::UINT_32;
+        PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Int(32, false));
       }
       break;
     case ArrowTypeId::INT32:
@@ -541,7 +636,7 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       break;
     case ArrowTypeId::UINT64:
       type = ParquetType::INT64;
-      logical_type = LogicalType::UINT_64;
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Int(64, false));
       break;
     case ArrowTypeId::INT64:
       type = ParquetType::INT64;
@@ -554,7 +649,7 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       break;
     case ArrowTypeId::STRING:
       type = ParquetType::BYTE_ARRAY;
-      logical_type = LogicalType::UTF8;
+      annotation = LogicalAnnotation::String();
       break;
     case ArrowTypeId::BINARY:
       type = ParquetType::BYTE_ARRAY;
@@ -567,37 +662,41 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     } break;
     case ArrowTypeId::DECIMAL: {
       type = ParquetType::FIXED_LEN_BYTE_ARRAY;
-      logical_type = LogicalType::DECIMAL;
       const auto& decimal_type =
           static_cast<const ::arrow::Decimal128Type&>(*field->type());
       precision = decimal_type.precision();
       scale = decimal_type.scale();
       length = DecimalSize(precision);
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Decimal(precision, scale));
     } break;
     case ArrowTypeId::DATE32:
       type = ParquetType::INT32;
-      logical_type = LogicalType::DATE;
+      annotation = LogicalAnnotation::Date();
       break;
     case ArrowTypeId::DATE64:
       type = ParquetType::INT32;
-      logical_type = LogicalType::DATE;
+      annotation = LogicalAnnotation::Date();
       break;
     case ArrowTypeId::TIMESTAMP:
       RETURN_NOT_OK(
           GetTimestampMetadata(static_cast<::arrow::TimestampType&>(*field->type()),
-                               arrow_properties, &type, &logical_type));
+                               arrow_properties, &type, &annotation));
       break;
     case ArrowTypeId::TIME32:
       type = ParquetType::INT32;
-      logical_type = LogicalType::TIME_MILLIS;
+      PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Time(
+                               false, LogicalAnnotation::TimeUnit::MILLIS));
       break;
     case ArrowTypeId::TIME64: {
+      type = ParquetType::INT64;
       auto time_type = static_cast<::arrow::Time64Type*>(field->type().get());
       if (time_type->unit() == ::arrow::TimeUnit::NANO) {
-        return Status::NotImplemented("Nanosecond time not supported in Parquet.");
+        PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Time(
+                                 false, LogicalAnnotation::TimeUnit::NANOS));
+      } else {
+        PARQUET_CATCH_NOT_OK(annotation = LogicalAnnotation::Time(
+                                 false, LogicalAnnotation::TimeUnit::MICROS));
       }
-      type = ParquetType::INT64;
-      logical_type = LogicalType::TIME_MICROS;
     } break;
     case ArrowTypeId::STRUCT: {
       auto struct_type = std::static_pointer_cast<::arrow::StructType>(field->type());
@@ -625,9 +724,10 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
           field->type()->ToString());
     }
   }
-  PARQUET_CATCH_NOT_OK(*out =
-                           PrimitiveNode::Make(field->name(), repetition, type,
-                                               logical_type, length, precision, scale));
+
+  PARQUET_CATCH_NOT_OK(*out = PrimitiveNode::Make(field->name(), repetition, annotation,
+                                                  type, length));
+
   return Status::OK();
 }
 
@@ -725,7 +825,7 @@ int32_t DecimalSize(int32_t precision) {
   }
   DCHECK(false);
   return -1;
-}  // namespace arrow
+}
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -570,10 +570,10 @@ static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
   }
 
   // The user implicitly wants timestamp data to retain its original time units,
-  // however the Arrow seconds time unit can not be represented (annotated) in Parquet.
+  // however the Arrow seconds time unit can not be represented (annotated) in
+  // Parquet and must be converted to milliseconds.
   if (type.unit() == ::arrow::TimeUnit::SECOND) {
-    return Status::NotImplemented(
-        "Only MILLI, MICRO, and NANO units supported for Arrow timestamps with Parquet.");
+    *annotation = TimestampAnnotationFromArrowTimestamp(type, ::arrow::TimeUnit::MILLI);
   }
 
   return Status::OK();

--- a/cpp/src/parquet/arrow/schema.h
+++ b/cpp/src/parquet/arrow/schema.h
@@ -20,8 +20,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "parquet/metadata.h"
@@ -78,11 +76,6 @@ PARQUET_EXPORT
 ::arrow::Status PARQUET_EXPORT FromParquetSchema(const SchemaDescriptor* parquet_schema,
                                                  std::shared_ptr<::arrow::Schema>* out);
 
-::arrow::Status PARQUET_EXPORT FieldToNode(
-    const std::shared_ptr<::arrow::Field>& field, const WriterProperties& properties,
-    const ArrowWriterProperties& arrow_properties,
-    std::unordered_map<std::string, std::string>& metadata_map, schema::NodePtr* out);
-
 ::arrow::Status PARQUET_EXPORT FieldToNode(const std::shared_ptr<::arrow::Field>& field,
                                            const WriterProperties& properties,
                                            const ArrowWriterProperties& arrow_properties,
@@ -91,22 +84,11 @@ PARQUET_EXPORT
 ::arrow::Status PARQUET_EXPORT
 ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
                 const ArrowWriterProperties& arrow_properties,
-                std::shared_ptr<const KeyValueMetadata>* parquet_metadata_out,
-                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
+                std::shared_ptr<SchemaDescriptor>* out);
 
-::arrow::Status PARQUET_EXPORT
-ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
-                std::shared_ptr<const KeyValueMetadata>* parquet_metadata_out,
-                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
-
-::arrow::Status PARQUET_EXPORT
-ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
-                const ArrowWriterProperties& arrow_properties,
-                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
-
-::arrow::Status PARQUET_EXPORT
-ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
-                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
+::arrow::Status PARQUET_EXPORT ToParquetSchema(const ::arrow::Schema* arrow_schema,
+                                               const WriterProperties& properties,
+                                               std::shared_ptr<SchemaDescriptor>* out);
 
 PARQUET_EXPORT
 int32_t DecimalSize(int32_t precision);

--- a/cpp/src/parquet/arrow/schema.h
+++ b/cpp/src/parquet/arrow/schema.h
@@ -20,6 +20,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "parquet/metadata.h"
@@ -76,6 +78,11 @@ PARQUET_EXPORT
 ::arrow::Status PARQUET_EXPORT FromParquetSchema(const SchemaDescriptor* parquet_schema,
                                                  std::shared_ptr<::arrow::Schema>* out);
 
+::arrow::Status PARQUET_EXPORT FieldToNode(
+    const std::shared_ptr<::arrow::Field>& field, const WriterProperties& properties,
+    const ArrowWriterProperties& arrow_properties,
+    std::unordered_map<std::string, std::string>& metadata_map, schema::NodePtr* out);
+
 ::arrow::Status PARQUET_EXPORT FieldToNode(const std::shared_ptr<::arrow::Field>& field,
                                            const WriterProperties& properties,
                                            const ArrowWriterProperties& arrow_properties,
@@ -84,11 +91,22 @@ PARQUET_EXPORT
 ::arrow::Status PARQUET_EXPORT
 ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
                 const ArrowWriterProperties& arrow_properties,
-                std::shared_ptr<SchemaDescriptor>* out);
+                std::shared_ptr<const KeyValueMetadata>* parquet_metadata_out,
+                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
 
-::arrow::Status PARQUET_EXPORT ToParquetSchema(const ::arrow::Schema* arrow_schema,
-                                               const WriterProperties& properties,
-                                               std::shared_ptr<SchemaDescriptor>* out);
+::arrow::Status PARQUET_EXPORT
+ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
+                std::shared_ptr<const KeyValueMetadata>* parquet_metadata_out,
+                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
+
+::arrow::Status PARQUET_EXPORT
+ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
+                const ArrowWriterProperties& arrow_properties,
+                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
+
+::arrow::Status PARQUET_EXPORT
+ToParquetSchema(const ::arrow::Schema* arrow_schema, const WriterProperties& properties,
+                std::shared_ptr<SchemaDescriptor>* parquet_schema_out);
 
 PARQUET_EXPORT
 int32_t DecimalSize(int32_t precision);

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -1128,16 +1128,21 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
                         const std::shared_ptr<WriterProperties>& properties,
                         const std::shared_ptr<ArrowWriterProperties>& arrow_properties,
                         std::unique_ptr<FileWriter>* writer) {
+  std::shared_ptr<const KeyValueMetadata> parquet_metadata;
   std::shared_ptr<SchemaDescriptor> parquet_schema;
-  RETURN_NOT_OK(
-      ToParquetSchema(&schema, *properties, *arrow_properties, &parquet_schema));
+  RETURN_NOT_OK(ToParquetSchema(&schema, *properties, *arrow_properties,
+                                &parquet_metadata, &parquet_schema));
+
+  if (parquet_metadata->size() == 0) {
+    parquet_metadata.reset();
+  }
 
   auto schema_node = std::static_pointer_cast<GroupNode>(parquet_schema->schema_root());
 
   std::unique_ptr<ParquetFileWriter> base_writer =
-      ParquetFileWriter::Open(sink, schema_node, properties, schema.metadata());
+      ParquetFileWriter::Open(sink, schema_node, properties, parquet_metadata);
 
-  auto schema_ptr = std::make_shared<::arrow::Schema>(schema);
+  auto schema_ptr = schema.AddMetadata(parquet_metadata);
   writer->reset(
       new FileWriter(pool, std::move(base_writer), schema_ptr, arrow_properties));
   return Status::OK();

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -498,11 +498,13 @@ std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Date() {
 
 std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Time(
     bool is_adjusted_to_utc, LogicalAnnotation::TimeUnit::unit time_unit) {
+  DCHECK(time_unit != LogicalAnnotation::TimeUnit::UNKNOWN);
   return TimeAnnotation::Make(is_adjusted_to_utc, time_unit);
 }
 
 std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Timestamp(
     bool is_adjusted_to_utc, LogicalAnnotation::TimeUnit::unit time_unit) {
+  DCHECK(time_unit != LogicalAnnotation::TimeUnit::UNKNOWN);
   return TimestampAnnotation::Make(is_adjusted_to_utc, time_unit);
 }
 
@@ -512,6 +514,7 @@ std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Interval() {
 
 std::shared_ptr<const LogicalAnnotation> LogicalAnnotation::Int(int bit_width,
                                                                 bool is_signed) {
+  DCHECK(bit_width == 64 || bit_width == 32 || bit_width == 16 || bit_width == 8);
   return IntAnnotation::Make(bit_width, is_signed);
 }
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1025,26 +1025,22 @@ def test_parquet_version_timestamp_differences():
     # Using Parquet version 1.0, seconds should be coerced to milliseconds
     # and nanoseconds should be coerced to microseconds by default
     expected = pa.Table.from_arrays([a_ms, a_ms, a_us, a_us], names)
-    actual = _roundtrip_table(table)
-    assert actual.equals(expected)
+    _check_roundtrip(table, expected)
 
     # Using Parquet version 2.0, seconds should be coerced to milliseconds
     # and nanoseconds should be retained by default
     expected = pa.Table.from_arrays([a_ms, a_ms, a_us, a_ns], names)
-    actual = _roundtrip_table(table, version='2.0')
-    assert actual.equals(expected)
+    _check_roundtrip(table, expected, version='2.0')
 
     # Using Parquet version 1.0, coercing to milliseconds or microseconds
     # is allowed
     expected = pa.Table.from_arrays([a_ms, a_ms, a_ms, a_ms], names)
-    actual = _roundtrip_table(table, coerce_timestamps='ms')
-    assert actual.equals(expected)
+    _check_roundtrip(table, expected, coerce_timestamps='ms')
 
     # Using Parquet version 2.0, coercing to milliseconds or microseconds
     # is allowed
     expected = pa.Table.from_arrays([a_us, a_us, a_us, a_us], names)
-    actual = _roundtrip_table(table, coerce_timestamps='us')
-    assert actual.equals(expected)
+    _check_roundtrip(table, expected, version='2.0', coerce_timestamps='us')
 
     # TODO: after pyarrow allows coerce_timestamps='ns', tests like the
     # following should pass ...
@@ -1056,18 +1052,15 @@ def test_parquet_version_timestamp_differences():
 
     # Using Parquet version 2.0, coercing to nanoseconds is allowed
     # expected = pa.Table.from_arrays([a_ns, a_ns, a_ns, a_ns], names)
-    # actual = _roundtrip_table(table, version='2.0', coerce_timestamps='ns')
-    # assert actual.equals(expected)
+    # _check_roundtrip(table, expected, version='2.0', coerce_timestamps='ns')
 
     # For either Parquet version, coercing to nanoseconds is allowed
     # if Int96 storage is used
     expected = pa.Table.from_arrays([a_ns, a_ns, a_ns, a_ns], names)
-    actual = _roundtrip_table(table,
-                              use_deprecated_int96_timestamps=True)
-    assert actual.equals(expected)
-    actual = _roundtrip_table(table, version='2.0',
-                              use_deprecated_int96_timestamps=True)
-    assert actual.equals(expected)
+    _check_roundtrip(table, expected,
+                     use_deprecated_int96_timestamps=True)
+    _check_roundtrip(table, expected, version='2.0',
+                     use_deprecated_int96_timestamps=True)
 
 
 def test_large_list_records():
@@ -2131,7 +2124,7 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
         pass
     assert filename.exists()
 
-    recovered_table = _roundtrip_table(tb, version='2.0')
+    recovered_table = pq.read_table(filename)
     assert tb.equals(recovered_table)
 
     # Loss of data thru coercion (without explicit override) still an error


### PR DESCRIPTION
This PR causes the Arrow Parquet I/O facility to recognize Parquet logical annotations (parquet.thrift LogicalType's) on read and to generate them (rather than converted types) on write.

Since Parquet logical annotations include nanosecond timestamps, this patch satisfies the feature requested in ARROW-3729.