### PR TITLE
ARROW-5456: [GLib][Plasma] Fix dependency order on building document

### DIFF
--- a/c_glib/doc/plasma-glib/meson.build
+++ b/c_glib/doc/plasma-glib/meson.build
@@ -53,8 +53,8 @@ source_directories = [
   join_paths(meson.build_root(), 'plasma-glib'),
 ]
 dependencies = [
-  arrow_glib,
   plasma_glib,
+  arrow_glib,
 ]
 if arrow_cuda.found()
   dependencies += [arrow_cuda_glib]


### PR DESCRIPTION
We use installed plasma-glib with allow_glib -> plasma_glib order.
We must use building plasma-glib instead of installed plasma-glib.