### PR TITLE
ARROW-5873: [Python] Guard for passed None in Schema.equals

### DIFF
--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -371,6 +371,15 @@ def test_schema_equals_propagates_check_metadata():
     assert schema1.equals(schema2, check_metadata=False)
 
 
+def test_schema_equals_invalid_type():
+    # ARROW-5873
+    schema = pa.schema([pa.field("a", pa.int64())])
+
+    for val in [None, 'string', pa.array([1, 2])]:
+        with pytest.raises(TypeError):
+            schema.equals(val)
+
+
 def test_schema_equality_operators():
     fields = [
         pa.field('foo', pa.int32()),

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -811,7 +811,7 @@ cdef class Schema:
             metadata=self.metadata
         )
 
-    def equals(self, other, bint check_metadata=True):
+    def equals(self, Schema other not None, bint check_metadata=True):
         """
         Test if this schema is equal to the other
 
@@ -825,8 +825,7 @@ cdef class Schema:
         -------
         is_equal : boolean
         """
-        cdef Schema _other = other
-        return self.sp_schema.get().Equals(deref(_other.schema),
+        return self.sp_schema.get().Equals(deref(other.schema),
                                            check_metadata)
 
     @classmethod


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5873

When cython ExtensionTypes are used as function arguments (can get a value passed by the user), they are allowed to be None, so when accessing attributes from them, need to explicitly check that they are not None (https://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#extension-types-and-none)