### PR TITLE
ARROW-5924: [Plasma] return a replica of GpuProcessHandle::ptr when create or get an object

### DIFF
--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -87,6 +87,9 @@ constexpr int64_t kBytesInMB = 1 << 20;
 // GPU support
 
 #ifdef PLASMA_CUDA
+
+namespace {
+
 struct GpuProcessHandle {
   /// Pointer to CUDA buffer that is backing this GPU object.
   std::shared_ptr<CudaBuffer> ptr;
@@ -97,8 +100,19 @@ struct GpuProcessHandle {
 // This is necessary as IPC handles can only be mapped once per process.
 // Thus if multiple clients in the same process get the same gpu object,
 // they need to access the same mapped CudaBuffer.
-static std::unordered_map<ObjectID, GpuProcessHandle*> gpu_object_map;
-static std::mutex gpu_mutex;
+std::unordered_map<ObjectID, GpuProcessHandle*> gpu_object_map;
+std::mutex gpu_mutex;
+
+// Return a new CudaBuffer pointing to the same data as the GpuProcessHandle,
+// but able to persist after the original IPC-backed buffer is closed
+// (ARROW-5924).
+std::shared_ptr<Buffer> MakeBufferFromGpuProcessHandle(GpuProcessHandle* handle) {
+  return std::make_shared<CudaBuffer>(handle->ptr->mutable_data(), handle->ptr->size(),
+                                      handle->ptr->context());
+}
+
+}  // namespace
+
 #endif
 
 // ----------------------------------------------------------------------
@@ -440,8 +454,7 @@ Status PlasmaClient::Impl::Create(const ObjectID& object_id, int64_t data_size,
       CudaBufferWriter writer(handle->ptr);
       RETURN_NOT_OK(writer.WriteAt(object.data_size, metadata, metadata_size));
     }
-    *data = std::make_shared<CudaBuffer>(handle->ptr->mutable_data(), handle->ptr->size(),
-                                         handle->ptr->context());
+    *data = MakeBufferFromGpuProcessHandle(handle);
 #else
     ARROW_LOG(FATAL) << "Arrow GPU library is not enabled.";
 #endif
@@ -519,9 +532,7 @@ Status PlasmaClient::Impl::GetBuffers(
         auto iter = gpu_object_map.find(object_ids[i]);
         ARROW_CHECK(iter != gpu_object_map.end());
         iter->second->client_count++;
-        physical_buf = std::make_shared<CudaBuffer>(iter->second->ptr->mutable_data(),
-                                                    iter->second->ptr->size(),
-                                                    iter->second->ptr->context());
+        physical_buf = MakeBufferFromGpuProcessHandle(iter->second);
 #else
         ARROW_LOG(FATAL) << "Arrow GPU library is not enabled.";
 #endif
@@ -584,22 +595,18 @@ Status PlasmaClient::Impl::GetBuffers(
       } else {
 #ifdef PLASMA_CUDA
         std::lock_guard<std::mutex> lock(gpu_mutex);
-        auto handle = gpu_object_map.find(object_ids[i]);
-        if (handle == gpu_object_map.end()) {
+        auto iter = gpu_object_map.find(object_ids[i]);
+        if (iter == gpu_object_map.end()) {
           std::shared_ptr<CudaContext> context;
           RETURN_NOT_OK(manager_->GetContext(object->device_num - 1, &context));
           GpuProcessHandle* obj_handle = new GpuProcessHandle();
           obj_handle->client_count = 1;
           RETURN_NOT_OK(context->OpenIpcBuffer(*object->ipc_handle, &obj_handle->ptr));
           gpu_object_map[object_ids[i]] = obj_handle;
-          physical_buf = std::make_shared<CudaBuffer>(obj_handle->ptr->mutable_data(),
-                                                      obj_handle->ptr->size(),
-                                                      obj_handle->ptr->context());
+          physical_buf = MakeBufferFromGpuProcessHandle(obj_handle);
         } else {
-          handle->second->client_count++;
-          physical_buf = std::make_shared<CudaBuffer>(handle->second->ptr->mutable_data(),
-                                                      handle->second->ptr->size(),
-                                                      handle->second->ptr->context());
+          iter->second->client_count++;
+          physical_buf = MakeBufferFromGpuProcessHandle(iter->second);
         }
 #else
         ARROW_LOG(FATAL) << "Arrow GPU library is not enabled.";

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -899,7 +899,8 @@ TEST_F(TestPlasmaStore, RepeatlyCreateGPUTest) {
   ARROW_CHECK_OK(client_.Delete(object_ids));
 }
 
-TEST_F(TestPlasmaStore, LetBufferAutoRelease) {
+TEST_F(TestPlasmaStore, GPUBufferLifetime) {
+  // ARROW-5924: GPU buffer is allowed to persist after Release()
   ObjectID object_id = random_object_id();
   const int64_t data_size = 40;
 

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -839,7 +839,6 @@ TEST_F(TestPlasmaStore, DeleteObjectsGPUTest) {
       client_.Create(object_id2, data_size, metadata, metadata_size, &data, 1));
   ARROW_CHECK_OK(client_.Seal(object_id2));
   // Release the ref count of Create function.
-  data = nullptr;
   ARROW_CHECK_OK(client_.Release(object_id1));
   ARROW_CHECK_OK(client_.Release(object_id2));
   // Increase the ref count by calling Get using client2_.
@@ -893,13 +892,34 @@ TEST_F(TestPlasmaStore, RepeatlyCreateGPUTest) {
     std::shared_ptr<Buffer> data;
     ARROW_CHECK_OK(client_.Create(object_id, data_size, 0, 0, &data, 1));
     ARROW_CHECK_OK(client_.Seal(object_id));
-
-    data = nullptr;
     ARROW_CHECK_OK(client_.Release(object_id));
   }
 
   // delete all
   ARROW_CHECK_OK(client_.Delete(object_ids));
+}
+
+TEST_F(TestPlasmaStore, LetBufferAutoRelease) {
+  ObjectID object_id = random_object_id();
+  const int64_t data_size = 40;
+
+  std::shared_ptr<Buffer> create_buff;
+  ARROW_CHECK_OK(client_.Create(object_id, data_size, nullptr, 0, &create_buff, 1));
+  ARROW_CHECK_OK(client_.Seal(object_id));
+  ARROW_CHECK_OK(client_.Release(object_id));
+
+  ObjectBuffer get_buff_1;
+  ARROW_CHECK_OK(client_.Get(&object_id, 1, -1, &get_buff_1));
+  ObjectBuffer get_buff_2;
+  ARROW_CHECK_OK(client_.Get(&object_id, 1, -1, &get_buff_2));
+  ARROW_CHECK_OK(client_.Release(object_id));
+  ARROW_CHECK_OK(client_.Release(object_id));
+
+  ObjectBuffer get_buff_3;
+  ARROW_CHECK_OK(client_.Get(&object_id, 1, -1, &get_buff_3));
+  ARROW_CHECK_OK(client_.Release(object_id));
+
+  ARROW_CHECK_OK(client_.Delete(object_id));
 }
 
 TEST_F(TestPlasmaStore, MultipleClientGPUTest) {


### PR DESCRIPTION
CloseIpc is in the CudaBuffer's destructor.
If a user doesn't release the buff promptly before he release the object, the CloseIpc will be blocked.