### PR TITLE
ARROW-5820: [Release] Remove undefined variable check from verify script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -46,7 +46,6 @@ case $# in
 esac
 
 set -e
-set -u
 set -x
 set -o pipefail
 


### PR DESCRIPTION
External shell scripts may refer unbound variable:

    /tmp/arrow-0.14.0.yum2X/apache-arrow-0.14.0/test-miniconda/etc/profile.d/conda.sh:
    line 55: PS1: unbound variable