### PR TITLE
ARROW-3325: [Python][Parquet] Add "read_dictionary" argument to parquet.read_table, ParquetDataset to enable direct-to-DictionaryArray reads

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -814,30 +814,37 @@ Status FileReader::Make(::arrow::MemoryPool* pool,
   return Make(pool, std::move(reader), default_arrow_reader_properties(), out);
 }
 
-FileReaderBuilder::FileReaderBuilder(std::unique_ptr<ParquetFileReader> raw_reader)
-    : raw_reader_(std::move(raw_reader)) {}
+FileReaderBuilder::FileReaderBuilder()
+    : pool_(::arrow::default_memory_pool()),
+      properties_(default_arrow_reader_properties()) {}
 
 Status FileReaderBuilder::Open(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                                const ReaderProperties& properties,
-                               const std::shared_ptr<FileMetaData>& metadata,
-                               std::unique_ptr<FileReaderBuilder>* builder) {
-  std::unique_ptr<ParquetReader> raw_reader;
-  PARQUET_CATCH_NOT_OK(raw_reader = ParquetReader::Open(file, properties, metadata));
-  builder->reset(new FileReaderBuilder(std::move(raw_reader)));
+                               const std::shared_ptr<FileMetaData>& metadata) {
+  PARQUET_CATCH_NOT_OK(raw_reader_ = ParquetReader::Open(file, properties, metadata));
   return Status::OK();
 }
 
-Status FileReaderBuilder::Build(MemoryPool* pool, const ArrowReaderProperties& properties,
-                                std::unique_ptr<FileReader>* out) {
-  return FileReader::Make(pool, std::move(raw_reader_), properties, out);
+FileReaderBuilder* FileReaderBuilder::memory_pool(::arrow::MemoryPool* pool) {
+  pool_ = pool;
+  return this;
+}
+
+FileReaderBuilder* FileReaderBuilder::properties(
+    const ArrowReaderProperties& arg_properties) {
+  properties_ = arg_properties;
+  return this;
+}
+
+Status FileReaderBuilder::Build(std::unique_ptr<FileReader>* out) {
+  return FileReader::Make(pool_, std::move(raw_reader_), properties_, out);
 }
 
 Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                 MemoryPool* pool, std::unique_ptr<FileReader>* reader) {
-  std::unique_ptr<FileReaderBuilder> builder;
-  RETURN_NOT_OK(FileReaderBuilder::Open(file, ::parquet::default_reader_properties(),
-                                        nullptr, &builder));
-  return builder->Build(pool, default_arrow_reader_properties(), reader);
+  FileReaderBuilder builder;
+  RETURN_NOT_OK(builder.Open(file));
+  return builder.memory_pool(pool)->Build(reader);
 }
 
 Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
@@ -845,19 +852,18 @@ Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                 const std::shared_ptr<FileMetaData>& metadata,
                 std::unique_ptr<FileReader>* reader) {
   // Deprecated since 0.15.0
-  std::unique_ptr<FileReaderBuilder> builder;
-  RETURN_NOT_OK(FileReaderBuilder::Open(file, props, metadata, &builder));
-  return builder->Build(pool, default_arrow_reader_properties(), reader);
+  FileReaderBuilder builder;
+  RETURN_NOT_OK(builder.Open(file, props, metadata));
+  return builder.memory_pool(pool)->Build(reader);
 }
 
 Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                 MemoryPool* pool, const ArrowReaderProperties& properties,
                 std::unique_ptr<FileReader>* reader) {
   // Deprecated since 0.15.0
-  std::unique_ptr<FileReaderBuilder> builder;
-  RETURN_NOT_OK(FileReaderBuilder::Open(file, ::parquet::default_reader_properties(),
-                                        nullptr, &builder));
-  return builder->Build(pool, properties, reader);
+  FileReaderBuilder builder;
+  RETURN_NOT_OK(builder.Open(file));
+  return builder.memory_pool(pool)->properties(properties)->Build(reader);
 }
 
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -857,7 +857,7 @@ Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
   std::unique_ptr<FileReaderBuilder> builder;
   RETURN_NOT_OK(FileReaderBuilder::Open(file, ::parquet::default_reader_properties(),
                                         nullptr, &builder));
