### PR TITLE
ARROW-5785: [Rust] Make the datafusion cli dependencies optional

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -36,7 +36,11 @@ path = "src/lib.rs"
 
 [[bin]]
 name = "datafusion-cli"
-path = "src/bin/repl.rs"
+path = "src/bin/main.rs"
+
+[features]
+default = ["cli"]
+cli = ["rustyline"]
 
 [dependencies]
 fnv = "1.0.3"
@@ -47,11 +51,12 @@ serde_derive = "1.0.80"
 serde_json = "1.0.33"
 sqlparser = "0.2.0"
 clap = "2.33.0"
-rustyline = "4.1.0"
 prettytable-rs = "0.8.0"
+rustyline = {version = "4.1.0", optional = true}
 
 [dev-dependencies]
 criterion = "0.2.0"
+
 
 [[bench]]
 name = "aggregate_query_sql"

--- a/rust/datafusion/src/bin/main.rs
+++ b/rust/datafusion/src/bin/main.rs
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Only bring in dependencies for the repl when the cli feature is enabled.
+#[cfg(feature = "cli")]
+mod repl;
+
+pub fn main() {
+    #[cfg(feature = "cli")]
+    repl::main()
+}

--- a/rust/datafusion/src/bin/repl.rs
+++ b/rust/datafusion/src/bin/repl.rs
@@ -17,12 +17,9 @@
 
 #![allow(bare_trait_objects)]
 
-#[macro_use]
-extern crate clap;
-
 use arrow::array::*;
 use arrow::datatypes::{DataType, TimeUnit};
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 use datafusion::error::{ExecutionError, Result};
 use datafusion::execution::context::ExecutionContext;
 use datafusion::execution::relation::Relation;
@@ -32,7 +29,7 @@ use std::cell::RefMut;
 use std::env;
 use std::path::Path;
 
-fn main() {
+pub fn main() {
     let matches = App::new("DataFusion")
         .version(crate_version!())
         .about(


### PR DESCRIPTION
Dependent crates may not want the rustyline dependency, specially since
the nightly support seems to be custom. Introduce a "cli" feature to
allow consumers to not bring in the cli depedencies.