### PR TITLE
ARROW-5670: [C++] Use requests in get_apache_mirror.py if available

### DIFF
--- a/cpp/build-support/get_apache_mirror.py
+++ b/cpp/build-support/get_apache_mirror.py
@@ -21,11 +21,20 @@
 
 import json
 try:
-    from urllib2 import urlopen
-except ImportError:
-    # py3
-    from urllib.request import urlopen
+    import requests
 
-suggested_mirror = urlopen('https://www.apache.org/dyn/'
-                           'closer.cgi?as_json=1').read()
+    def get_url(url):
+        return requests.get(url).content
+except ImportError:
+    try:
+        from urllib2 import urlopen
+    except ImportError:
+        # py3
+        from urllib.request import urlopen
+
+    def get_url(url):
+        return urlopen(url).read()
+
+suggested_mirror = get_url('https://www.apache.org/dyn/'
+                           'closer.cgi?as_json=1')
 print(json.loads(suggested_mirror.decode('utf-8'))['preferred'])

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -49,6 +49,8 @@ before_install:
   - source multibuild/travis_osx_steps.sh
 
   - before_install
+  # Fix SSL TLS issue for Python 3.5 on macOS
+  - pip install requests[security]
 
 install:
   - mkdir -p dist


### PR DESCRIPTION
requests is not in the standard library, but if it's available it may avoid certain HTTPS issues in some Python distributions