### PR TITLE
ARROW-5430: [Python] Raise ArrowInvalid for pyints larger than int64

### DIFF
--- a/cpp/src/arrow/python/common.cc
+++ b/cpp/src/arrow/python/common.cc
@@ -113,7 +113,8 @@ Status ConvertPyError(StatusCode code) {
       code = StatusCode::KeyError;
     } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_TypeError)) {
       code = StatusCode::TypeError;
-    } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_ValueError)) {
+    } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_ValueError) ||
+               PyErr_GivenExceptionMatches(exc_type, PyExc_OverflowError)) {
       code = StatusCode::Invalid;
     } else if (PyErr_GivenExceptionMatches(exc_type, PyExc_EnvironmentError)) {
       code = StatusCode::IOError;

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1374,3 +1374,10 @@ def test_numpy_string_overflow_to_chunked():
         for val in chunk:
             assert val.as_py() == values[value_index]
             value_index += 1
+
+
+def test_array_from_large_pyints():
+    # ARROW-5430
+    with pytest.raises(pa.ArrowInvalid):
+        # too large for int64 so dtype must be explicitly provided
+        pa.array([int(2 ** 63)])


### PR DESCRIPTION
Previously, this case would cause ArrowException: Unknown error, but ArrowInvalid makes more sense and is more likely to be dealt with by callers of pyarrow.array.