### PR TITLE
ARROW-6002: [C++][Gandiva] test casting int64 to decimal

### DIFF
--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -466,16 +466,14 @@ TEST_F(TestDecimal, TestCastFunctions) {
   DCHECK_OK(status);
 
   // Validate results
+  auto expected_int_dec = MakeArrowArrayDecimal(
+      decimal_type, MakeDecimalVector({"123", "158", "-123", "-158"}, scale), validity);
 
   // castDECIMAL(int32)
-  EXPECT_ARROW_ARRAY_EQUALS(
-      MakeArrowArrayDecimal(decimal_type,
-                            MakeDecimalVector({"123", "158", "-123", "-158"}, scale),
-                            validity),
-      outputs[0]);
+  EXPECT_ARROW_ARRAY_EQUALS(expected_int_dec, outputs[0]);
 
   // castDECIMAL(int64)
-  EXPECT_ARROW_ARRAY_EQUALS(array_dec, outputs[2]);
+  EXPECT_ARROW_ARRAY_EQUALS(expected_int_dec, outputs[1]);
 
   // castDECIMAL(float32)
   EXPECT_ARROW_ARRAY_EQUALS(array_dec, outputs[2]);


### PR DESCRIPTION
copy paste error: float32 was being checked twice, int64 not at all