### PR TITLE
ARROW-5335: [Python] Raise exception on variable dictionaries in conversion to Python/pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1145,6 +1145,19 @@ class CategoricalBlock : public PandasBlock {
       converted_col =
           std::make_shared<Column>(field(col->name(), out.type()), out.chunked_array());
     } else {
+      // check if all dictionaries are equal
+      const ChunkedArray& data = *col->data().get();
+      const std::shared_ptr<Array> arr_first = data.chunk(0);
+      const auto& dict_arr_first = checked_cast<const DictionaryArray&>(*arr_first);
+
+      for (int c = 1; c < data.num_chunks(); c++) {
+        const std::shared_ptr<Array> arr = data.chunk(c);
+        const auto& dict_arr = checked_cast<const DictionaryArray&>(*arr);
+
+        if (!(dict_arr_first.dictionary()->Equals(dict_arr.dictionary()))) {
+          return Status::NotImplemented("Variable dictionary type not supported");
+        }
+      }
       converted_col = col;
     }
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2781,6 +2781,21 @@ def test_dictionary_with_pandas():
     tm.assert_series_equal(pd.Series(pandas2), pd.Series(ex_pandas2))
 
 
+def test_variable_dictionary_with_pandas():
+    a1 = pa.DictionaryArray.from_arrays([0, 1, 2], ['a', 'b', 'c'])
+    a2 = pa.DictionaryArray.from_arrays([0, 1], ['a', 'c'])
+
+    a = pa.chunked_array([a1, a2])
+    assert a.to_pylist() == ['a', 'b', 'c', 'a', 'c']
+    with pytest.raises(NotImplementedError):
+        a.to_pandas()
+
+    a = pa.chunked_array([a2, a1])
+    assert a.to_pylist() == ['a', 'c', 'a', 'b', 'c']
+    with pytest.raises(NotImplementedError):
+        a.to_pandas()
+
+
 # ----------------------------------------------------------------------
 # Legacy metadata compatibility tests
 


### PR DESCRIPTION
Unification will happen later per ARROW-5717