### PR TITLE
ARROW-5496: [R][CI] Fix relative paths in R codecov.io reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -360,7 +360,7 @@ matrix:
     - export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib/pkgconfig
     - pushd ${TRAVIS_BUILD_DIR}/r
     after_success:
-    - Rscript -e 'covr::codecov()'
+    - Rscript ../ci/travis_upload_r_coverage.R
 
 
 after_failure:

--- a/ci/travis_upload_r_coverage.R
+++ b/ci/travis_upload_r_coverage.R
@@ -1,0 +1,7 @@
+library(covr)
+# Hack file paths to include the subdirectory
+trace("to_codecov", quote(per_line <- function(x) {
+   out <- covr:::per_line(x)
+   setNames(out, paste0("r/", names(out)))
+ }), where = package_coverage)
+codecov()

--- a/ci/travis_upload_r_coverage.R
+++ b/ci/travis_upload_r_coverage.R
@@ -1,3 +1,22 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(covr)
 # Hack file paths to include the subdirectory
 trace("to_codecov", quote(per_line <- function(x) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5418 added coverage stats for R, but due to an assumption in the coverage runner that the project would be at the top level of the GitHub repository, the `r/` subdirectory was not included, so R coverage stats were put in the wrong place, and detail files (such as https://codecov.io/gh/apache/arrow/src/master/R/ArrayData.R) return 404. 

This works around the issue (a proper fix belongs in the `covr` package, but I'll leave that for another time). You can see [here](https://codecov.io/gh/nealrichardson/arrow/tree/8ce221555a07ecff0fc173816df1ed7d946c38d7/r) that the R files are grouped appropriately in the `r/` subdir, and links to file details work: https://codecov.io/gh/nealrichardson/arrow/src/8ce221555a07ecff0fc173816df1ed7d946c38d7/r/R/ArrayData.R