### PR TITLE
ARROW-6068: [C++] Allow passing Field instances to StructArray::Make

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -918,6 +918,17 @@ class ARROW_EXPORT StructArray : public Array {
       std::shared_ptr<Buffer> null_bitmap = NULLPTR,
       int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
+  /// \brief Return a StructArray from child arrays and fields.
+  ///
+  /// The length is automatically inferred from the arguments.
+  /// There should be at least one child array.  This method does not
+  /// check that field types and child array types are consistent.
+  static Result<std::shared_ptr<Array>> Make(
+      const std::vector<std::shared_ptr<Array>>& children,
+      const std::vector<std::shared_ptr<Field>>& fields,
+      std::shared_ptr<Buffer> null_bitmap = NULLPTR,
+      int64_t null_count = kUnknownNullCount, int64_t offset = 0);
+
   const StructType* struct_type() const;
 
   // Return a shared pointer in case the requestor desires to share ownership

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -480,9 +480,17 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         # XXX Cython crashes if default argument values are declared here
         # https://github.com/cython/cython/issues/2167
         @staticmethod
-        CResult[shared_ptr[CArray]] Make(
+        CResult[shared_ptr[CArray]] MakeFromFieldNames "Make"(
             vector[shared_ptr[CArray]] children,
             vector[c_string] field_names,
+            shared_ptr[CBuffer] null_bitmap,
+            int64_t null_count,
+            int64_t offset)
+
+        @staticmethod
+        CResult[shared_ptr[CArray]] MakeFromFields "Make"(
+            vector[shared_ptr[CArray]] children,
+            vector[shared_ptr[CField]] fields,
             shared_ptr[CBuffer] null_bitmap,
             int64_t null_count,
             int64_t offset)

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -167,13 +167,11 @@ def arrays(draw, type, size=None):
 
     if pa.types.is_struct(type):
         h.assume(len(type) > 0)
-        names, child_arrays = [], []
+        fields, child_arrays = [], []
         for field in type:
-            names.append(field.name)
+            fields.append(field)
             child_arrays.append(draw(arrays(field.type, size=size)))
-        # fields' metadata are lost here, because from_arrays doesn't accept
-        # a fields argumentum, only names
-        return pa.StructArray.from_arrays(child_arrays, names=names)
+        return pa.StructArray.from_arrays(child_arrays, fields=fields)
 
     if (pa.types.is_boolean(type) or pa.types.is_integer(type) or
             pa.types.is_floating(type)):


### PR DESCRIPTION
This helps fix a Python test failure when hypothesis testing is enabled.