### PR TITLE
ARROW-4912: [C++] add method for easy renaming of a Table's columns

### DIFF
--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -507,6 +507,7 @@ TEST_F(TestTable, RenameColumns) {
   std::shared_ptr<Table> renamed;
   ASSERT_OK(table->RenameColumns({"zero", "one", "two"}, &renamed));
   EXPECT_THAT(renamed->ColumnNames(), testing::ElementsAre("zero", "one", "two"));
+  ASSERT_OK(renamed->Validate());
 
   ASSERT_RAISES(Invalid, table->RenameColumns({"hello", "world"}, &renamed));
 }

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
@@ -503,8 +504,10 @@ TEST_F(TestTable, RenameColumns) {
   auto table = Table::Make(schema_, columns_);
   ASSERT_EQ(table->ColumnNames(), std::vector<std::string>({"f0", "f1", "f2"}));
   std::shared_ptr<Table> renamed;
+  EXPECT_THAT(table->ColumnNames(), testing::ElementsAre("f0", "f1", "f2"));
+
   ASSERT_OK(table->RenameColumns({"zero", "one", "two"}, &renamed));
-  ASSERT_EQ(table->ColumnNames(), std::vector<std::string>({"zero", "one", "two"}));
+  EXPECT_THAT(table->ColumnNames(), testing::ElementsAre("zero", "one", "two"));
 
   ASSERT_RAISES(Invalid, table->RenameColumns({"hello", "world"}, &renamed));
 }

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -499,12 +499,14 @@ TEST_F(TestTable, SetColumn) {
 }
 
 TEST_F(TestTable, RenameColumns) {
+  MakeExample1(10);
   auto table = Table::Make(schema_, columns_);
   auto names = table->ColumnNames();
   ASSERT_EQ(names, std::vector<std::string>({"f0", "f1", "f2"}));
   names = {"zero", "one", "two"};
-  table->RenameColumns(names);
-  ASSERT_EQ(table->ColumnNames(), names);
+  std::shared_ptr<Table> renamed;
+  ASSERT_OK(table->RenameColumns(names, &renamed));
+  ASSERT_EQ(renamed->ColumnNames(), names);
 }
 
 TEST_F(TestTable, RemoveColumnEmpty) {

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -501,12 +501,12 @@ TEST_F(TestTable, SetColumn) {
 TEST_F(TestTable, RenameColumns) {
   MakeExample1(10);
   auto table = Table::Make(schema_, columns_);
-  auto names = table->ColumnNames();
-  ASSERT_EQ(names, std::vector<std::string>({"f0", "f1", "f2"}));
-  names = {"zero", "one", "two"};
+  ASSERT_EQ(table->ColumnNames(), std::vector<std::string>({"f0", "f1", "f2"}));
   std::shared_ptr<Table> renamed;
-  ASSERT_OK(table->RenameColumns(names, &renamed));
-  ASSERT_EQ(renamed->ColumnNames(), names);
+  ASSERT_OK(table->RenameColumns({"zero", "one", "two"}, &renamed));
+  ASSERT_EQ(table->ColumnNames(), std::vector<std::string>({"zero", "one", "two"}));
+
+  ASSERT_RAISES(Invalid, table->RenameColumns({"hello", "world"}, &renamed));
 }
 
 TEST_F(TestTable, RemoveColumnEmpty) {

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -498,6 +498,15 @@ TEST_F(TestTable, SetColumn) {
   ASSERT_TRUE(result->Equals(*expected));
 }
 
+TEST_F(TestTable, RenameColumns) {
+  auto table = Table::Make(schema_, columns_);
+  auto names = table->ColumnNames();
+  ASSERT_EQ(names, std::vector<std::string>({"f0", "f1", "f2"}));
+  names = {"zero", "one", "two"};
+  table->RenameColumns(names);
+  ASSERT_EQ(table->ColumnNames(), names);
+}
+
 TEST_F(TestTable, RemoveColumnEmpty) {
   // ARROW-1865
   const int64_t length = 10;

--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -502,12 +502,11 @@ TEST_F(TestTable, SetColumn) {
 TEST_F(TestTable, RenameColumns) {
   MakeExample1(10);
   auto table = Table::Make(schema_, columns_);
-  ASSERT_EQ(table->ColumnNames(), std::vector<std::string>({"f0", "f1", "f2"}));
-  std::shared_ptr<Table> renamed;
   EXPECT_THAT(table->ColumnNames(), testing::ElementsAre("f0", "f1", "f2"));
 
+  std::shared_ptr<Table> renamed;
   ASSERT_OK(table->RenameColumns({"zero", "one", "two"}, &renamed));
-  EXPECT_THAT(table->ColumnNames(), testing::ElementsAre("zero", "one", "two"));
+  EXPECT_THAT(renamed->ColumnNames(), testing::ElementsAre("zero", "one", "two"));
 
   ASSERT_RAISES(Invalid, table->RenameColumns({"hello", "world"}, &renamed));
 }

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -478,6 +478,23 @@ Status Table::FromChunkedStructArray(const std::shared_ptr<ChunkedArray>& array,
   return Status::OK();
 }
 
+std::vector<std::string> Table::ColumnNames() const {
+  std::vector<std::string> names(num_columns());
+  for (int i = 0; i < num_columns(); ++i) {
+    names[i] = column(i)->name();
+  }
+  return names;
+}
+
+std::shared_ptr<Table> Table::RenameColumns(const std::vector<std::string>& names) const {
+  std::vector<std::shared_ptr<Column>> columns(num_columns());
+  for (int i = 0; i < num_columns(); ++i) {
+    auto col = column(i);
+    columns[i] = std::make_shared<Column>(col->field()->WithName(names[i]), col->data());
+  }
+  return Table::Make(schema(), std::move(columns), num_rows());
+}
+
 Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
                          std::shared_ptr<Table>* table) {
   if (tables.size() == 0) {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -493,11 +493,12 @@ Status Table::RenameColumns(const std::vector<std::string>& names,
                            " columns but only ", names.size(), " names were provided");
   }
   std::vector<std::shared_ptr<Column>> columns(num_columns());
+  std::vector<std::shared_ptr<Field>> fields(num_columns());
   for (int i = 0; i < num_columns(); ++i) {
-    auto col = column(i);
-    columns[i] = std::make_shared<Column>(col->field()->WithName(names[i]), col->data());
+    fields[i] = column(i)->field()->WithName(names[i]);
+    columns[i] = std::make_shared<Column>(fields[i], column(i)->data());
   }
-  *out = Table::Make(schema(), std::move(columns), num_rows());
+  *out = Table::Make(::arrow::schema(std::move(fields)), std::move(columns), num_rows());
   return Status::OK();
 }
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -301,7 +301,8 @@ class ARROW_EXPORT Table {
   std::vector<std::string> ColumnNames() const;
 
   /// \brief Rename columns with provided names
-  std::shared_ptr<Table> RenameColumns(const std::vector<std::string>& names) const;
+  Status RenameColumns(const std::vector<std::string>& names,
+                       std::shared_ptr<Table>* out) const;
 
   /// \brief Replace schema key-value metadata with new metadata (EXPERIMENTAL)
   /// \since 0.5.0

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -297,6 +297,12 @@ class ARROW_EXPORT Table {
   virtual Status SetColumn(int i, const std::shared_ptr<Column>& column,
                            std::shared_ptr<Table>* out) const = 0;
 
+  /// \brief Return names of all columns
+  std::vector<std::string> ColumnNames() const;
+
+  /// \brief Rename columns with provided names
+  std::shared_ptr<Table> RenameColumns(const std::vector<std::string>& names) const;
+
   /// \brief Replace schema key-value metadata with new metadata (EXPERIMENTAL)
   /// \since 0.5.0
   ///

--- a/cpp/src/arrow/type-test.cc
+++ b/cpp/src/arrow/type-test.cc
@@ -121,6 +121,26 @@ TEST(TestField, TestFlatten) {
   ASSERT_TRUE(vec[1]->Equals(*expected1));
 }
 
+TEST(TestField, TestReplacement) {
+  auto metadata = std::shared_ptr<KeyValueMetadata>(
+      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto f0 = field("f0", int32(), true, metadata);
+  auto fzero = f0->WithType(utf8());
+  auto f1 = f0->WithName("f1");
+
+  ASSERT_FALSE(f0->Equals(fzero));
+  ASSERT_FALSE(fzero->Equals(f1));
+  ASSERT_FALSE(f1->Equals(f0));
+
+  ASSERT_EQ(fzero->name(), "f0");
+  ASSERT_TRUE(fzero->type()->Equals(utf8()));
+  ASSERT_TRUE(fzero->metadata()->Equals(*metadata));
+
+  ASSERT_EQ(f1->name(), "f1");
+  ASSERT_TRUE(f1->type()->Equals(int32()));
+  ASSERT_TRUE(f1->metadata()->Equals(*metadata));
+}
+
 class TestSchema : public ::testing::Test {
  public:
   void SetUp() {}

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -56,6 +56,10 @@ std::shared_ptr<Field> Field::WithType(const std::shared_ptr<DataType>& type) co
   return std::make_shared<Field>(name_, type, nullable_, metadata_);
 }
 
+std::shared_ptr<Field> Field::WithName(const std::string& name) const {
+  return std::make_shared<Field>(name, type_, nullable_, metadata_);
+}
+
 std::vector<std::shared_ptr<Field>> Field::Flatten() const {
   std::vector<std::shared_ptr<Field>> flattened;
   if (type_->id() == Type::STRUCT) {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -291,6 +291,9 @@ class ARROW_EXPORT Field {
   /// \brief Return a copy of this field with the replaced type.
   std::shared_ptr<Field> WithType(const std::shared_ptr<DataType>& type) const;
 
+  /// \brief Return a copy of this field with the replaced name.
+  std::shared_ptr<Field> WithName(const std::string& name) const;
+
   std::vector<std::shared_ptr<Field>> Flatten() const;
 
   bool Equals(const Field& other, bool check_metadata = true) const;

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -39,6 +39,14 @@ build. Check for style errors before submitting your pull request with:
    flake8 .
    flake8 --config=.flake8.cython .
 
+The package ``autopep8`` (also available from pip or conda) can automatically
+fix many of the errors reported by ``flake8``:
+
+.. code-block:: shell
+
+   autopep8 --in-place ../integration/integration_test.py
+   autopep8 --in-place --global-config=.flake8.cython pyarrow/table.pxi
+
 Unit Testing
 ============
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -549,6 +549,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CStatus SetColumn(int i, const shared_ptr[CColumn]& column,
                           shared_ptr[CTable]* out)
 
+        vector[c_string] ColumnNames()
+        CStatus RenameColumns(const vector[c_string]&, shared_ptr[CTable]* out)
+
         CStatus Flatten(CMemoryPool* pool, shared_ptr[CTable]* out)
 
         CStatus Validate()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1531,7 +1531,7 @@ cdef class Table(_PandasConvertible):
             vector[c_string] c_names
 
         for name in names:
-          c_names.push_back(name)
+            c_names.push_back(name)
 
         with nogil:
             check_status(self.table.RenameColumns(c_names, &c_table))

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1520,18 +1520,18 @@ cdef class Table(_PandasConvertible):
         Names of the table's columns
         """
         names = self.table.ColumnNames()
-        return [name for name in names]
+        return [frombytes(name) for name in names]
 
     def rename_columns(self, names):
         """
-        Rename columns with provided names
+        Create new table with columns renamed to provided names
         """
         cdef:
             shared_ptr[CTable] c_table
             vector[c_string] c_names
 
         for name in names:
-            c_names.push_back(name)
+            c_names.push_back(tobytes(name))
 
         with nogil:
             check_status(self.table.RenameColumns(c_names, &c_table))

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1514,6 +1514,30 @@ cdef class Table(_PandasConvertible):
 
         return pyarrow_wrap_table(c_table)
 
+    @property
+    def column_names(self):
+        """
+        Names of the table's columns
+        """
+        names = self.table.ColumnNames()
+        return [name for name in names]
+
+    def rename_columns(self, names):
+        """
+        Rename columns with provided names
+        """
+        cdef:
+            shared_ptr[CTable] c_table
+            vector[c_string] c_names
+
+        for name in names:
+          c_names.push_back(name)
+
+        with nogil:
+            check_status(self.table.RenameColumns(c_names, &c_table))
+
+        return pyarrow_wrap_table(c_table)
+
     def drop(self, columns):
         """
         Drop one or more columns and return a new table.

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -739,6 +739,23 @@ def test_table_remove_column_empty():
     assert t3.equals(table)
 
 
+def test_table_rename_columns():
+    data = [
+        pa.array(range(5)),
+        pa.array([-10, -5, 0, 5, 10]),
+        pa.array(range(5, 10))
+    ]
+    table = pa.Table.from_arrays(data, names=['a', 'b', 'c'])
+    assert table.column_names == ['a', 'b', 'c']
+
+    t2 = table.rename_columns(['eh', 'bee', 'sea'])
+    t2._validate()
+    assert t2.column_names == ['eh', 'bee', 'sea']
+
+    expected = pa.Table.from_arrays(data, names=['eh', 'bee', 'sea'])
+    assert t2.equals(expected)
+
+
 def test_table_flatten():
     ty1 = pa.struct([pa.field('x', pa.int16()),
                      pa.field('y', pa.float32())])


### PR DESCRIPTION
This will allow users to produce a table with custom column names from a csv file without specifying a schema (and requiring type inference)