### PR TITLE
ARROW-6294: [C++] Use hyphen for plasma-store-server executable

### DIFF
--- a/c_glib/test/helper/plasma-store.rb
+++ b/c_glib/test/helper/plasma-store.rb
@@ -36,7 +36,7 @@ module Helper
                    "-s", socket_path)
       until File.exist?(socket_path)
         if Process.waitpid(@pid, Process::WNOHANG)
-          raise "Failed to run plasma_store_server: #{@path}"
+          raise "Failed to run plasma-store-server: #{@path}"
         end
       end
     end

--- a/cpp/cmake_modules/FindPlasma.cmake
+++ b/cpp/cmake_modules/FindPlasma.cmake
@@ -42,7 +42,7 @@ if("$ENV{ARROW_HOME}" STREQUAL "")
 else()
   set(PLASMA_HOME "$ENV{ARROW_HOME}")
 
-  set(PLASMA_EXECUTABLE ${PLASMA_HOME}/bin/plasma_store_server)
+  set(PLASMA_EXECUTABLE ${PLASMA_HOME}/bin/plasma-store-server)
 
   set(PLASMA_SEARCH_HEADER_PATHS ${PLASMA_HOME}/include)
 

--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -139,16 +139,16 @@ endif()
 
 list(APPEND PLASMA_EXTERNAL_STORE_SOURCES "external_store.cc" "hash_table_store.cc")
 
-# We use static libraries for the plasma_store_server executable so that it can
+# We use static libraries for the plasma-store-server executable so that it can
 # be copied around and used in different locations.
-add_executable(plasma_store_server ${PLASMA_EXTERNAL_STORE_SOURCES} ${PLASMA_STORE_SRCS})
+add_executable(plasma-store-server ${PLASMA_EXTERNAL_STORE_SOURCES} ${PLASMA_STORE_SRCS})
 if(ARROW_BUILD_STATIC)
-  target_link_libraries(plasma_store_server plasma_static ${PLASMA_STATIC_LINK_LIBS})
+  target_link_libraries(plasma-store-server plasma_static ${PLASMA_STATIC_LINK_LIBS})
 else()
   # Fallback to shared libs in the case that static libraries are not build.
-  target_link_libraries(plasma_store_server plasma_shared ${PLASMA_LINK_LIBS})
+  target_link_libraries(plasma-store-server plasma_shared ${PLASMA_LINK_LIBS})
 endif()
-add_dependencies(plasma plasma_store_server)
+add_dependencies(plasma plasma-store-server)
 
 if(ARROW_RPATH_ORIGIN)
   if(APPLE)
@@ -156,7 +156,7 @@ if(ARROW_RPATH_ORIGIN)
   else()
     set(_lib_install_rpath "\$ORIGIN")
   endif()
