### PR TITLE
ARROW-5603: [Python] Register custom pytest markers to avoid warnings

### DIFF
--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -105,7 +105,10 @@ except ImportError:
 
 
 def pytest_configure(config):
-    pass
+    for mark in groups:
+        config.addinivalue_line(
+            "markers", mark,
+        )
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5603