### PR TITLE
ARROW-5579: [Java] shade flatbuffer dependency

### DIFF
--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -185,6 +185,9 @@
                   <include>com.google.protobuf:*</include>
                   <include>com.google.guava:*</include>
                 </includes>
+                <excludes>
+                  <exclude>com.google.flatbuffers:*</exclude>
+                </excludes>
               </artifactSet>
               <relocations>
                 <relocation>

--- a/java/format/pom.xml
+++ b/java/format/pom.xml
@@ -159,6 +159,26 @@
         <skip>true</skip>
       </configuration>
     </plugin>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-shade-plugin</artifactId>
+      <version>3.2.1</version>
+      <executions>
+        <execution>
+          <phase>package</phase>
+          <goals>
+            <goal>shade</goal>
+          </goals>
+          <configuration>
+            <artifactSet>
+              <excludes>
+                <exclude>com.google.flatbuffers:*</exclude>
+              </excludes>
+            </artifactSet>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
   </plugins>
 
 </build>

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -133,6 +133,31 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.google.flatbuffers:*</exclude>
+                  <exclude>io.netty:*</exclude>
+                  <exclude>com.fasterxml.jackson.core:*</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                  <exclude>org.apache.arrow:arrow-memory</exclude>
+                  <exclude>org.apache.arrow:arrow-format</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Related to [ARROW-5579](https://issues.apache.org/jira/browse/ARROW-5579).

After some discussion with the Flatbuffers maintainer, it appears that FB generated code is not guaranteed to be compatible with any other version of the runtime library other than the exact same version of the flatc used to compile it.

This makes depending on flatbuffers in a library (like arrow) quite risky, as if an app depends on any other version of FB, either directly or transitively, it's likely the versions will clash at some point and you'll see undefined behaviour at runtime.

Shading the dependency looks to me the best way to avoid this.