### PR TITLE
ARROW-6229: [C++][Dataset] implement FileSystemBasedDataSource

### DIFF
--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -34,7 +34,7 @@ Status SimpleDataFragment::Scan(std::shared_ptr<ScanContext> scan_context,
                                 std::unique_ptr<ScanTaskIterator>* out) {
   // Make an explicit copy of record_batches_ to ensure Scan can be called
   // multiple times.
-  auto it = MakeIterator(record_batches_);
+  auto it = MakeVectorIterator(record_batches_);
 
   // RecordBatch -> ScanTask
   auto fn = [](std::shared_ptr<RecordBatch> batch) -> std::unique_ptr<ScanTask> {

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -94,7 +94,7 @@ class ARROW_DS_EXPORT SimpleDataSource : public DataSource {
 
   std::unique_ptr<DataFragmentIterator> GetFragments(
       std::shared_ptr<ScanOptions> options) override {
-    return MakeIterator(fragments_);
+    return MakeVectorIterator(fragments_);
   }
 
   std::string type() const override { return "simple_data_source"; }

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -92,7 +92,7 @@ std::unique_ptr<DataFragmentIterator> FileSystemBasedDataSource::GetFragments(
       }
       FileSource src(stats_[i_++].path(), filesystem_);
 
-      std::unique_ptr<FileBasedDataFragment> fragment;
+      std::unique_ptr<DataFragment> fragment;
       RETURN_NOT_OK(format_->MakeFragment(src, scan_options_, &fragment));
       *out = std::move(fragment);
       return Status::OK();

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -17,9 +17,13 @@
 
 #include "arrow/dataset/file_base.h"
 
+#include <algorithm>
+#include <vector>
+
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
+#include "arrow/util/stl.h"
 
 namespace arrow {
 namespace dataset {
@@ -39,6 +43,69 @@ Status FileSource::Open(std::shared_ptr<arrow::io::RandomAccessFile>* out) const
 Status FileBasedDataFragment::Scan(std::shared_ptr<ScanContext> scan_context,
                                    std::unique_ptr<ScanTaskIterator>* out) {
   return format_->ScanFile(source_, scan_options_, scan_context, out);
+}
+
+FileSystemBasedDataSource::FileSystemBasedDataSource(
+    fs::FileSystem* filesystem, const fs::Selector& selector,
+    std::shared_ptr<FileFormat> format, std::shared_ptr<ScanOptions> scan_options,
+    std::vector<fs::FileStats> stats)
+    : filesystem_(filesystem),
+      selector_(std::move(selector)),
+      format_(std::move(format)),
+      scan_options_(std::move(scan_options)),
+      stats_(std::move(stats)) {}
+
+Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
+                                       const fs::Selector& selector,
+                                       std::shared_ptr<FileFormat> format,
+                                       std::shared_ptr<ScanOptions> scan_options,
+                                       std::unique_ptr<FileSystemBasedDataSource>* out) {
+  std::vector<fs::FileStats> stats;
+  RETURN_NOT_OK(filesystem->GetTargetStats(selector, &stats));
+
+  auto new_end =
+      std::remove_if(stats.begin(), stats.end(), [&](const fs::FileStats& stats) {
+        return stats.type() != fs::FileType::File ||
+               !format->IsKnownExtension(stats.extension());
+      });
+  stats.resize(new_end - stats.begin());
+
+  out->reset(new FileSystemBasedDataSource(filesystem, selector, std::move(format),
+                                           std::move(scan_options), std::move(stats)));
+  return Status::OK();
+}
+
+std::unique_ptr<DataFragmentIterator> FileSystemBasedDataSource::GetFragments(
+    std::shared_ptr<ScanOptions> options) {
+  struct Impl : DataFragmentIterator {
+    Impl(fs::FileSystem* filesystem, std::shared_ptr<FileFormat> format,
+         std::shared_ptr<ScanOptions> scan_options, std::vector<fs::FileStats> stats)
+        : filesystem_(filesystem),
+          format_(std::move(format)),
+          scan_options_(std::move(scan_options)),
+          stats_(std::move(stats)) {}
+
+    Status Next(std::shared_ptr<DataFragment>* out) {
+      if (i_ == stats_.size()) {
+        *out = nullptr;
+        return Status::OK();
+      }
+      FileSource src(stats_[i_++].path(), filesystem_);
+
+      std::unique_ptr<FileBasedDataFragment> fragment;
+      RETURN_NOT_OK(format_->MakeFragment(src, scan_options_, &fragment));
+      *out = std::move(fragment);
+      return Status::OK();
+    }
+
+    size_t i_ = 0;
+    fs::FileSystem* filesystem_;
+    std::shared_ptr<FileFormat> format_;
+    std::shared_ptr<ScanOptions> scan_options_;
+    std::vector<fs::FileStats> stats_;
+  };
+
+  return internal::make_unique<Impl>(filesystem_, format_, options, stats_);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "arrow/buffer.h"
 #include "arrow/dataset/dataset.h"
@@ -27,6 +28,7 @@
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
 #include "arrow/dataset/writer.h"
+#include "arrow/filesystem/filesystem.h"
 #include "arrow/io/file.h"
 #include "arrow/util/compression.h"
 
@@ -130,6 +132,11 @@ class ARROW_DS_EXPORT FileFormat {
                           std::shared_ptr<ScanOptions> scan_options,
                           std::shared_ptr<ScanContext> scan_context,
                           std::unique_ptr<ScanTaskIterator>* out) const = 0;
+
+  /// \brief Open a fragment
+  virtual Status MakeFragment(const FileSource& location,
+                              std::shared_ptr<ScanOptions> opts,
+                              std::unique_ptr<FileBasedDataFragment>* out) = 0;
 };
 
 /// \brief A DataFragment that is stored in a file with a known format
@@ -147,10 +154,42 @@ class ARROW_DS_EXPORT FileBasedDataFragment : public DataFragment {
   const FileSource& source() const { return source_; }
   std::shared_ptr<FileFormat> format() const { return format_; }
 
+  std::shared_ptr<ScanOptions> scan_options() const override { return scan_options_; }
+
  protected:
   FileSource source_;
   std::shared_ptr<FileFormat> format_;
   std::shared_ptr<ScanOptions> scan_options_;
+};
+
+/// \brief A DataSource which takes files of one format from a directory
+///
+/// The directory is crawled upon construction (Make) and not updated afterward.
+/// GetFragments() will not include files added after this DataDource is constructed and
+/// will error if files are deleted/moved.
+class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
+ public:
+  static Status Make(fs::FileSystem* filesystem, const fs::Selector& selector,
+                     std::shared_ptr<FileFormat> format,
+                     std::shared_ptr<ScanOptions> scan_options,
+                     std::unique_ptr<FileSystemBasedDataSource>* out);
+
+  std::string type() const override { return "directory"; }
+
+  std::unique_ptr<DataFragmentIterator> GetFragments(
+      std::shared_ptr<ScanOptions> options) override;
+
+ protected:
+  FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,
+                            std::shared_ptr<FileFormat> format,
+                            std::shared_ptr<ScanOptions> scan_options,
+                            std::vector<fs::FileStats> stats);
+
+  fs::FileSystem* filesystem_ = NULLPTR;
+  fs::Selector selector_;
+  std::shared_ptr<FileFormat> format_;
+  std::shared_ptr<ScanOptions> scan_options_;
+  std::vector<fs::FileStats> stats_;
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -136,7 +136,7 @@ class ARROW_DS_EXPORT FileFormat {
   /// \brief Open a fragment
   virtual Status MakeFragment(const FileSource& location,
                               std::shared_ptr<ScanOptions> opts,
-                              std::unique_ptr<FileBasedDataFragment>* out) = 0;
+                              std::unique_ptr<DataFragment>* out) = 0;
 };
 
 /// \brief A DataFragment that is stored in a file with a known format

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -177,12 +177,7 @@ Status ParquetFileFormat::ScanFile(const FileSource& source,
 
 Status ParquetFileFormat::MakeFragment(const FileSource& source,
                                        std::shared_ptr<ScanOptions> opts,
-                                       std::unique_ptr<FileBasedDataFragment>* out) {
-  fs::FileStats stats;
-  RETURN_NOT_OK(source.filesystem()->GetTargetStats(source.path(), &stats));
-  if (stats.type() == fs::FileType::NonExistent) {
-    return Status::Invalid("file doesn't exist");
-  }
+                                       std::unique_ptr<DataFragment>* out) {
   // TODO(bkietz) check location.path() against IsKnownExtension etc
   *out = internal::make_unique<ParquetFragment>(source, opts);
   return Status::OK();

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -178,6 +178,11 @@ Status ParquetFileFormat::ScanFile(const FileSource& source,
 Status ParquetFileFormat::MakeFragment(const FileSource& source,
                                        std::shared_ptr<ScanOptions> opts,
                                        std::unique_ptr<FileBasedDataFragment>* out) {
+  fs::FileStats stats;
+  RETURN_NOT_OK(source.filesystem()->GetTargetStats(source.path(), &stats));
+  if (stats.type() == fs::FileType::NonExistent) {
+    return Status::Invalid("file doesn't exist");
+  }
   // TODO(bkietz) check location.path() against IsKnownExtension etc
   *out = internal::make_unique<ParquetFragment>(source, opts);
   return Status::OK();

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -23,6 +23,7 @@
 #include "arrow/table.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/range.h"
+#include "arrow/util/stl.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/file_reader.h"
 
@@ -172,6 +173,14 @@ Status ParquetFileFormat::ScanFile(const FileSource& source,
   auto reader = parquet::ParquetFileReader::Open(input);
   return ParquetScanTaskIterator::Make(scan_options, scan_context, std::move(reader),
                                        out);
+}
+
+Status ParquetFileFormat::MakeFragment(const FileSource& source,
+                                       std::shared_ptr<ScanOptions> opts,
+                                       std::unique_ptr<FileBasedDataFragment>* out) {
+  // TODO(bkietz) check location.path() against IsKnownExtension etc
+  *out = internal::make_unique<ParquetFragment>(source, opts);
+  return Status::OK();
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -51,6 +51,9 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
   Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
                   std::shared_ptr<ScanContext> scan_context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
+
+  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanOptions> opts,
+                      std::unique_ptr<FileBasedDataFragment>* out) override;
 };
 
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
@@ -59,8 +62,6 @@ class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
       : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), options) {}
 
   bool splittable() const override { return true; }
-
-  std::shared_ptr<ScanOptions> scan_options() const override { return NULLPTR; }
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -53,7 +53,7 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
   Status MakeFragment(const FileSource& source, std::shared_ptr<ScanOptions> opts,
-                      std::unique_ptr<FileBasedDataFragment>* out) override;
+                      std::unique_ptr<DataFragment>* out) override;
 };
 
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -18,6 +18,7 @@
 #include "arrow/dataset/file_parquet.h"
 
 #include <utility>
+#include <vector>
 
 #include "arrow/dataset/test_util.h"
 #include "arrow/record_batch.h"

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -179,20 +179,16 @@ TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
   MakeDataSource();
   ASSERT_OK(this->fs_->DeleteFile("a/b.parquet"));
 
-  int count = 0;
   ASSERT_RAISES(
       Invalid,
       source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
         auto file_fragment =
             internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-        ++count;
         auto extension =
             fs::internal::GetAbstractPathExtension(file_fragment->source().path());
         EXPECT_TRUE(format_->IsKnownExtension(extension));
         return Status::OK();
       }));
