### PR TITLE
ARROW-5737: [Crossbow] Use Python version version 2.7 in the gandiva tasks

### DIFF
--- a/dev/tasks/gandiva-jars/build-cpp-linux.sh
+++ b/dev/tasks/gandiva-jars/build-cpp-linux.sh
@@ -25,11 +25,16 @@ set -e
 # Print commands for debugging
 set -x
 
+PYTHON_VERSION=2.7
+CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION} 16)"
+PYTHON_INTERPRETER="${CPYTHON_PATH}/bin/python"
+PIP="${CPYTHON_PATH}/bin/pip"
+
 ARROW_BUILD_DIR=/tmp/arrow-build
 mkdir -p "${ARROW_BUILD_DIR}"
 pushd "${ARROW_BUILD_DIR}"
 
-cmake -DCMAKE_BUILD_TYPE=Release \
+PATH="${CPYTHON_PATH}/bin:${PATH}" cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_DEPENDENCY_SOURCE="SYSTEM" \
     -DZLIB_ROOT=/usr/local \
     -DCMAKE_INSTALL_PREFIX=/arrow-dist \
@@ -43,6 +48,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_PYTHON=OFF \
     -DARROW_PARQUET=OFF \
     -DPARQUET_BUILD_ENCRYPTION=OFF \
+    -DPythonInterp_FIND_VERSION=${PYTHON_VERSION} \
     -DARROW_GANDIVA=ON \
     -DARROW_GANDIVA_JAVA=ON \
     -DARROW_GANDIVA_JAVA7=ON \

--- a/dev/tasks/gandiva-jars/build-cpp-linux.sh
+++ b/dev/tasks/gandiva-jars/build-cpp-linux.sh
@@ -34,7 +34,9 @@ ARROW_BUILD_DIR=/tmp/arrow-build
 mkdir -p "${ARROW_BUILD_DIR}"
 pushd "${ARROW_BUILD_DIR}"
 
-PATH="${CPYTHON_PATH}/bin:${PATH}" cmake -DCMAKE_BUILD_TYPE=Release \
+PATH="${CPYTHON_PATH}/bin:${PATH}"
+
+cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_DEPENDENCY_SOURCE="SYSTEM" \
     -DZLIB_ROOT=/usr/local \
     -DCMAKE_INSTALL_PREFIX=/arrow-dist \


### PR DESCRIPTION
- Use 2.7 version of python in the manylinux crossbow gandiva build.