### PR TITLE
ARROW-6028: [C++] Undefine timezone on later version of windows

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -18,6 +18,11 @@
 #ifndef ARROW_TYPE_H
 #define ARROW_TYPE_H
 
+// Workarround for ARROW-6028
+#if _MSC_VER >= 1900
+  #undef timezone
+#endif
+
 #include <climits>
 #include <cstdint>
 #include <iosfwd>


### PR DESCRIPTION
Detail can be found in https://issues.apache.org/jira/projects/ARROW/issues/ARROW-6028