### PR TITLE
ARROW-5602: [Java][Gandiva] Add tests for round/cast

### DIFF
--- a/cpp/src/gandiva/decimal_ir.cc
+++ b/cpp/src/gandiva/decimal_ir.cc
@@ -592,6 +592,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_value", i128},
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("ceil_decimal128", i128,
@@ -599,6 +601,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_value", i128},
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("floor_decimal128", i128,
@@ -606,6 +610,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_value", i128},
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("round_decimal128", i128,
@@ -613,6 +619,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_value", i128},
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("round_decimal128_int32", i128,
@@ -621,6 +629,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
                                                            {"round_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("truncate_decimal128", i128,
@@ -628,6 +638,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_value", i128},
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("truncate_decimal128_int32", i128,
@@ -636,6 +648,8 @@ Status DecimalIR::AddFunctions(Engine* engine) {
                                                            {"x_precision", i32},
                                                            {"x_scale", i32},
                                                            {"round_scale", i32},
+                                                           {"out_precision", i32},
+                                                           {"out_scale", i32},
                                                        }));
 
   ARROW_RETURN_NOT_OK(decimal_ir->BuildDecimalFunction("castDECIMAL_int64", i128,

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -99,7 +99,8 @@ int32_t compare_internal_decimal128_decimal128(int64_t x_high, uint64_t x_low,
 
 FORCE_INLINE
 void abs_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                             int32_t x_scale, int64_t* out_high, uint64_t* out_low) {
+                             int32_t x_scale, int32_t out_precision, int32_t out_scale,
+                             int64_t* out_high, uint64_t* out_low) {
   gandiva::BasicDecimal128 x(x_high, x_low);
   x.Abs();
   *out_high = x.high_bits();
@@ -108,7 +109,8 @@ void abs_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precision
 
 FORCE_INLINE
 void ceil_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                              int32_t x_scale, int64_t* out_high, uint64_t* out_low) {
+                              int32_t x_scale, int32_t out_precision, int32_t out_scale,
+                              int64_t* out_high, uint64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
 
   bool overflow = false;
@@ -119,7 +121,8 @@ void ceil_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precisio
 
 FORCE_INLINE
 void floor_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                               int32_t x_scale, int64_t* out_high, uint64_t* out_low) {
+                               int32_t x_scale, int32_t out_precision, int32_t out_scale,
+                               int64_t* out_high, uint64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
 
   bool overflow = false;
@@ -130,7 +133,8 @@ void floor_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precisi
 
 FORCE_INLINE
 void round_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                               int32_t x_scale, int64_t* out_high, uint64_t* out_low) {
+                               int32_t x_scale, int32_t out_precision, int32_t out_scale,
+                               int64_t* out_high, uint64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
 
   bool overflow = false;
@@ -142,6 +146,7 @@ void round_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precisi
 FORCE_INLINE
 void round_decimal128_int32_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
                                      int32_t x_scale, int32_t rounding_scale,
+                                     int32_t out_precision, int32_t out_scale,
                                      int64_t* out_high, uint64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
 
@@ -153,7 +158,9 @@ void round_decimal128_int32_internal(int64_t x_high, uint64_t x_low, int32_t x_p
 
 FORCE_INLINE
 void truncate_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                                  int32_t x_scale, int64_t* out_high, uint64_t* out_low) {
+                                  int32_t x_scale, int32_t out_precision,
+                                  int32_t out_scale, int64_t* out_high,
+                                  uint64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
 
   bool overflow = false;
@@ -165,7 +172,8 @@ void truncate_decimal128_internal(int64_t x_high, uint64_t x_low, int32_t x_prec
 FORCE_INLINE
 void truncate_decimal128_int32_internal(int64_t x_high, uint64_t x_low,
                                         int32_t x_precision, int32_t x_scale,
-                                        int32_t rounding_scale, int64_t* out_high,
+                                        int32_t rounding_scale, int32_t out_precision,
+                                        int32_t out_scale, int64_t* out_high,
                                         uint64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
 

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -314,7 +314,7 @@ TEST_F(TestDecimal, TestRoundFunctions) {
 
   // build expressions
   auto exprs = std::vector<ExpressionPtr>{
-      TreeExprBuilder::MakeExpression("abs", {field_a}, field("abs_ceil", decimal_type)),
+      TreeExprBuilder::MakeExpression("abs", {field_a}, field("res_abs", decimal_type)),
       TreeExprBuilder::MakeExpression("ceil", {field_a},
                                       field("res_ceil", arrow::decimal(precision, 0))),
       TreeExprBuilder::MakeExpression("floor", {field_a},

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
@@ -123,7 +123,7 @@ public class AllocationOutcomeDetails {
           .append(" used: " + used)
           .append(" requestedSize: " + requestedSize)
           .append(" allocatedSize: " + allocatedSize)
-          .append(" localAllocationStatus: " + (allocationFailed ? "success" : "fail"))
+          .append(" localAllocationStatus: " + (allocationFailed ? "fail" : "success"))
           .append("\n")
           .toString();
     }


### PR DESCRIPTION
- Added java tests for round, cast
- Fixed wrapper fns in cpp to also take out_precision and
  out_scale as args. Not doing this caused a failure in
  docker with llvm-7.