### PR TITLE
ARROW-5476: [Java][Memory] Fix Netty Arrow Buf.

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -106,7 +106,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
 
   @Override
   public ByteBuf unwrap() {
-    throw new UnsupportedOperationException("Operation not supported");
+    return arrowBuf.getReferenceManager().getUnderlying();
   }
 
   @Override
@@ -224,17 +224,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
   @Override
   public ByteBuffer nioBuffer(int index, int length) {
     chk(index, length);
-    final ByteBuffer buffer = getDirectBuffer();
-    buffer.position(index).limit(index + length);
-    return buffer;
-  }
-
-  /**
-   * Get this ArrowBuf as a direct {@link ByteBuffer}.
-   * @return ByteBuffer
-   */
-  private ByteBuffer getDirectBuffer() {
-    return PlatformDependent.directBuffer(address, length);
+    UnsafeDirectLittleEndian underlying = arrowBuf.getReferenceManager().getUnderlying();
+    return underlying.nioBuffer((int)(address - underlying.memoryAddress()) + index, length);
   }
 
   @Override
@@ -335,8 +326,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
     if (length == 0) {
       return 0;
     } else {
-      final ByteBuffer tmpBuf = getDirectBuffer();
-      tmpBuf.clear().position(index).limit(index + length);
+      final ByteBuffer tmpBuf = nioBuffer(index, length);
+      tmpBuf.clear();
       return out.write(tmpBuf);
     }
   }
@@ -347,8 +338,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
     if (length == 0) {
       return 0;
     } else {
-      final ByteBuffer tmpBuf = getDirectBuffer();
-      tmpBuf.clear().position(index).limit(index + length);
+      final ByteBuffer tmpBuf = nioBuffer(index, length);
+      tmpBuf.clear();
       return out.write(tmpBuf, position);
     }
   }

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -234,7 +234,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
    * @return ByteBuffer
    */
   private ByteBuffer getDirectBuffer(int index) {
-    return PlatformDependent.directBuffer(addr(index), length);
+    return PlatformDependent.directBuffer(addr(index), length - index);
   }
 
   @Override

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -205,7 +205,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
   public ByteBuffer internalNioBuffer(int index, int length) {
     ByteBuffer nioBuf =  getDirectBuffer(index);
     // Follows convention from other ByteBuf implementations.
-    return (ByteBuffer)nioBuf.clear().position(index).limit(index + length);
+    return (ByteBuffer)nioBuf.clear().limit(length);
   }
 
   @Override

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -106,7 +106,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
 
   @Override
   public ByteBuf unwrap() {
-    return arrowBuf.getReferenceManager().getUnderlying();
+    throw new UnsupportedOperationException("Unwrap not supported.");
   }
 
   @Override
@@ -224,8 +224,17 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
   @Override
   public ByteBuffer nioBuffer(int index, int length) {
     chk(index, length);
-    UnsafeDirectLittleEndian underlying = arrowBuf.getReferenceManager().getUnderlying();
-    return underlying.nioBuffer((int)(address - underlying.memoryAddress()) + index, length);
+    final ByteBuffer buffer = getDirectBuffer(index);
+    buffer.limit(length);
+    return buffer;
+  }
+
+  /**
+   * Get this ArrowBuf as a direct {@link ByteBuffer}.
+   * @return ByteBuffer
+   */
+  private ByteBuffer getDirectBuffer(int index) {
+    return PlatformDependent.directBuffer(addr(index), length);
   }
 
   @Override
@@ -326,8 +335,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
     if (length == 0) {
       return 0;
     } else {
-      final ByteBuffer tmpBuf = nioBuffer(index, length);
-      tmpBuf.clear();
+      final ByteBuffer tmpBuf = getDirectBuffer(index);
+      tmpBuf.clear().limit(length);
       return out.write(tmpBuf);
     }
   }
@@ -338,8 +347,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
     if (length == 0) {
       return 0;
     } else {
-      final ByteBuffer tmpBuf = nioBuffer(index, length);
-      tmpBuf.clear();
+      final ByteBuffer tmpBuf = getDirectBuffer(index );
+      tmpBuf.clear().limit(length);
       return out.write(tmpBuf, position);
     }
   }

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -204,6 +204,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
   @Override
   public ByteBuffer internalNioBuffer(int index, int length) {
     ByteBuffer nioBuf =  getDirectBuffer(index);
+    // Follows convention from other ByteBuf implementations.
     return (ByteBuffer)nioBuf.clear().position(index).limit(index + length);
   }
 
