### PR TITLE
ARROW-5771: [Python] Add pytz to conda_env_python.yml to fix python-nopandas build

### DIFF
--- a/ci/conda_env_python.yml
+++ b/ci/conda_env_python.yml
@@ -22,5 +22,6 @@ numpy>=1.14
 pandas
 pytest
 pytest-faulthandler
+pytz
 setuptools
 setuptools_scm=3.2.0


### PR DESCRIPTION
It seems perhaps due to the conda upgrade that pytz was getting uninstalled. pytz is nevertheless a test dependency so we should include it explicitly in the conda requirements