### PR TITLE
ARROW-5028: [Python] Avoid malformed ListArray types caused by reaching StringBuilder capacity when converting from Python sequence

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1531,6 +1531,13 @@ def test_numpy_string_overflow_to_chunked():
             value_index += 1
 
 
+@pytest.mark.large_memory
+def test_list_child_overflow_to_chunked():
+    vals = [['x' * 1024]] * ((2 << 20) + 1)
+    with pytest.raises(ValueError, match="overflowed"):
+        pa.array(vals)
+
+
 def test_infer_type_masked():
     # ARROW-5208
     ty = pa.infer_type([u'foo', u'bar', None, 2],


### PR DESCRIPTION
This fixes the root cause of ARROW-5028 was was malformed `list<string>` being produced by `pyarrow.array` when the contents of the child builder exceed the 2GB capacity limit of a StringArray. Internally, the child `SeqConverter` was correctly yielding multiple chunks, but this was passing unbeknownst to the parent `ListConverter`. We'll have to do some follow up work to produce chunked ListArray in the future but this at least raises an exception for now so that we aren't creating malformed arrays. 