### PR TITLE
ARROW-5788: [Rust] Use both "path" and "version" for internal dependencies

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -188,10 +188,10 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
-                       ["-arrow = { path = \"../arrow\" }",
-                        "-parquet = { path = \"../parquet\" }",
-                        "+arrow = \"#{@release_version}\"",
-                        "+parquet = \"#{@release_version}\""]
+                       ["-arrow = { path = \"../arrow\", version = \"#{@snapshot_version}\" }",
+                        "-parquet = { path = \"../parquet\", version = \"#{@snapshot_version}\" }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@release_version}\" }",
+                        "+parquet = { path = \"../parquet\", version = \"#{@release_version}\" }"]
                      ],
                    },
                    {
@@ -206,8 +206,8 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
-                       ["-arrow = { path = \"../arrow\" }",
-                        "+arrow = \"#{@release_version}\""]
+                       ["-arrow = { path = \"../arrow\", version = \"#{@snapshot_version}\" }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@release_version}\" }"]
                      ],
                    },
                    {
@@ -231,14 +231,14 @@ class PrepareTest < Test::Unit::TestCase
                      path: "c_glib/configure.ac",
                      hunks: [
                        ["-m4_define([arrow_glib_version], #{@release_version})",
-                        "+m4_define([arrow_glib_version], #{@next_version}-SNAPSHOT)"],
+                        "+m4_define([arrow_glib_version], #{@next_snapshot_version})"],
                      ],
                    },
                    {
                      path: "c_glib/meson.build",
                      hunks: [
                        ["-version = '#{@release_version}'",
-                        "+version = '#{@next_version}-SNAPSHOT'"],
+                        "+version = '#{@next_snapshot_version}'"],
                      ],
                    },
                    {
@@ -252,35 +252,35 @@ class PrepareTest < Test::Unit::TestCase
                      path: "cpp/CMakeLists.txt",
                      hunks: [
                        ["-set(ARROW_VERSION \"#{@release_version}\")",
-                        "+set(ARROW_VERSION \"#{@next_version}-SNAPSHOT\")"],
+                        "+set(ARROW_VERSION \"#{@next_snapshot_version}\")"],
                      ],
                    },
                    {
                      path: "csharp/Directory.Build.props",
                      hunks: [
                        ["-    <Version>#{@release_version}</Version>",
-                        "+    <Version>#{@next_version}-SNAPSHOT</Version>"],
+                        "+    <Version>#{@next_snapshot_version}</Version>"],
                      ],
                    },
                    {
                      path: "js/package.json",
                      hunks: [
                        ["-  \"version\": \"#{@release_version}\"",
-                        "+  \"version\": \"#{@next_version}-SNAPSHOT\""],
+                        "+  \"version\": \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "matlab/CMakeLists.txt",
                      hunks: [
                        ["-set(MLARROW_VERSION \"#{@release_version}\")",
-                        "+set(MLARROW_VERSION \"#{@next_version}-SNAPSHOT\")"],
+                        "+set(MLARROW_VERSION \"#{@next_snapshot_version}\")"],
                      ],
                    },
                    {
                      path: "python/setup.py",
                      hunks: [
                        ["-default_version = '#{@release_version}'",
-                        "+default_version = '#{@next_version}-SNAPSHOT'"],
+                        "+default_version = '#{@next_snapshot_version}'"],
                      ],
                    },
                    {
@@ -302,78 +302,78 @@ class PrepareTest < Test::Unit::TestCase
                      path: "ruby/red-arrow-cuda/lib/arrow-cuda/version.rb",
                      hunks: [
                        ["-  VERSION = \"#{@release_version}\"",
-                        "+  VERSION = \"#{@next_version}-SNAPSHOT\""],
+                        "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-arrow/lib/arrow/version.rb",
                      hunks: [
                        ["-  VERSION = \"#{@release_version}\"",
-                        "+  VERSION = \"#{@next_version}-SNAPSHOT\""],
+                        "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-gandiva/lib/gandiva/version.rb",
                      hunks: [
                        ["-  VERSION = \"#{@release_version}\"",
-                        "+  VERSION = \"#{@next_version}-SNAPSHOT\""],
+                        "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-parquet/lib/parquet/version.rb",
                      hunks: [
                        ["-  VERSION = \"#{@release_version}\"",
-                        "+  VERSION = \"#{@next_version}-SNAPSHOT\""],
+                        "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "ruby/red-plasma/lib/plasma/version.rb",
                      hunks: [
                        ["-  VERSION = \"#{@release_version}\"",
-                        "+  VERSION = \"#{@next_version}-SNAPSHOT\""],
+                        "+  VERSION = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "rust/arrow/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@release_version}\"",
-                        "+version = \"#{@next_version}-SNAPSHOT\""],
+                        "+version = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "rust/datafusion/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@release_version}\"",
-                        "+version = \"#{@next_version}-SNAPSHOT\""],
-                       ["-arrow = \"#{@release_version}\"",
-                        "-parquet = \"#{@release_version}\"",
-                        "+arrow = { path = \"../arrow\" }",
-                        "+parquet = { path = \"../parquet\" }"]
+                        "+version = \"#{@next_snapshot_version}\""],
+                       ["-arrow = { path = \"../arrow\", version = \"#{@release_version}\" }",
+                        "-parquet = { path = \"../parquet\", version = \"#{@release_version}\" }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@next_snapshot_version}\" }",
+                        "+parquet = { path = \"../parquet\", version = \"#{@next_snapshot_version}\" }"]
                      ],
                    },
                    {
                      path: "rust/datafusion/README.md",
                      hunks: [
                        ["-datafusion = \"#{@release_version}\"",
-                        "+datafusion = \"#{@next_version}-SNAPSHOT\""],
+                        "+datafusion = \"#{@next_snapshot_version}\""],
                      ],
                    },
                    {
                      path: "rust/parquet/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@release_version}\"",
-                        "+version = \"#{@next_version}-SNAPSHOT\""],
-                       ["-arrow = \"#{@release_version}\"",
-                        "+arrow = { path = \"../arrow\" }"]
+                        "+version = \"#{@next_snapshot_version}\""],
+                       ["-arrow = { path = \"../arrow\", version = \"#{@release_version}\" }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@next_snapshot_version}\" }"]
                      ],
                    },
                    {
                      path: "rust/parquet/README.md",
                      hunks: [
                        ["-parquet = \"#{@release_version}\"",
-                        "+parquet = \"#{@next_version}-SNAPSHOT\""],
+                        "+parquet = \"#{@next_snapshot_version}\""],
                        ["-See [crate documentation](https://docs.rs/crate/parquet/#{@release_version}) on available API.",
-                        "+See [crate documentation](https://docs.rs/crate/parquet/#{@next_version}-SNAPSHOT) on available API."],
+                        "+See [crate documentation](https://docs.rs/crate/parquet/#{@next_snapshot_version}) on available API."],
                      ],
                    },
                  ],

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -136,20 +136,11 @@ update_versions() {
   cd -
 
   cd "${SOURCE_DIR}/../../rust"
-  sed -i.bak -E -e \
-    "s/^version = \".+\"/version = \"${version}\"/g" \
+  sed -i.bak -E \
+    -e "s/^version = \".+\"/version = \"${version}\"/g" \
+    -e "s/^(arrow = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
+    -e "s/^(parquet = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
     */Cargo.toml
-  if [ ${type} = "snapshot" ]; then
-    sed -i.bak -E \
-      -e "s/^arrow = \".+\"/arrow = { path = \"..\/arrow\" }/g" \
-      -e "s/^parquet = \".+\"/parquet = { path = \"..\/parquet\" }/g" \
-      */Cargo.toml
-  else
-    sed -i.bak -E \
-      -e "s/^arrow = \{ path = \".+\" \}/arrow = \"${version}\"/g" \
-      -e "s/^parquet = \{ path = \".+\" \}/parquet = \"${version}\"/g" \
-      */Cargo.toml
-  fi
   rm -f */Cargo.toml.bak
   git add */Cargo.toml
 

--- a/dev/release/test-helper.rb
+++ b/dev/release/test-helper.rb
@@ -73,6 +73,7 @@ module VersionDetectable
     @snapshot_version = cpp_cmake_lists.read[/ARROW_VERSION "(.+?)"/, 1]
     @release_version = @snapshot_version.gsub(/-SNAPSHOT\z/, "")
     @next_version = @release_version.gsub(/\A\d+/) {|major| major.succ}
+    @next_snapshot_version = "#{@next_version}-SNAPSHOT"
     r_description = top_dir + "r" + "DESCRIPTION"
     @previous_version = r_description.read[/^Version: (.+?)\.9000$/, 1]
   end

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -44,8 +44,8 @@ cli = ["rustyline"]
 
 [dependencies]
 fnv = "1.0.3"
-arrow = { path = "../arrow" }
-parquet = { path = "../parquet" }
+arrow = { path = "../arrow", version = "1.0.0-SNAPSHOT" }
+parquet = { path = "../parquet", version = "1.0.0-SNAPSHOT" }
 serde = { version = "1.0.80", features = ["rc"] }
 serde_derive = "1.0.80"
 serde_json = "1.0.33"

--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -40,7 +40,7 @@ lz4 = "1.23"
 zstd = "0.4"
 chrono = "0.4"
 num-bigint = "0.2"
-arrow = { path = "../arrow" }
+arrow = { path = "../arrow", version = "1.0.0-SNAPSHOT" }
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
We need "path" to release a new version by "cargo publish".
We need "version" to use released packages.