### PR TITLE
ARROW-6042: [C++][Parquet] Add Dictionary32Builder that always returns 32-bit dictionary indices

### DIFF
--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -1023,4 +1023,7 @@ TEST(TestDictionary, DISABLED_ListOfDictionary) {
   ASSERT_ARRAYS_EQUAL(*expected_dict, *actual_dict);
 }
 
+// ----------------------------------------------------------------------
+// Dictionary32Builder: produce int32 indices consistently
+
 }  // namespace arrow

--- a/cpp/src/arrow/array-dict-test.cc
+++ b/cpp/src/arrow/array-dict-test.cc
@@ -282,6 +282,26 @@ TYPED_TEST(TestDictionaryBuilder, DoubleDeltaDictionary) {
   ASSERT_TRUE(expected_delta2.Equals(result_delta2));
 }
 
+TYPED_TEST(TestDictionaryBuilder, Dictionary32_BasicPrimitive) {
+  using c_type = typename TypeParam::c_type;
+  auto type = std::make_shared<TypeParam>();
+  auto dict_type = dictionary(int32(), type);
+
+  Dictionary32Builder<TypeParam> builder;
+
+  ASSERT_OK(builder.Append(static_cast<c_type>(1)));
+  ASSERT_OK(builder.Append(static_cast<c_type>(2)));
+  ASSERT_OK(builder.Append(static_cast<c_type>(1)));
+  ASSERT_OK(builder.Append(static_cast<c_type>(2)));
+  std::shared_ptr<Array> result;
+  FinishAndCheckPadding(&builder, &result);
+
+  // Build expected data for the initial dictionary
+  auto ex_dict1 = ArrayFromJSON(type, "[1, 2]");
+  DictionaryArray expected(dict_type, ArrayFromJSON(int32(), "[0, 1, 0, 1]"), ex_dict1);
+  ASSERT_TRUE(expected.Equals(result));
+}
+
 TEST(TestStringDictionaryBuilder, Basic) {
   // Build the dictionary Array
   StringDictionaryBuilder builder;
@@ -301,11 +321,14 @@ TEST(TestStringDictionaryBuilder, Basic) {
   ASSERT_TRUE(expected.Equals(result));
 }
 
-TEST(TestStringDictionaryBuilder, AppendIndices) {
+template <typename BuilderType, typename IndexType, typename AppendCType>
+void TestStringDictionaryAppendIndices() {
+  auto index_type = TypeTraits<IndexType>::type_singleton();
+
   auto ex_dict = ArrayFromJSON(utf8(), R"(["c", "a", "b", "d"])");
   auto invalid_dict = ArrayFromJSON(binary(), R"(["e", "f"])");
 
-  StringDictionaryBuilder builder;
+  BuilderType builder;
   ASSERT_OK(builder.InsertMemoValues(*ex_dict));
 
   // Inserting again should have no effect
@@ -314,7 +337,7 @@ TEST(TestStringDictionaryBuilder, AppendIndices) {
   // Type mismatch
   ASSERT_RAISES(Invalid, builder.InsertMemoValues(*invalid_dict));
 
-  std::vector<int64_t> raw_indices = {0, 1, 2, -1, 3};
+  std::vector<AppendCType> raw_indices = {0, 1, 2, -1, 3};
   std::vector<uint8_t> is_valid = {1, 1, 1, 0, 1};
   for (int i = 0; i < 2; ++i) {
     ASSERT_OK(builder.AppendIndices(
@@ -326,10 +349,17 @@ TEST(TestStringDictionaryBuilder, AppendIndices) {
   std::shared_ptr<Array> result;
   ASSERT_OK(builder.Finish(&result));
 
-  auto ex_indices = ArrayFromJSON(int8(), R"([0, 1, 2, null, 3, 0, 1, 2, null, 3])");
-  auto dtype = dictionary(int8(), utf8());
+  auto ex_indices = ArrayFromJSON(index_type, R"([0, 1, 2, null, 3, 0, 1, 2, null, 3])");
+  auto dtype = dictionary(index_type, utf8());
   DictionaryArray expected(dtype, ex_indices, ex_dict);
   ASSERT_TRUE(expected.Equals(result));
+}
+
+TEST(TestStringDictionaryBuilder, AppendIndices) {
+  // Currently AdaptiveIntBuilder only accepts int64_t in bulk appends
+  TestStringDictionaryAppendIndices<StringDictionaryBuilder, Int8Type, int64_t>();
+
+  TestStringDictionaryAppendIndices<StringDictionary32Builder, Int32Type, int32_t>();
 }
 
 TEST(TestStringDictionaryBuilder, ArrayInit) {
@@ -1022,8 +1052,5 @@ TEST(TestDictionary, DISABLED_ListOfDictionary) {
       checked_cast<const DictionaryArray&>(*list_array->values()).dictionary();
   ASSERT_ARRAYS_EQUAL(*expected_dict, *actual_dict);
 }
-
-// ----------------------------------------------------------------------
-// Dictionary32Builder: produce int32 indices consistently
 
 }  // namespace arrow

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1311,7 +1311,7 @@ class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
  private:
   using BinaryDictDecoder = DictDecoder<ByteArrayType>;
 
-  ::arrow::BinaryDictionaryBuilder builder_;
+  ::arrow::BinaryDictionary32Builder builder_;
   std::vector<std::shared_ptr<::arrow::Array>> result_chunks_;
 };
 

--- a/cpp/src/parquet/encoding-benchmark.cc
+++ b/cpp/src/parquet/encoding-benchmark.cc
@@ -36,6 +36,7 @@ using arrow::default_memory_pool;
 using arrow::MemoryPool;
 
 namespace {
+
 // The min/max number of values used to drive each family of encoding benchmarks
 constexpr int MIN_RANGE = 1024;
 constexpr int MAX_RANGE = 65536;
@@ -335,7 +336,7 @@ class BenchmarkDecodeArrow : public ::benchmark::Fixture {
   std::shared_ptr<Buffer> buffer_;
 };
 
-using ::arrow::BinaryDictionaryBuilder;
+using ::arrow::BinaryDictionary32Builder;
 using ::arrow::internal::ChunkedBinaryBuilder;
 
 template <>
@@ -346,9 +347,9 @@ std::unique_ptr<ChunkedBinaryBuilder> BenchmarkDecodeArrow::CreateBuilder() {
 }
 
 template <>
-std::unique_ptr<BinaryDictionaryBuilder> BenchmarkDecodeArrow::CreateBuilder() {
-  return std::unique_ptr<BinaryDictionaryBuilder>(
-      new BinaryDictionaryBuilder(default_memory_pool()));
+std::unique_ptr<BinaryDictionary32Builder> BenchmarkDecodeArrow::CreateBuilder() {
+  return std::unique_ptr<BinaryDictionary32Builder>(
+      new BinaryDictionary32Builder(default_memory_pool()));
 }
 
 // ----------------------------------------------------------------------
@@ -379,12 +380,14 @@ BENCHMARK_REGISTER_F(BM_PlainDecodingByteArray, DecodeArrowNonNull_Dense)
     ->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_PlainDecodingByteArray, DecodeArrow_Dict)
-(benchmark::State& state) { DecodeArrowBenchmark<BinaryDictionaryBuilder>(state); }
+(benchmark::State& state) { DecodeArrowBenchmark<BinaryDictionary32Builder>(state); }
 BENCHMARK_REGISTER_F(BM_PlainDecodingByteArray, DecodeArrow_Dict)
     ->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_PlainDecodingByteArray, DecodeArrowNonNull_Dict)
-(benchmark::State& state) { DecodeArrowNonNullBenchmark<BinaryDictionaryBuilder>(state); }
+(benchmark::State& state) {
+  DecodeArrowNonNullBenchmark<BinaryDictionary32Builder>(state);
+}
 BENCHMARK_REGISTER_F(BM_PlainDecodingByteArray, DecodeArrowNonNull_Dict)
     ->Range(MIN_RANGE, MAX_RANGE);
 
@@ -439,12 +442,14 @@ BENCHMARK_REGISTER_F(BM_DictDecodingByteArray, DecodeArrowNonNull_Dense)
     ->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_DictDecodingByteArray, DecodeArrow_Dict)
-(benchmark::State& state) { DecodeArrowBenchmark<BinaryDictionaryBuilder>(state); }
+(benchmark::State& state) { DecodeArrowBenchmark<BinaryDictionary32Builder>(state); }
 BENCHMARK_REGISTER_F(BM_DictDecodingByteArray, DecodeArrow_Dict)
     ->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_DictDecodingByteArray, DecodeArrowNonNull_Dict)
-(benchmark::State& state) { DecodeArrowNonNullBenchmark<BinaryDictionaryBuilder>(state); }
+(benchmark::State& state) {
+  DecodeArrowNonNullBenchmark<BinaryDictionary32Builder>(state);
+}
 BENCHMARK_REGISTER_F(BM_DictDecodingByteArray, DecodeArrowNonNull_Dict)
     ->Range(MIN_RANGE, MAX_RANGE);
 

--- a/cpp/src/parquet/encoding-test.cc
+++ b/cpp/src/parquet/encoding-test.cc
@@ -328,7 +328,7 @@ TEST(TestDictionaryEncoding, CannotDictDecodeBoolean) {
 class TestArrowBuilderDecoding : public ::testing::Test {
  public:
   using DenseBuilder = ::arrow::internal::ChunkedBinaryBuilder;
-  using DictBuilder = ::arrow::BinaryDictionaryBuilder;
+  using DictBuilder = ::arrow::BinaryDictionary32Builder;
 
   void SetUp() override { null_probabilities_ = {0.0, 0.5, 1.0}; }
   void TearDown() override {}

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -29,7 +29,7 @@
 namespace arrow {
 
 class ArrayBuilder;
-class BinaryDictionaryBuilder;
+class BinaryDictionary32Builder;
 
 namespace internal {
 
@@ -225,10 +225,10 @@ class ByteArrayDecoder : virtual public TypedDecoder<ByteArrayType> {
 
   virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                           int64_t valid_bits_offset,
-                          ::arrow::BinaryDictionaryBuilder* builder) = 0;
+                          ::arrow::BinaryDictionary32Builder* builder) = 0;
 
   virtual int DecodeArrowNonNull(int num_values,
-                                 ::arrow::BinaryDictionaryBuilder* builder) = 0;
+                                 ::arrow::BinaryDictionary32Builder* builder) = 0;
 
   virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                           int64_t valid_bits_offset,


### PR DESCRIPTION
Without this, DictionaryArrays produced by different parts of a Parquet file could have different index types depending on the cardinality of each decoded part. 

Refactors DictionaryBuilder (which uses AdaptiveIntBuilder) and Dictionary32Builder (which uses Int32Builder) to have a common base class.