### PR TITLE
ARROW-6031: [Java] Support iterating a vector by ArrowBufPointer

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ElementAddressableVectorIterator.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ElementAddressableVectorIterator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import java.util.Iterator;
+
+import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.SimpleHasher;
+import org.apache.arrow.vector.ElementAddressableVector;
+
+/**
+ * Iterator for traversing elements of a {@link ElementAddressableVector}.
+ * @param <T> vector type.
+ */
+public class ElementAddressableVectorIterator<T extends ElementAddressableVector>
+        implements Iterator<ArrowBufPointer> {
+
+  private final T vector;
+
+  /**
+   * Index of the next element to access.
+   */
+  private int index = 0;
+
+  private final ArrowBufPointer reusablePointer;
+
+  /**
+   * Constructs an iterator for the {@link ElementAddressableVector}.
+   * @param vector the vector to iterate.
+   */
+  public ElementAddressableVectorIterator(T vector) {
+    this(vector, SimpleHasher.INSTANCE);
+  }
+
+  /**
+   * Constructs an iterator for the {@link ElementAddressableVector}.
+   * @param vector the vector to iterate.
+   * @param hasher the hasher to calculate the hash code.
+   */
+  public ElementAddressableVectorIterator(T vector, ArrowBufHasher hasher) {
+    this.vector = vector;
+    reusablePointer = new ArrowBufPointer(hasher);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return index < vector.getValueCount();
+  }
+
+  /**
+   * Retrieves the next pointer from the vector.
+   * @return the pointer pointing to the next element in the vector.
+   *     Note that the returned pointer is only valid before the next call to this method.
+   */
+  @Override
+  public ArrowBufPointer next() {
+    vector.getDataPointer(index, reusablePointer);
+    index += 1;
+    return reusablePointer;
+  }
+
+  /**
+   * Retrieves the next pointer from the vector.
+   * @param outPointer the pointer to populate.
+   */
+  public void next(ArrowBufPointer outPointer) {
+    vector.getDataPointer(index, outPointer);
+    index += 1;
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestElementAddressableVectorIterator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestElementAddressableVectorIterator.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link ElementAddressableVectorIterator}.
+ */
+public class TestElementAddressableVectorIterator {
+
+  private final int VECTOR_LENGTH = 100;
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testIterateIntVector() {
+    try (IntVector intVector = new IntVector("", allocator)) {
+      intVector.allocateNew(VECTOR_LENGTH);
+      intVector.setValueCount(VECTOR_LENGTH);
+
+      // prepare data in sorted order
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        if (i == 0) {
+          intVector.setNull(i);
+        } else {
+          intVector.set(i, i);
+        }
+      }
+
+      // iterate
+      ElementAddressableVectorIterator<IntVector> it = new ElementAddressableVectorIterator<>(intVector);
+      int index = 0;
+      while (it.hasNext()) {
+        ArrowBufPointer pt;
+
+        if (index % 2 == 0) {
+          // use populated pointer.
+          pt = new ArrowBufPointer();
+          it.next(pt);
+        } else {
+          // use iterator inner pointer
+          pt = it.next();
+        }
+        if (index == 0) {
+          assertNull(pt.getBuf());
+        } else {
+          assertEquals(index, pt.getBuf().getInt(pt.getOffset()));
+        }
+        index += 1;
+      }
+    }
+  }
+
+  @Test
+  public void testIterateVarCharVector() {
+    try (VarCharVector strVector = new VarCharVector("", allocator)) {
+      strVector.allocateNew(VECTOR_LENGTH * 10, VECTOR_LENGTH);
+      strVector.setValueCount(VECTOR_LENGTH);
+
+      // prepare data in sorted order
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        if (i == 0) {
+          strVector.setNull(i);
+        } else {
+          strVector.set(i, String.valueOf(i).getBytes());
+        }
+      }
+
+      // iterate
+      ElementAddressableVectorIterator<VarCharVector> it = new ElementAddressableVectorIterator<>(strVector);
+      int index = 0;
+      while (it.hasNext()) {
+        ArrowBufPointer pt;
+
+        if (index % 2 == 0) {
+          // use populated pointer.
+          pt = new ArrowBufPointer();
+          it.next(pt);
+        } else {
+          // use iterator inner pointer
+          pt = it.next();
+        }
+
+        if (index == 0) {
+          assertNull(pt.getBuf());
+        } else {
+          String expected = String.valueOf(index);
+          byte[] actual = new byte[expected.length()];
+          assertEquals(expected.length(), pt.getLength());
+
+          pt.getBuf().getBytes(pt.getOffset(), actual);
+          assertEquals(expected, new String(actual));
+        }
+        index += 1;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Provide the functionality to traverse a vector (fixed-width vector & variable-width vector) by an iterator. This is convenient for scenarios when accessing vector elements in sequence.