### PR TITLE
[Format] Fix typo in Sparse Union Type example

### DIFF
--- a/docs/source/format/Layout.rst
+++ b/docs/source/format/Layout.rst
@@ -643,7 +643,7 @@ will have the following layout: ::
           * Length: 7,  Null count: 0
           * Null bitmap buffer: Not required
 
-            | Bytes 0-7  | Bytes 8-63            |
+            | Bytes 0-6  | Bytes 7-63            |
             |------------|-----------------------|
             | joemark    | unspecified (padding) |
 


### PR DESCRIPTION
There is a minor error in the "joemark" string/byte layout in that it only stretches to byte 6 (and not 7).