### PR TITLE
ARROW-6199: [Java] Avro adapter avoid potential resource leak.

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -20,7 +20,6 @@ package org.apache.arrow;
 import static org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE;
 import static org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +36,7 @@ import org.apache.arrow.consumers.AvroLongConsumer;
 import org.apache.arrow.consumers.AvroNullConsumer;
 import org.apache.arrow.consumers.AvroStringConsumer;
 import org.apache.arrow.consumers.AvroUnionsConsumer;
+import org.apache.arrow.consumers.CompositeAvroConsumer;
 import org.apache.arrow.consumers.Consumer;
 import org.apache.arrow.consumers.NullableTypeConsumer;
 import org.apache.arrow.memory.BufferAllocator;
@@ -246,19 +246,10 @@ public class AvroToArrowUtils {
 
     VectorSchemaRoot root = new VectorSchemaRoot(fields, vectors, 0);
 
-    int valueCount = 0;
-    while (true) {
-      try {
-        for (Consumer consumer : consumers) {
-          consumer.consume(decoder);
-        }
-        valueCount++;
-        //reach end will throw EOFException.
-      } catch (EOFException eofException) {
-        root.setRowCount(valueCount);
-        break;
-      }
+    try (CompositeAvroConsumer compositeConsumer = new CompositeAvroConsumer(consumers)) {
+      compositeConsumer.consume(decoder, root);
     }
+
     return root;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -246,8 +246,13 @@ public class AvroToArrowUtils {
 
     VectorSchemaRoot root = new VectorSchemaRoot(fields, vectors, 0);
 
-    try (CompositeAvroConsumer compositeConsumer = new CompositeAvroConsumer(consumers)) {
+    CompositeAvroConsumer compositeConsumer = null;
+    try {
+      compositeConsumer = new CompositeAvroConsumer(consumers);
       compositeConsumer.consume(decoder, root);
+    } catch (Exception e) {
+      compositeConsumer.close();
+      throw new RuntimeException("Error occurs while consume process.", e);
     }
 
     return root;

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -63,4 +63,9 @@ public class AvroBooleanConsumer implements Consumer {
     return this.vector;
   }
 
+  @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -81,9 +81,7 @@ public class AvroBytesConsumer implements Consumer {
   }
 
   @Override
-  public void close() {
-    if (cacheBuffer != null) {
-      cacheBuffer.clear();
-    }
+  public void close() throws Exception {
+    writer.close();
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -79,4 +79,11 @@ public class AvroBytesConsumer implements Consumer {
   public FieldVector getVector() {
     return vector;
   }
+
+  @Override
+  public void close() {
+    if (cacheBuffer != null) {
+      cacheBuffer.clear();
+    }
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -62,4 +62,9 @@ public class AvroDoubleConsumer implements Consumer {
   public FieldVector getVector() {
     return vector;
   }
+
+  @Override
+  public void close() throws Exception {
+    writer.close();
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -62,4 +62,9 @@ public class AvroFloatConsumer implements Consumer {
   public FieldVector getVector() {
     return this.vector;
   }
+
+  @Override
+  public void close() throws Exception {
+    writer.close();
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -62,4 +62,9 @@ public class AvroIntConsumer implements Consumer {
   public FieldVector getVector() {
     return this.vector;
   }
+
+  @Override
+  public void close() throws Exception {
+    writer.close();
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -62,4 +62,9 @@ public class AvroLongConsumer implements Consumer {
   public FieldVector getVector() {
     return this.vector;
   }
+
+  @Override
+  public void close() throws Exception {
+    writer.close();
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
@@ -48,4 +48,9 @@ public class AvroNullConsumer implements Consumer {
   public FieldVector getVector() {
     return this.vector;
   }
+
+  @Override
+  public void close() {
+    vector.close();
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -82,9 +82,7 @@ public class AvroStringConsumer implements Consumer {
   }
 
   @Override
-  public void close() {
-    if (cacheBuffer != null) {
-      cacheBuffer.clear();
-    }
+  public void close() throws Exception {
+    writer.close();
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -80,4 +80,11 @@ public class AvroStringConsumer implements Consumer {
   public FieldVector getVector() {
     return this.vector;
   }
+
+  @Override
+  public void close() {
+    if (cacheBuffer != null) {
+      cacheBuffer.clear();
+    }
+  }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
@@ -31,7 +31,7 @@ import org.apache.avro.io.Decoder;
  */
 public class AvroUnionsConsumer implements Consumer {
 
-  private Consumer[] indexDelegates;
+  private Consumer[] delegates;
   private Types.MinorType[] types;
 
   private UnionWriter writer;
@@ -40,11 +40,11 @@ public class AvroUnionsConsumer implements Consumer {
   /**
    * Instantiate a AvroUnionConsumer.
    */
-  public AvroUnionsConsumer(UnionVector vector, Consumer[] indexDelegates, Types.MinorType[] types) {
+  public AvroUnionsConsumer(UnionVector vector, Consumer[] delegates, Types.MinorType[] types) {
 
     this.writer = new UnionWriter(vector);
     this.vector = vector;
-    this.indexDelegates = indexDelegates;
+    this.delegates = delegates;
     this.types = types;
   }
 
@@ -53,7 +53,7 @@ public class AvroUnionsConsumer implements Consumer {
     int fieldIndex = decoder.readInt();
     int position = writer.getPosition();
 
-    Consumer delegate = indexDelegates[fieldIndex];
+    Consumer delegate = delegates[fieldIndex];
 
     vector.setType(position, types[fieldIndex]);
     // In UnionVector we need to set sub vector writer position before consume a value
@@ -79,5 +79,12 @@ public class AvroUnionsConsumer implements Consumer {
   public FieldVector getVector() {
     vector.setValueCount(writer.getPosition());
     return this.vector;
+  }
+
+  @Override
+  public void close() {
+    for (Consumer consumer : delegates) {
+      consumer.close();
+    }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroUnionsConsumer.java
@@ -82,9 +82,10 @@ public class AvroUnionsConsumer implements Consumer {
   }
 
   @Override
-  public void close() {
-    for (Consumer consumer : delegates) {
-      consumer.close();
+  public void close() throws Exception {
+    writer.close();
+    for (Consumer delegate: delegates) {
+      delegate.close();
     }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/CompositeAvroConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/CompositeAvroConsumer.java
@@ -59,7 +59,11 @@ public class CompositeAvroConsumer implements AutoCloseable {
   public void close() {
     // clean up
     for (Consumer consumer : consumers) {
-      consumer.close();
+      try {
+        consumer.close();
+      } catch (Exception e) {
+        throw new RuntimeException("Error occurs in close.", e);
+      }
     }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -50,7 +50,7 @@ public interface Consumer extends AutoCloseable {
   FieldVector getVector();
 
   /**
-   * Close this consumer, do some clean work such as clear reuse ArrowBuf.
+   * Close this consumer, do some clean work such as clear reuse ByteBuffer.
    */
   default void close() {}
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -50,7 +50,7 @@ public interface Consumer extends AutoCloseable {
   FieldVector getVector();
 
   /**
-   * Close this consumer, do some clean work such as clear reuse ByteBuffer.
+   * Close this consumer, do some clean work such as clear vectors.
    */
-  default void close() {}
+  void close() throws Exception;
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -25,7 +25,7 @@ import org.apache.avro.io.Decoder;
 /**
  * Interface that is used to consume values from avro decoder.
  */
-public interface Consumer {
+public interface Consumer extends AutoCloseable {
 
   /**
    * Consume a specific type value from avro decoder and write it to vector.
@@ -48,4 +48,9 @@ public interface Consumer {
    * Get the vector within the consumer.
    */
   FieldVector getVector();
+
+  /**
+   * Close this consumer, do some clean work such as clear reuse ArrowBuf.
+   */
+  default void close() {}
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -50,7 +50,7 @@ public interface Consumer extends AutoCloseable {
   FieldVector getVector();
 
   /**
-   * Close this consumer, do some clean work such as clear vectors.
+   * Close this consumer when occurs exception to avoid potential leak.
    */
   void close() throws Exception;
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
@@ -66,7 +66,7 @@ public class NullableTypeConsumer implements Consumer {
   }
 
   @Override
-  public void close() {
+  public void close() throws Exception {
     delegate.close();
   }
 


### PR DESCRIPTION
Related to [ARROW-6199](https://issues.apache.org/jira/browse/ARROW-6199).

Currently, avro consumer interface has no close API, which may cause resource leak like AvroBytesConsumer#cacheBuffer.
To resolve this, make consumer extends AutoCloseable and create CompositeAvroConsumer to encompasses consume and close logic. 