### PR TITLE
ARROW-6240: [Ruby] Arrow::Decimal128Array#get_value returns BigDecimal

### DIFF
--- a/ruby/red-arrow/lib/arrow/decimal128-array.rb
+++ b/ruby/red-arrow/lib/arrow/decimal128-array.rb
@@ -15,24 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class Decimal128ArrayTest < Test::Unit::TestCase
-  sub_test_case(".new") do
-    test("build") do
-      data_type = Arrow::Decimal128DataType.new(3, 1)
-      values = [
-        10.1,
-        nil,
-        "10.1",
-        BigDecimal("10.1"),
-      ]
-      array = Arrow::Decimal128Array.new(data_type, values)
-      assert_equal([
-                     BigDecimal("10.1"),
-                     nil,
-                     BigDecimal("10.1"),
-                     BigDecimal("10.1"),
-                   ],
-                   array.to_a)
+module Arrow
+  class Decimal128Array
+    def get_value(i)
+      BigDecimal(format_value(i))
     end
   end
 end

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -46,6 +46,7 @@ module Arrow
       require "arrow/date64-array"
       require "arrow/date64-array-builder"
       require "arrow/decimal128"
+      require "arrow/decimal128-array"
       require "arrow/decimal128-array-builder"
       require "arrow/decimal128-data-type"
       require "arrow/dense-union-data-type"
@@ -115,7 +116,10 @@ module Arrow
           method_name = "get_value"
         end
         super(info, klass, method_name)
-      when "Arrow::TimestampArray", "Arrow::Date32Array", "Arrow::Date64Array"
+      when "Arrow::Date32Array",
+           "Arrow::Date64Array",
+           "Arrow::Decimal128Array",
+           "Arrow::TimestampArray"
         case method_name
         when "get_value"
           method_name = "get_raw_value"

--- a/ruby/red-arrow/test/test-decimal128-array-builder.rb
+++ b/ruby/red-arrow/test/test-decimal128-array-builder.rb
@@ -17,7 +17,7 @@
 
 class Decimal128ArrayBuilderTest < Test::Unit::TestCase
   def setup
-    @data_type = Arrow::Decimal128DataType.new(8, 2)
+    @data_type = Arrow::Decimal128DataType.new(3, 1)
     @builder = Arrow::Decimal128ArrayBuilder.new(@data_type)
   end
 
@@ -31,28 +31,28 @@ class Decimal128ArrayBuilderTest < Test::Unit::TestCase
     test("Arrow::Decimal128") do
       @builder.append_value(Arrow::Decimal128.new("10.1"))
       array = @builder.finish
-      assert_equal(Arrow::Decimal128.new("10.1"),
+      assert_equal(BigDecimal("10.1"),
                    array[0])
     end
 
     test("String") do
       @builder.append_value("10.1")
       array = @builder.finish
-      assert_equal(Arrow::Decimal128.new("10.1"),
+      assert_equal(BigDecimal("10.1"),
                    array[0])
     end
 
     test("Float") do
       @builder.append_value(10.1)
       array = @builder.finish
-      assert_equal(Arrow::Decimal128.new("10.1"),
+      assert_equal(BigDecimal("10.1"),
                    array[0])
     end
 
     test("BigDecimal") do
       @builder.append_value(BigDecimal("10.1"))
       array = @builder.finish
-      assert_equal(Arrow::Decimal128.new("10.1"),
+      assert_equal(BigDecimal("10.1"),
                    array[0])
     end
   end
@@ -68,11 +68,11 @@ class Decimal128ArrayBuilderTest < Test::Unit::TestCase
                              ])
       array = @builder.finish
       assert_equal([
-                     Arrow::Decimal128.new("10.1"),
+                     BigDecimal("10.1"),
                      nil,
-                     Arrow::Decimal128.new("10.1"),
-                     Arrow::Decimal128.new("10.1"),
-                     Arrow::Decimal128.new("10.1"),
+                     BigDecimal("10.1"),
+                     BigDecimal("10.1"),
+                     BigDecimal("10.1"),
                    ],
                    array.to_a)
     end
@@ -85,9 +85,9 @@ class Decimal128ArrayBuilderTest < Test::Unit::TestCase
                              ])
       array = @builder.finish
       assert_equal([
-                     Arrow::Decimal128.new("10.1"),
+                     BigDecimal("10.1"),
                      nil,
-                     Arrow::Decimal128.new("10.1"),
+                     BigDecimal("10.1"),
                    ],
                    array.to_a)
     end


### PR DESCRIPTION
Instead of Arrow::Decimal128. This is a backward incompatible change but
it's acceptable. Because BigDecimal is easy to use than
Arrow::Decimal128 in Ruby. BigDecimal is a self-contained object. It
means that we can get expected result by #to_s without
Arrow::Decimal128DataType.

Users can still get value as Arrow::Deciaml128 by
Arrow::Decimal128Array#get_raw_value.