### PR TITLE
ARROW-5739: [CI] Fix python docker image

### DIFF
--- a/ci/docker_build_python.sh
+++ b/ci/docker_build_python.sh
@@ -35,6 +35,7 @@ export PYARROW_WITH_PLASMA=${PYARROW_WITH_PLASMA:-1}
 pushd ${source_dir}
   # hacky again, setuptools_scm writes _generated_version.py before pyarrow
   # directory is created by setuptools
+  rm -rf ${build_dir}
   mkdir -p $build_dir/pyarrow
 
   relative_build_dir=$(realpath --relative-to=. $build_dir)


### PR DESCRIPTION
python docker image will fail to clean the build directory, installing a previous invocation of `docker-compose run python`. This is not affecting CI that drops the `/build` mount, but only local users.