### PR TITLE
ARROW-6224: [Python] fix deprecated usage of .data (previouly Column.data)

### DIFF
--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -59,7 +59,7 @@ class FeatherReader(ext.FeatherReader):
 
 
 def check_chunked_overflow(col):
-    if col.data.num_chunks == 1:
+    if col.num_chunks == 1:
         return
 
     if col.type in (ext.binary(), ext.string()):
@@ -94,7 +94,7 @@ class FeatherWriter(object):
             for i, name in enumerate(table.schema.names):
                 col = table[i]
                 check_chunked_overflow(col)
-                self.writer.write_array(name, col.data.chunk(0))
+                self.writer.write_array(name, col.chunk(0))
 
         self.writer.close()
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -302,7 +302,7 @@ def _sanitize_schema(schema, flavor):
 def _sanitize_table(table, new_schema, flavor):
     # TODO: This will not handle prohibited characters in nested field names
     if 'spark' in flavor:
-        column_data = [table[i].data for i in range(table.num_columns)]
+        column_data = [table[i] for i in range(table.num_columns)]
         return pa.Table.from_arrays(column_data, schema=new_schema)
     else:
         return table

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -697,7 +697,8 @@ def test_cast_chunked_array():
 
 def test_chunked_array_data_warns():
     with pytest.warns(FutureWarning):
-        pa.chunked_array([[]]).data
+        res = pa.chunked_array([[]]).data
+    assert isinstance(res, pa.ChunkedArray)
 
 
 def test_cast_integers_unsafe():

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -796,7 +796,7 @@ class TestConvertPrimitiveTypes(object):
             schema = pa.schema([pa.field('has_nulls', ty)])
             result = pa.Table.from_pandas(df, schema=schema,
                                           preserve_index=False)
-            assert result[0].data.chunk(0).equals(expected)
+            assert result[0].chunk(0).equals(expected)
 
     def test_int_object_nulls(self):
         arr = np.array([None, 1, np.int64(3)] * 5, dtype=object)
@@ -955,7 +955,7 @@ class TestConvertDateTimeLikeTypes(object):
         })
 
         table = pa.Table.from_pandas(df)
-        assert isinstance(table[0].data.chunk(0), pa.TimestampArray)
+        assert isinstance(table[0].chunk(0), pa.TimestampArray)
 
         result = table.to_pandas()
         expected_df = pd.DataFrame({
@@ -1004,7 +1004,7 @@ class TestConvertDateTimeLikeTypes(object):
         df = pd.DataFrame({"datetime": pd.Series(date_array, dtype=object)})
 
         table = pa.Table.from_pandas(df)
-        assert isinstance(table[0].data.chunk(0), pa.TimestampArray)
+        assert isinstance(table[0].chunk(0), pa.TimestampArray)
 
         result = table.to_pandas()
         expected_df = pd.DataFrame({"datetime": date_array})
@@ -1023,7 +1023,7 @@ class TestConvertDateTimeLikeTypes(object):
         df = pd.DataFrame({"date": pd.Series(date_array, dtype=object)})
 
         table = pa.Table.from_pandas(df)
-        assert isinstance(table[0].data.chunk(0), pa.Date32Array)
+        assert isinstance(table[0].chunk(0), pa.Date32Array)
 
         result = table.to_pandas()
         expected_df = pd.DataFrame(
@@ -1414,7 +1414,7 @@ class TestConvertStringLikeTypes(object):
         arr = None
 
         table = pa.Table.from_pandas(df)
-        assert table[0].data.num_chunks == 2
+        assert table[0].num_chunks == 2
 
     def test_fixed_size_bytes(self):
         values = [b'foo', None, bytearray(b'bar'), None, None, b'hey']

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -235,7 +235,7 @@ def test_empty_table_roundtrip():
     # Create a non-empty table to infer the types correctly, then slice to 0
     table = pa.Table.from_pandas(df)
     table = pa.Table.from_arrays(
-        [col.data.chunk(0)[:0] for col in table.itercolumns()],
+        [col.chunk(0)[:0] for col in table.itercolumns()],
         names=table.schema.names)
 
     assert table.schema.field_by_name('null').type == pa.null()
@@ -2378,7 +2378,7 @@ def test_binary_array_overflow_to_chunked():
     tbl = pa.Table.from_pandas(df, preserve_index=False)
     read_tbl = _simple_table_roundtrip(tbl)
 
-    col0_data = read_tbl[0].data
+    col0_data = read_tbl[0]
     assert isinstance(col0_data, pa.ChunkedArray)
 
     # Split up into 2GB chunks


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6224