### PR TITLE
ARROW-5455: [Rust] Build broken by 2019-05-30 Rust nightly

### DIFF
--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -24,6 +24,7 @@
 #![feature(specialization)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
+#![allow(bare_trait_objects)]
 
 pub mod array;
 pub mod array_data;

--- a/rust/datafusion/src/bin/repl.rs
+++ b/rust/datafusion/src/bin/repl.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![allow(bare_trait_objects)]
+
 #[macro_use]
 extern crate clap;
 

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -19,6 +19,7 @@
 //! Apache Arrow as the memory model
 
 #![warn(missing_docs)]
+#![allow(bare_trait_objects)]
 
 extern crate arrow;
 #[macro_use]

--- a/rust/parquet/src/lib.rs
+++ b/rust/parquet/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(specialization)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
+#![allow(bare_trait_objects)]
 
 #[macro_use]
 pub mod errors;


### PR DESCRIPTION
Temporarily disable the lint on bare trait objects. Will switch to the new "dyn trait" syntax later and re-enable the lint.