### PR TITLE
ARROW-6016: [Python] Fix get_library_dirs() when Arrow installed as a system package

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -262,8 +262,11 @@ def get_library_dirs():
         if _has_pkg_config(pkgname):
             library_dir = _read_pkg_config_variable(pkgname,
                                                     ["--libs-only-L"])
-            assert library_dir.startswith("-L")
-            append_library_dir(library_dir[2:])
+            # pkg-config output could be empty if Arrow is installed
+            # as a system package.
+            if library_dir:
+                assert library_dir.startswith("-L")
+                append_library_dir(library_dir[2:])
 
     if _sys.platform == 'win32':
         # TODO(wesm): Is this necessary, or does setuptools within a conda

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -265,7 +265,10 @@ def get_library_dirs():
             # pkg-config output could be empty if Arrow is installed
             # as a system package.
             if library_dir:
-                assert library_dir.startswith("-L")
+                if not library_dir.startswith("-L"):
+                    raise ValueError(
+                        "pkg-config --libs-only-L returned unexpected "
+                        "value {0!r}".format(library_dir))
                 append_library_dir(library_dir[2:])
 
     if _sys.platform == 'win32':


### PR DESCRIPTION
Presumably this should fix the issue, though I can't check.