### PR TITLE
ARROW-5881: [Java] Provide functionalities to efficiently determine if a validity buffer has completely 1 bits/0 bits

### DIFF
--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -50,6 +50,8 @@ public class BitVectorHelperBenchmarks {
 
   private ArrowBuf validityBuffer;
 
+  private ArrowBuf oneBitValidityBuffer;
+
   /**
    * Setup benchmarks.
    */
@@ -65,6 +67,11 @@ public class BitVectorHelperBenchmarks {
         BitVectorHelper.setValidityBit(validityBuffer, i, (byte) 0);
       }
     }
+
+    // only one 1 bit in the middle of the buffer
+    oneBitValidityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
+    oneBitValidityBuffer.setZero(0, VALIDITY_BUFFER_CAPACITY / 8);
+    BitVectorHelper.setValidityBit(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY / 2, (byte) 1);
   }
 
   /**
@@ -73,6 +80,7 @@ public class BitVectorHelperBenchmarks {
   @TearDown
   public void tearDown() {
     validityBuffer.close();
+    oneBitValidityBuffer.close();
     allocator.close();
   }
 
@@ -81,6 +89,13 @@ public class BitVectorHelperBenchmarks {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public int getNullCountBenchmark() {
     return BitVectorHelper.getNullCount(validityBuffer, VALIDITY_BUFFER_CAPACITY);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public boolean allBitsNullBenchmark() {
+    return BitVectorHelper.allBitsNullOrig(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY);
   }
 
   //@Test

--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -95,7 +95,7 @@ public class BitVectorHelperBenchmarks {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public boolean allBitsNullBenchmark() {
-    return BitVectorHelper.allBitsNullOrig(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY);
+    return BitVectorHelper.allBitsNull(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY);
   }
 
   //@Test

--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -95,7 +95,7 @@ public class BitVectorHelperBenchmarks {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public boolean allBitsNullBenchmark() {
-    return BitVectorHelper.allBitsNull(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY);
+    return BitVectorHelper.checkAllBitsEqualTo(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY, true);
   }
 
   //@Test

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -139,12 +140,7 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
   }
 
   private boolean nullFilled(ValueVector vector) {
-    for (int r = 0; r < vector.getValueCount(); r++) {
-      if (!vector.isNull(r)) {
-        return false;
-      }
-    }
-    return true;
+    return BitVectorHelper.allBitsNull(vector.getValidityBuffer(), vector.getValueCount());
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -140,7 +140,7 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
   }
 
   private boolean nullFilled(ValueVector vector) {
-    return BitVectorHelper.allBitsNull(vector.getValidityBuffer(), vector.getValueCount());
+    return BitVectorHelper.checkAllBitsEqualTo(vector.getValidityBuffer(), vector.getValueCount(), false);
   }
 
   /**

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -76,36 +76,36 @@ public class TestBitVectorHelper {
 
       validityBuffer.setZero(0, bufferLength);
       int bitLength = 1024;
-      assertTrue(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertTrue(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       bitLength = 1027;
-      assertTrue(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertTrue(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1025;
       BitVectorHelper.setValidityBit(validityBuffer, 12, 1);
-      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1025;
       BitVectorHelper.setValidityBit(validityBuffer, 1024, 1);
-      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1026;
       BitVectorHelper.setValidityBit(validityBuffer, 1024, 1);
-      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1027;
       BitVectorHelper.setValidityBit(validityBuffer, 1025, 1);
-      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1031;
       BitVectorHelper.setValidityBit(validityBuffer, 1029, 1);
       BitVectorHelper.setValidityBit(validityBuffer, 1030, 1);
-      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
     }
   }
 
@@ -117,36 +117,36 @@ public class TestBitVectorHelper {
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       int bitLength = 1024;
-      assertTrue(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertTrue(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       bitLength = 1028;
-      assertTrue(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertTrue(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1025;
       BitVectorHelper.setValidityBit(validityBuffer, 12, 0);
-      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1025;
       BitVectorHelper.setValidityBit(validityBuffer, 1024, 0);
-      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1026;
       BitVectorHelper.setValidityBit(validityBuffer, 1024, 0);
-      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1027;
       BitVectorHelper.setValidityBit(validityBuffer, 1025, 0);
-      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1031;
       BitVectorHelper.setValidityBit(validityBuffer, 1029, 0);
       BitVectorHelper.setValidityBit(validityBuffer, 1030, 0);
-      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+      assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -18,12 +18,16 @@
 package org.apache.arrow.vector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.RootAllocator;
 import org.junit.Test;
 
 import io.netty.buffer.ArrowBuf;
 import io.netty.buffer.PooledByteBufAllocatorL;
+import io.netty.util.internal.PlatformDependent;
 
 public class TestBitVectorHelper {
   @Test
@@ -62,5 +66,87 @@ public class TestBitVectorHelper {
 
     count = BitVectorHelper.getNullCount(validityBuffer, 11);
     assertEquals(count, 5);
+  }
+
+  @Test
+  public void testAllBitsNull() {
+    final int bufferLength = 32 * 1024;
+    try (RootAllocator allocator = new RootAllocator(bufferLength);
+    ArrowBuf validityBuffer = allocator.buffer(bufferLength)) {
+
+      validityBuffer.setZero(0, bufferLength);
+      int bitLength = 1024;
+      assertTrue(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+
+      bitLength = 1027;
+      assertTrue(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+
+      validityBuffer.setZero(0, bufferLength);
+      bitLength = 1025;
+      BitVectorHelper.setValidityBit(validityBuffer, 12, 1);
+      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+
+      validityBuffer.setZero(0, bufferLength);
+      bitLength = 1025;
+      BitVectorHelper.setValidityBit(validityBuffer, 1024, 1);
+      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+
+      validityBuffer.setZero(0, bufferLength);
+      bitLength = 1026;
+      BitVectorHelper.setValidityBit(validityBuffer, 1024, 1);
+      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+
+      validityBuffer.setZero(0, bufferLength);
+      bitLength = 1027;
+      BitVectorHelper.setValidityBit(validityBuffer, 1025, 1);
+      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+
+      validityBuffer.setZero(0, bufferLength);
+      bitLength = 1031;
+      BitVectorHelper.setValidityBit(validityBuffer, 1029, 1);
+      BitVectorHelper.setValidityBit(validityBuffer, 1030, 1);
+      assertFalse(BitVectorHelper.allBitsNull(validityBuffer, bitLength));
+    }
+  }
+
+  @Test
+  public void testAllBitsSet() {
+    final int bufferLength = 32 * 1024;
+    try (RootAllocator allocator = new RootAllocator(bufferLength);
+         ArrowBuf validityBuffer = allocator.buffer(bufferLength)) {
+
+      PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
+      int bitLength = 1024;
+      assertTrue(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+
+      bitLength = 1028;
+      assertTrue(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+
+      PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
+      bitLength = 1025;
+      BitVectorHelper.setValidityBit(validityBuffer, 12, 0);
+      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+
+      PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
+      bitLength = 1025;
+      BitVectorHelper.setValidityBit(validityBuffer, 1024, 0);
+      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+
+      PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
+      bitLength = 1026;
+      BitVectorHelper.setValidityBit(validityBuffer, 1024, 0);
+      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+
+      PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
+      bitLength = 1027;
+      BitVectorHelper.setValidityBit(validityBuffer, 1025, 0);
+      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+
+      PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
+      bitLength = 1031;
+      BitVectorHelper.setValidityBit(validityBuffer, 1029, 0);
+      BitVectorHelper.setValidityBit(validityBuffer, 1030, 0);
+      assertFalse(BitVectorHelper.allBitsSet(validityBuffer, bitLength));
+    }
   }
 }


### PR DESCRIPTION
These utilities can be used to efficiently determine, for example,

If all values in a vector are null
If a vector contains no null
If a vector contains any valid element
If a vector contains any invalid element