### PR TITLE
ARROW-6218: [Java] Add UINT type test in integration to avoid potential overflow

### DIFF
--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
@@ -413,7 +413,7 @@ public class TestJSONFile extends BaseFileTest {
         final UInt4Vector uInt4Vector = new UInt4Vector("uint4", allocator);
         final UInt1Vector uInt1Vector = new UInt1Vector("uint1", allocator)) {
 
-      long[] longValues = new long[]{0x8000000000000000L, 0x7fffffffffffffffL, 0xffffffffffffffffL};
+      long[] longValues = new long[]{Long.MIN_VALUE, Long.MAX_VALUE, -1L};
       uInt8Vector.allocateNew(3);
       uInt8Vector.setValueCount(3);
       for (int i = 0; i < longValues.length; i++) {
@@ -422,7 +422,7 @@ public class TestJSONFile extends BaseFileTest {
         assertEquals(readValue, longValues[i]);
       }
 
-      int[] intValues = new int[]{0x80000000, 0x7fffffff, 0xffffffff};
+      int[] intValues = new int[]{Integer.MIN_VALUE, Integer.MAX_VALUE, -1};
       uInt4Vector.allocateNew(3);
       uInt4Vector.setValueCount(3);
       for (int i = 0; i < intValues.length; i++) {
@@ -431,7 +431,7 @@ public class TestJSONFile extends BaseFileTest {
         assertEquals(intValues[i], actualValue);
       }
 
-      byte[] byteValues = new byte[]{-128, 127, -1};
+      byte[] byteValues = new byte[]{Byte.MIN_VALUE, Byte.MAX_VALUE, -1};
       uInt1Vector.allocateNew(3);
       uInt1Vector.setValueCount(3);
       for (int i = 0; i < byteValues.length; i++) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
@@ -17,11 +17,16 @@
 
 package org.apache.arrow.vector.ipc;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.impl.ComplexWriterImpl;
@@ -399,6 +404,41 @@ public class TestJSONFile extends BaseFileTest {
         validateMapData(root);
       }
       reader.close();
+    }
+  }
+
+  @Test
+  public void testNoOverFlowWithUINT() {
+    try (final UInt8Vector uInt8Vector = new UInt8Vector("uint8", allocator);
+        final UInt4Vector uInt4Vector = new UInt4Vector("uint4", allocator);
+        final UInt1Vector uInt1Vector = new UInt1Vector("uint1", allocator)) {
+
+      long[] longValues = new long[]{0x8000000000000000L, 0x7fffffffffffffffL, 0xffffffffffffffffL};
+      uInt8Vector.allocateNew(3);
+      uInt8Vector.setValueCount(3);
+      for (int i = 0; i < longValues.length; i++) {
+        uInt8Vector.set(i, longValues[i]);
+        long readValue = uInt8Vector.getObjectNoOverflow(i).longValue();
+        assertEquals(readValue, longValues[i]);
+      }
+
+      int[] intValues = new int[]{0x80000000, 0x7fffffff, 0xffffffff};
+      uInt4Vector.allocateNew(3);
+      uInt4Vector.setValueCount(3);
+      for (int i = 0; i < intValues.length; i++) {
+        uInt4Vector.set(i, intValues[i]);
+        int actualValue = (int) UInt4Vector.getNoOverflow(uInt4Vector.getDataBuffer(), i);
+        assertEquals(intValues[i], actualValue);
+      }
+
+      byte[] byteValues = new byte[]{-128, 127, -1};
+      uInt1Vector.allocateNew(3);
+      uInt1Vector.setValueCount(3);
+      for (int i = 0; i < byteValues.length; i++) {
+        uInt1Vector.set(i, byteValues[i]);
+        byte actualValue = (byte) UInt1Vector.getNoOverflow(uInt1Vector.getDataBuffer(),i);
+        assertEquals(byteValues[i], actualValue);
+      }
     }
   }
 }


### PR DESCRIPTION
Related to [ARROW-6218](https://issues.apache.org/jira/browse/ARROW-6218).
As per discussion https://github.com/apache/arrow/pull/5002

For UINT type, when write/read json data in integration test, it extend data type(i.e. Long->BigInteger, Int->Long) to avoid potential overflow.

Like UINT8 the write side and read side code like this:
>case UINT8:
  generator.writeNumber(UInt8Vector.getNoOverflow(buffer, index));
  break;
 
>BigInteger value = parser.getBigIntegerValue();
buf.writeLong(value.longValue());

Should add a test to avoid potential overflow in the data transfer process.