### PR TITLE
ARROW-5985: [Developer] Do not suggest setting Fix Version for patch releases by default

### DIFF
--- a/ci/travis_lint.sh
+++ b/ci/travis_lint.sh
@@ -23,7 +23,8 @@ set -ex
 export ARROW_TRAVIS_USE_TOOLCHAIN=0
 source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
-pip install pre_commit cmake_format==0.5.2 pytest
+# pytest, requests, and jira are needed to run the PR merge script unit tests
+pip install pre_commit cmake_format==0.5.2 pytest requests jira
 pre-commit install
 
 # TODO: Move more checks into pre-commit as this gives a nice summary

--- a/ci/travis_lint.sh
+++ b/ci/travis_lint.sh
@@ -23,7 +23,7 @@ set -ex
 export ARROW_TRAVIS_USE_TOOLCHAIN=0
 source $TRAVIS_BUILD_DIR/ci/travis_env_common.sh
 
-pip install pre_commit
+pip install pre_commit cmake_format==0.5.2 pytest
 pre-commit install
 
 # TODO: Move more checks into pre-commit as this gives a nice summary
@@ -31,7 +31,6 @@ pre-commit install
 pre-commit run hadolint -a
 
 # CMake formatting check
-pip install cmake_format==0.5.2
 $TRAVIS_BUILD_DIR/run-cmake-format.py --check
 
 # C++ code linting
@@ -54,7 +53,10 @@ FLAKE8="python3 -m flake8"
 python3 -m pip install -q flake8
 
 if [ "$ARROW_CI_DEV_AFFECTED" != "0" ]; then
-  $FLAKE8 --count $ARROW_DEV_DIR
+  pushd $ARROW_DEV_DIR
+  $FLAKE8 --count .
+  py.test test_merge_arrow_pr.py
+  popd
 fi
 
 if [ "$ARROW_CI_INTEGRATION_AFFECTED" != "0" ]; then

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -107,6 +107,22 @@ def test_jira_fix_versions():
     assert default_versions == ['0.11.0']
 
 
+def test_jira_no_suggest_patch_release():
+    versions_json = [
+        {'version': '0.11.1', 'released': False},
+        {'version': '0.12.0', 'released': False},
+    ]
+
+    versions = [FakeProjectVersion(raw['version'], raw)
+                for raw in versions_json]
+
+    jira = FakeJIRA(project_versions=versions, transitions=TRANSITIONS)
+    issue = merge_arrow_pr.JiraIssue(jira, 'ARROW-1234', 'ARROW', FakeCLI())
+    all_versions, default_versions = issue.get_candidate_fix_versions()
+    assert all_versions == versions
+    assert default_versions == ['0.12.0']
+
+
 def test_jira_invalid_issue():
     class Mock:
 
@@ -188,7 +204,7 @@ def test_jira_output_no_components():
     # ARROW-5472
     status = 'Interesting work'
     components = []
-    output = merge_arrow_pr.format_resolved_issue_status(
+    output = merge_arrow_pr.format_jira_output(
         'ARROW-1234', 'Resolved', status, FakeAssignee('Foo Bar'),
         components)
 
@@ -199,7 +215,7 @@ Components\tNO COMPONENTS!!!
 Status\t\tResolved
 URL\t\thttps://issues.apache.org/jira/browse/ARROW-1234"""
 
-    output = merge_arrow_pr.format_resolved_issue_status(
+    output = merge_arrow_pr.format_jira_output(
         'ARROW-1234', 'Resolved', status, FakeAssignee('Foo Bar'),
         [FakeComponent('C++'), FakeComponent('Python')])
 


### PR DESCRIPTION
This makes the merge script behave more in line with the development style of this project in which patch releases are handled on a one-off basis with patches by default going into the next major release.

Also adds the merge script unit tests to the Lint job since they had been broken by a recent patch. 