### PR TITLE
ARROW-6290: [Rust] [DataFusion] Fix bug in type coercion rule

### DIFF
--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -99,7 +99,11 @@ fn rewrite_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
             let left_type = left.get_type(schema);
             let right_type = right.get_type(schema);
             if left_type == right_type {
-                Ok(expr.clone())
+                Ok(Expr::BinaryExpr {
+                    left: Arc::new(left),
+                    op: op.clone(),
+                    right: Arc::new(right),
+                })
             } else {
                 let super_type = utils::get_supertype(&left_type, &right_type)?;
                 Ok(Expr::BinaryExpr {


### PR DESCRIPTION
The `csv_sql` example in master is broken (CI is no longer running examples so this went undetected).

This PR fixes a bug in the `TypeCoercionRule` that was causing the example to fail.