### PR TITLE
ARROW-5082: [Python] Stop exporting copies of shared libraries in wheel

### DIFF
--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -111,6 +111,7 @@ PATH="$PATH:${CPYTHON_PATH}/bin" $PYTHON_INTERPRETER setup.py build_ext \
     --bundle-boost \
     --boost-namespace=arrow_boost
 PATH="$PATH:${CPYTHON_PATH}/bin" $PYTHON_INTERPRETER setup.py bdist_wheel
+# Source distribution is used for debian pyarrow packages.
 PATH="$PATH:${CPYTHON_PATH}/bin" $PYTHON_INTERPRETER setup.py sdist
 
 if [ -n "$UBUNTU_WHEELS" ]; then

--- a/python/setup.py
+++ b/python/setup.py
@@ -499,11 +499,6 @@ def _move_shared_libs_unix(build_prefix, build_lib, lib_name):
     lib_filename = os.path.basename(libs[0])
     shutil.move(pjoin(build_prefix, lib_filename),
                 pjoin(build_lib, 'pyarrow', lib_filename))
-    for lib in libs[1:]:
-        filename = os.path.basename(lib)
-        link_name = pjoin(build_lib, 'pyarrow', filename)
-        if not os.path.exists(link_name):
-            os.symlink(lib_filename, link_name)
 
 
 # If the event of not running from a git clone (e.g. from a git archive


### PR DESCRIPTION
This reduces the size from 50mb to 28mb. I haven't tested if this breaks the OSX wheel. Note that the fix is brittle since currently (on Linux) it links with the full-versioned shared library binary. This works out due to the `-len(x)` sorting applied. A proper fix would be to keep the one linked (found via `ldd` or some other methods). I suspect that auditwheel and subsequent install & test will catch this if the contract were to change.