-
-  ASSERT_EQ(count, 2);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -173,5 +173,27 @@ TEST_F(TestFileSystemBasedDataSource, Recursive) {
   ASSERT_EQ(count, 4);
 }
 
+TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
+  selector_.base_dir = "/";
+  selector_.recursive = true;
+  MakeDataSource();
+  ASSERT_OK(this->fs_->DeleteFile("a/b.parquet"));
+
+  int count = 0;
+  ASSERT_RAISES(
+      Invalid,
+      source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+        auto file_fragment =
+            internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+        ++count;
+        auto extension =
+            fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+        EXPECT_TRUE(format_->IsKnownExtension(extension));
+        return Status::OK();
+      }));
+
+  ASSERT_EQ(count, 2);
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -20,18 +20,12 @@
 #include <utility>
 
 #include "arrow/dataset/test_util.h"
-#include "arrow/filesystem/localfs.h"
-#include "arrow/filesystem/path_util.h"
 #include "arrow/record_batch.h"
 #include "arrow/testing/util.h"
-#include "arrow/util/io_util.h"
 #include "parquet/arrow/writer.h"
 
 namespace arrow {
 namespace dataset {
-
-using fs::internal::GetAbstractPathExtension;
-using internal::TemporaryDir;
 
 constexpr int64_t kBatchSize = 1UL << 15;
 constexpr int64_t kBatchRepetitions = 1 << 10;
@@ -94,105 +88,18 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   ASSERT_EQ(row_count, kNumRows);
 }
 
-class TestFileSystemBasedDataSource : public FileSourceFixtureMixin {
- public:
-  void SetUp() override {
-    format_ = std::make_shared<ParquetFileFormat>();
-
-    ASSERT_OK(TemporaryDir::Make("test-fsdatasource-", &temp_dir_));
-    local_fs_ = std::make_shared<fs::LocalFileSystem>();
-
-    auto path = temp_dir_->path().ToString();
-    fs_ = std::make_shared<fs::SubTreeFileSystem>(path, local_fs_);
-
-    CreateEmptyFiles();
+class TestParquetFileSystemBasedDataSource
+    : public FileSystemBasedDataSourceMixin<ParquetFileFormat> {
+  std::vector<std::string> file_names() const override {
+    return {"a/b/c.parquet", "a/b/c/d.parquet", "a/b.parquet", "a.parquet"};
   }
-
-  void CreateFile(std::string path, std::string contents) {
-    auto parent = fs::internal::GetAbstractPathParent(path).first;
-    if (parent != "") {
-      ASSERT_OK(this->fs_->CreateDir(parent, true));
-    }
-    std::shared_ptr<io::OutputStream> file;
-    ASSERT_OK(this->fs_->OpenOutputStream(path, &file));
-    ASSERT_OK(file->Write(contents));
-  }
-
-  void CreateEmptyFiles() {
-    for (auto path : {"a/b/c.parquet", "a/b/c/d.parquet", "a/b.parquet", "a.parquet"}) {
-      CreateFile(path, "");
-    }
-  }
-
-  void MakeDataSource() {
-    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_,
-                                              std::make_shared<ScanOptions>(), &source_));
-  }
-
- protected:
-  fs::Selector selector_;
-  std::unique_ptr<FileSystemBasedDataSource> source_;
-  std::shared_ptr<fs::LocalFileSystem> local_fs_;
-  std::shared_ptr<fs::FileSystem> fs_;
-  std::unique_ptr<TemporaryDir> temp_dir_;
-  std::shared_ptr<ParquetFileFormat> format_;
 };
 
-TEST_F(TestFileSystemBasedDataSource, NonRecursive) {
-  selector_.base_dir = "/";
-  MakeDataSource();
+TEST_F(TestParquetFileSystemBasedDataSource, NonRecursive) { this->NonRecursive(); }
 
-  int count = 0;
-  ASSERT_OK(source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
-    auto file_fragment = internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-    ++count;
-    auto extension =
-        fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-    EXPECT_TRUE(format_->IsKnownExtension(extension));
-    std::shared_ptr<io::RandomAccessFile> f;
-    return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-  }));
+TEST_F(TestParquetFileSystemBasedDataSource, Recursive) { this->Recursive(); }
 
