### PR TITLE
ARROW-5874: [Python] Fix macOS wheels to depend on system or Homebrew OpenSSL

### DIFF
--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -138,6 +138,7 @@ function build_wheel {
           -DgRPC_SOURCE=SYSTEM \
           -Dc-ares_SOURCE=BUNDLED \
           -DARROW_PROTOBUF_USE_SHARED=OFF \
+          -DOPENSSL_USE_STATIC_LIBS=ON  \
           -DMAKE=make \
           ..
     make -j5

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -68,7 +68,7 @@ install:
 
   # test the built wheels, remove llvm and grpc dependencies to ensure
   # things are properly statically-linked
-  - brew uninstall llvm@7 grpc c-ares openssl
+  - brew uninstall --ignore-dependencies llvm@7 grpc c-ares openssl
   - install_run arrow
 
   # move built wheels to a top level directory

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -73,6 +73,8 @@ install:
 
   # move built wheels to a top level directory
   - mv -v arrow/python/dist/* dist/
+  # reinstall openssl because travis' deployment script depends on it
+  - brew install openssl
 
 deploy:
   provider: releases

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -68,7 +68,7 @@ install:
 
   # test the built wheels, remove llvm and grpc dependencies to ensure
   # things are properly statically-linked
-  - brew uninstall llvm@7 grpc c-ares
+  - brew uninstall llvm@7 grpc c-ares openssl
   - install_run arrow
 
   # move built wheels to a top level directory


### PR DESCRIPTION
The wheel build and test build succeeds, just the deployments fails because of removed openssl for testing: https://travis-ci.org/ursa-labs/crossbow/builds/555822505

The currently running build should pass: https://travis-ci.org/ursa-labs/crossbow/builds/555849713
although we have a bunch of warnings `<lib> was built for newer OSX version (10.12) than being linked (10.9)` for the dependencies coming from brew.

cc @xhochy 