### PR TITLE
ARROW-6141: [C++] Enable memory-mapping a file region

### DIFF
--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -185,8 +185,13 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
   static Status Create(const std::string& path, int64_t size,
                        std::shared_ptr<MemoryMappedFile>* out);
 
+  // mmap() with whole file
   static Status Open(const std::string& path, FileMode::type mode,
                      std::shared_ptr<MemoryMappedFile>* out);
+
+  // mmap() with a region of file, the offset must be a multiple of the page size
+  static Status Open(const std::string& path, FileMode::type mode, const int64_t offset,
+                     const int64_t length, std::shared_ptr<MemoryMappedFile>* out);
 
   Status Close() override;
 


### PR DESCRIPTION
This patch adds an Open() method for MemoryMappedFile() with
length and offset params. In this way user can memory map a file
region just like mmap(). The new API is:

* MemoryMappedFile::Open(path, mode, length, offset, &mmap)

The original API is still available. Calling the original API
will memory map the whole file:

* MemoryMappedFile::Open(path, mode, &mmap)

A new field map_len_ is added in MemoryMappedFile::MemoryMap to
track the real memory map length.

Also MemoryMappedFile::Read()/ReadAt()/Write()/WriteAt() are changed
to check the memory map length if it's a region based memory map.

Note the MemoryMappedFile::Resize() is not supported if it's a
region based memory map.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>