### PR TITLE
ARROW-5527: [C++] Uses Buffer/Builder in HashTable and MemoTable

### DIFF
--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -184,7 +184,7 @@ TYPED_TEST(TestDictionaryBuilder, DoubleTableSize) {
     ASSERT_OK(int_builder.Finish(&int_array));
 
     DictionaryArray expected(dtype, int_array, dict_array);
-    ASSERT_TRUE(expected.Equals(result));
+    AssertArraysEqual(expected, *result);
   }
 }
 

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -290,9 +290,7 @@ class BaseBinaryBuilder : public ArrayBuilder {
     return value_data_builder_.data() + offset;
   }
 
-  int32_t offset(int64_t i) const {
-    return offsets_data()[i];
-  }
+  int32_t offset(int64_t i) const { return offsets_data()[i]; }
 
   /// Temporary access to a value.
   ///

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -290,7 +290,7 @@ class BaseBinaryBuilder : public ArrayBuilder {
     return value_data_builder_.data() + offset;
   }
 
-  int32_t OffsetOf(int64_t i) const {
+  int32_t offset(int64_t i) const {
     return offsets_data()[i];
   }
 

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -290,7 +290,7 @@ class BaseBinaryBuilder : public ArrayBuilder {
     return value_data_builder_.data() + offset;
   }
 
-  int32_t offset(int64_t i) const { return offsets_data()[i]; }
+  offset_type offset(int64_t i) const { return offsets_data()[i]; }
 
   /// Temporary access to a value.
   ///

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -290,7 +290,7 @@ class BaseBinaryBuilder : public ArrayBuilder {
     return value_data_builder_.data() + offset;
   }
 
-  const int32_t OffsetOf(int64_t i) const {
+  int32_t OffsetOf(int64_t i) const {
     return offsets_data()[i];
   }
 

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -266,10 +266,15 @@ class BaseBinaryBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
+  /// \return data pointer of the value date builder
+  const uint8_t* value_data() const { return value_data_builder_.data(); }
   /// \return size of values buffer so far
   int64_t value_data_length() const { return value_data_builder_.length(); }
   /// \return capacity of values buffer
   int64_t value_data_capacity() const { return value_data_builder_.capacity(); }
+
+  /// \return data pointer of the value date builder
+  const int32_t* offsets_data() const { return offsets_builder_.data(); }
 
   /// Temporary access to a value.
   ///
@@ -283,6 +288,10 @@ class BaseBinaryBuilder : public ArrayBuilder {
       *out_length = offsets[i + 1] - offset;
     }
     return value_data_builder_.data() + offset;
+  }
+
+  const int32_t OffsetOf(int64_t i) const {
+    return offsets_data()[i];
   }
 
   /// Temporary access to a value.

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -274,7 +274,7 @@ class BaseBinaryBuilder : public ArrayBuilder {
   int64_t value_data_capacity() const { return value_data_builder_.capacity(); }
 
   /// \return data pointer of the value date builder
-  const int32_t* offsets_data() const { return offsets_builder_.data(); }
+  const offset_type* offsets_data() const { return offsets_builder_.data(); }
 
   /// Temporary access to a value.
   ///

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -71,7 +71,7 @@ struct UnifyDictionaryValues {
     using DictTraits = typename internal::DictionaryTraits<T>;
     using MemoTableType = typename DictTraits::MemoTableType;
 
-    MemoTableType memo_table;
+    MemoTableType memo_table(pool_);
     if (out_transpose_maps_ != nullptr) {
       out_transpose_maps_->clear();
       out_transpose_maps_->reserve(types_.size());
@@ -176,7 +176,8 @@ class internal::DictionaryMemoTable::DictionaryMemoTableImpl {
     template <typename T>
     enable_if_memoize<T, Status> Visit(const T&) {
       using MemoTable = typename internal::DictionaryTraits<T>::MemoTableType;
-      memo_table_->reset(new MemoTable(0));
+      // TODO(fsaintjacques): Propagate memory pool
+      memo_table_->reset(new MemoTable(default_memory_pool(), 0));
       return Status::OK();
     }
   };

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -176,9 +176,14 @@ class ARROW_EXPORT BufferBuilder {
   int64_t size_;
 };
 
+template <typename T, typename Enable = void>
+class TypedBufferBuilder;
+
 /// \brief A BufferBuilder for building a buffer of arithmetic elements
 template <typename T>
-class TypedBufferBuilder {
+class TypedBufferBuilder<
+    T, typename std::enable_if<std::is_arithmetic<T>::value ||
+                               std::is_standard_layout<T>::value>::type> {
  public:
   explicit TypedBufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : bytes_builder_(pool) {}

--- a/cpp/src/arrow/buffer-builder.h
+++ b/cpp/src/arrow/buffer-builder.h
@@ -176,12 +176,9 @@ class ARROW_EXPORT BufferBuilder {
   int64_t size_;
 };
 
-template <typename T, typename Enable = void>
-class TypedBufferBuilder;
-
 /// \brief A BufferBuilder for building a buffer of arithmetic elements
 template <typename T>
-class TypedBufferBuilder<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+class TypedBufferBuilder {
  public:
   explicit TypedBufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : bytes_builder_(pool) {}

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -406,10 +406,10 @@ BENCHMARK(BuildChunkedBinaryArray);
 BENCHMARK(BuildFixedSizeBinaryArray);
 BENCHMARK(BuildDecimalArray);
 
-BENCHMARK(BuildInt64DictionaryArrayRandom);
-BENCHMARK(BuildInt64DictionaryArraySequential);
-BENCHMARK(BuildInt64DictionaryArraySimilar);
-BENCHMARK(BuildStringDictionaryArray);
+BENCHMARK(BuildInt64DictionaryArrayRandom)->MinTime(1.0);
+BENCHMARK(BuildInt64DictionaryArraySequential)->MinTime(1.0);
+BENCHMARK(BuildInt64DictionaryArraySimilar)->MinTime(1.0);
+BENCHMARK(BuildStringDictionaryArray)->MinTime(1.0);
 
 BENCHMARK(ArrayDataConstructDestruct);
 

--- a/cpp/src/arrow/builder-benchmark.cc
+++ b/cpp/src/arrow/builder-benchmark.cc
@@ -406,10 +406,10 @@ BENCHMARK(BuildChunkedBinaryArray);
 BENCHMARK(BuildFixedSizeBinaryArray);
 BENCHMARK(BuildDecimalArray);
 
-BENCHMARK(BuildInt64DictionaryArrayRandom)->MinTime(1.0);
-BENCHMARK(BuildInt64DictionaryArraySequential)->MinTime(1.0);
-BENCHMARK(BuildInt64DictionaryArraySimilar)->MinTime(1.0);
-BENCHMARK(BuildStringDictionaryArray)->MinTime(1.0);
+BENCHMARK(BuildInt64DictionaryArrayRandom);
+BENCHMARK(BuildInt64DictionaryArraySequential);
+BENCHMARK(BuildInt64DictionaryArraySimilar);
+BENCHMARK(BuildStringDictionaryArray);
 
 BENCHMARK(ArrayDataConstructDestruct);
 

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -279,7 +279,7 @@ class RegularHashKernelImpl : public HashKernelImpl {
       : pool_(pool), type_(type), action_(type, pool) {}
 
   Status Reset() override {
-    memo_table_.reset(new MemoTable(0));
+    memo_table_.reset(new MemoTable(pool_, 0));
     return action_.Reset();
   }
 

--- a/cpp/src/arrow/compute/kernels/isin.cc
+++ b/cpp/src/arrow/compute/kernels/isin.cc
@@ -81,8 +81,8 @@ struct MemoTableRight {
     return Status::OK();
   }
 
-  Status Reset() {
-    memo_table_.reset(new MemoTable(0));
+  Status Reset(MemoryPool *pool) {
+    memo_table_.reset(new MemoTable(pool, 0));
     return Status::OK();
   }
 
@@ -147,7 +147,7 @@ class IsInKernel : public IsInKernelImpl {
 
   Status ConstructRight(FunctionContext* ctx, const Datum& right) override {
     MemoTableRight<Type, Scalar> func;
-    RETURN_NOT_OK(func.Reset());
+    RETURN_NOT_OK(func.Reset(pool_));
 
     if (right.kind() == Datum::ARRAY) {
       RETURN_NOT_OK(func.Append(ctx, right));

--- a/cpp/src/arrow/compute/kernels/isin.cc
+++ b/cpp/src/arrow/compute/kernels/isin.cc
@@ -81,7 +81,7 @@ struct MemoTableRight {
     return Status::OK();
   }
 
-  Status Reset(MemoryPool *pool) {
+  Status Reset(MemoryPool* pool) {
     memo_table_.reset(new MemoTable(pool, 0));
     return Status::OK();
   }

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -405,7 +405,8 @@ inline Status ConvertAsPyObjects(const PandasOptions& options, const ChunkedArra
   using Scalar = typename MemoizationTraits<Type>::Scalar;
 
   PyAcquireGIL lock;
-  ::arrow::internal::ScalarMemoTable<Scalar> memo_table;
+  // TODO(fsaintjacques): propagate memory pool.
+  ::arrow::internal::ScalarMemoTable<Scalar> memo_table(default_memory_pool());
   std::vector<PyObject*> unique_values;
   int32_t memo_size = 0;
 

--- a/cpp/src/arrow/util/hashing-test.cc
+++ b/cpp/src/arrow/util/hashing-test.cc
@@ -150,7 +150,7 @@ TEST(ScalarMemoTable, Int64) {
   const int64_t A = 1234, B = 0, C = -98765321, D = 12345678901234LL, E = -1, F = 1,
                 G = 9223372036854775807LL, H = -9223372036854775807LL - 1;
 
-  ScalarMemoTable<int64_t> table(0);
+  ScalarMemoTable<int64_t> table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   ASSERT_EQ(table.Get(A), kKeyNotFound);
   ASSERT_EQ(table.GetNull(), kKeyNotFound);
@@ -198,7 +198,7 @@ TEST(ScalarMemoTable, Int64) {
 TEST(ScalarMemoTable, UInt16) {
   const uint16_t A = 1236, B = 0, C = 65535, D = 32767, E = 1;
 
-  ScalarMemoTable<uint16_t> table(0);
+  ScalarMemoTable<uint16_t> table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   ASSERT_EQ(table.Get(A), kKeyNotFound);
   ASSERT_EQ(table.GetNull(), kKeyNotFound);
@@ -237,7 +237,7 @@ TEST(ScalarMemoTable, UInt16) {
 TEST(SmallScalarMemoTable, Int8) {
   const int8_t A = 1, B = 0, C = -1, D = -128, E = 127;
 
-  SmallScalarMemoTable<int8_t> table(0);
+  SmallScalarMemoTable<int8_t> table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   ASSERT_EQ(table.Get(A), kKeyNotFound);
   ASSERT_EQ(table.GetNull(), kKeyNotFound);
@@ -266,7 +266,7 @@ TEST(SmallScalarMemoTable, Int8) {
 }
 
 TEST(SmallScalarMemoTable, Bool) {
-  SmallScalarMemoTable<bool> table(0);
+  SmallScalarMemoTable<bool> table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   ASSERT_EQ(table.Get(true), kKeyNotFound);
   ASSERT_EQ(table.GetOrInsert(true), 0);
@@ -290,7 +290,7 @@ TEST(ScalarMemoTable, Float64) {
   const double A = 0.0, B = 1.5, C = -0.0, D = std::numeric_limits<double>::infinity(),
                E = -D, F = std::nan("");
 
-  ScalarMemoTable<double> table(0);
+  ScalarMemoTable<double> table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   ASSERT_EQ(table.Get(A), kKeyNotFound);
   ASSERT_EQ(table.GetOrInsert(A), 0);
@@ -335,7 +335,7 @@ TEST(ScalarMemoTable, StressInt64) {
   const int32_t n_repeats = 10000;
 #endif
 
-  ScalarMemoTable<int64_t> table(0);
+  ScalarMemoTable<int64_t> table(default_memory_pool(), 0);
   std::unordered_map<int64_t, int32_t> map;
 
   for (int32_t i = 0; i < n_repeats; ++i) {
@@ -359,7 +359,7 @@ TEST(BinaryMemoTable, Basics) {
   F += '\0';
   F += "trailing";
 
-  BinaryMemoTable table(0);
+  BinaryMemoTable table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   ASSERT_EQ(table.Get(A), kKeyNotFound);
   ASSERT_EQ(table.GetNull(), kKeyNotFound);
@@ -433,7 +433,7 @@ TEST(BinaryMemoTable, Stress) {
 
   const auto values = MakeDistinctStrings(n_values);
 
-  BinaryMemoTable table(0);
+  BinaryMemoTable table(default_memory_pool(), 0);
   std::unordered_map<std::string, int32_t> map;
 
   for (int32_t i = 0; i < n_repeats; ++i) {

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -685,8 +685,7 @@ class BinaryMemoTable : public MemoTable {
       *out_data++ = cast_offset;
     }
 
-    // Copy last value since BinaryBuilder only materialize it on the Finalize
-    // call.
+    // Copy last value since BinaryBuilder only materializes it on in Finish()
     *out_data = binary_builder_.value_data_length() - delta;
   }
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -201,7 +201,7 @@ class HashTable {
     operator bool() const { return h != kSentinel; }
   };
 
-  explicit HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
+  HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
     DCHECK_NE(pool, nullptr);
     // Presize for at least 512 elements
     capacity = std::max(capacity, static_cast<uint64_t>(512U));

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -328,9 +328,9 @@ class HashTable {
     for (uint64_t i = 0; i < capacity_; i++) {
       const auto& entry = old_entries[i];
       if (entry) {
-        // Dummy compare function (will not be called)
-        auto cmp_func = [](const Payload*) { return false; };
-        auto p = Lookup<NoCompare>(entry.h, entries_, new_mask, cmp_func);
+        // Dummy compare function will not be called
+        auto p = Lookup<NoCompare>(entry.h, entries_, new_mask,
+                                   [](const Payload*) { return false; });
         // Lookup<NoCompare> (and CompareEntry<NoCompare>) ensure that an
         // empty slots is always returned
         assert(!p.second);

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -202,8 +202,8 @@ class HashTable {
   };
 
   explicit HashTable(uint64_t capacity) {
-    // Presize for at least 8 elements
-    capacity = std::max(capacity, static_cast<uint64_t>(8U));
+    // Presize for at least 512 elements
+    capacity = std::max(capacity, static_cast<uint64_t>(512U));
     size_ = BitUtil::NextPower2(capacity * 4U);
     size_mask_ = size_ - 1;
     n_filled_ = 0;

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -204,7 +204,7 @@ class HashTable {
 
   HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
     DCHECK_NE(pool, nullptr);
-    capacity = std::max(capacity, 512UL) * kLoadFactor;
+    capacity = std::max(capacity, uint64_t(512UL)) * kLoadFactor;
     capacity_ = BitUtil::NextPower2(capacity);
     capacity_mask_ = capacity_ - 1;
     size_ = 0;
@@ -669,7 +669,7 @@ class BinaryMemoTable : public MemoTable {
     return static_cast<int32_t>(hash_table_.size() + (GetNull() != kKeyNotFound));
   }
 
-  int32_t values_size() const { return binary_builder_.value_data_length(); }
+  int64_t values_size() const { return binary_builder_.value_data_length(); }
 
   // Copy (n + 1) offsets starting from index `start` into `out_data`
   template <class Offset>

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -204,7 +204,8 @@ class HashTable {
 
   HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
     DCHECK_NE(pool, nullptr);
-    capacity = std::max(capacity, uint64_t(512UL)) * kLoadFactor;
+    // Minimum of 8 elements
+    capacity = std::max<uint64_t>(capacity, 8UL);
     capacity_ = BitUtil::NextPower2(capacity);
     capacity_mask_ = capacity_ - 1;
     size_ = 0;
@@ -237,7 +238,8 @@ class HashTable {
     ++size_;
 
     if (NeedUpsizing()) {
-      DCHECK_OK(Upsize(capacity_ * kLoadFactor));
+      // Resize less frequently since it is expensive
+      DCHECK_OK(Upsize(capacity_ * kLoadFactor * 2));
     }
   }
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -705,7 +705,7 @@ class BinaryMemoTable : public MemoTable {
     DCHECK_LT(start, size());
 
     // The absolute byte offset of `start` value in the binary buffer.
-    int32_t offset = binary_builder_.OffsetOf(start);
+    int32_t offset = binary_builder_.offset(start);
     auto length = binary_builder_.value_data_length() - static_cast<size_t>(offset);
 
     if (out_size != -1) {
@@ -742,7 +742,7 @@ class BinaryMemoTable : public MemoTable {
       return;
     }
 
-    int32_t left_offset = binary_builder_.OffsetOf(start);
+    int32_t left_offset = binary_builder_.offset(start);
 
     // Ensure that the data length is exactly missing width_size bytes to fit
     // in the expected output (n_values * width_size).
@@ -755,7 +755,7 @@ class BinaryMemoTable : public MemoTable {
     auto in_data = binary_builder_.value_data() + left_offset;
     // The null use 0-length in the data, slice the data in 2 and skip by
     // width_size in out_data. [part_1][width_size][part_2]
-    auto null_data_offset = binary_builder_.OffsetOf(null_index);
+    auto null_data_offset = binary_builder_.offset(null_index);
     auto left_size = null_data_offset - left_offset;
     if (left_size > 0) {
       memcpy(out_data, in_data + left_offset, left_size);

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -204,8 +204,8 @@ class HashTable {
 
   HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
     DCHECK_NE(pool, nullptr);
-    // Minimum of 8 elements
-    capacity = std::max<uint64_t>(capacity, 8UL);
+    // Minimum of 32 elements
+    capacity = std::max<uint64_t>(capacity, 32UL);
     capacity_ = BitUtil::NextPower2(capacity);
     capacity_mask_ = capacity_ - 1;
     size_ = 0;
@@ -237,7 +237,7 @@ class HashTable {
     entry->payload = payload;
     ++size_;
 
-    if (NeedUpsizing()) {
+    if (ARROW_PREDICT_FALSE(NeedUpsizing())) {
       // Resize less frequently since it is expensive
       DCHECK_OK(Upsize(capacity_ * kLoadFactor * 2));
     }

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -688,7 +688,7 @@ class BinaryMemoTable : public MemoTable {
     }
 
     // Copy last value since BinaryBuilder only materializes it on in Finish()
-    *out_data = binary_builder_.value_data_length() - delta;
+    *out_data = static_cast<Offset>(binary_builder_.value_data_length() - delta);
   }
 
   template <class Offset>

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -674,6 +674,8 @@ class BinaryMemoTable : public MemoTable {
   // Copy (n + 1) offsets starting from index `start` into `out_data`
   template <class Offset>
   void CopyOffsets(int32_t start, Offset* out_data) const {
+    DCHECK_LT(start, size());
+
     const int32_t* offsets = binary_builder_.offsets_data();
     int32_t delta = offsets[start];
     for (int32_t i = start; i < size(); ++i) {
@@ -700,9 +702,7 @@ class BinaryMemoTable : public MemoTable {
 
   // Same as above, but check output size in debug mode
   void CopyValues(int32_t start, int64_t out_size, uint8_t* out_data) const {
-    if (start >= size()) {
-      return;
-    }
+    DCHECK_LT(start, size());
 
     // The absolute byte offset of `start` value in the binary buffer.
     int32_t offset = binary_builder_.OffsetOf(start);
@@ -937,7 +937,6 @@ struct DictionaryTraits<T, enable_if_binary<T>> {
     memo_table.CopyOffsets(static_cast<int32_t>(start_offset), raw_offsets);
 
     // Create the data buffer
-    DCHECK_EQ(raw_offsets[0], 0);
     RETURN_NOT_OK(AllocateBuffer(pool, raw_offsets[dict_length], &dict_data));
     memo_table.CopyValues(static_cast<int32_t>(start_offset), dict_data->size(),
                           dict_data->mutable_data());

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -420,12 +420,12 @@ void DictEncoderImpl<DType>::WriteDict(uint8_t* buffer) {
 // ByteArray and FLBA already have the dictionary encoded in their data heaps
 template <>
 void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) {
-  memo_table_.VisitValues(0, [&](const ::arrow::util::string_view& v) {
+  memo_table_.VisitValues(0, [&buffer](const ::arrow::util::string_view& v) {
     uint32_t len = static_cast<uint32_t>(v.length());
-    memcpy(buffer, &len, sizeof(uint32_t));
-    buffer += sizeof(uint32_t);
-    memcpy(buffer, v.data(), v.length());
-    buffer += v.length();
+    memcpy(buffer, &len, sizeof(len));
+    buffer += sizeof(len);
+    memcpy(buffer, v.data(), len);
+    buffer += len;
   });
 }
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -358,7 +358,7 @@ DictEncoderImpl<DType>::DictEncoderImpl(const ColumnDescriptor* desc,
                                         ::arrow::MemoryPool* pool)
     : EncoderImpl(desc, Encoding::PLAIN_DICTIONARY, pool),
       dict_encoded_size_(0),
-      memo_table_(INITIAL_HASH_TABLE_SIZE) {}
+      memo_table_(pool, INITIAL_HASH_TABLE_SIZE) {}
 
 template <typename DType>
 int64_t DictEncoderImpl<DType>::EstimatedDataEncodedSize() {


### PR DESCRIPTION
In order to prepare for the GroupBy operator, we need to cap memory usage of hash tables. This is done by passing a custom allocator to all HashTable/MemoTable and forces them to use Buffers for heap storage instead of std::vector and std::string (in the case of BinaryMemoTable).

There's a noted 5-10% performance penalty in the string benchmarks (negligible change for integers). The BuildStringDictionary benchmark pays a 30% penalty, due to Upsize and the memset. This overhead is mostly in memset, which can be controlled by a better default table size. One can validate by changing the default MemoTable values in the Hash kernel.

This patch hides the failure via DCHECK_OK internaly, the next step will be to bubble up the failing status to kernels, but this will require more careful tuning.

There's still improvement to be done, e.g. the CopyValues/CopyOffsets/GetDictionary can now be mostly zero-copy, as long as the MemoTable is also finalized/moved. I didn't change this contract because I think some consumers uses this class in an iterative fashion (the pandas stuff?). The final end goal is to take ownership of indices and values in a zero copy fashion for the future group-by on multiple keys.