### PR TITLE
ARROW-6082: [Python] check type of the index_type passed to pa.dictionary()

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -357,6 +357,12 @@ def test_dictionary_type():
     assert ty2.value_type == pa.string()
     assert ty2.ordered is False
 
+    # invalid index type raises
+    with pytest.raises(TypeError):
+        pa.dictionary(pa.string(), pa.int64())
+    with pytest.raises(TypeError):
+        pa.dictionary(pa.uint32(), pa.string())
+
 
 def test_types_hashable():
     many_types = get_many_types()

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1664,6 +1664,9 @@ cpdef DictionaryType dictionary(index_type, value_type, bint ordered=False):
         DictionaryType out = DictionaryType.__new__(DictionaryType)
         shared_ptr[CDataType] dict_type
 
+    if _index_type.id not in {Type_INT8, Type_INT16, Type_INT32, Type_INT64}:
+        raise TypeError("The dictionary index type should be signed integer.")
+
     dict_type.reset(new CDictionaryType(_index_type.sp_type,
                                         _value_type.sp_type, ordered == 1))
     out.init(dict_type)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6082