### PR TITLE
ARROW-5776: [Gandiva][Crossbow] Use commit id instead of fetch head.

### DIFF
--- a/cpp/src/arrow/array-union-test.cc
+++ b/cpp/src/arrow/array-union-test.cc
@@ -35,7 +35,7 @@ TEST(TestUnionArray, TestSliceEquals) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeUnion(&batch));
 
-  auto CheckUnion = [](std::shared_ptr<Array> array) { 
+  auto CheckUnion = [](std::shared_ptr<Array> array) {
     const int64_t size = array->length();
     std::shared_ptr<Array> slice, slice2;
     slice = array->Slice(2);

--- a/cpp/src/arrow/array-union-test.cc
+++ b/cpp/src/arrow/array-union-test.cc
@@ -35,7 +35,7 @@ TEST(TestUnionArray, TestSliceEquals) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeUnion(&batch));
 
-  auto CheckUnion = [](std::shared_ptr<Array> array) {
+  auto CheckUnion = [](std::shared_ptr<Array> array) { 
     const int64_t size = array->length();
     std::shared_ptr<Array> slice, slice2;
     slice = array->Slice(2);
@@ -283,7 +283,7 @@ class UnionBuilderTest : public ::testing::Test {
   std::shared_ptr<Int8Builder> i8_builder = std::make_shared<Int8Builder>();
   std::shared_ptr<StringBuilder> str_builder = std::make_shared<StringBuilder>();
   std::shared_ptr<DoubleBuilder> dbl_builder = std::make_shared<DoubleBuilder>();
-  std::shared_ptr<B> union_builder{new B(default_memory_pool())};
+  std::shared_ptr<B> union_builder = std::make_shared<B>(default_memory_pool());
   std::shared_ptr<UnionArray> actual;
 };
 

--- a/dev/tasks/gandiva-jars/build-cpp-linux.sh
+++ b/dev/tasks/gandiva-jars/build-cpp-linux.sh
@@ -22,9 +22,6 @@ source /multibuild/manylinux_utils.sh
 # Quit on failure
 set -e
 
-# Print commands for debugging
-set -x
-
 PYTHON_VERSION=2.7
 CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION} 16)"
 PYTHON_INTERPRETER="${CPYTHON_PATH}/bin/python"

--- a/dev/tasks/gandiva-jars/build-java.sh
+++ b/dev/tasks/gandiva-jars/build-java.sh
@@ -27,7 +27,7 @@ pushd java
   fi
 
   # build the entire project
-  mvn clean install -DskipTests -P arrow-jni -Darrow.cpp.build.dir=$CPP_BUILD_DIR
+  mvn clean install -q -DskipTests -P arrow-jni -Darrow.cpp.build.dir=$CPP_BUILD_DIR
   # test only gandiva
   mvn test -q -P arrow-jni -pl gandiva -Dgandiva.cpp.build.dir=$CPP_BUILD_DIR
 

--- a/dev/tasks/gandiva-jars/build-java.sh
+++ b/dev/tasks/gandiva-jars/build-java.sh
@@ -29,7 +29,8 @@ pushd java
   # build the entire project
   mvn clean install -DskipTests -P arrow-jni -Darrow.cpp.build.dir=$CPP_BUILD_DIR
   # test only gandiva
-  mvn test -P arrow-jni -pl gandiva -Darrow.cpp.build.dir=$CPP_BUILD_DIR
+  mvn test -q -P gandiva -pl gandiva -Dgandiva.cpp.build.dir=$CPP_BUILD_DIR
+
   # copy the jars to distribution folder
   find gandiva/target/ -name "*.jar" -not -name "*tests*" -exec cp  {} $CPP_BUILD_DIR \;
 popd

--- a/dev/tasks/gandiva-jars/build-java.sh
+++ b/dev/tasks/gandiva-jars/build-java.sh
@@ -29,7 +29,7 @@ pushd java
   # build the entire project
   mvn clean install -DskipTests -P arrow-jni -Darrow.cpp.build.dir=$CPP_BUILD_DIR
   # test only gandiva
-  mvn test -q -P gandiva -pl gandiva -Dgandiva.cpp.build.dir=$CPP_BUILD_DIR
+  mvn test -q -P arrow-jni -pl gandiva -Dgandiva.cpp.build.dir=$CPP_BUILD_DIR
 
   # copy the jars to distribution folder
   find gandiva/target/ -name "*.jar" -not -name "*tests*" -exec cp  {} $CPP_BUILD_DIR \;

--- a/dev/tasks/gandiva-jars/travis.linux.yml
+++ b/dev/tasks/gandiva-jars/travis.linux.yml
@@ -43,7 +43,7 @@ before_install:
 before_script:
   - git clone --no-checkout {{ arrow.remote }} arrow
   - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-  - git -C arrow checkout FETCH_HEAD
+  - git -C arrow checkout {{ arrow.head }}
 
   - export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR/arrow
 

--- a/dev/tasks/gandiva-jars/travis.linux.yml
+++ b/dev/tasks/gandiva-jars/travis.linux.yml
@@ -43,7 +43,7 @@ before_install:
 before_script:
   - git clone --no-checkout {{ arrow.remote }} arrow
   - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-  - if [ $CROSSBOW_USE_COMMIT_ID != "1" ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
+  - if [ $CROSSBOW_USE_COMMIT_ID == true ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
 
   - export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR/arrow
 

--- a/dev/tasks/gandiva-jars/travis.linux.yml
+++ b/dev/tasks/gandiva-jars/travis.linux.yml
@@ -43,7 +43,7 @@ before_install:
 before_script:
   - git clone --no-checkout {{ arrow.remote }} arrow
   - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-  - git -C arrow checkout {{ arrow.head }}
+  - if [ $CROSSBOW_USE_COMMIT_ID != "1" ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
 
   - export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR/arrow
 

--- a/dev/tasks/gandiva-jars/travis.osx.yml
+++ b/dev/tasks/gandiva-jars/travis.osx.yml
@@ -35,7 +35,7 @@ env:
 before_script:
   - git clone --no-checkout {{ arrow.remote }} arrow
   - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-  - git -C arrow checkout FETCH_HEAD
+  - git -C arrow checkout {{ arrow.head }}
 
   - export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR/arrow
   - brew update

--- a/dev/tasks/gandiva-jars/travis.osx.yml
+++ b/dev/tasks/gandiva-jars/travis.osx.yml
@@ -35,7 +35,7 @@ env:
 before_script:
   - git clone --no-checkout {{ arrow.remote }} arrow
   - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-  - git -C arrow checkout {{ arrow.head }}
+  - if [ $CROSSBOW_USE_COMMIT_ID != "1" ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
 
   - export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR/arrow
   - brew update

--- a/dev/tasks/gandiva-jars/travis.osx.yml
+++ b/dev/tasks/gandiva-jars/travis.osx.yml
@@ -35,7 +35,7 @@ env:
 before_script:
   - git clone --no-checkout {{ arrow.remote }} arrow
   - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
-  - if [ $CROSSBOW_USE_COMMIT_ID != "1" ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
+  - if [ $CROSSBOW_USE_COMMIT_ID == true ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
 
   - export TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR/arrow
   - brew update


### PR DESCRIPTION
- It is important to use the same commit to build the various gandiva artifacts
  on OsX/Linux etc, so that they are consistent.
- We use the commit id to pin all of the builds to the same commit on the tree.