### PR TITLE
ARROW-5751: [Python][Packaging] Ensure that c-ares is linked statically in Python wheels

### DIFF
--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -136,6 +136,7 @@ function build_wheel {
           -DBoost_NAMESPACE=arrow_boost \
           -DARROW_FLIGHT=ON \
           -DgRPC_SOURCE=SYSTEM \
+          -Dc-ares_SOURCE=BUNDLED \
           -DARROW_PROTOBUF_USE_SHARED=OFF \
           -DMAKE=make \
           ..

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -66,9 +66,9 @@ install:
   # the following functions are defined in osx-build.sh
   - build_wheel arrow
 
-  # test the built wheels, remove llvm and grpc to ensure they link statically
-  - brew uninstall llvm@7
-  - brew uninstall grpc
+  # test the built wheels, remove llvm and grpc dependencies to ensure
+  # things are properly statically-linked
+  - brew uninstall llvm@7 grpc c-ares
   - install_run arrow
 
   # move built wheels to a top level directory


### PR DESCRIPTION
Using the Homebrew provided c-ares results in a shared library dependency. I think it's easier to statically link this than to bundle it

```
$ otool -L /Users/wesm/miniconda/envs/wheel-test-3.7/lib/python3.7/site-packages/pyarrow/libarrow_flight.14.dylib 
/Users/wesm/miniconda/envs/wheel-test-3.7/lib/python3.7/site-packages/pyarrow/libarrow_flight.14.dylib:
	@rpath/libarrow_flight.14.dylib (compatibility version 14.0.0, current version 14.0.0)
	@rpath/libarrow.14.dylib (compatibility version 14.0.0, current version 14.0.0)
	/usr/local/opt/c-ares/lib/libcares.2.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/local/opt/openssl/lib/libssl.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.5.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.50.2)
```