### PR TITLE
ARROW-1875: [Java] Write 64-bit ints as strings in integration test JSON files

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -318,7 +318,8 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
 
         for (int i = 0; i < count; i++) {
           parser.nextToken();
-          buf.writeLong(parser.getLongValue());
+          String value = parser.getValueAsString();
+          buf.writeLong(Long.valueOf(value));
         }
 
         return buf;
@@ -378,7 +379,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
 
         for (int i = 0; i < count; i++) {
           parser.nextToken();
-          BigInteger value = parser.getBigIntegerValue();
+          BigInteger value = new BigInteger(parser.getValueAsString());
           buf.writeLong(value.longValue());
         }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileWriter.java
@@ -273,7 +273,7 @@ public class JsonFileWriter implements AutoCloseable {
           generator.writeNumber(IntVector.get(buffer, index));
           break;
         case BIGINT:
-          generator.writeNumber(BigIntVector.get(buffer, index));
+          generator.writeString(String.valueOf(BigIntVector.get(buffer, index)));
           break;
         case UINT1:
           generator.writeNumber(UInt1Vector.getNoOverflow(buffer, index));
@@ -285,7 +285,7 @@ public class JsonFileWriter implements AutoCloseable {
           generator.writeNumber(UInt4Vector.getNoOverflow(buffer, index));
           break;
         case UINT8:
-          generator.writeNumber(UInt8Vector.getNoOverflow(buffer, index));
+          generator.writeString(UInt8Vector.getNoOverflow(buffer, index).toString());
           break;
         case FLOAT4:
           generator.writeNumber(Float4Vector.get(buffer, index));


### PR DESCRIPTION
Related to [ARROW-1875](https://issues.apache.org/jira/browse/ARROW-1875).
This is Java side implementation.