### PR TITLE
ARROW-5968: [Java] Remove duplicate Preconditions check in JDBC adapter

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
@@ -60,8 +60,6 @@ import com.google.common.base.Preconditions;
  * CLOB --> ArrowType.Utf8
  * BLOB --> ArrowType.Binary
  *
- * <p>TODO: At this time, SQL Data type java.sql.Types.ARRAY is still not supported.
- *
  * @since 0.10.0
  */
 public class JdbcToArrow {
@@ -83,8 +81,6 @@ public class JdbcToArrow {
    */
   public static VectorSchemaRoot sqlToArrow(Connection connection, String query, BaseAllocator allocator)
       throws SQLException, IOException {
-    Preconditions.checkNotNull(connection, "JDBC connection object can not be null");
-    Preconditions.checkArgument(query != null && query.length() > 0, "SQL query can not be null or empty");
     Preconditions.checkNotNull(allocator, "Memory allocator object can not be null");
 
     JdbcToArrowConfig config =
@@ -111,8 +107,6 @@ public class JdbcToArrow {
       BaseAllocator allocator,
       Calendar calendar) throws SQLException, IOException {
 
-    Preconditions.checkNotNull(connection, "JDBC connection object can not be null");
-    Preconditions.checkArgument(query != null && query.length() > 0, "SQL query can not be null or empty");
     Preconditions.checkNotNull(allocator, "Memory allocator object can not be null");
     Preconditions.checkNotNull(calendar, "Calendar object can not be null");
 
@@ -135,7 +129,6 @@ public class JdbcToArrow {
       throws SQLException, IOException {
     Preconditions.checkNotNull(connection, "JDBC connection object can not be null");
     Preconditions.checkArgument(query != null && query.length() > 0, "SQL query can not be null or empty");
-    Preconditions.checkNotNull(config, "The configuration cannot be null");
 
     try (Statement stmt = connection.createStatement()) {
       return sqlToArrow(stmt.executeQuery(query), config);
@@ -166,7 +159,6 @@ public class JdbcToArrow {
    */
   public static VectorSchemaRoot sqlToArrow(ResultSet resultSet, BaseAllocator allocator)
       throws SQLException, IOException {
-    Preconditions.checkNotNull(resultSet, "JDBC ResultSet object can not be null");
     Preconditions.checkNotNull(allocator, "Memory Allocator object can not be null");
 
     JdbcToArrowConfig config = 
@@ -201,7 +193,6 @@ public class JdbcToArrow {
           BaseAllocator allocator,
           Calendar calendar)
       throws SQLException, IOException {
-    Preconditions.checkNotNull(resultSet, "JDBC ResultSet object can not be null");
     Preconditions.checkNotNull(allocator, "Memory Allocator object can not be null");
 
     return sqlToArrow(resultSet, new JdbcToArrowConfig(allocator, calendar));

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -243,39 +243,28 @@ public class JdbcToArrowUtils {
       timezone = null;
     }
 
-
-    final ArrowType arrowType;
-
     switch (fieldInfo.getJdbcType()) {
       case Types.BOOLEAN:
       case Types.BIT:
-        arrowType = new ArrowType.Bool();
-        break;
+        return new ArrowType.Bool();
       case Types.TINYINT:
-        arrowType = new ArrowType.Int(8, true);
-        break;
+        return new ArrowType.Int(8, true);
       case Types.SMALLINT:
-        arrowType = new ArrowType.Int(16, true);
-        break;
+        return new ArrowType.Int(16, true);
       case Types.INTEGER:
-        arrowType = new ArrowType.Int(32, true);
-        break;
+        return new ArrowType.Int(32, true);
       case Types.BIGINT:
-        arrowType = new ArrowType.Int(64, true);
-        break;
+        return new ArrowType.Int(64, true);
       case Types.NUMERIC:
       case Types.DECIMAL:
         int precision = fieldInfo.getPrecision();
         int scale = fieldInfo.getScale();
-        arrowType = new ArrowType.Decimal(precision, scale);
-        break;
+        return new ArrowType.Decimal(precision, scale);
       case Types.REAL:
       case Types.FLOAT:
-        arrowType = new ArrowType.FloatingPoint(SINGLE);
-        break;
+        return new ArrowType.FloatingPoint(SINGLE);
       case Types.DOUBLE:
-        arrowType = new ArrowType.FloatingPoint(DOUBLE);
-        break;
+        return new ArrowType.FloatingPoint(DOUBLE);
       case Types.CHAR:
       case Types.NCHAR:
       case Types.VARCHAR:
@@ -283,33 +272,24 @@ public class JdbcToArrowUtils {
       case Types.LONGVARCHAR:
       case Types.LONGNVARCHAR:
       case Types.CLOB:
-        arrowType = new ArrowType.Utf8();
-        break;
+        return new ArrowType.Utf8();
       case Types.DATE:
-        arrowType = new ArrowType.Date(DateUnit.MILLISECOND);
-        break;
+        return new ArrowType.Date(DateUnit.MILLISECOND);
       case Types.TIME:
-        arrowType = new ArrowType.Time(TimeUnit.MILLISECOND, 32);
-        break;
+        return new ArrowType.Time(TimeUnit.MILLISECOND, 32);
       case Types.TIMESTAMP:
-        arrowType = new ArrowType.Timestamp(TimeUnit.MILLISECOND, timezone);
-        break;
+        return new ArrowType.Timestamp(TimeUnit.MILLISECOND, timezone);
       case Types.BINARY:
       case Types.VARBINARY:
       case Types.LONGVARBINARY:
       case Types.BLOB:
-        arrowType = new ArrowType.Binary();
-        break;
+        return new ArrowType.Binary();
       case Types.ARRAY:
-        arrowType = new ArrowType.List();
-        break;
+        return new ArrowType.List();
       default:
         // no-op, shouldn't get here
-        arrowType = null;
-        break;
+        return null;
     }
-
-    return arrowType;
   }
 
   /* Uses the configuration to determine what the array sub-type JdbcFieldInfo is.
@@ -382,7 +362,7 @@ public class JdbcToArrowUtils {
       throws SQLException, IOException {
 
     Preconditions.checkNotNull(rs, "JDBC ResultSet object can't be null");
-    Preconditions.checkNotNull(root, "JDBC ResultSet object can't be null");
+    Preconditions.checkNotNull(root, "VectorSchemaRoot object can't be null");
     Preconditions.checkNotNull(config, "JDBC-to-Arrow configuration cannot be null");
 
     ResultSetMetaData rsmd = rs.getMetaData();
@@ -510,7 +490,6 @@ public class JdbcToArrowUtils {
         updateVector((VarBinaryVector) vector,
                 rs.getBlob(columnIndex), !rs.wasNull(), rowCount);
         break;
-
       default:
         // no-op, shouldn't get here
         break;


### PR DESCRIPTION
Related to [ARROW-5968](https://issues.apache.org/jira/browse/ARROW-5968).
Some Preconditions check are duplicate in JdbcToArrow#sqlToArrow