-  return builder->Build(pool, default_arrow_reader_properties(), reader);
+  return builder->Build(pool, properties, reader);
 }
 
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "parquet/platform.h"
+#include "parquet/properties.h"
 
 namespace arrow {
 
@@ -290,20 +291,21 @@ class PARQUET_EXPORT ColumnReader {
 /// either with std::move or C++ exceptions
 class FileReaderBuilder {
  public:
-  explicit FileReaderBuilder(std::unique_ptr<ParquetFileReader> raw_reader);
+  FileReaderBuilder();
 
-  static ::arrow::Status Open(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
-                              const ReaderProperties& properties,
-                              const std::shared_ptr<FileMetaData>& metadata,
-                              std::unique_ptr<FileReaderBuilder>* builder);
+  ::arrow::Status Open(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
+                       const ReaderProperties& properties = default_reader_properties(),
+                       const std::shared_ptr<FileMetaData>& metadata = NULLPTR);
 
   ParquetFileReader* raw_reader() { return raw_reader_.get(); }
 
-  ::arrow::Status Build(::arrow::MemoryPool* allocator,
-                        const ArrowReaderProperties& arrow_properties,
-                        std::unique_ptr<FileReader>* out);
+  FileReaderBuilder* memory_pool(::arrow::MemoryPool* pool);
+  FileReaderBuilder* properties(const ArrowReaderProperties& arg_properties);
+  ::arrow::Status Build(std::unique_ptr<FileReader>* out);
 
  private:
+  ::arrow::MemoryPool* pool_;
+  ArrowReaderProperties properties_;
   std::unique_ptr<ParquetFileReader> raw_reader_;
 };
 

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -289,7 +289,7 @@ class PARQUET_EXPORT ColumnReader {
 
 /// \brief Experimental helper class for bindings (like Python) that struggle
 /// either with std::move or C++ exceptions
-class FileReaderBuilder {
+class PARQUET_EXPORT FileReaderBuilder {
  public:
   FileReaderBuilder();
 

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -286,10 +286,33 @@ class PARQUET_EXPORT ColumnReader {
                                     std::shared_ptr<::arrow::ChunkedArray>* out) = 0;
 };
 
-// Helper function to create a file reader from an implementation of an Arrow
-// random access file
-//
-// metadata : separately-computed file metadata, can be nullptr
+/// \brief Experimental helper class for bindings (like Python) that struggle
+/// either with std::move or C++ exceptions
+class FileReaderBuilder {
+ public:
+  explicit FileReaderBuilder(std::unique_ptr<ParquetFileReader> raw_reader);
+
+  static ::arrow::Status Open(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
+                              const ReaderProperties& properties,
+                              const std::shared_ptr<FileMetaData>& metadata,
+                              std::unique_ptr<FileReaderBuilder>* builder);
+
+  ParquetFileReader* raw_reader() { return raw_reader_.get(); }
+
+  ::arrow::Status Build(::arrow::MemoryPool* allocator,
+                        const ArrowReaderProperties& arrow_properties,
+                        std::unique_ptr<FileReader>* out);
+
+ private:
+  std::unique_ptr<ParquetFileReader> raw_reader_;
+};
+
+PARQUET_EXPORT
+::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
+                         ::arrow::MemoryPool* allocator,
+                         std::unique_ptr<FileReader>* reader);
+
+ARROW_DEPRECATED("Deprecated since 0.15.0. Use FileReaderBuilder")
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                          ::arrow::MemoryPool* allocator,
@@ -297,11 +320,7 @@ PARQUET_EXPORT
                          const std::shared_ptr<FileMetaData>& metadata,
                          std::unique_ptr<FileReader>* reader);
 
-PARQUET_EXPORT
-::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
-                         ::arrow::MemoryPool* allocator,
-                         std::unique_ptr<FileReader>* reader);
-
+ARROW_DEPRECATED("Deprecated since 0.15.0. Use FileReaderBuilder")
 PARQUET_EXPORT
 ::arrow::Status OpenFile(const std::shared_ptr<::arrow::io::RandomAccessFile>& file,
                          ::arrow::MemoryPool* allocator,

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -210,6 +210,19 @@ Alternatively python ``with`` syntax can also be use:
 Data Type Handling
 ------------------
 
+Reading types as DictionaryArray
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``read_dictionary`` option in ``read_table`` and ``ParquetDataset`` will
+cause columns to be read as ``DictionaryArray``, which will become
+``pandas.Categorical`` when converted to pandas. This option is only valid for
+string and binary column types, and it can yield significantly lower memory use
+and improved performance for columns with many repeated string values.
+
+.. code-block:: python
+
+   pq.read_table(table, where, read_dictionary=['binary_c0', 'stringb_c2'])
+
 Storing timestamps
 ~~~~~~~~~~~~~~~~~~
 
@@ -305,7 +318,7 @@ A dataset partitioned by year and month may look like on disk:
      ...
 
 Writing to Partitioned Datasets
-------------------------------------------------
+-------------------------------
 
 You can write a partitioned dataset for any ``pyarrow`` file system that is a
 file-store (e.g. local, HDFS, S3). The default behaviour when no filesystem is

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -381,16 +381,15 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
         void set_use_threads(c_bool use_threads)
 
     cdef cppclass FileReaderBuilder:
-        @staticmethod
+        FileReaderBuilder()
         CStatus Open(const shared_ptr[RandomAccessFile]& file,
                      const ReaderProperties& properties,
-                     const shared_ptr[CFileMetaData]& metadata,
-                     unique_ptr[FileReaderBuilder]* builder)
+                     const shared_ptr[CFileMetaData]& metadata)
 
         ParquetFileReader* raw_reader()
-        CStatus Build(CMemoryPool* pool,
-                      const ArrowReaderProperties& arrow_properties,
-                      unique_ptr[FileReader]* out)
+        FileReaderBuilder* memory_pool(CMemoryPool*)
+        FileReaderBuilder* properties(const ArrowReaderProperties&)
+        CStatus Build(unique_ptr[FileReader]* out)
 
     CStatus FromParquetSchema(
         const SchemaDescriptor* parquet_schema,

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -328,14 +328,6 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
     ReaderProperties default_reader_properties()
 
     cdef cppclass ParquetFileReader:
-        @staticmethod
-        unique_ptr[ParquetFileReader] Open(
-            const shared_ptr[RandomAccessFile]& file,
-            const ReaderProperties& props,
-            const shared_ptr[CFileMetaData]& metadata)
-
-        @staticmethod
-        unique_ptr[ParquetFileReader] OpenFile(const c_string& path)
         shared_ptr[CFileMetaData] metadata()
 
 
@@ -359,15 +351,13 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
 
 cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
     cdef cppclass ArrowReaderProperties:
-        pass
+        ArrowReaderProperties()
+        void set_read_dictionary(int column_index, c_bool read_dict)
+        c_bool read_dictionary()
+        void set_batch_size()
+        int64_t batch_size()
 
     ArrowReaderProperties default_arrow_reader_properties()
-
-    CStatus OpenFile(const shared_ptr[RandomAccessFile]& file,
-                     CMemoryPool* allocator,
-                     const ReaderProperties& properties,
-                     const shared_ptr[CFileMetaData]& metadata,
-                     unique_ptr[FileReader]* reader)
 
     cdef cppclass FileReader:
         FileReader(CMemoryPool* pool, unique_ptr[ParquetFileReader] reader)
@@ -389,6 +379,18 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
         const ParquetFileReader* parquet_reader()
 
         void set_use_threads(c_bool use_threads)
+
+    cdef cppclass FileReaderBuilder:
+        @staticmethod
+        CStatus Open(const shared_ptr[RandomAccessFile]& file,
+                     const ReaderProperties& properties,
+                     const shared_ptr[CFileMetaData]& metadata,
+                     unique_ptr[FileReaderBuilder]* builder)
+
+        ParquetFileReader* raw_reader()
+        CStatus Build(CMemoryPool* pool,
+                      const ArrowReaderProperties& arrow_properties,
+                      unique_ptr[FileReader]* out)
 
     CStatus FromParquetSchema(
         const SchemaDescriptor* parquet_schema,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -999,7 +999,6 @@ cdef class ParquetReader:
                 default_arrow_reader_properties())
             c_string path
             unique_ptr[FileReaderBuilder] builder
-            const CFileMetaData* metadata
 
         if metadata is not None:
             c_metadata = metadata.sp_metadata
@@ -1013,9 +1012,9 @@ cdef class ParquetReader:
 
         # Set up metadata
         with nogil:
-            metadata = builder.get().raw_reader().metadata()
+            c_metadata = builder.get().raw_reader().metadata()
         self._metadata = result = FileMetaData()
-        result.init(metadata)
+        result.init(c_metadata)
 
         if read_dictionary is not None:
             self._set_read_dictionary(read_dictionary, &arrow_props)
@@ -1029,7 +1028,7 @@ cdef class ParquetReader:
         for column in read_dictionary:
             if not isinstance(column, int):
                 column = self.column_name_idx(column)
-            props.set_read_dictionary(column_index, True)
+            props.set_read_dictionary(column, True)
 
     @property
     def column_paths(self):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1052,6 +1052,12 @@ cdef class ListArray(Array):
                                                cpool, &out))
         return pyarrow_wrap_array(out)
 
