### PR TITLE
ARROW-3531: [Python] add Schema.field() method / deprecate field_by_name

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -352,7 +352,7 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
                 "Sparse pandas data (column {}) not supported.".format(name))
 
         if schema is not None:
-            field = schema.field_by_name(name)
+            field = schema.field(name)
         else:
             field = None
 

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -63,8 +63,8 @@ def test_table():
                                  ['a', 'b'])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
-    node_b = builder.make_field(table.schema.field_by_name("b"))
+    node_a = builder.make_field(table.schema.field("a"))
+    node_b = builder.make_field(table.schema.field("b"))
 
     sum = builder.make_function("add", [node_a, node_b], pa.float64())
 
@@ -90,7 +90,7 @@ def test_filter():
                                  ['a'])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     thousand = builder.make_literal(1000.0, pa.float64())
     cond = builder.make_function("less_than", [node_a, thousand], pa.bool_())
     condition = builder.make_condition(cond)
@@ -109,7 +109,7 @@ def test_in_expr():
 
     # string
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [u"an", u"nd"], pa.string())
     condition = builder.make_condition(cond)
     filter = gandiva.make_filter(table.schema, condition)
@@ -119,7 +119,7 @@ def test_in_expr():
     # int32
     arr = pa.array([3, 1, 4, 1, 5, 9, 2, 6, 5, 4])
     table = pa.Table.from_arrays([arr.cast(pa.int32())], ["a"])
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [1, 5], pa.int32())
     condition = builder.make_condition(cond)
     filter = gandiva.make_filter(table.schema, condition)
@@ -129,7 +129,7 @@ def test_in_expr():
     # int64
     arr = pa.array([3, 1, 4, 1, 5, 9, 2, 6, 5, 4])
     table = pa.Table.from_arrays([arr], ["a"])
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [1, 5], pa.int64())
     condition = builder.make_condition(cond)
     filter = gandiva.make_filter(table.schema, condition)
@@ -151,7 +151,7 @@ def test_in_expr_todo():
     table = pa.Table.from_arrays([arr], ["a"])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [b'an', b'nd'], pa.binary())
     condition = builder.make_condition(cond)
 
@@ -168,7 +168,7 @@ def test_in_expr_todo():
     table = pa.Table.from_arrays([arr], ["a"])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [datetime_2], pa.timestamp('ms'))
     condition = builder.make_condition(cond)
 
@@ -185,7 +185,7 @@ def test_in_expr_todo():
     table = pa.Table.from_arrays([arr], ["a"])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [time_2], pa.time64('ms'))
     condition = builder.make_condition(cond)
 
@@ -202,7 +202,7 @@ def test_in_expr_todo():
     table = pa.Table.from_arrays([arr], ["a"])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     cond = builder.make_in_expression(node_a, [date_2], pa.date32())
     condition = builder.make_condition(cond)
 
@@ -221,8 +221,8 @@ def test_boolean():
                                  ['a', 'b'])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
-    node_b = builder.make_field(table.schema.field_by_name("b"))
+    node_a = builder.make_field(table.schema.field("a"))
+    node_b = builder.make_field(table.schema.field("b"))
     fifty = builder.make_literal(50.0, pa.float64())
     eleven = builder.make_literal(11.0, pa.float64())
 
@@ -287,7 +287,7 @@ def test_regex():
     table = pa.Table.from_arrays([data], names=['a'])
 
     builder = gandiva.TreeExprBuilder()
-    node_a = builder.make_field(table.schema.field_by_name("a"))
+    node_a = builder.make_field(table.schema.field("a"))
     regex = builder.make_literal("%spark%", pa.string())
     like = builder.make_function("like", [node_a, regex], pa.bool_())
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1659,7 +1659,7 @@ class TestConvertListTypes(object):
         assert table.schema.equals(expected_schema)
 
         for column in df.columns:
-            field = schema.field_by_name(column)
+            field = schema.field(column)
             _check_array_roundtrip(df[column], type=field.type)
 
     def test_column_of_arrays_to_py(self):
@@ -1710,7 +1710,7 @@ class TestConvertListTypes(object):
         assert table.schema.equals(expected_schema)
 
         for column in df.columns:
-            field = schema.field_by_name(column)
+            field = schema.field(column)
             _check_array_roundtrip(df[column], type=field.type)
 
     def test_column_of_lists_first_empty(self):
@@ -2688,9 +2688,9 @@ def test_table_from_pandas_keeps_schema_nullability():
     ])
 
     table = pa.Table.from_pandas(df)
-    assert table.schema.field_by_name('a').nullable is True
+    assert table.schema.field('a').nullable is True
     table = pa.Table.from_pandas(df, schema=schema)
-    assert table.schema.field_by_name('a').nullable is False
+    assert table.schema.field('a').nullable is False
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -238,8 +238,8 @@ def test_empty_table_roundtrip():
         [col.chunk(0)[:0] for col in table.itercolumns()],
         names=table.schema.names)
 
-    assert table.schema.field_by_name('null').type == pa.null()
-    assert table.schema.field_by_name('null_list').type == pa.list_(pa.null())
+    assert table.schema.field('null').type == pa.null()
+    assert table.schema.field('null_list').type == pa.list_(pa.null())
     _check_roundtrip(table, version='2.0')
 
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -541,6 +541,27 @@ def test_table_pickle():
     assert result.equals(table)
 
 
+def test_table_get_field():
+    data = [
+        pa.array(range(5)),
+        pa.array([-10, -5, 0, 5, 10]),
+        pa.array(range(5, 10))
+    ]
+    table = pa.Table.from_arrays(data, names=('a', 'b', 'c'))
+
+    assert table.field('a').equals(table.schema.field('a'))
+    assert table.field(0).equals(table.schema.field('a'))
+
+    with pytest.raises(KeyError):
+        table.field('d')
+
+    with pytest.raises(TypeError):
+        table.field(None)
+
+    with pytest.raises(IndexError):
+        table.field(4)
+
+
 def test_table_select_column():
     data = [
         pa.array(range(5)),
@@ -556,6 +577,9 @@ def test_table_select_column():
 
     with pytest.raises(TypeError):
         table.column(None)
+
+    with pytest.raises(IndexError):
+        table.column(4)
 
 
 def test_table_add_column():


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-3531

- add `Schema.field(i)` (similarly as Table.field(i), Table.column(i), etc)
- deprecate `Schema.field_by_name(name)` in favor of the above
- expand `Table.field(i)` to also accept string name (similar as Table.column(i)
- harmonize some of the code to check out of bounds indices (using `_normalize_index`)