### PR TITLE
ARROW-5821: [Java] Support compact fixed-width vectors

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/compact/VectorDataCompactor.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/compact/VectorDataCompactor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.compact;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.util.TransferPair;
+
+/**
+ * Utility for compact/uncompact vector data element.
+ */
+public class VectorDataCompactor {
+
+  /**
+   * Compact the vector and reset valueCount, meanwhile generate a {@link BitVector} to trace non-null indices.
+   * @param vector the vector to compact.
+   */
+  public static <V extends BaseFixedWidthVector> BitVector compact(V vector) {
+
+    int valueCount = vector.getValueCount();
+
+    BitVector bitVector = new BitVector("", vector.getAllocator());
+    bitVector.allocateNew(valueCount);
+    bitVector.setValueCount(valueCount);
+
+    //record index from 0 to valueCount
+    int recordIndex = 0;
+    //index indicates the location to write value
+    int writeIndex = 0;
+
+    while (recordIndex < valueCount) {
+      if (vector.isNull(recordIndex)) {
+        recordIndex++;
+      } else {
+        bitVector.setSafe(recordIndex, 1);
+        //copy the value at recordIndex to writeIndex
+        vector.copyFromSafe(recordIndex, writeIndex, vector);
+        recordIndex++;
+        writeIndex++;
+      }
+    }
+    vector.setValueCount(writeIndex);
+
+    return bitVector;
+
+  }
+
+  /**
+   * Recovery the vector with the given compacted vector and {@link BitVector}.
+   * @param bitVector the vector which holds non-null indices
+   * @param compactedVector the compacted vector.
+   */
+  public static <V extends BaseFixedWidthVector> V uncompact(BitVector bitVector, V compactedVector) {
+    int valueCount = bitVector.getValueCount();
+
+    TransferPair transfer = compactedVector.getTransferPair(compactedVector.getAllocator());
+
+    int readIndex = 0;
+    for (int i = 0; i < valueCount; i++) {
+      if (!bitVector.isNull(i)) {
+        transfer.copyValueSafe(readIndex++, i);
+      }
+    }
+    V result = (V) transfer.getTo();
+    result.setValueCount(valueCount);
+    return result;
+  }
+}

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/compact/TestFixedWidthVectorCompact.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/compact/TestFixedWidthVectorCompact.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.compact;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.IntVector;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestFixedWidthVectorCompact {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testInt() {
+    try (IntVector vec = new IntVector("", allocator)) {
+      vec.allocateNew(10);
+      vec.setValueCount(10);
+
+      vec.set(0, 10);
+      vec.setNull(1);
+      vec.setNull(2);
+      vec.setNull(3);
+      vec.set(4, 20);
+      vec.setNull(5);
+      vec.set(6, 30);
+      vec.set(7, 40);
+      vec.setNull(8);
+      vec.setNull(9);
+
+      BitVector bitVector = VectorDataCompactor.compact(vec);
+
+      assertEquals(4, vec.getValueCount());
+      assertEquals(6, bitVector.getNullCount());
+      assertEquals(10, vec.get(0));
+      assertEquals(20, vec.get(1));
+      assertEquals(30, vec.get(2));
+      assertEquals(40, vec.get(3));
+
+
+      IntVector resVec = VectorDataCompactor.uncompact(bitVector, vec);
+
+      assertEquals(10, resVec.getValueCount());
+      assertEquals(10, resVec.get(0));
+      assertTrue(resVec.isNull(1));
+      assertTrue(resVec.isNull(2));
+      assertTrue(resVec.isNull(3));
+      assertEquals(20, resVec.get(4));
+      assertTrue(resVec.isNull(5));
+      assertEquals(30, resVec.get(6));
+      assertEquals(40, resVec.get(7));
+      assertTrue(resVec.isNull(8));
+      assertTrue(resVec.isNull(9));
+
+      bitVector.close();
+      resVec.close();
+    }
+  }
+
+}


### PR DESCRIPTION
Related to [ARROW-5821](https://issues.apache.org/jira/browse/ARROW-5821).
In shuffle stage of some applications, FixedWitdhVectors may have very little non-null data.
In this case, directly serialize vectors is not a good choice, generally we can compact the vector make it only holding non-null value and create a BitVector to trace the indices for non-null values so that it could be deserialized properly.