+    @property
+    def values(self):
+        return self.flatten()
+
+    # TODO(wesm): Add offsets property
+
     def flatten(self):
         """
         Unnest this ListArray by one level

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -891,49 +891,6 @@ def _open_dataset_file(dataset, path, meta=None):
 
 
 class ParquetDataset(object):
-    """
-    Encapsulates details of reading a complete Parquet dataset possibly
-    consisting of multiple files and partitions in subdirectories
-
-    Parameters
-    ----------
-    path_or_paths : str or List[str]
-        A directory name, single file name, or list of file names
-    filesystem : FileSystem, default None
-        If nothing passed, paths assumed to be found in the local on-disk
-        filesystem
-    metadata : pyarrow.parquet.FileMetaData
-        Use metadata obtained elsewhere to validate file schemas
-    schema : pyarrow.parquet.Schema
-        Use schema obtained elsewhere to validate file schemas. Alternative to
-        metadata parameter
-    split_row_groups : boolean, default False
-        Divide files into pieces for each row group in the file
-    validate_schema : boolean, default True
-        Check that individual file schemas are all the same / compatible
-    filters : List[Tuple] or List[List[Tuple]] or None (default)
-        List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
-        implements partition-level (hive) filtering only, i.e., to prevent the
-        loading of some files of the dataset.
-
-        Predicates are expressed in disjunctive normal form (DNF). This means
-        that the innermost tuple describe a single column predicate. These
-        inner predicate make are all combined with a conjunction (AND) into a
-        larger predicate. The most outer list then combines all filters
-        with a disjunction (OR). By this, we should be able to express all
-        kinds of filters that are possible using boolean logic.
-
-        This function also supports passing in as List[Tuple]. These predicates
-        are evaluated as a conjunction. To express OR in predictates, one must
-        use the (preferred) List[List[Tuple]] notation.
-    metadata_nthreads: int, default 1
-        How many threads to allow the thread pool which is used to read the
-        dataset metadata. Increasing this is helpful to read partitioned
-        datasets.
-    memory_map : boolean, default True
-        If the source is a file path, use a memory map to read each file in the
-        dataset if possible, which can improve performance in some environments
-    """
     def __init__(self, path_or_paths, filesystem=None, schema=None,
                  metadata=None, split_row_groups=False, validate_schema=True,
                  filters=None, metadata_nthreads=1,
@@ -1148,6 +1105,62 @@ def _make_manifest(path_or_paths, fs, pathsep='/', metadata_nthreads=1,
     return pieces, partitions, common_metadata_path, metadata_path
 
 
+_read_docstring_common = """\
+read_dictionary : list, default None
+    List of names or column paths (for nested types) to read directly
+    as DictionaryArray. Only supported for BYTE_ARRAY storage. To read
+    a flat column as dictionary-encoded pass the column name. For
+    nested types, you must pass the full column "path", which could be
+    something like level1.level2.list.item. Refer to the Parquet
+    file's schema to obtain the paths.
+memory_map : boolean, default True
+    If the source is a file path, use a memory map to read file, which can
+    improve performance in some environments"""
+
+
+ParquetDataset.__doc__ = """
+Encapsulates details of reading a complete Parquet dataset possibly
+consisting of multiple files and partitions in subdirectories
+
+Parameters
+----------
+path_or_paths : str or List[str]
+    A directory name, single file name, or list of file names
+filesystem : FileSystem, default None
+    If nothing passed, paths assumed to be found in the local on-disk
+    filesystem
+metadata : pyarrow.parquet.FileMetaData
+    Use metadata obtained elsewhere to validate file schemas
+schema : pyarrow.parquet.Schema
+    Use schema obtained elsewhere to validate file schemas. Alternative to
+    metadata parameter
+split_row_groups : boolean, default False
+    Divide files into pieces for each row group in the file
+validate_schema : boolean, default True
+    Check that individual file schemas are all the same / compatible
+filters : List[Tuple] or List[List[Tuple]] or None (default)
+    List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
+    implements partition-level (hive) filtering only, i.e., to prevent the
+    loading of some files of the dataset.
+
+    Predicates are expressed in disjunctive normal form (DNF). This means
+    that the innermost tuple describe a single column predicate. These
+    inner predicate make are all combined with a conjunction (AND) into a
+    larger predicate. The most outer list then combines all filters
+    with a disjunction (OR). By this, we should be able to express all
+    kinds of filters that are possible using boolean logic.
+
+    This function also supports passing in as List[Tuple]. These predicates
+    are evaluated as a conjunction. To express OR in predictates, one must
+    use the (preferred) List[List[Tuple]] notation.
+metadata_nthreads: int, default 1
+    How many threads to allow the thread pool which is used to read the
+    dataset metadata. Increasing this is helpful to read partitioned
+    datasets.
+{0}
+""".format(_read_docstring_common)
+
+
 _read_table_docstring = """
 {0}
 
