### PR TITLE
ARROW-6142: [R] Install instructions on linux could be clearer

### DIFF
--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -98,7 +98,8 @@ OR_SEE_DEV_GUIDE <- paste0(
 SEE_ARROW_INSTALL <- paste(
   "See the Apache Arrow project installation page",
   "<https://arrow.apache.org/install/>",
-  "for how to install the C++ package from a PPA."
+  "to find pre-compiled binary packages for some common Linux distributions,",
+  "such as Debian, Ubuntu, CentOS, and Fedora."
 )
 
 THEN_REINSTALL <- paste(

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -101,7 +101,7 @@ SEE_ARROW_INSTALL <- paste(
   "to find pre-compiled binary packages for some common Linux distributions,",
   "including Debian, Ubuntu, and CentOS. You'll need to install",
   "'libparquet-dev' on Debian and Ubuntu, or 'parquet-devel' on CentOS. This",
-  "will also automatically install the arrow C++ library as a dependency."
+  "will also automatically install the Arrow C++ library as a dependency."
 )
 
 THEN_REINSTALL <- paste(

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -99,7 +99,8 @@ SEE_ARROW_INSTALL <- paste(
   "See the Apache Arrow project installation page",
   "<https://arrow.apache.org/install/>",
   "to find pre-compiled binary packages for some common Linux distributions,",
-  "such as Debian, Ubuntu, CentOS, and Fedora."
+  "including Debian, Ubuntu, and CentOS. You'll need to install 'libarrow-dev'",
+  "and 'libparquet-dev'."
 )
 
 THEN_REINSTALL <- paste(

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -99,8 +99,9 @@ SEE_ARROW_INSTALL <- paste(
   "See the Apache Arrow project installation page",
   "<https://arrow.apache.org/install/>",
   "to find pre-compiled binary packages for some common Linux distributions,",
-  "including Debian, Ubuntu, and CentOS. You'll need to install 'libarrow-dev'",
-  "and 'libparquet-dev'."
+  "including Debian, Ubuntu, and CentOS. You'll need to install",
+  "'libparquet-dev' on Debian and Ubuntu, or 'parquet-devel' on CentOS. This",
+  "will also automatically install the arrow C++ library as a dependency."
 )
 
 THEN_REINSTALL <- paste(

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -56,7 +56,7 @@ install_arrow_msg <- function(has_arrow, version, from_cran, os) {
       # Point to compilation instructions on readme
       msg <- c(SEE_DEV_GUIDE, THEN_REINSTALL)
     } else {
-      # Suggest arrow.apache.org/install for PPAs, or compilation instructions
+      # Suggest arrow.apache.org/install, or compilation instructions
       msg <- c(paste(SEE_ARROW_INSTALL, OR_SEE_DEV_GUIDE), THEN_REINSTALL)
     }
   } else if (!dev_version && !from_cran) {

--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -30,7 +30,7 @@ Install the latest release of `arrow` from CRAN with
 install.packages("arrow")
 ```
 
-On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) to find pre-compiled binary packages for some common Linux distributions, including Debian, Ubuntu, and CentOS. You'll need to install `libarrow-dev` and `libparquet-dev`.
+On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) to find pre-compiled binary packages for some common Linux distributions, including Debian, Ubuntu, and CentOS. You'll need to install `libparquet-dev` on Debian and Ubuntu, or `parquet-devel` on CentOS. This will also automatically install the arrow C++ library as a dependency.
 
 If you install the `arrow` package from source and the C++ library is not found, the R package functions will notify you that Arrow is not available. Call
 

--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -30,7 +30,7 @@ Install the latest release of `arrow` from CRAN with
 install.packages("arrow")
 ```
 
-On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) to find pre-compiled binary packages for some common Linux distributions, including Debian, Ubuntu, and CentOS. You'll need to install `libparquet-dev` on Debian and Ubuntu, or `parquet-devel` on CentOS. This will also automatically install the arrow C++ library as a dependency.
+On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) to find pre-compiled binary packages for some common Linux distributions, including Debian, Ubuntu, and CentOS. You'll need to install `libparquet-dev` on Debian and Ubuntu, or `parquet-devel` on CentOS. This will also automatically install the Arrow C++ library as a dependency.
 
 If you install the `arrow` package from source and the C++ library is not found, the R package functions will notify you that Arrow is not available. Call
 

--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -30,7 +30,7 @@ Install the latest release of `arrow` from CRAN with
 install.packages("arrow")
 ```
 
-On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) for a list of PPAs from which you can obtain it.
+On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) to find pre-compiled binary packages for some common Linux distributions, including Debian, Ubuntu, and CentOS. You'll need to install `libarrow-dev` and `libparquet-dev`.
 
 If you install the `arrow` package from source and the C++ library is not found, the R package functions will notify you that Arrow is not available. Call
 

--- a/r/README.md
+++ b/r/README.md
@@ -34,7 +34,7 @@ page](https://arrow.apache.org/install/) to find pre-compiled binary
 packages for some common Linux distributions, including Debian, Ubuntu,
 and CentOS. You’ll need to install `libparquet-dev` on Debian and
 Ubuntu, or `parquet-devel` on CentOS. This will also automatically
-install the arrow C++ library as a dependency.
+install the Arrow C++ library as a dependency.
 
 If you install the `arrow` package from source and the C++ library is
 not found, the R package functions will notify you that Arrow is not
@@ -60,7 +60,7 @@ set.seed(24)
 
 tab <- arrow::table(x = 1:10, y = rnorm(10))
 tab$schema
-#> arrow::Schema 
+#> arrow::Schema
 #> x: int32
 #> y: double
 tab

--- a/r/README.md
+++ b/r/README.md
@@ -32,7 +32,9 @@ Arrow’s C++ dependencies for you. On Linux, you’ll need to first install
 the C++ library. See the [Arrow project installation
 page](https://arrow.apache.org/install/) to find pre-compiled binary
 packages for some common Linux distributions, including Debian, Ubuntu,
-and CentOS. You’ll need to install `libarrow-dev` and `libparquet-dev`.
+and CentOS. You’ll need to install `libparquet-dev` on Debian and
+Ubuntu, or `parquet-devel` on CentOS. This will also automatically
+install the arrow C++ library as a dependency.
 
 If you install the `arrow` package from source and the C++ library is
 not found, the R package functions will notify you that Arrow is not

--- a/r/README.md
+++ b/r/README.md
@@ -30,8 +30,9 @@ install.packages("arrow")
 On macOS and Windows, installing a binary package from CRAN will handle
 Arrow’s C++ dependencies for you. On Linux, you’ll need to first install
 the C++ library. See the [Arrow project installation
-page](https://arrow.apache.org/install/) for a list of PPAs from which
-you can obtain it.
+page](https://arrow.apache.org/install/) to find pre-compiled binary
+packages for some common Linux distributions, including Debian, Ubuntu,
+and CentOS. You’ll need to install `libarrow-dev` and `libparquet-dev`.
 
 If you install the `arrow` package from source and the C++ library is
 not found, the R package functions will notify you that Arrow is not

--- a/r/tests/testthat/test-install-arrow.R
+++ b/r/tests/testthat/test-install-arrow.R
@@ -51,7 +51,7 @@ r_only({
   test_that("Linux on release version gets pointed to PPA first, then C++", {
     expect_match(
       install_arrow_msg(FALSE, "0.13.0", os="linux"),
-      "PPA. Or, see the Arrow C++ developer guide",
+      "Fedora. Or, see the Arrow C++ developer guide",
       fixed = TRUE
     )
   })

--- a/r/tests/testthat/test-install-arrow.R
+++ b/r/tests/testthat/test-install-arrow.R
@@ -51,7 +51,7 @@ r_only({
   test_that("Linux on release version gets pointed to PPA first, then C++", {
     expect_match(
       install_arrow_msg(FALSE, "0.13.0", os="linux"),
-      "Fedora. Or, see the Arrow C++ developer guide",
+      "'libparquet-dev'. Or, see the Arrow C++ developer guide",
       fixed = TRUE
     )
   })

--- a/r/tests/testthat/test-install-arrow.R
+++ b/r/tests/testthat/test-install-arrow.R
@@ -51,7 +51,7 @@ r_only({
   test_that("Linux on release version gets pointed to PPA first, then C++", {
     expect_match(
       install_arrow_msg(FALSE, "0.13.0", os="linux"),
-      "'libparquet-dev'. Or, see the Arrow C++ developer guide",
+      "dependency. Or, see the Arrow C++ developer guide",
       fixed = TRUE
     )
   })


### PR DESCRIPTION
This updates the language in `install_arrow()` to follow the README revision that will land in https://github.com/apache/arrow/pull/4948/files#diff-563b2cb2c8c2d51b2ff6b177e2d84286R33. 

The [Jira ticket](https://issues.apache.org/jira/browse/ARROW-6142) requested three things; this is `#2` in the list. On `#1`, I defer to the C++ installation docs, which are already included in the install_arrow message, rather than duplicating content here. `#3` is out of scope.