### PR TITLE
ARROW-5772: [GLib][Plasma][CUDA] Fix a bug that data can't be got

### DIFF
--- a/c_glib/arrow-glib/buffer.cpp
+++ b/c_glib/arrow-glib/buffer.cpp
@@ -142,7 +142,7 @@ garrow_buffer_class_init(GArrowBufferClass *klass)
 
   spec = g_param_spec_pointer("buffer",
                               "Buffer",
-                              "The raw std::shared<arrow::Buffer> *",
+                              "The raw std::shared_ptr<arrow::Buffer> *",
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_BUFFER, spec);

--- a/c_glib/plasma-glib/object.hpp
+++ b/c_glib/plasma-glib/object.hpp
@@ -31,13 +31,17 @@ gplasma_object_id_get_raw(GPlasmaObjectID *id);
 GPlasmaCreatedObject *
 gplasma_created_object_new_raw(GPlasmaClient *client,
                                GPlasmaObjectID *id,
+                               std::shared_ptr<arrow::Buffer> *plasma_data,
                                GArrowBuffer *data,
+                               std::shared_ptr<arrow::Buffer> *plasma_metadata,
                                GArrowBuffer *metadata,
                                gint gpu_device);
 
 GPlasmaReferredObject *
 gplasma_referred_object_new_raw(GPlasmaClient *client,
                                 GPlasmaObjectID *id,
+                                std::shared_ptr<arrow::Buffer> *plasma_data,
                                 GArrowBuffer *data,
+                                std::shared_ptr<arrow::Buffer> *plasma_metadata,
                                 GArrowBuffer *metadata,
                                 gint gpu_device);

--- a/c_glib/test/plasma/test-plasma-client.rb
+++ b/c_glib/test/plasma/test-plasma-client.rb
@@ -63,7 +63,6 @@ class TestPlasmaClient < Test::Unit::TestCase
 
     test("options: GPU device") do
       omit("Arrow CUDA is required") unless defined?(::ArrowCUDA)
-      omit("TODO: Fix this failure: ARROW-5772")
 
       gpu_device = 0
 


### PR DESCRIPTION
We need to keep a reference to std::shared_ptr<arrow::Buffer> returned
by plasma::Client::Get(). If the returned buffer is destructed, we
can't get data from the returned buffer.

Without this change, we just keep a reference to a
std::shared_ptr<arrow::cuda::CudaBuffer> returned from
arrow::cuda::CudaBuffer::FromBuffer().