### PR TITLE
ARROW-6097: [Java] Avro adapter implement unions type

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrow.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrow.java
@@ -41,9 +41,6 @@ public class AvroToArrow {
       throws IOException {
     Preconditions.checkNotNull(schema, "Avro schema object can not be null");
 
-    VectorSchemaRoot root = VectorSchemaRoot.create(
-        AvroToArrowUtils.avroToArrowSchema(schema), allocator);
-    AvroToArrowUtils.avroToArrowVectors(decoder, root);
-    return root;
+    return AvroToArrowUtils.avroToArrowVectors(schema, decoder, allocator);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.arrow.consumers.AvroBooleanConsumer;
 import org.apache.arrow.consumers.AvroBytesConsumer;
@@ -33,22 +34,23 @@ import org.apache.arrow.consumers.AvroDoubleConsumer;
 import org.apache.arrow.consumers.AvroFloatConsumer;
 import org.apache.arrow.consumers.AvroIntConsumer;
 import org.apache.arrow.consumers.AvroLongConsumer;
+import org.apache.arrow.consumers.AvroNullConsumer;
 import org.apache.arrow.consumers.AvroStringConsumer;
 import org.apache.arrow.consumers.AvroUnionsConsumer;
 import org.apache.arrow.consumers.Consumer;
 import org.apache.arrow.consumers.NullableTypeConsumer;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
-import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.UnionMode;
@@ -64,12 +66,8 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroToArrowUtils {
 
-  private static final int DEFAULT_BUFFER_SIZE = 256;
-  public static final String NULL_INDEX = "nullIndex";
-  public static final String FIELD_INDEX = "index";
-
   /**
-   * Creates a {@link Field} from the {@link Schema}
+   * Creates a {@link Consumer} from the {@link Schema}
    *
    <p>This method currently performs following type mapping for Avro data types to corresponding Arrow data types.
    *
@@ -83,116 +81,124 @@ public class AvroToArrowUtils {
    *   <li>BYTES --> ArrowType.Binary</li>
    * </ul>
    */
-  private static Field getArrowField(Schema schema, String name, boolean nullable) {
+  private static Consumer createConsumer(Schema schema, String name, BufferAllocator allocator) {
+    return createConsumer(schema, name, false, -1, allocator);
+  }
+
+  private static Consumer createConsumer(
+      Schema schema,
+      String name,
+      boolean nullable,
+      int nullIndex,
+      BufferAllocator allocator) {
     Preconditions.checkNotNull(schema, "Avro schema object can't be null");
 
     Type type = schema.getType();
-    ArrowType arrowType;
+
+    final ArrowType arrowType;
+    final FieldType fieldType;
+    final FieldVector vector;
+    final Consumer consumer;
 
     switch (type) {
       case UNION:
-        return getUnionField(schema, name);
+        return createUnionConsumer(schema, name, allocator);
       case STRING:
         arrowType = new ArrowType.Utf8();
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer =  new AvroStringConsumer((VarCharVector) vector);
         break;
       case INT:
         arrowType = new ArrowType.Int(32, /*signed=*/true);
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer = new AvroIntConsumer((IntVector) vector);
         break;
       case BOOLEAN:
         arrowType = new ArrowType.Bool();
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer = new AvroBooleanConsumer((BitVector) vector);
         break;
       case LONG:
         arrowType = new ArrowType.Int(64, /*signed=*/true);
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer =  new AvroLongConsumer((BigIntVector) vector);
         break;
       case FLOAT:
         arrowType =  new ArrowType.FloatingPoint(SINGLE);
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer = new AvroFloatConsumer((Float4Vector) vector);
         break;
       case DOUBLE:
         arrowType = new ArrowType.FloatingPoint(DOUBLE);
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer = new AvroDoubleConsumer((Float8Vector) vector);
         break;
       case BYTES:
         arrowType = new ArrowType.Binary();
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer = new AvroBytesConsumer((VarBinaryVector) vector);
         break;
       case NULL:
         arrowType = new ArrowType.Null();
+        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+        vector = fieldType.createNewSingleVector(name, allocator, null);
+        consumer = new AvroNullConsumer((ZeroVector) vector);
         break;
       default:
         // no-op, shouldn't get here
         throw new RuntimeException("Can't convert avro type %s to arrow type." + type.getName());
     }
 
-    final FieldType fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null,
-        getMetaData(schema));
-    return new Field(name, fieldType, null);
+    if (nullable) {
+      return new NullableTypeConsumer(consumer, nullIndex);
+    }
+    return consumer;
   }
 
-  private static Field getUnionField(Schema schema, String name) {
+  private static Consumer createUnionConsumer(Schema schema, String name, BufferAllocator allocator) {
     int size = schema.getTypes().size();
     long nullCount = schema.getTypes().stream().filter(s -> s.getType() == Type.NULL).count();
 
     // union only has one type, convert to primitive type
     if (size == 1) {
       Schema subSchema = schema.getTypes().get(0);
-      return getArrowField(subSchema, name, /*nullable=*/false);
+      return createConsumer(subSchema, name, allocator);
 
       // size == 2 and has null type, convert to nullable primitive type
     } else if (size == 2 && nullCount == 1) {
       Schema nullSchema = schema.getTypes().stream().filter(s -> s.getType() == Type.NULL).findFirst().get();
-      String nullIndex = String.valueOf(schema.getTypes().indexOf(nullSchema));
+      int nullIndex = schema.getTypes().indexOf(nullSchema);
       Schema subSchema = schema.getTypes().stream().filter(s -> s.getType() != Type.NULL).findFirst().get();
       Preconditions.checkNotNull(subSchema, "schema should not be null.");
-      subSchema.addProp(NULL_INDEX, nullIndex);
-      return getArrowField(subSchema, name,true);
+      return createConsumer(subSchema, name, true, nullIndex, allocator);
 
       // real union type
     } else {
-      List<Field> children = new ArrayList<>();
+
+      final FieldType fieldType =  new FieldType(/*nullable=*/true,
+          new ArrowType.Union(UnionMode.Sparse, null), /*dictionary=*/null, getMetaData(schema));
+      UnionVector unionVector =
+          (UnionVector) fieldType.createNewSingleVector(name, allocator, null);
+
+      Consumer[] delegates = new Consumer[size];
+      Types.MinorType[] types = new Types.MinorType[size];
 
       for (int i = 0; i < size; i++) {
         Schema subSchema = schema.getTypes().get(i);
-        if (subSchema.getType() != Type.NULL) {
-          subSchema.addProp(FIELD_INDEX, i);
-          Field arrowSubField = getArrowField(subSchema, createFieldName(subSchema), /*nullable=*/false);
-          children.add(arrowSubField);
-        }
+        Consumer delegate = createConsumer(subSchema, subSchema.getName(), allocator);
+        unionVector.directAddVector(delegate.getVector());
+        delegates[i] = delegate;
+        types[i] = delegate.getVector().getMinorType();
       }
-      // arrow Union type always nullable, and settings for it's FieldType seems not work
-      final FieldType fieldType =  new FieldType(/*nullable=*/true,
-          new ArrowType.Union(UnionMode.Dense, null), /*dictionary=*/null, getMetaData(schema));
-      return new Field(name, fieldType, children);
+      return new AvroUnionsConsumer(unionVector, delegates, types);
     }
-  }
-
-  // keep field name with MinorType name, so UnionVector.getVector(i) will return existing vectors.
-  private static String createFieldName(Schema schema) {
-    String minorTypeName;
-    switch (schema.getType()) {
-      case STRING:
-        minorTypeName = Types.MinorType.VARCHAR.toString();
-        break;
-      case INT:
-        minorTypeName = Types.MinorType.INT.toString();
-        break;
-      case BOOLEAN:
-        minorTypeName = Types.MinorType.BIT.toString();
-        break;
-      case FLOAT:
-        minorTypeName = Types.MinorType.FLOAT4.toString();
-        break;
-      case DOUBLE:
-        minorTypeName = Types.MinorType.FLOAT8.toString();
-        break;
-      case LONG:
-        minorTypeName = Types.MinorType.BIGINT.toString();
-        break;
-      case BYTES:
-        minorTypeName = Types.MinorType.VARBINARY.toString();
-        break;
-      default:
-        throw new UnsupportedOperationException();
-    }
-
-    return minorTypeName.toLowerCase();
   }
 
   private static Map<String, String> getMetaData(Schema schema) {
@@ -202,19 +208,22 @@ public class AvroToArrowUtils {
   }
 
   /**
-   * Create Arrow {@link org.apache.arrow.vector.types.pojo.Schema} object for the given Avro {@link Schema}.
+   * Read data from {@link Decoder} and generate a {@link VectorSchemaRoot}.
+   * @param schema avro schema
+   * @param decoder avro decoder to read data from
    */
-  public static org.apache.arrow.vector.types.pojo.Schema avroToArrowSchema(Schema schema) {
+  public static VectorSchemaRoot avroToArrowVectors(Schema schema, Decoder decoder, BufferAllocator allocator)
+      throws IOException {
 
-    Preconditions.checkNotNull(schema, "Avro Schema object can't be null");
-    List<Field> arrowFields = new ArrayList<>();
+    List<FieldVector> vectors = new ArrayList<>();
+    List<Consumer> consumers = new ArrayList<>();
 
     Schema.Type type = schema.getType();
-    final Map<String, String> metadata = getMetaData(schema);
-
     if (type == Type.RECORD) {
       for (Schema.Field field : schema.getFields()) {
-        arrowFields.add(getArrowField(field.schema(), field.name(),false));
+        Consumer consumer = createConsumer(field.schema(), field.name(), allocator);
+        consumers.add(consumer);
+        vectors.add(consumer.getVector());
       }
     } else if (type == Type.MAP) {
       throw new UnsupportedOperationException();
@@ -223,110 +232,17 @@ public class AvroToArrowUtils {
     } else if (type == Type.ENUM) {
       throw new UnsupportedOperationException();
     } else {
-      arrowFields.add(getArrowField(schema, "", false));
+      Consumer consumer = createConsumer(schema, "", allocator);
+      consumers.add(consumer);
+      vectors.add(consumer.getVector());
     }
 
-    return new org.apache.arrow.vector.types.pojo.Schema(arrowFields, /*metadata=*/ metadata);
-  }
+    Preconditions.checkArgument(vectors.size() == consumers.size(),
+        "vectors size not equals consumers size");
 
-  private static Consumer createConsumer(ValueVector vector) {
-    ArrowType arrowType = vector.getField().getType();
-    if (!arrowType.isComplex()) {
-      return createPrimitiveConsumer(vector);
-    } else if (arrowType.getTypeID() == ArrowType.Union.TYPE_TYPE) {
-      return createUnionConsumer(vector);
-    } else {
-      throw new UnsupportedOperationException("Consumer is not supported for type: " + arrowType.getTypeID().name());
-    }
-  }
+    List<Field> fields = vectors.stream().map(t -> t.getField()).collect(Collectors.toList());
 
-  private static Consumer createUnionConsumer(ValueVector vector) {
-    UnionVector unionVector = (UnionVector) vector;
-    List<FieldVector> internals = unionVector.getChildrenFromFields();
-
-    Consumer[] delegates = new Consumer[internals.size() + 1];
-    Types.MinorType[] types = new Types.MinorType[internals.size() + 1];
-    for (int i = 0; i < internals.size(); i++) {
-      ValueVector v = internals.get(i);
-      int index = Integer.parseInt(v.getField().getMetadata().get(FIELD_INDEX));
-      Consumer consumer = createConsumer(v);
-      delegates[index] = consumer;
-      types[index] = v.getMinorType();
-    }
-
-    return new AvroUnionsConsumer(unionVector, delegates, types);
-  }
-
-  /**
-   * Create primitive consumer to read data from decoder, will reduce boxing/unboxing operations.
-   */
-  private static Consumer createPrimitiveConsumer(ValueVector vector) {
-
-    Consumer consumer;
-    switch (vector.getMinorType()) {
-      case INT:
-        consumer = new AvroIntConsumer((IntVector) vector);
-        break;
-      case VARBINARY:
-        consumer = new AvroBytesConsumer((VarBinaryVector) vector);
-        break;
-      case VARCHAR:
-        consumer = new AvroStringConsumer((VarCharVector) vector);
-        break;
-      case BIGINT:
-        consumer = new AvroLongConsumer((BigIntVector) vector);
-        break;
-      case FLOAT4:
-        consumer = new AvroFloatConsumer((Float4Vector) vector);
-        break;
-      case FLOAT8:
-        consumer = new AvroDoubleConsumer((Float8Vector) vector);
-        break;
-      case BIT:
-        consumer = new AvroBooleanConsumer((BitVector) vector);
-        break;
-      default:
-        throw new RuntimeException("could not get consumer from type:" + vector.getMinorType());
-    }
-
-    if (vector.getField().isNullable()) {
-      int nullIndex = getNullFieldIndex(vector.getField());
-      return new NullableTypeConsumer(consumer, nullIndex);
-    }
-
-    return consumer;
-  }
-
-  /**
-   * Get avro null field index from vector field metadata.
-   */
-  private static int getNullFieldIndex(Field field) {
-    Map<String, String> metadata = field.getMetadata();
-    Preconditions.checkNotNull(metadata, "metadata should not be null when vector is nullable");
-    String index = metadata.get(AvroToArrowUtils.NULL_INDEX);
-    Preconditions.checkNotNull(index, "nullIndex should not be null when vector is nullable");
-    return Integer.parseInt(index);
-  }
-
-  /**
-   * Iterate the given Avro {@link Decoder} object to fetch the data and transpose it to populate
-   * the given Arrow Vector objects.
-   * @param decoder avro decoder to read data.
-   * @param root Arrow {@link VectorSchemaRoot} object to populate
-   */
-  public static void avroToArrowVectors(Decoder decoder, VectorSchemaRoot root) throws IOException {
-
-    Preconditions.checkNotNull(decoder, "Avro decoder object can't be null");
-    Preconditions.checkNotNull(root, "VectorSchemaRoot object can't be null");
-
-    allocateVectors(root, DEFAULT_BUFFER_SIZE);
-
-    // create consumers
-    Consumer[] consumers = new Consumer[root.getFieldVectors().size()];
-    for (int i = 0; i < root.getFieldVectors().size(); i++) {
-      FieldVector vector = root.getFieldVectors().get(i);
-      consumers[i] = createConsumer(vector);
-    }
+    VectorSchemaRoot root = new VectorSchemaRoot(fields, vectors, 0);
 
     int valueCount = 0;
     while (true) {
@@ -341,17 +257,6 @@ public class AvroToArrowUtils {
         break;
       }
     }
-  }
-
-  private static void allocateVectors(VectorSchemaRoot root, int size) {
-    List<FieldVector> vectors = root.getFieldVectors();
-    for (FieldVector fieldVector : vectors) {
-      if (fieldVector instanceof BaseFixedWidthVector) {
-        ((BaseFixedWidthVector) fieldVector).allocateNew(size);
-      } else {
-        fieldVector.allocateNew();
-      }
-      fieldVector.setInitialCapacity(size);
-    }
+    return root;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -66,6 +66,8 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroToArrowUtils {
 
+  private static final int INVALID_NULL_INDEX = -1;
+
   /**
    * Creates a {@link Consumer} from the {@link Schema}
    *
@@ -82,7 +84,7 @@ public class AvroToArrowUtils {
    * </ul>
    */
   private static Consumer createConsumer(Schema schema, String name, BufferAllocator allocator) {
-    return createConsumer(schema, name, false, -1, allocator);
+    return createConsumer(schema, name, false, INVALID_NULL_INDEX, allocator);
   }
 
   private static Consumer createConsumer(

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -20,6 +20,7 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.impl.BitWriterImpl;
 import org.apache.arrow.vector.complex.writer.BitWriter;
 import org.apache.avro.io.Decoder;
@@ -31,11 +32,13 @@ import org.apache.avro.io.Decoder;
 public class AvroBooleanConsumer implements Consumer {
 
   private final BitWriter writer;
+  private final BitVector vector;
 
   /**
    * Instantiate a AvroBooleanConsumer.
    */
   public AvroBooleanConsumer(BitVector vector) {
+    this.vector = vector;
     this.writer = new BitWriterImpl(vector);
   }
 
@@ -53,6 +56,11 @@ public class AvroBooleanConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
   }
 
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -46,19 +46,13 @@ public class AvroBooleanConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-    writer.setPosition(index);
-    writer.writeBit(decoder.readBoolean() ? 1 : 0);
-    writer.setPosition(index + 1);
-  }
-
-  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void addNull(int index) {
-    writer.setPosition(index + 1);
+  public void setPosition(int index) {
+    writer.setPosition(index);
   }
+
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -46,7 +46,19 @@ public class AvroBooleanConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writer.writeBit(decoder.readBoolean() ? 1 : 0);
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -20,6 +20,7 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.complex.impl.VarBinaryWriterImpl;
 import org.apache.arrow.vector.complex.writer.VarBinaryWriter;
@@ -72,5 +73,10 @@ public class AvroBytesConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -51,13 +51,6 @@ public class AvroBytesConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-    writer.setPosition(index);
-    writeValue(decoder);
-    writer.setPosition(index + 1);
-  }
-
-  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
@@ -77,7 +70,7 @@ public class AvroBytesConsumer implements Consumer {
   }
 
   @Override
-  public void addNull(int index) {
-    writer.setPosition(index + 1);
+  public void setPosition(int index) {
+    writer.setPosition(index);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -51,6 +51,13 @@ public class AvroBytesConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writeValue(decoder);
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
@@ -67,5 +74,10 @@ public class AvroBytesConsumer implements Consumer {
     holder.buffer = vector.getAllocator().buffer(cacheBuffer.limit());
     holder.buffer.setBytes(0, cacheBuffer, 0,  cacheBuffer.limit());
     writer.write(holder);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -46,7 +46,19 @@ public class AvroDoubleConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writer.writeFloat8(decoder.readDouble());
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.complex.impl.Float8WriterImpl;
 import org.apache.arrow.vector.complex.writer.Float8Writer;
@@ -31,11 +32,13 @@ import org.apache.avro.io.Decoder;
 public class AvroDoubleConsumer implements Consumer {
 
   private final Float8Writer writer;
+  private final Float8Vector vector;
 
   /**
    * Instantiate a AvroDoubleConsumer.
    */
   public AvroDoubleConsumer(Float8Vector vector) {
+    this.vector = vector;
     this.writer = new Float8WriterImpl(vector);
   }
 
@@ -53,5 +56,10 @@ public class AvroDoubleConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -46,19 +46,12 @@ public class AvroFloatConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-    writer.setPosition(index);
-    writer.writeFloat4(decoder.readFloat());
-    writer.setPosition(index + 1);
-  }
-
-  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void addNull(int index) {
-    writer.setPosition(index + 1);
+  public void setPosition(int index) {
+    writer.setPosition(index);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.complex.impl.Float4WriterImpl;
 import org.apache.arrow.vector.complex.writer.Float4Writer;
@@ -31,11 +32,13 @@ import org.apache.avro.io.Decoder;
 public class AvroFloatConsumer implements Consumer {
 
   private final Float4Writer writer;
+  private final Float4Vector vector;
 
   /**
    * Instantiate a AvroFloatConsumer.
    */
   public AvroFloatConsumer(Float4Vector vector) {
+    this.vector = vector;
     this.writer = new Float4WriterImpl(vector);
   }
 
@@ -53,5 +56,10 @@ public class AvroFloatConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -46,7 +46,19 @@ public class AvroFloatConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writer.writeFloat4(decoder.readFloat());
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.complex.impl.IntWriterImpl;
 import org.apache.arrow.vector.complex.writer.IntWriter;
@@ -31,11 +32,13 @@ import org.apache.avro.io.Decoder;
 public class AvroIntConsumer implements Consumer {
 
   private final IntWriter writer;
+  private final IntVector vector;
 
   /**
    * Instantiate a AvroIntConsumer.
    */
   public AvroIntConsumer(IntVector vector) {
+    this.vector = vector;
     this.writer = new IntWriterImpl(vector);
   }
 
@@ -53,5 +56,10 @@ public class AvroIntConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -46,19 +46,12 @@ public class AvroIntConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-    writer.setPosition(index);
-    writer.writeInt(decoder.readInt());
-    writer.setPosition(index + 1);
-  }
-
-  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void addNull(int index) {
-    writer.setPosition(index + 1);
+  public void setPosition(int index) {
+    writer.setPosition(index);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -46,7 +46,19 @@ public class AvroIntConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writer.writeInt(decoder.readInt());
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -20,6 +20,7 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.impl.BigIntWriterImpl;
 import org.apache.arrow.vector.complex.writer.BigIntWriter;
 import org.apache.avro.io.Decoder;
@@ -31,11 +32,13 @@ import org.apache.avro.io.Decoder;
 public class AvroLongConsumer implements Consumer {
 
   private final BigIntWriter writer;
+  private final BigIntVector vector;
 
   /**
    * Instantiate a AvroLongConsumer.
    */
   public AvroLongConsumer(BigIntVector vector) {
+    this.vector = vector;
     this.writer = new BigIntWriterImpl(vector);
   }
 
@@ -53,5 +56,10 @@ public class AvroLongConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -46,7 +46,19 @@ public class AvroLongConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writer.writeBigInt(decoder.readLong());
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -46,19 +46,12 @@ public class AvroLongConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-    writer.setPosition(index);
-    writer.writeBigInt(decoder.readLong());
-    writer.setPosition(index + 1);
-  }
-
-  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
-  public void addNull(int index) {
-    writer.setPosition(index + 1);
+  public void setPosition(int index) {
+    writer.setPosition(index);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
@@ -19,39 +19,23 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.Float8Vector;
-import org.apache.arrow.vector.complex.impl.Float8WriterImpl;
-import org.apache.arrow.vector.complex.writer.Float8Writer;
+import org.apache.arrow.vector.ZeroVector;
 import org.apache.avro.io.Decoder;
 
 /**
- * Consumer which consume double type values from avro decoder.
- * Write the data to {@link Float8Vector}.
+ * Consumer which consume null type values from avro decoder.
+ * Corresponding to {@link org.apache.arrow.vector.ZeroVector}.
  */
-public class AvroDoubleConsumer implements Consumer {
+public class AvroNullConsumer implements Consumer {
 
-  private final Float8Writer writer;
-
-  /**
-   * Instantiate a AvroDoubleConsumer.
-   */
-  public AvroDoubleConsumer(Float8Vector vector) {
-    this.writer = new Float8WriterImpl(vector);
-  }
+  public AvroNullConsumer(ZeroVector vector) {}
 
   @Override
-  public void consume(Decoder decoder) throws IOException {
-    writer.writeFloat8(decoder.readDouble());
-    writer.setPosition(writer.getPosition() + 1);
-  }
+  public void consume(Decoder decoder) throws IOException {}
 
   @Override
-  public void addNull() {
-    writer.setPosition(writer.getPosition() + 1);
-  }
+  public void addNull() {}
 
   @Override
-  public void setPosition(int index) {
-    writer.setPosition(index);
-  }
+  public void setPosition(int index) {}
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.avro.io.Decoder;
 
@@ -28,7 +29,11 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroNullConsumer implements Consumer {
 
-  public AvroNullConsumer(ZeroVector vector) {}
+  private final ZeroVector vector;
+
+  public AvroNullConsumer(ZeroVector vector) {
+    this.vector = vector;
+  }
 
   @Override
   public void consume(Decoder decoder) throws IOException {}
@@ -38,4 +43,9 @@ public class AvroNullConsumer implements Consumer {
 
   @Override
   public void setPosition(int index) {}
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -51,13 +51,6 @@ public class AvroStringConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-    writer.setPosition(index);
-    writeValue(decoder);
-    writer.setPosition(index + 1);
-  }
-
-  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
@@ -78,7 +71,7 @@ public class AvroStringConsumer implements Consumer {
   }
 
   @Override
-  public void addNull(int index) {
-    writer.setPosition(index + 1);
+  public void setPosition(int index) {
+    writer.setPosition(index);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -20,6 +20,7 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.impl.VarCharWriterImpl;
 import org.apache.arrow.vector.complex.writer.VarCharWriter;
@@ -73,5 +74,10 @@ public class AvroStringConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -51,6 +51,13 @@ public class AvroStringConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    writer.setPosition(index);
+    writeValue(decoder);
+    writer.setPosition(index + 1);
+  }
+
+  @Override
   public void addNull() {
     writer.setPosition(writer.getPosition() + 1);
   }
@@ -68,5 +75,10 @@ public class AvroStringConsumer implements Consumer {
     holder.buffer.setBytes(0, cacheBuffer, 0, cacheBuffer.limit());
 
     writer.write(holder);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
@@ -56,6 +56,7 @@ public class AvroUnionsConsumer implements Consumer {
     Consumer delegate = indexDelegates[fieldIndex];
 
     vector.setType(position, types[fieldIndex]);
+    // in UnionVector we need to set sub vector writer position before consume a value.
     delegate.setPosition(position);
     delegate.consume(decoder);
 

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
@@ -56,7 +56,8 @@ public class AvroUnionsConsumer implements Consumer {
     Consumer delegate = indexDelegates[fieldIndex];
 
     vector.setType(position, types[fieldIndex]);
-    // in UnionVector we need to set sub vector writer position before consume a value.
+    // In UnionVector we need to set sub vector writer position before consume a value
+    // because in the previous iterations we might not have written to the specific union sub vector.
     delegate.setPosition(position);
     delegate.consume(decoder);
 
@@ -76,6 +77,7 @@ public class AvroUnionsConsumer implements Consumer {
 
   @Override
   public FieldVector getVector() {
+    vector.setValueCount(writer.getPosition());
     return this.vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.complex.impl.UnionWriter;
 import org.apache.arrow.vector.types.Types;
@@ -53,14 +54,10 @@ public class AvroUnionsConsumer implements Consumer {
     int position = writer.getPosition();
 
     Consumer delegate = indexDelegates[fieldIndex];
-    // null value
-    if (delegate == null) {
-      // do nothing
-    } else {
-      vector.setType(position, types[fieldIndex]);
-      delegate.setPosition(position);
-      delegate.consume(decoder);
-    }
+
+    vector.setType(position, types[fieldIndex]);
+    delegate.setPosition(position);
+    delegate.consume(decoder);
 
     writer.setPosition(position + 1);
 
@@ -74,5 +71,10 @@ public class AvroUnionsConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     writer.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.complex.impl.UnionWriter;
+import org.apache.arrow.vector.types.Types;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume unions type values from avro decoder.
+ * Write the data to {@link org.apache.arrow.vector.complex.UnionVector}.
+ */
+public class AvroUnionsConsumer implements Consumer {
+
+  private Map<Integer, Consumer> indexDelegates;
+  private Map<Integer, Types.MinorType> types;
+
+  private UnionWriter writer;
+  private UnionVector vector;
+
+  /**
+   * Instantiate a AvroUnionConsumer.
+   */
+  public AvroUnionsConsumer(UnionVector vector, Map<Integer, Consumer> indexDelegates,
+      Map<Integer, Types.MinorType> types) {
+
+    this.writer = new UnionWriter(vector);
+    this.vector = vector;
+    this.indexDelegates = indexDelegates;
+    this.types = types;
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    int fieldIndex = decoder.readInt();
+    int position = writer.getPosition();
+
+    Consumer delegate = indexDelegates.get(fieldIndex);
+    // null value
+    if (delegate == null) {
+      // do nothing
+    } else {
+      vector.setType(position, types.get(fieldIndex));
+      delegate.consume(decoder, position);
+    }
+
+    writer.setPosition(position + 1);
+
+  }
+
+  @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+    int fieldIndex = decoder.readInt();
+    writer.setPosition(index + 1);
+
+    Consumer delegate = indexDelegates.get(fieldIndex);
+    if (delegate == null) {
+      // do nothing
+    } else {
+      vector.setType(index, types.get(fieldIndex));
+      delegate.consume(decoder, index);
+    }
+    writer.setPosition(index + 1);
+  }
+
+  @Override
+  public void addNull() {
+    writer.setPosition(writer.getPosition() + 1);
+  }
+
+  @Override
+  public void addNull(int index) {
+    writer.setPosition(index + 1);
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -33,12 +33,13 @@ public interface Consumer {
    */
   void consume(Decoder decoder) throws IOException;
 
-  void consume(Decoder decoder, int index) throws IOException;
-
   /**
    * Add null value to vector by making writer position + 1.
    */
   void addNull();
 
-  void addNull(int index);
+  /**
+   * Set the position to write value into vector.
+   */
+  void setPosition(int index);
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -42,4 +43,9 @@ public interface Consumer {
    * Set the position to write value into vector.
    */
   void setPosition(int index);
+
+  /**
+   * Get the vector within the consumer.
+   */
+  FieldVector getVector();
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -57,6 +58,11 @@ public class NullableTypeConsumer implements Consumer {
   @Override
   public void setPosition(int index) {
     delegate.setPosition(index);
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return delegate.getVector();
   }
 
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
@@ -50,7 +50,17 @@ public class NullableTypeConsumer implements Consumer {
   }
 
   @Override
+  public void consume(Decoder decoder, int index) throws IOException {
+
+  }
+
+  @Override
   public void addNull() {
     delegate.addNull();
+  }
+
+  @Override
+  public void addNull(int index) {
+    delegate.addNull(index);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
@@ -50,17 +50,13 @@ public class NullableTypeConsumer implements Consumer {
   }
 
   @Override
-  public void consume(Decoder decoder, int index) throws IOException {
-
-  }
-
-  @Override
   public void addNull() {
     delegate.addNull();
   }
 
   @Override
-  public void addNull(int index) {
-    delegate.addNull(index);
+  public void setPosition(int index) {
+    delegate.setPosition(index);
   }
+
 }

--- a/java/adapter/avro/src/test/resources/schema/test_nullable_union.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nullable_union.avsc
@@ -15,30 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.consumers;
-
-import java.io.IOException;
-
-import org.apache.avro.io.Decoder;
-
-/**
- * Interface that is used to consume values from avro decoder.
- */
-public interface Consumer {
-
-  /**
-   * Consume a specific type value from avro decoder and write it to vector.
-   * @param decoder avro decoder to read data
-   * @throws IOException on error
-   */
-  void consume(Decoder decoder) throws IOException;
-
-  void consume(Decoder decoder, int index) throws IOException;
-
-  /**
-   * Add null value to vector by making writer position + 1.
-   */
-  void addNull();
-
-  void addNull(int index);
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "testNullableUnions",
+ "fields": [
+     {"name": "f0", "type": ["string", "int", "null"]}
+ ]
 }

--- a/java/adapter/avro/src/test/resources/schema/test_union.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_union.avsc
@@ -15,30 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.consumers;
-
-import java.io.IOException;
-
-import org.apache.avro.io.Decoder;
-
-/**
- * Interface that is used to consume values from avro decoder.
- */
-public interface Consumer {
-
-  /**
-   * Consume a specific type value from avro decoder and write it to vector.
-   * @param decoder avro decoder to read data
-   * @throws IOException on error
-   */
-  void consume(Decoder decoder) throws IOException;
-
-  void consume(Decoder decoder, int index) throws IOException;
-
-  /**
-   * Add null value to vector by making writer position + 1.
-   */
-  void addNull();
-
-  void addNull(int index);
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "testUnions",
+ "fields": [
+     {"name": "f0", "type": ["string", "int"]}
+ ]
 }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -389,6 +389,15 @@ public class UnionVector implements FieldVector {
     return newVector;
   }
 
+  public void directAddVector(FieldVector v) {
+    String name = v.getMinorType().name().toLowerCase();
+    Preconditions.checkState(internalStruct.getChild(name) == null, String.format("%s vector already exists", name));
+    internalStruct.putChild(name, v);
+    if (callBack != null) {
+      callBack.doWork();
+    }
+  }
+
   private class TransferImpl implements TransferPair {
     private final TransferPair internalStructVectorTransferPair;
     private final UnionVector to;

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -389,6 +389,9 @@ public class UnionVector implements FieldVector {
     return newVector;
   }
 
+  /**
+   * Directly put a vector to internalStruct without creating a new one with same type.
+   */
   public void directAddVector(FieldVector v) {
     String name = v.getMinorType().name().toLowerCase();
     Preconditions.checkState(internalStruct.getChild(name) == null, String.format("%s vector already exists", name));


### PR DESCRIPTION
Related to [ARROW-6097](https://issues.apache.org/jira/browse/ARROW-6097).
Support convert unions type like ["string"], ["string", 'int"] and nullable ["string", "int", "null"]