### PR TITLE
ARROW-5747: [C++] Improve CSV header and column names options

### DIFF
--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -902,7 +902,6 @@ enum {
   PROP_ESCAPE_CHARACTER,
   PROP_ALLOW_NEWLINES_IN_VALUES,
   PROP_IGNORE_EMPTY_LINES,
-  PROP_N_HEADER_ROWS,
   PROP_CHECK_UTF8,
   PROP_ALLOW_NULL_STRINGS
 };
@@ -955,9 +954,6 @@ garrow_csv_read_options_set_property(GObject *object,
   case PROP_IGNORE_EMPTY_LINES:
     priv->parse_options.ignore_empty_lines = g_value_get_boolean(value);
     break;
-  case PROP_N_HEADER_ROWS:
-    priv->parse_options.header_rows = g_value_get_uint(value);
-    break;
   case PROP_CHECK_UTF8:
     priv->convert_options.check_utf8 = g_value_get_boolean(value);
     break;
@@ -1008,9 +1004,6 @@ garrow_csv_read_options_get_property(GObject *object,
     break;
   case PROP_IGNORE_EMPTY_LINES:
     g_value_set_boolean(value, priv->parse_options.ignore_empty_lines);
-    break;
-  case PROP_N_HEADER_ROWS:
-    g_value_set_uint(value, priv->parse_options.header_rows);
     break;
   case PROP_CHECK_UTF8:
     g_value_set_boolean(value, priv->convert_options.check_utf8);
@@ -1208,26 +1201,6 @@ garrow_csv_read_options_class_init(GArrowCSVReadOptionsClass *klass)
                               static_cast<GParamFlags>(G_PARAM_READWRITE));
   g_object_class_install_property(gobject_class,
                                   PROP_IGNORE_EMPTY_LINES,
-                                  spec);
-
-  /**
-   * GArrowCSVReadOptions:n-header-rows:
-   *
-   * The number of header rows to skip (including the first row
-   * containing column names)
-   *
-   * Since: 0.12.0
-   */
-  spec = g_param_spec_uint("n-header-rows",
-                           "N header rows",
-                           "The number of header rows to skip "
-                           "(including the first row containing column names",
-                           0,
-                           G_MAXUINT,
-                           parse_options.header_rows,
-                           static_cast<GParamFlags>(G_PARAM_READWRITE));
-  g_object_class_install_property(gobject_class,
-                                  PROP_N_HEADER_ROWS,
                                   spec);
 
   auto convert_options = arrow::csv::ConvertOptions::Defaults();

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -53,10 +53,6 @@ struct ARROW_EXPORT ParseOptions {
   // a single empty value (assuming a one-column CSV file).
   bool ignore_empty_lines = true;
 
-  // XXX Should this be in ReadOptions?
-  // Number of header rows to skip (including the first row containing column names)
-  int32_t header_rows = 1;
-
   static ParseOptions Defaults();
 };
 
@@ -88,6 +84,11 @@ struct ARROW_EXPORT ReadOptions {
   // Block size we request from the IO layer; also determines the size of
   // chunks when use_threads is true
   int32_t block_size = 1 << 20;  // 1 MB
+
+  // Number of header rows to skip (not including the row of column names, if any)
+  int32_t skip_rows = 0;
+  // Column names (if empty, will be read from first row after `skip_rows`)
+  std::vector<std::string> column_names;
 
   static ReadOptions Defaults();
 };

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -96,6 +96,21 @@ class ARROW_EXPORT BlockParser {
     return Status::OK();
   }
 
+  template <typename Visitor>
+  Status VisitLastRow(Visitor&& visit) const {
+    const auto& values_buffer = values_buffers_.back();
+    const auto values = reinterpret_cast<const ValueDesc*>(values_buffer->data());
+    const auto start_pos =
+        static_cast<int32_t>(values_buffer->size() / sizeof(ValueDesc)) - num_cols_ - 1;
+    for (int32_t col_index = 0; col_index < num_cols_; ++col_index) {
+      auto start = values[start_pos + col_index].offset;
+      auto stop = values[start_pos + col_index + 1].offset;
+      auto quoted = values[start_pos + col_index + 1].quoted;
+      ARROW_RETURN_NOT_OK(visit(parsed_ + start, stop - start, quoted));
+    }
+    return Status::OK();
+  }
+
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(BlockParser);
 

--- a/cpp/src/arrow/csv/parser.h
+++ b/cpp/src/arrow/csv/parser.h
@@ -37,6 +37,13 @@ namespace csv {
 
 constexpr int32_t kMaxParserNumRows = 100000;
 
+/// Skip at most num_rows from the given input.  The input pointer is updated
+/// and the number of actually skipped rows is returns (may be less than
+/// requested if the input is too short).
+ARROW_EXPORT
+int32_t SkipRows(const uint8_t* data, uint32_t size, int32_t num_rows,
+                 const uint8_t** out_data);
+
 /// \class BlockParser
 /// \brief A reusable block-based parser for CSV data
 ///

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -145,34 +145,54 @@ class BaseTableReader : public csv::TableReader {
   // Read header and column names from current block, create column builders
   Status ProcessHeader() {
     DCHECK_GT(cur_size_, 0);
-    if (parse_options_.header_rows == 0) {
-      // TODO allow passing names and/or generate column numbers?
-      return Status::Invalid("header_rows == 0 needs explicit column names");
+
+    int32_t header_rows = read_options_.skip_rows;
+    if (read_options_.column_names.empty()) {
+      // One row with column names
+      ++header_rows;
+    } else {
+      column_names_ = read_options_.column_names;
     }
 
-    BlockParser parser(pool_, parse_options_, num_cols_, parse_options_.header_rows);
+    if (header_rows > 0) {
+      // Read header rows
+      BlockParser parser(pool_, parse_options_, num_cols_, header_rows);
+      uint32_t parsed_size = 0;
+      RETURN_NOT_OK(parser.Parse(reinterpret_cast<const char*>(cur_data_),
+                                 static_cast<uint32_t>(cur_size_), &parsed_size));
+      if (parser.num_rows() != header_rows) {
+        return Status::Invalid(
+            "Could not read header rows from CSV file, either "
+            "file is too short or header is larger than block size");
+      }
+      if (parser.num_cols() == 0) {
+        return Status::Invalid("No columns in CSV file");
+      }
+      if (read_options_.column_names.empty()) {
+        // Read column names from last header row
+        auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
+          column_names_.emplace_back(reinterpret_cast<const char*>(data), size);
+          return Status::OK();
+        };
+        RETURN_NOT_OK(parser.VisitLastRow(visit));
+        DCHECK_EQ(static_cast<size_t>(parser.num_cols()), column_names_.size());
+      } else {
+        if (static_cast<size_t>(parser.num_cols()) != column_names_.size()) {
+          return Status::Invalid("CSV file has ", parser.num_cols(), " columns, but ",
+                                 column_names_.size(), " column names were given");
+        }
+      }
 
-    uint32_t parsed_size = 0;
-    RETURN_NOT_OK(parser.Parse(reinterpret_cast<const char*>(cur_data_),
-                               static_cast<uint32_t>(cur_size_), &parsed_size));
-    if (parser.num_rows() != parse_options_.header_rows) {
-      return Status::Invalid(
-          "Could not read header rows from CSV file, either "
-          "file is too short or header is larger than block size");
+      // Skip parsed header rows
+      cur_data_ += parsed_size;
+      cur_size_ -= parsed_size;
     }
-    if (parser.num_cols() == 0) {
-      return Status::Invalid("No columns in CSV file");
-    }
-    num_cols_ = parser.num_cols();
+
+    num_cols_ = static_cast<int32_t>(column_names_.size());
     DCHECK_GT(num_cols_, 0);
 
+    // Construct column builders
     for (int32_t col_index = 0; col_index < num_cols_; ++col_index) {
-      auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
-        DCHECK_EQ(column_names_.size(), static_cast<uint32_t>(col_index));
-        column_names_.emplace_back(reinterpret_cast<const char*>(data), size);
-        return Status::OK();
-      };
-      RETURN_NOT_OK(parser.VisitColumn(col_index, visit));
       std::shared_ptr<ColumnBuilder> builder;
       // Does the named column have a fixed type?
       auto it = convert_options_.column_types.find(column_names_[col_index]);
@@ -186,9 +206,6 @@ class BaseTableReader : public csv::TableReader {
       column_builders_.push_back(builder);
     }
 
-    // Skip parsed header rows
-    cur_data_ += parsed_size;
-    cur_size_ -= parsed_size;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -149,8 +149,8 @@ class BaseTableReader : public csv::TableReader {
     if (read_options_.skip_rows) {
       // Skip initial rows (potentially invalid CSV data)
       auto data = cur_data_;
-      auto num_skipped_rows =
-          SkipRows(cur_data_, cur_size_, read_options_.skip_rows, &data);
+      auto num_skipped_rows = SkipRows(cur_data_, static_cast<uint32_t>(cur_size_),
+                                       read_options_.skip_rows, &data);
       cur_size_ -= data - cur_data_;
       cur_data_ = data;
       if (num_skipped_rows < read_options_.skip_rows) {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1056,7 +1056,6 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         c_bool double_quote
         c_bool escaping
         unsigned char escape_char
-        int32_t header_rows
         c_bool newlines_in_values
         c_bool ignore_empty_lines
 
@@ -1077,6 +1076,8 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
     cdef cppclass CCSVReadOptions" arrow::csv::ReadOptions":
         c_bool use_threads
         int32_t block_size
+        int32_t skip_rows
+        vector[c_string] column_names
 
         @staticmethod
         CCSVReadOptions Defaults()

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -72,9 +72,20 @@ def test_read_options():
     opts.use_threads = False
     assert opts.use_threads is False
 
-    opts = cls(block_size=1234, use_threads=False)
+    assert opts.skip_rows == 0
+    opts.skip_rows = 3
+    assert opts.skip_rows == 3
+
+    assert opts.column_names == []
+    opts.column_names = ["ab", "cd"]
+    assert opts.column_names == ["ab", "cd"]
+
+    opts = cls(block_size=1234, use_threads=False, skip_rows=42,
+               column_names=["a", "b", "c"])
     assert opts.block_size == 1234
     assert opts.use_threads is False
+    assert opts.skip_rows == 42
+    assert opts.column_names == ["a", "b", "c"]
 
 
 def test_parse_options():
@@ -84,7 +95,6 @@ def test_parse_options():
     assert opts.quote_char == '"'
     assert opts.double_quote is True
     assert opts.escape_char is False
-    assert opts.header_rows == 1
     assert opts.newlines_in_values is False
     assert opts.ignore_empty_lines is True
 
@@ -110,17 +120,13 @@ def test_parse_options():
     opts.ignore_empty_lines = False
     assert opts.ignore_empty_lines is False
 
-    opts.header_rows = 2
-    assert opts.header_rows == 2
-
     opts = cls(delimiter=';', quote_char='%', double_quote=False,
-               escape_char='\\', header_rows=2, newlines_in_values=True,
+               escape_char='\\', newlines_in_values=True,
                ignore_empty_lines=False)
     assert opts.delimiter == ';'
     assert opts.quote_char == '%'
     assert opts.double_quote is False
     assert opts.escape_char == '\\'
-    assert opts.header_rows == 2
     assert opts.newlines_in_values is True
     assert opts.ignore_empty_lines is False
 
@@ -213,6 +219,75 @@ class BaseTestCSVRead:
         expected_data = {'a': [1], 'b': [2]}
         table = self.read_bytes(rows)
         assert table.to_pydict() == expected_data
+
+    def test_header_skip_rows(self):
+        rows = b"ab,cd\nef,gh\nij,kl\nmn,op\n"
+
+        opts = ReadOptions()
+        opts.skip_rows = 1
+        table = self.read_bytes(rows, read_options=opts)
+        self.check_names(table, ["ef", "gh"])
+        assert table.to_pydict() == {
+            "ef": ["ij", "mn"],
+            "gh": ["kl", "op"],
+            }
+
+        opts.skip_rows = 3
+        table = self.read_bytes(rows, read_options=opts)
+        self.check_names(table, ["mn", "op"])
+        assert table.to_pydict() == {
+            "mn": [],
+            "op": [],
+            }
+
+        opts.skip_rows = 4
+        with pytest.raises(pa.ArrowInvalid):
+            # Not enough rows
+            table = self.read_bytes(rows, read_options=opts)
+
+    def test_header_column_names(self):
+        rows = b"ab,cd\nef,gh\nij,kl\nmn,op\n"
+
+        opts = ReadOptions()
+        opts.column_names = ["x", "y"]
+        table = self.read_bytes(rows, read_options=opts)
+        self.check_names(table, ["x", "y"])
+        assert table.to_pydict() == {
+            "x": ["ab", "ef", "ij", "mn"],
+            "y": ["cd", "gh", "kl", "op"],
+            }
+
+        opts.skip_rows = 3
+        table = self.read_bytes(rows, read_options=opts)
+        self.check_names(table, ["x", "y"])
+        assert table.to_pydict() == {
+            "x": ["mn"],
+            "y": ["op"],
+            }
+
+        opts.skip_rows = 4
+        table = self.read_bytes(rows, read_options=opts)
+        self.check_names(table, ["x", "y"])
+        assert table.to_pydict() == {
+            "x": [],
+            "y": [],
+            }
+
+        opts.skip_rows = 5
+        with pytest.raises(pa.ArrowInvalid):
+            # Not enough rows
+            table = self.read_bytes(rows, read_options=opts)
+
+        opts.skip_rows = 0
+        opts.column_names = ["x", "y", "z"]
+        with pytest.raises(pa.ArrowInvalid,
+                           match="Expected 3 columns, got 2"):
+            table = self.read_bytes(rows, read_options=opts)
+        opts.skip_rows = 1
+        with pytest.raises(pa.ArrowInvalid,
+                           match="CSV file has 2 columns, "
+                           "but 3 column names were given"):
+            table = self.read_bytes(rows, read_options=opts)
 
     def test_simple_ints(self):
         # Infer integer columns

--- a/r/README.md
+++ b/r/README.md
@@ -48,14 +48,6 @@ library.
 
 ``` r
 library(arrow)
-#> 
-#> Attaching package: 'arrow'
-#> The following object is masked from 'package:utils':
-#> 
-#>     timestamp
-#> The following objects are masked from 'package:base':
-#> 
-#>     array, table
 set.seed(24)
 
 tab <- arrow::table(x = 1:10, y = rnorm(10))

--- a/r/man/csv_parse_options.Rd
+++ b/r/man/csv_parse_options.Rd
@@ -8,7 +8,7 @@
 csv_parse_options(delimiter = ",", quoting = TRUE,
   quote_char = "\\"", double_quote = TRUE, escaping = FALSE,
   escape_char = "\\\\", newlines_in_values = FALSE,
-  ignore_empty_lines = TRUE, header_rows = 1L)
+  ignore_empty_lines = TRUE)
 
 json_parse_options(newlines_in_values = FALSE)
 }
@@ -28,8 +28,6 @@ json_parse_options(newlines_in_values = FALSE)
 \item{newlines_in_values}{Whether values are allowed to contain CR (\code{0x0d}) and LF (\code{0x0a}) characters}
 
 \item{ignore_empty_lines}{Whether empty lines are ignored.  If \code{FALSE}, an empty line represents}
-
-\item{header_rows}{Number of header rows to skip (including the first row containing column names)}
 }
 \description{
 Parsing options for Arrow file readers

--- a/r/man/csv_read_options.Rd
+++ b/r/man/csv_read_options.Rd
@@ -6,14 +6,22 @@
 \title{Read options for the Arrow file readers}
 \usage{
 csv_read_options(use_threads = option_use_threads(),
-  block_size = 1048576L)
+  block_size = 1048576L, skip_rows = 0L, column_names = character(0))
 
 json_read_options(use_threads = TRUE, block_size = 1048576L)
 }
 \arguments{
 \item{use_threads}{Whether to use the global CPU thread pool}
 
-\item{block_size}{Block size we request from the IO layer; also determines the size of chunks when use_threads is \code{TRUE}. NB: if false, JSON input must end with an empty line}
+\item{block_size}{Block size we request from the IO layer; also determines
+the size of chunks when use_threads is \code{TRUE}. NB: if \code{FALSE}, JSON input
+must end with an empty line.}
+
+\item{skip_rows}{Number of lines to skip before reading data.}
+
+\item{column_names}{Character vector to supply column names. If length-0
+(the default), the first non-skipped row will be parsed to generate column
+names.}
 }
 \description{
 Read options for the Arrow file readers

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -7,22 +7,20 @@
 \title{Read a CSV or other delimited file with Arrow}
 \usage{
 read_delim_arrow(file, delim = ",", quote = "\\"",
-  escape_double = TRUE, escape_backslash = FALSE, col_select = NULL,
-  skip_empty_rows = TRUE, parse_options = NULL,
-  convert_options = NULL, read_options = csv_read_options(),
+  escape_double = TRUE, escape_backslash = FALSE, col_names = TRUE,
+  col_select = NULL, skip_empty_rows = TRUE, skip = 0L,
+  parse_options = NULL, convert_options = NULL, read_options = NULL,
   as_tibble = TRUE)
 
 read_csv_arrow(file, quote = "\\"", escape_double = TRUE,
-  escape_backslash = FALSE, col_select = NULL,
-  skip_empty_rows = TRUE, parse_options = NULL,
-  convert_options = NULL, read_options = csv_read_options(),
-  as_tibble = TRUE)
+  escape_backslash = FALSE, col_names = TRUE, col_select = NULL,
+  skip_empty_rows = TRUE, skip = 0L, parse_options = NULL,
+  convert_options = NULL, read_options = NULL, as_tibble = TRUE)
 
 read_tsv_arrow(file, quote = "\\"", escape_double = TRUE,
-  escape_backslash = FALSE, col_select = NULL,
-  skip_empty_rows = TRUE, parse_options = NULL,
-  convert_options = NULL, read_options = csv_read_options(),
-  as_tibble = TRUE)
+  escape_backslash = FALSE, col_names = TRUE, col_select = NULL,
+  skip_empty_rows = TRUE, skip = 0L, parse_options = NULL,
+  convert_options = NULL, read_options = NULL, as_tibble = TRUE)
 }
 \arguments{
 \item{file}{A character path to a local file, or an Arrow input stream}
@@ -40,12 +38,19 @@ characters? This is more general than \code{escape_double} as backslashes
 can be used to escape the delimiter character, the quote character, or
 to add special characters like \code{\\n}.}
 
+\item{col_names}{If \code{TRUE}, the first row of the input will be used as the
+column names and will not be included in the data frame. (Note that \code{FALSE}
+is not currently supported.) Alternatively, you can specify a character
+vector of column names.}
+
 \item{col_select}{A \link[tidyselect:vars_select]{tidy selection specification}
 of columns, as used in \code{dplyr::select()}.}
 
 \item{skip_empty_rows}{Should blank rows be ignored altogether? If
 \code{TRUE}, blank rows will not be represented at all. If \code{FALSE}, they will be
 filled with missings.}
+
+\item{skip}{Number of lines to skip before reading data.}
 
 \item{parse_options}{see \code{\link[=csv_parse_options]{csv_parse_options()}}. If given, this overrides any
 parsing options provided in other arguments (e.g. \code{delim}, \code{quote}, etc.).}

--- a/r/src/csv.cpp
+++ b/r/src/csv.cpp
@@ -28,6 +28,8 @@ std::shared_ptr<arrow::csv::ReadOptions> csv___ReadOptions__initialize(List_ opt
       std::make_shared<arrow::csv::ReadOptions>(arrow::csv::ReadOptions::Defaults());
   res->use_threads = options["use_threads"];
   res->block_size = options["block_size"];
+  res->skip_rows = options["skip_rows"];
+  res->column_names = Rcpp::as<std::vector<std::string>>(options["column_names"]);
   return res;
 }
 
@@ -43,7 +45,6 @@ std::shared_ptr<arrow::csv::ParseOptions> csv___ParseOptions__initialize(List_ o
   res->double_quote = options["double_quote"];
   res->escape_char = get_char(options["escape_char"]);
   res->newlines_in_values = options["newlines_in_values"];
-  res->header_rows = options["header_rows"];
   res->ignore_empty_lines = options["ignore_empty_lines"];
   return res;
 }

--- a/r/tests/testthat/test-arrow-csv.R
+++ b/r/tests/testthat/test-arrow-csv.R
@@ -81,29 +81,39 @@ test_that("read_delim_arrow parsing options: quote", {
 })
 
 test_that("read_csv_arrow parsing options: col_names", {
-  skip("Invalid: Empty CSV file")
   tf <- tempfile()
   on.exit(unlink(tf))
 
+  # Writing the CSV without the header
   write.table(iris, tf, sep = ",", row.names = FALSE, col.names = FALSE)
-  tab1 <- read_csv_arrow(tf, col_names = FALSE)
+
+  expect_error(read_csv_arrow(tf, col_names = FALSE), "Not implemented")
+
+  tab1 <- read_csv_arrow(tf, col_names = names(iris))
 
   expect_identical(names(tab1), names(iris))
   iris$Species <- as.character(iris$Species)
   expect_equivalent(iris, tab1)
+
+  # This errors (correctly) because I haven't given enough names
+  # but the error message is "Invalid: Empty CSV file", which is not accurate
+  expect_error(
+    read_csv_arrow(tf, col_names = names(iris)[1])
+  )
+  # Same here
+  expect_error(
+    read_csv_arrow(tf, col_names = c(names(iris), names(iris)))
+  )
 })
 
 test_that("read_csv_arrow parsing options: skip", {
-  skip("Invalid: Empty CSV file")
   tf <- tempfile()
   on.exit(unlink(tf))
 
+  # Adding two garbage lines to start the csv
   cat("asdf\nqwer\n", file = tf)
   suppressWarnings(write.table(iris, tf, sep = ",", row.names = FALSE, append = TRUE))
-  # This works:
-  # print(head(readr::read_csv(tf, skip = 2)))
 
-  # This errors:
   tab1 <- read_csv_arrow(tf, skip = 2)
 
   expect_identical(names(tab1), names(iris))


### PR DESCRIPTION
The `header_rows` option is removed (it seemed untested and probably didn't work well)
and replaced with a `skip_rows` option that dictates how many rows are skipped at
the start of the CSV file (default 0).

Furthermore, a `column_names` option is added to hardcode the column names.
If empty (default), they are read from the first non-skipped row in the CSV file.