### PR TITLE
ARROW-6264: [Java] There is no need to consider byte order in ArrowBufHasher

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ArrowBufPointer.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ArrowBufPointer.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.memory.util;
 
-import java.nio.ByteOrder;
-
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.util.Preconditions;
@@ -30,8 +28,6 @@ import io.netty.buffer.ArrowBuf;
  * It will be used as the basis for calculating hash code within a vector, and equality determination.
  */
 public final class ArrowBufPointer {
-
-  public static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   /**
    * The hash code when the arrow buffer is null.

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
@@ -20,8 +20,6 @@ package org.apache.arrow.memory.util.hash;
 import static io.netty.util.internal.PlatformDependent.getByte;
 import static io.netty.util.internal.PlatformDependent.getInt;
 
-import org.apache.arrow.memory.util.ArrowBufPointer;
-
 import io.netty.buffer.ArrowBuf;
 
 /**
@@ -93,9 +91,6 @@ public class MurmurHasher implements ArrowBufHasher {
     int hash = seed;
     while (index + 4 <= length) {
       int intValue = getInt(address + index);
-      if (!ArrowBufPointer.LITTLE_ENDIAN) {
-        intValue = Integer.reverseBytes(intValue);
-      }
       hash = combineHashCode(hash, intValue);
       index += 4;
     }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
@@ -21,8 +21,6 @@ import static io.netty.util.internal.PlatformDependent.getByte;
 import static io.netty.util.internal.PlatformDependent.getInt;
 import static io.netty.util.internal.PlatformDependent.getLong;
 
-import org.apache.arrow.memory.util.ArrowBufPointer;
-
 import io.netty.buffer.ArrowBuf;
 
 /**
@@ -61,10 +59,6 @@ public class SimpleHasher implements ArrowBufHasher {
     int index = 0;
     while (index + 8 <= length) {
       long longValue = getLong(address + index);
-      if (!ArrowBufPointer.LITTLE_ENDIAN) {
-        // assume the buffer is in little endian
-        longValue = Long.reverseBytes(longValue);
-      }
       int longHash = getLongHashCode(longValue);
       hashValue = combineHashCode(hashValue, longHash);
       index += 8;
@@ -72,9 +66,6 @@ public class SimpleHasher implements ArrowBufHasher {
 
     while (index + 4 <= length) {
       int intValue = getInt(address + index);
-      if (!ArrowBufPointer.LITTLE_ENDIAN) {
-        intValue = Integer.reverseBytes(intValue);
-      }
       int intHash = intValue;
       hashValue = combineHashCode(hashValue, intHash);
       index += 4;


### PR DESCRIPTION
According to the discussion in https://github.com/apache/arrow/pull/5063#issuecomment-521276547, Arrow has a mechanism to make sure the data is stored in little-endian, so there is no need to check byte order.