### PR TITLE
ARROW-6040: [Java] Dictionary entries are required in IPC streams even when empty

### DIFF
--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
@@ -114,4 +114,9 @@ public class OrcStripeReader extends ArrowReader {
   protected ArrowDictionaryBatch readDictionary() throws IOException {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  protected void readDictionaries(Map<Long, Dictionary> dictionaries) throws IOException {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
@@ -19,14 +19,11 @@ package org.apache.arrow.adapter.orc;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ReadChannel;
-import org.apache.arrow.vector.ipc.message.ArrowDictionaryBatch;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.ipc.message.MessageChannelReader;

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
@@ -111,14 +111,4 @@ public class OrcStripeReader extends ArrowReader {
       return MessageSerializer.deserializeSchema(result.getMessage());
     }
   }
-
-  @Override
-  protected ArrowDictionaryBatch readDictionary() throws IOException {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected void readDictionaries(Map<Long, Dictionary> dictionaries) throws IOException {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
@@ -19,9 +19,11 @@ package org.apache.arrow.adapter.orc;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ReadChannel;
 import org.apache.arrow.vector.ipc.message.ArrowDictionaryBatch;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
@@ -159,6 +159,8 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
    */
   protected abstract ArrowDictionaryBatch readDictionary() throws IOException;
 
+  protected abstract void readDictionaries(Map<Long, Dictionary> dictionaries) throws IOException;
+
   /**
    * Initialize if not done previously.
    *
@@ -192,11 +194,7 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
     this.loader = new VectorLoader(root);
     this.dictionaries = Collections.unmodifiableMap(dictionaries);
 
-    // Read and load all dictionaries from schema
-    for (int i = 0; i < dictionaries.size(); i++) {
-      ArrowDictionaryBatch dictionaryBatch = readDictionary();
-      loadDictionary(dictionaryBatch);
-    }
+    readDictionaries(dictionaries);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
@@ -46,7 +46,7 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
   private VectorLoader loader;
   private VectorSchemaRoot root;
   private Map<Long, Dictionary> dictionaries;
-  private boolean initialized = false;
+  protected boolean initialized = false;
 
   protected ArrowReader(BufferAllocator allocator) {
     this.allocator = allocator;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
@@ -162,7 +162,7 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
   /**
    * Read dictionaries from IPC stream after read schema.
    * Note that if the stream is empty (only has schema), no dictionaries is available.
-   * @throws IOException
+   * @throws IOException on error
    */
   protected abstract void readDictionaries(Map<Long, Dictionary> dictionaries) throws IOException;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
@@ -45,8 +45,8 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
   protected final BufferAllocator allocator;
   private VectorLoader loader;
   private VectorSchemaRoot root;
-  private Map<Long, Dictionary> dictionaries;
-  protected boolean initialized = false;
+  protected Map<Long, Dictionary> dictionaries;
+  private boolean initialized = false;
 
   protected ArrowReader(BufferAllocator allocator) {
     this.allocator = allocator;
@@ -151,22 +151,6 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
   protected abstract Schema readSchema() throws IOException;
 
   /**
-   * Read a dictionary batch from the source, will be invoked after the schema has been read and
-   * called N times, where N is the number of dictionaries indicated by the schema Fields.
-   *
-   * @return the read ArrowDictionaryBatch
-   * @throws IOException on error
-   */
-  protected abstract ArrowDictionaryBatch readDictionary() throws IOException;
-
-  /**
-   * Read dictionaries from IPC stream after read schema.
-   * Note that if the stream is empty (only has schema), no dictionaries is available.
-   * @throws IOException on error
-   */
-  protected abstract void readDictionaries(Map<Long, Dictionary> dictionaries) throws IOException;
-
-  /**
    * Initialize if not done previously.
    *
    * @throws IOException on error
@@ -181,7 +165,7 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
   /**
    * Reads the schema and initializes the vectors.
    */
-  private void initialize() throws IOException {
+  protected void initialize() throws IOException {
     Schema originalSchema = readSchema();
     List<Field> fields = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
@@ -198,8 +182,6 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
     this.root = new VectorSchemaRoot(schema, vectors, 0);
     this.loader = new VectorLoader(root);
     this.dictionaries = Collections.unmodifiableMap(dictionaries);
-
-    readDictionaries(dictionaries);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java
@@ -159,6 +159,11 @@ public abstract class ArrowReader implements DictionaryProvider, AutoCloseable {
    */
   protected abstract ArrowDictionaryBatch readDictionary() throws IOException;
 
+  /**
+   * Read dictionaries from IPC stream after read schema.
+   * Note that if the stream is empty (only has schema), no dictionaries is available.
+   * @throws IOException
+   */
   protected abstract void readDictionaries(Map<Long, Dictionary> dictionaries) throws IOException;
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
@@ -181,6 +181,10 @@ public class ArrowStreamReader extends ArrowReader {
       if (dictionaryBatch == null) {
         // empty stream has no dictionaries in IPC.
         if (i == 0) {
+          initialized = true;
+          if (loadNextBatch()) {
+            throw new IOException("DictionaryBatch is missing.");
+          }
           break;
         } else {
           throw new IOException("Unexpected end of input. Expected DictionaryBatch");

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamReader.java
@@ -183,11 +183,11 @@ public class ArrowStreamReader extends ArrowReader {
         if (i == 0) {
           initialized = true;
           if (loadNextBatch()) {
-            throw new IOException("DictionaryBatch is missing.");
+            throw new IOException("DictionaryBatch is missing at index:" + i);
           }
           break;
         } else {
-          throw new IOException("Unexpected end of input. Expected DictionaryBatch");
+          throw new IOException("Unexpected end of input. Expected DictionaryBatch at index:" + i);
         }
       }
       loadDictionary(dictionaryBatch);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -105,7 +105,7 @@ public abstract class ArrowWriter implements AutoCloseable {
    */
   public void writeBatch() throws IOException {
     ensureStarted();
-    writeDictionaries();
+    ensureDictionariesWritten();
     try (ArrowRecordBatch batch = unloader.getRecordBatch()) {
       writeRecordBatch(batch);
     }
@@ -148,7 +148,7 @@ public abstract class ArrowWriter implements AutoCloseable {
    * Write dictionaries after schema and before recordBatches, dictionaries won't be
    * written if empty stream (only has schema data in IPC).
    */
-  private void writeDictionaries() throws IOException {
+  private void ensureDictionariesWritten() throws IOException {
     if (!dictWritten) {
       dictWritten = true;
       // write out any dictionaries

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -57,6 +57,8 @@ public abstract class ArrowWriter implements AutoCloseable {
   private boolean started = false;
   private boolean ended = false;
 
+  private boolean dictWritten = false;
+
   /**
    * Note: fields are not closed when the writer is closed.
    *
@@ -103,6 +105,7 @@ public abstract class ArrowWriter implements AutoCloseable {
    */
   public void writeBatch() throws IOException {
     ensureStarted();
+    writeDictionaries();
     try (ArrowRecordBatch batch = unloader.getRecordBatch()) {
       writeRecordBatch(batch);
     }
@@ -138,6 +141,16 @@ public abstract class ArrowWriter implements AutoCloseable {
       // write the schema - for file formats this is duplicated in the footer, but matches
       // the streaming format
       MessageSerializer.serialize(out, schema);
+    }
+  }
+
+  /**
+   * Write dictionaries after schema and before recordBatches, dictionaries won't be
+   * written if empty stream (only has schema data in IPC).
+   */
+  private void writeDictionaries() throws IOException {
+    if (!dictWritten) {
+      dictWritten = true;
       // write out any dictionaries
       for (ArrowDictionaryBatch batch : dictionaries) {
         try {

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -330,7 +330,7 @@ public class BaseFileTest {
     encodedVector1B.allocateNewSafe();
     encodedVector1B.set(0, 2);  // "baz"
     encodedVector1B.set(1, 1);  // "bar"
-    encodedVector1B.set(2, 2);  // "baz"d
+    encodedVector1B.set(2, 2);  // "baz"
     encodedVector1B.set(4, 1);  // "bar"
     encodedVector1B.set(5, 0);  // "foo"
     encodedVector1B.setValueCount(6);

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -330,7 +330,7 @@ public class BaseFileTest {
     encodedVector1B.allocateNewSafe();
     encodedVector1B.set(0, 2);  // "baz"
     encodedVector1B.set(1, 1);  // "bar"
-    encodedVector1B.set(2, 2);  // "baz"
+    encodedVector1B.set(2, 2);  // "baz"d
     encodedVector1B.set(4, 1);  // "bar"
     encodedVector1B.set(5, 0);  // "foo"
     encodedVector1B.setValueCount(6);

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -203,7 +203,7 @@ public class TestArrowReaderWriter {
   }
 
   @Test
-  public void testEmptyStream1() throws IOException {
+  public void testEmptyStreamInFileIPC() throws IOException {
 
     DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
     provider.put(dictionary);
@@ -241,7 +241,7 @@ public class TestArrowReaderWriter {
   }
 
   @Test
-  public void testEmptyStream2() throws IOException {
+  public void testEmptyStreamInStreamingIPC() throws IOException {
 
     DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
     provider.put(dictionary);


### PR DESCRIPTION
Related to [ARROW-6040](https://issues.apache.org/jira/browse/ARROW-6040).

Java's ArrowReader requires that dictionaries are sent in an IPC stream: https://github.com/apache/arrow/blob/master/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowReader.java#L196-L200.
However, as noted in ARROW-6006, that is not required if the stream contains no values.