### PR TITLE
ARROW-6227: [Python] Apply from_pandas option in pyarrow.array consistently across types

### DIFF
--- a/cpp/src/arrow/python/python_test.cc
+++ b/cpp/src/arrow/python/python_test.cc
@@ -426,10 +426,13 @@ TEST_F(DecimalTest, TestNoneAndNaN) {
   ASSERT_EQ(0, PyList_SetItem(list, 2, missing_value2));
   ASSERT_EQ(0, PyList_SetItem(list, 3, missing_value3));
 
-  std::shared_ptr<ChunkedArray> arr;
-  ASSERT_OK(ConvertPySequence(list, {}, &arr));
+  std::shared_ptr<ChunkedArray> arr, arr_from_pandas;
+  PyConversionOptions options;
+  ASSERT_RAISES(TypeError, ConvertPySequence(list, options, &arr));
 
-  auto c0 = arr->chunk(0);
+  options.from_pandas = true;
+  ASSERT_OK(ConvertPySequence(list, options, &arr_from_pandas));
+  auto c0 = arr_from_pandas->chunk(0);
   ASSERT_TRUE(c0->IsValid(0));
   ASSERT_TRUE(c0->IsNull(1));
   ASSERT_TRUE(c0->IsNull(2));

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -194,8 +194,7 @@ struct Unbox<DoubleType> {
 
 // We use CRTP to avoid virtual calls to the AppendItem(), AppendNull(), and
 // IsNull() on the hot path
-template <typename Type, class Derived,
-          NullCoding null_coding = NullCoding::PANDAS_SENTINELS>
+template <typename Type, class Derived, NullCoding null_coding = NullCoding::NONE_ONLY>
 class TypedConverter : public SeqConverter {
  public:
   using BuilderType = typename TypeTraits<Type>::BuilderType;
@@ -257,7 +256,9 @@ class TypedConverter : public SeqConverter {
 // ----------------------------------------------------------------------
 // Sequence converter for null type
 
-class NullConverter : public TypedConverter<NullType, NullConverter> {
+template <NullCoding null_coding>
+class NullConverter
+    : public TypedConverter<NullType, NullConverter<null_coding>, null_coding> {
  public:
   Status AppendItem(PyObject* obj) {
     return internal::InvalidValue(obj, "converting to null type");
@@ -267,13 +268,15 @@ class NullConverter : public TypedConverter<NullType, NullConverter> {
 // ----------------------------------------------------------------------
 // Sequence converter for boolean type
 
-class BoolConverter : public TypedConverter<BooleanType, BoolConverter> {
+template <NullCoding null_coding>
+class BoolConverter
+    : public TypedConverter<BooleanType, BoolConverter<null_coding>, null_coding> {
  public:
   Status AppendItem(PyObject* obj) {
     if (obj == Py_True) {
-      return typed_builder_->Append(true);
+      return this->typed_builder_->Append(true);
     } else if (obj == Py_False) {
-      return typed_builder_->Append(false);
+      return this->typed_builder_->Append(false);
     } else {
       return internal::InvalidValue(obj, "tried to convert to boolean");
     }
@@ -290,7 +293,9 @@ class NumericConverter
 // ----------------------------------------------------------------------
 // Sequence converters for temporal types
 
-class Date32Converter : public TypedConverter<Date32Type, Date32Converter> {
+template <NullCoding null_coding>
+class Date32Converter
+    : public TypedConverter<Date32Type, Date32Converter<null_coding>, null_coding> {
  public:
   Status AppendItem(PyObject* obj) {
     int32_t t;
@@ -300,11 +305,13 @@ class Date32Converter : public TypedConverter<Date32Type, Date32Converter> {
     } else {
       RETURN_NOT_OK(internal::CIntFromPython(obj, &t, "Integer too large for date32"));
     }
-    return typed_builder_->Append(t);
+    return this->typed_builder_->Append(t);
   }
 };
 
-class Date64Converter : public TypedConverter<Date64Type, Date64Converter> {
+template <NullCoding null_coding>
+class Date64Converter
+    : public TypedConverter<Date64Type, Date64Converter<null_coding>, null_coding> {
  public:
   Status AppendItem(PyObject* obj) {
     int64_t t;
@@ -314,11 +321,13 @@ class Date64Converter : public TypedConverter<Date64Type, Date64Converter> {
     } else {
       RETURN_NOT_OK(internal::CIntFromPython(obj, &t, "Integer too large for date64"));
     }
-    return typed_builder_->Append(t);
+    return this->typed_builder_->Append(t);
   }
 };
 
-class Time32Converter : public TypedConverter<Time32Type, Time32Converter> {
+template <NullCoding null_coding>
+class Time32Converter
+    : public TypedConverter<Time32Type, Time32Converter<null_coding>, null_coding> {
  public:
   explicit Time32Converter(TimeUnit::type unit) : unit_(unit) {}
 
@@ -337,7 +346,7 @@ class Time32Converter : public TypedConverter<Time32Type, Time32Converter> {
         default:
           return Status::UnknownError("Invalid time unit");
       }
-      return typed_builder_->Append(t);
+      return this->typed_builder_->Append(t);
     } else {
       return internal::InvalidValue(obj, "converting to time32");
     }
@@ -347,7 +356,9 @@ class Time32Converter : public TypedConverter<Time32Type, Time32Converter> {
   TimeUnit::type unit_;
 };
 
-class Time64Converter : public TypedConverter<Time64Type, Time64Converter> {
+template <NullCoding null_coding>
+class Time64Converter
+    : public TypedConverter<Time64Type, Time64Converter<null_coding>, null_coding> {
  public:
   explicit Time64Converter(TimeUnit::type unit) : unit_(unit) {}
 
@@ -365,7 +376,7 @@ class Time64Converter : public TypedConverter<Time64Type, Time64Converter> {
         default:
           return Status::UnknownError("Invalid time unit");
       }
-      return typed_builder_->Append(t);
+      return this->typed_builder_->Append(t);
     } else {
       return internal::InvalidValue(obj, "converting to time64");
     }
@@ -375,7 +386,9 @@ class Time64Converter : public TypedConverter<Time64Type, Time64Converter> {
   TimeUnit::type unit_;
 };
 
-class TimestampConverter : public TypedConverter<TimestampType, TimestampConverter> {
+template <NullCoding null_coding>
+class TimestampConverter
+    : public TypedConverter<TimestampType, TimestampConverter<null_coding>, null_coding> {
  public:
   explicit TimestampConverter(TimeUnit::type unit) : unit_(unit) {}
 
@@ -418,12 +431,12 @@ class TimestampConverter : public TypedConverter<TimestampType, TimestampConvert
       t = reinterpret_cast<PyDatetimeScalarObject*>(obj)->obval;
       if (traits::isnull(t)) {
         // checks numpy NaT sentinel after conversion
-        return typed_builder_->AppendNull();
+        return this->typed_builder_->AppendNull();
       }
     } else {
       RETURN_NOT_OK(internal::CIntFromPython(obj, &t));
     }
-    return typed_builder_->Append(t);
+    return this->typed_builder_->Append(t);
   }
 
  private:
@@ -482,8 +495,9 @@ inline Status BuilderAppend(FixedSizeBinaryBuilder* builder, PyObject* obj,
 
 }  // namespace detail
 
-template <typename Type>
-class BinaryLikeConverter : public TypedConverter<Type, BinaryLikeConverter<Type>> {
+template <typename Type, NullCoding null_coding>
+class BinaryLikeConverter
+    : public TypedConverter<Type, BinaryLikeConverter<Type, null_coding>, null_coding> {
  public:
   Status AppendItem(PyObject* obj) {
     // Accessing members of the templated base requires using this-> here
@@ -503,17 +517,22 @@ class BinaryLikeConverter : public TypedConverter<Type, BinaryLikeConverter<Type
   }
 };
 
-class BytesConverter : public BinaryLikeConverter<BinaryType> {};
+template <NullCoding null_coding>
+class BytesConverter : public BinaryLikeConverter<BinaryType, null_coding> {};
 
-class LargeBytesConverter : public BinaryLikeConverter<LargeBinaryType> {};
+template <NullCoding null_coding>
+class LargeBytesConverter : public BinaryLikeConverter<LargeBinaryType, null_coding> {};
 
-class FixedWidthBytesConverter : public BinaryLikeConverter<FixedSizeBinaryType> {};
+template <NullCoding null_coding>
+class FixedWidthBytesConverter
+    : public BinaryLikeConverter<FixedSizeBinaryType, null_coding> {};
 
 // For String/UTF8, if strict_conversions enabled, we reject any non-UTF8,
 // otherwise we allow but return results as BinaryArray
-template <typename TypeClass, bool STRICT>
+template <typename TypeClass, bool STRICT, NullCoding null_coding>
 class StringConverter
-    : public TypedConverter<TypeClass, StringConverter<TypeClass, STRICT>> {
+    : public TypedConverter<TypeClass, StringConverter<TypeClass, STRICT, null_coding>,
+                            null_coding> {
  public:
   StringConverter() : binary_count_(0) {}
 
@@ -838,45 +857,44 @@ class StructConverter : public TypedConverter<StructType, StructConverter> {
   bool strict_conversions_;
 };
 
-class DecimalConverter : public TypedConverter<arrow::Decimal128Type, DecimalConverter> {
+template <NullCoding null_coding>
+class DecimalConverter
+    : public TypedConverter<arrow::Decimal128Type, DecimalConverter<null_coding>,
+                            null_coding> {
  public:
-  using BASE = TypedConverter<arrow::Decimal128Type, DecimalConverter>;
+  using BASE =
+      TypedConverter<arrow::Decimal128Type, DecimalConverter<null_coding>, null_coding>;
 
   Status Init(ArrayBuilder* builder) override {
     RETURN_NOT_OK(BASE::Init(builder));
-    decimal_type_ = checked_cast<const DecimalType*>(typed_builder_->type().get());
+    decimal_type_ = checked_cast<const DecimalType*>(this->typed_builder_->type().get());
     return Status::OK();
   }
 
   Status AppendItem(PyObject* obj) {
     Decimal128 value;
     RETURN_NOT_OK(internal::DecimalFromPyObject(obj, *decimal_type_, &value));
-    return typed_builder_->Append(value);
+    return this->typed_builder_->Append(value);
   }
 
  private:
   const DecimalType* decimal_type_ = nullptr;
 };
 
-#define NUMERIC_CONVERTER(TYPE_ENUM, TYPE)                           \
-  case Type::TYPE_ENUM:                                              \
-    if (from_pandas) {                                               \
-      *out = std::unique_ptr<SeqConverter>(                          \
-          new NumericConverter<TYPE, NullCoding::PANDAS_SENTINELS>); \
-    } else {                                                         \
-      *out = std::unique_ptr<SeqConverter>(                          \
-          new NumericConverter<TYPE, NullCoding::NONE_ONLY>);        \
-    }                                                                \
+#define NUMERIC_CONVERTER(TYPE_ENUM, TYPE)                                         \
+  case Type::TYPE_ENUM:                                                            \
+    *out = std::unique_ptr<SeqConverter>(new NumericConverter<TYPE, null_coding>); \
     break;
 
-#define SIMPLE_CONVERTER_CASE(TYPE_ENUM, TYPE_CLASS)      \
-  case Type::TYPE_ENUM:                                   \
-    *out = std::unique_ptr<SeqConverter>(new TYPE_CLASS); \
+#define SIMPLE_CONVERTER_CASE(TYPE_ENUM, TYPE_CLASS)                   \
+  case Type::TYPE_ENUM:                                                \
+    *out = std::unique_ptr<SeqConverter>(new TYPE_CLASS<null_coding>); \
     break;
 
 // Dynamic constructor for sequence converters
-Status GetConverter(const std::shared_ptr<DataType>& type, bool from_pandas,
-                    bool strict_conversions, std::unique_ptr<SeqConverter>* out) {
+template <NullCoding null_coding>
+Status GetConverterFlat(const std::shared_ptr<DataType>& type, bool strict_conversions,
+                        std::unique_ptr<SeqConverter>* out) {
   switch (type->id()) {
     SIMPLE_CONVERTER_CASE(NA, NullConverter);
     SIMPLE_CONVERTER_CASE(BOOL, BoolConverter);
@@ -899,50 +917,68 @@ Status GetConverter(const std::shared_ptr<DataType>& type, bool from_pandas,
     SIMPLE_CONVERTER_CASE(DATE64, Date64Converter);
     case Type::STRING:
       if (strict_conversions) {
-        *out = std::unique_ptr<SeqConverter>(new StringConverter<StringType, true>());
+        *out = std::unique_ptr<SeqConverter>(
+            new StringConverter<StringType, true, null_coding>());
       } else {
-        *out = std::unique_ptr<SeqConverter>(new StringConverter<StringType, false>());
+        *out = std::unique_ptr<SeqConverter>(
+            new StringConverter<StringType, false, null_coding>());
       }
       break;
     case Type::LARGE_STRING:
       if (strict_conversions) {
-        *out =
-            std::unique_ptr<SeqConverter>(new StringConverter<LargeStringType, true>());
+        *out = std::unique_ptr<SeqConverter>(
+            new StringConverter<LargeStringType, true, null_coding>());
       } else {
-        *out =
-            std::unique_ptr<SeqConverter>(new StringConverter<LargeStringType, false>());
+        *out = std::unique_ptr<SeqConverter>(
+            new StringConverter<LargeStringType, false, null_coding>());
       }
       break;
     case Type::TIME32: {
-      *out = std::unique_ptr<SeqConverter>(
-          new Time32Converter(checked_cast<const Time32Type&>(*type).unit()));
+      *out = std::unique_ptr<SeqConverter>(new Time32Converter<null_coding>(
+          checked_cast<const Time32Type&>(*type).unit()));
       break;
     }
     case Type::TIME64: {
-      *out = std::unique_ptr<SeqConverter>(
-          new Time64Converter(checked_cast<const Time64Type&>(*type).unit()));
+      *out = std::unique_ptr<SeqConverter>(new Time64Converter<null_coding>(
+          checked_cast<const Time64Type&>(*type).unit()));
       break;
     }
     case Type::TIMESTAMP: {
-      *out = std::unique_ptr<SeqConverter>(
-          new TimestampConverter(checked_cast<const TimestampType&>(*type).unit()));
+      *out = std::unique_ptr<SeqConverter>(new TimestampConverter<null_coding>(
+          checked_cast<const TimestampType&>(*type).unit()));
       break;
     }
-    case Type::LIST:
-      *out = std::unique_ptr<SeqConverter>(
-          new ListConverter<ListType>(from_pandas, strict_conversions));
-      break;
-    case Type::LARGE_LIST:
-      *out = std::unique_ptr<SeqConverter>(
-          new ListConverter<LargeListType>(from_pandas, strict_conversions));
-      break;
-    case Type::STRUCT:
-      *out = std::unique_ptr<SeqConverter>(
-          new StructConverter(from_pandas, strict_conversions));
-      break;
     default:
       return Status::NotImplemented("Sequence converter for type ", type->ToString(),
                                     " not implemented");
+  }
+  return Status::OK();
+}
+
+Status GetConverter(const std::shared_ptr<DataType>& type, bool from_pandas,
+                    bool strict_conversions, std::unique_ptr<SeqConverter>* out) {
+  switch (type->id()) {
+    case Type::LIST:
+      *out = std::unique_ptr<SeqConverter>(
+          new ListConverter<ListType>(from_pandas, strict_conversions));
+      return Status::OK();
+    case Type::LARGE_LIST:
+      *out = std::unique_ptr<SeqConverter>(
+          new ListConverter<LargeListType>(from_pandas, strict_conversions));
+      return Status::OK();
+    case Type::STRUCT:
+      *out = std::unique_ptr<SeqConverter>(
+          new StructConverter(from_pandas, strict_conversions));
+      return Status::OK();
+    default:
+      break;
+  }
+
+  if (from_pandas) {
+    RETURN_NOT_OK(
+        GetConverterFlat<NullCoding::PANDAS_SENTINELS>(type, strict_conversions, out));
+  } else {
+    RETURN_NOT_OK(GetConverterFlat<NullCoding::NONE_ONLY>(type, strict_conversions, out));
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -346,10 +346,10 @@ class Time32Converter
         default:
           return Status::UnknownError("Invalid time unit");
       }
-      return this->typed_builder_->Append(t);
     } else {
-      return internal::InvalidValue(obj, "converting to time32");
+      RETURN_NOT_OK(internal::CIntFromPython(obj, &t, "Integer too large for int32"));
     }
+    return this->typed_builder_->Append(t);
   }
 
  private:
@@ -376,10 +376,10 @@ class Time64Converter
         default:
           return Status::UnknownError("Invalid time unit");
       }
-      return this->typed_builder_->Append(t);
     } else {
-      return internal::InvalidValue(obj, "converting to time64");
+      RETURN_NOT_OK(internal::CIntFromPython(obj, &t, "Integer too large for int64"));
     }
+    return this->typed_builder_->Append(t);
   }
 
  private:
@@ -1056,13 +1056,6 @@ Status ConvertPySequence(PyObject* sequence_source, PyObject* mask,
     strict_conversions = true;
   }
   DCHECK_GE(size, 0);
-
-  // Handle NA / NullType case
-  if (real_type->id() == Type::NA) {
-    ArrayVector chunks = {std::make_shared<NullArray>(size)};
-    *out = std::make_shared<ChunkedArray>(chunks);
-    return Status::OK();
-  }
 
   // Create the sequence converter, initialize with the builder
   std::unique_ptr<SeqConverter> converter;

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1046,6 +1046,21 @@ def test_array_conversions_no_sentinel_values():
     assert arr3.null_count == 0
 
 
+def test_binary_string_pandas_null_sentinels():
+    def _check_case(ty):
+        with pytest.raises(TypeError):
+            # NaN is a float by default
+            pa.array(['string', np.nan], type=ty)
+
+        arr = pa.array(['string', np.nan], type=ty, from_pandas=True)
+        expected = pa.array(['string', None], type=ty)
+        assert arr.equals(expected)
+
+    _check_case(None)
+    _check_case('binary')
+    _check_case('utf8')
+
+
 def test_array_from_numpy_datetimeD():
     arr = np.array([None, datetime.date(2017, 4, 4)], dtype='datetime64[D]')
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import datetime
+import decimal
 import hypothesis as h
 import hypothesis.strategies as st
 import itertools
@@ -1046,6 +1047,33 @@ def test_array_conversions_no_sentinel_values():
     assert arr3.null_count == 0
 
 
+def test_time32_time64_from_integer():
+    # ARROW-4111
+    result = pa.array([1, 2, None], type=pa.time32('s'))
+    expected = pa.array([datetime.time(second=1),
+                         datetime.time(second=2), None],
+                        type=pa.time32('s'))
+    assert result.equals(expected)
+
+    result = pa.array([1, 2, None], type=pa.time32('ms'))
+    expected = pa.array([datetime.time(microsecond=1000),
+                         datetime.time(microsecond=2000), None],
+                        type=pa.time32('ms'))
+    assert result.equals(expected)
+
+    result = pa.array([1, 2, None], type=pa.time64('us'))
+    expected = pa.array([datetime.time(microsecond=1),
+                         datetime.time(microsecond=2), None],
+                        type=pa.time64('us'))
+    assert result.equals(expected)
+
+    result = pa.array([1000, 2000, None], type=pa.time64('ns'))
+    expected = pa.array([datetime.time(microsecond=1),
+                         datetime.time(microsecond=2), None],
+                        type=pa.time64('ns'))
+    assert result.equals(expected)
+
+
 def test_binary_string_pandas_null_sentinels():
     # ARROW-6227
     def _check_case(ty):
@@ -1066,6 +1094,8 @@ def test_pandas_null_sentinels_raise_error():
         (['string', np.nan], 'large_utf8'),
         ([b'string', np.nan], pa.binary(6)),
         ([True, np.nan], pa.bool_()),
+        ([decimal.Decimal('0'), np.nan], pa.decimal128(12, 2)),
+        ([0, np.nan], pa.date32()),
         ([0, np.nan], pa.date32()),
         ([0, np.nan], pa.date64()),
         ([0, np.nan], pa.time32('s')),

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1219,11 +1219,16 @@ def test_structarray_from_arrays_coerce():
 
 def test_decimal_array_with_none_and_nan():
     values = [decimal.Decimal('1.234'), None, np.nan, decimal.Decimal('nan')]
-    array = pa.array(values)
+
+    with pytest.raises(TypeError):
+        # ARROW-6227: Without from_pandas=True, NaN is considered a float
+        array = pa.array(values)
+
+    array = pa.array(values, from_pandas=True)
     assert array.type == pa.decimal128(4, 3)
     assert array.to_pylist() == values[:2] + [None, None]
 
-    array = pa.array(values, type=pa.decimal128(10, 4))
+    array = pa.array(values, type=pa.decimal128(10, 4), from_pandas=True)
     assert array.to_pylist() == [decimal.Decimal('1.2340'), None, None, None]
 
 


### PR DESCRIPTION
Many sequence converters were not using the `from_pandas` option in `pyarrow.array` (which is `False` by default), so `NaN` and other pandas null sentinel values were being silently converted to Arrow null. For example as in the original report `pyarrow.array(['string', np.nan])` would return an array with 1 null. This is definitely not good.

I made an effort to apply this consistently where it wasn't being applied and add appropriate unit tests. 

Some notes:

* We don't consistently raise TypeError or ValueError on mixed type input. For example

```
In [4]: pa.array(['string', np.nan])
TypeError
In [7]: pa.array([0, np.nan], type=pa.time32('s')) 
ValueError
```

* We weren't handling integer inputs for time32/time64 types (see ARROW-4111). That's fixed and tested in passing here (though not for correctness...) 