### PR TITLE
ARROW-6247: [Java] Provide a common interface for float4 and float8 vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * float values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class Float4Vector extends BaseFixedWidthVector {
+public class Float4Vector extends BaseFixedWidthVector implements FloatingPointVector {
   public static final byte TYPE_WIDTH = 4;
   private final FieldReader reader;
 
@@ -282,6 +282,20 @@ public class Float4Vector extends BaseFixedWidthVector {
     return buffer.getFloat(index * TYPE_WIDTH);
   }
 
+  @Override
+  public void setWithPossibleTruncate(int index, double value) {
+    set(index, (float) value);
+  }
+
+  @Override
+  public void setSafeWithPossibleTruncate(int index, double value) {
+    setSafe(index, (float) value);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
+  }
 
   /*----------------------------------------------------------------*
    |                                                                |

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -36,7 +36,7 @@ import io.netty.buffer.ArrowBuf;
  * double values which could be null. A validity buffer (bit vector) is
  * maintained to track which elements in the vector are null.
  */
-public class Float8Vector extends BaseFixedWidthVector {
+public class Float8Vector extends BaseFixedWidthVector implements FloatingPointVector {
   public static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
 
@@ -283,6 +283,20 @@ public class Float8Vector extends BaseFixedWidthVector {
     return buffer.getDouble(index * TYPE_WIDTH);
   }
 
+  @Override
+  public void setWithPossibleTruncate(int index, double value) {
+    set(index, value);
+  }
+
+  @Override
+  public void setSafeWithPossibleTruncate(int index, double value) {
+    setSafe(index, value);
+  }
+
+  @Override
+  public double getValueAsDouble(int index) {
+    return get(index);
+  }
 
   /*----------------------------------------------------------------*
    |                                                                |

--- a/java/vector/src/main/java/org/apache/arrow/vector/FloatingPointVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FloatingPointVector.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+/**
+ * The interface for vectors with floating point values.
+ */
+public interface FloatingPointVector {
+
+  /**
+   * Sets the value at the given index, note this value may be truncated internally.
+   * @param index the index to set.
+   * @param value the value to set.
+   */
+  void setWithPossibleTruncate(int index, double value);
+
+  /**
+   * Sets the value at the given index, note this value may be truncated internally.
+   * Any expansion/reallocation is handled automatically.
+   * @param index the index to set.
+   * @param value the value to set.
+   */
+  void setSafeWithPossibleTruncate(int index, double value);
+
+  /**
+   * Gets the value at the given index.
+   * @param index the index to retrieve the value.
+   * @return the value at the index.
+   */
+  double getValueAsDouble(int index);
+}


### PR DESCRIPTION
We want to provide an interface for floating point vectors (float4 & float8). This interface will make it convenient for many operations on a vector. With this interface, the client code will be greatly simplified, with many branches/switch removed.

The design is similar to BaseIntVector (the interface for all integer vectors). We provide 3 methods for setting & getting floating point values:

         setWithPossibleTruncate

         setSafeWithPossibleTruncate

         getValueAsDouble