### PR TITLE
ARROW-5651: [Python] Fix Incorrect conversion from strided Numpy array

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2348,6 +2348,13 @@ class TestConvertMisc(object):
         arr = pa.array(data['y'], type=pa.int16())
         assert arr.to_pylist() == [-1, 2]
 
+    def test_array_from_strided_numpy_array(self):
+        # ARROW-5651
+        np_arr = np.arange(0, 10, dtype=np.float32)[1:-1:2]
+        pa_arr = pa.array(np_arr, type=pa.float64())
+        expected = pa.array([1.0, 3.0, 5.0, 7.0], type=pa.float64())
+        pa_arr.equals(expected)
+
     def test_safe_unsafe_casts(self):
         # ARROW-2799
         df = pd.DataFrame({


### PR DESCRIPTION
This is a second attempt to resolve ARROW-5651. The previous attempt was #4958.
I withdrew the previous PR because it introduces the performance degradation, but I confirmed that this PR does not.

Benchmarks on macOS High Sierra. on master:
```
In [3]: %timeit b = pa.array(a)
4.17 µs ± 116 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
In [4]: %timeit b = pa.array(strided)
46.8 µs ± 1.78 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [5]: %timeit b = pa.array(a, type=pa.float64())
39.2 µs ± 1.79 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [6]: %timeit b = pa.array(strided, type=pa.float64())
78.3 µs ± 280 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```
on this PR:
```
In [3]: %timeit b = pa.array(a)
4.77 µs ± 276 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
In [4]: %timeit b = pa.array(strided)
49.5 µs ± 2.5 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [5]: %timeit b = pa.array(a, type=pa.float64())
39.6 µs ± 1.53 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
In [6]: %timeit b = pa.array(strided, type=pa.float64())
76.3 µs ± 295 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```