### PR TITLE
ARROW-6268: [Java] Empty buffers to have a valid address.

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -278,7 +278,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   private ArrowBuf createEmpty() {
-    return new ArrowBuf(ReferenceManager.NO_OP, null, 0, 0, true);
+    return new ArrowBuf(ReferenceManager.NO_OP, null, 0, AllocationManager.EMPTY.memoryAddress(), true);
   }
 
   @Override

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestBaseAllocator.java
@@ -114,6 +114,7 @@ public class TestBaseAllocator {
       final ArrowBuf arrowBuf = rootAllocator.buffer(0);
       assertNotNull("allocation failed", arrowBuf);
       assertEquals("capacity was non-zero", 0, arrowBuf.capacity());
+      assertTrue("address should be valid", arrowBuf.memoryAddress() != 0);
       arrowBuf.getReferenceManager().release();
     }
   }


### PR DESCRIPTION
- As part of arrow buffer refactoring done earlier, the empty buffers are now created with an invalid addresses.
- This breaks client code that assumed that even empty buffers are valid.
- Uses the address of EMPTY buffer from allocation manager.
