### PR TITLE
ARROW-5992: [C++][Python] Support String->Binary in Array::View. Add Python bindings for Array::View

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -1021,7 +1021,8 @@ struct ViewDataImpl {
           return;
         }
       }
-      if (in_layouts[in_layout_idx].bit_widths[in_buffer_idx] > 0) {
+      auto bit_width = in_layouts[in_layout_idx].bit_widths[in_buffer_idx];
+      if (bit_width > 0 || bit_width == DataTypeLayout::kVariableSizeBuffer) {
         return;
       }
       // Skip always-null input buffers
@@ -1128,8 +1129,8 @@ struct ViewDataImpl {
       }
 
       RETURN_NOT_OK(CheckInputAvailable());
-      if (out_bit_width == DataTypeLayout::kVariableSizeBuffer ||
-          out_bit_width != in_layouts[in_layout_idx].bit_widths[in_buffer_idx]) {
+      auto in_bit_width = in_layouts[in_layout_idx].bit_widths[in_buffer_idx];
+      if (out_bit_width != in_bit_width) {
         return InvalidView("incompatible layouts");
       }
       // Copy input buffer

--- a/cpp/src/arrow/array_view_test.cc
+++ b/cpp/src/arrow/array_view_test.cc
@@ -111,6 +111,13 @@ TEST(TestArrayView, PrimitiveAsFixedSizeBinary) {
   CheckView(expected, arr);
 }
 
+TEST(TestArrayView, StringAsBinary) {
+  auto arr = ArrayFromJSON(utf8(), R"(["foox", "barz", null])");
+  auto expected = ArrayFromJSON(binary(), R"(["foox", "barz", null])");
+  CheckView(arr, expected);
+  CheckView(expected, arr);
+}
+
 TEST(TestArrayView, PrimitiveWrongSize) {
   auto arr = ArrayFromJSON(int16(), "[0, -1, 42]");
   CheckViewFails(arr, int8());

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -205,9 +205,9 @@ std::shared_ptr<arrow::Array> RandomArrayGenerator::BinaryWithRepeats(
     double null_probability) {
   auto strings =
       StringWithRepeats(size, unique, min_length, max_length, null_probability);
-  auto data = strings->data()->Copy();
-  data->type = binary();
-  return MakeArray(data);
+  std::shared_ptr<Array> out;
+  ABORT_NOT_OK(strings->View(binary(), &out));
+  return out;
 }
 
 std::shared_ptr<arrow::Array> RandomArrayGenerator::StringWithRepeats(

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -523,6 +523,25 @@ cdef class Array(_PandasConvertible):
 
         return pyarrow_wrap_array(result)
 
+    def view(self, object target_type):
+        """Return zero-copy "view" of array as another data type. The data
+        types must have compatible columnar buffer layouts
+
+        Parameters
+        ----------
+        target_type : DataType
+            Type to construct view as
+
+        Returns
+        -------
+        view : Array
+        """
+        cdef DataType type = ensure_type(target_type)
+        cdef shared_ptr[CArray] result
+        with nogil:
+            check_status(self.ap.View(type.sp_type, &result))
+        return pyarrow_wrap_array(result)
+
     def sum(self):
         """
         Sum the values in a numerical array.

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -152,6 +152,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CArray] Slice(int64_t offset, int64_t length)
 
         CStatus Validate() const
+        CStatus View(const shared_ptr[CDataType]& type,
+                     shared_ptr[CArray]* out)
 
     shared_ptr[CArray] MakeArray(const shared_ptr[CArrayData]& data)
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -806,6 +806,15 @@ def test_cast_from_null():
             in_arr.cast(out_type)
 
 
+def test_view():
+    # ARROW-5992
+    arr = pa.array(['foo', 'bar', 'baz'], type=pa.utf8())
+    expected = pa.array(['foo', 'bar', 'baz'], type=pa.binary())
+
+    assert arr.view(pa.binary()).equals(expected)
+    assert arr.view('binary').equals(expected)
+
+
 def test_unique_simple():
     cases = [
         (pa.array([1, 2, 3, 1, 2, 3]), pa.array([1, 2, 3])),


### PR DESCRIPTION
Note that calling View won't perform UTF-8 validation, but I think that is probably okay