### PR TITLE
ARROW-6321: [Python] Ability to create ExtensionBlock on conversion to pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1482,7 +1482,7 @@ class ExtensionBlock : public PandasBlock {
     return Status::OK();
   }
 
-  Status Write(const std::shared_ptr<ChunkedArray>& data, int64_t abs_placement,
+  Status Write(std::shared_ptr<ChunkedArray> data, int64_t abs_placement,
                int64_t rel_placement) override {
     PyAcquireGIL lock;
 
@@ -1644,9 +1644,7 @@ class DataFrameBlockCreator {
   explicit DataFrameBlockCreator(const PandasOptions& options,
                                  const std::unordered_set<std::string>& extension_columns,
                                  const std::shared_ptr<Table>& table)
-      : table_(table),
-        options_(options),
-        extension_columns_(extension_columns) {}
+      : table_(table), options_(options), extension_columns_(extension_columns) {}
 
   Status Convert(PyObject** output) {
     column_types_.resize(table_->num_columns());

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1486,10 +1486,8 @@ class ExtensionBlock : public PandasBlock {
                int64_t rel_placement) override {
     PyAcquireGIL lock;
 
-    // TODO taking the first chunk because there is no wrap_chunked_array
-    auto array = data->chunk(0);
     PyObject* py_array;
-    py_array = wrap_array(array);
+    py_array = wrap_chunked_array(data);
     py_array_.reset(py_array);
 
     placement_data_[rel_placement] = abs_placement;
@@ -1508,7 +1506,7 @@ class ExtensionBlock : public PandasBlock {
     return Status::OK();
   }
 
-protected:
+ protected:
   OwnedRefNoGIL py_array_;
 };
 

--- a/cpp/src/arrow/python/arrow_to_pandas.h
+++ b/cpp/src/arrow/python/arrow_to_pandas.h
@@ -97,8 +97,7 @@ ARROW_PYTHON_EXPORT
 Status ConvertTableToPandas(const PandasOptions& options,
                             const std::unordered_set<std::string>& categorical_columns,
                             const std::unordered_set<std::string>& extension_columns,
-                            const std::shared_ptr<Table>& table, MemoryPool* pool,
-                            PyObject** out);
+                            const std::shared_ptr<Table>& table, PyObject** out);
 
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/python/arrow_to_pandas.h
+++ b/cpp/src/arrow/python/arrow_to_pandas.h
@@ -93,6 +93,13 @@ Status ConvertTableToPandas(const PandasOptions& options,
                             const std::unordered_set<std::string>& categorical_columns,
                             const std::shared_ptr<Table>& table, PyObject** out);
 
+ARROW_PYTHON_EXPORT
+Status ConvertTableToPandas(const PandasOptions& options,
+                            const std::unordered_set<std::string>& categorical_columns,
+                            const std::unordered_set<std::string>& extension_columns,
+                            const std::shared_ptr<Table>& table, MemoryPool* pool,
+                            PyObject** out);
+
 }  // namespace py
 }  // namespace arrow
 

--- a/cpp/src/arrow/python/pyarrow.cc
+++ b/cpp/src/arrow/python/pyarrow.cc
@@ -113,6 +113,10 @@ PyObject* wrap_array(const std::shared_ptr<Array>& array) {
   return ::pyarrow_wrap_array(array);
 }
 
+PyObject* wrap_chunked_array(const std::shared_ptr<ChunkedArray>& array) {
+  return ::pyarrow_wrap_chunked_array(array);
+}
+
 bool is_tensor(PyObject* tensor) { return ::pyarrow_is_tensor(tensor) != 0; }
 
 Status unwrap_tensor(PyObject* tensor, std::shared_ptr<Tensor>* out) {

--- a/cpp/src/arrow/python/pyarrow.h
+++ b/cpp/src/arrow/python/pyarrow.h
@@ -66,6 +66,8 @@ ARROW_PYTHON_EXPORT PyObject* wrap_schema(const std::shared_ptr<Schema>& schema)
 ARROW_PYTHON_EXPORT bool is_array(PyObject* array);
 ARROW_PYTHON_EXPORT Status unwrap_array(PyObject* array, std::shared_ptr<Array>* out);
 ARROW_PYTHON_EXPORT PyObject* wrap_array(const std::shared_ptr<Array>& array);
+ARROW_PYTHON_EXPORT PyObject* wrap_chunked_array(
+    const std::shared_ptr<ChunkedArray>& array);
 
 ARROW_PYTHON_EXPORT bool is_tensor(PyObject* tensor);
 ARROW_PYTHON_EXPORT Status unwrap_tensor(PyObject* tensor, std::shared_ptr<Tensor>* out);

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1440,6 +1440,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
     CStatus ConvertTableToPandas(
         const PandasOptions& options,
         const unordered_set[c_string]& categorical_columns,
+        const unordered_set[c_string]& extension_columns,
         const shared_ptr[CTable]& table,
         PyObject** out)
 

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -677,7 +677,8 @@ def _reconstruct_block(item):
         bitmask = buflist[0]
         if bitmask is not None:
             mask = pa.BooleanArray.from_buffers(
-                pa.bool_(), len(arr), [None, bitmask]).to_pandas()
+                pa.bool_(), len(arr), [None, bitmask])
+            mask = np.asarray(mask)
         else:
             mask = np.ones(len(arr), dtype=bool)
         block_arr = _pandas_api.pd.arrays.IntegerArray(

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3207,6 +3207,7 @@ def _to_pandas(table, extension_columns=None):
     from pyarrow.pandas_compat import table_to_blockmanager
 
     options = dict(
+        pool=None,
         strings_to_categorical=False,
         zero_copy_only=False,
         integer_object_nulls=False,

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3199,6 +3199,50 @@ def test_array_protocol():
 
 
 # ----------------------------------------------------------------------
+# Pandas ExtensionArray support
+
+
+def _to_pandas(table, extension_columns=None):
+    # temporary test function as long as we have no public API to do this
+    from pyarrow.pandas_compat import table_to_blockmanager
+
+    options = dict(
+        strings_to_categorical=False,
+        zero_copy_only=False,
+        integer_object_nulls=False,
+        date_as_object=True,
+        use_threads=True,
+        deduplicate_objects=True)
+
+    mgr = table_to_blockmanager(
+        options, table, extension_columns=extension_columns)
+    return pd.DataFrame(mgr)
+
+
+def test_convert_to_extension_array():
+    if LooseVersion(pd.__version__) < '0.24.0':
+        pytest.skip(reason='IntegerArray only introduced in 0.24')
+
+    import pandas.core.internals as _int
+
+    table = pa.table({'a': [1, 2, 3], 'b': [2, 3, 4]})
+
+    df = _to_pandas(table)
+    assert len(df._data.blocks) == 1
+    assert isinstance(df._data.blocks[0], _int.IntBlock)
+
+    df = _to_pandas(table, extension_columns=['b'])
+    assert isinstance(df._data.blocks[0], _int.IntBlock)
+    assert isinstance(df._data.blocks[1], _int.ExtensionBlock)
+
+    table = pa.table({'a': [1, 2, None]})
+    df = _to_pandas(table, extension_columns=['a'])
+    assert isinstance(df._data.blocks[0], _int.ExtensionBlock)
+    expected = pd.DataFrame({'a': pd.Series([1, 2, None], dtype='Int64')})
+    tm.assert_frame_equal(df, expected)
+
+
+# ----------------------------------------------------------------------
 # Legacy metadata compatibility tests
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6321

This adds some code to create pandas ExtensionBlocks on the conversion to pandas. The approach taken is that for this case, instead of converting the Arrow array to a numpy array that can be stored in the block, the arrow_to_pandas C++ code sents the actual Arrow array to the pyarrow compat code (no conversion), and then there can be a mechanism to convert the arrow Array to a pandas ExtensionArray called from pyarrow.

~~As example (to test this), I changed the `integer_object_nulls` option (if triggered) to return a pandas nullable IntegerArray instead of object dtype array.~~ For now (to test this), I added a `extension_columns` to `table_to_blockmanager` to specify which columns should be put into an ExtensionBlock. And then in the pyarrow code for now hardcoded a conversion from pyarrow integer array to pandas IntegerArray. 

This (hardcoded) example works:

```
In [1]: df = pd.DataFrame({'a': [1, 2, 3], 'b': np.array([0, 1, None], dtype='object')}) 
   ...: table = pa.table(df)

In [2]: table
Out[2]: 
pyarrow.Table
a: int64
b: int64
metadata
--------
{b'pandas': ...

In [3]: table.to_pandas()   # default, you get floats if there are NULLs
Out[3]: 
   a    b
0  1  0.0
1  2  1.0
2  3  NaN

In [4]: table.to_pandas(integer_object_nulls=True)
Out[4]: 
   a    b
0  1    0
1  2    1
2  3  NaN

In [5]: table.to_pandas(integer_object_nulls=True).dtypes
Out[5]: 
a    int64
b    Int64   # <--- nullable integer type (ExtensionArray)
dtype: object
```

What is missing:

- a mechanism to indicate to the C++ `ConvertTableToPandas` function which columns to convert to extension block (maybe with a similar option as the current "categorical_columns" option?) EDIT: added such a column
- a mechanism to know how to convert the Arrow array to a pandas ExtensionArray (this is related to https://issues.apache.org/jira/browse/ARROW-2428


