### PR TITLE
ARROW-517: [C++] array comparison, uses D**2 space Myers

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -91,6 +91,7 @@ set(ARROW_SRCS
     array/builder_primitive.cc
     array/builder_union.cc
     array/concatenate.cc
+    array/diff.cc
     buffer.cc
     compare.cc
     extension_type.cc

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -137,6 +137,7 @@ set(ARROW_SRCS
     util/logging.cc
     util/key_value_metadata.cc
     util/memory.cc
+    util/string.cc
     util/string_builder.cc
     util/task-group.cc
     util/thread-pool.cc

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -558,7 +558,7 @@ StructArray::StructArray(const std::shared_ptr<DataType>& type, int64_t length,
   boxed_fields_.resize(children.size());
 }
 
-Result<std::shared_ptr<Array>> StructArray::Make(
+Result<std::shared_ptr<StructArray>> StructArray::Make(
     const std::vector<std::shared_ptr<Array>>& children,
     const std::vector<std::shared_ptr<Field>>& fields,
     std::shared_ptr<Buffer> null_bitmap, int64_t null_count, int64_t offset) {
@@ -582,7 +582,7 @@ Result<std::shared_ptr<Array>> StructArray::Make(
                                        null_bitmap, null_count, offset);
 }
 
-Result<std::shared_ptr<Array>> StructArray::Make(
+Result<std::shared_ptr<StructArray>> StructArray::Make(
     const std::vector<std::shared_ptr<Array>>& children,
     const std::vector<std::string>& field_names, std::shared_ptr<Buffer> null_bitmap,
     int64_t null_count, int64_t offset) {

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -913,7 +913,7 @@ class ARROW_EXPORT StructArray : public Array {
   ///
   /// The length and data type are automatically inferred from the arguments.
   /// There should be at least one child array.
-  static Result<std::shared_ptr<Array>> Make(
+  static Result<std::shared_ptr<StructArray>> Make(
       const std::vector<std::shared_ptr<Array>>& children,
       const std::vector<std::string>& field_names,
       std::shared_ptr<Buffer> null_bitmap = NULLPTR,
@@ -924,7 +924,7 @@ class ARROW_EXPORT StructArray : public Array {
   /// The length is automatically inferred from the arguments.
   /// There should be at least one child array.  This method does not
   /// check that field types and child array types are consistent.
-  static Result<std::shared_ptr<Array>> Make(
+  static Result<std::shared_ptr<StructArray>> Make(
       const std::vector<std::shared_ptr<Array>>& children,
       const std::vector<std::shared_ptr<Field>>& fields,
       std::shared_ptr<Buffer> null_bitmap = NULLPTR,

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -639,6 +639,7 @@ class ARROW_EXPORT MapArray : public ListArray {
 class ARROW_EXPORT FixedSizeListArray : public Array {
  public:
   using TypeClass = FixedSizeListType;
+  using offset_type = TypeClass::offset_type;
 
   explicit FixedSizeListArray(const std::shared_ptr<ArrayData>& data);
 

--- a/cpp/src/arrow/array/CMakeLists.txt
+++ b/cpp/src/arrow/array/CMakeLists.txt
@@ -16,6 +16,7 @@
 # under the License.
 
 add_arrow_test(concatenate-test)
+add_arrow_test(diff-test)
 
 # Headers: top level
 arrow_install_all_headers("arrow/array")

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -234,7 +234,7 @@ TEST_F(DiffTest, CompareRandomStrings) {
   compute::FunctionContext ctx;
   for (auto null_probability : {0.0, 0.25}) {
     auto values = this->rng_.StringWithRepeats(1 << 10, 1 << 8, 0, 32, null_probability);
-    for (const double filter_probability : {0.99, 0.75, 0.5}) {
+    for (const double filter_probability : {0.99, 0.11, 0.70, 0.9, 0.75, 0.5}) {
       auto filter_1 = this->rng_.Boolean(values->length(), filter_probability, 0.0);
       auto filter_2 = this->rng_.Boolean(values->length(), filter_probability, 0.0);
 

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -494,6 +494,26 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
 -[]
 )");
 
+  // maps
+  base_ = ArrayFromJSON(map(utf8(), int32()), R"([
+    [["foo", 2], ["bar", 3], ["baz", 1]],
+    [],
+    [["quux", 13]],
+    []
+  ])");
+  target_ = ArrayFromJSON(map(utf8(), int32()), R"([
+    [["foo", 2], ["bar", 3], ["baz", 1]],
+    [["ytho", 11]],
+    [],
+    [["quux", 13]]
+  ])");
+  AssertDiffAndFormat(R"(
+@@ -1, +1 @@
++[{key: "ytho", value: 11}]
+@@ -3, +4 @@
+-[]
+)");
+
   // structs
   auto type = struct_({field("foo", utf8()), field("bar", int32())});
   base_ = ArrayFromJSON(type, R"([{"foo": "!", "bar": 3}, {}, {"bar": 13}])");

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -470,10 +470,13 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
 )");
   }
 
-  // small difference
-  base_ = ArrayFromJSON(uint16(), "[0, 1, 2, 3, 5, 8, 11, 13, 17]");
-  target_ = ArrayFromJSON(uint16(), "[2, 3, 5, 7, 11, 13, 17, 19]");
-  AssertDiffAndFormat(R"(
+  for (auto type : {int8(), uint8(),  // verify that these are printed as numbers rather
+                                      // than their ascii characters
+                    int16(), uint16()}) {
+    // small difference
+    base_ = ArrayFromJSON(type, "[0, 1, 2, 3, 5, 8, 11, 13, 17]");
+    target_ = ArrayFromJSON(type, "[2, 3, 5, 7, 11, 13, 17, 19]");
+    AssertDiffAndFormat(R"(
 @@ -0, +0 @@
 -0
 -1
@@ -484,10 +487,10 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
 +19
 )");
 
-  // large difference
-  base_ = ArrayFromJSON(uint16(), "[57, 10, 22, 126, 42]");
-  target_ = ArrayFromJSON(uint16(), "[58, 57, 75, 93, 53, 8, 22, 42, 79, 11]");
-  AssertDiffAndFormat(R"(
+    // large difference
+    base_ = ArrayFromJSON(type, "[57, 10, 22, 126, 42]");
+    target_ = ArrayFromJSON(type, "[58, 57, 75, 93, 53, 8, 22, 42, 79, 11]");
+    AssertDiffAndFormat(R"(
 @@ -0, +0 @@
 +58
 @@ -1, +2 @@
@@ -502,6 +505,7 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
 +79
 +11
 )");
+  }
 }
 
 TEST_F(DiffTest, DictionaryDiffFormatter) {

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -484,6 +484,17 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
 +null
 )");
 
+  // strings with escaped chars
+  base_ = ArrayFromJSON(utf8(), R"(["newline:\n", "quote:'", "backslash:\\"])");
+  target_ =
+      ArrayFromJSON(utf8(), R"(["newline:\n", "tab:\t", "quote:\"", "backslash:\\"])");
+  AssertDiffAndFormat(R"(
+@@ -1, +1 @@
+-"quote:'"
++"tab:\t"
++"quote:\""
+)");
+
   // lists
   base_ = ArrayFromJSON(list(int32()), R"([[2, 3, 1], [], [13], []])");
   target_ = ArrayFromJSON(list(int32()), R"([[2, 3, 1], [5, 9], [], [13]])");

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -209,13 +209,15 @@ TYPED_TEST(DiffTestWithNumeric, Basics) {
   this->base_ = ArrayFromJSON(this->type_singleton(), "[1, 2, 3, null, 5]");
   this->target_ = ArrayFromJSON(this->type_singleton(), "[1, 2, 3, null, 5, 6, 7, 8, 9]");
   this->DoDiff();
-  ASSERT_EQ(this->edits_->length(), 5);
-  ASSERT_EQ(this->insert_->Value(0), false);
-  ASSERT_EQ(this->run_lengths_->Value(0), 5);
-  for (int64_t i = 1; i < this->edits_->length(); ++i) {
-    ASSERT_EQ(this->insert_->Value(i), true);
-    ASSERT_EQ(this->run_lengths_->Value(i), 0);
-  }
+  this->AssertInsertIs("[false, true, true, true, true]");
+  this->AssertRunLengthIs("[5, 0, 0, 0, 0]");
+
+  // prepend some
+  this->base_ = ArrayFromJSON(this->type_singleton(), "[1, 2, 3, null, 5]");
+  this->target_ = ArrayFromJSON(this->type_singleton(), "[6, 4, 2, 0, 1, 2, 3, null, 5]");
+  this->DoDiff();
+  this->AssertInsertIs("[false, true, true, true, true]");
+  this->AssertRunLengthIs("[0, 0, 0, 0, 5]");
 }
 
 TEST_F(DiffTest, CompareRandomInt64) {

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -645,10 +645,11 @@ TEST_F(DiffTest, CompareRandomStruct) {
                                 &utf8_target));
       MakeSameLength(&int32_target, &utf8_target);
 
-      auto base_res = StructArray::Make({int32_base, utf8_base}, {"i", "s"});
+      auto type = struct_({field("i", int32()), field("s", utf8())});
+      auto base_res = StructArray::Make({int32_base, utf8_base}, type->children());
       ASSERT_OK(base_res.status());
       base_ = base_res.ValueOrDie();
-      auto target_res = StructArray::Make({int32_target, utf8_target}, {"i", "s"});
+      auto target_res = StructArray::Make({int32_target, utf8_target}, type->children());
       ASSERT_OK(target_res.status());
       target_ = target_res.ValueOrDie();
 

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -440,6 +440,42 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
 +"quote:\""
 )");
 
+  // date32
+  base_ = ArrayFromJSON(date32(), R"([0, 1, 2, 31, 4])");
+  target_ = ArrayFromJSON(date32(), R"([0, 1, 31, 2, 4])");
+  AssertDiffAndFormat(R"(
+@@ -2, +2 @@
+-1970-01-03
+@@ -4, +3 @@
++1970-01-03
+)");
+
+  // date64
+  constexpr int64_t ms_per_day = 24 * 60 * 60 * 1000;
+  ArrayFromVector<Date64Type>(
+      {0 * ms_per_day, 1 * ms_per_day, 2 * ms_per_day, 31 * ms_per_day, 4 * ms_per_day},
+      &base_);
+  ArrayFromVector<Date64Type>(
+      {0 * ms_per_day, 1 * ms_per_day, 31 * ms_per_day, 2 * ms_per_day, 4 * ms_per_day},
+      &target_);
+  AssertDiffAndFormat(R"(
+@@ -2, +2 @@
+-1970-01-03
+@@ -4, +3 @@
++1970-01-03
+)");
+
+  // timestamp
+  auto x = 678 + 1000000 * (5 + 60 * (4 + 60 * (3 + 24 * int64_t(1))));
+  ArrayFromVector<TimestampType>(timestamp(TimeUnit::MICRO), {0, 1, x, 2, 4}, &base_);
+  ArrayFromVector<TimestampType>(timestamp(TimeUnit::MICRO), {0, 1, 2, x, 4}, &target_);
+  AssertDiffAndFormat(R"(
+@@ -2, +2 @@
+-1970-01-02 03:04:05.000678
+@@ -4, +3 @@
++1970-01-02 03:04:05.000678
+)");
+
   // lists
   base_ = ArrayFromJSON(list(int32()), R"([[2, 3, 1], [], [13], []])");
   target_ = ArrayFromJSON(list(int32()), R"([[2, 3, 1], [5, 9], [], [13]])");

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -1,0 +1,151 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/array.h"
+#include "arrow/array/diff.h"
+#include "arrow/buffer.h"
+#include "arrow/builder.h"
+#include "arrow/status.h"
+#include "arrow/testing/gtest_common.h"
+#include "arrow/testing/random.h"
+#include "arrow/testing/util.h"
+#include "arrow/type.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+using internal::checked_pointer_cast;
+
+constexpr random::SeedType kSeed = 0xdeadbeef;
+static const auto edits_type =
+    struct_({field("insert", boolean()), field("run_length", uint64())});
+
+class DiffTest : public ::testing::Test {
+ protected:
+  DiffTest()
+      : rng_(kSeed),
+        sizes_({0, 1, 2, 4, 16, 31, 1234}),
+        null_probabilities_({0.0, 0.1, 0.5, 0.9, 1.0}) {}
+
+  void DoDiff() {
+    ASSERT_OK(Diff(*base_, *target_, default_memory_pool(), &edits_));
+    ASSERT_OK(ValidateArray(*edits_));
+    ASSERT_TRUE(edits_->type()->Equals(edits_type));
+    const auto& edits = checked_cast<const StructArray&>(*edits_);
+    insert_ = checked_pointer_cast<BooleanArray>(edits.field(0));
+    run_lengths_ = checked_pointer_cast<UInt64Array>(edits.field(1));
+  }
+
+  random::RandomArrayGenerator rng_;
+  std::shared_ptr<Array> base_, target_, edits_;
+  std::shared_ptr<BooleanArray> insert_;
+  std::shared_ptr<UInt64Array> run_lengths_;
+  std::vector<int32_t> sizes_;
+  std::vector<double> null_probabilities_;
+};
+
+TEST_F(DiffTest, Trivial) {
+  base_ = ArrayFromJSON(int32(), "[]");
+  target_ = ArrayFromJSON(int32(), "[]");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 1);
+  ASSERT_EQ(run_lengths_->Value(0), 0);
+
+  base_ = ArrayFromJSON(int32(), "[1, 2, 3]");
+  target_ = ArrayFromJSON(int32(), "[1, 2, 3]");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 1);
+  ASSERT_EQ(run_lengths_->Value(0), 3);
+}
+
+TEST_F(DiffTest, Basics) {
+  // insert one
+  base_ = ArrayFromJSON(int32(), "[1, 2, 4, 5]");
+  target_ = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5]");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 2);
+  ASSERT_EQ(run_lengths_->Value(0), 2);
+  ASSERT_EQ(insert_->Value(1), true);
+  ASSERT_EQ(run_lengths_->Value(1), 2);
+
+  // delete one
+  base_ = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5]");
+  target_ = ArrayFromJSON(int32(), "[1, 2, 4, 5]");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 2);
+  ASSERT_EQ(run_lengths_->Value(0), 2);
+  ASSERT_EQ(insert_->Value(1), false);
+  ASSERT_EQ(run_lengths_->Value(1), 2);
+
+  // change one
+  base_ = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5]");
+  target_ = ArrayFromJSON(int32(), "[1, 2, -3, 4, 5]");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 3);
+  ASSERT_EQ(run_lengths_->Value(0), 2);
+  ASSERT_EQ(insert_->Value(1), false);
+  ASSERT_EQ(run_lengths_->Value(1), 0);
+  ASSERT_EQ(insert_->Value(2), true);
+  ASSERT_EQ(run_lengths_->Value(2), 2);
+}
+
+TEST_F(DiffTest, BasicsWithStrings) {
+  // insert one
+  base_ = ArrayFromJSON(utf8(), R"(["give", "a", "break"])");
+  target_ = ArrayFromJSON(utf8(), R"(["give", "me", "a", "break"])");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 2);
+  ASSERT_EQ(run_lengths_->Value(0), 1);
+  ASSERT_EQ(insert_->Value(1), true);
+  ASSERT_EQ(run_lengths_->Value(1), 2);
+
+  // delete one
+  base_ = ArrayFromJSON(utf8(), R"(["give", "me", "a", "break"])");
+  target_ = ArrayFromJSON(utf8(), R"(["give", "a", "break"])");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 2);
+  ASSERT_EQ(run_lengths_->Value(0), 1);
+  ASSERT_EQ(insert_->Value(1), false);
+  ASSERT_EQ(run_lengths_->Value(1), 2);
+
+  // change one
+  base_ = ArrayFromJSON(utf8(), R"(["give", "a", "break"])");
+  target_ = ArrayFromJSON(utf8(), R"(["gimme", "a", "break"])");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 3);
+  ASSERT_EQ(run_lengths_->Value(0), 0);
+  ASSERT_EQ(insert_->Value(1), false);
+  ASSERT_EQ(run_lengths_->Value(1), 0);
+  ASSERT_EQ(insert_->Value(2), true);
+  ASSERT_EQ(run_lengths_->Value(2), 2);
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -48,7 +48,7 @@ using internal::checked_pointer_cast;
 
 constexpr random::SeedType kSeed = 0xdeadbeef;
 static const auto edits_type =
-    struct_({field("insert", boolean()), field("run_length", uint64())});
+    struct_({field("insert", boolean()), field("run_length", int64())});
 
 struct AssertEditScript : DiffVisitor {
   AssertEditScript(const Array& base, const Array& target)
@@ -94,7 +94,7 @@ class DiffTest : public ::testing::Test {
     ASSERT_OK(ValidateArray(*edits_));
     ASSERT_TRUE(edits_->type()->Equals(edits_type));
     insert_ = checked_pointer_cast<BooleanArray>(edits_->field(0));
-    run_lengths_ = checked_pointer_cast<UInt64Array>(edits_->field(1));
+    run_lengths_ = checked_pointer_cast<Int64Array>(edits_->field(1));
   }
 
   void DoDiffAndFormat(std::stringstream* out) {
@@ -125,14 +125,14 @@ class DiffTest : public ::testing::Test {
   }
 
   void AssertRunLengthIs(const std::string& run_lengths_json) {
-    ASSERT_ARRAYS_EQUAL(*ArrayFromJSON(uint64(), run_lengths_json), *run_lengths_);
+    ASSERT_ARRAYS_EQUAL(*ArrayFromJSON(int64(), run_lengths_json), *run_lengths_);
   }
 
   random::RandomArrayGenerator rng_;
   std::shared_ptr<StructArray> edits_;
   std::shared_ptr<Array> base_, target_;
   std::shared_ptr<BooleanArray> insert_;
-  std::shared_ptr<UInt64Array> run_lengths_;
+  std::shared_ptr<Int64Array> run_lengths_;
 };
 
 TEST_F(DiffTest, Trivial) {

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -98,7 +98,7 @@ class DiffTest : public ::testing::Test {
 
   void DoDiffAndFormat(std::stringstream* out) {
     DoDiff();
-    auto formatter = MakeUnifiedDiffFormatter(*out, *base_, *target_);
+    auto formatter = MakeUnifiedDiffFormatter(out, *base_, *target_);
     ASSERT_OK(formatter.status());
     ASSERT_OK(formatter.ValueOrDie()->Visit(*edits_));
   }

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -154,14 +154,6 @@ TEST_F(DiffTest, Trivial) {
   ASSERT_EQ(run_lengths_->Value(0), 3);
 }
 
-template <typename ArrowType>
-class DiffTestWithNumeric : public DiffTest {
- protected:
-  std::shared_ptr<DataType> type_singleton() {
-    return TypeTraits<ArrowType>::type_singleton();
-  }
-};
-
 TEST_F(DiffTest, Errors) {
   std::stringstream formatted;
 
@@ -172,6 +164,14 @@ TEST_F(DiffTest, Errors) {
   ASSERT_FALSE(base_->Equals(*target_, EqualOptions().diff_sink(&formatted)));
   ASSERT_EQ(formatted.str(), R"(# Array types differed: int32 vs string)");
 }
+
+template <typename ArrowType>
+class DiffTestWithNumeric : public DiffTest {
+ protected:
+  std::shared_ptr<DataType> type_singleton() {
+    return TypeTraits<ArrowType>::type_singleton();
+  }
+};
 
 TYPED_TEST_CASE(DiffTestWithNumeric, NumericArrowTypes);
 

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -128,7 +128,19 @@ TEST_F(DiffTest, Trivial) {
   target_ = ArrayFromJSON(int32(), "[]");
   DoDiff();
   ASSERT_EQ(edits_->length(), 1);
+  ASSERT_EQ(insert_->Value(0), false);
   ASSERT_EQ(run_lengths_->Value(0), 0);
+
+  base_ = ArrayFromJSON(null(), "[null, null]");
+  target_ = ArrayFromJSON(null(), "[null, null, null, null]");
+  DoDiff();
+  ASSERT_EQ(edits_->length(), 3);
+  ASSERT_EQ(insert_->Value(0), false);
+  ASSERT_EQ(run_lengths_->Value(0), 2);
+  ASSERT_EQ(insert_->Value(1), true);
+  ASSERT_EQ(run_lengths_->Value(1), 0);
+  ASSERT_EQ(insert_->Value(2), true);
+  ASSERT_EQ(run_lengths_->Value(2), 0);
 
   base_ = ArrayFromJSON(int32(), "[1, 2, 3]");
   target_ = ArrayFromJSON(int32(), "[1, 2, 3]");
@@ -150,6 +162,10 @@ TEST_F(DiffTest, Errors) {
   base_ = ArrayFromJSON(int32(), "[]");
   target_ = ArrayFromJSON(utf8(), "[]");
   ASSERT_RAISES(TypeError, Diff(*base_, *target_, default_memory_pool(), &edits_));
+
+  base_ = ArrayFromJSON(struct_({}), "[]");
+  target_ = ArrayFromJSON(struct_({}), "[]");
+  ASSERT_RAISES(NotImplemented, Diff(*base_, *target_, default_memory_pool(), &edits_));
 }
 
 TYPED_TEST_CASE(DiffTestWithNumeric, NumericArrowTypes);

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -96,13 +96,25 @@ class DiffTest : public ::testing::Test {
     run_lengths_ = checked_pointer_cast<UInt64Array>(edits.field(1));
   }
 
-  void DoDiffAndFormat(std::string* out) {
+  void DoDiffAndFormat(std::stringstream* out) {
     DoDiff();
-    std::stringstream ss;
-    auto formatter = MakeUnifiedDiffFormatter(ss, *base_, *target_);
+    auto formatter = MakeUnifiedDiffFormatter(*out, *base_, *target_);
     ASSERT_OK(formatter.status());
     ASSERT_OK(formatter.ValueOrDie()->Visit(*edits_));
-    *out = ss.str();
+  }
+
+  // validate diff and assert that it formats as expected, both directly
+  // and through Array::Equals
+  void AssertDiffAndFormat(const std::string& formatted_expected) {
+    std::stringstream formatted;
+
+    DoDiffAndFormat(&formatted);
+    ASSERT_EQ(formatted.str(), formatted_expected) << "formatted diff incorrectly";
+    formatted.str("");
+
+    base_->Equals(*target_, EqualOptions().diff_sink(&formatted));
+    ASSERT_EQ(formatted.str(), formatted_expected)
+        << "Array::Equals formatted diff incorrectly";
   }
 
   random::RandomArrayGenerator rng_;
@@ -200,11 +212,11 @@ TYPED_TEST(DiffTestWithNumeric, CompareRandomNumeric) {
       ASSERT_OK(compute::Filter(&ctx, *values, *filter_1, &this->base_));
       ASSERT_OK(compute::Filter(&ctx, *values, *filter_2, &this->target_));
 
-      std::string formatted;
+      std::stringstream formatted;
       this->DoDiffAndFormat(&formatted);
       auto st = AssertEditScript{*this->base_, *this->target_}.Visit(*this->edits_);
       if (!st.ok()) {
-        ASSERT_OK(Status(st.code(), st.message() + "\n" + formatted));
+        ASSERT_OK(Status(st.code(), st.message() + "\n" + formatted.str()));
       }
     }
   }
@@ -245,13 +257,10 @@ TEST_F(DiffTest, BasicsWithStrings) {
 }
 
 TEST_F(DiffTest, UnifiedDiffFormatter) {
-  std::string formatted;
-
   // insert one
   base_ = ArrayFromJSON(utf8(), R"(["give", "a", "break"])");
   target_ = ArrayFromJSON(utf8(), R"(["give", "me", "a", "break"])");
-  DoDiffAndFormat(&formatted);
-  ASSERT_EQ(formatted, R"(
+  AssertDiffAndFormat(R"(
 @@ -1, +1 @@
 +"me"
 )");
@@ -259,8 +268,7 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
   // delete one
   base_ = ArrayFromJSON(utf8(), R"(["give", "me", "a", "break"])");
   target_ = ArrayFromJSON(utf8(), R"(["give", "a", "break"])");
-  DoDiffAndFormat(&formatted);
-  ASSERT_EQ(formatted, R"(
+  AssertDiffAndFormat(R"(
 @@ -1, +1 @@
 -"me"
 )");
@@ -268,8 +276,7 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
   // change one
   base_ = ArrayFromJSON(utf8(), R"(["give", "a", "break"])");
   target_ = ArrayFromJSON(utf8(), R"(["gimme", "a", "break"])");
-  DoDiffAndFormat(&formatted);
-  ASSERT_EQ(formatted, R"(
+  AssertDiffAndFormat(R"(
 @@ -0, +0 @@
 -"give"
 +"gimme"
@@ -278,8 +285,7 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
   // small difference
   base_ = ArrayFromJSON(uint16(), "[0, 1, 2, 3, 5, 8, 11, 13, 17]");
   target_ = ArrayFromJSON(uint16(), "[2, 3, 5, 7, 11, 13, 17, 19]");
-  DoDiffAndFormat(&formatted);
-  ASSERT_EQ(formatted, R"(
+  AssertDiffAndFormat(R"(
 @@ -0, +0 @@
 -0
 -1
@@ -293,8 +299,7 @@ TEST_F(DiffTest, UnifiedDiffFormatter) {
   // large difference
   base_ = ArrayFromJSON(uint16(), "[57, 10, 22, 126, 42]");
   target_ = ArrayFromJSON(uint16(), "[58, 57, 75, 93, 53, 8, 22, 42, 79, 11]");
-  DoDiffAndFormat(&formatted);
-  ASSERT_EQ(formatted, R"(
+  AssertDiffAndFormat(R"(
 @@ -0, +0 @@
 +58
 @@ -1, +2 @@

--- a/cpp/src/arrow/array/diff-test.cc
+++ b/cpp/src/arrow/array/diff-test.cc
@@ -234,7 +234,7 @@ TEST_F(DiffTest, CompareRandomStrings) {
   compute::FunctionContext ctx;
   for (auto null_probability : {0.0, 0.25}) {
     auto values = this->rng_.StringWithRepeats(1 << 10, 1 << 8, 0, 32, null_probability);
-    for (const double filter_probability : {0.99, 0.11, 0.70, 0.9, 0.75, 0.5}) {
+    for (const double filter_probability : {0.99, 0.75, 0.5}) {
       auto filter_1 = this->rng_.Boolean(values->length(), filter_probability, 0.0);
       auto filter_2 = this->rng_.Boolean(values->length(), filter_probability, 0.0);
 

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -318,6 +318,12 @@ struct DiffImplVisitor {
     return Diff(base.begin(), base.end(), target.begin(), target.end());
   }
 
+  Status Visit(const ExtensionType&) {
+    auto base = checked_cast<const ExtensionArray&>(base_).storage();
+    auto target = checked_cast<const ExtensionArray&>(target_).storage();
+    return arrow::Diff(*base, *target, pool_, out_);
+  }
+
   Status Visit(const DataType& t) {
     return Status::NotImplemented("diffing arrays of type ", t);
   }

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -552,6 +552,8 @@ class Formatter {
     return Status::OK();
   }
 
+  // TODO(bkietz) format maps better
+
   Status Visit(const StructArray& arr) {
     struct StructImpl : Impl {
       StructImpl(std::vector<Formatter> f) : field_formatters_(std::move(f)) {}

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -469,7 +469,7 @@ class Formatter {
 
   template <typename Fn>
   struct FnImpl : Impl {
-    FnImpl(Fn fn) : fn_(std::move(fn)) {}
+    explicit FnImpl(Fn fn) : fn_(std::move(fn)) {}
     void Format(const Array& array, int64_t index, std::ostream* os) override {
       fn_(array, index, os);
     }
@@ -530,7 +530,7 @@ class Formatter {
 
   Status Visit(const ListArray& arr) {
     struct ListImpl : Impl {
-      ListImpl(Formatter f) : values_formatter_(std::move(f)) {}
+      explicit ListImpl(Formatter f) : values_formatter_(std::move(f)) {}
 
       void Format(const Array& array, int64_t index, std::ostream* os) override {
         const auto& list_array = checked_cast<const ListArray&>(array);
@@ -556,7 +556,7 @@ class Formatter {
 
   Status Visit(const StructArray& arr) {
     struct StructImpl : Impl {
-      StructImpl(std::vector<Formatter> f) : field_formatters_(std::move(f)) {}
+      explicit StructImpl(std::vector<Formatter> f) : field_formatters_(std::move(f)) {}
 
       void Format(const Array& array, int64_t index, std::ostream* os) override {
         const auto& struct_array = checked_cast<const StructArray&>(array);

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -1,0 +1,259 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/array/diff.h"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/lazy.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/visibility.h"
+#include "arrow/visitor_inline.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+using internal::MakeLazyRange;
+
+template <typename Iterator>
+class DiffImpl {
+ public:
+  // represents an intermediate state in the comparison of two arrays
+  struct EditPoint {
+    Iterator base, target;
+
+    bool operator==(EditPoint other) const {
+      return base == other.base && target == other.target;
+    }
+  };
+
+  DiffImpl(Iterator base_begin, Iterator base_end, Iterator target_begin,
+           Iterator target_end)
+      : base_begin_(base_begin),
+        base_end_(base_end),
+        target_begin_(target_begin),
+        target_end_(target_end),
+        endpoint_base_({ExtendFrom({base_begin_, target_begin_})}),
+        insert_({true}) {
+    if (std::distance(base_begin_, base_end_) ==
+            std::distance(target_begin_, target_end_) &&
+        endpoint_base_[0] == base_end_) {
+      finish_index_ = 0;
+    }
+  }
+
+  // beginning of a range for storing per-edit state in endpoint_base_ and insert_
+  uint64_t begin(uint64_t edit_count) const { return edit_count * (edit_count + 1) / 2; }
+
+  // end of a range for storing per-edit state in endpoint_base_ and insert_
+  uint64_t end(uint64_t edit_count) const { return begin(edit_count + 1); }
+
+  EditPoint GetEditPoint(uint64_t edit_count, uint64_t index) const {
+    DCHECK_GE(index, begin(edit_count));
+    DCHECK_LT(index, end(edit_count));
+    int64_t base_distance = endpoint_base_[index] - base_begin_;
+    auto k = static_cast<int64_t>(edit_count) - 2 * (index - begin(edit_count));
+    return {endpoint_base_[index], target_begin_ + (base_distance - k)};
+  }
+
+  Iterator ExtendFrom(EditPoint p) const {
+    for (; p.base != base_end_ && p.target != target_end_; ++p.base, ++p.target) {
+      if (*p.base != *p.target) {
+        break;
+      }
+    }
+    return p.base;
+  }
+
+  void Next() {
+    endpoint_base_.resize(end(edit_count_ + 1), base_begin_);
+    insert_.resize(end(edit_count_ + 1), false);
+
+    // try deleting from base first
+    for (uint64_t i = begin(edit_count_), i_out = end(edit_count_); i != end(edit_count_);
+         ++i, ++i_out) {
+      auto stepped = GetEditPoint(edit_count_, i);
+      ++stepped.base;
+      endpoint_base_[i_out] = ExtendFrom(stepped);
+    }
+
+    // check if inserting from target could do better
+    for (uint64_t i = begin(edit_count_), i_out = end(edit_count_) + 1;
+         i != end(edit_count_); ++i, ++i_out) {
+      auto x_endpoint = GetEditPoint(edit_count_ + 1, i_out);
+
+      auto stepped = GetEditPoint(edit_count_, i);
+      ++stepped.target;
+      endpoint_base_[i_out] = ExtendFrom(stepped);
+      auto y_endpoint = GetEditPoint(edit_count_ + 1, i_out);
+
+      if (y_endpoint.base - x_endpoint.base >= 0) {
+        insert_[i_out] = true;
+      } else {
+        endpoint_base_[i_out] = x_endpoint.base;
+      }
+    }
+
+    ++edit_count_;
+
+    // check for completion
+    EditPoint finish = {base_end_, target_end_};
+    for (uint64_t i = begin(edit_count_); i != end(edit_count_); ++i) {
+      if (GetEditPoint(edit_count_, i) == finish) {
+        finish_index_ = i;
+        return;
+      }
+    }
+  }
+
+  bool Done() { return finish_index_ != static_cast<uint64_t>(-1); }
+
+  Status GetEdits(MemoryPool* pool, std::shared_ptr<Array>* out) {
+    DCHECK(Done());
+
+    int64_t length = edit_count_ + 1;
+    std::shared_ptr<Buffer> insert_buf, run_length_buf;
+    RETURN_NOT_OK(AllocateBitmap(pool, length, &insert_buf));
+    RETURN_NOT_OK(AllocateBuffer(pool, length * sizeof(int64_t), &run_length_buf));
+    auto run_length = reinterpret_cast<int64_t*>(run_length_buf->mutable_data());
+
+    auto index = finish_index_;
+    auto endpoint = GetEditPoint(edit_count_, finish_index_);
+
+    for (int64_t i = edit_count_; i > 0; --i) {
+      bool insert = insert_[index];
+      BitUtil::SetBitTo(insert_buf->mutable_data(), i, insert);
+
+      auto x_minus_y = (endpoint.base - base_begin_) - (endpoint.target - target_begin_);
+      if (insert) {
+        ++x_minus_y;
+      } else {
+        --x_minus_y;
+      }
+      index = (i - 1 - x_minus_y) / 2 + begin(i - 1);
+
+      // endpoint of previous edit
+      auto previous = GetEditPoint(i - 1, index);
+      run_length[i] = endpoint.base - previous.base - !insert;
+
+      endpoint = previous;
+    }
+    run_length[0] = endpoint.base - base_begin_;
+
+    ARROW_ASSIGN_OR_RAISE(
+        *out, StructArray::Make({std::make_shared<BooleanArray>(length, insert_buf),
+                                 std::make_shared<UInt64Array>(length, run_length_buf)},
+                                {"insert", "run_length"}));
+    return Status::OK();
+  }
+
+ private:
+  uint64_t finish_index_ = -1;
+  uint64_t edit_count_ = 0;
+  Iterator base_begin_, base_end_;
+  Iterator target_begin_, target_end_;
+  std::vector<Iterator> endpoint_base_;
+  std::vector<bool> insert_;
+};
+
+// check whether a type's array class is an instantiation of NumericArray
+template <typename T>
+struct array_is_numeric {
+  static std::false_type test(...);
+
+  template <typename U>
+  static std::true_type test(NumericArray<U>*);
+
+  static constexpr bool value = decltype(array_is_numeric::test(
+      static_cast<typename TypeTraits<T>::ArrayType*>(nullptr)))::value;
+};
+
+static_assert(array_is_numeric<Int32Type>::value, "int32");
+static_assert(!array_is_numeric<BinaryType>::value, "binary");
+static_assert(array_is_numeric<Date32Type>::value, "date32");
+
+struct DiffImplVisitor {
+  template <typename T>
+  typename std::enable_if<array_is_numeric<T>::value, Status>::type Visit(const T&) {
+    auto base_data = checked_cast<const NumericArray<T>&>(base_).raw_values();
+    auto target_data = checked_cast<const NumericArray<T>&>(target_).raw_values();
+    return Diff(base_data, base_data + base_.length(), target_data,
+                target_data + target_.length());
+  }
+
+  template <typename T>
+  enable_if_binary_like<T, Status> Visit(const T&) {
+    using ArrayType = typename TypeTraits<T>::ArrayType;
+    struct ViewGenerator {
+      ViewGenerator(const Array& arr) : arr_(checked_cast<const ArrayType&>(arr)) {}
+
+      util::string_view operator()(int64_t i) const { return arr_.GetView(i); }
+
+      const ArrayType& arr_;
+    };
+
+    auto base = MakeLazyRange(ViewGenerator(base_), base_.length());
+    auto target = MakeLazyRange(ViewGenerator(target_), target_.length());
+    return Diff(base.begin(), base.end(), target.begin(), target.end());
+  }
+
+  Status Visit(const DataType& t) {
+    return Status::NotImplemented("diffing arrays of type ", t);
+  }
+
+  Status Diff() { return VisitTypeInline(*base_.type(), this); }
+
+  template <typename Iterator>
+  Status Diff(Iterator base_begin, Iterator base_end, Iterator target_begin,
+              Iterator target_end) {
+    DiffImpl<Iterator> impl(base_begin, base_end, target_begin, target_end);
+    while (!impl.Done()) {
+      impl.Next();
+    }
+    return impl.GetEdits(pool_, out_);
+  }
+
+  const Array& base_;
+  const Array& target_;
+  MemoryPool* pool_;
+  std::shared_ptr<Array>* out_;
+};
+
+Status Diff(const Array& base, const Array& target, MemoryPool* pool,
+            std::shared_ptr<Array>* out) {
+  if (!base.type()->Equals(target.type())) {
+    return Status::TypeError("only taking the diff of like-typed arrays is supported.");
+  }
+
+  if (base.null_count() != 0 || target.null_count() != 0) {
+    return Status::NotImplemented(
+        "taking the diff of arrays with nulls is not supported");
+  }
+
+  return DiffImplVisitor{base, target, pool, out}.Diff();
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -361,7 +361,13 @@ void Format(std::ostream& os, const BooleanArray& arr, int64_t index) {
 // format Numerics with std::ostream defaults
 template <typename T>
 void Format(std::ostream& os, const NumericArray<T>& arr, int64_t index) {
-  os << arr.Value(index);
+  if (sizeof(decltype(arr.Value(index))) == sizeof(char)) {
+    // override std::ostream defaults for /(u|)int8_t/ since they are
+    // formatted as potentially unprintable/tty borking characters
+    os << static_cast<int16_t>(arr.Value(index));
+  } else {
+    os << arr.Value(index);
+  }
 }
 
 // format Binary and FixedSizeBinary in hexadecimal

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -357,7 +357,7 @@ struct DiffImpl {
     RETURN_NOT_OK(run_length_builder.Finish(&run_length_buf));
 
     ARROW_ASSIGN_OR_RAISE(
-        *out_,
+        out_,
         StructArray::Make({std::make_shared<BooleanArray>(edit_count + 1, insert_buf),
                            std::make_shared<UInt64Array>(edit_count + 1, run_length_buf)},
                           {field("insert", boolean()), field("run_length", uint64())}));
@@ -370,12 +370,12 @@ struct DiffImpl {
     if (base_.null_count() == 0 && target_.null_count() == 0) {
       auto base = MakeViewRange<ArrayType>(base_);
       auto target = MakeViewRange<ArrayType>(target_);
-      ARROW_ASSIGN_OR_RAISE(*out_,
+      ARROW_ASSIGN_OR_RAISE(out_,
                             Diff(base.begin(), base.end(), target.begin(), target.end()));
     } else {
       auto base = MakeNullOrViewRange<ArrayType>(base_);
       auto target = MakeNullOrViewRange<ArrayType>(target_);
-      ARROW_ASSIGN_OR_RAISE(*out_,
+      ARROW_ASSIGN_OR_RAISE(out_,
                             Diff(base.begin(), base.end(), target.begin(), target.end()));
     }
     return Status::OK();
@@ -384,7 +384,7 @@ struct DiffImpl {
   Status Visit(const ExtensionType&) {
     auto base = checked_cast<const ExtensionArray&>(base_).storage();
     auto target = checked_cast<const ExtensionArray&>(target_).storage();
-    ARROW_ASSIGN_OR_RAISE(*out_, arrow::Diff(*base, *target, pool_));
+    ARROW_ASSIGN_OR_RAISE(out_, arrow::Diff(*base, *target, pool_));
     return Status::OK();
   }
 
@@ -394,7 +394,7 @@ struct DiffImpl {
 
   Result<std::shared_ptr<StructArray>> Diff() {
     RETURN_NOT_OK(VisitTypeInline(*base_.type(), this));
-    return *out_;
+    return out_;
   }
 
   template <typename Iterator>
@@ -411,7 +411,7 @@ struct DiffImpl {
   const Array& base_;
   const Array& target_;
   MemoryPool* pool_;
-  std::shared_ptr<StructArray>* out_;
+  std::shared_ptr<StructArray> out_;
 };
 
 Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -256,8 +256,9 @@ class QuadraticSpaceMyersDiff {
     auto insertions_minus_deletions =
         2 * (index - StorageOffset(edit_count)) - edit_count;
     auto maximal_base = endpoint_base_[index];
-    auto maximal_target =
-        target_begin_ + ((maximal_base - base_begin_) + insertions_minus_deletions);
+    auto maximal_target = std::min(
+        target_begin_ + ((maximal_base - base_begin_) + insertions_minus_deletions),
+        target_end_);
     return {maximal_base, maximal_target};
   }
 

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -322,9 +322,10 @@ class QuadraticSpaceMyersDiff {
     run_length[0] = endpoint.base - base_begin_;
 
     ARROW_ASSIGN_OR_RAISE(
-        *out, StructArray::Make({std::make_shared<BooleanArray>(length, insert_buf),
-                                 std::make_shared<UInt64Array>(length, run_length_buf)},
-                                {"insert", "run_length"}));
+        *out,
+        StructArray::Make({std::make_shared<BooleanArray>(length, insert_buf),
+                           std::make_shared<UInt64Array>(length, run_length_buf)},
+                          {field("insert", boolean()), field("run_length", uint64())}));
     return Status::OK();
   }
 
@@ -362,7 +363,7 @@ struct DiffImpl {
         *out_,
         StructArray::Make({std::make_shared<BooleanArray>(edit_count + 1, insert_buf),
                            std::make_shared<UInt64Array>(edit_count + 1, run_length_buf)},
-                          {"insert", "run_length"}));
+                          {field("insert", boolean()), field("run_length", uint64())}));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -160,7 +160,7 @@ class NullOrListGenerator {
 };
 
 template <typename Iterator>
-class DiffImpl {
+class QuadraticSpaceMyersDiff {
  public:
   // represents an intermediate state in the comparison of two arrays
   struct EditPoint {
@@ -171,8 +171,8 @@ class DiffImpl {
     }
   };
 
-  DiffImpl(Iterator base_begin, Iterator base_end, Iterator target_begin,
-           Iterator target_end)
+  QuadraticSpaceMyersDiff(Iterator base_begin, Iterator base_end, Iterator target_begin,
+                          Iterator target_end)
       : base_begin_(base_begin),
         base_end_(base_end),
         target_begin_(target_begin),
@@ -331,7 +331,7 @@ static_assert(array_has_GetView<Date32Type>::value, "date32");
 static_assert(!array_has_GetView<StructType>::value, "struct");
 static_assert(array_has_GetView<ListType>::value, "list");
 
-struct DiffImplVisitor {
+struct DiffImpl {
   Status Visit(const NullType&) {
     bool insert = base_.length() < target_.length();
     auto run_length = std::min(base_.length(), target_.length());
@@ -388,7 +388,8 @@ struct DiffImplVisitor {
   template <typename Iterator>
   Status Diff(Iterator base_begin, Iterator base_end, Iterator target_begin,
               Iterator target_end) {
-    DiffImpl<Iterator> impl(base_begin, base_end, target_begin, target_end);
+    QuadraticSpaceMyersDiff<Iterator> impl(base_begin, base_end, target_begin,
+                                           target_end);
     while (!impl.Done()) {
       impl.Next();
     }
@@ -407,7 +408,7 @@ Status Diff(const Array& base, const Array& target, MemoryPool* pool,
     return Status::TypeError("only taking the diff of like-typed arrays is supported.");
   }
 
-  return DiffImplVisitor{base, target, pool, out}.Diff();
+  return DiffImpl{base, target, pool, out}.Diff();
 }
 
 Status DiffVisitor::Visit(const Array& edits) {

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -661,9 +661,9 @@ class Formatter {
 
 class UnifiedDiffFormatter : public DiffVisitor {
  public:
-  UnifiedDiffFormatter(std::ostream& os, const Array& base, const Array& target,
+  UnifiedDiffFormatter(std::ostream* os, const Array& base, const Array& target,
                        Formatter formatter)
-      : os_(os), base_(base), target_(target), formatter_(std::move(formatter)) {
+      : os_(*os), base_(base), target_(target), formatter_(std::move(formatter)) {
     os_ << std::endl;
   }
 
@@ -720,7 +720,7 @@ class UnifiedDiffFormatter : public DiffVisitor {
   Formatter formatter_;
 };
 
-Result<std::unique_ptr<DiffVisitor>> MakeUnifiedDiffFormatter(std::ostream& os,
+Result<std::unique_ptr<DiffVisitor>> MakeUnifiedDiffFormatter(std::ostream* os,
                                                               const Array& base,
                                                               const Array& target) {
   if (!base.type()->Equals(target.type())) {

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
+#include <iosfwd>
 #include <memory>
-#include <vector>
 
 #include "arrow/array.h"
 #include "arrow/result.h"
@@ -80,6 +80,6 @@ class ARROW_EXPORT DiffVisitor {
 /// \brief return a DiffVisitor which will format an edit script in unified
 /// diff format
 ARROW_EXPORT Result<std::unique_ptr<DiffVisitor>> MakeUnifiedDiffFormatter(
-    std::ostream& os, const Array& base, const Array& target);
+    std::ostream* os, const Array& base, const Array& target);
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -32,7 +32,7 @@ class MemoryPool;
 /// \brief Compare two arrays, returning an edit script which expresses the difference
 /// between them
 ///
-/// An edit script is an array of struct(insert: bool, run_length: uint64_t).
+/// An edit script is an array of struct(insert: bool, run_length: int64_t).
 /// Each element of "insert" determines whether an element was inserted into (true)
 /// or deleted from (false) base. Each insertion or deletion is followed by a run of
 /// elements which are unchanged from base to target; the length of this run is stored

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class MemoryPool;
+
+/// \brief Compare two arrays, returning an edit script which expresses the difference
+/// between them
+///
+/// An edit script is an array of struct(insert: bool, run_length: uint64_t).
+/// Each element of "insert" determines whether an element was inserted into (true)
+/// or deleted from (false) base. Each insertion or deletion is followed by a run of
+/// elements which are unchanged from base to target; the length of this run is stored
+/// in "run_length".
+///
+/// For example for base "hlloo" and target "hello", the edit script would be
+/// [
+///   {"insert": true, "run_length": 1}, // leading run of length 1 ("h")
+///   {"insert": true, "run_length": 3}, // insert("e") then a run of length 3 ("llo")
+///   {"insert": false, "run_length": 0} // delete("o") then an empty run
+/// ]
+///
+/// Diffing arrays containing nulls is not currently supported.
+///
+/// \param[in] base baseline for comparison
+/// \param[in] target an array of identical type to base whose elements differ from base's
+/// \param[in] pool memory to store the result will be allocated from this memory pool
+/// \param[out] out an edit script array which can be applied to base to produce target
+/// \return Status
+ARROW_EXPORT
+Status Diff(const Array& base, const Array& target, MemoryPool* pool,
+            std::shared_ptr<Array>* out);
+
+}  // namespace arrow

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "arrow/array.h"
+#include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/visibility.h"
 
@@ -55,8 +56,6 @@ ARROW_EXPORT
 Status Diff(const Array& base, const Array& target, MemoryPool* pool,
             std::shared_ptr<Array>* out);
 
-// XXX would it be less confusing to switch vocabulary to actual/expected?
-
 /// \brief visitor interface for easy traversal of an edit script
 ///
 /// Implement whichever methods correspond to edits you are interested in then
@@ -77,5 +76,10 @@ class ARROW_EXPORT DiffVisitor {
   /// \brief visit each insertion, deletion, or run of edits
   Status Visit(const Array& edits);
 };
+
+/// \brief return a DiffVisitor which will format an edit script in unified
+/// diff format
+ARROW_EXPORT Result<std::unique_ptr<DiffVisitor>> MakeUnifiedDiffFormatter(
+    std::ostream& os, const Array& base, const Array& target);
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -50,11 +50,10 @@ class MemoryPool;
 /// \param[in] base baseline for comparison
 /// \param[in] target an array of identical type to base whose elements differ from base's
 /// \param[in] pool memory to store the result will be allocated from this memory pool
-/// \param[out] out an edit script array which can be applied to base to produce target
-/// \return Status
+/// \return an edit script array which can be applied to base to produce target
 ARROW_EXPORT
-Status Diff(const Array& base, const Array& target, MemoryPool* pool,
-            std::shared_ptr<Array>* out);
+Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,
+                                          MemoryPool* pool);
 
 /// \brief visitor interface for easy traversal of an edit script
 ///

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -36,7 +36,9 @@ class MemoryPool;
 /// Each element of "insert" determines whether an element was inserted into (true)
 /// or deleted from (false) base. Each insertion or deletion is followed by a run of
 /// elements which are unchanged from base to target; the length of this run is stored
-/// in "run_length".
+/// in "run_length". (Note that the edit script begins and ends with a run of shared
+/// elements but both fields of the struct must have the same length. To accomodate this
+/// the first element of "insert" should be ignored.)
 ///
 /// For example for base "hlloo" and target "hello", the edit script would be
 /// [

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -940,10 +940,9 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
     return Status::OK();
   }
 
-  for (auto nested_id :
-       {Type::LIST, Type::FIXED_SIZE_LIST, Type::MAP, Type::STRUCT, Type::UNION}) {
+  for (auto nested_id : {Type::STRUCT, Type::UNION}) {
     if (left.type_id() == nested_id) {
-      *os << "# Nested arrays of " << *left.type() << " differed";
+      *os << "# Arrays of " << *left.type() << " differed";
       return Status::OK();
     }
   }

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -943,28 +943,28 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
   if (left.type()->id() == Type::DICTIONARY) {
     *os << "# Dictionary arrays differed" << std::endl;
 
-    std::shared_ptr<Array> edits;
     const auto& left_dict = checked_cast<const DictionaryArray&>(left);
     const auto& right_dict = checked_cast<const DictionaryArray&>(right);
 
     *os << "## dictionary diff";
-    RETURN_NOT_OK(Diff(*left_dict.dictionary(), *right_dict.dictionary(),
-                       default_memory_pool(), &edits));
+    ARROW_ASSIGN_OR_RAISE(
+        auto dict_edits,
+        Diff(*left_dict.dictionary(), *right_dict.dictionary(), default_memory_pool()));
     ARROW_ASSIGN_OR_RAISE(
         auto formatter,
         MakeUnifiedDiffFormatter(os, *left_dict.dictionary(), *right_dict.dictionary()));
-    RETURN_NOT_OK(formatter->Visit(*edits));
+    RETURN_NOT_OK(formatter->Visit(*dict_edits));
 
     *os << "## indices diff";
-    RETURN_NOT_OK(
-        Diff(*left_dict.indices(), *right_dict.indices(), default_memory_pool(), &edits));
+    ARROW_ASSIGN_OR_RAISE(
+        auto indices_edits,
+        Diff(*left_dict.dictionary(), *right_dict.dictionary(), default_memory_pool()));
     ARROW_ASSIGN_OR_RAISE(formatter, MakeUnifiedDiffFormatter(os, *left_dict.indices(),
                                                               *right_dict.indices()));
-    return formatter->Visit(*edits);
+    return formatter->Visit(*indices_edits);
   }
 
-  std::shared_ptr<Array> edits;
-  RETURN_NOT_OK(Diff(left, right, default_memory_pool(), &edits));
+  ARROW_ASSIGN_OR_RAISE(auto edits, Diff(left, right, default_memory_pool()));
   ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(os, left, right));
   return formatter->Visit(*edits);
 }

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -958,7 +958,7 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
     *os << "## indices diff";
     ARROW_ASSIGN_OR_RAISE(
         auto indices_edits,
-        Diff(*left_dict.dictionary(), *right_dict.dictionary(), default_memory_pool()));
+        Diff(*left_dict.indices(), *right_dict.indices(), default_memory_pool()));
     ARROW_ASSIGN_OR_RAISE(formatter, MakeUnifiedDiffFormatter(os, *left_dict.indices(),
                                                               *right_dict.indices()));
     return formatter->Visit(*indices_edits);

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -952,20 +952,20 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
                        default_memory_pool(), &edits));
     ARROW_ASSIGN_OR_RAISE(
         auto formatter,
-        MakeUnifiedDiffFormatter(*os, *left_dict.dictionary(), *right_dict.dictionary()));
+        MakeUnifiedDiffFormatter(os, *left_dict.dictionary(), *right_dict.dictionary()));
     RETURN_NOT_OK(formatter->Visit(*edits));
 
     *os << "## indices diff";
     RETURN_NOT_OK(
         Diff(*left_dict.indices(), *right_dict.indices(), default_memory_pool(), &edits));
-    ARROW_ASSIGN_OR_RAISE(formatter, MakeUnifiedDiffFormatter(*os, *left_dict.indices(),
+    ARROW_ASSIGN_OR_RAISE(formatter, MakeUnifiedDiffFormatter(os, *left_dict.indices(),
                                                               *right_dict.indices()));
     return formatter->Visit(*edits);
   }
 
   std::shared_ptr<Array> edits;
   RETURN_NOT_OK(Diff(left, right, default_memory_pool(), &edits));
-  ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(*os, left, right));
+  ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(os, left, right));
   return formatter->Visit(*edits);
 }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -950,11 +950,6 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
     return Status::OK();
   }
 
-  if (left.type()->id() == Type::EXTENSION) {
-    *os << "# Extension arrays differed";
-    return Status::OK();
-  }
-
   std::shared_ptr<Array> edits;
   RETURN_NOT_OK(Diff(left, right, default_memory_pool(), &edits));
   ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(*os, left, right));

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -940,6 +940,21 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
     return Status::OK();
   }
 
+  if (left.type()->num_children() != 0) {
+    *os << "# Nested arrays differed";
+    return Status::OK();
+  }
+
+  if (left.type()->id() == Type::DICTIONARY) {
+    *os << "# Dictionary arrays differed";
+    return Status::OK();
+  }
+
+  if (left.type()->id() == Type::EXTENSION) {
+    *os << "# Extension arrays differed";
+    return Status::OK();
+  }
+
   std::shared_ptr<Array> edits;
   RETURN_NOT_OK(Diff(left, right, default_memory_pool(), &edits));
   ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(*os, left, right));

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -940,13 +940,6 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
     return Status::OK();
   }
 
-  for (auto nested_id : {Type::STRUCT, Type::UNION}) {
-    if (left.type_id() == nested_id) {
-      *os << "# Arrays of " << *left.type() << " differed";
-      return Status::OK();
-    }
-  }
-
   if (left.type()->id() == Type::DICTIONARY) {
     *os << "# Dictionary arrays differed" << std::endl;
 

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -21,7 +21,9 @@
 #define ARROW_COMPARE_H
 
 #include <cstdint>
+#include <iostream>
 
+#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -57,11 +59,22 @@ class EqualOptions {
     return res;
   }
 
+  /// The ostream to which a diff will be formatted if arrays disagree
+  std::ostream* diff_sink() const { return diff_sink_; }
+
+  /// Return a new EqualOptions object with the "diff_sink" property changed.
+  EqualOptions diff_sink(std::ostream* diff_sink) const {
+    auto res = EqualOptions(*this);
+    res.diff_sink_ = diff_sink;
+    return res;
+  }
+
   static EqualOptions Defaults() { return EqualOptions(); }
 
  protected:
   double atol_ = kDefaultAbsoluteTolerance;
   bool nans_equal_ = false;
+  std::ostream* diff_sink_ = NULLPTR;
 };
 
 /// Returns true if the arrays are exactly equal

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -21,7 +21,7 @@
 #define ARROW_COMPARE_H
 
 #include <cstdint>
-#include <iostream>
+#include <iosfwd>
 
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -59,7 +59,8 @@ class EqualOptions {
     return res;
   }
 
-  /// The ostream to which a diff will be formatted if arrays disagree
+  /// The ostream to which a diff will be formatted if arrays disagree.
+  /// If this is null (the default) no diff will be formatted.
   std::ostream* diff_sink() const { return diff_sink_; }
 
   /// Return a new EqualOptions object with the "diff_sink" property changed.

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -583,6 +583,7 @@ class ARROW_EXPORT MapType : public ListType {
 class ARROW_EXPORT FixedSizeListType : public NestedType {
  public:
   static constexpr Type::type type_id = Type::FIXED_SIZE_LIST;
+  using offset_type = int32_t;
 
   static constexpr const char* type_name() { return "fixed_size_list"; }
 

--- a/cpp/src/arrow/util/lazy.h
+++ b/cpp/src/arrow/util/lazy.h
@@ -67,13 +67,17 @@ class LazyRange {
     using _Unchecked_type = typename LazyRange<Generator>::RangeIter;
 #endif
 
+    RangeIter() = delete;
+    RangeIter(const RangeIter& other) = default;
+    RangeIter& operator=(const RangeIter& other) = default;
+
     RangeIter(const LazyRange<Generator>& range, int64_t index)
-        : range_(range), index_(index) {}
+        : range_(&range), index_(index) {}
 
-    const return_type operator*() { return range_.gen_(index_); }
+    const return_type operator*() const { return range_->gen_(index_); }
 
-    RangeIter operator+(difference_type length) {
-      return RangeIter(range_, index_ + length);
+    RangeIter operator+(difference_type length) const {
+      return RangeIter(*range_, index_ + length);
     }
 
     // pre-increment
@@ -90,20 +94,20 @@ class LazyRange {
     }
 
     bool operator==(const typename LazyRange<Generator>::RangeIter& other) const {
-      return this->index_ == other.index_ && &this->range_ == &other.range_;
+      return this->index_ == other.index_ && this->range_ == other.range_;
     }
 
     bool operator!=(const typename LazyRange<Generator>::RangeIter& other) const {
-      return this->index_ != other.index_ || &this->range_ != &other.range_;
+      return this->index_ != other.index_ || this->range_ != other.range_;
     }
 
-    int64_t operator-(const typename LazyRange<Generator>::RangeIter& other) {
+    int64_t operator-(const typename LazyRange<Generator>::RangeIter& other) const {
       return this->index_ - other.index_;
     }
 
    private:
     // parent range reference
-    const LazyRange& range_;
+    const LazyRange* range_;
     // current index
     int64_t index_;
   };

--- a/cpp/src/arrow/util/lazy.h
+++ b/cpp/src/arrow/util/lazy.h
@@ -105,6 +105,10 @@ class LazyRange {
       return this->index_ - other.index_;
     }
 
+    bool operator<(const typename LazyRange<Generator>::RangeIter& other) const {
+      return this->index_ < other.index_;
+    }
+
    private:
     // parent range reference
     const LazyRange* range_;

--- a/cpp/src/arrow/util/string.cc
+++ b/cpp/src/arrow/util/string.cc
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/string.h"
+
+#include <algorithm>
+
+#include "arrow/status.h"
+
+namespace arrow {
+
+static const char* kAsciiTable = "0123456789ABCDEF";
+
+std::string HexEncode(const uint8_t* data, size_t length) {
+  std::string hex_string;
+  hex_string.reserve(length * 2);
+  for (size_t j = 0; j < length; ++j) {
+    // Convert to 2 base16 digits
+    hex_string.push_back(kAsciiTable[data[j] >> 4]);
+    hex_string.push_back(kAsciiTable[data[j] & 15]);
+  }
+  return hex_string;
+}
+
+std::string Escape(const char* data, size_t length) {
+  std::string escaped_string;
+  escaped_string.reserve(length);
+  for (size_t j = 0; j < length; ++j) {
+    switch (data[j]) {
+      case '"':
+        escaped_string += R"(\")";
+        break;
+      case '\\':
+        escaped_string += R"(\\)";
+        break;
+      case '\t':
+        escaped_string += R"(\t)";
+        break;
+      case '\r':
+        escaped_string += R"(\r)";
+        break;
+      case '\n':
+        escaped_string += R"(\n)";
+        break;
+      default:
+        escaped_string.push_back(data[j]);
+    }
+  }
+  return escaped_string;
+}
+
+std::string HexEncode(const char* data, size_t length) {
+  return HexEncode(reinterpret_cast<const uint8_t*>(data), length);
+}
+
+std::string HexEncode(util::string_view str) { return HexEncode(str.data(), str.size()); }
+
+std::string Escape(util::string_view str) { return Escape(str.data(), str.size()); }
+
+Status ParseHexValue(const char* data, uint8_t* out) {
+  char c1 = data[0];
+  char c2 = data[1];
+
+  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
+  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
+
+  // Error checking
+  if (*pos1 != c1 || *pos2 != c2) {
+    return Status::Invalid("Encountered non-hex digit");
+  }
+
+  *out = static_cast<uint8_t>((pos1 - kAsciiTable) << 4 | (pos2 - kAsciiTable));
+  return Status::OK();
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -39,12 +39,38 @@ static inline std::string HexEncode(const uint8_t* data, size_t length) {
   return hex_string;
 }
 
+static inline std::string Escape(const char* data, size_t length) {
+  std::string escaped_string;
+  escaped_string.reserve(length);
+  for (size_t j = 0; j < length; ++j) {
+    switch (data[j]) {
+      case '"':
+        escaped_string += R"(\")";
+      case '\\':
+        escaped_string += R"(\\)";
+      case '\t':
+        escaped_string += R"(\t)";
+      case '\r':
+        escaped_string += R"(\r)";
+      case '\n':
+        escaped_string += R"(\n)";
+      default:
+        escaped_string.push_back(data[j]);
+    }
+  }
+  return escaped_string;
+}
+
 static inline std::string HexEncode(const char* data, size_t length) {
   return HexEncode(reinterpret_cast<const uint8_t*>(data), length);
 }
 
 static inline std::string HexEncode(util::string_view str) {
   return HexEncode(str.data(), str.size());
+}
+
+static inline std::string Escape(util::string_view str) {
+  return Escape(str.data(), str.size());
 }
 
 static inline Status ParseHexValue(const char* data, uint8_t* out) {

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -15,85 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_UTIL_STRING_UTIL_H
-#define ARROW_UTIL_STRING_UTIL_H
+#pragma once
 
-#include <algorithm>
 #include <string>
 
-#include "arrow/status.h"
 #include "arrow/util/string_view.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 
-static const char* kAsciiTable = "0123456789ABCDEF";
+class Status;
 
-static inline std::string HexEncode(const uint8_t* data, size_t length) {
-  std::string hex_string;
-  hex_string.reserve(length * 2);
-  for (size_t j = 0; j < length; ++j) {
-    // Convert to 2 base16 digits
-    hex_string.push_back(kAsciiTable[data[j] >> 4]);
-    hex_string.push_back(kAsciiTable[data[j] & 15]);
-  }
-  return hex_string;
-}
+ARROW_EXPORT std::string HexEncode(const uint8_t* data, size_t length);
 
-static inline std::string Escape(const char* data, size_t length) {
-  std::string escaped_string;
-  escaped_string.reserve(length);
-  for (size_t j = 0; j < length; ++j) {
-    switch (data[j]) {
-      case '"':
-        escaped_string += R"(\")";
-        break;
-      case '\\':
-        escaped_string += R"(\\)";
-        break;
-      case '\t':
-        escaped_string += R"(\t)";
-        break;
-      case '\r':
-        escaped_string += R"(\r)";
-        break;
-      case '\n':
-        escaped_string += R"(\n)";
-        break;
-      default:
-        escaped_string.push_back(data[j]);
-    }
-  }
-  return escaped_string;
-}
+ARROW_EXPORT std::string Escape(const char* data, size_t length);
 
-static inline std::string HexEncode(const char* data, size_t length) {
-  return HexEncode(reinterpret_cast<const uint8_t*>(data), length);
-}
+ARROW_EXPORT std::string HexEncode(const char* data, size_t length);
 
-static inline std::string HexEncode(util::string_view str) {
-  return HexEncode(str.data(), str.size());
-}
+ARROW_EXPORT std::string HexEncode(util::string_view str);
 
-static inline std::string Escape(util::string_view str) {
-  return Escape(str.data(), str.size());
-}
+ARROW_EXPORT std::string Escape(util::string_view str);
 
-static inline Status ParseHexValue(const char* data, uint8_t* out) {
-  char c1 = data[0];
-  char c2 = data[1];
-
-  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
-  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
-
-  // Error checking
-  if (*pos1 != c1 || *pos2 != c2) {
-    return Status::Invalid("Encountered non-hex digit");
-  }
-
-  *out = static_cast<uint8_t>((pos1 - kAsciiTable) << 4 | (pos2 - kAsciiTable));
-  return Status::OK();
-}
+ARROW_EXPORT Status ParseHexValue(const char* data, uint8_t* out);
 
 }  // namespace arrow
-
-#endif  // ARROW_UTIL_STRING_UTIL_H

--- a/cpp/src/arrow/util/string.h
+++ b/cpp/src/arrow/util/string.h
@@ -46,14 +46,19 @@ static inline std::string Escape(const char* data, size_t length) {
     switch (data[j]) {
       case '"':
         escaped_string += R"(\")";
+        break;
       case '\\':
         escaped_string += R"(\\)";
+        break;
       case '\t':
         escaped_string += R"(\t)";
+        break;
       case '\r':
         escaped_string += R"(\r)";
+        break;
       case '\n':
         escaped_string += R"(\n)";
+        break;
       default:
         escaped_string.push_back(data[j]);
     }


### PR DESCRIPTION
Adds `arrow::Diff`, which compares two arrays returning an edit script which expresses the difference between them.

The edit script is represented as an array of `struct<insert: bool, run_length: uint64_t>`.
Each element of the "insert" column determines whether an element was inserted into (true) or deleted from (false) base. Each insertion or deletion is followed by a run of elements which are unchanged from base to target; the length of this run is stored in the "run_length" column. (The first element of the "insert" column is always false; the first element of the "run_length" column is the number of leading elements unchanged from base to target.)

For example for base "hlloo" and target "hello", the edit script would be

```js
[
  {"insert": true, "run_length": 1}, // leading run of length 1 ("h")
  {"insert": true, "run_length": 3}, // insert("e") then a run of length 3 ("llo")
  {"insert": false, "run_length": 0} // delete("o") then an empty run
]
```