-  ASSERT_EQ(count, 1);
-}
-
-TEST_F(TestFileSystemBasedDataSource, Recursive) {
-  selector_.base_dir = "/";
-  selector_.recursive = true;
-  MakeDataSource();
-
-  int count = 0;
-  ASSERT_OK(source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
-    auto file_fragment = internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-    ++count;
-    auto extension =
-        fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-    EXPECT_TRUE(format_->IsKnownExtension(extension));
-    std::shared_ptr<io::RandomAccessFile> f;
-    return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-  }));
-
-  ASSERT_EQ(count, 4);
-}
-
-TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
-  selector_.base_dir = "/";
-  selector_.recursive = true;
-  MakeDataSource();
-  ASSERT_OK(this->fs_->DeleteFile("a/b.parquet"));
-
-  ASSERT_RAISES(
-      IOError,
-      source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
-        auto file_fragment =
-            internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-        auto extension =
-            fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-        EXPECT_TRUE(format_->IsKnownExtension(extension));
-        std::shared_ptr<io::RandomAccessFile> f;
-        return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-      }));
-}
+TEST_F(TestParquetFileSystemBasedDataSource, DeletedFile) { this->DeletedFile(); }
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -149,7 +149,8 @@ TEST_F(TestFileSystemBasedDataSource, NonRecursive) {
     auto extension =
         fs::internal::GetAbstractPathExtension(file_fragment->source().path());
     EXPECT_TRUE(format_->IsKnownExtension(extension));
-    return Status::OK();
+    std::shared_ptr<io::RandomAccessFile> f;
+    return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
   }));
 
   ASSERT_EQ(count, 1);
