### PR TITLE
ARROW-5559: [C++] Add an IpcOptions structure

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -255,6 +255,7 @@ if(ARROW_IPC)
       ipc/json-simple.cc
       ipc/message.cc
       ipc/metadata-internal.cc
+      ipc/options.cc
       ipc/reader.cc
       ipc/writer.cc)
   set(ARROW_SRCS ${ARROW_SRCS} ${ARROW_IPC_SRCS})

--- a/cpp/src/arrow/extension_type-test.cc
+++ b/cpp/src/arrow/extension_type-test.cc
@@ -221,7 +221,8 @@ auto RoundtripBatch = [](const std::shared_ptr<RecordBatch>& batch,
                          std::shared_ptr<RecordBatch>* out) {
   std::shared_ptr<io::BufferOutputStream> out_stream;
   ASSERT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &out_stream));
-  ASSERT_OK(ipc::WriteRecordBatchStream({batch}, out_stream.get()));
+  ASSERT_OK(ipc::WriteRecordBatchStream({batch}, ipc::IpcOptions::Defaults(),
+                                        out_stream.get()));
 
   std::shared_ptr<Buffer> complete_ipc_stream;
   ASSERT_OK(out_stream->Finish(&complete_ipc_stream));
@@ -273,7 +274,8 @@ TEST_F(TestExtensionType, UnrecognizedExtension) {
   // and ensure that a plain instance of the storage type is created
   std::shared_ptr<io::BufferOutputStream> out_stream;
   ASSERT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &out_stream));
-  ASSERT_OK(ipc::WriteRecordBatchStream({batch}, out_stream.get()));
+  ASSERT_OK(ipc::WriteRecordBatchStream({batch}, ipc::IpcOptions::Defaults(),
+                                        out_stream.get()));
 
   std::shared_ptr<Buffer> complete_ipc_stream;
   ASSERT_OK(out_stream->Finish(&complete_ipc_stream));

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -251,13 +251,13 @@ class GrpcStreamWriter : public FlightStreamWriter {
       std::shared_ptr<grpc::ClientReaderWriter<pb::FlightData, pb::PutResult>> writer,
       std::unique_ptr<FlightStreamWriter>* out);
 
