### PR TITLE
ARROW-6070: [Java] Avoid creating new schema before IPC sending

### DIFF
--- a/java/flight/src/main/java/org/apache/arrow/flight/DictionaryUtils.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/DictionaryUtils.java
@@ -50,12 +50,8 @@ final class DictionaryUtils {
    */
   static Schema generateSchemaMessages(final Schema originalSchema, final FlightDescriptor descriptor,
       final DictionaryProvider provider, final Consumer<ArrowMessage> messageCallback) {
-    final List<Field> fields = new ArrayList<>(originalSchema.getFields().size());
     final Set<Long> dictionaryIds = new HashSet<>();
-    for (final Field field : originalSchema.getFields()) {
-      fields.add(DictionaryUtility.toMessageFormat(field, provider, dictionaryIds));
-    }
-    final Schema schema = new Schema(fields, originalSchema.getCustomMetadata());
+    final Schema schema = generateSchema(originalSchema, provider, dictionaryIds);
     // Send the schema message
     messageCallback.accept(new ArrowMessage(descriptor == null ? null : descriptor.toProtocol(), schema));
     // Create and write dictionary batches
@@ -83,7 +79,38 @@ final class DictionaryUtils {
     schema.getFields().forEach(field -> DictionaryUtility.toMessageFormat(field, provider, dictionaryIds));
 
     final List<AutoCloseable> dictionaryVectors = dictionaryIds.stream()
-        .map(id -> (AutoCloseable) provider.lookup(id).getVector()).collect(Collectors.toList());
+            .map(id -> (AutoCloseable) provider.lookup(id).getVector()).collect(Collectors.toList());
     AutoCloseables.close(dictionaryVectors);
+  }
+
+  /**
+   * Generates the schema to send with flight messages.
+   * If the schema contains no field with a dictionary, it will return the schema as is.
+   * Otherwise, it will return a newly created a new schema after converting the fields.
+   * @param originalSchema the original schema.
+   * @param provider the dictionary provider.
+   * @param dictionaryIds dictionary IDs that are used.
+   * @return the schema to send with the flight messages.
+   */
+  static Schema generateSchema(
+          final Schema originalSchema, final DictionaryProvider provider, Set<Long> dictionaryIds) {
+    // first determine if a new schema needs to be created.
+    boolean createSchema = false;
+    for (Field field : originalSchema.getFields()) {
+      if (DictionaryUtility.needConvertToMessageFormat(field)) {
+        createSchema = true;
+        break;
+      }
+    }
+
+    if (!createSchema) {
+      return originalSchema;
+    } else {
+      final List<Field> fields = new ArrayList<>(originalSchema.getFields().size());
+      for (final Field field : originalSchema.getFields()) {
+        fields.add(DictionaryUtility.toMessageFormat(field, provider, dictionaryIds));
+      }
+      return new Schema(fields, originalSchema.getCustomMetadata());
+    }
   }
 }

--- a/java/flight/src/test/java/org/apache/arrow/flight/TestDictionaryUtils.java
+++ b/java/flight/src/test/java/org/apache/arrow/flight/TestDictionaryUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.TreeSet;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Test cases for {@link DictionaryUtils}.
+ */
+public class TestDictionaryUtils {
+
+  @Test
+  public void testReuseSchema() {
+    FieldType varcharType = new FieldType(true, new ArrowType.Utf8(), null);
+    FieldType intType = new FieldType(true, new ArrowType.Int(32, true), null);
+
+    ImmutableList<Field> build = ImmutableList.of(
+            new Field("stringCol", varcharType, null),
+            new Field("intCol", intType, null));
+
+    Schema schema = new Schema(build);
+    Schema newSchema = DictionaryUtils.generateSchema(schema, null, new TreeSet<>());
+
+    // assert that no new schema is created.
+    assertTrue(schema == newSchema);
+  }
+
+  @Test
+  public void testCreateSchema() {
+    try (BufferAllocator allocator = new RootAllocator(1024)) {
+      DictionaryEncoding dictionaryEncoding =
+              new DictionaryEncoding(0, true, new ArrowType.Int(8, true));
+      VarCharVector dictVec = new VarCharVector("dict vector", allocator);
+      Dictionary dictionary = new Dictionary(dictVec, dictionaryEncoding);
+      DictionaryProvider dictProvider = new DictionaryProvider.MapDictionaryProvider(dictionary);
+      TreeSet<Long> dictionaryUsed = new TreeSet<>();
+
+      FieldType encodedVarcharType = new FieldType(true, new ArrowType.Int(8, true), dictionaryEncoding);
+      FieldType intType = new FieldType(true, new ArrowType.Int(32, true), null);
+
+      ImmutableList<Field> build = ImmutableList.of(
+              new Field("stringCol", encodedVarcharType, null),
+              new Field("intCol", intType, null));
+
+      Schema schema = new Schema(build);
+      Schema newSchema = DictionaryUtils.generateSchema(schema, dictProvider, dictionaryUsed);
+
+      // assert that a new schema is created.
+      assertTrue(schema != newSchema);
+
+      // assert the column is converted as expected
+      ArrowType newColType = newSchema.getFields().get(0).getType();
+      assertEquals(new ArrowType.Utf8(), newColType);
+
+      assertEquals(1, dictionaryUsed.size());
+      assertEquals(0, dictionaryUsed.first());
+    }
+  }
+}


### PR DESCRIPTION
If a dictionary is attached to a schema, it may need to be converted before IPC sending. When this is not the case (which is most likely in practice), there is no need to do the conversion and no need to create a new schema. 

We solve the above problem by quickly determining if conversion is required, and if not, we avoid creating a new schema and return the original one immediately.