### PR TITLE
ARROW-5728: [Python] Pin jpype1 version to 0.6.3 due to CI breakage from 0.7.0

### DIFF
--- a/ci/travis_script_python.sh
+++ b/ci/travis_script_python.sh
@@ -46,7 +46,8 @@ if [ "$ARROW_TRAVIS_PYTHON_GANDIVA" == "1" ]; then
 fi
 
 if [ "$ARROW_TRAVIS_PYTHON_JVM" == "1" ]; then
-    CONDA_PACKAGES="$CONDA_PACKAGES jpype1"
+    JPYPE_VERSION=0.6.3
+    CONDA_PACKAGES="$CONDA_PACKAGES jpype1=$JPYPE_VERSION"
 fi
 
 conda create -y -q -p $CONDA_ENV_DIR \


### PR DESCRIPTION
I opened an issue on the feedstock in case it elicits any useful information

https://github.com/conda-forge/jpype1-feedstock/issues/8