### PR TITLE
ARROW-5415: [Release] Release script should update R version everywhere

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -128,6 +128,13 @@ class PrepareTest < Test::Unit::TestCase
                      ],
                    },
                    {
+                     path: "r/NEWS.md",
+                     hunks: [
+                       ["-\# arrow #{@previous_version}.9000",
+                        "+\# arrow #{@release_version}"],
+                     ],
+                   },
+                   {
                      path: "ruby/red-arrow-cuda/lib/arrow-cuda/version.rb",
                      hunks: [
                        ["-  VERSION = \"#{@snapshot_version}\"",
@@ -267,6 +274,14 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-Version: #{@release_version}",
                         "+Version: #{@release_version}.9000"],
+                     ],
+                   },
+                   {
+                     path: "r/NEWS.md",
+                     # Note that these are additions only, no replacement
+                     hunks: [
+                       ["+# arrow 0.14.0.9000",
+                        "+"],
                      ],
                    },
                    {

--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -280,7 +280,7 @@ class PrepareTest < Test::Unit::TestCase
                      path: "r/NEWS.md",
                      # Note that these are additions only, no replacement
                      hunks: [
-                       ["+# arrow 0.14.0.9000",
+                       ["+# arrow #{@release_version}.9000",
                         "+"],
                      ],
                    },

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -101,6 +101,24 @@ update_versions() {
   git add DESCRIPTION
   cd -
 
+  cd "${SOURCE_DIR}/../../r"
+  if [[ ${r_version} == *".9000" ]]; then
+    # Add a news entry for the new dev version
+    echo "dev"
+    sed -i.bak -E -e \
+      "0,/^# arrow /s/^(# arrow .+)/# arrow ${r_version}\n\n\1/" \
+      NEWS.md
+  else
+    # Replace dev version with release version
+    echo "release"
+    sed -i.bak -E -e \
+      "0,/^# arrow /s/^# arrow .+/# arrow ${r_version}/" \
+      NEWS.md
+  fi
+  rm -f NEWS.md.bak
+  git add NEWS.md
+  cd -
+
   cd "${SOURCE_DIR}/../../ruby"
   sed -i.bak -E -e \
     "s/^  VERSION = \".+\"/  VERSION = \"${version}\"/g" \

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -102,7 +102,7 @@ update_versions() {
   cd -
 
   cd "${SOURCE_DIR}/../../r"
-  if [[ ${r_version} == *".9000" ]]; then
+  if [[ ${type} = "snapshot" ]]; then
     # Add a news entry for the new dev version
     echo "dev"
     sed -i.bak -E -e \

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -102,7 +102,7 @@ update_versions() {
   cd -
 
   cd "${SOURCE_DIR}/../../r"
-  if [[ ${type} = "snapshot" ]]; then
+  if [ ${type} = "snapshot" ]; then
     # Add a news entry for the new dev version
     echo "dev"
     sed -i.bak -E -e \


### PR DESCRIPTION
In previous patches, I removed other places where the version was explicitly referenced, making them parse it from `r/DESCRIPTION` where necessary. The only remaining one (added by #4711) is `r/NEWS.md`, and it works a little differently when bumping from a release version to a dev version. So from dev to release, we go from e.g. 

```
# arrow 0.13.0.9000

* Stuff we did in this release
* More stuff
```

to

```
# arrow 0.14.0

* Stuff we did in this release
* More stuff
```

but when bumping after release for the next dev version, it goes to

```
# arrow 0.14.0.9000

# arrow 0.14.0

* Stuff we did in this release
* More stuff
```

so that we have a place to accumulate the list of changes in the next release.