### PR TITLE
ARROW-5738: [Crossbow][Conda] OSX package builds are failing with missing intrinsics

### DIFF
--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -78,7 +78,7 @@ jobs:
   # upload script.
   - script: |
       source activate base
-      python -m pip install github3-py click
+      conda install -c conda-forge -y github3.py click
       python upload-assets.py \
         --sha {{ task.branch }} \
         --tag {{ task.tag }} \

--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -40,6 +40,8 @@ jobs:
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+      #XXX: pin conda
+      conda install --yes conda=4.6
     displayName: Configure conda and conda-build
     workingDirectory: arrow/dev/tasks/conda-recipes
     env: {

--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -40,7 +40,10 @@ jobs:
       export CI=azure
       source run_conda_forge_build_setup
       conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
-      #XXX: pin conda
+      # ARROW-5738: OSX package builds are failing with missing intrinsics
+      #             Conda 4.7 has introduced a new format, probably broken
+      #             packages cause the error, so using a temporary solution:
+      #             pin `conda` to 4.6.
       conda install --yes conda=4.6
     displayName: Configure conda and conda-build
     workingDirectory: arrow/dev/tasks/conda-recipes

--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -77,6 +77,7 @@ jobs:
   # The tag upload took 43 minutes because of this scan, so use an alternative
   # upload script.
   - script: |
+      source activate base
       python -m pip install github3-py click
       python upload-assets.py \
         --sha {{ task.branch }} \


### PR DESCRIPTION
Temporary solution is to pin conda to version 4.6