### PR TITLE
ARROW-5491: [C++] Remove unecessary semicolons following MACRO definitions

### DIFF
--- a/cpp/src/arrow/ipc/json-test.cc
+++ b/cpp/src/arrow/ipc/json-test.cc
@@ -383,7 +383,7 @@ TEST(TestJsonFileReadWrite, MinimalFormatExample) {
                     &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,             \
                     &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion, \
                     &MakeDates, &MakeTimestamps, &MakeTimes, &MakeFWBinary,        \
-                    &MakeDecimal, &MakeDictionary, &MakeIntervals);
+                    &MakeDecimal, &MakeDictionary, &MakeIntervals)
 
 class TestJsonRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*> {
  public:

--- a/cpp/src/arrow/ipc/read-write-test.cc
+++ b/cpp/src/arrow/ipc/read-write-test.cc
@@ -218,7 +218,7 @@ TEST_F(TestSchemaMetadata, KeyValueMetadata) {
                     &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion,      \
                     &MakeDictionary, &MakeDates, &MakeTimestamps, &MakeTimes,           \
                     &MakeFWBinary, &MakeNull, &MakeDecimal, &MakeBooleanBatch,          \
-                    &MakeIntervals);
+                    &MakeIntervals)
 
 static int g_file_number = 0;
 


### PR DESCRIPTION
To be honest I'm not sure how these semicolons aren't causing an issue currently. Either way, removing them seems like a noop and improves clarity in my opinion.