### PR TITLE
ARROW-5977: [C++] [Python] Allow specifying which columns to include

### DIFF
--- a/cpp/src/arrow/csv/column-builder.h
+++ b/cpp/src/arrow/csv/column-builder.h
@@ -63,15 +63,21 @@ class ARROW_EXPORT ColumnBuilder {
   std::shared_ptr<internal::TaskGroup> task_group() { return task_group_; }
 
   /// Construct a strictly-typed ColumnBuilder.
-  static Status Make(const std::shared_ptr<DataType>& type, int32_t col_index,
-                     const ConvertOptions& options,
+  static Status Make(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+                     int32_t col_index, const ConvertOptions& options,
                      const std::shared_ptr<internal::TaskGroup>& task_group,
                      std::shared_ptr<ColumnBuilder>* out);
 
   /// Construct a type-inferring ColumnBuilder.
-  static Status Make(int32_t col_index, const ConvertOptions& options,
+  static Status Make(MemoryPool* pool, int32_t col_index, const ConvertOptions& options,
                      const std::shared_ptr<internal::TaskGroup>& task_group,
                      std::shared_ptr<ColumnBuilder>* out);
+
+  /// Construct a ColumnBuilder for a column of nulls
+  /// (i.e. not present in the CSV file).
+  static Status MakeNull(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+                         const std::shared_ptr<internal::TaskGroup>& task_group,
+                         std::shared_ptr<ColumnBuilder>* out);
 
  protected:
   explicit ColumnBuilder(const std::shared_ptr<internal::TaskGroup>& task_group)

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -73,6 +73,19 @@ struct ARROW_EXPORT ConvertOptions {
   // If false, then all strings are valid string values.
   bool strings_can_be_null = false;
 
+  // XXX Should we have a separate FilterOptions?
+
+  // If non-empty, indicates the names of columns from the CSV file that should
+  // be actually read and converted (in the vector's order).
+  // Columns not in this vector will be ignored.
+  std::vector<std::string> include_columns;
+  // If false, columns in `include_columns` but not in the CSV file will error out.
+  // If true, columns in `include_columns` but not in the CSV file will produce
+  // a column of nulls (whose type is selected using `column_types`,
+  // or null by default)
+  // This option is ignored if `include_columns` is empty.
+  bool include_missing_columns = false;
+
   static ConvertOptions Defaults();
 };
 

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -513,7 +513,11 @@ Status BlockParser::ParseFinal(const char* data, uint32_t size, uint32_t* out_si
 
 BlockParser::BlockParser(MemoryPool* pool, ParseOptions options, int32_t num_cols,
                          int32_t max_num_rows)
-    : pool_(pool), options_(options), num_cols_(num_cols), max_num_rows_(max_num_rows) {}
+    : pool_(pool),
+      options_(options),
+      num_rows_(-1),
+      num_cols_(num_cols),
+      max_num_rows_(max_num_rows) {}
 
 BlockParser::BlockParser(ParseOptions options, int32_t num_cols, int32_t max_num_rows)
     : BlockParser(default_memory_pool(), options, num_cols, max_num_rows) {}

--- a/cpp/src/arrow/csv/reader.h
+++ b/cpp/src/arrow/csv/reader.h
@@ -41,7 +41,6 @@ class ARROW_EXPORT TableReader {
 
   virtual Status Read(std::shared_ptr<Table>* out) = 0;
 
-  // XXX pass optional schema?
   static Status Make(MemoryPool* pool, std::shared_ptr<io::InputStream> input,
                      const ReadOptions&, const ParseOptions&, const ConvertOptions&,
                      std::shared_ptr<TableReader>* out);

--- a/python/pyarrow/error.pxi
+++ b/python/pyarrow/error.pxi
@@ -37,7 +37,9 @@ class ArrowIOError(IOError, ArrowException):
 
 
 class ArrowKeyError(KeyError, ArrowException):
-    pass
+    def __str__(self):
+        # Override KeyError.__str__, as it uses the repr() of the key
+        return ArrowException.__str__(self)
 
 
 class ArrowTypeError(TypeError, ArrowException):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1113,6 +1113,8 @@ cdef extern from "arrow/csv/api.h" namespace "arrow::csv" nogil:
         vector[c_string] true_values
         vector[c_string] false_values
         c_bool strings_can_be_null
+        vector[c_string] include_columns
+        c_bool include_missing_columns
 
         @staticmethod
         CCSVConvertOptions Defaults()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -78,6 +78,13 @@ cdef class ChunkedArray(_PandasConvertible):
     def __str__(self):
         return self.format()
 
+    def validate(self):
+        """
+        Validate chunked array consistency.
+        """
+        with nogil:
+            check_status(self.sp_chunked_array.get().Validate())
+
     @property
     def null_count(self):
         """

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -30,6 +30,7 @@ def test_chunked_array_basics():
     data = pa.chunked_array([], type=pa.string())
     assert data.type == pa.string()
     assert data.to_pylist() == []
+    data.validate()
 
     with pytest.raises(ValueError):
         pa.chunked_array([])
@@ -43,6 +44,7 @@ def test_chunked_array_basics():
     assert all(isinstance(c, pa.lib.Int64Array) for c in data.chunks)
     assert all(isinstance(c, pa.lib.Int64Array) for c in data.iterchunks())
     assert len(data.chunks) == 3
+    data.validate()
 
 
 def test_chunked_array_mismatch_types():
@@ -177,7 +179,9 @@ def test_chunked_array_pickle(data, typ):
         arrays.append(pa.array(data[:2], type=typ))
         data = data[2:]
     array = pa.chunked_array(arrays, type=typ)
+    array.validate()
     result = pickle.loads(pickle.dumps(array))
+    result.validate()
     assert result.equals(array)
 
 


### PR DESCRIPTION
If the `include_columns` option is not empty:
- columns are included in that order
- columns not in `include_columns` are ignored
- columns in `include_columns` but not in the CSV file produce a null column