### PR TITLE
ARROW-6134: [C++][Gandiva] Add concat function in Gandiva

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -83,6 +83,8 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      kResultNullIfNull, "concatOperator_utf8_utf8",
                      NativeFunction::kNeedsContext),
 
+      // concat treats null inputs as empty strings whereas concatOperator returns null if
+      // one of the inputs is null
       NativeFunction("concat", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullNever, "concat_utf8_utf8", NativeFunction::kNeedsContext),
 

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -79,8 +79,12 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      utf8(), kResultNullIfNull, "substr_utf8_int64",
                      NativeFunction::kNeedsContext),
 
-      NativeFunction("concatOperator", {"concat"}, DataTypeVector{utf8(), utf8()}, utf8(),
+      NativeFunction("concatOperator", {}, DataTypeVector{utf8(), utf8()}, utf8(),
                      kResultNullIfNull, "concatOperator_utf8_utf8",
+                     NativeFunction::kNeedsContext),
+
+      NativeFunction("concat", {}, DataTypeVector{utf8(), utf8()}, utf8(),
+                     kResultNullInternal, "concat_utf8_utf8",
                      NativeFunction::kNeedsContext),
 
       NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary()},

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -84,8 +84,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext),
 
       NativeFunction("concat", {}, DataTypeVector{utf8(), utf8()}, utf8(),
-                     kResultNullInternal, "concat_utf8_utf8",
-                     NativeFunction::kNeedsContext),
+                     kResultNullNever, "concat_utf8_utf8", NativeFunction::kNeedsContext),
 
       NativeFunction("convert_fromUTF8", {"convert_fromutf8"}, DataTypeVector{binary()},
                      utf8(), kResultNullIfNull, "convert_fromUTF8_binary",

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -191,8 +191,8 @@ VAR_LEN_TYPES(IS_NOT_NULL, isnotnull)
 #undef IS_NOT_NULL
 
 FORCE_INLINE
-char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
-                              int64 offset64, int64 length, int32* out_len) {
+const char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
+                                    int64 offset64, int64 length, int32* out_len) {
   if (length <= 0 || input == nullptr || in_len <= 0) {
     *out_len = 0;
     const char* empty_str = "";
@@ -209,8 +209,7 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
 
   if (startIndex < 0 || startIndex >= in_len) {
     *out_len = 0;
-    const char* empty_str = "";
-    return const_cast<char*>(empty_str);
+    return "";
   }
 
   *out_len = static_cast<int32>(length);
@@ -222,23 +221,22 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    const char* empty_str = "";
-    return const_cast<char*>(empty_str);
+    return "";
   }
   memcpy(ret, input + startIndex, *out_len);
   return ret;
 }
 
 FORCE_INLINE
