### PR TITLE
ARROW-5884: [Java] Fix the get method of StructVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -482,6 +482,9 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   @Override
   public void get(int index, ComplexHolder holder) {
     holder.isSet = isSet(index);
+    if (holder.isSet == 0) {
+      return;
+    }
     super.get(index, holder);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -483,6 +483,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   public void get(int index, ComplexHolder holder) {
     holder.isSet = isSet(index);
     if (holder.isSet == 0) {
+      holder.reader = null;
       return;
     }
     super.get(index, holder);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
@@ -18,6 +18,8 @@
 package org.apache.arrow.vector;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
@@ -29,6 +31,7 @@ import org.apache.arrow.vector.holders.ComplexHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.FieldType;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -115,11 +118,16 @@ public class TestStructVector {
 
       IntVector intVector = (IntVector) vector.getChild("intchild");
       intVector.setSafe(0, 100);
+      vector.setIndexDefined(0);
       intVector.setNull(1);
+      vector.setNull(1);
 
       ComplexHolder holder = new ComplexHolder();
-      vector.get(1, holder);
+      vector.get(0, holder);
+      assertNotEquals(0, holder.isSet);
+      assertNotNull(holder.reader);
 
+      vector.get(1, holder);
       assertEquals(0, holder.isSet);
       assertNull(holder.reader);
     }


### PR DESCRIPTION
When the data at the specified location is null, there is no need to call the method from super to set the reader

 holder.isSet = isSet(index);
 super.get(index, holder);