### PR TITLE
ARROW-5020: [CI] Split Gandiva-related packages into separate .yml file

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -104,7 +104,7 @@ set CONDA_PACKAGES=--file=ci\conda_env_python.yml python=%PYTHON% numpy=1.14 boo
 
 if "%ARROW_BUILD_GANDIVA%" == "ON" (
   @rem Install llvmdev in the toolchain if building gandiva.dll
-  set CONDA_PACKAGES=%CONDA_PACKAGES% llvmdev=%ARROW_LLVM_VERSION% clangdev=%ARROW_LLVM_VERSION%
+  set CONDA_PACKAGES=%CONDA_PACKAGES% --file=ci\conda_env_gandiva.yml
 )
 
 if "%JOB%" == "Toolchain" (

--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -28,15 +28,12 @@ glog
 gmock>=1.8.1
 grpc-cpp
 gtest>=1.8.1
-clangdev=7
-llvmdev=7
 libprotobuf
 lz4-c
 ninja
 pkg-config
 python
 rapidjson
-re2
 snappy
 thrift-cpp>=0.11.0
 zlib

--- a/ci/conda_env_gandiva.yml
+++ b/ci/conda_env_gandiva.yml
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,23 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
-
-source $TRAVIS_BUILD_DIR/ci/travis_install_conda.sh
-
-if [ ! -e $CPP_TOOLCHAIN ]; then
-    CONDA_PACKAGES=""
-
-    if [ "$ARROW_TRAVIS_GANDIVA" == "1" ]; then
-        CONDA_PACKAGES="$CONDA_PACKAGES --file=$TRAVIS_BUILD_DIR/ci/conda_env_gandiva.yml"
-    fi
-
-    # Set up C++ toolchain from conda-forge packages for faster builds
-    time conda create -y -q -p $CPP_TOOLCHAIN \
-        --file=$TRAVIS_BUILD_DIR/ci/conda_env_cpp.yml \
-        --file=$TRAVIS_BUILD_DIR/ci/conda_env_unix.yml \
-        $CONDA_PACKAGES \
-        compilers \
-        nomkl \
-        python=3.6
-fi
+clangdev=7
+llvmdev=7
+re2

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -38,20 +38,28 @@ CONDA_ENV_DIR=$TRAVIS_BUILD_DIR/pyarrow-test-$PYTHON_VERSION
 # may not have NumPy (which is required for python-test)
 export ZLIB_HOME=$CONDA_ENV_DIR
 
+CONDA_FILES=""
+CONDA_PACKAGES=""
+
+if [ "$ARROW_TRAVIS_PYTHON_GANDIVA" == "1" ]; then
+    CONDA_FILES="$CONDA_FILES --file=$TRAVIS_BUILD_DIR/ci/conda_env_gandiva.yml"
+fi
+
 if [ "$ARROW_TRAVIS_PYTHON_JVM" == "1" ]; then
-  CONDA_JVM_DEPS="jpype1"
+    CONDA_PACKAGES="$CONDA_PACKAGES jpype1"
 fi
 
 conda create -y -q -p $CONDA_ENV_DIR \
       --file $TRAVIS_BUILD_DIR/ci/conda_env_cpp.yml \
       --file $TRAVIS_BUILD_DIR/ci/conda_env_python.yml \
+      ${CONDA_FILES} \
       nomkl \
       pip \
       numpy=1.14 \
       'libgfortran<4' \
       python=${PYTHON_VERSION} \
       compilers \
-      ${CONDA_JVM_DEPS}
+      ${CONDA_PACKAGES}
 
 conda activate $CONDA_ENV_DIR
 


### PR DESCRIPTION
Avoid installing heavy packages such as clangdev and llvmdev if not building Gandiva.