### PR TITLE
ARROW-4224: [Python] Support integration with pydata/sparse library

### DIFF
--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -203,7 +203,7 @@ shape: {0.shape}""".format(self)
         coords = np.require(coords, dtype='i8', requirements='F')
 
         check_status(NdarraysToSparseCOOTensor(c_default_memory_pool(),
-                     obj.data.view(), coords, c_shape, c_dim_names,
+                     obj.data, coords, c_shape, c_dim_names,
                      &csparse_tensor))
         return pyarrow_wrap_sparse_coo_tensor(csparse_tensor)
 
@@ -227,10 +227,10 @@ shape: {0.shape}""".format(self)
             for x in dim_names:
                 c_dim_names.push_back(tobytes(x))
 
-        coords = np.require(obj.coords.T.view(), dtype='i8', requirements='F')
+        coords = np.require(obj.coords.T, dtype='i8', requirements='F')
 
         check_status(NdarraysToSparseCOOTensor(c_default_memory_pool(),
-                     obj.data.view(), coords, c_shape, c_dim_names,
+                     obj.data, coords, c_shape, c_dim_names,
                      &csparse_tensor))
         return pyarrow_wrap_sparse_coo_tensor(csparse_tensor)
 
@@ -286,7 +286,7 @@ shape: {0.shape}""".format(self)
                                               &out_data, &out_coords))
         data = PyObject_to_object(out_data)
         coords = PyObject_to_object(out_coords)
-        result = COO(data=data, coords=coords.T, shape=self.shape)
+        result = COO(data=data[:, 0], coords=coords.T, shape=self.shape)
         return result
 
     def to_tensor(self):

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -212,6 +212,11 @@ shape: {0.shape}""".format(self)
         """
         Convert pydata/sparse.COO to arrow::SparseCOOTensor
         """
+        import sparse
+        if not isinstance(obj, sparse.COO):
+            raise TypeError(
+                "Expected sparse.COO, got {}".format(type(obj)))
+
         cdef shared_ptr[CSparseCOOTensor] csparse_tensor
         cdef vector[int64_t] c_shape
         cdef vector[c_string] c_dim_names

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -46,6 +46,11 @@ except ImportError:
     coo_matrix = None
     csr_matrix = None
 
+try:
+    import sparse
+except ImportError:
+    sparse = None
+
 
 def assert_equal(obj1, obj2):
     if torch is not None and torch.is_tensor(obj1) and torch.is_tensor(obj2):
@@ -595,6 +600,22 @@ def test_scipy_sparse_coo_tensor_serialization():
     result = serialized.deserialize()
 
     assert np.array_equal(sparse_array.toarray(), result.toarray())
+
+
+@pytest.mark.skipif(not sparse, reason="requires pydata/sparse")
+def test_pydata_sparse_sparse_coo_tensor_serialization():
+    data = np.array([1, 2, 3, 4, 5, 6])
+    coords = np.array([
+        [0, 0, 2, 3, 1, 3],
+        [0, 2, 0, 4, 5, 5],
+    ])
+    shape = (4, 6)
+
+    sparse_array = sparse.COO(data=data, coords=coords, shape=shape)
+    serialized = pa.serialize(sparse_array)
+    result = serialized.deserialize()
+
+    assert np.array_equal(sparse_array.todense(), result.todense())
 
 
 @pytest.mark.parametrize('tensor_type', tensor_types)

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -27,6 +27,11 @@ except ImportError:
     coo_matrix = None
     csr_matrix = None
 
+try:
+    import sparse
+except ImportError:
+    sparse = None
+
 
 tensor_type_pairs = [
     ('i1', pa.int8()),
@@ -325,3 +330,27 @@ def test_sparse_csr_matrix_scipy_roundtrip(dtype_str, arrow_type):
     else:
         dense_array = sparse_array.toarray()
     assert np.array_equal(dense_array, sparse_tensor.to_tensor().to_numpy())
+
+
+@pytest.mark.skipif(not sparse, reason="requires pydata/sparse")
+@pytest.mark.parametrize('dtype_str,arrow_type', tensor_type_pairs)
+def test_pydata_sparse_sparse_coo_tensor_roundtrip(dtype_str, arrow_type):
+    dtype = np.dtype(dtype_str)
+    data = np.array([[1, 2, 3, 4, 5, 6]]).T.astype(dtype)
+    coords = np.array([
+        [0, 0, 2, 3, 1, 3],
+        [0, 2, 0, 4, 5, 5],
+    ])
+    shape = (4, 6)
+    dim_names = ("x", "y")
+
+    sparse_array = sparse.COO(data=data, coords=coords, shape=shape)
+    sparse_tensor = pa.SparseCOOTensor.from_pydata_sparse(sparse_array,
+                                                          dim_names=dim_names)
+    out_sparse_array = sparse_tensor.to_pydata_sparse()
+
+    assert sparse_tensor.type == arrow_type
+    assert sparse_tensor.dim_names == dim_names
+    assert sparse_array.dtype == out_sparse_array.dtype
+    assert np.array_equal(sparse_array.data, out_sparse_array.data)
+    assert np.array_equal(sparse_array.coords, out_sparse_array.coords)

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -336,7 +336,7 @@ def test_sparse_csr_matrix_scipy_roundtrip(dtype_str, arrow_type):
 @pytest.mark.parametrize('dtype_str,arrow_type', tensor_type_pairs)
 def test_pydata_sparse_sparse_coo_tensor_roundtrip(dtype_str, arrow_type):
     dtype = np.dtype(dtype_str)
-    data = np.array([[1, 2, 3, 4, 5, 6]]).T.astype(dtype)
+    data = np.array([1, 2, 3, 4, 5, 6]).astype(dtype)
     coords = np.array([
         [0, 0, 2, 3, 1, 3],
         [0, 2, 0, 4, 5, 5],
@@ -354,3 +354,5 @@ def test_pydata_sparse_sparse_coo_tensor_roundtrip(dtype_str, arrow_type):
     assert sparse_array.dtype == out_sparse_array.dtype
     assert np.array_equal(sparse_array.data, out_sparse_array.data)
     assert np.array_equal(sparse_array.coords, out_sparse_array.coords)
+    assert np.array_equal(sparse_array.todense(),
+                          sparse_tensor.to_tensor().to_numpy())


### PR DESCRIPTION
This is to resolve [ARROW-4224](https://issues.apache.org/jira/browse/ARROW-4224).

Please note this requires #4779 to be reviewed and merged first.