### PR TITLE
ARROW-6101: [Rust] [DataFusion] Parallel execution of physical query plan

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -54,7 +54,7 @@ crossbeam = "0.7.1"
 
 [dev-dependencies]
 criterion = "0.2.0"
-
+tempdir = "0.3.7"
 
 [[bench]]
 name = "aggregate_query_sql"

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -18,16 +18,17 @@
 //! CSV Data source
 
 use std::fs::File;
-use std::string::String;
-use std::sync::{Arc, Mutex};
 
+use std::string::String;
+use std::sync::Arc;
 use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::{ScanResult, TableProvider};
 use crate::error::Result;
-use crate::execution::physical_plan::BatchIterator;
+use crate::execution::physical_plan::csv::CsvExec;
+use crate::execution::physical_plan::{BatchIterator, ExecutionPlan};
 
 /// Represents a CSV file with a provided schema
 // TODO: usage example (rather than documenting `new()`)
@@ -58,13 +59,19 @@ impl TableProvider for CsvFile {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
     ) -> Result<Vec<ScanResult>> {
-        Ok(vec![Arc::new(Mutex::new(CsvBatchIterator::new(
+        let exec = CsvExec::try_new(
             &self.filename,
             self.schema.clone(),
             self.has_header,
-            projection,
+            projection.clone(),
             batch_size,
-        )))])
+        )?;
+        let partitions = exec.partitions()?;
+        let iterators = partitions
+            .iter()
+            .map(|p| p.execute())
+            .collect::<Result<Vec<_>>>()?;
+        Ok(iterators)
     }
 }
 

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -19,11 +19,11 @@
 
 use std::fs::File;
 
-use std::string::String;
-use std::sync::Arc;
 use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
+use std::string::String;
+use std::sync::Arc;
 
 use crate::datasource::{ScanResult, TableProvider};
 use crate::error::Result;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -39,6 +39,7 @@ use crate::execution::filter::FilterRelation;
 use crate::execution::limit::LimitRelation;
 use crate::execution::physical_plan::datasource::DatasourceExec;
 use crate::execution::physical_plan::projection::ProjectionExec;
+use crate::execution::physical_plan::expressions::Column;
 use crate::execution::physical_plan::{ExecutionPlan, PhysicalExpr};
 use crate::execution::projection::ProjectRelation;
 use crate::execution::relation::{DataSourceRelation, Relation};