@@ -167,7 +168,8 @@ TEST_F(TestFileSystemBasedDataSource, Recursive) {
     auto extension =
         fs::internal::GetAbstractPathExtension(file_fragment->source().path());
     EXPECT_TRUE(format_->IsKnownExtension(extension));
-    return Status::OK();
+    std::shared_ptr<io::RandomAccessFile> f;
+    return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
   }));
 
   ASSERT_EQ(count, 4);
@@ -180,14 +182,15 @@ TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
   ASSERT_OK(this->fs_->DeleteFile("a/b.parquet"));
 
   ASSERT_RAISES(
-      Invalid,
+      IOError,
       source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
         auto file_fragment =
             internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
         auto extension =
             fs::internal::GetAbstractPathExtension(file_fragment->source().path());
         EXPECT_TRUE(format_->IsKnownExtension(extension));
-        return Status::OK();
+        std::shared_ptr<io::RandomAccessFile> f;
+        return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
       }));
 }
 

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -40,14 +40,19 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "arrow/dataset/api.h"
+#include "arrow/dataset/test_util.h"
+#include "arrow/filesystem/localfs.h"
+#include "arrow/filesystem/path_util.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
-
-#include "arrow/dataset/api.h"
-#include "arrow/filesystem/localfs.h"
+#include "arrow/util/io_util.h"
 
 namespace arrow {
 namespace dataset {
+
+using fs::internal::GetAbstractPathExtension;
+using internal::TemporaryDir;
 
 TEST(FileSource, PathBased) {
   fs::LocalFileSystem localfs;
@@ -87,6 +92,85 @@ TEST(FileSource, BufferBased) {
   ASSERT_EQ(FileSource::BUFFER, source2.type());
   ASSERT_TRUE(source2.buffer()->Equals(*buf));
   ASSERT_EQ(Compression::LZ4, source2.compression());
+}
+
+class TestFileSystemBasedDataSource : public FileSourceFixtureMixin {
+ public:
+  void SetUp() override {
+    format_ = std::make_shared<DummyFileFormat>();
+
+    ASSERT_OK(TemporaryDir::Make("test-fsdatasource-", &temp_dir_));
+    local_fs_ = std::make_shared<fs::LocalFileSystem>();
+
+    auto path = temp_dir_->path().ToString();
+    fs_ = std::make_shared<fs::SubTreeFileSystem>(path, local_fs_);
+
+    CreateEmptyFiles();
+  }
+
+  void CreateFile(std::string path, std::string contents) {
+    auto parent = fs::internal::GetAbstractPathParent(path).first;
+    if (parent != "") {
+      ASSERT_OK(this->fs_->CreateDir(parent, true));
+    }
+    std::shared_ptr<io::OutputStream> file;
+    ASSERT_OK(this->fs_->OpenOutputStream(path, &file));
+    ASSERT_OK(file->Write(contents));
+  }
+
+  void CreateEmptyFiles() {
+    for (auto path : {"a/b/c.dummy", "a/b/c/d.dummy", "a/b.dummy", "a.dummy"}) {
+      CreateFile(path, "");
+    }
+  }
+
+  void MakeDataSource() {
+    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_,
+                                              std::make_shared<ScanOptions>(), &source_));
+  }
+
+ protected:
+  fs::Selector selector_;
+  std::unique_ptr<FileSystemBasedDataSource> source_;
+  std::shared_ptr<fs::LocalFileSystem> local_fs_;
+  std::shared_ptr<fs::FileSystem> fs_;
+  std::unique_ptr<TemporaryDir> temp_dir_;
+  std::shared_ptr<DummyFileFormat> format_;
+};
+
+TEST_F(TestFileSystemBasedDataSource, NonRecursive) {
+  selector_.base_dir = "/";
+  MakeDataSource();
+
+  int count = 0;
+  ASSERT_OK(source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+    auto file_fragment = internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+    ++count;
+    auto extension =
+        fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+    EXPECT_TRUE(format_->IsKnownExtension(extension));
+    return Status::OK();
+  }));
+
+  ASSERT_EQ(count, 1);
+}
+
+TEST_F(TestFileSystemBasedDataSource, Recursive) {
+  selector_.base_dir = "/";
+  selector_.recursive = true;
+  MakeDataSource();
+
+  int count = 0;
+  ASSERT_OK(source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+    auto file_fragment = internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+    ++count;
+    auto extension =
+        fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+    EXPECT_TRUE(format_->IsKnownExtension(extension));
+    return Status::OK();
+  }));
+
+  ASSERT_EQ(count, 4);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -149,7 +149,8 @@ TEST_F(TestFileSystemBasedDataSource, NonRecursive) {
     auto extension =
         fs::internal::GetAbstractPathExtension(file_fragment->source().path());
     EXPECT_TRUE(format_->IsKnownExtension(extension));
-    return Status::OK();
+    std::shared_ptr<io::RandomAccessFile> f;
+    return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
   }));
 
   ASSERT_EQ(count, 1);
