### PR TITLE
ARROW-5567: [C++] Fix build error of memory-benchmark

### DIFF
--- a/cpp/src/arrow/io/memory-benchmark.cc
+++ b/cpp/src/arrow/io/memory-benchmark.cc
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#if defined(__x86_64__)
+#if defined(__SSE4_2__)
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
@@ -230,4 +230,4 @@ BENCHMARK(ParallelMemoryCopy)
     ->UseRealTime();
 
 }  // namespace arrow
-#endif  // __x86_64__
+#endif  // __SSE4_2__

--- a/cpp/src/arrow/io/memory-benchmark.cc
+++ b/cpp/src/arrow/io/memory-benchmark.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#if defined(__x86_64__)
 #ifdef _MSC_VER
 #include <intrin.h>
 #else
@@ -229,3 +230,4 @@ BENCHMARK(ParallelMemoryCopy)
     ->UseRealTime();
 
 }  // namespace arrow
+#endif  // __x86_64__

--- a/cpp/src/arrow/io/memory-benchmark.cc
+++ b/cpp/src/arrow/io/memory-benchmark.cc
@@ -15,13 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#if defined(__SSE4_2__)
-#ifdef _MSC_VER
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
-
 #include <iostream>
 
 #include "arrow/api.h"
@@ -29,9 +22,11 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/cpu-info.h"
+#include "arrow/util/sse-util.h"
 
 #include "benchmark/benchmark.h"
 
+#ifdef ARROW_HAVE_SSE4_2
 namespace arrow {
 
 using internal::CpuInfo;
@@ -230,4 +225,4 @@ BENCHMARK(ParallelMemoryCopy)
     ->UseRealTime();
 
 }  // namespace arrow
-#endif  // __SSE4_2__
+#endif  // ARROW_HAVE_SSE4_2


### PR DESCRIPTION
'memory-benchmark.cc' is implemented by x86 AVX and SSE instructions.
Build would failed on Arm64 when DARROW_BUILD_BENCHMARKS is enabled.
