### PR TITLE
ARROW-6073: [C++] Reset Decimal128Builder in Finish().

### DIFF
--- a/cpp/src/arrow/array-test.cc
+++ b/cpp/src/arrow/array-test.cc
@@ -1755,6 +1755,7 @@ class DecimalTest : public ::testing::TestWithParam<int> {
 
     std::shared_ptr<Array> out;
     FinishAndCheckPadding(builder.get(), &out);
+    ASSERT_EQ(builder->length(), 0);
 
     std::vector<uint8_t> raw_bytes;
 

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -69,7 +69,7 @@ Status Decimal128Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(null_bitmap_builder_.Finish(&null_bitmap));
 
   *out = ArrayData::Make(type_, length_, {null_bitmap, data}, null_count_);
-
+  capacity_ = length_ = null_count_ = 0;
   return Status::OK();
 }
 


### PR DESCRIPTION
This change updates the FinishInternal implementation in Decimal128Builder to reset the internal state at finish time, honoring the contract for array builders.