### PR TITLE
PARQUET-1623: [C++] Fix invalid memory access encountered when reading some parquet files

### DIFF
--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -186,7 +186,7 @@ static inline void DefinitionLevelsToBitmap(
   // We assume here that valid_bits is large enough to accommodate the
   // additional definition levels and the ones that have already been written
   ::arrow::internal::BitmapWriter valid_bits_writer(valid_bits, valid_bits_offset,
-                                                    valid_bits_offset + num_def_levels);
+                                                    num_def_levels);
 
   // TODO(itaiin): As an interim solution we are splitting the code path here
   // between repeated+flat column reads, and non-repeated+nested reads.


### PR DESCRIPTION
There are a number of conditions that are needed to observe this invalid memory access when reading from a parquet file:

* Must have a number of records equal to a power of two
* The column must be serialized across multiple data pages