### PR TITLE
[Release] Set C++ libraries runtime path to LD_LIBRARY_PATH when running integration tests

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -488,7 +488,7 @@ test_integration() {
 
   # Flight integration test executable have runtime dependency on
   # release/libgtest.so
-  LD_LIBRARY_PATH=$ARROW_CPP_EXE_PATH:$PATH \
+  LD_LIBRARY_PATH=$ARROW_CPP_EXE_PATH:$LD_LIBRARY_PATH \
       python integration_test.py $INTEGRATION_TEST_ARGS
 
   popd

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -486,7 +486,10 @@ test_integration() {
     INTEGRATION_TEST_ARGS=--run_flight
   fi
 
-  python integration_test.py $INTEGRATION_TEST_ARGS
+  # Flight integration test executable have runtime dependency on
+  # release/libgtest.so
+  LD_LIBRARY_PATH=$ARROW_CPP_EXE_PATH:$PATH \
+      python integration_test.py $INTEGRATION_TEST_ARGS
 
   popd
 }


### PR DESCRIPTION
This is also required (and set) when running the unit tests