### PR TITLE
ARROW-6205: [C++] ARROW_DEPRECATED warning when including io/interfaces.h

### DIFF
--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -191,7 +191,7 @@ class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile, public Writ
 };
 
 // TODO(kszucs): remove this after 0.13
-#if not defined(_MSC_VER) && not defined(__CUDACC__)
+#if !defined(_MSC_VER) && !defined(__CUDACC__)
 using WriteableFile ARROW_DEPRECATED("Use WritableFile") = WritableFile;
 using ReadableFileInterface ARROW_DEPRECATED("Use RandomAccessFile") = RandomAccessFile;
 #else

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -190,16 +190,6 @@ class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile, public Writ
   ReadWriteFileInterface() { RandomAccessFile::set_mode(FileMode::READWRITE); }
 };
 
-// TODO(kszucs): remove this after 0.13
-#if !defined(_MSC_VER) && !defined(__CUDACC__)
-using WriteableFile ARROW_DEPRECATED("Use WritableFile") = WritableFile;
-using ReadableFileInterface ARROW_DEPRECATED("Use RandomAccessFile") = RandomAccessFile;
-#else
-// MSVC does not like using ARROW_DEPRECATED with using declarations
-using WriteableFile = WritableFile;
-using ReadableFileInterface = RandomAccessFile;
-#endif
-
 }  // namespace io
 }  // namespace arrow
 

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -191,7 +191,7 @@ class ARROW_EXPORT ReadWriteFileInterface : public RandomAccessFile, public Writ
 };
 
 // TODO(kszucs): remove this after 0.13
-#ifndef _MSC_VER
+#if not defined(_MSC_VER) && not defined(__CUDACC__)
 using WriteableFile ARROW_DEPRECATED("Use WritableFile") = WritableFile;
 using ReadableFileInterface ARROW_DEPRECATED("Use RandomAccessFile") = RandomAccessFile;
 #else


### PR DESCRIPTION
ARROW_DEPRECATED on using statements causes warnings when including interfaces.h from CUDA source files (.cu) compiled with nvcc.

This PR works around this issue the same way it is done for MSVC by changing a single preprocessor condition.

Fixes [JIRA 6205 ](https://issues.apache.org/jira/browse/ARROW-6205?jql=project%20%3D%20ARROW%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22ARROW_DEPRECATED%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)