### PR TITLE
ARROW-5619: [C++] Make get_apache_mirror.py workable with Python 3.5

### DIFF
--- a/cpp/build-support/get_apache_mirror.py
+++ b/cpp/build-support/get_apache_mirror.py
@@ -28,4 +28,4 @@ except ImportError:
 
 suggested_mirror = urlopen('https://www.apache.org/dyn/'
                            'closer.cgi?as_json=1').read()
-print(json.loads(suggested_mirror)['preferred'])
+print(json.loads(suggested_mirror.decode('utf-8'))['preferred'])


### PR DESCRIPTION
    % python3 --version
    Python 3.5.3
    % python3 cpp/build-support/get_apache_mirror.py
    Traceback (most recent call last):
      File "cpp/build-support/get_apache_mirror.py", line 31, in <module>
        print(json.loads(suggested_mirror)['preferred'])
      File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
        s.__class__.__name__))
    TypeError: the JSON object must be str, not 'bytes'

Debian stretch ships Python 3.5 as python3.
