### PR TITLE
ARROW-5704: [C++] Stop using ARROW_TEMPLATE_EXPORT for SparseTensorImpl

### DIFF
--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -237,76 +237,77 @@ namespace internal {
 namespace {
 
 template <typename TYPE, typename SparseIndexType>
-Status MakeSparseTensorFromTensor(const Tensor& tensor,
-                                  std::shared_ptr<SparseIndex>* sparse_index,
-                                  std::shared_ptr<Buffer>* data) {
+void MakeSparseTensorFromTensor(const Tensor& tensor,
+                                std::shared_ptr<SparseIndex>* sparse_index,
+                                std::shared_ptr<Buffer>* data) {
   NumericTensor<TYPE> numeric_tensor(tensor.data(), tensor.shape(), tensor.strides());
   SparseTensorConverter<TYPE, SparseIndexType> converter(numeric_tensor);
-  Status s = converter.Convert();
-  RETURN_NOT_OK(s);
+  ARROW_CHECK_OK(converter.Convert());
   *sparse_index = converter.sparse_index;
   *data = converter.data;
-  return Status::OK();
 }
 
 template <typename SparseIndexType>
-inline Status MakeSparseTensorFromTensor(const Tensor& tensor,
-                                         std::shared_ptr<SparseIndex>* sparse_index,
-                                         std::shared_ptr<Buffer>* data) {
+inline void MakeSparseTensorFromTensor(const Tensor& tensor,
+                                       std::shared_ptr<SparseIndex>* sparse_index,
+                                       std::shared_ptr<Buffer>* data) {
   switch (tensor.type()->id()) {
     case Type::UINT8:
-      return MakeSparseTensorFromTensor<UInt8Type, SparseIndexType>(tensor, sparse_index,
-                                                                    data);
+      MakeSparseTensorFromTensor<UInt8Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::INT8:
-      return MakeSparseTensorFromTensor<Int8Type, SparseIndexType>(tensor, sparse_index,
-                                                                   data);
+      MakeSparseTensorFromTensor<Int8Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::UINT16:
-      return MakeSparseTensorFromTensor<UInt16Type, SparseIndexType>(tensor, sparse_index,
-                                                                     data);
+      MakeSparseTensorFromTensor<UInt16Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::INT16:
-      return MakeSparseTensorFromTensor<Int16Type, SparseIndexType>(tensor, sparse_index,
-                                                                    data);
+      MakeSparseTensorFromTensor<Int16Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::UINT32:
-      return MakeSparseTensorFromTensor<UInt32Type, SparseIndexType>(tensor, sparse_index,
-                                                                     data);
+      MakeSparseTensorFromTensor<UInt32Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::INT32:
-      return MakeSparseTensorFromTensor<Int32Type, SparseIndexType>(tensor, sparse_index,
-                                                                    data);
+      MakeSparseTensorFromTensor<Int32Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::UINT64:
-      return MakeSparseTensorFromTensor<UInt64Type, SparseIndexType>(tensor, sparse_index,
-                                                                     data);
+      MakeSparseTensorFromTensor<UInt64Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::INT64:
-      return MakeSparseTensorFromTensor<Int64Type, SparseIndexType>(tensor, sparse_index,
-                                                                    data);
+      MakeSparseTensorFromTensor<Int64Type, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::HALF_FLOAT:
-      return MakeSparseTensorFromTensor<HalfFloatType, SparseIndexType>(
-          tensor, sparse_index, data);
+      MakeSparseTensorFromTensor<HalfFloatType, SparseIndexType>(tensor, sparse_index,
+                                                                 data);
+      break;
     case Type::FLOAT:
-      return MakeSparseTensorFromTensor<FloatType, SparseIndexType>(tensor, sparse_index,
-                                                                    data);
+      MakeSparseTensorFromTensor<FloatType, SparseIndexType>(tensor, sparse_index, data);
+      break;
     case Type::DOUBLE:
-      return MakeSparseTensorFromTensor<DoubleType, SparseIndexType>(tensor, sparse_index,
-                                                                     data);
+      MakeSparseTensorFromTensor<DoubleType, SparseIndexType>(tensor, sparse_index, data);
+      break;
     default:
-      return Status::NotImplemented("Unspported Tensor value type");
+      ARROW_LOG(FATAL) << "Unsupported Tensor value type";
+      break;
   }
 }
 
 }  // namespace
 
-Status MakeSparseTensorFromTensor(const Tensor& tensor,
-                                  SparseTensorFormat::type sparse_format_id,
-                                  std::shared_ptr<SparseIndex>* sparse_index,
-                                  std::shared_ptr<Buffer>* data) {
+void MakeSparseTensorFromTensor(const Tensor& tensor,
+                                SparseTensorFormat::type sparse_format_id,
+                                std::shared_ptr<SparseIndex>* sparse_index,
+                                std::shared_ptr<Buffer>* data) {
   switch (sparse_format_id) {
     case SparseTensorFormat::COO:
-      return MakeSparseTensorFromTensor<SparseCOOIndex>(tensor, sparse_index, data);
-
+      MakeSparseTensorFromTensor<SparseCOOIndex>(tensor, sparse_index, data);
+      break;
     case SparseTensorFormat::CSR:
-      return MakeSparseTensorFromTensor<SparseCSRIndex>(tensor, sparse_index, data);
-
+      MakeSparseTensorFromTensor<SparseCSRIndex>(tensor, sparse_index, data);
+      break;
     default:
-      return Status::Invalid("Invalid sparse tensor format ID");
+      ARROW_LOG(FATAL) << "Invalid sparse tensor format ID";
+      break;
   }
 }
 

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -244,11 +244,11 @@ class ARROW_EXPORT SparseTensorImpl : public SparseTensor {
   SparseTensorImpl(const std::shared_ptr<DataType>& type,
                    const std::vector<int64_t>& shape,
                    const std::vector<std::string>& dim_names = {})
-      : SparseTensorImpl(nullptr, type, nullptr, shape, dim_names) {}
+      : SparseTensorImpl(NULLPTR, type, NULLPTR, shape, dim_names) {}
 
   // Constructor with a dense tensor
   explicit SparseTensorImpl(const Tensor& tensor)
-      : SparseTensorImpl(nullptr, tensor.type(), nullptr, tensor.shape(),
+      : SparseTensorImpl(NULLPTR, tensor.type(), NULLPTR, tensor.shape(),
                          tensor.dim_names_) {
     (void)internal::MakeSparseTensorFromTensor(tensor, SparseIndexType::format_id,
                                                &sparse_index_, &data_);

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -219,12 +219,13 @@ class ARROW_EXPORT SparseTensor {
 
 namespace internal {
 
-Status MakeSparseTensorFromTensor(const Tensor& tensor,
-                                  SparseTensorFormat::type sparse_format_id,
-                                  std::shared_ptr<SparseIndex>* sparse_index,
-                                  std::shared_ptr<Buffer>* data);
+ARROW_EXPORT
+void MakeSparseTensorFromTensor(const Tensor& tensor,
+                                SparseTensorFormat::type sparse_format_id,
+                                std::shared_ptr<SparseIndex>* sparse_index,
+                                std::shared_ptr<Buffer>* data);
 
-}
+}  // namespace internal
 
 /// \brief EXPERIMENTAL: Concrete sparse tensor implementation classes with sparse index
 /// type
@@ -250,8 +251,8 @@ class SparseTensorImpl : public SparseTensor {
   explicit SparseTensorImpl(const Tensor& tensor)
       : SparseTensorImpl(NULLPTR, tensor.type(), NULLPTR, tensor.shape(),
                          tensor.dim_names_) {
-    (void)internal::MakeSparseTensorFromTensor(tensor, SparseIndexType::format_id,
-                                               &sparse_index_, &data_);
+    internal::MakeSparseTensorFromTensor(tensor, SparseIndexType::format_id,
+                                         &sparse_index_, &data_);
   }
 
  private:

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -229,7 +229,7 @@ Status MakeSparseTensorFromTensor(const Tensor& tensor,
 /// \brief EXPERIMENTAL: Concrete sparse tensor implementation classes with sparse index
 /// type
 template <typename SparseIndexType>
-class ARROW_EXPORT SparseTensorImpl : public SparseTensor {
+class SparseTensorImpl : public SparseTensor {
  public:
   virtual ~SparseTensorImpl() = default;
 

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -43,14 +43,4 @@
 #endif
 #endif  // Non-Windows
 
-// This is a complicated topic, some reading on it:
-// http://www.codesynthesis.com/~boris/blog/2010/01/18/dll-export-cxx-templates/
-#if defined(_MSC_VER) || defined(__clang__)
-#define ARROW_TEMPLATE_CLASS_EXPORT
-#define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
-#else
-#define ARROW_TEMPLATE_CLASS_EXPORT ARROW_EXPORT
-#define ARROW_TEMPLATE_EXPORT
-#endif
-
 #endif  // ARROW_UTIL_VISIBILITY_H


### PR DESCRIPTION
I'd like to stop using ARROW_TEMPLATE_EXPORT for SparseTensorImpl class so that it can be wrapped in Arrow GLib library on the mingw platform.

This is the continuation of #3509.