### PR TITLE
ARROW-6145: [Java] UnionVector created by MinorType#getNewVector could not keep field type info properly

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -598,7 +598,7 @@ public class Types {
           throw new UnsupportedOperationException("Dictionary encoding not supported for complex " +
               "types");
         }
-        return new UnionVector(field.getName(), allocator, schemaChangeCallback);
+        return new UnionVector(field.getName(), allocator, field.getFieldType(), schemaChangeCallback);
       }
 
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector.types.pojo;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Collections2;
@@ -101,6 +102,18 @@ public class FieldType {
   public FieldVector createNewSingleVector(Field field, BufferAllocator allocator, CallBack schemaCallBack) {
     MinorType minorType = Types.getMinorTypeForArrowType(type);
     return minorType.getNewVector(field, allocator, schemaCallBack);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof FieldType)) {
+      return false;
+    }
+    Field that = (Field) obj;
+    return Objects.equals(this.isNullable(), that.isNullable()) &&
+        Objects.equals(this.getType(), that.getType()) &&
+        Objects.equals(this.getDictionary(), that.getDictionary()) &&
+        Objects.equals(this.getMetadata(), that.getMetadata());
   }
 
 }


### PR DESCRIPTION
Related to [ARROW-6145](https://issues.apache.org/jira/browse/ARROW-6145).
When I worked for other items, I found UnionVector created by VectorSchemaRoot#create(Schema schema, BufferAllocator allocator) could not keep field type info properly. For example, if we set metadata in Field in schema, we could not get it back by UnionVector#getField.

This is mainly because MinorType.Union.getNewVector did not pass FieldType to vector and UnionVector#getField create a new Field which cause inconsistent.