### PR TITLE
ARROW-6109: [Integration] Docker image for integration testing can't be built on windows

### DIFF
--- a/dev/docker_common/Dockerfile.xenial.base
+++ b/dev/docker_common/Dockerfile.xenial.base
@@ -26,6 +26,7 @@ RUN apt-get update \
       build-essential \
       software-properties-common \
       ninja-build \
+      dos2unix \
  && apt-get clean
 
 ENV PATH="/opt/conda/bin:${PATH}"
@@ -63,5 +64,6 @@ RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -
       setuptools_scm \
  && conda clean --all
 
-ADD docker_common/install_clang_tools_xenial.sh /
+ADD docker_common/install_clang_tools_xenial.sh /install_clang_tools_xenial.sh
+RUN dos2unix /install_clang_tools_xenial.sh && apt-get --purge remove -y dos2unix && rm -rf /var/lib/apt/lists/*
 RUN /install_clang_tools_xenial.sh


### PR DESCRIPTION
Git for windows checks files out with windows line endings and converts them back before checking them in.

This causes issues in the bash scripts (which are copied from the windows file system into the image) we use to build the "arrow_integration_xenial_base" image when using docker on windows.

@kszucs PTAL.  I'm not sure if this Dockerfile is used as part of CI (and so CI will test that the changes don't break building the image on other platforms)?