@@ -261,11 +262,14 @@ impl ExecutionContext {
     /// Create a physical expression from a logical expression
     pub fn create_physical_expr(
         &self,
-        _e: &Expr,
+        e: &Expr,
         _input_schema: &Schema,
     ) -> Result<Arc<dyn PhysicalExpr>> {
-        //TODO: implement this next
-        unimplemented!()
+
+        match e {
+            Expr::Column(i) => Ok(Arc::new(Column::new(*i))),
+            _ => Err(ExecutionError::NotImplemented("Unsupported expression".to_string()))
+        }
     }
 
     /// Execute a physical plan and collect the results in memory
@@ -545,7 +549,8 @@ mod tests {
 
         let results = ctx.collect(physical_plan.as_ref())?;
 
-        assert_eq!(123, results.len());
+        assert_eq!(1, results.len());
+        assert_eq!(2, results[0].num_columns());
 
         Ok(())
     }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -38,8 +38,8 @@ use crate::execution::expression::*;
 use crate::execution::filter::FilterRelation;
 use crate::execution::limit::LimitRelation;
 use crate::execution::physical_plan::datasource::DatasourceExec;
-use crate::execution::physical_plan::projection::ProjectionExec;
 use crate::execution::physical_plan::expressions::Column;
+use crate::execution::physical_plan::projection::ProjectionExec;
 use crate::execution::physical_plan::{ExecutionPlan, PhysicalExpr};
 use crate::execution::projection::ProjectRelation;
 use crate::execution::relation::{DataSourceRelation, Relation};
@@ -265,10 +265,11 @@ impl ExecutionContext {
         e: &Expr,
         _input_schema: &Schema,
     ) -> Result<Arc<dyn PhysicalExpr>> {
-
         match e {
             Expr::Column(i) => Ok(Arc::new(Column::new(*i))),
-            _ => Err(ExecutionError::NotImplemented("Unsupported expression".to_string()))
+            _ => Err(ExecutionError::NotImplemented(
+                "Unsupported expression".to_string(),
+            )),
         }
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -304,7 +304,7 @@ impl ExecutionContext {
         let mut combined_results: Vec<RecordBatch> = vec![];
         for thread in threads {
             let result = thread.join().unwrap();
-            let result = result.unwrap();
+            let result = result?;
             result
                 .iter()
                 .for_each(|batch| combined_results.push(batch.clone()));
@@ -534,7 +534,7 @@ mod tests {
             let mut file = File::create(file_path)?;
 
             // generate some data
-            for i in 0..10 {
+            for i in 0..=10 {
                 let data = format!("{},{}\n", partition, i);
                 file.write_all(data.as_bytes())?;
             }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -279,10 +279,18 @@ impl ExecutionContext {
                     let it = p.execute().unwrap();
                     let mut it = it.lock().unwrap();
                     let mut results: Vec<RecordBatch> = vec![];
-                    while let Ok(Some(batch)) = it.next() {
-                        results.push(batch);
+                    loop {
+                        match it.next() {
+                            Ok(Some(batch)) => {
+                                results.push(batch);
+                            }
+                            Ok(None) => {
+                                // end of result set
+                                return Ok(results);
+                            }
+                            Err(e) => return Err(e),
+                        }
                     }
-                    Ok(results)
                 })
             })
             .collect();

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -18,8 +18,8 @@
 //! Execution plan for reading CSV files
 
 use std::fs;
-use std::fs::File;
 use std::fs::metadata;
+use std::fs::File;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, Mutex};
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
 use arrow::csv;
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
 /// Execution plan for scanning a CSV file
@@ -77,19 +77,9 @@ impl CsvExec {
         projection: Option<Vec<usize>>,
         batch_size: usize,
     ) -> Result<Self> {
-        let projected_schema = match &projection {
-            Some(p) => {
-                let projected_fields: Vec<Field> =
-                    p.iter().map(|i| schema.fields()[*i].clone()).collect();
-
-                Arc::new(Schema::new(projected_fields))
-            }
-            None => schema,
-        };
-
         Ok(Self {
             path: path.to_string(),
-            schema: projected_schema,
+            schema,
             has_header,
             projection,
             batch_size,

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! ExecutionPlan implementation for DataFusion data sources
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::Result;
+use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
+use arrow::datatypes::Schema;
+
+/// Datasource execution plan
+pub struct DatasourceExec {
+    schema: Arc<Schema>,
+    partitions: Vec<Arc<Mutex<dyn BatchIterator>>>,
+}
+
+impl DatasourceExec {
+    /// Create a new data source execution plan
+    pub fn new(
+        schema: Arc<Schema>,
+        partitions: Vec<Arc<Mutex<dyn BatchIterator>>>,
+    ) -> Self {
+        Self { schema, partitions }
+    }
+}
+
+impl ExecutionPlan for DatasourceExec {
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+
+    fn partitions(&self) -> Result<Vec<Arc<dyn Partition>>> {
+        Ok(self
+            .partitions
+            .iter()
+            .map(|it| {
+                Arc::new(DatasourcePartition::new(it.clone())) as Arc<dyn Partition>
+            })
+            .collect::<Vec<_>>())
+    }
+}
+
+/// Wrapper to convert a BatchIterator into a Partition
+pub struct DatasourcePartition {
+    batch_iter: Arc<Mutex<dyn BatchIterator>>,
+}
+
+impl DatasourcePartition {
+    fn new(batch_iter: Arc<Mutex<dyn BatchIterator>>) -> Self {
+        Self { batch_iter }
+    }
+}
+
+impl Partition for DatasourcePartition {
+    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+        Ok(self.batch_iter.clone())
+    }
+}

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -57,5 +57,6 @@ pub trait PhysicalExpr: Send + Sync {
 }
 
 pub mod csv;
+pub mod datasource;
 pub mod expressions;
 pub mod projection;


### PR DESCRIPTION
This PR implements parallel query execution, with the ability to create a physical query plan from a logical plan, and call `ExecutionContext.collect()` to execute the plan and collect the results into a single vector.

This currently only supports trivial projections against partitioned CSV files.

I will create separate PRs to add the other operators (selection, limit, aggregation, etc).
