### PR TITLE
ARROW-3459: [C++][Gandiva] support for string o/p

### DIFF
--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -54,12 +54,13 @@ class GANDIVA_EXPORT Annotator {
 
  private:
   /// Annotate a field and return the descriptor.
-  FieldDescriptorPtr MakeDesc(FieldPtr field);
+  FieldDescriptorPtr MakeDesc(FieldPtr field, bool is_output);
 
   /// Populate eval_batch by extracting the raw buffers from the arrow array, whose
   /// contents are represent by the annotated descriptor 'desc'.
   void PrepareBuffersForField(const FieldDescriptor& desc,
-                              const arrow::ArrayData& array_data, EvalBatch* eval_batch);
+                              const arrow::ArrayData& array_data, EvalBatch* eval_batch,
+                              bool is_output);
 
   /// The list of input/output buffers (includes bitmap buffers, value buffers and
   /// offset buffers).

--- a/cpp/src/gandiva/annotator_test.cc
+++ b/cpp/src/gandiva/annotator_test.cc
@@ -73,6 +73,7 @@ TEST_F(TestAnnotator, TestAdd) {
   EXPECT_EQ(desc_sum->field(), field_sum);
   EXPECT_EQ(desc_sum->data_idx(), 4);
   EXPECT_EQ(desc_sum->validity_idx(), 5);
+  EXPECT_EQ(desc_sum->data_buffer_ptr_idx(), 6);
 
   // prepare record batch
   int num_records = 100;
@@ -85,7 +86,7 @@ TEST_F(TestAnnotator, TestAdd) {
 
   auto arrow_sum = MakeInt32Array(num_records);
   EvalBatchPtr batch = annotator.PrepareEvalBatch(*record_batch, {arrow_sum->data()});
-  EXPECT_EQ(batch->GetNumBuffers(), 6);
+  EXPECT_EQ(batch->GetNumBuffers(), 7);
 
   auto buffers = batch->GetBufferArray();
   EXPECT_EQ(buffers[desc_a->validity_idx()], arrow_v0->data()->buffers.at(0)->data());
@@ -94,6 +95,8 @@ TEST_F(TestAnnotator, TestAdd) {
   EXPECT_EQ(buffers[desc_b->data_idx()], arrow_v1->data()->buffers.at(1)->data());
   EXPECT_EQ(buffers[desc_sum->validity_idx()], arrow_sum->data()->buffers.at(0)->data());
   EXPECT_EQ(buffers[desc_sum->data_idx()], arrow_sum->data()->buffers.at(1)->data());
+  EXPECT_EQ(buffers[desc_sum->data_buffer_ptr_idx()],
+            reinterpret_cast<uint8_t*>(arrow_sum->data()->buffers.at(1).get()));
 
   auto bitmaps = batch->GetLocalBitMapArray();
   EXPECT_EQ(bitmaps, nullptr);

--- a/cpp/src/gandiva/expr_validator.cc
+++ b/cpp/src/gandiva/expr_validator.cc
@@ -89,6 +89,12 @@ Status ExprValidator::Visit(const IfNode& node) {
   auto then_node_ret_type = node.then_node()->return_type();
   auto else_node_ret_type = node.else_node()->return_type();
 
+  // condition must be of boolean type.
+  ARROW_RETURN_IF(
+      !node.condition()->return_type()->Equals(arrow::boolean()),
+      Status::ExpressionValidationError("condition must be of boolean type, found type ",
+                                        node.condition()->return_type()->ToString()));
+
   // Then-branch return type must match.
   ARROW_RETURN_IF(!if_node_ret_type->Equals(*then_node_ret_type),
                   Status::ExpressionValidationError(

--- a/cpp/src/gandiva/field_descriptor.h
+++ b/cpp/src/gandiva/field_descriptor.h
@@ -31,11 +31,12 @@ class FieldDescriptor {
   static const int kInvalidIdx = -1;
 
   FieldDescriptor(FieldPtr field, int data_idx, int validity_idx = kInvalidIdx,
-                  int offsets_idx = kInvalidIdx)
+                  int offsets_idx = kInvalidIdx, int data_buffer_ptr_idx = kInvalidIdx)
       : field_(field),
         data_idx_(data_idx),
         validity_idx_(validity_idx),
-        offsets_idx_(offsets_idx) {}
+        offsets_idx_(offsets_idx),
+        data_buffer_ptr_idx_(data_buffer_ptr_idx) {}
 
   /// Index of validity array in the array-of-buffers
   int validity_idx() const { return validity_idx_; }
@@ -46,6 +47,9 @@ class FieldDescriptor {
   /// Index of offsets array in the array-of-buffers
   int offsets_idx() const { return offsets_idx_; }
 
+  /// Index of data buffer pointer in the array-of-buffers
+  int data_buffer_ptr_idx() const { return data_buffer_ptr_idx_; }
+
   FieldPtr field() const { return field_; }
 
   const std::string& Name() const { return field_->name(); }
@@ -53,11 +57,14 @@ class FieldDescriptor {
 
   bool HasOffsetsIdx() const { return offsets_idx_ != kInvalidIdx; }
 
+  bool HasDataBufferPtrIdx() const { return data_buffer_ptr_idx_ != kInvalidIdx; }
+
  private:
   FieldPtr field_;
   int data_idx_;
   int validity_idx_;
   int offsets_idx_;
+  int data_buffer_ptr_idx_;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -180,6 +180,9 @@ class GANDIVA_EXPORT LLVMGenerator {
   /// Generate code to load the vector at specified index and cast it as offsets array.
   llvm::Value* GetOffsetsReference(llvm::Value* arg_addrs, int idx, FieldPtr field);
 
+  /// Generate code to load the vector at specified index and cast it as buffer pointer.
+  llvm::Value* GetDataBufferPtrReference(llvm::Value* arg_addrs, int idx, FieldPtr field);
+
   /// Generate code for the value array of one expression.
   Status CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr output, int suffix_idx,
                           llvm::Function** fn,

--- a/cpp/src/gandiva/projector.h
+++ b/cpp/src/gandiva/projector.h
@@ -122,8 +122,8 @@ class GANDIVA_EXPORT Projector {
             const FieldVector& output_fields, std::shared_ptr<Configuration>);
 
   /// Allocate an ArrowData of length 'length'.
-  Status AllocArrayData(const DataTypePtr& type, int64_t length, arrow::MemoryPool* pool,
-                        ArrayDataPtr* array_data);
+  Status AllocArrayData(const DataTypePtr& type, int64_t num_records,
+                        arrow::MemoryPool* pool, ArrayDataPtr* array_data);
 
   /// Validate that the ArrayData has sufficient capacity to accomodate 'num_records'.
   Status ValidateArrayDataCapacity(const arrow::ArrayData& array_data,


### PR DESCRIPTION
- If the output vectors aren't provided, allow resizable
  data buffers.
- If the output vectors are provided, assert that the data
  buffer is resizeable.
- use a cpp function to write to string-like o/p buffers,
  this checks for capacity and updates the offset vector.