### PR TITLE
ARROW-6259: [C++] Add -Wno-extra-semi-stmt when compiling with clang 8 to work around Flatbuffers bug, suppress other new LLVM 8 warnings

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -173,7 +173,8 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
       # ARROW-6259: Flatbuffers generates code with superfluous semicolons, so
       # we suppress this warning for now. See upstream bug report
       # https://github.com/google/flatbuffers/issues/5482
-      set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-extra-semi-stmt")
+      set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-extra-semi-stmt \
+-Wno-shadow-field -Wno-c++2a-compat")
     endif()
 
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -168,6 +168,14 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
     if("${COMPILER_VERSION}" VERSION_GREATER "3.9")
       set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-zero-as-null-pointer-constant")
     endif()
+
+    if("${COMPILER_VERSION}" VERSION_GREATER "7.0")
+      # ARROW-6259: Flatbuffers generates code with superfluous semicolons, so
+      # we suppress this warning for now. See upstream bug report
+      # https://github.com/google/flatbuffers/issues/5482
+      set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-extra-semi-stmt")
+    endif()
+
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")
   elseif("${COMPILER_FAMILY}" STREQUAL "gcc")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wall \


### PR DESCRIPTION
LLVM 8 introduces `-Wextra-semi-stmt` and Flatbuffers generates code with superfluous semicolons (upstream bug report https://github.com/google/flatbuffers/issues/5482). This is breaking our macOS builds for the last few hours because conda-forge upgraded their compiler toolchain from Apple clang 4.0.1 to clang 8.0.0 this afternoon. 