### PR TITLE
ARROW-4752: [Rust] Add explicit SIMD vectorization for the divide kernel

### DIFF
--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -26,7 +26,6 @@ use std::sync::Arc;
 extern crate arrow;
 
 use arrow::array::*;
-//use arrow::builder::*;
 use arrow::compute::array_ops::{limit, sum};
 use arrow::compute::kernels::arithmetic::*;
 use arrow::error::Result;

--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -17,13 +17,16 @@
 
 #[macro_use]
 extern crate criterion;
+use arrow::error::ArrowError;
 use criterion::Criterion;
+use num::Zero;
 
 use std::sync::Arc;
 
 extern crate arrow;
 
 use arrow::array::*;
+//use arrow::builder::*;
 use arrow::compute::array_ops::{limit, sum};
 use arrow::compute::kernels::arithmetic::*;
 use arrow::error::Result;
@@ -63,6 +66,12 @@ fn multiply_simd(size: usize) {
     criterion::black_box(multiply(&arr_a, &arr_b).unwrap());
 }
 
+fn divide_simd(size: usize) {
+    let arr_a = create_array(size);
+    let arr_b = create_array(size);
+    criterion::black_box(divide(&arr_a, &arr_b).unwrap());
+}
+
 fn sum_no_simd(size: usize) {
     let arr_a = create_array(size);
     criterion::black_box(sum(&arr_a).unwrap());
@@ -86,6 +95,18 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bin_op_no_simd(512, |a, b| Ok(a * b)))
     });
     c.bench_function("multiply 512 simd", |b| b.iter(|| multiply_simd(512)));
