### PR TITLE
ARROW-6053: [Python] Fix pyarrow's RecordBatchStreamReader::Open2 type signature

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -949,7 +949,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
 
         @staticmethod
         CStatus Open2" Open"(unique_ptr[CMessageReader] message_reader,
-                             shared_ptr[CRecordBatchStreamReader]* out)
+                             shared_ptr[CRecordBatchReader]* out)
 
     cdef cppclass CRecordBatchStreamWriter \
             " arrow::ipc::RecordBatchStreamWriter"(CRecordBatchWriter):


### PR DESCRIPTION
Fixes a type mismatch between Arrow C++'s RecordBatchStreamReader::Open method:

https://github.com/apache/arrow/blob/38b01764da445ce6383b60a50d1e9b313857a3d7/cpp/src/arrow/ipc/reader.h#L66-L67

and its Cython defintion:
https://github.com/apache/arrow/blob/38b01764da445ce6383b60a50d1e9b313857a3d7/python/pyarrow/includes/libarrow.pxd#L950-L952

I don't know if this causes problems in python, but I ran into it today while working with  pyarrow in cython. Closes https://issues.apache.org/jira/browse/ARROW-6053.