### PR TITLE
ARROW-5749: [Python] Added python binding for Table::CombineChunks

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -558,6 +558,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         CStatus Flatten(CMemoryPool* pool, shared_ptr[CTable]* out)
 
+        CStatus CombineChunks(CMemoryPool* pool, shared_ptr[CTable]* out)
+
         CStatus Validate()
 
         shared_ptr[CTable] ReplaceSchemaMetadata(

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1027,6 +1027,31 @@ cdef class Table(_PandasConvertible):
 
         return pyarrow_wrap_table(flattened)
 
+    def combine_chunks(self, MemoryPool memory_pool=None):
+        """
+        Make a new table by combining the chunks this table has.
+
+        All the underlying chunks in the ChunkedArray of each column are
+        concatenated into zero or one chunk.
+
+        Parameters
+        ----------
+        memory_pool : MemoryPool, default None
+            For memory allocations, if required, otherwise use default pool
+
+        Returns
+        -------
+        result : Table
+        """
+        cdef:
+            shared_ptr[CTable] combined
+            CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
+
+        with nogil:
+            check_status(self.table.CombineChunks(pool, &combined))
+
+        return pyarrow_wrap_table(combined)
+
     def __eq__(self, other):
         try:
             return self.equals(other)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -781,6 +781,17 @@ def test_table_flatten():
     assert t2.equals(expected)
 
 
+def test_table_combine_chunks():
+    batch1 = pa.RecordBatch.from_arrays([pa.array([1]), pa.array(["a"])],
+                                        names=['f1', 'f2'])
+    batch2 = pa.RecordBatch.from_arrays([pa.array([2]), pa.array(["b"])],
+                                        names=['f1', 'f2'])
+    table = pa.Table.from_batches([batch1, batch2])
+    combined = table.combine_chunks()
+    combined._validate()
+    assert combined.equals(table)
+
+
 def test_concat_tables():
     data = [
         list(range(5)),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -791,7 +791,7 @@ def test_table_combine_chunks():
     combined._validate()
     assert combined.equals(table)
     for c in combined.columns:
-      assert c.data.num_chunks == 1
+        assert c.data.num_chunks == 1
 
 
 def test_concat_tables():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -790,6 +790,8 @@ def test_table_combine_chunks():
     combined = table.combine_chunks()
     combined._validate()
     assert combined.equals(table)
+    for c in combined.columns:
+      assert c.data.num_chunks == 1
 
 
 def test_concat_tables():


### PR DESCRIPTION
Table::CombineChunks was added in https://github.com/apache/arrow/pull/4598 . This PR adds the python binding for it.