### PR TITLE
ARROW-6287: [Rust] [DataFusion] TableProvider.scan() returns thread-safe BatchIterator

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -50,6 +50,7 @@ sqlparser = "0.2.0"
 clap = "2.33.0"
 prettytable-rs = "0.8.0"
 rustyline = {version = "4.1.0", optional = true}
+crossbeam = "0.7.1"
 
 [dev-dependencies]
 criterion = "0.2.0"

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -111,8 +111,8 @@ impl CsvBatchIterator {
 }
 
 impl BatchIterator for CsvBatchIterator {
-    fn schema(&self) -> &Arc<Schema> {
-        &self.schema
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
     }
 
     fn next(&mut self) -> Result<Option<RecordBatch>> {

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -25,8 +25,9 @@ use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::{RecordBatchIterator, ScanResult, TableProvider};
+use crate::datasource::{ScanResult, TableProvider};
 use crate::error::Result;
+use crate::execution::physical_plan::BatchIterator;
 
 /// Represents a CSV file with a provided schema
 // TODO: usage example (rather than documenting `new()`)
@@ -109,7 +110,7 @@ impl CsvBatchIterator {
     }
 }
 
-impl RecordBatchIterator for CsvBatchIterator {
+impl BatchIterator for CsvBatchIterator {
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::Schema;
 use crate::error::Result;
 use crate::execution::physical_plan::BatchIterator;
 
-/// Returned by implementors of `Table#scan`, this `RecordBatchIterator` is wrapped with
+/// Returned by implementors of `Table#scan`, this `BatchIterator` is wrapped with
 /// an `Arc` and `Mutex` so that it can be shared across threads as it is used.
 pub type ScanResult = Arc<Mutex<dyn BatchIterator>>;
 

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -20,13 +20,13 @@
 use std::sync::{Arc, Mutex};
 
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
 
 use crate::error::Result;
+use crate::execution::physical_plan::BatchIterator;
 
 /// Returned by implementors of `Table#scan`, this `RecordBatchIterator` is wrapped with
 /// an `Arc` and `Mutex` so that it can be shared across threads as it is used.
-pub type ScanResult = Arc<Mutex<dyn RecordBatchIterator>>;
+pub type ScanResult = Arc<Mutex<dyn BatchIterator>>;
 
 /// Source table
 pub trait TableProvider {
@@ -40,13 +40,4 @@ pub trait TableProvider {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
     ) -> Result<Vec<ScanResult>>;
-}
-
-/// Iterator for reading a series of record batches with a known schema
-pub trait RecordBatchIterator : Send + Sync {
-    /// Get the schema of this iterator
-    fn schema(&self) -> &Arc<Schema>;
-
-    /// Get the next batch in this iterator
-    fn next(&mut self) -> Result<Option<RecordBatch>>;
 }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -43,7 +43,7 @@ pub trait TableProvider {
 }
 
 /// Iterator for reading a series of record batches with a known schema
-pub trait RecordBatchIterator {
+pub trait RecordBatchIterator : Send + Sync {
     /// Get the schema of this iterator
     fn schema(&self) -> &Arc<Schema>;
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -132,8 +132,8 @@ pub struct MemBatchIterator {
 }
 
 impl BatchIterator for MemBatchIterator {
-    fn schema(&self) -> &Arc<Schema> {
-        &self.schema
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
     }
 
     fn next(&mut self) -> Result<Option<RecordBatch>> {

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -24,8 +24,9 @@ use std::sync::{Arc, Mutex};
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::{RecordBatchIterator, ScanResult, TableProvider};
+use crate::datasource::{ScanResult, TableProvider};
 use crate::error::{ExecutionError, Result};
+use crate::execution::physical_plan::BatchIterator;
 
 /// In-memory table
 pub struct MemTable {
@@ -130,7 +131,7 @@ pub struct MemBatchIterator {
     batches: Vec<RecordBatch>,
 }
 
-impl RecordBatchIterator for MemBatchIterator {
+impl BatchIterator for MemBatchIterator {
     fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -23,5 +23,5 @@ pub mod memory;
 pub mod parquet;
 
 pub use self::csv::{CsvBatchIterator, CsvFile};
-pub use self::datasource::{RecordBatchIterator, ScanResult, TableProvider};
+pub use self::datasource::{ScanResult, TableProvider};
 pub use self::memory::{MemBatchIterator, MemTable};

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -152,8 +152,8 @@ impl ParquetScanPartition {
 }
 
 impl BatchIterator for ParquetScanPartition {
-    fn schema(&self) -> &Arc<Schema> {
-        &self.schema
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
     }
 
     fn next(&mut self) -> Result<Option<RecordBatch>> {

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -163,6 +163,8 @@ impl Partition for CsvPartition {
 
 /// Iterator over batches
 struct CsvIterator {
+    /// Schema
+    schema: Arc<Schema>,
     /// Arrow CSV reader
     reader: csv::Reader<File>,
 }
@@ -185,11 +187,19 @@ impl CsvIterator {
             projection.clone(),
         );
 
-        Ok(Self { reader })
+        Ok(Self {
+            schema: schema.clone(),
+            reader,
+        })
     }
 }
 
 impl BatchIterator for CsvIterator {
+    /// Get the schema
+    fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
+
     /// Get the next RecordBatch
     fn next(&mut self) -> Result<Option<RecordBatch>> {
         Ok(self.reader.next()?)

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -163,8 +163,6 @@ impl Partition for CsvPartition {
 
 /// Iterator over batches
 struct CsvIterator {
-    /// Schema
-    schema: Arc<Schema>,
     /// Arrow CSV reader
     reader: csv::Reader<File>,
 }
@@ -187,17 +185,14 @@ impl CsvIterator {
             projection.clone(),
         );
 
-        Ok(Self {
-            schema: schema.clone(),
-            reader,
-        })
+        Ok(Self { reader })
     }
 }
 
 impl BatchIterator for CsvIterator {
     /// Get the schema
-    fn schema(&self) -> &Arc<Schema> {
-        &self.schema
+    fn schema(&self) -> Arc<Schema> {
+        self.reader.schema()
     }
 
     /// Get the next RecordBatch

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -40,6 +40,8 @@ pub trait Partition: Send + Sync {
 
 /// Iterator over RecordBatch that can be sent between threads
 pub trait BatchIterator: Send + Sync {
+    /// Get the schema for the batches returned by this iterator
+    fn schema(&self) -> &Arc<Schema>;
     /// Get the next RecordBatch
     fn next(&mut self) -> Result<Option<RecordBatch>>;
 }

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -41,7 +41,7 @@ pub trait Partition: Send + Sync {
 /// Iterator over RecordBatch that can be sent between threads
 pub trait BatchIterator: Send + Sync {
     /// Get the schema for the batches returned by this iterator
-    fn schema(&self) -> &Arc<Schema>;
+    fn schema(&self) -> Arc<Schema>;
     /// Get the next RecordBatch
     fn next(&mut self) -> Result<Option<RecordBatch>>;
 }

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -116,6 +116,11 @@ struct ProjectionIterator {
 }
 
 impl BatchIterator for ProjectionIterator {
+    /// Get the schema
+    fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
+
     /// Get the next batch
     fn next(&mut self) -> Result<Option<RecordBatch>> {
         let mut input = self.input.lock().unwrap();

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -117,8 +117,8 @@ struct ProjectionIterator {
 
 impl BatchIterator for ProjectionIterator {
     /// Get the schema
-    fn schema(&self) -> &Arc<Schema> {
-        &self.schema
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
     }
 
     /// Get the next batch

--- a/rust/datafusion/src/execution/relation.rs
+++ b/rust/datafusion/src/execution/relation.rs
@@ -24,8 +24,8 @@ use std::sync::{Arc, Mutex};
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-use crate::datasource::RecordBatchIterator;
 use crate::error::Result;
+use crate::execution::physical_plan::BatchIterator;
 
 /// trait for all relations (a relation is essentially just an iterator over batches
 /// of data, with a known schema)
@@ -40,11 +40,11 @@ pub trait Relation {
 /// Implementation of a relation that represents a DataFusion data source
 pub(super) struct DataSourceRelation {
     schema: Arc<Schema>,
-    ds: Arc<Mutex<dyn RecordBatchIterator>>,
+    ds: Arc<Mutex<dyn BatchIterator>>,
 }
 
 impl DataSourceRelation {
-    pub fn new(ds: Arc<Mutex<dyn RecordBatchIterator>>) -> Self {
+    pub fn new(ds: Arc<Mutex<dyn BatchIterator>>) -> Self {
         let schema = ds.lock().unwrap().schema().clone();
         Self { ds, schema }
     }


### PR DESCRIPTION
`TableProvider.scan()` now returns the thread-safe `BatchIterator` from the new physical execution plan, which replaces the `RecordBatchIterator` from the datasource module, which is removed in this PR.