### PR TITLE
ARROW-5541 [R]: cast from negative int32 to uint32 and uint64 are now safe

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -316,14 +316,12 @@ test_that("integer types casts (ARROW-3741)", {
   expect_true(a_uint64$IsNull(10L))
 })
 
-test_that("integer types cast safety (ARROW-3741)", {
+test_that("integer types cast safety (ARROW-3741, ARROW-5541)", {
   a <- array(-(1:10))
-  expect_error(a$cast(uint8()))
-  expect_error(a$cast(uint16()))
-
-  # this looks like a bug in the C++
-  # expect_error(a$cast(uint32()))
-  # expect_error(a$cast(uint64()))
+  expect_error(a$cast(uint8()), regexp = "Integer value out of bounds")
+  expect_error(a$cast(uint16()), regexp = "Integer value out of bounds")
+  expect_error(a$cast(uint32()), regexp = "Integer value out of bounds")
+  expect_error(a$cast(uint64()), regexp = "Integer value out of bounds")
 
   expect_error(a$cast(uint8(), safe = FALSE), NA)
   expect_error(a$cast(uint16(), safe = FALSE), NA)


### PR DESCRIPTION
Minor test update: 

``` r
library(arrow, warn.conflicts = FALSE)

a <- array(-(1:10))
a$cast(uint32())
#> Error in Array__cast(self, target_type, options): Invalid: Integer value out of bounds
a$cast(uint64())
#> Error in Array__cast(self, target_type, options): Invalid: Integer value out of bounds
```

<sup>Created on 2019-06-10 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>