### PR TITLE
ARROW-5544: [Archery] Don't return non-zero on regressions

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -383,16 +383,12 @@ def benchmark_diff(ctx, src, preserve, suite_filter, benchmark_filter,
             src, root, baseline, conf,
             suite_filter=suite_filter, benchmark_filter=benchmark_filter)
 
-        regressions = 0
         runner_comp = RunnerComparator(runner_cont, runner_base, threshold)
 
         # TODO(kszucs): test that the output is properly formatted jsonlines
         for comparator in runner_comp.comparisons:
-            regressions += comparator.regression
             json.dump(comparator, output, cls=JsonEncoder)
             output.write("\n")
-
-        sys.exit(regressions)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The return code should be used to return when the command did not
execute successfully. In this case, the command did run without issues,
we leave to the calling user to decide what to do with the data.

This will simplify integration with ursabot CI.