### PR TITLE
ARROW-5596: [Python] Fix Python-3 syntax only in test_flight.py

### DIFF
--- a/cpp/build-support/lint_cpp_cli.py
+++ b/cpp/build-support/lint_cpp_cli.py
@@ -98,7 +98,8 @@ def lint_files():
 
             # Only run on header files
             if filename.endswith('.h'):
-                yield from lint_file(full_path)
+                for _ in lint_file(full_path):
+                    yield _
 
 
 if __name__ == '__main__':

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -29,9 +29,8 @@ import pytest
 
 import pyarrow as pa
 
-from pathlib import Path
 from pyarrow.compat import tobytes
-
+from pyarrow.util import pathlib
 
 flight = pytest.importorskip("pyarrow.flight")
 
@@ -41,7 +40,7 @@ def resource_root():
     if not os.environ.get("ARROW_TEST_DATA"):
         raise RuntimeError("Test resources not found; set "
                            "ARROW_TEST_DATA to <repo root>/testing")
-    return Path(os.environ["ARROW_TEST_DATA"]) / "flight"
+    return pathlib.Path(os.environ["ARROW_TEST_DATA"]) / "flight"
 
 
 def read_flight_resource(path):

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -23,6 +23,7 @@ import socket
 import tempfile
 import threading
 import time
+import traceback
 
 import pytest
 
@@ -51,10 +52,11 @@ def read_flight_resource(path):
     try:
         with (root / path).open("rb") as f:
             return f.read()
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         raise RuntimeError(
             "Test resource {} not found; did you initialize the "
-            "test resource submodule?".format(root / path)) from e
+            "test resource submodule?\n{}".format(root / path,
+                                                  traceback.format_exc()))
 
 
 def example_tls_certs():


### PR DESCRIPTION
Even though Flight is only available in Python 3, having Py3-only syntax is enough to break py.test