-char* substr_utf8_int64(int64 context, const char* input, int32 in_len, int64 offset64,
-                        int32* out_len) {
+const char* substr_utf8_int64(int64 context, const char* input, int32 in_len,
+                              int64 offset64, int32* out_len) {
   return substr_utf8_int64_int64(context, input, in_len, offset64, in_len, out_len);
 }
 
 FORCE_INLINE
-char* concat_utf8_utf8(int64 context, const char* left, int32 left_len,
-                       bool left_validity, const char* right, int32 right_len,
-                       bool right_validity, int32* out_len) {
+const char* concat_utf8_utf8(int64 context, const char* left, int32 left_len,
+                             bool left_validity, const char* right, int32 right_len,
+                             bool right_validity, int32* out_len) {
   if (!left_validity) {
     left_len = 0;
   }
@@ -249,20 +247,18 @@ char* concat_utf8_utf8(int64 context, const char* left, int32 left_len,
 }
 
 FORCE_INLINE
-char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
-                               const char* right, int32 right_len, int32* out_len) {
+const char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
+                                     const char* right, int32 right_len, int32* out_len) {
   *out_len = left_len + right_len;
   if (*out_len <= 0) {
     *out_len = 0;
-    const char* empty_str = "";
-    return const_cast<char*>(empty_str);
+    return "";
   }
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    const char* empty_str = "";
-    return const_cast<char*>(empty_str);
+    return "";
   }
   memcpy(ret, left, left_len);
   memcpy(ret + left_len, right, right_len);
@@ -270,15 +266,14 @@ char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
 }
 
 FORCE_INLINE
-char* convert_fromUTF8_binary(int64 context, const char* bin_in, int32 len,
-                              int32* out_len) {
+const char* convert_fromUTF8_binary(int64 context, const char* bin_in, int32 len,
+                                    int32* out_len) {
   *out_len = len;
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    const char* empty_str = "";
-    return const_cast<char*>(empty_str);
+    return "";
   }
   memcpy(ret, bin_in, *out_len);
   return ret;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -232,8 +232,16 @@ char* substr_utf8_int64(int64 context, const char* input, int32 in_len, int64 of
 }
 
 FORCE_INLINE
-char* concat_utf8_utf8(int64 context, const char* left, int32 left_len, const char* right,
-                       int32 right_len, int32* out_len) {
+char* concat_utf8_utf8(int64 context, const char* left, int32 left_len,
+                       bool left_validity, const char* right, int32 right_len,
+                       bool right_validity, bool* out_valid, int32* out_len) {
+  if (!left_validity) {
+    left_len = 0;
+  }
+  if (!right_validity) {
+    right_len = 0;
+  }
+  *out_valid = true;
   return concatOperator_utf8_utf8(context, left, left_len, right, right_len, out_len);
 }
 
@@ -251,14 +259,8 @@ char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
     *out_len = 0;
     return nullptr;
   }
-  int32 copied_left_len = 0;
-  if (left != nullptr) {
-    memcpy(ret, left, left_len);
-    copied_left_len = left_len;
-  }
-  if (right != nullptr) {
-    memcpy(ret + copied_left_len, right, right_len);
-  }
+  memcpy(ret, left, left_len);
+  memcpy(ret + left_len, right, right_len);
   return ret;
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -165,8 +165,9 @@ FORCE_INLINE
 char* castVARCHAR_utf8_int64(int64 context, const char* data, int32 data_len,
                              int64_t out_len, int32_t* out_length) {
   // TODO: handle allocation failures
-  int32_t len = data_len <= static_cast<int32_t>(out_len) ? data_len
-                                                          : static_cast<int32_t>(out_len);
+  int32_t len = data_len <= static_cast<int32_t>(out_len) || out_len == 0
+                    ? data_len
+                    : static_cast<int32_t>(out_len);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, len));
   memcpy(ret, data, len);
   *out_length = len;
@@ -194,7 +195,7 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
                               int64 offset64, int64 length, int32* out_len) {
   if (length <= 0 || input == nullptr || in_len <= 0) {
     *out_len = 0;
-    return nullptr;
+    return (char*)"";
   }
 
   int32 offset = static_cast<int32>(offset64);
@@ -207,7 +208,7 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
 
   if (startIndex < 0 || startIndex >= in_len) {
     *out_len = 0;
-    return nullptr;
+    return (char*)"";
   }
 
   *out_len = static_cast<int32>(length);
@@ -219,7 +220,7 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    return nullptr;
+    return (char*)"";
   }
   memcpy(ret, input + startIndex, *out_len);
   return ret;
@@ -250,13 +251,13 @@ char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
   *out_len = left_len + right_len;
   if (*out_len <= 0) {
     *out_len = 0;
-    return nullptr;
+    return (char*)"";
   }
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    return nullptr;
+    return (char*)"";
   }
   memcpy(ret, left, left_len);
   memcpy(ret + left_len, right, right_len);
@@ -271,7 +272,7 @@ char* convert_fromUTF8_binary(int64 context, const char* bin_in, int32 len,
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    return nullptr;
+    return (char*)"";
   }
   memcpy(ret, bin_in, *out_len);
   return ret;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -165,9 +165,8 @@ FORCE_INLINE
 char* castVARCHAR_utf8_int64(int64 context, const char* data, int32 data_len,
                              int64_t out_len, int32_t* out_length) {
   // TODO: handle allocation failures
-  int32_t len = data_len <= static_cast<int32_t>(out_len) || out_len == 0
-                    ? data_len
-                    : static_cast<int32_t>(out_len);
+  int32_t len = data_len <= static_cast<int32_t>(out_len) ? data_len
+                                                          : static_cast<int32_t>(out_len);
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, len));
   memcpy(ret, data, len);
   *out_length = len;
@@ -195,8 +194,7 @@ const char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_l
                                     int64 offset64, int64 length, int32* out_len) {
   if (length <= 0 || input == nullptr || in_len <= 0) {
     *out_len = 0;
-    const char* empty_str = "";
-    return const_cast<char*>(empty_str);
+    return "";
   }
 
   int32 offset = static_cast<int32>(offset64);

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -195,7 +195,8 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
                               int64 offset64, int64 length, int32* out_len) {
   if (length <= 0 || input == nullptr || in_len <= 0) {
     *out_len = 0;
-    return (char*)"";
+    const char* empty_str = "";
+    return const_cast<char*>(empty_str);
   }
 
   int32 offset = static_cast<int32>(offset64);
@@ -208,7 +209,8 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
 
   if (startIndex < 0 || startIndex >= in_len) {
     *out_len = 0;
-    return (char*)"";
+    const char* empty_str = "";
+    return const_cast<char*>(empty_str);
   }
 
   *out_len = static_cast<int32>(length);
@@ -220,7 +222,8 @@ char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    return (char*)"";
+    const char* empty_str = "";
+    return const_cast<char*>(empty_str);
   }
   memcpy(ret, input + startIndex, *out_len);
   return ret;
