### PR TITLE
ARROW-5608: [C++][parquet] Fix invalid memory access when using parquet::arrow::ColumnReader

### DIFF
--- a/cpp/src/parquet/arrow/record_reader.cc
+++ b/cpp/src/parquet/arrow/record_reader.cc
@@ -353,12 +353,14 @@ class RecordReader::RecordReaderImpl {
       int16_t* rep_data = rep_levels();
 
       std::copy(def_data + levels_position_, def_data + levels_written_, def_data);
-      std::copy(rep_data + levels_position_, rep_data + levels_written_, rep_data);
+      PARQUET_THROW_NOT_OK(
+                           def_levels_->Resize(levels_remaining * sizeof(int16_t), false));
 
-      PARQUET_THROW_NOT_OK(
-          def_levels_->Resize(levels_remaining * sizeof(int16_t), false));
-      PARQUET_THROW_NOT_OK(
-          rep_levels_->Resize(levels_remaining * sizeof(int16_t), false));
+      if (max_rep_level_ > 0) {
+        std::copy(rep_data + levels_position_, rep_data + levels_written_, rep_data);
+        PARQUET_THROW_NOT_OK(
+                             rep_levels_->Resize(levels_remaining * sizeof(int16_t), false));
+      }
 
       levels_written_ -= levels_position_;
       levels_position_ = 0;

--- a/cpp/src/parquet/arrow/record_reader.cc
+++ b/cpp/src/parquet/arrow/record_reader.cc
@@ -354,12 +354,12 @@ class RecordReader::RecordReaderImpl {
 
       std::copy(def_data + levels_position_, def_data + levels_written_, def_data);
       PARQUET_THROW_NOT_OK(
-                           def_levels_->Resize(levels_remaining * sizeof(int16_t), false));
+          def_levels_->Resize(levels_remaining * sizeof(int16_t), false));
 
       if (max_rep_level_ > 0) {
         std::copy(rep_data + levels_position_, rep_data + levels_written_, rep_data);
         PARQUET_THROW_NOT_OK(
-                             rep_levels_->Resize(levels_remaining * sizeof(int16_t), false));
+            rep_levels_->Resize(levels_remaining * sizeof(int16_t), false));
       }
 
       levels_written_ -= levels_position_;


### PR DESCRIPTION
This fix appears to resolve the ASAN failures detected by this [gist](https://gist.github.com/hatemhelal/892e76a48e5b372f0e28a34403893ddd#file-reader-writer-cc-L130). 

This invalid memory access is only observed when:

* The `batch_size` is smaller than the row group
* There are zero repetition levels.

Included with this patch is a type parameterized unittest (might be overkill) that I've qualified on macOS.