### PR TITLE
ARROW-6167: [R] macOS binary R packages on CRAN don't have arrow_available

### DIFF
--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -30,6 +30,12 @@ Install the latest release of `arrow` from CRAN with
 install.packages("arrow")
 ```
 
+> Warning: the macOS binary packages on CRAN for 0.14.1 do not work as described
+> below. To install, you'll first need to use Homebrew to get the Arrow C++
+> library (`brew install apache-arrow`), and then from R you can
+> `install.packages("arrow", type = "source")`. We hope to have this resolved
+> in the next release.
+
 On macOS and Windows, installing a binary package from CRAN will handle Arrow's C++ dependencies for you. On Linux, you'll need to first install the C++ library. See the [Arrow project installation page](https://arrow.apache.org/install/) for a list of PPAs from which you can obtain it.
 
 If you install the `arrow` package from source and the C++ library is not found, the R package functions will notify you that Arrow is not available. Call

--- a/r/README.md
+++ b/r/README.md
@@ -27,6 +27,12 @@ Install the latest release of `arrow` from CRAN with
 install.packages("arrow")
 ```
 
+> Warning: the macOS binary packages on CRAN for 0.14.1 do not work as
+> described below. To install, you’ll first need to use Homebrew to get
+> the Arrow C++ library (`brew install apache-arrow`), and then from R
+> you can `install.packages("arrow", type = "source")`. We hope to have
+> this resolved in the next release.
+
 On macOS and Windows, installing a binary package from CRAN will handle
 Arrow’s C++ dependencies for you. On Linux, you’ll need to first install
 the C++ library. See the [Arrow project installation

--- a/r/configure
+++ b/r/configure
@@ -48,41 +48,41 @@ else
   # Use pkg-config if available
   pkg-config --version >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    echo "$ pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}"
+    # echo "$ pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}"
     PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
-    echo "PKGCONFIG_CFLAGS = \"${PKGCONFIG_CFLAGS}\""
+    # echo "PKGCONFIG_CFLAGS = \"${PKGCONFIG_CFLAGS}\""
 
-    echo "$ pkg-config --libs ${PKG_CONFIG_NAME}"
+    # echo "$ pkg-config --libs ${PKG_CONFIG_NAME}"
     PKGCONFIG_LIBS=`pkg-config --libs --silence-errors ${PKG_CONFIG_NAME}`
-    echo "PKGCONFIG_LIBS = \"${PKGCONFIG_LIBS}\""
-    echo ""
+    # echo "PKGCONFIG_LIBS = \"${PKGCONFIG_LIBS}\""
+    # echo ""
   fi
 
   if [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
-    echo "Found pkg-config cflags and libs!"
+    echo "Arrow C++ libraries found via pkg-config"
     PKG_CFLAGS="$PKGCONFIG_CFLAGS"
     PKG_LIBS=${PKGCONFIG_LIBS}
   else
     if [[ "$OSTYPE" == "darwin"* ]]; then
       if [ "$(command -v brew)" ]; then
-        echo "brew is available"
-        BREWDIR=$(brew --prefix)
-
-        if brew ls --versions apache-arrow > /dev/null; then
-          # Install apache-arrow via Homebrew if we don't already have it
+        if [ "$(brew ls --versions apache-arrow)" == "" ]; then
+          echo "Installing apache-arrow via Homebrew"
           brew install apache-arrow
+        else
+          # We already have it so no need to install
+          echo "Using Homebrew apache-arrow"
         fi
 
+        BREWDIR=$(brew --prefix)
         PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
         PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
       else
-        echo "brew is not available, trying autobrew"
+        echo "Installing apache-arrow via Autobrew"
         curl -sfL "https://jeroen.github.io/autobrew/$PKG_BREW_NAME" > autobrew
         source autobrew
         PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
         PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
       fi
-
     fi
   fi
 fi

--- a/r/configure
+++ b/r/configure
@@ -48,14 +48,8 @@ else
   # Use pkg-config if available
   pkg-config --version >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    # echo "$ pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}"
     PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
-    # echo "PKGCONFIG_CFLAGS = \"${PKGCONFIG_CFLAGS}\""
-
-    # echo "$ pkg-config --libs ${PKG_CONFIG_NAME}"
     PKGCONFIG_LIBS=`pkg-config --libs --silence-errors ${PKG_CONFIG_NAME}`
-    # echo "PKGCONFIG_LIBS = \"${PKGCONFIG_LIBS}\""
-    # echo ""
   fi
 
   if [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
@@ -65,19 +59,19 @@ else
   else
     if [[ "$OSTYPE" == "darwin"* ]]; then
       if [ "$(command -v brew)" ]; then
-        if [ "$(brew ls --versions apache-arrow)" == "" ]; then
-          echo "Installing apache-arrow via Homebrew"
-          brew install apache-arrow
+        if [ "$(brew ls --versions ${PKG_BREW_NAME})" == "" ]; then
+          echo "Installing ${PKG_BREW_NAME} via Homebrew"
+          brew install ${PKG_BREW_NAME}
         else
           # We already have it so no need to install
-          echo "Using Homebrew apache-arrow"
+          echo "Using Homebrew ${PKG_BREW_NAME}"
         fi
 
         BREWDIR=$(brew --prefix)
         PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"
         PKG_LIBS="-L$BREWDIR/opt/$PKG_BREW_NAME/lib $PKG_LIBS"
       else
-        echo "Installing apache-arrow via Autobrew"
+        echo "Installing ${PKG_BREW_NAME} via Autobrew"
         curl -sfL "https://jeroen.github.io/autobrew/$PKG_BREW_NAME" > autobrew
         source autobrew
         PKG_CFLAGS="-I$BREWDIR/opt/$PKG_BREW_NAME/include"


### PR DESCRIPTION
This fixes one of the three possibilities described on the ticket, and certainly not the one that affected CRAN. It also adds a warning to the README with workaround instructions.