### PR TITLE
ARROW-5823: [Rust] CI scripts miss --all-targets cargo argument

### DIFF
--- a/ci/rust-build-main.bat
+++ b/ci/rust-build-main.bat
@@ -29,7 +29,7 @@ pushd rust
 
 rustup default nightly
 rustup show
-cargo build --target %TARGET% --release || exit /B
+cargo build --target %TARGET% --all-targets --release || exit /B
 @echo
 @echo Test (release)
 @echo --------------

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -31,7 +31,7 @@ rustup show
 # raises on any formatting errors
 cargo +stable fmt --all -- --check
 
-RUSTFLAGS="-D warnings" cargo build
+RUSTFLAGS="-D warnings" cargo build --all-targets
 cargo test
 
 # run examples

--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::builder::*;
 use arrow::compute::array_ops::{limit, sum};
 use arrow::compute::kernels::arithmetic::*;
 use arrow::error::Result;

--- a/rust/arrow/benches/array_from_vec.rs
+++ b/rust/arrow/benches/array_from_vec.rs
@@ -22,7 +22,6 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::array_data::ArrayDataBuilder;
 use arrow::buffer::Buffer;
 use arrow::datatypes::*;
 

--- a/rust/arrow/benches/boolean_kernels.rs
+++ b/rust/arrow/benches/boolean_kernels.rs
@@ -22,7 +22,6 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::builder::*;
 use arrow::compute::kernels::boolean as boolean_kernels;
 use arrow::error::{ArrowError, Result};
 

--- a/rust/arrow/benches/builder.rs
+++ b/rust/arrow/benches/builder.rs
@@ -25,7 +25,7 @@ use criterion::*;
 use rand::distributions::Standard;
 use rand::{thread_rng, Rng};
 
-use arrow::builder::*;
+use arrow::array::*;
 
 // Build arrays with 512k elements.
 const BATCH_SIZE: usize = 8 << 10;

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -22,7 +22,6 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::builder::*;
 use arrow::compute::*;
 
 fn create_array(size: usize) -> Float32Array {


### PR DESCRIPTION
Rust build breaks because some changes in array builder. However this error is not detected in ci scripts because missing --all-targets in cargo build command.