### PR TITLE
ARROW-6258: [R] Add macOS build scripts

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1759,3 +1759,14 @@ Dynamic NDArray Developers list:
 
 Some source code from Ibis (https://github.com/cloudera/ibis) has been adapted
 for PyArrow. Ibis is released under the Apache License, Version 2.0.
+
+--------------------------------------------------------------------------------
+
+This project includes code from the autobrew project.
+
+* r/tools/autobrew and r/tools/apache-arrow.rb are based on code
+  from the autobrew project.
+
+Copyright: Copyright (c) 2017 - 2019, Jeroen Ooms.
+All rights reserved.
+Homepage: https://github.com/jeroen/autobrew

--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -11,8 +11,10 @@ Dockerfile
 clang_format.sh
 ^cran-comments\.md$
 ^arrow_.*.tar.gz$
+^arrow_.*.tgz$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
 ^Makefile$
 ^.*\.orig$
+^.*\.cmd$

--- a/r/.gitignore
+++ b/r/.gitignore
@@ -13,3 +13,4 @@ src/Makevars
 src/Makevars.win
 windows/
 arrow_*.tar.gz
+arrow_*.tgz

--- a/r/configure
+++ b/r/configure
@@ -63,9 +63,13 @@ else
         BREWDIR=$(brew --prefix)
       else
         echo "Downloading ${PKG_BREW_NAME}"
-        curl -sfL "https://jeroen.github.io/autobrew/$PKG_BREW_NAME" > autobrew
-        if [ $? -ne 0 ]; then
-          echo "Failed to download manifest for ${PKG_BREW_NAME}"
+        if [ -f "autobrew" ]; then
+          echo "Using local manifest for ${PKG_BREW_NAME}"
+        else
+          curl -sfL "https://jeroen.github.io/autobrew/$PKG_BREW_NAME" > autobrew
+          if [ $? -ne 0 ]; then
+            echo "Failed to download manifest for ${PKG_BREW_NAME}"
+          fi
         fi
         source autobrew
         if [ $? -ne 0 ]; then

--- a/r/configure
+++ b/r/configure
@@ -47,7 +47,7 @@ if [ "$INCLUDE_DIR" ] || [ "$LIB_DIR" ]; then
 else
   # Use pkg-config if available
   pkg-config --version >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
+  if [ "$FORCE_AUTOBREW" != "TRUE" ] && [ $? -eq 0 ]; then
     PKGCONFIG_CFLAGS=`pkg-config --cflags --silence-errors ${PKG_CONFIG_NAME}`
     PKGCONFIG_LIBS=`pkg-config --libs --silence-errors ${PKG_CONFIG_NAME}`
   fi
@@ -58,7 +58,7 @@ else
     PKG_LIBS=${PKGCONFIG_LIBS}
   else
     if [[ "$OSTYPE" == "darwin"* ]]; then
-      if [ "$(command -v brew)" ] && [ "$(brew ls --versions ${PKG_BREW_NAME})" != "" ]; then
+      if [ "$FORCE_AUTOBREW" != "TRUE" ] && [ "$(command -v brew)" ] && [ "$(brew ls --versions ${PKG_BREW_NAME})" != "" ]; then
         echo "Using Homebrew ${PKG_BREW_NAME}"
         BREWDIR=$(brew --prefix)
       else

--- a/r/tools/apache-arrow.rb
+++ b/r/tools/apache-arrow.rb
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # https://github.com/autobrew/homebrew-core/blob/master/Formula/apache-arrow.rb
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"

--- a/r/tools/apache-arrow.rb
+++ b/r/tools/apache-arrow.rb
@@ -1,0 +1,64 @@
+# https://github.com/autobrew/homebrew-core/blob/master/Formula/apache-arrow.rb
+class ApacheArrow < Formula
+  desc "Columnar in-memory analytics layer designed to accelerate big data"
+  homepage "https://arrow.apache.org/"
+  url "https://archive.apache.org/dist/arrow/arrow-0.14.1/apache-arrow-0.14.1.tar.gz"
+  sha256 "9948ddb6d4798b51552d0dca3252dd6e3a7d0f9702714fc6f5a1b59397ce1d28"
+  head "https://github.com/apache/arrow.git"
+
+  bottle do
+    cellar :any
+    sha256 "b00e518cda38f90ecefaf542d4c030a966eae50623b057e9edb6fbe93fc3f4ab" => :el_capitan_or_later
+    root_url "https://jeroen.github.io/bottles"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "flatbuffers" => :build
+  depends_on "double-conversion"
+  depends_on "boost"
+  depends_on "lz4"
+  depends_on "thrift"
+  depends_on "snappy"
+
+  def install
+    ENV.cxx11
+    args = %W[
+      -DARROW_PARQUET=ON
+      -DARROW_PLASMA=OFF
+      -DARROW_HDFS=OFF
+      -DARROW_BUILD_TESTS=OFF
+      -DARROW_TEST_LINKAGE="static"
+      -DARROW_BUILD_SHARED=OFF
+      -DARROW_JEMALLOC=OFF
+      -DARROW_WITH_BROTLI=OFF
+      -DARROW_USE_GLOG=OFF
+      -DARROW_PYTHON=OFF
+      -DARROW_WITH_ZSTD=OFF
+      -DARROW_WITH_SNAPPY=ON
+      -DARROW_BUILD_UTILITIES=ON
+      -DPARQUET_BUILD_EXECUTABLES=ON
+      -DFLATBUFFERS_HOME=#{Formula["flatbuffers"].prefix}
+      -DLZ4_HOME=#{Formula["lz4"].prefix}
+      -DTHRIFT_HOME=#{Formula["thrift"].prefix}
+    ]
+
+    mkdir "build"
+    cd "build" do
+      system "cmake", "../cpp", *std_cmake_args, *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include "arrow/api.h"
+      int main(void) {
+        arrow::int64();
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
+    system "./test"
+  end
+end

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # https://github.com/jeroen/autobrew/blob/gh-pages/apache-arrow
 export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_AUTO_UPDATE=1

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -1,0 +1,46 @@
+# https://github.com/jeroen/autobrew/blob/gh-pages/apache-arrow
+export HOMEBREW_NO_ANALYTICS=1
+export HOMEBREW_NO_AUTO_UPDATE=1
+
+# Offical Homebrew formula can't be statically linked
+UPSTREAM_ORG="autobrew"
+
+if [ "$DISABLE_AUTOBREW" ]; then return 0; fi
+AUTOBREW=${TMPDIR-/tmp}
+export HOMEBREW_TEMP="$AUTOBREW/hbtmp"
+BREWDIR="$AUTOBREW/build-$PKG_BREW_NAME"
+BREW="$BREWDIR/bin/brew"
+rm -Rf $BREWDIR
+mkdir -p $BREWDIR
+echo "Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
+curl -fsSL https://github.com/$UPSTREAM_ORG/brew/tarball/master | tar xz --strip 1 -C $BREWDIR
+
+# Install bottle + dependencies
+if [ -f "./${PKG_BREW_NAME}.rb" ]; then
+  # Use the local brew formula and install --HEAD
+  $BREW deps -n "./${PKG_BREW_NAME}.rb" 2>/dev/null
+  BREW_DEPS=$($BREW deps -n "./${PKG_BREW_NAME}.rb" 2>/dev/null)
+  HOMEBREW_CACHE="$AUTOBREW" $BREW install --force-bottle $BREW_DEPS 2>&1 | perl -pe 's/Warning/Note/gi'
+  HOMEBREW_CACHE="$AUTOBREW" $BREW install --build-from-source --HEAD "./${PKG_BREW_NAME}.rb" 2>&1 | perl -pe 's/Warning/Note/gi'
+else
+  HOMEBREW_CACHE="$AUTOBREW" $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'
+fi
+
+# Hardcode this for my custom autobrew build
+rm -f $BREWDIR/lib/*.dylib
+PKG_LIBS="-L$BREWDIR/lib -lparquet -larrow -lthrift -llz4 -lboost_system -lboost_filesystem -lboost_regex -ldouble-conversion -lsnappy"
+
+# Prevent CRAN builder from linking against old libs in /usr/local/lib
+for FILE in $BREWDIR/Cellar/*/*/lib/*.a; do
+  BASENAME=`basename $FILE`
+  LIBNAME=`echo "${BASENAME%.*}" | cut -c4-`
+  cp -f $FILE $BREWDIR/lib/libbrew$LIBNAME.a
+  echo "created $BREWDIR/lib/libbrew$LIBNAME.a"
+  PKG_LIBS=`echo $PKG_LIBS | sed "s/-l$LIBNAME/-lbrew$LIBNAME/g"`
+done
+
+unset HOMEBREW_NO_ANALYTICS
+unset HOMEBREW_NO_AUTO_UPDATE
+
+# Hack to work around segfault on CRAN server
+# rm -f tests/testthat.R


### PR DESCRIPTION
When installing the R package from source on macOS, if the configure script cannot find libarrow with pkgconfig, and if `apache-arrow` has not been installed via Homebrew (neither of which is the case on CRAN), an "autobrew" step happens: a script is downloaded and sourced, which uses a fork of Homebrew to download and install binary dependencies for bundling with the R package.

This patch alters the configure script to let you `FORCE_AUTOBREW`, which is useful for testing, and it will use a local `autobrew` script file, if found, rather than downloading it. The patch also adds the `autobrew` script and the `apache-arrow.rb` brew formula to the `r/tools` directory, alongside the similar script that downloads the Arrow C++ binary on Windows. The two scripts are copied exactly from their "upstream" versions (noted on L18 of each file), with two minor modifications: (1) `autobrew` will use a local `apache-arrow.rb` formula if the file exists, and (2) the formula adds the `head` reference so you can `brew install --build-from-source --HEAD apache-arrow.rb` and pull the latest master branch of `apache/arrow` from GitHub.

See this in action at https://github.com/nealrichardson/arrow-r-nightly/blob/34d27bf482fa1d9f490003a8396fabdff5beea37/.travis.yml. Ordinarily I would add a Travis-CI job to `apache/arrow` for this, but I know we're anxious not to delay build times further, so I'll run this job nightly. Nightly runs will solve https://issues.apache.org/jira/browse/ARROW-5134, and it will also allow us to host an R package repository with nightly binaries for macOS (and Windows too, using the existing Appveyor config + deploy to bintray). 

To install a binary from that repository on macOS, `install.packages("arrow", repos="https://dl.bintray.com/nealrichardson/arrow-r")`.

One TODO: get @jeroen 's approval to include these scripts here under the Apache license and add a citation to LICENSE.txt.