### PR TITLE
ARROW-5651: [Python] Fix Incorrect conversion from strided Numpy array

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -389,8 +389,9 @@ Status CopyStridedArray(PyArrayObject* arr, const int64_t length,
   std::shared_ptr<Buffer> new_buffer;
   RETURN_NOT_OK(AllocateBuffer(pool, itemsize * length, &new_buffer));
 
-  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)), length, itemsize, stride,
-                        reinterpret_cast<int8_t*>(new_buffer->mutable_data()));
+  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)),
+                      length, itemsize, stride,
+                      reinterpret_cast<int8_t*>(new_buffer->mutable_data()));
 
   *out = new_buffer;
   return Status::OK();

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -389,7 +389,7 @@ Status CopyStridedArray(PyArrayObject* arr, const int64_t length,
   std::shared_ptr<Buffer> new_buffer;
   RETURN_NOT_OK(AllocateBuffer(pool, itemsize * length, &new_buffer));
 
-  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)), itemsize, length, stride,
+  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)), length, itemsize, stride,
                         reinterpret_cast<int8_t*>(new_buffer->mutable_data()));
 
   *out = new_buffer;

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -382,16 +382,15 @@ void CopyStridedBytewise(const int8_t* input_data, const int64_t length,
   }
 }
 
-Status CopyStridedArray(PyArrayObject* arr, const int64_t length,
-                        const int64_t itemsize, const int64_t stride,
-                        MemoryPool* pool, std::shared_ptr<Buffer>* out) {
+Status CopyStridedArray(PyArrayObject* arr, const int64_t length, const int64_t itemsize,
+                        const int64_t stride, MemoryPool* pool,
+                        std::shared_ptr<Buffer>* out) {
   // Strided, must copy into new contiguous memory
   std::shared_ptr<Buffer> new_buffer;
   RETURN_NOT_OK(AllocateBuffer(pool, itemsize * length, &new_buffer));
 
-  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)),
-                      length, itemsize, stride,
-                      reinterpret_cast<int8_t*>(new_buffer->mutable_data()));
+  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)), length, itemsize,
+                      stride, reinterpret_cast<int8_t*>(new_buffer->mutable_data()));
 
   *out = new_buffer;
   return Status::OK();

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -375,7 +375,6 @@ Status StaticCastBuffer(const Buffer& input, const int64_t length, MemoryPool* p
 void CopyStridedBytewise(const int8_t* input_data, const int64_t length,
                          const int64_t itemsize, const int64_t stride,
                          int8_t* output_data) {
-  // Passing input_data as non-const is a concession to PyObject*
   for (int64_t i = 0; i < length; ++i) {
     memcpy(output_data + i * itemsize, input_data, itemsize);
     input_data += stride;

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -372,9 +372,9 @@ Status StaticCastBuffer(const Buffer& input, const int64_t length, MemoryPool* p
   return Status::OK();
 }
 
-void CopyStridedBytewise(const int8_t* input_data, const int64_t length,
+void CopyStridedBytewise(const uint8_t* input_data, const int64_t length,
                          const int64_t itemsize, const int64_t stride,
-                         int8_t* output_data) {
+                         uint8_t* output_data) {
   for (int64_t i = 0; i < length; ++i) {
     memcpy(output_data + i * itemsize, input_data, itemsize);
     input_data += stride;
@@ -389,7 +389,7 @@ Status CopyStridedArray(PyArrayObject* arr, const int64_t length, const int64_t 
   RETURN_NOT_OK(AllocateBuffer(pool, itemsize * length, &new_buffer));
 
   CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)), length, itemsize,
-                      stride, reinterpret_cast<int8_t*>(new_buffer->mutable_data()));
+                      stride, new_buffer->mutable_data());
 
   *out = new_buffer;
   return Status::OK();

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -388,7 +388,7 @@ Status CopyStridedArray(PyArrayObject* arr, const int64_t length, const int64_t 
   std::shared_ptr<Buffer> new_buffer;
   RETURN_NOT_OK(AllocateBuffer(pool, itemsize * length, &new_buffer));
 
-  CopyStridedBytewise(reinterpret_cast<int8_t*>(PyArray_DATA(arr)), length, itemsize,
+  CopyStridedBytewise(reinterpret_cast<uint8_t*>(PyArray_DATA(arr)), length, itemsize,
                       stride, new_buffer->mutable_data());
 
   *out = new_buffer;

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1499,3 +1499,10 @@ def test_concat_array():
 def test_concat_array_different_types():
     with pytest.raises(pa.ArrowInvalid):
         pa.concat_arrays([pa.array([1]), pa.array([2.])])
+
+def test_array_from_strided_numpy_array():
+    np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
+    pa_arr = pa.array(np_arr, type=pa.float64())
+    expected = pa.array([1.0, 3.0, 5.0, 7.0], type=pa.float64())
+    pa_arr.equals(expected)
+

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1500,9 +1500,9 @@ def test_concat_array_different_types():
     with pytest.raises(pa.ArrowInvalid):
         pa.concat_arrays([pa.array([1]), pa.array([2.])])
 
+
 def test_array_from_strided_numpy_array():
     np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
     pa_arr = pa.array(np_arr, type=pa.float64())
     expected = pa.array([1.0, 3.0, 5.0, 7.0], type=pa.float64())
     pa_arr.equals(expected)
-

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1499,10 +1499,3 @@ def test_concat_array():
 def test_concat_array_different_types():
     with pytest.raises(pa.ArrowInvalid):
         pa.concat_arrays([pa.array([1]), pa.array([2.])])
-
-
-def test_array_from_strided_numpy_array():
-    np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
-    pa_arr = pa.array(np_arr, type=pa.float64())
-    expected = pa.array([1.0, 3.0, 5.0, 7.0], type=pa.float64())
-    pa_arr.equals(expected)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2348,6 +2348,13 @@ class TestConvertMisc(object):
         arr = pa.array(data['y'], type=pa.int16())
         assert arr.to_pylist() == [-1, 2]
 
+    def test_array_from_strided_numpy_array(self):
+        # ARROW-5651
+        np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
+        pa_arr = pa.array(np_arr, type=pa.float64())
+        expected = pa.array([1.0, 3.0, 5.0, 7.0], type=pa.float64())
+        pa_arr.equals(expected)
+
     def test_safe_unsafe_casts(self):
         # ARROW-2799
         df = pd.DataFrame({


### PR DESCRIPTION
Fix the issue described in https://issues.apache.org/jira/browse/ARROW-5651

### Problem
`pa.array` gives wrong results for numpy arrays with a non-trivial stride when the type is different from the original one.
```
>>> np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
>>> print(np_arr)
[1. 3. 5. 7.]
>>> pa_arr = pa.array(np_arr, type=pa.float64())
>>> print(pa_arr)
[
  1,
  2,
  3,
  4
]
```

### Cause
The problem arises due to the function [`CopyStridedArray`](https://github.com/apache/arrow/blob/38b01764da445ce6383b60a50d1e9b313857a3d7/cpp/src/arrow/python/numpy_to_arrow.cc#L396), which is supposed to copy the elements of a given numpy array with a non-trivial stride to a contiguous memory buffer. The current implementation does not deliver the expected result.

Tracing the execution of the above example with gdb shows that the function just copies all elements of the given numpy array.
```
$ vim sample.py
$ cat sample.py
import numpy as np
import pyarrow as pa
np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
pa_arr = pa.array(np_arr, type=pa.float64())
$ gdb --args python sample.py
... several commands to reach the invocation of `CopyStridedArray`
(gdb) bt 1
#0  arrow::py::NumPyConverter::PrepareInputData<arrow::DoubleType> (this=0x7fffffffdc50, data=0x7fffffffda40)
    at /vagrant/arrow/cpp/src/arrow/python/numpy_to_arrow.cc:429
(gdb) li 429
424	    // TODO
425	    return Status::NotImplemented("Byte-swapped arrays not supported");
426	  }
427
428	  if (is_strided()) {
429	    RETURN_NOT_OK(CopyStridedArray<ArrowType>(arr_, length_, pool_, data));
430	  } else if (dtype_->type_num == NPY_BOOL) {
431	    int64_t nbytes = BitUtil::BytesForBits(length_);
432	    std::shared_ptr<Buffer> buffer;
433	    RETURN_NOT_OK(AllocateBuffer(pool_, nbytes, &buffer));
(gdb) print PyArray_DATA(arr_)
$7 = (void *) 0x5555560a1834
(gdb) x/32bx  0x5555560a1834
0x5555560a1834:	0x00	0x00	0x80	0x3f	0x00	0x00	0x00	0x40
0x5555560a183c:	0x00	0x00	0x40	0x40	0x00	0x00	0x80	0x40
0x5555560a1844:	0x00	0x00	0xa0	0x40	0x00	0x00	0xc0	0x40
0x5555560a184c:	0x00	0x00	0xe0	0x40	0x00	0x00	0x00	0x41
(gdb) n
(gdb) print (*data)->size_
$12 = 32
x/32bx (*data)->mutable_data_
0x7fffee409000:	0x00	0x00	0x80	0x3f	0x00	0x00	0x00	0x40
0x7fffee409008:	0x00	0x00	0x40	0x40	0x00	0x00	0x80	0x40
0x7fffee409010:	0x00	0x00	0xa0	0x40	0x00	0x00	0xc0	0x40
0x7fffee409018:	0x00	0x00	0xe0	0x40	0x00	0x00	0x00	0x41
```
However, the expected result is a contigous array of 1, 3, 5, 7 encoded in float32 type.
```
(gdb) print (*data)->size_
$12 = 16
(gdb) x/16bx (*data)->mutable_data_
0x7fffee409000:	0x00	0x00	0x80	0x3f	0x00	0x00	0x40	0x40
0x7fffee409008:	0x00	0x00	0xa0	0x40	0x00	0x00	0xe0	0x40
```
Note that float32 encoding of 1, 2, 3, 4, ... are
```
1.0: 0x00	0x00	0x80	0x3f
2.0: 0x00	0x00	0x00	0x40
3.0: 0x00	0x00	0x40	0x40
4.0: 0x00	0x00	0x80	0x40
...
```

### Solution
As described in the [ticket](https://issues.apache.org/jira/browse/ARROW-5651), the wrong behavior of the function `CopyStridedArray` could be fixed by changing the type [`T`](https://github.com/apache/arrow/blob/38b01764da445ce6383b60a50d1e9b313857a3d7/cpp/src/arrow/python/numpy_to_arrow.cc#L399) declared in the function not to take the type of the output type (float64 in the above example) but to take the input type (float32 in the above example). However, I could not change the behavior of the function in this way because the function does not take the type of the input array explicitly. Instead, I used the [`itemisize_`](https://github.com/apache/arrow/blob/38b01764da445ce6383b60a50d1e9b313857a3d7/cpp/src/arrow/python/numpy_to_arrow.cc#L198-L199) retrieved from the input array to get the type (size) of each element of the input and passed it to the `CopyStridedArray`.

Use of `itemsize` instead of type `T` forces me to remove function `CopyStridedNatural` because `reinterpret_cast<T*>` cannot not be used because the type `T` is necessary. 

### Note
AMD64 Conda C++ Test fails now, but it seems unrelated to this PR.