### PR TITLE
ARROW-5615: [C++] gcc 5.4.0 doesn't want to parse inline C++11 string R literal

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -270,7 +270,12 @@ if(NOT ARROW_BUILD_TESTS)
   set(NO_TESTS 1)
 else()
   add_custom_target(all-tests)
-  add_custom_target(unittest ctest -L unittest)
+  add_custom_target(unittest
+                    ctest
+                    -j4
+                    -L
+                    unittest
+                    --output-on-failure)
   add_dependencies(unittest all-tests)
 endif()
 

--- a/cpp/src/arrow/ipc/json-simple-test.cc
+++ b/cpp/src/arrow/ipc/json-simple-test.cc
@@ -540,13 +540,15 @@ TEST(TestMap, IntegerToInteger) {
   auto type = map(int16(), int16());
   std::shared_ptr<Array> expected, actual;
 
-  ASSERT_OK(ArrayFromJSON(type, R"([
+  const char* input = R"(
+[
     [[0, 1], [1, 1], [2, 2], [3, 3], [4, 5], [5, 8]],
     null,
     [[0, null], [1, null], [2, 0], [3, 1], [4, null], [5, 2]],
     []
-  ])",
-                          &actual));
+  ]
+)";
+  ASSERT_OK(ArrayFromJSON(type, input, &actual));
 
   std::unique_ptr<ArrayBuilder> builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), type, &builder));
@@ -569,12 +571,15 @@ TEST(TestMap, IntegerToInteger) {
 
 TEST(TestMap, StringToInteger) {
   auto type = map(utf8(), int32());
-  auto actual = ArrayFromJSON(type, R"([
+  const char* input = R"(
+[
     [["joe", 0], ["mark", null]],
     null,
     [["cap", 8]],
     []
-  ])");
+  ]
+)";
+  auto actual = ArrayFromJSON(type, input);
   std::vector<int32_t> offsets = {0, 2, 2, 3, 3};
   auto expected_keys = ArrayFromJSON(utf8(), R"(["joe", "mark", "cap"])");
   auto expected_values = ArrayFromJSON(int32(), "[0, null, 8]");
@@ -610,7 +615,8 @@ TEST(TestMap, IntegerMapToStringList) {
   auto type = map(map(int16(), int16()), list(utf8()));
   std::shared_ptr<Array> expected, actual;
 
-  ASSERT_OK(ArrayFromJSON(type, R"([
+  const char* input = R"(
+[
     [
       [
         [],
@@ -626,8 +632,9 @@ TEST(TestMap, IntegerMapToStringList) {
       ]
     ],
     null
-  ])",
-                          &actual));
+  ]
+)";
+  ASSERT_OK(ArrayFromJSON(type, input, &actual));
 
   std::unique_ptr<ArrayBuilder> builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), type, &builder));

--- a/cpp/src/parquet/schema-test.cc
+++ b/cpp/src/parquet/schema-test.cc
@@ -586,13 +586,13 @@ TEST(TestColumnDescriptor, TestAttrs) {
 
   ASSERT_EQ(-1, descr.type_length());
   const char* expected_descr = R"(column descriptor = {
-  name: name
-  path:
-  physical_type: BYTE_ARRAY
-  logical_type: UTF8
-  logical_annotation: String
-  max_definition_level: 4
-  max_repetition_level: 1
+  name: name,
+  path: ,
+  physical_type: BYTE_ARRAY,
+  logical_type: UTF8,
+  logical_annotation: String,
+  max_definition_level: 4,
+  max_repetition_level: 1,
 })";
   ASSERT_EQ(expected_descr, descr.ToString());
 
@@ -605,16 +605,16 @@ TEST(TestColumnDescriptor, TestAttrs) {
   ASSERT_EQ(12, descr.type_length());
 
   expected_descr = R"(column descriptor = {
-  name: name
-  path:
-  physical_type: FIXED_LEN_BYTE_ARRAY
-  logical_type: DECIMAL
-  logical_annotation: Decimal(precision=10, scale=4)
-  max_definition_level: 4
-  max_repetition_level: 1
-  length: 12
-  precision: 10
-  scale: 4
+  name: name,
+  path: ,
+  physical_type: FIXED_LEN_BYTE_ARRAY,
+  logical_type: DECIMAL,
+  logical_annotation: Decimal(precision=10, scale=4),
+  max_definition_level: 4,
+  max_repetition_level: 1,
+  length: 12,
+  precision: 10,
+  scale: 4,
 })";
   ASSERT_EQ(expected_descr, descr.ToString());
 }

