### PR TITLE
ARROW-5358: [Rust] Implement equality check for ArrayData and Array

### DIFF
--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::*;
-use crate::array_data::*;
+use super::*;
 use crate::datatypes::*;
 use crate::util::bit_util;
 
@@ -425,9 +424,6 @@ mod tests {
 
     use std::convert::TryFrom;
 
-    use crate::builder::{
-        ArrayBuilder, BinaryBuilder, Int32Builder, ListBuilder, StructBuilder,
-    };
     use crate::error::Result;
 
     #[test]
@@ -743,25 +739,3 @@ mod tests {
         Ok(builder.finish())
     }
 }
-
-// let string_builder = builder.field_builder::<BinaryBuilder>(0).unwrap();
-// string_builder.append_string("joe").unwrap();
-// string_builder.append_null().unwrap();
-// string_builder.append_null().unwrap();
-// string_builder.append_string("mark").unwrap();
-// string_builder.append_string("doe").unwrap();
-
-// let int_builder = builder.field_builder::<Int32Builder>(1).unwrap();
-// int_builder.append_value(1).unwrap();
-// int_builder.append_value(2).unwrap();
-// int_builder.append_null().unwrap();
-// int_builder.append_value(4).unwrap();
-// int_builder.append_value(5).unwrap();
-
-// builder.append(true).unwrap();
-// builder.append(true).unwrap();
-// builder.append_null().unwrap();
-// builder.append(true).unwrap();
-// builder.append(true).unwrap();
-
-// builder.finish()

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -57,68 +57,17 @@
 mod array;
 mod builder;
 mod data;
+mod equal;
+
+use crate::datatypes::*;
+
+// --------------------- Array & ArrayData ---------------------
 
 pub use self::array::Array;
 pub use self::array::ArrayRef;
 pub use self::data::ArrayData;
 pub use self::data::ArrayDataBuilder;
 pub use self::data::ArrayDataRef;
-
-use crate::datatypes::*;
-
-pub use self::builder::BufferBuilder;
-pub use self::builder::BufferBuilderTrait;
-
-pub type BooleanBufferBuilder = BufferBuilder<BooleanType>;
-pub type Int8BufferBuilder = BufferBuilder<Int8Type>;
-pub type Int16BufferBuilder = BufferBuilder<Int16Type>;
-pub type Int32BufferBuilder = BufferBuilder<Int32Type>;
-pub type Int64BufferBuilder = BufferBuilder<Int64Type>;
-pub type UInt8BufferBuilder = BufferBuilder<UInt8Type>;
-pub type UInt16BufferBuilder = BufferBuilder<UInt16Type>;
-pub type UInt32BufferBuilder = BufferBuilder<UInt32Type>;
-pub type UInt64BufferBuilder = BufferBuilder<UInt64Type>;
-pub type Float32BufferBuilder = BufferBuilder<Float32Type>;
-pub type Float64BufferBuilder = BufferBuilder<Float64Type>;
-
-pub type TimestampSecondBufferBuilder = BufferBuilder<TimestampSecondType>;
-pub type TimestampMillisecondBufferBuilder = BufferBuilder<TimestampMillisecondType>;
-pub type TimestampMicrosecondBufferBuilder = BufferBuilder<TimestampMicrosecondType>;
-pub type TimestampNanosecondBufferBuilder = BufferBuilder<TimestampNanosecondType>;
-pub type Date32BufferBuilder = BufferBuilder<Date32Type>;
-pub type Date64BufferBuilder = BufferBuilder<Date64Type>;
-pub type Time32SecondBufferBuilder = BufferBuilder<Time32SecondType>;
-pub type Time32MillisecondBufferBuilder = BufferBuilder<Time32MillisecondType>;
-pub type Time64MicrosecondBufferBuilder = BufferBuilder<Time64MicrosecondType>;
-pub type Time64NanosecondBufferBuilder = BufferBuilder<Time64NanosecondType>;
-
-pub use self::builder::PrimitiveBuilder;
-pub type BooleanBuilder = PrimitiveBuilder<BooleanType>;
-pub type Int8Builder = PrimitiveBuilder<Int8Type>;
-pub type Int16Builder = PrimitiveBuilder<Int16Type>;
-pub type Int32Builder = PrimitiveBuilder<Int32Type>;
-pub type Int64Builder = PrimitiveBuilder<Int64Type>;
-pub type UInt8Builder = PrimitiveBuilder<UInt8Type>;
-pub type UInt16Builder = PrimitiveBuilder<UInt16Type>;
-pub type UInt32Builder = PrimitiveBuilder<UInt32Type>;
-pub type UInt64Builder = PrimitiveBuilder<UInt64Type>;
-pub type Float32Builder = PrimitiveBuilder<Float32Type>;
-pub type Float64Builder = PrimitiveBuilder<Float64Type>;
-
-pub type TimestampSecondBuilder = PrimitiveBuilder<TimestampSecondType>;
-pub type TimestampMillisecondBuilder = PrimitiveBuilder<TimestampMillisecondType>;
-pub type TimestampMicrosecondBuilder = PrimitiveBuilder<TimestampMicrosecondType>;
-pub type TimestampNanosecondBuilder = PrimitiveBuilder<TimestampNanosecondType>;
-pub type Date32Builder = PrimitiveBuilder<Date32Type>;
-pub type Date64Builder = PrimitiveBuilder<Date64Type>;
-pub type Time32SecondBuilder = PrimitiveBuilder<Time32SecondType>;
-pub type Time32MillisecondBuilder = PrimitiveBuilder<Time32MillisecondType>;
-pub type Time64MicrosecondBuilder = PrimitiveBuilder<Time64MicrosecondType>;
-pub type Time64NanosecondBuilder = PrimitiveBuilder<Time64NanosecondType>;
-
-pub use self::builder::BinaryBuilder;
-pub use self::builder::ListBuilder;
-pub use self::builder::StructBuilder;
 
 pub use self::array::BinaryArray;
 pub use self::array::ListArray;
