### PR TITLE
ARROW-6267: [Ruby] Add Arrow::Time for Arrow::Time{32,64}DataType value

### DIFF
--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -23,8 +23,16 @@
 
 namespace red_arrow {
   VALUE cDate;
+  VALUE cArrowTime;
+
+  VALUE ArrowTimeUnitSECOND;
+  VALUE ArrowTimeUnitMILLI;
+  VALUE ArrowTimeUnitMICRO;
+  VALUE ArrowTimeUnitNANO;
+
   ID id_BigDecimal;
   ID id_jd;
+  ID id_new;
   ID id_to_datetime;
 }
 
@@ -34,14 +42,27 @@ extern "C" void Init_arrow() {
   rb_define_method(cArrowRecordBatch, "raw_records",
                    reinterpret_cast<rb::RawMethod>(red_arrow::record_batch_raw_records),
                    0);
+
   auto cArrowTable = rb_const_get_at(mArrow, rb_intern("Table"));
   rb_define_method(cArrowTable, "raw_records",
                    reinterpret_cast<rb::RawMethod>(red_arrow::table_raw_records),
                    0);
 
   red_arrow::cDate = rb_const_get(rb_cObject, rb_intern("Date"));
+  red_arrow::cArrowTime = rb_const_get_at(mArrow, rb_intern("Time"));
+
+  auto cArrowTimeUnit = rb_const_get_at(mArrow, rb_intern("TimeUnit"));
+  red_arrow::ArrowTimeUnitSECOND =
+    rb_const_get_at(cArrowTimeUnit, rb_intern("SECOND"));
+  red_arrow::ArrowTimeUnitMILLI =
+    rb_const_get_at(cArrowTimeUnit, rb_intern("MILLI"));
+  red_arrow::ArrowTimeUnitMICRO =
+    rb_const_get_at(cArrowTimeUnit, rb_intern("MICRO"));
+  red_arrow::ArrowTimeUnitNANO =
+    rb_const_get_at(cArrowTimeUnit, rb_intern("NANO"));
 
   red_arrow::id_BigDecimal = rb_intern("BigDecimal");
   red_arrow::id_jd = rb_intern("jd");
+  red_arrow::id_new = rb_intern("new");
   red_arrow::id_to_datetime = rb_intern("to_datetime");
 }

