### PR TITLE
ARROW-6178: [Developer] Keep prompting for authors in merge script for multi-author PRs if given bad input

### DIFF
--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -182,6 +182,25 @@ def test_jira_resolve_released_fix_version():
     assert fix_versions_json == [RAW_VERSION_JSON[-1]]
 
 
+def test_multiple_authors_bad_input():
+    a0 = 'Jimbob Crawfish <jimbob.crawfish@gmail.com>'
+    a1 = 'Jarvis McCratchett <jarvis.mccratchett@hotmail.com>'
+    a2 = 'Hank Miller <hank.miller@protonmail.com>'
+    distinct_authors = [a0, a1]
+
+    cmd = FakeCLI(responses=['oops', a1])
+    primary_author, new_distinct_authors = merge_arrow_pr.get_primary_author(
+        cmd, distinct_authors)
+    assert primary_author == a1
+    assert new_distinct_authors == [a1, a0]
+
+    cmd = FakeCLI(responses=[a2])
+    primary_author, new_distinct_authors = merge_arrow_pr.get_primary_author(
+        cmd, distinct_authors)
+    assert primary_author == a2
+    assert new_distinct_authors == [a2, a0, a1]
+
+
 def test_jira_already_resolved():
     status = FakeStatus('Resolved')
     fields = FakeFields(status, 'issue summary', FakeAssignee('groundhog'),


### PR DESCRIPTION
If you aren't paying attention in an multi-author PR and you enter "y" or similar, the script would crash and force you to have to do manual cleanup of the branches created by the merge script. 