### PR TITLE
ARROW-5741: [JS] Make numeric vector from functions consistent with TypedArray.from

### DIFF
--- a/js/.vscode/launch.json
+++ b/js/.vscode/launch.json
@@ -41,6 +41,7 @@
                 "test/unit/",
                 // "test/unit/builders/",
 
+                // Uncomment any of these to run individual test suites
                 // "test/unit/builders/builder-tests.ts",
                 // "test/unit/builders/int64-tests.ts",
                 // "test/unit/builders/uint64-tests.ts",
@@ -49,8 +50,8 @@
                 // "test/unit/builders/dictionary-tests.ts",
                 // "test/unit/builders/utf8-tests.ts",
 
-                // Uncomment any of these to run individual test suites
                 // "test/unit/int-tests.ts",
+                // "test/unit/math-tests.ts",
                 // "test/unit/table-tests.ts",
                 // "test/unit/generated-data-tests.ts",
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apache-arrow",
-  "version": "0.14.0-SNAPSHOT",
+  "version": "1.0.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13411,8 +13411,8 @@
       "dev": true
     },
     "typedoc": {
-      "version": "github:TypeStrong/typedoc#f781b20dda3dfafd453cf540f58fcd8cf4473316",
-      "from": "github:TypeStrong/typedoc",
+      "version": "0.15.0-0",
+      "resolved": "github:TypeStrong/typedoc#f781b20dda3dfafd453cf540f58fcd8cf4473316",
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.3",
@@ -13425,7 +13425,7 @@
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
         "typedoc-default-themes": "^0.6.0-0",
-        "typescript": "3.5.x"
+        "typescript": "3.4.x"
       },
       "dependencies": {
         "handlebars": {
@@ -13447,9 +13447,9 @@
           "dev": true
         },
         "typescript": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-          "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
           "dev": true
         }
       }

--- a/js/package.json
+++ b/js/package.json
@@ -103,7 +103,7 @@
     "ts-jest": "24.0.2",
     "ts-node": "8.2.0",
     "tslint": "5.12.1",
-    "typedoc": "TypeStrong/typedoc",
+    "typedoc": "0.15.0-0",
     "typescript": "3.5.1",
     "web-stream-tools": "0.0.1",
     "web-streams-polyfill": "2.0.3",

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -102,6 +102,7 @@ export { DataFrame, FilteredDataFrame, CountByResult, BindFunc, NextFunc } from 
 import * as util_bn_ from './util/bn';
 import * as util_int_ from './util/int';
 import * as util_bit_ from './util/bit';
+import * as util_math_ from './util/math';
 import * as util_buffer_ from './util/buffer';
 import * as util_vector_ from './util/vector';
 import * as predicate from './compute/predicate';
@@ -112,6 +113,7 @@ export const util = {
     ...util_bn_,
     ...util_int_,
     ...util_bit_,
+    ...util_math_,
     ...util_buffer_,
     ...util_vector_
 };

--- a/js/src/builder/float.ts
+++ b/js/src/builder/float.ts
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import { float64ToUint16 } from '../util/math';
 import { FixedWidthBuilder } from '../builder';
 import { Float, Float16, Float32, Float64 } from '../type';
 
@@ -22,7 +23,12 @@ import { Float, Float16, Float32, Float64 } from '../type';
 export class FloatBuilder<T extends Float = Float, TNull = any> extends FixedWidthBuilder<T, TNull> {}
 
 /** @ignore */
