### PR TITLE
ARROW-6078: [Java] Implement dictionary-encoded subfields for List type

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.complex;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BaseValueVector;
+import org.apache.arrow.vector.FieldVector;
+
+/**
+ * Abstraction for all list type vectors.
+ */
+public abstract class BaseListVector extends BaseValueVector implements PromotableVector {
+
+  protected BaseListVector(BufferAllocator allocator) {
+    super(allocator);
+  }
+
+  /**
+   * Get data vector start index with the given list index.
+   */
+  public abstract int getStartIndex(int index);
+
+  /**
+   * Get data vector end index with the given list index.
+   */
+  public abstract int getEndIndex(int index);
+
+  /**
+   * Get the inner data vector for this list vector.
+   */
+  public abstract FieldVector getDataVector();
+
+  /**
+   * Set offset buffer value at (index + 1) if needed.
+   */
+  public abstract void setOffsetBufferValueIfNeeded(int index, int value);
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
@@ -17,36 +17,25 @@
 
 package org.apache.arrow.vector.complex;
 
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.FieldVector;
 
 /**
  * Abstraction for all list type vectors.
  */
-public abstract class BaseListVector extends BaseValueVector implements PromotableVector {
-
-  protected BaseListVector(BufferAllocator allocator) {
-    super(allocator);
-  }
+public interface BaseListVector extends FieldVector {
 
   /**
    * Get data vector start index with the given list index.
    */
-  public abstract int getElementStartIndex(int index);
+  int getElementStartIndex(int index);
 
   /**
    * Get data vector end index with the given list index.
    */
-  public abstract int getElementEndIndex(int index);
+  int getElementEndIndex(int index);
 
   /**
-   * Get the inner data vector for this list vector.
+   * Set data vector for this list vector.
    */
-  public abstract FieldVector getDataVector();
-
-  /**
-   * Set the inner data vector for this list vector.
-   */
-  public abstract void setDataVector(FieldVector dataVector);
+  void setDataVector(FieldVector dataVector);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
@@ -33,12 +33,12 @@ public abstract class BaseListVector extends BaseValueVector implements Promotab
   /**
    * Get data vector start index with the given list index.
    */
-  public abstract int getStartIndex(int index);
+  public abstract int getElementStartIndex(int index);
 
   /**
    * Get data vector end index with the given list index.
    */
-  public abstract int getEndIndex(int index);
+  public abstract int getElementEndIndex(int index);
 
   /**
    * Get the inner data vector for this list vector.
@@ -46,7 +46,7 @@ public abstract class BaseListVector extends BaseValueVector implements Promotab
   public abstract FieldVector getDataVector();
 
   /**
-   * Set offset buffer value at (index + 1) if needed.
+   * Set the inner data vector for this list vector.
    */
-  public abstract void setOffsetBufferValueIfNeeded(int index, int value);
+  public abstract void setDataVector(FieldVector dataVector);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
@@ -35,7 +35,7 @@ public interface BaseListVector extends FieldVector {
   int getElementEndIndex(int index);
 
   /**
-   * Set data vector for this list vector.
+   * Replace the data vector in this list vector.
    */
-  void setDataVector(FieldVector dataVector);
+  void replaceDataVector(FieldVector v);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseListVector.java
@@ -33,9 +33,4 @@ public interface BaseListVector extends FieldVector {
    * Get data vector end index with the given list index.
    */
   int getElementEndIndex(int index);
-
-  /**
-   * Replace the data vector in this list vector.
-   */
-  void replaceDataVector(FieldVector v);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -28,6 +28,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
@@ -43,7 +44,7 @@ import org.apache.arrow.vector.util.SchemaChangeRuntimeException;
 import io.netty.buffer.ArrowBuf;
 
 /** Base class for Vectors that contain repeated values. */
-public abstract class BaseRepeatedValueVector extends BaseListVector implements RepeatedValueVector {
+public abstract class BaseRepeatedValueVector extends BaseValueVector implements RepeatedValueVector {
 
   public static final FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
   public static final String DATA_VECTOR_NAME = "$data$";

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -28,7 +28,6 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BaseFixedWidthVector;
-import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
@@ -44,7 +43,7 @@ import org.apache.arrow.vector.util.SchemaChangeRuntimeException;
 import io.netty.buffer.ArrowBuf;
 
 /** Base class for Vectors that contain repeated values. */
-public abstract class BaseRepeatedValueVector extends BaseValueVector implements RepeatedValueVector {
+public abstract class BaseRepeatedValueVector extends BaseListVector implements RepeatedValueVector {
 
   public static final FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
   public static final String DATA_VECTOR_NAME = "$data$";

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -300,7 +300,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     return new AddOrGetResult<>((T) vector, created);
   }
 
-  public void replaceDataVector(FieldVector v) {
+  protected void replaceDataVector(FieldVector v) {
     vector.clear();
     vector = v;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -44,7 +44,7 @@ import org.apache.arrow.vector.util.SchemaChangeRuntimeException;
 import io.netty.buffer.ArrowBuf;
 
 /** Base class for Vectors that contain repeated values. */
-public abstract class BaseRepeatedValueVector extends BaseValueVector implements RepeatedValueVector {
+public abstract class BaseRepeatedValueVector extends BaseValueVector implements RepeatedValueVector, BaseListVector {
 
   public static final FieldVector DEFAULT_DATA_VECTOR = ZeroVector.INSTANCE;
   public static final String DATA_VECTOR_NAME = "$data$";
@@ -300,11 +300,10 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
     return new AddOrGetResult<>((T) vector, created);
   }
 
-  protected void replaceDataVector(FieldVector v) {
+  public void replaceDataVector(FieldVector v) {
     vector.clear();
     vector = v;
   }
-
 
   @Override
   public int getValueCount() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -554,9 +554,9 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   }
 
   @Override
-  public void setDataVector(FieldVector dataVector) {
+  public void replaceDataVector(FieldVector v) {
     vector.clear();
-    this.vector = dataVector;
+    vector = v;
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -57,7 +57,7 @@ import org.apache.arrow.vector.util.TransferPair;
 import io.netty.buffer.ArrowBuf;
 
 /** A ListVector where every list value is of the same size. */
-public class FixedSizeListVector extends BaseValueVector implements FieldVector, PromotableVector {
+public class FixedSizeListVector extends BaseListVector implements FieldVector, PromotableVector {
 
   public static FixedSizeListVector empty(String name, int size, BufferAllocator allocator) {
     FieldType fieldType = FieldType.nullable(new ArrowType.FixedSizeList(size));
@@ -541,6 +541,21 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
   @Override
   public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
     return visitor.visit(this, value);
+  }
+
+  @Override
+  public int getStartIndex(int index) {
+    return listSize * index;
+  }
+
+  @Override
+  public int getEndIndex(int index) {
+    return listSize * (index + 1);
+  }
+
+  @Override
+  public void setOffsetBufferValueIfNeeded(int index, int value) {
+
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -544,18 +544,19 @@ public class FixedSizeListVector extends BaseListVector implements FieldVector, 
   }
 
   @Override
-  public int getStartIndex(int index) {
+  public int getElementStartIndex(int index) {
     return listSize * index;
   }
 
   @Override
-  public int getEndIndex(int index) {
+  public int getElementEndIndex(int index) {
     return listSize * (index + 1);
   }
 
   @Override
-  public void setOffsetBufferValueIfNeeded(int index, int value) {
-
+  public void setDataVector(FieldVector dataVector) {
+    vector.clear();
+    this.vector = dataVector;
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -57,7 +57,7 @@ import org.apache.arrow.vector.util.TransferPair;
 import io.netty.buffer.ArrowBuf;
 
 /** A ListVector where every list value is of the same size. */
-public class FixedSizeListVector extends BaseListVector implements FieldVector, PromotableVector {
+public class FixedSizeListVector extends BaseValueVector implements BaseListVector, PromotableVector {
 
   public static FixedSizeListVector empty(String name, int size, BufferAllocator allocator) {
     FieldType fieldType = FieldType.nullable(new ArrowType.FixedSizeList(size));

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -553,12 +553,6 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
     return listSize * (index + 1);
   }
 
-  @Override
-  public void replaceDataVector(FieldVector v) {
-    vector.clear();
-    vector = v;
-  }
-
   private class TransferImpl implements TransferPair {
 
     FixedSizeListVector to;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -64,7 +64,7 @@ import io.netty.buffer.ArrowBuf;
  * </ol>
  * The latter two are managed by its superclass.
  */
-public class ListVector extends BaseRepeatedValueVector implements FieldVector, PromotableVector {
+public class ListVector extends BaseRepeatedValueVector implements BaseListVector, PromotableVector {
 
   public static ListVector empty(String name, BufferAllocator allocator) {
     return new ListVector(name, allocator, FieldType.nullable(ArrowType.List.INSTANCE), null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -831,17 +831,18 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
   }
 
   @Override
-  public int getStartIndex(int index) {
+  public int getElementStartIndex(int index) {
     return offsetBuffer.getInt(index * OFFSET_WIDTH);
   }
 
   @Override
-  public int getEndIndex(int index) {
+  public int getElementEndIndex(int index) {
     return offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
   }
 
   @Override
-  public void setOffsetBufferValueIfNeeded(int index, int value) {
-    offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, value);
+  public void setDataVector(FieldVector dataVector) {
+    this.vector.clear();
+    this.vector = dataVector;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -64,7 +64,7 @@ import io.netty.buffer.ArrowBuf;
  * </ol>
  * The latter two are managed by its superclass.
  */
-public class ListVector extends BaseRepeatedValueVector implements BaseListVector, PromotableVector {
+public class ListVector extends BaseRepeatedValueVector implements PromotableVector {
 
   public static ListVector empty(String name, BufferAllocator allocator) {
     return new ListVector(name, allocator, FieldType.nullable(ArrowType.List.INSTANCE), null);
@@ -838,11 +838,5 @@ public class ListVector extends BaseRepeatedValueVector implements BaseListVecto
   @Override
   public int getElementEndIndex(int index) {
     return offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
-  }
-
-  @Override
-  public void setDataVector(FieldVector dataVector) {
-    this.vector.clear();
-    this.vector = dataVector;
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -36,7 +36,6 @@ import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
@@ -829,11 +828,6 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
 
   public int getLastSet() {
     return lastSet;
-  }
-
-  @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -36,6 +36,7 @@ import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
+import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
@@ -828,5 +829,25 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
 
   public int getLastSet() {
     return lastSet;
+  }
+
+  @Override
+  public boolean accept(RangeEqualsVisitor visitor) {
+    return visitor.visit(this);
+  }
+
+  @Override
+  public int getStartIndex(int index) {
+    return offsetBuffer.getInt(index * OFFSET_WIDTH);
+  }
+
+  @Override
+  public int getEndIndex(int index) {
+    return offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
+  }
+
+  @Override
+  public void setOffsetBufferValueIfNeeded(int index, int value) {
+    offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, value);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -72,6 +72,60 @@ public class DictionaryEncoder {
   }
 
   /**
+   * Build index vector with the given vector and hash table.
+   * @param vector the vector to encode
+   * @param indices the index vector
+   * @param hashTable the hash table
+   * @param start the start index
+   * @param end the end index
+   */
+  static void buildIndexVector(
+      ValueVector vector,
+      BaseIntVector indices,
+      DictionaryHashTable hashTable,
+      int start,
+      int end) {
+
+    for (int i = start; i < end; i++) {
+      if (!vector.isNull(i)) {
+        // if it's null leave it null
+        // note: this may fail if value was not included in the dictionary
+        //int encoded = lookUps.get(value);
+        int encoded = hashTable.getIndex(i, vector);
+        if (encoded == -1) {
+          throw new IllegalArgumentException("Dictionary encoding not defined for value:" + vector.getObject(i));
+        }
+        indices.setWithPossibleTruncate(i, encoded);
+      }
+    }
+  }
+
+  /**
+   * Retrieve values to target vector from index vector.
+   * @param indices the index vector
+   * @param transfer the {@link TransferPair} to copy dictionary data into target vector.
+   * @param dictionaryCount the value count of dictionary vector.
+   * @param start the start index
+   * @param end the end index
+   */
+  static void retrieveIndexVector(
+      BaseIntVector indices,
+      TransferPair transfer,
+      int dictionaryCount,
+      int start,
+      int end) {
+    for (int i = start; i < end; i++) {
+      if (!indices.isNull(i)) {
+        int indexAsInt = (int) indices.getValueAsLong(i);
+        if (indexAsInt > dictionaryCount) {
+          throw new IllegalArgumentException("Provided dictionary does not contain value for index " + indexAsInt);
+        }
+        transfer.copyValueSafe(indexAsInt, i);
+      }
+    }
+  }
+
+  /**
    * Encodes a vector with the built hash table in this encoder.
    */
   public ValueVector encode(ValueVector vector) {
@@ -91,22 +145,8 @@ public class DictionaryEncoder {
     BaseIntVector indices = (BaseIntVector) createdVector;
     indices.allocateNew();
 
-    int count = vector.getValueCount();
-
-    for (int i = 0; i < count; i++) {
-      if (!vector.isNull(i)) { // if it's null leave it null
-        // note: this may fail if value was not included in the dictionary
-        //int encoded = lookUps.get(value);
-        int encoded = hashTable.getIndex(i, vector);
-        if (encoded == -1) {
-          throw new IllegalArgumentException("Dictionary encoding not defined for value:" + vector.getObject(i));
-        }
-        indices.setWithPossibleTruncate(i, encoded);
-      }
-    }
-
-    indices.setValueCount(count);
-
+    buildIndexVector(vector, indices, hashTable, 0, vector.getValueCount());
+    indices.setValueCount(vector.getValueCount());
     return indices;
   }
 
@@ -122,15 +162,7 @@ public class DictionaryEncoder {
     transfer.getTo().allocateNewSafe();
 
     BaseIntVector baseIntVector = (BaseIntVector) indices;
-    for (int i = 0; i < count; i++) {
-      if (!baseIntVector.isNull(i)) {
-        int indexAsInt = (int) baseIntVector.getValueAsLong(i);
-        if (indexAsInt > dictionaryCount) {
-          throw new IllegalArgumentException("Provided dictionary does not contain value for index " + indexAsInt);
-        }
-        transfer.copyValueSafe(indexAsInt, i);
-      }
-    }
+    retrieveIndexVector(baseIntVector, transfer, dictionaryCount, 0, count);
     ValueVector decoded = transfer.getTo();
     decoded.setValueCount(count);
     return decoded;

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -72,17 +72,17 @@ public class DictionaryEncoder {
   }
 
   /**
-   * Build index vector with the given vector and hash table.
+   * Populates indices between start and end with the encoded values of vector.
    * @param vector the vector to encode
    * @param indices the index vector
-   * @param hashTable the hash table
+   * @param encoding the hash table for encoding
    * @param start the start index
    * @param end the end index
    */
   static void buildIndexVector(
       ValueVector vector,
       BaseIntVector indices,
-      DictionaryHashTable hashTable,
+      DictionaryHashTable encoding,
       int start,
       int end) {
 
@@ -90,8 +90,7 @@ public class DictionaryEncoder {
       if (!vector.isNull(i)) {
         // if it's null leave it null
         // note: this may fail if value was not included in the dictionary
-        //int encoded = lookUps.get(value);
-        int encoded = hashTable.getIndex(i, vector);
+        int encoded = encoding.getIndex(i, vector);
         if (encoded == -1) {
           throw new IllegalArgumentException("Dictionary encoding not defined for value:" + vector.getObject(i));
         }

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
@@ -56,7 +56,7 @@ public class ListSubfieldEncoder {
 
     final FieldType fieldType = vector.getField().getFieldType();
     BaseListVector cloned = (BaseListVector) fieldType.createNewSingleVector(vector.getField().getName(),
-        allocator, null);
+        allocator, /*schemaCallBack=*/null);
 
     final ArrowFieldNode fieldNode = new ArrowFieldNode(vector.getValueCount(), vector.getNullCount());
     cloned.loadFieldBuffers(fieldNode, vector.getFieldBuffers());

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
@@ -42,7 +42,11 @@ public class ListSubfieldEncoder {
     this.dictionary = dictionary;
     this.allocator = allocator;
     BaseListVector dictVector = (BaseListVector) dictionary.getVector();
-    hashTable = new DictionaryHashTable(dictVector.getDataVector());
+    hashTable = new DictionaryHashTable(getDataVector(dictVector));
+  }
+
+  private FieldVector getDataVector(BaseListVector vector) {
+    return vector.getChildrenFromFields().get(0);
   }
 
   private BaseListVector cloneVector(BaseListVector vector) {
@@ -81,7 +85,7 @@ public class ListSubfieldEncoder {
       if (!vector.isNull(i)) {
         int start = vector.getElementStartIndex(i);
         int end = vector.getElementEndIndex(i);
-        ValueVector dataVector = vector.getDataVector();
+        ValueVector dataVector = getDataVector(vector);
 
         DictionaryEncoder.buildIndexVector(dataVector, indices, hashTable, start, end);
       }
@@ -99,10 +103,10 @@ public class ListSubfieldEncoder {
 
     int valueCount = vector.getValueCount();
     BaseListVector dictionaryVector = (BaseListVector) dictionary.getVector();
-    int dictionaryValueCount = dictionaryVector.getDataVector().getValueCount();
+    int dictionaryValueCount = getDataVector(dictionaryVector).getValueCount();
 
     // create data vector
-    ValueVector dataVector = dictionaryVector.getDataVector().getTransferPair(allocator).getTo();
+    ValueVector dataVector = getDataVector(dictionaryVector).getTransferPair(allocator).getTo();
     dataVector.allocateNewSafe();
 
     // clone list vector and reset data vector
@@ -110,8 +114,8 @@ public class ListSubfieldEncoder {
     decoded.setDataVector((FieldVector) dataVector);
 
 
-    TransferPair transfer = dictionaryVector.getDataVector().makeTransferPair(dataVector);
-    BaseIntVector indices = (BaseIntVector) vector.getDataVector();
+    TransferPair transfer = getDataVector(dictionaryVector).makeTransferPair(dataVector);
+    BaseIntVector indices = (BaseIntVector) getDataVector(vector);
 
     for (int i = 0; i < valueCount; i++) {
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.dictionary;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BaseIntVector;
+import org.apache.arrow.vector.BitVectorHelper;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.complex.BaseListVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.util.TransferPair;
+
+/**
+ * Sub fields encoder/decoder for Dictionary encoded {@link ListVector} and {@link FixedSizeListVector}.
+ */
+public class ListSubfieldEncoder {
+
+  private final DictionaryHashTable hashTable;
+  private final Dictionary dictionary;
+  private final BufferAllocator allocator;
+
+  /**
+   * Construct an instance.
+   */
+  public ListSubfieldEncoder(Dictionary dictionary, BufferAllocator allocator) {
+    this.dictionary = dictionary;
+    this.allocator = allocator;
+    BaseListVector dictVector = (BaseListVector) dictionary.getVector();
+    hashTable = new DictionaryHashTable(dictVector.getDataVector());
+  }
+
+  /**
+   * Dictionary encodes subfields for complex vector with a provided dictionary.
+   * The dictionary must contain all values in the sub fields vector.
+   * @param vector vector to encode
+   * @return dictionary encoded vector
+   */
+  public BaseListVector encodeListSubField(BaseListVector vector) {
+    final int valueCount = vector.getValueCount();
+
+    Field valueField = vector.getField();
+    FieldType indexFieldType = new FieldType(valueField.isNullable(), dictionary.getEncoding().getIndexType(),
+        dictionary.getEncoding(), valueField.getMetadata());
+
+    BaseListVector encoded = (BaseListVector) valueField.createVector(allocator);
+    encoded.allocateNewSafe();
+    encoded.setValueCount(valueCount);
+    BaseIntVector indices = (BaseIntVector) encoded.addOrGetVector(indexFieldType).getVector();
+
+    // copy validity buffer
+    int validityBufferSize = BitVectorHelper.getValidityBufferSize(valueCount);
+    encoded.getValidityBuffer().setBytes(0, vector.getValidityBuffer(), 0, validityBufferSize);
+    for (int i = 0; i < valueCount; i++) {
+      if (!vector.isNull(i)) {
+        int start = vector.getStartIndex(i);
+        int end = vector.getEndIndex(i);
+        ValueVector dataVector = vector.getDataVector();
+
+        encoded.setOffsetBufferValueIfNeeded(i, end);
+
+        DictionaryEncoder.buildIndexVector(dataVector, indices, hashTable, start, end);
+      }
+    }
+
+    return encoded;
+  }
+
+  /**
+   * Decodes a dictionary subfields encoded vector using the provided dictionary.
+   * @param vector dictionary encoded vector, its data vector must be int type
+   * @return vector with values restored from dictionary
+   */
+  public BaseListVector decodeListSubField(BaseListVector vector) {
+
+    int valueCount = vector.getValueCount();
+    BaseListVector dictionaryVector = (BaseListVector) dictionary.getVector();
+    int dictionaryValueCount = dictionaryVector.getDataVector().getValueCount();
+    // copy the dictionary values into the decoded vector
+
+    BaseListVector decoded =
+        (BaseListVector) dictionaryVector.getTransferPair(allocator).getTo();
+    decoded.allocateNewSafe();
+    decoded.setValueCount(valueCount);
+
+    TransferPair transfer = dictionaryVector.getDataVector().makeTransferPair(decoded.getDataVector());
+
+    BaseIntVector baseIntVector = (BaseIntVector) vector.getDataVector();
+    // copy validity buffer
+    int validityBufferSize = BitVectorHelper.getValidityBufferSize(valueCount);
+    decoded.getValidityBuffer().setBytes(0, vector.getValidityBuffer(), 0, validityBufferSize);
+    for (int i = 0; i < valueCount; i++) {
+
+      if (!vector.isNull(i)) {
+        int start = vector.getStartIndex(i);
+        int end = vector.getEndIndex(i);
+        decoded.setOffsetBufferValueIfNeeded(i, end);
+
+        DictionaryEncoder.retrieveIndexVector(baseIntVector, transfer, dictionaryValueCount, start, end);
+      }
+    }
+    return decoded;
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
@@ -79,7 +79,7 @@ public class ListSubfieldEncoder {
 
     // clone list vector and reset data vector
     BaseListVector encoded = cloneVector(vector);
-    encoded.setDataVector((FieldVector) indices);
+    encoded.replaceDataVector((FieldVector) indices);
 
     for (int i = 0; i < valueCount; i++) {
       if (!vector.isNull(i)) {
@@ -111,7 +111,7 @@ public class ListSubfieldEncoder {
 
     // clone list vector and reset data vector
     BaseListVector decoded = cloneVector(vector);
-    decoded.setDataVector((FieldVector) dataVector);
+    decoded.replaceDataVector((FieldVector) dataVector);
 
 
     TransferPair transfer = getDataVector(dictionaryVector).makeTransferPair(dataVector);


### PR DESCRIPTION
Related to [ARROW-6078](https://issues.apache.org/jira/browse/ARROW-6078).
For example, int type List (valueCount = 5) has data like below:
10, 20
10, 20
30, 40, 50
30, 40, 50
10, 20
could be encoded to:
0, 1
0, 1
2, 3, 4
2, 3, 4
0, 1
with list type dictionary
10, 20, 30, 40, 50
or
10,
20,
30,
40,
50