### PR TITLE
ARROW-6112: [Java] Support int64 buffer  lengths in Java

### DIFF
--- a/cpp/src/gandiva/jni/jni_common.cc
+++ b/cpp/src/gandiva/jni/jni_common.cc
@@ -694,8 +694,8 @@ Status JavaResizableBuffer::Resize(const int64_t new_size, bool shrink_to_fit) {
   }
 
   // callback into java to expand the buffer
-  jobject ret = env_->CallObjectMethod(jexpander_, vector_expander_method_, vector_idx_,
-                                       new_size);
+  jobject ret =
+      env_->CallObjectMethod(jexpander_, vector_expander_method_, vector_idx_, new_size);
   if (env_->ExceptionCheck()) {
     env_->ExceptionDescribe();
     env_->ExceptionClear();

--- a/cpp/src/gandiva/jni/jni_common.cc
+++ b/cpp/src/gandiva/jni/jni_common.cc
@@ -106,7 +106,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
   vector_expander_method_ = env->GetMethodID(
       vector_expander_class_, "expandOutputVectorAtIndex",
-      "(II)Lorg/apache/arrow/gandiva/evaluator/VectorExpander$ExpandResult;");
+      "(IJ)Lorg/apache/arrow/gandiva/evaluator/VectorExpander$ExpandResult;");
 
   jclass local_expander_ret_class =
       env->FindClass("org/apache/arrow/gandiva/evaluator/VectorExpander$ExpandResult");
@@ -116,7 +116,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   vector_expander_ret_address_ =
       env->GetFieldID(vector_expander_ret_class_, "address", "J");
   vector_expander_ret_capacity_ =
-      env->GetFieldID(vector_expander_ret_class_, "capacity", "I");
+      env->GetFieldID(vector_expander_ret_class_, "capacity", "J");
   return JNI_VERSION;
 }
 
@@ -693,14 +693,9 @@ Status JavaResizableBuffer::Resize(const int64_t new_size, bool shrink_to_fit) {
     return Status::OK();
   }
 
-  if (new_size > INT32_MAX) {
-    return Status::OutOfMemory("java supports buffer sizes upto 2GB only");
-  }
-
   // callback into java to expand the buffer
