### PR TITLE
ARROW-5726: [Java] Implement a common interface for int vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+/**
+ * Interface for all int type vectors.
+ */
+public interface BaseIntVector extends ValueVector {
+
+  /**
+   * set the encoded value from a {@link org.apache.arrow.vector.dictionary.Dictionary}.
+   */
+  void setEncodedValue(int index, Object value);
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
@@ -25,5 +25,5 @@ public interface BaseIntVector extends ValueVector {
   /**
    * set the encoded value from a {@link org.apache.arrow.vector.dictionary.Dictionary}.
    */
-  void setEncodedValue(int index, Object value);
+  void setEncodedValue(int index, int value);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -340,7 +340,7 @@ public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector 
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
+  public void setEncodedValue(int index, int value) {
     this.setSafe(index, (long) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -341,7 +341,7 @@ public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector 
 
   @Override
   public void setEncodedValue(int index, int value) {
-    this.setSafe(index, (long) value);
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class BigIntVector extends BaseFixedWidthVector {
+public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector {
   public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
@@ -337,6 +337,11 @@ public class BigIntVector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((BigIntVector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (long) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -344,8 +344,8 @@ public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (int) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class IntVector extends BaseFixedWidthVector {
+public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
   public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -341,6 +341,11 @@ public class IntVector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((IntVector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -371,8 +371,8 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (int) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * short values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class SmallIntVector extends BaseFixedWidthVector {
+public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector {
   public static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -368,6 +368,11 @@ public class SmallIntVector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((SmallIntVector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.SmallIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableSmallIntHolder;
@@ -372,6 +373,7 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
 
   @Override
   public void setEncodedValue(int index, int value) {
+    Preconditions.checkArgument(value <= Short.MAX_VALUE, "value is overflow:" + value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -373,7 +373,7 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
 
   @Override
   public void setEncodedValue(int index, int value) {
-    Preconditions.checkArgument(value <= Short.MAX_VALUE, "value is overflow:" + value);
+    Preconditions.checkArgument(value <= Short.MAX_VALUE, "value is overflow: %s", value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -371,8 +371,8 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (int) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * byte values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class TinyIntVector extends BaseFixedWidthVector {
+public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector {
   public static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -368,6 +368,11 @@ public class TinyIntVector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((TinyIntVector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.TinyIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableTinyIntHolder;
@@ -372,6 +373,7 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
 
   @Override
   public void setEncodedValue(int index, int value) {
+    Preconditions.checkArgument(value <= Byte.MAX_VALUE, "value is overflow:" + value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -373,7 +373,7 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
 
   @Override
   public void setEncodedValue(int index, int value) {
-    Preconditions.checkArgument(value <= Byte.MAX_VALUE, "value is overflow:" + value);
+    Preconditions.checkArgument(value <= Byte.MAX_VALUE, "value is overflow: %s", value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -332,7 +332,7 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setEncodedValue(int index, int value) {
-    Preconditions.checkArgument(value <= 0xFF, "value is overflow:" + value);
+    Preconditions.checkArgument(value <= 0xFF, "value is overflow: %s", value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -330,8 +330,8 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (int) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt1Vector extends BaseFixedWidthVector {
+public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
   private static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -327,6 +327,11 @@ public class UInt1Vector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((UInt1Vector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.UInt1ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableUInt1Holder;
@@ -150,7 +151,7 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   /**
-   * Identical to {@link #copyFrom()} but reallocates buffer if index is larger
+   * Identical to {@link #copyFrom(int, int, UInt1Vector)} but reallocates buffer if index is larger
    * than capacity.
    */
   public void copyFromSafe(int fromIndex, int thisIndex, UInt1Vector from) {
@@ -331,8 +332,11 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setEncodedValue(int index, int value) {
+    Preconditions.checkArgument(value <= 0xFF, "value is overflow:" + value);
     this.setSafe(index, value);
   }
+
+
 
   private class TransferImpl implements TransferPair {
     UInt1Vector to;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -309,8 +309,8 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (int) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt2Vector extends BaseFixedWidthVector {
+public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
   private static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -306,6 +306,11 @@ public class UInt2Vector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((UInt2Vector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -311,7 +311,7 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setEncodedValue(int index, int value) {
-    Preconditions.checkArgument(value <= 0xFFFF, "value is overflow:" + value);
+    Preconditions.checkArgument(value <= Character.MAX_VALUE, "value is overflow: %s", value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.UInt2ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableUInt2Holder;
@@ -310,6 +311,7 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setEncodedValue(int index, int value) {
+    Preconditions.checkArgument(value <= 0xFFFF, "value is overflow:" + value);
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -302,8 +302,8 @@ public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (int) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -35,7 +35,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt4Vector extends BaseFixedWidthVector {
+public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
   private static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -299,6 +299,11 @@ public class UInt4Vector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((UInt4Vector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -303,8 +303,8 @@ public class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, Object value) {
-    this.setSafe(index, (long) value);
+  public void setEncodedValue(int index, int value) {
+    this.setSafe(index, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -37,7 +37,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt8Vector extends BaseFixedWidthVector {
+public class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector {
   private static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
@@ -300,6 +300,11 @@ public class UInt8Vector extends BaseFixedWidthVector {
   @Override
   public TransferPair makeTransferPair(ValueVector to) {
     return new TransferImpl((UInt8Vector) to);
+  }
+
+  @Override
+  public void setEncodedValue(int index, Object value) {
+    this.setSafe(index, (long) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -74,7 +74,7 @@ public class DictionaryEncoder {
       Object value = vector.getObject(i);
       if (value != null) { // if it's null leave it null
         // note: this may fail if value was not included in the dictionary
-        Object encoded = lookUps.get(value);
+        Integer encoded = lookUps.get(value);
         if (encoded == null) {
           throw new IllegalArgumentException("Dictionary encoding not defined for value:" + value);
         }

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -17,12 +17,10 @@
 
 package org.apache.arrow.vector.dictionary;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.types.Types.MinorType;
@@ -61,43 +59,27 @@ public class DictionaryEncoder {
     Field indexField = new Field(valueField.getName(), indexFieldType, null);
 
     // vector to hold our indices (dictionary encoded values)
-    FieldVector indices = indexField.createVector(vector.getAllocator());
+    FieldVector createdVector = indexField.createVector(vector.getAllocator());
+    if (! (createdVector instanceof BaseIntVector)) {
+      throw new IllegalArgumentException("Dictionary encoding does not have a valid int type:" +
+          createdVector.getClass());
+    }
 
-    // use reflection to pull out the set method
-    // TODO implement a common interface for int vectors
-    Method setter = null;
-    for (Class<?> c : Arrays.asList(int.class, long.class)) {
-      try {
-        setter = indices.getClass().getMethod("setSafe", int.class, c);
-        break;
-      } catch (NoSuchMethodException e) {
-        // ignore
-      }
-    }
-    if (setter == null) {
-      throw new IllegalArgumentException("Dictionary encoding does not have a valid int type:" + indices.getClass());
-    }
+    BaseIntVector indices = (BaseIntVector) createdVector;
+    indices.allocateNew();
 
     int count = vector.getValueCount();
 
-    indices.allocateNew();
-
-    try {
-      for (int i = 0; i < count; i++) {
-        Object value = vector.getObject(i);
-        if (value != null) { // if it's null leave it null
-          // note: this may fail if value was not included in the dictionary
-          Object encoded = lookUps.get(value);
-          if (encoded == null) {
-            throw new IllegalArgumentException("Dictionary encoding not defined for value:" + value);
-          }
-          setter.invoke(indices, i, encoded);
+    for (int i = 0; i < count; i++) {
+      Object value = vector.getObject(i);
+      if (value != null) { // if it's null leave it null
+        // note: this may fail if value was not included in the dictionary
+        Object encoded = lookUps.get(value);
+        if (encoded == null) {
+          throw new IllegalArgumentException("Dictionary encoding not defined for value:" + value);
         }
+        indices.setEncodedValue(i, encoded);
       }
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException("IllegalAccessException invoking vector mutator set():", e);
-    } catch (InvocationTargetException e) {
-      throw new RuntimeException("InvocationTargetException invoking vector mutator set():", e.getCause());
     }
 
     indices.setValueCount(count);


### PR DESCRIPTION
Related to [ARROW-5726](https://issues.apache.org/jira/browse/ARROW-5726).
Now in DictionaryEncoder#encode it use reflection to pull out the set method and then set values. 

Set values by reflection is not efficient and code structure is not elegant such as

Method setter = null;
for (Class<?> c : Arrays.asList(int.class, long.class)) {
try {
setter = indices.getClass().getMethod("setSafe", int.class, c);
break;
} catch (NoSuchMethodException e) {
// ignore
}
}

Implement a common interface for int vectors to directly get set method and set values seems a good choice.