### PR TITLE
ARROW-6128: [C++] Suppress a class-memaccess warning

### DIFF
--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -310,7 +310,7 @@ class HashTable {
   Status UpsizeBuffer(uint64_t capacity) {
     RETURN_NOT_OK(entries_builder_.Resize(capacity));
     entries_ = entries_builder_.mutable_data();
-    memset(entries_, 0, capacity * sizeof(Entry));
+    memset(static_cast<void*>(entries_), 0, capacity * sizeof(Entry));
 
     return Status::OK();
   }


### PR DESCRIPTION
    src/arrow/util/hashing.h:313:11: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct arrow::internal::HashTable<arrow::internal::ScalarMemoTable<nonstd::sv_lite::basic_string_view<char>, arrow::internal::HashTable>::Payload>::Entry'; use assignment or value-initialization instead [-Werror=class-memaccess]
         memset(entries_, 0, capacity * sizeof(Entry));
         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    src/arrow/util/hashing.h:197:10: note: 'struct arrow::internal::HashTable<arrow::internal::ScalarMemoTable<nonstd::sv_lite::basic_string_view<char>, arrow::internal::HashTable>::Payload>::Entry' declared here
       struct Entry {
              ^~~~~