### PR TITLE
ARROW-6328: [Developer][crossbow] Click.option-s should have help text

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -724,7 +724,9 @@ def crossbow(ctx, github_token, arrow_path, queue_path):
               help='Path of changelog to update')
 @click.option('--arrow-version', '-v', default=None,
               help='Set target version explicitly')
-@click.option('--is-website', '-w', default=False, is_flag=True, help='Whether to use website format for changelog. Uses markdown format if false.')
+@click.option('--is-website', '-w', default=False, is_flag=True,
+              help='Whether to use website format for changelog. '
+                   'Uses markdown format if false.')
 @click.option('--jira-username', '-u', default=None, help='JIRA username')
 @click.option('--jira-password', '-P', default=None, help='JIRA password')
 @click.option('--dry-run/--write', default=False,

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -724,7 +724,7 @@ def crossbow(ctx, github_token, arrow_path, queue_path):
               help='Path of changelog to update')
 @click.option('--arrow-version', '-v', default=None,
               help='Set target version explicitly')
-@click.option('--is-website', '-w', default=False)
+@click.option('--is-website', '-w', default=False, is_flag=True, help='Whether to use website format for changelog. Uses markdown format if false.')
 @click.option('--jira-username', '-u', default=None, help='JIRA username')
 @click.option('--jira-password', '-P', default=None, help='JIRA password')
 @click.option('--dry-run/--write', default=False,

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -725,8 +725,7 @@ def crossbow(ctx, github_token, arrow_path, queue_path):
 @click.option('--arrow-version', '-v', default=None,
               help='Set target version explicitly')
 @click.option('--is-website', '-w', default=False, is_flag=True,
-              help='Whether to use website format for changelog. '
-                   'Uses markdown format if false.')
+              help='Whether to use website format for changelog. ')
 @click.option('--jira-username', '-u', default=None, help='JIRA username')
 @click.option('--jira-password', '-P', default=None, help='JIRA password')
 @click.option('--dry-run/--write', default=False,


### PR DESCRIPTION
Click.option-s should have `help` text

## What?
Add `help` text to click.option

## Why?
Click.option should ideally have a `help` text defined to be useful.
