### PR TITLE
ARROW-5427: [Python] pandas conversion preserve_index=True to force RangeIndex serialization

### DIFF
--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -144,7 +144,7 @@ def open_file(source, footer_offset=None):
     return RecordBatchFileReader(source, footer_offset=footer_offset)
 
 
-def serialize_pandas(df, nthreads=None, preserve_index=True):
+def serialize_pandas(df, nthreads=None, preserve_index=None):
     """Serialize a pandas DataFrame into a buffer protocol compatible object.
 
     Parameters
@@ -152,9 +152,11 @@ def serialize_pandas(df, nthreads=None, preserve_index=True):
     df : pandas.DataFrame
     nthreads : int, default None
         Number of threads to use for conversion to Arrow, default all CPUs
-    preserve_index : boolean, default True
-        If True, preserve the pandas index data, otherwise the result will have
-        a default RangeIndex
+    preserve_index : boolean, default None
+        The default of None will store the index as a column, except for
+        RangeIndex which is stored as metadata only. If True, always
+        preserve the pandas index data as a column. If False, no index
+        information is saved and the result will have a default RangeIndex.
 
     Returns
     -------

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -212,7 +212,7 @@ def construct_metadata(df, column_names, index_levels, index_descriptors,
         column_metadata.append(metadata)
 
     index_column_metadata = []
-    if preserve_index:
+    if preserve_index is not False:
         for level, arrow_type, descriptor in zip(index_levels, index_types,
                                                  index_descriptors):
             if isinstance(descriptor, dict):
@@ -329,7 +329,10 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
 
     column_names = []
 
-    index_levels = _get_index_level_values(df.index) if preserve_index else []
+    index_levels = (
+        _get_index_level_values(df.index) if preserve_index is not False
+        else []
+    )
 
     columns_to_convert = []
     convert_fields = []
@@ -360,7 +363,8 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
     index_column_names = []
     for i, index_level in enumerate(index_levels):
         name = _index_level_name(index_level, i, column_names)
-        if isinstance(index_level, _pandas_api.pd.RangeIndex):
+        if (isinstance(index_level, _pandas_api.pd.RangeIndex)
+                and preserve_index is None):
             descr = _get_range_index_descriptor(index_level)
         else:
             columns_to_convert.append(index_level)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -836,7 +836,7 @@ cdef class RecordBatch(_PandasConvertible):
         return Table.from_batches([self])._to_pandas(options, **kwargs)
 
     @classmethod
-    def from_pandas(cls, df, Schema schema=None, bint preserve_index=True,
+    def from_pandas(cls, df, Schema schema=None, preserve_index=None,
                     nthreads=None, columns=None):
         """
         Convert pandas.DataFrame to an Arrow RecordBatch
@@ -849,7 +849,9 @@ cdef class RecordBatch(_PandasConvertible):
             indicate the type of columns if we cannot infer it automatically.
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
-            ``RecordBatch``.
+            ``RecordBatch``. The default of None will store the index as a
+            column, except for RangeIndex which is stored as metadata only. Use
+            ``preserve_index=True`` to force it to be stored as a column.
         nthreads : int, default None (may use up to system CPU count threads)
             If greater than 1, convert columns to Arrow in parallel using
             indicated number of threads
@@ -1090,7 +1092,7 @@ cdef class Table(_PandasConvertible):
         return Table.from_arrays(newcols, schema=target_schema)
 
     @classmethod
-    def from_pandas(cls, df, Schema schema=None, bint preserve_index=True,
+    def from_pandas(cls, df, Schema schema=None, preserve_index=None,
                     nthreads=None, columns=None, bint safe=True):
         """
         Convert pandas.DataFrame to an Arrow Table.
@@ -1116,7 +1118,9 @@ cdef class Table(_PandasConvertible):
             indicate the type of columns if we cannot infer it automatically.
         preserve_index : bool, optional
             Whether to store the index as an additional column in the resulting
-            ``Table``.
+            ``Table``. The default of None will store the index as a column,
+            except for RangeIndex which is stored as metadata only. Use
+            ``preserve_index=True`` to force it to be stored as a column.
         nthreads : int, default None (may use up to system CPU count threads)
             If greater than 1, convert columns to Arrow in parallel using
             indicated number of threads

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2037,7 +2037,7 @@ def test_dataset_no_memory_map(tempdir):
 
 
 @pytest.mark.pandas
-@pytest.mark.parametrize('preserve_index', [True, False])
+@pytest.mark.parametrize('preserve_index', [True, False, None])
 def test_dataset_read_pandas_common_metadata(tempdir, preserve_index):
     # ARROW-1103
     nfiles = 5
@@ -2076,7 +2076,8 @@ def test_dataset_read_pandas_common_metadata(tempdir, preserve_index):
     columns = ['uint8', 'strings']
     result = dataset.read_pandas(columns=columns).to_pandas()
     expected = pd.concat([x[columns] for x in frames])
-    expected.index.name = df.index.name if preserve_index else None
+    expected.index.name = (
+        df.index.name if preserve_index is not False else None)
     tm.assert_frame_equal(result, expected)
 
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -855,7 +855,7 @@ cdef class Schema:
                                            check_metadata)
 
     @classmethod
-    def from_pandas(cls, df, bint preserve_index=True):
+    def from_pandas(cls, df, preserve_index=None):
         """
         Returns implied schema from dataframe
 
@@ -865,6 +865,9 @@ cdef class Schema:
         preserve_index : bool, default True
             Whether to store the index as an additional column (or columns, for
             MultiIndex) in the resulting `Table`.
+            The default of None will store the index as a column, except for
+            RangeIndex which is stored as metadata only. Use
+            ``preserve_index=True`` to force it to be stored as a column.
 
         Returns
         -------


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5427

This proposes to let `preserve_index=True` force the index to be a column, also RangeIndexes. The default is unchanged (only now codified as None) to have store a RangeIndex as metadata only. But this gives the possibility to force serialization if consistent results are required (or need to match a specified schema, cfr https://issues.apache.org/jira/browse/ARROW-5220)