### PR TITLE
ARROW-5781: [Archery] Ensure benchmark clone accepts remote in revision

### DIFF
--- a/dev/archery/archery/benchmark/runner.py
+++ b/dev/archery/archery/benchmark/runner.py
@@ -66,7 +66,10 @@ class BenchmarkRunner:
             build = CMakeBuild.from_path(rev_or_path)
             return CppBenchmarkRunner(build, **kwargs)
         else:
-            root_rev = os.path.join(root, rev_or_path)
+            # Revisions can references remote via the `/` character, ensure
+            # that the revision is path friendly
+            path_rev = rev_or_path.replace("/", "_")
+            root_rev = os.path.join(root, path_rev)
             os.mkdir(root_rev)
 
             clone_dir = os.path.join(root_rev, "arrow")

--- a/dev/archery/archery/utils/git.py
+++ b/dev/archery/archery/utils/git.py
@@ -55,9 +55,9 @@ class Git(Command):
     def log(self, *argv, **kwargs):
         return self.run_cmd(*argv, **kwargs)
 
+    @capture_stdout(strip=True)
     @git_cmd
     def rev_parse(self, *argv, **kwargs):
-        print(self.head())
         return self.run_cmd(*argv, **kwargs)
 
     @capture_stdout(strip=True)

--- a/dev/archery/archery/utils/source.py
+++ b/dev/archery/archery/utils/source.py
@@ -87,7 +87,13 @@ class ArrowSources:
         # that builds depending on said sources are not invalidated (or worse
         # slightly affected when re-invoking the generator).
         git.clone("--local", self.path, clone_dir)
-        git.checkout(revision, git_dir=clone_dir)
+
+        # Revision can reference "origin/" (or any remotes) that are not found
+        # in the local clone. Thus, revisions are dereferenced in the source
+        # repository.
+        original_revision = git.rev_parse(revision)
+
+        git.checkout(original_revision, git_dir=clone_dir)
 
         return ArrowSources(clone_dir), True
 


### PR DESCRIPTION
A user can pass a revision that references a remote, e.g. `origin/master`. The notion of `origin` and any remotes, should be resolved in the source repository and not the fresh clone.