@@ -167,7 +168,8 @@ TEST_F(TestFileSystemBasedDataSource, Recursive) {
     auto extension =
         fs::internal::GetAbstractPathExtension(file_fragment->source().path());
     EXPECT_TRUE(format_->IsKnownExtension(extension));
-    return Status::OK();
+    std::shared_ptr<io::RandomAccessFile> f;
+    return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
   }));
 
   ASSERT_EQ(count, 4);
@@ -180,14 +182,15 @@ TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
   ASSERT_OK(this->fs_->DeleteFile("a/b.dummy"));
 
   ASSERT_RAISES(
-      Invalid,
+      IOError,
       source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
         auto file_fragment =
             internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
         auto extension =
             fs::internal::GetAbstractPathExtension(file_fragment->source().path());
         EXPECT_TRUE(format_->IsKnownExtension(extension));
-        return Status::OK();
+        std::shared_ptr<io::RandomAccessFile> f;
+        return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
       }));
 }
 

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -179,20 +179,16 @@ TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
   MakeDataSource();
   ASSERT_OK(this->fs_->DeleteFile("a/b.dummy"));
 
-  int count = 0;
   ASSERT_RAISES(
       Invalid,
       source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
         auto file_fragment =
             internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-        ++count;
         auto extension =
             fs::internal::GetAbstractPathExtension(file_fragment->source().path());
         EXPECT_TRUE(format_->IsKnownExtension(extension));
         return Status::OK();
       }));
-
-  ASSERT_EQ(count, 2);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -173,5 +173,27 @@ TEST_F(TestFileSystemBasedDataSource, Recursive) {
   ASSERT_EQ(count, 4);
 }
 
