### PR TITLE
ARROW-6266: [Java] Resolve the ambiguous method overload in RangeEqualsVisitor

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -260,6 +260,6 @@ public abstract class ExtensionTypeVector<T extends BaseValueVector & FieldVecto
 
   @Override
   public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visit(getUnderlyingVector());
+    return visitor.visitGeneral(getUnderlyingVector());
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -260,6 +260,6 @@ public abstract class ExtensionTypeVector<T extends BaseValueVector & FieldVecto
 
   @Override
   public boolean accept(RangeEqualsVisitor visitor) {
-    return visitor.visitGeneral(getUnderlyingVector());
+    return getUnderlyingVector().accept(visitor);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -112,30 +112,6 @@ public class RangeEqualsVisitor {
     return validate(left);
   }
 
-  /**
-   * Visit a general value vector.
-   * @param left the vector to compare.
-   * @return if the vector is equal to this.
-   */
-  public boolean visitGeneral(ValueVector left) {
-    if (left instanceof BaseFixedWidthVector) {
-      return visit((BaseFixedWidthVector) left);
-    } else if (left instanceof BaseVariableWidthVector) {
-      return visit((BaseVariableWidthVector) left);
-    } else if (left instanceof ListVector) {
-      return visit((ListVector) left);
-    } else if (left instanceof FixedSizeListVector) {
-      return visit((FixedSizeListVector) left);
-    } else if (left instanceof NonNullableStructVector) {
-      return visit((NonNullableStructVector) left);
-    } else if (left instanceof UnionVector) {
-      return visit((UnionVector) left);
-    } else if (left instanceof ZeroVector) {
-      return visit((ZeroVector) left);
-    }
-    throw new UnsupportedOperationException();
-  }
-
   protected boolean compareValueVector(ValueVector left, ValueVector right) {
     if (!typeCheckNeeded) {
       return true;

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -112,7 +112,27 @@ public class RangeEqualsVisitor {
     return validate(left);
   }
 
-  public boolean visit(ValueVector left) {
+  /**
+   * Visit a general value vector.
+   * @param left the vector to compare.
+   * @return if the vector is equal to this.
+   */
+  public boolean visitGeneral(ValueVector left) {
+    if (left instanceof BaseFixedWidthVector) {
+      return visit((BaseFixedWidthVector) left);
+    } else if (left instanceof BaseVariableWidthVector) {
+      return visit((BaseVariableWidthVector) left);
+    } else if (left instanceof ListVector) {
+      return visit((ListVector) left);
+    } else if (left instanceof FixedSizeListVector) {
+      return visit((FixedSizeListVector) left);
+    } else if (left instanceof NonNullableStructVector) {
+      return visit((NonNullableStructVector) left);
+    } else if (left instanceof UnionVector) {
+      return visit((UnionVector) left);
+    } else if (left instanceof ZeroVector) {
+      return visit((ZeroVector) left);
+    }
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
In RangeEqualsVisitor, there are overload methods for both super class and sub class. This will lead to unexpected behavior.

For example, if we call RangeEqualsVisitor#visit(v), where v is a fixed width vector, the method actually called may be visit(ValueVector), which is unexpected.

In general, in the visitor pattern, it is not a good idea to support method overload for both super class and sub-class as parameters.