### PR TITLE
ARROW-6088: [Rust] [DataFusion] Projection execution plan

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Execution plan for reading CSV files
+
+use crate::error::Result;
+use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use std::sync::Arc;
+
+pub struct CsvExec {
+    /// Path to directory containing partitioned CSV files with the same schema
+    path: String,
+    /// Schema representing the CSV files
+    schema: Arc<Schema>,
+}
+
+impl ExecutionPlan for CsvExec {
+    /// Get the schema for this execution plan
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+
+    /// Get the partitions for this execution plan. Each partition can be executed in parallel.
+    fn partitions(&self) -> Result<Vec<Arc<Partition>>> {
+        // TODO get list of files in the directory and create a partition for each one
+        unimplemented!()
+    }
+}
+
+impl CsvExec {
+    /// Create a new execution plan for reading a set of CSV files
+    pub fn try_new(path: &str, schema: Arc<Schema>) -> Result<Self> {
+        //TODO
+        Ok(Self {
+            path: path.to_string(),
+            schema: schema.clone(),
+        })
+    }
+}
+
+/// CSV Partition
+struct CsvPartition {
+    /// Path to the CSV File
+    path: String,
+    /// Schema representing the CSV file
+    schema: Arc<Schema>,
+}
+
+impl Partition for CsvPartition {
+    /// Execute this partition and return an iterator over RecordBatch
+    fn execute(&self) -> Result<Arc<dyn BatchIterator>> {
+        unimplemented!()
+    }
+}
+
+/// Iterator over batches
+struct CsvIterator {}
+
+impl BatchIterator for CsvIterator {
+    /// Get the next RecordBatch
+    fn next(&self) -> Result<Option<RecordBatch>> {
+        unimplemented!()
+    }
+}

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -20,6 +20,7 @@
 use crate::error::Result;
 use crate::execution::physical_plan::PhysicalExpr;
 use arrow::array::ArrayRef;
+use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
 /// Represents the column at a given index in a RecordBatch
@@ -28,6 +29,16 @@ pub struct Column {
 }
 
 impl PhysicalExpr for Column {
+    /// Get the name to use in a schema to represent the result of this expression
+    fn name(&self) -> String {
+        format!("c{}", self.index)
+    }
+
+    /// Get the data type of this expression, given the schema of the input
+    fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
+        Ok(input_schema.field(self.index).data_type().clone())
+    }
+
     /// Evaluate the expression
     fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         Ok(batch.column(self.index).clone())

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -17,14 +17,14 @@
 
 //! Defines physical expressions that can evaluated at runtime during query execution
 
-use arrow::array::ArrayRef;
-use arrow::record_batch::RecordBatch;
 use crate::error::Result;
 use crate::execution::physical_plan::PhysicalExpr;