@@ -1165,12 +1178,6 @@ use_threads : boolean, default True
     Perform multi-threaded column reads
 metadata : FileMetaData
     If separately computed
-memory_map : boolean, default True
-    If the source is a file path, use a memory map to read file, which can
-    improve performance in some environments
-read_dictionary : list, default None
-    List of column paths to read directly as DictionaryArray. Only supported
-    for BYTE_ARRAY storage
 {1}
 filters : List[Tuple] or List[List[Tuple]] or None (default)
     List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
@@ -1201,9 +1208,10 @@ def read_table(source, columns=None, use_threads=True, metadata=None,
 
 read_table.__doc__ = _read_table_docstring.format(
     'Read a Table from Parquet format',
-    """use_pandas_metadata : boolean, default False
+    "\n".join((_read_docstring_common,
+               """use_pandas_metadata : boolean, default False
     If True and file has custom pandas schema metadata, ensure that
-    index columns are also loaded""",
+    index columns are also loaded""")),
     """pyarrow.Table
     Content of the file as a table (of columns)""")
 
@@ -1220,7 +1228,7 @@ def read_pandas(source, columns=None, use_threads=True, memory_map=True,
 read_pandas.__doc__ = _read_table_docstring.format(
     'Read a Table from Parquet format, also reading DataFrame\n'
     'index values if known in the file metadata',
-    '',
+    _read_docstring_common,
     """pyarrow.Table
     Content of the file as a Table of Columns, including DataFrame
     indexes as columns""")

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -960,16 +960,13 @@ class ParquetDataset(object):
 
         if self.common_metadata_path is not None:
             with self.fs.open(self.common_metadata_path) as f:
-                self.common_metadata = (ParquetFile(f, memory_map=memory_map)
-                                        .metadata)
+                self.common_metadata = read_metadata(f, memory_map=memory_map)
         else:
             self.common_metadata = None
 
         if metadata is None and self.metadata_path is not None:
             with self.fs.open(self.metadata_path) as f:
-                self.metadata = ParquetFile(
-                    f, memory_map=memory_map,
-                    read_dictionary=read_dictionary).metadata
+                self.metadata = read_metadata(f, memory_map=memory_map)
         else:
             self.metadata = metadata
 

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -562,7 +562,7 @@ class TestSerialCSVRead(BaseTestCSVRead, unittest.TestCase):
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = False
         table = read_csv(*args, **kwargs)
-        table._validate()
+        table.validate()
         return table
 
 
@@ -572,7 +572,7 @@ class TestParallelCSVRead(BaseTestCSVRead, unittest.TestCase):
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = True
         table = read_csv(*args, **kwargs)
-        table._validate()
+        table.validate()
         return table
 
 
@@ -595,7 +595,7 @@ class BaseTestCompressedCSVRead:
         csv_path = os.path.join(self.tmpdir, self.csv_filename)
         self.write_file(csv_path, csv)
         table = self.read_csv(csv_path)
-        table._validate()
+        table.validate()
         assert table.schema == expected.schema
         assert table.equals(expected)
         assert table.to_pydict() == expected.to_pydict()

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -133,7 +133,7 @@ class TestSerialJSONRead(BaseTestJSONRead, unittest.TestCase):
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = False
         table = read_json(*args, **kwargs)
-        table._validate()
+        table.validate()
         return table
 
 
@@ -143,5 +143,5 @@ class TestParallelJSONRead(BaseTestJSONRead, unittest.TestCase):
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = True
         table = read_json(*args, **kwargs)
-        table._validate()
+        table.validate()
         return table

--- a/python/pyarrow/tests/test_orc.py
+++ b/python/pyarrow/tests/test_orc.py
@@ -87,7 +87,7 @@ def check_example_file(orc_path, expected_df, need_fix=False):
     # Exercise ORCFile.read()
     table = orc_file.read()
     assert isinstance(table, pa.Table)
-    table._validate()
+    table.validate()
 
     # This workaround needed because of ARROW-3080
     orc_df = pd.DataFrame(table.to_pydict())

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2847,8 +2847,8 @@ def test_partitioned_dataset(tempdir):
 
 
 def test_read_column_invalid_index():
-    table = pa.Table.from_arrays([pa.array([4, 5]), pa.array(["foo", "bar"])],
-                                 ['ints', 'strs'])
+    table = pa.table([pa.array([4, 5]), pa.array(["foo", "bar"])],
+                     names=['ints', 'strs'])
     bio = pa.BufferOutputStream()
     pq.write_table(table, bio)
     f = pq.ParquetFile(bio.getvalue())
@@ -2857,6 +2857,71 @@ def test_read_column_invalid_index():
     for index in (-1, 2):
         with pytest.raises((ValueError, IndexError)):
             f.reader.read_column(index)
+
+
+def test_direct_read_dictionary():
+    # ARROW-3325
+    repeats = 10
+    nunique = 5
+
+    data = [
+        [tm.rands(10) for i in range(nunique)] * repeats,
+
+    ]
+    table = pa.table(data, names=['f0'])
+
+    bio = pa.BufferOutputStream()
+    pq.write_table(table, bio)
+    contents = bio.getvalue()
+
+    result = pq.read_table(pa.BufferReader(contents),
+                           read_dictionary=['f0'])
+
+    # Compute dictionary-encoded subfield
+    expected = pa.table([table[0].dictionary_encode()], names=['f0'])
+    assert result.equals(expected)
+
+
+def test_dataset_read_dictionary(tempdir):
+    path = tempdir / "ARROW-3325-dataset"
+    data = [
+        [tm.rands(10) for i in range(5)] * 10,
+    ]
+    table = pa.table(data, names=['f0'])
+    pq.write_to_dataset(table, root_path=str(path))
+    result = pq.ParquetDataset(path, read_dictionary=['f0']).read()
+    expected = pa.table([table[0].dictionary_encode()], names=['f0'])
+    assert result.equals(expected)
+
+
+def test_direct_read_dictionary_subfield():
+    repeats = 10
+    nunique = 5
+
+    data = [
+        [[tm.rands(10)] for i in range(nunique)] * repeats,
+    ]
+    table = pa.table(data, names=['f0'])
+
+    bio = pa.BufferOutputStream()
+    pq.write_table(table, bio)
+    contents = bio.getvalue()
+    result = pq.read_table(pa.BufferReader(contents),
+                           read_dictionary=['f0.list.item'])
+
+    arr = pa.array(data[0])
+    values_as_dict = arr.values.dictionary_encode()
+
+    inner_indices = values_as_dict.indices.cast('int32')
+    new_values = pa.DictionaryArray.from_arrays(inner_indices,
+                                                values_as_dict.dictionary)
+
+    offsets = pa.array(range(51), type='int32')
+    expected_arr = pa.ListArray.from_arrays(offsets, new_values)
+    expected = pa.table([expected_arr], names=['f0'])
+
+    assert result.equals(expected)
+    assert result[0].num_chunks == 1
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2884,14 +2884,24 @@ def test_direct_read_dictionary():
 
 def test_dataset_read_dictionary(tempdir):
     path = tempdir / "ARROW-3325-dataset"
-    data = [
-        [tm.rands(10) for i in range(5)] * 10,
-    ]
-    table = pa.table(data, names=['f0'])
-    pq.write_to_dataset(table, root_path=str(path))
+    t1 = pa.table([[tm.rands(10) for i in range(5)] * 10], names=['f0'])
+    t2 = pa.table([[tm.rands(10) for i in range(5)] * 10], names=['f0'])
+    pq.write_to_dataset(t1, root_path=str(path))
+    pq.write_to_dataset(t2, root_path=str(path))
+
     result = pq.ParquetDataset(path, read_dictionary=['f0']).read()
-    expected = pa.table([table[0].dictionary_encode()], names=['f0'])
-    assert result.equals(expected)
+
+    # The order of the chunks is non-deterministic
+    ex_chunks = [t1[0].chunk(0).dictionary_encode(),
+                 t2[0].chunk(0).dictionary_encode()]
+
+    assert result[0].num_chunks == 2
+    c0, c1 = result[0].chunk(0), result[0].chunk(1)
+    if c0.equals(ex_chunks[0]):
+        assert c1.equals(ex_chunks[1])
+    else:
+        assert c0.equals(ex_chunks[1])
+        assert c1.equals(ex_chunks[0])
 
 
 def test_direct_read_dictionary_subfield():

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1356,19 +1356,7 @@ def test_parquet_piece_open_and_get_metadata(tempdir):
     meta1 = piece.get_metadata()
     assert isinstance(meta1, pq.FileMetaData)
 
-    def open_parquet(fn):
-        return pq.ParquetFile(open(fn, mode='rb'))
-
-    # test deprecated open_file_func
-    with pytest.warns(DeprecationWarning):
-        table2 = piece.read(open_file_func=open_parquet)
-        assert isinstance(table2, pa.Table)
-    with pytest.warns(DeprecationWarning):
-        meta2 = piece.get_metadata(open_file_func=open_parquet)
-        assert isinstance(meta2, pq.FileMetaData)
-
-    assert table == table1 == table2
-    assert meta1 == meta2
+    assert table == table1
 
 
 def test_parquet_piece_basics():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -503,21 +503,23 @@ def test_table_from_arrays_invalid_names():
         pa.Table.from_arrays(data, names=['a'])
 
 
-def test_table_from_lists_raises():
+def test_table_from_lists():
     data = [
         list(range(5)),
         [-10, -5, 0, 5, 10]
     ]
 
-    with pytest.raises(TypeError):
-        pa.table(data, names=['a', 'b'])
+    result = pa.table(data, names=['a', 'b'])
+    expected = pa.Table.from_arrays(data, names=['a', 'b'])
+    assert result.equals(expected)
 
     schema = pa.schema([
         pa.field('a', pa.uint16()),
         pa.field('b', pa.int64())
     ])
-    with pytest.raises(TypeError):
-        pa.table(data, schema=schema)
+    result = pa.table(data, schema=schema)
+    expected = pa.Table.from_arrays(data, schema=schema)
+    assert result.equals(expected)
 
 
 def test_table_pickle():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -186,7 +186,7 @@ def test_chunked_array_to_pandas():
     data = [
         pa.array([-10, -5, 0, 5, 10])
     ]
-    table = pa.Table.from_arrays(data, names=['a'])
+    table = pa.table(data, names=['a'])
     col = table.column(0)
     assert isinstance(col, pa.ChunkedArray)
     array = col.to_pandas()
@@ -445,8 +445,8 @@ def test_table_basics():
         pa.array(range(5)),
         pa.array([-10, -5, 0, 5, 10])
     ]
