### PR TITLE
ARROW-6296: [Java] Cleanup JDBC interfaces and eliminate one memcopy for binary/varchar fields

### DIFF
--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -76,6 +76,12 @@
             <version>${dep.jackson.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>	

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -360,13 +360,20 @@ public class JdbcToArrowUtils {
           root.getVector(rsmd.getColumnName(i)), config);
     }
 
-    try (CompositeJdbcConsumer compositeConsumer = new CompositeJdbcConsumer(consumers)) {
+    CompositeJdbcConsumer compositeConsumer = null;
+    try {
+      compositeConsumer = new CompositeJdbcConsumer(consumers);
       int readRowCount = 0;
       while (rs.next()) {
         compositeConsumer.consume(rs);
         readRowCount++;
       }
       root.setRowCount(readRowCount);
+    } catch (Exception e) {
+      // error occurs and clean up resources.
+      if (compositeConsumer != null) {
+        compositeConsumer.close();
+      }
     }
   }
 
@@ -421,8 +428,8 @@ public class JdbcToArrowUtils {
       case Types.CLOB:
         return new ClobConsumer((VarCharVector) vector, columnIndex);
       case Types.BLOB:
-        BinaryConsumer delegateConsumer = new BinaryConsumer((VarBinaryVector) vector, columnIndex);
-        return new BlobConsumer(delegateConsumer, columnIndex);
+        BinaryConsumer blobDelegate = new BinaryConsumer((VarBinaryVector) vector, columnIndex);
+        return new BlobConsumer(blobDelegate, columnIndex);
       default:
         // no-op, shouldn't get here
         throw new UnsupportedOperationException();

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -361,6 +361,8 @@ public class JdbcToArrowUtils {
     }
 
     CompositeJdbcConsumer compositeConsumer = null;
+    // Only clean resources when occurs error,
+    // vectors within consumers are useful and users are responsible for its close.
     try {
       compositeConsumer = new CompositeJdbcConsumer(consumers);
       int readRowCount = 0;

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
@@ -22,7 +22,6 @@ import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.complex.ListVector;
 
 /**
@@ -35,6 +34,7 @@ public class ArrayConsumer implements JdbcConsumer<ListVector> {
   private final int columnIndexInResultSet;
 
   private ListVector vector;
+  private int currentIndex;
 
   /**
    * Instantiate a ArrayConsumer.
@@ -48,10 +48,9 @@ public class ArrayConsumer implements JdbcConsumer<ListVector> {
   @Override
   public void consume(ResultSet resultSet) throws SQLException, IOException {
     final Array array = resultSet.getArray(columnIndexInResultSet);
-    int idx = vector.getValueCount();
     if (!resultSet.wasNull()) {
 
-      vector.startNewValue(idx);
+      vector.startNewValue(currentIndex);
       int count = 0;
       try (ResultSet rs = array.getResultSet()) {
         while (rs.next()) {
@@ -59,11 +58,9 @@ public class ArrayConsumer implements JdbcConsumer<ListVector> {
           count++;
         }
       }
-      int end = vector.getOffsetBuffer().getInt(idx * 4) + count;
-      vector.getOffsetBuffer().setInt((idx + 1) * 4, end);
-      BitVectorHelper.setValidityBitToOne(vector.getValidityBuffer(), vector.getValueCount());
+      vector.endValue(currentIndex, count);
     }
-    vector.setValueCount(idx + 1);
+    currentIndex++;
   }
 
   @Override
@@ -75,5 +72,6 @@ public class ArrayConsumer implements JdbcConsumer<ListVector> {
   @Override
   public void resetValueVector(ListVector vector) {
     this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
@@ -67,6 +67,12 @@ public class ArrayConsumer implements JdbcConsumer<ListVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    this.vector.close();
+    this.delegate.close();
+  }
+
+  @Override
   public void resetValueVector(ListVector vector) {
     this.vector = vector;
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
@@ -51,6 +51,11 @@ public class BigIntConsumer implements JdbcConsumer<BigIntVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    this.writer.close();
+  }
+
+  @Override
   public void resetValueVector(BigIntVector vector) {
     this.writer = new BigIntWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.BigIntVector;
-import org.apache.arrow.vector.complex.impl.BigIntWriterImpl;
-import org.apache.arrow.vector.complex.writer.BigIntWriter;
 
 /**
  * Consumer which consume bigint type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.BigIntWriter;
  */
 public class BigIntConsumer implements JdbcConsumer<BigIntVector> {
 
-  private BigIntWriter writer;
+  private BigIntVector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a BigIntConsumer.
    */
   public BigIntConsumer(BigIntVector vector, int index) {
-    this.writer = new BigIntWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class BigIntConsumer implements JdbcConsumer<BigIntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     long value = resultSet.getLong(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeBigInt(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    this.writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(BigIntVector vector) {
-    this.writer = new BigIntWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumer.java
@@ -63,7 +63,7 @@ public class BinaryConsumer implements JdbcConsumer<VarBinaryVector> {
       ArrowBuf offsetBuffer = vector.getOffsetBuffer();
       int startIndex = offsetBuffer.getInt(currentIndex * 4);
       while ((read = is.read(bytes)) != -1) {
-        if ((dataBuffer.writerIndex() + read) > dataBuffer.capacity()) {
+        while ((dataBuffer.writerIndex() + read) > dataBuffer.capacity()) {
           vector.reallocDataBuffer();
         }
         PlatformDependent.copyMemory(bytes, 0,

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
@@ -51,6 +51,11 @@ public class BitConsumer implements JdbcConsumer<BitVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    this.writer.close();
+  }
+
+  @Override
   public void resetValueVector(BitVector vector) {
     this.writer = new BitWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.BitVector;
-import org.apache.arrow.vector.complex.impl.BitWriterImpl;
-import org.apache.arrow.vector.complex.writer.BitWriter;
 
 /**
  * Consumer which consume bit type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.BitWriter;
  */
 public class BitConsumer implements JdbcConsumer<BitVector> {
 
-  private BitWriter writer;
+  private BitVector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a BitConsumer.
    */
   public BitConsumer(BitVector vector, int index) {
-    this.writer = new BitWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class BitConsumer implements JdbcConsumer<BitVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     boolean value = resultSet.getBoolean(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeBit(value ? 1 : 0);
+      vector.setSafe(currentIndex++, value ? 1 : 0);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    this.writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(BitVector vector) {
-    this.writer = new BitWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BlobConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BlobConsumer.java
@@ -52,7 +52,7 @@ public class BlobConsumer implements JdbcConsumer<VarBinaryVector> {
   }
 
   @Override
-  public void close() {
+  public void close() throws Exception {
     delegate.close();
   }
 

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ClobConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ClobConsumer.java
@@ -67,7 +67,7 @@ public class ClobConsumer implements JdbcConsumer<VarCharVector> {
           String str = clob.getSubString(read, readSize);
           byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
 
-          if ((dataBuffer.writerIndex() + bytes.length) > dataBuffer.capacity()) {
+          while ((dataBuffer.writerIndex() + bytes.length) > dataBuffer.capacity()) {
             vector.reallocDataBuffer();
           }
           PlatformDependent.copyMemory(bytes, 0,

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.ValueVector;
 
 /**
@@ -47,13 +48,12 @@ public class CompositeJdbcConsumer implements JdbcConsumer {
 
   @Override
   public void close() {
+
     try {
       // clean up
-      for (JdbcConsumer consumer : consumers) {
-        consumer.close();
-      }
+      AutoCloseables.close(consumers);
     } catch (Exception e) {
-      throw new RuntimeException("Error occurs while releasing resources.", e);
+      throw new RuntimeException("Error occured while releasing resources.", e);
     }
 
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/CompositeJdbcConsumer.java
@@ -47,10 +47,15 @@ public class CompositeJdbcConsumer implements JdbcConsumer {
 
   @Override
   public void close() {
-    // clean up
-    for (JdbcConsumer consumer : consumers) {
-      consumer.close();
+    try {
+      // clean up
+      for (JdbcConsumer consumer : consumers) {
+        consumer.close();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Error occurs while releasing resources.", e);
     }
+
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
@@ -63,6 +63,11 @@ public class DateConsumer implements JdbcConsumer<DateMilliVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    this.writer.close();
+  }
+
+  @Override
   public void resetValueVector(DateMilliVector vector) {
     this.writer = new DateMilliWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
@@ -23,8 +23,6 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.apache.arrow.vector.DateMilliVector;
-import org.apache.arrow.vector.complex.impl.DateMilliWriterImpl;
-import org.apache.arrow.vector.complex.writer.DateMilliWriter;
 
 /**
  * Consumer which consume date type values from {@link ResultSet}.
@@ -32,9 +30,11 @@ import org.apache.arrow.vector.complex.writer.DateMilliWriter;
  */
 public class DateConsumer implements JdbcConsumer<DateMilliVector> {
 
-  private DateMilliWriter writer;
+  private DateMilliVector vector;
   private final int columnIndexInResultSet;
   private final Calendar calendar;
+
+  private int currentIndex;
 
   /**
    * Instantiate a DateConsumer.
@@ -47,7 +47,7 @@ public class DateConsumer implements JdbcConsumer<DateMilliVector> {
    * Instantiate a DateConsumer.
    */
   public DateConsumer(DateMilliVector vector, int index, Calendar calendar) {
-    this.writer = new DateMilliWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
     this.calendar = calendar;
   }
@@ -57,18 +57,18 @@ public class DateConsumer implements JdbcConsumer<DateMilliVector> {
     Date date = calendar == null ? resultSet.getDate(columnIndexInResultSet) :
         resultSet.getDate(columnIndexInResultSet, calendar);
     if (!resultSet.wasNull()) {
-      writer.writeDateMilli(date.getTime());
+      vector.setSafe(currentIndex++, date.getTime());
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    this.writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(DateMilliVector vector) {
-    this.writer = new DateMilliWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
@@ -52,6 +52,11 @@ public class DecimalConsumer implements JdbcConsumer<DecimalVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    this.writer.close();
+  }
+
+  @Override
   public void resetValueVector(DecimalVector vector) {
     this.writer = new DecimalWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
@@ -22,8 +22,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.DecimalVector;
-import org.apache.arrow.vector.complex.impl.DecimalWriterImpl;
-import org.apache.arrow.vector.complex.writer.DecimalWriter;
 
 /**
  * Consumer which consume decimal type values from {@link ResultSet}.
@@ -31,14 +29,16 @@ import org.apache.arrow.vector.complex.writer.DecimalWriter;
  */
 public class DecimalConsumer implements JdbcConsumer<DecimalVector> {
 
-  private DecimalWriter writer;
+  private DecimalVector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a DecimalConsumer.
    */
   public DecimalConsumer(DecimalVector vector, int index) {
-    this.writer = new DecimalWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -46,18 +46,18 @@ public class DecimalConsumer implements JdbcConsumer<DecimalVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeDecimal(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    this.writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(DecimalVector vector) {
-    this.writer = new DecimalWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
@@ -51,6 +51,11 @@ public class DoubleConsumer implements JdbcConsumer<Float8Vector> {
   }
 
   @Override
+  public void close() throws Exception {
+    this.writer.close();
+  }
+
+  @Override
   public void resetValueVector(Float8Vector vector) {
     this.writer = new Float8WriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.Float8Vector;
-import org.apache.arrow.vector.complex.impl.Float8WriterImpl;
-import org.apache.arrow.vector.complex.writer.Float8Writer;
 
 /**
  * Consumer which consume double type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.Float8Writer;
  */
 public class DoubleConsumer implements JdbcConsumer<Float8Vector> {
 
-  private Float8Writer writer;
+  private Float8Vector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a DoubleConsumer.
    */
   public DoubleConsumer(Float8Vector vector, int index) {
-    this.writer = new Float8WriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class DoubleConsumer implements JdbcConsumer<Float8Vector> {
   public void consume(ResultSet resultSet) throws SQLException {
     double value = resultSet.getDouble(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeFloat8(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    this.writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(Float8Vector vector) {
-    this.writer = new Float8WriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
@@ -51,6 +51,11 @@ public class FloatConsumer implements JdbcConsumer<Float4Vector> {
   }
 
   @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
+  @Override
   public void resetValueVector(Float4Vector vector) {
     this.writer = new Float4WriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.Float4Vector;
-import org.apache.arrow.vector.complex.impl.Float4WriterImpl;
-import org.apache.arrow.vector.complex.writer.Float4Writer;
 
 /**
  * Consumer which consume float type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.Float4Writer;
  */
 public class FloatConsumer implements JdbcConsumer<Float4Vector> {
 
-  private Float4Writer writer;
+  private Float4Vector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a FloatConsumer.
    */
   public FloatConsumer(Float4Vector vector, int index) {
-    this.writer = new Float4WriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class FloatConsumer implements JdbcConsumer<Float4Vector> {
   public void consume(ResultSet resultSet) throws SQLException {
     float value = resultSet.getFloat(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeFloat4(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(Float4Vector vector) {
-    this.writer = new Float4WriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
@@ -51,6 +51,11 @@ public class IntConsumer implements JdbcConsumer<IntVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
+  @Override
   public void resetValueVector(IntVector vector) {
     this.writer = new IntWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.IntVector;
-import org.apache.arrow.vector.complex.impl.IntWriterImpl;
-import org.apache.arrow.vector.complex.writer.IntWriter;
 
 /**
  * Consumer which consume int type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.IntWriter;
  */
 public class IntConsumer implements JdbcConsumer<IntVector> {
 
-  private IntWriter writer;
+  private IntVector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a IntConsumer.
    */
   public IntConsumer(IntVector vector, int index) {
-    this.writer = new IntWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class IntConsumer implements JdbcConsumer<IntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     int value = resultSet.getInt(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeInt(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(IntVector vector) {
-    this.writer = new IntWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/JdbcConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/JdbcConsumer.java
@@ -37,7 +37,7 @@ public interface JdbcConsumer<T extends ValueVector> extends AutoCloseable {
   /**
    * Close this consumer, do some clean work such as clear reuse ArrowBuf.
    */
-  default void close() {}
+  void close() throws Exception;
 
   /**
    * Reset the vector within consumer for partial read purpose.

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.SmallIntVector;
-import org.apache.arrow.vector.complex.impl.SmallIntWriterImpl;
-import org.apache.arrow.vector.complex.writer.SmallIntWriter;
 
 /**
  * Consumer which consume smallInt type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.SmallIntWriter;
  */
 public class SmallIntConsumer implements JdbcConsumer<SmallIntVector> {
 
-  private SmallIntWriter writer;
+  private SmallIntVector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a SmallIntConsumer.
    */
   public SmallIntConsumer(SmallIntVector vector, int index) {
-    this.writer = new SmallIntWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class SmallIntConsumer implements JdbcConsumer<SmallIntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     short value = resultSet.getShort(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeSmallInt(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(SmallIntVector vector) {
-    this.writer = new SmallIntWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
@@ -51,6 +51,11 @@ public class SmallIntConsumer implements JdbcConsumer<SmallIntVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
+  @Override
   public void resetValueVector(SmallIntVector vector) {
     this.writer = new SmallIntWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
@@ -63,6 +63,11 @@ public class TimeConsumer implements JdbcConsumer<TimeMilliVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
+  @Override
   public void resetValueVector(TimeMilliVector vector) {
     this.writer = new TimeMilliWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
@@ -23,8 +23,6 @@ import java.sql.Time;
 import java.util.Calendar;
 
 import org.apache.arrow.vector.TimeMilliVector;
-import org.apache.arrow.vector.complex.impl.TimeMilliWriterImpl;
-import org.apache.arrow.vector.complex.writer.TimeMilliWriter;
 
 /**
  * Consumer which consume time type values from {@link ResultSet}.
@@ -32,9 +30,11 @@ import org.apache.arrow.vector.complex.writer.TimeMilliWriter;
  */
 public class TimeConsumer implements JdbcConsumer<TimeMilliVector> {
 
-  private TimeMilliWriter writer;
+  private TimeMilliVector vector;
   private final int columnIndexInResultSet;
   private final Calendar calendar;
+
+  private int currentIndex;
 
   /**
    * Instantiate a TimeConsumer.
@@ -47,7 +47,7 @@ public class TimeConsumer implements JdbcConsumer<TimeMilliVector> {
    * Instantiate a TimeConsumer.
    */
   public TimeConsumer(TimeMilliVector vector, int index, Calendar calendar) {
-    this.writer = new TimeMilliWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
     this.calendar = calendar;
   }
@@ -57,18 +57,18 @@ public class TimeConsumer implements JdbcConsumer<TimeMilliVector> {
     Time time = calendar == null ? resultSet.getTime(columnIndexInResultSet) :
         resultSet.getTime(columnIndexInResultSet, calendar);
     if (!resultSet.wasNull()) {
-      writer.writeTimeMilli((int) time.getTime());
+      vector.setSafe(currentIndex++, (int) time.getTime());
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(TimeMilliVector vector) {
-    this.writer = new TimeMilliWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
@@ -23,8 +23,6 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 
 import org.apache.arrow.vector.TimeStampMilliTZVector;
-import org.apache.arrow.vector.complex.impl.TimeStampMilliTZWriterImpl;
-import org.apache.arrow.vector.complex.writer.TimeStampMilliTZWriter;
 
 /**
  * Consumer which consume timestamp type values from {@link ResultSet}.
@@ -32,9 +30,11 @@ import org.apache.arrow.vector.complex.writer.TimeStampMilliTZWriter;
  */
 public class TimestampConsumer implements JdbcConsumer<TimeStampMilliTZVector> {
 
-  private TimeStampMilliTZWriter writer;
+  private TimeStampMilliTZVector vector;
   private final int columnIndexInResultSet;
   private final Calendar calendar;
+
+  private int currentIndex;
 
   /**
    * Instantiate a TimestampConsumer.
@@ -47,7 +47,7 @@ public class TimestampConsumer implements JdbcConsumer<TimeStampMilliTZVector> {
    * Instantiate a TimestampConsumer.
    */
   public TimestampConsumer(TimeStampMilliTZVector vector, int index, Calendar calendar) {
-    this.writer = new TimeStampMilliTZWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
     this.calendar = calendar;
   }
@@ -57,18 +57,18 @@ public class TimestampConsumer implements JdbcConsumer<TimeStampMilliTZVector> {
     Timestamp timestamp = calendar == null ? resultSet.getTimestamp(columnIndexInResultSet) :
         resultSet.getTimestamp(columnIndexInResultSet, calendar);
     if (!resultSet.wasNull()) {
-      writer.writeTimeStampMilliTZ(timestamp.getTime());
+      vector.setSafe(currentIndex++, timestamp.getTime());
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(TimeStampMilliTZVector vector) {
-    this.writer = new TimeStampMilliTZWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
@@ -63,6 +63,11 @@ public class TimestampConsumer implements JdbcConsumer<TimeStampMilliTZVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
+  @Override
   public void resetValueVector(TimeStampMilliTZVector vector) {
     this.writer = new TimeStampMilliTZWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
@@ -51,6 +51,11 @@ public class TinyIntConsumer implements JdbcConsumer<TinyIntVector> {
   }
 
   @Override
+  public void close() throws Exception {
+    writer.close();
+  }
+
+  @Override
   public void resetValueVector(TinyIntVector vector) {
     this.writer = new TinyIntWriterImpl(vector);
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.apache.arrow.vector.TinyIntVector;
-import org.apache.arrow.vector.complex.impl.TinyIntWriterImpl;
-import org.apache.arrow.vector.complex.writer.TinyIntWriter;
 
 /**
  * Consumer which consume tinyInt type values from {@link ResultSet}.
@@ -30,14 +28,16 @@ import org.apache.arrow.vector.complex.writer.TinyIntWriter;
  */
 public class TinyIntConsumer implements JdbcConsumer<TinyIntVector> {
 
-  private TinyIntWriter writer;
+  private TinyIntVector vector;
   private final int columnIndexInResultSet;
+
+  private int currentIndex;
 
   /**
    * Instantiate a TinyIntConsumer.
    */
   public TinyIntConsumer(TinyIntVector vector, int index) {
-    this.writer = new TinyIntWriterImpl(vector);
+    this.vector = vector;
     this.columnIndexInResultSet = index;
   }
 
@@ -45,18 +45,18 @@ public class TinyIntConsumer implements JdbcConsumer<TinyIntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     byte value = resultSet.getByte(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      writer.writeTinyInt(value);
+      vector.setSafe(currentIndex++, value);
     }
-    writer.setPosition(writer.getPosition() + 1);
   }
 
   @Override
   public void close() throws Exception {
-    writer.close();
+    this.vector.close();
   }
 
   @Override
   public void resetValueVector(TinyIntVector vector) {
-    this.writer = new TinyIntWriterImpl(vector);
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }


### PR DESCRIPTION
Related to [ARROW-6296](https://issues.apache.org/jira/browse/ARROW-6296).
i. If we use direct setting of fields, we can avoid the extra temporary buffer and memcpy by setting bytes directly.
ii. We should overwrite existing vectors in consumers before returning results, to avoid the possibility of closing vectors in use (or alternatively make sure we retain the underlying buffers).
iii. Try to eliminate some of the state in load() by moving initialization to the constructor.