### PR TITLE
ARROW-6104: [Rust] [DataFusion] Remove use of bare trait objects

### DIFF
--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -26,7 +26,7 @@ use crate::error::Result;
 
 /// Returned by implementors of `Table#scan`, this `RecordBatchIterator` is wrapped with
 /// an `Arc` and `Mutex` so that it can be shared across threads as it is used.
-pub type ScanResult = Arc<Mutex<RecordBatchIterator>>;
+pub type ScanResult = Arc<Mutex<dyn RecordBatchIterator>>;
 
 /// Source table
 pub trait TableProvider {

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -49,7 +49,7 @@ impl MemTable {
     }
 
     /// Create a mem table by reading from another data source
-    pub fn load(t: &TableProvider) -> Result<Self> {
+    pub fn load(t: &dyn TableProvider) -> Result<Self> {
         let schema = t.schema();
         let partitions = t.scan(&None, 1024 * 1024)?;
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -51,7 +51,7 @@ use sqlparser::sqlast::{SQLColumnDef, SQLType};
 
 /// Execution context for registering data sources and executing queries
 pub struct ExecutionContext {
-    datasources: Rc<RefCell<HashMap<String, Rc<TableProvider>>>>,
+    datasources: Rc<RefCell<HashMap<String, Rc<dyn TableProvider>>>>,
 }
 
 impl ExecutionContext {
@@ -64,7 +64,11 @@ impl ExecutionContext {
 
     /// Execute a SQL query and produce a Relation (a schema-aware iterator over a series
     /// of RecordBatch instances)
-    pub fn sql(&mut self, sql: &str, batch_size: usize) -> Result<Rc<RefCell<Relation>>> {
+    pub fn sql(
+        &mut self,
+        sql: &str,
+        batch_size: usize,
+    ) -> Result<Rc<RefCell<dyn Relation>>> {
         let plan = self.create_logical_plan(sql)?;
         let plan = self.optimize(&plan)?;
         Ok(self.execute(&plan, batch_size)?)
@@ -76,7 +80,7 @@ impl ExecutionContext {
 
         match ast {
             DFASTNode::ANSI(ansi) => {
-                let schema_provider: Arc<SchemaProvider> =
+                let schema_provider: Arc<dyn SchemaProvider> =
                     Arc::new(ExecutionContextSchemaProvider {
                         datasources: self.datasources.clone(),
                     });
@@ -160,14 +164,14 @@ impl ExecutionContext {
     }
 
     /// Register a table so that it can be queried from SQL
-    pub fn register_table(&mut self, name: &str, provider: Rc<TableProvider>) {
+    pub fn register_table(&mut self, name: &str, provider: Rc<dyn TableProvider>) {
         self.datasources
             .borrow_mut()
             .insert(name.to_string(), provider);
     }
 
     /// Get a table by name
-    pub fn table(&mut self, table_name: &str) -> Result<Arc<Table>> {
+    pub fn table(&mut self, table_name: &str) -> Result<Arc<dyn Table>> {
         match (*self.datasources).borrow().get(table_name) {
             Some(provider) => {
                 Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::TableScan {
@@ -187,7 +191,7 @@ impl ExecutionContext {
 
     /// Optimize the logical plan by applying optimizer rules
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<Arc<LogicalPlan>> {
-        let rules: Vec<Box<OptimizerRule>> = vec![
+        let rules: Vec<Box<dyn OptimizerRule>> = vec![
             Box::new(ProjectionPushDown::new()),
             Box::new(TypeCoercionRule::new()),
         ];
@@ -204,7 +208,7 @@ impl ExecutionContext {
         &mut self,
         plan: &LogicalPlan,
         batch_size: usize,
-    ) -> Result<Rc<RefCell<Relation>>> {
+    ) -> Result<Rc<RefCell<dyn Relation>>> {
         match *plan {
             LogicalPlan::TableScan {
                 ref table_name,
@@ -376,7 +380,7 @@ impl ExecutionContext {
 }
 
 struct ExecutionContextSchemaProvider {
-    datasources: Rc<RefCell<HashMap<String, Rc<TableProvider>>>>,
+    datasources: Rc<RefCell<HashMap<String, Rc<dyn TableProvider>>>>,
 }
 impl SchemaProvider for ExecutionContextSchemaProvider {
     fn get_table_meta(&self, name: &str) -> Option<Arc<Schema>> {

--- a/rust/datafusion/src/execution/expression.rs
+++ b/rust/datafusion/src/execution/expression.rs
@@ -30,10 +30,10 @@ use crate::execution::context::ExecutionContext;
 use crate::logicalplan::{Expr, Operator, ScalarValue};
 
 /// Function that accepts a RecordBatch and returns an ArrayRef
-pub type ArrayFunction = Rc<Fn(&RecordBatch) -> Result<ArrayRef>>;
+pub type ArrayFunction = Rc<dyn Fn(&RecordBatch) -> Result<ArrayRef>>;
 
 /// Function that accepts an ArrayRef and returns an ArrayRef
-pub type CompiledCastFunction = Rc<Fn(&ArrayRef) -> Result<ArrayRef>>;
+pub type CompiledCastFunction = Rc<dyn Fn(&ArrayRef) -> Result<ArrayRef>>;
 
 /// Enumeration of supported aggregate functions
 #[allow(missing_docs)] // seems like these variants are self-evident

--- a/rust/datafusion/src/execution/filter.rs
+++ b/rust/datafusion/src/execution/filter.rs
@@ -37,14 +37,14 @@ pub(super) struct FilterRelation {
     /// input relation.
     schema: Arc<Schema>,
     /// Relation that is  being filtered
-    input: Rc<RefCell<Relation>>,
+    input: Rc<RefCell<dyn Relation>>,
     /// Filter expression
     expr: CompiledExpr,
 }
 
 impl FilterRelation {
     pub fn new(
-        input: Rc<RefCell<Relation>>,
+        input: Rc<RefCell<dyn Relation>>,
         expr: CompiledExpr,
         schema: Arc<Schema>,
     ) -> Self {

--- a/rust/datafusion/src/execution/limit.rs
+++ b/rust/datafusion/src/execution/limit.rs
@@ -32,7 +32,7 @@ use crate::execution::relation::Relation;
 /// Implementation of a LIMIT relation
 pub(super) struct LimitRelation {
     /// The relation which the limit is being applied to
-    input: Rc<RefCell<Relation>>,
+    input: Rc<RefCell<dyn Relation>>,
     /// The schema for the limit relation, which is always the same as the schema of the
     /// input relation
     schema: Arc<Schema>,
@@ -43,7 +43,11 @@ pub(super) struct LimitRelation {
 }
 
 impl LimitRelation {
-    pub fn new(input: Rc<RefCell<Relation>>, limit: usize, schema: Arc<Schema>) -> Self {
+    pub fn new(
+        input: Rc<RefCell<dyn Relation>>,
+        limit: usize,
+        schema: Arc<Schema>,
+    ) -> Self {
         Self {
             input,
             schema,

--- a/rust/datafusion/src/execution/physical_plan.rs
+++ b/rust/datafusion/src/execution/physical_plan.rs
@@ -28,13 +28,13 @@ pub trait ExecutionPlan {
     /// Get the schema for this execution plan
     fn schema(&self) -> Arc<Schema>;
     /// Get the partitions for this execution plan. Each partition can be executed in parallel.
-    fn partitions(&self) -> Result<Vec<Arc<Partition>>>;
+    fn partitions(&self) -> Result<Vec<Arc<dyn Partition>>>;
 }
 
 /// Represents a partition of an execution plan that can be executed on a thread
 pub trait Partition: Send + Sync {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<BatchIterator>>;
+    fn execute(&self) -> Result<Arc<dyn BatchIterator>>;
 }
 
 /// Iterator over RecordBatch that can be sent between threads

--- a/rust/datafusion/src/execution/projection.rs
+++ b/rust/datafusion/src/execution/projection.rs
@@ -37,14 +37,14 @@ pub(super) struct ProjectRelation {
     /// Schema for the result of the projection
     schema: Arc<Schema>,
     /// The relation that the projection is being applied to
-    input: Rc<RefCell<Relation>>,
+    input: Rc<RefCell<dyn Relation>>,
     /// Projection expressions
     expr: Vec<CompiledExpr>,
 }
 
 impl ProjectRelation {
     pub fn new(
-        input: Rc<RefCell<Relation>>,
+        input: Rc<RefCell<dyn Relation>>,
         expr: Vec<CompiledExpr>,
         schema: Arc<Schema>,
     ) -> Self {

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -40,11 +40,11 @@ pub trait Relation {
 /// Implementation of a relation that represents a DataFusion data source
 pub(super) struct DataSourceRelation {
     schema: Arc<Schema>,
-    ds: Arc<Mutex<RecordBatchIterator>>,
+    ds: Arc<Mutex<dyn RecordBatchIterator>>,
 }
 
 impl DataSourceRelation {
-    pub fn new(ds: Arc<Mutex<RecordBatchIterator>>) -> Self {
+    pub fn new(ds: Arc<Mutex<dyn RecordBatchIterator>>) -> Self {
         let schema = ds.lock().unwrap().schema().clone();
         Self { ds, schema }
     }

--- a/rust/datafusion/src/execution/table_impl.rs
+++ b/rust/datafusion/src/execution/table_impl.rs
@@ -40,7 +40,7 @@ impl TableImpl {
 
 impl Table for TableImpl {
     /// Apply a projection based on a list of column names
-    fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<Table>> {
+    fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<dyn Table>> {
         let mut expr: Vec<Expr> = Vec::with_capacity(columns.len());
         for column_name in columns {
             let i = self.column_index(column_name)?;
@@ -50,7 +50,7 @@ impl Table for TableImpl {
     }
 
     /// Create a projection based on arbitrary expressions
-    fn select(&self, expr_list: Vec<Expr>) -> Result<Arc<Table>> {
+    fn select(&self, expr_list: Vec<Expr>) -> Result<Arc<dyn Table>> {
         let schema = self.plan.schema();
         let mut field: Vec<Field> = Vec::with_capacity(expr_list.len());
 
@@ -78,7 +78,7 @@ impl Table for TableImpl {
     }
 
     /// Create a selection based on a filter expression
-    fn filter(&self, expr: Expr) -> Result<Arc<Table>> {
+    fn filter(&self, expr: Expr) -> Result<Arc<dyn Table>> {
         Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::Selection {
             expr,
             input: self.plan.clone(),
@@ -90,7 +90,7 @@ impl Table for TableImpl {
         &self,
         group_expr: Vec<Expr>,
         aggr_expr: Vec<Expr>,
-    ) -> Result<Arc<Table>> {
+    ) -> Result<Arc<dyn Table>> {
         Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::Aggregate {
             input: self.plan.clone(),
             group_expr,
@@ -100,7 +100,7 @@ impl Table for TableImpl {
     }
 
     /// Limit the number of rows
-    fn limit(&self, n: usize) -> Result<Arc<Table>> {
+    fn limit(&self, n: usize) -> Result<Arc<dyn Table>> {
         Ok(Arc::new(TableImpl::new(Arc::new(LogicalPlan::Limit {
             expr: Literal(ScalarValue::UInt32(n as u32)),
             input: self.plan.clone(),

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -19,7 +19,6 @@
 //! Apache Arrow as the memory model
 
 #![warn(missing_docs)]
-#![allow(bare_trait_objects)]
 
 extern crate arrow;
 extern crate sqlparser;

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -39,12 +39,12 @@ pub trait SchemaProvider {
 
 /// SQL query planner
 pub struct SqlToRel {
-    schema_provider: Arc<SchemaProvider>,
+    schema_provider: Arc<dyn SchemaProvider>,
 }
 
 impl SqlToRel {
     /// Create a new query planner
-    pub fn new(schema_provider: Arc<SchemaProvider>) -> Self {
+    pub fn new(schema_provider: Arc<dyn SchemaProvider>) -> Self {
         SqlToRel { schema_provider }
     }
 

--- a/rust/datafusion/src/table.rs
+++ b/rust/datafusion/src/table.rs
@@ -25,23 +25,23 @@ use std::sync::Arc;
 /// Table is an abstraction of a logical query plan
 pub trait Table {
     /// Select columns by name
-    fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<Table>>;
+    fn select_columns(&self, columns: Vec<&str>) -> Result<Arc<dyn Table>>;
 
     /// Create a projection based on arbitrary expressions
-    fn select(&self, expr: Vec<Expr>) -> Result<Arc<Table>>;
+    fn select(&self, expr: Vec<Expr>) -> Result<Arc<dyn Table>>;
 
     /// Create a selection based on a filter expression
-    fn filter(&self, expr: Expr) -> Result<Arc<Table>>;
+    fn filter(&self, expr: Expr) -> Result<Arc<dyn Table>>;
 
     /// Perform an aggregate query
     fn aggregate(
         &self,
         group_expr: Vec<Expr>,
         aggr_expr: Vec<Expr>,
-    ) -> Result<Arc<Table>>;
+    ) -> Result<Arc<dyn Table>>;
 
     /// limit the number of rows
-    fn limit(&self, n: usize) -> Result<Arc<Table>>;
+    fn limit(&self, n: usize) -> Result<Arc<dyn Table>>;
 
     /// Return the logical plan
     fn to_logical_plan(&self) -> Arc<LogicalPlan>;


### PR DESCRIPTION
Remove use of bare trait objects and use `dyn` syntax instead