--- a/ruby/red-arrow/ext/arrow/raw-records.cpp
+++ b/ruby/red-arrow/ext/arrow/raw-records.cpp
@@ -171,16 +171,26 @@ namespace red_arrow {
 
       inline VALUE convert(const arrow::Time32Array& array,
                            const int64_t i) {
-        // TODO: unit treatment
+        const auto type =
+          arrow::internal::checked_cast<const arrow::Time32Type*>(array.type().get());
         const auto value = array.Value(i);
-        return INT2NUM(value);
+        return rb_funcall(red_arrow::cArrowTime,
+                          id_new,
+                          2,
+                          time_unit_to_enum(type->unit()),
+                          INT2NUM(value));
       }
 
       inline VALUE convert(const arrow::Time64Array& array,
                            const int64_t i) {
-        // TODO: unit treatment
+        const auto type =
+          arrow::internal::checked_cast<const arrow::Time64Type*>(array.type().get());
         const auto value = array.Value(i);
-        return LL2NUM(value);
+        return rb_funcall(red_arrow::cArrowTime,
+                          id_new,
+                          2,
+                          time_unit_to_enum(type->unit()),
+                          LL2NUM(value));
       }
 
       inline VALUE convert(const arrow::TimestampArray& array,
@@ -188,9 +198,6 @@ namespace red_arrow {
         const auto type =
           arrow::internal::checked_cast<const arrow::TimestampType*>(array.type().get());
         auto scale = time_unit_to_scale(type->unit());
-        if (NIL_P(scale)) {
-          rb_raise(rb_eArgError, "Invalid TimeUnit");
-        }
         auto value = array.Value(i);
         auto sec = rb_rational_new(LL2NUM(value), scale);
         return rb_time_num_new(sec, Qnil);

--- a/ruby/red-arrow/ext/arrow/red-arrow.hpp
+++ b/ruby/red-arrow/ext/arrow/red-arrow.hpp
@@ -34,15 +34,22 @@
 
 namespace red_arrow {
   extern VALUE cDate;
+  extern VALUE cArrowTime;
+
+  extern VALUE ArrowTimeUnitSECOND;
+  extern VALUE ArrowTimeUnitMILLI;
+  extern VALUE ArrowTimeUnitMICRO;
+  extern VALUE ArrowTimeUnitNANO;
 
   extern ID id_BigDecimal;
   extern ID id_jd;
+  extern ID id_new;
   extern ID id_to_datetime;
 
   VALUE record_batch_raw_records(VALUE obj);
   VALUE table_raw_records(VALUE obj);
 
-  inline VALUE time_unit_to_scale(arrow::TimeUnit::type unit) {
+  inline VALUE time_unit_to_scale(const arrow::TimeUnit::type unit) {
     switch (unit) {
     case arrow::TimeUnit::SECOND:
       return INT2FIX(1);
@@ -54,8 +61,24 @@ namespace red_arrow {
       // NOTE: INT2FIX works for 1e+9 because: FIXNUM_MAX >= (1<<30) - 1 > 1e+9
       return INT2FIX(1000 * 1000 * 1000);
     default:
-      break; // NOT REACHED
+      rb_raise(rb_eArgError, "invalid arrow::TimeUnit: %d", unit);
+      return Qnil;
     }
-    return Qnil;
+  }
+
+  inline VALUE time_unit_to_enum(const arrow::TimeUnit::type unit) {
+    switch (unit) {
+    case arrow::TimeUnit::SECOND:
+      return red_arrow::ArrowTimeUnitSECOND;
+    case arrow::TimeUnit::MILLI:
+      return red_arrow::ArrowTimeUnitMILLI;
+    case arrow::TimeUnit::MICRO:
+      return red_arrow::ArrowTimeUnitMICRO;
+    case arrow::TimeUnit::NANO:
+      return red_arrow::ArrowTimeUnitNANO;
+    default:
+      rb_raise(rb_eArgError, "invalid arrow::TimeUnit: %d", unit);
+      return Qnil;
+    }
   }
 }

--- a/ruby/red-arrow/lib/arrow/array.rb
+++ b/ruby/red-arrow/lib/arrow/array.rb
@@ -73,5 +73,10 @@ module Arrow
     def to_arrow
       self
     end
+
+    alias_method :value_data_type_raw, :value_data_type
+    def value_data_type
+      @value_data_type ||= value_data_type_raw
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/csv-loader.rb
+++ b/ruby/red-arrow/lib/arrow/csv-loader.rb
@@ -221,7 +221,7 @@ module Arrow
         field
       else
         begin
-          Time.iso8601(encoded_field)
+          ::Time.iso8601(encoded_field)
         rescue ArgumentError
           field
         end
@@ -317,7 +317,7 @@ module Arrow
             if current_column_type == :integer
               column_types[i] = candidate_type
             end
-          when Time
+          when ::Time
             candidate_type = :time
           when DateTime
             candidate_type = :date_time

--- a/ruby/red-arrow/lib/arrow/date64-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/date64-array-builder.rb
@@ -19,11 +19,11 @@ module Arrow
   class Date64ArrayBuilder
     private
     def convert_to_arrow_value(value)
-      if value.respond_to?(:to_time) and not value.is_a?(Time)
+      if value.respond_to?(:to_time) and not value.is_a?(::Time)
         value = value.to_time
       end
 
-      if value.is_a?(Time)
+      if value.is_a?(::Time)
         value.to_i * 1_000 + value.usec / 1_000
       else
         value

--- a/ruby/red-arrow/lib/arrow/date64-array.rb
+++ b/ruby/red-arrow/lib/arrow/date64-array.rb
@@ -23,7 +23,7 @@ module Arrow
 
     private
     def to_datetime(raw_value)
-      Time.at(*raw_value.divmod(1_000)).to_datetime
+      ::Time.at(*raw_value.divmod(1_000)).to_datetime
     end
   end
 end

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -76,8 +76,11 @@ module Arrow
       require "arrow/table-loader"
       require "arrow/table-saver"
       require "arrow/tensor"
+      require "arrow/time"
+      require "arrow/time32-array"
       require "arrow/time32-array-builder"
       require "arrow/time32-data-type"
+      require "arrow/time64-array"
       require "arrow/time64-array-builder"
       require "arrow/time64-data-type"
       require "arrow/timestamp-array"
@@ -119,6 +122,8 @@ module Arrow
       when "Arrow::Date32Array",
            "Arrow::Date64Array",
            "Arrow::Decimal128Array",
+           "Arrow::Time32Array",
+           "Arrow::Time64Array",
            "Arrow::TimestampArray"
         case method_name
         when "get_value"

--- a/ruby/red-arrow/lib/arrow/table-table-formatter.rb
+++ b/ruby/red-arrow/lib/arrow/table-table-formatter.rb
@@ -33,7 +33,7 @@ module Arrow
     def format_column_name(column)
       case column.data_type
       when TimestampDataType
-        "%*s" % [Time.now.iso8601.size, column.name]
+        "%*s" % [::Time.now.iso8601.size, column.name]
       when FloatDataType, DoubleDataType
         "%*s" % [FLOAT_N_DIGITS, column.name]
       else
@@ -55,7 +55,7 @@ module Arrow
 
     def format_column_value(column, value)
       case value
-      when Time
+      when ::Time
         value.iso8601
       when Float
         "%*f" % [[column.name.size, FLOAT_N_DIGITS].max, value]

--- a/ruby/red-arrow/lib/arrow/time.rb
+++ b/ruby/red-arrow/lib/arrow/time.rb
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module Arrow
+  class Time
+    attr_reader :unit
+    attr_reader :value
+    def initialize(unit, value)
+      @unit = unit
+      @value = value
+      @unconstructed = false
+    end
+
+    def ==(other)
+      other.is_a?(self.class) and
+        positive? == other.positive? and
+        hour == other.hour and
+        minute == other.minute and
+        second == other.second and
+        nano_second == other.nano_second
+    end
+
+    def cast(target_unit)
+      return self.class.new(@unit, @value) if @unit == target_unit
+
+      target_value = (hour * 60 * 60) + (minute * 60) + second
+      case target_unit
+      when TimeUnit::MILLI
+        target_value *= 1000
+        target_value += nano_second / 1000 / 1000
+      when TimeUnit::MICRO
+        target_value *= 1000 * 1000
+        target_value += nano_second / 1000
+      when TimeUnit::NANO
+        target_value *= 1000 * 1000 * 1000
+        target_value += nano_second
+      end
+      target_value = -target_value if negative?
+      self.class.new(target_unit, target_value)
+    end
+
+    def to_f
+      case @unit
+      when TimeUnit::SECOND
+        @value.to_f
+      when TimeUnit::MILLI
+        @value.to_f / 1000.0
+      when TimeUnit::MICRO
+        @value.to_f / 1000.0 / 1000.0
+      when TimeUnit::NANO
+        @value.to_f / 1000.0 / 1000.0 / 1000.0
+      end
+    end
+
+    def positive?
+      @value.positive?
+    end
+
+    def negative?
+      @value.negative?
+    end
+
+    def hour
+      unconstruct
+      @hour
+    end
+
+    def minute
+      unconstruct
+      @minute
+    end
+    alias_method :min, :minute
+
+    def second
+      unconstruct
+      @second
+    end
+    alias_method :sec, :second
+
+    def nano_second
+      unconstruct
+      @nano_second
+    end
+    alias_method :nsec, :nano_second
+
+    def to_s
+      unconstruct
+      if @nano_second.zero?
+        nano_second_string = ""
+      else
+        nano_second_string = (".%09d" % @nano_second).gsub(/0+\z/, "")
+      end
+      "%s%02d:%02d:%02d%s" % [
+        @value.negative? ? "-" : "",
+        @hour,
+        @minute,
+        @second,
+        nano_second_string,
+      ]
+    end
+
+    private
+    def unconstruct
+      return if @unconstructed
+      abs_value = @value.abs
+      case unit
+      when TimeUnit::SECOND
+        unconstruct_second(abs_value)
+        @nano_second = 0
+      when TimeUnit::MILLI
+        unconstruct_second(abs_value / 1000)
+        @nano_second = (abs_value % 1000) * 1000 * 1000
+      when TimeUnit::MICRO
+        unconstruct_second(abs_value / 1000 / 1000)
+        @nano_second = (abs_value % (1000 * 1000)) * 1000
+      when TimeUnit::NANO
+        unconstruct_second(abs_value / 1000 / 1000 / 1000)
+        @nano_second = abs_value % (1000 * 1000 * 1000)
+      else
+        raise ArgumentError, "invalid unit: #{@unit.inspect}"
+      end
+      @unconstructed = true
+    end
+
+    def unconstruct_second(abs_value_in_second)
+      if abs_value_in_second < 60
+        hour = 0
+        minute = 0
+        second = abs_value_in_second
+      elsif abs_value_in_second < (60 * 60)
+        hour = 0
+        minute = abs_value_in_second / 60
+        second = abs_value_in_second % 60
+      else
+        in_minute = abs_value_in_second / 60
+        hour = in_minute / 60
+        minute = in_minute % 60
+        second = abs_value_in_second % 60
+      end
+      @hour = hour
+      @minute = minute
+      @second = second
+    end
+  end
+end

--- a/ruby/red-arrow/lib/arrow/time32-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/time32-array-builder.rb
@@ -35,5 +35,15 @@ module Arrow
       end
       initialize_raw(data_type)
     end
+
+    def unit
+      @unit ||= value_data_type.unit
+    end
+
+    private
+    def convert_to_arrow_value(value)
+      return value unless value.is_a?(Time)
+      value.cast(unit).value
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/time32-array.rb
+++ b/ruby/red-arrow/lib/arrow/time32-array.rb
@@ -16,27 +16,13 @@
 # under the License.
 
 module Arrow
-  class TimestampArray
+  class Time32Array
     def get_value(i)
-      cast_to_time(get_raw_value(i))
+      Time.new(unit, get_raw_value(i))
     end
 
     def unit
       @unit ||= value_data_type.unit
-    end
-
-    private
-    def cast_to_time(raw_value)
-      case unit
-      when TimeUnit::SECOND
-        ::Time.at(raw_value)
-      when TimeUnit::MILLI
-        ::Time.at(*raw_value.divmod(1_000))
-      when TimeUnit::MICRO
-        ::Time.at(*raw_value.divmod(1_000_000))
-      else
-        ::Time.at(raw_value / 1_000_000_000.0)
-      end
     end
   end
 end

--- a/ruby/red-arrow/lib/arrow/time64-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/time64-array-builder.rb
@@ -35,5 +35,15 @@ module Arrow
       end
       initialize_raw(data_type)
     end
+
+    def unit
+      @unit ||= value_data_type.unit
+    end
+
+    private
+    def convert_to_arrow_value(value)
+      return value unless value.is_a?(Time)
+      value.cast(unit).value
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/time64-array.rb
+++ b/ruby/red-arrow/lib/arrow/time64-array.rb
@@ -16,27 +16,13 @@
 # under the License.
 
 module Arrow
-  class TimestampArray
+  class Time64Array
     def get_value(i)
-      cast_to_time(get_raw_value(i))
+      Time.new(unit, get_raw_value(i))
     end
 
     def unit
       @unit ||= value_data_type.unit
-    end
-
-    private
-    def cast_to_time(raw_value)
-      case unit
-      when TimeUnit::SECOND
-        ::Time.at(raw_value)
-      when TimeUnit::MILLI
-        ::Time.at(*raw_value.divmod(1_000))
-      when TimeUnit::MICRO
-        ::Time.at(*raw_value.divmod(1_000_000))
-      else
-        ::Time.at(raw_value / 1_000_000_000.0)
-      end
     end
   end
 end

--- a/ruby/red-arrow/lib/arrow/timestamp-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/timestamp-array-builder.rb
@@ -46,7 +46,7 @@ module Arrow
         value = value.to_time
       end
 
-      if value.is_a?(Time)
+      if value.is_a?(::Time)
         case unit_id
         when :second
           value.to_i

--- a/ruby/red-arrow/test/raw-records/test-basic-arrays.rb
+++ b/ruby/red-arrow/test/raw-records/test-basic-arrays.rb
@@ -242,10 +242,11 @@ module RawRecordsBasicArraysTests
   end
 
   def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
     records = [
-      [60 * 10], # 00:10:00
+      [Arrow::Time.new(unit, 60 * 10)], # 00:10:00
       [nil],
-      [60 * 60 * 2 + 9], # 02:00:09
+      [Arrow::Time.new(unit, 60 * 60 * 2 + 9)], # 02:00:09
     ]
     target = build({
                      column: {
@@ -258,10 +259,11 @@ module RawRecordsBasicArraysTests
   end
 
   def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
     records = [
-      [(60 * 10) * 1000 + 123], # 00:10:00.123
+      [Arrow::Time.new(unit, (60 * 10) * 1000 + 123)], # 00:10:00.123
       [nil],
-      [(60 * 60 * 2 + 9) * 1000 + 987], # 02:00:09.987
+      [Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1000 + 987)], # 02:00:09.987
     ]
     target = build({
                      column: {
@@ -274,10 +276,13 @@ module RawRecordsBasicArraysTests
   end
 
   def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
     records = [
-      [(60 * 10) * 1_000_000 + 123_456], # 00:10:00.123456
+      # 00:10:00.123456
+      [Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)],
       [nil],
-      [(60 * 60 * 2 + 9) * 1_000_000 + 987_654], # 02:00:09.987654
+      # 02:00:09.987654
+      [Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000 + 987_654)],
     ]
     target = build({
                      column: {
@@ -290,10 +295,13 @@ module RawRecordsBasicArraysTests
   end
 
   def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
     records = [
-      [(60 * 10) * 1_000_000_000 + 123_456_789], # 00:10:00.123456789
+      # 00:10:00.123456789
+      [Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)],
       [nil],
-      [(60 * 60 * 2 + 9) * 1_000_000_000 + 987_654_321], # 02:00:09.987654321
+      # 02:00:09.987654321
+      [Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000_000 + 987_654_321)],
     ]
     target = build({
                      column: {

--- a/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
@@ -295,8 +295,10 @@ module RawRecordsDenseUnionArrayTests
   end
 
   def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
     records = [
-      [{"0" => 60 * 10}], # 00:10:00
+      # 00:10:00
+      [{"0" => Arrow::Time.new(unit, 60 * 10)}],
       [nil],
       [{"1" => nil}],
     ]
@@ -309,8 +311,10 @@ module RawRecordsDenseUnionArrayTests
   end
 
   def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
     records = [
-      [{"0" => (60 * 10) * 1000 + 123}], # 00:10:00.123
+      # 00:10:00.123
+      [{"0" => Arrow::Time.new(unit, (60 * 10) * 1000 + 123)}],
       [nil],
       [{"1" => nil}],
     ]
@@ -323,8 +327,10 @@ module RawRecordsDenseUnionArrayTests
   end
 
   def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
     records = [
-      [{"0" => (60 * 10) * 1_000_000 + 123_456}], # 00:10:00.123456
+      # 00:10:00.123456
+      [{"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)}],
       [nil],
       [{"1" => nil}],
     ]
@@ -337,9 +343,10 @@ module RawRecordsDenseUnionArrayTests
   end
 
   def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
     records = [
       # 00:10:00.123456789
-      [{"0" => (60 * 10) * 1_000_000_000 + 123_456_789}],
+      [{"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)}],
       [nil],
       [{"1" => nil}],
     ]

--- a/ruby/red-arrow/test/raw-records/test-list-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-list-array.rb
@@ -271,13 +271,16 @@ module RawRecordsListArrayTests
     assert_equal(records, target.raw_records)
   end
 
-  def test_time32_test
+  def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
     records = [
       [
         [
-          60 * 10, # 00:10:00
+          # 00:10:00
+          Arrow::Time.new(unit, 60 * 10),
           nil,
-          60 * 60 * 2 + 9, # 02:00:09
+          # 02:00:09
+          Arrow::Time.new(unit, 60 * 60 * 2 + 9),
         ],
       ],
       [nil],
@@ -291,12 +294,15 @@ module RawRecordsListArrayTests
   end
 
   def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
     records = [
       [
         [
-          (60 * 10) * 1000 + 123, # 00:10:00.123
+          # 00:10:00.123
+          Arrow::Time.new(unit, (60 * 10) * 1000 + 123),
           nil,
-          (60 * 60 * 2 + 9) * 1000 + 987, # 02:00:09.987
+          # 02:00:09.987
+          Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1000 + 987),
         ],
       ],
       [nil],
@@ -310,12 +316,15 @@ module RawRecordsListArrayTests
   end
 
   def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
     records = [
       [
         [
-          (60 * 10) * 1_000_000 + 123_456, # 00:10:00.123456
+          # 00:10:00.123456
+          Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456),
           nil,
-          (60 * 60 * 2 + 9) * 1_000_000 + 987_654, # 02:00:09.987654
+          # 02:00:09.987654
+          Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000 + 987_654),
         ],
       ],
       [nil],
@@ -329,12 +338,15 @@ module RawRecordsListArrayTests
   end
 
   def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
     records = [
       [
         [
-          (60 * 10) * 1_000_000_000 + 123_456_789, # 00:10:00.123456789
+          # 00:10:00.123456789
+          Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
           nil,
-          (60 * 60 * 2 + 9) * 1_000_000_000 + 987_654_321, # 02:00:09.987654321
+          # 02:00:09.987654321
+          Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000_000 + 987_654_321),
         ],
       ],
       [nil],

--- a/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
@@ -284,8 +284,10 @@ module RawRecordsSparseUnionArrayTests
   end
 
   def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
     records = [
-      [{"0" => 60 * 10}], # 00:10:00
+      # 00:10:00
+      [{"0" => Arrow::Time.new(unit, 60 * 10)}],
       [nil],
       [{"1" => nil}],
     ]
@@ -298,8 +300,10 @@ module RawRecordsSparseUnionArrayTests
   end
 
   def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
     records = [
-      [{"0" => (60 * 10) * 1000 + 123}], # 00:10:00.123
+      # 00:10:00.123
+      [{"0" => Arrow::Time.new(unit, (60 * 10) * 1000 + 123)}],
       [nil],
       [{"1" => nil}],
     ]
@@ -312,8 +316,10 @@ module RawRecordsSparseUnionArrayTests
   end
 
   def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
     records = [
-      [{"0" => (60 * 10) * 1_000_000 + 123_456}], # 00:10:00.123456
+      # 00:10:00.123456
+      [{"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)}],
       [nil],
       [{"1" => nil}],
     ]
@@ -326,8 +332,10 @@ module RawRecordsSparseUnionArrayTests
   end
 
   def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
     records = [
-      [{"0" => (60 * 10) * 1_000_000_000 + 123_456_789}], # 00:10:00.123456789
+      # 00:10:00.123456789
+      [{"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)}],
       [nil],
       [{"1" => nil}],
     ]

--- a/ruby/red-arrow/test/raw-records/test-struct-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-struct-array.rb
@@ -251,8 +251,10 @@ module RawRecordsStructArrayTests
   end
 
   def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
     records = [
-      [{"field" => 60 * 10}], # 00:10:00
+      # 00:10:00
+      [{"field" => Arrow::Time.new(unit, 60 * 10)}],
       [nil],
       [{"field" => nil}],
     ]
@@ -265,8 +267,10 @@ module RawRecordsStructArrayTests
   end
 
   def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
     records = [
-      [{"field" => (60 * 10) * 1000 + 123}], # 00:10:00.123
+      # 00:10:00.123
+      [{"field" => Arrow::Time.new(unit, (60 * 10) * 1000 + 123)}],
       [nil],
       [{"field" => nil}],
     ]
@@ -279,8 +283,10 @@ module RawRecordsStructArrayTests
   end
 
   def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
     records = [
-      [{"field" => (60 * 10) * 1_000_000 + 123_456}], # 00:10:00.123456
+      # 00:10:00.123456
+      [{"field" => Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)}],
       [nil],
       [{"field" => nil}],
     ]
@@ -293,9 +299,10 @@ module RawRecordsStructArrayTests
   end
 
   def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
     records = [
       # 00:10:00.123456789
-      [{"field" => (60 * 10) * 1_000_000_000 + 123_456_789}],
+      [{"field" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)}],
       [nil],
       [{"field" => nil}],
     ]

--- a/ruby/red-arrow/test/test-time.rb
+++ b/ruby/red-arrow/test/test-time.rb
@@ -1,0 +1,288 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TimeTest < Test::Unit::TestCase
+  sub_test_case("#==") do
+    test("same unit") do
+      assert do
+        Arrow::Time.new(:second, 10) == Arrow::Time.new(:second, 10)
+      end
+    end
+
+    test("different unit") do
+      assert do
+        Arrow::Time.new(:second, 10) == Arrow::Time.new(:milli, 10 * 1000)
+      end
+    end
+
+    test("false") do
+      assert do
+        not(Arrow::Time.new(:second, 10) == Arrow::Time.new(:second, 11))
+      end
+    end
+  end
+
+  sub_test_case("#cast") do
+    test("same unit") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      casted_time = time.cast(Arrow::TimeUnit::SECOND)
+      assert_equal([time.unit, time.value],
+                   [casted_time.unit, casted_time.value])
+    end
+
+    test("second -> milli") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      casted_time = time.cast(Arrow::TimeUnit::MILLI)
+      assert_equal([
+                     Arrow::TimeUnit::MILLI,
+                     time.value * 1000,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("second -> micro") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      casted_time = time.cast(Arrow::TimeUnit::MICRO)
+      assert_equal([
+                     Arrow::TimeUnit::MICRO,
+                     time.value * 1000 * 1000,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("second -> nano") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      casted_time = time.cast(Arrow::TimeUnit::NANO)
+      assert_equal([
+                     Arrow::TimeUnit::NANO,
+                     time.value * 1000 * 1000 * 1000,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("milli -> second") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MILLI, 10_200)
+      casted_time = time.cast(Arrow::TimeUnit::SECOND)
+      assert_equal([
+                     Arrow::TimeUnit::SECOND,
+                     10,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("milli -> micro") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MILLI, 10_200)
+      casted_time = time.cast(Arrow::TimeUnit::MICRO)
+      assert_equal([
+                     Arrow::TimeUnit::MICRO,
+                     time.value * 1000,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("milli -> nano") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MILLI, 10_200)
+      casted_time = time.cast(Arrow::TimeUnit::NANO)
+      assert_equal([
+                     Arrow::TimeUnit::NANO,
+                     time.value * 1000 * 1000,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("micro -> second") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MICRO, 10_200_300)
+      casted_time = time.cast(Arrow::TimeUnit::SECOND)
+      assert_equal([
+                     Arrow::TimeUnit::SECOND,
+                     10,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("micro -> milli") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MICRO, 10_200_300)
+      casted_time = time.cast(Arrow::TimeUnit::MILLI)
+      assert_equal([
+                     Arrow::TimeUnit::MILLI,
+                     10_200,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("micro -> nano") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MICRO, 10_200_300)
+      casted_time = time.cast(Arrow::TimeUnit::NANO)
+      assert_equal([
+                     Arrow::TimeUnit::NANO,
+                     time.value * 1000,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("nano -> second") do
+      time = Arrow::Time.new(Arrow::TimeUnit::NANO, 10_200_300_400)
+      casted_time = time.cast(Arrow::TimeUnit::SECOND)
+      assert_equal([
+                     Arrow::TimeUnit::SECOND,
+                     10,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("nano -> milli") do
+      time = Arrow::Time.new(Arrow::TimeUnit::NANO, 10_200_300_400)
+      casted_time = time.cast(Arrow::TimeUnit::MILLI)
+      assert_equal([
+                     Arrow::TimeUnit::MILLI,
+                     10_200,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+
+    test("nano -> micro") do
+      time = Arrow::Time.new(Arrow::TimeUnit::NANO, 10_200_300_400)
+      casted_time = time.cast(Arrow::TimeUnit::MICRO)
+      assert_equal([
+                     Arrow::TimeUnit::MICRO,
+                     10_200_300,
+                   ],
+                   [
+                     casted_time.unit,
+                     casted_time.value,
+                   ])
+    end
+  end
+
+  sub_test_case("#to_f") do
+    test("second") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      assert_in_delta(10.0, time.to_f)
+    end
+
+    test("milli") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MILLI, 10_200)
+      assert_in_delta(10.2, time.to_f)
+    end
+
+    test("micro") do
+      time = Arrow::Time.new(Arrow::TimeUnit::MICRO, 10_200_300)
+      assert_in_delta(10.2003, time.to_f)
+    end
+
+    test("nano") do
+      time = Arrow::Time.new(Arrow::TimeUnit::NANO, 10_200_300_400)
+      assert_in_delta(10.2003004, time.to_f)
+    end
+  end
+
+  sub_test_case("#positive?") do
+    test("true") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      assert do
+        time.positive?
+      end
+    end
+
+    test("false") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, -10)
+      assert do
+        not time.positive?
+      end
+    end
+  end
+
+  sub_test_case("#negative?") do
+    test("true") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, -10)
+      assert do
+        time.negative?
+      end
+    end
+
+    test("false") do
+      time = Arrow::Time.new(Arrow::TimeUnit::SECOND, 10)
+      assert do
+        not time.negative?
+      end
+    end
+  end
+
+  test("#hour") do
+    time = Arrow::Time.new(Arrow::TimeUnit::SECOND,
+                           (5 * 60 * 60) + (12 * 60) + 10)
+    assert_equal(5, time.hour)
+  end
+
+  test("#minute") do
+    time = Arrow::Time.new(Arrow::TimeUnit::SECOND,
+                           (5 * 60 * 60) + (12 * 60) + 10)
+    assert_equal(12, time.minute)
+  end
+
+  test("#second") do
+    time = Arrow::Time.new(Arrow::TimeUnit::SECOND,
+                           (5 * 60 * 60) + (12 * 60) + 10)
+    assert_equal(10, time.second)
+  end
+
+  test("#nano_second") do
+    time = Arrow::Time.new(Arrow::TimeUnit::NANO, 1234)
+    assert_equal(1234, time.nano_second)
+  end
+
+  test("#to_s") do
+    time = Arrow::Time.new(Arrow::TimeUnit::NANO,
+                           -(((5 * 60 * 60) + (12 * 60) + 10) * 1_000_000_000 +
+                             1234))
+    assert_equal("-05:12:10.000001234",
+                 time.to_s)
+  end
+end

--- a/ruby/red-arrow/test/test-time32-array.rb
+++ b/ruby/red-arrow/test/test-time32-array.rb
@@ -17,30 +17,65 @@
 
 class Time32ArrayTest < Test::Unit::TestCase
   sub_test_case(".new") do
-    test("Arrow::TimeUnit") do
-      values = [1000 * 10, nil]
-      array = Arrow::Time32Array.new(Arrow::TimeUnit::MILLI, values)
-      assert_equal([
-                     "time32[ms]",
-                     values,
-                   ],
-                   [
-                     array.value_data_type.to_s,
-                     array.to_a,
-                   ])
+    sub_test_case("unit") do
+      test("Arrow::TimeUnit") do
+        values = [1000 * 10, nil]
+        array = Arrow::Time32Array.new(Arrow::TimeUnit::MILLI, values)
+        assert_equal([
+                       "time32[ms]",
+                       [
+                         Arrow::Time.new(Arrow::TimeUnit::MILLI,
+                                         1000 * 10),
+                         nil,
+                       ],
+                     ],
+                     [
+                       array.value_data_type.to_s,
+                       array.to_a,
+                     ])
+      end
+
+      test("Symbol") do
+        values = [60 * 10, nil]
+        array = Arrow::Time32Array.new(:second, values)
+        assert_equal([
+                       "time32[s]",
+                       [
+                         Arrow::Time.new(Arrow::TimeUnit::SECOND,
+                                         60 * 10),
+                         nil,
+                       ],
+                     ],
+                     [
+                       array.value_data_type.to_s,
+                       array.to_a,
+                     ])
+      end
     end
 
-    test("Symbol") do
-      values = [60 * 10, nil]
-      array = Arrow::Time32Array.new(:second, values)
-      assert_equal([
-                     "time32[s]",
-                     values,
-                   ],
-                   [
-                     array.value_data_type.to_s,
-                     array.to_a,
-                   ])
+    sub_test_case("values") do
+      test("Arrow::Time") do
+        data_type = Arrow::Time32DataType.new(:second)
+        values = [
+          Arrow::Time.new(Arrow::TimeUnit::SECOND,
+                          60 * 10),
+          nil,
+        ]
+        array = Arrow::Time32Array.new(data_type, values)
+        assert_equal(values, array.to_a)
+      end
+
+      test("Integer") do
+        data_type = Arrow::Time32DataType.new(:second)
+        values = [60 * 10, nil]
+        array = Arrow::Time32Array.new(data_type, values)
+        assert_equal([
+                       Arrow::Time.new(Arrow::TimeUnit::SECOND,
+                                       60 * 10),
+                       nil,
+                     ],
+                     array.to_a)
+      end
     end
   end
 end

--- a/ruby/red-arrow/test/test-time64-array.rb
+++ b/ruby/red-arrow/test/test-time64-array.rb
@@ -17,30 +17,65 @@
 
 class Time64ArrayTest < Test::Unit::TestCase
   sub_test_case(".new") do
-    test("Arrow::TimeUnit") do
-      values = [1000 * 10, nil]
-      array = Arrow::Time64Array.new(Arrow::TimeUnit::NANO, values)
-      assert_equal([
-                     "time64[ns]",
-                     values,
-                   ],
-                   [
-                     array.value_data_type.to_s,
-                     array.to_a,
-                   ])
+    sub_test_case("unit") do
+      test("Arrow::TimeUnit") do
+        values = [1000 * 10, nil]
+        array = Arrow::Time64Array.new(Arrow::TimeUnit::NANO, values)
+        assert_equal([
+                       "time64[ns]",
+                       [
+                         Arrow::Time.new(Arrow::TimeUnit::NANO,
+                                         1000 * 10),
+                         nil,
+                       ],
+                     ],
+                     [
+                       array.value_data_type.to_s,
+                       array.to_a,
+                     ])
+      end
+
+      test("Symbol") do
+        values = [1000 * 10, nil]
+        array = Arrow::Time64Array.new(:micro, values)
+        assert_equal([
+                       "time64[us]",
+                       [
+                         Arrow::Time.new(Arrow::TimeUnit::MICRO,
+                                         1000 * 10),
+                         nil,
+                       ],
+                     ],
+                     [
+                       array.value_data_type.to_s,
+                       array.to_a,
+                     ])
+      end
     end
 
-    test("Symbol") do
-      values = [1000 * 10, nil]
-      array = Arrow::Time64Array.new(:micro, values)
-      assert_equal([
-                     "time64[us]",
-                     values,
-                   ],
-                   [
-                     array.value_data_type.to_s,
-                     array.to_a,
-                   ])
+    sub_test_case("values") do
+      test("Arrow::Time") do
+        data_type = Arrow::Time64DataType.new(:nano)
+        values = [
+          Arrow::Time.new(Arrow::TimeUnit::NANO,
+                          1000 * 10),
+          nil,
+        ]
+        array = Arrow::Time64Array.new(data_type, values)
+        assert_equal(values, array.to_a)
+      end
+
+      test("Integer") do
+        data_type = Arrow::Time64DataType.new(:nano)
+        values = [1000 * 10, nil]
+        array = Arrow::Time64Array.new(data_type, values)
+        assert_equal([
+                       Arrow::Time.new(Arrow::TimeUnit::NANO,
+                                       1000 * 10),
+                       nil,
+                     ],
+                     array.to_a)
+      end
     end
   end
 end


### PR DESCRIPTION
This is a backward incompatible change. But it's OK. Because this was a
TODO feature.