-export class Float16Builder<TNull = any> extends FloatBuilder<Float16, TNull> {}
+export class Float16Builder<TNull = any> extends FloatBuilder<Float16, TNull> {
+    public setValue(index: number, value: number) {
+        // convert JS float64 to a uint16
+        this._values.set(index, float64ToUint16(value));
+    }
+}
 
 /** @ignore */
 export class Float32Builder<TNull = any> extends FloatBuilder<Float32, TNull> {

--- a/js/src/util/buffer.ts
+++ b/js/src/util/buffer.ts
@@ -125,27 +125,6 @@ export function toArrayBufferView(ArrayBufferViewCtor: any, input: ArrayBufferVi
 /** @ignore */ export const toUint8ClampedArray = (input: ArrayBufferViewInput) => toArrayBufferView(Uint8ClampedArray, input);
 
 /** @ignore */
-export const toFloat16Array = (input: ArrayBufferViewInput) => {
-    let floats: Float32Array | Float64Array | null = null;
-    if (ArrayBuffer.isView(input)) {
-        switch (input.constructor) {
-            case Float32Array: floats = input as Float32Array; break;
-            case Float64Array: floats = input as Float64Array; break;
-        }
-    } else if (isIterable(input)) {
-        floats = toFloat64Array(input);
-    }
-    if (floats) {
-        const u16s = new Uint16Array(floats.length);
-        for (let i = -1, n = u16s.length; ++i < n;) {
-            u16s[i] = (floats[i] * 32767) + 32767;
-        }
-        return u16s;
-    }
-    return toUint16Array(input);
-};
-
-/** @ignore */
 type ArrayBufferViewIteratorInput = Iterable<ArrayBufferViewInput> | ArrayBufferViewInput;
 
 /** @ignore */

--- a/js/src/util/math.ts
+++ b/js/src/util/math.ts
@@ -30,7 +30,7 @@ export function uint16ToFloat64(h: number) {
     let sigf = (h & 0x03FF) / 1024;
     let sign = (-1) ** ((h & 0x8000) >> 15);
     switch (expo) {
-        case 0x1F: return sign * (sigf ? NaN : 1/0);
+        case 0x1F: return sign * (sigf ? NaN : 1 / 0);
         case 0x00: return sign * (sigf ? 6.103515625e-5 * sigf : 0);
     }
     return sign * (2 ** (expo - 15)) * (1 + sigf);
@@ -45,7 +45,7 @@ export function uint16ToFloat64(h: number) {
  */
 export function float64ToUint16(d: number) {
 
-    if (d !== d) return 0x7E00; // NaN
+    if (d !== d) { return 0x7E00; } // NaN
 
     f64[0] = d;
 
@@ -58,20 +58,20 @@ export function float64ToUint16(d: number) {
     let expo = (u32[1] & 0x7ff00000), sigf = 0x0000;
 
     if (expo >= 0x40f00000) {
-        // 
+        //
         // If exponent overflowed, the float16 is either NaN or Infinity.
         // Rules to propagate the sign bit: mantissa > 0 ? NaN : +/-Infinity
-        // 
+        //
         // Magic numbers:
         // 0x40F00000 = 01000000 11110000 00000000 00000000 -- 6-bit exponent overflow
         // 0x7C000000 = 01111100 00000000 00000000 00000000 -- masks the 27th-31st bits
-        // 
+        //
         // returns:
         // qNaN, aka 32256 decimal, 0x7E00 hex, or 01111110 00000000 binary
         // sNaN, aka 32000 decimal, 0x7D00 hex, or 01111101 00000000 binary
         // +inf, aka 31744 decimal, 0x7C00 hex, or 01111100 00000000 binary
         // -inf, aka 64512 decimal, 0xFC00 hex, or 11111100 00000000 binary
-        // 
+        //
         // If mantissa is greater than 23 bits, set to +Infinity like numpy
         if (u32[0] > 0) {
             expo = 0x7C00;
@@ -80,21 +80,21 @@ export function float64ToUint16(d: number) {
             sigf = (u32[1] & 0x000fffff) >> 10;
         }
     } else if (expo <= 0x3f000000) {
-        // 
+        //
         // If exponent underflowed, the float is either signed zero or subnormal.
-        // 
+        //
         // Magic numbers:
         // 0x3F000000 = 00111111 00000000 00000000 00000000 -- 6-bit exponent underflow
-        // 
+        //
         sigf = 0x100000 + (u32[1] & 0x000fffff);
         sigf = 0x100000 + (sigf << ((expo >> 20) - 998)) >> 21;
         expo = 0;
     } else {
-        // 
+        //
         // No overflow or underflow, rebase the exponent and round the mantissa
         // Magic numbers:
         // 0x200 = 00000010 00000000 -- masks off the 10th bit
-        // 
+        //
 
         // Ensure the first mantissa bit (the 10th one) is 1 and round
         expo = (expo - 0x3f000000) >> 10;

--- a/js/src/util/math.ts
+++ b/js/src/util/math.ts
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/**
+ * Convert uint16 (logically a float16) to a JS float64.
+ * Adapted from https://gist.github.com/zed/59a413ae2ed4141d2037
+ * @param n {number} the uint16 to convert
+ * @private
+ * @ignore
+ */
+export function uint16ToFloat64(n: number) {
+
+    // magic numbers:
+    // 31 = b011111
+    // 1024 = 2 ** 10
+
+    const sign = n >> 15;
+    const exponent = (n >> 10) & 31;
+    const fraction = n & (1024 - 1);
+
+    if (exponent === 0) {
+        if (fraction === 0) {
+            return sign ? -0 : 0;
+        }
+        return ((-1) ** sign) * (fraction / 1024) * (2 ** -14);
+    }
+    if (exponent === 31) {
+        if (fraction === 0) {
+            return sign ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY;
+        }
+        return NaN;
+    }
+    return ((-1) ** sign) * (1 + fraction / 1024) * (2 ** (exponent - 15));
+}
+
+/**
+ * Convert a float64 to uint16 (assuming the float64 is logically a float16).
+ * Adapted from https://gist.github.com/zed/59a413ae2ed4141d2037
+ * @param n {number} The JS float64 to convert
+ * @private
+ * @ignore
+ */
+export function float64ToUint16(n: number) {
+
+    // magic numbers:
+    // 31 = b011111
+    // 1024 = 2 ** 10
+    // 16777216 = 2 ** 24
+    // 31744 = b0111110000000000 (positive infinity)
+    // 64512 = b1111110000000000 (negative infinity)
+
+    // Anything with exponent == 31 and mantissa > 0 is NaN,
+    // 65535 is b1111111111111111, the max 16 bit value with exponent 31
+    if (n !== n) { return 65535; }
+    // negative zero (-0) is uint16_t 32768
+    if (n === 0 && (1 / n < 0)) { return 32768; }
+
+    const sign = Math.sign(n) < 0;
+
+    if (!isFinite(n)) {
+        return sign ? 64512 : 31744;
+    }
+
+    let [mantissa, exponent] = frexp(n);
+    if (mantissa === 0 && exponent === 0) { return sign ? -0 : 0; }
+    if (mantissa !== mantissa || exponent !== exponent) { return 65535; }
+
+    mantissa = Math.trunc((2 * Math.abs(mantissa) - 1) * 1024); // round toward zero
+    exponent = exponent + 14;
+
+    if (exponent <= 0) { // subnormal
+        mantissa = (16777216 * Math.abs(n) + .5) | 0; // round
+        exponent = 0;
+    } else if (exponent >= 31) {
+        return sign ? 64512 : 31744;
+    }
+
+    return (+sign << 15) | (exponent << 10) | mantissa;
+}
+
+/**
+ * Extract the mantissa and exponent from a JS float64, such that `f = mantissa * 2^exponent`.
+ * Adapted from http://croquetweak.blogspot.com/2014/08/deconstructing-floats-frexp-and-ldexp.html
+ * @returns `Float64Array` of the mantissa and exponent respectively
+ * @private
+ * @ignore
+ */
+const frexp = (() => {
+
+    // Float64Array used to store and return the [mantissa, exponent] of a JS float64
+    const f64 = new Float64Array(2);
+    // Uint32Array used to store the [lo, hi] bits of a JS float64
+    const u32 = new Uint32Array(f64.buffer);
+
+    return frexp;
+
+    function frexp(f: number) {
+        f64[0] = f;
+        f64[1] = 0;
+        if (f === 0) { return f64; }
+        // extract the unsigned exponent bits
+        let exponent = (u32[1] >>> 20) & 0x7FF;
+        // if the exponent is 0, the rest of the 53 bits are being used to represent
+        // a decimal number between -1.0 < f < 1.0.
+        if (exponent === 0) { // subnormal
+            f64[0] = f * Math.pow(2, 64);
+            exponent = ((u32[1] >>> 20) & 0x7FF) - 64;
+        }
+        // apply the bias
+        f64[1] = exponent - 1022;
+        // compute the mantissa
+        f64[0] = ldexp(f, -f64[1]);
+        return f64;
+    }
+
+    function ldexp(f: number, exp: number) {
+        // Multiply the mantissa by the exponent in stages. The exponent can
+        // be as high as 1073, and 2^1073 is larger than max float at 2^1023
+        let n = Math.min(3, Math.ceil(Math.abs(exp) / 1023));
+        for (let i = -1; ++i < n;) {
+            f *= (2 ** ((exp + i) / n | 0));
+        }
+        return f;
+    }
+})();

--- a/js/src/vector/chunked.ts
+++ b/js/src/vector/chunked.ts
@@ -267,9 +267,9 @@ const typedSet = (src: TypedArray, dst: TypedArray, offset: number) => {
 
 /** @ignore */
 const arraySet = (src: any[], dst: any[], offset: number) => {
-    let idx = offset - 1;
+    let idx = offset;
     for (let i = -1, n = src.length; ++i < n;) {
-        dst[++idx] = src[i];
+        dst[idx++] = src[i];
     }
     return idx;
 };

--- a/js/src/vector/float.ts
+++ b/js/src/vector/float.ts
@@ -17,38 +17,88 @@
 
 import { Data } from '../data';
 import { Vector } from '../vector';
+import { Chunked } from './chunked';
 import { BaseVector } from './base';
-import { VectorType as V } from '../interfaces';
-import { Float, Float16, Float32, Float64 } from '../type';
-import { toFloat16Array, toFloat32Array, toFloat64Array } from '../util/buffer';
+import { VectorBuilderOptions } from './index';
+import { vectorFromValuesWithType } from './index';
+import { VectorBuilderOptionsAsync } from './index';
+import { Float, Float16, Float32, Float64, FloatArray } from '../type';
+import { VectorType as V, TypedArrayConstructor } from '../interfaces';
+
+/** @ignore */
+type FloatVectorConstructors =
+    typeof FloatVector   |
+    typeof Float16Vector |
+    typeof Float32Vector |
+    typeof Float64Vector ;
+
+/** @ignore */
+type FromInput<T extends Float, TNull = any> =
+    FloatArray                          |
+    Iterable<T['TValue'] | TNull>       |
+    AsyncIterable<T['TValue'] | TNull>  |
+    VectorBuilderOptions<T, TNull>      |
+    VectorBuilderOptionsAsync<T, TNull> ;
+
+/** @ignore */
+type FloatArrayCtor = TypedArrayConstructor<FloatArray>;
 
 /** @ignore */
 export class FloatVector<T extends Float = Float> extends BaseVector<T> {
 
-    public static from(this: typeof FloatVector, data: Float16['TArray']): Float16Vector;
-    public static from(this: typeof FloatVector, data: Float32['TArray']): Float32Vector;
-    public static from(this: typeof FloatVector, data: Float64['TArray']): Float64Vector;
-    public static from<T extends Float>(this: typeof FloatVector, data: T['TArray']): V<T>;
+    // Guaranteed zero-copy variants
+    public static from(this: typeof FloatVector, input: Uint16Array): Float16Vector;
+    public static from(this: typeof FloatVector, input: Float32Array): Float32Vector;
+    public static from(this: typeof FloatVector, input: Float64Array): Float64Vector;
 
-    public static from(this: typeof Float16Vector, data: Float16['TArray'] | Iterable<number>): Float16Vector;
-    public static from(this: typeof Float32Vector, data: Float32['TArray'] | Iterable<number>): Float32Vector;
-    public static from(this: typeof Float64Vector, data: Float64['TArray'] | Iterable<number>): Float64Vector;
+    // Zero-copy if input is a TypedArray of the same type as the
+    // Vector that from is called on, otherwise uses the Builders
+    public static from<TNull = any>(this: typeof Float16Vector,  input: FromInput<Float16, TNull>): Float16Vector;
+    public static from<TNull = any>(this: typeof Float32Vector,  input: FromInput<Float32, TNull>): Float32Vector;
+    public static from<TNull = any>(this: typeof Float64Vector,  input: FromInput<Float64, TNull>): Float64Vector;
+
+    // Not zero-copy
+    public static from<T extends Float, TNull = any>(this: typeof FloatVector, input: Iterable<T['TValue'] | TNull>): V<T>;
+    public static from<T extends Float, TNull = any>(this: typeof FloatVector, input: AsyncIterable<T['TValue'] | TNull>): Promise<V<T>>;
+    public static from<T extends Float, TNull = any>(this: typeof FloatVector, input: VectorBuilderOptions<T, TNull>): Chunked<T>;
+    public static from<T extends Float, TNull = any>(this: typeof FloatVector, input: VectorBuilderOptionsAsync<T, TNull>): Promise<Chunked<T>>;
     /** @nocollapse */
-    public static from<T extends Float>(data: T['TArray']) {
-        let type: Float | null = null;
-        switch (this) {
-            case Float16Vector: data = toFloat16Array(data); break;
-            case Float32Vector: data = toFloat32Array(data); break;
-            case Float64Vector: data = toFloat64Array(data); break;
+    public static from<T extends Float, TNull = any>(this: FloatVectorConstructors, input: FromInput<T, TNull>) {
+
+        let ArrowType = vectorTypeToDataType(this);
+
+        if ((input instanceof ArrayBuffer) || ArrayBuffer.isView(input)) {
+            let InputType = arrayTypeToDataType(input.constructor as FloatArrayCtor) || ArrowType;
+            // Special case, infer the Arrow DataType from the input if calling the base
+            // FloatVector.from with a TypedArray, e.g. `FloatVector.from(new Float32Array())`
+            if (ArrowType === null) {
+                ArrowType = InputType;
+            }
+            // If the DataType inferred from the Vector constructor matches the
+            // DataType inferred from the input arguments, return zero-copy view
+            if (ArrowType && ArrowType === InputType) {
+                let type = new ArrowType();
+                let length = input.byteLength / type.ArrayType.BYTES_PER_ELEMENT;
+                // If the ArrowType is Float16 but the input type isn't a Uint16Array,
+                // let the Float16Builder handle casting the input values to Uint16s.
+                if (!convertTo16Bit(ArrowType, input.constructor)) {
+                    return Vector.new(Data.Float(type, 0, length, 0, null, input as FloatArray));
+                }
+            }
         }
-        switch (data.constructor) {
-            case Uint16Array:  type = new Float16(); break;
-            case Float32Array: type = new Float32(); break;
-            case Float64Array: type = new Float64(); break;
+
+        if (ArrowType) {
+            // If the DataType inferred from the Vector constructor is different than
+            // the DataType inferred from the input TypedArray, or if input isn't a
+            // TypedArray, use the Builders to construct the result Vector
+            return vectorFromValuesWithType(() => new ArrowType!() as T, input);
         }
-        return type !== null
-            ? Vector.new(Data.Float(type, 0, data.length, 0, null, data))
-            : (() => { throw new TypeError('Unrecognized FloatVector input'); })();
+
+        if ((input instanceof DataView) || (input instanceof ArrayBuffer)) {
+            throw new TypeError(`Cannot infer float type from instance of ${input.constructor.name}`);
+        }
+
+        throw new TypeError('Unrecognized FloatVector input');
     }
 }
 
@@ -68,3 +118,27 @@ export class Float16Vector extends FloatVector<Float16> {
 export class Float32Vector extends FloatVector<Float32> {}
 /** @ignore */
 export class Float64Vector extends FloatVector<Float64> {}
+
+const convertTo16Bit = (typeCtor: any, dataCtor: any) => {
+    return (typeCtor === Float16) && (dataCtor !== Uint16Array);
+};
+
+/** @ignore */
+const arrayTypeToDataType = (ctor: FloatArrayCtor) => {
+    switch (ctor) {
+        case Uint16Array:    return Float16;
+        case Float32Array:   return Float32;
+        case Float64Array:   return Float64;
+        default: return null;
+    }
+};
+
+/** @ignore */
+const vectorTypeToDataType = (ctor: FloatVectorConstructors) => {
+    switch (ctor) {
+        case Float16Vector: return Float16;
+        case Float32Vector: return Float32;
+        case Float64Vector: return Float64;
+        default: return null;
+    }
+};

--- a/js/src/vector/int.ts
+++ b/js/src/vector/int.ts
@@ -17,70 +17,111 @@
 
 import { Data } from '../data';
 import { Vector } from '../vector';
+import { Chunked } from './chunked';
 import { BaseVector } from './base';
-import { VectorType as V } from '../interfaces';
-import { Int, Uint8, Uint16, Uint32, Uint64, Int8, Int16, Int32, Int64 } from '../type';
-import {
-    toInt8Array, toInt16Array, toInt32Array,
-    toUint8Array, toUint16Array, toUint32Array,
-    toBigInt64Array, toBigUint64Array
-} from '../util/buffer';
+import { VectorBuilderOptions } from './index';
+import { vectorFromValuesWithType } from './index';
+import { VectorBuilderOptionsAsync } from './index';
+import { BigInt64Array, BigUint64Array } from '../util/compat';
+import { toBigInt64Array, toBigUint64Array } from '../util/buffer';
+import { Int, Uint8, Uint16, Uint32, Uint64, Int8, Int16, Int32, Int64, IntArray } from '../type';
+import { VectorType as V, TypedArrayConstructor, BigIntArrayConstructor, BigIntArray } from '../interfaces';
+
+/** @ignore */
+type IntVectorConstructors =
+    typeof IntVector    |
+    typeof Int8Vector   |
+    typeof Int16Vector  |
+    typeof Int32Vector  |
+    typeof Uint8Vector  |
+    typeof Uint16Vector |
+    typeof Uint32Vector |
+    typeof Int64Vector  |
+    typeof Uint64Vector ;
+
+/** @ignore */
+type FromInput<T extends Int, TNull = any> =
+    IntArray | BigIntArray              |
+    Iterable<T['TValue'] | TNull>       |
+    AsyncIterable<T['TValue'] | TNull>  |
+    VectorBuilderOptions<T, TNull>      |
+    VectorBuilderOptionsAsync<T, TNull> ;
+
+/** @ignore */
+type FromArgs<T extends Int, TNull = any> = [FromInput<T, TNull>, boolean?];
+
+/** @ignore */
+type IntArrayCtor = TypedArrayConstructor<IntArray> | BigIntArrayConstructor<BigIntArray>;
 
 /** @ignore */
 export class IntVector<T extends Int = Int> extends BaseVector<T> {
 
-    public static from(this: typeof IntVector, data: Int8Array): Int8Vector;
-    public static from(this: typeof IntVector, data: Int16Array): Int16Vector;
-    public static from(this: typeof IntVector, data: Int32Array): Int32Vector;
-    public static from(this: typeof IntVector, data: Uint8Array): Uint8Vector;
-    public static from(this: typeof IntVector, data: Uint16Array): Uint16Vector;
-    public static from(this: typeof IntVector, data: Uint32Array): Uint32Vector;
+    // Guaranteed zero-copy variants
+    public static from(this: typeof IntVector, input: Int8Array): Int8Vector;
+    public static from(this: typeof IntVector, input: Int16Array): Int16Vector;
+    public static from(this: typeof IntVector, input: Int32Array): Int32Vector;
+    public static from(this: typeof IntVector, input: BigInt64Array): Int64Vector;
+    public static from(this: typeof IntVector, input: Int32Array, is64bit: true): Int64Vector;
+    public static from(this: typeof IntVector, input: Uint8Array): Uint8Vector;
+    public static from(this: typeof IntVector, input: Uint16Array): Uint16Vector;
+    public static from(this: typeof IntVector, input: Uint32Array): Uint32Vector;
+    public static from(this: typeof IntVector, input: BigUint64Array): Uint64Vector;
+    public static from(this: typeof IntVector, input: Uint32Array, is64bit: true): Uint64Vector;
 
-    // @ts-ignore
-    public static from(this: typeof IntVector, data: Int32Array, is64: true): Int64Vector;
-    public static from(this: typeof IntVector, data: Uint32Array, is64: true): Uint64Vector;
-    public static from<T extends Int>(this: typeof IntVector, data: T['TArray']): V<T>;
+    // Zero-copy if input is a TypedArray of the same type as the
+    // Vector that from is called on, otherwise uses the Builders
+    public static from<TNull = any>(this: typeof Int8Vector,   input: FromInput<Int8, TNull>): Int8Vector;
+    public static from<TNull = any>(this: typeof Int16Vector,  input: FromInput<Int16, TNull>): Int16Vector;
+    public static from<TNull = any>(this: typeof Int32Vector,  input: FromInput<Int32, TNull>): Int32Vector;
+    public static from<TNull = any>(this: typeof Int64Vector,  input: FromInput<Int64, TNull>): Int64Vector;
+    public static from<TNull = any>(this: typeof Uint8Vector,  input: FromInput<Uint8, TNull>): Uint8Vector;
+    public static from<TNull = any>(this: typeof Uint16Vector, input: FromInput<Uint16, TNull>): Uint16Vector;
+    public static from<TNull = any>(this: typeof Uint32Vector, input: FromInput<Uint32, TNull>): Uint32Vector;
+    public static from<TNull = any>(this: typeof Uint64Vector, input: FromInput<Uint64, TNull>): Uint64Vector;
 
-    public static from(this: typeof Int8Vector,   data: Int8['TArray']   | Iterable<number>): Int8Vector;
-    public static from(this: typeof Int16Vector,  data: Int16['TArray']  | Iterable<number>): Int16Vector;
-    public static from(this: typeof Int32Vector,  data: Int32['TArray']  | Iterable<number>): Int32Vector;
-    public static from(this: typeof Int64Vector,  data: Int32['TArray']  | Iterable<number>): Int64Vector;
-    public static from(this: typeof Uint8Vector,  data: Uint8['TArray']  | Iterable<number>): Uint8Vector;
-    public static from(this: typeof Uint16Vector, data: Uint16['TArray'] | Iterable<number>): Uint16Vector;
-    public static from(this: typeof Uint32Vector, data: Uint32['TArray'] | Iterable<number>): Uint32Vector;
-    public static from(this: typeof Uint64Vector, data: Uint32['TArray'] | Iterable<number>): Uint64Vector;
-
+    // Not zero-copy
+    public static from<T extends Int, TNull = any>(this: typeof IntVector, input: Iterable<T['TValue'] | TNull>): V<T>;
+    public static from<T extends Int, TNull = any>(this: typeof IntVector, input: AsyncIterable<T['TValue'] | TNull>): Promise<V<T>>;
+    public static from<T extends Int, TNull = any>(this: typeof IntVector, input: VectorBuilderOptions<T, TNull>): Chunked<T>;
+    public static from<T extends Int, TNull = any>(this: typeof IntVector, input: VectorBuilderOptionsAsync<T, TNull>): Promise<Chunked<T>>;
     /** @nocollapse */
-    public static from<T extends Int>(data: T['TArray'], is64?: boolean) {
-        let length: number = 0;
-        let type: Int | null = null;
-        switch (this) {
-            case Int8Vector:   data = toInt8Array(data);   is64 = false; break;
-            case Int16Vector:  data = toInt16Array(data);  is64 = false; break;
-            case Int32Vector:  data = toInt32Array(data);  is64 = false; break;
-            case Int64Vector:  data = toInt32Array(data);  is64 =  true; break;
-            case Uint8Vector:  data = toUint8Array(data);  is64 = false; break;
-            case Uint16Vector: data = toUint16Array(data); is64 = false; break;
-            case Uint32Vector: data = toUint32Array(data); is64 = false; break;
-            case Uint64Vector: data = toUint32Array(data); is64 =  true; break;
-        }
-        if (is64 === true) {
-            length = data.length * 0.5;
-            type = data instanceof Int32Array ? new Int64() : new Uint64();
-        } else {
-            length = data.length;
-            switch (data.constructor) {
-                case Int8Array:   type = new Int8();   break;
-                case Int16Array:  type = new Int16();  break;
-                case Int32Array:  type = new Int32();  break;
-                case Uint8Array:  type = new Uint8();  break;
-                case Uint16Array: type = new Uint16(); break;
-                case Uint32Array: type = new Uint32(); break;
+    public static from<T extends Int, TNull = any>(this: IntVectorConstructors, ...args: FromArgs<T, TNull>) {
+
+        let [input, is64bit = false] = args;
+        let ArrowType = vectorTypeToDataType(this, is64bit);
+
+        if ((input instanceof ArrayBuffer) || ArrayBuffer.isView(input)) {
+            let InputType = arrayTypeToDataType(input.constructor as IntArrayCtor, is64bit) || ArrowType;
+            // Special case, infer the Arrow DataType from the input if calling the base
+            // IntVector.from with a TypedArray, e.g. `IntVector.from(new Int32Array())`
+            if (ArrowType === null) {
+                ArrowType = InputType;
+            }
+            // If the DataType inferred from the Vector constructor matches the
+            // DataType inferred from the input arguments, return zero-copy view
+            if (ArrowType && ArrowType === InputType) {
+                let type = new ArrowType();
+                let length = input.byteLength / type.ArrayType.BYTES_PER_ELEMENT;
+                // If the ArrowType is 64bit but the input type is 32bit pairs, update the logical length
+                if (convert32To64Bit(ArrowType, input.constructor)) {
+                    length *= 0.5;
+                }
+                return Vector.new(Data.Int(type, 0, length, 0, null, input as IntArray));
             }
         }
-        return type !== null
-            ? Vector.new(Data.Int(type, 0, length, 0, null, data))
-            : (() => { throw new TypeError('Unrecognized IntVector input'); })();
+
+        if (ArrowType) {
+            // If the DataType inferred from the Vector constructor is different than
+            // the DataType inferred from the input TypedArray, or if input isn't a
+            // TypedArray, use the Builders to construct the result Vector
+            return vectorFromValuesWithType(() => new ArrowType!() as T, input);
+        }
+
+        if ((input instanceof DataView) || (input instanceof ArrayBuffer)) {
+            throw new TypeError(`Cannot infer integer type from instance of ${input.constructor.name}`);
+        }
+
+        throw new TypeError('Unrecognized IntVector input');
     }
 }
 
@@ -119,3 +160,38 @@ export class Uint64Vector extends IntVector<Uint64> {
         return this._values64 || (this._values64 = this.toBigUint64Array());
     }
 }
+
+const convert32To64Bit = (typeCtor: any, dataCtor: any) => {
+    return (typeCtor === Int64 || typeCtor === Uint64) &&
+           (dataCtor === Int32Array || dataCtor === Uint32Array);
+};
+
+/** @ignore */
+const arrayTypeToDataType = (ctor: IntArrayCtor, is64bit: boolean) => {
+    switch (ctor) {
+        case Int8Array:      return Int8;
+        case Int16Array:     return Int16;
+        case Int32Array:     return is64bit ? Int64 : Int32;
+        case BigInt64Array:  return Int64;
+        case Uint8Array:     return Uint8;
+        case Uint16Array:    return Uint16;
+        case Uint32Array:    return is64bit ? Uint64 : Uint32;
+        case BigUint64Array: return Uint64;
+        default: return null;
+    }
+};
+
+/** @ignore */
+const vectorTypeToDataType = (ctor: IntVectorConstructors, is64bit: boolean) => {
+    switch (ctor) {
+        case Int8Vector:   return Int8;
+        case Int16Vector:  return Int16;
+        case Int32Vector:  return is64bit ? Int64 : Int32;
+        case Int64Vector:  return Int64;
+        case Uint8Vector:  return Uint8;
+        case Uint16Vector: return Uint16;
+        case Uint32Vector: return is64bit ? Uint64 : Uint32;
+        case Uint64Vector: return Uint64;
+        default: return null;
+    }
+};

--- a/js/src/visitor/get.ts
+++ b/js/src/visitor/get.ts
@@ -18,8 +18,9 @@
 import { Data } from '../data';
 import { BN } from '../util/bn';
 import { Visitor } from '../visitor';
-import { VectorType } from '../interfaces';
 import { decodeUtf8 } from '../util/utf8';
+import { VectorType } from '../interfaces';
+import { uint16ToFloat64 } from '../util/math';
 import { Type, UnionMode, Precision, DateUnit, TimeUnit, IntervalUnit } from '../enum';
 import {
     DataType, Dictionary,
@@ -123,7 +124,7 @@ const getDateMillisecond = <T extends DateMillisecond>({ values         }: Vecto
 /** @ignore */
 const getNumeric         = <T extends Numeric1X>      ({ stride, values }: VectorType<T>, index: number): T['TValue'] => values[stride * index];
 /** @ignore */
-const getFloat16         = <T extends Float16>        ({ stride, values }: VectorType<T>, index: number): T['TValue'] => (values[stride * index] - 32767) / 32767;
+const getFloat16         = <T extends Float16>        ({ stride, values }: VectorType<T>, index: number): T['TValue'] => uint16ToFloat64(values[stride * index]);
 /** @ignore */
 const getBigInts         = <T extends Numeric2X>({ stride, values, type }: VectorType<T>, index: number): T['TValue'] => <any> BN.new(values.subarray(stride * index, stride * (index + 1)), type.isSigned);
 /** @ignore */

--- a/js/src/visitor/set.ts
+++ b/js/src/visitor/set.ts
@@ -17,8 +17,9 @@
 
 import { Data } from '../data';
 import { Visitor } from '../visitor';
-import { VectorType } from '../interfaces';
 import { encodeUtf8 } from '../util/utf8';
+import { VectorType } from '../interfaces';
+import { float64ToUint16 } from '../util/math';
 import { toArrayBufferView } from '../util/buffer';
 import { Type, UnionMode, Precision, DateUnit, TimeUnit, IntervalUnit } from '../enum';
 import {
@@ -131,7 +132,7 @@ const setDateMillisecond = <T extends DateMillisecond>({ values         }: Vecto
 /** @ignore */
 const setNumeric         = <T extends Numeric1X>      ({ stride, values }: VectorType<T>, index: number, value: T['TValue']): void => { values[stride * index] = value; };
 /** @ignore */
-const setFloat16         = <T extends Float16>        ({ stride, values }: VectorType<T>, index: number, value: T['TValue']): void => { values[stride * index] = (value * 32767) + 32767; };
+const setFloat16         = <T extends Float16>        ({ stride, values }: VectorType<T>, index: number, value: T['TValue']): void => { values[stride * index] = float64ToUint16(value); };
 /** @ignore */
 const setNumericX2       = <T extends Numeric2X>      (vector: VectorType<T>, index: number, value: T['TValue']): void => {
     switch (typeof value) {

--- a/js/test/generate-test-data.ts
+++ b/js/test/generate-test-data.ts
@@ -41,7 +41,8 @@ import {
     Interval, IntervalDayTime, IntervalYearMonth,
     FixedSizeList,
     Map_,
-    DateUnit, TimeUnit, UnionMode
+    DateUnit, TimeUnit, UnionMode,
+    util
 } from './Arrow';
 
 type TKeys = Int8 | Int16 | Int32 | Uint8 | Uint16 | Uint32;
@@ -269,7 +270,8 @@ function generateFloat<T extends Float>(this: TestDataVectorGenerator, type: T, 
     const values = memoize(() => {
         const values = [] as (number | null)[];
         iterateBitmap(length, nullBitmap, (i, valid) => {
-            values[i] = !valid ? null : precision > 0 ? data[i] : (data[i] - 32767) / 32767;
+            // values[i] = !valid ? null : precision > 0 ? data[i] : (data[i] - 32767) / 32767;
+            values[i] = !valid ? null : precision > 0 ? data[i] : util.uint16ToFloat64(data[i]);
         });
         return values;
     });

--- a/js/test/unit/builders/primitive-tests.ts
+++ b/js/test/unit/builders/primitive-tests.ts
@@ -144,3 +144,11 @@ type PrimitiveTypeOpts<T extends DataType> = [
         }
     });
 });
+
+describe('Float16Builder', () => {
+    const encode = encodeAll(() => new Float16());
+    it(`encodes the weird values`, async () => {
+        const vals = [0, 5.960464477539063e-8, NaN, 65504, 2, -0];
+        validateVector(vals, await encode(vals, []), []);
+    });
+});

--- a/js/test/unit/builders/utils.ts
+++ b/js/test/unit/builders/utils.ts
@@ -83,7 +83,7 @@ export const uint64sNoNulls = (length = 20) => Array.from({ length }, (_, i) => 
         default: return bn[0];
     }
 });
-export const float16sNoNulls = (length = 20) => Array.from(new Uint16Array(randomBytes(length * Uint16Array.BYTES_PER_ELEMENT).buffer)).map((x) => (x - 32767) / 32767);
+export const float16sNoNulls = (length = 20) => Array.from(new Uint16Array(randomBytes(length * Uint16Array.BYTES_PER_ELEMENT).buffer)).map(util.uint16ToFloat64);
 export const float32sNoNulls = (length = 20) => Array.from(new Float32Array(randomBytes(length * Float32Array.BYTES_PER_ELEMENT).buffer));
 export const float64sNoNulls = (length = 20) => Array.from(new Float64Array(randomBytes(length * Float64Array.BYTES_PER_ELEMENT).buffer));
 

--- a/js/test/unit/math-tests.ts
+++ b/js/test/unit/math-tests.ts
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import * as Arrow from '../Arrow';
+const { float64ToUint16, uint16ToFloat64 } = Arrow.util;
+
+describe('Float16', () => {
+    test('Uint16 to Float64 works', () => {
+        for (let val, i = -1; ++i < 65536;) {
+            val = uint16ToFloat64(i);
+            if (val === val) {
+                if (isFinite(val)) {
+                    expect(float64ToUint16(val)).toEqual(i);
+                }
+            } else {
+                // the default NaN we've chosen for float16
+                expect(float64ToUint16(val)).toEqual(65535);
+            }
+        }
+    });
+});


### PR DESCRIPTION
This PR updates `IntVector.from()` and `FloatVector.from()` to use the new Builders to cast input values that don't exactly match the expected numeric type, per [this discussion](https://lists.apache.org/thread.html/b648a781cba7f10d5a6072ff2e7dab6c03e2d1f12e359d9261891486@%3Cdev.arrow.apache.org%3E) on the mailing list.

Previously, these methods behaved like `reinterpret_cast` in C++, but now they behave like numpy's `ndarray.astype()`. The new behavior of zero-copy vs. copied is:
* If the input type is the same as the Vector we want to create, the Vector is created zero-copy
* If if the input type is different (or the input isn't a TypedArray), we use the Builders to enumerate the values, cast each one to the desired type, and construct a new Vector from the results.

Closes [ARROW-5741](https://issues.apache.org/jira/browse/ARROW-5741)