### PR TITLE
ARROW-5702: [C++] parquet::arrow::FileReader::GetSchema()

### DIFF
--- a/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
+++ b/cpp/src/parquet/arrow/arrow-reader-writer-test.cc
@@ -2686,6 +2686,11 @@ TEST_P(TestArrowReaderAdHocSparkAndHvr, ReadDecimals) {
   std::shared_ptr<::arrow::Table> table;
   ASSERT_OK_NO_THROW(arrow_reader->ReadTable(&table));
 
+  std::shared_ptr<::arrow::Schema> schema;
+  ASSERT_OK_NO_THROW(arrow_reader->GetSchema(&schema));
+  ASSERT_EQ(1, schema->num_fields());
+  ASSERT_TRUE(schema->field(0)->type()->Equals(*decimal_type));
+
   ASSERT_EQ(1, table->num_columns());
 
   constexpr int32_t expected_length = 24;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -485,9 +485,13 @@ Status FileReader::Impl::ReadColumn(int i, std::shared_ptr<ChunkedArray>* out) {
 
 Status FileReader::Impl::GetSchema(const std::vector<int>& indices,
                                    std::shared_ptr<::arrow::Schema>* out) {
-  auto descr = reader_->metadata()->schema();
-  auto parquet_key_value_metadata = reader_->metadata()->key_value_metadata();
-  return FromParquetSchema(descr, indices, parquet_key_value_metadata, out);
+  return FromParquetSchema(reader_->metadata()->schema(), indices,
+                           reader_->metadata()->key_value_metadata(), out);
+}
+
+Status FileReader::Impl::GetSchema(std::shared_ptr<::arrow::Schema>* out) {
+  return FromParquetSchema(reader_->metadata()->schema(),
+                           reader_->metadata()->key_value_metadata(), out);
 }
 
 Status FileReader::Impl::ReadColumnChunk(int column_index, int row_group_index,

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -739,6 +739,10 @@ Status FileReader::GetColumn(int i, std::unique_ptr<ColumnReader>* out) {
   return impl_->GetColumn(i, iterator_factory, out);
 }
 
+Status FileReader::GetSchema(std::shared_ptr<::arrow::Schema>* out) {
+  return impl_->GetSchema(out);
+}
+
 Status FileReader::GetSchema(const std::vector<int>& indices,
                              std::shared_ptr<::arrow::Schema>* out) {
   return impl_->GetSchema(indices, out);

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -168,6 +168,9 @@ class PARQUET_EXPORT FileReader {
   // Returns error status if the column of interest is not flat.
   ::arrow::Status GetColumn(int i, std::unique_ptr<ColumnReader>* out);
 
+  /// \brief Return arrow schema for all the columns.
+  ::arrow::Status GetSchema(std::shared_ptr<::arrow::Schema>* out);
+
   /// \brief Return arrow schema by apply selection of column indices.
   /// \returns error status if passed wrong indices.
   ::arrow::Status GetSchema(const std::vector<int>& indices,


### PR DESCRIPTION
This adds this method to `parquet::arrow::FileReader` : 

```cpp
/// \brief Return arrow schema for all the columns.
  ::arrow::Status GetSchema(std::shared_ptr<::arrow::Schema>* out);
```

might be useful for e.g. #4627