### PR TITLE
ARROW-5787: [Release][Rust] Use local modules to verify RC

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -458,6 +458,14 @@ test_rust() {
   # we are targeting Rust nightly for releases
   rustup default nightly
 
+  # use local modules because we don't publish modules to crates.io yet
+  sed \
+    -i.bak \
+    -E \
+    -e 's/^arrow = "([^"]*)"/arrow = { version = "\1", path = "..\/arrow" }/g' \
+    -e 's/^parquet = "([^"]*)"/parquet = { version = "\1", path = "..\/parquet" }/g' \
+    */Cargo.toml
+
   # raises on any warnings
   RUSTFLAGS="-D warnings" cargo build
   cargo test


### PR DESCRIPTION
Because we don't publish modules to crates.io yet.