### PR TITLE
ARROW-6048: [C++] Add ChunkedArray::View method that dispatches to Array::View

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -1157,7 +1157,7 @@ struct ViewDataImpl {
 }  // namespace
 
 Status Array::View(const std::shared_ptr<DataType>& out_type,
-                   std::shared_ptr<Array>* out) {
+                   std::shared_ptr<Array>* out) const {
   ViewDataImpl impl;
   impl.root_in_type = data_->type;
   impl.root_out_type = out_type;

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -320,7 +320,7 @@ class ARROW_EXPORT Array {
   /// Nested types are traversed in depth-first order. Data buffers must have
   /// the same item sizes, even though the logical types may be different.
   /// An error is returned if the types are not layout-compatible.
-  Status View(const std::shared_ptr<DataType>& type, std::shared_ptr<Array>* out);
+  Status View(const std::shared_ptr<DataType>& type, std::shared_ptr<Array>* out) const;
 
   /// Construct a zero-copy slice of the array with the indicated offset and
   /// length

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -179,6 +179,16 @@ Status ChunkedArray::Flatten(MemoryPool* pool,
   return Status::OK();
 }
 
+Status ChunkedArray::View(const std::shared_ptr<DataType>& type,
+                          std::shared_ptr<ChunkedArray>* out) const {
+  ArrayVector out_chunks(this->num_chunks());
+  for (int i = 0; i < this->num_chunks(); ++i) {
+    RETURN_NOT_OK(chunks_[i]->View(type, &out_chunks[i]));
+  }
+  *out = std::make_shared<ChunkedArray>(out_chunks, type);
+  return Status::OK();
+}
+
 Status ChunkedArray::Validate() const {
   if (chunks_.size() == 0) {
     return Status::OK();

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -88,6 +88,12 @@ class ARROW_EXPORT ChunkedArray {
   /// \param[out] out The resulting vector of arrays
   Status Flatten(MemoryPool* pool, std::vector<std::shared_ptr<ChunkedArray>>* out) const;
 
+  /// Construct a zero-copy view of this chunked array with the given
+  /// type. Calls Array::View on each constituent chunk. Always succeeds if
+  /// there are zero chunks
+  Status View(const std::shared_ptr<DataType>& type,
+              std::shared_ptr<ChunkedArray>* out) const;
+
   std::shared_ptr<DataType> type() const { return type_; }
 
   /// \brief Determine if two chunked arrays are equal.


### PR DESCRIPTION
In the case where there are no chunks, it is not possible at the moment to validate whether a view would have been compatible if there had been chunks. Not sure if we want to fix that now