### PR TITLE
ARROW-5962: [CI][Python] Remove manylinux1 builds from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,14 +167,6 @@ matrix:
     script:
     - if [ $ARROW_CI_PYTHON_AFFECTED != "1" ]; then exit; fi
     - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
-  - name: "[manylinux1] Python"
-    language: cpp
-    env:
-    - PYTHON_VERSIONS="3.6,16 3.7,16"
-    before_script:
-    - if [ $ARROW_CI_PYTHON_AFFECTED == "1" ]; then docker-compose pull python-manylinux1; fi
-    script:
-    - if [ $ARROW_CI_PYTHON_AFFECTED == "1" ]; then $TRAVIS_BUILD_DIR/ci/travis_script_manylinux.sh; fi
   - name: "Java OpenJDK8 and OpenJDK11"
     language: cpp
     os: linux

--- a/ci/travis_script_manylinux.sh
+++ b/ci/travis_script_manylinux.sh
@@ -17,6 +17,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# NB(wesm): Here is the Travis CI entry removed in ARROW-5962
+
+# - name: "[manylinux1] Python"
+#   language: cpp
+#   env:
+#   - PYTHON_VERSIONS="3.6,16 3.7,16"
+#   before_script:
+#   - if [ $ARROW_CI_PYTHON_AFFECTED == "1" ]; then docker-compose pull python-manylinux1; fi
+#   script:
+#   - if [ $ARROW_CI_PYTHON_AFFECTED == "1" ]; then $TRAVIS_BUILD_DIR/ci/travis_script_manylinux.sh; fi
+
 set -ex
 
 # Testing for https://issues.apache.org/jira/browse/ARROW-2657


### PR DESCRIPTION
These can be tested via Crossbow on-demand or nightly. About 10% of our total CI build time is this job, so this will make our build queue about 10% less clogged