### PR TITLE
ARROW-5765: [C++] Fix TestDictionary.Validate in release mode, add docker-compose job for testing C++ release build

### DIFF
--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -856,7 +856,7 @@ TEST(TestDictionary, Validate) {
   // Only checking index type for now
   ASSERT_OK(ValidateArray(*arr));
 
-#ifdef NDEBUG
+#ifndef NDEBUG
   std::shared_ptr<Array> null_dict_arr =
       std::make_shared<DictionaryArray>(dict_type, indices, nullptr);
 

--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -856,8 +856,12 @@ TEST(TestDictionary, Validate) {
   // Only checking index type for now
   ASSERT_OK(ValidateArray(*arr));
 
-  // Other checks are handled by ARROW_CHECK_* and cannot be put in
-  // unit test form
+  ASSERT_DEATH(
+      {
+        std::shared_ptr<Array> null_dict_arr =
+            std::make_shared<DictionaryArray>(dict_type, indices, nullptr);
+      },
+      "");
 }
 
 TEST(TestDictionary, FromArray) {

--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -856,27 +856,8 @@ TEST(TestDictionary, Validate) {
   // Only checking index type for now
   ASSERT_OK(ValidateArray(*arr));
 
-#ifndef NDEBUG
-  std::shared_ptr<Array> null_dict_arr =
-      std::make_shared<DictionaryArray>(dict_type, indices, nullptr);
-
-  // Only checking index type for now
-  ASSERT_RAISES(Invalid, ValidateArray(*null_dict_arr));
-#endif
-
-  // TODO(wesm) In ARROW-1199, there is now a DCHECK to compare the indices
-  // type with the dict_type. How can we test for this?
-
-  // std::shared_ptr<Array> indices2;
-  // vector<float> indices2_values = {1., 2., 0., 0., 2., 0.};
-  // ArrayFromVector<FloatType, float>(is_valid, indices2_values, &indices2);
-
-  // std::shared_ptr<Array> indices3;
-  // vector<int64_t> indices3_values = {1, 2, 0, 0, 2, 0};
-  // ArrayFromVector<Int64Type, int64_t>(is_valid, indices3_values, &indices3);
-  // std::shared_ptr<Array> arr2 = std::make_shared<DictionaryArray>(dict_type, indices2);
-  // std::shared_ptr<Array> arr3 = std::make_shared<DictionaryArray>(dict_type, indices3);
-  // ASSERT_OK(ValidateArray(*arr3));
+  // Other checks are handled by ARROW_CHECK_* and cannot be put in
+  // unit test form
 }
 
 TEST(TestDictionary, FromArray) {

--- a/dev/tasks/tests.yml
+++ b/dev/tasks/tests.yml
@@ -105,6 +105,15 @@ tasks:
         - docker-compose build cpp
         - docker-compose run cpp
 
+  docker-cpp-release:
+    ci: circle
+    platform: linux
+    template: docker-tests/circle.linux.yml
+    params:
+      commands:
+        - docker-compose build cpp
+        - docker-compose run cpp-release
+
   docker-cpp-alpine:
     ci: circle
     platform: linux

--- a/dev/tasks/tests.yml
+++ b/dev/tasks/tests.yml
@@ -24,6 +24,7 @@ groups:
     - docker-cpp
     - docker-cpp-alpine
     - docker-cpp-cmake32
+    - docker-cpp-release
     - docker-c_glib
     - docker-go
     - docker-python-2.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,20 @@ services:
       PARQUET_TEST_DATA: /arrow/cpp/submodules/parquet-testing/data
     volumes: *ubuntu-volumes
 
+  cpp-release:
+    # Usage:
+    #   docker-compose build cpp
+    #   docker-compose run cpp-release
+    image: arrow:cpp
+    shm_size: 2G
+    build:
+      context: .
+      dockerfile: cpp/Dockerfile
+    environment:
+      ARROW_BUILD_TYPE: release
+      PARQUET_TEST_DATA: /arrow/cpp/submodules/parquet-testing/data
+    volumes: *ubuntu-volumes
+
   cpp-static-only:
     # Usage:
     #   docker-compose build cpp


### PR DESCRIPTION
This was exposed by ARROW-5145 https://github.com/apache/arrow/commit/f77c3427ca801597b572fb197b92b0133269049b

I also added a docker-compose job for testing the release build nightly at least in Crossbow on https://github.com/ursa-labs/crossbow