### PR TITLE
ARROW-5955: [Plasma] Support setting memory quotas per plasma client for better isolation

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -78,6 +78,7 @@ set(PLASMA_STORE_SRCS
     dlmalloc.cc
     events.cc
     eviction_policy.cc
+    quota_aware_policy.cc
     plasma_allocator.cc
     store.cc
     thirdparty/ae/ae.c)

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -65,6 +65,13 @@ class ARROW_EXPORT PlasmaClient {
                  const std::string& manager_socket_name = "", int release_delay = 0,
                  int num_retries = -1);
 
+  /// Set runtime options for this client.
+  ///
+  /// \param client_name The name of the client, used in debug messages.
+  /// \param output_memory_quota The memory quota in bytes for objects created by
+  ///        this client.
+  Status SetClientOptions(const std::string& client_name, int64_t output_memory_quota);
+
   /// Create an object in the Plasma Store. Any metadata for this object must be
   /// be passed in when the object is created.
   ///
@@ -249,6 +256,11 @@ class ARROW_EXPORT PlasmaClient {
   ///
   /// \return The return status.
   Status Disconnect();
+
+  /// Get the current debug string from the plasma store server.
+  ///
+  /// \return The debug string.
+  std::string DebugString();
 
   /// Get the memory capacity of the store.
   ///

--- a/cpp/src/plasma/format/plasma.fbs
+++ b/cpp/src/plasma/format/plasma.fbs
@@ -67,7 +67,13 @@ enum MessageType:long {
   // reply messages get sent. Each one contains a fixed number of bytes.
   PlasmaDataReply,
   // Object notifications.
-  PlasmaNotification
+  PlasmaNotification,
+  // Set memory quota for a client.
+  PlasmaSetOptionsRequest,
+  PlasmaSetOptionsReply,
+  // Get debugging information from the store.
+  PlasmaGetDebugStringRequest,
+  PlasmaGetDebugStringReply,
 }
 
 enum PlasmaError:int {
@@ -82,7 +88,7 @@ enum PlasmaError:int {
   // Trying to delete an object but it's not sealed.
   ObjectNotSealed,
   // Trying to delete an object but it's in use.
-  ObjectInUse
+  ObjectInUse,
 }
 
 // Plasma store messages
@@ -101,6 +107,26 @@ struct PlasmaObjectSpec {
   metadata_size: ulong;
   // Device to create buffer on.
   device_num: int;
+}
+
+table PlasmaSetOptionsRequest {
+  // The name of the client.
+  client_name: string;
+  // The size of the output memory limit in bytes.
+  output_memory_quota: long;
+}
+
+table PlasmaSetOptionsReply {
+  // Whether setting options succeeded.
+  error: PlasmaError;
+}
+
+table PlasmaGetDebugStringRequest {
+}
+
+table PlasmaGetDebugStringReply {
+  // The debug string from the server.
+  debug_string: string;
 }
 
 table PlasmaCreateRequest {

--- a/cpp/src/plasma/plasma.h
+++ b/cpp/src/plasma/plasma.h
@@ -69,7 +69,25 @@ struct ObjectInfoT;
 /// Allocation granularity used in plasma for object allocation.
 constexpr int64_t kBlockSize = 64;
 
-struct Client;
+/// Contains all information that is associated with a Plasma store client.
+struct Client {
+  explicit Client(int fd);
+
+  /// The file descriptor used to communicate with the client.
+  int fd;
+
+  /// Object ids that are used by this client.
+  std::unordered_set<ObjectID> object_ids;
+
+  /// File descriptors that are used by this client.
+  std::unordered_set<int> used_fds;
+
+  /// The file descriptor used to push notifications to client. This is only valid
+  /// if client subscribes to plasma store. -1 indicates invalid.
+  int notification_fd;
+
+  std::string name = "anonymous_client";
+};
 
 // TODO(pcm): Replace this by the flatbuffers message PlasmaObjectSpec.
 struct PlasmaObject {

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -100,6 +100,61 @@ Status PlasmaErrorStatus(fb::PlasmaError plasma_error) {
   return Status::OK();
 }
 
+// Set options messages.
+
+Status SendSetOptionsRequest(int sock, const std::string& client_name,
+                             int64_t output_memory_limit) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = fb::CreatePlasmaSetOptionsRequest(fbb, fbb.CreateString(client_name),
+                                                   output_memory_limit);
+  return PlasmaSend(sock, MessageType::PlasmaSetOptionsRequest, &fbb, message);
+}
+
+Status ReadSetOptionsRequest(uint8_t* data, size_t size, std::string* client_name,
+                             int64_t* output_memory_quota) {
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<fb::PlasmaSetOptionsRequest>(data);
+  DCHECK(VerifyFlatbuffer(message, data, size));
+  *client_name = std::string(message->client_name()->str());
+  *output_memory_quota = message->output_memory_quota();
+  return Status::OK();
+}
+
+Status SendSetOptionsReply(int sock, PlasmaError error) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = fb::CreatePlasmaSetOptionsReply(fbb, error);
+  return PlasmaSend(sock, MessageType::PlasmaSetOptionsReply, &fbb, message);
+}
+
+Status ReadSetOptionsReply(uint8_t* data, size_t size) {
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<fb::PlasmaSetOptionsReply>(data);
+  DCHECK(VerifyFlatbuffer(message, data, size));
+  return PlasmaErrorStatus(message->error());
+}
+
+// Get debug string messages.
+
+Status SendGetDebugStringRequest(int sock) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = fb::CreatePlasmaGetDebugStringRequest(fbb);
+  return PlasmaSend(sock, MessageType::PlasmaGetDebugStringRequest, &fbb, message);
+}
+
+Status SendGetDebugStringReply(int sock, const std::string& debug_string) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = fb::CreatePlasmaGetDebugStringReply(fbb, fbb.CreateString(debug_string));
+  return PlasmaSend(sock, MessageType::PlasmaGetDebugStringReply, &fbb, message);
+}
+
+Status ReadGetDebugStringReply(uint8_t* data, size_t size, std::string* debug_string) {
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<fb::PlasmaGetDebugStringReply>(data);
+  DCHECK(VerifyFlatbuffer(message, data, size));
+  *debug_string = message->debug_string()->str();
+  return Status::OK();
+}
+
 // Create messages.
 
 Status SendCreateRequest(int sock, ObjectID object_id, int64_t data_size,

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -44,6 +44,26 @@ bool VerifyFlatbuffer(T* object, uint8_t* data, size_t size) {
 
 Status PlasmaReceive(int sock, MessageType message_type, std::vector<uint8_t>* buffer);
 
+/* Set options messages. */
+
+Status SendSetOptionsRequest(int sock, const std::string& client_name,
+                             int64_t output_memory_limit);
+
+Status ReadSetOptionsRequest(uint8_t* data, size_t size, std::string* client_name,
+                             int64_t* output_memory_quota);
+
+Status SendSetOptionsReply(int sock, PlasmaError error);
+
+Status ReadSetOptionsReply(uint8_t* data, size_t size);
+
+/* Debug string messages. */
+
+Status SendGetDebugStringRequest(int sock);
+
+Status SendGetDebugStringReply(int sock, const std::string& debug_string);
+
+Status ReadGetDebugStringReply(uint8_t* data, size_t size, std::string* debug_string);
+
 /* Plasma Create message functions. */
 
 Status SendCreateRequest(int sock, ObjectID object_id, int64_t data_size,

--- a/cpp/src/plasma/quota_aware_policy.cc
+++ b/cpp/src/plasma/quota_aware_policy.cc
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "plasma/quota_aware_policy.h"
+#include "plasma/common.h"
+#include "plasma/plasma_allocator.h"
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+
+namespace plasma {
+
+QuotaAwarePolicy::QuotaAwarePolicy(PlasmaStoreInfo* store_info, int64_t max_size)
+    : EvictionPolicy(store_info, max_size) {}
+
+bool QuotaAwarePolicy::HasQuota(Client* client, bool is_create) {
+  if (!is_create) {
+    return false;  // no quota enforcement on read requests yet
+  }
+  return per_client_cache_.find(client) != per_client_cache_.end();
+}
+
+void QuotaAwarePolicy::ObjectCreated(const ObjectID& object_id, Client* client,
+                                     bool is_create) {
+  if (HasQuota(client, is_create)) {
+    per_client_cache_[client]->Add(object_id, GetObjectSize(object_id));
+    owned_by_client_[object_id] = client;
+  } else {
+    EvictionPolicy::ObjectCreated(object_id, client, is_create);
+  }
+}
+
+bool QuotaAwarePolicy::SetClientQuota(Client* client, int64_t output_memory_quota) {
+  if (per_client_cache_.find(client) != per_client_cache_.end()) {
+    ARROW_LOG(WARNING) << "Cannot change the client quota once set";
+    return false;
+  }
+
+  if (cache_.Capacity() - output_memory_quota <
+      cache_.OriginalCapacity() * kGlobalLruReserveFraction) {
+    ARROW_LOG(WARNING) << "Not enough memory to set client quota: " << DebugString();
+    return false;
+  }
+
+  // those objects will be lazily evicted on the next call
+  cache_.AdjustCapacity(-output_memory_quota);
+  per_client_cache_[client] =
+      std::unique_ptr<LRUCache>(new LRUCache(client->name, output_memory_quota));
+  return true;
+}
+
+bool QuotaAwarePolicy::EnforcePerClientQuota(Client* client, int64_t size, bool is_create,
+                                             std::vector<ObjectID>* objects_to_evict) {
+  if (!HasQuota(client, is_create)) {
+    return true;
+  }
+
+  auto& client_cache = per_client_cache_[client];
+  if (size > client_cache->Capacity()) {
+    ARROW_LOG(WARNING) << "object too large (" << size
+                       << " bytes) to fit in client quota " << client_cache->Capacity()
+                       << " " << DebugString();
+    return false;
+  }
+
+  if (client_cache->RemainingCapacity() >= size) {
+    return true;
+  }
+
+  int64_t space_to_free = size - client_cache->RemainingCapacity();
+  if (space_to_free > 0) {
+    std::vector<ObjectID> candidates;
+    client_cache->ChooseObjectsToEvict(space_to_free, &candidates);
+    for (ObjectID& object_id : candidates) {
+      if (shared_for_read_.count(object_id)) {
+        // Pinned so we can't evict it, so demote the object to global LRU instead.
+        // We an do this by simply removing it from all data structures, so that
+        // the next EndObjectAccess() will add it back to global LRU.
+        shared_for_read_.erase(object_id);
+      } else {
+        objects_to_evict->push_back(object_id);
+      }
+      owned_by_client_.erase(object_id);
+      client_cache->Remove(object_id);
+    }
+  }
+  return true;
+}
+
+void QuotaAwarePolicy::BeginObjectAccess(const ObjectID& object_id) {
+  if (owned_by_client_.find(object_id) != owned_by_client_.end()) {
+    shared_for_read_.insert(object_id);
+    pinned_memory_bytes_ += GetObjectSize(object_id);
+    return;
+  }
+  EvictionPolicy::BeginObjectAccess(object_id);
+}
+
+void QuotaAwarePolicy::EndObjectAccess(const ObjectID& object_id) {
+  if (owned_by_client_.find(object_id) != owned_by_client_.end()) {
+    shared_for_read_.erase(object_id);
+    pinned_memory_bytes_ -= GetObjectSize(object_id);
+    return;
+  }
+  EvictionPolicy::EndObjectAccess(object_id);
+}
+
+void QuotaAwarePolicy::RemoveObject(const ObjectID& object_id) {
+  if (owned_by_client_.find(object_id) != owned_by_client_.end()) {
+    per_client_cache_[owned_by_client_[object_id]]->Remove(object_id);
+    owned_by_client_.erase(object_id);
+    shared_for_read_.erase(object_id);
+    return;
+  }
+  EvictionPolicy::RemoveObject(object_id);
+}
+
+void QuotaAwarePolicy::ClientDisconnected(Client* client) {
+  if (per_client_cache_.find(client) == per_client_cache_.end()) {
+    return;
+  }
+  // return capacity back to global LRU
+  cache_.AdjustCapacity(per_client_cache_[client]->Capacity());
+  // clean up any entries used to track this client's quota usage
+  per_client_cache_[client]->Foreach([this](const ObjectID& obj) {
+    if (!shared_for_read_.count(obj)) {
+      // only add it to the global LRU if we have it in pinned mode
+      // otherwise, EndObjectAccess will add it later
+      cache_.Add(obj, GetObjectSize(obj));
+    }
+    owned_by_client_.erase(obj);
+    shared_for_read_.erase(obj);
+  });
+  per_client_cache_.erase(client);
+}
+
+std::string QuotaAwarePolicy::DebugString() const {
+  std::stringstream result;
+  result << "num clients with quota: " << per_client_cache_.size();
+  result << "\nquota map size: " << owned_by_client_.size();
+  result << "\npinned quota map size: " << shared_for_read_.size();
+  result << "\nallocated bytes: " << PlasmaAllocator::Allocated();
+  result << "\nallocation limit: " << PlasmaAllocator::GetFootprintLimit();
+  result << "\npinned bytes: " << pinned_memory_bytes_;
+  result << cache_.DebugString();
+  for (const auto& pair : per_client_cache_) {
+    result << pair.second->DebugString();
+  }
+  return result.str();
+}
+
+}  // namespace plasma

--- a/cpp/src/plasma/quota_aware_policy.h
+++ b/cpp/src/plasma/quota_aware_policy.h
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PLASMA_QUOTA_AWARE_POLICY_H
+#define PLASMA_QUOTA_AWARE_POLICY_H
+
+#include <list>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "plasma/common.h"
+#include "plasma/eviction_policy.h"
+#include "plasma/plasma.h"
+
+namespace plasma {
+
+/// Reserve this fraction of memory for shared usage. Attempts to set client
+/// quotas that would cause the global LRU memory fraction to fall below this
+/// value will be rejected.
+constexpr double kGlobalLruReserveFraction = 0.3;
+
+/// Extends the basic eviction policy to implement per-client memory quotas.
+/// This effectively gives each client its own LRU queue, which caps its
+/// memory usage and protects this memory from being evicted by other clients.
+///
+/// The quotas are enforced when objects are first created, by evicting the
+/// necessary number of objects from the client's own LRU queue to cap its
+/// memory usage. Once that is done, allocation is handled by the normal
+/// eviction policy. This may result in the eviction of objects from the
+/// global LRU queue, if not enough memory can be allocated even after the
+/// evictions from the client's own LRU queue.
+///
+/// Some special cases:
+/// - When a pinned object is "evicted" from a per-client queue, it is
+/// instead transferred into the global LRU queue.
+/// - When a client disconnects, its LRU queue is merged into the head of the
+/// global LRU queue.
+class QuotaAwarePolicy : public EvictionPolicy {
+ public:
+  /// Construct a quota-aware eviction policy.
+  ///
+  /// @param store_info Information about the Plasma store that is exposed
+  ///        to the eviction policy.
+  /// @param max_size Max size in bytes total of objects to store.
+  explicit QuotaAwarePolicy(PlasmaStoreInfo* store_info, int64_t max_size);
+  void ObjectCreated(const ObjectID& object_id, Client* client, bool is_create) override;
+  bool SetClientQuota(Client* client, int64_t output_memory_quota) override;
+  bool EnforcePerClientQuota(Client* client, int64_t size, bool is_create,
+                             std::vector<ObjectID>* objects_to_evict) override;
+  void ClientDisconnected(Client* client) override;
+  void BeginObjectAccess(const ObjectID& object_id) override;
+  void EndObjectAccess(const ObjectID& object_id) override;
+  void RemoveObject(const ObjectID& object_id) override;
+  std::string DebugString() const override;
+
+ private:
+  /// Returns whether we are enforcing memory quotas for an operation.
+  bool HasQuota(Client* client, bool is_create);
+
+  /// Per-client LRU caches, if quota is enabled.
+  std::unordered_map<Client*, std::unique_ptr<LRUCache>> per_client_cache_;
+  /// Tracks which client created which object. This only applies to clients
+  /// that have a memory quota set.
+  std::unordered_map<ObjectID, Client*> owned_by_client_;
+  /// Tracks which objects are mapped for read and hence can't be evicted.
+  /// However these objects are still tracked within the client caches.
+  std::unordered_set<ObjectID> shared_for_read_;
+};
+
+}  // namespace plasma
+
+#endif  // PLASMA_EVICTION_POLICY_H

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -138,6 +138,11 @@ cdef extern from "plasma/client.h" nogil:
 
         CStatus Delete(const c_vector[CUniqueID] object_ids)
 
+        CStatus SetClientOptions(const c_string& client_name,
+                                 int64_t limit_output_memory)
+
+        c_string DebugString()
+
         int64_t store_capacity()
 
 cdef extern from "plasma/client.h" nogil:
@@ -740,6 +745,19 @@ cdef class PlasmaClient:
             ids.push_back(object_id.data)
         with nogil:
             plasma_check_status(self.client.get().Delete(ids))
+
+    def set_client_options(self, client_name, int64_t limit_output_memory):
+        cdef c_string name
+        name = client_name.encode()
+        with nogil:
+            plasma_check_status(
+                self.client.get().SetClientOptions(name, limit_output_memory))
+
+    def debug_string(self):
+        cdef c_string result
+        with nogil:
+            result = self.client.get().DebugString()
+        return result.decode()
 
     def list(self):
         """


### PR DESCRIPTION
Currently, plasma evicts objects according a global LRU queue. In Ray, this often causes memory-intensive workloads to fail unpredictably, since a client that creates objects at a high rate can evict objects created by clients at lower rates. This is despite the fact that the true working set of both clients may be quite small.

This PR adds
- support for configuring per-client LRU eviction queues at runtime
- improved debugging of memory usage of clients

**Details on the implementation:**

QuotaAwarePolicy extends the basic eviction policy to implement per-client memory quotas.  This effectively gives each client its own LRU queue, which caps its memory usage and protects this memory from being evicted by other clients.

The quotas are enforced when objects are first created, by evicting the necessary number of objects from the client's own LRU queue to cap its memory usage. Once that is done, allocation is handled by the normal eviction policy. This may result in the eviction of objects from the global LRU queue, if not enough memory can be allocated even after the evictions from the client's own LRU queue.

Some special cases:
- When a pinned object is "evicted" from a per-client queue, it is instead transferred into the global LRU queue.
- When a client disconnects, its LRU queue is merged into the head of the global LRU queue.

cc @pcmoritz 
