### PR TITLE
ARROW-6211: [Java] Remove dependency on RangeEqualsVisitor from ValueVector interface

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -20,6 +20,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -38,7 +39,7 @@ import io.netty.buffer.ArrowBuf;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -678,7 +679,7 @@ public class UnionVector implements FieldVector {
     }
 
     @Override
-    public boolean accept(RangeEqualsVisitor visitor) {
-      return visitor.visit(this);
+    public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+      return visitor.visit(this, value);
     }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -26,7 +26,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.util.CallBack;
@@ -885,7 +885,8 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   }
 
   @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(this, value);
   }
+
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -28,7 +28,7 @@ import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.util.CallBack;
@@ -1368,7 +1368,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   }
 
   @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(this, value);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.Types.MinorType;
@@ -259,7 +259,12 @@ public abstract class ExtensionTypeVector<T extends BaseValueVector & FieldVecto
   }
 
   @Override
+<<<<<<< HEAD
   public boolean accept(RangeEqualsVisitor visitor) {
     return getUnderlyingVector().accept(visitor);
+=======
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(getUnderlyingVector(), value);
+>>>>>>> ARROW-6211: [Java] Remove dependency on RangeEqualsVisitor from ValueVector interface
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -259,12 +259,7 @@ public abstract class ExtensionTypeVector<T extends BaseValueVector & FieldVecto
   }
 
   @Override
-<<<<<<< HEAD
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return getUnderlyingVector().accept(visitor);
-=======
   public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
-    return visitor.visit(getUnderlyingVector(), value);
->>>>>>> ARROW-6211: [Java] Remove dependency on RangeEqualsVisitor from ValueVector interface
+    return getUnderlyingVector().accept(visitor, value);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -21,7 +21,7 @@ import java.io.Closeable;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -266,9 +266,9 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   void copyFromSafe(int fromIndex, int thisIndex, ValueVector from);
 
   /**
-   * Compare range values in this vector and vector in visitor.
-   * @param visitor visitor which holds the vector to compare.
-   * @return true if equals, otherwise false.
+   * Accept a generic {@link VectorVisitor} and return the result.
+   * @param <OUT> the output result type.
+   * @param <IN> the input data together with visitor.
    */
-  boolean accept(RangeEqualsVisitor visitor);
+  <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.NullReader;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -252,6 +252,11 @@ public class ZeroVector implements FieldVector {
   }
 
   @Override
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(this, value);
+  }
+
+  @Override
   public void copyFrom(int fromIndex, int thisIndex, ValueVector from) {
     throw new UnsupportedOperationException();
   }
