### PR TITLE
ARROW-6126: [C++] Return error when an IPC stream terminates in the middle of receiving dictionaries

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -885,6 +885,9 @@ TEST(TestRecordBatchStreamReader, EmptyStreamWithDictionaries) {
   ASSERT_EQ(nullptr, batch);
 }
 
+// Delimit IPC stream messages and reassemble with the indicated messages
+// included. This way we can remove messages from an IPC stream to test
+// different failure modes or other difficult-to-test behaviors
 void SpliceMessages(std::shared_ptr<Buffer> stream,
                     const std::vector<int>& included_indices,
                     std::shared_ptr<Buffer>* spliced_stream) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -507,8 +507,8 @@ class RecordBatchStreamReader::RecordBatchStreamReaderImpl {
           empty_stream_ = true;
           break;
         } else {
-          // ARROW-6126, we can fail in two cases, either that record batches
-          // begin before
+          // ARROW-6126, the stream terminated before receiving the expected
+          // number of dictionaries
           return Status::Invalid("IPC stream ended without reading the expected number (",
                                  dictionary_memo_.num_fields(), ") of dictionaries");
         }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -498,19 +498,27 @@ class RecordBatchStreamReader::RecordBatchStreamReaderImpl {
     for (int i = 0; i < dictionary_memo_.num_fields(); ++i) {
       RETURN_NOT_OK(message_reader_->ReadNextMessage(&message));
       if (!message) {
-        /// ARROW-6006: If we fail to find any dictionaries in the stream, then
-        /// it may be that the stream has a schema but no actual data. In such
-        /// case we communicate that we were unable to find the dictionaries
-        /// (but there was no failure otherwise), so the caller can decide what
-        /// to do
-        empty_stream_ = true;
-        break;
+        if (i == 0) {
+          /// ARROW-6006: If we fail to find any dictionaries in the stream, then
+          /// it may be that the stream has a schema but no actual data. In such
+          /// case we communicate that we were unable to find the dictionaries
+          /// (but there was no failure otherwise), so the caller can decide what
+          /// to do
+          empty_stream_ = true;
+          break;
+        } else {
+          // ARROW-6126, we can fail in two cases, either that record batches
+          // begin before
+          return Status::Invalid("IPC stream ended without reading the expected number (",
+                                 dictionary_memo_.num_fields(), ") of dictionaries");
+        }
       }
 
       if (message->type() != Message::DICTIONARY_BATCH) {
-        return Status::Invalid(
-            "IPC stream did not find the expected number of "
-            "dictionaries at the start of the stream");
+        return Status::Invalid("IPC stream did not have the expected number (",
+                               dictionary_memo_.num_fields(),
+                               ") of dictionaries at "
+                               "the start of the stream");
       }
       RETURN_NOT_OK(ParseDictionary(*message));
     }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -517,8 +517,7 @@ class RecordBatchStreamReader::RecordBatchStreamReaderImpl {
       if (message->type() != Message::DICTIONARY_BATCH) {
         return Status::Invalid("IPC stream did not have the expected number (",
                                dictionary_memo_.num_fields(),
-                               ") of dictionaries at "
-                               "the start of the stream");
+                               ") of dictionaries at the start of the stream");
       }
       RETURN_NOT_OK(ParseDictionary(*message));
     }

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -391,6 +391,10 @@ ARROW_EXPORT
 Status GetRecordBatchPayload(const RecordBatch& batch, const IpcOptions& options,
                              MemoryPool* pool, IpcPayload* out);
 
+ARROW_EXPORT
+Status WriteIpcPayload(const IpcPayload& payload, io::OutputStream* dst,
+                       int32_t* metadata_length);
+
 }  // namespace internal
 
 }  // namespace ipc


### PR DESCRIPTION
The test case was a little bit tedious to construct, but we had a loophole where the two cases of:

* An empty stream with schema only and neither dictionaries nor record batches
* A stream with a schema and at least one dictionary batch, but insufficient to satisfy the schema

were considered to be the same. In the first case, we do not return any error (see ARROW-6006). In the second case we should return an error