### PR TITLE
ARROW-5812: [Java] Refactor method name and param type in BaseIntVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
@@ -23,7 +23,7 @@ package org.apache.arrow.vector;
 public interface BaseIntVector extends ValueVector {
 
   /**
-   * set the encoded value from a {@link org.apache.arrow.vector.dictionary.Dictionary}.
+   * set value at specific index, note this value may need to be need truncated.
    */
-  void setEncodedValue(int index, int value);
+  void setWithPossibleTruncate(int index, long value);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -340,7 +340,7 @@ public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector 
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
+  public void setWithPossibleTruncate(int index, long value) {
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -27,8 +27,6 @@ import org.apache.arrow.vector.holders.NullableIntHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -38,7 +36,6 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
-  private static final Logger logger = LoggerFactory.getLogger(IntVector.class);
   public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -348,9 +345,6 @@ public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    if (value > Integer.MAX_VALUE) {
-      logger.warn("value is overflow: %s", value);
-    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.IntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.IntHolder;
@@ -28,6 +27,8 @@ import org.apache.arrow.vector.holders.NullableIntHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -37,6 +38,7 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
+  private static final Logger logger = LoggerFactory.getLogger(IntVector.class);
   public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -346,7 +348,9 @@ public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    Preconditions.checkArgument(value <= Integer.MAX_VALUE, "value is overflow: %s", value);
+    if (value > Integer.MAX_VALUE) {
+      logger.warn("value is overflow: %s", value);
+    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.IntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.IntHolder;
@@ -344,8 +345,9 @@ public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
-    this.setSafe(index, value);
+  public void setWithPossibleTruncate(int index, long value) {
+    Preconditions.checkArgument(value <= Integer.MAX_VALUE, "value is overflow: %s", value);
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -27,8 +27,6 @@ import org.apache.arrow.vector.holders.SmallIntHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -38,7 +36,6 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector {
-  private static final Logger logger = LoggerFactory.getLogger(SmallIntVector.class);
   public static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -375,9 +372,6 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    if (value > Short.MAX_VALUE) {
-      logger.warn("value is overflow: %s", value);
-    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -372,9 +372,9 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
+  public void setWithPossibleTruncate(int index, long value) {
     Preconditions.checkArgument(value <= Short.MAX_VALUE, "value is overflow: %s", value);
-    this.setSafe(index, value);
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.SmallIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableSmallIntHolder;
@@ -28,6 +27,8 @@ import org.apache.arrow.vector.holders.SmallIntHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -37,6 +38,7 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector {
+  private static final Logger logger = LoggerFactory.getLogger(SmallIntVector.class);
   public static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -373,7 +375,9 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    Preconditions.checkArgument(value <= Short.MAX_VALUE, "value is overflow: %s", value);
+    if (value > Short.MAX_VALUE) {
+      logger.warn("value is overflow: %s", value);
+    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.TinyIntReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableTinyIntHolder;
@@ -28,6 +27,8 @@ import org.apache.arrow.vector.holders.TinyIntHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -37,6 +38,7 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector {
+  private static final Logger logger = LoggerFactory.getLogger(TinyIntVector.class);
   public static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -373,7 +375,9 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    Preconditions.checkArgument(value <= Byte.MAX_VALUE, "value is overflow: %s", value);
+    if (value > Byte.MAX_VALUE) {
+      logger.warn("value is overflow: %s", value);
+    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -27,8 +27,6 @@ import org.apache.arrow.vector.holders.TinyIntHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -38,7 +36,6 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector {
-  private static final Logger logger = LoggerFactory.getLogger(TinyIntVector.class);
   public static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -375,9 +372,6 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    if (value > Byte.MAX_VALUE) {
-      logger.warn("value is overflow: %s", value);
-    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -372,9 +372,9 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
+  public void setWithPossibleTruncate(int index, long value) {
     Preconditions.checkArgument(value <= Byte.MAX_VALUE, "value is overflow: %s", value);
-    this.setSafe(index, value);
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -27,8 +27,6 @@ import org.apache.arrow.vector.holders.UInt1Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -39,7 +37,6 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
-  private static final Logger logger = LoggerFactory.getLogger(UInt1Vector.class);
   private static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -335,9 +332,6 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    if (value > 0xff) {
-      logger.warn("value is overflow: %s", value);
-    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -331,9 +331,9 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
+  public void setWithPossibleTruncate(int index, long value) {
     Preconditions.checkArgument(value <= 0xFF, "value is overflow: %s", value);
-    this.setSafe(index, value);
+    this.setSafe(index, (int) value);
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.UInt1ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableUInt1Holder;
@@ -28,8 +27,11 @@ import org.apache.arrow.vector.holders.UInt1Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
+
 
 /**
  * UInt1Vector implements a fixed width (1 bytes) vector of
@@ -37,6 +39,7 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
+  private static final Logger logger = LoggerFactory.getLogger(UInt1Vector.class);
   private static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -332,7 +335,9 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    Preconditions.checkArgument(value <= 0xFF, "value is overflow: %s", value);
+    if (value > 0xff) {
+      logger.warn("value is overflow: %s", value);
+    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -310,9 +310,9 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
+  public void setWithPossibleTruncate(int index, long value) {
     Preconditions.checkArgument(value <= Character.MAX_VALUE, "value is overflow: %s", value);
-    this.setSafe(index, value);
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.UInt2ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableUInt2Holder;
@@ -28,6 +27,8 @@ import org.apache.arrow.vector.holders.UInt2Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -37,6 +38,7 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
+  private static final Logger logger = LoggerFactory.getLogger(UInt2Vector.class);
   private static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -311,7 +313,9 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    Preconditions.checkArgument(value <= Character.MAX_VALUE, "value is overflow: %s", value);
+    if (value > Character.MAX_VALUE) {
+      logger.warn("value is overflow: %s", value);
+    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -27,8 +27,6 @@ import org.apache.arrow.vector.holders.UInt2Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -38,7 +36,6 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
-  private static final Logger logger = LoggerFactory.getLogger(UInt2Vector.class);
   private static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -313,9 +310,6 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    if (value > Character.MAX_VALUE) {
-      logger.warn("value is overflow: %s", value);
-    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.UInt4ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableUInt4Holder;
@@ -28,6 +27,8 @@ import org.apache.arrow.vector.holders.UInt4Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -37,6 +38,7 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
+  private static final Logger logger = LoggerFactory.getLogger(UInt4Vector.class);
   private static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -304,7 +306,9 @@ public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    Preconditions.checkArgument(value <= 0x00000000ffffffffL, "value is overflow: %s", value);
+    if (value > 0x00000000ffffffffL) {
+      logger.warn("value is overflow: %s", value);
+    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -27,8 +27,6 @@ import org.apache.arrow.vector.holders.UInt4Holder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -38,7 +36,6 @@ import io.netty.buffer.ArrowBuf;
  * maintained to track which elements in the vector are null.
  */
 public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
-  private static final Logger logger = LoggerFactory.getLogger(UInt4Vector.class);
   private static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -306,9 +303,6 @@ public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
 
   @Override
   public void setWithPossibleTruncate(int index, long value) {
-    if (value > 0x00000000ffffffffL) {
-      logger.warn("value is overflow: %s", value);
-    }
     this.setSafe(index, (int) value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.UInt4ReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.NullableUInt4Holder;
@@ -302,8 +303,9 @@ public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
-    this.setSafe(index, value);
+  public void setWithPossibleTruncate(int index, long value) {
+    Preconditions.checkArgument(value <= 0x00000000ffffffffL, "value is overflow: %s", value);
+    this.setSafe(index, (int) value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -303,7 +303,7 @@ public class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector {
   }
 
   @Override
-  public void setEncodedValue(int index, int value) {
+  public void setWithPossibleTruncate(int index, long value) {
     this.setSafe(index, value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -78,7 +78,7 @@ public class DictionaryEncoder {
         if (encoded == null) {
           throw new IllegalArgumentException("Dictionary encoding not defined for value:" + value);
         }
-        indices.setEncodedValue(i, encoded);
+        indices.setWithPossibleTruncate(i, encoded);
       }
     }
 


### PR DESCRIPTION
Related to [ARROW-5812](https://issues.apache.org/jira/browse/ARROW-5812).
Change to void setWithPossibleTruncate(int index, long value); for better generality.