### PR TITLE
ARROW-6237: [R] Allow compilation flags to be passed for R package with ARROW_R_CXXFLAGS

### DIFF
--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -46,7 +46,7 @@ arrow::install_arrow()
 
 for version- and platform-specific guidance on installing the Arrow C++ library.
 
-When installing from source, if the R and C++ library versions do not match, installation may fail. If you've previously installed the libraries and want to upgrade the R package, you'll need to update the Arrow C++ library first.  
+When installing from source, if the R and C++ library versions do not match, installation may fail. If you've previously installed the libraries and want to upgrade the R package, you'll need to update the Arrow C++ library first.
 
 ## Example
 
@@ -121,9 +121,9 @@ unable to load shared object '/Users/you/R/00LOCK-r/00new/arrow/libs/arrow.so':
 dlopen(/Users/you/R/00LOCK-r/00new/arrow/libs/arrow.so, 6): Library not loaded: @rpath/libarrow.14.dylib
 ```
 
-try setting the environment variable `LD_LIBRARY_PATH` (or `DYLD_LIBRARY_PATH`
-on macOS) to wherever Arrow C++ was put in `make install`, e.g. `export
-LD_LIBRARY_PATH=/usr/local/lib`, and retry installing the R package.
+try setting the environment variable `R_LD_LIBRARY_PATH` to wherever Arrow C++
+was put in `make install`, e.g. `export R_LD_LIBRARY_PATH=/usr/local/lib`, and
+retry installing the R package.
 
 For any other build/configuration challenges, see the [C++ developer
 guide](https://arrow.apache.org/docs/developers/cpp.html#building).

--- a/r/README.Rmd
+++ b/r/README.Rmd
@@ -112,6 +112,14 @@ R -e 'install.packages("devtools"); devtools::install_dev_deps()'
 R CMD INSTALL .
 ```
 
+If you need to set any compilation flags while building the Rcpp extensions,
+you can use the `ARROW_R_CXXFLAGS` environment variable. For example, if you
+are using `perf` to profile the R extensions, you may need to set
+
+```shell
+export ARROW_R_CXXFLAGS=-fno-omit-frame-pointer
+```
+
 If the package fails to install/load with an error like this:
 
 ```

--- a/r/README.md
+++ b/r/README.md
@@ -40,7 +40,8 @@ page](https://arrow.apache.org/install/) to find pre-compiled binary
 packages for some common Linux distributions, including Debian, Ubuntu,
 and CentOS. You’ll need to install `libparquet-dev` on Debian and
 Ubuntu, or `parquet-devel` on CentOS. This will also automatically
-install the Arrow C++ library as a dependency.
+install the Arrow C++ library as a dependency. Other Linux distributions
+must install the C++ library from source.
 
 If you install the `arrow` package from source and the C++ library is
 not found, the R package functions will notify you that Arrow is not
@@ -62,6 +63,14 @@ Arrow C++ library first.
 
 ``` r
 library(arrow)
+#> 
+#> Attaching package: 'arrow'
+#> The following object is masked from 'package:utils':
+#> 
+#>     timestamp
+#> The following objects are masked from 'package:base':
+#> 
+#>     array, table
 set.seed(24)
 
 tab <- arrow::table(x = 1:10, y = rnorm(10))
@@ -168,10 +177,9 @@ If the package fails to install/load with an error like this:
     unable to load shared object '/Users/you/R/00LOCK-r/00new/arrow/libs/arrow.so':
     dlopen(/Users/you/R/00LOCK-r/00new/arrow/libs/arrow.so, 6): Library not loaded: @rpath/libarrow.14.dylib
 
-try setting the environment variable `LD_LIBRARY_PATH` (or
-`DYLD_LIBRARY_PATH` on macOS) to wherever Arrow C++ was put in `make
-install`, e.g. `export LD_LIBRARY_PATH=/usr/local/lib`, and retry
-installing the R package.
+try setting the environment variable `R_LD_LIBRARY_PATH` to wherever
+Arrow C++ was put in `make install`, e.g. `export
+R_LD_LIBRARY_PATH=/usr/local/lib`, and retry installing the R package.
 
 For any other build/configuration challenges, see the [C++ developer
 guide](https://arrow.apache.org/docs/developers/cpp.html#building).

--- a/r/README.md
+++ b/r/README.md
@@ -63,14 +63,6 @@ Arrow C++ library first.
 
 ``` r
 library(arrow)
-#> 
-#> Attaching package: 'arrow'
-#> The following object is masked from 'package:utils':
-#> 
-#>     timestamp
-#> The following objects are masked from 'package:base':
-#> 
-#>     array, table
 set.seed(24)
 
 tab <- arrow::table(x = 1:10, y = rnorm(10))
@@ -168,6 +160,15 @@ checkout:
 cd ../../r
 R -e 'install.packages("devtools"); devtools::install_dev_deps()'
 R CMD INSTALL .
+```
+
+If you need to set any compilation flags while building the Rcpp
+extensions, you can use the `ARROW_R_CXXFLAGS` environment variable. For
+example, if you are using `perf` to profile the R extensions, you may
+need to set
+
+``` shell
+export ARROW_R_CXXFLAGS=-fno-omit-frame-pointer
 ```
 
 If the package fails to install/load with an error like this:

--- a/r/configure
+++ b/r/configure
@@ -89,10 +89,6 @@ if [ "$ARROW_USE_OLD_CXXABI" ]; then
   PKG_CFLAGS="$PKG_CFLAGS -D_GLIBCXX_USE_CXX11_ABI=0"
 fi
 
-if [ "$ARROW_R_CXXFLAGS" ]; then
-  PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
-fi
-
 # Test configuration
 TEST_CMD="${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXX11FLAGS} ${CXX11STD} -xc++ -"
 echo "#include $PKG_TEST_HEADER" | ${TEST_CMD} >/dev/null 2>&1
@@ -114,6 +110,11 @@ else
   echo "---------------------------------------------------------"
   PKG_LIBS=""
   PKG_CFLAGS=""
+fi
+
+# Set any user-defined CXXFLAGS
+if [ "$ARROW_R_CXXFLAGS" ]; then
+  PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
 fi
 
 # Write to Makevars

--- a/r/configure
+++ b/r/configure
@@ -86,7 +86,11 @@ CPPFLAGS=$("${R_HOME}"/bin/R CMD config CPPFLAGS)
 
 # If libarrow uses the old GLIBCXX ABI, so we have to use it too
 if [ "$ARROW_USE_OLD_CXXABI" ]; then
-  $PKG_CFLAGS="$PKG_CFLAGS -D_GLIBCXX_USE_CXX11_ABI=0"
+  PKG_CFLAGS="$PKG_CFLAGS -D_GLIBCXX_USE_CXX11_ABI=0"
+fi
+
+if [ "$ARROW_R_CXXFLAGS" ]; then
+  PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
 fi
 
 # Test configuration


### PR DESCRIPTION
For example:

```
export ARROW_R_CXXFLAGS="-fno-omit-frame-pointer"
```

(this flag is needed to record performance data on Linux with `perf`)

I also amended the README.Rmd to say to use `$R_LD_LIBRARY_PATH` instead of `$LD_LIBRARY_PATH` for custom install location