### PR TITLE
ARROW-5528: [C++] Fixed a bug when Concatenate() arrays with no value buffers.

### DIFF
--- a/cpp/src/arrow/array/concatenate-test.cc
+++ b/cpp/src/arrow/array/concatenate-test.cc
@@ -30,7 +30,6 @@
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
-#include "arrow/builder.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/buffer.h"
 #include "arrow/builder.h"

--- a/cpp/src/arrow/array/concatenate-test.cc
+++ b/cpp/src/arrow/array/concatenate-test.cc
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
+#include "arrow/builder.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/buffer.h"
 #include "arrow/status.h"
@@ -108,6 +109,22 @@ class ConcatenateTest : public ::testing::Test {
   std::vector<int32_t> sizes_;
   std::vector<double> null_probabilities_;
 };
+
+TEST(ConcatenateEmptyArraysTest, TestValueBuffersNullPtr) {
+  BinaryBuilder builder;
+  std::shared_ptr<Array> binary_array;
+  ArrayVector inputs;
+  ASSERT_OK(builder.Finish(&binary_array));
+  inputs.push_back(std::move(binary_array));
+  builder.Reset();
+  ASSERT_OK(builder.AppendNull());
+  ASSERT_OK(builder.Finish(&binary_array));
+  inputs.push_back(std::move(binary_array));
+
+  std::shared_ptr<Array> actual;
+  ASSERT_OK(Concatenate(inputs, default_memory_pool(), &actual));
+  AssertArraysEqual(*actual, *inputs[1]);
+}
 
 template <typename PrimitiveType>
 class PrimitiveConcatenateTest : public ConcatenateTest {

--- a/cpp/src/arrow/array/concatenate-test.cc
+++ b/cpp/src/arrow/array/concatenate-test.cc
@@ -111,11 +111,13 @@ class ConcatenateTest : public ::testing::Test {
 };
 
 TEST(ConcatenateEmptyArraysTest, TestValueBuffersNullPtr) {
-  BinaryBuilder builder;
-  std::shared_ptr<Array> binary_array;
   ArrayVector inputs;
+
+  std::shared_ptr<Array> binary_array;
+  BinaryBuilder builder;
   ASSERT_OK(builder.Finish(&binary_array));
   inputs.push_back(std::move(binary_array));
+
   builder.Reset();
   ASSERT_OK(builder.AppendNull());
   ASSERT_OK(builder.Finish(&binary_array));

--- a/cpp/src/arrow/array/concatenate-test.cc
+++ b/cpp/src/arrow/array/concatenate-test.cc
@@ -33,6 +33,7 @@
 #include "arrow/builder.h"
 #include "arrow/array/concatenate.h"
 #include "arrow/buffer.h"
+#include "arrow/builder.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_common.h"
 #include "arrow/testing/random.h"

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -248,11 +248,10 @@ class ConcatenateImpl {
   BufferVector Buffers(size_t index) {
     BufferVector buffers;
     buffers.reserve(in_.size());
-    for (size_t i = 0; i < in_.size(); ++i) {
-      const auto& buffer = in_[i].buffers[index];
-      if (buffer) {
-        buffers.push_back(
-            SliceBuffer(in_[i].buffers[index], in_[i].offset, in_[i].length));
+    for (const ArrayData& array_data : in_) {
+      const auto& buffer = array_data.buffers[index];
+      if (buffer != nullptr) {
+        buffers.push_back(SliceBuffer(buffer, array_data.offset, array_data.length));
       }
     }
     return buffers;
@@ -268,9 +267,8 @@ class ConcatenateImpl {
     buffers.reserve(in_.size());
     for (size_t i = 0; i < in_.size(); ++i) {
       const auto& buffer = in_[i].buffers[index];
-      if (buffer) {
-        buffers.push_back(
-            SliceBuffer(in_[i].buffers[index], ranges[i].offset, ranges[i].length));
+      if (buffer != nullptr) {
+        buffers.push_back(SliceBuffer(buffer, ranges[i].offset, ranges[i].length));
       } else {
         DCHECK_EQ(ranges[i].length, 0);
       }
@@ -288,11 +286,11 @@ class ConcatenateImpl {
     auto byte_width = fixed.bit_width() / 8;
     BufferVector buffers;
     buffers.reserve(in_.size());
-    for (size_t i = 0; i < in_.size(); ++i) {
-      const auto& buffer = in_[i].buffers[index];
-      if (buffer) {
-        buffers.push_back(SliceBuffer(in_[i].buffers[index], in_[i].offset * byte_width,
-                                      in_[i].length * byte_width));
+    for (const ArrayData& array_data : in_) {
+      const auto& buffer = array_data.buffers[index];
+      if (buffer != nullptr) {
+        buffers.push_back(SliceBuffer(buffer, array_data.offset * byte_width,
+                                      array_data.length * byte_width));
       }
     }
     return buffers;

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -270,8 +270,7 @@ class ConcatenateImpl {
       const auto& buffer = in_[i].buffers[index];
       if (buffer) {
         buffers.push_back(
-            SliceBuffer(
-                in_[i].buffers[index], ranges[i].offset, ranges[i].length));
+            SliceBuffer(in_[i].buffers[index], ranges[i].offset, ranges[i].length));
       } else {
         DCHECK_EQ(ranges[i].length, 0);
       }
@@ -292,9 +291,8 @@ class ConcatenateImpl {
     for (size_t i = 0; i < in_.size(); ++i) {
       const auto& buffer = in_[i].buffers[index];
       if (buffer) {
-        buffers.push_back(SliceBuffer(
-            in_[i].buffers[index], in_[i].offset * byte_width,
-            in_[i].length * byte_width));
+        buffers.push_back(SliceBuffer(in_[i].buffers[index], in_[i].offset * byte_width,
+                                      in_[i].length * byte_width));
       }
     }
     return buffers;


### PR DESCRIPTION
An empty BinaryArray or a BinaryArray contains only nulls has no value
buffer.