### PR TITLE
ARROW-6250: [Java] Implement ApproxEqualsVisitor comparing approx for floating point

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -17,21 +17,40 @@
 
 package org.apache.arrow.vector.compare;
 
+import java.util.List;
+
 import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
-
 import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
 
 /**
  * Visitor to compare floating point.
  */
-public class ApproxEqualsVisitor extends VectorEqualsVisitor {
+public class ApproxEqualsVisitor extends RangeEqualsVisitor {
 
+  /**
+   * The float/double values are treated as equal as long as the delta is <= epsilon.
+   */
   private final float epsilon;
 
   public ApproxEqualsVisitor(ValueVector right, float epsilon) {
-    super(right);
+    this (right, epsilon, true);
+  }
+
+  public ApproxEqualsVisitor(ValueVector right, float epsilon, boolean typeCheckNeeded) {
+    this (right, epsilon, typeCheckNeeded, 0, 0, right.getValueCount());
+  }
+
+  public ApproxEqualsVisitor(ValueVector right, float epsilon, boolean typeCheckNeeded,
+      int leftStart, int rightStart, int length) {
+    super(right, rightStart, leftStart, length, typeCheckNeeded);
     this.epsilon = epsilon;
   }
 
@@ -44,6 +63,125 @@ public class ApproxEqualsVisitor extends VectorEqualsVisitor {
     } else {
       return super.visit(left, value);
     }
+  }
+
+  @Override
+  protected boolean compareUnionVectors(UnionVector left) {
+
+    UnionVector rightVector = (UnionVector) right;
+
+    List<FieldVector> leftChildren = left.getChildrenFromFields();
+    List<FieldVector> rightChildren = rightVector.getChildrenFromFields();
+
+    if (leftChildren.size() != rightChildren.size()) {
+      return false;
+    }
+
+    for (int k = 0; k < leftChildren.size(); k++) {
+      ApproxEqualsVisitor visitor = new ApproxEqualsVisitor(rightChildren.get(k),
+          epsilon);
+      if (!leftChildren.get(k).accept(visitor, null)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  protected boolean compareStructVectors(NonNullableStructVector left) {
+
+    NonNullableStructVector rightVector = (NonNullableStructVector) right;
+
+    if (!left.getChildFieldNames().equals(rightVector.getChildFieldNames())) {
+      return false;
+    }
+
+    for (String name : left.getChildFieldNames()) {
+      ApproxEqualsVisitor visitor = new ApproxEqualsVisitor(rightVector.getChild(name),
+          epsilon);
+      if (!left.getChild(name).accept(visitor, null)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  protected boolean compareListVectors(ListVector left) {
+
+    for (int i = 0; i < length; i++) {
+      int leftIndex = leftStart + i;
+      int rightIndex = rightStart + i;
+
+      boolean isNull = left.isNull(leftIndex);
+      if (isNull != right.isNull(rightIndex)) {
+        return false;
+      }
+
+      int offsetWidth = BaseRepeatedValueVector.OFFSET_WIDTH;
+
+      if (!isNull) {
+        final int startIndexLeft = left.getOffsetBuffer().getInt(leftIndex * offsetWidth);
+        final int endIndexLeft = left.getOffsetBuffer().getInt((leftIndex + 1) * offsetWidth);
+
+        final int startIndexRight = right.getOffsetBuffer().getInt(rightIndex * offsetWidth);
+        final int endIndexRight = right.getOffsetBuffer().getInt((rightIndex + 1) * offsetWidth);
+
+        if ((endIndexLeft - startIndexLeft) != (endIndexRight - startIndexRight)) {
+          return false;
+        }
+
+        ValueVector leftDataVector = left.getDataVector();
+        ValueVector rightDataVector = ((ListVector)right).getDataVector();
+
+        if (!leftDataVector.accept(new ApproxEqualsVisitor(rightDataVector, epsilon, typeCheckNeeded,
+            startIndexLeft, startIndexRight, (endIndexLeft - startIndexLeft)), null)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  protected boolean compareFixedSizeListVectors(FixedSizeListVector left) {
+
+    if (left.getListSize() != ((FixedSizeListVector)right).getListSize()) {
+      return false;
+    }
+
+    for (int i = 0; i < length; i++) {
+      int leftIndex = leftStart + i;
+      int rightIndex = rightStart + i;
+
+      boolean isNull = left.isNull(leftIndex);
+      if (isNull != right.isNull(rightIndex)) {
+        return false;
+      }
+
+      int listSize = left.getListSize();
+
+      if (!isNull) {
+        final int startIndexLeft = leftIndex * listSize;
+        final int endIndexLeft = (leftIndex + 1) * listSize;
+
+        final int startIndexRight = rightIndex * listSize;
+        final int endIndexRight = (rightIndex + 1) * listSize;
+
+        if ((endIndexLeft - startIndexLeft) != (endIndexRight - startIndexRight)) {
+          return false;
+        }
+
+        ValueVector leftDataVector = left.getDataVector();
+        ValueVector rightDataVector = ((FixedSizeListVector)right).getDataVector();
+
+        if (!leftDataVector.accept(new ApproxEqualsVisitor(rightDataVector, epsilon, typeCheckNeeded,
+            startIndexLeft, startIndexRight, (endIndexLeft - startIndexLeft)), null)) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private boolean float4ApproxEquals(Float4Vector left) {
@@ -61,7 +199,7 @@ public class ApproxEqualsVisitor extends VectorEqualsVisitor {
       if (!isNull) {
 
         float leftValue = left.get(leftIndex);
-        float rightValue = ((Float4Vector)right).get(leftIndex);
+        float rightValue = ((Float4Vector)right).get(rightIndex);
         if (Math.abs(leftValue - rightValue) > epsilon) {
           return false;
         }
@@ -84,7 +222,7 @@ public class ApproxEqualsVisitor extends VectorEqualsVisitor {
       if (!isNull) {
 
         double leftValue = left.get(leftIndex);
-        double rightValue = ((Float8Vector)right).get(leftIndex);
+        double rightValue = ((Float8Vector)right).get(rightIndex);
         if (Math.abs(leftValue - rightValue) > epsilon) {
           return false;
         }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.compare;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * Visitor to compare floating point.
+ */
+public class ApproxEqualsVisitor extends VectorEqualsVisitor {
+
+  private final float epsilon;
+
+  public ApproxEqualsVisitor(ValueVector right, float epsilon) {
+    super(right);
+    this.epsilon = epsilon;
+  }
+
+  @Override
+  public Boolean visit(BaseFixedWidthVector left, Void value) {
+    if (left instanceof Float4Vector) {
+      return validate(left) && float4ApproxEquals((Float4Vector) left);
+    } else if (left instanceof Float8Vector) {
+      return validate(left) && float8ApproxEquals((Float8Vector) left);
+    } else {
+      return super.visit(left, value);
+    }
+  }
+
+  private boolean float4ApproxEquals(Float4Vector left) {
+
+    for (int i = 0; i < length; i++) {
+      int leftIndex = leftStart + i;
+      int rightIndex = rightStart + i;
+
+      boolean isNull = left.isNull(leftIndex);
+
+      if (isNull != right.isNull(rightIndex)) {
+        return false;
+      }
+
+      if (!isNull) {
+
+        float leftValue = left.get(leftIndex);
+        float rightValue = ((Float4Vector)right).get(leftIndex);
+        if (Math.abs(leftValue - rightValue) > epsilon) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private boolean float8ApproxEquals(Float8Vector left) {
+    for (int i = 0; i < length; i++) {
+      int leftIndex = leftStart + i;
+      int rightIndex = rightStart + i;
+
+      boolean isNull = left.isNull(leftIndex);
+
+      if (isNull != right.isNull(rightIndex)) {
+        return false;
+      }
+
+      if (!isNull) {
+
+        double leftValue = left.get(leftIndex);
+        double rightValue = ((Float8Vector)right).get(leftIndex);
+        if (Math.abs(leftValue - rightValue) > epsilon) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -66,7 +66,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Void> {
   /**
    * Do some validation work, like type check and indices check.
    */
-  private boolean validate(ValueVector left) {
+  protected boolean validate(ValueVector left) {
 
     if (!compareValueVector(left, right)) {
       return false;

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -25,6 +25,8 @@ import java.nio.charset.Charset;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.ZeroVector;
@@ -250,6 +252,68 @@ public class TestRangeEqualsVisitor {
 
       VectorEqualsVisitor intVisitor = new VectorEqualsVisitor(intVector, false);
       assertTrue(intVisitor.equals(zeroVector));
+    }
+  }
+
+  @Test
+  public void testFloat4ApproxEquals() {
+    try (final Float4Vector vector1 = new Float4Vector("float", allocator);
+         final Float4Vector vector2 = new Float4Vector("float", allocator);
+         final Float4Vector vector3 = new Float4Vector("float", allocator)) {
+
+      vector1.allocateNew(2);
+      vector1.setValueCount(2);
+      vector2.allocateNew(2);
+      vector2.setValueCount(2);
+      vector3.allocateNew(2);
+      vector3.setValueCount(2);
+
+      vector1.setSafe(0, 1.1f);
+      vector1.setSafe(1, 2.2f);
+
+      float epsilon = 1.0E-6f;
+
+      vector2.setSafe(0, 1.1f + epsilon / 2);
+      vector2.setSafe(1, 2.2f + epsilon / 2);
+
+      vector3.setSafe(0, 1.1f + epsilon * 2);
+      vector3.setSafe(1, 2.2f + epsilon * 2);
+
+      ApproxEqualsVisitor visitor = new ApproxEqualsVisitor(vector1, epsilon);
+
+      assertTrue(visitor.equals(vector2));
+      assertFalse(visitor.equals(vector3));
+    }
+  }
+
+  @Test
+  public void testFloat8ApproxEquals() {
+    try (final Float8Vector vector1 = new Float8Vector("float", allocator);
+        final Float8Vector vector2 = new Float8Vector("float", allocator);
+        final Float8Vector vector3 = new Float8Vector("float", allocator)) {
+
+      vector1.allocateNew(2);
+      vector1.setValueCount(2);
+      vector2.allocateNew(2);
+      vector2.setValueCount(2);
+      vector3.allocateNew(2);
+      vector3.setValueCount(2);
+
+      vector1.setSafe(0, 1.1);
+      vector1.setSafe(1, 2.2);
+
+      float epsilon = 1.0E-6f;
+
+      vector2.setSafe(0, 1.1 + epsilon / 2);
+      vector2.setSafe(1, 2.2 + epsilon / 2);
+
+      vector3.setSafe(0, 1.1 + epsilon * 2);
+      vector3.setSafe(1, 2.2 + epsilon * 2);
+
+      ApproxEqualsVisitor visitor = new ApproxEqualsVisitor(vector1, epsilon);
+
+      assertTrue(visitor.equals(vector2));
+      assertFalse(visitor.equals(vector3));
     }
   }
 


### PR DESCRIPTION
Related to [ARROW-6250](https://issues.apache.org/jira/browse/ARROW-6250).

Currently we already implemented RangeEqualsVisitor/VectorEqualsVisitor for comparing range/vector.
And ARROW-6211 is created to make ValueVector work with generic visitor.
We should also implement ApproxEqualsVisitor to compare floating point just like cpp does
https://github.com/apache/arrow/blob/master/cpp/src/arrow/compare.cc