### PR TITLE
ARROW-5453: [C++] Update to cmake-format=0.5.2 and pin again

### DIFF
--- a/ci/travis_lint.sh
+++ b/ci/travis_lint.sh
@@ -31,7 +31,7 @@ pre-commit install
 pre-commit run hadolint -a
 
 # CMake formatting check
-pip install cmake_format
+pip install cmake_format==0.5.2
 $TRAVIS_BUILD_DIR/run-cmake-format.py --check
 
 # C++ code linting

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -333,8 +333,11 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   if(NOT APPLE)
     set(MORE_ARGS "-T")
   endif()
-  execute_process(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
-                                              ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
+  execute_process(COMMAND ln
+                          ${MORE_ARGS}
+                          -sf
+                          ${BUILD_OUTPUT_ROOT_DIRECTORY}
+                          ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
 else()
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUBDIR_NAME}/")
 endif()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1598,10 +1598,12 @@ macro(build_lz4)
   # We need to copy the header in lib to directory outside of the build
   externalproject_add(lz4_ep
                       URL ${LZ4_SOURCE_URL} ${EP_LOG_OPTIONS}
-                      UPDATE_COMMAND ${CMAKE_COMMAND} -E copy_directory
-                                                         "${LZ4_BUILD_DIR}/lib"
-                                                         "${LZ4_PREFIX}/include"
-                                                         ${LZ4_PATCH_COMMAND}
+                      UPDATE_COMMAND ${CMAKE_COMMAND}
+                                     -E
+                                     copy_directory
+                                     "${LZ4_BUILD_DIR}/lib"
+                                     "${LZ4_PREFIX}/include"
+                                     ${LZ4_PATCH_COMMAND}
                       CONFIGURE_COMMAND ""
                       INSTALL_COMMAND ""
                       BINARY_DIR ${LZ4_BUILD_DIR}

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -72,7 +72,11 @@ if(NOT FLATC_EXECUTABLE)
 endif()
 message(STATUS "flatc: ${FLATC_EXECUTABLE}")
 add_custom_command(OUTPUT ${FBS_OUTPUT_FILES}
-                   COMMAND ${FLATC_EXECUTABLE} -c -o ${OUTPUT_DIR} ${ABS_FBS_SRC}
+                   COMMAND ${FLATC_EXECUTABLE}
+                           -c
+                           -o
+                           ${OUTPUT_DIR}
+                           ${ABS_FBS_SRC}
                    DEPENDS flatbuffers::flatc
                    COMMENT "Running flatc compiler on ${ABS_FBS_SRC}"
                    VERBATIM)

--- a/cpp/src/gandiva/jni/CMakeLists.txt
+++ b/cpp/src/gandiva/jni/CMakeLists.txt
@@ -37,9 +37,11 @@ get_filename_component(ABS_GANDIVA_PROTO ${CMAKE_SOURCE_DIR}/src/gandiva/proto/T
 
 add_custom_command(OUTPUT ${PROTO_OUTPUT_FILES}
                    COMMAND protobuf::protoc
-                           --proto_path ${CMAKE_SOURCE_DIR}/src/gandiva/proto
-                           --cpp_out ${PROTO_OUTPUT_DIR}
-                                     ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto
+                           --proto_path
+                           ${CMAKE_SOURCE_DIR}/src/gandiva/proto
+                           --cpp_out
+                           ${PROTO_OUTPUT_DIR}
+                           ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto
                    DEPENDS ${ABS_GANDIVA_PROTO} protobuf::libprotobuf
                    COMMENT "Running PROTO compiler on Types.proto"
                    VERBATIM)

--- a/cpp/src/gandiva/precompiled/CMakeLists.txt
+++ b/cpp/src/gandiva/precompiled/CMakeLists.txt
@@ -53,7 +53,8 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
   set(BC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${SRC_BASE}.bc)
   add_custom_command(
     OUTPUT ${BC_FILE}
-    COMMAND ${CLANG_EXECUTABLE} ${PLATFORM_CLANG_OPTIONS}
+    COMMAND ${CLANG_EXECUTABLE}
+            ${PLATFORM_CLANG_OPTIONS}
             -DGANDIVA_IR
             -DNDEBUG # DCHECK macros not implemented in precompiled code
             -DARROW_STATIC # Do not set __declspec(dllimport) on MSVC on Arrow symbols
@@ -64,7 +65,8 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
             -c
             ${ABSOLUTE_SRC}
             -o
-            ${BC_FILE} ${ARROW_GANDIVA_PC_CXX_FLAGS}
+            ${BC_FILE}
+            ${ARROW_GANDIVA_PC_CXX_FLAGS}
             -I${CMAKE_SOURCE_DIR}/src
     DEPENDS ${SRC_FILE})
   list(APPEND BC_FILES ${BC_FILE})
@@ -73,7 +75,7 @@ endforeach()
 # link all of the bitcode files into a single bitcode file.
 add_custom_command(OUTPUT ${GANDIVA_PRECOMPILED_BC_PATH}
                    COMMAND ${LLVM_LINK_EXECUTABLE} -o ${GANDIVA_PRECOMPILED_BC_PATH}
-                                                      ${BC_FILES}
+                           ${BC_FILES}
                    DEPENDS ${BC_FILES})
 
 # write a cmake script to replace precompiled bitcode file's content into a .cc file
@@ -90,8 +92,7 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/WritePrecompiledCC.cmake" "\
 
 # add the previous command to the execution chain
 add_custom_command(OUTPUT ${GANDIVA_PRECOMPILED_CC_PATH}
-                   COMMAND ${CMAKE_COMMAND}
-                           -P
+                   COMMAND ${CMAKE_COMMAND} -P
                            "${CMAKE_CURRENT_BINARY_DIR}/WritePrecompiledCC.cmake"
                    DEPENDS ${GANDIVA_PRECOMPILED_CC_IN_PATH}
                            ${GANDIVA_PRECOMPILED_BC_PATH})

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -140,9 +140,11 @@ get_filename_component(ABS_PARQUET_THRIFT parquet.thrift ABSOLUTE)
 
 add_custom_command(OUTPUT ${THRIFT_OUTPUT_FILES}
                    COMMAND ${THRIFT_COMPILER}
-                           --gen cpp
+                           --gen
+                           cpp
                            -out
-                           ${THRIFT_OUTPUT_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/parquet.thrift
+                           ${THRIFT_OUTPUT_DIR}
+                           ${CMAKE_CURRENT_SOURCE_DIR}/parquet.thrift
                    DEPENDS ${ABS_PARQUET_THRIFT} Thrift::thrift
                    COMMENT "Running thrift compiler on parquet.thrift"
                    VERBATIM)

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -53,8 +53,10 @@ add_custom_command(
          # messages in data structures. This is currently used for ObjectInfo for
          # example.
   COMMAND flatbuffers::flatc
-          -c -o
-          ${OUTPUT_DIR} ${PLASMA_FBS_SRC}
+          -c
+          -o
+          ${OUTPUT_DIR}
+          ${PLASMA_FBS_SRC}
           --gen-object-api
           --scoped-enums
   DEPENDS ${PLASMA_FBS_SRC}

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -157,8 +157,11 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR})
   if(NOT APPLE)
     set(MORE_ARGS "-T")
   endif()
-  execute_process(COMMAND ln ${MORE_ARGS} -sf ${BUILD_OUTPUT_ROOT_DIRECTORY}
-                                              ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
+  execute_process(COMMAND ln
+                          ${MORE_ARGS}
+                          -sf
+                          ${BUILD_OUTPUT_ROOT_DIRECTORY}
+                          ${CMAKE_CURRENT_BINARY_DIR}/build/latest)
 else()
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUBDIR_NAME}")
 endif()


### PR DESCRIPTION
I think we need to put cmake-format back into the doghouse until we observe a period of stability in the formatting algorithm