### PR TITLE
ARROW-6215: [Java] Fix case when ZeroVector is compared against other vector types

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -268,6 +268,6 @@ public class ZeroVector implements FieldVector {
 
   @Override
   public boolean accept(RangeEqualsVisitor visitor) {
-    return true;
+    return visitor.visit(this);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -76,7 +76,7 @@ public class RangeEqualsVisitor {
   }
 
   public boolean visit(ZeroVector left) {
-    return true;
+    return compareValueVector(left, right);
   }
 
   public boolean visit(ValueVector left) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2266,6 +2266,19 @@ public class TestValueVector {
   }
 
   @Test
+  public void testZeroVectorNotEquals() {
+    try (final IntVector intVector = new IntVector("int", allocator);
+         final ZeroVector zeroVector = new ZeroVector()) {
+
+      VectorEqualsVisitor zeroVisitor = new VectorEqualsVisitor(zeroVector);
+      assertFalse(intVector.accept(zeroVisitor));
+
+      VectorEqualsVisitor intVisitor = new VectorEqualsVisitor(intVector);
+      assertFalse(zeroVector.accept(intVisitor));
+    }
+  }
+
+  @Test
   public void testIntVectorEqualsWithNull() {
     try (final IntVector vector1 = new IntVector("int", allocator);
         final IntVector vector2 = new IntVector("int", allocator)) {


### PR DESCRIPTION
This fixes a bug that when a ZeroVector is compared with a vector of any other type, it always returns true. Instead of hard-coding a return value of `true` in `ZeroVector.accept`, the `RangeEqualsVisitor` is used to compare the vector types.