@@ -150,3 +99,67 @@ pub type Time32MillisecondArray = PrimitiveArray<Time32MillisecondType>;
 pub type Time64MicrosecondArray = PrimitiveArray<Time64MicrosecondType>;
 pub type Time64NanosecondArray = PrimitiveArray<Time64NanosecondType>;
 // TODO add interval
+
+pub use self::array::ListArrayOps;
+pub use self::array::PrimitiveArrayOps;
+
+// --------------------- Array Builder ---------------------
+
+pub use self::builder::BufferBuilder;
+pub use self::builder::BufferBuilderTrait;
+
+pub type BooleanBufferBuilder = BufferBuilder<BooleanType>;
+pub type Int8BufferBuilder = BufferBuilder<Int8Type>;
+pub type Int16BufferBuilder = BufferBuilder<Int16Type>;
+pub type Int32BufferBuilder = BufferBuilder<Int32Type>;
+pub type Int64BufferBuilder = BufferBuilder<Int64Type>;
+pub type UInt8BufferBuilder = BufferBuilder<UInt8Type>;
+pub type UInt16BufferBuilder = BufferBuilder<UInt16Type>;
+pub type UInt32BufferBuilder = BufferBuilder<UInt32Type>;
+pub type UInt64BufferBuilder = BufferBuilder<UInt64Type>;
+pub type Float32BufferBuilder = BufferBuilder<Float32Type>;
+pub type Float64BufferBuilder = BufferBuilder<Float64Type>;
+
+pub type TimestampSecondBufferBuilder = BufferBuilder<TimestampSecondType>;
+pub type TimestampMillisecondBufferBuilder = BufferBuilder<TimestampMillisecondType>;
+pub type TimestampMicrosecondBufferBuilder = BufferBuilder<TimestampMicrosecondType>;
+pub type TimestampNanosecondBufferBuilder = BufferBuilder<TimestampNanosecondType>;
+pub type Date32BufferBuilder = BufferBuilder<Date32Type>;
+pub type Date64BufferBuilder = BufferBuilder<Date64Type>;
+pub type Time32SecondBufferBuilder = BufferBuilder<Time32SecondType>;
+pub type Time32MillisecondBufferBuilder = BufferBuilder<Time32MillisecondType>;
+pub type Time64MicrosecondBufferBuilder = BufferBuilder<Time64MicrosecondType>;
+pub type Time64NanosecondBufferBuilder = BufferBuilder<Time64NanosecondType>;
+
+pub use self::builder::ArrayBuilder;
+pub use self::builder::BinaryBuilder;
+pub use self::builder::ListBuilder;
+pub use self::builder::PrimitiveBuilder;
+pub use self::builder::StructBuilder;
+
+pub type BooleanBuilder = PrimitiveBuilder<BooleanType>;
+pub type Int8Builder = PrimitiveBuilder<Int8Type>;
+pub type Int16Builder = PrimitiveBuilder<Int16Type>;
+pub type Int32Builder = PrimitiveBuilder<Int32Type>;
+pub type Int64Builder = PrimitiveBuilder<Int64Type>;
+pub type UInt8Builder = PrimitiveBuilder<UInt8Type>;
+pub type UInt16Builder = PrimitiveBuilder<UInt16Type>;
+pub type UInt32Builder = PrimitiveBuilder<UInt32Type>;
+pub type UInt64Builder = PrimitiveBuilder<UInt64Type>;
+pub type Float32Builder = PrimitiveBuilder<Float32Type>;
+pub type Float64Builder = PrimitiveBuilder<Float64Type>;
+
+pub type TimestampSecondBuilder = PrimitiveBuilder<TimestampSecondType>;
+pub type TimestampMillisecondBuilder = PrimitiveBuilder<TimestampMillisecondType>;
+pub type TimestampMicrosecondBuilder = PrimitiveBuilder<TimestampMicrosecondType>;
+pub type TimestampNanosecondBuilder = PrimitiveBuilder<TimestampNanosecondType>;
+pub type Date32Builder = PrimitiveBuilder<Date32Type>;
+pub type Date64Builder = PrimitiveBuilder<Date64Type>;
+pub type Time32SecondBuilder = PrimitiveBuilder<Time32SecondType>;
+pub type Time32MillisecondBuilder = PrimitiveBuilder<Time32MillisecondType>;
+pub type Time64MicrosecondBuilder = PrimitiveBuilder<Time64MicrosecondType>;
+pub type Time64NanosecondBuilder = PrimitiveBuilder<Time64NanosecondType>;
+
+// --------------------- Array Equality ---------------------
+
+pub use self::equal::ArrayEqual;

