### PR TITLE
ARROW-5334: [C++] Ensure all type classes end with "Type"

### DIFF
--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -60,13 +60,13 @@ namespace ipc {
 namespace internal {
 namespace json {
 
-static std::string GetFloatingPrecisionName(FloatingPoint::Precision precision) {
+static std::string GetFloatingPrecisionName(FloatingPointType::Precision precision) {
   switch (precision) {
-    case FloatingPoint::HALF:
+    case FloatingPointType::HALF:
       return "HALF";
-    case FloatingPoint::SINGLE:
+    case FloatingPointType::SINGLE:
       return "SINGLE";
-    case FloatingPoint::DOUBLE:
+    case FloatingPointType::DOUBLE:
       return "DOUBLE";
     default:
       break;
@@ -170,14 +170,14 @@ class SchemaWriter {
                           void>::type
   WriteTypeMetadata(const T& type) {}
 
-  void WriteTypeMetadata(const Integer& type) {
+  void WriteTypeMetadata(const IntegerType& type) {
     writer_->Key("bitWidth");
     writer_->Int(type.bit_width());
     writer_->Key("isSigned");
     writer_->Bool(type.is_signed());
   }
 
-  void WriteTypeMetadata(const FloatingPoint& type) {
+  void WriteTypeMetadata(const FloatingPointType& type) {
     writer_->Key("precision");
     writer_->String(GetFloatingPrecisionName(type.precision()));
   }
@@ -297,9 +297,9 @@ class SchemaWriter {
 
   Status Visit(const NullType& type) { return WritePrimitive("null", type); }
   Status Visit(const BooleanType& type) { return WritePrimitive("bool", type); }
-  Status Visit(const Integer& type) { return WritePrimitive("int", type); }
+  Status Visit(const IntegerType& type) { return WritePrimitive("int", type); }
 
-  Status Visit(const FloatingPoint& type) {
+  Status Visit(const FloatingPointType& type) {
     return WritePrimitive("floatingpoint", type);
   }
 

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -100,7 +100,7 @@ Status Kind::ForType(const DataType& type, Kind::type* kind) {
   struct {
     Status Visit(const NullType&) { return SetKind(Kind::kNull); }
     Status Visit(const BooleanType&) { return SetKind(Kind::kBoolean); }
-    Status Visit(const Number&) { return SetKind(Kind::kNumber); }
+    Status Visit(const NumberType&) { return SetKind(Kind::kNumber); }
     Status Visit(const TimeType&) { return SetKind(Kind::kNumber); }
     Status Visit(const DateType&) { return SetKind(Kind::kNumber); }
     Status Visit(const BinaryType&) { return SetKind(Kind::kString); }

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1662,8 +1662,8 @@ class ArrowDeserializer {
   // types
 
   template <typename Type>
-  typename std::enable_if<std::is_base_of<FloatingPoint, Type>::value, Status>::type
-  Visit(const Type& type) {
+  typename std::enable_if<is_floating_type<Type>::value, Status>::type Visit(
+      const Type& type) {
     constexpr int TYPE = Type::type_id;
     using traits = internal::arrow_traits<TYPE>;
 
@@ -1755,7 +1755,7 @@ class ArrowDeserializer {
 
   // Integer specialization
   template <typename Type>
-  typename std::enable_if<std::is_base_of<Integer, Type>::value, Status>::type Visit(
+  typename std::enable_if<is_integer_type<Type>::value, Status>::type Visit(
       const Type& type) {
     constexpr int TYPE = Type::type_id;
     using traits = internal::arrow_traits<TYPE>;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -127,11 +127,17 @@ std::ostream& operator<<(std::ostream& os, const DataType& type) {
 
 std::string BooleanType::ToString() const { return name(); }
 
-FloatingPoint::Precision HalfFloatType::precision() const { return FloatingPoint::HALF; }
+FloatingPointType::Precision HalfFloatType::precision() const {
+  return FloatingPointType::HALF;
+}
 
-FloatingPoint::Precision FloatType::precision() const { return FloatingPoint::SINGLE; }
+FloatingPointType::Precision FloatType::precision() const {
+  return FloatingPointType::SINGLE;
+}
 
-FloatingPoint::Precision DoubleType::precision() const { return FloatingPoint::DOUBLE; }
+FloatingPointType::Precision DoubleType::precision() const {
+  return FloatingPointType::DOUBLE;
+}
 
 std::string StringType::ToString() const { return std::string("string"); }
 
@@ -386,7 +392,7 @@ DictionaryType::DictionaryType(const std::shared_ptr<DataType>& index_type,
       value_type_(value_type),
       ordered_(ordered) {
 #ifndef NDEBUG
-  const auto& int_type = checked_cast<const Integer&>(*index_type);
+  const auto& int_type = checked_cast<const IntegerType&>(*index_type);
   DCHECK_EQ(int_type.is_signed(), true) << "dictionary index type should be signed";
 #endif
 }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -215,22 +215,22 @@ class ARROW_EXPORT PrimitiveCType : public FixedWidthType {
 };
 
 /// \brief Base class for all numeric data types
-class ARROW_EXPORT Number : public PrimitiveCType {
+class ARROW_EXPORT NumberType : public PrimitiveCType {
  public:
   using PrimitiveCType::PrimitiveCType;
 };
 
 /// \brief Base class for all integral data types
-class ARROW_EXPORT Integer : public Number {
+class ARROW_EXPORT IntegerType : public NumberType {
  public:
-  using Number::Number;
+  using NumberType::NumberType;
   virtual bool is_signed() const = 0;
 };
 
 /// \brief Base class for all floating-point data types
-class ARROW_EXPORT FloatingPoint : public Number {
+class ARROW_EXPORT FloatingPointType : public NumberType {
  public:
-  using Number::Number;
+  using NumberType::NumberType;
   enum Precision { HALF, SINGLE, DOUBLE };
   virtual Precision precision() const = 0;
 };
@@ -323,7 +323,7 @@ class ARROW_EXPORT CTypeImpl : public BASE {
 };
 
 template <typename DERIVED, Type::type TYPE_ID, typename C_TYPE>
-class IntegerTypeImpl : public detail::CTypeImpl<DERIVED, Integer, TYPE_ID, C_TYPE> {
+class IntegerTypeImpl : public detail::CTypeImpl<DERIVED, IntegerType, TYPE_ID, C_TYPE> {
   bool is_signed() const override { return std::is_signed<C_TYPE>::value; }
 };
 
@@ -412,7 +412,8 @@ class ARROW_EXPORT Int64Type
 
 /// Concrete type class for 16-bit floating-point data
 class ARROW_EXPORT HalfFloatType
-    : public detail::CTypeImpl<HalfFloatType, FloatingPoint, Type::HALF_FLOAT, uint16_t> {
+    : public detail::CTypeImpl<HalfFloatType, FloatingPointType, Type::HALF_FLOAT,
+                               uint16_t> {
  public:
   Precision precision() const override;
   std::string name() const override { return "halffloat"; }
@@ -420,7 +421,7 @@ class ARROW_EXPORT HalfFloatType
 
 /// Concrete type class for 32-bit floating-point data (C "float")
 class ARROW_EXPORT FloatType
-    : public detail::CTypeImpl<FloatType, FloatingPoint, Type::FLOAT, float> {
+    : public detail::CTypeImpl<FloatType, FloatingPointType, Type::FLOAT, float> {
  public:
   Precision precision() const override;
   std::string name() const override { return "float"; }
@@ -428,7 +429,7 @@ class ARROW_EXPORT FloatType
 
 /// Concrete type class for 64-bit floating-point data (C "double")
 class ARROW_EXPORT DoubleType
-    : public detail::CTypeImpl<DoubleType, FloatingPoint, Type::DOUBLE, double> {
+    : public detail::CTypeImpl<DoubleType, FloatingPointType, Type::DOUBLE, double> {
  public:
   Precision precision() const override;
   std::string name() const override { return "double"; }

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -327,13 +327,13 @@ struct TypeTraits<ExtensionType> {
 //
 
 template <typename T>
-using is_number_type = std::is_base_of<Number, T>;
+using is_number_type = std::is_base_of<NumberType, T>;
 
 template <typename T>
-using is_integer_type = std::is_base_of<Integer, T>;
+using is_integer_type = std::is_base_of<IntegerType, T>;
 
 template <typename T>
-using is_floating_type = std::is_base_of<FloatingPoint, T>;
+using is_floating_type = std::is_base_of<FloatingPointType, T>;
 
 template <typename T>
 using is_temporal_type = std::is_base_of<TemporalType, T>;
@@ -361,12 +361,11 @@ using enable_if_primitive_ctype =
     typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value, R>::type;
 
 template <typename T, typename R = void>
-using enable_if_integer =
-    typename std::enable_if<std::is_base_of<Integer, T>::value, R>::type;
+using enable_if_integer = typename std::enable_if<is_integer_type<T>::value, R>::type;
 
 template <typename T>
 using is_signed_integer =
-    std::integral_constant<bool, std::is_base_of<Integer, T>::value &&
+    std::integral_constant<bool, is_integer_type<T>::value &&
                                      std::is_signed<typename T::c_type>::value>;
 
 template <typename T, typename R = void>
@@ -374,14 +373,12 @@ using enable_if_signed_integer =
     typename std::enable_if<is_signed_integer<T>::value, R>::type;
 
 template <typename T, typename R = void>
-using enable_if_unsigned_integer =
-    typename std::enable_if<std::is_base_of<Integer, T>::value &&
-                                std::is_unsigned<typename T::c_type>::value,
-                            R>::type;
+using enable_if_unsigned_integer = typename std::enable_if<
+    is_integer_type<T>::value && std::is_unsigned<typename T::c_type>::value, R>::type;
 
 template <typename T, typename R = void>
 using enable_if_floating_point =
-    typename std::enable_if<std::is_base_of<FloatingPoint, T>::value, R>::type;
+    typename std::enable_if<is_floating_type<T>::value, R>::type;
 
 template <typename T>
 using is_date = std::is_base_of<DateType, T>;


### PR DESCRIPTION
This is for consistency and also for readability ("Integer" or "Number" do not explicitly stand out as *type* classes or instances).