### PR TITLE
ARROW-5480: [Python] Add unit test asserting specifically that pandas.Categorical roundtrips to Parquet format without special options

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -3034,18 +3034,17 @@ def test_pandas_categorical_na_type_row_groups():
 
 def test_categorical_roundtrip():
     # ARROW-5480, this was enabled by ARROW-3246
-    from io import BytesIO
 
-    # Have one of the categories unobserved
+    # Have one of the categories unobserved and include a null (-1)
     codes = np.array([2, 0, 0, 2, 0, -1, 2], dtype='int32')
     categories = ['foo', 'bar', 'baz']
     df = pd.DataFrame({'x': pd.Categorical.from_codes(
         codes, categories=categories)})
 
-    buf = BytesIO()
-    df.to_parquet(buf)
+    buf = pa.BufferOutputStream()
+    pq.write_table(pa.table(df), buf)
 
-    result = pd.read_parquet(BytesIO(buf.getvalue()))
+    result = pq.read_table(buf.getvalue()).to_pandas()
     assert result.x.dtype == 'category'
     assert (result.x.cat.categories == categories).all()
     tm.assert_frame_equal(result, df)

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -3015,6 +3015,7 @@ def test_dictionary_array_automatically_read():
     assert result.schema.metadata is None
 
 
+@pytest.mark.pandas
 def test_pandas_categorical_na_type_row_groups():
     # ARROW-5085
     df = pd.DataFrame({"col": [None] * 100, "int": [1.0] * 100})
@@ -3032,7 +3033,8 @@ def test_pandas_categorical_na_type_row_groups():
     assert result[1].equals(table[1])
 
 
-def test_categorical_roundtrip():
+@pytest.mark.pandas
+def test_pandas_categorical_roundtrip():
     # ARROW-5480, this was enabled by ARROW-3246
 
     # Have one of the categories unobserved and include a null (-1)


### PR DESCRIPTION
This only works for string types for the moment. Once ARROW-6277 is addressed we can expand to other types. 