### PR TITLE
ARROW-6117: [Java] Fix the set method of FixedSizeBinaryVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.FixedSizeBinaryReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.FixedSizeBinaryHolder;
@@ -163,6 +164,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
   /** Sets the value at index to the provided one. */
   public void set(int index, byte[] value) {
     assert index >= 0;
+    Preconditions.checkNotNull(value, "expecting a valid byte array");
     assert byteWidth <= value.length;
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
     valueBuffer.setBytes(index * byteWidth, value, 0, byteWidth);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeBinaryVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeBinaryVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector;
 
 import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.holders.FixedSizeBinaryHolder;
@@ -146,6 +147,18 @@ public class TestFixedSizeBinaryVector {
     vector.setValueCount(numValues);
     for (int i = 0; i < numValues; i++) {
       assertArrayEquals(values[i], vector.getObject(i));
+    }
+  }
+
+  @Test
+  public void testSetUsingNull() {
+    final byte[] value = null;
+    for (int i = 0; i < numValues; i++) {
+      final int index = i;
+      Exception e = assertThrows(NullPointerException.class, () -> {
+        vector.set(index, value);
+      });
+      assertEquals("expecting a valid byte array", e.getMessage());
     }
   }
 


### PR DESCRIPTION
For the set method, if the parameter is null, it should clear the validity bit. However, the current implementation throws a NullPointerException.