### PR TITLE
ARROW-6311: [Java] Make ApproxEqualsVisitor accept DiffFunction to make it more flexible

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/DiffFunction.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/DiffFunction.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.compare;
+
+/**
+ * Difference calculation function for approx equals.
+ * @param <T> type for param and return value.
+ */
+@FunctionalInterface
+public interface DiffFunction<T> {
+  T apply(T value1, T value2);
+}


### PR DESCRIPTION
Related to [ARROW-6311](https://issues.apache.org/jira/browse/ARROW-6311).

Currently ApproxEqualsVisitor will accept a epsilon for both float and double compare, and the difference calculation is always Math.abs(f1-f2)

For some cases like Validator it is not very suitable as:
i. it has different epsilon values for float/double
ii. it difference function is not Math.abs(f1-f2)

To resolve these, make this visitor accept both float/double epsilons and diff functions.