### PR TITLE
ARROW-6054: [Python] Fix the type erasion bug when serializing structured type ndarray.

### DIFF
--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -165,4 +165,49 @@ def get_socket_from_fd(fileno, family, type):
         return socket.socket(fileno=fileno, family=family, type=type)
 
 
+try:
+    # This function is available after numpy-0.16.0.
+    # See also: https://github.com/numpy/numpy/blob/master/numpy/lib/format.py
+    from numpy.lib.format import descr_to_dtype
+except ImportError:
+    def descr_to_dtype(descr):
+        '''
+        descr may be stored as dtype.descr, which is a list of
+        (name, format, [shape]) tuples where format may be a str or a tuple.
+        Offsets are not explicitly saved, rather empty fields with
+        name, format == '', '|Vn' are added as padding.
+        This function reverses the process, eliminating the empty padding fields.
+        '''
+        if isinstance(descr, str):
+            # No padding removal needed
+            return np.dtype(descr)
+        elif isinstance(descr, tuple):
+            # subtype, will always have a shape descr[1]
+            dt = descr_to_dtype(descr[0])
+            return np.dtype((dt, descr[1]))
+        fields = []
+        offset = 0
+        for field in descr:
+            if len(field) == 2:
+                name, descr_str = field
+                dt = descr_to_dtype(descr_str)
+            else:
+                name, descr_str, shape = field
+                dt = np.dtype((descr_to_dtype(descr_str), shape))
+
+            # Ignore padding bytes, which will be void bytes with '' as name
+            # Once support for blank names is removed, only "if name == ''" needed)
+            is_pad = (name == '' and dt.type is np.void and dt.names is None)
+            if not is_pad:
+                fields.append((name, dt, offset))
+
+            offset += dt.itemsize
+
+        names, formats, offsets = zip(*fields)
+        # names may be (title, names) tuples
+        nametups = (n  if isinstance(n, tuple) else (None, n) for n in names)
+        titles, names = zip(*nametups)
+        return np.dtype({'names': names, 'formats': formats, 'titles': titles,
+                            'offsets': offsets, 'itemsize': offset})
+
 __all__ = []

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -44,9 +44,9 @@ def _serialize_numpy_array_list(obj):
         # the view.
         if not obj.flags.c_contiguous:
             obj = np.ascontiguousarray(obj)
-        return obj.view('uint8'), obj.dtype.str
+        return obj.view('uint8'), obj.dtype.descr
     else:
-        return obj.tolist(), obj.dtype.str
+        return obj.tolist(), obj.dtype.descr
 
 
 def _deserialize_numpy_array_list(data):
@@ -63,9 +63,9 @@ def _serialize_numpy_matrix(obj):
         # the view.
         if not obj.flags.c_contiguous:
             obj = np.ascontiguousarray(obj.A)
-        return obj.A.view('uint8'), obj.A.dtype.str
+        return obj.A.view('uint8'), obj.A.dtype.descr
     else:
-        return obj.A.tolist(), obj.A.dtype.str
+        return obj.A.tolist(), obj.A.dtype.descr
 
 
 def _deserialize_numpy_matrix(data):

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -44,15 +44,15 @@ def _serialize_numpy_array_list(obj):
         # the view.
         if not obj.flags.c_contiguous:
             obj = np.ascontiguousarray(obj)
-        return obj.view('uint8'), obj.dtype.descr
+        return obj.view('uint8'), np.lib.format.dtype_to_descr(obj.dtype)
     else:
-        return obj.tolist(), obj.dtype.descr
+        return obj.tolist(), np.lib.format.dtype_to_descr(obj.dtype)
 
 
 def _deserialize_numpy_array_list(data):
     if data[1] != '|O':
         assert data[0].dtype == np.uint8
-        return data[0].view(data[1])
+        return data[0].view(np.lib.format.descr_to_dtype(data[1]))
     else:
         return np.array(data[0], dtype=np.dtype(data[1]))
 
@@ -63,15 +63,16 @@ def _serialize_numpy_matrix(obj):
         # the view.
         if not obj.flags.c_contiguous:
             obj = np.ascontiguousarray(obj.A)
-        return obj.A.view('uint8'), obj.A.dtype.descr
+        return obj.A.view('uint8'), np.lib.format.dtype_to_descr(obj.dtype)
     else:
-        return obj.A.tolist(), obj.A.dtype.descr
+        return obj.A.tolist(), np.lib.format.dtype_to_descr(obj.dtype)
 
 
 def _deserialize_numpy_matrix(data):
     if data[1] != '|O':
         assert data[0].dtype == np.uint8
