### PR TITLE
ARROW-6160: [Java] AbstractStructVector#getPrimitiveVectors fails to work with complex child vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -252,15 +252,32 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
    */
   public List<ValueVector> getPrimitiveVectors() {
     final List<ValueVector> primitiveVectors = new ArrayList<>();
-    for (final ValueVector v : vectors.values()) {
-      if (v instanceof AbstractStructVector) {
-        AbstractStructVector structVector = (AbstractStructVector) v;
-        primitiveVectors.addAll(structVector.getPrimitiveVectors());
-      } else {
-        primitiveVectors.add(v);
-      }
+    for (final FieldVector v : vectors.values()) {
+      primitiveVectors.addAll(getPrimitveVectors(v));
     }
     return primitiveVectors;
+  }
+
+  private List<ValueVector> getPrimitveVectors(FieldVector v) {
+    final List<ValueVector> primitives = new ArrayList<>();
+    if (v instanceof AbstractStructVector) {
+      AbstractStructVector structVector = (AbstractStructVector) v;
+      primitives.addAll(structVector.getPrimitiveVectors());
+    } else if (v instanceof ListVector) {
+      ListVector listVector = (ListVector) v;
+      primitives.addAll(getPrimitveVectors(listVector.getDataVector()));
+    } else if (v instanceof FixedSizeListVector) {
+      ListVector listVector = (ListVector) v;
+      primitives.addAll(getPrimitveVectors(listVector.getDataVector()));
+    } else if (v instanceof UnionVector) {
+      UnionVector unionVector = (UnionVector) v;
+      for (final FieldVector vector : unionVector.getChildrenFromFields()) {
+        primitives.addAll(getPrimitveVectors(vector));
+      }
+    } else {
+      primitives.add(v);
+    }
+    return primitives;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -253,26 +253,26 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
   public List<ValueVector> getPrimitiveVectors() {
     final List<ValueVector> primitiveVectors = new ArrayList<>();
     for (final FieldVector v : vectors.values()) {
-      primitiveVectors.addAll(getPrimitveVectors(v));
+      primitiveVectors.addAll(getPrimitiveVectors(v));
     }
     return primitiveVectors;
   }
 
-  private List<ValueVector> getPrimitveVectors(FieldVector v) {
+  private List<ValueVector> getPrimitiveVectors(FieldVector v) {
     final List<ValueVector> primitives = new ArrayList<>();
     if (v instanceof AbstractStructVector) {
       AbstractStructVector structVector = (AbstractStructVector) v;
       primitives.addAll(structVector.getPrimitiveVectors());
     } else if (v instanceof ListVector) {
       ListVector listVector = (ListVector) v;
-      primitives.addAll(getPrimitveVectors(listVector.getDataVector()));
+      primitives.addAll(getPrimitiveVectors(listVector.getDataVector()));
     } else if (v instanceof FixedSizeListVector) {
       ListVector listVector = (ListVector) v;
-      primitives.addAll(getPrimitveVectors(listVector.getDataVector()));
+      primitives.addAll(getPrimitiveVectors(listVector.getDataVector()));
     } else if (v instanceof UnionVector) {
       UnionVector unionVector = (UnionVector) v;
       for (final FieldVector vector : unionVector.getChildrenFromFields()) {
-        primitives.addAll(getPrimitveVectors(vector));
+        primitives.addAll(getPrimitiveVectors(vector));
       }
     } else {
       primitives.add(v);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
@@ -17,16 +17,16 @@
 
 package org.apache.arrow.vector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.holders.ComplexHolder;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
@@ -130,6 +130,34 @@ public class TestStructVector {
       vector.get(1, holder);
       assertEquals(0, holder.isSet);
       assertNull(holder.reader);
+    }
+  }
+
+  @Test
+  public void testGetPrimitiveVectors() {
+    FieldType type = new FieldType(true, Struct.INSTANCE, null, null);
+    try (StructVector vector = new StructVector("struct", allocator, type, null)) {
+
+      // add list vector
+      vector.addOrGet("list", FieldType.nullable(MinorType.LIST.getType()), ListVector.class);
+      ListVector listVector = vector.addOrGetList("list");
+      listVector.addOrGetVector(FieldType.nullable(MinorType.INT.getType()));
+
+      // add union vector
+      vector.addOrGet("union", FieldType.nullable(MinorType.UNION.getType()), UnionVector.class);
+      UnionVector unionVector = vector.addOrGetUnion("union");
+      unionVector.addVector(new BigIntVector("bigInt", allocator));
+      unionVector.addVector(new SmallIntVector("smallInt", allocator));
+
+      // add varchar vector
+      vector.addOrGet("varchar", FieldType.nullable(MinorType.VARCHAR.getType()), VarCharVector.class);
+
+      List<ValueVector> primitiveVectors = vector.getPrimitiveVectors();
+      assertEquals(4, primitiveVectors.size());
+      assertEquals(MinorType.INT, primitiveVectors.get(0).getMinorType());
+      assertEquals(MinorType.BIGINT, primitiveVectors.get(1).getMinorType());
+      assertEquals(MinorType.SMALLINT, primitiveVectors.get(2).getMinorType());
+      assertEquals(MinorType.VARCHAR, primitiveVectors.get(3).getMinorType());
     }
   }
 }


### PR DESCRIPTION
Related to [ARROW-6160](https://issues.apache.org/jira/browse/ARROW-6160).

Currently in AbstractStructVector#getPrimitiveVectors, only struct type child vectors will recursively get primitive vectors, other complex type like ListVector, UnionVector was treated as primitive type and return directly.

For example, Struct(List(Int), Struct(Int, Varchar)) getPrimitiveVectors should return [IntVector, IntVector, VarCharVector] instead of [ListVector, IntVector, VarCharVector]