### PR TITLE
ARROW-3052: [C++] Detect Apache ORC C++ libraries in system/conda toolchain, add to conda requirements

### DIFF
--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -31,7 +31,6 @@ gtest>=1.8.1
 libprotobuf
 lz4-c
 ninja
-orc
 pkg-config
 python
 rapidjson

--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -31,6 +31,7 @@ gtest>=1.8.1
 libprotobuf
 lz4-c
 ninja
+orc
 pkg-config
 python
 rapidjson

--- a/ci/conda_env_unix.yml
+++ b/ci/conda_env_unix.yml
@@ -19,6 +19,7 @@
 
 autoconf
 ccache
+orc
 pkg-config
 rsync
 valgrind

--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -51,6 +51,7 @@ fi
 
 conda create -y -q -p $CONDA_ENV_DIR \
       --file $TRAVIS_BUILD_DIR/ci/conda_env_cpp.yml \
+      --file $TRAVIS_BUILD_DIR/ci/conda_env_unix.yml \
       --file $TRAVIS_BUILD_DIR/ci/conda_env_python.yml \
       ${CONDA_FILES} \
       nomkl \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -601,9 +601,9 @@ if(ARROW_WITH_ZSTD)
 endif()
 
 if(ARROW_ORC)
-  list(APPEND ARROW_LINK_LIBS protobuf::libprotobuf orc_static)
-  list(APPEND ARROW_STATIC_LINK_LIBS protobuf::libprotobuf orc_static)
-  list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS protobuf::libprotobuf orc)
+  list(APPEND ARROW_LINK_LIBS protobuf::libprotobuf orc::liborc)
+  list(APPEND ARROW_STATIC_LINK_LIBS protobuf::libprotobuf orc::liborc)
+  list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS protobuf::libprotobuf orc::liborc)
 endif()
 
 if(ARROW_USE_GLOG)

--- a/cpp/cmake_modules/FindORC.cmake
+++ b/cpp/cmake_modules/FindORC.cmake
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# - Find Apache ORC C++ (orc/orc-config.h, liborc.a)
+# This module defines
+#  ORC_INCLUDE_DIR, directory containing headers
+#  ORC_STATIC_LIB, path to liborc.a
+#  ORC_FOUND, whether orc has been found
+
+if(ORC_ROOT)
+  find_library(ORC_STATIC_LIB
+               NAMES orc
+               PATHS ${ORC_ROOT}
+               NO_DEFAULT_PATH
+               PATH_SUFFIXES ${LIB_PATH_SUFFIXES})
+  find_path(ORC_INCLUDE_DIR
+            NAMES orc/orc-config.hh
+            PATHS ${ORC_ROOT}
+            NO_DEFAULT_PATH
+            PATH_SUFFIXES ${INCLUDE_PATH_SUFFIXES})
+else()
+  find_library(ORC_STATIC_LIB NAMES orc PATH_SUFFIXES ${LIB_PATH_SUFFIXES})
+  find_path(ORC_INCLUDE_DIR
+            NAMES orc/orc-config.hh
+            PATH_SUFFIXES ${INCLUDE_PATH_SUFFIXES})
+endif()
+
+if(ORC_STATIC_LIB AND ORC_INCLUDE_DIR)
+  set(ORC_FOUND TRUE)
+  add_library(orc::liborc STATIC IMPORTED)
+  set_target_properties(orc::liborc
+                        PROPERTIES IMPORTED_LOCATION "${ORC_STATIC_LIB}"
+                                   INTERFACE_INCLUDE_DIRECTORIES
+                                   "${ORC_INCLUDE_DIR}")
+else()
+  if (ORC_FIND_REQUIRED)
+    message(FATAL_ERROR "ORC library was required in toolchain and unable to locate")
+  endif()
+  set(ORC_FOUND FALSE)
+endif()

--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -42,7 +42,7 @@ elseif(NOT MSVC)
 endif()
 
 set(ORC_STATIC_TEST_LINK_LIBS ${ORC_MIN_TEST_LIBS} ${ARROW_LIBRARIES_FOR_STATIC_TESTS}
-                              orc_static)
+                              orc::liborc)
 
 add_arrow_test(adapter-test
                PREFIX

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -65,6 +65,9 @@ else
   export BUILD_ARROW_GANDIVA=OFF
 fi
 
+# ARROW-3052(wesm): ORC is being bundled until it can be added to the
+# manylinux1 image
+
 echo "=== (${PYTHON_VERSION}) Building Arrow C++ libraries ==="
 ARROW_BUILD_DIR=/tmp/build-PY${PYTHON_VERSION}-${UNICODE_WIDTH}
 mkdir -p "${ARROW_BUILD_DIR}"
@@ -90,7 +93,7 @@ PATH="${CPYTHON_PATH}/bin:${PATH}" cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_GANDIVA_JAVA=OFF \
     -DBoost_NAMESPACE=arrow_boost \
     -DBOOST_ROOT=/arrow_boost_dist \
-    -DORC_SOURCE=BUNDLED \  # ARROW-3052
+    -DORC_SOURCE=BUNDLED \
     -GNinja /arrow/cpp
 ninja install
 popd

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -90,6 +90,7 @@ PATH="${CPYTHON_PATH}/bin:${PATH}" cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_GANDIVA_JAVA=OFF \
     -DBoost_NAMESPACE=arrow_boost \
     -DBOOST_ROOT=/arrow_boost_dist \
+    -DORC_SOURCE=BUNDLED \  # ARROW-3052
     -GNinja /arrow/cpp
 ninja install
 popd


### PR DESCRIPTION
This is now available on conda-forge, so we can include it in our toolchain requirements

https://github.com/conda-forge/orc-feedstock

This is only enabled on non-Windows builds. Adding ORC to the manylinux1 image will have to happen separately, so I have set it to build in BUNDLED mode there