-    table = pa.Table.from_arrays(data, names=('a', 'b'))
-    table._validate()
+    table = pa.table(data, names=('a', 'b'))
+    table.validate()
     assert len(table) == 5
     assert table.num_rows == 5
     assert table.num_columns == 2
@@ -474,9 +474,8 @@ def test_table_basics():
             col.chunk(col.num_chunks)
 
     assert table.columns == columns
-    assert table == pa.Table.from_arrays(columns, names=table.column_names)
-    assert table != pa.Table.from_arrays(columns[1:],
-                                         names=table.column_names[1:])
+    assert table == pa.table(columns, names=table.column_names)
+    assert table != pa.table(columns[1:], names=table.column_names[1:])
     assert table != columns
 
 
@@ -511,14 +510,14 @@ def test_table_from_lists_raises():
     ]
 
     with pytest.raises(TypeError):
-        pa.Table.from_arrays(data, names=['a', 'b'])
+        pa.table(data, names=['a', 'b'])
 
     schema = pa.schema([
         pa.field('a', pa.uint16()),
         pa.field('b', pa.int64())
     ])
     with pytest.raises(TypeError):
-        pa.Table.from_arrays(data, schema=schema)
+        pa.table(data, schema=schema)
 
 
 def test_table_pickle():
@@ -532,7 +531,7 @@ def test_table_pickle():
     table = pa.Table.from_arrays(data, schema=schema)
 
     result = pickle.loads(pickle.dumps(table))
