### PR TITLE
ARROW-5830: [C++] Stop using memcmp in TensorEquals for tensors with float values

### DIFF
--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1047,7 +1047,6 @@ bool IntegerTensorEquals(const Tensor& left, const Tensor& right) {
 
     if (!(left_row_major_p && right_row_major_p) &&
         !(left_column_major_p && right_column_major_p)) {
-      const auto& shape = left.shape();
       const auto& type = checked_cast<const FixedWidthType&>(*left.type());
       are_equal =
           StridedIntegerTensorContentEquals(0, 0, 0, type.bit_width() / 8, left, right);

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1096,6 +1096,8 @@ bool StridedFloatTensorContentEquals(int dim_index, int64_t left_offset, int64_t
 
 template <typename DataType>
 bool FloatTensorEquals(const Tensor& left, const Tensor& right) {
+  static_assert(std::is_floating_point<typename DataType::c_type>::value,
+                "DataType must be a floating point type");
   return StridedFloatTensorContentEquals<DataType>(0, 0, 0, left, right);
 }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1126,7 +1126,7 @@ bool FloatTensorEquals(const Tensor& left, const Tensor& right,
 bool TensorEquals(const Tensor& left, const Tensor& right, const EqualOptions& opts) {
   if (left.type_id() != right.type_id()) {
     return false;
-  } else if (left.size() == 0) {
+  } else if (left.size() == 0 && right.size() == 0) {
     return true;
   } else if (left.shape() != right.shape()) {
     return false;

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1019,8 +1019,7 @@ bool StridedIntegerTensorContentEquals(const int dim_index, int64_t left_offset,
   if (dim_index == left.ndim() - 1) {
     for (int64_t i = 0; i < n; ++i) {
       if (memcmp(left.raw_data() + left_offset + i * left_stride,
-                 right.raw_data() + right_offset + i * right_stride,
-                 elem_size) != 0) {
+                 right.raw_data() + right_offset + i * right_stride, elem_size) != 0) {
         return false;
       }
     }

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1010,8 +1010,9 @@ bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_
 
 namespace {
 
-bool StridedIntegerTensorContentEquals(int dim_index, int64_t left_offset, int64_t right_offset,
-                                       int elem_size, const Tensor& left, const Tensor& right) {
+bool StridedIntegerTensorContentEquals(int dim_index, int64_t left_offset,
+                                       int64_t right_offset, int elem_size,
+                                       const Tensor& left, const Tensor& right) {
   if (dim_index == left.ndim() - 1) {
     for (int64_t i = 0; i < left.shape()[dim_index]; ++i) {
       if (memcmp(left.raw_data() + left_offset + i * left.strides()[dim_index],
@@ -1023,8 +1024,8 @@ bool StridedIntegerTensorContentEquals(int dim_index, int64_t left_offset, int64
     return true;
   }
   for (int64_t i = 0; i < left.shape()[dim_index]; ++i) {
-    if (!StridedIntegerTensorContentEquals(dim_index + 1, left_offset, right_offset, elem_size,
-                                           left, right)) {
+    if (!StridedIntegerTensorContentEquals(dim_index + 1, left_offset, right_offset,
+                                           elem_size, left, right)) {
       return false;
     }
     left_offset += left.strides()[dim_index];
@@ -1066,8 +1067,9 @@ bool IntegerTensorEquals(const Tensor& left, const Tensor& right) {
 }
 
 template <typename DataType>
-bool StridedFloatTensorContentEquals(int dim_index, int64_t left_offset, int64_t right_offset,
-                                     const Tensor& left, const Tensor& right) {
+bool StridedFloatTensorContentEquals(int dim_index, int64_t left_offset,
+                                     int64_t right_offset, const Tensor& left,
+                                     const Tensor& right) {
   using c_type = typename DataType::c_type;
   const int64_t n = left.shape()[dim_index];
   if (dim_index == left.ndim() - 1) {
@@ -1076,16 +1078,20 @@ bool StridedFloatTensorContentEquals(int dim_index, int64_t left_offset, int64_t
     auto left_stride = left.strides()[dim_index];
     auto right_stride = right.strides()[dim_index];
     for (int64_t i = 0; i < n; ++i) {
-      c_type left_value = *reinterpret_cast<const c_type*>(left_data + left_offset + i * left_stride);
-      c_type right_value = *reinterpret_cast<const c_type*>(right_data + right_offset + i * right_stride);
-      if (left_value != right_value || std::isnan(left_value) || std::isnan(right_value)) {
+      c_type left_value =
+          *reinterpret_cast<const c_type*>(left_data + left_offset + i * left_stride);
+      c_type right_value =
+          *reinterpret_cast<const c_type*>(right_data + right_offset + i * right_stride);
+      if (left_value != right_value || std::isnan(left_value) ||
+          std::isnan(right_value)) {
         return false;
       }
     }
     return true;
   }
   for (int64_t i = 0; i < n; ++i) {
-    if (!StridedFloatTensorContentEquals<DataType>(dim_index + 1, left_offset, right_offset, left, right)) {
+    if (!StridedFloatTensorContentEquals<DataType>(dim_index + 1, left_offset,
+                                                   right_offset, left, right)) {
       return false;
     }
     left_offset += left.strides()[dim_index];
@@ -1101,7 +1107,7 @@ bool FloatTensorEquals(const Tensor& left, const Tensor& right) {
   return StridedFloatTensorContentEquals<DataType>(0, 0, 0, left, right);
 }
 
-}
+}  // namespace
 
 bool TensorEquals(const Tensor& left, const Tensor& right) {
   if (left.type_id() != right.type_id()) {

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -82,7 +82,8 @@ class EqualOptions {
 bool ARROW_EXPORT ArrayEquals(const Array& left, const Array& right,
                               const EqualOptions& = EqualOptions::Defaults());
 
-bool ARROW_EXPORT TensorEquals(const Tensor& left, const Tensor& right);
+bool ARROW_EXPORT TensorEquals(const Tensor& left, const Tensor& right,
+                               const EqualOptions& = EqualOptions::Defaults());
 
 /// EXPERIMENTAL: Returns true if the given sparse tensors are exactly equal
 bool ARROW_EXPORT SparseTensorEquals(const SparseTensor& left, const SparseTensor& right);

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -26,7 +26,6 @@
 #include <type_traits>
 #include <vector>
 
-#include "arrow/compare.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
@@ -124,7 +123,9 @@ bool Tensor::is_column_major() const {
 
 Type::type Tensor::type_id() const { return type_->id(); }
 
-bool Tensor::Equals(const Tensor& other) const { return TensorEquals(*this, other); }
+bool Tensor::Equals(const Tensor& other, const EqualOptions& opts) const {
+  return TensorEquals(*this, other, opts);
+}
 
 namespace {
 

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "arrow/buffer.h"
+#include "arrow/compare.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/macros.h"
@@ -102,7 +103,7 @@ class ARROW_EXPORT Tensor {
 
   Type::type type_id() const;
 
-  bool Equals(const Tensor& other) const;
+  bool Equals(const Tensor& other, const EqualOptions& = EqualOptions::Defaults()) const;
 
   /// Compute the number of non-zero values in the tensor
   Status CountNonZero(int64_t* result) const;

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -245,6 +245,15 @@ TEST(TestTensor, EqualsInt64) {
   // column-major and non-contiguous
   EXPECT_TRUE(tf1.Equals(tnc));
   EXPECT_FALSE(tf3.Equals(tnc));
+
+  // zero-size tensor
+  std::shared_ptr<Buffer> empty_buffer1, empty_buffer2;
+  ASSERT_OK(AllocateBuffer(0, &empty_buffer1));
+  ASSERT_OK(AllocateBuffer(0, &empty_buffer2));
+  Tensor empty1(int64(), empty_buffer1, {0});
+  Tensor empty2(int64(), empty_buffer2, {0});
+  EXPECT_FALSE(empty1.Equals(tc1));
+  EXPECT_TRUE(empty1.Equals(empty2));
 }
 
 template <typename DataType>

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -326,13 +326,16 @@ TYPED_TEST_P(TestFloatTensor, Equals) {
   const c_data_type nan_value = static_cast<c_data_type>(NAN);
   c_values[0] = nan_value;
   EXPECT_TRUE(std::isnan(tc1.Value<DataType>({0, 0})));
-  EXPECT_FALSE(tc1.Equals(tc1));                            // same object
-  EXPECT_FALSE(std::isnan(tc2.Value<DataType>({0, 0})));  // check the different memory
-  EXPECT_FALSE(tc1.Equals(tc2));
+  EXPECT_FALSE(tc1.Equals(tc1));                                  // same object
+  EXPECT_TRUE(tc1.Equals(tc1, EqualOptions().nans_equal(true)));  // same object
+  EXPECT_FALSE(std::isnan(tc2.Value<DataType>({0, 0})));
+  EXPECT_FALSE(tc1.Equals(tc2));                                   // different memory
+  EXPECT_FALSE(tc1.Equals(tc2, EqualOptions().nans_equal(true)));  // different memory
 
   c_values_2[0] = nan_value;
   EXPECT_TRUE(std::isnan(tc2.Value<DataType>({0, 0})));
-  EXPECT_FALSE(tc1.Equals(tc2));  // different memory
+  EXPECT_FALSE(tc1.Equals(tc2));                                  // different memory
+  EXPECT_TRUE(tc1.Equals(tc2, EqualOptions().nans_equal(true)));  // different memory
 }
 
 REGISTER_TYPED_TEST_CASE_P(TestFloatTensor, Equals);

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -184,20 +184,26 @@ TEST(TestTensor, ElementAccessInt32) {
   });
 }
 
-TEST(TestTensor, Equals) {
+TEST(TestTensor, EqualsInt64) {
   std::vector<int64_t> shape = {4, 4};
 
   std::vector<int64_t> c_values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
   std::vector<int64_t> c_strides = {32, 8};
   Tensor tc1(int64(), Buffer::Wrap(c_values), shape, c_strides);
-  Tensor tc2(int64(), Buffer::Wrap(c_values), shape, c_strides);
+
+  std::vector<int64_t> c_values_2 = c_values;
+  Tensor tc2(int64(), Buffer::Wrap(c_values_2), shape, c_strides);
 
   std::vector<int64_t> f_values = {1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16};
   Tensor tc3(int64(), Buffer::Wrap(f_values), shape, c_strides);
 
   std::vector<int64_t> f_strides = {8, 32};
   Tensor tf1(int64(), Buffer::Wrap(f_values), shape, f_strides);
-  Tensor tf2(int64(), Buffer::Wrap(c_values), shape, f_strides);
+
+  std::vector<int64_t> f_values_2 = f_values;
+  Tensor tf2(int64(), Buffer::Wrap(f_values_2), shape, f_strides);
+
+  Tensor tf3(int64(), Buffer::Wrap(c_values), shape, f_strides);
 
   std::vector<int64_t> nc_values = {1, 0, 5, 0, 9,  0, 13, 0, 2, 0, 6, 0, 10, 0, 14, 0,
                                     3, 0, 7, 0, 11, 0, 15, 0, 4, 0, 8, 0, 12, 0, 16, 0};
@@ -217,8 +223,9 @@ TEST(TestTensor, Equals) {
   EXPECT_TRUE(tf1.Equals(tf1));
   EXPECT_TRUE(tnc.Equals(tnc));
 
-  // different objects
+  // different memory
   EXPECT_TRUE(tc1.Equals(tc2));
+  EXPECT_TRUE(tf1.Equals(tf2));
   EXPECT_FALSE(tc1.Equals(tc3));
 
   // row-major and column-major
@@ -231,7 +238,7 @@ TEST(TestTensor, Equals) {
 
   // column-major and non-contiguous
   EXPECT_TRUE(tf1.Equals(tnc));
-  EXPECT_FALSE(tf2.Equals(tnc));
+  EXPECT_FALSE(tf3.Equals(tnc));
 }
 
 TEST(TestNumericTensor, ElementAccessWithRowMajorStrides) {

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -306,13 +306,13 @@ TEST(TestTensor, EqualsFloat64) {
   // tensors with NaNs
   c_values[0] = NAN;
   EXPECT_TRUE(std::isnan(tc1.Value<DoubleType>({0, 0})));
-  EXPECT_FALSE(tc1.Equals(tc1)); // same object
-  EXPECT_FALSE(std::isnan(tc2.Value<DoubleType>({0, 0}))); // check the different memory
+  EXPECT_FALSE(tc1.Equals(tc1));                            // same object
+  EXPECT_FALSE(std::isnan(tc2.Value<DoubleType>({0, 0})));  // check the different memory
   EXPECT_FALSE(tc1.Equals(tc2));
 
   c_values_2[0] = NAN;
   EXPECT_TRUE(std::isnan(tc2.Value<DoubleType>({0, 0})));
-  EXPECT_FALSE(tc1.Equals(tc2)); // different memory
+  EXPECT_FALSE(tc1.Equals(tc2));  // different memory
 }
 
 TEST(TestNumericTensor, ElementAccessWithRowMajorStrides) {

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -198,6 +198,8 @@ TEST(TestTensor, EqualsInt64) {
   std::vector<int64_t> f_values = {1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15, 4, 8, 12, 16};
   Tensor tc3(int64(), Buffer::Wrap(f_values), shape, c_strides);
 
+  Tensor tc4(int64(), Buffer::Wrap(c_values), {8, 2}, {16, 8});
+
   std::vector<int64_t> f_strides = {8, 32};
   Tensor tf1(int64(), Buffer::Wrap(f_values), shape, f_strides);
 
@@ -228,6 +230,9 @@ TEST(TestTensor, EqualsInt64) {
   EXPECT_TRUE(tc1.Equals(tc2));
   EXPECT_TRUE(tf1.Equals(tf2));
   EXPECT_FALSE(tc1.Equals(tc3));
+
+  // different shapes but same data
+  EXPECT_FALSE(tc1.Equals(tc4));
 
   // row-major and column-major
   EXPECT_TRUE(tc1.Equals(tf1));


### PR DESCRIPTION
`memcmp` is an inappropriate way to examine the equality of float tensors because float tensors can have NaNs.  In addition to fix this issue, I made the following fixes in this pull request:

- Change the namespace of `StridedIntegerTensorContentsEquals`, that is renamed from `StridedTensorContentsEquals`, to anonymous because it isn't referred from the outside of compare.cc
- Let the result of `Tensor::Equals` be false when two tensors has the different shapes.