-        return np.matrix(data[0].view(data[1]), copy=False)
+        return np.matrix(data[0].view(np.lib.format.descr_to_dtype(data[1])),
+                         copy=False)
     else:
         return np.matrix(data[0], dtype=np.dtype(data[1]), copy=False)
 

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -24,7 +24,7 @@ import sys
 import numpy as np
 
 import pyarrow
-from pyarrow.compat import builtin_pickle
+from pyarrow.compat import builtin_pickle, descr_to_dtype
 from pyarrow.lib import SerializationContext, py_buffer
 
 try:
@@ -52,7 +52,7 @@ def _serialize_numpy_array_list(obj):
 def _deserialize_numpy_array_list(data):
     if data[1] != '|O':
         assert data[0].dtype == np.uint8
-        return data[0].view(np.lib.format.descr_to_dtype(data[1]))
+        return data[0].view(descr_to_dtype(data[1]))
     else:
         return np.array(data[0], dtype=np.dtype(data[1]))
 
@@ -71,7 +71,7 @@ def _serialize_numpy_matrix(obj):
 def _deserialize_numpy_matrix(data):
     if data[1] != '|O':
         assert data[0].dtype == np.uint8
-        return np.matrix(data[0].view(np.lib.format.descr_to_dtype(data[1])),
+        return np.matrix(data[0].view(descr_to_dtype(data[1])),
                          copy=False)
     else:
         return np.matrix(data[0], dtype=np.dtype(data[1]), copy=False)

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -362,7 +362,9 @@ def test_default_dict_serialization(large_buffer):
 def test_numpy_serialization(large_buffer):
     for t in ["bool", "int8", "uint8", "int16", "uint16", "int32",
               "uint32", "float16", "float32", "float64", "<U1", "<U2", "<U3",
-              "<U4", "|S1", "|S2", "|S3", "|S4", "|O"]:
+              "<U4", "|S1", "|S2", "|S3", "|S4", "|O",
+              np.dtype([('a', 'int64'), ('b', 'float')]),
+              np.dtype([('x', 'uint32'), ('y', '<U8')])]:
         obj = np.random.randint(0, 10, size=(100, 100)).astype(t)
         serialization_roundtrip(obj, large_buffer)
         obj = obj[1:99, 10:90]
@@ -523,10 +525,12 @@ def test_numpy_matrix_serialization(tmpdir):
         def __init__(self, val):
             self.val = val
 
+    rec_type = np.dtype([('x', 'int64'), ('y', 'double'), ('z', '<U4')])
+
     path = os.path.join(str(tmpdir), 'pyarrow_npmatrix_serialization_test.bin')
     array = np.random.randint(low=-1, high=1, size=(2, 2))
 
-    for data_type in [str, int, float, CustomType]:
+    for data_type in [str, int, float, rec_type, CustomType]:
         matrix = np.matrix(array.astype(data_type))
 
         with open(path, 'wb') as f:


### PR DESCRIPTION
Fix the type erasion bug when serializing structured arrays of numpy.

Without this patch, we could see something like:

```python
In [1]: import pyarrow as pa
In [2]: import numpy as np
In [3]: x = np.array([(1, "a"), (2, "bb")], dtype=np.dtype([('x', 'int32'), ('y', '<U4')]))
In [4]: y = pa.deserialize(pa.serialize(x).to_buffer())
In [5]: y
Out[5]:
array([b'\x01\x00\x00\x00\x61\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'\x02\x00\x00\x00\x62\x00\x00\x00\x62\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'],
      dtype='|V20')
In [6]: x.dtype
Out[6]: dtype([('x', '<i4'), ('y', '<U4')])
```

Note that the dtype of deserialized result `y` is lost, which is really annoying. The reason is that `x.type.str` is `'|V20'`, rather than the structured type it self. Thus we need `dtype.descr`.

After this PR, we get something like

```python
In [1]: import pyarrow as pa
In [2]: import numpy as np
In [3]: x = np.array([(1, "a"), (2, "bb")], dtype=np.dtype([('x', 'int32'), ('y', '<U4')]))
In [4]: y  = pa.deserialize(pa.serialize(x).to_buffer())
In [5]: y
Out[5]: array([(1, 'a'), (2, 'bb')], dtype=[('x', '<i4'), ('y', '<U4')])
In [6]: y.dtype
Out[6]: dtype([('x', '<i4'), ('y', '<U4')])
```

I didn't see any existing test that checks the `dtype` when testing serialization of `numpy` thus I didn't add test case for this PR. If a test case is needed please let me know.