### PR TITLE
ARROW-6030: [Java] Efficiently compute hash code for ArrowBufPointer

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/DirectHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/DirectHasher.java
@@ -79,4 +79,9 @@ public class DirectHasher extends ArrowBufHasher {
 
     return hash;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj != null && this.getClass() == obj.getClass();
+  }
 }


### PR DESCRIPTION
As ArrowBufHasher is introduced, we can compute the hash code of a continuous region within an ArrowBuf. 

We optimize the process to make it efficient to avoid recomputation. 