### PR TITLE
ARROW-5616: [C++][Python] Fix -Wwrite-strings warning when building against Python 2.7 headers 

### DIFF
--- a/cpp/src/arrow/python/common.h
+++ b/cpp/src/arrow/python/common.h
@@ -259,6 +259,17 @@ class ARROW_PYTHON_EXPORT PyBuffer : public Buffer {
   Py_buffer py_buf_;
 };
 
+// This is annoying: because C++11 does not allow implicit conversion of string
+// literals to non-const char*, we need to go through some gymnastics to use
+// PyObject_CallMethod without a lot of pain (its arguments are non-const
+// char*)
+template <typename... ArgTypes>
+static inline PyObject* cpp_PyObject_CallMethod(PyObject* obj, const char* method_name,
+                                                const char* argspec, ArgTypes... args) {
+  return PyObject_CallMethod(obj, const_cast<char*>(method_name),
+                             const_cast<char*>(argspec), args...);
+}
+
 }  // namespace py
 }  // namespace arrow
 

--- a/cpp/src/arrow/python/extension_type.cc
+++ b/cpp/src/arrow/python/extension_type.cc
@@ -33,7 +33,8 @@ namespace {
 
 // Serialize a Python ExtensionType instance
 Status SerializeExtInstance(PyObject* type_instance, std::string* out) {
-  OwnedRef res(PyObject_CallMethod(type_instance, "__arrow_ext_serialize__", nullptr));
+  OwnedRef res(
+      cpp_PyObject_CallMethod(type_instance, "__arrow_ext_serialize__", nullptr));
   if (!res) {
     return ConvertPyError();
   }

--- a/cpp/src/arrow/python/extension_type.cc
+++ b/cpp/src/arrow/python/extension_type.cc
@@ -61,8 +61,8 @@ PyObject* DeserializeExtInstance(PyObject* type_class,
     return nullptr;
   }
 
-  return PyObject_CallMethod(type_class, "__arrow_ext_deserialize__", "OO",
-                             storage_ref.obj(), data_ref.obj());
+  return cpp_PyObject_CallMethod(type_class, "__arrow_ext_deserialize__", "OO",
+                                 storage_ref.obj(), data_ref.obj());
 }
 
 }  // namespace

--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -36,17 +36,6 @@ namespace py {
 // ----------------------------------------------------------------------
 // Python file
 
-// This is annoying: because C++11 does not allow implicit conversion of string
-// literals to non-const char*, we need to go through some gymnastics to use
-// PyObject_CallMethod without a lot of pain (its arguments are non-const
-// char*)
-template <typename... ArgTypes>
-static inline PyObject* cpp_PyObject_CallMethod(PyObject* obj, const char* method_name,
-                                                const char* argspec, ArgTypes... args) {
-  return PyObject_CallMethod(obj, const_cast<char*>(method_name),
-                             const_cast<char*>(argspec), args...);
-}
-
 // A common interface to a Python file-like object. Must acquire GIL before
 // calling any methods
 class PythonFile {

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -114,7 +114,7 @@ def test_ext_array_lifetime():
     storage = pa.array([b"foo", b"bar"], type=pa.binary(3))
     arr = pa.ExtensionArray.from_storage(ty, storage)
 
-    refs = [weakref.ref(obj) for obj in (ty, arr, storage)]
+    refs = [weakref.ref(ty), weakref.ref(arr), weakref.ref(storage)]
     del ty, storage, arr
     for ref in refs:
         assert ref() is None


### PR DESCRIPTION
`PyObject_CallMethod` uses `const char*` for its arguments while Python 2.7 it's `char*` so this warning only occurs there