### PR TITLE
ARROW-6012: [C++] Fall back on known Apache mirror for Thrift downloads

### DIFF
--- a/cpp/build-support/get_apache_mirror.py
+++ b/cpp/build-support/get_apache_mirror.py
@@ -20,6 +20,8 @@
 # mirror for downloading dependencies, e.g. in CMake
 
 import json
+import warnings
+
 try:
     import requests
 
@@ -35,6 +37,14 @@ except ImportError:
     def get_url(url):
         return urlopen(url).read()
 
-suggested_mirror = get_url('https://www.apache.org/dyn/'
-                           'closer.cgi?as_json=1')
-print(json.loads(suggested_mirror.decode('utf-8'))['preferred'])
+url = 'https://www.apache.org/dyn/closer.cgi?as_json=1'
+
+try:
+    suggested_mirror = get_url(url)
+except Exception as e:
+    warnings.warn("Failed loading {url!r}: {e}".format(**locals()),
+                  RuntimeWarning)
+    # Well-known mirror, in case the URL above fails loading
+    print("http://apache.osuosl.org/")
+else:
+    print(json.loads(suggested_mirror.decode('utf-8'))['preferred'])

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -40,11 +40,10 @@ set(APACHE_MIRROR "")
 
 macro(get_apache_mirror)
   if(APACHE_MIRROR STREQUAL "")
-    exec_program(${PYTHON_EXECUTABLE}
-                 ARGS
-                 ${CMAKE_SOURCE_DIR}/build-support/get_apache_mirror.py
-                 OUTPUT_VARIABLE
-                 APACHE_MIRROR)
+    execute_process(COMMAND ${PYTHON_EXECUTABLE}
+                            ${CMAKE_SOURCE_DIR}/build-support/get_apache_mirror.py
+                    OUTPUT_VARIABLE APACHE_MIRROR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
   endif()
 endmacro()
 


### PR DESCRIPTION
Needed to fix AppVeyor builds