--- a/rust/arrow/src/array_equal.rs
+++ b/rust/arrow/src/array_equal.rs
@@ -1,0 +1,751 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::array::*;
+use crate::array_data::*;
+use crate::datatypes::*;
+use crate::util::bit_util;
+
+/// Trait for `Array` equality.
+pub trait ArrayEqual {
+    /// Returns true if this array is equal to the `other` array
+    fn equals(&self, other: &dyn Array) -> bool;
+
+    /// Returns true if the range [start_idx, end_idx) is equal to
+    /// [other_start_idx, other_start_idx + end_idx - start_idx) in the `other` array
+    fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool;
+}
+
+impl<T: ArrowPrimitiveType> ArrayEqual for PrimitiveArray<T> {
+    default fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let value_buf = self.data_ref().buffers()[0].clone();
+        let other_value_buf = other.data_ref().buffers()[0].clone();
+        let byte_width = T::get_bit_width() / 8;
+
+        if self.null_count() > 0 {
+            let values = value_buf.data();
+            let other_values = other_value_buf.data();
+
+            for i in 0..self.len() {
+                if self.is_valid(i) {
+                    let start = (i + self.offset()) * byte_width;
+                    let data = &values[start..(start + byte_width)];
+                    let other_start = (i + other.offset()) * byte_width;
+                    let other_data =
+                        &other_values[other_start..(other_start + byte_width)];
+                    if data != other_data {
+                        return false;
+                    }
+                }
+            }
+        } else {
+            let start = self.offset() * byte_width;
+            let other_start = other.offset() * byte_width;
+            let len = self.len() * byte_width;
+            let data = &value_buf.data()[start..(start + len)];
+            let other_data = &other_value_buf.data()[other_start..(other_start + len)];
+            if data != other_data {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    default fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool {
+        let other = other.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+
+        let mut j = other_start_idx;
+        for i in start_idx..end_idx {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(j);
+            if is_null != other_is_null || (!is_null && self.value(i) != other.value(j)) {
+                return false;
+            }
+            j += 1;
+        }
+
+        true
+    }
+}
+
+impl ArrayEqual for BooleanArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let values = self.data_ref().buffers()[0].data();
+        let other_values = other.data_ref().buffers()[0].data();
+
+        // TODO: we can do this more efficiently if all values are not-null
+        for i in 0..self.len() {
+            if self.is_valid(i) {
+                if bit_util::get_bit(values, i + self.offset())
+                    != bit_util::get_bit(other_values, i + other.offset())
+                {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+impl<T: ArrowNumericType> PartialEq for PrimitiveArray<T> {
+    fn eq(&self, other: &PrimitiveArray<T>) -> bool {
+        self.equals(other)
+    }
+}
+
+impl ArrayEqual for ListArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let other = other.as_any().downcast_ref::<ListArray>().unwrap();
+
+        if !value_offset_equal(self, other) {
+            return false;
+        }
+
+        if !self.values().range_equals(
+            &*other.values(),
+            self.value_offset(0) as usize,
+            self.value_offset(self.len()) as usize,
+            other.value_offset(0) as usize,
+        ) {
+            return false;
+        }
+
+        true
+    }
+
+    fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool {
+        let other = other.as_any().downcast_ref::<ListArray>().unwrap();
+
+        let mut j = other_start_idx;
+        for i in start_idx..end_idx {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(j);
+
+            if is_null != other_is_null {
+                return false;
+            }
+
+            if is_null {
+                continue;
+            }
+
+            let start_offset = self.value_offset(i) as usize;
+            let end_offset = self.value_offset(i + 1) as usize;
+            let other_start_offset = other.value_offset(j) as usize;
+            let other_end_offset = other.value_offset(j + 1) as usize;
+
+            if end_offset - start_offset != other_end_offset - other_start_offset {
+                return false;
+            }
+
+            if !self.values().range_equals(
+                &*other.values(),
+                start_offset,
+                end_offset,
+                other_start_offset,
+            ) {
+                return false;
+            }
+
+            j += 1;
+        }
+
+        true
+    }
+}
+
+impl ArrayEqual for BinaryArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let other = other.as_any().downcast_ref::<BinaryArray>().unwrap();
+
+        if !value_offset_equal(self, other) {
+            return false;
+        }
+
+        // TODO: handle null & length == 0 case?
+
+        let value_buf = self.value_data();
+        let other_value_buf = other.value_data();
+        let value_data = value_buf.data();
+        let other_value_data = other_value_buf.data();
+
+        if self.null_count() == 0 {
+            // No offset in both - just do memcmp
+            if self.offset() == 0 && other.offset() == 0 {
+                let len = self.value_offset(self.len()) as usize;
+                return value_data[..len] == other_value_data[..len];
+            } else {
+                let start = self.value_offset(0) as usize;
+                let other_start = other.value_offset(0) as usize;
+                let len = (self.value_offset(self.len()) - self.value_offset(0)) as usize;
+                return value_data[start..(start + len)]
+                    == other_value_data[other_start..(other_start + len)];
+            }
+        } else {
+            for i in 0..self.len() {
+                if self.is_null(i) {
+                    continue;
+                }
+
+                let start = self.value_offset(i) as usize;
+                let other_start = other.value_offset(i) as usize;
+                let len = self.value_length(i) as usize;
+                if value_data[start..(start + len)]
+                    != other_value_data[other_start..(other_start + len)]
+                {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool {
+        let other = other.as_any().downcast_ref::<BinaryArray>().unwrap();
+
+        let mut j = other_start_idx;
+        for i in start_idx..end_idx {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(j);
+
+            if is_null != other_is_null {
+                return false;
+            }
+
+            if is_null {
+                continue;
+            }
+
+            let start_offset = self.value_offset(i) as usize;
+            let end_offset = self.value_offset(i + 1) as usize;
+            let other_start_offset = other.value_offset(j) as usize;
+            let other_end_offset = other.value_offset(j + 1) as usize;
+
+            if end_offset - start_offset != other_end_offset - other_start_offset {
+                return false;
+            }
+
+            let value_buf = self.value_data();
+            let other_value_buf = other.value_data();
+            let value_data = value_buf.data();
+            let other_value_data = other_value_buf.data();
+
+            if end_offset - start_offset > 0 {
+                let len = end_offset - start_offset;
+                if value_data[start_offset..(start_offset + len)]
+                    != other_value_data[other_start_offset..(other_start_offset + len)]
+                {
+                    return false;
+                }
+            }
+
+            j += 1;
+        }
+
+        true
+    }
+}
+
+impl ArrayEqual for StructArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let other = other.as_any().downcast_ref::<StructArray>().unwrap();
+
+        for i in 0..self.len() {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(i);
+
+            if is_null != other_is_null {
+                return false;
+            }
+
+            if is_null {
+                continue;
+            }
+            for j in 0..self.num_columns() {
+                if !self.column(j).range_equals(&**other.column(j), i, i + 1, i) {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool {
+        let other = other.as_any().downcast_ref::<StructArray>().unwrap();
+
+        let mut j = other_start_idx;
+        for i in start_idx..end_idx {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(i);
+
+            if is_null != other_is_null {
+                return false;
+            }
+
+            if is_null {
+                continue;
+            }
+            for k in 0..self.num_columns() {
+                if !self.column(k).range_equals(&**other.column(k), i, i + 1, j) {
+                    return false;
+                }
+            }
+
+            j += 1;
+        }
+
+        true
+    }
+}
+
+// Compare if the common basic fields between the two arrays are equal
+fn base_equal(this: &ArrayDataRef, other: &ArrayDataRef) -> bool {
+    if this.data_type() != other.data_type() {
+        return false;
+    }
+    if this.len != other.len {
+        return false;
+    }
+    if this.null_count != other.null_count {
+        return false;
+    }
+    if this.null_count > 0 {
+        let null_bitmap = this.null_bitmap().as_ref().unwrap();
+        let other_null_bitmap = other.null_bitmap().as_ref().unwrap();
+        let null_buf = null_bitmap.bits.data();
+        let other_null_buf = other_null_bitmap.bits.data();
+        for i in 0..this.len() {
+            if bit_util::get_bit(null_buf, i + this.offset())
+                != bit_util::get_bit(other_null_buf, i + other.offset())
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+// Compare if the value offsets are equal between the two list arrays
+fn value_offset_equal<T: Array + ListArrayOps>(this: &T, other: &T) -> bool {
+    // Check if offsets differ
+    if this.offset() == 0 && other.offset() == 0 {
+        let offset_data = &this.data_ref().buffers()[0];
+        let other_offset_data = &other.data_ref().buffers()[0];
+        return offset_data.data()[0..((this.len() + 1) * 4)]
+            == other_offset_data.data()[0..((other.len() + 1) * 4)];
+    }
+
+    // The expensive case
+    for i in 0..this.len() + 1 {
+        if this.value_offset_at(i) - this.value_offset_at(0)
+            != other.value_offset_at(i) - other.value_offset_at(0)
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::builder::{
+        ArrayBuilder, BinaryBuilder, Int32Builder, ListBuilder, StructBuilder,
+    };
+
+    #[test]
+    fn test_primitive_equal() {
+        let a = Int32Array::from(vec![1, 2, 3]);
+        let b = Int32Array::from(vec![1, 2, 3]);
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        let b = Int32Array::from(vec![1, 2, 4]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where null_count > 0
+
+        let a = Int32Array::from(vec![Some(1), None, Some(2), Some(3)]);
+        let b = Int32Array::from(vec![Some(1), None, Some(2), Some(3)]);
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        let b = Int32Array::from(vec![Some(1), None, None, Some(3)]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        let b = Int32Array::from(vec![Some(1), None, Some(2), Some(4)]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where offset != 0
+
+        let a_slice = a.slice(1, 2);
+        let b_slice = b.slice(1, 2);
+        assert!(a_slice.equals(&*b_slice));
+        assert!(b_slice.equals(&*a_slice));
+    }
+
+    #[test]
+    fn test_boolean_equal() {
+        let a = BooleanArray::from(vec![false, false, true]);
+        let b = BooleanArray::from(vec![false, false, true]);
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        let b = BooleanArray::from(vec![false, false, false]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where null_count > 0
+
+        let a = BooleanArray::from(vec![Some(false), None, None, Some(true)]);
+        let b = BooleanArray::from(vec![Some(false), None, None, Some(true)]);
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        let b = BooleanArray::from(vec![None, None, None, Some(true)]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        let b = BooleanArray::from(vec![Some(true), None, None, Some(true)]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where offset != 0
+
+        let a = BooleanArray::from(vec![false, true, false, true, false, false, true]);
+        let b = BooleanArray::from(vec![false, false, false, true, false, true, true]);
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        let a_slice = a.slice(2, 3);
+        let b_slice = b.slice(2, 3);
+        assert!(a_slice.equals(&*b_slice));
+        assert!(b_slice.equals(&*a_slice));
+
+        let a_slice = a.slice(3, 4);
+        let b_slice = b.slice(3, 4);
+        assert!(!a_slice.equals(&*b_slice));
+        assert!(!b_slice.equals(&*a_slice));
+    }
+
+    #[test]
+    fn test_list_equal() {
+        let mut a_builder = ListBuilder::new(Int32Builder::new(10));
+        let mut b_builder = ListBuilder::new(Int32Builder::new(10));
+
+        a_builder.values().append_slice(&[1, 2, 3]).expect("");
+        a_builder.append(true).expect("");
+        a_builder.values().append_slice(&[4, 5]).expect("");
+        a_builder.append(true).expect("");
+
+        b_builder.values().append_slice(&[1, 2, 3]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.values().append_slice(&[4, 5]).expect("");
+        b_builder.append(true).expect("");
+
+        let a = a_builder.finish();
+        let b = b_builder.finish();
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        b_builder.values().append_slice(&[1, 2, 3]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.values().append_slice(&[4, 5, 6]).expect("");
+        b_builder.append(true).expect("");
+        let b = b_builder.finish();
+
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where null_count > 0
+
+        a_builder.values().append_slice(&[1, 2]).expect("");
+        a_builder.append(true).expect("");
+        a_builder.append(false).expect("");
+        a_builder.append(false).expect("");
+        a_builder.values().append_slice(&[3, 4]).expect("");
+        a_builder.append(true).expect("");
+        a_builder.append(false).expect("");
+        a_builder.append(false).expect("");
+
+        b_builder.values().append_slice(&[1, 2]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+        b_builder.values().append_slice(&[3, 4]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+
+        let a = a_builder.finish();
+        let b = b_builder.finish();
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        b_builder.values().append_slice(&[1, 2]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(true).expect("");
+        b_builder.values().append_slice(&[3, 4]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+
+        let b = b_builder.finish();
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        b_builder.values().append_slice(&[1, 2]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+        b_builder.values().append_slice(&[3, 4, 5]).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+
+        let b = b_builder.finish();
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where offset != 0
+
+        let a_slice = a.slice(0, 3);
+        let b_slice = b.slice(0, 3);
+        assert!(a_slice.equals(&*b_slice));
+        assert!(b_slice.equals(&*a_slice));
+
+        let a_slice = a.slice(0, 5);
+        let b_slice = b.slice(0, 5);
+        assert!(!a_slice.equals(&*b_slice));
+        assert!(!b_slice.equals(&*a_slice));
+
+        let a_slice = a.slice(4, 1);
+        let b_slice = b.slice(4, 1);
+        assert!(a_slice.equals(&*b_slice));
+        assert!(b_slice.equals(&*a_slice));
+    }
+
+    #[test]
+    fn test_binary_equal() {
+        let mut a_builder = BinaryBuilder::new(10);
+        let mut b_builder = BinaryBuilder::new(10);
+
+        a_builder.append_string("hello").expect("");
+        a_builder.append_string("world").expect("");
+
+        b_builder.append_string("hello").expect("");
+        b_builder.append_string("world").expect("");
+
+        let a = a_builder.finish();
+        let b = b_builder.finish();
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        b_builder.append_string("hello").expect("");
+        b_builder.append_string("arrow").expect("");
+        let b = b_builder.finish();
+
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where null_count > 0
+
+        a_builder.append_string("hello").expect("");
+        a_builder.append(false).expect("");
+        a_builder.append(false).expect("");
+        a_builder.append_string("world").expect("");
+        a_builder.append(false).expect("");
+        a_builder.append(false).expect("");
+
+        b_builder.append_string("hello").expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append_string("world").expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+
+        let a = a_builder.finish();
+        let b = b_builder.finish();
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+
+        b_builder.append_string("hello").expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(true).expect("");
+        b_builder.append_string("world").expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+
+        let b = b_builder.finish();
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        b_builder.append_string("hello").expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+        b_builder.append_string("arrow").expect("");
+        b_builder.append(false).expect("");
+        b_builder.append(false).expect("");
+
+        let b = b_builder.finish();
+        assert!(!a.equals(&b));
+        assert!(!b.equals(&a));
+
+        // Test the case where offset != 0
+
+        let a_slice = a.slice(0, 3);
+        let b_slice = b.slice(0, 3);
+        assert!(a_slice.equals(&*b_slice));
+        assert!(b_slice.equals(&*a_slice));
+
+        let a_slice = a.slice(0, 5);
+        let b_slice = b.slice(0, 5);
+        assert!(!a_slice.equals(&*b_slice));
+        assert!(!b_slice.equals(&*a_slice));
+
+        let a_slice = a.slice(4, 1);
+        let b_slice = b.slice(4, 1);
+        assert!(a_slice.equals(&*b_slice));
+        assert!(b_slice.equals(&*a_slice));
+    }
+
+    #[test]
+    fn test_struct_equal() {
+        let string_builder = BinaryBuilder::new(5);
+        let int_builder = Int32Builder::new(5);
+
+        let mut fields = Vec::new();
+        let mut field_builders = Vec::new();
+        fields.push(Field::new("f1", DataType::Utf8, false));
+        field_builders.push(Box::new(string_builder) as Box<ArrayBuilder>);
+        fields.push(Field::new("f2", DataType::Int32, false));
+        field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);
+
+        let mut builder = StructBuilder::new(fields, field_builders);
+
+        let a = {
+            let string_builder = builder.field_builder::<BinaryBuilder>(0).expect("");
+            string_builder.append_string("joe").unwrap();
+            string_builder.append_null().unwrap();
+            string_builder.append_null().unwrap();
+            string_builder.append_string("mark").unwrap();
+            string_builder.append_string("doe").unwrap();
+
+            let int_builder = builder.field_builder::<Int32Builder>(1).expect("");
+            int_builder.append_value(1).unwrap();
+            int_builder.append_value(2).unwrap();
+            int_builder.append_null().unwrap();
+            int_builder.append_value(4).unwrap();
+            int_builder.append_value(5).unwrap();
+
+            builder.append(true).unwrap();
+            builder.append(true).unwrap();
+            builder.append_null().unwrap();
+            builder.append(true).unwrap();
+            builder.append(true).unwrap();
+
+            builder.finish()
+        };
+
+        let b = {
+            let string_builder = builder.field_builder::<BinaryBuilder>(0).expect("");
+            string_builder.append_string("joe").unwrap();
+            string_builder.append_null().unwrap();
+            string_builder.append_null().unwrap();
+            string_builder.append_string("mark").unwrap();
+            string_builder.append_string("doe").unwrap();
+
+            let int_builder = builder.field_builder::<Int32Builder>(1).expect("");
+            int_builder.append_value(1).unwrap();
+            int_builder.append_value(2).unwrap();
+            int_builder.append_null().unwrap();
+            int_builder.append_value(4).unwrap();
+            int_builder.append_value(5).unwrap();
+
+            builder.append(true).unwrap();
+            builder.append(true).unwrap();
+            builder.append_null().unwrap();
+            builder.append(true).unwrap();
+            builder.append(true).unwrap();
+
+            builder.finish()
+        };
+
+        assert!(a.equals(&b));
+        assert!(b.equals(&a));
+    }
+}

--- a/rust/arrow/src/array_equal.rs
+++ b/rust/arrow/src/array_equal.rs
@@ -515,7 +515,7 @@ mod tests {
 
         let a = create_list_array(&mut a_builder, &[Some(&[1, 2, 3]), Some(&[4, 5, 6])])
             .unwrap();
-        let b = create_list_array(&mut a_builder, &[Some(&[1, 2, 3]), Some(&[4, 5, 6])])
+        let b = create_list_array(&mut b_builder, &[Some(&[1, 2, 3]), Some(&[4, 5, 6])])
             .unwrap();
 
         assert!(a.equals(&b));

--- a/rust/arrow/src/array_equal.rs
+++ b/rust/arrow/src/array_equal.rs
@@ -506,25 +506,25 @@ mod tests {
         let mut a_builder = ListBuilder::new(Int32Builder::new(10));
         let mut b_builder = ListBuilder::new(Int32Builder::new(10));
 
-        a_builder.values().append_slice(&[1, 2, 3]).expect("");
-        a_builder.append(true).expect("");
-        a_builder.values().append_slice(&[4, 5]).expect("");
-        a_builder.append(true).expect("");
+        a_builder.values().append_slice(&[1, 2, 3]).unwrap();
+        a_builder.append(true).unwrap();
+        a_builder.values().append_slice(&[4, 5]).unwrap();
+        a_builder.append(true).unwrap();
 
-        b_builder.values().append_slice(&[1, 2, 3]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.values().append_slice(&[4, 5]).expect("");
-        b_builder.append(true).expect("");
+        b_builder.values().append_slice(&[1, 2, 3]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.values().append_slice(&[4, 5]).unwrap();
+        b_builder.append(true).unwrap();
 
         let a = a_builder.finish();
         let b = b_builder.finish();
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        b_builder.values().append_slice(&[1, 2, 3]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.values().append_slice(&[4, 5, 6]).expect("");
-        b_builder.append(true).expect("");
+        b_builder.values().append_slice(&[1, 2, 3]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.values().append_slice(&[4, 5, 6]).unwrap();
+        b_builder.append(true).unwrap();
         let b = b_builder.finish();
 
         assert!(!a.equals(&b));
@@ -532,50 +532,50 @@ mod tests {
 
         // Test the case where null_count > 0
 
-        a_builder.values().append_slice(&[1, 2]).expect("");
-        a_builder.append(true).expect("");
-        a_builder.append(false).expect("");
-        a_builder.append(false).expect("");
-        a_builder.values().append_slice(&[3, 4]).expect("");
-        a_builder.append(true).expect("");
-        a_builder.append(false).expect("");
-        a_builder.append(false).expect("");
+        a_builder.values().append_slice(&[1, 2]).unwrap();
+        a_builder.append(true).unwrap();
+        a_builder.append(false).unwrap();
+        a_builder.append(false).unwrap();
+        a_builder.values().append_slice(&[3, 4]).unwrap();
+        a_builder.append(true).unwrap();
+        a_builder.append(false).unwrap();
+        a_builder.append(false).unwrap();
 
-        b_builder.values().append_slice(&[1, 2]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
-        b_builder.values().append_slice(&[3, 4]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
+        b_builder.values().append_slice(&[1, 2]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.values().append_slice(&[3, 4]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
 
         let a = a_builder.finish();
         let b = b_builder.finish();
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        b_builder.values().append_slice(&[1, 2]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(true).expect("");
-        b_builder.values().append_slice(&[3, 4]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
+        b_builder.values().append_slice(&[1, 2]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.values().append_slice(&[3, 4]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
 
         let b = b_builder.finish();
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        b_builder.values().append_slice(&[1, 2]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
-        b_builder.values().append_slice(&[3, 4, 5]).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
+        b_builder.values().append_slice(&[1, 2]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.values().append_slice(&[3, 4, 5]).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
 
         let b = b_builder.finish();
         assert!(!a.equals(&b));
@@ -604,19 +604,19 @@ mod tests {
         let mut a_builder = BinaryBuilder::new(10);
         let mut b_builder = BinaryBuilder::new(10);
 
-        a_builder.append_string("hello").expect("");
-        a_builder.append_string("world").expect("");
+        a_builder.append_string("hello").unwrap();
+        a_builder.append_string("world").unwrap();
 
-        b_builder.append_string("hello").expect("");
-        b_builder.append_string("world").expect("");
+        b_builder.append_string("hello").unwrap();
+        b_builder.append_string("world").unwrap();
 
         let a = a_builder.finish();
         let b = b_builder.finish();
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        b_builder.append_string("hello").expect("");
-        b_builder.append_string("arrow").expect("");
+        b_builder.append_string("hello").unwrap();
+        b_builder.append_string("arrow").unwrap();
         let b = b_builder.finish();
 
         assert!(!a.equals(&b));
@@ -624,42 +624,42 @@ mod tests {
 
         // Test the case where null_count > 0
 
-        a_builder.append_string("hello").expect("");
-        a_builder.append(false).expect("");
-        a_builder.append(false).expect("");
-        a_builder.append_string("world").expect("");
-        a_builder.append(false).expect("");
-        a_builder.append(false).expect("");
+        a_builder.append_string("hello").unwrap();
+        a_builder.append(false).unwrap();
+        a_builder.append(false).unwrap();
+        a_builder.append_string("world").unwrap();
+        a_builder.append(false).unwrap();
+        a_builder.append(false).unwrap();
 
-        b_builder.append_string("hello").expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append_string("world").expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
+        b_builder.append_string("hello").unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append_string("world").unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
 
         let a = a_builder.finish();
         let b = b_builder.finish();
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        b_builder.append_string("hello").expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(true).expect("");
-        b_builder.append_string("world").expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
+        b_builder.append_string("hello").unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(true).unwrap();
+        b_builder.append_string("world").unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
 
         let b = b_builder.finish();
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        b_builder.append_string("hello").expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
-        b_builder.append_string("arrow").expect("");
-        b_builder.append(false).expect("");
-        b_builder.append(false).expect("");
+        b_builder.append_string("hello").unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append_string("arrow").unwrap();
+        b_builder.append(false).unwrap();
+        b_builder.append(false).unwrap();
 
         let b = b_builder.finish();
         assert!(!a.equals(&b));
@@ -698,14 +698,14 @@ mod tests {
         let mut builder = StructBuilder::new(fields, field_builders);
 
         let a = {
-            let string_builder = builder.field_builder::<BinaryBuilder>(0).expect("");
+            let string_builder = builder.field_builder::<BinaryBuilder>(0).unwrap();
             string_builder.append_string("joe").unwrap();
             string_builder.append_null().unwrap();
             string_builder.append_null().unwrap();
             string_builder.append_string("mark").unwrap();
             string_builder.append_string("doe").unwrap();
 
-            let int_builder = builder.field_builder::<Int32Builder>(1).expect("");
+            let int_builder = builder.field_builder::<Int32Builder>(1).unwrap();
             int_builder.append_value(1).unwrap();
             int_builder.append_value(2).unwrap();
             int_builder.append_null().unwrap();
@@ -722,14 +722,14 @@ mod tests {
         };
 
         let b = {
-            let string_builder = builder.field_builder::<BinaryBuilder>(0).expect("");
+            let string_builder = builder.field_builder::<BinaryBuilder>(0).unwrap();
             string_builder.append_string("joe").unwrap();
             string_builder.append_null().unwrap();
             string_builder.append_null().unwrap();
             string_builder.append_string("mark").unwrap();
             string_builder.append_string("doe").unwrap();
 
-            let int_builder = builder.field_builder::<Int32Builder>(1).expect("");
+            let int_builder = builder.field_builder::<Int32Builder>(1).unwrap();
             int_builder.append_value(1).unwrap();
             int_builder.append_value(2).unwrap();
             int_builder.append_null().unwrap();


### PR DESCRIPTION
This implements equality comparison for `Array` type which checks whether two arrays are identical in content. 

Besides the above, this adds two traits: `PrimitiveArrayOps` and `ListArrayOps`. The former exposes a few common operations between numeric arrays and boolean array, while the latter between list and binary arrays.