+use arrow::array::ArrayRef;
+use arrow::record_batch::RecordBatch;
 
 /// Represents the column at a given index in a RecordBatch
 pub struct Column {
-    index: usize
+    index: usize,
 }
 
 impl PhysicalExpr for Column {

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines physical expressions that can evaluated at runtime during query execution
+
+use arrow::array::ArrayRef;
+use arrow::record_batch::RecordBatch;
+use crate::error::Result;
+use crate::execution::physical_plan::PhysicalExpr;
+
+/// Represents the column at a given index in a RecordBatch
+pub struct Column {
+    index: usize
+}
+
+impl PhysicalExpr for Column {
+    /// Evaluate the expression
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef> {
+        Ok(batch.column(self.index).clone())
+    }
+}

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -28,6 +28,13 @@ pub struct Column {
     index: usize,
 }
 
+impl Column {
+    // Create a new column expression
+    pub fn new(index: usize) -> Self {
+        Self { index }
+    }
+}
+
 impl PhysicalExpr for Column {
     /// Get the name to use in a schema to represent the result of this expression
     fn name(&self) -> String {

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -29,7 +29,7 @@ pub struct Column {
 }
 
 impl Column {
-    // Create a new column expression
+    /// Create a new column expression
     pub fn new(index: usize) -> Self {
         Self { index }
     }

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -17,12 +17,12 @@
 
 //! Traits for physical query plan, supporting parallel execution for partitioned relations.
 
-use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
 use std::sync::Arc;
 
 use crate::error::Result;
 use arrow::array::ArrayRef;
+use arrow::datatypes::{DataType, Schema};
+use arrow::record_batch::RecordBatch;
 
 /// Partition-aware execution plan for a relation
 pub trait ExecutionPlan {
@@ -46,9 +46,14 @@ pub trait BatchIterator: Send + Sync {
 
 /// Expression that can be evaluated against a RecordBatch
 pub trait PhysicalExpr: Send + Sync {
+    /// Get the name to use in a schema to represent the result of this expression
+    fn name(&self) -> String;
+    /// Get the data type of this expression, given the schema of the input
+    fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
     /// Evaluate an expression against a RecordBatch
     fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef>;
 }
 
+pub mod csv;
 pub mod expressions;
 pub mod projection;

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -47,7 +47,7 @@ pub trait BatchIterator: Send + Sync {
 /// Expression that can be evaluated against a RecordBatch
 pub trait PhysicalExpr: Send + Sync {
     /// Evaluate an expression against a RecordBatch
-    fn evaluate(&self, batch: RecordBatch) -> Result<ArrayRef>;
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef>;
 }
 
 pub mod projection;

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -50,4 +50,5 @@ pub trait PhysicalExpr: Send + Sync {
     fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef>;
 }
 
+pub mod expressions;
 pub mod projection;

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -17,7 +17,7 @@
 
 //! Traits for physical query plan, supporting parallel execution for partitioned relations.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
 use arrow::array::ArrayRef;
@@ -35,13 +35,13 @@ pub trait ExecutionPlan {
 /// Represents a partition of an execution plan that can be executed on a thread
 pub trait Partition: Send + Sync {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<dyn BatchIterator>>;
+    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>>;
 }
 
 /// Iterator over RecordBatch that can be sent between threads
 pub trait BatchIterator: Send + Sync {
     /// Get the next RecordBatch
-    fn next(&self) -> Result<Option<RecordBatch>>;
+    fn next(&mut self) -> Result<Option<RecordBatch>>;
 }
 
 /// Expression that can be evaluated against a RecordBatch

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -22,6 +22,7 @@ use arrow::record_batch::RecordBatch;
 use std::sync::Arc;
 
 use crate::error::Result;
+use arrow::array::ArrayRef;
 
 /// Partition-aware execution plan for a relation
 pub trait ExecutionPlan {
@@ -42,3 +43,11 @@ pub trait BatchIterator: Send + Sync {
     /// Get the next RecordBatch
     fn next(&self) -> Result<Option<RecordBatch>>;
 }
+
+/// Expression that can be evaluated against a RecordBatch
+pub trait PhysicalExpr: Send + Sync {
+    /// Evaluate an expression against a RecordBatch
+    fn evaluate(&self, batch: RecordBatch) -> Result<ArrayRef>;
+}
+
+pub mod projection;

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -76,10 +76,10 @@ impl ExecutionPlan for ProjectionExec {
             .iter()
             .map(|p| {
                 let expr = self.expr.clone();
-                let projection: Arc<Partition> = Arc::new(ProjectionPartition {
+                let projection: Arc<dyn Partition> = Arc::new(ProjectionPartition {
                     schema: self.schema.clone(),
                     expr,
-                    input: p.clone() as Arc<Partition>,
+                    input: p.clone() as Arc<dyn Partition>,
                 });
 
                 projection

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -41,7 +41,7 @@ pub struct ProjectionExec {
 
 impl ProjectionExec {
     /// Create a projection on an input
-    fn try_new(
+    pub fn try_new(
         expr: Vec<Arc<dyn PhysicalExpr>>,
         input: Arc<dyn ExecutionPlan>,
     ) -> Result<Self> {
@@ -164,7 +164,7 @@ mod tests {
         let partitions = 4;
         let path = create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema)?;
+        let csv = CsvExec::try_new(&path, schema, true, None, 1024)?;
 
         let projection =
             ProjectionExec::try_new(vec![Arc::new(Column::new(0))], Arc::new(csv))?;

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -159,10 +159,11 @@ mod tests {
 
         let path = format!("{}/tbd", testdata);
 
-        //TODO: working on this now ..
+        let csv = CsvExec::try_new(&path, schema)?;
 
-        let projection =
-            ProjectionExec::try_new(vec![], Arc::new(CsvExec::try_new(&path, schema)?))?;
+        let projection = ProjectionExec::try_new(vec![], Arc::new(csv))?;
+
+        //TODO assertions
 
         Ok(())
     }

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -142,6 +142,7 @@ mod tests {
     use std::fs::File;
     use std::io::prelude::*;
     use std::io::{BufReader, BufWriter};
+    use std::path::Path;
 
     #[test]
     fn project_first_column() -> Result<()> {
@@ -193,7 +194,10 @@ mod tests {
 
         let mut dir = env::temp_dir();
         dir.push(&format!("{}-{}", filename, partitions));
-        fs::remove_dir_all(dir.clone()).unwrap();
+
+        if Path::new(&dir).exists() {
+            fs::remove_dir_all(&dir).unwrap();
+        }
         fs::create_dir(dir.clone()).unwrap();
 
         let mut writers = vec![];

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the projection execution plan. A projection determines which columns or expressions
+//! are returned from a query. The SQL statement `SELECT a, b, a+b FROM t1` is an example
+//! of a projection on table `t1` where the expressions `a`, `b`, and `a+b` are the
+//! projection expressions.
+
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::execution::physical_plan::{
+    BatchIterator, ExecutionPlan, Partition, PhysicalExpr,
+};
+use arrow::datatypes::Schema;
+
+/// Execution plan for a projection
+pub struct ProjectionExec {
+    /// The projection expressions
+    expr: Vec<Arc<dyn PhysicalExpr>>,
+    /// The schema once the projection has been applied to the input
+    schema: Arc<Schema>,
+    /// The input plan
+    input: Arc<dyn ExecutionPlan>,
+}
+
+impl ExecutionPlan for ProjectionExec {
+    /// Get the schema for this execution plan
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+
+    /// Get the partitions for this execution plan
+    fn partitions(&self) -> Result<Vec<Arc<dyn Partition>>> {
+        let partitions: Vec<Arc<dyn Partition>> = self
+            .input
+            .partitions()?
+            .iter()
+            .map(|p| {
+                let expr = self.expr.clone();
+                let projection: Arc<Partition> = Arc::new(ProjectionPartition {
+                    expr,
+                    input: p.clone() as Arc<Partition>,
+                });
+
+                projection
+            })
+            .collect();
+
+        Ok(partitions)
+    }
+}
+
+/// Represents a single partition of a projection execution plan
+struct ProjectionPartition {
+    expr: Vec<Arc<dyn PhysicalExpr>>,
+    input: Arc<dyn Partition>,
+}
+
+impl Partition for ProjectionPartition {
+    /// Execute the projection
+    fn execute(&self) -> Result<Arc<dyn BatchIterator>> {
+        // execute the input partition and get an iterator
+        let it = self.input.execute()?;
+        //TODO wrap the iterator in a new one that performs the projection by evaluating the
+        // expressions against the batches
+        Ok(it)
+    }
+}


### PR DESCRIPTION
This PR implements the projection and CSV execution plans (I can split this into two PRs if necessary - one for CSV then one for projection).

Note that while I implement execution plans for each relational operator (projection, selection, aggregate, etc) there will be duplicate implementations because we already have the existing execution code that directly executes the logical plan. Once the new physical plan is in place, I will remove the original execution logic (and translate the logical plan to a physical plan).