### PR TITLE
ARROW-1279: [Integration] Enable MapType integration tests

### DIFF
--- a/cpp/src/arrow/ipc/json-internal.cc
+++ b/cpp/src/arrow/ipc/json-internal.cc
@@ -1274,8 +1274,8 @@ class ArrayReader {
 
   Status Visit(const MapType& type) {
     auto list_type = std::make_shared<ListType>(field(
-        "item",
-        struct_({field("key", type.key_type(), false), field("item", type.item_type())}),
+        "entries",
+        struct_({field("key", type.key_type(), false), field("value", type.item_type())}),
         false));
     std::shared_ptr<Array> list_array;
     RETURN_NOT_OK(CreateList(list_type, &list_array));

--- a/cpp/src/arrow/ipc/json-test.cc
+++ b/cpp/src/arrow/ipc/json-test.cc
@@ -204,7 +204,7 @@ TEST(TestJsonArrayWriter, NestedTypes) {
 
   TestArrayRoundTrip(list_array);
 
-  // List
+  // Map
   auto map_type = map(utf8(), int32());
   auto keys_array = ArrayFromJSON(utf8(), R"(["a", "b", "c", "d", "a", "b", "c"])");
 

--- a/cpp/src/arrow/ipc/metadata-internal.cc
+++ b/cpp/src/arrow/ipc/metadata-internal.cc
@@ -320,9 +320,7 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       if (children.size() != 1) {
         return Status::Invalid("Map must have exactly 1 child field");
       }
-      if (  // FIXME(bkietz) temporarily disabled: this field is sometimes read nullable
-            // children[0]->nullable() ||
-          children[0]->type()->id() != Type::STRUCT ||
+      if (children[0]->nullable() || children[0]->type()->id() != Type::STRUCT ||
           children[0]->type()->num_children() != 2) {
         return Status::Invalid("Map's key-item pairs must be non-nullable structs");
       }

--- a/cpp/src/arrow/ipc/test-common.cc
+++ b/cpp/src/arrow/ipc/test-common.cc
@@ -120,7 +120,7 @@ Status MakeRandomMapArray(const std::shared_ptr<Array>& key_array,
                           bool include_nulls, MemoryPool* pool,
                           std::shared_ptr<Array>* out) {
   auto pair_type = struct_(
-      {field("key", key_array->type(), false), field("item", item_array->type())});
+      {field("key", key_array->type(), false), field("value", item_array->type())});
 
   auto pair_array = std::make_shared<StructArray>(pair_type, num_maps,
                                                   ArrayVector{key_array, item_array});

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -154,9 +154,9 @@ std::string ListType::ToString() const {
 MapType::MapType(const std::shared_ptr<DataType>& key_type,
                  const std::shared_ptr<DataType>& item_type, bool keys_sorted)
     : ListType(std::make_shared<Field>(
-          "$data$",
+          "entries",
           struct_({std::make_shared<Field>("key", key_type, false),
-                   std::make_shared<Field>("item", item_type)}),
+                   std::make_shared<Field>("value", item_type)}),
           false)),
       keys_sorted_(keys_sorted) {
   id_ = type_id;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -153,8 +153,11 @@ std::string ListType::ToString() const {
 
 MapType::MapType(const std::shared_ptr<DataType>& key_type,
                  const std::shared_ptr<DataType>& item_type, bool keys_sorted)
-    : ListType(struct_({std::make_shared<Field>("key", key_type, false),
-                        std::make_shared<Field>("item", item_type)})),
+    : ListType(std::make_shared<Field>(
+          "$data$",
+          struct_({std::make_shared<Field>("key", key_type, false),
+                   std::make_shared<Field>("item", item_type)}),
+          false)),
       keys_sorted_(keys_sorted) {
   id_ = type_id;
 }

--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -714,7 +714,7 @@ class MapType(DataType):
         assert not key_type.nullable
         self.key_type = key_type
         self.item_type = item_type
-        self.pair_type = StructType('$data$', [key_type, item_type], False)
+        self.pair_type = StructType('entries', [key_type, item_type], False)
         self.keysSorted = keysSorted
 
     def _get_type(self):
@@ -1058,6 +1058,18 @@ def generate_interval_case():
     return _generate_file("interval", fields, batch_sizes)
 
 
+def generate_map_case():
+    # TODO(bkietz): separated from nested_case so it can be
+    # independently skipped, consolidate after JS supports map
+    fields = [
+        MapType('map_nullable', get_field('key', 'utf8', False),
+                get_field('value', 'int32')),
+    ]
+
+    batch_sizes = [7, 10]
+    return _generate_file("map", fields, batch_sizes)
+
+
 def generate_nested_case():
     fields = [
         ListType('list_nullable', get_field('item', 'int32')),
@@ -1065,8 +1077,6 @@ def generate_nested_case():
                           get_field('item', 'int32'), 4),
         StructType('struct_nullable', [get_field('f1', 'int32'),
                                        get_field('f2', 'utf8')]),
-        MapType('map_nullable', get_field('key', 'utf8', False),
-                get_field('item', 'int32')),
 
         # TODO(wesm): this causes segfault
         # ListType('list_nonnullable', get_field('item', 'int32'), False),
@@ -1140,6 +1150,7 @@ def get_generated_json_files(tempdir=None, flight=False):
         generate_decimal_case(),
         generate_datetime_case(),
         generate_interval_case(),
+        generate_map_case(),
         generate_nested_case(),
         generate_dictionary_case(),
         generate_nested_dictionary_case().skip_category(SKIP_ARROW)
@@ -1209,12 +1220,10 @@ class IntegrationRunner(object):
 
             file_id = guid()[:8]
 
-            if (('JS' in (producer.name, consumer.name) or
-                   'Java' in (producer.name, consumer.name)) and
+            if ('JS' in (producer.name, consumer.name) and
                     "map" in test_case.name):
                 print('TODO(ARROW-1279): Enable map tests ' +
-                      ' for Java and JS once Java supports them and JS\'' +
-                      ' are unbroken')
+                      ' for JS once they are unbroken')
                 continue
 
             if ('JS' in (producer.name, consumer.name) and
@@ -1696,6 +1705,7 @@ def run_all_tests(args):
 
 
 def write_js_test_json(directory):
+    generate_map_case().write(os.path.join(directory, 'map.json'))
     generate_nested_case().write(os.path.join(directory, 'nested.json'))
     generate_decimal_case().write(os.path.join(directory, 'decimal.json'))
     generate_datetime_case().write(os.path.join(directory, 'datetime.json'))


### PR DESCRIPTION
This PR enables MapType integration tests for C++ and Java, and fixes remaining issues to pass. Previously, C++ created a MapType with a StructType field that is nullable, which is required to be non-nullable from the spec. The struct field has the name "entries" and the struct data pairs are named "key" and "value."