### PR TITLE
ARROW-5911: [Java] Make ListVector and MapVector create reader lazily

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -109,11 +109,9 @@ public class MapVector extends ListVector {
    */
   @Override
   public UnionMapReader getReader() {
+    if (reader == null) {
+      reader = new UnionMapReader(this);
+    }
     return (UnionMapReader)reader;
-  }
-
-  @Override
-  protected void createReader() {
-    reader = new UnionMapReader(this);
   }
 }


### PR DESCRIPTION
Current implementation creates reader eagerly, which may cause unnecessary resource and time. This issue changes the behavior to lazily create the reader.

This is a follow-up issue for ARROW-5897.