### PR TITLE
ARROW-5675: [Doc] Fix typo in Xcode workflow documentation

### DIFF
--- a/docs/source/developers/cpp.rst
+++ b/docs/source/developers/cpp.rst
@@ -649,8 +649,7 @@ by generating an Xcode project:
    cd cpp
    mkdir xcode-build
    cd xcode-build
-   cmake .. -G Xcode ^
-         -DARROW_BUILD_TESTS=ON
+   cmake .. -G Xcode -DARROW_BUILD_TESTS=ON
    open arrow.xcodeproj
 
 This will generate a project and open it in the Xcode app. As an alternative, 


### PR DESCRIPTION
This is a followup to address @kou's comment here:

https://github.com/apache/arrow/pull/4596#discussion_r296093152
