### PR TITLE
ARROW-5590: [R] Run "no libarrow" R build in the same CI entry if possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -348,7 +348,7 @@ matrix:
     - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`
     - if [ $ARROW_CI_R_AFFECTED != "1" ]; then exit; fi
     # First check that it builds without libarrow
-    - R -e 'install.packages("devtools"); devtools::install_deps(dep = TRUE)'
+    - R -e 'install.packages("remotes"); remotes::install_deps(dep = TRUE)'
     - R CMD build .
     - R CMD check arrow_*tar.gz
     - rm arrow_*tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -370,10 +370,10 @@ matrix:
     - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib
     - export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$TRAVIS_BUILD_DIR/cpp-install/lib/pkgconfig
     - export CXX11FLAGS=-Wall
+    # Add this env var so we can assert in the tests that the library is installed correctly
+    - export TEST_R_WITH_ARROW=TRUE
     - pushd ${TRAVIS_BUILD_DIR}/r
     after_success:
-    # Double-check that we just ran with libarrow support
-    - Rscript -e 'if (!arrow::arrow_available()) q(status=1)'
     - Rscript ../ci/travis_upload_r_coverage.R
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -348,7 +348,7 @@ matrix:
     - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`
     - if [ $ARROW_CI_R_AFFECTED != "1" ]; then exit; fi
     # First check that it builds without libarrow
-    - R -e 'devtools::install_deps(dep = T)'
+    - R -e 'install.packages("devtools"); devtools::install_deps(dep = TRUE)'
     - R CMD build .
     - R CMD check arrow_*tar.gz
     - rm arrow_*tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -336,10 +336,9 @@ matrix:
     after_success:
     - pushd ${TRAVIS_BUILD_DIR}/go/arrow
     - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
-  - name: R
+  - name: R (with and without libarrow)
     language: r
     cache: packages
-    latex: false
     dist: xenial
     env:
     - ARROW_TRAVIS_PARQUET=1
@@ -348,6 +347,12 @@ matrix:
     # Have to copy-paste this here because of how R's build steps work
     - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`
     - if [ $ARROW_CI_R_AFFECTED != "1" ]; then exit; fi
+    # First check that it builds without libarrow
+    - R -e 'devtools::install_deps(dep = T)'
+    - R CMD build .
+    - R CMD check arrow_*tar.gz
+    - rm arrow_*tar.gz
+    # Now, proceed to install the c++ lib and the rest of the job
     - |
         if [ $TRAVIS_OS_NAME == "linux" ]; then
           sudo bash -c "echo -e 'Acquire::Retries 10; Acquire::http::Timeout \"20\";' > /etc/apt/apt.conf.d/99-travis-retry"
@@ -365,23 +370,9 @@ matrix:
     - export CXX11FLAGS=-Wall
     - pushd ${TRAVIS_BUILD_DIR}/r
     after_success:
+    # Double-check that we just ran with libarrow support
+    - Rscript -e 'if (!arrow::arrow_available()) q(status=1)'
     - Rscript ../ci/travis_upload_r_coverage.R
-  - name: R_no_libarrow
-    language: r
-    cache: packages
-    latex: false
-    dist: xenial
-    before_install:
-    # Have to copy-paste this here because of how R's build steps work
-    - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`
-    - if [ $ARROW_CI_R_AFFECTED != "1" ]; then exit; fi
-    - |
-        if [ $TRAVIS_OS_NAME == "linux" ]; then
-          sudo bash -c "echo -e 'Acquire::Retries 10; Acquire::http::Timeout \"20\";' > /etc/apt/apt.conf.d/99-travis-retry"
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update -qq
-        fi
-    - pushd ${TRAVIS_BUILD_DIR}/r
 
 after_failure:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -348,10 +348,12 @@ matrix:
     - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`
     - if [ $ARROW_CI_R_AFFECTED != "1" ]; then exit; fi
     # First check that it builds without libarrow
+    - pushd ${TRAVIS_BUILD_DIR}/r
     - R -e 'install.packages("remotes"); remotes::install_deps(dep = TRUE)'
     - R CMD build .
     - R CMD check arrow_*tar.gz
     - rm arrow_*tar.gz
+    - popd
     # Now, proceed to install the c++ lib and the rest of the job
     - |
         if [ $TRAVIS_OS_NAME == "linux" ]; then

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -17,7 +17,7 @@
 
 test_that <- function(what, code) {
   testthat::test_that(what, {
-    skip_if(!arrow:::arrow_available(), "arrow C++ library not available")
+    skip_if(!arrow::arrow_available(), "arrow C++ library not available")
     code
   })
 }

--- a/r/tests/testthat/test-arrow.R
+++ b/r/tests/testthat/test-arrow.R
@@ -1,0 +1,7 @@
+context("General checks")
+
+if (identical(Sys.getenv("TEST_R_WITH_ARROW"), "TRUE")) {
+  testthat::test_that("Arrow C++ is available", {
+    expect_true(arrow_available())
+  })
+}

--- a/r/tests/testthat/test-arrow.R
+++ b/r/tests/testthat/test-arrow.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 context("General checks")
 
 if (identical(Sys.getenv("TEST_R_WITH_ARROW"), "TRUE")) {


### PR DESCRIPTION
In reading the Travis docs to work on a different issue, I got an idea for how to poke in the without-libarrow check before the C++ lib gets installed in the same job. 

I also removed the `latex: false` flag from the job, so it will also test building the package man pages, which CRAN will do. 