### PR TITLE
ARROW-5641: [GLib] Remove enums files generated by GNU Autotools from Git targets

### DIFF
--- a/c_glib/.gitignore
+++ b/c_glib/.gitignore
@@ -52,9 +52,9 @@ Makefile.in
 /m4/
 /stamp-h1
 /arrow-cuda-glib/*.pc
-/arrow-glib/enums.c
-/arrow-glib/enums.h
-/arrow-glib/stamp-*
+/*-glib/enums.c
+/*-glib/enums.h
+/*-glib/stamp-*
 /arrow-glib/version.h
 /arrow-glib/*.pc
 /gandiva-glib/*.pc


### PR DESCRIPTION
This PR removes the following enums files from Git targets.

- gandiva-glib/enums.c
- gandiva-glib/enums.h
- gandiva-glib/stamp-enums.c
- gandiva-glib/stamp-enums.h