### PR TITLE
ARROW-5653: [C++] Ensure testing libraries are not installed

### DIFF
--- a/ci/docker_build_and_test_cpp.sh
+++ b/ci/docker_build_and_test_cpp.sh
@@ -24,5 +24,9 @@ pushd /build/cpp
 export ARROW_TEST_DATA=/arrow/testing/data
 export PARQUET_TEST_DATA=/arrow/cpp/submodules/parquet-testing/data
 
+# ARROW-5653
+if [[ ! -z "${CONDA_PREFIX}" ]]; then
+  export LD_LIBRARY_PATH=${CONDA_PREFIX}/lib
+fi
 ninja unittest
 popd

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -124,7 +124,7 @@ endfunction()
 
 # \arg OUTPUTS list to append built targets to
 function(ADD_ARROW_LIB LIB_NAME)
-  set(options BUILD_SHARED BUILD_STATIC)
+  set(options BUILD_SHARED BUILD_STATIC SKIP_INSTALL)
   set(one_value_args SHARED_LINK_FLAGS)
   set(multi_value_args
       SOURCES
@@ -279,12 +279,14 @@ function(ADD_ARROW_LIB LIB_NAME)
                                        "${_lib_install_name}")
     endif()
 
-    install(TARGETS ${LIB_NAME}_shared ${INSTALL_IS_OPTIONAL}
-            EXPORT ${PROJECT_NAME}-targets
-            RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    if(NOT ARG_SKIP_INSTALL)
+      install(TARGETS ${LIB_NAME}_shared ${INSTALL_IS_OPTIONAL}
+              EXPORT ${PROJECT_NAME}-targets
+              RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
+              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+              INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    endif()
   endif()
 
   if(BUILD_STATIC)
@@ -329,12 +331,14 @@ function(ADD_ARROW_LIB LIB_NAME)
                           "$<BUILD_INTERFACE:${ARG_STATIC_LINK_LIBS}>"
                           "$<INSTALL_INTERFACE:${INTERFACE_LIBS}>")
 
-    install(TARGETS ${LIB_NAME}_static ${INSTALL_IS_OPTIONAL}
-            EXPORT ${PROJECT_NAME}-targets
-            RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    if(NOT ARG_SKIP_INSTALL)
+      install(TARGETS ${LIB_NAME}_static ${INSTALL_IS_OPTIONAL}
+              EXPORT ${PROJECT_NAME}-targets
+              RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
+              LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+              ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+              INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    endif()
   endif()
 
   # Modify variable in calling scope

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -293,6 +293,7 @@ endif()
 if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS OR ARROW_BUILD_INTEGRATION)
   # that depend on gtest
   add_arrow_lib(arrow_testing
+                SKIP_INSTALL
                 SOURCES
                 io/test-common.cc
                 ipc/test-common.cc

--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -36,9 +36,9 @@ add_arrow_lib(arrow_dataset
               arrow_static)
 
 if(ARROW_DATASET_TEST_LINKAGE STREQUAL "static")
-  set(ARROW_DATASET_TEST_LINK_LIBS arrow_dataset_static ${ARROW_TEST_STATIC_LINK_LIBS})
+  set(ARROW_DATASET_TEST_LINK_LIBS arrow_dataset_static)
 else()
-  set(ARROW_DATASET_TEST_LINK_LIBS arrow_dataset_shared ${ARROW_TEST_SHARED_LINK_LIBS})
+  set(ARROW_DATASET_TEST_LINK_LIBS arrow_dataset_shared)
 endif()
 
 foreach(LIB_TARGET ${ARROW_DATASET_LIBRARIES})

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -111,6 +111,7 @@ endforeach()
 # Define arrow_flight_testing library
 if(ARROW_BUILD_TESTS OR ARROW_BUILD_BENCHMARKS OR ARROW_BUILD_INTEGRATION)
   add_arrow_lib(arrow_flight_testing
+                SKIP_INSTALL
                 OUTPUTS
                 ARROW_FLIGHT_TESTING_LIBRARIES
                 SOURCES


### PR DESCRIPTION
libarrow_testing and libarrow_flight_testing should not be installed.
Also fix the unit tests with LD_LIBRARY_PATH due to install target and
cmake handling of RPATH.
