### PR TITLE
ARROW-5935: [C++] ArrayBuilder::type() should be kept accurate

### DIFF
--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -36,7 +36,7 @@ namespace arrow {
 using internal::AdaptiveIntBuilderBase;
 
 AdaptiveIntBuilderBase::AdaptiveIntBuilderBase(MemoryPool* pool)
-    : ArrayBuilder(int64(), pool),
+    : ArrayBuilder(nullptr, pool),
       data_(nullptr),
       raw_data_(nullptr),
       int_size_(1),

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -134,7 +134,7 @@ Status AdaptiveIntBuilder::AppendValuesInternal(const int64_t* values, int64_t l
     if (new_int_size > int_size_) {
       // This updates int_size_
       RETURN_NOT_OK(ExpandIntSize(new_int_size));
-      root_builder_->UpdateType();
+      UpdateParentType();
     }
 
     switch (int_size_) {
@@ -258,7 +258,7 @@ Status AdaptiveIntBuilder::ExpandIntSize(uint8_t new_int_size) {
     default:
       DCHECK(false);
   }
-  root_builder_->UpdateType();
+  UpdateParentType();
   return Status::OK();
 }
 
@@ -318,7 +318,7 @@ Status AdaptiveUIntBuilder::AppendValuesInternal(const uint64_t* values, int64_t
     if (new_int_size > int_size_) {
       // This updates int_size_
       RETURN_NOT_OK(ExpandIntSize(new_int_size));
-      root_builder_->UpdateType();
+      UpdateParentType();
     }
 
     switch (int_size_) {
@@ -427,7 +427,7 @@ Status AdaptiveUIntBuilder::ExpandIntSize(uint8_t new_int_size) {
     default:
       DCHECK(false);
   }
-  root_builder_->UpdateType();
+  UpdateParentType();
   return Status::OK();
 }
 

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -68,29 +68,11 @@ AdaptiveIntBuilder::AdaptiveIntBuilder(MemoryPool* pool)
 Status AdaptiveIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(CommitPendingData());
 
-  std::shared_ptr<DataType> output_type;
-  switch (int_size_) {
-    case 1:
-      output_type = int8();
-      break;
-    case 2:
-      output_type = int16();
-      break;
-    case 4:
-      output_type = int32();
-      break;
-    case 8:
-      output_type = int64();
-      break;
-    default:
-      return Status::NotImplemented("Only ints of size 1,2,4,8 are supported");
-  }
-
   std::shared_ptr<Buffer> null_bitmap;
   RETURN_NOT_OK(null_bitmap_builder_.Finish(&null_bitmap));
   RETURN_NOT_OK(TrimBuffer(length_ * int_size_, data_.get()));
 
-  *out = ArrayData::Make(output_type, length_, {null_bitmap, data_}, null_count_);
+  *out = ArrayData::Make(type_, length_, {null_bitmap, data_}, null_count_);
 
   data_ = nullptr;
   capacity_ = length_ = null_count_ = 0;
@@ -268,29 +250,11 @@ AdaptiveUIntBuilder::AdaptiveUIntBuilder(MemoryPool* pool)
 Status AdaptiveUIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(CommitPendingData());
 
-  std::shared_ptr<DataType> output_type;
-  switch (int_size_) {
-    case 1:
-      output_type = uint8();
-      break;
-    case 2:
-      output_type = uint16();
-      break;
-    case 4:
-      output_type = uint32();
-      break;
-    case 8:
-      output_type = uint64();
-      break;
-    default:
-      return Status::NotImplemented("Only ints of size 1,2,4,8 are supported");
-  }
-
   std::shared_ptr<Buffer> null_bitmap;
   RETURN_NOT_OK(null_bitmap_builder_.Finish(&null_bitmap));
   RETURN_NOT_OK(TrimBuffer(length_ * int_size_, data_.get()));
 
-  *out = ArrayData::Make(output_type, length_, {null_bitmap, data_}, null_count_);
+  *out = ArrayData::Make(type_, length_, {null_bitmap, data_}, null_count_);
 
   data_ = nullptr;
   capacity_ = length_ = null_count_ = 0;

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -284,15 +284,7 @@ Status AdaptiveUIntBuilder::AppendValuesInternal(const uint64_t* values, int64_t
     const int64_t chunk_size = std::min(length, kAdaptiveIntChunkSize);
 
     uint8_t new_int_size;
-    if (values == pending_data_) {
-      // only the most recent addition to pending_data_ may expand int size
-      auto i = pending_pos_ - 1;
-      new_int_size = internal::DetectUIntWidth(
-          values + i, valid_bytes ? valid_bytes + i : nullptr, 1, int_size_);
-    } else {
-      new_int_size =
-          internal::DetectUIntWidth(values, valid_bytes, chunk_size, int_size_);
-    }
+    new_int_size = internal::DetectUIntWidth(values, valid_bytes, chunk_size, int_size_);
 
     DCHECK_GE(new_int_size, int_size_);
     if (new_int_size > int_size_) {

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -73,7 +73,7 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
   virtual Status CommitPendingData() = 0;
 
   std::shared_ptr<ResizableBuffer> data_;
-  uint8_t* raw_data_ = nullptr;
+  uint8_t* raw_data_ = NULLPTR;
   uint8_t int_size_ = sizeof(uint8_t);
   uint64_t expand_int_size_mask_ = ExpandIntSizeMask<sizeof(uint8_t)>();
 

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -154,7 +154,7 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
     pending_valid_[pending_pos_] = 1;
     ++pending_pos_;
 
-    if (v + expand_int_size_addend_ & expand_int_size_mask_) {
+    if ((v + expand_int_size_addend_) & expand_int_size_mask_) {
       return CommitPendingData();
     }
     if (ARROW_PREDICT_FALSE(pending_pos_ >= pending_size_)) {

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -25,24 +25,9 @@ namespace arrow {
 
 namespace internal {
 
-template <uint8_t size>
-constexpr uint64_t ExpandIntSizeMask() {
-  return ~static_cast<uint64_t>(0) << size * CHAR_BIT;
-}
-
-template <>
-constexpr uint64_t ExpandIntSizeMask<sizeof(int64_t)>() {
-  return 0;
-}
-
-template <uint8_t size>
-constexpr uint64_t ExpandIntSizeAddend() {
-  return static_cast<uint64_t>(1) << (size * CHAR_BIT - 1);
-}
-
 class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
  public:
-  AdaptiveIntBuilderBase(const std::shared_ptr<DataType>& type, MemoryPool* pool);
+  AdaptiveIntBuilderBase(MemoryPool* pool);
 
   /// \brief Append multiple nulls
   /// \param[in] length the number of nulls to append
@@ -75,7 +60,6 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
   std::shared_ptr<ResizableBuffer> data_;
   uint8_t* raw_data_ = NULLPTR;
   uint8_t int_size_ = sizeof(uint8_t);
-  uint64_t expand_int_size_mask_ = ExpandIntSizeMask<sizeof(uint8_t)>();
 
   static constexpr int32_t pending_size_ = 1024;
   uint8_t pending_valid_[pending_size_];
@@ -99,9 +83,6 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
     pending_valid_[pending_pos_] = 1;
     ++pending_pos_;
 
-    if (val & expand_int_size_mask_) {
-      return CommitPendingData();
-    }
     if (ARROW_PREDICT_FALSE(pending_pos_ >= pending_size_)) {
       return CommitPendingData();
     }
@@ -154,9 +135,6 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
     pending_valid_[pending_pos_] = 1;
     ++pending_pos_;
 
-    if ((v + expand_int_size_addend_) & expand_int_size_mask_) {
-      return CommitPendingData();
-    }
     if (ARROW_PREDICT_FALSE(pending_pos_ >= pending_size_)) {
       return CommitPendingData();
     }
@@ -192,8 +170,6 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
   template <typename new_type>
   Status ExpandIntSizeN();
-
-  uint64_t expand_int_size_addend_ = internal::ExpandIntSizeAddend<sizeof(int8_t)>();
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -27,7 +27,7 @@ namespace internal {
 
 class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
  public:
-  AdaptiveIntBuilderBase(MemoryPool* pool);
+  explicit AdaptiveIntBuilderBase(MemoryPool* pool);
 
   /// \brief Append multiple nulls
   /// \param[in] length the number of nulls to append

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -119,6 +119,8 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  std::shared_ptr<DataType> type() const override;
+
  protected:
   Status CommitPendingData() override;
   Status ExpandIntSize(uint8_t new_int_size);
@@ -129,11 +131,9 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
   template <typename new_type, typename old_type>
   typename std::enable_if<sizeof(old_type) >= sizeof(new_type), Status>::type
   ExpandIntSizeInternal();
-#define __LESS(a, b) (a) < (b)
   template <typename new_type, typename old_type>
-  typename std::enable_if<__LESS(sizeof(old_type), sizeof(new_type)), Status>::type
+  typename std::enable_if<(sizeof(old_type) < sizeof(new_type)), Status>::type
   ExpandIntSizeInternal();
-#undef __LESS
 
   template <typename new_type>
   Status ExpandIntSizeN();
@@ -174,6 +174,8 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
+  std::shared_ptr<DataType> type() const override;
+
  protected:
   Status CommitPendingData() override;
   Status ExpandIntSize(uint8_t new_int_size);
@@ -184,11 +186,9 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
   template <typename new_type, typename old_type>
   typename std::enable_if<sizeof(old_type) >= sizeof(new_type), Status>::type
   ExpandIntSizeInternal();
-#define __LESS(a, b) (a) < (b)
   template <typename new_type, typename old_type>
-  typename std::enable_if<__LESS(sizeof(old_type), sizeof(new_type)), Status>::type
+  typename std::enable_if<(sizeof(old_type) < sizeof(new_type)), Status>::type
   ExpandIntSizeInternal();
-#undef __LESS
 
   template <typename new_type>
   Status ExpandIntSizeN();

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -34,10 +34,6 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
-ArrayBuilder::ArrayBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
-    : type_(type), pool_(pool), null_bitmap_builder_(pool) {
-  DCHECK_NE(type_, nullptr);
-}
 
 Status ArrayBuilder::TrimBuffer(const int64_t bytes_filled, ResizableBuffer* buffer) {
   if (buffer) {

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -34,6 +34,10 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
+ArrayBuilder::ArrayBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
+    : type_(type), pool_(pool), null_bitmap_builder_(pool) {
+  DCHECK_NE(type_, nullptr);
+}
 
 Status ArrayBuilder::TrimBuffer(const int64_t bytes_filled, ResizableBuffer* buffer) {
   if (buffer) {

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -230,7 +230,7 @@ class ARROW_EXPORT ArrayBuilder {
   // Child value array builders. These are owned by this class
   std::vector<std::shared_ptr<ArrayBuilder>> children_;
 
-  ArrayBuilder* parent_builder_ = nullptr;
+  ArrayBuilder* parent_builder_ = NULLPTR;
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(ArrayBuilder);

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -104,6 +104,11 @@ class ARROW_EXPORT ArrayBuilder {
   virtual Status AppendNull() = 0;
   virtual Status AppendNulls(int64_t length) = 0;
 
+  /// For cases where raw data was memcpy'd into the internal buffers, allows us
+  /// to advance the length of the builder. It is your responsibility to use
+  /// this function responsibly.
+  Status Advance(int64_t elements);
+
   /// \brief Return result of builder as an internal generic ArrayData
   /// object. Resets builder except for dictionary builder
   ///
@@ -126,11 +131,6 @@ class ARROW_EXPORT ArrayBuilder {
   std::shared_ptr<DataType> type() const { return type_; }
 
  protected:
-  /// For cases where raw data was memcpy'd into the internal buffers, allows us
-  /// to advance the length of the builder. It is your responsibility to use
-  /// this function responsibly.
-  Status Advance(int64_t elements);
-
   /// Append to null bitmap
   Status AppendToBitmap(bool is_valid);
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -53,8 +53,7 @@ constexpr int64_t kListMaximumElements = std::numeric_limits<int32_t>::max() - 1
 /// For example, ArrayBuilder* pointing to BinaryBuilder should be downcast before use.
 class ARROW_EXPORT ArrayBuilder {
  public:
-  ArrayBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
-      : type_(type), pool_(pool), null_bitmap_builder_(pool) {}
+  ArrayBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool);
 
   virtual ~ArrayBuilder() = default;
 

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -104,11 +104,6 @@ class ARROW_EXPORT ArrayBuilder {
   virtual Status AppendNull() = 0;
   virtual Status AppendNulls(int64_t length) = 0;
 
-  /// For cases where raw data was memcpy'd into the internal buffers, allows us
-  /// to advance the length of the builder. It is your responsibility to use
-  /// this function responsibly.
-  Status Advance(int64_t elements);
-
   /// \brief Return result of builder as an internal generic ArrayData
   /// object. Resets builder except for dictionary builder
   ///
@@ -124,9 +119,18 @@ class ARROW_EXPORT ArrayBuilder {
   /// \return Status
   Status Finish(std::shared_ptr<Array>* out);
 
+  /// \brief Return the type of the built Array
+  ///
+  /// \note this will be nullptr if (and only if) the type of the built
+  /// array may mutate or is otherwise indeterminate until Finish is called.
   std::shared_ptr<DataType> type() const { return type_; }
 
  protected:
+  /// For cases where raw data was memcpy'd into the internal buffers, allows us
+  /// to advance the length of the builder. It is your responsibility to use
+  /// this function responsibly.
+  Status Advance(int64_t elements);
+
   /// Append to null bitmap
   Status AppendToBitmap(bool is_valid);
 

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -41,24 +41,11 @@ namespace arrow {
 using internal::checked_cast;
 
 // ----------------------------------------------------------------------
-// String and binary
-
-BinaryBuilder::BinaryBuilder(MemoryPool* pool) : BaseBinaryBuilder(binary(), pool) {}
-
-StringBuilder::StringBuilder(MemoryPool* pool) : BinaryBuilder(utf8(), pool) {}
-
-LargeBinaryBuilder::LargeBinaryBuilder(MemoryPool* pool)
-    : BaseBinaryBuilder(large_binary(), pool) {}
-
-LargeStringBuilder::LargeStringBuilder(MemoryPool* pool)
-    : LargeBinaryBuilder(large_utf8(), pool) {}
-
-// ----------------------------------------------------------------------
 // Fixed width binary
 
 FixedSizeBinaryBuilder::FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& type,
                                                MemoryPool* pool)
-    : ArrayBuilder(type, pool),
+    : ArrayBuilder(pool),
       byte_width_(checked_cast<const FixedSizeBinaryType&>(*type).byte_width()),
       byte_builder_(pool) {}
 
@@ -103,7 +90,7 @@ Status FixedSizeBinaryBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
 
   std::shared_ptr<Buffer> null_bitmap;
   RETURN_NOT_OK(null_bitmap_builder_.Finish(&null_bitmap));
-  *out = ArrayData::Make(type_, length_, {null_bitmap, data}, null_count_);
+  *out = ArrayData::Make(type(), length_, {null_bitmap, data}, null_count_);
 
   capacity_ = length_ = null_count_ = 0;
   return Status::OK();

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -44,7 +44,8 @@ namespace arrow {
 
 Decimal128Builder::Decimal128Builder(const std::shared_ptr<DataType>& type,
                                      MemoryPool* pool)
-    : FixedSizeBinaryBuilder(type, pool) {}
+    : FixedSizeBinaryBuilder(type, pool),
+      decimal_type_(internal::checked_pointer_cast<Decimal128Type>(type)) {}
 
 Status Decimal128Builder::Append(Decimal128 value) {
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Reserve(1));
@@ -68,7 +69,7 @@ Status Decimal128Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   std::shared_ptr<Buffer> null_bitmap;
   RETURN_NOT_OK(null_bitmap_builder_.Finish(&null_bitmap));
 
-  *out = ArrayData::Make(type_, length_, {null_bitmap, data}, null_count_);
+  *out = ArrayData::Make(type(), length_, {null_bitmap, data}, null_count_);
   capacity_ = length_ = null_count_ = 0;
   return Status::OK();
 }

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -48,6 +48,11 @@ class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
   /// \endcond
 
   Status Finish(std::shared_ptr<Decimal128Array>* out) { return FinishTyped(out); }
+
+  std::shared_ptr<DataType> type() const override { return decimal_type_; }
+
+ protected:
+  std::shared_ptr<Decimal128Type> decimal_type_;
 };
 
 using DecimalBuilder = Decimal128Builder;

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -104,24 +104,26 @@ class DictionaryBuilderBase : public ArrayBuilder {
   template <typename T1 = T>
   DictionaryBuilderBase(
       typename std::enable_if<!std::is_base_of<FixedSizeBinaryType, T1>::value,
-                              const std::shared_ptr<DataType>&>::type type,
+                              const std::shared_ptr<DataType>&>::type value_type,
       MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(type, pool),
-        memo_table_(new DictionaryMemoTable(type)),
+      : ArrayBuilder(NULLPTR, pool),
+        memo_table_(new DictionaryMemoTable(value_type)),
         delta_offset_(0),
         byte_width_(-1),
-        values_builder_(pool) {}
+        indices_builder_(pool),
+        value_type_(value_type) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
       typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T1>::value,
-                              const std::shared_ptr<DataType>&>::type type,
+                              const std::shared_ptr<DataType>&>::type value_type,
       MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(type, pool),
-        memo_table_(new DictionaryMemoTable(type)),
+      : ArrayBuilder(NULLPTR, pool),
+        memo_table_(new internal::DictionaryMemoTable(value_type)),
         delta_offset_(0),
-        byte_width_(static_cast<const T1&>(*type).byte_width()),
-        values_builder_(pool) {}
+        byte_width_(static_cast<const T1&>(*value_type).byte_width()),
+        indices_builder_(pool),
+        value_type_(value_type) {}
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
@@ -131,11 +133,12 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
                         MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(dictionary->type(), pool),
-        memo_table_(new DictionaryMemoTable(dictionary)),
+      : ArrayBuilder(NULLPTR, pool),
+        memo_table_(new internal::DictionaryMemoTable(dictionary)),
         delta_offset_(0),
         byte_width_(-1),
-        values_builder_(pool) {}
+        indices_builder_(pool),
+        value_type_(dictionary->type()) {}
 
   ~DictionaryBuilderBase() override = default;
 
@@ -144,7 +147,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
     ARROW_RETURN_NOT_OK(Reserve(1));
 
     auto memo_index = memo_table_->GetOrInsert(value);
-    ARROW_RETURN_NOT_OK(values_builder_.Append(memo_index));
+    ARROW_RETURN_NOT_OK(indices_builder_.Append(memo_index));
     length_ += 1;
 
     return Status::OK();
@@ -169,14 +172,14 @@ class DictionaryBuilderBase : public ArrayBuilder {
     length_ += 1;
     null_count_ += 1;
 
-    return values_builder_.AppendNull();
+    return indices_builder_.AppendNull();
   }
 
   Status AppendNulls(int64_t length) final {
     length_ += length;
     null_count_ += length;
 
-    return values_builder_.AppendNulls(length);
+    return indices_builder_.AppendNulls(length);
   }
 
   /// \brief Insert values into the dictionary's memo, but do not append any
@@ -210,7 +213,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
   Status AppendArray(
       typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T1>::value,
                               const Array&>::type array) {
-    if (!type_->Equals(*array.type())) {
+    if (!value_type_->Equals(*array.type())) {
       return Status::Invalid(
           "Cannot append FixedSizeBinary array with non-matching type");
     }
@@ -228,8 +231,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   void Reset() override {
     ArrayBuilder::Reset();
-    values_builder_.Reset();
-    memo_table_.reset(new DictionaryMemoTable(type_));
+    indices_builder_.Reset();
+    memo_table_.reset(new internal::DictionaryMemoTable(value_type_));
     delta_offset_ = 0;
   }
 
@@ -242,14 +245,14 @@ class DictionaryBuilderBase : public ArrayBuilder {
       // XXX should we let the user pass additional size heuristics?
       delta_offset_ = 0;
     }
-    ARROW_RETURN_NOT_OK(values_builder_.Resize(capacity));
-    capacity_ = values_builder_.capacity();
+    ARROW_RETURN_NOT_OK(indices_builder_.Resize(capacity));
+    capacity_ = indices_builder_.capacity();
     return Status::OK();
   }
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override {
     // Finalize indices array
-    ARROW_RETURN_NOT_OK(values_builder_.FinishInternal(out));
+    ARROW_RETURN_NOT_OK(indices_builder_.FinishInternal(out));
 
     // Generate dictionary array from hash table contents
     std::shared_ptr<ArrayData> dictionary_data;
@@ -258,12 +261,12 @@ class DictionaryBuilderBase : public ArrayBuilder {
         memo_table_->GetArrayData(pool_, delta_offset_, &dictionary_data));
 
     // Set type of array data to the right dictionary type
-    (*out)->type = dictionary((*out)->type, type_);
+    (*out)->type = dictionary((*out)->type, value_type_);
     (*out)->dictionary = MakeArray(dictionary_data);
 
     // Update internals for further uses of this DictionaryBuilder
     delta_offset_ = memo_table_->size();
-    values_builder_.Reset();
+    indices_builder_.Reset();
 
     return Status::OK();
   }
@@ -284,36 +287,37 @@ class DictionaryBuilderBase : public ArrayBuilder {
   // Only used for FixedSizeBinaryType
   int32_t byte_width_;
 
-  BuilderType values_builder_;
+  AdaptiveIntBuilder indices_builder_;
+  std::shared_ptr<DataType> value_type_;
 };
 
 template <typename BuilderType>
 class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
  public:
-  DictionaryBuilderBase(const std::shared_ptr<DataType>& type,
+  DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
                         MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(type, pool), values_builder_(pool) {}
+      : ArrayBuilder(value_type, pool), indices_builder_(pool) {}
 
   explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(null(), pool), values_builder_(pool) {}
+      : ArrayBuilder(null(), pool), indices_builder_(pool) {}
 
   DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
                         MemoryPool* pool = default_memory_pool())
-      : ArrayBuilder(dictionary->type(), pool), values_builder_(pool) {}
+      : ArrayBuilder(dictionary->type(), pool), indices_builder_(pool) {}
 
   /// \brief Append a scalar null value
   Status AppendNull() final {
     length_ += 1;
     null_count_ += 1;
 
-    return values_builder_.AppendNull();
+    return indices_builder_.AppendNull();
   }
 
   Status AppendNulls(int64_t length) final {
     length_ += length;
     null_count_ += length;
 
-    return values_builder_.AppendNulls(length);
+    return indices_builder_.AppendNulls(length);
   }
 
   /// \brief Append a whole dense array to the builder
@@ -328,17 +332,15 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
     ARROW_RETURN_NOT_OK(CheckCapacity(capacity, capacity_));
     capacity = std::max(capacity, kMinBuilderCapacity);
 
-    ARROW_RETURN_NOT_OK(values_builder_.Resize(capacity));
-    capacity_ = values_builder_.capacity();
+    ARROW_RETURN_NOT_OK(indices_builder_.Resize(capacity));
+    capacity_ = indices_builder_.capacity();
     return Status::OK();
   }
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override {
-    std::shared_ptr<Array> dictionary = std::make_shared<NullArray>(0);
-
-    ARROW_RETURN_NOT_OK(values_builder_.FinishInternal(out));
-    (*out)->type = std::make_shared<DictionaryType>((*out)->type, type_);
-    (*out)->dictionary = dictionary;
+    ARROW_RETURN_NOT_OK(indices_builder_.FinishInternal(out));
+    (*out)->type = dictionary((*out)->type, null());
+    (*out)->dictionary.reset(new NullArray(0));
 
     return Status::OK();
   }
@@ -350,7 +352,7 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
  protected:
-  BuilderType values_builder_;
+  BuilderType indices_builder_;
 };
 
 }  // namespace internal
@@ -368,10 +370,10 @@ class DictionaryBuilder : public internal::DictionaryBuilderBase<AdaptiveIntBuil
   /// NOTE: Experimental API
   Status AppendIndices(const int64_t* values, int64_t length,
                        const uint8_t* valid_bytes = NULLPTR) {
-    int64_t null_count_before = this->values_builder_.null_count();
-    ARROW_RETURN_NOT_OK(this->values_builder_.AppendValues(values, length, valid_bytes));
+    int64_t null_count_before = this->indices_builder_.null_count();
+    ARROW_RETURN_NOT_OK(this->indices_builder_.AppendValues(values, length, valid_bytes));
     this->length_ += length;
-    this->null_count_ += this->values_builder_.null_count() - null_count_before;
+    this->null_count_ += this->indices_builder_.null_count() - null_count_before;
     return Status::OK();
   }
 };
@@ -390,10 +392,10 @@ class Dictionary32Builder : public internal::DictionaryBuilderBase<Int32Builder,
   /// NOTE: Experimental API
   Status AppendIndices(const int32_t* values, int64_t length,
                        const uint8_t* valid_bytes = NULLPTR) {
-    int64_t null_count_before = this->values_builder_.null_count();
-    ARROW_RETURN_NOT_OK(this->values_builder_.AppendValues(values, length, valid_bytes));
+    int64_t null_count_before = this->indices_builder_.null_count();
+    ARROW_RETURN_NOT_OK(this->indices_builder_.AppendValues(values, length, valid_bytes));
     this->length_ += length;
-    this->null_count_ += this->values_builder_.null_count() - null_count_before;
+    this->null_count_ += this->indices_builder_.null_count() - null_count_before;
     return Status::OK();
   }
 };

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -229,7 +229,7 @@ Status StructBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
 std::shared_ptr<DataType> StructBuilder::type() const {
   DCHECK_EQ(type_->children().size(), children_.size());
   std::vector<std::shared_ptr<Field>> fields(children_.size());
-  for (size_t i = 0; i < fields.size(); ++i) {
+  for (int i = 0; i < static_cast<int>(fields.size()); ++i) {
     fields[i] = type_->child(i)->WithType(children_[i]->type());
   }
   return struct_(std::move(fields));

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -230,7 +230,7 @@ std::shared_ptr<DataType> StructBuilder::type() const {
   DCHECK_EQ(type_->children().size(), children_.size());
   std::vector<std::shared_ptr<Field>> fields(children_.size());
   for (size_t i = 0; i < fields.size(); ++i) {
-    fields[i] = fields[i]->WithType(children_[i]->type());
+    fields[i] = type_->child(i)->WithType(children_[i]->type());
   }
   return struct_(std::move(fields));
 }

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -227,8 +227,8 @@ Status StructBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
 }
 
 std::shared_ptr<DataType> StructBuilder::type() const {
-  auto fields = type_->children();
-  DCHECK_EQ(fields.size(), children_.size());
+  DCHECK_EQ(type_->children().size(), children_.size());
+  std::vector<std::shared_ptr<Field>> fields(children_.size());
   for (size_t i = 0; i < fields.size(); ++i) {
     fields[i] = fields[i]->WithType(children_[i]->type());
   }

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -203,7 +203,7 @@ Status FixedSizeListBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
 StructBuilder::StructBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool,
                              std::vector<std::shared_ptr<ArrayBuilder>> field_builders)
     : ArrayBuilder(type, pool) {
-  for (auto&& field_builder : field_builders) {
+  for (const auto& field_builder : field_builders) {
     if (field_builder->type() == nullptr) {
       type_ = nullptr;
       break;

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -44,7 +44,7 @@ class BaseListBuilder : public ArrayBuilder {
       : ArrayBuilder(pool),
         offsets_builder_(pool),
         value_builder_(value_builder),
-        value_field_(type->child(0)) {}
+        value_field_(type->child(0)->WithType(NULLPTR)) {}
 
   BaseListBuilder(MemoryPool* pool, std::shared_ptr<ArrayBuilder> const& value_builder)
       : BaseListBuilder(pool, value_builder, list(value_builder->type())) {}

--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -45,7 +45,7 @@ Status NullBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
 }
 
 BooleanBuilder::BooleanBuilder(MemoryPool* pool)
-    : ArrayBuilder(boolean(), pool), data_builder_(pool) {}
+    : ArrayBuilder(pool), data_builder_(pool) {}
 
 BooleanBuilder::BooleanBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
     : BooleanBuilder(pool) {

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -168,6 +168,7 @@ class NumericBuilder : public ArrayBuilder {
   }
 
   /// \cond FALSE
+  using ArrayBuilder::Advance;
   using ArrayBuilder::Finish;
   /// \endcond
 
@@ -417,6 +418,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
   /// \cond FALSE
+  using ArrayBuilder::Advance;
   using ArrayBuilder::Finish;
   /// \endcond
 

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -168,7 +168,6 @@ class NumericBuilder : public ArrayBuilder {
   }
 
   /// \cond FALSE
-  using ArrayBuilder::Advance;
   using ArrayBuilder::Finish;
   /// \endcond
 
@@ -418,7 +417,6 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override;
 
   /// \cond FALSE
-  using ArrayBuilder::Advance;
   using ArrayBuilder::Finish;
   /// \endcond
 

--- a/cpp/src/arrow/array/builder_time.h
+++ b/cpp/src/arrow/array/builder_time.h
@@ -42,8 +42,7 @@ class ARROW_EXPORT DayTimeIntervalBuilder : public ArrayBuilder {
 
   DayTimeIntervalBuilder(std::shared_ptr<DataType> type,
                          MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
-      : ArrayBuilder(type, pool),
-        builder_(fixed_size_binary(sizeof(DayMilliseconds)), pool) {}
+      : ArrayBuilder(pool), builder_(fixed_size_binary(sizeof(DayMilliseconds)), pool) {}
 
   void Reset() override { builder_.Reset(); }
   Status Resize(int64_t capacity) override { return builder_.Resize(capacity); }
@@ -63,6 +62,8 @@ class ARROW_EXPORT DayTimeIntervalBuilder : public ArrayBuilder {
     }
     return result;
   }
+
+  std::shared_ptr<DataType> type() const override { return day_time_interval(); }
 
  private:
   FixedSizeBinaryBuilder builder_;

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -92,8 +92,7 @@ BasicUnionBuilder::BasicUnionBuilder(
 
 int8_t BasicUnionBuilder::AppendChild(const std::shared_ptr<ArrayBuilder>& new_child,
                                       const std::string& field_name) {
-  // force type inferrence in Finish
-  type_ = nullptr;
+  DCHECK_EQ(type_, nullptr);
 
   field_names_.push_back(field_name);
   children_.push_back(new_child);

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -33,31 +33,12 @@ Status BasicUnionBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(types_builder_.Finish(&types));
 
   // If the type has not been specified in the constructor, gather type_codes
-  std::vector<uint8_t> type_codes;
-  if (type_ == nullptr) {
-    for (size_t i = 0; i < children_.size(); ++i) {
-      if (type_id_to_children_[i] != nullptr) {
-        type_codes.push_back(static_cast<uint8_t>(i));
-      }
-    }
-  } else {
-    type_codes = checked_cast<const UnionType&>(*type_).type_codes();
-  }
+  auto type_codes = checked_cast<const UnionType&>(*type_).type_codes();
   DCHECK_EQ(type_codes.size(), children_.size());
 
   std::vector<std::shared_ptr<ArrayData>> child_data(children_.size());
   for (size_t i = 0; i < children_.size(); ++i) {
     RETURN_NOT_OK(children_[i]->FinishInternal(&child_data[i]));
-  }
-
-  // If the type has not been specified in the constructor, infer it
-  if (type_ == nullptr) {
-    std::vector<std::shared_ptr<Field>> fields;
-    auto field_names_it = field_names_.begin();
-    for (auto&& data : child_data) {
-      fields.push_back(field(*field_names_it++, data->type));
-    }
-    type_ = union_(fields, type_codes, mode_);
   }
 
   *out = ArrayData::Make(type_, length(), {null_bitmap, types, nullptr}, null_count_);
@@ -92,18 +73,29 @@ BasicUnionBuilder::BasicUnionBuilder(
 
 int8_t BasicUnionBuilder::AppendChild(const std::shared_ptr<ArrayBuilder>& new_child,
                                       const std::string& field_name) {
-  DCHECK_EQ(type_, nullptr);
-
-  field_names_.push_back(field_name);
   children_.push_back(new_child);
 
+  auto new_type_id = NextTypeId();
+  type_id_to_children_[new_type_id] = new_child;
+
+  auto fields = type_->children();
+  fields.push_back(field(field_name, new_child->type()));
+
+  auto type_codes = checked_cast<const UnionType&>(*type_).type_codes();
+  type_codes.push_back(static_cast<uint8_t>(new_type_id));
+
+  type_ = union_(std::move(fields), std::move(type_codes), mode_);
+  root_builder_->UpdateType();
+  return new_type_id;
+}
+
+int8_t BasicUnionBuilder::NextTypeId() {
   // Find type_id such that type_id_to_children_[type_id] == nullptr
   // and use that for the new child. Start searching at dense_type_id_
   // since type_id_to_children_ is densely packed up at least up to dense_type_id_
   for (; static_cast<size_t>(dense_type_id_) < type_id_to_children_.size();
        ++dense_type_id_) {
     if (type_id_to_children_[dense_type_id_] == nullptr) {
-      type_id_to_children_[dense_type_id_] = new_child;
       return dense_type_id_++;
     }
   }
@@ -113,7 +105,7 @@ int8_t BasicUnionBuilder::AppendChild(const std::shared_ptr<ArrayBuilder>& new_c
                 std::numeric_limits<int8_t>::max()));
 
   // type_id_to_children_ is already densely packed, so just append the new child
-  type_id_to_children_.push_back(new_child);
+  type_id_to_children_.resize(type_id_to_children_.size() + 1);
   return dense_type_id_++;
 }
 

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -63,7 +63,7 @@ BasicUnionBuilder::BasicUnionBuilder(
   DCHECK_LT(type_id_to_children_.size(), std::numeric_limits<int8_t>::max());
 
   for (size_t i = 0; i < children.size(); ++i) {
-    child_fields_[i] = union_type.child(i);
+    child_fields_[i] = union_type.child(static_cast<int>(i));
 
     auto type_id = union_type.type_codes()[i];
     type_id_to_children_[type_id] = children[i].get();

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -49,7 +49,7 @@ class ARROW_EXPORT BasicUnionBuilder : public ArrayBuilder {
   int8_t AppendChild(const std::shared_ptr<ArrayBuilder>& new_child,
                      const std::string& field_name = "");
 
-  std::shared_ptr<DataType> type() const override { return type_; }
+  std::shared_ptr<DataType> type() const override;
 
  protected:
   /// Use this constructor to initialize the UnionBuilder with no child builders,
@@ -65,7 +65,10 @@ class ARROW_EXPORT BasicUnionBuilder : public ArrayBuilder {
 
   int8_t NextTypeId();
 
-  std::shared_ptr<UnionType> type_;
+  std::vector<std::shared_ptr<Field>> child_fields_;
+  std::vector<uint8_t> type_codes_;
+  UnionMode::type mode_;
+
   std::vector<ArrayBuilder*> type_id_to_children_;
   // for all type_id < dense_type_id_, type_id_to_children_[type_id] != nullptr
   int8_t dense_type_id_ = 0;

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -49,14 +49,13 @@ class ARROW_EXPORT BasicUnionBuilder : public ArrayBuilder {
   int8_t AppendChild(const std::shared_ptr<ArrayBuilder>& new_child,
                      const std::string& field_name = "");
 
- protected:
-  void UpdateType() override;
+  std::shared_ptr<DataType> type() const override { return type_; }
 
+ protected:
   /// Use this constructor to initialize the UnionBuilder with no child builders,
   /// allowing type to be inferred. You will need to call AppendChild for each of the
   /// children builders you want to use.
-  BasicUnionBuilder(MemoryPool* pool, UnionMode::type mode)
-      : ArrayBuilder(union_({}, mode), pool), mode_(mode), types_builder_(pool) {}
+  BasicUnionBuilder(MemoryPool* pool, UnionMode::type mode);
 
   /// Use this constructor to specify the type explicitly.
   /// You can still add child builders to the union after using this constructor
@@ -66,12 +65,11 @@ class ARROW_EXPORT BasicUnionBuilder : public ArrayBuilder {
 
   int8_t NextTypeId();
 
-  UnionMode::type mode_;
-  std::vector<std::shared_ptr<ArrayBuilder>> type_id_to_children_;
+  std::shared_ptr<UnionType> type_;
+  std::vector<ArrayBuilder*> type_id_to_children_;
   // for all type_id < dense_type_id_, type_id_to_children_[type_id] != nullptr
   int8_t dense_type_id_ = 0;
   TypedBufferBuilder<int8_t> types_builder_;
-  std::vector<std::string> field_names_;
 };
 
 /// \class DenseUnionBuilder

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -49,24 +49,9 @@ class ARROW_EXPORT BasicUnionBuilder : public ArrayBuilder {
   int8_t AppendChild(const std::shared_ptr<ArrayBuilder>& new_child,
                      const std::string& field_name = "");
 
-  void UpdateType() override {
-    auto fields = type_->children();
-    auto type_codes = internal::checked_cast<const UnionType&>(*type_).type_codes();
-    for (int i = 0; i < type_->num_children(); ++i) {
-      children_[i]->UpdateType();
-      fields[i] = fields[i]->WithType(children_[i]->type());
-    }
-    type_ = union_(std::move(fields), std::move(type_codes), mode_);
-  }
-
-  void SetRootBuilder(ArrayBuilder* root_builder) override {
-    ArrayBuilder::SetRootBuilder(root_builder);
-    for (const auto& field_builder : children_) {
-      field_builder->SetRootBuilder(root_builder);
-    }
-  }
-
  protected:
+  void UpdateType() override;
+
   /// Use this constructor to initialize the UnionBuilder with no child builders,
   /// allowing type to be inferred. You will need to call AppendChild for each of the
   /// children builders you want to use.

--- a/cpp/src/arrow/array/builder_union.h
+++ b/cpp/src/arrow/array/builder_union.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/array.h"

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -1060,7 +1060,7 @@ TEST(TestDictionary, TransposeNulls) {
   CheckTranspose(sliced, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
 }
 
-TEST(TestDictionary, DISABLED_ListOfDictionary) {
+TEST(TestDictionary, ListOfDictionary) {
   std::unique_ptr<ArrayBuilder> root_builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), list(dictionary(int8(), utf8())),
                         &root_builder));
@@ -1068,19 +1068,22 @@ TEST(TestDictionary, DISABLED_ListOfDictionary) {
   auto dict_builder =
       checked_cast<DictionaryBuilder<StringType>*>(list_builder->value_builder());
 
+  ASSERT_EQ(dict_builder->type(), nullptr);
+  ASSERT_EQ(list_builder->type(), nullptr);
+
   ASSERT_OK(list_builder->Append());
   std::vector<std::string> expected;
-  for (char a : "abc") {
-    for (char d : "def") {
-      for (char g : "ghi") {
-        for (char j : "jkl") {
-          for (char m : "mno") {
-            for (char p : "pqr") {
+  for (char a : util::string_view("abc")) {
+    for (char d : util::string_view("def")) {
+      for (char g : util::string_view("ghi")) {
+        for (char j : util::string_view("jkl")) {
+          for (char m : util::string_view("mno")) {
+            for (char p : util::string_view("pqr")) {
               if ((static_cast<int>(a) + d + g + j + m + p) % 16 == 0) {
                 ASSERT_OK(list_builder->Append());
               }
               // 3**6 distinct strings; too large for int8
-              char str[6] = {a, d, g, j, m, p};
+              char str[] = {a, d, g, j, m, p, '\0'};
               ASSERT_OK(dict_builder->Append(str));
               expected.push_back(str);
             }

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -1068,9 +1068,6 @@ TEST(TestDictionary, ListOfDictionary) {
   auto dict_builder =
       checked_cast<DictionaryBuilder<StringType>*>(list_builder->value_builder());
 
-  ASSERT_EQ(dict_builder->type(), nullptr);
-  ASSERT_EQ(list_builder->type(), nullptr);
-
   ASSERT_OK(list_builder->Append());
   std::vector<std::string> expected;
   for (char a : util::string_view("abc")) {
@@ -1092,6 +1089,9 @@ TEST(TestDictionary, ListOfDictionary) {
       }
     }
   }
+
+  ASSERT_TRUE(list_builder->type()->Equals(list(dictionary(int16(), utf8()))));
+
   std::shared_ptr<Array> expected_dict;
   ArrayFromVector<StringType, std::string>(expected, &expected_dict);
 

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -792,10 +792,10 @@ TEST(TestDecimalDictionaryBuilder, DoubleTableSize) {
   const auto& decimal_type = arrow::decimal(21, 0);
 
   // Build the dictionary Array
-  DictionaryBuilder<FixedSizeBinaryType> builder(decimal_type);
+  DictionaryBuilder<FixedSizeBinaryType> dict_builder(decimal_type);
 
   // Build expected data
-  FixedSizeBinaryBuilder fsb_builder(decimal_type);
+  Decimal128Builder decimal_builder(decimal_type);
   Int16Builder int_builder;
 
   // Fill with 1024 different values
@@ -816,29 +816,29 @@ TEST(TestDecimalDictionaryBuilder, DoubleTableSize) {
                              12,
                              static_cast<uint8_t>(i / 128),
                              static_cast<uint8_t>(i % 128)};
-    ASSERT_OK(builder.Append(bytes));
-    ASSERT_OK(fsb_builder.Append(bytes));
+    ASSERT_OK(dict_builder.Append(bytes));
+    ASSERT_OK(decimal_builder.Append(bytes));
     ASSERT_OK(int_builder.Append(static_cast<uint16_t>(i)));
   }
   // Fill with an already existing value
   const uint8_t known_value[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 12, 0, 1};
   for (int64_t i = 0; i < 1024; i++) {
-    ASSERT_OK(builder.Append(known_value));
+    ASSERT_OK(dict_builder.Append(known_value));
     ASSERT_OK(int_builder.Append(1));
   }
 
   // Finalize result
   std::shared_ptr<Array> result;
-  ASSERT_OK(builder.Finish(&result));
+  ASSERT_OK(dict_builder.Finish(&result));
 
   // Finalize expected data
-  std::shared_ptr<Array> fsb_array;
-  ASSERT_OK(fsb_builder.Finish(&fsb_array));
+  std::shared_ptr<Array> decimal_array;
+  ASSERT_OK(decimal_builder.Finish(&decimal_array));
 
   std::shared_ptr<Array> int_array;
   ASSERT_OK(int_builder.Finish(&int_array));
 
-  DictionaryArray expected(dictionary(int16(), decimal_type), int_array, fsb_array);
+  DictionaryArray expected(dictionary(int16(), decimal_type), int_array, decimal_array);
   ASSERT_TRUE(expected.Equals(result));
 }
 

--- a/cpp/src/arrow/array_list_test.cc
+++ b/cpp/src/arrow/array_list_test.cc
@@ -713,7 +713,7 @@ TEST_F(TestFixedSizeListArray, TestZeroLength) {
   ASSERT_OK(result_->Validate());
 }
 
-TEST_F(TestFixedSizeListArray, TestBuilderPreserveFieleName) {
+TEST_F(TestFixedSizeListArray, TestBuilderPreserveFieldName) {
   auto list_type_with_name = fixed_size_list(field("counts", int32()), list_size());
 
   std::unique_ptr<ArrayBuilder> tmp;

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -493,6 +493,17 @@ void TestPrimitiveBuilder<PBoolean>::Check(const std::unique_ptr<BooleanBuilder>
   ASSERT_EQ(0, builder->null_count());
 }
 
+TEST(TestPrimitiveAdHoc, TestType) {
+  Int8Builder i8(default_memory_pool());
+  ASSERT_TRUE(i8.type()->Equals(int8()));
+
+  DictionaryBuilder<Int8Type> d_i8(utf8());
+  ASSERT_TRUE(d_i8.type()->Equals(dictionary(int8(), utf8())));
+
+  Dictionary32Builder<Int8Type> d32_i8(utf8());
+  ASSERT_TRUE(d32_i8.type()->Equals(dictionary(int32(), utf8())));
+}
+
 TEST(NumericBuilderAccessors, TestSettersGetters) {
   int64_t datum = 42;
   int64_t new_datum = 43;

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -1478,6 +1478,20 @@ TEST_F(TestAdaptiveIntBuilder, TestInt16) {
   AssertArraysEqual(*expected_, *result_);
 }
 
+TEST_F(TestAdaptiveIntBuilder, TestInt16Nulls) {
+  ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::INT8);
+  ASSERT_OK(builder_->Append(128));
+  ASSERT_EQ(builder_->type()->id(), Type::INT16);
+  ASSERT_OK(builder_->AppendNull());
+  ASSERT_EQ(builder_->type()->id(), Type::INT16);
+  Done();
+
+  std::vector<int16_t> expected_values({0, 128, 0});
+  ArrayFromVector<Int16Type, int16_t>({1, 1, 0}, expected_values, &expected_);
+  ASSERT_ARRAYS_EQUAL(*expected_, *result_);
+}
+
 TEST_F(TestAdaptiveIntBuilder, TestInt32) {
   ASSERT_OK(builder_->Append(0));
   ASSERT_EQ(builder_->type()->id(), Type::INT8);
@@ -1679,6 +1693,20 @@ TEST_F(TestAdaptiveUIntBuilder, TestUInt16) {
 
   ArrayFromVector<UInt16Type, uint16_t>(expected_values, &expected_);
   ASSERT_TRUE(expected_->Equals(result_));
+}
+
+TEST_F(TestAdaptiveUIntBuilder, TestUInt16Nulls) {
+  ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT8);
+  ASSERT_OK(builder_->Append(256));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT16);
+  ASSERT_OK(builder_->AppendNull());
+  ASSERT_EQ(builder_->type()->id(), Type::UINT16);
+  Done();
+
+  std::vector<uint16_t> expected_values({0, 256, 0});
+  ArrayFromVector<UInt16Type, uint16_t>({1, 1, 0}, expected_values, &expected_);
+  ASSERT_ARRAYS_EQUAL(*expected_, *result_);
 }
 
 TEST_F(TestAdaptiveUIntBuilder, TestUInt32) {

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -1425,6 +1425,7 @@ class TestAdaptiveIntBuilder : public TestBuilder {
 };
 
 TEST_F(TestAdaptiveIntBuilder, TestInt8) {
+  ASSERT_EQ(builder_->type()->id(), Type::INT8);
   ASSERT_OK(builder_->Append(0));
   ASSERT_OK(builder_->Append(127));
   ASSERT_OK(builder_->Append(-128));
@@ -1438,7 +1439,9 @@ TEST_F(TestAdaptiveIntBuilder, TestInt8) {
 
 TEST_F(TestAdaptiveIntBuilder, TestInt16) {
   ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::INT8);
   ASSERT_OK(builder_->Append(128));
+  ASSERT_EQ(builder_->type()->id(), Type::INT16);
   Done();
 
   std::vector<int16_t> expected_values({0, 128});
@@ -1466,8 +1469,10 @@ TEST_F(TestAdaptiveIntBuilder, TestInt16) {
 
 TEST_F(TestAdaptiveIntBuilder, TestInt32) {
   ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::INT8);
   ASSERT_OK(
       builder_->Append(static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1));
+  ASSERT_EQ(builder_->type()->id(), Type::INT32);
   Done();
 
   std::vector<int32_t> expected_values(
@@ -1497,8 +1502,10 @@ TEST_F(TestAdaptiveIntBuilder, TestInt32) {
 
 TEST_F(TestAdaptiveIntBuilder, TestInt64) {
   ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::INT8);
   ASSERT_OK(
       builder_->Append(static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1));
+  ASSERT_EQ(builder_->type()->id(), Type::INT64);
   Done();
 
   std::vector<int64_t> expected_values(
@@ -1645,12 +1652,14 @@ TEST_F(TestAdaptiveUIntBuilder, TestUInt8) {
 
 TEST_F(TestAdaptiveUIntBuilder, TestUInt16) {
   ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT8);
   ASSERT_OK(builder_->Append(256));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT16);
   Done();
 
   std::vector<uint16_t> expected_values({0, 256});
   ArrayFromVector<UInt16Type, uint16_t>(expected_values, &expected_);
-  ASSERT_TRUE(expected_->Equals(result_));
+  ASSERT_ARRAYS_EQUAL(*expected_, *result_);
 
   SetUp();
   ASSERT_OK(builder_->Append(std::numeric_limits<uint16_t>::max()));
@@ -1663,8 +1672,10 @@ TEST_F(TestAdaptiveUIntBuilder, TestUInt16) {
 
 TEST_F(TestAdaptiveUIntBuilder, TestUInt32) {
   ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT8);
   ASSERT_OK(
       builder_->Append(static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT32);
   Done();
 
   std::vector<uint32_t> expected_values(
@@ -1683,8 +1694,10 @@ TEST_F(TestAdaptiveUIntBuilder, TestUInt32) {
 
 TEST_F(TestAdaptiveUIntBuilder, TestUInt64) {
   ASSERT_OK(builder_->Append(0));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT8);
   ASSERT_OK(
       builder_->Append(static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1));
+  ASSERT_EQ(builder_->type()->id(), Type::UINT64);
   Done();
 
   std::vector<uint64_t> expected_values(

--- a/cpp/src/arrow/array_union_test.cc
+++ b/cpp/src/arrow/array_union_test.cc
@@ -399,4 +399,14 @@ TEST_F(SparseUnionBuilderTest, InferredType) {
   ASSERT_EQ(expected->type()->ToString(), actual->type()->ToString());
   ASSERT_ARRAYS_EQUAL(*expected, *actual);
 }
+
+TEST_F(SparseUnionBuilderTest, StructWithUnion) {
+  auto union_builder = std::make_shared<SparseUnionBuilder>(default_memory_pool());
+  StructBuilder builder(struct_({field("u", union_({}))}), default_memory_pool(),
+                        {union_builder});
+  ASSERT_EQ(union_builder->AppendChild(std::make_shared<Int32Builder>(), "i"), 0);
+  ASSERT_TRUE(
+      builder.type()->Equals(struct_({field("u", union_({field("i", int32())}, {0}))})));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/array_union_test.cc
+++ b/cpp/src/arrow/array_union_test.cc
@@ -272,10 +272,6 @@ class UnionBuilderTest : public ::testing::Test {
 
     ASSERT_OK(list_builder.Finish(actual));
     ArrayFromVector<Int8Type, uint8_t>(expected_types_vector, &expected_types);
-
-    ASSERT_EQ(I8, 0);
-    ASSERT_EQ(STR, 1);
-    ASSERT_EQ(DBL, 2);
   }
 
   std::vector<uint8_t> expected_types_vector;

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -111,11 +111,13 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       BUILDER_CASE(LARGE_BINARY, LargeBinaryBuilder);
       BUILDER_CASE(FIXED_SIZE_BINARY, FixedSizeBinaryBuilder);
       BUILDER_CASE(DECIMAL, Decimal128Builder);
+
     case Type::DICTIONARY: {
       const auto& dict_type = static_cast<const DictionaryType&>(*type);
       DictionaryBuilderCase visitor = {pool, dict_type.value_type(), nullptr, out};
       return visitor.Make();
     }
+
     case Type::INTERVAL: {
       const auto& interval_type = internal::checked_cast<const IntervalType&>(*type);
       if (interval_type.interval_type() == IntervalType::MONTHS) {
@@ -128,6 +130,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       }
       break;
     }
+
     case Type::LIST: {
       std::unique_ptr<ArrayBuilder> value_builder;
       std::shared_ptr<DataType> value_type =
@@ -136,6 +139,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       out->reset(new ListBuilder(pool, std::move(value_builder), type));
       return Status::OK();
     }
+
     case Type::LARGE_LIST: {
       std::unique_ptr<ArrayBuilder> value_builder;
       std::shared_ptr<DataType> value_type =
@@ -144,6 +148,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       out->reset(new LargeListBuilder(pool, std::move(value_builder), type));
       return Status::OK();
     }
+
     case Type::MAP: {
       const auto& map_type = internal::checked_cast<const MapType&>(*type);
       std::unique_ptr<ArrayBuilder> key_builder, item_builder;
@@ -155,9 +160,9 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
     }
 
     case Type::FIXED_SIZE_LIST: {
+      const auto& list_type = internal::checked_cast<const FixedSizeListType&>(*type);
       std::unique_ptr<ArrayBuilder> value_builder;
-      std::shared_ptr<DataType> value_type =
-          internal::checked_cast<const FixedSizeListType&>(*type).value_type();
+      auto value_type = list_type.value_type();
       RETURN_NOT_OK(MakeBuilder(pool, value_type, &value_builder));
       out->reset(new FixedSizeListBuilder(pool, std::move(value_builder), type));
       return Status::OK();

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -172,7 +172,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       const std::vector<std::shared_ptr<Field>>& fields = type->children();
       std::vector<std::shared_ptr<ArrayBuilder>> field_builders;
 
-      for (auto it : fields) {
+      for (const auto& it : fields) {
         std::unique_ptr<ArrayBuilder> builder;
         RETURN_NOT_OK(MakeBuilder(pool, it->type(), &builder));
         field_builders.emplace_back(std::move(builder));
@@ -186,7 +186,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       const std::vector<std::shared_ptr<Field>>& fields = type->children();
       std::vector<std::shared_ptr<ArrayBuilder>> field_builders;
 
-      for (auto it : fields) {
+      for (const auto& it : fields) {
         std::unique_ptr<ArrayBuilder> builder;
         RETURN_NOT_OK(MakeBuilder(pool, it->type(), &builder));
         field_builders.emplace_back(std::move(builder));
@@ -199,10 +199,8 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       return Status::OK();
     }
 
-    default: {
-      return Status::NotImplemented("MakeBuilder: cannot construct builder for type ",
-                                    type->ToString());
-    }
+    default:
+      break;
   }
   return Status::NotImplemented("MakeBuilder: cannot construct builder for type ",
                                 type->ToString());

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -263,7 +263,10 @@ class SequenceBuilder {
 class DictBuilder {
  public:
   explicit DictBuilder(MemoryPool* pool = nullptr) : keys_(pool), vals_(pool) {
-    builder_.reset(new StructBuilder(nullptr, pool, {keys_.builder(), vals_.builder()}));
+    builder_.reset(
+        new StructBuilder(struct_({field("keys", union_({}, UnionMode::DENSE)),
+                                   field("keys", union_({}, UnionMode::DENSE))}),
+                          pool, {keys_.builder(), vals_.builder()}));
   }
 
   // Builder for the keys of the dictionary

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -265,7 +265,7 @@ class DictBuilder {
   explicit DictBuilder(MemoryPool* pool = nullptr) : keys_(pool), vals_(pool) {
     builder_.reset(
         new StructBuilder(struct_({field("keys", union_({}, UnionMode::DENSE)),
-                                   field("keys", union_({}, UnionMode::DENSE))}),
+                                   field("vals", union_({}, UnionMode::DENSE))}),
                           pool, {keys_.builder(), vals_.builder()}));
   }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -283,13 +283,13 @@ std::string DurationType::ToString() const {
 // ----------------------------------------------------------------------
 // Union type
 
-UnionType::UnionType(std::vector<std::shared_ptr<Field>> fields,
-                     std::vector<uint8_t> type_codes, UnionMode::type mode)
-    : NestedType(Type::UNION), mode_(mode), type_codes_(std::move(type_codes)) {
+UnionType::UnionType(const std::vector<std::shared_ptr<Field>>& fields,
+                     const std::vector<uint8_t>& type_codes, UnionMode::type mode)
+    : NestedType(Type::UNION), mode_(mode), type_codes_(type_codes) {
   DCHECK_LE(fields.size(), type_codes.size()) << "union field with unknown type id";
   DCHECK_GE(fields.size(), type_codes.size())
       << "type id provided without corresponding union field";
-  children_ = std::move(fields);
+  children_ = fields;
 }
 
 DataTypeLayout UnionType::layout() const {
@@ -365,9 +365,9 @@ class StructType::Impl {
   const std::unordered_multimap<std::string, int> name_to_index_;
 };
 
-StructType::StructType(std::vector<std::shared_ptr<Field>> fields)
+StructType::StructType(const std::vector<std::shared_ptr<Field>>& fields)
     : NestedType(Type::STRUCT), impl_(new Impl(fields)) {
-  children_ = std::move(fields);
+  children_ = fields;
 }
 
 StructType::~StructType() {}
@@ -1101,19 +1101,19 @@ std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<Field>& value_fi
   return std::make_shared<FixedSizeListType>(value_field, list_size);
 }
 
-std::shared_ptr<DataType> struct_(std::vector<std::shared_ptr<Field>> fields) {
+std::shared_ptr<DataType> struct_(const std::vector<std::shared_ptr<Field>>& fields) {
   return std::make_shared<StructType>(fields);
 }
 
-std::shared_ptr<DataType> union_(std::vector<std::shared_ptr<Field>> child_fields,
-                                 std::vector<uint8_t> type_codes, UnionMode::type mode) {
-  return std::make_shared<UnionType>(std::move(child_fields), std::move(type_codes),
-                                     mode);
+std::shared_ptr<DataType> union_(const std::vector<std::shared_ptr<Field>>& child_fields,
+                                 const std::vector<uint8_t>& type_codes,
+                                 UnionMode::type mode) {
+  return std::make_shared<UnionType>(child_fields, type_codes, mode);
 }
 
-std::shared_ptr<DataType> union_(std::vector<std::shared_ptr<Array>> children,
-                                 std::vector<std::string> field_names,
-                                 std::vector<uint8_t> given_type_codes,
+std::shared_ptr<DataType> union_(const std::vector<std::shared_ptr<Array>>& children,
+                                 const std::vector<std::string>& field_names,
+                                 const std::vector<uint8_t>& given_type_codes,
                                  UnionMode::type mode) {
   std::vector<std::shared_ptr<Field>> fields;
   std::vector<uint8_t> type_codes(given_type_codes);
@@ -1129,7 +1129,7 @@ std::shared_ptr<DataType> union_(std::vector<std::shared_ptr<Array>> children,
     }
     counter++;
   }
-  return union_(std::move(fields), std::move(type_codes), mode);
+  return union_(fields, std::move(type_codes), mode);
 }
 
 std::shared_ptr<DataType> dictionary(const std::shared_ptr<DataType>& index_type,

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -283,13 +283,13 @@ std::string DurationType::ToString() const {
 // ----------------------------------------------------------------------
 // Union type
 
-UnionType::UnionType(const std::vector<std::shared_ptr<Field>>& fields,
-                     const std::vector<uint8_t>& type_codes, UnionMode::type mode)
-    : NestedType(Type::UNION), mode_(mode), type_codes_(type_codes) {
+UnionType::UnionType(std::vector<std::shared_ptr<Field>> fields,
+                     std::vector<uint8_t> type_codes, UnionMode::type mode)
+    : NestedType(Type::UNION), mode_(mode), type_codes_(std::move(type_codes)) {
   DCHECK_LE(fields.size(), type_codes.size()) << "union field with unknown type id";
   DCHECK_GE(fields.size(), type_codes.size())
       << "type id provided without corresponding union field";
-  children_ = fields;
+  children_ = std::move(fields);
 }
 
 DataTypeLayout UnionType::layout() const {
@@ -365,9 +365,9 @@ class StructType::Impl {
   const std::unordered_multimap<std::string, int> name_to_index_;
 };
 
-StructType::StructType(const std::vector<std::shared_ptr<Field>>& fields)
+StructType::StructType(std::vector<std::shared_ptr<Field>> fields)
     : NestedType(Type::STRUCT), impl_(new Impl(fields)) {
-  children_ = fields;
+  children_ = std::move(fields);
 }
 
 StructType::~StructType() {}
@@ -1101,35 +1101,35 @@ std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<Field>& value_fi
   return std::make_shared<FixedSizeListType>(value_field, list_size);
 }
 
-std::shared_ptr<DataType> struct_(const std::vector<std::shared_ptr<Field>>& fields) {
+std::shared_ptr<DataType> struct_(std::vector<std::shared_ptr<Field>> fields) {
   return std::make_shared<StructType>(fields);
 }
 
-std::shared_ptr<DataType> union_(const std::vector<std::shared_ptr<Field>>& child_fields,
-                                 const std::vector<uint8_t>& type_codes,
-                                 UnionMode::type mode) {
-  return std::make_shared<UnionType>(child_fields, type_codes, mode);
+std::shared_ptr<DataType> union_(std::vector<std::shared_ptr<Field>> child_fields,
+                                 std::vector<uint8_t> type_codes, UnionMode::type mode) {
+  return std::make_shared<UnionType>(std::move(child_fields), std::move(type_codes),
+                                     mode);
 }
 
-std::shared_ptr<DataType> union_(const std::vector<std::shared_ptr<Array>>& children,
-                                 const std::vector<std::string>& field_names,
-                                 const std::vector<uint8_t>& given_type_codes,
+std::shared_ptr<DataType> union_(std::vector<std::shared_ptr<Array>> children,
+                                 std::vector<std::string> field_names,
+                                 std::vector<uint8_t> given_type_codes,
                                  UnionMode::type mode) {
-  std::vector<std::shared_ptr<Field>> types;
+  std::vector<std::shared_ptr<Field>> fields;
   std::vector<uint8_t> type_codes(given_type_codes);
   uint8_t counter = 0;
   for (const auto& child : children) {
     if (field_names.size() == 0) {
-      types.push_back(field(std::to_string(counter), child->type()));
+      fields.push_back(field(std::to_string(counter), child->type()));
     } else {
-      types.push_back(field(field_names[counter], child->type()));
+      fields.push_back(field(std::move(field_names[counter]), child->type()));
     }
     if (given_type_codes.size() == 0) {
       type_codes.push_back(counter);
     }
     counter++;
   }
-  return union_(types, type_codes, mode);
+  return union_(std::move(fields), std::move(type_codes), mode);
 }
 
 std::shared_ptr<DataType> dictionary(const std::shared_ptr<DataType>& index_type,

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -24,7 +24,6 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "arrow/result.h"
@@ -845,7 +844,7 @@ class ARROW_EXPORT StructType : public NestedType {
 
   static constexpr const char* type_name() { return "struct"; }
 
-  explicit StructType(std::vector<std::shared_ptr<Field>> fields);
+  explicit StructType(const std::vector<std::shared_ptr<Field>>& fields);
 
   ~StructType() override;
 
@@ -929,7 +928,8 @@ class ARROW_EXPORT UnionType : public NestedType {
 
   static constexpr const char* type_name() { return "union"; }
 
-  UnionType(std::vector<std::shared_ptr<Field>> fields, std::vector<uint8_t> type_codes,
+  UnionType(const std::vector<std::shared_ptr<Field>>& fields,
+            const std::vector<uint8_t>& type_codes,
             UnionMode::type mode = UnionMode::SPARSE);
 
   DataTypeLayout layout() const override;
@@ -1448,30 +1448,32 @@ std::shared_ptr<DataType> ARROW_EXPORT time64(TimeUnit::type unit);
 
 /// \brief Create a StructType instance
 std::shared_ptr<DataType> ARROW_EXPORT
-struct_(std::vector<std::shared_ptr<Field>> fields);
+struct_(const std::vector<std::shared_ptr<Field>>& fields);
 
 /// \brief Create a UnionType instance
 std::shared_ptr<DataType> ARROW_EXPORT
-union_(std::vector<std::shared_ptr<Field>> child_fields, std::vector<uint8_t> type_codes,
-       UnionMode::type mode = UnionMode::SPARSE);
+union_(const std::vector<std::shared_ptr<Field>>& child_fields,
+       const std::vector<uint8_t>& type_codes, UnionMode::type mode = UnionMode::SPARSE);
 
 /// \brief Create a UnionType instance
 std::shared_ptr<DataType> ARROW_EXPORT
-union_(std::vector<std::shared_ptr<Array>> children, std::vector<std::string> field_names,
-       std::vector<uint8_t> type_codes, UnionMode::type mode = UnionMode::SPARSE);
+union_(const std::vector<std::shared_ptr<Array>>& children,
+       const std::vector<std::string>& field_names,
+       const std::vector<uint8_t>& type_codes, UnionMode::type mode = UnionMode::SPARSE);
 
 /// \brief Create a UnionType instance
 inline std::shared_ptr<DataType> ARROW_EXPORT
-union_(std::vector<std::shared_ptr<Array>> children, std::vector<std::string> field_names,
+union_(const std::vector<std::shared_ptr<Array>>& children,
+       const std::vector<std::string>& field_names,
        UnionMode::type mode = UnionMode::SPARSE) {
-  return union_(std::move(children), std::move(field_names), {}, mode);
+  return union_(children, field_names, {}, mode);
 }
 
 /// \brief Create a UnionType instance
 inline std::shared_ptr<DataType> ARROW_EXPORT
-union_(std::vector<std::shared_ptr<Array>> children,
+union_(const std::vector<std::shared_ptr<Array>>& children,
        UnionMode::type mode = UnionMode::SPARSE) {
-  return union_(std::move(children), {}, {}, mode);
+  return union_(children, {}, {}, mode);
 }
 
 /// \brief Create a DictionaryType instance

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -24,6 +24,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/result.h"

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -844,7 +844,7 @@ class ARROW_EXPORT StructType : public NestedType {
 
   static constexpr const char* type_name() { return "struct"; }
 
-  explicit StructType(const std::vector<std::shared_ptr<Field>>& fields);
+  explicit StructType(std::vector<std::shared_ptr<Field>> fields);
 
   ~StructType() override;
 
@@ -928,8 +928,7 @@ class ARROW_EXPORT UnionType : public NestedType {
 
   static constexpr const char* type_name() { return "union"; }
 
-  UnionType(const std::vector<std::shared_ptr<Field>>& fields,
-            const std::vector<uint8_t>& type_codes,
+  UnionType(std::vector<std::shared_ptr<Field>> fields, std::vector<uint8_t> type_codes,
             UnionMode::type mode = UnionMode::SPARSE);
 
   DataTypeLayout layout() const override;
@@ -1448,32 +1447,30 @@ std::shared_ptr<DataType> ARROW_EXPORT time64(TimeUnit::type unit);
 
 /// \brief Create a StructType instance
 std::shared_ptr<DataType> ARROW_EXPORT
-struct_(const std::vector<std::shared_ptr<Field>>& fields);
+struct_(std::vector<std::shared_ptr<Field>> fields);
 
 /// \brief Create a UnionType instance
 std::shared_ptr<DataType> ARROW_EXPORT
-union_(const std::vector<std::shared_ptr<Field>>& child_fields,
-       const std::vector<uint8_t>& type_codes, UnionMode::type mode = UnionMode::SPARSE);
+union_(std::vector<std::shared_ptr<Field>> child_fields, std::vector<uint8_t> type_codes,
+       UnionMode::type mode = UnionMode::SPARSE);
 
 /// \brief Create a UnionType instance
 std::shared_ptr<DataType> ARROW_EXPORT
-union_(const std::vector<std::shared_ptr<Array>>& children,
-       const std::vector<std::string>& field_names,
-       const std::vector<uint8_t>& type_codes, UnionMode::type mode = UnionMode::SPARSE);
+union_(std::vector<std::shared_ptr<Array>> children, std::vector<std::string> field_names,
+       std::vector<uint8_t> type_codes, UnionMode::type mode = UnionMode::SPARSE);
 
 /// \brief Create a UnionType instance
 inline std::shared_ptr<DataType> ARROW_EXPORT
-union_(const std::vector<std::shared_ptr<Array>>& children,
-       const std::vector<std::string>& field_names,
+union_(std::vector<std::shared_ptr<Array>> children, std::vector<std::string> field_names,
        UnionMode::type mode = UnionMode::SPARSE) {
-  return union_(children, field_names, {}, mode);
+  return union_(std::move(children), std::move(field_names), {}, mode);
 }
 
 /// \brief Create a UnionType instance
 inline std::shared_ptr<DataType> ARROW_EXPORT
-union_(const std::vector<std::shared_ptr<Array>>& children,
+union_(std::vector<std::shared_ptr<Array>> children,
        UnionMode::type mode = UnionMode::SPARSE) {
-  return union_(children, {}, {}, mode);
+  return union_(std::move(children), {}, {}, mode);
 }
 
 /// \brief Create a DictionaryType instance


### PR DESCRIPTION
`ArrayBuilder::type()` should always be identical to the type of the array which would be produced by `ArrayBuilder::Finish()`, even for builders whose type may change. This includes:
- adaptive int builders, which may increase the size of integers built
- dictionary builders, which may increase the size of their indices
- union builders, which may append a new child
- nested builders whose children include a builder with mutable type
