### PR TITLE
ARROW-6116: [C++][Gandiva] Fix TimedTestFilterAdd2

### DIFF
--- a/cpp/src/gandiva/tests/micro_benchmarks.cc
+++ b/cpp/src/gandiva/tests/micro_benchmarks.cc
@@ -139,7 +139,7 @@ static void TimedTestFilterAdd2(benchmark::State& state) {
 
   // Build expression
   auto sum = TreeExprBuilder::MakeFunction(
-      "add", {TreeExprBuilder::MakeField(field1), TreeExprBuilder::MakeField(field2)},
+      "add", {TreeExprBuilder::MakeField(field1), TreeExprBuilder::MakeField(field0)},
       int64());
   auto less_than = TreeExprBuilder::MakeFunction(
       "less_than", {sum, TreeExprBuilder::MakeField(field2)}, boolean());
@@ -391,7 +391,6 @@ static void DecimalAdd3Large(benchmark::State& state) {
 }
 
 BENCHMARK(TimedTestAdd3)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
-BENCHMARK(TimedTestBigNested)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
 BENCHMARK(TimedTestBigNested)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
 BENCHMARK(TimedTestExtractYear)->MinTime(1.0)->Unit(benchmark::kMicrosecond);
 BENCHMARK(TimedTestFilterAdd2)->MinTime(1.0)->Unit(benchmark::kMicrosecond);


### PR DESCRIPTION
Test should be 'field0 + field1	< field2' based	on
https://github.com/dremio/gandiva/blob/master/java/src/test/java/org/apache/arrow/gandiva/evaluator/MicroBenchmarkTest.java#L124

Also removed redundant benchmark run.