### PR TITLE
ARROW-5626: [C++] Fix caching of expressions with decimals

### DIFF
--- a/cpp/src/gandiva/expr_validator.cc
+++ b/cpp/src/gandiva/expr_validator.cc
@@ -34,9 +34,9 @@ Status ExprValidator::Validate(const ExpressionPtr& expr) {
   // support validation is not required because root type is already supported.
   ARROW_RETURN_IF(!root.return_type()->Equals(*expr->result()->type()),
                   Status::ExpressionValidationError("Return type of root node ",
-                                                    root.return_type()->name(),
+                                                    root.return_type()->ToString(),
                                                     " does not match that of expression ",
-                                                    expr->result()->type()->name()));
+                                                    expr->result()->type()->ToString()));
 
   return Status::OK();
 }

--- a/cpp/src/gandiva/like_holder_test.cc
+++ b/cpp/src/gandiva/like_holder_test.cc
@@ -98,12 +98,12 @@ TEST_F(TestLikeHolder, TestOptimise) {
   // optimise for 'starts_with'
   auto fnode = LikeHolder::TryOptimize(BuildLike("xy 123z%"));
   EXPECT_EQ(fnode.descriptor()->name(), "starts_with");
-  EXPECT_EQ(fnode.ToString(), "bool starts_with((utf8) in, (const string) xy 123z)");
+  EXPECT_EQ(fnode.ToString(), "bool starts_with((string) in, (const string) xy 123z)");
 
   // optimise for 'ends_with'
   fnode = LikeHolder::TryOptimize(BuildLike("%xyz"));
   EXPECT_EQ(fnode.descriptor()->name(), "ends_with");
-  EXPECT_EQ(fnode.ToString(), "bool ends_with((utf8) in, (const string) xyz)");
+  EXPECT_EQ(fnode.ToString(), "bool ends_with((string) in, (const string) xyz)");
 
   // no optimisation for others.
   fnode = LikeHolder::TryOptimize(BuildLike("xyz_"));

--- a/cpp/src/gandiva/node.h
+++ b/cpp/src/gandiva/node.h
@@ -105,7 +105,7 @@ class GANDIVA_EXPORT FieldNode : public Node {
   const FieldPtr& field() const { return field_; }
 
   std::string ToString() const override {
-    return "(" + field()->type()->name() + ") " + field()->name();
+    return "(" + field()->type()->ToString() + ") " + field()->name();
   }
 
  private:
@@ -124,7 +124,7 @@ class GANDIVA_EXPORT FunctionNode : public Node {
 
   std::string ToString() const override {
     std::stringstream ss;
-    ss << descriptor()->return_type()->name() << " " << descriptor()->name() << "(";
+    ss << descriptor()->return_type()->ToString() << " " << descriptor()->name() << "(";
     bool skip_comma = true;
     for (auto& child : children()) {
       if (skip_comma) {


### PR DESCRIPTION
- use full DataType instead of just name
- added test for caching decimal expr