### PR TITLE
ARROW-4723: [Python] Ignore "hidden" files that starts with underscore

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -832,7 +832,8 @@ class ParquetManifest(object):
     def _should_silently_exclude(self, file_name):
         return (file_name.endswith('.crc') or  # Checksums
                 file_name.endswith('_$folder$') or  # HDFS directories in S3
-                file_name.startswith('.') or  # Hidden files
+                file_name.startswith('.') or  # Hidden files starting with .
+                file_name.startswith('_') or  # Hidden files starting with _
                 file_name in EXCLUDED_PARQUET_PATHS)
 
     def _visit_directories(self, level, directories, part_keys):

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1921,7 +1921,7 @@ def test_ignore_private_directories(tempdir):
 
 
 @pytest.mark.pandas
-def test_ignore_hidden_files(tempdir):
+def test_ignore_hidden_files_dot(tempdir):
     dirpath = tempdir / guid()
     dirpath.mkdir()
 
@@ -1933,6 +1933,24 @@ def test_ignore_hidden_files(tempdir):
 
     with (dirpath / '.private').open('wb') as f:
         f.write(b'gibberish')
+
+    dataset = pq.ParquetDataset(dirpath)
+    assert set(map(str, paths)) == set(x.path for x in dataset.pieces)
+
+
+@pytest.mark.pandas
+def test_ignore_hidden_files_underscore(tempdir):
+    dirpath = tempdir / guid()
+    dirpath.mkdir()
+
+    paths = _make_example_multifile_dataset(dirpath, nfiles=10,
+                                            file_nrows=5)
+
+    with (dirpath / '_committed_123').open('wb') as f:
+        f.write(b'abcd')
+
+    with (dirpath / '_started_321').open('wb') as f:
+        f.write(b'abcd')
 
     dataset = pq.ParquetDataset(dirpath)
     assert set(map(str, paths)) == set(x.path for x in dataset.pieces)


### PR DESCRIPTION
This PR proposes to ignore "hidden" files that start with underscore as well. This is a Hadoop convention.