### PR TITLE
ARROW-5961: [R] Be able to run R-only tests even without C++ library

### DIFF
--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -15,9 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Wrap testthat::test_that with a check for the C++ library
+options(..skip.tests = !arrow::arrow_available())
+
 test_that <- function(what, code) {
   testthat::test_that(what, {
-    skip_if(!arrow::arrow_available(), "arrow C++ library not available")
+    skip_if(getOption("..skip.tests", TRUE), "arrow C++ library not available")
     code
   })
+}
+
+# Wrapper to run tests that only touch R code even when the C++ library isn't
+# available (so that at least some tests are run on those platforms)
+r_only <- function(code) {
+  old <- options(..skip.tests = FALSE)
+  on.exit(options(old))
+  code
 }

--- a/r/tests/testthat/test-install-arrow.R
+++ b/r/tests/testthat/test-install-arrow.R
@@ -17,64 +17,66 @@
 
 context("install_arrow()")
 
-test_that("install_arrow() prints a message", {
-  expect_message(install_arrow())
-})
-
 i_have_arrow_msg <- "It appears you already have Arrow installed successfully: are you trying to install a different version of the library?
 
 Refer to the R package README <https://github.com/apache/arrow/blob/master/r/README.md> for further details.
 
 If you have other trouble, or if you think this message could be improved, please report an issue here: <https://issues.apache.org/jira/projects/ARROW/issues>"
 
-test_that("Messages get the standard postscript appended", {
-  expect_identical(
-    install_arrow_msg(has_arrow = TRUE, "0.13.0"),
-    i_have_arrow_msg
-  )
-})
+r_only({
+  test_that("install_arrow() prints a message", {
+    expect_message(install_arrow())
+  })
 
-test_that("Solaris and Linux dev version get pointed to C++ guide", {
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0", os="sunos"),
-    "See the Arrow C++ developer guide",
-    fixed = TRUE
-  )
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0.9000", os="linux"),
-    "See the Arrow C++ developer guide",
-    fixed = TRUE
-  )
-})
+  test_that("Messages get the standard postscript appended", {
+    expect_identical(
+      install_arrow_msg(has_arrow = TRUE, "0.13.0"),
+      i_have_arrow_msg
+    )
+  })
 
-test_that("Linux on release version gets pointed to PPA first, then C++", {
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0", os="linux"),
-    "PPA. Or, see the Arrow C++ developer guide",
-    fixed = TRUE
-  )
-})
+  test_that("Solaris and Linux dev version get pointed to C++ guide", {
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0", os="sunos"),
+      "See the Arrow C++ developer guide",
+      fixed = TRUE
+    )
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0.9000", os="linux"),
+      "See the Arrow C++ developer guide",
+      fixed = TRUE
+    )
+  })
 
-test_that("Win/mac release version get pointed to CRAN", {
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0", os="darwin", from_cran=FALSE),
-    "install.packages",
-    fixed = TRUE
-  )
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0", os="windows", from_cran=FALSE),
-    "install.packages",
-    fixed = TRUE
-  )
-})
+  test_that("Linux on release version gets pointed to PPA first, then C++", {
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0", os="linux"),
+      "PPA. Or, see the Arrow C++ developer guide",
+      fixed = TRUE
+    )
+  })
 
-test_that("Win/mac dev version get recommendations", {
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0.9000", os="darwin", from_cran=FALSE),
-    "Homebrew"
-  )
-  expect_match(
-    install_arrow_msg(FALSE, "0.13.0.9000", os="windows", from_cran=FALSE),
-    "RWINLIB_LOCAL"
-  )
+  test_that("Win/mac release version get pointed to CRAN", {
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0", os="darwin", from_cran=FALSE),
+      "install.packages",
+      fixed = TRUE
+    )
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0", os="windows", from_cran=FALSE),
+      "install.packages",
+      fixed = TRUE
+    )
+  })
+
+  test_that("Win/mac dev version get recommendations", {
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0.9000", os="darwin", from_cran=FALSE),
+      "Homebrew"
+    )
+    expect_match(
+      install_arrow_msg(FALSE, "0.13.0.9000", os="windows", from_cran=FALSE),
+      "RWINLIB_LOCAL"
+    )
+  })
 })


### PR DESCRIPTION
`r/tests/testthat/helper-arrow.R` has the meat of the change; the change to the test file is mostly just added indentation. 