-  int32_t updated_capacity = static_cast<int32_t>(new_size);
   jobject ret = env_->CallObjectMethod(jexpander_, vector_expander_method_, vector_idx_,
-                                       updated_capacity);
+                                       new_size);
   if (env_->ExceptionCheck()) {
     env_->ExceptionDescribe();
     env_->ExceptionClear();
@@ -708,8 +703,8 @@ Status JavaResizableBuffer::Resize(const int64_t new_size, bool shrink_to_fit) {
   }
 
   jlong ret_address = env_->GetLongField(ret, vector_expander_ret_address_);
-  jint ret_capacity = env_->GetIntField(ret, vector_expander_ret_capacity_);
-  DCHECK_GE(ret_capacity, updated_capacity);
+  jlong ret_capacity = env_->GetLongField(ret, vector_expander_ret_capacity_);
+  DCHECK_GE(ret_capacity, new_size);
 
   data_ = mutable_data_ = reinterpret_cast<uint8_t*>(ret_address);
   size_ = new_size;

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcReferenceManager.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcReferenceManager.java
@@ -86,7 +86,7 @@ public class OrcReferenceManager implements ReferenceManager {
   }
 
   @Override
-  public ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, int index, int length) {
+  public ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, long index, long length) {
     final long derivedBufferAddress = sourceBuffer.memoryAddress() + index;
 
     // create new ArrowBuf
@@ -111,12 +111,12 @@ public class OrcReferenceManager implements ReferenceManager {
   }
 
   @Override
-  public int getSize() {
-    return (int)memory.getSize();
+  public long getSize() {
+    return memory.getSize();
   }
 
   @Override
-  public int getAccountedSize() {
+  public long getAccountedSize() {
     return 0;
   }
 }

--- a/java/flight/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.flight;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -309,7 +311,7 @@ class ArrowMessage implements AutoCloseable {
         size += b.readableBytes();
         // [ARROW-4213] These buffers must be aligned to an 8-byte boundary in order to be readable from C++.
         if (b.readableBytes() % 8 != 0) {
-          int paddingBytes = 8 - (b.readableBytes() % 8);
+          int paddingBytes = checkedCastToInt(8 - (b.readableBytes() % 8));
           assert paddingBytes > 0 && paddingBytes < 8;
           size += paddingBytes;
           allBufs.add(PADDING_BUFFERS.get(paddingBytes).retain());

--- a/java/flight/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.flight;
 
-import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -311,7 +309,7 @@ class ArrowMessage implements AutoCloseable {
         size += b.readableBytes();
         // [ARROW-4213] These buffers must be aligned to an 8-byte boundary in order to be readable from C++.
         if (b.readableBytes() % 8 != 0) {
-          int paddingBytes = checkedCastToInt(8 - (b.readableBytes() % 8));
+          int paddingBytes = (int)(8 - (b.readableBytes() % 8));
           assert paddingBytes > 0 && paddingBytes < 8;
           size += paddingBytes;
           allBufs.add(PADDING_BUFFERS.get(paddingBytes).retain());

--- a/java/flight/src/main/java/org/apache/arrow/flight/example/integration/IntegrationTestClient.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/example/integration/IntegrationTestClient.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.flight.example.integration;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -112,7 +114,7 @@ class IntegrationTestClient {
 
             @Override
             public void onNext(PutResult val) {
-              final byte[] metadataRaw = new byte[val.getApplicationMetadata().readableBytes()];
+              final byte[] metadataRaw = new byte[checkedCastToInt(val.getApplicationMetadata().readableBytes())];
               val.getApplicationMetadata().readBytes(metadataRaw);
               final String metadata = new String(metadataRaw, StandardCharsets.UTF_8);
               if (!Integer.toString(counter).equals(metadata)) {

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVector.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.gandiva.evaluator;
 
-import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 
 import org.apache.arrow.gandiva.ipc.GandivaTypes.SelectionVectorType;
 
@@ -44,7 +44,7 @@ public abstract class SelectionVector {
    * The maximum number of records that the selection vector can hold.
    */
   public final int getMaxRecords() {
-    return checkedCastToInt(buffer.capacity() / getRecordSize());
+    return capAtMaxInt(buffer.capacity() / getRecordSize());
   }
 
   /*

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVector.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.gandiva.evaluator;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import org.apache.arrow.gandiva.ipc.GandivaTypes.SelectionVectorType;
 
 import io.netty.buffer.ArrowBuf;
@@ -42,7 +44,7 @@ public abstract class SelectionVector {
    * The maximum number of records that the selection vector can hold.
    */
   public final int getMaxRecords() {
-    return buffer.capacity() / getRecordSize();
+    return checkedCastToInt(buffer.capacity() / getRecordSize());
   }
 
   /*

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/VectorExpander.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/VectorExpander.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.gandiva.evaluator;
 
-import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
-
 import org.apache.arrow.vector.BaseVariableWidthVector;
 
 /**
@@ -60,7 +58,7 @@ public class VectorExpander {
     }
 
     BaseVariableWidthVector vector = vectors[index];
-    while (vector.getDataBuffer().capacity() < checkedCastToInt(toCapacity)) {
+    while (vector.getDataBuffer().capacity() < toCapacity) {
       vector.reallocDataBuffer();
     }
     return new ExpandResult(

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/VectorExpander.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/VectorExpander.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.gandiva.evaluator;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import org.apache.arrow.vector.BaseVariableWidthVector;
 
 /**
@@ -35,9 +37,9 @@ public class VectorExpander {
    */
   public static class ExpandResult {
     public long address;
-    public int capacity;
+    public long capacity;
 
-    public ExpandResult(long address, int capacity) {
+    public ExpandResult(long address, long capacity) {
       this.address = address;
       this.capacity = capacity;
     }
@@ -52,13 +54,13 @@ public class VectorExpander {
    *
    * @return address and size  of the buffer after expansion.
    */
-  public ExpandResult expandOutputVectorAtIndex(int index, int toCapacity) {
+  public ExpandResult expandOutputVectorAtIndex(int index, long toCapacity) {
     if (index >= vectors.length || vectors[index] == null) {
       throw new IllegalArgumentException("invalid index " + index);
     }
 
     BaseVariableWidthVector vector = vectors[index];
-    while (vector.getDataBuffer().capacity() < toCapacity) {
+    while (vector.getDataBuffer().capacity() < checkedCastToInt(toCapacity)) {
       vector.reallocDataBuffer();
     }
     return new ExpandResult(

--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -33,6 +33,7 @@ import org.apache.arrow.memory.BufferLedger;
 import org.apache.arrow.memory.BufferManager;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.memory.util.HistoricalLog;
+import org.apache.arrow.memory.util.LargeMemoryUtil;
 import org.apache.arrow.util.Preconditions;
 
 import io.netty.util.internal.PlatformDependent;
@@ -74,11 +75,11 @@ public final class ArrowBuf implements AutoCloseable {
   private final BufferManager bufferManager;
   private final long addr;
   private final boolean isEmpty;
-  private int readerIndex;
-  private int writerIndex;
+  private long readerIndex;
+  private long writerIndex;
   private final HistoricalLog historicalLog = BaseAllocator.DEBUG ?
           new HistoricalLog(BaseAllocator.DEBUG_LOG_LENGTH, "ArrowBuf[%d]", id) : null;
-  private volatile int length;
+  private volatile long length;
 
   /**
    * Constructs a new ArrowBuf
@@ -89,7 +90,7 @@ public final class ArrowBuf implements AutoCloseable {
   public ArrowBuf(
       final ReferenceManager referenceManager,
       final BufferManager bufferManager,
-      final int length,
+      final long length,
       final long memoryAddress,
       boolean isEmpty) {
     this.referenceManager = referenceManager;
@@ -118,7 +119,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param start The starting position of the bytes to be read.
    * @param end   The exclusive endpoint of the bytes to be read.
    */
-  public void checkBytes(int start, int end) {
+  public void checkBytes(long start, long end) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       checkIndexD(start, end - start);
     }
@@ -143,9 +144,9 @@ public final class ArrowBuf implements AutoCloseable {
     final NettyArrowBuf nettyArrowBuf = new NettyArrowBuf(
             this,
             isEmpty ? null : referenceManager.getAllocator().getAsByteBufAllocator(),
-            length);
-    nettyArrowBuf.readerIndex(readerIndex);
-    nettyArrowBuf.writerIndex(writerIndex);
+            LargeMemoryUtil.checkedCastToInt(length));
+    nettyArrowBuf.readerIndex(LargeMemoryUtil.checkedCastToInt(readerIndex));
+    nettyArrowBuf.writerIndex(LargeMemoryUtil.checkedCastToInt(writerIndex));
     return nettyArrowBuf;
   }
 
@@ -161,7 +162,7 @@ public final class ArrowBuf implements AutoCloseable {
     return isEmpty;
   }
 
-  public int capacity() {
+  public long capacity() {
     return length;
   }
 
@@ -170,7 +171,7 @@ public final class ArrowBuf implements AutoCloseable {
    *
    * @param newCapacity Must be in in the range [0, length).
    */
-  public synchronized ArrowBuf capacity(int newCapacity) {
+  public synchronized ArrowBuf capacity(long newCapacity) {
 
     if (newCapacity == length) {
       return this;
@@ -196,7 +197,7 @@ public final class ArrowBuf implements AutoCloseable {
   /**
    * Returns the number of bytes still available to read in this buffer.
    */
-  public int readableBytes() {
+  public long readableBytes() {
     Preconditions.checkState(writerIndex >= readerIndex,
             "Writer index cannot be less than reader index");
     return writerIndex - readerIndex;
@@ -205,7 +206,7 @@ public final class ArrowBuf implements AutoCloseable {
   /**
    * Returns the number of bytes still available to write into this buffer before capacity is reached.
    */
-  public int writableBytes() {
+  public long writableBytes() {
     return capacity() - writerIndex;
   }
 
@@ -219,7 +220,7 @@ public final class ArrowBuf implements AutoCloseable {
   /**
    *  Returns a slice (view) starting at <code>index</code> with the given <code>length</code>.
    */
-  public ArrowBuf slice(int index, int length) {
+  public ArrowBuf slice(long index, long length) {
     if (isEmpty) {
       return this;
     }
@@ -294,7 +295,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param index the index at which we the user wants to read/write
    * @return the absolute address within the memory
    */
-  private long addr(int index) {
+  private long addr(long index) {
     return addr + index;
   }
 
@@ -317,13 +318,13 @@ public final class ArrowBuf implements AutoCloseable {
    * @param index index (0 based relative to this ArrowBuf)
    * @param length provided length of data for get/set
    */
-  private void chk(int index, int length) {
+  private void chk(long index, long length) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       checkIndexD(index, length);
     }
   }
 
-  private void checkIndexD(int index, int fieldLength) {
+  private void checkIndexD(long index, long fieldLength) {
     // check reference count
     ensureAccessible();
     // check bounds
@@ -344,7 +345,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return 8 byte long value
    */
-  public long getLong(int index) {
+  public long getLong(long index) {
     chk(index, LONG_SIZE);
     return PlatformDependent.getLong(addr(index));
   }
@@ -356,7 +357,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setLong(int index, long value) {
+  public void setLong(long index, long value) {
     chk(index, LONG_SIZE);
     PlatformDependent.putLong(addr(index), value);
   }
@@ -368,7 +369,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return 4 byte float value
    */
-  public float getFloat(int index) {
+  public float getFloat(long index) {
     return Float.intBitsToFloat(getInt(index));
   }
 
@@ -379,7 +380,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setFloat(int index, float value) {
+  public void setFloat(long index, float value) {
     chk(index, FLOAT_SIZE);
     PlatformDependent.putInt(addr(index), Float.floatToRawIntBits(value));
   }
@@ -391,7 +392,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return 8 byte double value
    */
-  public double getDouble(int index) {
+  public double getDouble(long index) {
     return Double.longBitsToDouble(getLong(index));
   }
 
@@ -402,7 +403,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setDouble(int index, double value) {
+  public void setDouble(long index, double value) {
     chk(index, DOUBLE_SIZE);
     PlatformDependent.putLong(addr(index), Double.doubleToRawLongBits(value));
   }
@@ -414,7 +415,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return 2 byte char value
    */
-  public char getChar(int index) {
+  public char getChar(long index) {
     return (char) getShort(index);
   }
 
@@ -425,7 +426,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setChar(int index, int value) {
+  public void setChar(long index, int value) {
     chk(index, SHORT_SIZE);
     PlatformDependent.putShort(addr(index), (short) value);
   }
@@ -437,7 +438,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return 4 byte int value
    */
-  public int getInt(int index) {
+  public int getInt(long index) {
     chk(index, INT_SIZE);
     return PlatformDependent.getInt(addr(index));
   }
@@ -449,7 +450,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setInt(int index, int value) {
+  public void setInt(long index, int value) {
     chk(index, INT_SIZE);
     PlatformDependent.putInt(addr(index), value);
   }
@@ -461,7 +462,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return 2 byte short value
    */
-  public short getShort(int index) {
+  public short getShort(long index) {
     chk(index, SHORT_SIZE);
     return PlatformDependent.getShort(addr(index));
   }
@@ -473,7 +474,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setShort(int index, int value) {
+  public void setShort(long index, int value) {
     setShort(index, (short)value);
   }
 
@@ -484,7 +485,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setShort(int index, short value) {
+  public void setShort(long index, short value) {
     chk(index, SHORT_SIZE);
     PlatformDependent.putShort(addr(index), value);
   }
@@ -496,7 +497,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setByte(int index, int value) {
+  public void setByte(long index, int value) {
     chk(index, 1);
     PlatformDependent.putByte(addr(index), (byte) value);
   }
@@ -508,7 +509,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be written
    * @param value value to write
    */
-  public void setByte(int index, byte value) {
+  public void setByte(long index, byte value) {
     chk(index, 1);
     PlatformDependent.putByte(addr(index), value);
   }
@@ -520,7 +521,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              where the value will be read from
    * @return byte value
    */
-  public byte getByte(int index) {
+  public byte getByte(long index) {
     chk(index, 1);
     return PlatformDependent.getByte(addr(index));
   }
@@ -591,7 +592,7 @@ public final class ArrowBuf implements AutoCloseable {
   public void readBytes(byte[] dst) {
     Preconditions.checkArgument(dst != null, "expecting valid dst bytearray");
     ensureReadable(dst.length);
-    getBytes(readerIndex, dst, 0, dst.length);
+    getBytes(LargeMemoryUtil.checkedCastToInt(readerIndex), dst, 0, LargeMemoryUtil.checkedCastToInt(dst.length));
   }
 
   /**
@@ -704,11 +705,11 @@ public final class ArrowBuf implements AutoCloseable {
    * @return {@code true} if the requested {@code index} and {@code length} will fit within {@code capacity}.
    * {@code false} if this would result in an index out of bounds exception.
    */
-  private static boolean isOutOfBounds(int index, int length, int capacity) {
+  private static boolean isOutOfBounds(long index, long length, long capacity) {
     return (index | length | (index + length) | (capacity - (index + length))) < 0;
   }
 
-  private void checkIndex(int index, int fieldLength) {
+  private void checkIndex(long index, long fieldLength) {
     // check reference count
     this.ensureAccessible();
     // check bounds
@@ -725,7 +726,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              this ArrowBuf has access to
    * @param dst byte array to copy the data into
    */
-  public void getBytes(int index, byte[] dst) {
+  public void getBytes(long index, byte[] dst) {
     getBytes(index, dst, 0, dst.length);
   }
 
@@ -737,7 +738,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param dstIndex starting index in dst byte array to copy into
    * @param length length of data to copy from this ArrowBuf
    */
-  public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+  public void getBytes(long index, byte[] dst, int dstIndex, int length) {
     // bound check for this ArrowBuf where the data will be copied from
     checkIndex(index, length);
     // null check
@@ -761,7 +762,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              this ArrowBuf has access to
    * @param src byte array to copy the data from
    */
-  public void setBytes(int index, byte[] src) {
+  public void setBytes(long index, byte[] src) {
     setBytes(index, src, 0, src.length);
   }
 
@@ -774,7 +775,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param srcIndex index in the byte array where the copy will start from
    * @param length length of data to copy from byte array
    */
-  public void setBytes(int index, byte[] src, int srcIndex, int length) {
+  public void setBytes(long index, byte[] src, int srcIndex, long length) {
     // bound check for this ArrowBuf where the data will be copied into
     checkIndex(index, length);
     // null check
@@ -787,7 +788,7 @@ public final class ArrowBuf implements AutoCloseable {
     if (length > 0) {
       // copy "length" bytes from src byte array at the starting index (srcIndex)
       // into this ArrowBuf starting at address "addr(index)"
-      PlatformDependent.copyMemory(src, srcIndex, addr(index), (long)length);
+      PlatformDependent.copyMemory(src, srcIndex, addr(index), length);
     }
   }
 
@@ -798,7 +799,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              has access to)
    * @param dst dst ByteBuffer where the data will be copied into
    */
-  public void getBytes(int index, ByteBuffer dst) {
+  public void getBytes(long index, ByteBuffer dst) {
     // bound check for this ArrowBuf where the data will be copied from
     checkIndex(index, dst.remaining());
     // dst.remaining() bytes of data will be copied into dst ByteBuffer
@@ -837,7 +838,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              this ArrowBuf has access to)
    * @param src src ByteBuffer where the data will be copied from
    */
-  public void setBytes(int index, ByteBuffer src) {
+  public void setBytes(long index, ByteBuffer src) {
     // bound check for this ArrowBuf where the data will be copied into
     checkIndex(index, src.remaining());
     // length of data to copy
@@ -861,6 +862,13 @@ public final class ArrowBuf implements AutoCloseable {
         src.position(src.position() + length);
       } else {
         // copy word at a time
+        while (length - 128 >= LONG_SIZE) {
+          for (int x = 0; x < 16; x++) {
+            PlatformDependent.putLong(dstAddress, src.getLong());
+            length -= LONG_SIZE;
+            dstAddress += LONG_SIZE;
+          }
+        }
         while (length >= LONG_SIZE) {
           PlatformDependent.putLong(dstAddress, src.getLong());
           length -= LONG_SIZE;
@@ -887,7 +895,7 @@ public final class ArrowBuf implements AutoCloseable {
    *                 will start from
    * @param length length of data to copy from src ByteBuffer
    */
-  public void setBytes(int index, ByteBuffer src, int srcIndex, int length) {
+  public void setBytes(long index, ByteBuffer src, int srcIndex, int length) {
     // bound check for this ArrowBuf where the data will be copied into
     checkIndex(index, length);
     if (src.isDirect()) {
@@ -919,7 +927,7 @@ public final class ArrowBuf implements AutoCloseable {
    *              dst ArrowBuf has access to)
    * @param length length of data to copy
    */
-  public void getBytes(int index, ArrowBuf dst, int dstIndex, int length) {
+  public void getBytes(long index, ArrowBuf dst, int dstIndex, int length) {
     // bound check for this ArrowBuf where the data will be copied from
     checkIndex(index, length);
     // bound check for this ArrowBuf where the data will be copied into
@@ -949,7 +957,7 @@ public final class ArrowBuf implements AutoCloseable {
    *                 will begin from
    * @param length length of data to copy from src ArrowBuf
    */
-  public void setBytes(int index, ArrowBuf src, int srcIndex, int length) {
+  public void setBytes(long index, ArrowBuf src, long srcIndex, long length) {
     // bound check for this ArrowBuf where the data will be copied into
     checkIndex(index, length);
     // null check
@@ -963,9 +971,9 @@ public final class ArrowBuf implements AutoCloseable {
       // copy length bytes of data from src ArrowBuf starting at
       // address srcAddress into this ArrowBuf starting at address
       // dstAddress
-      final long srcAddress = src.memoryAddress() + (long)srcIndex;
+      final long srcAddress = src.memoryAddress() + srcIndex;
       final long dstAddress = addr(index);
-      PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+      PlatformDependent.copyMemory(srcAddress, dstAddress, length);
     }
   }
 
@@ -977,15 +985,15 @@ public final class ArrowBuf implements AutoCloseable {
    *              this ArrowBuf has access to)
    * @param src src ArrowBuf where the data will be copied from
    */
-  public void setBytes(int index, ArrowBuf src) {
+  public void setBytes(long index, ArrowBuf src) {
     // null check
     Preconditions.checkArgument(src != null, "expecting valid ArrowBuf");
-    final int length = src.readableBytes();
+    final long length = src.readableBytes();
     // bound check for this ArrowBuf where the data will be copied into
     checkIndex(index, length);
-    final long srcAddress = src.memoryAddress() + (long)src.readerIndex;
+    final long srcAddress = src.memoryAddress() + src.readerIndex;
     final long dstAddress = addr(index);
-    PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+    PlatformDependent.copyMemory(srcAddress, dstAddress, length);
     src.readerIndex(src.readerIndex + length);
   }
 
@@ -999,7 +1007,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @return number of bytes copied from stream into ArrowBuf
    * @throws IOException on failing to read from stream
    */
-  public int setBytes(int index, InputStream in, int length) throws IOException {
+  public int setBytes(long index, InputStream in, int length) throws IOException {
     Preconditions.checkArgument(in != null, "expecting valid input stream");
     checkIndex(index, length);
     int readBytes = 0;
@@ -1025,7 +1033,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param length length of data to copy
    * @throws IOException on failing to write to stream
    */
-  public void getBytes(int index, OutputStream out, int length) throws IOException {
+  public void getBytes(long index, OutputStream out, int length) throws IOException {
     Preconditions.checkArgument(out != null, "expecting valid output stream");
     checkIndex(index, length);
     if (length > 0) {
@@ -1048,7 +1056,7 @@ public final class ArrowBuf implements AutoCloseable {
    * (not shared, connected to larger underlying buffer of allocated memory)
    * @return Size in bytes.
    */
-  public int getPossibleMemoryConsumed() {
+  public long getPossibleMemoryConsumed() {
     return isEmpty ? 0 : referenceManager.getSize();
   }
 
@@ -1057,7 +1065,7 @@ public final class ArrowBuf implements AutoCloseable {
    * context of the associated allocator).
    * @return Size in bytes.
    */
-  public int getActualMemoryConsumed() {
+  public long getActualMemoryConsumed() {
     return isEmpty ? 0 : referenceManager.getAccountedSize();
   }
 
@@ -1068,12 +1076,12 @@ public final class ArrowBuf implements AutoCloseable {
    * @param length how many bytes to log
    * @return A hex dump in a String.
    */
-  public String toHexString(final int start, final int length) {
-    final int roundedStart = (start / LOG_BYTES_PER_ROW) * LOG_BYTES_PER_ROW;
+  public String toHexString(final long start, final int length) {
+    final long roundedStart = (start / LOG_BYTES_PER_ROW) * LOG_BYTES_PER_ROW;
 
     final StringBuilder sb = new StringBuilder("buffer byte dump\n");
-    int index = roundedStart;
-    for (int nLogged = 0; nLogged < length; nLogged += LOG_BYTES_PER_ROW) {
+    long index = roundedStart;
+    for (long nLogged = 0; nLogged < length; nLogged += LOG_BYTES_PER_ROW) {
       sb.append(String.format(" [%05d-%05d]", index, index + LOG_BYTES_PER_ROW - 1));
       for (int i = 0; i < LOG_BYTES_PER_ROW; ++i) {
         try {
@@ -1117,7 +1125,7 @@ public final class ArrowBuf implements AutoCloseable {
    * Get the index at which the next byte will be read from.
    * @return reader index
    */
-  public int readerIndex() {
+  public long readerIndex() {
     return readerIndex;
   }
 
@@ -1125,7 +1133,7 @@ public final class ArrowBuf implements AutoCloseable {
    * Get the index at which next byte will be written to.
    * @return writer index
    */
-  public int writerIndex() {
+  public long writerIndex() {
     return writerIndex;
   }
 
@@ -1134,7 +1142,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param readerIndex new reader index
    * @return this ArrowBuf
    */
-  public ArrowBuf readerIndex(int readerIndex) {
+  public ArrowBuf readerIndex(long readerIndex) {
     this.readerIndex = readerIndex;
     return this;
   }
@@ -1144,7 +1152,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param writerIndex new writer index
    * @return this ArrowBuf
    */
-  public ArrowBuf writerIndex(int writerIndex) {
+  public ArrowBuf writerIndex(long writerIndex) {
     this.writerIndex = writerIndex;
     return this;
   }
@@ -1157,7 +1165,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param length length of bytes to zero-out
    * @return this ArrowBuf
    */
-  public ArrowBuf setZero(int index, int length) {
+  public ArrowBuf setZero(long index, long length) {
     if (length != 0) {
       this.checkIndex(index, length);
       PlatformDependent.setMemory(this.addr + index, length, (byte) 0);
@@ -1182,9 +1190,9 @@ public final class ArrowBuf implements AutoCloseable {
 
   /**
    * Returns <code>this</code> if size is less then {@link #capacity()}, otherwise
-   * delegates to {@link BufferManager#replace(ArrowBuf, int)} to get a new buffer.
+   * delegates to {@link BufferManager#replace(ArrowBuf, long)} to get a new buffer.
    */
-  public ArrowBuf reallocIfNeeded(final int size) {
+  public ArrowBuf reallocIfNeeded(final long size) {
     Preconditions.checkArgument(size >= 0, "reallocation size must be non-negative");
     if (this.capacity() >= size) {
       return this;

--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -242,7 +242,7 @@ public final class ArrowBuf implements AutoCloseable {
     return isEmpty ? ByteBuffer.allocateDirect(0) : asNettyBuffer().nioBuffer();
   }
 
-  public ByteBuffer nioBuffer(int index, int length) {
+  public ByteBuffer nioBuffer(long index, int length) {
     return isEmpty ? ByteBuffer.allocateDirect(0) : asNettyBuffer().nioBuffer(index, length);
   }
 
@@ -901,9 +901,9 @@ public final class ArrowBuf implements AutoCloseable {
     if (src.isDirect()) {
       // copy length bytes of data from src ByteBuffer starting at address
       // srcAddress into this ArrowBuf at address dstAddress
-      final long srcAddress = PlatformDependent.directBufferAddress(src) + (long)srcIndex;
+      final long srcAddress = PlatformDependent.directBufferAddress(src) + srcIndex;
       final long dstAddress = addr(index);
-      PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+      PlatformDependent.copyMemory(srcAddress, dstAddress, length);
     } else {
       if (srcIndex == 0 && src.capacity() == length) {
         // copy the entire ByteBuffer from start to end of length

--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -17,6 +17,8 @@
 
 package io.netty.buffer;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -33,7 +35,6 @@ import org.apache.arrow.memory.BufferLedger;
 import org.apache.arrow.memory.BufferManager;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.memory.util.HistoricalLog;
-import org.apache.arrow.memory.util.LargeMemoryUtil;
 import org.apache.arrow.util.Preconditions;
 
 import io.netty.util.internal.PlatformDependent;
@@ -144,9 +145,9 @@ public final class ArrowBuf implements AutoCloseable {
     final NettyArrowBuf nettyArrowBuf = new NettyArrowBuf(
             this,
             isEmpty ? null : referenceManager.getAllocator().getAsByteBufAllocator(),
-            LargeMemoryUtil.checkedCastToInt(length));
-    nettyArrowBuf.readerIndex(LargeMemoryUtil.checkedCastToInt(readerIndex));
-    nettyArrowBuf.writerIndex(LargeMemoryUtil.checkedCastToInt(writerIndex));
+            checkedCastToInt(length));
+    nettyArrowBuf.readerIndex(checkedCastToInt(readerIndex));
+    nettyArrowBuf.writerIndex(checkedCastToInt(writerIndex));
     return nettyArrowBuf;
   }
 
@@ -592,7 +593,7 @@ public final class ArrowBuf implements AutoCloseable {
   public void readBytes(byte[] dst) {
     Preconditions.checkArgument(dst != null, "expecting valid dst bytearray");
     ensureReadable(dst.length);
-    getBytes(LargeMemoryUtil.checkedCastToInt(readerIndex), dst, 0, LargeMemoryUtil.checkedCastToInt(dst.length));
+    getBytes(readerIndex, dst, 0, checkedCastToInt(dst.length));
   }
 
   /**

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -156,7 +156,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
 
   @Override
   public int capacity() {
-    return arrowBuf.capacity();
+    return (int) Math.min(Integer.MAX_VALUE, arrowBuf.capacity());
   }
 
   @Override

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -17,6 +17,8 @@
 
 package io.netty.buffer;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -223,12 +225,24 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return nioBuffer(readerIndex(), readableBytes());
   }
 
-  @Override
+
   /**
    * Returns a buffer that is zero positioned but points
    * to a slice of the original buffer starting at given index.
    */
+  @Override
   public ByteBuffer nioBuffer(int index, int length) {
+    chk(index, length);
+    final ByteBuffer buffer = getDirectBuffer(index);
+    buffer.limit(length);
+    return buffer;
+  }
+
+  /**
+   * Returns a buffer that is zero positioned but points
+   * to a slice of the original buffer starting at given index.
+   */
+  public ByteBuffer nioBuffer(long index, int length) {
     chk(index, length);
     final ByteBuffer buffer = getDirectBuffer(index);
     buffer.limit(length);
@@ -239,8 +253,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
    * Get this ArrowBuf as a direct {@link ByteBuffer}.
    * @return ByteBuffer
    */
-  private ByteBuffer getDirectBuffer(int index) {
-    return PlatformDependent.directBuffer(addr(index), length - index);
+  private ByteBuffer getDirectBuffer(long index) {
+    return PlatformDependent.directBuffer(addr(index), checkedCastToInt(length - index));
   }
 
   @Override
@@ -494,7 +508,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
     return this;
   }
 
-  private long addr(int index) {
+  private long addr(long index) {
     return address + index;
   }
 
@@ -504,7 +518,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
    * @param index index (0 based relative to this ArrowBuf)
    * @param fieldLength provided length of data for get/set
    */
-  private void chk(int index, int fieldLength) {
+  private void chk(long index, long fieldLength) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       // check reference count
       ensureAccessible();

--- a/java/memory/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/java/memory/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.memory.util.LargeMemoryUtil;
 
 import io.netty.util.internal.StringUtil;
 
@@ -51,9 +52,9 @@ public class PooledByteBufAllocatorL {
   /**
    * Returns a {@linkplain io.netty.buffer.UnsafeDirectLittleEndian} of the given size.
    */
-  public UnsafeDirectLittleEndian allocate(int size) {
+  public UnsafeDirectLittleEndian allocate(long size) {
     try {
-      return allocator.directBuffer(size, Integer.MAX_VALUE);
+      return allocator.directBuffer(LargeMemoryUtil.checkedCastToInt(size), Integer.MAX_VALUE);
     } catch (OutOfMemoryError e) {
       throw new OutOfMemoryException("Failure allocating buffer.", e);
     }

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -53,7 +53,7 @@ public abstract class AllocationManager {
   // see JIRA for details
   private final LowCostIdentityHashMap<BaseAllocator, BufferLedger> map = new LowCostIdentityHashMap<>();
   private final long amCreationTime = System.nanoTime();
-  private final int size;
+  private final long size;
 
   // The ReferenceManager created at the time of creation of this AllocationManager
   // is treated as the owning reference manager for the underlying chunk of memory
@@ -61,7 +61,7 @@ public abstract class AllocationManager {
   private volatile BufferLedger owningLedger;
   private volatile long amDestructionTime = 0;
 
-  protected AllocationManager(BaseAllocator accountingAllocator, int size) {
+  protected AllocationManager(BaseAllocator accountingAllocator, long size) {
     Preconditions.checkNotNull(accountingAllocator);
     accountingAllocator.assertOpen();
 
@@ -183,7 +183,7 @@ public abstract class AllocationManager {
    *
    * @return size of underlying memory chunk
    */
-  public int getSize() {
+  public long getSize() {
     return size;
   }
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -211,6 +211,6 @@ public abstract class AllocationManager {
      * @param size Size (in bytes) of memory managed by the AllocationManager
      * @return The created AllocationManager used by this allocator
      */
-    AllocationManager create(BaseAllocator accountingAllocator, int size);
+    AllocationManager create(BaseAllocator accountingAllocator, long size);
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -356,12 +356,12 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     return buffer;
   }
 
-  private AllocationManager newAllocationManager(int size) {
+  private AllocationManager newAllocationManager(long size) {
     return newAllocationManager(this, size);
   }
 
 
-  private AllocationManager newAllocationManager(BaseAllocator accountingAllocator, int size) {
+  private AllocationManager newAllocationManager(BaseAllocator accountingAllocator, long size) {
     return allocationManagerFactory.create(accountingAllocator, size);
   }
 
@@ -722,7 +722,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       sb.append("UnsafeDirectLittleEndian[identityHashCode == ");
       sb.append(Integer.toString(System.identityHashCode(am)));
       sb.append("] size ");
-      sb.append(Integer.toString(am.getSize()));
+      sb.append(Long.toString(am.getSize()));
       sb.append('\n');
     }
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -131,7 +131,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
   }
 
-  private static String createErrorMsg(final BufferAllocator allocator, final int rounded, final int requested) {
+  private static String createErrorMsg(final BufferAllocator allocator, final long rounded, final long requested) {
     if (rounded != requested) {
       return String.format(
         "Unable to allocate buffer of size %d (rounded from %d) due to memory limit. Current " +
@@ -274,7 +274,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   @Override
-  public ArrowBuf buffer(final int initialRequestSize) {
+  public ArrowBuf buffer(final long initialRequestSize) {
     assertOpen();
 
     return buffer(initialRequestSize, null);
@@ -285,7 +285,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   @Override
-  public ArrowBuf buffer(final int initialRequestSize, BufferManager manager) {
+  public ArrowBuf buffer(final long initialRequestSize, BufferManager manager) {
     assertOpen();
 
     Preconditions.checkArgument(initialRequestSize >= 0, "the requested size must be non-negative");
@@ -295,7 +295,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     }
 
     // round the request size according to the rounding policy
-    final int actualRequestSize = roundingPolicy.getRoundedSize(initialRequestSize);
+    final long actualRequestSize = roundingPolicy.getRoundedSize(initialRequestSize);
 
     listener.onPreAllocation(actualRequestSize);
 
@@ -341,7 +341,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
    * Skips the typical accounting associated with creating a new buffer.
    */
   private ArrowBuf bufferWithoutReservation(
-      final int size,
+      final long size,
       BufferManager bufferManager) throws OutOfMemoryException {
     assertOpen();
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -37,7 +37,7 @@ public interface BufferAllocator extends AutoCloseable {
    * @return a new ArrowBuf, or null if the request can't be satisfied
    * @throws OutOfMemoryException if buffer cannot be allocated
    */
-  ArrowBuf buffer(int size);
+  ArrowBuf buffer(long size);
 
   /**
    * Allocate a new or reused buffer of the provided size. Note that the buffer may technically
@@ -50,7 +50,7 @@ public interface BufferAllocator extends AutoCloseable {
    * @return a new ArrowBuf, or null if the request can't be satisfied
    * @throws OutOfMemoryException if buffer cannot be allocated
    */
-  ArrowBuf buffer(int size, BufferManager manager);
+  ArrowBuf buffer(long size, BufferManager manager);
 
   /**
    * Returns the allocator this allocator falls back to when it needs more memory.

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -208,7 +208,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    * @return derived buffer
    */
   @Override
-  public ArrowBuf deriveBuffer(final ArrowBuf sourceBuffer, int index, int length) {
+  public ArrowBuf deriveBuffer(final ArrowBuf sourceBuffer, long index, long length) {
     /*
      * Usage type 1 for deriveBuffer():
      * Used for slicing where index represents a relative index in the source ArrowBuf
@@ -265,7 +265,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    * @return A new ArrowBuf that shares references with all ArrowBufs associated
    *         with this BufferLedger
    */
-  ArrowBuf newArrowBuf(final int length, final BufferManager manager) {
+  ArrowBuf newArrowBuf(final long length, final BufferManager manager) {
     allocator.assertOpen();
 
     // the start virtual address of the ArrowBuf will be same as address of memory chunk
@@ -326,7 +326,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     // and this will be true for all the existing buffers currently managed by targetrefmanager
     final BufferLedger targetRefManager = allocationManager.associate((BaseAllocator)target);
     // create a new ArrowBuf to associate with new allocator and target ref manager
-    final int targetBufLength = srcBuffer.capacity();
+    final long targetBufLength = srcBuffer.capacity();
     ArrowBuf targetArrowBuf = targetRefManager.deriveBuffer(srcBuffer, 0, targetBufLength);
     targetArrowBuf.readerIndex(srcBuffer.readerIndex());
     targetArrowBuf.writerIndex(srcBuffer.writerIndex());
@@ -423,7 +423,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     // and this will be true for all the existing buffers currently managed by targetrefmanager
     final BufferLedger targetRefManager = allocationManager.associate((BaseAllocator)target);
     // create a new ArrowBuf to associate with new allocator and target ref manager
-    final int targetBufLength = srcBuffer.capacity();
+    final long targetBufLength = srcBuffer.capacity();
     final ArrowBuf targetArrowBuf = targetRefManager.deriveBuffer(srcBuffer, 0, targetBufLength);
     targetArrowBuf.readerIndex(srcBuffer.readerIndex());
     targetArrowBuf.writerIndex(srcBuffer.writerIndex());
@@ -463,7 +463,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    * @return Size (in bytes) of the memory chunk
    */
   @Override
-  public int getSize() {
+  public long getSize() {
     return allocationManager.getSize();
   }
 
@@ -474,7 +474,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    * @return Amount of accounted(owned) memory associated with this ledger.
    */
   @Override
-  public int getAccountedSize() {
+  public long getAccountedSize() {
     synchronized (allocationManager) {
       if (allocationManager.getOwningLedger() == this) {
         return allocationManager.getSize();

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferManager.java
@@ -34,7 +34,7 @@ public interface BufferManager extends AutoCloseable {
    * @param newSize Size of new replacement buffer.
    * @return A new version of the buffer.
    */
-  ArrowBuf replace(ArrowBuf old, int newSize);
+  ArrowBuf replace(ArrowBuf old, long newSize);
 
   /**
    * Get a managed buffer of indeterminate size.
@@ -49,7 +49,7 @@ public interface BufferManager extends AutoCloseable {
    * @param size The desired size
    * @return A buffer
    */
-  ArrowBuf getManagedBuffer(int size);
+  ArrowBuf getManagedBuffer(long size);
 
   void close();
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.memory;
 
+import org.apache.arrow.memory.util.LargeMemoryUtil;
+
 import io.netty.buffer.PooledByteBufAllocatorL;
 import io.netty.buffer.UnsafeDirectLittleEndian;
 
@@ -60,7 +62,7 @@ public class NettyAllocationManager extends AllocationManager {
   }
 
   @Override
-  public int getSize() {
+  public long getSize() {
     return size;
   }
 
@@ -71,8 +73,8 @@ public class NettyAllocationManager extends AllocationManager {
     private Factory() {}
 
     @Override
-    public AllocationManager create(BaseAllocator accountingAllocator, int size) {
-      return new NettyAllocationManager(accountingAllocator, size);
+    public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+      return new NettyAllocationManager(accountingAllocator, LargeMemoryUtil.checkedCastToInt(size));
     }
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ReferenceManager.java
@@ -89,7 +89,7 @@ public interface ReferenceManager {
    *               have access to in underlying memory
    * @return derived buffer
    */
-  ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, int index, int length);
+  ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, long index, long length);
 
   /**
    * Transfer the memory accounting ownership of this ArrowBuf to another allocator.
@@ -111,13 +111,13 @@ public interface ReferenceManager {
    * Total size (in bytes) of memory underlying this reference manager.
    * @return Size (in bytes) of the memory chunk.
    */
-  int getSize();
+  long getSize();
 
   /**
    * Get the total accounted size (in bytes).
    * @return accounted size.
    */
-  int getAccountedSize();
+  long getAccountedSize();
 
   String NO_OP_ERROR_MESSAGE = "Operation not supported on NO_OP Reference Manager";
 
@@ -150,7 +150,7 @@ public interface ReferenceManager {
     }
 
     @Override
-    public ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, int index, int length) {
+    public ArrowBuf deriveBuffer(ArrowBuf sourceBuffer, long index, long length) {
       return sourceBuffer;
     }
 
@@ -165,13 +165,13 @@ public interface ReferenceManager {
     }
 
     @Override
-    public int getSize() {
-      return 0;
+    public long getSize() {
+      return 0L;
     }
 
     @Override
-    public int getAccountedSize() {
-      return 0;
+    public long getAccountedSize() {
+      return 0L;
     }
 
   };

--- a/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
@@ -47,7 +47,7 @@ public class DefaultRoundingPolicy implements RoundingPolicy {
   }
 
   @Override
-  public int getRoundedSize(int requestSize) {
+  public long getRoundedSize(long requestSize) {
     return requestSize < chunkSize ?
             BaseAllocator.nextPowerOfTwo(requestSize) : requestSize;
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/rounding/RoundingPolicy.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/rounding/RoundingPolicy.java
@@ -22,5 +22,5 @@ package org.apache.arrow.memory.rounding;
  * In particular, given a requested buffer size, the policy will determine the rounded buffer size.
  */
 public interface RoundingPolicy {
-  int getRoundedSize(int requestSize);
+  long getRoundedSize(long requestSize);
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/rounding/SegmentRoundingPolicy.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/rounding/SegmentRoundingPolicy.java
@@ -50,7 +50,7 @@ public class SegmentRoundingPolicy implements RoundingPolicy {
   }
 
   @Override
-  public int getRoundedSize(int requestSize) {
+  public long getRoundedSize(long requestSize) {
     return (requestSize + (segmentSize - 1)) / segmentSize * segmentSize;
   }
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ArrowBufPointer.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ArrowBufPointer.java
@@ -36,9 +36,9 @@ public final class ArrowBufPointer {
 
   private ArrowBuf buf;
 
-  private int offset;
+  private long offset;
 
-  private int length;
+  private long length;
 
   private int hashCode = NULL_HASH_CODE;
 
@@ -71,7 +71,7 @@ public final class ArrowBufPointer {
    * @param offset the start off set of the memory region pointed to.
    * @param length the length off set of the memory region pointed to.
    */
-  public ArrowBufPointer(ArrowBuf buf, int offset, int length) {
+  public ArrowBufPointer(ArrowBuf buf, long offset, long length) {
     this(buf, offset, length, SimpleHasher.INSTANCE);
   }
 
@@ -82,7 +82,7 @@ public final class ArrowBufPointer {
    * @param length the length off set of the memory region pointed to.
    * @param hasher the hasher used to calculate the hash code.
    */
-  public ArrowBufPointer(ArrowBuf buf, int offset, int length, ArrowBufHasher hasher) {
+  public ArrowBufPointer(ArrowBuf buf, long offset, long length, ArrowBufHasher hasher) {
     Preconditions.checkNotNull(hasher);
     this.hasher = hasher;
     set(buf, offset, length);
@@ -94,7 +94,7 @@ public final class ArrowBufPointer {
    * @param offset the start off set of the memory region pointed to.
    * @param length the length off set of the memory region pointed to.
    */
-  public void set(ArrowBuf buf, int offset, int length) {
+  public void set(ArrowBuf buf, long offset, long length) {
     this.buf = buf;
     this.offset = offset;
     this.length = length;
@@ -110,11 +110,11 @@ public final class ArrowBufPointer {
     return buf;
   }
 
-  public int getOffset() {
+  public long getOffset() {
     return offset;
   }
 
-  public int getLength() {
+  public long getLength() {
     return length;
   }
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -59,6 +59,19 @@ public class ByteFunctionHelpers {
       long lPos = laddr + lStart;
       long rPos = raddr + rStart;
 
+      while (n > 63) {
+        for (int x = 0; x < 8; x++) {
+          long leftLong = PlatformDependent.getLong(lPos);
+          long rightLong = PlatformDependent.getLong(rPos);
+          if (leftLong != rightLong) {
+            return 0;
+          }
+          lPos += 8;
+          rPos += 8;
+        }
+        n -= 64;
+      }
+
       while (n > 7) {
         long leftLong = PlatformDependent.getLong(lPos);
         long rightLong = PlatformDependent.getLong(rPos);
@@ -135,6 +148,19 @@ public class ByteFunctionHelpers {
     long n = Math.min(rLen, lLen);
     long lPos = laddr + lStart;
     long rPos = raddr + rStart;
+
+    while (n > 63) {
+      for (int x = 0; x < 8; x++) {
+        long leftLong = PlatformDependent.getLong(lPos);
+        long rightLong = PlatformDependent.getLong(rPos);
+        if (leftLong != rightLong) {
+          return unsignedLongCompare(Long.reverseBytes(leftLong), Long.reverseBytes(rightLong));
+        }
+        lPos += 8;
+        rPos += 8;
+      }
+      n -= 64;
+    }
 
     while (n > 7) {
       long leftLong = PlatformDependent.getLong(lPos);

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -111,11 +111,11 @@ public class ByteFunctionHelpers {
    */
   public static int compare(
       final ArrowBuf left,
-      int lStart,
-      int lEnd,
+      long lStart,
+      long lEnd,
       final ArrowBuf right,
-      int rStart,
-      int rEnd) {
+      long rStart,
+      long rEnd) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       left.checkBytes(lStart, lEnd);
       right.checkBytes(rStart, rEnd);
@@ -125,14 +125,14 @@ public class ByteFunctionHelpers {
 
   private static int memcmp(
       final long laddr,
-      int lStart,
-      int lEnd,
+      long lStart,
+      long lEnd,
       final long raddr,
-      int rStart,
-      final int rEnd) {
-    int lLen = lEnd - lStart;
-    int rLen = rEnd - rStart;
-    int n = Math.min(rLen, lLen);
+      long rStart,
+      final long rEnd) {
+    long lLen = lEnd - lStart;
+    long rLen = rEnd - rStart;
+    long n = Math.min(rLen, lLen);
     long lPos = laddr + lStart;
     long rPos = raddr + rStart;
 
@@ -281,7 +281,7 @@ public class ByteFunctionHelpers {
   /**
    * Compute hashCode with the given {@link ArrowBufHasher}, {@link ArrowBuf} and start/end index.
    */
-  public static final int hash(ArrowBufHasher hasher, final ArrowBuf buf, int start, int end) {
+  public static final int hash(ArrowBufHasher hasher, final ArrowBuf buf, long start, long end) {
 
     if (hasher == null) {
       hasher = SimpleHasher.INSTANCE;

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -43,7 +43,7 @@ public class ByteFunctionHelpers {
    * @param rEnd   end offset in the buffer
    * @return 1 if equals, 0 otherwise
    */
-  public static final int equal(final ArrowBuf left, int lStart, int lEnd, final ArrowBuf right, int rStart, int rEnd) {
+  public static int equal(final ArrowBuf left, long lStart, long lEnd, final ArrowBuf right, long rStart, long rEnd) {
     if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
       left.checkBytes(lStart, lEnd);
       right.checkBytes(rStart, rEnd);
@@ -51,10 +51,10 @@ public class ByteFunctionHelpers {
     return memEqual(left.memoryAddress(), lStart, lEnd, right.memoryAddress(), rStart, rEnd);
   }
 
-  private static int memEqual(final long laddr, int lStart, int lEnd, final long raddr, int rStart,
-                                    final int rEnd) {
+  private static int memEqual(final long laddr, long lStart, long lEnd, final long raddr, long rStart,
+                                    final long rEnd) {
 
-    int n = lEnd - lStart;
+    long n = lEnd - lStart;
     if (n == rEnd - rStart) {
       long lPos = laddr + lStart;
       long rPos = raddr + rStart;
@@ -109,7 +109,7 @@ public class ByteFunctionHelpers {
    * @param rEnd   end offset in the buffer
    * @return 1 if left input is greater, -1 if left input is smaller, 0 otherwise
    */
-  public static final int compare(
+  public static int compare(
       final ArrowBuf left,
       int lStart,
       int lEnd,
@@ -187,7 +187,7 @@ public class ByteFunctionHelpers {
    * @param rEnd   end offset in the byte array
    * @return 1 if left input is greater, -1 if left input is smaller, 0 otherwise
    */
-  public static final int compare(
+  public static int compare(
       final ArrowBuf left,
       int lStart,
       int lEnd,
@@ -273,7 +273,7 @@ public class ByteFunctionHelpers {
   /**
    * Compute hashCode with the given {@link ArrowBuf} and start/end index.
    */
-  public static final int hash(final ArrowBuf buf, int start, int end) {
+  public static int hash(final ArrowBuf buf, long start, long end) {
 
     return hash(SimpleHasher.INSTANCE, buf, start, end);
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory.util;
+
+import org.apache.arrow.util.Preconditions;
+
+/** Contains utilities for dealing with a 64-bit address base. */
+public final class LargeMemoryUtil {
+
+  private LargeMemoryUtil() {}
+
+  /**
+   * Casts length to an int, but raises an exception the value is outside
+   * the range of an int.
+   */
+  public static int checkedCastToInt(long length) {
+    Preconditions.checkArgument(length <= Integer.MAX_VALUE || length >= Integer.MIN_VALUE,
+        "Can't cast long to int: %s", length);
+    return (int) length;
+  }
+}

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
@@ -36,4 +36,11 @@ public final class LargeMemoryUtil {
     }
     return (int) length;
   }
+
+  /**
+   * Returns a min(Integer.MAX_VALUE, length).
+   */
+  public static int capAtMaxInt(long length) {
+    return (int)Math.min(length, Integer.MAX_VALUE);
+  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.memory.util;
 
+import org.apache.arrow.memory.BoundsChecking;
 import org.apache.arrow.util.Preconditions;
 
 /** Contains utilities for dealing with a 64-bit address base. */
@@ -29,8 +30,10 @@ public final class LargeMemoryUtil {
    * the range of an int.
    */
   public static int checkedCastToInt(long length) {
-    Preconditions.checkArgument(length <= Integer.MAX_VALUE || length >= Integer.MIN_VALUE,
-        "Can't cast long to int: %s", length);
+    if (BoundsChecking.BOUNDS_CHECKING_ENABLED) {
+      Preconditions.checkArgument(length <= Integer.MAX_VALUE || length >= Integer.MIN_VALUE,
+          "Can't cast long to int: %s", length);
+    }
     return (int) length;
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/ArrowBufHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/ArrowBufHasher.java
@@ -34,7 +34,7 @@ public interface ArrowBufHasher {
    * @param length length of the memory region.
    * @return the hash code.
    */
-  int hashCode(long address, int length);
+  int hashCode(long address, long length);
 
   /**
    * Calculates the hash code for a memory region.
@@ -43,5 +43,5 @@ public interface ArrowBufHasher {
    * @param length length of the memory region.
    * @return the hash code.
    */
-  int hashCode(ArrowBuf buf, int offset, int length);
+  int hashCode(ArrowBuf buf, long offset, long length);
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
@@ -56,12 +56,12 @@ public class MurmurHasher implements ArrowBufHasher {
   }
 
   @Override
-  public int hashCode(long address, int length) {
+  public int hashCode(long address, long length) {
     return hashCode(address, length, seed);
   }
 
   @Override
-  public int hashCode(ArrowBuf buf, int offset, int length) {
+  public int hashCode(ArrowBuf buf, long offset, long length) {
     buf.checkBytes(offset, offset + length);
     return hashCode(buf.memoryAddress() + offset, length);
   }
@@ -74,7 +74,7 @@ public class MurmurHasher implements ArrowBufHasher {
    * @param seed the seed.
    * @return the hash code.
    */
-  public static int hashCode(ArrowBuf buf, int offset, int length, int seed) {
+  public static int hashCode(ArrowBuf buf, long offset, long length, int seed) {
     buf.checkBytes(offset, offset + length);
     return hashCode(buf.memoryAddress() + offset, length, seed);
   }
@@ -86,7 +86,7 @@ public class MurmurHasher implements ArrowBufHasher {
    * @param seed the seed.
    * @return the hash code.
    */
-  public static int hashCode(long address, int length, int seed) {
+  public static int hashCode(long address, long length, int seed) {
     int index = 0;
     int hash = seed;
     while (index + 4 <= length) {
@@ -142,8 +142,8 @@ public class MurmurHasher implements ArrowBufHasher {
    * @param length the length of the memory region.
    * @return the finalized hash code.
    */
-  public static int finalizeHashCode(int hashCode, int length) {
-    hashCode = hashCode ^ length;
+  public static int finalizeHashCode(int hashCode, long length) {
+    hashCode = hashCode ^ (int)length;
 
     hashCode = hashCode ^ (hashCode >>> 16);
     hashCode = hashCode * 0x85ebca6b;

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
@@ -54,7 +54,7 @@ public class SimpleHasher implements ArrowBufHasher {
    * @param length length of the memory region.
    * @return the hash code.
    */
-  public int hashCode(long address, int length) {
+  public int hashCode(long address, long length) {
     int hashValue = 0;
     int index = 0;
     while (index + 8 <= length) {
@@ -88,7 +88,8 @@ public class SimpleHasher implements ArrowBufHasher {
    * @param length length of the memory region.
    * @return the hash code.
    */
-  public int hashCode(ArrowBuf buf, int offset, int length) {
+  @Override
+  public int hashCode(ArrowBuf buf, long offset, long length) {
     buf.checkBytes(offset, offset + length);
     return hashCode(buf.memoryAddress() + offset, length);
   }

--- a/java/memory/src/main/java/org/apache/arrow/util/Preconditions.java
+++ b/java/memory/src/main/java/org/apache/arrow/util/Preconditions.java
@@ -1214,7 +1214,7 @@ public final class Preconditions {
    * @throws IllegalArgumentException if {@code size} is negative
    */
 
-  public static int checkPositionIndex(int index, int size) {
+  public static long checkPositionIndex(long index, long size) {
     return checkPositionIndex(index, size, "index");
   }
 
@@ -1230,7 +1230,7 @@ public final class Preconditions {
    * @throws IllegalArgumentException if {@code size} is negative
    */
 
-  public static int checkPositionIndex(int index, int size, String desc) {
+  public static long checkPositionIndex(long index, long size, String desc) {
     // Carefully optimized for execution by hotspot (explanatory comment above)
     if (index < 0 || index > size) {
       throw new IndexOutOfBoundsException(badPositionIndex(index, size, desc));
@@ -1238,7 +1238,7 @@ public final class Preconditions {
     return index;
   }
 
-  private static String badPositionIndex(int index, int size, String desc) {
+  private static String badPositionIndex(long index, long size, String desc) {
     if (index < 0) {
       return format("%s (%s) must not be negative", desc, index);
     } else if (size < 0) {

--- a/java/memory/src/test/java/org/apache/arrow/memory/util/TestArrowBufPointer.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/util/TestArrowBufPointer.java
@@ -194,13 +194,13 @@ public class TestArrowBufPointer {
     protected int counter = 0;
 
     @Override
-    public int hashCode(long address, int length) {
+    public int hashCode(long address, long length) {
       counter += 1;
       return SimpleHasher.INSTANCE.hashCode(address, length);
     }
 
     @Override
-    public int hashCode(ArrowBuf buf, int offset, int length) {
+    public int hashCode(ArrowBuf buf, long offset, long length) {
       counter += 1;
       return SimpleHasher.INSTANCE.hashCode(buf, offset, length);
     }

--- a/java/performance/src/test/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatchBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatchBenchmarks.java
@@ -82,7 +82,7 @@ public class ArrowRecordBatchBenchmarks {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  public int createAndGetLength() {
+  public long createAndGetLength() {
     try (ArrowRecordBatch batch = new ArrowRecordBatch(VECTOR_LENGTH, nodes, vector.getFieldBuffers())) {
       return batch.computeBodyLength();
     }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -57,6 +57,7 @@ import org.apache.arrow.util.Preconditions;
 
 import static org.apache.arrow.vector.types.UnionMode.Sparse;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 
 
 
@@ -689,7 +690,7 @@ public class UnionVector implements FieldVector {
     }
 
     private int getTypeBufferValueCapacity() {
-      return checkedCastToInt(typeBuffer.capacity() / TYPE_WIDTH);
+      return capAtMaxInt(typeBuffer.capacity() / TYPE_WIDTH);
     }
 
     @Override

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -56,6 +56,7 @@ import org.apache.arrow.vector.util.OversizedAllocationException;
 import org.apache.arrow.util.Preconditions;
 
 import static org.apache.arrow.vector.types.UnionMode.Sparse;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 
 
 
@@ -150,7 +151,7 @@ public class UnionVector implements FieldVector {
     ArrowBuf buffer = ownBuffers.get(0);
     typeBuffer.getReferenceManager().release();
     typeBuffer = buffer.getReferenceManager().retain(buffer, allocator);
-    typeBufferAllocationSizeInBytes = typeBuffer.capacity();
+    typeBufferAllocationSizeInBytes = checkedCastToInt(typeBuffer.capacity());
     this.valueCount = fieldNode.getLength();
   }
 
@@ -310,11 +311,11 @@ public class UnionVector implements FieldVector {
   }
 
   private void reallocTypeBuffer() {
-    final int currentBufferCapacity = typeBuffer.capacity();
+    final long currentBufferCapacity = typeBuffer.capacity();
     long baseSize  = typeBufferAllocationSizeInBytes;
 
-    if (baseSize < (long)currentBufferCapacity) {
-      baseSize = (long)currentBufferCapacity;
+    if (baseSize < currentBufferCapacity) {
+      baseSize = currentBufferCapacity;
     }
 
     long newAllocationSize = baseSize * 2L;
@@ -325,7 +326,7 @@ public class UnionVector implements FieldVector {
       throw new OversizedAllocationException("Unable to expand the buffer");
     }
 
-    final ArrowBuf newBuf = allocator.buffer((int)newAllocationSize);
+    final ArrowBuf newBuf = allocator.buffer(checkedCastToInt(newAllocationSize));
     newBuf.setBytes(0, typeBuffer, 0, currentBufferCapacity);
     newBuf.setZero(currentBufferCapacity, newBuf.capacity() - currentBufferCapacity);
     typeBuffer.getReferenceManager().release(1);
@@ -688,7 +689,7 @@ public class UnionVector implements FieldVector {
     }
 
     private int getTypeBufferValueCapacity() {
-      return typeBuffer.capacity() / TYPE_WIDTH;
+      return checkedCastToInt(typeBuffer.capacity() / TYPE_WIDTH);
     }
 
     @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -185,11 +185,11 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   }
 
   private int getValueBufferValueCapacity() {
-    return checkedCastToInt(valueBuffer.capacity() / typeWidth);
+    return capAtMaxInt(valueBuffer.capacity() / typeWidth);
   }
 
   private int getValidityBufferValueCapacity() {
-    return checkedCastToInt(validityBuffer.capacity() * 8);
+    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -183,11 +185,11 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   }
 
   private int getValueBufferValueCapacity() {
-    return valueBuffer.capacity() / typeWidth;
+    return checkedCastToInt(valueBuffer.capacity() / typeWidth);
   }
 
   private int getValidityBufferValueCapacity() {
-    return validityBuffer.capacity() * 8;
+    return checkedCastToInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -40,7 +40,7 @@ public abstract class BaseValueVector implements ValueVector {
   private static final Logger logger = LoggerFactory.getLogger(BaseValueVector.class);
 
   public static final String MAX_ALLOCATION_SIZE_PROPERTY = "arrow.vector.max_allocation_bytes";
-  public static final int MAX_ALLOCATION_SIZE = Integer.getInteger(MAX_ALLOCATION_SIZE_PROPERTY, Integer.MAX_VALUE);
+  public static final long MAX_ALLOCATION_SIZE = Long.getLong(MAX_ALLOCATION_SIZE_PROPERTY, Long.MAX_VALUE);
   /*
    * For all fixed width vectors, the value and validity buffers are sliced from a single buffer.
    * Similarly, for variable width vectors, the offsets and validity buffers are sliced from a

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 
 import java.nio.ByteBuffer;
@@ -216,11 +217,11 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   }
 
   private int getValidityBufferValueCapacity() {
-    return checkedCastToInt(validityBuffer.capacity() * 8);
+    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   private int getOffsetBufferValueCapacity() {
-    return checkedCastToInt(offsetBuffer.capacity() / OFFSET_WIDTH);
+    return capAtMaxInt(offsetBuffer.capacity() / OFFSET_WIDTH);
   }
 
   /**
@@ -461,7 +462,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     initValidityBuffer();
 
     lastValueCapacity = getValueCapacity();
-    lastValueAllocationSizeInBytes = checkedCastToInt(valueBuffer.capacity());
+    lastValueAllocationSizeInBytes = capAtMaxInt(valueBuffer.capacity());
   }
 
   /* allocate offset buffer */
@@ -498,8 +499,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @throws OutOfMemoryException if the internal memory allocation fails
    */
   public void reallocDataBuffer() {
-    final int currentBufferCapacity = checkedCastToInt(valueBuffer.capacity());
-    long newAllocationSize = currentBufferCapacity * 2;
+    final long currentBufferCapacity = valueBuffer.capacity();
+    int newAllocationSize = checkedCastToInt(currentBufferCapacity * 2);
     if (newAllocationSize == 0) {
       if (lastValueAllocationSizeInBytes > 0) {
         newAllocationSize = lastValueAllocationSizeInBytes;
@@ -512,11 +513,11 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
 
     checkDataBufferSize(newAllocationSize);
 
-    final ArrowBuf newBuf = allocator.buffer((int) newAllocationSize);
+    final ArrowBuf newBuf = allocator.buffer(newAllocationSize);
     newBuf.setBytes(0, valueBuffer, 0, currentBufferCapacity);
     valueBuffer.getReferenceManager().release();
     valueBuffer = newBuf;
-    lastValueAllocationSizeInBytes = checkedCastToInt(valueBuffer.capacity());
+    lastValueAllocationSizeInBytes = capAtMaxInt(valueBuffer.capacity());
   }
 
   /**
@@ -543,8 +544,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @throws OutOfMemoryException if the internal memory allocation fails
    */
   public void reallocValidityAndOffsetBuffers() {
-    int targetOffsetCount = checkedCastToInt((offsetBuffer.capacity() / OFFSET_WIDTH)  * 2);
-
+    int targetOffsetCount = capAtMaxInt((offsetBuffer.capacity() / OFFSET_WIDTH)  * 2);
     if (targetOffsetCount == 0) {
       if (lastValueCapacity > 0) {
         targetOffsetCount = (lastValueCapacity + 1);
@@ -576,7 +576,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   @Override
   public int getByteCapacity() {
-    return checkedCastToInt(valueBuffer.capacity());
+    return capAtMaxInt(valueBuffer.capacity());
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -543,7 +543,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @throws OutOfMemoryException if the internal memory allocation fails
    */
   public void reallocValidityAndOffsetBuffers() {
-    int targetOffsetCount = capAtMaxInt((offsetBuffer.capacity() / OFFSET_WIDTH)  * 2);
+    int targetOffsetCount = capAtMaxInt((offsetBuffer.capacity() / OFFSET_WIDTH) * 2);
     if (targetOffsetCount == 0) {
       if (lastValueCapacity > 0) {
         targetOffsetCount = (lastValueCapacity + 1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -120,7 +121,7 @@ public final class BitVector extends BaseFixedWidthVector {
    */
   @Override
   public int getValueCapacity() {
-    return validityBuffer.capacity() * 8;
+    return checkedCastToInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -121,7 +121,7 @@ public final class BitVector extends BaseFixedWidthVector {
    */
   @Override
   public int getValueCapacity() {
-    return checkedCastToInt(validityBuffer.capacity() * 8);
+    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
@@ -28,7 +28,7 @@ public interface VariableWidthVector extends ElementAddressableVector, DensityAw
    * @param totalBytes Desired size of the underlying data buffer.
    * @param valueCount Number of values in the vector.
    */
-  void allocateNew(int totalBytes, int valueCount);
+  void allocateNew(long totalBytes, int valueCount);
 
   /**
    * Allocate a new memory space for this vector.  Must be called prior to using the ValueVector.

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector.complex;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 
 import java.util.ArrayList;
@@ -207,7 +208,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
   protected int getOffsetBufferValueCapacity() {
-    return checkedCastToInt(offsetBuffer.capacity() / OFFSET_WIDTH);
+    return capAtMaxInt(offsetBuffer.capacity() / OFFSET_WIDTH);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.complex;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -111,7 +113,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
   protected void reallocOffsetBuffer() {
-    final int currentBufferCapacity = offsetBuffer.capacity();
+    final int currentBufferCapacity = checkedCastToInt(offsetBuffer.capacity());
     long baseSize = offsetAllocationSizeInBytes;
 
     if (baseSize < (long) currentBufferCapacity) {
@@ -205,7 +207,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
   protected int getOffsetBufferValueCapacity() {
-    return offsetBuffer.capacity() / OFFSET_WIDTH;
+    return checkedCastToInt(offsetBuffer.capacity() / OFFSET_WIDTH);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -18,7 +18,6 @@
 package org.apache.arrow.vector.complex;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
-import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,7 +57,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   protected FieldVector vector;
   protected final CallBack callBack;
   protected int valueCount;
-  protected int offsetAllocationSizeInBytes = INITIAL_VALUE_ALLOCATION * OFFSET_WIDTH;
+  protected long offsetAllocationSizeInBytes = INITIAL_VALUE_ALLOCATION * OFFSET_WIDTH;
   private final String name;
 
   protected String defaultDataVectorName = DATA_VECTOR_NAME;
@@ -114,27 +113,28 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   }
 
   protected void reallocOffsetBuffer() {
-    final int currentBufferCapacity = checkedCastToInt(offsetBuffer.capacity());
+    final long currentBufferCapacity = offsetBuffer.capacity();
     long baseSize = offsetAllocationSizeInBytes;
 
-    if (baseSize < (long) currentBufferCapacity) {
-      baseSize = (long) currentBufferCapacity;
+    if (baseSize < currentBufferCapacity) {
+      baseSize = currentBufferCapacity;
     }
 
     long newAllocationSize = baseSize * 2L;
     newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = Math.min(newAllocationSize, (long)(OFFSET_WIDTH) * Integer.MAX_VALUE);
     assert newAllocationSize >= 1;
 
-    if (newAllocationSize > MAX_ALLOCATION_SIZE) {
+    if (newAllocationSize > MAX_ALLOCATION_SIZE || newAllocationSize <= baseSize) {
       throw new OversizedAllocationException("Unable to expand the buffer");
     }
 
-    final ArrowBuf newBuf = allocator.buffer((int) newAllocationSize);
+    final ArrowBuf newBuf = allocator.buffer(newAllocationSize);
     newBuf.setBytes(0, offsetBuffer, 0, currentBufferCapacity);
     newBuf.setZero(currentBufferCapacity, newBuf.capacity() - currentBufferCapacity);
     offsetBuffer.getReferenceManager().release(1);
     offsetBuffer = newBuf;
-    offsetAllocationSizeInBytes = (int) newAllocationSize;
+    offsetAllocationSizeInBytes = newAllocationSize;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex;
 
 import static java.util.Collections.singletonList;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 
 import java.util.ArrayList;
@@ -163,7 +164,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
     validityBuffer = BitVectorHelper.loadValidityBuffer(fieldNode, bitBuffer, allocator);
     valueCount = fieldNode.getLength();
 
-    validityAllocationSizeInBytes = validityBuffer.capacity();
+    validityAllocationSizeInBytes = checkedCastToInt(validityBuffer.capacity());
   }
 
   @Override
@@ -244,7 +245,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   }
 
   private void reallocValidityBuffer() {
-    final int currentBufferCapacity = validityBuffer.capacity();
+    final int currentBufferCapacity = checkedCastToInt(validityBuffer.capacity());
     long baseSize = validityAllocationSizeInBytes;
 
     if (baseSize < (long) currentBufferCapacity) {
@@ -483,7 +484,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
    * current capacity.
    */
   private int getValidityBufferValueCapacity() {
-    return validityBuffer.capacity() * 8;
+    return checkedCastToInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex;
 
 import static java.util.Collections.singletonList;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 
@@ -484,7 +485,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
    * current capacity.
    */
   private int getValidityBufferValueCapacity() {
-    return checkedCastToInt(validityBuffer.capacity() * 8);
+    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex;
 
 import static java.util.Collections.singletonList;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
 import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkNotNull;
 
@@ -757,7 +758,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   }
 
   private int getValidityBufferValueCapacity() {
-    return checkedCastToInt(validityBuffer.capacity() * 8);
+    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex;
 
 import static java.util.Collections.singletonList;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
@@ -205,8 +206,8 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
     offsetBuffer.getReferenceManager().release();
     offsetBuffer = offBuffer.getReferenceManager().retain(offBuffer, allocator);
 
-    validityAllocationSizeInBytes = validityBuffer.capacity();
-    offsetAllocationSizeInBytes = offsetBuffer.capacity();
+    validityAllocationSizeInBytes = checkedCastToInt(validityBuffer.capacity());
+    offsetAllocationSizeInBytes = checkedCastToInt(offsetBuffer.capacity());
 
     lastSet = fieldNode.getLength() - 1;
     valueCount = fieldNode.getLength();
@@ -312,7 +313,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   }
 
   private void reallocValidityBuffer() {
-    final int currentBufferCapacity = validityBuffer.capacity();
+    final int currentBufferCapacity = checkedCastToInt(validityBuffer.capacity());
     long baseSize = validityAllocationSizeInBytes;
 
     if (baseSize < (long) currentBufferCapacity) {
@@ -756,7 +757,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   }
 
   private int getValidityBufferValueCapacity() {
-    return validityBuffer.capacity() * 8;
+    return checkedCastToInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -208,7 +208,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
     offsetBuffer = offBuffer.getReferenceManager().retain(offBuffer, allocator);
 
     validityAllocationSizeInBytes = checkedCastToInt(validityBuffer.capacity());
-    offsetAllocationSizeInBytes = checkedCastToInt(offsetBuffer.capacity());
+    offsetAllocationSizeInBytes = offsetBuffer.capacity();
 
     lastSet = fieldNode.getLength() - 1;
     valueCount = fieldNode.getLength();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector.complex;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.util.Preconditions.checkNotNull;
 
 import java.util.ArrayList;
@@ -107,7 +108,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
     validityBuffer.getReferenceManager().release();
     validityBuffer = BitVectorHelper.loadValidityBuffer(fieldNode, bitBuffer, allocator);
     valueCount = fieldNode.getLength();
-    validityAllocationSizeInBytes = validityBuffer.capacity();
+    validityAllocationSizeInBytes = checkedCastToInt(validityBuffer.capacity());
   }
 
   @Override
@@ -260,7 +261,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
    * @return number of elements that validity buffer can hold
    */
   private int getValidityBufferValueCapacity() {
-    return validityBuffer.capacity() * 8;
+    return checkedCastToInt(validityBuffer.capacity() * 8);
   }
 
   /**
@@ -420,7 +421,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   }
 
   private void reallocValidityBuffer() {
-    final int currentBufferCapacity = validityBuffer.capacity();
+    final int currentBufferCapacity = checkedCastToInt(validityBuffer.capacity());
     long baseSize = validityAllocationSizeInBytes;
 
     if (baseSize < (long) currentBufferCapacity) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -76,14 +76,21 @@ public class ReadChannel implements AutoCloseable {
    * Reads up to len into buffer. Returns bytes read.
    *
    * @param buffer the buffer to read to
-   * @param l      the amount of bytes to read
+   * @param length the amount of bytes to read
    * @return the number of bytes read
    * @throws IOException if nit enough bytes left to read
    */
-  public int readFully(ArrowBuf buffer, int l) throws IOException {
-    int n = readFully(buffer.nioBuffer(buffer.writerIndex(), l));
-    buffer.writerIndex(buffer.writerIndex() + n);
-    return n;
+  public long readFully(ArrowBuf buffer, long length) throws IOException {
+    boolean fullRead = true;
+    long bytesLeft = length;
+    while (fullRead && bytesLeft > 0) {
+      int bytesToRead = (int) Math.min(length, Integer.MAX_VALUE);
+      int n = readFully(buffer.nioBuffer(buffer.writerIndex(), bytesToRead));
+      buffer.writerIndex(buffer.writerIndex() + n);
+      fullRead = n == bytesToRead;
+      bytesLeft -= n;
+    }
+    return length - bytesLeft;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
@@ -58,7 +58,7 @@ public class ArrowDictionaryBatch implements ArrowMessage {
   }
 
   @Override
-  public int computeBodyLength() {
+  public long computeBodyLength() {
     return dictionary.computeBodyLength();
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFieldNode.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowFieldNode.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.ipc.message;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import org.apache.arrow.flatbuf.FieldNode;
 
 import com.google.flatbuffers.FlatBufferBuilder;
@@ -35,15 +37,15 @@ public class ArrowFieldNode implements FBSerializable {
    * @param length The number of values written.
    * @param nullCount The number of null values.
    */
-  public ArrowFieldNode(int length, int nullCount) {
+  public ArrowFieldNode(long length, long nullCount) {
     super();
-    this.length = length;
-    this.nullCount = nullCount;
+    this.length = checkedCastToInt(length);
+    this.nullCount = checkedCastToInt(nullCount);
   }
 
   @Override
   public int writeTo(FlatBufferBuilder builder) {
-    return FieldNode.createFieldNode(builder, (long) length, (long) nullCount);
+    return FieldNode.createFieldNode(builder, length, nullCount);
   }
 
   public int getNullCount() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowMessage.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowMessage.java
@@ -22,7 +22,7 @@ package org.apache.arrow.vector.ipc.message;
  */
 public interface ArrowMessage extends FBSerializable, AutoCloseable {
 
-  int computeBodyLength();
+  long computeBodyLength();
 
   <T> T accepts(ArrowMessageVisitor<T> visitor);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -237,7 +237,7 @@ public class MessageSerializer {
   public static ArrowBlock serialize(WriteChannel out, ArrowRecordBatch batch, IpcOption option) throws IOException {
 
     long start = out.getCurrentPosition();
-    int bodyLength = batch.computeBodyLength();
+    long bodyLength = batch.computeBodyLength();
     Preconditions.checkArgument(bodyLength % 8 == 0, "batch is not aligned");
 
     ByteBuffer serializedMessage = serializeMetadata(batch);
@@ -445,7 +445,8 @@ public class MessageSerializer {
   public static ArrowBlock serialize(WriteChannel out, ArrowDictionaryBatch batch, IpcOption option)
       throws IOException {
     long start = out.getCurrentPosition();
-    int bodyLength = batch.computeBodyLength();
+
+    long bodyLength = batch.computeBodyLength();
     Preconditions.checkArgument(bodyLength % 8 == 0, "batch is not aligned");
 
     ByteBuffer serializedMessage = serializeMetadata(batch);
@@ -627,7 +628,7 @@ public class MessageSerializer {
       FlatBufferBuilder builder,
       byte headerType,
       int headerOffset,
-      int bodyLength) {
+      long bodyLength) {
     Message.startMessage(builder);
     Message.addHeaderType(builder, headerType);
     Message.addHeader(builder, headerOffset);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.ipc.message;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -287,7 +289,7 @@ public class MessageSerializer {
       ArrowBuffer layout = buffersLayout.get(i);
       long startPosition = bufferStart + layout.getOffset();
       if (startPosition != out.getCurrentPosition()) {
-        out.writeZeros((int) (startPosition - out.getCurrentPosition()));
+        out.writeZeros(startPosition - out.getCurrentPosition());
       }
       out.write(buffer);
       if (out.getCurrentPosition() != startPosition + layout.getSize()) {
@@ -340,7 +342,7 @@ public class MessageSerializer {
     if (result.getMessage().headerType() != MessageHeader.RecordBatch) {
       throw new IOException("Expected RecordBatch but header was " + result.getMessage().headerType());
     }
-    int bodyLength = (int) result.getMessageBodyLength();
+    long bodyLength = result.getMessageBodyLength();
     ArrowBuf bodyBuffer = readMessageBody(in, bodyLength, allocator);
     return deserializeRecordBatch(result.getMessage(), bodyBuffer);
   }
@@ -360,12 +362,8 @@ public class MessageSerializer {
     // Metadata length contains prefix_size bytes plus byte padding
     long totalLen = block.getMetadataLength() + block.getBodyLength();
 
-    if (totalLen > Integer.MAX_VALUE) {
-      throw new IOException("Cannot currently deserialize record batches over 2GB");
-    }
-
-    ArrowBuf buffer = alloc.buffer((int) totalLen);
-    if (in.readFully(buffer, (int) totalLen) != totalLen) {
+    ArrowBuf buffer = alloc.buffer(totalLen);
+    if (in.readFully(buffer, totalLen) != totalLen) {
       throw new IOException("Unexpected end of input trying to read batch.");
     }
 
@@ -380,7 +378,7 @@ public class MessageSerializer {
 
     // Now read the body
     final ArrowBuf body = buffer.slice(block.getMetadataLength(),
-        (int) totalLen - block.getMetadataLength());
+         totalLen - block.getMetadataLength());
     return deserializeRecordBatch(recordBatchFB, body);
   }
 
@@ -401,21 +399,21 @@ public class MessageSerializer {
       if ((int) node.length() != node.length() ||
           (int) node.nullCount() != node.nullCount()) {
         throw new IOException("Cannot currently deserialize record batches with " +
-                              "node length larger than Int.MAX_VALUE");
+                              "node length larger than INT_MAX records.");
       }
-      nodes.add(new ArrowFieldNode((int) node.length(), (int) node.nullCount()));
+      nodes.add(new ArrowFieldNode(node.length(), node.nullCount()));
     }
     List<ArrowBuf> buffers = new ArrayList<>();
     for (int i = 0; i < recordBatchFB.buffersLength(); ++i) {
       Buffer bufferFB = recordBatchFB.buffers(i);
-      ArrowBuf vectorBuffer = body.slice((int) bufferFB.offset(), (int) bufferFB.length());
+      ArrowBuf vectorBuffer = body.slice(bufferFB.offset(), bufferFB.length());
       buffers.add(vectorBuffer);
     }
     if ((int) recordBatchFB.length() != recordBatchFB.length()) {
-      throw new IOException("Cannot currently deserialize record batches over 2GB");
+      throw new IOException("Cannot currently deserialize record batches with more than INT_MAX records.");
     }
     ArrowRecordBatch arrowRecordBatch =
-        new ArrowRecordBatch((int) recordBatchFB.length(), nodes, buffers);
+        new ArrowRecordBatch(checkedCastToInt(recordBatchFB.length()), nodes, buffers);
     body.getReferenceManager().release();
     return arrowRecordBatch;
   }
@@ -527,7 +525,7 @@ public class MessageSerializer {
     if (result.getMessage().headerType() != MessageHeader.DictionaryBatch) {
       throw new IOException("Expected DictionaryBatch but header was " + result.getMessage().headerType());
     }
-    int bodyLength = (int) result.getMessageBodyLength();
+    long bodyLength = result.getMessageBodyLength();
     ArrowBuf bodyBuffer = readMessageBody(in, bodyLength, allocator);
     return deserializeDictionaryBatch(result.getMessage(), bodyBuffer);
   }
@@ -549,12 +547,8 @@ public class MessageSerializer {
     // Metadata length contains integer prefix plus byte padding
     long totalLen = block.getMetadataLength() + block.getBodyLength();
 
-    if (totalLen > Integer.MAX_VALUE) {
-      throw new IOException("Cannot currently deserialize record batches over 2GB");
-    }
-
-    ArrowBuf buffer = alloc.buffer((int) totalLen);
-    if (in.readFully(buffer, (int) totalLen) != totalLen) {
+    ArrowBuf buffer = alloc.buffer(totalLen);
+    if (in.readFully(buffer, totalLen) != totalLen) {
       throw new IOException("Unexpected end of input trying to read batch.");
     }
 
@@ -569,7 +563,7 @@ public class MessageSerializer {
 
     // Now read the body
     final ArrowBuf body = buffer.slice(block.getMetadataLength(),
-        (int) totalLen - block.getMetadataLength());
+         totalLen - block.getMetadataLength());
     ArrowRecordBatch recordBatch = deserializeRecordBatch(dictionaryBatchFB.data(), body);
     return new ArrowDictionaryBatch(dictionaryBatchFB.id(), recordBatch);
   }
@@ -692,7 +686,8 @@ public class MessageSerializer {
    * @return an ArrowBuf containing the message body data
    * @throws IOException on error
    */
-  public static ArrowBuf readMessageBody(ReadChannel in, int bodyLength, BufferAllocator allocator) throws IOException {
+  public static ArrowBuf readMessageBody(ReadChannel in, long bodyLength,
+      BufferAllocator allocator) throws IOException {
     ArrowBuf bodyBuffer = allocator.buffer(bodyLength);
     if (in.readFully(bodyBuffer, bodyLength) != bodyLength) {
       throw new IOException("Unexpected end of input trying to read batch.");

--- a/java/vector/src/test/java/org/apache/arrow/vector/DirtyRootAllocator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/DirtyRootAllocator.java
@@ -36,12 +36,12 @@ public class DirtyRootAllocator extends RootAllocator {
   }
 
   @Override
-  public ArrowBuf buffer(int size) {
+  public ArrowBuf buffer(long size) {
     return buffer(size, null);
   }
 
   @Override
-  public ArrowBuf buffer(int size, BufferManager manager) {
+  public ArrowBuf buffer(long size, BufferManager manager) {
     ArrowBuf buffer = super.buffer(size, manager);
     // contaminate the buffer
     for (int i = 0; i < buffer.capacity(); i++) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestOversizedAllocationForValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestOversizedAllocationForValueVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -52,7 +53,7 @@ public class TestOversizedAllocationForValueVector {
   public void testFixedVectorReallocation() {
     final UInt4Vector vector = new UInt4Vector(EMPTY_SCHEMA_PATH, allocator);
     // edge case 1: buffer size = max value capacity
-    final int expectedValueCapacity = BaseValueVector.MAX_ALLOCATION_SIZE / 4;
+    final int expectedValueCapacity = checkedCastToInt(BaseValueVector.MAX_ALLOCATION_SIZE / 4);
     try {
       vector.allocateNew(expectedValueCapacity);
       assertEquals(expectedValueCapacity, vector.getValueCapacity());
@@ -64,7 +65,7 @@ public class TestOversizedAllocationForValueVector {
 
     // common case: value count < max value capacity
     try {
-      vector.allocateNew(BaseValueVector.MAX_ALLOCATION_SIZE / 8);
+      vector.allocateNew(checkedCastToInt(BaseValueVector.MAX_ALLOCATION_SIZE / 8));
       vector.reAlloc(); // value allocation reaches to MAX_VALUE_ALLOCATION
       vector.reAlloc(); // this should throw an IOOB
     } finally {
@@ -106,7 +107,7 @@ public class TestOversizedAllocationForValueVector {
   public void testVariableVectorReallocation() {
     final VarCharVector vector = new VarCharVector(EMPTY_SCHEMA_PATH, allocator);
     // edge case 1: value count = MAX_VALUE_ALLOCATION
-    final int expectedAllocationInBytes = BaseValueVector.MAX_ALLOCATION_SIZE;
+    final long expectedAllocationInBytes = BaseValueVector.MAX_ALLOCATION_SIZE;
     final int expectedOffsetSize = 10;
     try {
       vector.allocateNew(expectedAllocationInBytes, 10);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
@@ -89,7 +89,7 @@ public class TestStructVector {
        */
       vector.allocateNewSafe(); // Initial allocation
       vector.reAlloc(); // Double the allocation size of self, and all children.
-      int savedValidityBufferCapacity = vector.getValidityBuffer().capacity();
+      long savedValidityBufferCapacity = vector.getValidityBuffer().capacity();
       int savedValueCapacity = vector.getValueCapacity();
 
       /*

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -1408,7 +1408,7 @@ public class TestValueVector {
       /* the above set method should NOT have triggered a realloc */
       assertEquals(initialCapacity, vector.getValueCapacity());
 
-      int bufSizeBefore = vector.getFieldBuffers().get(1).capacity();
+      long bufSizeBefore = vector.getFieldBuffers().get(1).capacity();
       vector.setValueCount(initialCapacity);
       assertEquals(bufSizeBefore, vector.getFieldBuffers().get(1).capacity());
       assertEquals(initialCapacity, vector.getValueCapacity());

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -174,7 +174,7 @@ public class TestVectorReAlloc {
       vector.allocateNewSafe(); // Initial allocation
       vector.reAlloc(); // Double the allocation size.
       int savedValueCapacity = vector.getValueCapacity();
-      int savedValueBufferSize = vector.valueBuffer.capacity();
+      long savedValueBufferSize = vector.valueBuffer.capacity();
 
       /*
        * Clear and allocate again.

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReset.java
@@ -55,7 +55,7 @@ public class TestVectorReset {
   }
 
   private void resetVectorAndVerify(ValueVector vector, ArrowBuf[] bufs) {
-    int[] sizeBefore = new int[bufs.length];
+    long[] sizeBefore = new long[bufs.length];
     for (int i = 0; i < bufs.length; i++) {
       sizeBefore[i] = bufs[i].capacity();
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -150,13 +150,13 @@ public class TestVectorUnloadLoad {
         List<ArrowBuf> oldBuffers = recordBatch.getBuffers();
         List<ArrowBuf> newBuffers = new ArrayList<>();
         for (ArrowBuf oldBuffer : oldBuffers) {
-          int l = oldBuffer.readableBytes();
+          long l = oldBuffer.readableBytes();
           if (l % 64 != 0) {
             // pad
             l = l + 64 - l % 64;
           }
           ArrowBuf newBuffer = allocator.buffer(l);
-          for (int i = oldBuffer.readerIndex(); i < oldBuffer.writerIndex(); i++) {
+          for (long i = oldBuffer.readerIndex(); i < oldBuffer.writerIndex(); i++) {
             newBuffer.setByte(i - oldBuffer.readerIndex(), oldBuffer.getByte(i));
           }
           newBuffer.readerIndex(0);

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/MessageSerializerTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/MessageSerializerTest.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.ipc;
 
 import static java.util.Arrays.asList;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -58,7 +59,7 @@ public class MessageSerializerTest {
   }
 
   public static byte[] array(ArrowBuf buf) {
-    byte[] bytes = new byte[buf.readableBytes()];
+    byte[] bytes = new byte[checkedCastToInt(buf.readableBytes())];
     buf.readBytes(bytes);
     return bytes;
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/MessageSerializerTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/MessageSerializerTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.ipc.message.ArrowBlock;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.ipc.message.ArrowMessage;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
@@ -148,18 +147,6 @@ public class MessageSerializerTest {
 
   @Rule
   public ExpectedException expectedEx = ExpectedException.none();
-
-  @Test
-  public void testDeserializeRecordBatchLongMetaData() throws IOException {
-    expectedEx.expect(IOException.class);
-    expectedEx.expectMessage("Cannot currently deserialize record batches over 2GB");
-    int offset = 0;
-    int metadataLength = 1;
-    long bodyLength = Integer.MAX_VALUE + 10L;
-    ArrowBlock block = new ArrowBlock(offset, metadataLength, bodyLength);
-    long totalLen = block.getMetadataLength() + block.getBodyLength();
-    MessageSerializer.deserializeRecordBatch(null, block, null);
-  }
 
   @Test
   public void testSerializeRecordBatch() throws IOException {

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -541,7 +541,7 @@ public class TestArrowReaderWriter {
       arrBuf.writerIndex(4);
       assertEquals(4, arrBuf.writerIndex());
 
-      int n = channel.readFully(arrBuf, 4);
+      long n = channel.readFully(arrBuf, 4);
       assertEquals(4, n);
       assertEquals(8, arrBuf.writerIndex());
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector.ipc;
 
 import static java.nio.channels.Channels.newChannel;
 import static java.util.Arrays.asList;
+import static org.apache.arrow.memory.util.LargeMemoryUtil.checkedCastToInt;
 import static org.apache.arrow.vector.TestUtils.newVarCharVector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -121,7 +122,7 @@ public class TestArrowReaderWriter {
   }
 
   byte[] array(ArrowBuf buf) {
-    byte[] bytes = new byte[buf.readableBytes()];
+    byte[] bytes = new byte[checkedCastToInt(buf.readableBytes())];
     buf.readBytes(bytes);
     return bytes;
   }


### PR DESCRIPTION
For followup PRs:
- Provide an allocator that can allocator 64-bit address spaces
- Allow for serializing vectors of larger sizes over the wire given the allocator above.

