### PR TITLE
ARROW-5850: [CI][R] R appveyor job is broken after release

### DIFF
--- a/ci/PKGBUILD
+++ b/ci/PKGBUILD
@@ -18,7 +18,7 @@
 _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.13.0.9000
+pkgver=0.14.0.9000
 pkgrel=8000
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=("any")
@@ -46,6 +46,8 @@ cmake_build_type=release
 cpp_build_dir=build-${CARCH}-cpp
 
 pkgver() {
+  # The only purpose of this here is to cause the job to error if the
+  # version in pkgver is different from what is in r/DESCRIPTION
   cd "$source_dir"
   grep Version r/DESCRIPTION | cut -d " " -f 2
 }

--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -86,6 +86,13 @@ class PrepareTest < Test::Unit::TestCase
                      ],
                    },
                    {
+                     path: "ci/PKGBUILD",
+                     hunks: [
+                       ["-pkgver=#{@previous_version}.9000",
+                        "+pkgver=#{@release_version}"],
+                     ],
+                   },
+                   {
                      path: "cpp/CMakeLists.txt",
                      hunks: [
                        ["-set(ARROW_VERSION \"#{@snapshot_version}\")",
@@ -232,6 +239,13 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = '#{@release_version}'",
                         "+version = '#{@next_version}-SNAPSHOT'"],
+                     ],
+                   },
+                   {
+                     path: "ci/PKGBUILD",
+                     hunks: [
+                       ["-pkgver=#{@release_version}",
+                        "+pkgver=#{@release_version}.9000"],
                      ],
                    },
                    {

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -101,6 +101,14 @@ update_versions() {
   git add DESCRIPTION
   cd -
 
+  cd "${SOURCE_DIR}/../../ci"
+  sed -i.bak -E -e \
+    "s/^pkgver=.+/pkgver=${r_version}/" \
+    PKGBUILD
+  rm -f PKGBUILD.bak
+  git add PKGBUILD
+  cd -
+
   cd "${SOURCE_DIR}/../../r"
   if [ ${type} = "snapshot" ]; then
     # Add a news entry for the new dev version


### PR DESCRIPTION
This patch bumps the version and makes sure that the release scripts bump it next time. After some reflection, the other idea of removing `pkgver` from the PKGBUILD probably wouldn't work, given the order of the build steps in makepkg.