### PR TITLE
ARROW-5908: [C#] ArrowStreamWriter doesn't align buffers to 8 bytes

### DIFF
--- a/csharp/src/Apache.Arrow/BitUtility.cs
+++ b/csharp/src/Apache.Arrow/BitUtility.cs
@@ -117,6 +117,14 @@ namespace Apache.Arrow
             RoundUpToMultiplePowerOfTwo(n, 64);
 
         /// <summary>
+        /// Rounds an integer to the nearest multiple of 8.
+        /// </summary>
+        /// <param name="n">Integer to round.</param>
+        /// <returns>Integer rounded to the nearest multiple of 8.</returns>
+        public static long RoundUpToMultipleOf8(long n) =>
+            RoundUpToMultiplePowerOfTwo(n, 8);
+
+        /// <summary>
         /// Rounds an integer up to the nearest multiple of factor, where
         /// factor must be a power of two.
         /// 

--- a/csharp/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
+++ b/csharp/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Apache.Arrow.Ipc;
+using Apache.Arrow.Tests;
+using BenchmarkDotNet.Attributes;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Apache.Arrow.Benchmarks
+{
+    //[EtwProfiler] - needs elevated privileges
+    [MemoryDiagnoser]
+    public class ArrowWriterBenchmark
+    {
+        [Params(10_000, 1_000_000)]
+        public int BatchLength{ get; set; }
+
+        [Params(10, 25)]
+        public int ColumnSetCount { get; set; }
+
+        private MemoryStream _memoryStream;
+        private RecordBatch _batch;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _batch = TestData.CreateSampleRecordBatch(BatchLength, ColumnSetCount);
+            _memoryStream = new MemoryStream();
+        }
+
+        [IterationSetup]
+        public void Setup()
+        {
+            _memoryStream.Position = 0;
+        }
+
+        [Benchmark]
+        public async Task WriteBatch()
+        {
+            ArrowStreamWriter writer = new ArrowStreamWriter(_memoryStream, _batch.Schema);
+            await writer.WriteRecordBatchAsync(_batch);
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -23,26 +23,34 @@ namespace Apache.Arrow.Tests
     {
         public static RecordBatch CreateSampleRecordBatch(int length)
         {
+            return CreateSampleRecordBatch(length, columnSetCount: 1);
+        }
+
+        public static RecordBatch CreateSampleRecordBatch(int length, int columnSetCount)
+        {
             Schema.Builder builder = new Schema.Builder();
-            builder.Field(CreateField(BooleanType.Default));
-            builder.Field(CreateField(UInt8Type.Default));
-            builder.Field(CreateField(Int8Type.Default));
-            builder.Field(CreateField(UInt16Type.Default));
-            builder.Field(CreateField(Int16Type.Default));
-            builder.Field(CreateField(UInt32Type.Default));
-            builder.Field(CreateField(Int32Type.Default));
-            builder.Field(CreateField(UInt64Type.Default));
-            builder.Field(CreateField(Int64Type.Default));
-            builder.Field(CreateField(FloatType.Default));
-            builder.Field(CreateField(DoubleType.Default));
-            //builder.Field(CreateField(new DecimalType(19, 2)));
-            //builder.Field(CreateField(HalfFloatType.Default));
-            //builder.Field(CreateField(StringType.Default));
-            //builder.Field(CreateField(Date32Type.Default));
-            //builder.Field(CreateField(Date64Type.Default));
-            //builder.Field(CreateField(Time32Type.Default));
-            //builder.Field(CreateField(Time64Type.Default));
-            //builder.Field(CreateField(TimestampType.Default));
+            for (int i = 0; i < columnSetCount; i++)
+            {
+                builder.Field(CreateField(BooleanType.Default, i));
+                builder.Field(CreateField(UInt8Type.Default, i));
+                builder.Field(CreateField(Int8Type.Default, i));
+                builder.Field(CreateField(UInt16Type.Default, i));
+                builder.Field(CreateField(Int16Type.Default, i));
+                builder.Field(CreateField(UInt32Type.Default, i));
+                builder.Field(CreateField(Int32Type.Default, i));
+                builder.Field(CreateField(UInt64Type.Default, i));
+                builder.Field(CreateField(Int64Type.Default, i));
+                builder.Field(CreateField(FloatType.Default, i));
+                builder.Field(CreateField(DoubleType.Default, i));
+                //builder.Field(CreateField(new DecimalType(19, 2)));
+                //builder.Field(CreateField(HalfFloatType.Default));
+                //builder.Field(CreateField(StringType.Default));
+                //builder.Field(CreateField(Date32Type.Default));
+                //builder.Field(CreateField(Date64Type.Default));
+                //builder.Field(CreateField(Time32Type.Default));
+                //builder.Field(CreateField(Time64Type.Default));
+                //builder.Field(CreateField(TimestampType.Default));
+            }
 
             Schema schema = builder.Build();
 
@@ -51,9 +59,9 @@ namespace Apache.Arrow.Tests
             return new RecordBatch(schema, arrays, length);
         }
 
-        private static Field CreateField(ArrowType type)
+        private static Field CreateField(ArrowType type, int iteration)
         {
-            return new Field(type.Name, type, nullable: false);
+            return new Field(type.Name + iteration, type, nullable: false);
         }
 
         private static IEnumerable<IArrowArray> CreateArrays(Schema schema, int length)


### PR DESCRIPTION
Ensure 8-byte alignment on each buffer in a RecordBatch as specified in https://arrow.apache.org/docs/format/Layout.html#requirements-goals-and-non-goals

>It is required to have all the contiguous memory buffers in an IPC payload aligned at 8-byte boundaries. In other words, each buffer must start at an aligned 8-byte offset. Additionally, each buffer should be padded to a multiple of 8 bytes.

/cc @pgovind @stephentoub @imback82

@wesm - If possible, can we also include this patch in the next release (0.14.1 or 0.15.0)? We hit this issue trying to update .NET for Apache Spark to the latest Arrow release - https://github.com/dotnet/spark/pull/167.