### PR TITLE
ARROW-4885: [C++/Python] Enable Decimal parsing in CSV

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -60,22 +60,21 @@ inline bool IsWhitespace(uint8_t c) {
 // Updates data and size to not include leading/trailing whitespace
 // characters.
 inline void TrimWhiteSpace(const uint8_t*& data, uint32_t& size) {
- // Skip trailing whitespace
-      if (ARROW_PREDICT_TRUE(size > 0) &&
-          ARROW_PREDICT_FALSE(IsWhitespace(data[size - 1]))) {
-        const uint8_t* p = data + size - 1;
-        while (size > 0 && IsWhitespace(*p)) {
-          --size;
-          --p;
-        }
-      }
-      // Skip leading whitespace
-      if (ARROW_PREDICT_TRUE(size > 0) && ARROW_PREDICT_FALSE(IsWhitespace(data[0]))) {
-        while (size > 0 && IsWhitespace(*data)) {
-          --size;
-          ++data;
-        }
-      }
+  // Skip trailing whitespace
+  if (ARROW_PREDICT_TRUE(size > 0) && ARROW_PREDICT_FALSE(IsWhitespace(data[size - 1]))) {
+    const uint8_t* p = data + size - 1;
+    while (size > 0 && IsWhitespace(*p)) {
+      --size;
+      --p;
+    }
+  }
+  // Skip leading whitespace
+  if (ARROW_PREDICT_TRUE(size > 0) && ARROW_PREDICT_FALSE(IsWhitespace(data[0]))) {
+    while (size > 0 && IsWhitespace(*data)) {
+      --size;
+      ++data;
+    }
+  }
 }
 
 Status InitializeTrie(const std::vector<std::string>& inputs, Trie* trie) {
@@ -302,7 +301,7 @@ Status NumericConverter<T>::Convert(const BlockParser& parser, int32_t col_index
       return Status::OK();
     }
     if (!std::is_same<BooleanType, T>::value) {
-      TrimWhiteSpace(data, size);	  
+      TrimWhiteSpace(data, size);
     }
     if (ARROW_PREDICT_FALSE(
             !converter(reinterpret_cast<const char*>(data), size, &value))) {

--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -57,9 +57,11 @@ inline bool IsWhitespace(uint8_t c) {
   return c == ' ' || c == '\t';
 }
 
-// Updates data and size to not include leading/trailing whitespace
+// Updates data_inout and size_inout to not include leading/trailing whitespace
 // characters.
-inline void TrimWhiteSpace(const uint8_t*& data, uint32_t& size) {
+inline void TrimWhiteSpace(const uint8_t** data_inout, uint32_t* size_inout) {
+  const uint8_t*& data = *data_inout;
+  uint32_t& size = *size_inout;
   // Skip trailing whitespace
   if (ARROW_PREDICT_TRUE(size > 0) && ARROW_PREDICT_FALSE(IsWhitespace(data[size - 1]))) {
     const uint8_t* p = data + size - 1;
@@ -301,7 +303,7 @@ Status NumericConverter<T>::Convert(const BlockParser& parser, int32_t col_index
       return Status::OK();
     }
     if (!std::is_same<BooleanType, T>::value) {
-      TrimWhiteSpace(data, size);
+      TrimWhiteSpace(&data, &size);
     }
     if (ARROW_PREDICT_FALSE(
             !converter(reinterpret_cast<const char*>(data), size, &value))) {
@@ -368,7 +370,7 @@ class DecimalConverter : public ConcreteConverter {
         builder.UnsafeAppendNull();
         return Status::OK();
       }
-      TrimWhiteSpace(data, size);
+      TrimWhiteSpace(&data, &size);
       Decimal128 decimal;
       int32_t precision, scale;
       util::string_view view(reinterpret_cast<const char*>(data), size);


### PR DESCRIPTION
- Create a new Decimal128 converter in csv (copies some code for eliminating white space, please let me know if this should be factored out).
- Add python unit test
-  I filed ARROW-5699 to track 2 performance enhancements:
   *  Add an UnsafeAppend and use it on the Decimal128Builder
   *  Avoid multiple string copies in Decimal128::FromString.