### PR TITLE
ARROW-6200: [Java] Method getBufferSizeFor in BaseRepeatedValueVector/ListVector not correct

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -209,7 +209,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
 
   @Override
   public int getBufferSize() {
-    if (getValueCount() == 0) {
+    if (valueCount == 0) {
       return 0;
     }
     return ((valueCount + 1) * OFFSET_WIDTH) + vector.getBufferSize();
@@ -221,7 +221,9 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
       return 0;
     }
 
-    return ((valueCount + 1) * OFFSET_WIDTH) + vector.getBufferSizeFor(valueCount);
+    int innerVectorValueCount = offsetBuffer.getInt(valueCount * OFFSET_WIDTH);
+
+    return ((valueCount + 1) * OFFSET_WIDTH) + vector.getBufferSizeFor(innerVectorValueCount);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -620,11 +620,9 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     if (valueCount == 0) {
       return 0;
     }
-    final int offsetBufferSize = (valueCount + 1) * OFFSET_WIDTH;
     final int validityBufferSize = getValidityBufferSizeFromCount(valueCount);
 
-    final int innerVectorValueCount = offsetBuffer.getInt(valueCount * OFFSET_WIDTH);
-    return offsetBufferSize + validityBufferSize + vector.getBufferSizeFor(innerVectorValueCount);
+    return super.getBufferSizeFor(valueCount) + validityBufferSize;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -616,6 +616,18 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
   }
 
   @Override
+  public int getBufferSizeFor(int valueCount) {
+    if (valueCount == 0) {
+      return 0;
+    }
+    final int offsetBufferSize = (valueCount + 1) * OFFSET_WIDTH;
+    final int validityBufferSize = getValidityBufferSizeFromCount(valueCount);
+
+    final int innerVectorValueCount = offsetBuffer.getInt(valueCount * OFFSET_WIDTH);
+    return offsetBufferSize + validityBufferSize + vector.getBufferSizeFor(innerVectorValueCount);
+  }
+
+  @Override
   public Field getField() {
     return new Field(getName(), fieldType, Collections.singletonList(getDataVector().getField()));
   }


### PR DESCRIPTION
Related to ARROW-6200.

>Currently, getBufferSizeFor in BaseRepeatedValueVector implemented as below:
if (valueCount == 0) {
  return 0;
}
return ((valueCount + 1) * OFFSET_WIDTH) + vector.getBufferSizeFor(valueCount);

Here vector.getBufferSizeFor(valueCount) seems not right which should be

>int innerVectorValueCount = offsetBuffer.getInt(valueCount * OFFSET_WIDTH);
vector.getBufferSizeFor(innerVectorValueCount)

 ListVector has the same problem.