### PR TITLE
ARROW-1837: [Java][Integration] Fix unsigned round trip integration tests

### DIFF
--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -1029,7 +1029,7 @@ def get_generated_json_files(tempdir=None, flight=False):
         return
 
     file_objs = [
-        (generate_primitive_case([], name='primitive_no_batches')
+        (generate_primitive_case([], name='primitive_no_batches'),
         generate_primitive_case([17, 20], name='primitive'),
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
         generate_decimal_case(),

--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -1029,7 +1029,7 @@ def get_generated_json_files(tempdir=None, flight=False):
         return
 
     file_objs = [
-        (generate_primitive_case([], name='primitive_no_batches'),
+        generate_primitive_case([], name='primitive_no_batches'),
         generate_primitive_case([17, 20], name='primitive'),
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
         generate_decimal_case(),

--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -194,13 +194,12 @@ class IntegerType(PrimitiveType):
         self.max_value = max_value
 
     def _get_generated_data_bounds(self):
-        signed_iinfo = np.iinfo('int' + str(self.bit_width))
         if self.is_signed:
+            signed_iinfo = np.iinfo('int' + str(self.bit_width))
             min_value, max_value = signed_iinfo.min, signed_iinfo.max
         else:
-            # ARROW-1837 Remove this hack and restore full unsigned integer
-            # range
-            min_value, max_value = 0, signed_iinfo.max
+            unsigned_iinfo = np.iinfo('uint' + str(self.bit_width))
+            min_value, max_value = 0, unsigned_iinfo.max
 
         lower_bound = max(min_value, self.min_value)
         upper_bound = min(max_value, self.max_value)
@@ -1031,7 +1030,6 @@ def get_generated_json_files(tempdir=None, flight=False):
 
     file_objs = [
         (generate_primitive_case([], name='primitive_no_batches')
-         .skip_category('Java')),
         generate_primitive_case([17, 20], name='primitive'),
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
         generate_decimal_case(),

--- a/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/FileToStream.java
@@ -44,12 +44,11 @@ public class FileToStream {
     try (ArrowFileReader reader = new ArrowFileReader(in.getChannel(), allocator)) {
       VectorSchemaRoot root = reader.getVectorSchemaRoot();
       // load the first batch before instantiating the writer so that we have any dictionaries
-      if (!reader.loadNextBatch()) {
-        throw new IOException("Unable to read first record batch");
-      }
+      // only writeBatches if we loaded one in the first palce.
+      boolean writeBatches = reader.loadNextBatch();
       try (ArrowStreamWriter writer = new ArrowStreamWriter(root, reader, out)) {
         writer.start();
-        while (true) {
+        while (writeBatches) {
           writer.writeBatch();
           if (!reader.loadNextBatch()) {
             break;

--- a/java/tools/src/main/java/org/apache/arrow/tools/StreamToFile.java
+++ b/java/tools/src/main/java/org/apache/arrow/tools/StreamToFile.java
@@ -42,13 +42,12 @@ public class StreamToFile {
     BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
     try (ArrowStreamReader reader = new ArrowStreamReader(in, allocator)) {
       VectorSchemaRoot root = reader.getVectorSchemaRoot();
-      // load the first batch before instantiating the writer so that we have any dictionaries
-      if (!reader.loadNextBatch()) {
-        throw new IOException("Unable to read first record batch");
-      }
+      // load the first batch before instantiating the writer so that we have any dictionaries.
+      // Only writeBatches if we load the first one.
+      boolean writeBatches = reader.loadNextBatch();
       try (ArrowFileWriter writer = new ArrowFileWriter(root, reader, Channels.newChannel(out))) {
         writer.start();
-        while (true) {
+        while (writeBatches) {
           writer.writeBatch();
           if (!reader.loadNextBatch()) {
             break;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -71,7 +71,7 @@ public class UInt1Vector extends BaseFixedWidthVector {
    * <p>To avoid overflow, the returned type is one step up from the signed
    * type.
    *
-   * <p>This method should not be used externally.
+   * <p>This method is mainly meant for integration tests.
    *
    * @param buffer data buffer
    * @param index position of the element.

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -28,6 +28,8 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
+import io.netty.buffer.ArrowBuf;
+
 /**
  * UInt1Vector implements a fixed width (1 bytes) vector of
  * integer values which could be null. A validity buffer (bit vector) is
@@ -62,6 +64,23 @@ public class UInt1Vector extends BaseFixedWidthVector {
    |          vector value retrieval methods                        |
    |                                                                |
    *----------------------------------------------------------------*/
+  /**
+   * Given a data buffer, get the value stored at a particular position
+   * in the vector.
+   *
+   * <p>To avoid overflow, the returned type is one step up from the signed
+   * type.
+   *
+   * <p>This method should not be used externally.
+   *
+   * @param buffer data buffer
+   * @param index position of the element.
+   * @return value stored at the index.
+   */
+  public static short getNoOverflow(final ArrowBuf buffer, final int index) {
+    byte b =  buffer.getByte(index * TYPE_WIDTH);
+    return (short)(0xFF & b);
+  }
 
 
   /**
@@ -104,6 +123,20 @@ public class UInt1Vector extends BaseFixedWidthVector {
       return null;
     } else {
       return valueBuffer.getByte(index * TYPE_WIDTH);
+    }
+  }
+
+  /**
+   * Returns the value stored at index without the potential for overflow.
+   *
+   * @param index   position of element
+   * @return element at given index
+   */
+  public Short getObjectNoOverflow(int index) {
+    if (isSet(index) == 0) {
+      return null;
+    } else {
+      return getNoOverflow(valueBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -28,6 +28,8 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
+import io.netty.buffer.ArrowBuf;
+
 /**
  * UInt2Vector implements a fixed width (2 bytes) vector of
  * integer values which could be null. A validity buffer (bit vector) is
@@ -63,6 +65,23 @@ public class UInt2Vector extends BaseFixedWidthVector {
    |                                                                |
    *----------------------------------------------------------------*/
 
+  /**
+   * Given a data buffer, get the value stored at a particular position
+   * in the vector.
+   *
+   * <p>To avoid overflow, the returned type is one step up from the signed
+   * type.
+   *
+   * <p>This method should not be used externally.
+   *
+   * @param buffer data buffer
+   * @param index position of the element.
+   * @return value stored at the index.
+   */
+  public static int getNoOverflow(final ArrowBuf buffer, final int index) {
+    int s =  buffer.getShort(index * TYPE_WIDTH);
+    return 0xFFFF & s;
+  }
 
   /**
    * Get the element at the given index from the vector.
@@ -104,6 +123,20 @@ public class UInt2Vector extends BaseFixedWidthVector {
       return null;
     } else {
       return valueBuffer.getChar(index * TYPE_WIDTH);
+    }
+  }
+
+  /**
+   * Same as {@link #get(int)}.
+   *
+   * @param index   position of element
+   * @return element at given index
+   */
+  public Integer getObjectNoOverflow(int index) {
+    if (isSet(index) == 0) {
+      return null;
+    } else {
+      return getNoOverflow(valueBuffer,index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -74,7 +74,7 @@ public class UInt2Vector extends BaseFixedWidthVector {
    * @param index position of the element.
    * @return value stored at the index.
    */
-  public static long get(final ArrowBuf buffer, final int index) {
+  public static char get(final ArrowBuf buffer, final int index) {
     return buffer.getChar(index * TYPE_WIDTH);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -64,23 +64,18 @@ public class UInt2Vector extends BaseFixedWidthVector {
    |          vector value retrieval methods                        |
    |                                                                |
    *----------------------------------------------------------------*/
-
   /**
    * Given a data buffer, get the value stored at a particular position
    * in the vector.
    *
-   * <p>To avoid overflow, the returned type is one step up from the signed
-   * type.
-   *
-   * <p>This method should not be used externally.
+   * <p>This method is mainly meant for integration tests.
    *
    * @param buffer data buffer
    * @param index position of the element.
    * @return value stored at the index.
    */
-  public static int getNoOverflow(final ArrowBuf buffer, final int index) {
-    int s =  buffer.getShort(index * TYPE_WIDTH);
-    return 0xFFFF & s;
+  public static long get(final ArrowBuf buffer, final int index) {
+    return buffer.getChar(index * TYPE_WIDTH);
   }
 
   /**
@@ -123,20 +118,6 @@ public class UInt2Vector extends BaseFixedWidthVector {
       return null;
     } else {
       return valueBuffer.getChar(index * TYPE_WIDTH);
-    }
-  }
-
-  /**
-   * Same as {@link #get(int)}.
-   *
-   * @param index   position of element
-   * @return element at given index
-   */
-  public Integer getObjectNoOverflow(int index) {
-    if (isSet(index) == 0) {
-      return null;
-    } else {
-      return getNoOverflow(valueBuffer,index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -28,6 +28,8 @@ import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 
+import io.netty.buffer.ArrowBuf;
+
 /**
  * UInt4Vector implements a fixed width (4 bytes) vector of
  * integer values which could be null. A validity buffer (bit vector) is
@@ -62,7 +64,23 @@ public class UInt4Vector extends BaseFixedWidthVector {
    |          vector value retrieval methods                        |
    |                                                                |
    *----------------------------------------------------------------*/
-
+  /**
+   * Given a data buffer, get the value stored at a particular position
+   * in the vector.
+   *
+   * <p>To avoid overflow, the returned type is one step up from the signed
+   * type.
+   *
+   * <p>This method should not be used externally.
+   *
+   * @param buffer data buffer
+   * @param index position of the element.
+   * @return value stored at the index.
+   */
+  public static long getNoOverflow(final ArrowBuf buffer, final int index) {
+    long l =  buffer.getInt(index * TYPE_WIDTH);
+    return ((long)0xFFFFFFFF) & l;
+  }
 
   /**
    * Get the element at the given index from the vector.
@@ -104,6 +122,20 @@ public class UInt4Vector extends BaseFixedWidthVector {
       return null;
     } else {
       return valueBuffer.getInt(index * TYPE_WIDTH);
+    }
+  }
+
+  /**
+   * Same as {@link #get(int)}.
+   *
+   * @param index   position of element
+   * @return element at given index
+   */
+  public Long getObjectNoOverflow(int index) {
+    if (isSet(index) == 0) {
+      return null;
+    } else {
+      return getNoOverflow(valueBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -71,7 +71,7 @@ public class UInt4Vector extends BaseFixedWidthVector {
    * <p>To avoid overflow, the returned type is one step up from the signed
    * type.
    *
-   * <p>This method should not be used externally.
+   * <p>This method is mainly meant for integration tests.
    *
    * @param buffer data buffer
    * @param index position of the element.

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -75,7 +75,7 @@ public class UInt8Vector extends BaseFixedWidthVector {
    * <p>To avoid overflow, the returned type is one step up from the signed
    * type.
    *
-   * <p>This method should not be used externally.
+   * <p>This method is mainly meant for integration tests.
    *
    * @param buffer data buffer
    * @param index position of the element.

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -19,6 +19,8 @@ package org.apache.arrow.vector;
 
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
+import java.math.BigInteger;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.impl.UInt8ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -27,6 +29,8 @@ import org.apache.arrow.vector.holders.UInt8Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+
+import io.netty.buffer.ArrowBuf;
 
 /**
  * UInt8Vector implements a fixed width vector (8 bytes) of
@@ -62,6 +66,25 @@ public class UInt8Vector extends BaseFixedWidthVector {
    |          vector value retrieval methods                        |
    |                                                                |
    *----------------------------------------------------------------*/
+  private static final BigInteger SAFE_CONVERSION_MASK = new BigInteger("ffffffffffffffff", 16);
+
+  /**
+   * Given a data buffer, get the value stored at a particular position
+   * in the vector.
+   *
+   * <p>To avoid overflow, the returned type is one step up from the signed
+   * type.
+   *
+   * <p>This method should not be used externally.
+   *
+   * @param buffer data buffer
+   * @param index position of the element.
+   * @return value stored at the index.
+   */
+  public static BigInteger getNoOverflow(final ArrowBuf buffer, final int index) {
+    BigInteger l =  BigInteger.valueOf(buffer.getLong(index * TYPE_WIDTH));
+    return SAFE_CONVERSION_MASK.and(l);
+  }
 
 
   /**
@@ -104,6 +127,20 @@ public class UInt8Vector extends BaseFixedWidthVector {
       return null;
     } else {
       return valueBuffer.getLong(index * TYPE_WIDTH);
+    }
+  }
+
+  /**
+   * Returns the value stored at index without the potential for overflow.
+   *
+   * @param index   position of element
+   * @return element at given index
+   */
+  public BigInteger getObjectNoOverflow(int index) {
+    if (isSet(index) == 0) {
+      return null;
+    } else {
+      return getNoOverflow(valueBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -58,6 +58,10 @@ import org.apache.arrow.vector.TimeStampSecTZVector;
 import org.apache.arrow.vector.TimeStampSecVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.TypeLayout;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
@@ -270,6 +274,18 @@ public class JsonFileWriter implements AutoCloseable {
           break;
         case BIGINT:
           generator.writeNumber(BigIntVector.get(buffer, index));
+          break;
+        case UINT1:
+          generator.writeNumber(UInt1Vector.getNoOverflow(buffer, index));
+          break;
+        case UINT2:
+          generator.writeNumber(UInt2Vector.getNoOverflow(buffer, index));
+          break;
+        case UINT4:
+          generator.writeNumber(UInt4Vector.getNoOverflow(buffer, index));
+          break;
+        case UINT8:
+          generator.writeNumber(UInt8Vector.getNoOverflow(buffer, index));
           break;
         case FLOAT4:
           generator.writeNumber(Float4Vector.get(buffer, index));

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -279,7 +279,7 @@ public class JsonFileWriter implements AutoCloseable {
           generator.writeNumber(UInt1Vector.getNoOverflow(buffer, index));
           break;
         case UINT2:
-          generator.writeNumber(UInt2Vector.getNoOverflow(buffer, index));
+          generator.writeNumber(UInt2Vector.get(buffer, index));
           break;
         case UINT4:
           generator.writeNumber(UInt4Vector.getNoOverflow(buffer, index));

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -40,6 +40,10 @@ import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -59,6 +63,10 @@ import org.apache.arrow.vector.complex.writer.TimeMilliWriter;
 import org.apache.arrow.vector.complex.writer.TimeStampMilliTZWriter;
 import org.apache.arrow.vector.complex.writer.TimeStampMilliWriter;
 import org.apache.arrow.vector.complex.writer.TimeStampNanoWriter;
+import org.apache.arrow.vector.complex.writer.UInt1Writer;
+import org.apache.arrow.vector.complex.writer.UInt2Writer;
+import org.apache.arrow.vector.complex.writer.UInt4Writer;
+import org.apache.arrow.vector.complex.writer.UInt8Writer;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
@@ -94,15 +102,37 @@ public class BaseFileTest {
     allocator.close();
   }
 
+
+  private static short [] uint1Values = new short[]{0, 255, 1, 128, 2};
+  private static int [] uint2Values = new int[]{0, Short.MAX_VALUE + 1, 1, Short.MAX_VALUE * 2, 2};
+  private static long [] uint4Values = new long[]{0, Integer.MAX_VALUE + 1, 1, Integer.MAX_VALUE * 2, 2};
+  private static BigInteger[] uint8Values = new BigInteger[]{BigInteger.valueOf(0),
+      BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(2)), BigInteger.valueOf(2),
+      BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.valueOf(1)), BigInteger.valueOf(2)};
+
   protected void writeData(int count, StructVector parent) {
     ComplexWriter writer = new ComplexWriterImpl("root", parent);
     StructWriter rootWriter = writer.rootAsStruct();
     IntWriter intWriter = rootWriter.integer("int");
+    UInt1Writer uint1Writer = rootWriter.uInt1("uint1");
+    UInt2Writer uint2Writer = rootWriter.uInt2("uint2");
+    UInt4Writer uint4Writer = rootWriter.uInt4("uint4");
+    UInt8Writer uint8Writer = rootWriter.uInt8("uint8");
     BigIntWriter bigIntWriter = rootWriter.bigInt("bigInt");
     Float4Writer float4Writer = rootWriter.float4("float");
     for (int i = 0; i < count; i++) {
       intWriter.setPosition(i);
       intWriter.writeInt(i);
+      uint1Writer.setPosition(i);
+      // TODO: Fix add safe write methods on uint methods.
+      uint1Writer.setPosition(i);
+      uint1Writer.writeUInt1((byte)uint1Values[i % uint1Values.length] );
+      uint2Writer.setPosition(i);
+      uint2Writer.writeUInt2((char)uint2Values[i % uint2Values.length] );
+      uint4Writer.setPosition(i);
+      uint4Writer.writeUInt4((int)uint4Values[i % uint4Values.length] );
+      uint8Writer.setPosition(i);
+      uint8Writer.writeUInt8(uint8Values[i % uint8Values.length].longValue());
       bigIntWriter.setPosition(i);
       bigIntWriter.writeBigInt(i);
       float4Writer.setPosition(i);
@@ -111,9 +141,18 @@ public class BaseFileTest {
     writer.setValueCount(count);
   }
 
+
   protected void validateContent(int count, VectorSchemaRoot root) {
     for (int i = 0; i < count; i++) {
       Assert.assertEquals(i, root.getVector("int").getObject(i));
+      Assert.assertEquals((Short)uint1Values[i % uint1Values.length],
+          ((UInt1Vector)root.getVector("uint1")).getObjectNoOverflow(i));
+      Assert.assertEquals("Failed for index: " + i, (Integer)uint2Values[i % uint8Values.length],
+          ((UInt2Vector)root.getVector("uint2")).getObjectNoOverflow(i));
+      Assert.assertEquals("Failed for index: " + i, (Long)uint4Values[i % uint8Values.length],
+          ((UInt4Vector)root.getVector("uint4")).getObjectNoOverflow(i));
+      Assert.assertEquals("Failed for index: " + i, uint8Values[i % uint8Values.length],
+          ((UInt8Vector)root.getVector("uint8")).getObjectNoOverflow(i));
       Assert.assertEquals(Long.valueOf(i), root.getVector("bigInt").getObject(i));
       Assert.assertEquals(i == 0 ? Float.NaN : i, root.getVector("float").getObject(i));
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -104,7 +104,7 @@ public class BaseFileTest {
 
 
   private static short [] uint1Values = new short[]{0, 255, 1, 128, 2};
-  private static int [] uint2Values = new int[]{0, Short.MAX_VALUE + 1, 1, Short.MAX_VALUE * 2, 2};
+  private static char [] uint2Values = new char[]{0, Character.MAX_VALUE, 1, Short.MAX_VALUE * 2, 2};
   private static long [] uint4Values = new long[]{0, Integer.MAX_VALUE + 1, 1, Integer.MAX_VALUE * 2, 2};
   private static BigInteger[] uint8Values = new BigInteger[]{BigInteger.valueOf(0),
       BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(2)), BigInteger.valueOf(2),
@@ -147,9 +147,9 @@ public class BaseFileTest {
       Assert.assertEquals(i, root.getVector("int").getObject(i));
       Assert.assertEquals((Short)uint1Values[i % uint1Values.length],
           ((UInt1Vector)root.getVector("uint1")).getObjectNoOverflow(i));
-      Assert.assertEquals("Failed for index: " + i, (Integer)uint2Values[i % uint8Values.length],
-          ((UInt2Vector)root.getVector("uint2")).getObjectNoOverflow(i));
-      Assert.assertEquals("Failed for index: " + i, (Long)uint4Values[i % uint8Values.length],
+      Assert.assertEquals("Failed for index: " + i, (Character)uint2Values[i % uint2Values.length],
+          (Character)((UInt2Vector)root.getVector("uint2")).get(i));
+      Assert.assertEquals("Failed for index: " + i, (Long)uint4Values[i % uint4Values.length],
           ((UInt4Vector)root.getVector("uint4")).getObjectNoOverflow(i));
       Assert.assertEquals("Failed for index: " + i, uint8Values[i % uint8Values.length],
           ((UInt8Vector)root.getVector("uint8")).getObjectNoOverflow(i));


### PR DESCRIPTION
- Show unsigned values can be round-tripped between java and C++
  in integration tests.  This doesn't fully fix the problem because
  the UInt* APIs are mostly wrong because they can't represent the
  full range of unsigned values (return types are all too small
  because java only has signed types).

- While I was at it, I fixed the issue with no batches.