### PR TITLE
ARROW-5309: [Python] clarify that Schema.append returns new object

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -926,7 +926,7 @@ cdef class Schema:
         """
         Append a field at the end of the schema.
 
-        In contract to Python's ``list.append()`` it does return a new
+        In contrast to Python's ``list.append()`` it does return a new
         object, leaving the original Schema unmodified.
 
         Parameters

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -926,6 +926,9 @@ cdef class Schema:
         """
         Append a field at the end of the schema.
 
+        In contract to Python's ``list.append()`` it does return a new
+        object, leaving the original Schema unmodified.
+
         Parameters
         ----------
         field: Field
@@ -933,6 +936,7 @@ cdef class Schema:
         Returns
         -------
         schema: Schema
+            New object with appended field.
         """
         return self.insert(self.schema.num_fields(), field)
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5309. I didn't find any other append method in the Python API (except for Table.append_column, which is already clear about returning a new table).