### PR TITLE
ARROW-6095: [C++] Fix unit test build when only building static libraries, add cpp-static-only to tests.yml

### DIFF
--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -35,7 +35,7 @@ add_arrow_lib(arrow_dataset
               STATIC_LINK_LIBS
               arrow_static)
 
-if(ARROW_DATASET_TEST_LINKAGE STREQUAL "static")
+if(ARROW_TEST_LINKAGE STREQUAL "static")
   set(ARROW_DATASET_TEST_LINK_LIBS arrow_dataset_static ${ARROW_TEST_STATIC_LINK_LIBS})
 else()
   set(ARROW_DATASET_TEST_LINK_LIBS arrow_dataset_shared ${ARROW_TEST_SHARED_LINK_LIBS})

--- a/cpp/src/arrow/python/CMakeLists.txt
+++ b/cpp/src/arrow/python/CMakeLists.txt
@@ -128,10 +128,13 @@ if(ARROW_BUILD_TESTS)
     target_link_libraries(arrow_python_test_main pthread ${CMAKE_DL_LIBS})
   endif()
 
-  set(ARROW_PYTHON_MIN_TEST_LIBS arrow_python_test_main arrow_python_shared
-                                 arrow_testing_shared arrow_shared)
-
-  set(ARROW_PYTHON_TEST_LINK_LIBS ${ARROW_PYTHON_MIN_TEST_LIBS})
+  if(ARROW_TEST_LINKAGE STREQUAL shared)
+    set(ARROW_PYTHON_TEST_LINK_LIBS arrow_python_test_main arrow_python_shared
+                                    arrow_testing_shared arrow_shared)
+  else()
+    set(ARROW_PYTHON_TEST_LINK_LIBS arrow_python_test_main arrow_python_static
+                                    arrow_testing_static arrow_static)
+  endif()
 
   add_arrow_test(python_test
                  STATIC_LINK_LIBS

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -175,7 +175,7 @@ function(ADD_GANDIVA_TEST REL_TEST_NAME)
 
   # and uses less disk space, but in some cases we need to force static
   # linking (see rationale below).
-  if(ARG_USE_STATIC_LINKING)
+  if(ARG_USE_STATIC_LINKING OR ARROW_TEST_LINKAGE STREQUAL "static")
     add_test_case(${REL_TEST_NAME}
                   ${TEST_ARGUMENTS}
                   STATIC_LINK_LIBS

--- a/dev/tasks/tests.yml
+++ b/dev/tasks/tests.yml
@@ -27,6 +27,7 @@ groups:
     - docker-cpp-cmake32
     - docker-cpp-release
     - docker-cpp-fuzzit
+    - docker-cpp-static-only
     - docker-c_glib
     - docker-go
     - docker-python-2.7
@@ -153,6 +154,15 @@ tasks:
         - docker-compose build cpp
         - docker-compose build fuzzit
         - docker-compose run fuzzit
+
+  docker-cpp-static-only:
+    ci: circle
+    platform: linux
+    template: docker-tests/circle.linux.yml
+    params:
+      commands:
+        - docker-compose build cpp-static-only
+        - docker-compose run cpp-static-only
 
   docker-c_glib:
     ci: circle

--- a/dev/tasks/tests.yml
+++ b/dev/tasks/tests.yml
@@ -161,7 +161,7 @@ tasks:
     template: docker-tests/circle.linux.yml
     params:
       commands:
-        - docker-compose build cpp-static-only
+        - docker-compose build cpp
         - docker-compose run cpp-static-only
 
   docker-c_glib:


### PR DESCRIPTION
the python subproject was linking tests to `arrow_python_shared` and other shared libraries regardless of `ARROW_TEST_LINKAGE`