### PR TITLE
[Website] Fix incorrect expansion of "SIMD" term

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -23,7 +23,7 @@ layout: default
 <div class="row">
   <div class="col-lg-4">
       <h2 class="mt-3">Fast</h2>
-      <p>Apache Arrow&#8482; enables execution engines to take advantage of the latest SIMD (Single input multiple data) operations included in modern processors, for native vectorized optimization of analytical data processing. Columnar layout is optimized for data locality for better performance on modern hardware like CPUs and GPUs.</p>
+      <p>Apache Arrow&#8482; enables execution engines to take advantage of the latest SIMD (Single instruction, multiple data) operations included in modern processors, for native vectorized optimization of analytical data processing. Columnar layout is optimized for data locality for better performance on modern hardware like CPUs and GPUs.</p>
       <p>The Arrow memory format supports <strong>zero-copy reads</strong> for lightning-fast data access without serialization overhead.</p>
   </div>
   <div class="col-lg-4">


### PR DESCRIPTION
[SIMD](https://www.google.com/search?q=SIMD) should be single "instruction" not "input"