### PR TITLE
ARROW-5142, ARROW-5732, ARROW-5735: [CI] Emergency fixes

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -100,7 +100,9 @@ if "%JOB%" == "Build_Debug" (
   exit /B 0
 )
 
-set CONDA_PACKAGES=--file=ci\conda_env_python.yml python=%PYTHON% numpy=1.14 boost-cpp
+@rem Avoid Boost 1.70 because of https://github.com/boostorg/process/issues/85
+set CONDA_PACKAGES=--file=ci\conda_env_python.yml ^
+  python=%PYTHON% numpy=1.14 "boost-cpp<1.70"
 
 if "%ARROW_BUILD_GANDIVA%" == "ON" (
   @rem Install llvmdev in the toolchain if building gandiva.dll

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -26,7 +26,6 @@ rd /s /q C:\OpenSSL-v11-Win64
 rd /s /q C:\OpenSSL-v111-Win32
 rd /s /q C:\OpenSSL-v111-Win64
 
-conda update -y -q conda
 conda config --set auto_update_conda false
 conda info -a
 

--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -117,30 +117,5 @@ python setup.py develop -q || exit /B
 py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B
 
 @rem
-@rem Build wheel
+@rem Wheels are built and tested separately (see ARROW-5142).
 @rem
-
-python setup.py bdist_wheel -q || exit /B
-
-for /F %%i in ('dir /B /S dist\*.whl') do set WHEEL_PATH=%%i
-
-popd
-
-@rem
-@rem Test pyarrow wheel from pristine environment
-@rem
-
-call deactivate
-
-conda create -n wheel_test -q -y python=%PYTHON% || exit /B
-
-call activate wheel_test
-
-pip install %WHEEL_PATH% || exit /B
-
-python -c "import pyarrow" || exit /B
-python -c "import pyarrow.parquet" || exit /B
-
-pip install pandas pickle5 pytest pytest-faulthandler hypothesis || exit /B
-
-py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B

--- a/ci/travis_install_conda.sh
+++ b/ci/travis_install_conda.sh
@@ -58,7 +58,6 @@ else
   bash miniconda.sh -b -p $MINICONDA
   source $MINICONDA/etc/profile.d/conda.sh
 
-  conda update -y -q conda
   conda config --set auto_update_conda false
   conda info -a
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1115,7 +1115,9 @@ macro(build_thrift)
       -DWITH_HASKELL=OFF
       -DWITH_CPP=ON
       -DWITH_STATIC_LIB=ON
-      -DWITH_LIBEVENT=OFF)
+      -DWITH_LIBEVENT=OFF
+      # Work around https://gitlab.kitware.com/cmake/cmake/issues/18865
+      -DBoost_NO_BOOST_CMAKE=ON)
 
   # Thrift also uses boost. Forward important boost settings if there were ones passed.
   if(DEFINED BOOST_ROOT)


### PR DESCRIPTION
There are multiple issues at play:
- A mysterious issue where conda 4.7.5 downloads smaller clang packages on macOS,
  with later build failures in clang includes: https://github.com/conda/conda/issues/8825
- A bug with boost 1.70's own CMake configuration files conflicting with CMake's
  FindBoost() function: https://gitlab.kitware.com/cmake/cmake/issues/18865
- A boost 1.70 compilation warning on Windows that gets turned into an error
  in our AppVeyor builds: https://github.com/boostorg/process/issues/85