### PR TITLE
ARROW-6020: [Java] Refactor ByteFunctionHelper#hash with new added ArrowBufHasher

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -18,11 +18,11 @@
 package org.apache.arrow.memory.util;
 
 import org.apache.arrow.memory.BoundsChecking;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.DirectHasher;
 
 import io.netty.buffer.ArrowBuf;
 import io.netty.util.internal.PlatformDependent;
-import org.apache.arrow.memory.util.hash.ArrowBufHasher;
-import org.apache.arrow.memory.util.hash.DirectHasher;
 
 /**
  * Utility methods for memory comparison at a byte level.

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -21,6 +21,8 @@ import org.apache.arrow.memory.BoundsChecking;
 
 import io.netty.buffer.ArrowBuf;
 import io.netty.util.internal.PlatformDependent;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.DirectHasher;
 
 /**
  * Utility methods for memory comparison at a byte level.
@@ -250,35 +252,10 @@ public class ByteFunctionHelpers {
    * Compute hashCode with the given {@link ArrowBuf} and start/end index.
    */
   public static final int hash(final ArrowBuf buf, int start, int end) {
-    long addr = buf.memoryAddress();
-    int len = end - start;
-    long pos = addr + start;
 
-    int hash = 0;
+    ArrowBufHasher hasher = DirectHasher.INSTANCE;
 
-    while (len > 7) {
-      long value = PlatformDependent.getLong(pos);
-      hash = comebineHash(hash, Long.hashCode(value));
-
-      pos += 8;
-      len -= 8;
-    }
-
-    while (len > 3) {
-      int value = PlatformDependent.getInt(pos);
-      hash = comebineHash(hash, value);
-
-      pos += 4;
-      len -= 4;
-    }
-
-    while (len-- != 0) {
-      byte value = PlatformDependent.getByte(pos);
-      hash = comebineHash(hash, value);
-      pos ++;
-    }
-
-    return hash;
+    return hasher.hashCode(buf, start, end - start);
   }
 
   /**


### PR DESCRIPTION
Related to [ARROW-6020](https://issues.apache.org/jira/browse/ARROW-6020).
Some logic in these two classes are similar, should replace ByteFunctionHelper#hash logic with ArrowBufHasher since it has murmur hash algorithm which could avoid hash collision.