### PR TITLE
ARROW-6285: [GLib] Add support for LargeBinary and LargeString types

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -2765,6 +2765,7 @@ garrow_large_string_array_builder_new(void)
  * garrow_large_string_array_builder_append_value:
  * @builder: A #GArrowLargeStringArrayBuilder.
  * @value: A string value.
+ * @length: The length of `value`.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
@@ -2774,14 +2775,17 @@ garrow_large_string_array_builder_new(void)
 gboolean
 garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBuilder *builder,
                                                const gchar *value,
+                                               gint64 length,
                                                GError **error)
 {
   auto arrow_builder =
     static_cast<arrow::LargeStringBuilder *>(
       garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
 
-  auto status = arrow_builder->Append(value,
-                                      static_cast<gint64>(strlen(value)));
+  if (length < 0) {
+    length = strlen(value);
+  }
+  auto status = arrow_builder->Append(value, length);
   return garrow_error_check(error,
                             status,
                             "[large-string-array-builder][append-value]");

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -2631,12 +2631,12 @@ garrow_binary_array_builder_append_value_bytes(GArrowBinaryArrayBuilder *builder
  * garrow_binary_array_builder_append_values:
  * @builder: A #GArrowLargeBinaryArrayBuilder.
  * @values: (array length=values_length): The array of #GBytes.
- * @values_length: The length of `values`.
+ * @values_length: The length of @values.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
- *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   Nth @is_valids is %TRUE, the Nth @values is valid value. Otherwise
  *   the Nth value is null value.
- * @is_valids_length: The length of `is_valids`.
+ * @is_valids_length: The length of @is_valids.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Append multiple values at once. It's more efficient than multiple
@@ -2721,7 +2721,7 @@ garrow_large_binary_array_builder_class_init(GArrowLargeBinaryArrayBuilderClass 
 /**
  * garrow_large_binary_array_builder_new:
  *
- * Returns: A newly created #GArrowBinaryArrayBuilder.
+ * Returns: A newly created #GArrowLargeBinaryArrayBuilder.
  *
  * Since: 1.0.0
  */
@@ -2793,12 +2793,12 @@ garrow_large_binary_array_builder_append_value_bytes(GArrowLargeBinaryArrayBuild
  * garrow_large_binary_array_builder_append_values:
  * @builder: A #GArrowLargeBinaryArrayBuilder.
  * @values: (array length=values_length): The array of #GBytes.
- * @values_length: The length of `values`.
+ * @values_length: The length of @values.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
- *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   Nth @is_valids is %TRUE, the Nth @values is valid value. Otherwise
  *   the Nth value is null value.
- * @is_valids_length: The length of `is_valids`.
+ * @is_valids_length: The length of @is_valids.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Append multiple values at once. It's more efficient than multiple
@@ -2966,12 +2966,12 @@ garrow_string_array_builder_append_string(GArrowStringArrayBuilder *builder,
  * garrow_string_array_builder_append_values: (skip)
  * @builder: A #GArrowStringArrayBuilder.
  * @values: (array length=values_length): The array of strings.
- * @values_length: The length of `values`.
+ * @values_length: The length of @values.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
- *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   Nth @is_valids is %TRUE, the Nth @values is valid value. Otherwise
  *   the Nth value is null value.
- * @is_valids_length: The length of `is_valids`.
+ * @is_valids_length: The length of @is_valids.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Append multiple values at once. It's more efficient than multiple
@@ -3004,12 +3004,12 @@ garrow_string_array_builder_append_values(GArrowStringArrayBuilder *builder,
  * garrow_string_array_builder_append_strings:
  * @builder: A #GArrowStringArrayBuilder.
  * @values: (array length=values_length): The array of strings.
- * @values_length: The length of `values`.
+ * @values_length: The length of @values.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
- *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   Nth @is_valids is %TRUE, the Nth @values is valid value. Otherwise
  *   the Nth value is null value.
- * @is_valids_length: The length of `is_valids`.
+ * @is_valids_length: The length of @is_valids.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Append multiple values at once. It's more efficient than multiple
@@ -3096,12 +3096,12 @@ garrow_large_string_array_builder_append_string(GArrowLargeStringArrayBuilder *b
  * garrow_large_string_array_builder_append_strings:
  * @builder: A #GArrowLargeStringArrayBuilder.
  * @values: (array length=values_length): The array of strings.
- * @values_length: The length of `values`.
+ * @values_length: The length of @values.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
- *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   Nth @is_valids is %TRUE, the Nth @values is valid value. Otherwise
  *   the Nth value is null value.
- * @is_valids_length: The length of `is_valids`.
+ * @is_valids_length: The length of @is_valids.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Append multiple values at once. It's more efficient than multiple

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -103,6 +103,81 @@ garrow_array_builder_append_values(GArrowArrayBuilder *builder,
 
 template <typename BUILDER>
 gboolean
+garrow_array_builder_append_values(GArrowArrayBuilder *builder,
+                                   GBytes **values,
+                                   gint64 values_length,
+                                   const gboolean *is_valids,
+                                   gint64 is_valids_length,
+                                   GError **error,
+                                   const gchar *context)
+{
+  auto arrow_builder =
+    static_cast<BUILDER>(garrow_array_builder_get_raw(builder));
+  arrow::Status status;
+  if (is_valids_length > 0 && values_length != is_valids_length) {
+    g_set_error(error,
+                GARROW_ERROR,
+                GARROW_ERROR_INVALID,
+                "%s: values length and is_valids length must be equal: "
+                "<%" G_GINT64_FORMAT "> != "
+                "<%" G_GINT64_FORMAT ">",
+                context,
+                values_length,
+                is_valids_length);
+    return FALSE;
+  }
+
+  const gint64 chunk_size = 4096;
+  gint64 n_chunks = values_length / chunk_size;
+  gint64 n_remains = values_length % chunk_size;
+  for (gint64 i = 0; i < n_chunks; ++i) {
+    std::vector<std::string> strings;
+    uint8_t *valid_bytes = nullptr;
+    uint8_t valid_bytes_buffer[chunk_size];
+    if (is_valids_length > 0) {
+      valid_bytes = valid_bytes_buffer;
+    }
+    const gint64 offset = chunk_size * i;
+    for (gint64 j = 0; j < chunk_size; ++j) {
+      auto value = values[offset + j];
+      size_t data_size;
+      auto raw_data = g_bytes_get_data(value, &data_size);
+      strings.push_back(std::string(static_cast<const char *>(raw_data),
+                                    data_size));
+      if (valid_bytes) {
+        valid_bytes_buffer[j] = is_valids[offset + j];
+      }
+    }
+    status = arrow_builder->AppendValues(strings, valid_bytes);
+    if (!garrow_error_check(error, status, context)) {
+      return FALSE;
+    }
+  }
+  {
+    std::vector<std::string> strings;
+    uint8_t *valid_bytes = nullptr;
+    uint8_t valid_bytes_buffer[chunk_size];
+    const gint64 offset = chunk_size * n_chunks;
+    if (is_valids_length > 0) {
+      valid_bytes = valid_bytes_buffer;
+    }
+    for (gint64 i = 0; i < n_remains; ++i) {
+      auto value = values[offset + i];
+      size_t data_size;
+      auto raw_data = g_bytes_get_data(value, &data_size);
+      strings.push_back(std::string(static_cast<const char *>(raw_data),
+                                    data_size));
+      if (valid_bytes) {
+        valid_bytes_buffer[i] = is_valids[offset + i];
+      }
+    }
+    status = arrow_builder->AppendValues(strings, valid_bytes);
+  }
+  return garrow_error_check(error, status, context);
+}
+
+template <typename BUILDER>
+gboolean
 garrow_array_builder_append_null(GArrowArrayBuilder *builder,
                                  GError **error,
                                  const gchar *context)
@@ -2525,6 +2600,43 @@ garrow_binary_array_builder_append_value(GArrowBinaryArrayBuilder *builder,
 }
 
 /**
+ * garrow_binary_array_builder_append_values:
+ * @builder: A #GArrowLargeBinaryArrayBuilder.
+ * @values: (array length=values_length): The array of #GBytes.
+ * @values_length: The length of `values`.
+ * @is_valids: (nullable) (array length=is_valids_length): The array of
+ *   boolean that shows whether the Nth value is valid or not. If the
+ *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   the Nth value is null value.
+ * @is_valids_length: The length of `is_valids`.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Append multiple values at once. It's more efficient than multiple
+ * `append()` and `append_null()` calls.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_binary_array_builder_append_values(GArrowBinaryArrayBuilder *builder,
+                                          GBytes **values,
+                                          gint64 values_length,
+                                          const gboolean *is_valids,
+                                          gint64 is_valids_length,
+                                          GError **error)
+{
+  return garrow_array_builder_append_values<arrow::BinaryBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     values,
+     values_length,
+     is_valids,
+     is_valids_length,
+     error,
+     "[binary-array-builder][append-values]");
+}
+
+/**
  * garrow_binary_array_builder_append_null:
  * @builder: A #GArrowBinaryArrayBuilder.
  * @error: (nullable): Return location for a #GError or %NULL.
@@ -2539,6 +2651,28 @@ garrow_binary_array_builder_append_null(GArrowBinaryArrayBuilder *builder,
     (GARROW_ARRAY_BUILDER(builder),
      error,
      "[binary-array-builder][append-null]");
+}
+
+/**
+ * garrow_binary_array_builder_append_nulls:
+ * @builder: A #GArrowBinaryArrayBuilder.
+ * @n: The number of null values to be appended.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_binary_array_builder_append_nulls(GArrowBinaryArrayBuilder *builder,
+                                         gint64 n,
+                                         GError **error)
+{
+  return garrow_array_builder_append_nulls<arrow::BinaryBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     n,
+     error,
+     "[binary-array-builder][append-nulls]");
 }
 
 
@@ -2561,7 +2695,7 @@ garrow_large_binary_array_builder_class_init(GArrowLargeBinaryArrayBuilderClass 
  *
  * Returns: A newly created #GArrowBinaryArrayBuilder.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowLargeBinaryArrayBuilder *
 garrow_large_binary_array_builder_new(void)
@@ -2581,7 +2715,7 @@ garrow_large_binary_array_builder_new(void)
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 gboolean
 garrow_large_binary_array_builder_append_value(GArrowLargeBinaryArrayBuilder *builder,
@@ -2600,13 +2734,50 @@ garrow_large_binary_array_builder_append_value(GArrowLargeBinaryArrayBuilder *bu
 }
 
 /**
+ * garrow_large_binary_array_builder_append_values:
+ * @builder: A #GArrowLargeBinaryArrayBuilder.
+ * @values: (array length=values_length): The array of #GBytes.
+ * @values_length: The length of `values`.
+ * @is_valids: (nullable) (array length=is_valids_length): The array of
+ *   boolean that shows whether the Nth value is valid or not. If the
+ *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   the Nth value is null value.
+ * @is_valids_length: The length of `is_valids`.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Append multiple values at once. It's more efficient than multiple
+ * `append()` and `append_null()` calls.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_large_binary_array_builder_append_values(GArrowLargeBinaryArrayBuilder *builder,
+                                                GBytes **values,
+                                                gint64 values_length,
+                                                const gboolean *is_valids,
+                                                gint64 is_valids_length,
+                                                GError **error)
+{
+  return garrow_array_builder_append_values<arrow::LargeBinaryBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     values,
+     values_length,
+     is_valids,
+     is_valids_length,
+     error,
+     "[large-binary-array-builder][append-values]");
+}
+
+/**
  * garrow_large_binary_array_builder_append_null:
  * @builder: A #GArrowLargeBinaryArrayBuilder.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 gboolean
 garrow_large_binary_array_builder_append_null(GArrowLargeBinaryArrayBuilder *builder,
@@ -2616,6 +2787,28 @@ garrow_large_binary_array_builder_append_null(GArrowLargeBinaryArrayBuilder *bui
     (GARROW_ARRAY_BUILDER(builder),
      error,
      "[large-binary-array-builder][append-null]");
+}
+
+/**
+ * garrow_large_binary_array_builder_append_nulls:
+ * @builder: A #GArrowLargeBinaryArrayBuilder.
+ * @n: The number of null values to be appended.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_large_binary_array_builder_append_nulls(GArrowLargeBinaryArrayBuilder *builder,
+                                               gint64 n,
+                                               GError **error)
+{
+  return garrow_array_builder_append_nulls<arrow::LargeBinaryBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     n,
+     error,
+     "[large-binary-array-builder][append-nulls]");
 }
 
 
@@ -2663,11 +2856,11 @@ garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                    const gchar *value,
                                    GError **error)
 {
-  return garrow_string_array_builder_append_value(builder, value, error);
+  return garrow_string_array_builder_append_string(builder, value, error);
 }
 
 /**
- * garrow_string_array_builder_append_value:
+ * garrow_string_array_builder_append_value: (skip)
  * @builder: A #GArrowStringArrayBuilder.
  * @value: A string value.
  * @error: (nullable): Return location for a #GError or %NULL.
@@ -2675,11 +2868,32 @@ garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.12.0
+ *
+ * Deprecated: 1.0.0:
+ *   Use garrow_string_array_builder_append_string() instead.
  */
 gboolean
 garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
                                          const gchar *value,
                                          GError **error)
+{
+  return garrow_string_array_builder_append_string(builder, value, error);
+}
+
+/**
+ * garrow_string_array_builder_append_string:
+ * @builder: A #GArrowStringArrayBuilder.
+ * @value: A string value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_string_array_builder_append_string(GArrowStringArrayBuilder *builder,
+                                          const gchar *value,
+                                          GError **error)
 {
   auto arrow_builder =
     static_cast<arrow::StringBuilder *>(
@@ -2689,14 +2903,13 @@ garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
                                       static_cast<gint32>(strlen(value)));
   return garrow_error_check(error,
                             status,
-                            "[string-array-builder][append-value]");
+                            "[string-array-builder][append-string]");
 }
 
 /**
- * garrow_string_array_builder_append_values:
+ * garrow_string_array_builder_append_values: (skip)
  * @builder: A #GArrowStringArrayBuilder.
- * @values: (array length=values_length): The array of
- *   strings.
+ * @values: (array length=values_length): The array of strings.
  * @values_length: The length of `values`.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
@@ -2711,6 +2924,9 @@ garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
  * Since: 0.10.0
+ *
+ * Deprecated: 1.0.0:
+ *   Use garrow_string_array_builder_append_strings() instead.
  */
 gboolean
 garrow_string_array_builder_append_values(GArrowStringArrayBuilder *builder,
@@ -2720,6 +2936,41 @@ garrow_string_array_builder_append_values(GArrowStringArrayBuilder *builder,
                                           gint64 is_valids_length,
                                           GError **error)
 {
+  return garrow_string_array_builder_append_strings(builder,
+                                                    values,
+                                                    values_length,
+                                                    is_valids,
+                                                    is_valids_length,
+                                                    error);
+}
+
+/**
+ * garrow_string_array_builder_append_strings:
+ * @builder: A #GArrowStringArrayBuilder.
+ * @values: (array length=values_length): The array of strings.
+ * @values_length: The length of `values`.
+ * @is_valids: (nullable) (array length=is_valids_length): The array of
+ *   boolean that shows whether the Nth value is valid or not. If the
+ *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
+ *   the Nth value is null value.
+ * @is_valids_length: The length of `is_valids`.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Append multiple values at once. It's more efficient than multiple
+ * `append()` and `append_null()` calls.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_string_array_builder_append_strings(GArrowStringArrayBuilder *builder,
+                                           const gchar **values,
+                                           gint64 values_length,
+                                           const gboolean *is_valids,
+                                           gint64 is_valids_length,
+                                           GError **error)
+{
   return garrow_array_builder_append_values<arrow::StringBuilder *>
     (GARROW_ARRAY_BUILDER(builder),
      values,
@@ -2727,7 +2978,7 @@ garrow_string_array_builder_append_values(GArrowStringArrayBuilder *builder,
      is_valids,
      is_valids_length,
      error,
-     "[string-array-builder][append-values]");
+     "[string-array-builder][append-strings]");
 }
 
 
@@ -2750,7 +3001,7 @@ garrow_large_string_array_builder_class_init(GArrowLargeStringArrayBuilderClass 
  *
  * Returns: A newly created #GArrowLargeStringArrayBuilder.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowLargeStringArrayBuilder *
 garrow_large_string_array_builder_new(void)
@@ -2762,40 +3013,33 @@ garrow_large_string_array_builder_new(void)
 }
 
 /**
- * garrow_large_string_array_builder_append_value:
+ * garrow_large_string_array_builder_append_string:
  * @builder: A #GArrowLargeStringArrayBuilder.
  * @value: A string value.
- * @length: The length of `value`.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 gboolean
-garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBuilder *builder,
-                                               const gchar *value,
-                                               gint64 length,
-                                               GError **error)
+garrow_large_string_array_builder_append_string(GArrowLargeStringArrayBuilder *builder,
+                                                const gchar *value,
+                                                GError **error)
 {
   auto arrow_builder =
     static_cast<arrow::LargeStringBuilder *>(
       garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
-
-  if (length < 0) {
-    length = strlen(value);
-  }
-  auto status = arrow_builder->Append(value, length);
+  auto status = arrow_builder->Append(value);
   return garrow_error_check(error,
                             status,
-                            "[large-string-array-builder][append-value]");
+                            "[large-string-array-builder][append-string]");
 }
 
 /**
  * garrow_large_string_array_builder_append_strings:
  * @builder: A #GArrowLargeStringArrayBuilder.
- * @values: (array length=values_length): The array of
- *   strings.
+ * @values: (array length=values_length): The array of strings.
  * @values_length: The length of `values`.
  * @is_valids: (nullable) (array length=is_valids_length): The array of
  *   boolean that shows whether the Nth value is valid or not. If the
@@ -2809,7 +3053,7 @@ garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBuilder *bu
  *
  * Returns: %TRUE on success, %FALSE if there was an error.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 gboolean
 garrow_large_string_array_builder_append_strings(GArrowLargeStringArrayBuilder *builder,
@@ -2826,62 +3070,7 @@ garrow_large_string_array_builder_append_strings(GArrowLargeStringArrayBuilder *
      is_valids,
      is_valids_length,
      error,
-     "[large-string-array-builder][append-values]");
-}
-
-/**
- * garrow_large_string_array_builder_append_values:
- * @builder: A #GArrowLargeStringArrayBuilder.
- * @values: (array length=values_length): The array of
- *   GBytes.
- * @values_length: The length of `values`.
- * @is_valids: (nullable) (array length=is_valids_length): The array of
- *   boolean that shows whether the Nth value is valid or not. If the
- *   Nth `is_valids` is %TRUE, the Nth `values` is valid value. Otherwise
- *   the Nth value is null value.
- * @is_valids_length: The length of `is_valids`.
- * @error: (nullable): Return location for a #GError or %NULL.
- *
- * Append multiple values at once. It's more efficient than multiple
- * `append()` and `append_null()` calls.
- *
- * Returns: %TRUE on success, %FALSE if there was an error.
- *
- * Since: 0.15.0
- */
-gboolean
-garrow_large_string_array_builder_append_values(GArrowLargeStringArrayBuilder *builder,
-                                                GBytes **values,
-                                                gint64 values_length,
-                                                const gboolean *is_valids,
-                                                gint64 is_valids_length,
-                                                GError **error)
-{
-  std::vector<std::string> strings;
-  for (gsize i = 0; i < values_length; ++i) {
-    auto value = values[i];
-    size_t data_size;
-    auto raw_data = g_bytes_get_data(value, &data_size);
-    strings.push_back(std::string(static_cast<const char *>(raw_data),
-                      data_size));
-  }
-  auto arrow_builder =
-    static_cast<arrow::LargeStringBuilder *>(
-      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
-  arrow::Status status;
-  if (is_valids_length > 0) {
-    uint8_t valid_bytes[is_valids_length];
-    for (gint64 i = 0; i < is_valids_length; ++i) {
-      valid_bytes[i] = is_valids[i];
-    }
-    status = arrow_builder->AppendValues(strings,
-                                         valid_bytes);
-  } else {
-    status = arrow_builder->AppendValues(strings, nullptr);
-  }
-  return garrow_error_check(error,
-                            status,
-                            "[large-string-array-builder][append-values]");
+     "[large-string-array-builder][append-strings]");
 }
 
 

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -2600,6 +2600,34 @@ garrow_binary_array_builder_append_value(GArrowBinaryArrayBuilder *builder,
 }
 
 /**
+ * garrow_binary_array_builder_append_value_bytes:
+ * @builder: A #GArrowBinaryArrayBuilder.
+ * @value: A binary value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_binary_array_builder_append_value_bytes(GArrowBinaryArrayBuilder *builder,
+                                               GBytes *value,
+                                               GError **error)
+{
+  auto arrow_builder =
+    static_cast<arrow::BinaryBuilder *>(
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
+
+  gsize size;
+  gconstpointer data = g_bytes_get_data(value, &size);
+  auto status = arrow_builder->Append(static_cast<const uint8_t *>(data),
+                                      size);
+  return garrow_error_check(error,
+                            status,
+                            "[binary-array-builder][append-value-bytes]");
+}
+
+/**
  * garrow_binary_array_builder_append_values:
  * @builder: A #GArrowLargeBinaryArrayBuilder.
  * @values: (array length=values_length): The array of #GBytes.
@@ -2731,6 +2759,34 @@ garrow_large_binary_array_builder_append_value(GArrowLargeBinaryArrayBuilder *bu
   return garrow_error_check(error,
                             status,
                             "[large-binary-array-builder][append-value]");
+}
+
+/**
+ * garrow_large_binary_array_builder_append_value_bytes:
+ * @builder: A #GArrowLargeBinaryArrayBuilder.
+ * @value: A binary value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_large_binary_array_builder_append_value_bytes(GArrowLargeBinaryArrayBuilder *builder,
+                                                     GBytes *value,
+                                                     GError **error)
+{
+  auto arrow_builder =
+    static_cast<arrow::LargeBinaryBuilder *>(
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
+
+  gsize size;
+  gconstpointer data = g_bytes_get_data(value, &size);
+  auto status = arrow_builder->Append(static_cast<const uint8_t *>(data),
+                                      size);
+  return garrow_error_check(error,
+                            status,
+                            "[large-binary-array-builder][append-value-bytes]");
 }
 
 /**

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -638,8 +638,8 @@ gboolean garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                             GError **error);
 #endif
 #ifndef GARROW_DISABLE_DEPRECATED
-GARROW_AVAILABLE_IN_0_12
 GARROW_DEPRECATED_IN_1_0_FOR(garrow_string_array_builder_append_string)
+GARROW_AVAILABLE_IN_0_12
 gboolean garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
                                                   const gchar *value,
                                                   GError **error);

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -672,7 +672,7 @@ G_DECLARE_DERIVABLE_TYPE(GArrowLargeStringArrayBuilder,
                          garrow_large_string_array_builder,
                          GARROW,
                          LARGE_STRING_ARRAY_BUILDER,
-                         GArrowBinaryArrayBuilder)
+                         GArrowLargeBinaryArrayBuilder)
 struct _GArrowLargeStringArrayBuilderClass
 {
   GArrowLargeBinaryArrayBuilderClass parent_class;

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -571,6 +571,30 @@ gboolean garrow_binary_array_builder_append_null(GArrowBinaryArrayBuilder *build
                                                  GError **error);
 
 
+#define GARROW_TYPE_LARGE_BINARY_ARRAY_BUILDER        \
+  (garrow_large_binary_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeBinaryArrayBuilder,
+                         garrow_large_binary_array_builder,
+                         GARROW,
+                         LARGE_BINARY_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
+struct _GArrowLargeBinaryArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_0_15
+GArrowLargeBinaryArrayBuilder *garrow_large_binary_array_builder_new(void);
+GARROW_AVAILABLE_IN_0_15
+gboolean garrow_large_binary_array_builder_append_value(GArrowLargeBinaryArrayBuilder *builder,
+                                                        const guint8 *value,
+                                                        gint64 length,
+                                                        GError **error);
+GARROW_AVAILABLE_IN_0_15
+gboolean garrow_large_binary_array_builder_append_null(GArrowLargeBinaryArrayBuilder *builder,
+                                                       GError **error);
+
+
 #define GARROW_TYPE_STRING_ARRAY_BUILDER        \
   (garrow_string_array_builder_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowStringArrayBuilder,
@@ -601,6 +625,33 @@ gboolean garrow_string_array_builder_append_values(GArrowStringArrayBuilder *bui
                                                    const gboolean *is_valids,
                                                    gint64 is_valids_length,
                                                    GError **error);
+
+
+#define GARROW_TYPE_LARGE_STRING_ARRAY_BUILDER        \
+  (garrow_large_string_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeStringArrayBuilder,
+                         garrow_large_string_array_builder,
+                         GARROW,
+                         LARGE_STRING_ARRAY_BUILDER,
+                         GArrowBinaryArrayBuilder)
+struct _GArrowLargeStringArrayBuilderClass
+{
+  GArrowLargeBinaryArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_0_15
+GArrowLargeStringArrayBuilder *garrow_large_string_array_builder_new(void);
+GARROW_AVAILABLE_IN_0_15
+gboolean garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBuilder *builder,
+                                                        const gchar *value,
+                                                        GError **error);
+GARROW_AVAILABLE_IN_0_15
+gboolean garrow_large_string_array_builder_append_values(GArrowLargeStringArrayBuilder *builder,
+                                                         const gchar **values,
+                                                         gint64 values_length,
+                                                         const gboolean *is_valids,
+                                                         gint64 is_valids_length,
+                                                         GError **error);
 
 
 #define GARROW_TYPE_DATE32_ARRAY_BUILDER        \

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -646,8 +646,15 @@ gboolean garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBu
                                                         const gchar *value,
                                                         GError **error);
 GARROW_AVAILABLE_IN_0_15
+gboolean garrow_large_string_array_builder_append_strings(GArrowLargeStringArrayBuilder *builder,
+                                                          const gchar **values,
+                                                          gint64 values_length,
+                                                          const gboolean *is_valids,
+                                                          gint64 is_valids_length,
+                                                          GError **error);
+GARROW_AVAILABLE_IN_0_15
 gboolean garrow_large_string_array_builder_append_values(GArrowLargeStringArrayBuilder *builder,
-                                                         const gchar **values,
+                                                         GBytes **values,
                                                          gint64 values_length,
                                                          const gboolean *is_valids,
                                                          gint64 is_valids_length,

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -567,8 +567,19 @@ gboolean garrow_binary_array_builder_append_value(GArrowBinaryArrayBuilder *buil
                                                   const guint8 *value,
                                                   gint32 length,
                                                   GError **error);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_binary_array_builder_append_values(GArrowBinaryArrayBuilder *builder,
+                                                   GBytes **values,
+                                                   gint64 values_length,
+                                                   const gboolean *is_valids,
+                                                   gint64 is_valids_length,
+                                                   GError **error);
 gboolean garrow_binary_array_builder_append_null(GArrowBinaryArrayBuilder *builder,
                                                  GError **error);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_binary_array_builder_append_nulls(GArrowBinaryArrayBuilder *builder,
+                                                  gint64 n,
+                                                  GError **error);
 
 
 #define GARROW_TYPE_LARGE_BINARY_ARRAY_BUILDER        \
@@ -583,16 +594,27 @@ struct _GArrowLargeBinaryArrayBuilderClass
   GArrowArrayBuilderClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowLargeBinaryArrayBuilder *garrow_large_binary_array_builder_new(void);
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 gboolean garrow_large_binary_array_builder_append_value(GArrowLargeBinaryArrayBuilder *builder,
                                                         const guint8 *value,
                                                         gint64 length,
                                                         GError **error);
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_large_binary_array_builder_append_values(GArrowLargeBinaryArrayBuilder *builder,
+                                                         GBytes **values,
+                                                         gint64 values_length,
+                                                         const gboolean *is_valids,
+                                                         gint64 is_valids_length,
+                                                         GError **error);
+GARROW_AVAILABLE_IN_1_0
 gboolean garrow_large_binary_array_builder_append_null(GArrowLargeBinaryArrayBuilder *builder,
                                                        GError **error);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_large_binary_array_builder_append_nulls(GArrowLargeBinaryArrayBuilder *builder,
+                                                        gint64 n,
+                                                        GError **error);
 
 
 #define GARROW_TYPE_STRING_ARRAY_BUILDER        \
@@ -615,16 +637,33 @@ gboolean garrow_string_array_builder_append(GArrowStringArrayBuilder *builder,
                                             const gchar *value,
                                             GError **error);
 #endif
+#ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_0_12
+GARROW_DEPRECATED_IN_1_0_FOR(garrow_string_array_builder_append_string)
 gboolean garrow_string_array_builder_append_value(GArrowStringArrayBuilder *builder,
                                                   const gchar *value,
                                                   GError **error);
+#endif
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_string_array_builder_append_string(GArrowStringArrayBuilder *builder,
+                                                   const gchar *value,
+                                                   GError **error);
+#ifndef GARROW_DISABLE_DEPRECATED
+GARROW_DEPRECATED_IN_1_0_FOR(garrow_string_array_builder_append_strings)
 gboolean garrow_string_array_builder_append_values(GArrowStringArrayBuilder *builder,
                                                    const gchar **values,
                                                    gint64 values_length,
                                                    const gboolean *is_valids,
                                                    gint64 is_valids_length,
                                                    GError **error);
+#endif
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_string_array_builder_append_strings(GArrowStringArrayBuilder *builder,
+                                                    const gchar **values,
+                                                    gint64 values_length,
+                                                    const gboolean *is_valids,
+                                                    gint64 is_valids_length,
+                                                    GError **error);
 
 
 #define GARROW_TYPE_LARGE_STRING_ARRAY_BUILDER        \
@@ -639,27 +678,19 @@ struct _GArrowLargeStringArrayBuilderClass
   GArrowLargeBinaryArrayBuilderClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowLargeStringArrayBuilder *garrow_large_string_array_builder_new(void);
-GARROW_AVAILABLE_IN_0_15
-gboolean garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBuilder *builder,
-                                                        const gchar *value,
-                                                        gint64 length,
-                                                        GError **error);
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_large_string_array_builder_append_string(GArrowLargeStringArrayBuilder *builder,
+                                                         const gchar *value,
+                                                         GError **error);
+GARROW_AVAILABLE_IN_1_0
 gboolean garrow_large_string_array_builder_append_strings(GArrowLargeStringArrayBuilder *builder,
                                                           const gchar **values,
                                                           gint64 values_length,
                                                           const gboolean *is_valids,
                                                           gint64 is_valids_length,
                                                           GError **error);
-GARROW_AVAILABLE_IN_0_15
-gboolean garrow_large_string_array_builder_append_values(GArrowLargeStringArrayBuilder *builder,
-                                                         GBytes **values,
-                                                         gint64 values_length,
-                                                         const gboolean *is_valids,
-                                                         gint64 is_valids_length,
-                                                         GError **error);
 
 
 #define GARROW_TYPE_DATE32_ARRAY_BUILDER        \

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -568,6 +568,10 @@ gboolean garrow_binary_array_builder_append_value(GArrowBinaryArrayBuilder *buil
                                                   gint32 length,
                                                   GError **error);
 GARROW_AVAILABLE_IN_1_0
+gboolean garrow_binary_array_builder_append_value_bytes(GArrowBinaryArrayBuilder *builder,
+                                                        GBytes *value,
+                                                        GError **error);
+GARROW_AVAILABLE_IN_1_0
 gboolean garrow_binary_array_builder_append_values(GArrowBinaryArrayBuilder *builder,
                                                    GBytes **values,
                                                    gint64 values_length,
@@ -601,6 +605,10 @@ gboolean garrow_large_binary_array_builder_append_value(GArrowLargeBinaryArrayBu
                                                         const guint8 *value,
                                                         gint64 length,
                                                         GError **error);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_large_binary_array_builder_append_value_bytes(GArrowLargeBinaryArrayBuilder *builder,
+                                                              GBytes *value,
+                                                              GError **error);
 GARROW_AVAILABLE_IN_1_0
 gboolean garrow_large_binary_array_builder_append_values(GArrowLargeBinaryArrayBuilder *builder,
                                                          GBytes **values,

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -644,6 +644,7 @@ GArrowLargeStringArrayBuilder *garrow_large_string_array_builder_new(void);
 GARROW_AVAILABLE_IN_0_15
 gboolean garrow_large_string_array_builder_append_value(GArrowLargeStringArrayBuilder *builder,
                                                         const gchar *value,
+                                                        gint64 length,
                                                         GError **error);
 GARROW_AVAILABLE_IN_0_15
 gboolean garrow_large_string_array_builder_append_strings(GArrowLargeStringArrayBuilder *builder,

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -1608,7 +1608,7 @@ garrow_large_binary_array_class_init(GArrowLargeBinaryArrayClass *klass)
  *
  * Returns: A newly created #GArrowLargeBinaryArray.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowLargeBinaryArray *
 garrow_large_binary_array_new(gint64 length,
@@ -1638,7 +1638,7 @@ garrow_large_binary_array_new(gint64 length,
  *
  * Returns: (transfer full): The i-th value.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GBytes *
 garrow_large_binary_array_get_value(GArrowLargeBinaryArray *array,
@@ -1659,7 +1659,7 @@ garrow_large_binary_array_get_value(GArrowLargeBinaryArray *array,
  *
  * Returns: (transfer full): The data of the array as #GArrowBuffer.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowBuffer *
 garrow_large_binary_array_get_buffer(GArrowLargeBinaryArray *array)
@@ -1677,7 +1677,7 @@ garrow_large_binary_array_get_buffer(GArrowLargeBinaryArray *array)
  *
  * Returns: (transfer full): The offsets of the array as #GArrowBuffer.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowBuffer *
 garrow_large_binary_array_get_offsets_buffer(GArrowLargeBinaryArray *array)
@@ -1790,7 +1790,7 @@ garrow_large_string_array_class_init(GArrowLargeStringArrayClass *klass)
  *
  * Returns: A newly created #GArrowLargeStringArray.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowLargeStringArray *
 garrow_large_string_array_new(gint64 length,
@@ -1820,7 +1820,7 @@ garrow_large_string_array_new(gint64 length,
  *
  * Returns: The i-th UTF-8 encoded string.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 gchar *
 garrow_large_string_array_get_string(GArrowLargeStringArray *array,

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -1764,7 +1764,7 @@ garrow_string_array_get_string(GArrowStringArray *array,
 
 G_DEFINE_TYPE(GArrowLargeStringArray,
               garrow_large_string_array,
-              GARROW_TYPE_BINARY_ARRAY)
+              GARROW_TYPE_LARGE_BINARY_ARRAY)
 
 static void
 garrow_large_string_array_init(GArrowLargeStringArray *object)

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -364,7 +364,7 @@ garrow_array_equal_range(GArrowArray *array,
  * @array: A #GArrowArray.
  * @i: The index of the target value.
  *
- * Returns: Whether the i-th value is null or not.
+ * Returns: Whether the @i-th value is null or not.
  *
  * Since: 0.3.0
  */
@@ -380,7 +380,7 @@ garrow_array_is_null(GArrowArray *array, gint64 i)
  * @array: A #GArrowArray.
  * @i: The index of the target value.
  *
- * Returns: Whether the i-th value is valid (not null) or not.
+ * Returns: Whether the @i-th value is valid (not null) or not.
  *
  * Since: 0.8.0
  */
@@ -692,7 +692,7 @@ garrow_boolean_array_new(gint64 length,
  * @array: A #GArrowBooleanArray.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gboolean
 garrow_boolean_array_get_value(GArrowBooleanArray *array,
@@ -790,7 +790,7 @@ garrow_int8_array_new(gint64 length,
  * @array: A #GArrowInt8Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gint8
 garrow_int8_array_get_value(GArrowInt8Array *array,
@@ -862,7 +862,7 @@ garrow_uint8_array_new(gint64 length,
  * @array: A #GArrowUInt8Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 guint8
 garrow_uint8_array_get_value(GArrowUInt8Array *array,
@@ -935,7 +935,7 @@ garrow_int16_array_new(gint64 length,
  * @array: A #GArrowInt16Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gint16
 garrow_int16_array_get_value(GArrowInt16Array *array,
@@ -1008,7 +1008,7 @@ garrow_uint16_array_new(gint64 length,
  * @array: A #GArrowUInt16Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 guint16
 garrow_uint16_array_get_value(GArrowUInt16Array *array,
@@ -1081,7 +1081,7 @@ garrow_int32_array_new(gint64 length,
  * @array: A #GArrowInt32Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gint32
 garrow_int32_array_get_value(GArrowInt32Array *array,
@@ -1154,7 +1154,7 @@ garrow_uint32_array_new(gint64 length,
  * @array: A #GArrowUInt32Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 guint32
 garrow_uint32_array_get_value(GArrowUInt32Array *array,
@@ -1227,7 +1227,7 @@ garrow_int64_array_new(gint64 length,
  * @array: A #GArrowInt64Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gint64
 garrow_int64_array_get_value(GArrowInt64Array *array,
@@ -1302,7 +1302,7 @@ garrow_uint64_array_new(gint64 length,
  * @array: A #GArrowUInt64Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 guint64
 garrow_uint64_array_get_value(GArrowUInt64Array *array,
@@ -1377,7 +1377,7 @@ garrow_float_array_new(gint64 length,
  * @array: A #GArrowFloatArray.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gfloat
 garrow_float_array_get_value(GArrowFloatArray *array,
@@ -1450,7 +1450,7 @@ garrow_double_array_new(gint64 length,
  * @array: A #GArrowDoubleArray.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  */
 gdouble
 garrow_double_array_get_value(GArrowDoubleArray *array,
@@ -1532,7 +1532,7 @@ garrow_binary_array_new(gint64 length,
  * @array: A #GArrowBinaryArray.
  * @i: The index of the target value.
  *
- * Returns: (transfer full): The i-th value.
+ * Returns: (transfer full): The @i-th value.
  */
 GBytes *
 garrow_binary_array_get_value(GArrowBinaryArray *array,
@@ -1636,7 +1636,7 @@ garrow_large_binary_array_new(gint64 length,
  * @array: A #GArrowLargeBinaryArray.
  * @i: The index of the target value.
  *
- * Returns: (transfer full): The i-th value.
+ * Returns: (transfer full): The @i-th value.
  *
  * Since: 1.0.0
  */
@@ -1746,7 +1746,7 @@ garrow_string_array_new(gint64 length,
  * @array: A #GArrowStringArray.
  * @i: The index of the target value.
  *
- * Returns: The i-th UTF-8 encoded string.
+ * Returns: The @i-th UTF-8 encoded string.
  */
 gchar *
 garrow_string_array_get_string(GArrowStringArray *array,
@@ -1818,7 +1818,7 @@ garrow_large_string_array_new(gint64 length,
  * @array: A #GArrowLargeStringArray.
  * @i: The index of the target value.
  *
- * Returns: The i-th UTF-8 encoded string.
+ * Returns: The @i-th UTF-8 encoded string.
  *
  * Since: 1.0.0
  */
@@ -1883,7 +1883,7 @@ garrow_date32_array_new(gint64 length,
  * @array: A #GArrowDate32Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  *
  * Since: 0.7.0
  */
@@ -1960,7 +1960,7 @@ garrow_date64_array_new(gint64 length,
  * @array: A #GArrowDate64Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  *
  * Since: 0.7.0
  */
@@ -2043,7 +2043,7 @@ garrow_timestamp_array_new(GArrowTimestampDataType *data_type,
  * @array: A #GArrowTimestampArray.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  *
  * Since: 0.7.0
  */
@@ -2126,7 +2126,7 @@ garrow_time32_array_new(GArrowTime32DataType *data_type,
  * @array: A #GArrowTime32Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  *
  * Since: 0.7.0
  */
@@ -2207,7 +2207,7 @@ garrow_time64_array_new(GArrowTime64DataType *data_type,
  * @array: A #GArrowTime64Array.
  * @i: The index of the target value.
  *
- * Returns: The i-th value.
+ * Returns: The @i-th value.
  *
  * Since: 0.7.0
  */
@@ -2271,7 +2271,7 @@ garrow_decimal128_array_class_init(GArrowDecimal128ArrayClass *klass)
  * @array: A #GArrowDecimal128Array.
  * @i: The index of the target value.
  *
- * Returns: (transfer full): The formatted i-th value.
+ * Returns: (transfer full): The formatted @i-th value.
  *
  *   The returned string should be freed with g_free() when no longer
  *   needed.
@@ -2294,7 +2294,7 @@ garrow_decimal128_array_format_value(GArrowDecimal128Array *array,
  * @array: A #GArrowDecimal128Array.
  * @i: The index of the target value.
  *
- * Returns: (transfer full): The i-th value.
+ * Returns: (transfer full): The @i-th value.
  *
  * Since: 0.10.0
  */

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -384,19 +384,19 @@ struct _GArrowLargeBinaryArrayClass
   GArrowArrayClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowLargeBinaryArray *garrow_large_binary_array_new(gint64 length,
                                                       GArrowBuffer *value_offsets,
                                                       GArrowBuffer *data,
                                                       GArrowBuffer *null_bitmap,
                                                       gint64 n_nulls);
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GBytes *garrow_large_binary_array_get_value(GArrowLargeBinaryArray *array,
                                             gint64 i);
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowBuffer *garrow_large_binary_array_get_buffer(GArrowLargeBinaryArray *array);
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowBuffer *garrow_large_binary_array_get_offsets_buffer(GArrowLargeBinaryArray *array);
 
 
@@ -432,14 +432,14 @@ struct _GArrowLargeStringArrayClass
   GArrowLargeBinaryArrayClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowLargeStringArray *garrow_large_string_array_new(gint64 length,
                                                       GArrowBuffer *value_offsets,
                                                       GArrowBuffer *data,
                                                       GArrowBuffer *null_bitmap,
                                                       gint64 n_nulls);
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 gchar *garrow_large_string_array_get_string(GArrowLargeStringArray *array,
                                             gint64 i);
 

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -372,6 +372,34 @@ GBytes *garrow_binary_array_get_value(GArrowBinaryArray *array,
 GArrowBuffer *garrow_binary_array_get_buffer(GArrowBinaryArray *array);
 GArrowBuffer *garrow_binary_array_get_offsets_buffer(GArrowBinaryArray *array);
 
+
+#define GARROW_TYPE_LARGE_BINARY_ARRAY (garrow_large_binary_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeBinaryArray,
+                         garrow_large_binary_array,
+                         GARROW,
+                         LARGE_BINARY_ARRAY,
+                         GArrowArray)
+struct _GArrowLargeBinaryArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_0_15
+GArrowLargeBinaryArray *garrow_large_binary_array_new(gint64 length,
+                                                      GArrowBuffer *value_offsets,
+                                                      GArrowBuffer *data,
+                                                      GArrowBuffer *null_bitmap,
+                                                      gint64 n_nulls);
+
+GARROW_AVAILABLE_IN_0_15
+GBytes *garrow_large_binary_array_get_value(GArrowLargeBinaryArray *array,
+                                            gint64 i);
+GARROW_AVAILABLE_IN_0_15
+GArrowBuffer *garrow_large_binary_array_get_buffer(GArrowLargeBinaryArray *array);
+GARROW_AVAILABLE_IN_0_15
+GArrowBuffer *garrow_large_binary_array_get_offsets_buffer(GArrowLargeBinaryArray *array);
+
+
 #define GARROW_TYPE_STRING_ARRAY (garrow_string_array_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowStringArray,
                          garrow_string_array,
@@ -391,6 +419,29 @@ GArrowStringArray *garrow_string_array_new(gint64 length,
 
 gchar *garrow_string_array_get_string(GArrowStringArray *array,
                                       gint64 i);
+
+
+#define GARROW_TYPE_LARGE_STRING_ARRAY (garrow_large_string_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeStringArray,
+                         garrow_large_string_array,
+                         GARROW,
+                         LARGE_STRING_ARRAY,
+                         GArrowLargeBinaryArray)
+struct _GArrowLargeStringArrayClass
+{
+  GArrowLargeBinaryArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_0_15
+GArrowLargeStringArray *garrow_large_string_array_new(gint64 length,
+                                                      GArrowBuffer *value_offsets,
+                                                      GArrowBuffer *data,
+                                                      GArrowBuffer *null_bitmap,
+                                                      gint64 n_nulls);
+
+GARROW_AVAILABLE_IN_0_15
+gchar *garrow_large_string_array_get_string(GArrowLargeStringArray *array,
+                                            gint64 i);
 
 
 #define GARROW_TYPE_DATE32_ARRAY (garrow_date32_array_get_type())

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -812,7 +812,7 @@ garrow_large_binary_data_type_class_init(GArrowLargeBinaryDataTypeClass *klass)
  *
  * Returns: The newly created #GArrowLargeBinaryDataType.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowLargeBinaryDataType *
 garrow_large_binary_data_type_new(void)
@@ -878,7 +878,7 @@ garrow_large_string_data_type_class_init(GArrowLargeStringDataTypeClass *klass)
  *
  * Returns: The newly created #GArrowLargeStringDataType.
  *
- * Since: 0.15.0
+ * Since: 1.0.0
  */
 GArrowLargeStringDataType *
 garrow_large_string_data_type_new(void)

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -66,10 +66,15 @@ G_BEGIN_DECLS
  *
  * #GArrowBinaryDataType is a class for binary data type.
  *
+ * #GArrowLargeBinaryDataType is a class for 64-bit offsets binary data type.
+ *
  * #GArrowFixedSizeBinaryDataType is a class for fixed-size binary data type.
  *
  * #GArrowStringDataType is a class for UTF-8 encoded string data
  * type.
+ *
+ * #GArrowLargeStringDataType is a class for 64-bit offsets UTF-8 encoded string
+ * data type.
  *
  * #GArrowDate32DataType is a class for the number of days since UNIX
  * epoch in 32-bit signed integer data type.
@@ -788,6 +793,40 @@ garrow_fixed_size_binary_data_type_get_byte_width(GArrowFixedSizeBinaryDataType 
 }
 
 
+G_DEFINE_TYPE(GArrowLargeBinaryDataType,
+              garrow_large_binary_data_type,
+              GARROW_TYPE_DATA_TYPE)
+
+static void
+garrow_large_binary_data_type_init(GArrowLargeBinaryDataType *object)
+{
+}
+
+static void
+garrow_large_binary_data_type_class_init(GArrowLargeBinaryDataTypeClass *klass)
+{
+}
+
+/**
+ * garrow_large_binary_data_type_new:
+ *
+ * Returns: The newly created #GArrowLargeBinaryDataType.
+ *
+ * Since: 0.15.0
+ */
+GArrowLargeBinaryDataType *
+garrow_large_binary_data_type_new(void)
+{
+  auto arrow_data_type = arrow::large_binary();
+
+  GArrowLargeBinaryDataType *data_type =
+    GARROW_LARGE_BINARY_DATA_TYPE(g_object_new(GARROW_TYPE_LARGE_BINARY_DATA_TYPE,
+                                               "data-type", &arrow_data_type,
+                                               NULL));
+  return data_type;
+}
+
+
 G_DEFINE_TYPE(GArrowStringDataType,
               garrow_string_data_type,
               GARROW_TYPE_DATA_TYPE)
@@ -816,6 +855,40 @@ garrow_string_data_type_new(void)
     GARROW_STRING_DATA_TYPE(g_object_new(GARROW_TYPE_STRING_DATA_TYPE,
                                          "data-type", &arrow_data_type,
                                          NULL));
+  return data_type;
+}
+
+
+G_DEFINE_TYPE(GArrowLargeStringDataType,
+              garrow_large_string_data_type,
+              GARROW_TYPE_DATA_TYPE)
+
+static void
+garrow_large_string_data_type_init(GArrowLargeStringDataType *object)
+{
+}
+
+static void
+garrow_large_string_data_type_class_init(GArrowLargeStringDataTypeClass *klass)
+{
+}
+
+/**
+ * garrow_large_string_data_type_new:
+ *
+ * Returns: The newly created #GArrowLargeStringDataType.
+ *
+ * Since: 0.15.0
+ */
+GArrowLargeStringDataType *
+garrow_large_string_data_type_new(void)
+{
+  auto arrow_data_type = arrow::large_utf8();
+
+  GArrowLargeStringDataType *data_type =
+    GARROW_LARGE_STRING_DATA_TYPE(g_object_new(GARROW_TYPE_LARGE_STRING_DATA_TYPE,
+                                               "data-type", &arrow_data_type,
+                                               NULL));
   return data_type;
 }
 
@@ -1269,11 +1342,17 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
   case arrow::Type::type::BINARY:
     type = GARROW_TYPE_BINARY_DATA_TYPE;
     break;
+  case arrow::Type::type::LARGE_BINARY:
+    type = GARROW_TYPE_LARGE_BINARY_DATA_TYPE;
+    break;
   case arrow::Type::type::FIXED_SIZE_BINARY:
     type = GARROW_TYPE_FIXED_SIZE_BINARY_DATA_TYPE;
     break;
   case arrow::Type::type::STRING:
     type = GARROW_TYPE_STRING_DATA_TYPE;
+    break;
+  case arrow::Type::type::LARGE_STRING:
+    type = GARROW_TYPE_LARGE_STRING_DATA_TYPE;
     break;
   case arrow::Type::type::DATE32:
     type = GARROW_TYPE_DATE32_DATA_TYPE;

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -320,10 +320,10 @@ G_DECLARE_DERIVABLE_TYPE(GArrowStringDataType,
                          garrow_string_data_type,
                          GARROW,
                          STRING_DATA_TYPE,
-                         GArrowDataType)
+                         GArrowBinaryDataType)
 struct _GArrowStringDataTypeClass
 {
-  GArrowDataTypeClass parent_class;
+  GArrowBinaryDataTypeClass parent_class;
 };
 
 GArrowStringDataType *garrow_string_data_type_new      (void);
@@ -334,10 +334,10 @@ G_DECLARE_DERIVABLE_TYPE(GArrowLargeStringDataType,
                          garrow_large_string_data_type,
                          GARROW,
                          LARGE_STRING_DATA_TYPE,
-                         GArrowDataType)
+                         GArrowLargeBinaryDataType)
 struct _GArrowLargeStringDataTypeClass
 {
-  GArrowDataTypeClass parent_class;
+  GArrowLargeBinaryDataTypeClass parent_class;
 };
 
 GARROW_AVAILABLE_IN_0_15

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -300,6 +300,21 @@ gint32
 garrow_fixed_size_binary_data_type_get_byte_width(GArrowFixedSizeBinaryDataType *data_type);
 
 
+#define GARROW_TYPE_LARGE_BINARY_DATA_TYPE (garrow_large_binary_data_type_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeBinaryDataType,
+                         garrow_large_binary_data_type,
+                         GARROW,
+                         LARGE_BINARY_DATA_TYPE,
+                         GArrowDataType)
+struct _GArrowLargeBinaryDataTypeClass
+{
+  GArrowDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_0_15
+GArrowLargeBinaryDataType *garrow_large_binary_data_type_new(void);
+
+
 #define GARROW_TYPE_STRING_DATA_TYPE (garrow_string_data_type_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowStringDataType,
                          garrow_string_data_type,
@@ -312,6 +327,21 @@ struct _GArrowStringDataTypeClass
 };
 
 GArrowStringDataType *garrow_string_data_type_new      (void);
+
+
+#define GARROW_TYPE_LARGE_STRING_DATA_TYPE (garrow_large_string_data_type_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeStringDataType,
+                         garrow_large_string_data_type,
+                         GARROW,
+                         LARGE_STRING_DATA_TYPE,
+                         GArrowDataType)
+struct _GArrowLargeStringDataTypeClass
+{
+  GArrowDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_0_15
+GArrowLargeStringDataType *garrow_large_string_data_type_new(void);
 
 
 #define GARROW_TYPE_DATE32_DATA_TYPE (garrow_date32_data_type_get_type())

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -311,7 +311,7 @@ struct _GArrowLargeBinaryDataTypeClass
   GArrowDataTypeClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowLargeBinaryDataType *garrow_large_binary_data_type_new(void);
 
 
@@ -340,7 +340,7 @@ struct _GArrowLargeStringDataTypeClass
   GArrowLargeBinaryDataTypeClass parent_class;
 };
 
-GARROW_AVAILABLE_IN_0_15
+GARROW_AVAILABLE_IN_1_0
 GArrowLargeStringDataType *garrow_large_string_data_type_new(void);
 
 

--- a/c_glib/arrow-glib/type.cpp
+++ b/c_glib/arrow-glib/type.cpp
@@ -64,8 +64,12 @@ garrow_type_from_raw(arrow::Type::type type)
     return GARROW_TYPE_DOUBLE;
   case arrow::Type::type::STRING:
     return GARROW_TYPE_STRING;
+  case arrow::Type::type::LARGE_STRING:
+    return GARROW_TYPE_LARGE_STRING;
   case arrow::Type::type::BINARY:
     return GARROW_TYPE_BINARY;
+  case arrow::Type::type::LARGE_BINARY:
+    return GARROW_TYPE_LARGE_BINARY;
   case arrow::Type::type::FIXED_SIZE_BINARY:
     return GARROW_TYPE_FIXED_SIZE_BINARY;
   case arrow::Type::type::DATE32:

--- a/c_glib/arrow-glib/type.h
+++ b/c_glib/arrow-glib/type.h
@@ -39,7 +39,9 @@ G_BEGIN_DECLS
  * @GARROW_TYPE_FLOAT: 4-byte floating point value.
  * @GARROW_TYPE_DOUBLE: 8-byte floating point value.
  * @GARROW_TYPE_STRING: UTF-8 variable-length string.
+ * @GARROW_TYPE_LARGE_STRING: 64bit offsets UTF-8 variable-length string.
  * @GARROW_TYPE_BINARY: Variable-length bytes (no guarantee of UTF-8-ness).
+ * @GARROW_TYPE_LARGE_BINARY: 64bit offsets Variable-length bytes (no guarantee of UTF-8-ness).
  * @GARROW_TYPE_FIXED_SIZE_BINARY: Fixed-size binary. Each value occupies
  *   the same number of bytes.
  * @GARROW_TYPE_DATE32: int32 days since the UNIX epoch.
@@ -85,7 +87,9 @@ typedef enum {
   GARROW_TYPE_LIST,
   GARROW_TYPE_STRUCT,
   GARROW_TYPE_UNION,
-  GARROW_TYPE_DICTIONARY
+  GARROW_TYPE_DICTIONARY,
+  GARROW_TYPE_LARGE_STRING,
+  GARROW_TYPE_LARGE_BINARY
 } GArrowType;
 
 /**

--- a/c_glib/arrow-glib/type.h
+++ b/c_glib/arrow-glib/type.h
@@ -39,9 +39,7 @@ G_BEGIN_DECLS
  * @GARROW_TYPE_FLOAT: 4-byte floating point value.
  * @GARROW_TYPE_DOUBLE: 8-byte floating point value.
  * @GARROW_TYPE_STRING: UTF-8 variable-length string.
- * @GARROW_TYPE_LARGE_STRING: 64bit offsets UTF-8 variable-length string.
  * @GARROW_TYPE_BINARY: Variable-length bytes (no guarantee of UTF-8-ness).
- * @GARROW_TYPE_LARGE_BINARY: 64bit offsets Variable-length bytes (no guarantee of UTF-8-ness).
  * @GARROW_TYPE_FIXED_SIZE_BINARY: Fixed-size binary. Each value occupies
  *   the same number of bytes.
  * @GARROW_TYPE_DATE32: int32 days since the UNIX epoch.
@@ -57,6 +55,13 @@ G_BEGIN_DECLS
  * @GARROW_TYPE_STRUCT: Struct of logical types.
  * @GARROW_TYPE_UNION: Unions of logical types.
  * @GARROW_TYPE_DICTIONARY: Dictionary aka Category type.
+ * @GARROW_TYPE_MAP: A repeated struct logical type.
+ * @GARROW_TYPE_EXTENSION: Custom data type, implemented by user.
+ * @GARROW_TYPE_FIXED_SIZE_LIST: Fixed size list of some logical type.
+ * @GARROW_TYPE_DURATION: Measure of elapsed time in either seconds,
+ *   milliseconds, microseconds or nanoseconds.
+ * @GARROW_TYPE_LARGE_STRING: 64bit offsets UTF-8 variable-length string.
+ * @GARROW_TYPE_LARGE_BINARY: 64bit offsets Variable-length bytes (no guarantee of UTF-8-ness).
  *
  * They are corresponding to `arrow::Type::type` values.
  */
@@ -88,6 +93,10 @@ typedef enum {
   GARROW_TYPE_STRUCT,
   GARROW_TYPE_UNION,
   GARROW_TYPE_DICTIONARY,
+  GARROW_TYPE_MAP,
+  GARROW_TYPE_EXTENSION,
+  GARROW_TYPE_FIXED_SIZE_LIST,
+  GARROW_TYPE_DURATION,
   GARROW_TYPE_LARGE_STRING,
   GARROW_TYPE_LARGE_BINARY
 } GArrowType;

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -101,8 +101,16 @@ module Helper
       build_array(Arrow::BinaryArrayBuilder.new, values)
     end
 
+    def build_large_binary_array(values)
+      build_array(Arrow::LargeBinaryArrayBuilder.new, values)
+    end
+
     def build_string_array(values)
       build_array(Arrow::StringArrayBuilder.new, values)
+    end
+
+    def build_large_string_array(values)
+      build_array(Arrow::LargeStringArrayBuilder.new, values)
     end
 
     def build_list_array(value_data_type, values_list, field_name: "value")

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -190,6 +190,8 @@ module Helper
       values.each do |value|
         if value.nil?
           builder.append_null
+        elsif builder.type_name == "GArrowLargeStringArrayBuilder"
+          builder.append_value(value, -1)
         else
           builder.append_value(value)
         end

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -190,8 +190,8 @@ module Helper
       values.each do |value|
         if value.nil?
           builder.append_null
-        elsif builder.type_name == "GArrowLargeStringArrayBuilder"
-          builder.append_value(value, -1)
+        elsif builder.respond_to?(:append_string)
+          builder.append_string(value)
         else
           builder.append_value(value)
         end

--- a/c_glib/test/run-test.sh
+++ b/c_glib/test/run-test.sh
@@ -35,8 +35,12 @@ for module in ${modules}; do
 done
 export LD_LIBRARY_PATH
 
-if [ -f "Makefile" -a "${NO_MAKE}" != "yes" ]; then
-  make -j8 > /dev/null || exit $?
+if [ "${BUILD}" != "no" ]; then
+  if [ -f "Makefile" ]; then
+    make -j8 > /dev/null || exit $?
+  elif [ -f "build.ninja" ]; then
+    ninja || exit $?
+  fi
 fi
 
 for module in ${modules}; do

--- a/c_glib/test/test-array-builder.rb
+++ b/c_glib/test/test-array-builder.rb
@@ -15,6 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+module ArrayBuilderAppendValueBytesTests
+  def test_append
+    builder = create_builder
+    value = "\x00\xff"
+    builder.append_value_bytes(GLib::Bytes.new(value))
+    assert_equal(build_array([value]),
+                 builder.finish)
+  end
+end
+
 module ArrayBuilderAppendValuesTests
   def test_empty
     require_gi(1, 42, 0)
@@ -783,6 +793,10 @@ class TestArrayBuilder < Test::Unit::TestCase
       include ArrayBuilderValueTypeTests
     end
 
+    sub_test_case("#append_value_bytes") do
+      include ArrayBuilderAppendValueBytesTests
+    end
+
     sub_test_case("#append_values") do
       include ArrayBuilderAppendValuesTests
 
@@ -819,6 +833,10 @@ class TestArrayBuilder < Test::Unit::TestCase
 
     sub_test_case("value type") do
       include ArrayBuilderValueTypeTests
+    end
+
+    sub_test_case("#append_value_bytes") do
+      include ArrayBuilderAppendValueBytesTests
     end
 
     sub_test_case("#append_values") do

--- a/c_glib/test/test-array-builder.rb
+++ b/c_glib/test/test-array-builder.rb
@@ -64,6 +64,55 @@ module ArrayBuilderAppendValuesTests
   end
 end
 
+module ArrayBuilderAppendStringsTests
+  def test_empty
+    require_gi(1, 42, 0)
+    builder = create_builder
+    builder.append_strings([])
+    assert_equal(build_array([]),
+                 builder.finish)
+  end
+
+  def test_strings_only
+    require_gi(1, 42, 0)
+    builder = create_builder
+    builder.append_strings(sample_values)
+    assert_equal(build_array(sample_values),
+                 builder.finish)
+  end
+
+  def test_with_is_valids
+    builder = create_builder
+    builder.append_strings(sample_values, [true, true, false])
+    sample_values_with_null = sample_values
+    sample_values_with_null[2] = nil
+    assert_equal(build_array(sample_values_with_null),
+                 builder.finish)
+  end
+
+  def test_with_large_is_valids
+    builder = create_builder
+    n = 10000
+    large_sample_values = sample_values * n
+    large_is_valids = [true, true, false] * n
+    builder.append_strings(large_sample_values, large_is_valids)
+    sample_values_with_null = sample_values
+    sample_values_with_null[2] = nil
+    large_sample_values_with_null = sample_values_with_null * n
+    assert_equal(build_array(large_sample_values_with_null),
+                 builder.finish)
+  end
+
+  def test_mismatch_length
+    builder = create_builder
+    message = "[#{builder_class_name}][append-strings]: " +
+      "values length and is_valids length must be equal: <3> != <2>"
+    assert_raise(Arrow::Error::Invalid.new(message)) do
+      builder.append_strings(sample_values, [true, true])
+    end
+  end
+end
+
 module ArrayBuilderAppendNullsTests
   def test_zero
     builder = create_builder
@@ -709,6 +758,82 @@ class TestArrayBuilder < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("BinaryArrayBuilder") do
+    def create_builder
+      Arrow::BinaryArrayBuilder.new
+    end
+
+    def value_data_type
+      Arrow::BinaryDataType.new
+    end
+
+    def builder_class_name
+      "binary-array-builder"
+    end
+
+    def sample_values
+      [
+        "\x00\x01",
+        "\xfe\xff",
+        "",
+      ]
+    end
+
+    sub_test_case("value type") do
+      include ArrayBuilderValueTypeTests
+    end
+
+    sub_test_case("#append_values") do
+      include ArrayBuilderAppendValuesTests
+
+      def setup
+        require_gi_bindings(3, 4, 1)
+      end
+    end
+
+    sub_test_case("#append_nulls") do
+      include ArrayBuilderAppendNullsTests
+    end
+  end
+
+  sub_test_case("LargeBinaryArrayBuilder") do
+    def create_builder
+      Arrow::LargeBinaryArrayBuilder.new
+    end
+
+    def value_data_type
+      Arrow::LargeBinaryDataType.new
+    end
+
+    def builder_class_name
+      "large-binary-array-builder"
+    end
+
+    def sample_values
+      [
+        "\x00\x01",
+        "\xfe\xff",
+        "",
+      ]
+    end
+
+    sub_test_case("value type") do
+      include ArrayBuilderValueTypeTests
+    end
+
+    sub_test_case("#append_values") do
+      include ArrayBuilderAppendValuesTests
+
+      def setup
+        require_gi_bindings(3, 4, 1)
+      end
+    end
+
+    sub_test_case("#append_nulls") do
+      include ArrayBuilderAppendNullsTests
+    end
+  end
+
   sub_test_case("StringArrayBuilder") do
     def create_builder
       Arrow::StringArrayBuilder.new
@@ -736,6 +861,26 @@ class TestArrayBuilder < Test::Unit::TestCase
 
     sub_test_case("#append_values") do
       include ArrayBuilderAppendValuesTests
+
+      def setup
+        require_gi_bindings(3, 4, 1)
+      end
+
+      def builder_class_name
+        "binary-array-builder"
+      end
+    end
+
+    sub_test_case("#append_strings") do
+      include ArrayBuilderAppendStringsTests
+    end
+
+    sub_test_case("#append_nulls") do
+      include ArrayBuilderAppendNullsTests
+
+      def builder_class_name
+        "binary-array-builder"
+      end
     end
   end
 
@@ -766,6 +911,26 @@ class TestArrayBuilder < Test::Unit::TestCase
 
     sub_test_case("#append_values") do
       include ArrayBuilderAppendValuesTests
+
+      def setup
+        require_gi_bindings(3, 4, 1)
+      end
+
+      def builder_class_name
+        "large-binary-array-builder"
+      end
+    end
+
+    sub_test_case("#append_strings") do
+      include ArrayBuilderAppendStringsTests
+    end
+
+    sub_test_case("#append_nulls") do
+      include ArrayBuilderAppendNullsTests
+
+      def builder_class_name
+        "large-binary-array-builder"
+      end
     end
   end
 end

--- a/c_glib/test/test-array-builder.rb
+++ b/c_glib/test/test-array-builder.rb
@@ -738,4 +738,34 @@ class TestArrayBuilder < Test::Unit::TestCase
       include ArrayBuilderAppendValuesTests
     end
   end
+
+  sub_test_case("LargeStringArrayBuilder") do
+    def create_builder
+      Arrow::LargeStringArrayBuilder.new
+    end
+
+    def value_data_type
+      Arrow::LargeStringDataType.new
+    end
+
+    def builder_class_name
+      "large-string-array-builder"
+    end
+
+    def sample_values
+      [
+        "hello",
+        "world!!",
+        "",
+      ]
+    end
+
+    sub_test_case("value type") do
+      include ArrayBuilderValueTypeTests
+    end
+
+    sub_test_case("#append_values") do
+      include ArrayBuilderAppendValuesTests
+    end
+  end
 end

--- a/c_glib/test/test-large-binary-array.rb
+++ b/c_glib/test/test-large-binary-array.rb
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestLargeBinaryArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def test_new
+    value_offsets = Arrow::Buffer.new([0, 2, 5, 5].pack("q*"))
+    data = Arrow::Buffer.new("\x00\x01\x02\x03\x04")
+    assert_equal(build_large_binary_array(["\x00\x01", "\x02\x03\x04", nil]),
+                 Arrow::LargeBinaryArray.new(3,
+                                             value_offsets,
+                                             data,
+                                             Arrow::Buffer.new([0b011].pack("C*")),
+                                             -1))
+  end
+
+  def test_value
+    data = "\x00\x01\x02"
+    builder = Arrow::LargeBinaryArrayBuilder.new
+    builder.append_value(data)
+    array = builder.finish
+    assert_equal(data, array.get_value(0).to_s)
+  end
+
+  def test_buffer
+    data1 = "\x00\x01\x02"
+    data2 = "\x03\x04\x05"
+    builder = Arrow::LargeBinaryArrayBuilder.new
+    builder.append_value(data1)
+    builder.append_value(data2)
+    array = builder.finish
+    assert_equal(data1 + data2, array.buffer.data.to_s)
+  end
+
+  def test_offsets_buffer
+    data1 = "\x00\x01"
+    data2 = "\x02\x03\x04"
+    builder = Arrow::LargeBinaryArrayBuilder.new
+    builder.append_value(data1)
+    builder.append_value(data2)
+    array = builder.finish
+    byte_per_offset = 8
+    assert_equal([0, 2, 5].pack("q*"),
+                 array.offsets_buffer.data.to_s[0, byte_per_offset * 3])
+  end
+end

--- a/c_glib/test/test-large-binary-data-type.rb
+++ b/c_glib/test/test-large-binary-data-type.rb
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestLargeBinaryDataType < Test::Unit::TestCase
+  def test_type
+    data_type = Arrow::LargeBinaryDataType.new
+    assert_equal(Arrow::Type::LARGE_BINARY, data_type.id)
+  end
+
+  def test_to_s
+    data_type = Arrow::LargeBinaryDataType.new
+    assert_equal("large_binary", data_type.to_s)
+  end
+end

--- a/c_glib/test/test-large-string-array.rb
+++ b/c_glib/test/test-large-string-array.rb
@@ -31,15 +31,15 @@ class TestLargeStringArray < Test::Unit::TestCase
 
   def test_value
     builder = Arrow::LargeStringArrayBuilder.new
-    builder.append_value("Hello World", 11)
+    builder.append_string("Hello World")
     array = builder.finish
     assert_equal("Hello World", array.get_string(0))
   end
 
   def test_buffer
     builder = Arrow::LargeStringArrayBuilder.new
-    builder.append_value("Hello", 5)
-    builder.append_value("World", 5)
+    builder.append_string("Hello")
+    builder.append_string("World")
     array = builder.finish
     assert_equal("HelloWorld", array.buffer.data.to_s)
   end

--- a/c_glib/test/test-large-string-array.rb
+++ b/c_glib/test/test-large-string-array.rb
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestLargeStringArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def test_new
+    value_offsets = Arrow::Buffer.new([0, 5, 11, 11].pack("q*"))
+    data = Arrow::Buffer.new("HelloWorld!")
+    assert_equal(build_large_string_array(["Hello", "World!", nil]),
+                 Arrow::LargeStringArray.new(3,
+                                             value_offsets,
+                                             data,
+                                             Arrow::Buffer.new([0b011].pack("C*")),
+                                             -1))
+  end
+
+  def test_value
+    builder = Arrow::LargeStringArrayBuilder.new
+    builder.append_value("Hello")
+    array = builder.finish
+    assert_equal("Hello", array.get_string(0))
+  end
+
+  def test_buffer
+    builder = Arrow::LargeStringArrayBuilder.new
+    builder.append_value("Hello")
+    builder.append_value("World")
+    array = builder.finish
+    assert_equal("HelloWorld", array.buffer.data.to_s)
+  end
+end

--- a/c_glib/test/test-large-string-array.rb
+++ b/c_glib/test/test-large-string-array.rb
@@ -31,15 +31,15 @@ class TestLargeStringArray < Test::Unit::TestCase
 
   def test_value
     builder = Arrow::LargeStringArrayBuilder.new
-    builder.append_value("Hello")
+    builder.append_value("Hello World", 11)
     array = builder.finish
-    assert_equal("Hello", array.get_string(0))
+    assert_equal("Hello World", array.get_string(0))
   end
 
   def test_buffer
     builder = Arrow::LargeStringArrayBuilder.new
-    builder.append_value("Hello")
-    builder.append_value("World")
+    builder.append_value("Hello", 5)
+    builder.append_value("World", 5)
     array = builder.finish
     assert_equal("HelloWorld", array.buffer.data.to_s)
   end

--- a/c_glib/test/test-large-string-data-type.rb
+++ b/c_glib/test/test-large-string-data-type.rb
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestLargeStringDataType < Test::Unit::TestCase
+  def test_type
+    data_type = Arrow::LargeStringDataType.new
+    assert_equal(Arrow::Type::LARGE_STRING, data_type.id)
+  end
+
+  def test_to_s
+    data_type = Arrow::LargeStringDataType.new
+    assert_equal("large_string", data_type.to_s)
+  end
+end

--- a/c_glib/test/test-string-array.rb
+++ b/c_glib/test/test-string-array.rb
@@ -31,15 +31,15 @@ class TestStringArray < Test::Unit::TestCase
 
   def test_value
     builder = Arrow::StringArrayBuilder.new
-    builder.append_value("Hello")
+    builder.append_string("Hello")
     array = builder.finish
     assert_equal("Hello", array.get_string(0))
   end
 
   def test_buffer
     builder = Arrow::StringArrayBuilder.new
-    builder.append_value("Hello")
-    builder.append_value("World")
+    builder.append_string("Hello")
+    builder.append_string("World")
     array = builder.finish
     assert_equal("HelloWorld", array.buffer.data.to_s)
   end


### PR DESCRIPTION
This PR add support `LargeBinary` and `LargeString` types.
These support the functions of `#GArrowString{Array, DataType}`, `#GArrowBinary{Array, DataType}`.