+TEST_F(TestFileSystemBasedDataSource, DeletedFile) {
+  selector_.base_dir = "/";
+  selector_.recursive = true;
+  MakeDataSource();
+  ASSERT_OK(this->fs_->DeleteFile("a/b.dummy"));
+
+  int count = 0;
+  ASSERT_RAISES(
+      Invalid,
+      source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+        auto file_fragment =
+            internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+        ++count;
+        auto extension =
+            fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+        EXPECT_TRUE(format_->IsKnownExtension(extension));
+        return Status::OK();
+      }));
+
+  ASSERT_EQ(count, 2);
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -17,11 +17,13 @@
 
 #include "arrow/dataset/scanner.h"
 
+#include "arrow/util/iterator.h"
+
 namespace arrow {
 namespace dataset {
 
 std::unique_ptr<RecordBatchIterator> SimpleScanTask::Scan() {
-  return MakeIterator(record_batches_);
+  return MakeVectorIterator(record_batches_);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "arrow/dataset/file_base.h"
 #include "arrow/filesystem/localfs.h"

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -199,8 +199,9 @@ class DummyFileFormat : public FileFormat {
     return Status::OK();
   }
 
-  Status MakeFragment(const FileSource& location, std::shared_ptr<ScanOptions> opts,
-                      std::unique_ptr<FileBasedDataFragment>* out) override;
+  inline Status MakeFragment(const FileSource& location,
+                             std::shared_ptr<ScanOptions> opts,
+                             std::unique_ptr<DataFragment>* out) override;
 };
 
 class DummyFragment : public FileBasedDataFragment {
@@ -213,12 +214,7 @@ class DummyFragment : public FileBasedDataFragment {
 
 Status DummyFileFormat::MakeFragment(const FileSource& source,
                                      std::shared_ptr<ScanOptions> opts,
-                                     std::unique_ptr<FileBasedDataFragment>* out) {
-  fs::FileStats stats;
-  RETURN_NOT_OK(source.filesystem()->GetTargetStats(source.path(), &stats));
-  if (stats.type() == fs::FileType::NonExistent) {
-    return Status::Invalid("file doesn't exist");
-  }
+                                     std::unique_ptr<DataFragment>* out) {
   *out = internal::make_unique<DummyFragment>(source, opts);
   return Status::OK();
 }

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -20,14 +20,20 @@
 #include <utility>
 
 #include "arrow/dataset/file_base.h"
+#include "arrow/filesystem/localfs.h"
+#include "arrow/filesystem/path_util.h"
 #include "arrow/record_batch.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/io_util.h"
 #include "arrow/util/stl.h"
 
 #include "parquet/arrow/writer.h"
 
 namespace arrow {
 namespace dataset {
+
+using fs::internal::GetAbstractPathExtension;
+using internal::TemporaryDir;
 
 using parquet::ArrowWriterProperties;
 using parquet::default_arrow_writer_properties;
@@ -175,6 +181,111 @@ class TestDataSourceMixin : public TestDataFragmentMixin {
       return Status::OK();
     }));
   }
+};
+
+template <typename Format>
+class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
+ public:
+  virtual std::vector<std::string> file_names() const = 0;
+
+  void SetUp() override {
+    format_ = std::make_shared<Format>();
+
+    ASSERT_OK(
+        TemporaryDir::Make("test-fsdatasource-" + format_->name() + "-", &temp_dir_));
+    local_fs_ = std::make_shared<fs::LocalFileSystem>();
+
+    auto path = temp_dir_->path().ToString();
+    fs_ = std::make_shared<fs::SubTreeFileSystem>(path, local_fs_);
+
+    for (auto path : file_names()) {
+      CreateFile(path, "");
+    }
+  }
+
+  void CreateFile(std::string path, std::string contents) {
+    auto parent = fs::internal::GetAbstractPathParent(path).first;
+    if (parent != "") {
+      ASSERT_OK(this->fs_->CreateDir(parent, true));
+    }
+    std::shared_ptr<io::OutputStream> file;
+    ASSERT_OK(this->fs_->OpenOutputStream(path, &file));
+    ASSERT_OK(file->Write(contents));
+  }
+
+  void MakeDataSource() {
+    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_,
+                                              std::make_shared<ScanOptions>(), &source_));
+  }
+
+ protected:
+  void NonRecursive() {
+    selector_.base_dir = "/";
+    MakeDataSource();
+
+    int count = 0;
+    ASSERT_OK(
+        source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+          auto file_fragment =
+              internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+          ++count;
+          auto extension =
+              fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+          EXPECT_TRUE(format_->IsKnownExtension(extension));
+          std::shared_ptr<io::RandomAccessFile> f;
+          return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
+        }));
+
+    ASSERT_EQ(count, 1);
+  }
+
+  void Recursive() {
+    selector_.base_dir = "/";
+    selector_.recursive = true;
+    MakeDataSource();
+
+    int count = 0;
+    ASSERT_OK(
+        source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+          auto file_fragment =
+              internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+          ++count;
+          auto extension =
+              fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+          EXPECT_TRUE(format_->IsKnownExtension(extension));
+          std::shared_ptr<io::RandomAccessFile> f;
+          return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
+        }));
+
+    ASSERT_EQ(count, 4);
+  }
+
+  void DeletedFile() {
+    selector_.base_dir = "/";
+    selector_.recursive = true;
+    MakeDataSource();
+    ASSERT_GT(file_names().size(), 0);
+    ASSERT_OK(this->fs_->DeleteFile(file_names()[0]));
+
+    ASSERT_RAISES(
+        IOError,
+        source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+          auto file_fragment =
+              internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+          auto extension =
+              fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+          EXPECT_TRUE(format_->IsKnownExtension(extension));
+          std::shared_ptr<io::RandomAccessFile> f;
+          return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
+        }));
+  }
+
+  fs::Selector selector_;
+  std::unique_ptr<FileSystemBasedDataSource> source_;
+  std::shared_ptr<fs::LocalFileSystem> local_fs_;
+  std::shared_ptr<fs::FileSystem> fs_;
+  std::unique_ptr<TemporaryDir> temp_dir_;
+  std::shared_ptr<FileFormat> format_;
 };
 
 template <typename Gen>

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -214,6 +214,11 @@ class DummyFragment : public FileBasedDataFragment {
 Status DummyFileFormat::MakeFragment(const FileSource& source,
                                      std::shared_ptr<ScanOptions> opts,
                                      std::unique_ptr<FileBasedDataFragment>* out) {
+  fs::FileStats stats;
+  RETURN_NOT_OK(source.filesystem()->GetTargetStats(source.path(), &stats));
+  if (stats.type() == fs::FileType::NonExistent) {
+    return Status::Invalid("file doesn't exist");
+  }
   *out = internal::make_unique<DummyFragment>(source, opts);
   return Status::OK();
 }

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -201,5 +201,9 @@ Status SubTreeFileSystem::OpenAppendStream(const std::string& path,
   return base_fs_->OpenAppendStream(s, out);
 }
 
+std::string FileStats::extension() const {
+  return internal::GetAbstractPathExtension(path_);
+}
+
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -97,6 +97,9 @@ struct ARROW_EXPORT FileStats {
   int64_t size() const { return size_; }
   void set_size(int64_t size) { size_ = size; }
 
+  // The file extension
+  std::string extension() const;
+
   // The time of last modification, if available.
   TimePoint mtime() const { return mtime_; }
   void set_mtime(TimePoint mtime) { mtime_ = mtime; }

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -85,6 +85,17 @@ TEST(PathUtil, SplitAbstractPath) {
   AssertPartsEqual(parts, {"abc", "def.ghi"});
 }
 
+TEST(PathUtil, GetAbstractPathExtension) {
+  ASSERT_EQ(GetAbstractPathExtension("abc.txt"), "txt");
+  ASSERT_EQ(GetAbstractPathExtension("dir/abc.txt"), "txt");
+  ASSERT_EQ(GetAbstractPathExtension("/dir/abc.txt"), "txt");
+  ASSERT_EQ(GetAbstractPathExtension("dir/abc.txt.gz"), "gz");
+  ASSERT_EQ(GetAbstractPathExtension("/run.d/abc.txt"), "txt");
+  ASSERT_EQ(GetAbstractPathExtension("abc"), "");
+  ASSERT_EQ(GetAbstractPathExtension("/dir/abc"), "");
+  ASSERT_EQ(GetAbstractPathExtension("/run.d/abc"), "");
+}
+
 TEST(PathUtil, GetAbstractPathParent) {
   std::pair<std::string, std::string> pair;
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -67,6 +67,20 @@ std::pair<std::string, std::string> GetAbstractPathParent(const std::string& s) 
   return {s.substr(0, pos), s.substr(pos + 1)};
 }
 
+std::string GetAbstractPathExtension(const std::string& s) {
+  util::string_view basename(s);
+  auto offset = basename.find_last_of(kSep);
+  if (offset != std::string::npos) {
+    basename = basename.substr(offset);
+  }
+  auto dot = basename.find_last_of('.');
+  if (dot == util::string_view::npos) {
+    // Empty extension
+    return "";
+  }
+  return basename.substr(dot + 1).to_string();
+}
+
 Status ValidateAbstractPathParts(const std::vector<std::string>& parts) {
   for (const auto& part : parts) {
     if (part.length() == 0) {

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -36,6 +36,10 @@ constexpr char kSep = '/';
 ARROW_EXPORT
 std::vector<std::string> SplitAbstractPath(const std::string& s);
 
+// Return the extension of the file
+ARROW_EXPORT
+std::string GetAbstractPathExtension(const std::string& s);
+
 // Return the parent directory and basename of an abstract path.  Both values may be
 // empty.
 ARROW_EXPORT

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -20,10 +20,15 @@
 
 #include <memory>
 
-#include "arrow/util/iterator.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+
+template <typename T>
+class Iterator;
+
+template <typename T>
+class Result;
 
 class Status;
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_TYPE_TRAITS_H
-#define ARROW_TYPE_TRAITS_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -665,5 +664,3 @@ static inline bool is_fixed_width(Type::type type_id) {
 }
 
 }  // namespace arrow
-
-#endif  // ARROW_TYPE_TRAITS_H

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -19,6 +19,8 @@
 
 #include <tuple>
 
+#include "arrow/util/macros.h"
+
 namespace arrow {
 
 /// Helper struct for examining lambdas and other callables.
@@ -44,7 +46,7 @@ struct single_call {
 
   template <typename F>
   static constexpr bool check() {
-    return decltype(check_impl<typename std::decay<F>::type>(nullptr))::value;
+    return decltype(check_impl<typename std::decay<F>::type>(NULLPTR))::value;
   }
 
   template <typename F, typename T = void>

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -26,16 +26,17 @@ namespace internal {
 
 /// Helper struct for examining lambdas and other callables.
 /// TODO(bkietz) support function pointers
+/// TODO(bkietz) provide return_type accessor
 struct call_traits {
  private:
   template <typename R, typename... A>
-  static std::true_type is_overloaded_impl(R(A...));
+  static std::false_type is_overloaded_impl(R(A...));
 
   template <typename F>
-  static std::true_type is_overloaded_impl(decltype(&F::operator())*);
+  static std::false_type is_overloaded_impl(decltype(&F::operator())*);
 
   template <typename F>
-  static std::false_type is_overloaded_impl(...);
+  static std::true_type is_overloaded_impl(...);
 
   template <std::size_t I, typename F, typename R, typename... A>
   static typename std::tuple_element<I, std::tuple<A...>>::type argument_type_impl(
@@ -46,8 +47,8 @@ struct call_traits {
       R (F::*)(A...) const);
 
  public:
-  /// bool constant indicating whether F is a callable with exactly one possible
-  /// signature. Will be false_type for objects which define multiple operator() or which
+  /// bool constant indicating whether F is a callable with more than one possible
+  /// signature. Will be true_type for objects which define multiple operator() or which
   /// define a template operator()
   template <typename F>
   using is_overloaded =

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <tuple>
+
+namespace arrow {
+
+/// Helper struct for examining lambdas and other callables.
+/// If the callable is not overloaded, the argument types of its call operator can be
+/// extracted via single_call::argument_type<Index, Function>
+struct single_call {
+  template <typename R, typename... A>
+  static std::true_type check_impl(R(A...));
+
+  template <typename F>
+  static std::true_type check_impl(decltype(&F::operator())*);
+
+  template <typename F>
+  static std::false_type check_impl(...);
+
+  template <std::size_t I, typename F, typename R, typename... A>
+  static typename std::tuple_element<I, std::tuple<A...>>::type argument_type_impl(
+      R (F::*)(A...));
+
+  template <std::size_t I, typename F, typename R, typename... A>
+  static typename std::tuple_element<I, std::tuple<A...>>::type argument_type_impl(
+      R (F::*)(A...) const);
+
+  template <typename F>
+  static constexpr bool check() {
+    return decltype(check_impl<typename std::decay<F>::type>(nullptr))::value;
+  }
+
+  template <typename F, typename T = void>
+  using enable_if = typename std::enable_if<check<F>(), T>::type;
+
+  template <std::size_t I, typename F>
+  using argument_type = decltype(argument_type_impl<I>(&std::decay<F>::type::operator()));
+};
+
+}  // namespace arrow

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -79,7 +79,7 @@ class VectorIterator : public Iterator<T> {
 };
 
 template <typename T>
-std::unique_ptr<Iterator<T>> MakeIterator(std::vector<T> v) {
+std::unique_ptr<Iterator<T>> MakeVectorIterator(std::vector<T> v) {
   return std::unique_ptr<VectorIterator<T>>(new VectorIterator<T>(std::move(v)));
 }
 

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -140,8 +140,8 @@ class FunctionIterator : public Iterator<T> {
 };
 
 template <typename Fn, typename T = typename std::remove_pointer<
-                           single_call::argument_type<0, Fn>>::type>
-std::unique_ptr<FunctionIterator<Fn, T>> MakeIterator(Fn fn) {
+                           internal::call_traits::argument_type<0, Fn>>::type>
+std::unique_ptr<FunctionIterator<Fn, T>> MakeFunctionIterator(Fn fn) {
   return std::unique_ptr<FunctionIterator<Fn, T>>(
       new FunctionIterator<Fn, T>(std::move(fn)));
 }


### PR DESCRIPTION
Adds FileSystemBasedDataSource, which is constructed with a file format and reads a given directory recursively on construction then yields data fragments from discovered files matching that format.

Also adds FileFormat::MakeFragment which creates a(n instance of a subclass of) FileBasedDataFragment given a FileSource and ScanOptions.

moved PR from: https://github.com/fsaintjacques/arrow/pull/2