@@ -223,6 +224,10 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
   }
 
   @Override
+  /**
+   * Returns a buffer that is zero positioned but points
+   * to a slice of the original buffer starting at given index.
+   */
   public ByteBuffer nioBuffer(int index, int length) {
     chk(index, length);
     final ByteBuffer buffer = getDirectBuffer(index);

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -161,7 +161,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable  {
 
   @Override
   public NettyArrowBuf slice() {
-    return arrowBuf.slice().asNettyBuffer();
+    return arrowBuf.slice(readerIndex, writerIndex - readerIndex).asNettyBuffer();
   }
 
   @Override

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -523,7 +523,6 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     }
   }
 
-  @Override
   public UnsafeDirectLittleEndian getUnderlying() {
     return allocationManager.getMemoryChunk();
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -523,6 +523,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     }
   }
 
+  @Override
   public UnsafeDirectLittleEndian getUnderlying() {
     return allocationManager.getMemoryChunk();
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
@@ -19,7 +19,6 @@ package org.apache.arrow.memory;
 
 
 import io.netty.buffer.ArrowBuf;
-import io.netty.buffer.UnsafeDirectLittleEndian;
 
 /**
  * Reference Manager manages one or more ArrowBufs that share the

--- a/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
@@ -122,8 +122,6 @@ public interface ReferenceManager {
 
   public static String NO_OP_ERROR_MESSAGE = "Operation not supported on NO_OP Reference Manager";
 
-  UnsafeDirectLittleEndian getUnderlying();
-
   // currently used for empty ArrowBufs
   ReferenceManager NO_OP = new ReferenceManager() {
     @Override
@@ -177,9 +175,5 @@ public interface ReferenceManager {
       return 0;
     }
 
-    @Override
-    public UnsafeDirectLittleEndian getUnderlying() {
-      return null;
-    }
   };
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
@@ -19,6 +19,7 @@ package org.apache.arrow.memory;
 
 
 import io.netty.buffer.ArrowBuf;
+import io.netty.buffer.UnsafeDirectLittleEndian;
 
 /**
  * Reference Manager manages one or more ArrowBufs that share the
@@ -121,6 +122,8 @@ public interface ReferenceManager {
 
   public static String NO_OP_ERROR_MESSAGE = "Operation not supported on NO_OP Reference Manager";
 
+  UnsafeDirectLittleEndian getUnderlying();
+
   // currently used for empty ArrowBufs
   ReferenceManager NO_OP = new ReferenceManager() {
     @Override
@@ -172,6 +175,11 @@ public interface ReferenceManager {
     @Override
     public int getAccountedSize() {
       return 0;
+    }
+
+    @Override
+    public UnsafeDirectLittleEndian getUnderlying() {
+      return null;
     }
   };
 }

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -39,16 +39,6 @@ public class TestNettyArrowBuf {
   }
 
   @Test
-  public void testUnWrap() {
-    try (BufferAllocator allocator = new RootAllocator(128);
-         ArrowBuf buf = allocator.buffer(20);
-    ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
-      Assert.assertNotNull(nettyBuf.unwrap());
-    }
-  }
-
-  @Test
   public void testNioBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -37,4 +37,24 @@ public class TestNettyArrowBuf {
       Assert.assertEquals(10, readableBytes);
     }
   }
+
+  @Test
+  public void testUnWrap() {
+    try (BufferAllocator allocator = new RootAllocator(128);
+         ArrowBuf buf = allocator.buffer(20);
+    ) {
+      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      Assert.assertNotNull(nettyBuf.unwrap());
+    }
+  }
+
+  @Test
+  public void testNioBuffer() {
+    try (BufferAllocator allocator = new RootAllocator(128);
+         ArrowBuf buf = allocator.buffer(20);
+    ) {
+      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      Assert.assertNotNull(nettyBuf.nioBuffer(4 ,6));
+    }
+  }
 }

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -17,6 +17,8 @@
 
 package io.netty.buffer;
 
+import java.nio.ByteBuffer;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Assert;
@@ -44,7 +46,11 @@ public class TestNettyArrowBuf {
          ArrowBuf buf = allocator.buffer(20);
     ) {
       NettyArrowBuf nettyBuf = buf.asNettyBuffer();
-      Assert.assertNotNull(nettyBuf.nioBuffer(4 ,6));
+      ByteBuffer byteBuffer = nettyBuf.nioBuffer(4 ,6);
+      // Nio Buffers should always be 0 indexed
+      Assert.assertEquals(0, byteBuffer.position());
+      Assert.assertEquals(6, byteBuffer.limit());
+
     }
   }
 }

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netty.buffer;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestNettyArrowBuf {
+
+  @Test
+  public void testSliceWithoutArgs() {
+    try (BufferAllocator allocator = new RootAllocator(128);
+         ArrowBuf buf = allocator.buffer(20);
+    ) {
+      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      nettyBuf.writerIndex(20);
+      nettyBuf.readerIndex(10);
+      NettyArrowBuf slicedBuffer = nettyBuf.slice();
+      int readableBytes = slicedBuffer.readableBytes();
+      Assert.assertEquals(10, readableBytes);
+    }
+  }
+}

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -50,6 +50,8 @@ public class TestNettyArrowBuf {
       // Nio Buffers should always be 0 indexed
       Assert.assertEquals(0, byteBuffer.position());
       Assert.assertEquals(6, byteBuffer.limit());
+      // Underlying buffer has size 32 excluding 4 should have capacity of 28.
+      Assert.assertEquals(28, byteBuffer.capacity());
 
     }
   }

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -64,8 +64,8 @@ public class TestNettyArrowBuf {
     ) {
       NettyArrowBuf nettyBuf = buf.asNettyBuffer();
       ByteBuffer byteBuffer = nettyBuf.internalNioBuffer(4, 6);
-      Assert.assertEquals(4, byteBuffer.position());
-      Assert.assertEquals(10, byteBuffer.limit());
+      Assert.assertEquals(0, byteBuffer.position());
+      Assert.assertEquals(6, byteBuffer.limit());
       // Underlying buffer has size 32 excluding 4 should have capacity of 28.
       Assert.assertEquals(28, byteBuffer.capacity());
 
@@ -78,17 +78,24 @@ public class TestNettyArrowBuf {
          ArrowBuf buf = allocator.buffer(20);
     ) {
       NettyArrowBuf nettyBuf = buf.asNettyBuffer();
-      int intValue = 1;
-      nettyBuf._setInt(0, intValue);
-      Assert.assertEquals(nettyBuf._getIntLE(0), Integer.reverseBytes(intValue));
+      int [] intVals = new int[] {Integer.MIN_VALUE, Short.MIN_VALUE - 1,  Short.MIN_VALUE, 0 ,
+        Short.MAX_VALUE , Short.MAX_VALUE + 1, Integer.MAX_VALUE};
+      for (int intValue :intVals ) {
+        nettyBuf._setInt(0, intValue);
+        Assert.assertEquals(nettyBuf._getIntLE(0), Integer.reverseBytes(intValue));
+      }
 
-      long longValue = 1;
-      nettyBuf._setLong(0, longValue);
-      Assert.assertEquals(nettyBuf._getLongLE(0), Long.reverseBytes(longValue));
+      long [] longVals = new long[] {Long.MIN_VALUE, 0 , Long.MAX_VALUE};
+      for (long longValue :longVals ) {
+        nettyBuf._setLong(0, longValue);
+        Assert.assertEquals(nettyBuf._getLongLE(0), Long.reverseBytes(longValue));
+      }
 
-      short shortValue = 2;
-      nettyBuf._setShort(0, shortValue);
-      Assert.assertEquals(nettyBuf._getShortLE(0), Short.reverseBytes(shortValue));
+      short [] shortVals = new short[] {Short.MIN_VALUE, 0 , Short.MAX_VALUE};
+      for (short shortValue :shortVals ) {
+        nettyBuf._setShort(0, shortValue);
+        Assert.assertEquals(nettyBuf._getShortLE(0), Short.reverseBytes(shortValue));
+      }
     }
   }
 

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -17,7 +17,6 @@
 
 package io.netty.buffer;
 
-import java.awt.*;
 import java.nio.ByteBuffer;
 
 import org.apache.arrow.memory.ArrowByteBufAllocator;


### PR DESCRIPTION
- Fixes the slice to use indexes in netty arrow buf, arrow buffer may not track the right indexes.