### PR TITLE
ARROW-5699: [C++] Optimize decimal128 parsing

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1773,7 +1773,7 @@ class DecimalTest : public ::testing::TestWithParam<int> {
 
     std::shared_ptr<Array> lhs = out->Slice(offset);
     std::shared_ptr<Array> rhs = expected->Slice(offset);
-    ASSERT_TRUE(lhs->Equals(rhs));
+    ASSERT_ARRAYS_EQUAL(*rhs, *lhs);
   }
 };
 

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -270,6 +270,11 @@ const uint8_t* FixedSizeBinaryBuilder::GetValue(int64_t i) const {
   return data_ptr + i * byte_width_;
 }
 
+uint8_t* FixedSizeBinaryBuilder::GetMutableValue(int64_t i) {
+  uint8_t* data_ptr = byte_builder_.mutable_data();
+  return data_ptr + i * byte_width_;
+}
+
 util::string_view FixedSizeBinaryBuilder::GetView(int64_t i) const {
   const uint8_t* data_ptr = byte_builder_.data();
   return util::string_view(reinterpret_cast<const char*>(data_ptr + i * byte_width_),

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -270,11 +270,6 @@ const uint8_t* FixedSizeBinaryBuilder::GetValue(int64_t i) const {
   return data_ptr + i * byte_width_;
 }
 
-uint8_t* FixedSizeBinaryBuilder::GetMutableValue(int64_t i) {
-  uint8_t* data_ptr = byte_builder_.mutable_data();
-  return data_ptr + i * byte_width_;
-}
-
 util::string_view FixedSizeBinaryBuilder::GetView(int64_t i) const {
   const uint8_t* data_ptr = byte_builder_.data();
   return util::string_view(reinterpret_cast<const char*>(data_ptr + i * byte_width_),

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -295,6 +295,11 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   int32_t byte_width_;
   BufferBuilder byte_builder_;
 
+  /// Temporary access to a value.
+  ///
+  /// This pointer becomes invalid on the next modifying operation.
+  uint8_t* GetMutableValue(int64_t i);
+
 #ifndef NDEBUG
   void CheckValueSize(int64_t size);
 #endif

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -298,7 +298,10 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   /// Temporary access to a value.
   ///
   /// This pointer becomes invalid on the next modifying operation.
-  uint8_t* GetMutableValue(int64_t i);
+  uint8_t* GetMutableValue(int64_t i) {
+    uint8_t* data_ptr = byte_builder_.mutable_data();
+    return data_ptr + i * byte_width_;
+  }
 
 #ifndef NDEBUG
   void CheckValueSize(int64_t size);

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -46,9 +46,20 @@ Decimal128Builder::Decimal128Builder(const std::shared_ptr<DataType>& type,
                                      MemoryPool* pool)
     : FixedSizeBinaryBuilder(type, pool) {}
 
-Status Decimal128Builder::Append(const Decimal128& value) {
+Status Decimal128Builder::Append(Decimal128 value) {
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Reserve(1));
-  return FixedSizeBinaryBuilder::Append(value.ToBytes());
+  UnsafeAppend(value);
+  return Status::OK();
+}
+
+void Decimal128Builder::UnsafeAppend(Decimal128 value) {
+  value.ToBytes(GetMutableValue(length()));
+  byte_builder_.UnsafeAdvance(16);
+  UnsafeAppendToBitmap(true);
+}
+
+void Decimal128Builder::UnsafeAppend(util::string_view value) {
+  FixedSizeBinaryBuilder::UnsafeAppend(value);
 }
 
 Status Decimal128Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -35,7 +35,9 @@ class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
   using FixedSizeBinaryBuilder::AppendValues;
   using FixedSizeBinaryBuilder::Reset;
 
-  Status Append(const Decimal128& val);
+  Status Append(Decimal128 val);
+  void UnsafeAppend(Decimal128 val);
+  void UnsafeAppend(util::string_view val);
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -194,7 +194,7 @@ static void BuildDecimalArray(benchmark::State& state) {  // NOLINT non-const re
     ABORT_NOT_OK(builder.Finish(&out));
   }
 
-  state.SetBytesProcessed(state.iterations() * kBytesProcessed * 2);
+  state.SetBytesProcessed(state.iterations() * kRounds * kNumberOfElements * 16);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -29,6 +29,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/bit-util.h"
+#include "arrow/util/decimal.h"
 #include "arrow/util/string_view.h"
 
 namespace arrow {
@@ -174,6 +175,26 @@ static void BuildFixedSizeBinaryArray(
   }
 
   state.SetBytesProcessed(state.iterations() * kBytesProcessed);
+}
+
+static void BuildDecimalArray(benchmark::State& state) {  // NOLINT non-const reference
+  auto type = decimal(10, 5);
+  Decimal128 value;
+  int32_t precision = 0;
+  int32_t scale = 0;
+  ABORT_NOT_OK(Decimal128::FromString("1234.1234", &value, &precision, &scale));
+  for (auto _ : state) {
+    Decimal128Builder builder(type);
+
+    for (int64_t i = 0; i < kRounds * kNumberOfElements; i++) {
+      ABORT_NOT_OK(builder.Append(value));
+    }
+
+    std::shared_ptr<Array> out;
+    ABORT_NOT_OK(builder.Finish(&out));
+  }
+
+  state.SetBytesProcessed(state.iterations() * kBytesProcessed * 2);
 }
 
 // ----------------------------------------------------------------------
@@ -383,6 +404,7 @@ BENCHMARK(BuildAdaptiveIntNoNullsScalarAppend);
 BENCHMARK(BuildBinaryArray);
 BENCHMARK(BuildChunkedBinaryArray);
 BENCHMARK(BuildFixedSizeBinaryArray);
+BENCHMARK(BuildDecimalArray);
 
 BENCHMARK(BuildInt64DictionaryArrayRandom);
 BENCHMARK(BuildInt64DictionaryArraySequential);

--- a/cpp/src/arrow/csv/converter-benchmark.cc
+++ b/cpp/src/arrow/csv/converter-benchmark.cc
@@ -55,6 +55,19 @@ static std::shared_ptr<BlockParser> BuildFloatData(int32_t num_rows) {
   return result;
 }
 
+static std::shared_ptr<BlockParser> BuildDecimal128Data(int32_t num_rows) {
+  const std::vector<std::string> base_rows = {"0\n", "123.456\n", "-3170.55766\n",
+                                              "\n",  "N/A\n",     "1233456789.123456789"};
+  std::vector<std::string> rows;
+  for (int32_t i = 0; i < num_rows; ++i) {
+    rows.push_back(base_rows[i % base_rows.size()]);
+  }
+
+  std::shared_ptr<BlockParser> result;
+  MakeCSVParser(rows, &result);
+  return result;
+}
+
 static void BenchmarkConversion(benchmark::State& state,  // NOLINT non-const reference
                                 BlockParser& parser,
                                 const std::shared_ptr<DataType>& type,
@@ -90,8 +103,16 @@ static void FloatConversion(benchmark::State& state) {  // NOLINT non-const refe
   BenchmarkConversion(state, *parser, float64(), options);
 }
 
+static void Decimal128Conversion(benchmark::State& state) {  // NOLINT non-const reference
+  auto parser = BuildDecimal128Data(num_rows);
+  auto options = ConvertOptions::Defaults();
+
+  BenchmarkConversion(state, *parser, decimal(24, 9), options);
+}
+
 BENCHMARK(Int64Conversion);
 BENCHMARK(FloatConversion);
+BENCHMARK(Decimal128Conversion);
 
 }  // namespace csv
 }  // namespace arrow

--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -383,9 +383,9 @@ class DecimalConverter : public ConcreteConverter {
       if (scale != type.scale()) {
         Decimal128 scaled;
         RETURN_NOT_OK(decimal.Rescale(scale, type.scale(), &scaled));
-        RETURN_NOT_OK(builder.Append(scaled.ToBytes()));
+        builder.UnsafeAppend(scaled);
       } else {
-        RETURN_NOT_OK(builder.Append(decimal.ToBytes()));
+        builder.UnsafeAppend(decimal);
       }
       return Status::OK();
     };

--- a/cpp/src/arrow/util/decimal-benchmark.cc
+++ b/cpp/src/arrow/util/decimal-benchmark.cc
@@ -27,13 +27,18 @@ namespace arrow {
 namespace Decimal {
 
 static void FromString(benchmark::State& state) {  // NOLINT non-const reference
-  std::vector<std::string> values = {"0", "1.23", "12.345e6", "-12.345e-6"};
+  std::vector<std::string> values = {"0",
+                                     "1.23",
+                                     "12.345e6",
+                                     "-12.345e-6",
+                                     "123456789.123456789",
+                                     "1231234567890.451234567890"};
 
   while (state.KeepRunning()) {
     for (const auto& value : values) {
       Decimal128 dec;
       int32_t scale, precision;
-      ARROW_UNUSED(Decimal128::FromString(value, &dec, &scale, &precision));
+      benchmark::DoNotOptimize(Decimal128::FromString(value, &dec, &scale, &precision));
     }
   }
   state.SetItemsProcessed(state.iterations() * values.size());

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -33,6 +33,7 @@
 #include "arrow/util/int-util.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/parsing.h"
 
 namespace arrow {
 
@@ -176,37 +177,46 @@ static constexpr int64_t kPowersOfTen[kInt64DecimalDigits + 1] = {1LL,
                                                                   100000000000000000LL,
                                                                   1000000000000000000LL};
 
-static void StringToInteger(const std::string& str, Decimal128* out) {
+// Iterates over data and for each group of kInt64DecimalDigits multiple out by
+// the appropriate power of 10 necessary to add source parsed as uint64 and
+// then adds the parsed value of source.
+static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out) {
+  static internal::StringConverter<Int64Type> converter;
+  for (size_t posn = 0; posn < length;) {
+    const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
+    const int64_t multiple = kPowersOfTen[group_size];
+    int64_t chunk = 0;
+    DCHECK(converter(data + posn, group_size, &chunk));
+
+    *out *= multiple;
+    *out += chunk;
+    posn += group_size;
+  }
+}
+
+static void StringToInteger(const util::string_view whole_digits,
+                            util::string_view fractional_digits, Decimal128* out) {
   using std::size_t;
 
   DCHECK_NE(out, nullptr) << "Decimal128 output variable cannot be nullptr";
   DCHECK_EQ(*out, 0)
       << "When converting a string to Decimal128 the initial output must be 0";
 
-  const size_t length = str.length();
+  DCHECK_GT(whole_digits.size() + fractional_digits.size(), 0)
+      << "length of parsed decimal string should be greater than 0";
 
-  DCHECK_GT(length, 0) << "length of parsed decimal string should be greater than 0";
-
-  for (size_t posn = 0; posn < length;) {
-    const size_t group = std::min(kInt64DecimalDigits, length - posn);
-    const int64_t chunk = std::stoll(str.substr(posn, group));
-    const int64_t multiple = kPowersOfTen[group];
-
-    *out *= multiple;
-    *out += chunk;
-
-    posn += group;
-  }
+  ShiftAndAdd(whole_digits.data(), whole_digits.length(), out);
+  ShiftAndAdd(fractional_digits.data(), fractional_digits.length(), out);
 }
 
 namespace {
 
 struct DecimalComponents {
-  std::string sign;
-  std::string whole_digits;
-  std::string fractional_digits;
-  std::string exponent_sign;
-  std::string exponent_digits;
+  util::string_view whole_digits;
+  util::string_view fractional_digits;
+  int32_t exponent;
+  char sign = 0;
+  bool has_exponent = false;
 };
 
 inline bool IsSign(char c) { return c == '-' || c == '+'; }
@@ -217,14 +227,15 @@ inline bool IsDigit(char c) { return c >= '0' && c <= '9'; }
 
 inline bool StartsExponent(char c) { return c == 'e' || c == 'E'; }
 
-inline size_t ParseDigitsRun(const char* s, size_t start, size_t size, std::string* out) {
+inline size_t ParseDigitsRun(const char* s, size_t start, size_t size,
+                             util::string_view* out) {
   size_t pos;
   for (pos = start; pos < size; ++pos) {
     if (!IsDigit(s[pos])) {
       break;
     }
   }
-  *out = std::string(s + start, pos - start);
+  *out = util::string_view(s + start, pos - start);
   return pos;
 }
 
@@ -236,7 +247,7 @@ bool ParseDecimalComponents(const char* s, size_t size, DecimalComponents* out) 
   }
   // Sign of the number
   if (IsSign(s[pos])) {
-    out->sign = std::string(s + pos, 1);
+    out->sign = *(s + pos);
     ++pos;
   }
   // First run of digits
@@ -261,19 +272,12 @@ bool ParseDecimalComponents(const char* s, size_t size, DecimalComponents* out) 
   // Optional exponent
   if (StartsExponent(s[pos])) {
     ++pos;
-    if (pos == size) {
-      return false;
-    }
-    // Optional exponent sign
-    if (IsSign(s[pos])) {
-      out->exponent_sign = std::string(s + pos, 1);
+    if (pos != size && s[pos] == '+') {
       ++pos;
     }
-    pos = ParseDigitsRun(s, pos, size, &out->exponent_digits);
-    if (out->exponent_digits.empty()) {
-      // Need some exponent digits
-      return false;
-    }
+    out->has_exponent = true;
+    static internal::StringConverter<Int32Type> exponent_converter;
+    return exponent_converter(s + pos, size - pos, &(out->exponent));
   }
   return pos == size;
 }
@@ -290,7 +294,6 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
   if (!ParseDecimalComponents(s.data(), s.size(), &dec)) {
     return Status::Invalid("The string '", s, "' is not a valid decimal number");
   }
-  std::string exponent_value = dec.exponent_sign + dec.exponent_digits;
 
   // Count number of significant digits (without leading zeros)
   size_t first_non_zero = dec.whole_digits.find_first_not_of('0');
@@ -304,8 +307,8 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
   }
 
   if (scale != nullptr) {
-    if (!exponent_value.empty()) {
-      auto adjusted_exponent = static_cast<int32_t>(std::stol(exponent_value));
+    if (dec.has_exponent) {
+      auto adjusted_exponent = dec.exponent;
       auto len = static_cast<int32_t>(significant_digits);
       *scale = -adjusted_exponent + len - 1;
     } else {
@@ -315,8 +318,8 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
 
   if (out != nullptr) {
     *out = 0;
-    StringToInteger(dec.whole_digits + dec.fractional_digits, out);
-    if (dec.sign == "-") {
+    StringToInteger(dec.whole_digits, dec.fractional_digits, out);
+    if (dec.sign == '-') {
       out->Negate();
     }
 

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -186,7 +186,7 @@ static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out)
     const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
     const int64_t multiple = kPowersOfTen[group_size];
     int64_t chunk = 0;
-    CHECK(converter(data + posn, group_size, &chunk));
+    ARROW_CHECK(converter(data + posn, group_size, &chunk));
 
     *out *= multiple;
     *out += chunk;

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -181,7 +181,7 @@ static constexpr int64_t kPowersOfTen[kInt64DecimalDigits + 1] = {1LL,
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
 static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out) {
-  static internal::StringConverter<Int64Type> converter;
+  internal::StringConverter<Int64Type> converter;
   for (size_t posn = 0; posn < length;) {
     const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
     const int64_t multiple = kPowersOfTen[group_size];
@@ -276,7 +276,7 @@ bool ParseDecimalComponents(const char* s, size_t size, DecimalComponents* out) 
       ++pos;
     }
     out->has_exponent = true;
-    static internal::StringConverter<Int32Type> exponent_converter;
+    internal::StringConverter<Int32Type> exponent_converter;
     return exponent_converter(s + pos, size - pos, &(out->exponent));
   }
   return pos == size;

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -186,7 +186,7 @@ static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out)
     const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
     const int64_t multiple = kPowersOfTen[group_size];
     int64_t chunk = 0;
-    DCHECK(converter(data + posn, group_size, &chunk));
+    CHECK(converter(data + posn, group_size, &chunk));
 
     *out *= multiple;
     *out += chunk;

--- a/cpp/src/arrow/util/parsing.h
+++ b/cpp/src/arrow/util/parsing.h
@@ -45,7 +45,7 @@ namespace internal {
 ///
 /// The class may have a non-trivial construction cost in some cases,
 /// so it's recommended to use a single instance many times, if doing bulk
-/// conversion.
+/// conversion. Instances of this class are not guaranteed to be thread-safe.
 ///
 template <typename ARROW_TYPE, typename Enable = void>
 class StringConverter;


### PR DESCRIPTION
- Remove multiple string copies/instantiations from Decimal128 parsing code
- Still figuring out the best way to transfer bytes from Decimal128 to a builder