### PR TITLE
ARROW-5605: [C++] Verify Flatbuffer messages in more places to prevent crashes due to bad inputs

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -43,12 +43,8 @@ class Message::MessageImpl {
       : metadata_(metadata), message_(nullptr), body_(body) {}
 
   Status Open() {
-    auto data = metadata_->data();
-    flatbuffers::Verifier verifier(data, metadata_->size(), /*max_depth=*/128);
-    if (!flatbuf::VerifyMessageBuffer(verifier)) {
-      return Status::IOError("Invalid flatbuffers message.");
-    }
-    message_ = flatbuf::GetMessage(data);
+    RETURN_NOT_OK(
+        internal::VerifyMessage(metadata_->data(), metadata_->size(), &message_));
 
     // Check that the metadata version is supported
     if (message_->version() < internal::kMinMetadataVersion) {
@@ -148,12 +144,8 @@ bool Message::Equals(const Message& other) const {
 
 Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStream* stream,
                          std::unique_ptr<Message>* out) {
-  auto data = metadata->data();
-  flatbuffers::Verifier verifier(data, metadata->size(), /*max_depth=*/128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Invalid flatbuffers message.");
-  }
-  auto fb_message = flatbuf::GetMessage(data);
+  const flatbuf::Message* fb_message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata->data(), metadata->size(), &fb_message));
 
   int64_t body_length = fb_message->bodyLength();
 
@@ -169,13 +161,8 @@ Status Message::ReadFrom(const std::shared_ptr<Buffer>& metadata, io::InputStrea
 
 Status Message::ReadFrom(const int64_t offset, const std::shared_ptr<Buffer>& metadata,
                          io::RandomAccessFile* file, std::unique_ptr<Message>* out) {
-  auto data = metadata->data();
-  flatbuffers::Verifier verifier(data, metadata->size(), /*max_depth=*/128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Invalid flatbuffers message.");
-  }
-  auto fb_message = flatbuf::GetMessage(data);
-
+  const flatbuf::Message* fb_message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata->data(), metadata->size(), &fb_message));
   int64_t body_length = fb_message->bodyLength();
 
   std::shared_ptr<Buffer> body;
@@ -219,9 +206,8 @@ Status Message::SerializeTo(io::OutputStream* stream, int32_t alignment,
 }
 
 bool Message::Verify() const {
-  std::shared_ptr<Buffer> meta = this->metadata();
-  flatbuffers::Verifier verifier(meta->data(), meta->size(), 128);
-  return flatbuf::VerifyMessageBuffer(verifier);
+  const flatbuf::Message* unused;
+  return internal::VerifyMessage(metadata()->data(), metadata()->size(), &unused).ok();
 }
 
 std::string FormatMessageType(Message::Type type) {

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -1157,7 +1157,8 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
   auto message = flatbuf::GetMessage(metadata.data());
   auto sparse_tensor = message->header_as_SparseTensor();
   if (sparse_tensor == nullptr) {
-    return Status::IOError("Header-type of flatbuffer-encoded Message is not SparseTensor.");
+    return Status::IOError(
+        "Header-type of flatbuffer-encoded Message is not SparseTensor.");
   }
   int ndim = static_cast<int>(sparse_tensor->shape()->size());
 

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -1112,6 +1112,10 @@ Status GetSchema(const void* opaque_schema, DictionaryMemo* dictionary_memo,
 Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type,
                          std::vector<int64_t>* shape, std::vector<int64_t>* strides,
                          std::vector<std::string>* dim_names) {
+  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
+  if (!flatbuf::VerifyMessageBuffer(verifier)) {
+    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
+  }
   auto message = flatbuf::GetMessage(metadata.data());
   auto tensor = reinterpret_cast<const flatbuf::Tensor*>(message->header());
 
@@ -1143,6 +1147,10 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
                                std::vector<std::string>* dim_names,
                                int64_t* non_zero_length,
                                SparseTensorFormat::type* sparse_tensor_format_id) {
+  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
+  if (!flatbuf::VerifyMessageBuffer(verifier)) {
+    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
+  }
   auto message = flatbuf::GetMessage(metadata.data());
   if (message->header_type() != flatbuf::MessageHeader_SparseTensor) {
     return Status::IOError("Header of flatbuffer-encoded Message is not SparseTensor.");

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -1112,11 +1112,8 @@ Status GetSchema(const void* opaque_schema, DictionaryMemo* dictionary_memo,
 Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type,
                          std::vector<int64_t>* shape, std::vector<int64_t>* strides,
                          std::vector<std::string>* dim_names) {
-  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
-  }
-  auto message = flatbuf::GetMessage(metadata.data());
+  const flatbuf::Message* message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
   auto tensor = message->header_as_Tensor();
   if (tensor == nullptr) {
     return Status::IOError("Header-type of flatbuffer-encoded Message is not Tensor.");
@@ -1150,11 +1147,8 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
                                std::vector<std::string>* dim_names,
                                int64_t* non_zero_length,
                                SparseTensorFormat::type* sparse_tensor_format_id) {
-  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
-  }
-  auto message = flatbuf::GetMessage(metadata.data());
+  const flatbuf::Message* message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
   auto sparse_tensor = message->header_as_SparseTensor();
   if (sparse_tensor == nullptr) {
     return Status::IOError(

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -1117,7 +1117,10 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
     return Status::IOError("Verification of flatbuffer-encoded Message failed.");
   }
   auto message = flatbuf::GetMessage(metadata.data());
-  auto tensor = reinterpret_cast<const flatbuf::Tensor*>(message->header());
+  auto tensor = message->header_as_Tensor();
+  if (tensor == nullptr) {
+    return Status::IOError("Header-type of flatbuffer-encoded Message is not Tensor.");
+  }
 
   int ndim = static_cast<int>(tensor->shape()->size());
 
@@ -1152,14 +1155,10 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
     return Status::IOError("Verification of flatbuffer-encoded Message failed.");
   }
   auto message = flatbuf::GetMessage(metadata.data());
-  if (message->header_type() != flatbuf::MessageHeader_SparseTensor) {
-    return Status::IOError("Header of flatbuffer-encoded Message is not SparseTensor.");
+  auto sparse_tensor = message->header_as_SparseTensor();
+  if (sparse_tensor == nullptr) {
+    return Status::IOError("Header-type of flatbuffer-encoded Message is not SparseTensor.");
   }
-  if (message->header() == nullptr) {
-    return Status::IOError("Header-pointer of flatbuffer-encoded Message is null.");
-  }
-
-  auto sparse_tensor = reinterpret_cast<const flatbuf::SparseTensor*>(message->header());
   int ndim = static_cast<int>(sparse_tensor->shape()->size());
 
   for (int i = 0; i < ndim; ++i) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -392,6 +392,10 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
 
 Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
                       io::RandomAccessFile* file) {
+  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
+  if (!flatbuf::VerifyMessageBuffer(verifier)) {
+    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
+  }
   auto message = flatbuf::GetMessage(metadata.data());
   auto dictionary_batch =
       reinterpret_cast<const flatbuf::DictionaryBatch*>(message->header());
@@ -880,6 +884,10 @@ Status ReadSparseTensor(const Buffer& metadata, io::RandomAccessFile* file,
   RETURN_NOT_OK(internal::GetSparseTensorMetadata(
       metadata, &type, &shape, &dim_names, &non_zero_length, &sparse_tensor_format_id));
 
+  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
+  if (!flatbuf::VerifyMessageBuffer(verifier)) {
+    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
+  }
   auto message = flatbuf::GetMessage(metadata.data());
   auto sparse_tensor = reinterpret_cast<const flatbuf::SparseTensor*>(message->header());
   const flatbuf::Buffer* buffer = sparse_tensor->data();

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -411,8 +411,7 @@ Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
 
   // The dictionary is embedded in a record batch with a single column
   std::shared_ptr<RecordBatch> batch;
-  auto batch_meta =
-      reinterpret_cast<const flatbuf::RecordBatch*>(dictionary_batch->data());
+  auto batch_meta = dictionary_batch->data();
   RETURN_NOT_OK(ReadRecordBatch(batch_meta, ::arrow::schema({value_field}),
                                 dictionary_memo, kMaxNestingDepth, file, &batch));
   if (batch->num_columns() != 1) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -385,7 +385,8 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
   auto message = flatbuf::GetMessage(metadata.data());
   auto batch = message->header_as_RecordBatch();
   if (batch == nullptr) {
-    return Status::IOError("Header-type of flatbuffer-encoded Message is not RecordBatch.");
+    return Status::IOError(
+        "Header-type of flatbuffer-encoded Message is not RecordBatch.");
   }
   return ReadRecordBatch(batch, schema, dictionary_memo, max_recursion_depth, file, out);
 }
@@ -399,7 +400,8 @@ Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
   auto message = flatbuf::GetMessage(metadata.data());
   auto dictionary_batch = message->header_as_DictionaryBatch();
   if (dictionary_batch == nullptr) {
-    return Status::IOError("Header-type of flatbuffer-encoded Message is not DictionaryBatch.");
+    return Status::IOError(
+        "Header-type of flatbuffer-encoded Message is not DictionaryBatch.");
   }
 
   int64_t id = dictionary_batch->id();
@@ -896,7 +898,8 @@ Status ReadSparseTensor(const Buffer& metadata, io::RandomAccessFile* file,
   auto message = flatbuf::GetMessage(metadata.data());
   auto sparse_tensor = message->header_as_SparseTensor();
   if (sparse_tensor == nullptr) {
-    return Status::IOError("Header-type of flatbuffer-encoded Message is not SparseTensor.");
+    return Status::IOError(
+        "Header-type of flatbuffer-encoded Message is not SparseTensor.");
   }
   const flatbuf::Buffer* buffer = sparse_tensor->data();
   DCHECK(BitUtil::IsMultipleOf8(buffer->offset()))

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -378,11 +378,8 @@ static inline Status ReadRecordBatch(const flatbuf::RecordBatch* metadata,
 Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& schema,
                        const DictionaryMemo* dictionary_memo, int max_recursion_depth,
                        io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out) {
-  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
-  }
-  auto message = flatbuf::GetMessage(metadata.data());
+  const flatbuf::Message* message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
   auto batch = message->header_as_RecordBatch();
   if (batch == nullptr) {
     return Status::IOError(
@@ -393,11 +390,8 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
 
 Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
                       io::RandomAccessFile* file) {
-  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
-  }
-  auto message = flatbuf::GetMessage(metadata.data());
+  const flatbuf::Message* message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
   auto dictionary_batch = message->header_as_DictionaryBatch();
   if (dictionary_batch == nullptr) {
     return Status::IOError(
@@ -891,11 +885,8 @@ Status ReadSparseTensor(const Buffer& metadata, io::RandomAccessFile* file,
   RETURN_NOT_OK(internal::GetSparseTensorMetadata(
       metadata, &type, &shape, &dim_names, &non_zero_length, &sparse_tensor_format_id));
 
-  flatbuffers::Verifier verifier(metadata.data(), metadata.size(), 128);
-  if (!flatbuf::VerifyMessageBuffer(verifier)) {
-    return Status::IOError("Verification of flatbuffer-encoded Message failed.");
-  }
-  auto message = flatbuf::GetMessage(metadata.data());
+  const flatbuf::Message* message;
+  RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
   auto sparse_tensor = message->header_as_SparseTensor();
   if (sparse_tensor == nullptr) {
     return Status::IOError(

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -397,8 +397,10 @@ Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
     return Status::IOError("Verification of flatbuffer-encoded Message failed.");
   }
   auto message = flatbuf::GetMessage(metadata.data());
-  auto dictionary_batch =
-      reinterpret_cast<const flatbuf::DictionaryBatch*>(message->header());
+  auto dictionary_batch = message->header_as_DictionaryBatch();
+  if (dictionary_batch == nullptr) {
+    return Status::IOError("Header-type of flatbuffer-encoded Message is not DictionaryBatch.");
+  }
 
   int64_t id = dictionary_batch->id();
 
@@ -892,7 +894,10 @@ Status ReadSparseTensor(const Buffer& metadata, io::RandomAccessFile* file,
     return Status::IOError("Verification of flatbuffer-encoded Message failed.");
   }
   auto message = flatbuf::GetMessage(metadata.data());
-  auto sparse_tensor = reinterpret_cast<const flatbuf::SparseTensor*>(message->header());
+  auto sparse_tensor = message->header_as_SparseTensor();
+  if (sparse_tensor == nullptr) {
+    return Status::IOError("Header-type of flatbuffer-encoded Message is not SparseTensor.");
+  }
   const flatbuf::Buffer* buffer = sparse_tensor->data();
   DCHECK(BitUtil::IsMultipleOf8(buffer->offset()))
       << "Buffer of sparse index data "


### PR DESCRIPTION
While the first commit (`fix ReadRecordBatch validation`) is sufficient to fix ARROW-5605, I took the time to fix very similar issues in the code IPC code base, so our users are probably protected and also to help the fuzzer to not run straight into a similar problem again.