@@ -259,10 +264,5 @@ public class ZeroVector implements FieldVector {
   @Override
   public void copyFromSafe(int fromIndex, int thisIndex, ValueVector from) {
     throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -88,22 +88,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Void> {
    * Check range equals without passing IN param in VectorVisitor.
    */
   public boolean equals(ValueVector left) {
-    if (left instanceof BaseFixedWidthVector) {
-      return visit((BaseFixedWidthVector) left, null);
-    } else if (left instanceof BaseVariableWidthVector) {
-      return visit((BaseVariableWidthVector) left, null);
-    } else if (left instanceof ListVector) {
-      return visit((ListVector) left, null);
-    } else if (left instanceof FixedSizeListVector) {
-      return visit((FixedSizeListVector) left, null);
-    } else if (left instanceof NonNullableStructVector) {
-      return visit((NonNullableStructVector) left, null);
-    } else if (left instanceof UnionVector) {
-      return visit((UnionVector) left, null);
-    } else if (left instanceof ZeroVector) {
-      return visit((ZeroVector) left, null);
-    }
-    throw new UnsupportedOperationException();
+    return left.accept(this, null);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -84,6 +84,28 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Void> {
     return true;
   }
 
+  /**
+   * Check range equals without passing IN param in VectorVisitor.
+   */
+  public boolean equals(ValueVector left) {
+    if (left instanceof BaseFixedWidthVector) {
+      return visit((BaseFixedWidthVector) left, null);
+    } else if (left instanceof BaseVariableWidthVector) {
+      return visit((BaseVariableWidthVector) left, null);
+    } else if (left instanceof ListVector) {
+      return visit((ListVector) left, null);
+    } else if (left instanceof FixedSizeListVector) {
+      return visit((FixedSizeListVector) left, null);
+    } else if (left instanceof NonNullableStructVector) {
+      return visit((NonNullableStructVector) left, null);
+    } else if (left instanceof UnionVector) {
+      return visit((UnionVector) left, null);
+    } else if (left instanceof ZeroVector) {
+      return visit((ZeroVector) left, null);
+    }
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   public Boolean visit(BaseFixedWidthVector left, Void value) {
     return validate(left) && compareBaseFixedWidthVectors(left);

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -35,7 +35,7 @@ import org.apache.arrow.vector.complex.UnionVector;
 /**
  * Visitor to compare a range of values for vectors.
  */
-public class RangeEqualsVisitor {
+public class RangeEqualsVisitor implements VectorVisitor<Boolean, Void> {
 
   protected final ValueVector right;
   protected int leftStart;
@@ -84,31 +84,38 @@ public class RangeEqualsVisitor {
     return true;
   }
 
-  public boolean visit(BaseFixedWidthVector left) {
+  @Override
+  public Boolean visit(BaseFixedWidthVector left, Void value) {
     return validate(left) && compareBaseFixedWidthVectors(left);
   }
 
-  public boolean visit(BaseVariableWidthVector left) {
+  @Override
+  public Boolean visit(BaseVariableWidthVector left, Void value) {
     return validate(left) && compareBaseVariableWidthVectors(left);
   }
 
-  public boolean visit(ListVector left) {
+  @Override
+  public Boolean visit(ListVector left, Void value) {
     return validate(left) && compareListVectors(left);
   }
 
-  public boolean visit(FixedSizeListVector left) {
+  @Override
+  public Boolean visit(FixedSizeListVector left, Void value) {
     return validate(left) && compareFixedSizeListVectors(left);
   }
 
-  public boolean visit(NonNullableStructVector left) {
+  @Override
+  public Boolean visit(NonNullableStructVector left, Void value) {
     return validate(left) && compareStructVectors(left);
   }
 
-  public boolean visit(UnionVector left) {
+  @Override
+  public Boolean visit(UnionVector left, Void value) {
     return validate(left) && compareUnionVectors(left);
   }
 
-  public boolean visit(ZeroVector left) {
+  @Override
+  public Boolean visit(ZeroVector left, Void value) {
     return validate(left);
   }
 
@@ -133,7 +140,7 @@ public class RangeEqualsVisitor {
     for (int k = 0; k < leftChildren.size(); k++) {
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(rightChildren.get(k),
           leftStart, rightStart, length);
-      if (!leftChildren.get(k).accept(visitor)) {
+      if (!leftChildren.get(k).accept(visitor, null)) {
         return false;
       }
     }
@@ -151,7 +158,7 @@ public class RangeEqualsVisitor {
     for (String name : left.getChildFieldNames()) {
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(rightVector.getChild(name),
           leftStart, rightStart, length);
-      if (!left.getChild(name).accept(visitor)) {
+      if (!left.getChild(name).accept(visitor, null)) {
         return false;
       }
     }
@@ -249,7 +256,7 @@ public class RangeEqualsVisitor {
         ValueVector rightDataVector = ((ListVector)right).getDataVector();
 
         if (!leftDataVector.accept(new RangeEqualsVisitor(rightDataVector, startIndexLeft,
-            startIndexRight, (endIndexLeft - startIndexLeft)))) {
+            startIndexRight, (endIndexLeft - startIndexLeft)), null)) {
           return false;
         }
       }
@@ -289,7 +296,7 @@ public class RangeEqualsVisitor {
         ValueVector rightDataVector = ((FixedSizeListVector)right).getDataVector();
 
         if (!leftDataVector.accept(new RangeEqualsVisitor(rightDataVector, startIndexLeft, startIndexRight,
-            (endIndexLeft - startIndexLeft)))) {
+            (endIndexLeft - startIndexLeft)), null)) {
           return false;
         }
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.compare;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.ZeroVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+
+/**
+ * Generic visitor to visit a {@link org.apache.arrow.vector.ValueVector}.
+ * @param <OUT> the output result type.
+ * @param <IN> the input data together with visitor.
+ */
+public interface VectorVisitor<OUT, IN> {
+
+  OUT visit(BaseFixedWidthVector left, IN value);
+
+  OUT visit(BaseVariableWidthVector left, IN value);
+
+  OUT visit(ListVector left, IN value);
+
+  OUT visit(FixedSizeListVector left, IN value);
+
+  OUT visit(NonNullableStructVector left, IN value);
+
+  OUT visit(UnionVector left, IN value);
+
+  OUT visit(ZeroVector left, IN value);
+
+  OUT visit(ValueVector left, IN value);
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorVisitor.java
@@ -19,7 +19,6 @@ package org.apache.arrow.vector.compare;
 
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
-import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -46,6 +45,4 @@ public interface VectorVisitor<OUT, IN> {
   OUT visit(UnionVector left, IN value);
 
   OUT visit(ZeroVector left, IN value);
-
-  OUT visit(ValueVector left, IN value);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -39,7 +39,7 @@ import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.UnionFixedSizeListReader;
 import org.apache.arrow.vector.complex.impl.UnionFixedSizeListWriter;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -539,8 +539,8 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
   }
 
   @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(this, value);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -36,7 +36,7 @@ import org.apache.arrow.vector.BufferBacked;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.ZeroVector;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.complex.impl.UnionListReader;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
@@ -431,6 +431,11 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     return hash;
   }
 
+  @Override
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(this, value);
+  }
+
   private class TransferImpl implements TransferPair {
 
     ListVector to;
@@ -823,10 +828,5 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
 
   public int getLastSet() {
     return lastSet;
-  }
-
-  @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -31,7 +31,7 @@ import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
-import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.SingleStructReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.holders.ComplexHolder;
@@ -309,8 +309,8 @@ public class NonNullableStructVector extends AbstractStructVector {
   }
 
   @Override
-  public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(this);
+  public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
+    return visitor.visit(this, value);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/Dictionary.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/Dictionary.java
@@ -65,7 +65,7 @@ public class Dictionary {
     }
     Dictionary that = (Dictionary) o;
     return Objects.equals(encoding, that.encoding) &&
-        dictionary.accept(new VectorEqualsVisitor(that.dictionary), null);
+        (new VectorEqualsVisitor(that.dictionary)).equals(dictionary);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/Dictionary.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/Dictionary.java
@@ -64,7 +64,8 @@ public class Dictionary {
       return false;
     }
     Dictionary that = (Dictionary) o;
-    return Objects.equals(encoding, that.encoding) && dictionary.accept(new VectorEqualsVisitor(that.dictionary));
+    return Objects.equals(encoding, that.encoding) &&
+        dictionary.accept(new VectorEqualsVisitor(that.dictionary), null);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
@@ -141,7 +141,8 @@ public class DictionaryHashTable {
     for (DictionaryHashTable.Entry e = table[index]; e != null ; e = e.next) {
       if ((e.hash == hash)) {
         int dictIndex = e.index;
-        if (toEncode.accept(new RangeEqualsVisitor(dictionary, dictIndex, indexInArray, 1, false))) {
+        if (toEncode.accept(new RangeEqualsVisitor(dictionary, dictIndex, indexInArray, 1, false),
+            null)) {
           return dictIndex;
         }
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
@@ -141,8 +141,9 @@ public class DictionaryHashTable {
     for (DictionaryHashTable.Entry e = table[index]; e != null ; e = e.next) {
       if ((e.hash == hash)) {
         int dictIndex = e.index;
-        if (toEncode.accept(new RangeEqualsVisitor(dictionary, dictIndex, indexInArray, 1, false),
-            null)) {
+
+        if (new RangeEqualsVisitor(dictionary, dictIndex, indexInArray, 1, false)
+            .equals(toEncode)) {
           return dictIndex;
         }
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2262,7 +2262,7 @@ public class TestValueVector {
         final ZeroVector vector2 = new ZeroVector()) {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2272,10 +2272,10 @@ public class TestValueVector {
         final ZeroVector zeroVector = new ZeroVector()) {
 
       VectorEqualsVisitor zeroVisitor = new VectorEqualsVisitor(zeroVector);
-      assertFalse(intVector.accept(zeroVisitor, null));
+      assertFalse(zeroVisitor.equals(intVector));
 
       VectorEqualsVisitor intVisitor = new VectorEqualsVisitor(intVector);
-      assertFalse(zeroVector.accept(intVisitor, null));
+      assertFalse(intVisitor.equals(zeroVector));
     }
   }
 
@@ -2295,7 +2295,7 @@ public class TestValueVector {
       vector2.setSafe(0, 1);
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
     }
   }
 
@@ -2318,14 +2318,14 @@ public class TestValueVector {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
 
       vector2.setValueCount(3);
       vector2.setSafe(2, 2);
       assertFalse(vector1.equals(vector2));
 
       vector2.setSafe(2, 3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2354,8 +2354,8 @@ public class TestValueVector {
       VectorEqualsVisitor visitor1 = new VectorEqualsVisitor(vector2);
       VectorEqualsVisitor visitor2 = new VectorEqualsVisitor(vector3);
 
-      assertTrue(vector1.accept(visitor1, null));
-      assertFalse(vector1.accept(visitor2, null));
+      assertTrue(visitor1.equals(vector1));
+      assertFalse(visitor2.equals(vector1));
     }
   }
 
@@ -2376,7 +2376,7 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
     }
   }
 
@@ -2399,11 +2399,11 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
 
       vector2.setSafe(2, STR3, 0, STR3.length);
       vector2.setValueCount(3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2426,11 +2426,11 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
 
       vector2.setSafe(2, STR3, 0, STR3.length);
       vector2.setValueCount(3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2458,7 +2458,7 @@ public class TestValueVector {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
     }
   }
 
@@ -2485,12 +2485,12 @@ public class TestValueVector {
       writer2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
 
       writeListVector(writer2, new int[] {5, 6});
       writer2.setValueCount(3);
 
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2520,7 +2520,7 @@ public class TestValueVector {
       writer2.setValueCount(3);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
     }
   }
 
@@ -2549,12 +2549,12 @@ public class TestValueVector {
       writer2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
 
       writeStructVector(writer2, 3, 30L);
       writer2.setValueCount(3);
 
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2582,7 +2582,7 @@ public class TestValueVector {
       writer2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
     }
   }
 
@@ -2614,7 +2614,7 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -2635,7 +2635,7 @@ public class TestValueVector {
       vector2.setSafe(1, 2);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 3, 2, 1);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2262,7 +2262,7 @@ public class TestValueVector {
         final ZeroVector vector2 = new ZeroVector()) {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2272,10 +2272,10 @@ public class TestValueVector {
         final ZeroVector zeroVector = new ZeroVector()) {
 
       VectorEqualsVisitor zeroVisitor = new VectorEqualsVisitor(zeroVector);
-      assertFalse(intVector.accept(zeroVisitor));
+      assertFalse(intVector.accept(zeroVisitor, null));
 
       VectorEqualsVisitor intVisitor = new VectorEqualsVisitor(intVector);
-      assertFalse(zeroVector.accept(intVisitor));
+      assertFalse(zeroVector.accept(intVisitor, null));
     }
   }
 
@@ -2295,7 +2295,7 @@ public class TestValueVector {
       vector2.setSafe(0, 1);
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
     }
   }
 
@@ -2318,14 +2318,14 @@ public class TestValueVector {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
 
       vector2.setValueCount(3);
       vector2.setSafe(2, 2);
       assertFalse(vector1.equals(vector2));
 
       vector2.setSafe(2, 3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2354,8 +2354,8 @@ public class TestValueVector {
       VectorEqualsVisitor visitor1 = new VectorEqualsVisitor(vector2);
       VectorEqualsVisitor visitor2 = new VectorEqualsVisitor(vector3);
 
-      assertTrue(vector1.accept(visitor1));
-      assertFalse(vector1.accept(visitor2));
+      assertTrue(vector1.accept(visitor1, null));
+      assertFalse(vector1.accept(visitor2, null));
     }
   }
 
@@ -2376,7 +2376,7 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
     }
   }
 
@@ -2399,11 +2399,11 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
 
       vector2.setSafe(2, STR3, 0, STR3.length);
       vector2.setValueCount(3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2426,11 +2426,11 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
 
       vector2.setSafe(2, STR3, 0, STR3.length);
       vector2.setValueCount(3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2458,7 +2458,7 @@ public class TestValueVector {
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
     }
   }
 
@@ -2485,12 +2485,12 @@ public class TestValueVector {
       writer2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
 
       writeListVector(writer2, new int[] {5, 6});
       writer2.setValueCount(3);
 
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2520,7 +2520,7 @@ public class TestValueVector {
       writer2.setValueCount(3);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
     }
   }
 
@@ -2549,12 +2549,12 @@ public class TestValueVector {
       writer2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
 
       writeStructVector(writer2, 3, 30L);
       writer2.setValueCount(3);
 
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2582,7 +2582,7 @@ public class TestValueVector {
       writer2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
     }
   }
 
@@ -2614,7 +2614,7 @@ public class TestValueVector {
       vector2.setValueCount(2);
 
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -2635,7 +2635,7 @@ public class TestValueVector {
       vector2.setSafe(1, 2);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 3, 2, 1);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -77,7 +77,7 @@ public class TestRangeEqualsVisitor {
       vector2.setSafe(0, 1);
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor, null));
+      assertFalse(visitor.equals(vector1));
     }
   }
 
@@ -104,7 +104,7 @@ public class TestRangeEqualsVisitor {
       vector2.setSafe(4,55);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -132,7 +132,7 @@ public class TestRangeEqualsVisitor {
       vector2.setValueCount(5);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -164,7 +164,7 @@ public class TestRangeEqualsVisitor {
       writer2.setValueCount(5);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -198,7 +198,7 @@ public class TestRangeEqualsVisitor {
       writer2.setValueCount(5);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -236,7 +236,7 @@ public class TestRangeEqualsVisitor {
       vector2.setValueCount(3);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 2);
-      assertTrue(vector1.accept(visitor, null));
+      assertTrue(visitor.equals(vector1));
     }
   }
 
@@ -246,10 +246,10 @@ public class TestRangeEqualsVisitor {
         final ZeroVector zeroVector = new ZeroVector()) {
 
       VectorEqualsVisitor zeroVisitor = new VectorEqualsVisitor(zeroVector, false);
-      assertTrue(intVector.accept(zeroVisitor, null));
+      assertTrue(zeroVisitor.equals(intVector));
 
       VectorEqualsVisitor intVisitor = new VectorEqualsVisitor(intVector, false);
-      assertTrue(zeroVector.accept(intVisitor, null));
+      assertTrue(intVisitor.equals(zeroVector));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -77,7 +77,7 @@ public class TestRangeEqualsVisitor {
       vector2.setSafe(0, 1);
       VectorEqualsVisitor visitor = new VectorEqualsVisitor(vector2);
 
-      assertFalse(vector1.accept(visitor));
+      assertFalse(vector1.accept(visitor, null));
     }
   }
 
@@ -104,7 +104,7 @@ public class TestRangeEqualsVisitor {
       vector2.setSafe(4,55);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -132,7 +132,7 @@ public class TestRangeEqualsVisitor {
       vector2.setValueCount(5);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -164,7 +164,7 @@ public class TestRangeEqualsVisitor {
       writer2.setValueCount(5);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -198,7 +198,7 @@ public class TestRangeEqualsVisitor {
       writer2.setValueCount(5);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 3);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -236,7 +236,7 @@ public class TestRangeEqualsVisitor {
       vector2.setValueCount(3);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector2, 1, 1, 2);
-      assertTrue(vector1.accept(visitor));
+      assertTrue(vector1.accept(visitor, null));
     }
   }
 
@@ -246,10 +246,10 @@ public class TestRangeEqualsVisitor {
         final ZeroVector zeroVector = new ZeroVector()) {
 
       VectorEqualsVisitor zeroVisitor = new VectorEqualsVisitor(zeroVector, false);
-      assertTrue(intVector.accept(zeroVisitor));
+      assertTrue(intVector.accept(zeroVisitor, null));
 
       VectorEqualsVisitor intVisitor = new VectorEqualsVisitor(intVector, false);
-      assertTrue(zeroVector.accept(intVisitor));
+      assertTrue(zeroVector.accept(intVisitor, null));
     }
   }
 


### PR DESCRIPTION
Related to [ARROW-6211](https://issues.apache.org/jira/browse/ARROW-6211).

This is a follow-up from https://github.com/apache/arrow/pull/4933

public interface VectorVisitor<OUT, IN, EX extends Exception> {..}
n ValueVector : 

public <OUT, IN, EX extends Exception> OUT accept(VectorVisitor<OUT, IN, EX> visitor, IN value) throws EX;