### PR TITLE
ARROW-5632: [Doc] Basic instructions for using Xcode with Arrow

### DIFF
--- a/docs/source/developers/cpp.rst
+++ b/docs/source/developers/cpp.rst
@@ -630,6 +630,27 @@ The report is then generated in ``compat_reports/libarrow`` as a HTML.
 
 .. _developers-cpp-windows:
 
+Debugging with Xcode on macOS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Xcode is the IDE provided with macOS and can be use to develop and debug Arrow 
+by generating an Xcode project:
+
+.. code-block:: shell
+
+   cd cpp
+   mkdir xcode-build
+   cd xcode-build
+   cmake .. -G Xcode ^
+         -DARROW_BUILD_TESTS=ON
+   open arrow.xcodeproj
+
+This will generate a project and open it in the Xcode app. As an alternative, 
+the command ``xcodebuild`` will perform a command-line build using the
+generated project. It is recommended to use the "Automatically Create Schemes"
+option when first launching the project.  Selecting an auto-generated scheme 
+will allow you to build and run a unittest with breakpoints enabled.
+
 Developing on Windows
 =====================
 


### PR DESCRIPTION
Added a new section on debugging with Xcode on macOS.  I am a bit wary of doing a step-by-step tutorial with screenshots as those tend to get quickly out of date as the Xcode app evolves, and I think there will always be better sources elsewhere for helping users ramp up on how to use Xcode.  The goal is to add enough to help someone familiar with C++ development in Xcode to get started working on Arrow.  

cc: @nealrichardson or @xhochy: I recall you both have macs, could you try these instructions out and let me know if you run into any trouble?  Any advice on clarity, readability, etc would also be very welcome.  I'm not sure if I found the right location to add this so let me know if this fits in ok with the rest of the overall cpp doc.