### PR TITLE
ARROW-5537: [JS] Support delta dictionaries in RecordBatchWriter and DictionaryBuilder

### DIFF
--- a/js/bin/print-buffer-alignment.js
+++ b/js/bin/print-buffer-alignment.js
@@ -73,9 +73,9 @@ const { VectorLoader } = require(`../targets/apache-arrow/visitor/vectorloader`)
 })().catch((e) => { console.error(e); process.exit(1); });
 
 function loadRecordBatch(schema, header, body) {
-    return new RecordBatch(schema, header.length, new VectorLoader(body, header.nodes, header.buffers).visitMany(schema.fields));
+    return new RecordBatch(schema, header.length, new VectorLoader(body, header.nodes, header.buffers, new Map()).visitMany(schema.fields));
 }
 
 function loadDictionaryBatch(header, body, dictionaryType) {
-    return RecordBatch.new(new VectorLoader(body, header.nodes, header.buffers).visitMany([dictionaryType]));
+    return RecordBatch.new(new VectorLoader(body, header.nodes, header.buffers, new Map()).visitMany([dictionaryType]));
 }

--- a/js/src/builder.ts
+++ b/js/src/builder.ts
@@ -157,13 +157,7 @@ export abstract class Builder<T extends DataType = any, TNull = any> {
      * @nocollapse
      */
     public static throughIterable<T extends DataType = any, TNull = any>(options: IterableBuilderOptions<T, TNull>) {
-        const build = throughIterable(options);
-        if (!DataType.isDictionary(options.type)) {
-            return build;
-        }
-        return function*(source: Iterable<T['TValue'] | TNull>) {
-            const chunks = []; for (const chunk of build(source)) { chunks.push(chunk); } yield* chunks;
-        };
+        return throughIterable(options);
     }
 
     /**
@@ -192,13 +186,7 @@ export abstract class Builder<T extends DataType = any, TNull = any> {
      * @nocollapse
      */
     public static throughAsyncIterable<T extends DataType = any, TNull = any>(options: IterableBuilderOptions<T, TNull>) {
-        const build = throughAsyncIterable(options);
-        if (!DataType.isDictionary(options.type)) {
-            return build;
-        }
-        return async function* (source: Iterable<T['TValue'] | TNull> | AsyncIterable<T['TValue'] | TNull>) {
-            const chunks = []; for await (const chunk of build(source)) { chunks.push(chunk); } yield* chunks;
-        };
+        return throughAsyncIterable(options);
     }
 
     /**

--- a/js/src/column.ts
+++ b/js/src/column.ts
@@ -49,7 +49,7 @@ export class Column<T extends DataType = any>
 
         if (typeof field === 'string') {
             const type = chunks[0].data.type;
-            field = new Field(field, type, chunks.some(({ nullCount }) => nullCount > 0));
+            field = new Field(field, type, true);
         } else if (!field.nullable && chunks.some(({ nullCount }) => nullCount > 0)) {
             field = field.clone({ nullable: true });
         }

--- a/js/src/interfaces.ts
+++ b/js/src/interfaces.ts
@@ -141,7 +141,7 @@ export type BuilderType<T extends Type | DataType = any, TNull = any> =
 
 /** @ignore */
 export type VectorCtor<T extends Type | DataType | VectorType> =
-    T extends VectorType        ? VectorCtorType<T>                  :
+    T extends VectorType    ? VectorCtorType<T>                      :
     T extends Type          ? VectorCtorType<VectorType<T>>          :
     T extends DataType      ? VectorCtorType<VectorType<T['TType']>> :
                               VectorCtorType<vecs.BaseVector>
@@ -157,7 +157,7 @@ export type BuilderCtor<T extends Type | DataType = any> =
 /** @ignore */
 export type DataTypeCtor<T extends Type | DataType | VectorType = any> =
     T extends DataType      ? ConstructorType<T>                 :
-    T extends VectorType        ? ConstructorType<T['type']>         :
+    T extends VectorType    ? ConstructorType<T['type']>         :
     T extends Type          ? ConstructorType<TypeToDataType<T>> :
                               never
     ;

--- a/js/src/io/node/builder.ts
+++ b/js/src/io/node/builder.ts
@@ -47,7 +47,6 @@ class BuilderDuplex<T extends DataType = any, TNull = any> extends Duplex {
 
     constructor(builder: Builder<T, TNull>, options: BuilderDuplexOptions<T, TNull>) {
 
-        const isDictionary = DataType.isDictionary(builder.type);
         const { queueingStrategy = 'count', autoDestroy = true } = options;
         const { highWaterMark = queueingStrategy !== 'bytes' ? 1000 : 2 ** 14 } = options;
 
@@ -58,20 +57,6 @@ class BuilderDuplex<T extends DataType = any, TNull = any> extends Duplex {
         this._builder = builder;
         this._desiredSize = highWaterMark;
         this._getSize = queueingStrategy !== 'bytes' ? builderLength : builderByteLength;
-
-        if (isDictionary) {
-            let chunks: any[] = [];
-            this.push = (chunk: any, _?: string) => {
-                if (chunk !== null) {
-                    chunks.push(chunk);
-                    return true;
-                }
-                const chunks_ = chunks;
-                chunks = [];
-                chunks_.forEach((x) => super.push(x));
-                return super.push(null) && false;
-            };
-        }
     }
     _read(size: number) {
         this._maybeFlush(this._builder, this._desiredSize = size);

--- a/js/src/io/whatwg/builder.ts
+++ b/js/src/io/whatwg/builder.ts
@@ -82,22 +82,6 @@ export class BuilderTransform<T extends DataType = any, TNull = any> {
             'highWaterMark': writableHighWaterMark,
             'size': (value: T['TValue'] | TNull) => this._writeValueAndReturnChunkSize(value),
         });
-
-        if (DataType.isDictionary(builderOptions.type)) {
-            let chunks: any[] = [];
-            this._enqueue = (controller: ReadableStreamDefaultController<V<T>>, chunk: V<T> | null) => {
-                this._bufferedSize = 0;
-                if (chunk !== null) {
-                    chunks.push(chunk);
-                } else {
-                    const chunks_ = chunks;
-                    chunks = [];
-                    chunks_.forEach((x) => controller.enqueue(x));
-                    controller.close();
-                    this._controller = null;
-                }
-            };
-        }
     }
 
     private _writeValueAndReturnChunkSize(value: T['TValue'] | TNull) {

--- a/js/src/ipc/reader.ts
+++ b/js/src/ipc/reader.ts
@@ -354,21 +354,17 @@ abstract class RecordBatchReaderImpl<T extends { [key: string]: DataType } = any
     protected _loadDictionaryBatch(header: metadata.DictionaryBatch, body: any) {
         const { id, isDelta, data } = header;
         const { dictionaries, schema } = this;
-        if (isDelta || !dictionaries.get(id)) {
-
+        const dictionary = dictionaries.get(id);
+        if (isDelta || !dictionary) {
             const type = schema.dictionaries.get(id)!;
-            const vector = (isDelta ? dictionaries.get(id)!.concat(
+            return (dictionary && isDelta ? dictionary.concat(
                 Vector.new(this._loadVectors(data, body, [type])[0])) :
                 Vector.new(this._loadVectors(data, body, [type])[0])) as Vector;
-
-            (schema.dictionaryFields.get(id) || []).forEach(({ type }) => type.dictionaryVector = vector);
-
-            return vector;
         }
-        return dictionaries.get(id)!;
+        return dictionary;
     }
     protected _loadVectors(header: metadata.RecordBatch, body: any, types: (Field | DataType)[]) {
-        return new VectorLoader(body, header.nodes, header.buffers).visitMany(types);
+        return new VectorLoader(body, header.nodes, header.buffers, this.dictionaries).visitMany(types);
     }
 }
 
@@ -676,7 +672,7 @@ class RecordBatchJSONReaderImpl<T extends { [key: string]: DataType } = any> ext
         super(source, dictionaries);
     }
     protected _loadVectors(header: metadata.RecordBatch, body: any, types: (Field | DataType)[]) {
-        return new JSONVectorLoader(body, header.nodes, header.buffers).visitMany(types);
+        return new JSONVectorLoader(body, header.nodes, header.buffers, this.dictionaries).visitMany(types);
     }
 }
 

--- a/js/src/ipc/writer.ts
+++ b/js/src/ipc/writer.ts
@@ -19,11 +19,10 @@ import { Table } from '../table';
 import { MAGIC } from './message';
 import { Vector } from '../vector';
 import { Column } from '../column';
+import { DataType } from '../type';
 import { Schema, Field } from '../schema';
-import { Chunked } from '../vector/chunked';
 import { Message } from './metadata/message';
 import * as metadata from './metadata/message';
-import { DataType, Dictionary } from '../type';
 import { FileBlock, Footer } from './metadata/file';
 import { MessageHeader, MetadataVersion } from '../enum';
 import { WritableSink, AsyncByteQueue } from '../io/stream';
@@ -65,6 +64,7 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
     protected _schema: Schema | null = null;
     protected _dictionaryBlocks: FileBlock[] = [];
     protected _recordBatchBlocks: FileBlock[] = [];
+    protected _dictionaryDeltaOffsets = new Map<number, number>();
 
     public toString(sync: true): string;
     public toString(sync?: false): Promise<string>;
@@ -119,12 +119,13 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
         }
 
         if (this._started && this._schema) {
-            this._writeFooter();
+            this._writeFooter(this._schema);
         }
 
         this._started = false;
         this._dictionaryBlocks = [];
         this._recordBatchBlocks = [];
+        this._dictionaryDeltaOffsets = new Map();
 
         if (!schema || !(schema.compareTo(this._schema))) {
             if (schema === null) {
@@ -206,12 +207,11 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
     }
 
     protected _writeSchema(schema: Schema<T>) {
-        return this
-            ._writeMessage(Message.from(schema))
-            ._writeDictionaries(schema.dictionaryFields);
+        return this._writeMessage(Message.from(schema));
     }
 
-    protected _writeFooter() {
+    // @ts-ignore
+    protected _writeFooter(schema: Schema<T>) {
         return this._writePadding(4); // eos bytes
     }
 
@@ -223,16 +223,18 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
         return nBytes > 0 ? this._write(new Uint8Array(nBytes)) : this;
     }
 
-    protected _writeRecordBatch(records: RecordBatch<T>) {
-        const { byteLength, nodes, bufferRegions, buffers } = VectorAssembler.assemble(records);
-        const recordBatch = new metadata.RecordBatch(records.length, nodes, bufferRegions);
+    protected _writeRecordBatch(batch: RecordBatch<T>) {
+        const { byteLength, nodes, bufferRegions, buffers } = VectorAssembler.assemble(batch);
+        const recordBatch = new metadata.RecordBatch(batch.length, nodes, bufferRegions);
         const message = Message.from(recordBatch, byteLength);
         return this
+            ._writeDictionaries(batch)
             ._writeMessage(message)
             ._writeBodyBuffers(buffers);
     }
 
     protected _writeDictionaryBatch(dictionary: Vector, id: number, isDelta = false) {
+        this._dictionaryDeltaOffsets.set(id, dictionary.length + (this._dictionaryDeltaOffsets.get(id) || 0));
         const { byteLength, nodes, bufferRegions, buffers } = VectorAssembler.assemble(dictionary);
         const recordBatch = new metadata.RecordBatch(dictionary.length, nodes, bufferRegions);
         const dictionaryBatch = new metadata.DictionaryBatch(recordBatch, id, isDelta);
@@ -256,15 +258,14 @@ export class RecordBatchWriter<T extends { [key: string]: DataType } = any> exte
         return this;
     }
 
-    protected _writeDictionaries(dictionaryFields: Map<number, Field<Dictionary<any, any>>[]>) {
-        for (const [id, fields] of dictionaryFields) {
-            const vector = fields[0].type.dictionaryVector;
-            if (!(vector instanceof Chunked)) {
-                this._writeDictionaryBatch(vector, id, false);
-            } else {
-                const chunks = vector.chunks;
-                for (let i = -1, n = chunks.length; ++i < n;) {
-                    this._writeDictionaryBatch(chunks[i], id, i > 0);
+    protected _writeDictionaries(batch: RecordBatch<T>) {
+        for (let [id, dictionary] of batch.dictionaries) {
+            let offset = this._dictionaryDeltaOffsets.get(id) || 0;
+            if (offset === 0 || (dictionary = dictionary.slice(offset)).length > 0) {
+                const chunks = 'chunks' in dictionary ? (dictionary as any).chunks : [dictionary];
+                for (const chunk of chunks) {
+                    this._writeDictionaryBatch(chunk, id, offset > 0);
+                    offset += chunk.length;
                 }
             }
         }
@@ -312,15 +313,14 @@ export class RecordBatchFileWriter<T extends { [key: string]: DataType } = any> 
         this._autoDestroy = true;
     }
 
+    // @ts-ignore
     protected _writeSchema(schema: Schema<T>) {
-        return this
-            ._writeMagic()._writePadding(2)
-            ._writeDictionaries(schema.dictionaryFields);
+        return this._writeMagic()._writePadding(2);
     }
 
-    protected _writeFooter() {
+    protected _writeFooter(schema: Schema<T>) {
         const buffer = Footer.encode(new Footer(
-            this._schema!, MetadataVersion.V4,
+            schema, MetadataVersion.V4,
             this._recordBatchBlocks, this._dictionaryBlocks
         ));
         return this
@@ -343,43 +343,66 @@ export class RecordBatchJSONWriter<T extends { [key: string]: DataType } = any> 
         return new RecordBatchJSONWriter<T>().writeAll(input as any);
     }
 
+    private _recordBatches: RecordBatch[];
+    private _dictionaries: RecordBatch[];
+
     constructor() {
         super();
         this._autoDestroy = true;
+        this._recordBatches = [];
+        this._dictionaries = [];
     }
 
     protected _writeMessage() { return this; }
     protected _writeSchema(schema: Schema<T>) {
         return this._write(`{\n  "schema": ${
             JSON.stringify({ fields: schema.fields.map(fieldToJSON) }, null, 2)
-        }`)._writeDictionaries(schema.dictionaryFields);
+        }`);
     }
-    protected _writeDictionaries(dictionaryFields: Map<number, Field<Dictionary<any, any>>[]>) {
-        this._write(`,\n  "dictionaries": [\n`);
-        super._writeDictionaries(dictionaryFields);
-        return this._write(`\n  ]`);
+    protected _writeDictionaries(batch: RecordBatch<T>) {
+        if (batch.dictionaries.size > 0) {
+            this._dictionaries.push(batch);
+        }
+        return this;
     }
     protected _writeDictionaryBatch(dictionary: Vector, id: number, isDelta = false) {
+        this._dictionaryDeltaOffsets.set(id, dictionary.length + (this._dictionaryDeltaOffsets.get(id) || 0));
         this._write(this._dictionaryBlocks.length === 0 ? `    ` : `,\n    `);
-        this._write(`${dictionaryBatchToJSON(this._schema!, dictionary, id, isDelta)}`);
+        this._write(`${dictionaryBatchToJSON(dictionary, id, isDelta)}`);
         this._dictionaryBlocks.push(new FileBlock(0, 0, 0));
         return this;
     }
-    protected _writeRecordBatch(records: RecordBatch<T>) {
-        this._write(this._recordBatchBlocks.length === 0
-            ? `,\n  "batches": [\n    `
-            : `,\n    `);
-        this._write(`${recordBatchToJSON(records)}`);
-        this._recordBatchBlocks.push(new FileBlock(0, 0, 0));
+    protected _writeRecordBatch(batch: RecordBatch<T>) {
+        this._writeDictionaries(batch);
+        this._recordBatches.push(batch);
         return this;
     }
     public close() {
-        if (this._recordBatchBlocks.length > 0) {
+
+        if (this._dictionaries.length > 0) {
+            this._write(`,\n  "dictionaries": [\n`);
+            for (const batch of this._dictionaries) {
+                super._writeDictionaries(batch);
+            }
             this._write(`\n  ]`);
         }
+
+        if (this._recordBatches.length > 0) {
+            for (let i = -1, n = this._recordBatches.length; ++i < n;) {
+                this._write(i === 0 ? `,\n  "batches": [\n    ` : `,\n    `);
+                this._write(`${recordBatchToJSON(this._recordBatches[i])}`);
+                this._recordBatchBlocks.push(new FileBlock(0, 0, 0));
+            }
+            this._write(`\n  ]`);
+        }
+
         if (this._schema) {
             this._write(`\n}`);
         }
+
+        this._dictionaries = [];
+        this._recordBatches = [];
+
         return super.close();
     }
 }
@@ -421,9 +444,8 @@ function fieldToJSON({ name, type, nullable }: Field): object {
 }
 
 /** @ignore */
-function dictionaryBatchToJSON(schema: Schema, dictionary: Vector, id: number, isDelta = false) {
-    const f = schema.dictionaryFields.get(id)![0];
-    const field = new Field(f.name, f.type.dictionary, f.nullable, f.metadata);
+function dictionaryBatchToJSON(dictionary: Vector, id: number, isDelta = false) {
+    const field = new Field(`${id}`, dictionary.type, dictionary.nullCount > 0);
     const columns = JSONVectorAssembler.assemble(new Column(field, [dictionary]));
     return JSON.stringify({
         'id': id,

--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -18,7 +18,6 @@
 /* tslint:disable:class-name */
 
 import { Field } from './schema';
-import { Vector } from './vector';
 import { flatbuffers } from 'flatbuffers';
 import { TypedArrayConstructor } from './interfaces';
 import { VectorType as V, TypeToDataType } from './interfaces';
@@ -553,13 +552,11 @@ export class Dictionary<T extends DataType = any, TKey extends TKeys = TKeys> ex
     public readonly indices: TKey;
     public readonly dictionary: T;
     public readonly isOrdered: boolean;
-    public dictionaryVector: Vector<T>;
-    constructor(dictionary: T, indices: TKey, id?: Long | number | null, isOrdered?: boolean | null, dictionaryVector?: Vector<T>) {
+    constructor(dictionary: T, indices: TKey, id?: Long | number | null, isOrdered?: boolean | null) {
         super();
         this.indices = indices;
         this.dictionary = dictionary;
         this.isOrdered = isOrdered || false;
-        this.dictionaryVector = dictionaryVector!;
         this.id = id == null ? getId() : typeof id === 'number' ? id : id.low;
     }
     public get typeId() { return Type.Dictionary as Type.Dictionary; }
@@ -572,7 +569,6 @@ export class Dictionary<T extends DataType = any, TKey extends TKeys = TKeys> ex
         (<any> proto).indices = null;
         (<any> proto).isOrdered = null;
         (<any> proto).dictionary = null;
-        (<any> proto).dictionaryVector = null;
         return proto[Symbol.toStringTag] = 'Dictionary';
     })(Dictionary.prototype);
 }

--- a/js/src/util/args.ts
+++ b/js/src/util/args.ts
@@ -132,14 +132,14 @@ function _selectFieldArgs<T extends { [key: string]: DataType }>(vals: any[], re
     while (++idx < len) {
         val = vals[idx];
         if (val instanceof Column && (values[++valueIndex] = val)) {
-            fields[++fieldIndex] = val.field.clone(keys[idx], val.type, val.nullCount > 0);
+            fields[++fieldIndex] = val.field.clone(keys[idx], val.type, true);
         } else {
             ({ [idx]: field = idx } = keys);
             if (val instanceof DataType && (values[++valueIndex] = val)) {
-                fields[++fieldIndex] = Field.new(field, val as DataType) as Field<T[keyof T]>;
+                fields[++fieldIndex] = Field.new(field, val as DataType, true) as Field<T[keyof T]>;
             } else if (val && val.type && (values[++valueIndex] = val)) {
                 val instanceof Data && (values[valueIndex] = val = Vector.new(val) as Vector);
-                fields[++fieldIndex] = Field.new(field, val.type, val.nullCount > 0) as Field<T[keyof T]>;
+                fields[++fieldIndex] = Field.new(field, val.type, true) as Field<T[keyof T]>;
             }
         }
     }

--- a/js/src/vector/chunked.ts
+++ b/js/src/vector/chunked.ts
@@ -19,13 +19,13 @@ import { Data } from '../data';
 import { Field } from '../schema';
 import { clampRange } from '../util/vector';
 import { DataType, Dictionary } from '../type';
+import { selectChunkArgs } from '../util/args';
 import { DictionaryVector } from './dictionary';
 import { AbstractVector, Vector } from '../vector';
-import { selectChunkArgs } from '../util/args';
 import { Clonable, Sliceable, Applicative } from '../vector';
 
 /** @ignore */
-type ChunkedDict<T extends DataType> = T extends Dictionary ? T['dictionaryVector'] : null | never;
+type ChunkedDict<T extends DataType> = T extends Dictionary ? Vector<T['dictionary']> : null | never;
 /** @ignore */
 type ChunkedKeys<T extends DataType> = T extends Dictionary ? Vector<T['indices']> | Chunked<T['indices']> : null | never;
 
@@ -105,7 +105,7 @@ export class Chunked<T extends DataType = any>
     }
     public get dictionary(): ChunkedDict<T> | null {
         if (DataType.isDictionary(this._type)) {
-            return (<any> this._type.dictionaryVector) as ChunkedDict<T>;
+            return this._chunks[this._chunks.length - 1].data.dictionary as ChunkedDict<T>;
         }
         return null;
     }

--- a/js/src/vector/date.ts
+++ b/js/src/vector/date.ts
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { DateUnit } from '../enum';
 import { Chunked } from './chunked';
 import { BaseVector } from './base';
 import { VectorType as V } from '../interfaces';
@@ -24,37 +25,27 @@ import { VectorBuilderOptionsAsync } from './index';
 import { Date_, DateDay, DateMillisecond  } from '../type';
 
 /** @ignore */
+type FromArgs<T extends Date_> = [Iterable<Date>, T['unit']];
+
+/** @ignore */
 export class DateVector<T extends Date_ = Date_> extends BaseVector<T> {
-    public static from<T extends Date_ = DateMillisecond, TNull = any>(input: Iterable<Date | TNull>): V<T>;
-    public static from<T extends Date_ = DateMillisecond, TNull = any>(input: AsyncIterable<Date | TNull>): Promise<V<T>>;
-    public static from<T extends Date_ = DateMillisecond, TNull = any>(input: VectorBuilderOptions<T, TNull>): Chunked<T>;
-    public static from<T extends Date_ = DateMillisecond, TNull = any>(input: VectorBuilderOptionsAsync<T, TNull>): Promise<Chunked<T>>;
+    public static from<T extends DateUnit.DAY>(...args: FromArgs<DateDay>): V<DateDay>;
+    public static from<T extends DateUnit.MILLISECOND>(...args: FromArgs<DateMillisecond>): V<DateMillisecond>;
+    public static from<T extends Date_, TNull = any>(input: Iterable<Date | TNull>): V<T>;
+    public static from<T extends Date_, TNull = any>(input: AsyncIterable<Date | TNull>): Promise<V<T>>;
+    public static from<T extends Date_, TNull = any>(input: VectorBuilderOptions<T, TNull>): Chunked<T>;
+    public static from<T extends Date_, TNull = any>(input: VectorBuilderOptionsAsync<T, TNull>): Promise<Chunked<T>>;
     /** @nocollapse */
-    public static from<T extends Date_ = DateMillisecond, TNull = any>(input: Iterable<Date | TNull> | AsyncIterable<Date | TNull> | VectorBuilderOptions<T, TNull> | VectorBuilderOptionsAsync<T, TNull>) {
-        return vectorFromValuesWithType(() => new DateMillisecond() as T, input);
+    public static from<T extends Date_, TNull = any>(...args: FromArgs<T> | [Iterable<Date | TNull> | AsyncIterable<Date | TNull> | VectorBuilderOptions<T, TNull> | VectorBuilderOptionsAsync<T, TNull>]) {
+        if (args.length === 2) {
+            return vectorFromValuesWithType(() => args[1] === DateUnit.DAY ? new DateDay() : new DateMillisecond() as T, args[0]);
+        }
+        return vectorFromValuesWithType(() => new DateMillisecond() as T, args[0]);
     }
 }
 
 /** @ignore */
-export class DateDayVector extends DateVector<DateDay> {
-    public static from<TNull = any>(input: Iterable<Date | TNull>): DateDayVector;
-    public static from<TNull = any>(input: AsyncIterable<Date | TNull>): Promise<DateDayVector>;
-    public static from<TNull = any>(input: VectorBuilderOptions<DateDay, TNull>): Chunked<DateDay>;
-    public static from<TNull = any>(input: VectorBuilderOptionsAsync<DateDay, TNull>): Promise<Chunked<DateDay>>;
-    /** @nocollapse */
-    public static from<TNull = any>(input: Iterable<Date | TNull> | AsyncIterable<Date | TNull> | VectorBuilderOptions<DateDay, TNull> | VectorBuilderOptionsAsync<DateDay, TNull>) {
-        return vectorFromValuesWithType(() => new DateDay(), input);
-    }
-}
+export class DateDayVector extends DateVector<DateDay> {}
 
 /** @ignore */
-export class DateMillisecondVector extends DateVector<DateMillisecond> {
-    public static from<TNull = any>(input: Iterable<Date | TNull>): DateMillisecondVector;
-    public static from<TNull = any>(input: AsyncIterable<Date | TNull>): Promise<DateMillisecondVector>;
-    public static from<TNull = any>(input: VectorBuilderOptions<DateMillisecond, TNull>): Chunked<DateMillisecond>;
-    public static from<TNull = any>(input: VectorBuilderOptionsAsync<DateMillisecond, TNull>): Promise<Chunked<DateMillisecond>>;
-    /** @nocollapse */
-    public static from<TNull = any>(input: Iterable<Date | TNull> | AsyncIterable<Date | TNull> | VectorBuilderOptions<DateMillisecond, TNull> | VectorBuilderOptionsAsync<DateMillisecond, TNull>) {
-        return vectorFromValuesWithType(() => new DateMillisecond(), input);
-    }
-}
+export class DateMillisecondVector extends DateVector<DateMillisecond> {}

--- a/js/src/vector/dictionary.ts
+++ b/js/src/vector/dictionary.ts
@@ -25,19 +25,19 @@ import { VectorBuilderOptionsAsync } from './index';
 import { DataType, Dictionary, TKeys } from '../type';
 
 /** @ignore */
-type DictionaryFromArgs<T extends DataType = any, TKey extends TKeys = TKeys> = [Vector<T>, TKey, ArrayLike<number> | TKey['TArray']];
+type FromArgs<T extends DataType = any, TKey extends TKeys = TKeys> = [Vector<T>, TKey, ArrayLike<number> | TKey['TArray']];
 
 /** @ignore */
 export class DictionaryVector<T extends DataType = any, TKey extends TKeys = TKeys> extends BaseVector<Dictionary<T, TKey>> {
-    public static from<T extends DataType = any, TKey extends TKeys = TKeys>(...args: DictionaryFromArgs<T, TKey>): V<Dictionary<T, TKey>>;
+    public static from<T extends DataType = any, TKey extends TKeys = TKeys>(...args: FromArgs<T, TKey>): V<Dictionary<T, TKey>>;
     public static from<T extends DataType = any, TKey extends TKeys = TKeys>(input: VectorBuilderOptions<Dictionary<T, TKey>>): Vector<Dictionary<T, TKey>>;
     public static from<T extends DataType = any, TKey extends TKeys = TKeys>(input: VectorBuilderOptionsAsync<Dictionary<T, TKey>>): Promise<Vector<Dictionary<T, TKey>>>;
     /** @nocollapse */
     public static from<T extends DataType = any, TKey extends TKeys = TKeys>(...args: any[]) {
         if (args.length === 3) {
-            const [values, indices, keys] = args as DictionaryFromArgs<T, TKey>;
-            const type = new Dictionary(values.type, indices, null, null, values);
-            return Vector.new(Data.Dictionary(type, 0, keys.length, 0, null, keys));
+            const [values, indices, keys] = args as FromArgs<T, TKey>;
+            const type = new Dictionary(values.type, indices, null, null);
+            return Vector.new(Data.Dictionary(type, 0, keys.length, 0, null, keys, values));
         }
         return vectorFromValuesWithType(() => args[0].type, args[0]);
     }
@@ -49,7 +49,7 @@ export class DictionaryVector<T extends DataType = any, TKey extends TKeys = TKe
 
     public readonly indices: V<TKey>;
 
-    public get dictionary() { return this.data.type.dictionaryVector; }
+    public get dictionary() { return <Vector<T>> this.data.dictionary; }
     public reverseLookup(value: T) { return this.dictionary.indexOf(value); }
     public getKey(idx: number): TKey['TValue'] | null { return this.indices.get(idx); }
     public getValue(key: number): T['TValue'] | null { return this.dictionary.get(key); }

--- a/js/test/data/tables.ts
+++ b/js/test/data/tables.ts
@@ -43,7 +43,6 @@ export function* generateRandomTables(batchLengths = [1000, 2000, 3000], minCols
 
         let names = allNames.slice(0, numCols);
         let types = names.map((fn) => vecs[fn](0).vector.type);
-        types.forEach((t) => t.dictionaryVector && (t.dictionaryVector = null));
         let schema = new Schema(names.map((name, i) => new Field(name, types[i])));
 
         yield generate.table(batchLengths, schema).table;

--- a/js/test/unit/ipc/writer/stream-writer-tests.ts
+++ b/js/test/unit/ipc/writer/stream-writer-tests.ts
@@ -20,10 +20,19 @@ import {
     generateDictionaryTables
 } from '../../../data/tables';
 
+import * as generate from '../../../generate-test-data';
 import { validateRecordBatchIterator } from '../validate';
-import { Table, RecordBatchReader, RecordBatchStreamWriter } from '../../../Arrow';
+import { DictionaryVector, Dictionary, Uint32, Int32 } from '../../../Arrow';
+import { Table, Schema, Chunked, Builder, RecordBatch, RecordBatchReader, RecordBatchStreamWriter } from '../../../Arrow';
 
 describe('RecordBatchStreamWriter', () => {
+
+    (() => {
+        const type = generate.sparseUnion(0, 0).vector.type;
+        const schema = Schema.new({ 'dictSparseUnion': type });
+        const table = generate.table([10, 20, 30], schema).table;
+        testStreamWriter(table, `[${table.schema.fields.join(', ')}]`);
+    })();
 
     for (const table of generateRandomTables([10, 20, 30])) {
         testStreamWriter(table, `[${table.schema.fields.join(', ')}]`);
@@ -33,7 +42,7 @@ describe('RecordBatchStreamWriter', () => {
         testStreamWriter(table, `${table.schema.fields[0]}`);
     }
 
-    test(`should write multiple tables to the same output stream`, async () => {
+    it(`should write multiple tables to the same output stream`, async () => {
         const tables = [] as Table[];
         const writer = new RecordBatchStreamWriter({ autoDestroy: false });
         const validate = (async () => {
@@ -54,6 +63,38 @@ describe('RecordBatchStreamWriter', () => {
         }
         writer.close();
         await validate;
+    });
+
+    it('should write delta dictionary batches', async () => {
+
+        const name = 'dictionary_encoded_uint32';
+        const chunks: DictionaryVector<Uint32, Int32>[] = [];
+        const {
+            vector: sourceVector, values: sourceValues,
+        } = generate.dictionary(1000, 20, new Uint32(), new Int32());
+
+        const writer = RecordBatchStreamWriter.writeAll((function* () {
+            const transform = Builder.throughIterable({
+                type: sourceVector.type, nullValues: [null],
+                queueingStrategy: 'count', highWaterMark: 50,
+            });
+            for (const chunk of transform(sourceValues())) {
+                chunks.push(chunk);
+                yield RecordBatch.new({ [name]: chunk });
+            }
+        })());
+
+        expect(Chunked.concat(chunks)).toEqualVector(sourceVector);
+
+        type T = { [name]: Dictionary<Uint32, Int32> };
+        const sourceTable = Table.new({ [name]: sourceVector });
+        const resultTable = await Table.from<T>(writer.toUint8Array());
+
+        const { dictionary } = resultTable.getColumn(name);
+
+        expect(resultTable).toEqualTable(sourceTable);
+        expect((dictionary as Chunked)).toBeInstanceOf(Chunked);
+        expect((dictionary as Chunked).chunks.length).toBe(20);
     });
 });
 

--- a/js/test/unit/table-tests.ts
+++ b/js/test/unit/table-tests.ts
@@ -123,7 +123,7 @@ describe(`Table`, () => {
             let i32 = Column.new('i32', Data.Int(new Int32(), 0, i32s.length, 0, null, i32s));
             expect(i32.name).toBe('i32');
             expect(i32.length).toBe(i32s.length);
-            expect(i32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
             expect(i32.nullCount).toBe(0);
 
             const table = Table.new(i32);
@@ -131,7 +131,7 @@ describe(`Table`, () => {
 
             expect(i32.name).toBe('i32');
             expect(i32.length).toBe(i32s.length);
-            expect(i32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
             expect(i32.nullCount).toBe(0);
 
             expect(i32).toEqualVector(Int32Vector.from(i32s));
@@ -148,8 +148,8 @@ describe(`Table`, () => {
             expect(f32.name).toBe('f32');
             expect(i32.length).toBe(i32s.length);
             expect(f32.length).toBe(f32s.length);
-            expect(i32.nullable).toBe(false);
-            expect(f32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
+            expect(f32.nullable).toBe(true);
             expect(i32.nullCount).toBe(0);
             expect(f32.nullCount).toBe(0);
 
@@ -161,8 +161,8 @@ describe(`Table`, () => {
             expect(f32.name).toBe('f32');
             expect(i32.length).toBe(i32s.length);
             expect(f32.length).toBe(f32s.length);
-            expect(i32.nullable).toBe(false);
-            expect(f32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
+            expect(f32.nullable).toBe(true);
             expect(i32.nullCount).toBe(0);
             expect(f32.nullCount).toBe(0);
 
@@ -182,8 +182,8 @@ describe(`Table`, () => {
             expect(f32.name).toBe('f32');
             expect(i32.length).toBe(i32s.length);
             expect(f32.length).toBe(f32s.length);
-            expect(i32.nullable).toBe(false);
-            expect(f32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
+            expect(f32.nullable).toBe(true);
             expect(i32.nullCount).toBe(0);
             expect(f32.nullCount).toBe(0);
 
@@ -195,7 +195,7 @@ describe(`Table`, () => {
             expect(f32.name).toBe('f32');
             expect(i32.length).toBe(i32s.length);
             expect(f32.length).toBe(i32s.length); // new length should be the same as the longest sibling
-            expect(i32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
             expect(f32.nullable).toBe(true); // true, with 12 additional nulls
             expect(i32.nullCount).toBe(0);
             expect(f32.nullCount).toBe(i32s.length - f32s.length);
@@ -221,8 +221,8 @@ describe(`Table`, () => {
             expect(f32.name).toBe('f32');
             expect(i32.length).toBe(i32s.length);
             expect(f32.length).toBe(f32s.length);
-            expect(i32.nullable).toBe(false);
-            expect(f32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
+            expect(f32.nullable).toBe(true);
             expect(i32.nullCount).toBe(0);
             expect(f32.nullCount).toBe(0);
 
@@ -234,7 +234,7 @@ describe(`Table`, () => {
             expect(f32.name).toBe('f32Renamed');
             expect(i32.length).toBe(i32s.length);
             expect(f32.length).toBe(i32s.length); // new length should be the same as the longest sibling
-            expect(i32.nullable).toBe(false);
+            expect(i32.nullable).toBe(true);
             expect(f32.nullable).toBe(true); // true, with 4 additional nulls
             expect(i32.nullCount).toBe(0);
             expect(f32.nullCount).toBe(i32s.length - f32s.length);

--- a/js/test/unit/vector/vector-tests.ts
+++ b/js/test/unit/vector/vector-tests.ts
@@ -74,8 +74,8 @@ describe(`DictionaryVector`, () => {
         const nullBitmap = util.packBools(validity);
         const nullCount = validity.reduce((acc, d) => acc + (d ? 0 : 1), 0);
         const values = Array.from(indices).map((d, i) => validity[i] ? dictionary[d] : null);
-        const type = new Dictionary(dictionary_vec.type, new Int32(), null, null, dictionary_vec);
-        const vector = Vector.new(Data.Dictionary(type, 0, indices.length, nullCount, nullBitmap, indices));
+        const type = new Dictionary(dictionary_vec.type, new Int32(), null, null);
+        const vector = Vector.new(Data.Dictionary(type, 0, indices.length, nullCount, nullBitmap, indices, dictionary_vec));
 
         basicVectorTests(vector, values, ['abc', '123']);
         describe(`sliced`, () => {


### PR DESCRIPTION
Adds support for building and writing delta dictionaries. Moves the `dictionary` Vector pointer to the Data class, similar to https://github.com/apache/arrow/pull/4316.

Forked from  https://github.com/apache/arrow/pull/4476 since this adds support for delta dictionaries to the DictionaryBuilder. Will rebase this PR after that's merged. All the work is in the last commit, here: https://github.com/apache/arrow/commit/b12d842ebe1b341b2b0c67525bcf3f85ea88fecd
