### PR TITLE
ARROW-6035: [Java] Avro adapter support convert nullable value

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -35,7 +35,7 @@ import org.apache.arrow.consumers.AvroIntConsumer;
 import org.apache.arrow.consumers.AvroLongConsumer;
 import org.apache.arrow.consumers.AvroStringConsumer;
 import org.apache.arrow.consumers.Consumer;
-import org.apache.arrow.consumers.NullablePrimitiveTypeConsumer;
+import org.apache.arrow.consumers.NullableTypeConsumer;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BigIntVector;
@@ -212,7 +212,7 @@ public class AvroToArrowUtils {
 
     if (vector.getField().isNullable()) {
       int nullIndex = getNullFieldIndex(vector.getField());
-      return new NullablePrimitiveTypeConsumer(consumer, nullIndex);
+      return new NullableTypeConsumer(consumer, nullIndex);
     }
 
     return consumer;

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -35,6 +35,7 @@ import org.apache.arrow.consumers.AvroIntConsumer;
 import org.apache.arrow.consumers.AvroLongConsumer;
 import org.apache.arrow.consumers.AvroStringConsumer;
 import org.apache.arrow.consumers.Consumer;
+import org.apache.arrow.consumers.NullablePrimitiveTypeConsumer;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BigIntVector;
@@ -43,6 +44,7 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -59,10 +61,10 @@ import org.apache.avro.io.Decoder;
 public class AvroToArrowUtils {
 
   private static final int DEFAULT_BUFFER_SIZE = 256;
-  public static final String NULL_INDEX = "null_index";
+  public static final String NULL_INDEX = "nullIndex";
 
   /**
-   * Creates an {@link org.apache.arrow.vector.types.pojo.ArrowType} from the {@link Schema.Field}
+   * Creates a {@link Field} from the {@link Schema}
    *
    <p>This method currently performs following type mapping for Avro data types to corresponding Arrow data types.
    *
@@ -129,7 +131,7 @@ public class AvroToArrowUtils {
       return getArrowField(subSchema, name,true);
     } else {
       //TODO convert avro unions type to arrow UnionVector
-      return null;
+      throw new UnsupportedOperationException();
     }
   }
 
@@ -168,42 +170,54 @@ public class AvroToArrowUtils {
   }
 
   /**
-   * Create consumers to consume avro values from decoder, will reduce boxing/unboxing operations.
+   * Create primitive consumer to read data from decoder, will reduce boxing/unboxing operations.
    */
-  public static Consumer[] createAvroConsumers(VectorSchemaRoot root) {
+  public static Consumer createPrimitiveConsumer(ValueVector vector) {
 
-    Consumer[] consumers = new Consumer[root.getFieldVectors().size()];
-    for (int i = 0; i < root.getFieldVectors().size(); i++) {
-      FieldVector vector = root.getFieldVectors().get(i);
-      Consumer consumer;
-      switch (vector.getMinorType()) {
-        case INT:
-          consumer = new AvroIntConsumer((IntVector) vector);
-          break;
-        case VARBINARY:
-          consumer = new AvroBytesConsumer((VarBinaryVector) vector);
-          break;
-        case VARCHAR:
-          consumer = new AvroStringConsumer((VarCharVector) vector);
-          break;
-        case BIGINT:
-          consumer = new AvroLongConsumer((BigIntVector) vector);
-          break;
-        case FLOAT4:
-          consumer = new AvroFloatConsumer((Float4Vector) vector);
-          break;
-        case FLOAT8:
-          consumer = new AvroDoubleConsumer((Float8Vector) vector);
-          break;
-        case BIT:
-          consumer = new AvroBooleanConsumer((BitVector) vector);
-          break;
-        default:
-          throw new RuntimeException("could not get consumer from type:" + vector.getMinorType());
-      }
-      consumers[i] = consumer;
+    Consumer consumer;
+    switch (vector.getMinorType()) {
+      case INT:
+        consumer = new AvroIntConsumer((IntVector) vector);
+        break;
+      case VARBINARY:
+        consumer = new AvroBytesConsumer((VarBinaryVector) vector);
+        break;
+      case VARCHAR:
+        consumer = new AvroStringConsumer((VarCharVector) vector);
+        break;
+      case BIGINT:
+        consumer = new AvroLongConsumer((BigIntVector) vector);
+        break;
+      case FLOAT4:
+        consumer = new AvroFloatConsumer((Float4Vector) vector);
+        break;
+      case FLOAT8:
+        consumer = new AvroDoubleConsumer((Float8Vector) vector);
+        break;
+      case BIT:
+        consumer = new AvroBooleanConsumer((BitVector) vector);
+        break;
+      default:
+        throw new RuntimeException("could not get consumer from type:" + vector.getMinorType());
     }
-    return consumers;
+
+    if (vector.getField().isNullable()) {
+      int nullIndex = getNullFieldIndex(vector.getField());
+      return new NullablePrimitiveTypeConsumer(consumer, nullIndex);
+    }
+
+    return consumer;
+  }
+
+  /**
+   * Get avro null field index from vector field metadata.
+   */
+  private static int getNullFieldIndex(Field field) {
+    Map<String, String> metadata = field.getMetadata();
+    Preconditions.checkNotNull(metadata, "metadata should not be null when vector is nullable");
+    String index = metadata.get(AvroToArrowUtils.NULL_INDEX);
+    Preconditions.checkNotNull(index, "nullIndex should not be null when vector is nullable");
+    return Integer.parseInt(index);
   }
 
   /**
@@ -218,7 +232,14 @@ public class AvroToArrowUtils {
     Preconditions.checkNotNull(root, "VectorSchemaRoot object can't be null");
 
     allocateVectors(root, DEFAULT_BUFFER_SIZE);
-    Consumer[] consumers = createAvroConsumers(root);
+
+    // create consumers
+    Consumer[] consumers = new Consumer[root.getFieldVectors().size()];
+    for (int i = 0; i < root.getFieldVectors().size(); i++) {
+      FieldVector vector = root.getFieldVectors().get(i);
+      consumers[i] = createPrimitiveConsumer(vector);
+    }
+
     int valueCount = 0;
     while (true) {
       try {

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -114,8 +114,8 @@ public class AvroToArrowUtils {
         throw new RuntimeException("Can't convert avro type %s to arrow type." + type.getName());
     }
 
-    final FieldType fieldType =  new FieldType(/*nullable=*/nullable, arrowType, /*dictionary=*/null,
-        /*metadata=*/getMetaData(schema));
+    final FieldType fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null,
+        getMetaData(schema));
     return new Field(name, fieldType, null);
   }
 

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -28,17 +28,31 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume boolean type values from avro decoder.
  * Write the data to {@link BitVector}.
  */
-public class AvroBooleanConsumer implements Consumer {
+public class AvroBooleanConsumer extends Consumer {
 
   private final BitWriter writer;
 
+  /**
+   * Instantiate a AvroBooleanConsumer.
+   */
   public AvroBooleanConsumer(BitVector vector) {
     this.writer = new BitWriterImpl(vector);
+    this.nullable = vector.getField().isNullable();
+    if (nullable) {
+      getNullFieldIndex(vector.getField());
+    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    writer.writeBit(decoder.readBoolean() ? 1 : 0);
+    if (!nullable) {
+      writer.writeBit(decoder.readBoolean() ? 1 : 0);
+    } else {
+      int index = decoder.readInt();
+      if (index != nullIndex) {
+        writer.writeBit(decoder.readBoolean() ? 1 : 0);
+      }
+    }
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -42,11 +42,11 @@ public class AvroBooleanConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writer.writeBit(decoder.readBoolean() ? 1 : 0);
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -30,7 +30,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume bytes type values from avro decoder.
  * Write the data to {@link VarBinaryVector}.
  */
-public class AvroBytesConsumer extends Consumer {
+public class AvroBytesConsumer implements Consumer {
 
   private final VarBinaryWriter writer;
   private final VarBinaryVector vector;
@@ -42,23 +42,16 @@ public class AvroBytesConsumer extends Consumer {
   public AvroBytesConsumer(VarBinaryVector vector) {
     this.vector = vector;
     this.writer = new VarBinaryWriterImpl(vector);
-    this.nullable = vector.getField().isNullable();
-    if (nullable) {
-      getNullFieldIndex(vector.getField());
-    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    if (!nullable) {
-      writeValue(decoder);
-    } else {
-      int index = decoder.readInt();
-      if (index != nullIndex) {
-        writeValue(decoder);
-      }
-    }
+    writeValue(decoder);
+    movePosition();
+  }
 
+  @Override
+  public void movePosition() {
     writer.setPosition(writer.getPosition() + 1);
   }
 

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -47,11 +47,11 @@ public class AvroBytesConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writeValue(decoder);
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -27,7 +27,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume double type values from avro decoder.
  * Write the data to {@link Float8Vector}.
  */
-public class AvroDoubleConsumer extends Consumer {
+public class AvroDoubleConsumer implements Consumer {
 
   private final Float8WriterImpl writer;
 
@@ -36,22 +36,16 @@ public class AvroDoubleConsumer extends Consumer {
    */
   public AvroDoubleConsumer(Float8Vector vector) {
     this.writer = new Float8WriterImpl(vector);
-    this.nullable = vector.getField().isNullable();
-    if (nullable) {
-      getNullFieldIndex(vector.getField());
-    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    if (!nullable) {
-      writer.writeFloat8(decoder.readDouble());
-    } else {
-      int index = decoder.readInt();
-      if (index != nullIndex) {
-        writer.writeFloat8(decoder.readDouble());
-      }
-    }
+    writer.writeFloat8(decoder.readDouble());
+    movePosition();
+  }
+
+  @Override
+  public void movePosition() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.complex.impl.Float8WriterImpl;
+import org.apache.arrow.vector.complex.writer.Float8Writer;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -29,7 +30,7 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroDoubleConsumer implements Consumer {
 
-  private final Float8WriterImpl writer;
+  private final Float8Writer writer;
 
   /**
    * Instantiate a AvroDoubleConsumer.

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -42,11 +42,11 @@ public class AvroDoubleConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writer.writeFloat8(decoder.readDouble());
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.complex.impl.Float4WriterImpl;
+import org.apache.arrow.vector.complex.writer.Float4Writer;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -29,7 +30,7 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroFloatConsumer implements Consumer {
 
-  private final Float4WriterImpl writer;
+  private final Float4Writer writer;
 
   /**
    * Instantiate a AvroFloatConsumer.

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -42,11 +42,11 @@ public class AvroFloatConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writer.writeFloat4(decoder.readFloat());
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -27,7 +27,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume float type values from avro decoder.
  * Write the data to {@link Float4Vector}.
  */
-public class AvroFloatConsumer extends Consumer {
+public class AvroFloatConsumer implements Consumer {
 
   private final Float4WriterImpl writer;
 
@@ -36,22 +36,16 @@ public class AvroFloatConsumer extends Consumer {
    */
   public AvroFloatConsumer(Float4Vector vector) {
     this.writer = new Float4WriterImpl(vector);
-    this.nullable = vector.getField().isNullable();
-    if (nullable) {
-      getNullFieldIndex(vector.getField());
-    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    if (!nullable) {
-      writer.writeFloat4(decoder.readFloat());
-    } else {
-      int index = decoder.readInt();
-      if (index != nullIndex) {
-        writer.writeFloat4(decoder.readFloat());
-      }
-    }
+    writer.writeFloat4(decoder.readFloat());
+    movePosition();
+  }
+
+  @Override
+  public void movePosition() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -27,7 +27,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume int type values from avro decoder.
  * Write the data to {@link IntVector}.
  */
-public class AvroIntConsumer extends Consumer {
+public class AvroIntConsumer implements Consumer {
 
   private final IntWriterImpl writer;
 
@@ -36,22 +36,16 @@ public class AvroIntConsumer extends Consumer {
    */
   public AvroIntConsumer(IntVector vector) {
     this.writer = new IntWriterImpl(vector);
-    this.nullable = vector.getField().isNullable();
-    if (nullable) {
-      getNullFieldIndex(vector.getField());
-    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    if (!nullable) {
-      writer.writeInt(decoder.readInt());
-    } else {
-      int index = decoder.readInt();
-      if (index != nullIndex) {
-        writer.writeInt(decoder.readInt());
-      }
-    }
+    writer.writeInt(decoder.readInt());
+    movePosition();
+  }
+
+  @Override
+  public void movePosition() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.complex.impl.IntWriterImpl;
+import org.apache.arrow.vector.complex.writer.IntWriter;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -29,7 +30,7 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroIntConsumer implements Consumer {
 
-  private final IntWriterImpl writer;
+  private final IntWriter writer;
 
   /**
    * Instantiate a AvroIntConsumer.

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -42,11 +42,11 @@ public class AvroIntConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writer.writeInt(decoder.readInt());
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -27,7 +27,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume long type values from avro decoder.
  * Write the data to {@link BigIntVector}.
  */
-public class AvroLongConsumer extends Consumer {
+public class AvroLongConsumer implements Consumer {
 
   private final BigIntWriterImpl writer;
 
@@ -36,22 +36,16 @@ public class AvroLongConsumer extends Consumer {
    */
   public AvroLongConsumer(BigIntVector vector) {
     this.writer = new BigIntWriterImpl(vector);
-    this.nullable = vector.getField().isNullable();
-    if (nullable) {
-      getNullFieldIndex(vector.getField());
-    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    if (!nullable) {
-      writer.writeBigInt(decoder.readLong());
-    } else {
-      int index = decoder.readInt();
-      if (index != nullIndex) {
-        writer.writeBigInt(decoder.readLong());
-      }
-    }
+    writer.writeBigInt(decoder.readLong());
+    movePosition();
+  }
+
+  @Override
+  public void movePosition() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -42,11 +42,11 @@ public class AvroLongConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writer.writeBigInt(decoder.readLong());
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.complex.impl.BigIntWriterImpl;
+import org.apache.arrow.vector.complex.writer.BigIntWriter;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -29,7 +30,7 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroLongConsumer implements Consumer {
 
-  private final BigIntWriterImpl writer;
+  private final BigIntWriter writer;
 
   /**
    * Instantiate a AvroLongConsumer.

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.impl.VarCharWriterImpl;
+import org.apache.arrow.vector.complex.writer.VarCharWriter;
 import org.apache.arrow.vector.holders.VarCharHolder;
 import org.apache.avro.io.Decoder;
 
@@ -32,7 +33,7 @@ import org.apache.avro.io.Decoder;
 public class AvroStringConsumer implements Consumer {
 
   private final VarCharVector vector;
-  private final VarCharWriterImpl writer;
+  private final VarCharWriter writer;
   private ByteBuffer cacheBuffer;
 
   /**

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -29,7 +29,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume string type values from avro decoder.
  * Write the data to {@link VarCharVector}.
  */
-public class AvroStringConsumer extends Consumer {
+public class AvroStringConsumer implements Consumer {
 
   private final VarCharVector vector;
   private final VarCharWriterImpl writer;
@@ -41,23 +41,16 @@ public class AvroStringConsumer extends Consumer {
   public AvroStringConsumer(VarCharVector vector) {
     this.vector = vector;
     this.writer = new VarCharWriterImpl(vector);
-    this.nullable = vector.getField().isNullable();
-    if (nullable) {
-      getNullFieldIndex(vector.getField());
-    }
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    if (!nullable) {
-      writeValue(decoder);
-    } else {
-      int index = decoder.readInt();
-      if (index != nullIndex) {
-        writeValue(decoder);
-      }
-    }
+    writeValue(decoder);
+    movePosition();
+  }
 
+  @Override
+  public void movePosition() {
     writer.setPosition(writer.getPosition() + 1);
   }
 

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -47,11 +47,11 @@ public class AvroStringConsumer implements Consumer {
   @Override
   public void consume(Decoder decoder) throws IOException {
     writeValue(decoder);
-    movePosition();
+    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void movePosition() {
+  public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -18,13 +18,38 @@
 package org.apache.arrow.consumers;
 
 import java.io.IOException;
+import java.util.Map;
 
+import org.apache.arrow.AvroToArrowUtils;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.avro.io.Decoder;
 
 /**
  * An abstraction that is used to consume values from avro decoder.
  */
-public interface Consumer {
+public abstract class Consumer {
 
-  void consume(Decoder decoder) throws IOException;
+  /**
+   * Indicates whether has null value.
+   */
+  protected boolean nullable;
+
+  /**
+   * Null field index in avro schema.
+   */
+  protected int nullIndex;
+
+  public abstract void consume(Decoder decoder) throws IOException;
+
+  /**
+   * Get avro null field index from vector field metadata.
+   */
+  protected void getNullFieldIndex(Field field) {
+    Map<String, String> metadata = field.getMetadata();
+    Preconditions.checkNotNull(metadata, "metadata should not be null when vector is nullable");
+    String index = metadata.get(AvroToArrowUtils.NULL_INDEX);
+    Preconditions.checkNotNull(index, "nullIndex should not be null when vector is nullable");
+    nullIndex = Integer.parseInt(index);
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -26,7 +26,15 @@ import org.apache.avro.io.Decoder;
  */
 public interface Consumer {
 
+  /**
+   * Consume a specific type value from avro decoder and write it to vector.
+   * @param decoder avro decoder to read data
+   * @throws IOException on error
+   */
   void consume(Decoder decoder) throws IOException;
 
-  void movePosition();
+  /**
+   * Add null value to vector by making writer position + 1.
+   */
+  void addNull();
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -18,38 +18,15 @@
 package org.apache.arrow.consumers;
 
 import java.io.IOException;
-import java.util.Map;
 
-import org.apache.arrow.AvroToArrowUtils;
-import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.avro.io.Decoder;
 
 /**
- * An abstraction that is used to consume values from avro decoder.
+ * Interface that is used to consume values from avro decoder.
  */
-public abstract class Consumer {
+public interface Consumer {
 
-  /**
-   * Indicates whether has null value.
-   */
-  protected boolean nullable;
+  void consume(Decoder decoder) throws IOException;
 
-  /**
-   * Null field index in avro schema.
-   */
-  protected int nullIndex;
-
-  public abstract void consume(Decoder decoder) throws IOException;
-
-  /**
-   * Get avro null field index from vector field metadata.
-   */
-  protected void getNullFieldIndex(Field field) {
-    Map<String, String> metadata = field.getMetadata();
-    Preconditions.checkNotNull(metadata, "metadata should not be null when vector is nullable");
-    String index = metadata.get(AvroToArrowUtils.NULL_INDEX);
-    Preconditions.checkNotNull(index, "nullIndex should not be null when vector is nullable");
-    nullIndex = Integer.parseInt(index);
-  }
+  void movePosition();
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullablePrimitiveTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullablePrimitiveTypeConsumer.java
@@ -19,34 +19,38 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.BitVector;
-import org.apache.arrow.vector.complex.impl.BitWriterImpl;
-import org.apache.arrow.vector.complex.writer.BitWriter;
 import org.apache.avro.io.Decoder;
 
 /**
- * Consumer which consume boolean type values from avro decoder.
- * Write the data to {@link BitVector}.
+ * Consumer holds a primitive consumer, could consume nullable values from avro decoder.
+ * Write data via writer of delegate consumer.
  */
-public class AvroBooleanConsumer implements Consumer {
+public class NullablePrimitiveTypeConsumer implements Consumer {
 
-  private final BitWriter writer;
+
+  private final Consumer delegate;
 
   /**
-   * Instantiate a AvroBooleanConsumer.
+   * Null field index in avro schema.
    */
-  public AvroBooleanConsumer(BitVector vector) {
-    this.writer = new BitWriterImpl(vector);
+  protected int nullIndex;
+
+  public NullablePrimitiveTypeConsumer(Consumer delegate, int nullIndex) {
+    this.delegate = delegate;
+    this.nullIndex = nullIndex;
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    writer.writeBit(decoder.readBoolean() ? 1 : 0);
-    movePosition();
+    if (nullIndex != decoder.readInt()) {
+      delegate.consume(decoder);
+    } else {
+      movePosition();
+    }
   }
 
   @Override
   public void movePosition() {
-    writer.setPosition(writer.getPosition() + 1);
+    delegate.movePosition();
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullablePrimitiveTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullablePrimitiveTypeConsumer.java
@@ -45,12 +45,12 @@ public class NullablePrimitiveTypeConsumer implements Consumer {
     if (nullIndex != decoder.readInt()) {
       delegate.consume(decoder);
     } else {
-      movePosition();
+      addNull();
     }
   }
 
   @Override
-  public void movePosition() {
-    delegate.movePosition();
+  public void addNull() {
+    delegate.addNull();
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
@@ -25,7 +25,7 @@ import org.apache.avro.io.Decoder;
  * Consumer holds a primitive consumer, could consume nullable values from avro decoder.
  * Write data via writer of delegate consumer.
  */
-public class NullablePrimitiveTypeConsumer implements Consumer {
+public class NullableTypeConsumer implements Consumer {
 
 
   private final Consumer delegate;
@@ -35,7 +35,7 @@ public class NullablePrimitiveTypeConsumer implements Consumer {
    */
   protected int nullIndex;
 
-  public NullablePrimitiveTypeConsumer(Consumer delegate, int nullIndex) {
+  public NullableTypeConsumer(Consumer delegate, int nullIndex) {
     this.delegate = delegate;
     this.nullIndex = nullIndex;
   }

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
@@ -36,6 +36,7 @@ import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -90,7 +91,22 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testNullableStringType() throws Exception {
+    Schema schema = getSchema("test_nullable_string.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? "test" + i : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
   }
 
   @Test
@@ -102,6 +118,7 @@ public class AvroToArrowTest {
       record.put(0, "test" + i);
       record.put(1, i);
       record.put(2, i % 2 == 0);
+      data.add(record);
     }
 
     VectorSchemaRoot root = writeAndRead(schema, data);
@@ -116,7 +133,22 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testNullableIntType() throws Exception {
+    Schema schema = getSchema("test_nullable_int.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? i : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
   }
 
   @Test
@@ -127,7 +159,22 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testNullableLongType() throws Exception {
+    Schema schema = getSchema("test_nullable_long.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? (long) i : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
   }
 
   @Test
@@ -138,7 +185,22 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testNullableFloatType() throws Exception {
+    Schema schema = getSchema("test_nullable_float.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? i + 0.1f : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
   }
 
   @Test
@@ -149,7 +211,22 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testNullableDoubleType() throws Exception {
+    Schema schema = getSchema("test_nullable_double.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? i + 0.1 : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
   }
 
   @Test
@@ -165,7 +242,22 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testNullableBytesType() throws Exception {
+    Schema schema = getSchema("test_nullable_bytes.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? ByteBuffer.wrap(("test" + i).getBytes(StandardCharsets.UTF_8)) : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
   }
 
   @Test
@@ -176,17 +268,36 @@ public class AvroToArrowTest {
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
 
-    checkPrimitiveResult(schema, data, vector);
+    checkPrimitiveResult(data, vector);
   }
 
-  private void checkPrimitiveResult(Schema schema, ArrayList data, FieldVector vector) {
+  @Test
+  public void testNullableBooleanType() throws Exception {
+    Schema schema = getSchema("test_nullable_boolean.avsc");
+
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, i % 2 == 0 ? true : null);
+      data.add(record);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    checkRecordResult(schema, data, root);
+  }
+
+  private void checkPrimitiveResult(ArrayList data, FieldVector vector) {
     assertEquals(data.size(), vector.getValueCount());
     for (int i = 0; i < data.size(); i++) {
       Object value1 = data.get(i);
       Object value2 = vector.getObject(i);
-      if (schema.getType() == Schema.Type.BYTES) {
+      if (value1 == null) {
+        assertTrue(value2 == null);
+        continue;
+      }
+      if (vector.getField().getType().getTypeID() == ArrowType.Binary.TYPE_TYPE) {
         value2 = ByteBuffer.wrap((byte[]) value2);
-      } else if (schema.getType() == Schema.Type.STRING) {
+      } else if (vector.getField().getType().getTypeID() == ArrowType.Utf8.TYPE_TYPE) {
         value2 = value2.toString();
       }
       assertTrue(Objects.equals(value1, value2));
@@ -203,7 +314,7 @@ public class AvroToArrowTest {
         fieldData.add(record.get(i));
       }
 
-      checkPrimitiveResult(schema.getFields().get(i).schema(), fieldData, root.getFieldVectors().get(i));
+      checkPrimitiveResult(fieldData, root.getFieldVectors().get(i));
     }
 
   }

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_boolean.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_boolean.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableBoolean",
+ "fields": [
+     {"name": "f0", "type": ["null", "boolean"]}
+ ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_bytes.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_bytes.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableBytes",
+ "fields": [
+     {"name": "f0", "type": ["null", "bytes"]}
+ ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_double.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_double.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableDouble",
+ "fields": [
+     {"name": "f0", "type": ["null", "double"]}
+ ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_float.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_float.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableFloat",
+ "fields": [
+     {"name": "f0", "type": ["null", "float"]}
+ ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_int.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_int.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableInt",
+ "fields": [
+     {"name": "f0", "type": ["null", "int"]}
+ ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_long.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_long.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableLong",
+ "fields": [
+     {"name": "f0", "type": ["null", "long"]}
+ ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_string.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_string.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "nullableString",
+ "fields": [
+     {"name": "f0", "type": ["null", "string"]}
+ ]
+}


### PR DESCRIPTION
Related to [ARROW-6035](https://issues.apache.org/jira/browse/ARROW-6035).

A  specific Avro unions type(has two types and one is null type) could convert to a nullable ArrowVector.
For instance, ["null", "string"] could represented by a VarcharVector which could has null value.