+    c.bench_function("divide 512", |b| {
+        b.iter(|| {
+            bin_op_no_simd(512, |a, b| {
+                if b.is_zero() {
+                    Err(ArrowError::DivideByZero)
+                } else {
+                    Ok(a / b)
+                }
+            })
+        })
+    });
+    c.bench_function("divide 512 simd", |b| b.iter(|| divide_simd(512)));
     c.bench_function("sum 512 no simd", |b| b.iter(|| sum_no_simd(512)));
     c.bench_function("limit 512, 256 no simd", |b| {
         b.iter(|| limit_no_simd(512, 256))

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -20,7 +20,7 @@
 //! These kernels can leverage SIMD if available on your system.  Currently no runtime
 //! detection is provided, you should enable the specific SIMD intrinsics using
 //! `RUSTFLAGS="-C target-feature=+avx2"` for example.  See the documentation
-//! [here] (https://doc.rust-lang.org/stable/std/arch/) for more information.
+//! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
 
 use std::mem;
 use std::ops::{Add, Div, Mul, Sub};
@@ -125,7 +125,7 @@ where
 }
 
 /// SIMD vectorized version of `divide`, the divide kernel needs it's own implementation as there
-/// is a need to handle situations where a divide by `0` occurs.  This is complicated by `NULl`
+/// is a need to handle situations where a divide by `0` occurs.  This is complicated by `NULL`
 /// slots and padding.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn simd_divide<T>(
@@ -135,10 +135,6 @@ fn simd_divide<T>(
 where
     T: datatypes::ArrowNumericType,
     T::Native: One + Zero,
-    T::Simd: Add<Output = T::Simd>
-        + Sub<Output = T::Simd>
-        + Mul<Output = T::Simd>
-        + Div<Output = T::Simd>,
 {
     if left.len() != right.len() {
         return Err(ArrowError::ComputeError(

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -20,18 +20,21 @@
 //! These kernels can leverage SIMD if available on your system.  Currently no runtime
 //! detection is provided, you should enable the specific SIMD intrinsics using
 //! `RUSTFLAGS="-C target-feature=+avx2"` for example.  See the documentation
-//! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
+//! [here] (https://doc.rust-lang.org/stable/std/arch/) for more information.
 
 use std::mem;
 use std::ops::{Add, Div, Mul, Sub};
 use std::slice::from_raw_parts_mut;
 use std::sync::Arc;
 
-use num::Zero;
+use num::{One, Zero};
 
 use crate::array::*;
+use crate::bitmap::Bitmap;
 use crate::buffer::MutableBuffer;
-use crate::compute::util::apply_bin_op_to_option_bitmap;
+use crate::compute::util::{
+    apply_bin_op_to_option_bitmap, simd_load_without_invalid_zeros,
+};
 use crate::datatypes;
 use crate::error::{ArrowError, Result};
 
@@ -121,6 +124,75 @@ where
     Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 
+/// SIMD vectorized version of `divide`, the divide kernel needs it's own implementation as there
+/// is a need to handle situations where a divide by `0` occurs.  This is complicated by `NULl`
+/// slots and padding.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn simd_divide<T>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+) -> Result<PrimitiveArray<T>>
+where
+    T: datatypes::ArrowNumericType,
+    T::Native: One + Zero,
+    T::Simd: Add<Output = T::Simd>
+        + Sub<Output = T::Simd>
+        + Mul<Output = T::Simd>
+        + Div<Output = T::Simd>,
+{
+    if left.len() != right.len() {
+        return Err(ArrowError::ComputeError(
+            "Cannot perform math operation on arrays of different length".to_string(),
+        ));
+    }
+
+    // Create the combined `Bitmap`
+    let null_bit_buffer = apply_bin_op_to_option_bitmap(
+        left.data().null_bitmap(),
+        right.data().null_bitmap(),
+        |a, b| a & b,
+    )?;
+    let bitmap = null_bit_buffer.map(Bitmap::from);
+
+    let lanes = T::lanes();
+    let buffer_size = left.len() * mem::size_of::<T::Native>();
+    let mut result = MutableBuffer::new(buffer_size).with_bitset(buffer_size, false);
+
+    for i in (0..left.len()).step_by(lanes) {
+        let right_no_invalid_zeros =
+            unsafe { simd_load_without_invalid_zeros(right, &bitmap, i, lanes) };
+        let is_zero = T::eq(T::init(T::Native::zero()), right_no_invalid_zeros);
+        if T::mask_any(is_zero) {
+            return Err(ArrowError::DivideByZero);
+        }
+        let right_no_invalid_zeros =
+            unsafe { simd_load_without_invalid_zeros(right, &bitmap, i, lanes) };
+        let simd_left = T::load(left.value_slice(i, lanes));
+        let simd_result = T::bin_op(simd_left, right_no_invalid_zeros, |a, b| a / b);
+
+        let result_slice: &mut [T::Native] = unsafe {
+            from_raw_parts_mut(
+                (result.data_mut().as_mut_ptr() as *mut T::Native).offset(i as isize),
+                lanes,
+            )
+        };
+        T::write(simd_result, result_slice);
+    }
+
+    let null_bit_buffer = bitmap.and_then(|b| Some(b.bits));
+
+    let data = ArrayData::new(
+        T::get_data_type(),
+        left.len(),
+        None,
+        null_bit_buffer,
+        left.offset(),
+        vec![result.freeze()],
+        vec![],
+    );
+    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
+}
+
 /// Perform `left + right` operation on two arrays. If either left or right value is null
 /// then the result is also null.
 pub fn add<T>(
@@ -197,8 +269,13 @@ where
         + Sub<Output = T::Native>
         + Mul<Output = T::Native>
         + Div<Output = T::Native>
-        + Zero,
+        + Zero
+        + One,
 {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    return simd_divide(&left, &right);
+
+    #[allow(unreachable_code)]
     math_op(left, right, |a, b| {
         if b.is_zero() {
             Err(ArrowError::DivideByZero)
@@ -272,6 +349,19 @@ mod tests {
         assert_eq!(1, c.value(2));
         assert_eq!(0, c.value(3));
         assert_eq!(9, c.value(4));
+    }
+
+    #[test]
+    fn test_primitive_array_divide_with_nulls() {
+        let a = Int32Array::from(vec![Some(15), None, Some(8), Some(1), Some(9), None]);
+        let b = Int32Array::from(vec![Some(5), Some(6), Some(8), Some(9), None, None]);
+        let c = divide(&a, &b).unwrap();
+        assert_eq!(3, c.value(0));
+        assert_eq!(true, c.is_null(1));
+        assert_eq!(1, c.value(2));
+        assert_eq!(0, c.value(3));
+        assert_eq!(true, c.is_null(4));
+        assert_eq!(true, c.is_null(5));
     }
 
     #[test]

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -22,9 +22,8 @@ use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
 use crate::datatypes::*;
 use crate::error::Result;
-use num::{One, Zero};
+use num::One;
 use std::cmp::min;
-use std::ops::{Add, Div, Mul, Sub};
 
 /// Applies a given binary operation, `op`, to two references to `Option<Bitmap>`'s.
 ///
@@ -130,6 +129,10 @@ where
 ///
 /// 'invalid' lanes are lanes where the corresponding array slots are either `NULL` or between the
 /// length and capacity of the array, i.e. in the padded region.
+///
+/// Note that the `array` below has it's own `Bitmap` separate from the `bitmap` argument.  This
+/// function is used to prepare `array`'s for binary operations.  The `bitmap` argument is the
+/// `Bitmap` after the binary operation.
 pub(super) unsafe fn simd_load_without_invalid_zeros<T>(
     array: &PrimitiveArray<T>,
     bitmap: &Option<Bitmap>,
@@ -138,11 +141,7 @@ pub(super) unsafe fn simd_load_without_invalid_zeros<T>(
 ) -> T::Simd
 where
     T: ArrowNumericType,
-    T::Native: One + Zero,
-    T::Simd: Add<Output = T::Simd>
-        + Sub<Output = T::Simd>
-        + Mul<Output = T::Simd>
-        + Div<Output = T::Simd>,
+    T::Native: One,
 {
     let simd_with_zeros = T::load(array.value_slice(i, simd_width));
     T::mask_select(

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -218,4 +218,31 @@ mod tests {
         .data();
         assert_eq!(data, indexed.data());
     }
+
+    #[test]
+    fn test_is_valid() {
+        let a = Int32Array::from(vec![
+            Some(15),
+            None,
+            None,
+            Some(1),
+            None,
+            None,
+            Some(5),
+            None,
+            None,
+            Some(4),
+        ]);
+        let simd_lanes = 16;
+        let data = a.data();
+        let bitmap = data.null_bitmap();
+        let result = unsafe { is_valid::<Int32Type>(&bitmap, 0, simd_lanes, a.len()) };
+        for i in 0..simd_lanes {
+            if i % 3 != 0 || i > 9 {
+                assert_eq!(false, result.extract(i));
+            } else {
+                assert_eq!(true, result.extract(i));
+            }
+        }
+    }
 }

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -245,4 +245,23 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_simd_load_without_invalid_zeros() {
+        let a = Int64Array::from(vec![None, Some(15), Some(5), Some(0)]);
+        let new_bitmap = &Some(Bitmap::from(Buffer::from([0b00001010])));
+        let simd_lanes = 8;
+        let result = unsafe {
+            simd_load_without_invalid_zeros::<Int64Type>(&a, &new_bitmap, 0, simd_lanes)
+        };
+        for i in 0..simd_lanes {
+            if i == 1 {
+                assert_eq!(15_i64, result.extract(i));
+            } else if i == 3 {
+                assert_eq!(0_i64, result.extract(i));
+            } else {
+                assert_eq!(1_i64, result.extract(i));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds SIMD support for divide binary op.  There are probably a few more optimizations to be made but the performance of divide is now very close to the other binary ops on my computer which is pretty good considering all the extra checking involved to allow for divide by zero correctly.

PTAL