-  Status WriteRecordBatch(const RecordBatch& batch, bool allow_64bit = false) override {
-    return WriteWithMetadata(batch, nullptr, allow_64bit);
+  Status WriteRecordBatch(const RecordBatch& batch) override {
+    return WriteWithMetadata(batch, nullptr);
   }
-  Status WriteWithMetadata(const RecordBatch& batch, std::shared_ptr<Buffer> app_metadata,
-                           bool allow_64bit = false) override {
+  Status WriteWithMetadata(const RecordBatch& batch,
+                           std::shared_ptr<Buffer> app_metadata) override {
     app_metadata_ = app_metadata;
-    return batch_writer_->WriteRecordBatch(batch, allow_64bit);
+    return batch_writer_->WriteRecordBatch(batch);
   }
   void set_memory_pool(MemoryPool* pool) override {
     batch_writer_->set_memory_pool(pool);

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -86,8 +86,7 @@ class ARROW_FLIGHT_EXPORT FlightStreamReader : public MetadataRecordBatchReader 
 class ARROW_FLIGHT_EXPORT FlightStreamWriter : public ipc::RecordBatchWriter {
  public:
   virtual Status WriteWithMetadata(const RecordBatch& batch,
-                                   std::shared_ptr<Buffer> app_metadata,
-                                   bool allow_64bit = false) = 0;
+                                   std::shared_ptr<Buffer> app_metadata) = 0;
 };
 
 #ifdef _MSC_VER

--- a/cpp/src/arrow/flight/perf-server.cc
+++ b/cpp/src/arrow/flight/perf-server.cc
@@ -74,7 +74,7 @@ class PerfDataStream : public FlightDataStream {
   std::shared_ptr<Schema> schema() override { return schema_; }
 
   Status GetSchemaPayload(FlightPayload* payload) override {
-    return ipc::internal::GetSchemaPayload(*schema_, &dictionary_memo_,
+    return ipc::internal::GetSchemaPayload(*schema_, ipc_options_, &dictionary_memo_,
                                            &payload->ipc_message);
   }
 
@@ -103,8 +103,8 @@ class PerfDataStream : public FlightDataStream {
     } else {
       records_sent_ += batch_length_;
     }
-    return ipc::internal::GetRecordBatchPayload(*batch, default_memory_pool(),
-                                                &payload->ipc_message);
+    return ipc::internal::GetRecordBatchPayload(
+        *batch, ipc_options_, default_memory_pool(), &payload->ipc_message);
   }
 
  private:
@@ -115,6 +115,7 @@ class PerfDataStream : public FlightDataStream {
   int64_t records_sent_;
   std::shared_ptr<Schema> schema_;
   ipc::DictionaryMemo dictionary_memo_;
+  ipc::IpcOptions ipc_options_;
   std::shared_ptr<RecordBatch> batch_;
   ArrayVector arrays_;
 };

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 
+#include "arrow/ipc/options.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -56,11 +57,6 @@ enum class MetadataVersion : char {
   /// >= 0.8.0
   V4
 };
-
-// ARROW-109: We set this number arbitrarily to help catch user mistakes. For
-// deeply nested schemas, it is expected the user will indicate explicitly the
-// maximum allowed recursion depth
-constexpr int kMaxNestingDepth = 64;
 
 // Read interface classes. We do not fully deserialize the flatbuffers so that
 // individual fields metadata can be retrieved from very large schema without

--- a/cpp/src/arrow/ipc/options.cc
+++ b/cpp/src/arrow/ipc/options.cc
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/ipc/options.h"
+
+namespace arrow {
+namespace ipc {
+
+IpcOptions IpcOptions::Defaults() { return IpcOptions(); }
+
+}  // namespace ipc
+}  // namespace arrow

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace ipc {
+
+// ARROW-109: We set this number arbitrarily to help catch user mistakes. For
+// deeply nested schemas, it is expected the user will indicate explicitly the
+// maximum allowed recursion depth
+constexpr int kMaxNestingDepth = 64;
+
+struct ARROW_EXPORT IpcOptions {
+  // If true, allow field lengths that don't fit in a signed 32-bit int.
+  // Some implementations may not be able to parse such streams.
+  bool allow_64bit = false;
+  // The maximum permitted schema nesting depth.
+  int max_recursion_depth = kMaxNestingDepth;
+
+  static IpcOptions Defaults();
+};
+
+}  // namespace ipc
+}  // namespace arrow

--- a/cpp/src/arrow/ipc/read-write-benchmark.cc
+++ b/cpp/src/arrow/ipc/read-write-benchmark.cc
@@ -50,6 +50,7 @@ std::shared_ptr<RecordBatch> MakeRecordBatch(int64_t total_size, int64_t num_fie
 static void WriteRecordBatch(benchmark::State& state) {  // NOLINT non-const reference
   // 1MB
   constexpr int64_t kTotalSize = 1 << 20;
+  auto options = ipc::IpcOptions::Defaults();
 
   std::shared_ptr<ResizableBuffer> buffer;
   ABORT_NOT_OK(AllocateResizableBuffer(kTotalSize & 2, &buffer));
@@ -60,7 +61,7 @@ static void WriteRecordBatch(benchmark::State& state) {  // NOLINT non-const ref
     int32_t metadata_length;
     int64_t body_length;
     if (!ipc::WriteRecordBatch(*record_batch, 0, &stream, &metadata_length, &body_length,
-                               default_memory_pool())
+                               options, default_memory_pool())
              .ok()) {
       state.SkipWithError("Failed to write!");
     }
@@ -71,6 +72,7 @@ static void WriteRecordBatch(benchmark::State& state) {  // NOLINT non-const ref
 static void ReadRecordBatch(benchmark::State& state) {  // NOLINT non-const reference
   // 1MB
   constexpr int64_t kTotalSize = 1 << 20;
+  auto options = ipc::IpcOptions::Defaults();
 
   std::shared_ptr<ResizableBuffer> buffer;
   ABORT_NOT_OK(AllocateResizableBuffer(kTotalSize & 2, &buffer));
@@ -81,7 +83,7 @@ static void ReadRecordBatch(benchmark::State& state) {  // NOLINT non-const refe
   int32_t metadata_length;
   int64_t body_length;
   if (!ipc::WriteRecordBatch(*record_batch, 0, &stream, &metadata_length, &body_length,
-                             default_memory_pool())
+                             options, default_memory_pool())
            .ok()) {
     state.SkipWithError("Failed to write!");
   }

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -25,6 +25,7 @@
 
 #include "arrow/ipc/dictionary.h"
 #include "arrow/ipc/message.h"
+#include "arrow/ipc/options.h"
 #include "arrow/record_batch.h"
 #include "arrow/util/visibility.h"
 
@@ -245,12 +246,12 @@ Status ReadRecordBatch(const Message& message, const std::shared_ptr<Schema>& sc
 /// dictionaries. Can be nullptr if you are sure there are no
 /// dictionary-encoded fields
 /// \param[in] file a random access file
-/// \param[in] max_recursion_depth the maximum permitted nesting depth
+/// \param[in] options options for deserialization
 /// \param[out] out the read record batch
 /// \return Status
 ARROW_EXPORT
 Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& schema,
-                       const DictionaryMemo* dictionary_memo, int max_recursion_depth,
+                       const DictionaryMemo* dictionary_memo, const IpcOptions& options,
                        io::RandomAccessFile* file, std::shared_ptr<RecordBatch>* out);
 
 /// \brief Read arrow::Tensor as encapsulated IPC message in file

--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -209,7 +209,7 @@ Status PyFlightDataStream::Next(FlightPayload* payload) { return stream_->Next(p
 PyGeneratorFlightDataStream::PyGeneratorFlightDataStream(
     PyObject* generator, std::shared_ptr<arrow::Schema> schema,
     PyGeneratorFlightDataStreamCallback callback)
-    : schema_(schema), callback_(callback) {
+    : schema_(schema), options_(ipc::IpcOptions::Defaults()), callback_(callback) {
   Py_INCREF(generator);
   generator_.reset(generator);
 }
@@ -217,7 +217,7 @@ PyGeneratorFlightDataStream::PyGeneratorFlightDataStream(
 std::shared_ptr<Schema> PyGeneratorFlightDataStream::schema() { return schema_; }
 
 Status PyGeneratorFlightDataStream::GetSchemaPayload(FlightPayload* payload) {
-  return ipc::internal::GetSchemaPayload(*schema_, &dictionary_memo_,
+  return ipc::internal::GetSchemaPayload(*schema_, options_, &dictionary_memo_,
                                          &payload->ipc_message);
 }
 

--- a/cpp/src/arrow/python/flight.h
+++ b/cpp/src/arrow/python/flight.h
@@ -194,6 +194,7 @@ class ARROW_PYTHON_EXPORT PyGeneratorFlightDataStream
   OwnedRefNoGIL generator_;
   std::shared_ptr<arrow::Schema> schema_;
   ipc::DictionaryMemo dictionary_memo_;
+  ipc::IpcOptions options_;
   PyGeneratorFlightDataStreamCallback callback_;
 };
 

--- a/cpp/src/arrow/python/serialize.h
+++ b/cpp/src/arrow/python/serialize.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#include "arrow/ipc/options.h"
 #include "arrow/python/visibility.h"
 #include "arrow/status.h"
 
@@ -52,6 +53,9 @@ struct ARROW_PYTHON_EXPORT SerializedPyObject {
   std::vector<std::shared_ptr<Tensor>> tensors;
   std::vector<std::shared_ptr<Tensor>> ndarrays;
   std::vector<std::shared_ptr<Buffer>> buffers;
+  ipc::IpcOptions ipc_options;
+
+  SerializedPyObject();
 
   /// \brief Write serialized Python object to OutputStream
   /// \param[in,out] dst an OutputStream

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -952,8 +952,18 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MessageType_V3" arrow::ipc::MetadataVersion::V3"
         MessageType_V4" arrow::ipc::MetadataVersion::V4"
 
+    cdef cppclass CIpcOptions" arrow::ipc::IpcOptions":
+        @staticmethod
+        CIpcOptions Defaults()
+
     cdef cppclass CDictionaryMemo" arrow::ipc::DictionaryMemo":
         pass
+
+    cdef cppclass CIpcPayload" arrow::ipc::internal::IpcPayload":
+        MessageType type
+        shared_ptr[CBuffer] metadata
+        vector[shared_ptr[CBuffer]] body_buffers
+        int64_t body_length
 
     cdef cppclass CMessage" arrow::ipc::Message":
         CStatus Open(const shared_ptr[CBuffer]& metadata,
@@ -981,8 +991,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
 
     cdef cppclass CRecordBatchWriter" arrow::ipc::RecordBatchWriter":
         CStatus Close()
-        CStatus WriteRecordBatch(const CRecordBatch& batch,
-                                 c_bool allow_64bit)
+        CStatus WriteRecordBatch(const CRecordBatch& batch)
         CStatus WriteTable(const CTable& table, int64_t max_chunksize)
 
     cdef cppclass CRecordBatchStreamReader \
@@ -1058,6 +1067,13 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
 
     CStatus AlignStream(InputStream* stream, int64_t alignment)
     CStatus AlignStream(OutputStream* stream, int64_t alignment)
+
+    cdef CStatus GetRecordBatchPayload\
+        " arrow::ipc::internal::GetRecordBatchPayload"(
+            const CRecordBatch& batch,
+            const CIpcOptions& options,
+            CMemoryPool* pool,
+            CIpcPayload* out)
 
     cdef cppclass CFeatherWriter" arrow::ipc::feather::TableWriter":
         @staticmethod

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -23,20 +23,6 @@ from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
 
-cdef extern from "arrow/ipc/api.h" namespace "arrow" nogil:
-    cdef cppclass CIpcPayload" arrow::ipc::internal::IpcPayload":
-        MessageType type
-        shared_ptr[CBuffer] metadata
-        vector[shared_ptr[CBuffer]] body_buffers
-        int64_t body_length
-
-    cdef CStatus _GetRecordBatchPayload\
-        " arrow::ipc::internal::GetRecordBatchPayload"(
-            const CRecordBatch& batch,
-            CMemoryPool* pool,
-            CIpcPayload* out)
-
-
 cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CActionType" arrow::flight::ActionType":
         c_string type
@@ -158,8 +144,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CFlightStreamWriter \
             " arrow::flight::FlightStreamWriter"(CRecordBatchWriter):
         CStatus WriteWithMetadata(const CRecordBatch& batch,
-                                  shared_ptr[CBuffer] app_metadata,
-                                  c_bool allow_64bit)
+                                  shared_ptr[CBuffer] app_metadata)
 
     cdef cppclass CRecordBatchStream \
             " arrow::flight::RecordBatchStream"(CFlightDataStream):

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -182,7 +182,7 @@ cdef class _CRecordBatchWriter:
         """
         with nogil:
             check_status(self.writer.get()
-                         .WriteRecordBatch(deref(batch.batch), 1))
+                         .WriteRecordBatch(deref(batch.batch)))
 
     def write_table(self, Table table, chunksize=None):
         """

--- a/r/src/recordbatchwriter.cpp
+++ b/r/src/recordbatchwriter.cpp
@@ -23,7 +23,7 @@
 void ipc___RecordBatchWriter__WriteRecordBatch(
     const std::shared_ptr<arrow::ipc::RecordBatchWriter>& batch_writer,
     const std::shared_ptr<arrow::RecordBatch>& batch) {
-  STOP_IF_NOT_OK(batch_writer->WriteRecordBatch(*batch, true));
+  STOP_IF_NOT_OK(batch_writer->WriteRecordBatch(*batch));
 }
 
 // [[arrow::export]]


### PR DESCRIPTION
Switch existing APIs to take IpcOptions rather than individual option arguments.