### PR TITLE
ARROW-6243: [C++][Dataset] Filter expressions

### DIFF
--- a/cpp/build-support/run_cpplint.py
+++ b/cpp/build-support/run_cpplint.py
@@ -35,6 +35,7 @@ _filters = '''
 -whitespace/comments
 -readability/casting
 -readability/todo
+-readability/alt_tokens
 -build/header_guard
 -build/c++11
 -runtime/references

--- a/cpp/src/arrow/compute/kernels/compare.cc
+++ b/cpp/src/arrow/compute/kernels/compare.cc
@@ -244,7 +244,10 @@ Status Compare(FunctionContext* context, const Datum& left, const Datum& right,
   DCHECK(out);
 
   auto type = left.type();
-  DCHECK(type->Equals(right.type()));
+  if (!type->Equals(right.type())) {
+    return Status::TypeError("Cannot compare data of differing type ", *type, " vs ",
+                             *right.type());
+  }
   // Requires that both types are equal.
   auto fn = MakeCompareFunction(context, *type, options);
   if (fn == nullptr) {

--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -23,7 +23,7 @@ arrow_install_all_headers("arrow/dataset")
 # pkg-config support
 arrow_add_pkg_config("arrow-dataset")
 
-set(ARROW_DATASET_SRCS dataset.cc file_base.cc scanner.cc)
+set(ARROW_DATASET_SRCS dataset.cc file_base.cc filter.cc scanner.cc)
 set(ARROW_DATASET_LINK_STATIC arrow_static)
 set(ARROW_DATASET_LINK_SHARED arrow_shared)
 
@@ -79,22 +79,23 @@ function(ADD_ARROW_DATASET_TEST REL_TEST_NAME)
     set(LABELS "arrow_dataset")
   endif()
 
-  if(NOT WIN32)
-    add_arrow_test(${REL_TEST_NAME}
-                   EXTRA_LINK_LIBS
-                   ${ARROW_DATASET_TEST_LINK_LIBS}
-                   PREFIX
-                   ${PREFIX}
-                   LABELS
-                   ${LABELS}
-                   ${ARG_UNPARSED_ARGUMENTS})
-  endif()
+  add_arrow_test(${REL_TEST_NAME}
+                 EXTRA_LINK_LIBS
+                 ${ARROW_DATASET_TEST_LINK_LIBS}
+                 PREFIX
+                 ${PREFIX}
+                 LABELS
+                 ${LABELS}
+                 ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
-add_arrow_dataset_test(dataset_test)
-add_arrow_dataset_test(file_test)
-add_arrow_dataset_test(scanner_test)
+if(NOT WIN32)
+  add_arrow_dataset_test(dataset_test)
+  add_arrow_dataset_test(file_test)
+  add_arrow_dataset_test(filter_test)
+  add_arrow_dataset_test(scanner_test)
 
-if(ARROW_PARQUET)
-  add_arrow_dataset_test(file_parquet_test)
+  if(ARROW_PARQUET)
+    add_arrow_dataset_test(file_parquet_test)
+  endif()
 endif()

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -329,6 +329,8 @@ Result<std::shared_ptr<Expression>> InvertBoolean(const Boolean& expr) {
   if (std::is_same<Boolean, OrExpression>::value) {
     return std::make_shared<AndExpression>(std::move(lhs), std::move(rhs));
   }
+
+  return Status::Invalid("unknown boolean expression ", expr.ToString());
 }
 
 Result<std::shared_ptr<Expression>> Invert(const Expression& expr) {

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -1,0 +1,375 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/filter.h"
+
+#include <cstring>
+
+#include "arrow/buffer.h"
+#include "arrow/util/logging.h"
+#include "arrow/visitor_inline.h"
+
+namespace arrow {
+namespace dataset {
+
+using internal::checked_cast;
+
+std::shared_ptr<ScalarExpression> ScalarExpression::Make(std::string value) {
+  return std::make_shared<ScalarExpression>(
+      std::make_shared<StringScalar>(Buffer::FromString(std::move(value))));
+}
+
+// return a pair<e is a boolean scalar expression, value of that expression>
+std::pair<bool, bool> IsBoolean(const Expression& e) {
+  if (e.type() == ExpressionType::SCALAR) {
+    auto value = checked_cast<const ScalarExpression&>(e).value();
+    if (value->type->id() == Type::BOOL) {
+      // FIXME(bkietz) null scalars do what?
+      return {true, checked_cast<const BooleanScalar&>(*value).value};
+    }
+  }
+  return {false, false};
+}
+
+Result<std::shared_ptr<Expression>> AssumeIfOperator(const std::shared_ptr<Expression>& e,
+                                                     const Expression& given) {
+  if (!e->IsOperatorExpression()) {
+    return e;
+  }
+  return checked_cast<const OperatorExpression&>(*e).Assume(given);
+}
+
+struct CompareVisitor {
+  Status Visit(const BooleanType&) {
+    result_ = checked_cast<const BooleanScalar&>(lhs_).value -
+              checked_cast<const BooleanScalar&>(rhs_).value;
+    return Status::OK();
+  }
+
+  Status Visit(const Int64Type&) {
+    result_ = checked_cast<const Int64Scalar&>(lhs_).value -
+              checked_cast<const Int64Scalar&>(rhs_).value;
+    return Status::OK();
+  }
+
+  Status Visit(const DoubleType&) {
+    double result = checked_cast<const DoubleScalar&>(lhs_).value -
+                    checked_cast<const DoubleScalar&>(rhs_).value;
+    result_ = result < 0.0 ? -1 : result > 0.0 ? +1 : 0;
+    return Status::OK();
+  }
+
+  Status Visit(const StringType&) {
+    auto lhs = checked_cast<const StringScalar&>(lhs_).value;
+    auto rhs = checked_cast<const StringScalar&>(rhs_).value;
+    result_ = std::memcmp(lhs->data(), rhs->data(), std::min(lhs->size(), rhs->size()));
+    if (result_ == 0) {
+      result_ = lhs->size() - rhs->size();
+    }
+    return Status::OK();
+  }
+
+  Status Visit(const DataType&) {
+    return Status::NotImplemented("comparison of scalars of type ", *lhs_.type);
+  }
+
+  int64_t result_;
+  const Scalar& lhs_;
+  const Scalar& rhs_;
+};
+
+Result<int64_t> Compare(const Scalar& lhs, const Scalar& rhs) {
+  CompareVisitor vis{0, lhs, rhs};
+  RETURN_NOT_OK(VisitTypeInline(*lhs.type, &vis));
+  return vis.result_;
+}
+
+Result<std::shared_ptr<Expression>> AssumeComparison(const OperatorExpression& e,
+                                                     const OperatorExpression& given) {
+  auto e_rhs = checked_cast<const ScalarExpression&>(*e.operands()[1]).value();
+  // TODO(bkietz) allow the RHS of given to be FROM_STRING
+  auto given_rhs = checked_cast<const ScalarExpression&>(*given.operands()[1]).value();
+
+  ARROW_ASSIGN_OR_RAISE(auto cmp, Compare(*e_rhs, *given_rhs));
+
+  static auto always = ScalarExpression::Make(true);
+  static auto never = ScalarExpression::Make(false);
+  auto unsimplified = MakeShared(e);
+
+  if (cmp == 0) {
+    // the rhs of the comparisons are equal
+    switch (e.type()) {
+      case ExpressionType::EQUAL:
+        switch (given.type()) {
+          case ExpressionType::NOT_EQUAL:
+          case ExpressionType::GREATER:
+          case ExpressionType::LESS:
+            return never;
+          case ExpressionType::EQUAL:
+          case ExpressionType::GREATER_EQUAL:
+          case ExpressionType::LESS_EQUAL:
+            return always;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::NOT_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+            return never;
+          case ExpressionType::NOT_EQUAL:
+          case ExpressionType::GREATER:
+          case ExpressionType::LESS:
+            return always;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::GREATER:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+          case ExpressionType::LESS_EQUAL:
+          case ExpressionType::LESS:
+            return never;
+          case ExpressionType::GREATER:
+            return always;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::GREATER_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::LESS:
+            return never;
+          case ExpressionType::EQUAL:
+          case ExpressionType::GREATER:
+          case ExpressionType::GREATER_EQUAL:
+            return always;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::LESS:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+          case ExpressionType::GREATER:
+          case ExpressionType::GREATER_EQUAL:
+            return never;
+          case ExpressionType::LESS:
+            return always;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::LESS_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::GREATER:
+            return never;
+          case ExpressionType::EQUAL:
+          case ExpressionType::LESS:
+          case ExpressionType::LESS_EQUAL:
+            return always;
+          default:
+            return unsimplified;
+        }
+      default:
+        return unsimplified;
+    }
+  } else if (cmp > 0) {
+    // the rhs of e is greater than that of given
+    switch (e.type()) {
+      case ExpressionType::EQUAL:
+      case ExpressionType::GREATER:
+      case ExpressionType::GREATER_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+          case ExpressionType::LESS:
+          case ExpressionType::LESS_EQUAL:
+            return never;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::NOT_EQUAL:
+      case ExpressionType::LESS:
+      case ExpressionType::LESS_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+          case ExpressionType::LESS:
+          case ExpressionType::LESS_EQUAL:
+            return always;
+          default:
+            return unsimplified;
+        }
+      default:
+        return unsimplified;
+    }
+  } else {
+    // the rhs of e is less than that of given
+    switch (e.type()) {
+      case ExpressionType::EQUAL:
+      case ExpressionType::LESS:
+      case ExpressionType::LESS_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+          case ExpressionType::GREATER:
+          case ExpressionType::GREATER_EQUAL:
+            return never;
+          default:
+            return unsimplified;
+        }
+      case ExpressionType::NOT_EQUAL:
+      case ExpressionType::GREATER:
+      case ExpressionType::GREATER_EQUAL:
+        switch (given.type()) {
+          case ExpressionType::EQUAL:
+          case ExpressionType::GREATER:
+          case ExpressionType::GREATER_EQUAL:
+            return always;
+          default:
+            return unsimplified;
+        }
+      default:
+        return unsimplified;
+    }
+  }
+
+  return unsimplified;
+}
+
+std::string GetName(const Expression& e) {
+  DCHECK_EQ(e.type(), ExpressionType::FIELD);
+  return checked_cast<const FieldReferenceExpression&>(e).name();
+}
+
+Result<std::shared_ptr<Expression>> OperatorExpression::Assume(
+    const Expression& given) const {
+  auto unsimplified = MakeShared(*this);
+
+  if (IsComparisonExpression()) {
+    if (!given.IsOperatorExpression()) {
+      return unsimplified;
+    }
+
+    const auto& given_op = checked_cast<const OperatorExpression&>(given);
+
+    if (given.IsComparisonExpression()) {
+      // Both this and given are simple comparisons. If they constrain
+      // the same field, try to simplify this assuming given
+      DCHECK_EQ(operands_.size(), 2);
+      DCHECK_EQ(given_op.operands_.size(), 2);
+      if (GetName(*operands_[0]) != GetName(*given_op.operands_[0])) {
+        return unsimplified;
+      }
+      return AssumeComparison(*this, given_op);
+    }
+
+    // must be NOT, AND, OR- decompose given
+    switch (given.type()) {
+      case ExpressionType::NOT: {
+        return unsimplified;
+      }
+
+      case ExpressionType::OR: {
+        bool simplify_to_always = true;
+        bool simplify_to_never = true;
+        for (auto operand : given_op.operands_) {
+          ARROW_ASSIGN_OR_RAISE(auto simplified, Assume(*operand));
+          auto isbool_value = IsBoolean(*simplified);
+          if (!isbool_value.first) {
+            return unsimplified;
+          }
+
+          if (isbool_value.second) {
+            simplify_to_never = false;
+          } else {
+            simplify_to_always = false;
+          }
+        }
+
+        if (simplify_to_always) {
+          return ScalarExpression::Make(true);
+        }
+
+        if (simplify_to_never) {
+          return ScalarExpression::Make(false);
+        }
+
+        return unsimplified;
+      }
+
+      case ExpressionType::AND: {
+        std::shared_ptr<Expression> simplified = unsimplified;
+        for (auto operand : given_op.operands_) {
+          auto isbool_value = IsBoolean(*simplified);
+          if (isbool_value.first) {
+            break;
+          }
+          DCHECK(simplified->IsOperatorExpression());
+          const auto& simplified_op =
+              checked_cast<const OperatorExpression&>(*simplified);
+          ARROW_ASSIGN_OR_RAISE(simplified, simplified_op.Assume(*operand));
+        }
+        return simplified;
+      }
+
+      default:
+        DCHECK(false);
+    }
+  }
+
+  switch (type_) {
+    case ExpressionType::NOT: {
+      DCHECK_EQ(operands_.size(), 1);
+      ARROW_ASSIGN_OR_RAISE(auto operand, AssumeIfOperator(operands_[0], given));
+      auto isbool_value = IsBoolean(*operand);
+      if (isbool_value.first) {
+        return ScalarExpression::Make(!isbool_value.second);
+      }
+      return std::make_shared<OperatorExpression>(
+          ExpressionType::NOT, std::vector<std::shared_ptr<Expression>>{operand});
+    }
+
+    case ExpressionType::OR:
+    case ExpressionType::AND: {
+      // if any of the operands matches trivial_condition, we can return a trivial
+      // expression:
+      // anything OR true => true
+      // anything AND false => false
+      bool trivial_condition = type_ == ExpressionType::OR;
+
+      std::vector<std::shared_ptr<Expression>> operands;
+      for (auto operand : operands_) {
+        ARROW_ASSIGN_OR_RAISE(operand, AssumeIfOperator(operand, given));
+
+        auto isbool_value = IsBoolean(*operand);
+        if (isbool_value.first) {
+          if (isbool_value.second == trivial_condition) {
+            return ScalarExpression::Make(trivial_condition);
+          }
+          continue;
+        }
+
+        operands.push_back(operand);
+      }
+
+      return std::make_shared<OperatorExpression>(type_, std::move(operands));
+    }
+
+    default:
+      DCHECK(false);
+  }
+
+  return unsimplified;
+}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -17,10 +17,13 @@
 
 #include "arrow/dataset/filter.h"
 
+#include <algorithm>
 #include <cstring>
+#include <string>
+#include <utility>
 
-#include "arrow/buffer-builder.h"
 #include "arrow/buffer.h"
+#include "arrow/buffer_builder.h"
 #include "arrow/compute/context.h"
 #include "arrow/compute/kernels/boolean.h"
 #include "arrow/compute/kernels/compare.h"

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -262,7 +262,7 @@ struct CompareVisitor {
 // if either is null, return is null
 Result<Comparison::type> Compare(const Scalar& lhs, const Scalar& rhs) {
   if (!lhs.type->Equals(*rhs.type)) {
-    return Status::TypeError("cannot compare scalars with differing type: ", *lhs.type,
+    return Status::TypeError("Cannot compare scalars of differing type: ", *lhs.type,
                              " vs ", *rhs.type);
   }
   if (!lhs.is_valid || !rhs.is_valid) {

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -670,6 +670,8 @@ std::string AllExpression::ToString() const { return EulerNotation("ALL", operan
 
 std::string AnyExpression::ToString() const { return EulerNotation("ANY", operands_); }
 
+std::string NotExpression::ToString() const { return EulerNotation("NOT", {operand_}); }
+
 std::string ComparisonExpression::ToString() const {
   return EulerNotation(OperatorName(op()), {left_operand_, right_operand_});
 }

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -20,12 +20,13 @@
 #include <memory>
 
 #include "arrow/dataset/visibility.h"
+#include "arrow/result.h"
+#include "arrow/scalar.h"
 
 namespace arrow {
 namespace dataset {
 
-class ARROW_DS_EXPORT Filter {
- public:
+struct FilterType {
   enum type {
     /// Simple boolean predicate consisting of comparisons and boolean
     /// logic (AND, OR, NOT) involving Schema fields
@@ -35,6 +36,188 @@ class ARROW_DS_EXPORT Filter {
     GENERIC
   };
 };
+
+class ARROW_DS_EXPORT Filter {
+ public:
+  explicit Filter(FilterType::type type) : type_(type) {}
+
+  virtual ~Filter() = 0;
+
+  FilterType::type type() const { return type_; }
+
+ private:
+  FilterType::type type_;
+};
+
+class Expression;
+
+class ARROW_DS_EXPORT ExpressionFilter : public Filter {
+ public:
+  explicit ExpressionFilter(const std::shared_ptr<Expression>& expression)
+      : Filter(FilterType::EXPRESSION), expression_(std::move(expression)) {}
+
+  const std::shared_ptr<Expression>& expression() const { return expression_; }
+
+ private:
+  std::shared_ptr<Expression> expression_;
+};
+
+struct ExpressionType {
+  enum type {
+    FIELD,
+    SCALAR,
+    FROM_STRING,
+
+    NOT,
+    AND,
+    OR,
+
+    EQUAL,
+    NOT_EQUAL,
+    GREATER,
+    GREATER_EQUAL,
+    LESS,
+    LESS_EQUAL,
+  };
+};
+
+template <typename T>
+std::shared_ptr<typename std::decay<T>::type> MakeShared(T&& t) {
+  return std::make_shared<typename std::decay<T>::type>(std::forward<T>(t));
+}
+
+class ARROW_DS_EXPORT Expression {
+ public:
+  explicit Expression(ExpressionType::type type) : type_(type) {}
+
+  virtual ~Expression() = default;
+
+  ExpressionType::type type() const { return type_; }
+
+  bool IsOperatorExpression() const {
+    return static_cast<int>(type_) >= static_cast<int>(ExpressionType::NOT) &&
+           static_cast<int>(type_) <= static_cast<int>(ExpressionType::LESS_EQUAL);
+  }
+
+  bool IsComparisonExpression() const {
+    return static_cast<int>(type_) >= static_cast<int>(ExpressionType::EQUAL) &&
+           static_cast<int>(type_) <= static_cast<int>(ExpressionType::LESS_EQUAL);
+  }
+
+ protected:
+  ExpressionType::type type_;
+};
+
+class ARROW_DS_EXPORT OperatorExpression : public Expression {
+ public:
+  OperatorExpression(ExpressionType::type type,
+                     std::vector<std::shared_ptr<Expression>> operands)
+      : Expression(type), operands_(std::move(operands)) {}
+
+  const std::vector<std::shared_ptr<Expression>>& operands() const { return operands_; }
+
+  OperatorExpression operator and(const OperatorExpression& other) const {
+    return OperatorExpression(ExpressionType::AND,
+                              {MakeShared(*this), MakeShared(other)});
+  }
+
+  OperatorExpression operator or(const OperatorExpression& other) const {
+    return OperatorExpression(ExpressionType::OR, {MakeShared(*this), MakeShared(other)});
+  }
+
+  OperatorExpression operator not() const {
+    return OperatorExpression(ExpressionType::NOT, {MakeShared(*this)});
+  }
+
+  Result<std::shared_ptr<Expression>> Assume(const Expression& given) const;
+
+ private:
+  std::vector<std::shared_ptr<Expression>> operands_;
+};
+
+class ARROW_DS_EXPORT ScalarExpression : public Expression {
+ public:
+  explicit ScalarExpression(const std::shared_ptr<Scalar>& value)
+      : Expression(ExpressionType::SCALAR), value_(std::move(value)) {}
+
+  const std::shared_ptr<Scalar>& value() const { return value_; }
+
+  static std::shared_ptr<ScalarExpression> Make(bool value) {
+    return std::make_shared<ScalarExpression>(std::make_shared<BooleanScalar>(value));
+  }
+
+  template <typename T>
+  static typename std::enable_if<std::is_integral<T>::value,
+                                 std::shared_ptr<ScalarExpression>>::type
+  Make(T value) {
+    return std::make_shared<ScalarExpression>(std::make_shared<Int64Scalar>(value));
+  }
+
+  template <typename T>
+  static typename std::enable_if<std::is_floating_point<T>::value,
+                                 std::shared_ptr<ScalarExpression>>::type
+  Make(T value) {
+    return std::make_shared<ScalarExpression>(std::make_shared<DoubleScalar>(value));
+  }
+
+  static std::shared_ptr<ScalarExpression> Make(std::string value);
+
+ private:
+  std::shared_ptr<Scalar> value_;
+};
+
+class ARROW_DS_EXPORT FieldReferenceExpression : public Expression {
+ public:
+  explicit FieldReferenceExpression(std::string name)
+      : Expression(ExpressionType::FIELD), name_(std::move(name)) {}
+
+  std::string name() const { return name_; }
+
+  template <typename T>
+  OperatorExpression operator==(T&& value) const {
+    return Comparison(ExpressionType::EQUAL, std::forward<T>(value));
+  }
+
+  template <typename T>
+  OperatorExpression operator!=(T&& value) const {
+    return Comparison(ExpressionType::NOT_EQUAL, std::forward<T>(value));
+  }
+
+  template <typename T>
+  OperatorExpression operator>(T&& value) const {
+    return Comparison(ExpressionType::GREATER, std::forward<T>(value));
+  }
+
+  template <typename T>
+  OperatorExpression operator>=(T&& value) const {
+    return Comparison(ExpressionType::GREATER_EQUAL, std::forward<T>(value));
+  }
+
+  template <typename T>
+  OperatorExpression operator<(T&& value) const {
+    return Comparison(ExpressionType::LESS, std::forward<T>(value));
+  }
+
+  template <typename T>
+  OperatorExpression operator<=(T&& value) const {
+    return Comparison(ExpressionType::LESS_EQUAL, std::forward<T>(value));
+  }
+
+ private:
+  template <typename T>
+  OperatorExpression Comparison(ExpressionType::type type, T&& value) const {
+    return OperatorExpression(
+        type, {MakeShared(*this), ScalarExpression::Make(std::forward<T>(value))});
+  }
+
+  std::string name_;
+};
+
+inline namespace string_literals {
+FieldReferenceExpression operator""_(const char* name, size_t name_length) {
+  return FieldReferenceExpression({name, name_length});
+}
+}  // namespace string_literals
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -107,7 +107,7 @@ class ARROW_DS_EXPORT Expression {
   /// Returns true iff the expressions are identical; does not check for equivalence.
   /// For example, (A and B) is not equal to (B and A) nor is (A and not A) equal to
   /// (false).
-  bool Equals(const Expression& other) const;
+  virtual bool Equals(const Expression& other) const = 0;
 
   bool Equals(const std::shared_ptr<Expression>& other) const;
 
@@ -173,13 +173,11 @@ class ARROW_DS_EXPORT UnaryExpression : public Expression {
  public:
   const std::shared_ptr<Expression>& operand() const { return operand_; }
 
+  bool Equals(const Expression& other) const override;
+
  protected:
   UnaryExpression(ExpressionType::type type, std::shared_ptr<Expression> operand)
       : Expression(type), operand_(std::move(operand)) {}
-
-  bool OperandsEqual(const UnaryExpression& other) const;
-
-  friend struct ExpressionEqual;
 
   std::shared_ptr<Expression> operand_;
 };
@@ -192,16 +190,14 @@ class ARROW_DS_EXPORT BinaryExpression : public Expression {
 
   const std::shared_ptr<Expression>& right_operand() const { return right_operand_; }
 
+  bool Equals(const Expression& other) const override;
+
  protected:
   BinaryExpression(ExpressionType::type type, std::shared_ptr<Expression> left_operand,
                    std::shared_ptr<Expression> right_operand)
       : Expression(type),
         left_operand_(std::move(left_operand)),
         right_operand_(std::move(right_operand)) {}
-
-  bool OperandsEqual(const BinaryExpression& other) const;
-
-  friend struct ExpressionEqual;
 
   std::shared_ptr<Expression> left_operand_, right_operand_;
 };
@@ -212,13 +208,11 @@ class ARROW_DS_EXPORT NnaryExpression : public Expression {
  public:
   const ExpressionVector& operands() const { return operands_; }
 
+  bool Equals(const Expression& other) const override;
+
  protected:
   NnaryExpression(ExpressionType::type type, ExpressionVector operands)
       : Expression(type), operands_(std::move(operands)) {}
-
-  bool OperandsEqual(const NnaryExpression& other) const;
-
-  friend struct ExpressionEqual;
 
   ExpressionVector operands_;
 };
@@ -233,6 +227,8 @@ class ARROW_DS_EXPORT ComparisonExpression final
       : ExpressionImpl(std::move(left_operand), std::move(right_operand)), op_(op) {}
 
   std::string ToString() const override;
+
+  bool Equals(const Expression& other) const override;
 
   // Result<std::shared_ptr<Expression>> Validate(const Schema& schema) const override;
 
@@ -305,6 +301,8 @@ class ARROW_DS_EXPORT ScalarExpression final : public Expression {
 
   std::string ToString() const override;
 
+  bool Equals(const Expression& other) const override;
+
   // Result<std::shared_ptr<Expression>> Validate(const Schema& schema) const override;
 
   static std::shared_ptr<ScalarExpression> Make(bool value) {
@@ -356,6 +354,8 @@ class ARROW_DS_EXPORT FieldExpression final : public Expression {
   std::string name() const { return name_; }
 
   std::string ToString() const override;
+
+  bool Equals(const Expression& other) const override;
 
   // Result<std::shared_ptr<Expression>> Validate(const Schema& schema) const override;
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -244,17 +244,19 @@ class ARROW_DS_EXPORT FieldReferenceExpression final : public Expression {
   std::string name_;
 };
 
-#define COMPARISON_FACTORY(NAME, FACTORY_NAME, OP)                                \
-  template <typename T>                                                           \
-  OperatorExpression FACTORY_NAME(const FieldReferenceExpression& lhs, T&& rhs) { \
-    return OperatorExpression(                                                    \
-        ExpressionType::NAME,                                                     \
-        {lhs.Copy(), ScalarExpression::Make(std::forward<T>(rhs))});              \
-  }                                                                               \
-                                                                                  \
-  template <typename T>                                                           \
-  OperatorExpression operator OP(const FieldReferenceExpression& lhs, T&& rhs) {  \
-    return FACTORY_NAME(lhs, std::forward<T>(rhs));                               \
+#define COMPARISON_FACTORY(NAME, FACTORY_NAME, OP)                               \
+  ARROW_DS_EXPORT std::shared_ptr<OperatorExpression> FACTORY_NAME(              \
+      const FieldReferenceExpression& lhs, const ScalarExpression& rhs) {        \
+    return std::make_shared<OperatorExpression>(                                 \
+        ExpressionType::NAME,                                                    \
+        std::vector<std::shared_ptr<Expression>>{lhs.Copy(), rhs.Copy()});       \
+  }                                                                              \
+                                                                                 \
+  template <typename T>                                                          \
+  OperatorExpression operator OP(const FieldReferenceExpression& lhs, T&& rhs) { \
+    return OperatorExpression(                                                   \
+        ExpressionType::NAME,                                                    \
+        {lhs.Copy(), ScalarExpression::Make(std::forward<T>(rhs))});             \
   }
 COMPARISON_FACTORY(EQUAL, equal, ==)
 COMPARISON_FACTORY(NOT_EQUAL, not_equal, !=)

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -359,15 +359,15 @@ class ARROW_DS_EXPORT FieldExpression final : public Expression {
 
 ARROW_DS_EXPORT std::shared_ptr<AllExpression> all(ExpressionVector operands);
 
-ARROW_DS_EXPORT AllExpression operator and(const Expression& lhs, const Expression& rhs);
+ARROW_DS_EXPORT AllExpression operator&&(const Expression& lhs, const Expression& rhs);
 
 ARROW_DS_EXPORT std::shared_ptr<AnyExpression> any(ExpressionVector operands);
 
-ARROW_DS_EXPORT AnyExpression operator or(const Expression& lhs, const Expression& rhs);
+ARROW_DS_EXPORT AnyExpression operator||(const Expression& lhs, const Expression& rhs);
 
 ARROW_DS_EXPORT std::shared_ptr<NotExpression> not_(std::shared_ptr<Expression> operand);
 
-ARROW_DS_EXPORT NotExpression operator not(const Expression& rhs);
+ARROW_DS_EXPORT NotExpression operator!(const Expression& rhs);
 
 #define COMPARISON_FACTORY(NAME, FACTORY_NAME, OP)                                     \
   inline std::shared_ptr<ComparisonExpression> FACTORY_NAME(                           \

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -325,9 +325,8 @@ class ARROW_DS_EXPORT ScalarExpression final : public Expression {
     return std::make_shared<ScalarExpression>(std::move(value));
   }
 
-  static std::shared_ptr<ScalarExpression> MakeNull() {
-    return std::make_shared<ScalarExpression>(std::make_shared<NullScalar>());
-  }
+  static std::shared_ptr<ScalarExpression> MakeNull(
+      const std::shared_ptr<DataType>& type);
 
   Result<std::shared_ptr<DataType>> Validate(const Schema& schema) const override;
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <memory>
+#include <string>
+#include <utility>
 
 #include "arrow/compute/kernels/compare.h"
 #include "arrow/dataset/type_fwd.h"
@@ -140,7 +142,8 @@ class ExpressionImpl : public Base {
   static constexpr ExpressionType::type expression_type = E;
 
   template <typename... A>
-  ExpressionImpl(A&&... args) : Base(expression_type, std::forward<A>(args)...) {}
+  explicit ExpressionImpl(A&&... args)
+      : Base(expression_type, std::forward<A>(args)...) {}
 
   std::shared_ptr<Expression> Copy() const override {
     return std::make_shared<Derived>(internal::checked_cast<const Derived&>(*this));

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -163,9 +163,9 @@ class ExpressionImpl : public Base {
  public:
   static constexpr ExpressionType::type expression_type = E;
 
-  template <typename... A>
-  explicit ExpressionImpl(A&&... args)
-      : Base(expression_type, std::forward<A>(args)...) {}
+  template <typename A0, typename... A>
+  explicit ExpressionImpl(A0&& arg0, A&&... args)
+      : Base(expression_type, std::forward<A0>(arg0), std::forward<A>(args)...) {}
 
   std::shared_ptr<Expression> Copy() const override {
     return std::make_shared<Derived>(internal::checked_cast<const Derived&>(*this));

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -37,7 +37,7 @@ struct FilterType {
     /// logic (AND, OR, NOT) involving Schema fields
     EXPRESSION,
 
-    ///
+    /// Non decomposable filter; must be evaluated against every record batch
     GENERIC
   };
 };
@@ -50,6 +50,8 @@ class ARROW_DS_EXPORT Filter {
 
   FilterType::type type() const { return type_; }
 
+  /// Evaluate this filter producing a boolean array which encodes whether each row
+  /// satisfies the filter
   virtual Status Execute(compute::FunctionContext* ctx, const RecordBatch& batch,
                          std::shared_ptr<BooleanArray>* filter) const = 0;
 
@@ -59,6 +61,8 @@ class ARROW_DS_EXPORT Filter {
 
 class Expression;
 
+/// Filter subclass encapsulating a simple boolean predicate consisting of comparisons and
+/// boolean logic (AND, OR, NOT) involving Schema fields
 class ARROW_DS_EXPORT ExpressionFilter : public Filter {
  public:
   explicit ExpressionFilter(const std::shared_ptr<Expression>& expression)
@@ -77,7 +81,6 @@ struct ExpressionType {
   enum type {
     FIELD,
     SCALAR,
-    FROM_STRING,
 
     NOT,
     AND,
@@ -92,74 +95,81 @@ struct ExpressionType {
   };
 };
 
-template <typename T>
-std::shared_ptr<typename std::decay<T>::type> MakeShared(T&& t) {
-  return std::make_shared<typename std::decay<T>::type>(std::forward<T>(t));
-}
-
+/// Represents an expression tree. The expression can be evaluated against a
+/// RecordBatch via ExpressionFilter
 class ARROW_DS_EXPORT Expression {
  public:
   explicit Expression(ExpressionType::type type) : type_(type) {}
 
   virtual ~Expression() = default;
 
+  /// Returns true iff the expressions are identical; does not check for equivalence.
+  /// For example, (A and B) is not equal to (B and A) nor is (A and not A) equal to
+  /// (false).
   bool Equals(const Expression& other) const;
 
-  bool Equals(const std::shared_ptr<Expression>& other) const {
-    if (other == NULLPTR) {
-      return false;
-    }
-    return Equals(*other);
-  }
+  bool Equals(const std::shared_ptr<Expression>& other) const;
 
+  /// Validate this expression for execution against a schema. This will check that all
+  /// reference fields are present and all subexpressions are executable. Returns a copy
+  /// of this expression with schema information incorporated:
+  /// - Scalars are cast to other data types if necessary to ensure comparisons are
+  ///   between data of identical type
+  // virtual Result<std::shared_ptr<Expression>> Validate(const Schema&) const;
+
+  /// returns a debug string representing this expression
   virtual std::string ToString() const = 0;
 
   ExpressionType::type type() const { return type_; }
 
-  bool IsOperatorExpression() const {
-    return static_cast<int>(type_) >= static_cast<int>(ExpressionType::NOT) &&
-           static_cast<int>(type_) <= static_cast<int>(ExpressionType::LESS_EQUAL);
-  }
+  /// If true, this Expression may be safely cast to OperatorExpression
+  bool IsOperatorExpression() const;
 
-  bool IsComparisonExpression() const {
-    return static_cast<int>(type_) >= static_cast<int>(ExpressionType::EQUAL) &&
-           static_cast<int>(type_) <= static_cast<int>(ExpressionType::LESS_EQUAL);
-  }
+  /// If true, this Expression may be safely cast to OperatorExpression
+  /// and there will be exactly two operands representing the left and right hand sides of
+  /// a comparison
+  bool IsComparisonExpression() const;
+
+  /// Copy this expression into a shared pointer.
+  virtual std::shared_ptr<Expression> Copy() const = 0;
 
  protected:
   ExpressionType::type type_;
 };
 
-class ARROW_DS_EXPORT OperatorExpression : public Expression {
+/// Represents an compound expression; for example comparison between a field and a scalar
+/// or a union of other expressions
+class ARROW_DS_EXPORT OperatorExpression final : public Expression {
  public:
   OperatorExpression(ExpressionType::type type,
                      std::vector<std::shared_ptr<Expression>> operands)
       : Expression(type), operands_(std::move(operands)) {}
 
+  /// Return a simplified form of this expression given some known conditions.
+  /// For example, (a > 3).Assume(a == 5) == (true). This can be used to do less work
+  /// in ExpressionFilter when partition conditions guarantee some of this expression.
+  /// In the example above, *no* filtering need be done on record batches in the partition
+  /// since (a == 5).
+  Result<std::shared_ptr<Expression>> Assume(const Expression& given) const;
+
   const std::vector<std::shared_ptr<Expression>>& operands() const { return operands_; }
 
   virtual std::string ToString() const override;
 
-  OperatorExpression operator and(const OperatorExpression& other) const {
-    return OperatorExpression(ExpressionType::AND,
-                              {MakeShared(*this), MakeShared(other)});
-  }
-
-  OperatorExpression operator or(const OperatorExpression& other) const {
-    return OperatorExpression(ExpressionType::OR, {MakeShared(*this), MakeShared(other)});
-  }
-
-  OperatorExpression operator not() const {
-    return OperatorExpression(ExpressionType::NOT, {MakeShared(*this)});
-  }
-
-  Result<std::shared_ptr<Expression>> Assume(const Expression& given) const;
+  std::shared_ptr<Expression> Copy() const override;
 
  private:
   std::vector<std::shared_ptr<Expression>> operands_;
 };
 
-class ARROW_DS_EXPORT ScalarExpression : public Expression {
+OperatorExpression operator and(const OperatorExpression& lhs,
+                                const OperatorExpression& rhs);
+OperatorExpression operator or(const OperatorExpression& lhs,
+                               const OperatorExpression& rhs);
+OperatorExpression operator not(const OperatorExpression& rhs);
+
+/// Represents a scalar value; thin wrapper around arrow::Scalar
+class ARROW_DS_EXPORT ScalarExpression final : public Expression {
  public:
   explicit ScalarExpression(const std::shared_ptr<Scalar>& value)
       : Expression(ExpressionType::SCALAR), value_(std::move(value)) {}
@@ -190,11 +200,15 @@ class ARROW_DS_EXPORT ScalarExpression : public Expression {
 
   static std::shared_ptr<ScalarExpression> Make(const char* value);
 
+  std::shared_ptr<Expression> Copy() const override;
+
  private:
   std::shared_ptr<Scalar> value_;
 };
 
-class ARROW_DS_EXPORT FieldReferenceExpression : public Expression {
+/// Represents a reference to a field. Stores only the field's name (type and other
+/// information is known only when a Schema is provided)
+class ARROW_DS_EXPORT FieldReferenceExpression final : public Expression {
  public:
   explicit FieldReferenceExpression(std::string name)
       : Expression(ExpressionType::FIELD), name_(std::move(name)) {}
@@ -203,45 +217,26 @@ class ARROW_DS_EXPORT FieldReferenceExpression : public Expression {
 
   virtual std::string ToString() const override;
 
-  template <typename T>
-  OperatorExpression operator==(T&& value) const {
-    return Comparison(ExpressionType::EQUAL, std::forward<T>(value));
-  }
-
-  template <typename T>
-  OperatorExpression operator!=(T&& value) const {
-    return Comparison(ExpressionType::NOT_EQUAL, std::forward<T>(value));
-  }
-
-  template <typename T>
-  OperatorExpression operator>(T&& value) const {
-    return Comparison(ExpressionType::GREATER, std::forward<T>(value));
-  }
-
-  template <typename T>
-  OperatorExpression operator>=(T&& value) const {
-    return Comparison(ExpressionType::GREATER_EQUAL, std::forward<T>(value));
-  }
-
-  template <typename T>
-  OperatorExpression operator<(T&& value) const {
-    return Comparison(ExpressionType::LESS, std::forward<T>(value));
-  }
-
-  template <typename T>
-  OperatorExpression operator<=(T&& value) const {
-    return Comparison(ExpressionType::LESS_EQUAL, std::forward<T>(value));
-  }
+  std::shared_ptr<Expression> Copy() const override;
 
  private:
-  template <typename T>
-  OperatorExpression Comparison(ExpressionType::type type, T&& value) const {
-    return OperatorExpression(
-        type, {MakeShared(*this), ScalarExpression::Make(std::forward<T>(value))});
-  }
-
   std::string name_;
 };
+
+#define COMPARISON_FACTORY(NAME, OP)                                             \
+  template <typename T>                                                          \
+  OperatorExpression operator OP(const FieldReferenceExpression& lhs, T&& rhs) { \
+    return OperatorExpression(                                                   \
+        ExpressionType::NAME,                                                    \
+        {lhs.Copy(), ScalarExpression::Make(std::forward<T>(rhs))});             \
+  }
+COMPARISON_FACTORY(EQUAL, ==)
+COMPARISON_FACTORY(NOT_EQUAL, !=)
+COMPARISON_FACTORY(GREATER, >)
+COMPARISON_FACTORY(GREATER_EQUAL, >=)
+COMPARISON_FACTORY(LESS, <)
+COMPARISON_FACTORY(LESS_EQUAL, <=)
+#undef COMPARISON_FACTORY
 
 inline namespace string_literals {
 FieldReferenceExpression operator""_(const char* name, size_t name_length) {

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -130,8 +130,11 @@ class ARROW_DS_EXPORT Expression {
     return Copy();
   }
 
-  // Evaluate an expression against a RecordBatch.
-  // Returned Datum must be of either SCALAR or ARRAY kind.
+  /// Evaluate this expression against each row of a RecordBatch.
+  /// Returned Datum will be of either SCALAR or ARRAY kind.
+  /// A return value of ARRAY kind will have length == batch.num_rows()
+  /// An return value of SCALAR kind is equivalent to an array of the same type whose
+  /// slots contain a single repeated value.
   virtual Result<compute::Datum> Evaluate(compute::FunctionContext* ctx,
                                           const RecordBatch& batch) const = 0;
 
@@ -387,7 +390,7 @@ auto scalar(T&& value) -> decltype(ScalarExpression::Make(std::forward<T>(value)
   return ScalarExpression::Make(std::forward<T>(value));
 }
 
-inline std::shared_ptr<FieldExpression> fieldRef(std::string name) {
+inline std::shared_ptr<FieldExpression> field_ref(std::string name) {
   return std::make_shared<FieldExpression>(std::move(name));
 }
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -135,7 +135,7 @@ class ARROW_DS_EXPORT Expression {
   }
 
   /// returns a debug string representing this expression
-  virtual std::string ToString() const { return "FIXME"; }
+  virtual std::string ToString() const = 0;
 
   ExpressionType::type type() const { return type_; }
 
@@ -281,7 +281,7 @@ class ARROW_DS_EXPORT NotExpression final
  public:
   using ExpressionImpl::ExpressionImpl;
 
-  // std::string ToString() const override;
+  std::string ToString() const override;
 
   // Result<std::shared_ptr<Expression>> Validate(const Schema& schema) const override;
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -165,7 +165,7 @@ class ExpressionImpl : public Base {
   }
 };
 
-/// Represents an expression with exactly one operand; for example negation
+/// Base class for an expression with exactly one operand
 class ARROW_DS_EXPORT UnaryExpression : public Expression {
  public:
   const std::shared_ptr<Expression>& operand() const { return operand_; }
@@ -179,8 +179,7 @@ class ARROW_DS_EXPORT UnaryExpression : public Expression {
   std::shared_ptr<Expression> operand_;
 };
 
-/// Represents an expression with exactly two operands; for example a comparison of two
-/// expressions
+/// Base class for an expression with exactly two operands
 class ARROW_DS_EXPORT BinaryExpression : public Expression {
  public:
   const std::shared_ptr<Expression>& left_operand() const { return left_operand_; }
@@ -199,8 +198,7 @@ class ARROW_DS_EXPORT BinaryExpression : public Expression {
   std::shared_ptr<Expression> left_operand_, right_operand_;
 };
 
-/// Represents an expression with multiple operands; for example a conjunction or
-/// disjunction of other expressions
+/// Base class for an expression with multiple operands
 class ARROW_DS_EXPORT NnaryExpression : public Expression {
  public:
   const ExpressionVector& operands() const { return operands_; }

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -302,19 +302,13 @@ class ARROW_DS_EXPORT ScalarExpression final : public Expression {
     return std::make_shared<ScalarExpression>(std::make_shared<BooleanScalar>(value));
   }
 
-  // FIXME(bkietz) create correct scalar type
   template <typename T>
-  static typename std::enable_if<std::is_integral<T>::value,
+  static typename std::enable_if<std::is_integral<T>::value ||
+                                     std::is_floating_point<T>::value,
                                  std::shared_ptr<ScalarExpression>>::type
   Make(T value) {
-    return std::make_shared<ScalarExpression>(std::make_shared<Int64Scalar>(value));
-  }
-
-  template <typename T>
-  static typename std::enable_if<std::is_floating_point<T>::value,
-                                 std::shared_ptr<ScalarExpression>>::type
-  Make(T value) {
-    return std::make_shared<ScalarExpression>(std::make_shared<DoubleScalar>(value));
+    using ScalarType = typename CTypeTraits<T>::ScalarType;
+    return std::make_shared<ScalarExpression>(std::make_shared<ScalarType>(value));
   }
 
   static std::shared_ptr<ScalarExpression> Make(std::string value);

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -82,7 +82,7 @@ TEST_F(ExpressionsTest, Equality) {
 TEST_F(ExpressionsTest, SimplificationOfCompoundQuery) {
   // chained "and" expressions are flattened
   auto multi_and = "b"_ > 5 and "b"_ < 10 and "b"_ != 7;
-  AssertOperandsAre(multi_and, ExpressionType::AND, "b"_ > 5, "b"_ < 10, "b"_ != 7);
+  AssertOperandsAre(multi_and, ExpressionType::ALL, "b"_ > 5, "b"_ < 10, "b"_ != 7);
 
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ == 3, *never);
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ == 6, *always);

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -92,6 +92,9 @@ TEST_F(ExpressionsTest, SimplificationOfCompoundQuery) {
   AssertSimplifiesTo("b"_ == 3 or "b"_ == 4, "b"_ > 3, "b"_ == 4);
   AssertSimplifiesTo("b"_ == 3 or "b"_ == 4, "b"_ >= 3, "b"_ == 3 or "b"_ == 4);
 
+  AssertSimplifiesTo("b"_ > 0.5 and "b"_ < 1.5, not("b"_ < 0.0 or "b"_ > 1.0),
+                     "b"_ > 0.5);
+
   AssertSimplifiesTo("b"_ == 4, "a"_ == 0, "b"_ == 4);
 
   AssertSimplifiesTo("a"_ == 3 or "b"_ == 4, "a"_ == 0, "b"_ == 4);

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -106,10 +106,10 @@ TEST_F(ExpressionsTest, SimplificationToNull) {
   auto null = ScalarExpression::MakeNull(boolean());
   auto null32 = ScalarExpression::MakeNull(int32());
 
-  AssertSimplifiesTo(*equal(fieldRef("b"), null32), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal(fieldRef("b"), null32), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal(fieldRef("b"), null32) and "b"_ > 3, "b"_ == 3, *null);
-  AssertSimplifiesTo("b"_ > 3 and *not_equal(fieldRef("b"), null32), "b"_ == 3, *null);
+  AssertSimplifiesTo(*equal(field_ref("b"), null32), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(field_ref("b"), null32), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(field_ref("b"), null32) and "b"_ > 3, "b"_ == 3, *null);
+  AssertSimplifiesTo("b"_ > 3 and *not_equal(field_ref("b"), null32), "b"_ == 3, *null);
 }
 
 class FilterTest : public ::testing::Test {

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -23,23 +23,67 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "arrow/compute/api.h"
+#include "arrow/dataset/api.h"
+#include "arrow/record_batch.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
-
-#include "arrow/dataset/api.h"
 
 namespace arrow {
 namespace dataset {
 
-TEST(Expressions, Basics) {
+class ExpressionsTest : public ::testing::Test {
+ public:
+  void AssertSimplifiesTo(OperatorExpression expr, const Expression& given,
+                          const Expression& expected) {
+    auto simplified = expr.Assume(given);
+    ASSERT_OK(simplified.status());
+    if (!simplified.ValueOrDie()->Equals(expected)) {
+      FAIL() << "  simplification of: " << expr.ToString() << std::endl
+             << "              given: " << expr.ToString() << std::endl
+             << "           expected: " << expected.ToString() << std::endl
+             << "                was: " << simplified.ValueOrDie()->ToString();
+    }
+  }
+
+  std::shared_ptr<ScalarExpression> always = ScalarExpression::Make(true);
+  std::shared_ptr<ScalarExpression> never = ScalarExpression::Make(false);
+};
+
+TEST_F(ExpressionsTest, Basics) {
   using namespace string_literals;
 
-  auto simplified = ("b"_ == 3).Assume("b"_ > 5 and "b"_ < 10);
-  ASSERT_OK(simplified.status());
-  ASSERT_EQ(simplified.ValueOrDie()->type(), ExpressionType::SCALAR);
-  auto value = internal::checked_cast<const ScalarExpression&>(**simplified).value();
-  ASSERT_EQ(value->type->id(), Type::BOOL);
-  ASSERT_FALSE(internal::checked_cast<const BooleanScalar&>(*value).value);
+  ASSERT_TRUE("a"_.Equals("a"_));
+  ASSERT_FALSE("a"_.Equals("b"_));
+
+  ASSERT_TRUE(("b"_ == 3).Equals("b"_ == 3));
+  ASSERT_FALSE(("b"_ == 3).Equals("b"_ < 3));
+  ASSERT_FALSE(("b"_ == 3).Equals("b"_));
+
+  AssertSimplifiesTo("b"_ == 3, "b"_ > 5 and "b"_ < 10, *never);
+  AssertSimplifiesTo("b"_ > 3, "b"_ > 5 and "b"_ < 10, *always);
+}
+
+TEST(FilterTest, Basics) {
+  using namespace string_literals;
+
+  auto batch = RecordBatch::FromStructArray(
+      ArrayFromJSON(struct_({field("a", int64()), field("b", float64())}), R"([
+      {"a": 0, "b": -0.1},
+      {"a": 0, "b": 0.3},
+      {"a": 1, "b": 0.2},
+      {"a": 2, "b": -0.1},
+      {"a": 0, "b": 0.1},
+      {"a": 0, "b": 1.0}
+  ])"));
+
+  arrow::compute::FunctionContext ctx;
+  std::shared_ptr<BooleanArray> filter;
+  ASSERT_OK(ExpressionFilter(MakeShared("a"_ == 0 and "b"_ > 0.0 and "b"_ < 1.0))
+                .Execute(&ctx, *batch, &filter));
+
+  auto expected_filter = ArrayFromJSON(boolean(), "[0, 1, 0, 0, 1, 0]");
+  ASSERT_ARRAYS_EQUAL(*expected_filter, *filter);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "arrow/dataset/filter.h"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -24,7 +26,6 @@
 #include <gtest/gtest.h>
 
 #include "arrow/compute/api.h"
-#include "arrow/dataset/api.h"
 #include "arrow/dataset/test_util.h"
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
@@ -33,7 +34,7 @@
 namespace arrow {
 namespace dataset {
 
-using namespace string_literals;
+using string_literals::operator""_;
 using internal::checked_pointer_cast;
 
 class ExpressionsTest : public ::testing::Test {

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -83,7 +83,7 @@ TEST_F(ExpressionsTest, Equality) {
 TEST_F(ExpressionsTest, SimplificationOfCompoundQuery) {
   // chained "and" expressions are flattened
   auto multi_and = "b"_ > 5 and "b"_ < 10 and "b"_ != 7;
-  AssertOperandsAre(multi_and, ExpressionType::ALL, "b"_ > 5, "b"_ < 10, "b"_ != 7);
+  AssertOperandsAre(multi_and, ExpressionType::AND, "b"_ > 5, "b"_ < 10, "b"_ != 7);
 
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ == 3, *never);
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ == 6, *always);

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -109,12 +109,12 @@ TEST_F(ExpressionsTest, SimplificationAgainstCompoundCondition) {
 
 TEST_F(ExpressionsTest, SimplificationToNull) {
   auto null = ScalarExpression::MakeNull(boolean());
-  auto null64 = ScalarExpression::MakeNull(int64());
+  auto null32 = ScalarExpression::MakeNull(int32());
 
-  AssertSimplifiesTo(*equal(fieldRef("b"), null64), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal(fieldRef("b"), null64), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal(fieldRef("b"), null64) and "b"_ > 3, "b"_ == 3, *null);
-  AssertSimplifiesTo("b"_ > 3 and *not_equal(fieldRef("b"), null64), "b"_ == 3, *null);
+  AssertSimplifiesTo(*equal(fieldRef("b"), null32), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(fieldRef("b"), null32), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(fieldRef("b"), null32) and "b"_ > 3, "b"_ == 3, *null);
+  AssertSimplifiesTo("b"_ > 3 and *not_equal(fieldRef("b"), null32), "b"_ == 3, *null);
 }
 
 class FilterTest : public ::testing::Test {
@@ -173,7 +173,7 @@ class FilterTest : public ::testing::Test {
 };
 
 TEST_F(FilterTest, Trivial) {
-  AssertFilter(*scalar(true), {field("a", int64()), field("b", float64())}, R"([
+  AssertFilter(*scalar(true), {field("a", int32()), field("b", float64())}, R"([
       {"a": 0, "b": -0.1, "in": 1},
       {"a": 0, "b":  0.3, "in": 1},
       {"a": 1, "b":  0.2, "in": 1},
@@ -183,7 +183,7 @@ TEST_F(FilterTest, Trivial) {
       {"a": 0, "b":  1.0, "in": 1}
   ])");
 
-  AssertFilter(*scalar(false), {field("a", int64()), field("b", float64())}, R"([
+  AssertFilter(*scalar(false), {field("a", int32()), field("b", float64())}, R"([
       {"a": 0, "b": -0.1, "in": 0},
       {"a": 0, "b":  0.3, "in": 0},
       {"a": 1, "b":  0.2, "in": 0},
@@ -194,7 +194,7 @@ TEST_F(FilterTest, Trivial) {
   ])");
 
   AssertFilter(*ScalarExpression::MakeNull(boolean()),
-               {field("a", int64()), field("b", float64())}, R"([
+               {field("a", int32()), field("b", float64())}, R"([
       {"a": 0, "b": -0.1, "in": null},
       {"a": 0, "b":  0.3, "in": null},
       {"a": 1, "b":  0.2, "in": null},
@@ -207,7 +207,7 @@ TEST_F(FilterTest, Trivial) {
 
 TEST_F(FilterTest, Basics) {
   AssertFilter("a"_ == 0 and "b"_ > 0.0 and "b"_ < 1.0,
-               {field("a", int64()), field("b", float64())}, R"([
+               {field("a", int32()), field("b", float64())}, R"([
       {"a": 0, "b": -0.1, "in": 0},
       {"a": 0, "b":  0.3, "in": 1},
       {"a": 1, "b":  0.2, "in": 0},
@@ -217,7 +217,7 @@ TEST_F(FilterTest, Basics) {
       {"a": 0, "b":  1.0, "in": 0}
   ])");
 
-  AssertFilter("a"_ != 0 and "b"_ > 0.1, {field("a", int64()), field("b", float64())},
+  AssertFilter("a"_ != 0 and "b"_ > 0.1, {field("a", int32()), field("b", float64())},
                R"([
       {"a": 0, "b": -0.1, "in": 0},
       {"a": 0, "b":  0.3, "in": 0},
@@ -231,7 +231,7 @@ TEST_F(FilterTest, Basics) {
 
 TEST_F(FilterTest, ConditionOnAbsentColumn) {
   AssertFilter("a"_ == 0 and "b"_ > 0.0 and "b"_ < 1.0 and "absent"_ == 0,
-               {field("a", int64()), field("b", float64())}, R"([
+               {field("a", int32()), field("b", float64())}, R"([
       {"a": 0, "b": -0.1, "in": null},
       {"a": 0, "b":  0.3, "in": null},
       {"a": 1, "b":  0.2, "in": null},

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -52,16 +52,11 @@ class ExpressionsTest : public ::testing::Test {
     }
   }
 
-  template <typename NnaryExpression, typename... T>
-  void AssertOperandsAre(const NnaryExpression& expr, ExpressionType::type type,
-                         T... expected_operands) {
+  void AssertOperandsAre(const BinaryExpression& expr, ExpressionType::type type,
+                         const Expression& lhs, const Expression& rhs) {
     ASSERT_EQ(expr.type(), type);
-    ASSERT_EQ(expr.operands().size(), sizeof...(T));
-    std::shared_ptr<Expression> expected_operand_ptrs[] = {expected_operands.Copy()...};
-
-    for (size_t i = 0; i < sizeof...(T); ++i) {
-      ASSERT_TRUE(expr.operands()[i]->Equals(expected_operand_ptrs[i]));
-    }
+    ASSERT_TRUE(expr.left_operand()->Equals(lhs));
+    ASSERT_TRUE(expr.right_operand()->Equals(rhs));
   }
 
   std::shared_ptr<ScalarExpression> always = ScalarExpression::Make(true);
@@ -83,7 +78,7 @@ TEST_F(ExpressionsTest, Equality) {
 TEST_F(ExpressionsTest, SimplificationOfCompoundQuery) {
   // chained "and" expressions are flattened
   auto multi_and = "b"_ > 5 and "b"_ < 10 and "b"_ != 7;
-  AssertOperandsAre(multi_and, ExpressionType::AND, "b"_ > 5, "b"_ < 10, "b"_ != 7);
+  AssertOperandsAre(multi_and, ExpressionType::AND, ("b"_ > 5 and "b"_ < 10), "b"_ != 7);
 
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ == 3, *never);
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ == 6, *always);

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -108,12 +108,13 @@ TEST_F(ExpressionsTest, SimplificationAgainstCompoundCondition) {
 }
 
 TEST_F(ExpressionsTest, SimplificationToNull) {
-  auto null = ScalarExpression::MakeNull();
+  auto null = ScalarExpression::MakeNull(boolean());
+  auto null64 = ScalarExpression::MakeNull(int64());
 
-  AssertSimplifiesTo(*equal(fieldRef("b"), null), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal(fieldRef("b"), null), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal(fieldRef("b"), null) and "b"_ > 3, "b"_ == 3, *null);
-  AssertSimplifiesTo("b"_ > 3 and *not_equal(fieldRef("b"), null), "b"_ == 3, *null);
+  AssertSimplifiesTo(*equal(fieldRef("b"), null64), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(fieldRef("b"), null64), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(fieldRef("b"), null64) and "b"_ > 3, "b"_ == 3, *null);
+  AssertSimplifiesTo("b"_ > 3 and *not_equal(fieldRef("b"), null64), "b"_ == 3, *null);
 }
 
 class FilterTest : public ::testing::Test {
@@ -192,7 +193,7 @@ TEST_F(FilterTest, Trivial) {
       {"a": 0, "b":  1.0, "in": 0}
   ])");
 
-  AssertFilter(*ScalarExpression::MakeNull(),
+  AssertFilter(*ScalarExpression::MakeNull(boolean()),
                {field("a", int64()), field("b", float64())}, R"([
       {"a": 0, "b": -0.1, "in": null},
       {"a": 0, "b":  0.3, "in": null},

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -109,10 +109,10 @@ TEST_F(ExpressionsTest, SimplificationToNull) {
 
   auto null = ScalarExpression::MakeNull();
 
-  AssertSimplifiesTo(*equal("b"_, *null), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal("b"_, *null), "b"_ == 3, *null);
-  AssertSimplifiesTo(*not_equal("b"_, *null) and "b"_ > 3, "b"_ == 3, *null);
-  AssertSimplifiesTo("b"_ > 3 and *not_equal("b"_, *null), "b"_ == 3, *null);
+  AssertSimplifiesTo(*equal(fieldRef("b"), null), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(fieldRef("b"), null), "b"_ == 3, *null);
+  AssertSimplifiesTo(*not_equal(fieldRef("b"), null) and "b"_ > 3, "b"_ == 3, *null);
+  AssertSimplifiesTo("b"_ > 3 and *not_equal(fieldRef("b"), null), "b"_ == 3, *null);
 }
 
 class FilterTest : public ::testing::Test {

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -15,12 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include "arrow/dataset/dataset.h"
-#include "arrow/dataset/discovery.h"
-#include "arrow/dataset/file_base.h"
-#include "arrow/dataset/file_csv.h"
-#include "arrow/dataset/file_feather.h"
-#include "arrow/dataset/filter.h"
-#include "arrow/dataset/scanner.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
+
+#include "arrow/dataset/api.h"
+
+namespace arrow {
+namespace dataset {
+
+TEST(Expressions, Basics) {
+  using namespace string_literals;
+
+  auto simplified = ("b"_ == 3).Assume("b"_ > 5 and "b"_ < 10);
+  ASSERT_OK(simplified.status());
+  ASSERT_EQ(simplified.ValueOrDie()->type(), ExpressionType::SCALAR);
+  auto value = internal::checked_cast<const ScalarExpression&>(**simplified).value();
+  ASSERT_EQ(value->type->id(), Type::BOOL);
+  ASSERT_FALSE(internal::checked_cast<const BooleanScalar&>(*value).value);
+}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -93,6 +93,8 @@ TEST_F(ExpressionsTest, Simplification) {
   AssertSimplifiesTo("b"_ == 3 or "b"_ == 4, "b"_ == 3, *always);
   AssertSimplifiesTo("b"_ == 3 or "b"_ == 4, "b"_ > 3, "b"_ == 4);
   AssertSimplifiesTo("b"_ == 3 or "b"_ == 4, "b"_ >= 3, "b"_ == 3 or "b"_ == 4);
+
+  AssertSimplifiesTo("a"_ == 3 or "b"_ == 4, "a"_ == 0, "b"_ == 4);
 }
 
 class FilterTest : public ::testing::Test {

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -25,6 +25,12 @@
 
 namespace arrow {
 
+namespace compute {
+
+class FunctionContext;
+
+}  // namespace compute
+
 namespace fs {
 
 class FileSystem;
@@ -49,6 +55,12 @@ class FileWriteOptions;
 
 class Filter;
 using FilterVector = std::vector<std::shared_ptr<Filter>>;
+
+class Expression;
+class OperatorExpression;
+class ScalarExpression;
+class FieldReferenceExpression;
+using ExpressionVector = std::vector<std::shared_ptr<Expression>>;
 
 class Partition;
 class PartitionKey;

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -57,7 +57,10 @@ class Filter;
 using FilterVector = std::vector<std::shared_ptr<Filter>>;
 
 class Expression;
-class OperatorExpression;
+class ComparisonExpression;
+class AndExpression;
+class OrExpression;
+class NotExpression;
 class ScalarExpression;
 class FieldReferenceExpression;
 using ExpressionVector = std::vector<std::shared_ptr<Expression>>;

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -197,10 +197,16 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(schema, num_rows, columns);
 }
-std::shared_ptr<RecordBatch> RecordBatch::FromStructArray(
-    const std::shared_ptr<Array>& array) {
-  return Make(arrow::schema(array->type()->children()), array->length(),
+
+Status RecordBatch::FromStructArray(const std::shared_ptr<Array>& array,
+                                    std::shared_ptr<RecordBatch>* out) {
+  if (array->type_id() != Type::STRUCT) {
+    return Status::Invalid("Cannot construct record batch from array of type ",
+                           *array->type());
+  }
+  *out = Make(arrow::schema(array->type()->children()), array->length(),
               array->data()->child_data);
+  return Status::OK();
 }
 
 const std::string& RecordBatch::column_name(int i) const {

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -197,6 +197,11 @@ std::shared_ptr<RecordBatch> RecordBatch::Make(
   DCHECK_EQ(schema->num_fields(), static_cast<int>(columns.size()));
   return std::make_shared<SimpleRecordBatch>(schema, num_rows, columns);
 }
+std::shared_ptr<RecordBatch> RecordBatch::FromStructArray(
+    const std::shared_ptr<Array>& array) {
+  return Make(arrow::schema(array->type()->children()), array->length(),
+              array->data()->child_data);
+}
 
 const std::string& RecordBatch::column_name(int i) const {
   return schema_->field(i)->name();

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -71,8 +71,8 @@ class ARROW_EXPORT RecordBatch {
       const std::shared_ptr<Schema>& schema, int64_t num_rows,
       const std::vector<std::shared_ptr<ArrayData>>& columns);
 
-  static std::shared_ptr<RecordBatch> FromStructArray(
-      const std::shared_ptr<Array>& array);
+  static Status FromStructArray(const std::shared_ptr<Array>& array,
+                                std::shared_ptr<RecordBatch>* out);
 
   /// \brief Determine if two record batches are exactly equal
   /// \return true if batches are equal

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -71,6 +71,9 @@ class ARROW_EXPORT RecordBatch {
       const std::shared_ptr<Schema>& schema, int64_t num_rows,
       const std::vector<std::shared_ptr<ArrayData>>& columns);
 
+  static std::shared_ptr<RecordBatch> FromStructArray(
+      const std::shared_ptr<Array>& array);
+
   /// \brief Determine if two record batches are exactly equal
   /// \return true if batches are equal
   bool Equals(const RecordBatch& other) const;

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -26,6 +26,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
+#include "arrow/visitor_inline.h"
 
 namespace arrow {
 
@@ -114,5 +115,30 @@ FixedSizeListScalar::FixedSizeListScalar(const std::shared_ptr<Array>& value,
 FixedSizeListScalar::FixedSizeListScalar(const std::shared_ptr<Array>& value,
                                          bool is_valid)
     : FixedSizeListScalar(value, value->type(), is_valid) {}
+
+struct MakeNullImpl {
+  template <typename T>
+  using ScalarType = typename TypeTraits<T>::ScalarType;
+
+  template <typename T>
+  typename std::enable_if<std::is_default_constructible<ScalarType<T>>::value,
+                          Status>::type
+  Visit(const T&) {
+    *out_ = std::make_shared<ScalarType<T>>();
+    return Status::OK();
+  }
+
+  Status Visit(const DataType& t) {
+    return Status::NotImplemented("construcing null scalars of type ", t);
+  }
+
+  std::shared_ptr<DataType> type_;
+  std::shared_ptr<Scalar>* out_;
+};
+
+Status MakeNull(const std::shared_ptr<DataType>& type, std::shared_ptr<Scalar>* null) {
+  MakeNullImpl impl = {type, null};
+  return VisitTypeInline(*type, &impl);
+}
 
 }  // namespace arrow

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -136,7 +136,8 @@ struct MakeNullImpl {
   std::shared_ptr<Scalar>* out_;
 };
 
-Status MakeNull(const std::shared_ptr<DataType>& type, std::shared_ptr<Scalar>* null) {
+Status MakeNullScalar(const std::shared_ptr<DataType>& type,
+                      std::shared_ptr<Scalar>* null) {
   MakeNullImpl impl = {type, null};
   return VisitTypeInline(*type, &impl);
 }

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -246,4 +246,10 @@ class ARROW_EXPORT UnionScalar : public Scalar {};
 class ARROW_EXPORT DictionaryScalar : public Scalar {};
 class ARROW_EXPORT ExtensionScalar : public Scalar {};
 
+/// \param[in] type the type of scalar to produce
+/// \param[out] null output scalar with is_valid=false
+/// \return Status
+ARROW_EXPORT
+Status MakeNull(const std::shared_ptr<DataType>& type, std::shared_ptr<Scalar>* null);
+
 }  // namespace arrow

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -76,6 +76,7 @@ struct ARROW_EXPORT BooleanScalar : public internal::PrimitiveScalar {
   bool value;
   explicit BooleanScalar(bool value, bool is_valid = true)
       : internal::PrimitiveScalar{boolean(), is_valid}, value(value) {}
+  BooleanScalar() : BooleanScalar(false, false) {}
 };
 
 template <typename Type>
@@ -85,6 +86,8 @@ struct NumericScalar : public internal::PrimitiveScalar {
 
   explicit NumericScalar(T value, bool is_valid = true)
       : NumericScalar(value, TypeTraits<Type>::type_singleton(), is_valid) {}
+
+  NumericScalar() : NumericScalar(0, false) {}
 
  protected:
   explicit NumericScalar(T value, const std::shared_ptr<DataType>& type, bool is_valid)
@@ -99,11 +102,15 @@ struct BaseBinaryScalar : public Scalar {
   BaseBinaryScalar(const std::shared_ptr<Buffer>& value,
                    const std::shared_ptr<DataType>& type, bool is_valid = true)
       : Scalar{type, is_valid}, value(value) {}
+
+  static std::shared_ptr<Buffer> Empty();
 };
 
 struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar<BinaryType> {
   explicit BinaryScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
       : BaseBinaryScalar(value, binary(), is_valid) {}
+
+  BinaryScalar() : BinaryScalar(NULLPTR, false) {}
 
  protected:
   using BaseBinaryScalar::BaseBinaryScalar;
@@ -112,11 +119,15 @@ struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar<BinaryType> {
 struct ARROW_EXPORT StringScalar : public BinaryScalar {
   explicit StringScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
       : BinaryScalar(value, utf8(), is_valid) {}
+
+  StringScalar() : StringScalar(NULLPTR, false) {}
 };
 
 struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar<LargeBinaryType> {
   explicit LargeBinaryScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
       : BaseBinaryScalar(value, large_binary(), is_valid) {}
+
+  LargeBinaryScalar() : LargeBinaryScalar(NULLPTR, false) {}
 
  protected:
   using BaseBinaryScalar::BaseBinaryScalar;
@@ -125,6 +136,8 @@ struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar<LargeBinaryType>
 struct ARROW_EXPORT LargeStringScalar : public LargeBinaryScalar {
   explicit LargeStringScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
       : LargeBinaryScalar(value, utf8(), is_valid) {}
+
+  LargeStringScalar() : LargeStringScalar(NULLPTR, false) {}
 };
 
 struct ARROW_EXPORT FixedSizeBinaryScalar : public BinaryScalar {

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -250,6 +250,7 @@ class ARROW_EXPORT ExtensionScalar : public Scalar {};
 /// \param[out] null output scalar with is_valid=false
 /// \return Status
 ARROW_EXPORT
-Status MakeNull(const std::shared_ptr<DataType>& type, std::shared_ptr<Scalar>* null);
+Status MakeNullScalar(const std::shared_ptr<DataType>& type,
+                      std::shared_ptr<Scalar>* null);
 
 }  // namespace arrow

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -102,8 +102,6 @@ struct BaseBinaryScalar : public Scalar {
   BaseBinaryScalar(const std::shared_ptr<Buffer>& value,
                    const std::shared_ptr<DataType>& type, bool is_valid = true)
       : Scalar{type, is_valid}, value(value) {}
-
-  static std::shared_ptr<Buffer> Empty();
 };
 
 struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar<BinaryType> {


### PR DESCRIPTION
Adds the Expression class which is used to represent an arbitrarily complex filter expression. Expressions can be constructed using factory functions, for example:

```c++
and_(
  equal(field_ref("a"), scalar<int16_t>(5)),   // column 'a' is equal to 5
  greater(field_ref("b"), scalar<double>(0.0)) // column 'b' is greater than 0.0
)
```

Operator overloads are also provided, so the above could also be written as
```c++
"a"_ == int16_t(5) and "b"_ > 0.0
```

These can be executed against a single record batch (using the `arrow::compute::` kernels).

Additionally, expressions may be simplified or even elided given partition information. For example, given a partition where column 'a' is equal to 5 the above query could be simplified to `"b"_ > 0.0` (since the condition on column 'a' is satisfied by the entire partition) and given a partition where column 'b' is between -1.0 and 0.0 the query simplifies to `false` (since no record in the partition will satisfy the condition on column 'b'). This can be used to support arbitrary partitioning schemes and do the least kernel work possible on each record batch.