### PR TITLE
ARROW-6175: [Java] Fix MapVector#getMinorType and extend AbstractContainerVector addOrGet complex vector API

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
@@ -23,6 +23,8 @@ import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.ArrowType.FixedSizeList;
 import org.apache.arrow.vector.types.pojo.ArrowType.List;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -111,6 +113,14 @@ public abstract class AbstractContainerVector implements ValueVector, DensityAwa
 
   public UnionVector addOrGetUnion(String name) {
     return addOrGet(name, FieldType.nullable(MinorType.UNION.getType()), UnionVector.class);
+  }
+
+  public FixedSizeListVector addOrGetFixedSizeList(String name, int listSize) {
+    return addOrGet(name, FieldType.nullable(new FixedSizeList(listSize)), FixedSizeListVector.class);
+  }
+
+  public MapVector addOrGetMap(String name, boolean keysSorted) {
+    return addOrGet(name, FieldType.nullable(new ArrowType.Map(keysSorted)), MapVector.class);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -114,4 +114,9 @@ public class MapVector extends ListVector {
     }
     return (UnionMapReader)reader;
   }
+
+  @Override
+  public MinorType getMinorType() {
+    return MinorType.MAP;
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedFixedWidthVectorLike.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/RepeatedFixedWidthVectorLike.java
@@ -29,12 +29,4 @@ public interface RepeatedFixedWidthVectorLike {
    * @param innerValueCount Number of supported values in the vector.
    */
   void allocateNew(int valueCount, int innerValueCount);
-
-  /**
-   * Load the records in the provided buffer based on the given number of values.
-   * @param valueCount   Number of separate repeating groupings.
-   * @param innerValueCount Number atomic values the buffer contains.
-   * @param buf Incoming buffer.
-   * @return The number of bytes of the buffer that were consumed.
-   */
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
@@ -160,4 +160,25 @@ public class TestStructVector {
       assertEquals(MinorType.VARCHAR, primitiveVectors.get(3).getMinorType());
     }
   }
+
+  @Test
+  public void testAddOrGetComplexChildVectors() {
+    FieldType type = new FieldType(true, Struct.INSTANCE, null, null);
+    try (StructVector vector = new StructVector("struct", allocator, type, null)) {
+
+      vector.addOrGetList("list");
+      vector.addOrGetFixedSizeList("fixedList", 2);
+      vector.addOrGetUnion("union");
+      vector.addOrGetStruct("struct");
+      vector.addOrGetMap("map", true);
+
+      List<FieldVector> childrens = vector.getChildrenFromFields();
+      assertEquals(5, childrens.size());
+      assertEquals(MinorType.LIST, childrens.get(0).getMinorType());
+      assertEquals(MinorType.FIXED_SIZE_LIST, childrens.get(1).getMinorType());
+      assertEquals(MinorType.UNION, childrens.get(2).getMinorType());
+      assertEquals(MinorType.STRUCT, childrens.get(3).getMinorType());
+      assertEquals(MinorType.MAP, childrens.get(4).getMinorType());
+    }
+  }
 }


### PR DESCRIPTION
Related to [ARROW-6175](https://issues.apache.org/jira/browse/ARROW-6175).

i. Currently MapVector#getMinorType extends ListVector which returns the wrong MinorType.
ii. AbstractContainerVector now only has addOrGetList, addOrGetUnion, addOrGetStruct which not support all complex type like MapVector and FixedSizeListVector.