### PR TITLE
ARROW-5654: [C++][Python] Add ChunkedArray::Validate method that checks chunk types for consistency, invoke in Python

### DIFF
--- a/cpp/src/arrow/table-test.cc
+++ b/cpp/src/arrow/table-test.cc
@@ -27,6 +27,7 @@
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/testing/gtest_common.h"
+#include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 
@@ -138,6 +139,26 @@ TEST_F(TestChunkedArray, SliceEquals) {
   ASSERT_EQ(slice5->length(), 0);
   ASSERT_EQ(slice5->num_chunks(), 0);
   ASSERT_TRUE(slice5->type()->Equals(one_->type()));
+}
+
+TEST_F(TestChunkedArray, Validate) {
+  // Valid if empty
+  ArrayVector empty = {};
+  auto no_chunks = std::make_shared<ChunkedArray>(empty, utf8());
+  ASSERT_OK(no_chunks->Validate());
+
+  random::RandomArrayGenerator gen(0);
+  arrays_one_.push_back(gen.Int32(50, 0, 100, 0.1));
+  Construct();
+  ASSERT_OK(one_->Validate());
+
+  arrays_one_.push_back(gen.Int32(50, 0, 100, 0.1));
+  Construct();
+  ASSERT_OK(one_->Validate());
+
+  arrays_one_.push_back(gen.String(50, 0, 10, 0.1));
+  Construct();
+  ASSERT_RAISES(Invalid, one_->Validate());
 }
 
 class TestColumn : public TestChunkedArray {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -176,6 +176,23 @@ Status ChunkedArray::Flatten(MemoryPool* pool,
   return Status::OK();
 }
 
+Status ChunkedArray::Validate() const {
+  if (chunks_.size() == 0) {
+    return Status::OK();
+  }
+
+  const auto& type = *chunks_[0]->type();
+  for (size_t i = 1; i < chunks_.size(); ++i) {
+    if (!chunks_[i]->type()->Equals(type)) {
+      return Status::Invalid("In chunk ", i, " expected type ", type.ToString(),
+                             " but saw ", chunks_[i]->type()->ToString());
+    }
+  }
+  return Status::OK();
+}
+
+// ----------------------------------------------------------------------
+
 Column::Column(const std::shared_ptr<Field>& field, const ArrayVector& chunks)
     : field_(field) {
   data_ = std::make_shared<ChunkedArray>(chunks, field->type());

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -98,6 +98,9 @@ class ARROW_EXPORT ChunkedArray {
   /// \brief Determine if two chunked arrays are equal.
   bool Equals(const std::shared_ptr<ChunkedArray>& other) const;
 
+  /// \brief Check that all chunks have the same data type
+  Status Validate() const;
+
  protected:
   ArrayVector chunks_;
   int64_t length_;

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -477,6 +477,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CChunkedArray] Slice(int64_t offset, int64_t length) const
         shared_ptr[CChunkedArray] Slice(int64_t offset) const
 
+        CStatus Validate() const
+
     cdef cppclass CColumn" arrow::Column":
         CColumn(const shared_ptr[CField]& field,
                 const shared_ptr[CArray]& data)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -268,6 +268,8 @@ def chunked_array(arrays, type=None):
     Parameters
     ----------
     arrays : list of Array or values coercible to arrays
+        Must all be the same data type. Can be empty only if type also
+        passed
     type : DataType or string coercible to DataType
 
     Returns
@@ -298,6 +300,10 @@ def chunked_array(arrays, type=None):
             raise ValueError("Cannot construct a chunked array with neither "
                              "arrays nor type")
         sp_chunked_array.reset(new CChunkedArray(c_arrays))
+
+    with nogil:
+        check_status(sp_chunked_array.get().Validate())
+
     return pyarrow_wrap_chunked_array(sp_chunked_array)
 
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -44,6 +44,11 @@ def test_chunked_array_basics():
     assert len(data.chunks) == 3
 
 
+def test_chunked_array_mismatch_types():
+    with pytest.raises(pa.ArrowInvalid):
+        pa.chunked_array([pa.array([1, 2]), pa.array(['foo', 'bar'])])
+
+
 def test_chunked_array_str():
     data = [
         pa.array([1, 2, 3]),
@@ -955,7 +960,7 @@ def test_table_from_pydict():
 
     # With chunked arrays as values
     data = OrderedDict([('strs', pa.chunked_array([[u''], [u'foo', u'bar']])),
-                        ('floats', pa.chunked_array([[4.5], [5, None]]))])
+                        ('floats', pa.chunked_array([[4.5], [5., None]]))])
     table = pa.Table.from_pydict(data)
     assert table.num_columns == 2
     assert table.num_rows == 3


### PR DESCRIPTION
This prevents users from constructing ChunkedArray with different data types