### PR TITLE
ARROW-5772: [GLib][Plasma][CUDA] Disable Plasma::Client#refer_object test for now

### DIFF
--- a/c_glib/test/plasma/test-plasma-client.rb
+++ b/c_glib/test/plasma/test-plasma-client.rb
@@ -63,6 +63,7 @@ class TestPlasmaClient < Test::Unit::TestCase
 
     test("options: GPU device") do
       omit("Arrow CUDA is required") unless defined?(::ArrowCUDA)
+      omit("TODO: Fix this failure: ARROW-5772")
 
       gpu_device = 0
 


### PR DESCRIPTION
It's a known problem of 0.14.0. We should fix this until 1.0.0.