### PR TITLE
ARROW-6058: [C++][Parquet] Validate whole ColumnChunk raw data reads so that underlying filesystem issues are caught earlier

### DIFF
--- a/cpp/src/parquet/properties.cc
+++ b/cpp/src/parquet/properties.cc
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <sstream>
 #include <utility>
 
 #include "parquet/properties.h"
 
 #include "arrow/io/buffered.h"
+#include "arrow/util/logging.h"
 
 namespace parquet {
 
@@ -37,6 +39,13 @@ std::shared_ptr<ArrowInputStream> ReaderProperties::GetStream(
   } else {
     std::shared_ptr<Buffer> data;
     PARQUET_THROW_NOT_OK(source->ReadAt(start, num_bytes, &data));
+
+    if (data->size() != num_bytes) {
+      std::stringstream ss;
+      ss << "Tried reading " << num_bytes << " bytes starting at position "
+         << start << " from file but only got " << data->size();
+      throw ParquetException(ss.str());
+    }
     return std::make_shared<::arrow::io::BufferReader>(data);
   }
 }

--- a/cpp/src/parquet/properties.cc
+++ b/cpp/src/parquet/properties.cc
@@ -42,8 +42,8 @@ std::shared_ptr<ArrowInputStream> ReaderProperties::GetStream(
 
     if (data->size() != num_bytes) {
       std::stringstream ss;
-      ss << "Tried reading " << num_bytes << " bytes starting at position "
-         << start << " from file but only got " << data->size();
+      ss << "Tried reading " << num_bytes << " bytes starting at position " << start
+         << " from file but only got " << data->size();
       throw ParquetException(ss.str());
     }
     return std::make_shared<::arrow::io::BufferReader>(data);


### PR DESCRIPTION
Incomplete reads from files were not being caught here, which would result in an unhelpful exception being raised later when data pages could not be decoded. If the entire ColumnChunk read is incomplete here, then the chunk cannot be deserialized, so raising an error here is the proper thing to do. This also helped me debug the root cause of ARROW-6058