### PR TITLE
ARROW-5888: [C++][Parquet][Python] Restore timezone metadata when original Arrow schema has been stored in Parquet metadata

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -174,7 +174,7 @@ def test_pandas_parquet_2_0_roundtrip(tempdir, chunk_size):
     assert arrow_table.schema.metadata == table_read.schema.metadata
 
     df_read = table_read.to_pandas()
-    tm.assert_frame_equal(df, df_read, check_categorical=False)
+    tm.assert_frame_equal(df, df_read)
 
 
 def test_set_data_page_size():

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1093,6 +1093,14 @@ def test_date_time_types(tempdir):
     assert read_table.equals(expected)
 
 
+def test_timestamp_restore_timezone():
+    # ARROW-5888, restore timezone from serialized metadata
+    ty = pa.timestamp('ms', tz='America/New_York')
+    arr = pa.array([1, 2, 3], type=ty)
+    t = pa.table([arr], names=['f0'])
+    _check_roundtrip(t)
+
+
 @pytest.mark.pandas
 def test_list_of_datetime_time_roundtrip():
     # ARROW-4135


### PR DESCRIPTION
We can preserve the original timezone now that we're serializing the schema in the Parquet Thrift metadata