### PR TITLE
ARROW-6245: [Java] Provide an interface for numeric vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector {
+public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
@@ -323,6 +323,11 @@ public class BigIntVector extends BaseFixedWidthVector implements BaseIntVector 
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -39,7 +39,7 @@ import io.netty.buffer.ArrowBuf;
  * boolean values which could be null. Each value in the vector corresponds
  * to a single bit in the underlying data stream backing the vector.
  */
-public class BitVector extends BaseFixedWidthVector {
+public class BitVector extends BaseFixedWidthVector implements PrimitiveNumericVector {
   private final FieldReader reader;
 
   /**
@@ -166,6 +166,11 @@ public class BitVector extends BaseFixedWidthVector {
             valueBuffer, target.valueBuffer);
 
     target.setValueCount(length);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
   }
 
   private ArrowBuf splitAndTransferBuffer(

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * float values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class Float4Vector extends BaseFixedWidthVector {
+public class Float4Vector extends BaseFixedWidthVector implements PrimitiveNumericVector {
   public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -280,6 +280,11 @@ public class Float4Vector extends BaseFixedWidthVector {
    */
   public static float get(final ArrowBuf buffer, final int index) {
     return buffer.getFloat(index * TYPE_WIDTH);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * double values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class Float8Vector extends BaseFixedWidthVector {
+public class Float8Vector extends BaseFixedWidthVector implements PrimitiveNumericVector {
   public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
@@ -283,6 +283,10 @@ public class Float8Vector extends BaseFixedWidthVector {
     return buffer.getDouble(index * TYPE_WIDTH);
   }
 
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
+  }
 
   /*----------------------------------------------------------------*
    |                                                                |

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
+public class IntVector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -327,6 +327,11 @@ public class IntVector extends BaseFixedWidthVector implements BaseIntVector {
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/PrimitiveNumericVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/PrimitiveNumericVector.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+/**
+ * The interface for all primitive numeric vectors.
+ */
+public interface PrimitiveNumericVector {
+
+  /**
+   * Gets the underlying value at the index as a double.
+   * @param index the index to get.
+   * @return the double value at the given index.
+   */
+  double getValueAsDouble(int index);
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * short values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector {
+public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   public static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -354,6 +354,11 @@ public class SmallIntVector extends BaseFixedWidthVector implements BaseIntVecto
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * byte values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector {
+public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   public static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -355,6 +355,11 @@ public class TinyIntVector extends BaseFixedWidthVector implements BaseIntVector
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -37,7 +37,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
+public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   private static final byte TYPE_WIDTH = 1;
   private final FieldReader reader;
 
@@ -287,6 +287,10 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
     set(index, isSet, value);
   }
 
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index) & 0xff;
+  }
 
   /*----------------------------------------------------------------*
    |                                                                |
@@ -319,8 +323,6 @@ public class UInt1Vector extends BaseFixedWidthVector implements BaseIntVector {
   public long getValueAsLong(int index) {
     return this.get(index);
   }
-
-
 
   private class TransferImpl implements TransferPair {
     UInt1Vector to;

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
+public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   private static final byte TYPE_WIDTH = 2;
   private final FieldReader reader;
 
@@ -267,6 +267,10 @@ public class UInt2Vector extends BaseFixedWidthVector implements BaseIntVector {
     set(index, isSet, value);
   }
 
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index) & 0xffff;
+  }
 
   /*----------------------------------------------------------------*
    |                                                                |

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
+public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   private static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -257,6 +257,10 @@ public class UInt4Vector extends BaseFixedWidthVector implements BaseIntVector {
     set(index, isSet, value);
   }
 
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index) & 0xffffffffL;
+  }
 
   /*----------------------------------------------------------------*
    |                                                                |

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -38,7 +38,7 @@ import io.netty.buffer.ArrowBuf;
  * integer values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector {
+public class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector, PrimitiveNumericVector {
   private static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
@@ -289,6 +289,24 @@ public class UInt8Vector extends BaseFixedWidthVector implements BaseIntVector {
   @Override
   public long getValueAsLong(int index) {
     return this.get(index);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    long value = get(index);
+    if (value >= 0) {
+      return value;
+    } else {
+      // clear the highest bit
+      double ret = value ^ Long.MIN_VALUE;
+
+      // when interpreted as the an unsigned integer,
+      // the highest bit equals to Long.MAX_VALUE plus 1.
+      ret += 1;
+      ret += Long.MAX_VALUE;
+      
+      return ret;
+    }
   }
 
   private class TransferImpl implements TransferPair {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestPrimitiveNumericVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestPrimitiveNumericVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPrimitiveNumericVector {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testGetUInt8() {
+    try (final UInt8Vector vector = new UInt8Vector("vec", allocator)) {
+      vector.allocateNew(10);
+      vector.set(0, Long.MIN_VALUE);
+
+      assertEquals(Math.pow(2, 63), vector.getValueAsDouble(0), 1);
+    }
+  }
+}


### PR DESCRIPTION
We want to provide an interface for all vectors with numeric types (small int, float4, float8, etc). This interface will make it convenient for many operations on a vector, like average, sum, variance, etc. With this interface, the client code will be greatly simplified, with many branches/switch removed.

 

The design is similar to BaseIntVector (the interface for all integer vectors). We provide 3 methods for setting & getting numeric values:

         setWithPossibleRounding

         setSafeWithPossibleRounding

         getValueAsDouble