### PR TITLE
ARROW-5635: [C++] Added a Compact() method to Table.

### DIFF
--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -423,7 +423,7 @@ TEST_F(TestTable, FromRecordBatchesZeroLength) {
   ASSERT_TRUE(result->schema()->Equals(*schema_));
 }
 
-TEST_F(TestTable, CompactEmptyTable) {
+TEST_F(TestTable, CombineChunksEmptyTable) {
   MakeExample1(10);
 
   std::shared_ptr<Table> table;
@@ -431,19 +431,17 @@ TEST_F(TestTable, CompactEmptyTable) {
   ASSERT_EQ(0, table->num_rows());
 
   std::shared_ptr<Table> compacted;
-  ASSERT_OK(table->Compact(default_memory_pool(), &compacted));
+  ASSERT_OK(table->CombineChunks(default_memory_pool(), &compacted));
 
   EXPECT_TRUE(compacted->Equals(*table));
 }
 
-TEST_F(TestTable, CompactTable) {
-  const int64_t length = 10;
+TEST_F(TestTable, CombineChunks) {
+  MakeExample1(10);
+  auto batch1 = RecordBatch::Make(schema_, 10, arrays_);
 
-  MakeExample1(length);
-  auto batch1 = RecordBatch::Make(schema_, length, arrays_);
-
-  MakeExample1(length);
-  auto batch2 = RecordBatch::Make(schema_, length, arrays_);
+  MakeExample1(15);
+  auto batch2 = RecordBatch::Make(schema_, 15, arrays_);
 
   std::shared_ptr<Table> table;
   ASSERT_OK(Table::FromRecordBatches({batch1, batch2}, &table));
@@ -452,7 +450,7 @@ TEST_F(TestTable, CompactTable) {
   }
 
   std::shared_ptr<Table> compacted;
-  ASSERT_OK(table->Compact(default_memory_pool(), &compacted));
+  ASSERT_OK(table->CombineChunks(default_memory_pool(), &compacted));
 
   EXPECT_TRUE(compacted->Equals(*table));
   for (int i = 0; i < compacted->num_columns(); ++i) {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -33,8 +33,10 @@
 #include "arrow/util/stl.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace {
-using ::arrow::internal::checked_cast;
 
 // If a column contains multiple chunks, concatenates those chunks into one and
 // makes a new column out of it. Otherwise makes `compacted` point to the same
@@ -591,7 +593,7 @@ bool Table::Equals(const Table& other) const {
   return true;
 }
 
-Status Table::Compact(MemoryPool* pool, std::shared_ptr<Table>* out) const {
+Status Table::CombineChunks(MemoryPool* pool, std::shared_ptr<Table>* out) const {
   const int ncolumns = num_columns();
   std::vector<std::shared_ptr<Column>> compacted_columns(ncolumns);
   for (int i = 0; i < ncolumns; ++i) {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -593,12 +593,9 @@ bool Table::Equals(const Table& other) const {
 
 Status Table::Compact(MemoryPool* pool, std::shared_ptr<Table>* out) const {
   const int ncolumns = num_columns();
-  std::vector<std::shared_ptr<Column>> compacted_columns;
-  compacted_columns.reserve(ncolumns);
+  std::vector<std::shared_ptr<Column>> compacted_columns(ncolumns);
   for (int i = 0; i < ncolumns; ++i) {
-    std::shared_ptr<Column> compacted_column;
-    RETURN_NOT_OK(CompactColumn(column(i), pool, &compacted_column));
-    compacted_columns.push_back(std::move(compacted_column));
+    RETURN_NOT_OK(CompactColumn(column(i), pool, &compacted_columns[i]));
   }
   *out = Table::Make(schema(), compacted_columns);
   return Status::OK();

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -337,12 +337,14 @@ class ARROW_EXPORT Table {
   /// However, they may be equal even if they have different chunkings.
   bool Equals(const Table& other) const;
 
-  // Returns a new table of the same schema and contents but with all the
-  // underlying chunks in the ChunkedArray of each column concatenated
-  // into one chunk.
-  // \param[in] pool The pool for buffer allocations.
-  // \param[out] out The compacted table.
-  Status Compact(MemoryPool* pool, std::shared_ptr<Table>* out) const;
+  /// \brief Make a new table by combining the chunks this table has.
+  ///
+  /// All the underlying chunks in the ChunkedArray of each column are
+  /// concatenated into zero or one chunk.
+  ///
+  /// \param[in] pool The pool for buffer allocations
+  /// \param[out] out The table with chunks combined
+  Status CombineChunks(MemoryPool* pool, std::shared_ptr<Table>* out) const;
 
  protected:
   Table();

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -337,6 +337,13 @@ class ARROW_EXPORT Table {
   /// However, they may be equal even if they have different chunkings.
   bool Equals(const Table& other) const;
 
+  // Returns a new table of the same schema and contents but with all the
+  // underlying chunks in the ChunkedArray of each column concatenated
+  // into one chunk.
+  // \param[in] pool The pool for buffer allocations.
+  // \param[out] out The compacted table.
+  Status Compact(MemoryPool* pool, std::shared_ptr<Table>* out) const;
+
  protected:
   Table();
 


### PR DESCRIPTION
A column in a table may consist of multiple chunks. This PR is proposing a Table.Compact() method that returns a table whose columns are of one chunk, which is the concatenation of the corresponding column's chunks.

This method could be useful if the table is fragmented (after Table.slice(), then Table.concatenate()) while one wants to conduct vectorized computation through to_numpy().