### PR TITLE
ARROW-5553: [Ruby] Use the official packages to install Apache Arrow

### DIFF
--- a/ruby/red-arrow-cuda/README.md
+++ b/ruby/red-arrow-cuda/README.md
@@ -33,9 +33,7 @@ gobject-introspection gem is a Ruby bindings of GObject Introspection. Red Arrow
 
 ## Install
 
-Install Apache Arrow CUDA GLib before install Red Arrow CUDA. Use [packages.red-data-tools.org](https://github.com/red-data-tools/packages.red-data-tools.org) for installing Apache Arrow CUDA GLib.
-
-Note that the Apache Arrow CUDA GLib packages are "unofficial". "Official" packages will be released in the future.
+Install Apache Arrow CUDA GLib before install Red Arrow CUDA. Install Apache Arrow GLib before install Red Arrow. See [Apache Arrow install document](https://arrow.apache.org/install/) for details.
 
 Install Red Arrow CUDA after you install Apache Arrow CUDA GLib:
 

--- a/ruby/red-arrow/README.md
+++ b/ruby/red-arrow/README.md
@@ -33,9 +33,7 @@ gobject-introspection gem is a Ruby bindings of GObject Introspection. Red Arrow
 
 ## Install
 
-Install Apache Arrow GLib before install Red Arrow. Use [packages.red-data-tools.org](https://github.com/red-data-tools/packages.red-data-tools.org) for installing Apache Arrow GLib.
-
-Note that the Apache Arrow GLib packages are "unofficial". "Official" packages will be released in the future.
+Install Apache Arrow GLib before install Red Arrow. See [Apache Arrow install document](https://arrow.apache.org/install/) for details.
 
 Install Red Arrow after you install Apache Arrow GLib:
 

--- a/ruby/red-gandiva/README.md
+++ b/ruby/red-gandiva/README.md
@@ -33,9 +33,7 @@ gobject-introspection gem is a Ruby bindings of GObject Introspection. Red Gandi
 
 ## Install
 
-Install Gandiva GLib before install Red Gandiva. Use [packages.red-data-tools.org](https://github.com/red-data-tools/packages.red-data-tools.org) for installing Gandiva GLib.
-
-Note that the Gandiva GLib packages are "unofficial". "Official" packages will be released in the future.
+Install Gandiva GLib before install Red Gandiva. See [Apache Arrow install document](https://arrow.apache.org/install/) for details.
 
 Install Red Gandiva after you install Gandiva GLib:
 

--- a/ruby/red-parquet/README.md
+++ b/ruby/red-parquet/README.md
@@ -33,9 +33,7 @@ gobject-introspection gem is a Ruby bindings of GObject Introspection. Red Parqu
 
 ## Install
 
-Install Apache Parquet GLib before install Red Parquet. Use [packages.red-data-tools.org](https://github.com/red-data-tools/packages.red-data-tools.org) for installing Apache Parquet GLib.
-
-Note that the Apache Parquet GLib packages are "unofficial". "Official" packages will be released in the future.
+Install Apache Parquet GLib before install Red Parquet. See [Apache Arrow install document](https://arrow.apache.org/install/) for details.
 
 Install Red Parquet after you install Apache Parquet GLib:
 

--- a/ruby/red-plasma/README.md
+++ b/ruby/red-plasma/README.md
@@ -33,9 +33,7 @@ gobject-introspection gem is a Ruby bindings of GObject Introspection. Red Plasm
 
 ## Install
 
-Install Plasma GLib before install Red Plasma. Use [packages.red-data-tools.org](https://github.com/red-data-tools/packages.red-data-tools.org) for installing Plasma GLib.
-
-Note that the Plasma GLib packages are "unofficial". "Official" packages will be released in the future.
+Install Plasma GLib before install Red Plasma. See [Apache Arrow install document](https://arrow.apache.org/install/) for details.
 
 Install Red Plasma after you install Plasma GLib:
 


### PR DESCRIPTION
packages.red-data-tools.org is deprecated.