-    result._validate()
+    result.validate()
     assert result.equals(table)
 
 
@@ -620,7 +619,7 @@ def test_table_remove_column():
     table = pa.Table.from_arrays(data, names=('a', 'b', 'c'))
 
     t2 = table.remove_column(0)
-    t2._validate()
+    t2.validate()
     expected = pa.Table.from_arrays(data[1:], names=('b', 'c'))
     assert t2.equals(expected)
 
@@ -633,11 +632,11 @@ def test_table_remove_column_empty():
     table = pa.Table.from_arrays(data, names=['a'])
 
     t2 = table.remove_column(0)
-    t2._validate()
+    t2.validate()
     assert len(t2) == len(table)
 
     t3 = t2.add_column(0, table.field(0), table[0])
-    t3._validate()
+    t3.validate()
     assert t3.equals(table)
 
 
@@ -651,7 +650,7 @@ def test_table_rename_columns():
     assert table.column_names == ['a', 'b', 'c']
 
     t2 = table.rename_columns(['eh', 'bee', 'sea'])
-    t2._validate()
+    t2.validate()
     assert t2.column_names == ['eh', 'bee', 'sea']
 
     expected = pa.Table.from_arrays(data, names=['eh', 'bee', 'sea'])
@@ -668,7 +667,7 @@ def test_table_flatten():
 
     table = pa.Table.from_arrays([a, b, c], names=['a', 'b', 'c'])
     t2 = table.flatten()
-    t2._validate()
+    t2.validate()
     expected = pa.Table.from_arrays([
         pa.array([1, 3], type=pa.int16()),
         pa.array([2.5, 4.5], type=pa.float32()),
@@ -685,7 +684,7 @@ def test_table_combine_chunks():
                                         names=['f1', 'f2'])
     table = pa.Table.from_batches([batch1, batch2])
     combined = table.combine_chunks()
-    combined._validate()
+    combined.validate()
     assert combined.equals(table)
     for c in combined.columns:
         assert c.num_chunks == 1
@@ -707,7 +706,7 @@ def test_concat_tables():
                               names=('a', 'b'))
 
     result = pa.concat_tables([t1, t2])
-    result._validate()
+    result.validate()
     assert len(result) == 10
 
     expected = pa.Table.from_arrays([pa.array(x + y)


### PR DESCRIPTION
I also added support to `pyarrow.table` to invoke `Table.from_arrays` if a list or tuple of arrays is passed. This makes for more natural code IMHO. 

Using this option with heavily compressed data results in far less memory use and much better performance. See example benchmarks

https://gist.github.com/wesm/450d85e52844aee685c0680111cbb1d7