### PR TITLE
ARROW-6295:[Rust][DataFusion] ExecutionError Cannot compare Float32 w…

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -35,13 +35,13 @@ datafusion = "0.15.0-SNAPSHOT"
 #### Use as a bin
 ##### Build your own bin(requires rust toolchains)
 ```sh
-git clone https://github/apache/arrow
+git clone https://github.com/apache/arrow
 cd arrow/rust/datafusion
 cargo run --bin datafusion-cli
 ```
 ##### Use Dockerfile
 ```sh
-git clone https://github/apache/arrow
+git clone https://github.com/apache/arrow
 cd arrow
 docker build -f rust/datafusion/Dockerfile . --tag datafusion-cli
 docker run -it -v $(your_data_location):/data datafusion-cli

--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -43,7 +43,7 @@ fn main() {
         Field::new("c8", DataType::UInt16, false),
         Field::new("c9", DataType::UInt32, false),
         Field::new("c10", DataType::UInt64, false),
-        Field::new("c11", DataType::Float32, false),
+        Field::new("c11", DataType::Float64, false),
         Field::new("c12", DataType::Float64, false),
         Field::new("c13", DataType::Utf8, false),
     ]));


### PR DESCRIPTION
fixes
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ExecutionError("Cannot compare Float32 with Float64")', src/libcore/result.rs:1084:5
Change github address