@@ -251,13 +254,15 @@ char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
   *out_len = left_len + right_len;
   if (*out_len <= 0) {
     *out_len = 0;
-    return (char*)"";
+    const char* empty_str = "";
+    return const_cast<char*>(empty_str);
   }
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    return (char*)"";
+    const char* empty_str = "";
+    return const_cast<char*>(empty_str);
   }
   memcpy(ret, left, left_len);
   memcpy(ret + left_len, right, right_len);
@@ -272,7 +277,8 @@ char* convert_fromUTF8_binary(int64 context, const char* bin_in, int32 len,
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
-    return (char*)"";
+    const char* empty_str = "";
+    return const_cast<char*>(empty_str);
   }
   memcpy(ret, bin_in, *out_len);
   return ret;

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -234,14 +234,13 @@ char* substr_utf8_int64(int64 context, const char* input, int32 in_len, int64 of
 FORCE_INLINE
 char* concat_utf8_utf8(int64 context, const char* left, int32 left_len,
                        bool left_validity, const char* right, int32 right_len,
-                       bool right_validity, bool* out_valid, int32* out_len) {
+                       bool right_validity, int32* out_len) {
   if (!left_validity) {
     left_len = 0;
   }
   if (!right_validity) {
     right_len = 0;
   }
-  *out_valid = true;
   return concatOperator_utf8_utf8(context, left, left_len, right, right_len, out_len);
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -232,17 +232,33 @@ char* substr_utf8_int64(int64 context, const char* input, int32 in_len, int64 of
 }
 
 FORCE_INLINE
+char* concat_utf8_utf8(int64 context, const char* left, int32 left_len, const char* right,
+                       int32 right_len, int32* out_len) {
+  return concatOperator_utf8_utf8(context, left, left_len, right, right_len, out_len);
+}
+
+FORCE_INLINE
 char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
                                const char* right, int32 right_len, int32* out_len) {
   *out_len = left_len + right_len;
+  if (*out_len <= 0) {
+    *out_len = 0;
+    return nullptr;
+  }
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
     *out_len = 0;
     return nullptr;
   }
-  memcpy(ret, left, left_len);
-  memcpy(ret + left_len, right, right_len);
+  int32 copied_left_len = 0;
+  if (left != nullptr) {
+    memcpy(ret, left, left_len);
+    copied_left_len = left_len;
+  }
+  if (right != nullptr) {
+    memcpy(ret + copied_left_len, right, right_len);
+  }
   return ret;
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -79,7 +79,7 @@ TEST(TestStringOps, TestSubstring) {
   uint64_t ctx_ptr = reinterpret_cast<int64>(&ctx);
   int32 out_len = 0;
 
-  char* out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, 1, 0, &out_len);
+  const char* out_str = substr_utf8_int64_int64(ctx_ptr, "asdf", 4, 1, 0, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_FALSE(ctx.has_error());
 
@@ -125,7 +125,7 @@ TEST(TestStringOps, TestConcat) {
   uint64_t ctx_ptr = reinterpret_cast<int64>(&ctx);
   int32 out_len = 0;
 
-  char* out_str = concatOperator_utf8_utf8(ctx_ptr, "asdf", 4, "jkl", 3, &out_len);
+  const char* out_str = concatOperator_utf8_utf8(ctx_ptr, "asdf", 4, "jkl", 3, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "asdfjkl");
   EXPECT_FALSE(ctx.has_error());
 

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -168,12 +168,12 @@ timestamp castTIMESTAMP_date64(date64);
 
 int64 truncate_int64_int32(int64 in, int32 out_scale);
 
-char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
-                              int64 offset64, int64 length, int32* out_len);
-char* substr_utf8_int64(int64 context, const char* input, int32 in_len, int64 offset64,
-                        int32* out_len);
-char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
-                               const char* right, int32 right_len, int32* out_len);
+const char* substr_utf8_int64_int64(int64 context, const char* input, int32 in_len,
+                                    int64 offset64, int64 length, int32* out_len);
+const char* substr_utf8_int64(int64 context, const char* input, int32 in_len,
+                              int64 offset64, int32* out_len);
+const char* concatOperator_utf8_utf8(int64 context, const char* left, int32 left_len,
+                                     const char* right, int32 right_len, int32* out_len);
 }  // extern "C"
 
 #endif  // PRECOMPILED_TYPES_H


### PR DESCRIPTION
- remove concat alias for concatOperator
- add concat(utf8, utf8) function. The difference between concat and concatOperator is in null input handling. concatOperator returns null if one of the inputs is null; concat treats null input as empty string