### PR TITLE
ARROW-5988: [Java] Avro adapter implement simple Record type

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -113,7 +113,15 @@ public class AvroToArrowUtils {
     schema.getObjectProps().forEach((k,v) -> metadata.put(k, v.toString()));
 
     if (type == Type.RECORD) {
-      throw new UnsupportedOperationException();
+      for (Schema.Field field : schema.getFields()) {
+        final ArrowType arrowType = getArrowType(field.schema().getType());
+        if (arrowType != null) {
+          final FieldType fieldType = new FieldType(true, arrowType, null, null);
+          List<Field> children = null;
+          //TODO support complex type
+          arrowFields.add(new Field(field.name(), fieldType, children));
+        }
+      }
     } else if (type == Type.MAP) {
       throw new UnsupportedOperationException();
     } else if (type == Type.UNION) {

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -115,12 +115,10 @@ public class AvroToArrowUtils {
     if (type == Type.RECORD) {
       for (Schema.Field field : schema.getFields()) {
         final ArrowType arrowType = getArrowType(field.schema().getType());
-        if (arrowType != null) {
-          final FieldType fieldType = new FieldType(true, arrowType, null, null);
-          List<Field> children = null;
-          //TODO support complex type
-          arrowFields.add(new Field(field.name(), fieldType, children));
-        }
+        final FieldType fieldType = new FieldType(/*nullable=*/true, arrowType, /*dictionary=*/null, /*metadata=*/null);
+        List<Field> children = null;
+        //TODO support complex type (i.e. nested records, lists, etc )
+        arrowFields.add(new Field(field.name(), fieldType, children));
       }
     } else if (type == Type.MAP) {
       throw new UnsupportedOperationException();

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -100,6 +100,12 @@ public class AvroToArrowUtils {
     }
   }
 
+  private static Map<String, String> getMetaData(Schema schema) {
+    Map<String, String> metadata = new HashMap<>();
+    schema.getObjectProps().forEach((k,v) -> metadata.put(k, v.toString()));
+    return metadata;
+  }
+
   /**
    * Create Arrow {@link org.apache.arrow.vector.types.pojo.Schema} object for the given Avro {@link Schema}.
    */
@@ -109,13 +115,13 @@ public class AvroToArrowUtils {
     List<Field> arrowFields = new ArrayList<>();
 
     Schema.Type type = schema.getType();
-    final Map<String, String> metadata = new HashMap<>();
-    schema.getObjectProps().forEach((k,v) -> metadata.put(k, v.toString()));
+    final Map<String, String> metadata = getMetaData(schema);
 
     if (type == Type.RECORD) {
       for (Schema.Field field : schema.getFields()) {
         final ArrowType arrowType = getArrowType(field.schema().getType());
-        final FieldType fieldType = new FieldType(/*nullable=*/true, arrowType, /*dictionary=*/null, /*metadata=*/null);
+        final FieldType fieldType = new FieldType(/*nullable=*/false, arrowType, /*dictionary=*/null,
+            /*metadata=*/getMetaData(field.schema()));
         List<Field> children = null;
         //TODO support complex type (i.e. nested records, lists, etc )
         arrowFields.add(new Field(field.name(), fieldType, children));

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -45,8 +45,8 @@ public class AvroBytesConsumer implements Consumer {
   public void consume(Decoder decoder) throws IOException {
     VarBinaryHolder holder = new VarBinaryHolder();
 
-    //cacheBuffer is initialized null and create in the first consume,
-    //if its capacity < size to read, decoder will create a new one with new capacity.
+    // cacheBuffer is initialized null and create in the first consume,
+    // if its capacity < size to read, decoder will create a new one with new capacity.
     cacheBuffer = decoder.readBytes(cacheBuffer);
 
     holder.start = 0;

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -34,6 +34,7 @@ public class AvroBytesConsumer implements Consumer {
 
   private final VarBinaryWriter writer;
   private final VarBinaryVector vector;
+  private ByteBuffer cacheBuffer;
 
   public AvroBytesConsumer(VarBinaryVector vector) {
     this.vector = vector;
@@ -43,12 +44,15 @@ public class AvroBytesConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     VarBinaryHolder holder = new VarBinaryHolder();
-    ByteBuffer byteBuffer = decoder.readBytes(null);
+
+    //cacheBuffer is initialized null and create in the first consume,
+    //if its capacity < size to read, decoder will create a new one with new capacity.
+    cacheBuffer = decoder.readBytes(cacheBuffer);
 
     holder.start = 0;
-    holder.end = byteBuffer.capacity();
-    holder.buffer = vector.getAllocator().buffer(byteBuffer.capacity());
-    holder.buffer.setBytes(0, byteBuffer);
+    holder.end = cacheBuffer.limit();
+    holder.buffer = vector.getAllocator().buffer(cacheBuffer.limit());
+    holder.buffer.setBytes(0, cacheBuffer, 0,  cacheBuffer.limit());
 
     writer.write(holder);
     writer.setPosition(writer.getPosition() + 1);

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -34,6 +34,7 @@ public class AvroStringConsumer implements Consumer {
 
   private final VarCharVector vector;
   private final VarCharWriter writer;
+  private ByteBuffer cacheBuffer;
 
   public AvroStringConsumer(VarCharVector vector) {
     this.vector = vector;
@@ -43,12 +44,15 @@ public class AvroStringConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     VarCharHolder holder = new VarCharHolder();
-    ByteBuffer byteBuffer = decoder.readBytes(null);
+
+    //cacheBuffer is initialized null and create in the first consume,
+    //if its capacity < size to read, decoder will create a new one with new capacity.
+    cacheBuffer = decoder.readBytes(cacheBuffer);
 
     holder.start = 0;
-    holder.end = byteBuffer.capacity();
-    holder.buffer = vector.getAllocator().buffer(byteBuffer.capacity());
-    holder.buffer.setBytes(0, byteBuffer);
+    holder.end = cacheBuffer.limit();
+    holder.buffer = vector.getAllocator().buffer(cacheBuffer.limit());
+    holder.buffer.setBytes(0, cacheBuffer, 0, cacheBuffer.limit());
 
     writer.write(holder);
     writer.setPosition(writer.getPosition() + 1);

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -45,8 +45,8 @@ public class AvroStringConsumer implements Consumer {
   public void consume(Decoder decoder) throws IOException {
     VarCharHolder holder = new VarCharHolder();
 
-    //cacheBuffer is initialized null and create in the first consume,
-    //if its capacity < size to read, decoder will create a new one with new capacity.
+    // cacheBuffer is initialized null and create in the first consume,
+    // if its capacity < size to read, decoder will create a new one with new capacity.
     cacheBuffer = decoder.readBytes(cacheBuffer);
 
     holder.start = 0;

--- a/java/adapter/avro/src/test/resources/schema/test_record.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_record.avsc
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "testRecord",
+ "fields": [
+     {"name": "f0", "type": "string"},
+     {"name": "f1", "type": "int"},
+     {"name": "f2", "type": "boolean"}
+ ]
+}


### PR DESCRIPTION
Related to [ARROW-5988](https://issues.apache.org/jira/browse/ARROW-5988).

1. implement simple Record type witch only contains primitive types
2. add ByteBuffer cache in String/Bytes consumer to reduce creations.