### PR TITLE
ARROW-5900: [Java] Bounds check for decimal args. 

### DIFF
--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
@@ -23,6 +23,7 @@ import org.apache.arrow.flatbuf.Type;
 import org.apache.arrow.gandiva.exceptions.GandivaException;
 import org.apache.arrow.gandiva.exceptions.UnsupportedTypeException;
 import org.apache.arrow.gandiva.ipc.GandivaTypes;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -114,6 +115,9 @@ public class ArrowTypeHelper {
 
   private static void initArrowTypeDecimal(ArrowType.Decimal decimalType,
                                            GandivaTypes.ExtGandivaType.Builder builder) {
+    Preconditions.checkArgument(decimalType.getPrecision() > 0 &&
+            decimalType.getPrecision() < 38, "Gandiva only supports decimals of upto 38 precision" +
+            ". Input precision : " + decimalType.getPrecision());
     builder.setPrecision(decimalType.getPrecision());
     builder.setScale(decimalType.getScale());
     builder.setType(GandivaTypes.GandivaType.DECIMAL);

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/ArrowTypeHelper.java
@@ -116,8 +116,8 @@ public class ArrowTypeHelper {
   private static void initArrowTypeDecimal(ArrowType.Decimal decimalType,
                                            GandivaTypes.ExtGandivaType.Builder builder) {
     Preconditions.checkArgument(decimalType.getPrecision() > 0 &&
-            decimalType.getPrecision() < 38, "Gandiva only supports decimals of upto 38 precision" +
-            ". Input precision : " + decimalType.getPrecision());
+            decimalType.getPrecision() <= 38, "Gandiva only supports decimals of upto 38 " +
+            "precision. Input precision : " + decimalType.getPrecision());
     builder.setPrecision(decimalType.getPrecision());
     builder.setScale(decimalType.getScale());
     builder.setType(GandivaTypes.GandivaType.DECIMAL);

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
@@ -42,11 +42,15 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Decimal;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.google.common.collect.Lists;
 
 public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.BaseEvaluatorTest {
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void test_add() throws GandivaException {
@@ -750,6 +754,25 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
       }
       eval.close();
     }
+  }
+
+  @Test
+  public void testInvalidDecimal() throws GandivaException {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Gandiva only supports decimals of upto 38 precision. Input precision" +
+            " : 0");
+    Decimal decimalType = new Decimal(0, 0);
+    Field int64f = Field.nullable("int64", int64);
+
+    Schema schema = new Schema(Lists.newArrayList(int64f));
+    Projector eval = Projector.make(schema,
+            Lists.newArrayList(
+                    TreeBuilder.makeExpression("castDECIMAL",
+                            Lists.newArrayList(int64f),
+                            Field.nullable("invalid_dec", decimalType)
+                    )
+            )
+    );
   }
 }
 

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
@@ -774,5 +774,24 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
             )
     );
   }
+
+  @Test
+  public void testInvalidDecimalGt38() throws GandivaException {
+    exception.expect(IllegalArgumentException.class);
+    exception.expectMessage("Gandiva only supports decimals of upto 38 precision. Input precision" +
+            " : 42");
+    Decimal decimalType = new Decimal(42, 0);
+    Field int64f = Field.nullable("int64", int64);
+
+    Schema schema = new Schema(Lists.newArrayList(int64f));
+    Projector eval = Projector.make(schema,
+            Lists.newArrayList(
+                    TreeBuilder.makeExpression("castDECIMAL",
+                            Lists.newArrayList(int64f),
+                            Field.nullable("invalid_dec", decimalType)
+                    )
+            )
+    );
+  }
 }
 


### PR DESCRIPTION
Add bounds checks on decimal data types.