--- a/cpp/src/parquet/schema-test.cc
+++ b/cpp/src/parquet/schema-test.cc
@@ -585,17 +585,16 @@ TEST(TestColumnDescriptor, TestAttrs) {
   ASSERT_EQ(Type::BYTE_ARRAY, descr.physical_type());
 
   ASSERT_EQ(-1, descr.type_length());
-  ASSERT_EQ(
-      R"(column descriptor = {
+  const char* expected_descr = R"(column descriptor = {
   name: name
-  path: 
+  path:
   physical_type: BYTE_ARRAY
   logical_type: UTF8
   logical_annotation: String
   max_definition_level: 4
   max_repetition_level: 1
-})",
-      descr.ToString());
+})";
+  ASSERT_EQ(expected_descr, descr.ToString());
 
   // Test FIXED_LEN_BYTE_ARRAY
   node = PrimitiveNode::Make("name", Repetition::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
@@ -605,10 +604,9 @@ TEST(TestColumnDescriptor, TestAttrs) {
   ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, descr.physical_type());
   ASSERT_EQ(12, descr.type_length());
 
-  ASSERT_EQ(
-      R"(column descriptor = {
+  expected_descr = R"(column descriptor = {
   name: name
-  path: 
+  path:
   physical_type: FIXED_LEN_BYTE_ARRAY
   logical_type: DECIMAL
   logical_annotation: Decimal(precision=10, scale=4)
@@ -617,8 +615,8 @@ TEST(TestColumnDescriptor, TestAttrs) {
   length: 12
   precision: 10
   scale: 4
-})",
-      descr.ToString());
+})";
+  ASSERT_EQ(expected_descr, descr.ToString());
 }
 
 class TestSchemaDescriptor : public ::testing::Test {

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -921,21 +921,21 @@ std::string SchemaDescriptor::ToString() const {
 std::string ColumnDescriptor::ToString() const {
   std::ostringstream ss;
   ss << "column descriptor = {" << std::endl
-     << "  name: " << name() << std::endl
-     << "  path: " << path()->ToDotString() << std::endl
-     << "  physical_type: " << TypeToString(physical_type()) << std::endl
-     << "  logical_type: " << LogicalTypeToString(logical_type()) << std::endl
-     << "  logical_annotation: " << logical_annotation()->ToString() << std::endl
-     << "  max_definition_level: " << max_definition_level() << std::endl
-     << "  max_repetition_level: " << max_repetition_level() << std::endl;
+     << "  name: " << name() << "," << std::endl
+     << "  path: " << path()->ToDotString() << "," << std::endl
+     << "  physical_type: " << TypeToString(physical_type()) << "," << std::endl
+     << "  logical_type: " << LogicalTypeToString(logical_type()) << "," << std::endl
+     << "  logical_annotation: " << logical_annotation()->ToString() << "," << std::endl
+     << "  max_definition_level: " << max_definition_level() << "," << std::endl
+     << "  max_repetition_level: " << max_repetition_level() << "," << std::endl;
 
   if (physical_type() == ::parquet::Type::FIXED_LEN_BYTE_ARRAY) {
-    ss << "  length: " << type_length() << std::endl;
+    ss << "  length: " << type_length() << "," << std::endl;
   }
 
   if (logical_type() == parquet::LogicalType::DECIMAL) {
-    ss << "  precision: " << type_precision() << std::endl
-       << "  scale: " << type_scale() << std::endl;
+    ss << "  precision: " << type_precision() << "," << std::endl
+       << "  scale: " << type_scale() << "," << std::endl;
   }
 
   ss << "}";


### PR DESCRIPTION
I ran into this while trying to tinker with ARROW-5474 (checking minimum Boost version).

This occurs for me on master with

```
docker-compose build cpp-ubuntu-xenial
docker-compose run cpp-ubuntu-xenial
```

Error looks like 

```
/arrow/cpp/src/arrow/ipc/json-simple-test.cc:543:9: error: missing terminating " character [-Werror]
   ASSERT_OK(ArrayFromJSON(type, R"delim(
         ^
/arrow/cpp/src/arrow/ipc/json-simple-test.cc:543:2: error: missing terminating " character
   ASSERT_OK(ArrayFromJSON(type, R"delim(
  ^
/arrow/cpp/src/arrow/ipc/json-simple-test.cc:550:1: error: stray '\' in program
 )delim",
```

I'm perplexed about why this is a problem and why it has not been encountered by others. 