### PR TITLE
ARROW-6155: [Java] Extract a super interface for vectors whose elements reside in continuous memory segments

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.BitReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -469,6 +470,16 @@ public class BitVector extends BaseFixedWidthVector {
   public void setSafeToOne(int index) {
     handleSafe(index);
     setToOne(index);
+  }
+
+  @Override
+  public ArrowBufPointer getDataPointer(int index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse) {
+    throw new UnsupportedOperationException();
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/ElementAddressableVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ElementAddressableVector.java
@@ -17,29 +17,26 @@
 
 package org.apache.arrow.vector;
 
+import org.apache.arrow.memory.util.ArrowBufPointer;
+
 /**
- * Interface vectors that contain variable width members (e.g. Strings, Lists, etc).
+ * Vector for which each data element resides in a continuous memory region,
+ * so it can be pointed to by an {@link org.apache.arrow.memory.util.ArrowBufPointer}.
  */
-public interface VariableWidthVector extends ElementAddressableVector, DensityAwareVector {
+public interface ElementAddressableVector extends ValueVector {
 
   /**
-   * Allocate a new memory space for this vector.  Must be called prior to using the ValueVector.
-   *
-   * @param totalBytes Desired size of the underlying data buffer.
-   * @param valueCount Number of values in the vector.
+   * Gets the pointer for the data at the given index.
+   * @param index the index for the data.
+   * @return the pointer to the data.
    */
-  void allocateNew(int totalBytes, int valueCount);
+  ArrowBufPointer getDataPointer(int index);
 
   /**
-   * Provide the maximum amount of variable width bytes that can be stored in this vector.
-   *
-   * @return the byte capacity of this vector
+   * Gets the pointer for the data at the given index.
+   * @param index the index for the data.
+   * @param reuse the data pointer to fill, this avoids creating a new pointer object.
+   * @return the pointer to the data, it should be the same one as the input parameter
    */
-  int getByteCapacity();
-
-  /**
-   * Provide the number of bytes contained in the valueBuffer.
-   * @return the number of bytes in valueBuffer.
-   */
-  int sizeOfValueBuffer();
+  ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedWidthVector.java
@@ -17,13 +17,10 @@
 
 package org.apache.arrow.vector;
 
-
-import org.apache.arrow.memory.util.ArrowBufPointer;
-
 /**
- * Interface for all fixed width {@link ValueVector} (e.g. integer, fixed size binary, etc).
+ * Interface for all fixed width {@link ElementAddressableVector} (e.g. integer, fixed size binary, etc).
  */
-public interface FixedWidthVector extends ValueVector {
+public interface FixedWidthVector extends ElementAddressableVector {
 
   /**
    * Allocate a new memory space for this vector.  Must be called prior to using the ValueVector.
@@ -36,19 +33,4 @@ public interface FixedWidthVector extends ValueVector {
    * Zero out the underlying buffer backing this vector.
    */
   void zeroVector();
-
-  /**
-   * Gets the pointer for the data at the given index.
-   * @param index the index for the data.
-   * @return the pointer to the data.
-   */
-  ArrowBufPointer getDataPointer(int index);
-
-  /**
-   * Gets the pointer for the data at the given index.
-   * @param index the index for the data.
-   * @param reuse the data pointer to fill, this avoids creating a new pointer object.
-   * @return the pointer to the data, it should be the same one as the input parameter
-   */
-  ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse);
 }


### PR DESCRIPTION
For vectors whose data elements reside in continuous memory segments, they should implement a common super interface. This will avoid unnecessary code branches.

For now, such vectors include fixed-width vectors and variable-width vectors. In the future, there can be more vectors included.