### PR TITLE
ARROW-5606: [Python] deal with deprecated RangeIndex._start/_stop/_step

### DIFF
--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -174,6 +174,13 @@ cdef class _PandasAPIShim(object):
         self._check_import()
         return self._pd.util.testing.assert_frame_equal
 
+    def get_rangeindex_attribute(self, level, name):
+        # public start/stop/step attributes added in pandas 0.25.0
+        self._check_import()
+        if hasattr(level, name):
+            return getattr(level, name)
+        return getattr(level, '_' + name)
+
 
 cdef _PandasAPIShim pandas_api = _PandasAPIShim()
 _pandas_api = pandas_api

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -386,14 +386,13 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
 
 
 def _get_range_index_descriptor(level):
-    # TODO(wesm): Why are these non-public and is there a more public way to
-    # get them?
+    # public start/stop/step attributes added in pandas 0.25.0
     return {
         'kind': 'range',
         'name': level.name,
-        'start': level._start,
-        'stop': level._stop,
-        'step': level._step
+        'start': _pandas_api.get_rangeindex_attribute(level, 'start'),
+        'stop': _pandas_api.get_rangeindex_attribute(level, 'stop'),
+        'step': _pandas_api.get_rangeindex_attribute(level, 'step')
     }
 
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -33,7 +33,8 @@ import numpy.testing as npt
 import pytest
 import pytz
 
-from pyarrow.pandas_compat import get_logical_type
+from pyarrow.pandas_compat import get_logical_type, _pandas_api
+
 import pyarrow as pa
 
 try:
@@ -183,13 +184,13 @@ class TestConvertMetadata(object):
         result = table.to_pandas()
         tm.assert_frame_equal(result, df)
         assert isinstance(result.index, pd.RangeIndex)
-        assert result.index._step == 2
+        assert _pandas_api.get_rangeindex_attribute(result.index, 'step') == 2
         assert result.index.name == index_name
 
         result2 = table_no_index_name.to_pandas()
         tm.assert_frame_equal(result2, df2)
         assert isinstance(result2.index, pd.RangeIndex)
-        assert result2.index._step == 1
+        assert _pandas_api.get_rangeindex_attribute(result2.index, 'step') == 1
         assert result2.index.name is None
 
     def test_multiindex_columns(self):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -193,6 +193,16 @@ class TestConvertMetadata(object):
         assert _pandas_api.get_rangeindex_attribute(result2.index, 'step') == 1
         assert result2.index.name is None
 
+    def test_rangeindex_doesnt_warn(self):
+        # ARROW-5606: pandas 0.25 deprecated private _start/stop/step
+        # attributes -> can be removed if support < pd 0.25 is dropped
+        df = pd.DataFrame(np.random.randn(4, 2), columns=['a', 'b'])
+
+        with pytest.warns(None) as record:
+            _check_pandas_roundtrip(df, preserve_index=True)
+
+        assert len(record) == 0
+
     def test_multiindex_columns(self):
         columns = pd.MultiIndex.from_arrays([
             ['one', 'two'], ['X', 'Y']


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5606