### PR TITLE
ARROW-5730: [Python][CI] Selectively skip test cases in the dask integration test

### DIFF
--- a/integration/dask/runtest.sh
+++ b/integration/dask/runtest.sh
@@ -29,7 +29,7 @@ python -c "import pyarrow.parquet"
 # pytest -sv --pyargs dask.bytes.tests.test_hdfs
 # pytest -sv --pyargs dask.bytes.tests.test_local
 
-# TODO(kszucs): re-enable it, for more see ARROW-3910
-# pytest -v --pyargs dask.dataframe.io.tests.test_orc
-pytest -v --pyargs dask.dataframe.io.tests.test_parquet
 pytest -v --pyargs dask.dataframe.tests.test_dataframe
+pytest -v --pyargs dask.dataframe.io.tests.test_orc
+pytest -v --pyargs dask.dataframe.io.tests.test_parquet \
+  -k "not test_timestamp_index and not test_roundtrip_from_pandas"


### PR DESCRIPTION
Two tests are failing in [dask/dataframe/io/tests/test_parquet.py](https://github.com/dask/dask/blob/22b32a53a9d3293859b47d8bd3352f78b47bc8b0/dask/dataframe/io/tests/test_parquet.py)

- [test_timestamp_index](https://github.com/dask/dask/blob/22b32a53a9d3293859b47d8bd3352f78b47bc8b0/dask/dataframe/io/tests/test_parquet.py#L996)

  Caused by https://github.com/apache/arrow/commit/74841f5bfcfdeab7d90fda9e469a92aef02a23f3.
  Seemingly it only affects timestamp indices, and should be handled in [_to_ns](https://github.com/dask/dask/blob/7e4beffb339c69278091d4e305c2ae18ddf8c74f/dask/dataframe/io/parquet.py#L929)

- [test_roundtrip_from_pandas](https://github.com/dask/dask/blob/22b32a53a9d3293859b47d8bd3352f78b47bc8b0/dask/dataframe/io/tests/test_parquet.py#L616)

  Caused by the new default value of `preserve_index` https://github.com/apache/arrow/commit/a02cfe05deacea52008586a79cec8fa09fc00b59

  @wesm should we fall back to `preserve_index=True` with note to remain backward compatible and change in the next release?
  
  cc @jorisvandenbossche 