-  set_target_properties(plasma_store_server
+  set_target_properties(plasma-store-server
                         PROPERTIES INSTALL_RPATH ${_lib_install_rpath})
 elseif(APPLE)
   # With OSX and conda, we need to set the correct RPATH so that dependencies
@@ -165,7 +165,7 @@ elseif(APPLE)
   # $ENV{CONDA_PREFIX}/lib but our test libraries and executables are not
   # installed there.
   if(NOT "$ENV{CONDA_PREFIX}" STREQUAL "" AND APPLE)
-    set_target_properties(plasma_store_server
+    set_target_properties(plasma-store-server
                           PROPERTIES BUILD_WITH_INSTALL_RPATH
                                      TRUE
                                      INSTALL_RPATH_USE_LINK_PATH
@@ -183,8 +183,8 @@ install(FILES common.h
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/plasma")
 
 # Plasma store
-set_target_properties(plasma_store_server PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-install(TARGETS plasma_store_server ${INSTALL_IS_OPTIONAL} DESTINATION
+set_target_properties(plasma-store-server PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+install(TARGETS plasma-store-server ${INSTALL_IS_OPTIONAL} DESTINATION
                 ${CMAKE_INSTALL_BINDIR})
 
 # pkg-config support
@@ -269,9 +269,9 @@ add_plasma_test(test/client_tests
                 EXTRA_LINK_LIBS
                 ${PLASMA_TEST_LIBS}
                 EXTRA_DEPENDENCIES
-                plasma_store_server)
+                plasma-store-server)
 add_plasma_test(test/external_store_tests
                 EXTRA_LINK_LIBS
                 ${PLASMA_TEST_LIBS}
                 EXTRA_DEPENDENCIES
-                plasma_store_server)
+                plasma-store-server)

--- a/cpp/src/plasma/plasma.pc.in
+++ b/cpp/src/plasma/plasma.pc.in
@@ -22,7 +22,7 @@ includedir=${prefix}/include
 so_version=@PLASMA_SO_VERSION@
 abi_version=@PLASMA_SO_VERSION@
 full_so_version=@PLASMA_FULL_SO_VERSION@
-executable=${prefix}/@CMAKE_INSTALL_BINDIR@/plasma_store_server
+executable=${prefix}/@CMAKE_INSTALL_BINDIR@/plasma-store-server
 
 Name: Plasma
 Description: Plasma is an in-memory object store and cache for big data.

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -61,7 +61,7 @@ class TestPlasmaStore : public ::testing::Test {
     std::string plasma_directory =
         test_executable.substr(0, test_executable.find_last_of("/"));
     std::string plasma_command =
-        plasma_directory + "/plasma_store_server -m 10000000 -s " + store_socket_name_ +
+        plasma_directory + "/plasma-store-server -m 10000000 -s " + store_socket_name_ +
         " 1> /dev/null 2> /dev/null & " + "echo $! > " + store_socket_name_ + ".pid";
     PLASMA_CHECK_SYSTEM(system(plasma_command.c_str()));
     ARROW_CHECK_OK(client_.Connect(store_socket_name_, ""));

--- a/cpp/src/plasma/test/external_store_tests.cc
+++ b/cpp/src/plasma/test/external_store_tests.cc
@@ -60,7 +60,7 @@ class TestPlasmaStoreWithExternal : public ::testing::Test {
     std::string plasma_directory =
         external_test_executable.substr(0, external_test_executable.find_last_of('/'));
     std::string plasma_command = plasma_directory +
-                                 "/plasma_store_server -m 1024000 -e " +
+                                 "/plasma-store-server -m 1024000 -e " +
                                  "hashtable://test -s " + store_socket_name_ +
                                  " 1> /tmp/log.stdout 2> /tmp/log.stderr & " +
                                  "echo $! > " + store_socket_name_ + ".pid";

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -42,4 +42,4 @@ nm_arrow.log
 visible_symbols.log
 
 # plasma store
-pyarrow/plasma_store_server
+pyarrow/plasma-store-server

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -196,7 +196,7 @@ def _plasma_store_entry_point():
     """
     import pyarrow
     plasma_store_executable = _os.path.join(pyarrow.__path__[0],
-                                            "plasma_store_server")
+                                            "plasma-store-server")
     _os.execv(plasma_store_executable, _sys.argv)
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/plasma.py
+++ b/python/pyarrow/plasma.py
@@ -106,7 +106,7 @@ def start_plasma_store(plasma_store_memory,
     try:
         plasma_store_name = os.path.join(tmpdir, 'plasma.sock')
         plasma_store_executable = os.path.join(
-            pa.__path__[0], "plasma_store_server")
+            pa.__path__[0], "plasma-store-server")
         command = [plasma_store_executable,
                    "-s", plasma_store_name,
                    "-m", str(plasma_store_memory)]

--- a/python/setup.py
+++ b/python/setup.py
@@ -394,10 +394,10 @@ class build_ext(_build_ext):
 
             if self.with_plasma:
                 # Move the plasma store
-                source = os.path.join(self.build_type, "plasma_store_server")
+                source = os.path.join(self.build_type, "plasma-store-server")
                 target = os.path.join(build_lib,
                                       self._get_build_dir(),
-                                      "plasma_store_server")
+                                      "plasma-store-server")
                 shutil.move(source, target)
 
     def _failure_permitted(self, name):

--- a/ruby/red-plasma/README.md
+++ b/ruby/red-plasma/README.md
@@ -46,7 +46,7 @@ Install Red Plasma after you install Plasma GLib:
 Starting the Plasma store
 
 ```console
-plasma_store_server -m 1000000000 -s /tmp/plasma
+plasma-store-server -m 1000000000 -s /tmp/plasma
 ```
 
 Creating a Plasma client

--- a/ruby/red-plasma/test/helper/plasma-store.rb
+++ b/ruby/red-plasma/test/helper/plasma-store.rb
@@ -36,7 +36,7 @@ module Helper
                    "-s", socket_path)
       until File.exist?(socket_path)
         if Process.waitpid(@pid, Process::WNOHANG)
-          raise "Failed to run plasma_store_server: #{@path}"
+          raise "Failed to run plasma-store-server: #{@path}"
         end
       end
     end


### PR DESCRIPTION
To follow ARROW-4648 https://github.com/apache/arrow/pull/5069 :

> hyphens in executable file names

But this causes backward incompatibility.