### PR TITLE
ARROW-3811 [R]: Support inferring data.frame column as StructArray in array constructors

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -415,3 +415,10 @@ test_that("array() recognise arrow::Array (ARROW-3815)", {
   a <- array(1:10)
   expect_equal(a, array(a))
 })
+
+test_that("array() handles data frame -> struct arrays (ARROW-3811)", {
+  df <- tibble::tibble(x = 1:10, y = x / 2, z = letters[1:10])
+  a <- array(df)
+  expect_equal(a$type, struct(x = int32(), y = float64(), z = utf8()))
+  expect_equivalent(a$as_vector(), df)
+})

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -422,3 +422,20 @@ test_that("array() handles data frame -> struct arrays (ARROW-3811)", {
   expect_equal(a$type, struct(x = int32(), y = float64(), z = utf8()))
   expect_equivalent(a$as_vector(), df)
 })
+
+test_that("array() can handle data frame with custom struct type (not infered)", {
+  df <- tibble::tibble(x = 1:10, y = 1:10)
+  type <- struct(x = float64(), y = int16())
+  a <- array(df, type = type)
+  expect_equal(a$type, type)
+
+  type <- struct(x = float64(), y = int16(), z = int32())
+  expect_error(array(df, type = type), regexp = "Number of fields in struct.* incompatible with number of columns in the data frame")
+
+  type <- struct(y = int16(), x = float64())
+  expect_error(array(df, type = type), regexp = "Field name in position.*does not match the name of the column of the data frame")
+
+  type <- struct(x = float64(), y = utf8())
+  expect_error(array(df, type = type), regexp = "Cannot convert R object to string array")
+})
+

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -150,3 +150,23 @@ test_that("record_batch() handles arrow::Array", {
   batch <- record_batch(x = 1:10, y = arrow::array(1:10))
   expect_equal(batch$schema, schema(x = int32(), y = int32()))
 })
+
+test_that("record_batch() handles data frame columns", {
+  tib <- tibble::tibble(x = 1:10, y = 1:10)
+  batch <- record_batch(a = 1:10, b = tib)
+  expect_equal(batch$schema, schema(a = int32(), struct(x = int32(), y = int32())))
+  out <- as.data.frame(batch)
+  expect_equivalent(out, tibble::tibble(a = 1:10, b = tib))
+})
+
+test_that("record_batch() handles data frame columns with schema spec", {
+  tib <- tibble::tibble(x = 1:10, y = 1:10)
+  schema <- schema(a = int32(), b = struct(x = int16(), y = float64()))
+  batch <- record_batch(a = 1:10, b = tib, schema = schema)
+  expect_equal(batch$schema, schema)
+  out <- as.data.frame(batch)
+  expect_equivalent(out, tibble::tibble(a = 1:10, b = tib))
+
+  schema <- schema(a = int32(), b = struct(x = int16(), y = utf8()))
+  expect_error(record_batch(a = 1:10, b = tib, schema = schema))
+})

--- a/r/tests/testthat/test-chunkedarray.R
+++ b/r/tests/testthat/test-chunkedarray.R
@@ -272,3 +272,10 @@ test_that("chunked_array() can ingest arrays (ARROW-3815)", {
     1:10
   )
 })
+
+test_that("chunked_array() handles data frame -> struct arrays (ARROW-3811)", {
+  df <- tibble::tibble(x = 1:10, y = x / 2, z = letters[1:10])
+  a <- chunked_array(df, df)
+  expect_equal(a$type, struct(x = int32(), y = float64(), z = utf8()))
+  expect_equivalent(a$as_vector(), rbind(df, df))
+})

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -50,3 +50,8 @@ test_that("type() infers from R type", {
     int64()
   )
 })
+
+test_that("type() can infer struct types from data frames", {
+  df <- tibble::tibble(x = 1:10, y = rnorm(10), z = letters[1:10])
+  expect_equal(type(df), struct(x = int32(), y = float64(), z = utf8()))
+})


### PR DESCRIPTION
So that `array()` and `chunked_array()` handle data frame columns (struct arrays in arrow speech), and record batches and tables handle them too. 

``` r
library(arrow, warn.conflicts = FALSE)
library(tibble)

df <- tibble(x = 1:10, y = letters[1:10])
a <- array(df)
a$type
#> arrow::StructType 
#> struct<x: int32, y: string>
a$as_vector()
#>     x y
#> 1   1 a
#> 2   2 b
#> 3   3 c
#> 4   4 d
#> 5   5 e
#> 6   6 f
#> 7   7 g
#> 8   8 h
#> 9   9 i
#> 10 10 j

batch <- record_batch(a = rnorm(10), y = df)
batch$schema
#> arrow::Schema 
#> a: double
#> y: struct<x: int32, y: string>
as_tibble(batch)
#> # A tibble: 10 x 2
#>         a   y$x $y   
#>     <dbl> <int> <chr>
#>  1 -0.747     1 a    
#>  2  0.285     2 b    
#>  3  0.159     3 c    
#>  4  0.707     4 d    
#>  5  0.366     5 e    
#>  6  0.237     6 f    
#>  7 -0.730     7 g    
#>  8 -0.880     8 h    
#>  9 -0.833     9 i    
#> 10  1.21     10 j

tab <- table(a = rnorm(10), y = df)
tab$schema
#> arrow::Schema 
#> a: double
#> y: struct<x: int32, y: string>
as_tibble(tab)
#> # A tibble: 10 x 2
#>         a   y$x $y   
#>     <dbl> <int> <chr>
#>  1  0.828     1 a    
#>  2  1.57      2 b    
#>  3 -1.54      3 c    
#>  4  0.723     4 d    
#>  5  1.07      5 e    
#>  6  1.08      6 f    
#>  7 -0.338     7 g    
#>  8 -2.26      8 h    
#>  9  0.198     9 i    
#> 10 -1.58     10 j
```

<sup>Created on 2019-06-25 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>