### PR TITLE
ARROW-6326: [C++] Nullable fields when converting std::tuple to Table

### DIFF
--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 #include "arrow/builder.h"
@@ -46,7 +47,7 @@ using BareTupleElement = typename std::remove_const<typename std::remove_referen
 }  // namespace internal
 
 /// Traits meta class to map standard C/C++ types to equivalent Arrow types.
-template <typename T>
+template <typename T, typename = void>
 struct ConversionTraits {};
 
 #define ARROW_STL_CONVERSION(c_type, ArrowType_)                                    \
@@ -120,6 +121,26 @@ struct ConversionTraits<std::vector<value_c_type>>
   constexpr static bool nullable = false;
 };
 
+template <typename Optional>
+struct ConversionTraits<Optional, enable_if_optional_like<Optional>>
+    : public CTypeTraits<Optional> {
+  // Dependent names from base template class needs to be brought into scope.
+  using typename CTypeTraits<Optional>::OptionalInnerType;
+  using typename CTypeTraits<Optional>::ArrowType;
+  using CTypeTraits<Optional>::type_singleton;
+
+  constexpr static bool nullable = true;
+
+  static Status AppendRow(typename TypeTraits<ArrowType>::BuilderType& builder,
+                          const Optional& cell) {
+    if (cell) {
+      return ConversionTraits<OptionalInnerType>::AppendRow(builder, *cell);
+    } else {
+      return builder.AppendNull();
+    }
+  }
+};
+
 /// Build an arrow::Schema based upon the types defined in a std::tuple-like structure.
 ///
 /// While the type information is available at compile-time, we still need to add the
@@ -138,7 +159,7 @@ struct SchemaFromTuple {
     std::vector<std::shared_ptr<Field>> ret =
         SchemaFromTuple<Tuple, N - 1>::MakeSchemaRecursion(names);
     std::shared_ptr<DataType> type = CTypeTraits<Element>::type_singleton();
-    ret.push_back(field(names[N - 1], type, false /* nullable */));
+    ret.push_back(field(names[N - 1], type, ConversionTraits<Element>::nullable));
     return ret;
   }
 

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -19,6 +19,7 @@
 #define ARROW_STL_H
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -47,7 +47,7 @@ using BareTupleElement = typename std::remove_const<typename std::remove_referen
 }  // namespace internal
 
 /// Traits meta class to map standard C/C++ types to equivalent Arrow types.
-template <typename T, typename = void>
+template <typename T, typename Enable = void>
 struct ConversionTraits {};
 
 #define ARROW_STL_CONVERSION(c_type, ArrowType_)                                    \

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <gtest/gtest.h>
+#include <boost/optional.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 
 #include "arrow/stl.h"
@@ -31,6 +32,17 @@
 
 using primitive_types_tuple = std::tuple<int8_t, int16_t, int32_t, int64_t, uint8_t,
                                          uint16_t, uint32_t, uint64_t, bool, std::string>;
+
+using boost_optional_types_tuple =
+    std::tuple<boost::optional<int8_t>, boost::optional<int16_t>,
+               boost::optional<int32_t>, boost::optional<int64_t>,
+               boost::optional<uint8_t>, boost::optional<uint16_t>,
+               boost::optional<uint32_t>, boost::optional<uint64_t>,
+               boost::optional<bool>, boost::optional<std::string>>;
+
+using raw_pointer_optional_types_tuple =
+    std::tuple<int8_t*, int16_t*, int32_t*, int64_t*, uint8_t*, uint16_t*, uint32_t*,
+               uint64_t*, bool*, std::string*>;
 
 struct CustomType {
   int8_t i8;
@@ -48,6 +60,7 @@ struct CustomType {
   auto tie() const -> decltype(ARROW_CUSTOM_TYPE_TIED) { return ARROW_CUSTOM_TYPE_TIED; }
 #undef ARROW_CUSTOM_TYPE_TIED
 };
+
 
 namespace arrow {
 namespace stl {
@@ -180,6 +193,96 @@ TEST(TestTableFromTupleVector, ReferenceTuple) {
   std::shared_ptr<Array> uint64_array = ArrayFromJSON(uint64(), "[4, 40]");
   std::shared_ptr<Array> bool_array = ArrayFromJSON(boolean(), "[true, false]");
   std::shared_ptr<Array> string_array = ArrayFromJSON(utf8(), R"(["Tests", "Other"])");
+  auto expected_table =
+      Table::Make(expected_schema,
+                  {int8_array, int16_array, int32_array, int64_array, uint8_array,
+                   uint16_array, uint32_array, uint64_array, bool_array, string_array});
+
+  ASSERT_TRUE(expected_table->Equals(*table));
+}
+
+TEST(TestTableFromTupleVector, NullableTypesWithBoostOptional) {
+  std::vector<std::string> names{"column1", "column2", "column3", "column4", "column5",
+                                 "column6", "column7", "column8", "column9", "column10"};
+  using types_tuple = boost_optional_types_tuple;
+  std::vector<types_tuple> rows{
+      types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, "Tests"),
+      types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false, "Other"),
+      types_tuple(boost::none, boost::none, boost::none, boost::none, boost::none,
+                  boost::none, boost::none, boost::none, boost::none, boost::none),
+  };
+  std::shared_ptr<Table> table;
+  ASSERT_OK(TableFromTupleRange(default_memory_pool(), rows, names, &table));
+
+  std::shared_ptr<Schema> expected_schema =
+      schema({field("column1", int8(), true), field("column2", int16(), true),
+              field("column3", int32(), true), field("column4", int64(), true),
+              field("column5", uint8(), true), field("column6", uint16(), true),
+              field("column7", uint32(), true), field("column8", uint64(), true),
+              field("column9", boolean(), true), field("column10", utf8(), true)});
+
+  // Construct expected arrays
+  std::shared_ptr<Array> int8_array = ArrayFromJSON(int8(), "[-1, -10, null]");
+  std::shared_ptr<Array> int16_array = ArrayFromJSON(int16(), "[-2, -20, null]");
+  std::shared_ptr<Array> int32_array = ArrayFromJSON(int32(), "[-3, -30, null]");
+  std::shared_ptr<Array> int64_array = ArrayFromJSON(int64(), "[-4, -40, null]");
+  std::shared_ptr<Array> uint8_array = ArrayFromJSON(uint8(), "[1, 10, null]");
+  std::shared_ptr<Array> uint16_array = ArrayFromJSON(uint16(), "[2, 20, null]");
+  std::shared_ptr<Array> uint32_array = ArrayFromJSON(uint32(), "[3, 30, null]");
+  std::shared_ptr<Array> uint64_array = ArrayFromJSON(uint64(), "[4, 40, null]");
+  std::shared_ptr<Array> bool_array = ArrayFromJSON(boolean(), "[true, false, null]");
+  std::shared_ptr<Array> string_array = ArrayFromJSON(utf8(), R"(["Tests", "Other", null])");
+  auto expected_table =
+      Table::Make(expected_schema,
+                  {int8_array, int16_array, int32_array, int64_array, uint8_array,
+                   uint16_array, uint32_array, uint64_array, bool_array, string_array});
+
+  ASSERT_TRUE(expected_table->Equals(*table));
+}
+
+TEST(TestTableFromTupleVector, NullableTypesWithRawPointer) {
+  std::vector<std::string> names{"column1", "column2", "column3", "column4", "column5",
+                                 "column6", "column7", "column8", "column9", "column10"};
+  std::vector<primitive_types_tuple> data_rows{
+      primitive_types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, "Tests"),
+      primitive_types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false, "Other"),
+  };
+  std::vector<raw_pointer_optional_types_tuple> pointer_rows;
+  for (auto& row : data_rows) {
+    pointer_rows.emplace_back(std::addressof(std::get<0>(row)),
+                              std::addressof(std::get<1>(row)),
+                              std::addressof(std::get<2>(row)),
+                              std::addressof(std::get<3>(row)),
+                              std::addressof(std::get<4>(row)),
+                              std::addressof(std::get<5>(row)),
+                              std::addressof(std::get<6>(row)),
+                              std::addressof(std::get<7>(row)),
+                              std::addressof(std::get<8>(row)),
+                              std::addressof(std::get<9>(row)));
+  }
+  pointer_rows.emplace_back(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+                            nullptr, nullptr, nullptr);
+  std::shared_ptr<Table> table;
+  ASSERT_OK(TableFromTupleRange(default_memory_pool(), pointer_rows, names, &table));
+
+  std::shared_ptr<Schema> expected_schema =
+      schema({field("column1", int8(), true), field("column2", int16(), true),
+              field("column3", int32(), true), field("column4", int64(), true),
+              field("column5", uint8(), true), field("column6", uint16(), true),
+              field("column7", uint32(), true), field("column8", uint64(), true),
+              field("column9", boolean(), true), field("column10", utf8(), true)});
+
+  // Construct expected arrays
+  std::shared_ptr<Array> int8_array = ArrayFromJSON(int8(), "[-1, -10, null]");
+  std::shared_ptr<Array> int16_array = ArrayFromJSON(int16(), "[-2, -20, null]");
+  std::shared_ptr<Array> int32_array = ArrayFromJSON(int32(), "[-3, -30, null]");
+  std::shared_ptr<Array> int64_array = ArrayFromJSON(int64(), "[-4, -40, null]");
+  std::shared_ptr<Array> uint8_array = ArrayFromJSON(uint8(), "[1, 10, null]");
+  std::shared_ptr<Array> uint16_array = ArrayFromJSON(uint16(), "[2, 20, null]");
+  std::shared_ptr<Array> uint32_array = ArrayFromJSON(uint32(), "[3, 30, null]");
+  std::shared_ptr<Array> uint64_array = ArrayFromJSON(uint64(), "[4, 40, null]");
+  std::shared_ptr<Array> bool_array = ArrayFromJSON(boolean(), "[true, false, null]");
+  std::shared_ptr<Array> string_array = ArrayFromJSON(utf8(), R"(["Tests", "Other", null])");
   auto expected_table =
       Table::Make(expected_schema,
                   {int8_array, int16_array, int32_array, int64_array, uint8_array,

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -68,15 +68,23 @@ struct CustomType {
 // specialization isn't broken with templated Optionals.
 struct CustomOptionalTypeMock {
   static int counter;
+  mutable bool was_casted_once_ = false;
+
   CustomOptionalTypeMock() = default;
   explicit operator bool() const {
-    counter++;
-    return counter % 3 != 0;
+    if (!was_casted_once_) {
+      was_casted_once_ = true;
+      counter++;
+      return counter % 3 != 0;
+    }
+    ADD_FAILURE() << "A CustomOptionalTypeMock should be casted to bool only once.";
+    return false;
   }
   std::string operator*() const {
     switch (counter % 3) {
       case 0:
         ADD_FAILURE() << "Optional dereferenced in null value";
+        break;
       case 1:
         return "yes";
       case 2:

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -344,8 +344,6 @@ TEST(TestTableFromTupleVector, NullableTypesDoNotBreakUserSpecialization) {
   std::shared_ptr<Table> table;
   ASSERT_OK(TableFromTupleRange(default_memory_pool(), rows, names, &table));
 
-  const Table& tab = *table;
-
   std::shared_ptr<Schema> expected_schema =
       schema({field("column1", utf8(), true)});
   std::shared_ptr<Array> string_array =

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -90,9 +90,7 @@ template <>
 struct CTypeTraits<CustomOptionalTypeMock> {
   using ArrowType = ::arrow::StringType;
 
-  static std::shared_ptr<::arrow::DataType> type_singleton() {
-    return ::arrow::utf8();
-  }
+  static std::shared_ptr<::arrow::DataType> type_singleton() { return ::arrow::utf8(); }
 };
 
 namespace stl {
@@ -105,9 +103,9 @@ struct ConversionTraits<CustomOptionalTypeMock>
   static Status AppendRow(typename TypeTraits<ArrowType>::BuilderType& builder,
                           const CustomOptionalTypeMock& cell) {
     if (cell) {
-        return builder.Append("mock " + *cell);
+      return builder.Append("mock " + *cell);
     } else {
-        return builder.AppendNull();
+      return builder.AppendNull();
     }
   }
 };
@@ -278,7 +276,8 @@ TEST(TestTableFromTupleVector, NullableTypesWithBoostOptional) {
   std::shared_ptr<Array> uint32_array = ArrayFromJSON(uint32(), "[3, 30, null]");
   std::shared_ptr<Array> uint64_array = ArrayFromJSON(uint64(), "[4, 40, null]");
   std::shared_ptr<Array> bool_array = ArrayFromJSON(boolean(), "[true, false, null]");
-  std::shared_ptr<Array> string_array = ArrayFromJSON(utf8(), R"(["Tests", "Other", null])");
+  std::shared_ptr<Array> string_array =
+      ArrayFromJSON(utf8(), R"(["Tests", "Other", null])");
   auto expected_table =
       Table::Make(expected_schema,
                   {int8_array, int16_array, int32_array, int64_array, uint8_array,
@@ -296,16 +295,12 @@ TEST(TestTableFromTupleVector, NullableTypesWithRawPointer) {
   };
   std::vector<raw_pointer_optional_types_tuple> pointer_rows;
   for (auto& row : data_rows) {
-    pointer_rows.emplace_back(std::addressof(std::get<0>(row)),
-                              std::addressof(std::get<1>(row)),
-                              std::addressof(std::get<2>(row)),
-                              std::addressof(std::get<3>(row)),
-                              std::addressof(std::get<4>(row)),
-                              std::addressof(std::get<5>(row)),
-                              std::addressof(std::get<6>(row)),
-                              std::addressof(std::get<7>(row)),
-                              std::addressof(std::get<8>(row)),
-                              std::addressof(std::get<9>(row)));
+    pointer_rows.emplace_back(
+        std::addressof(std::get<0>(row)), std::addressof(std::get<1>(row)),
+        std::addressof(std::get<2>(row)), std::addressof(std::get<3>(row)),
+        std::addressof(std::get<4>(row)), std::addressof(std::get<5>(row)),
+        std::addressof(std::get<6>(row)), std::addressof(std::get<7>(row)),
+        std::addressof(std::get<8>(row)), std::addressof(std::get<9>(row)));
   }
   pointer_rows.emplace_back(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                             nullptr, nullptr, nullptr);
@@ -329,7 +324,8 @@ TEST(TestTableFromTupleVector, NullableTypesWithRawPointer) {
   std::shared_ptr<Array> uint32_array = ArrayFromJSON(uint32(), "[3, 30, null]");
   std::shared_ptr<Array> uint64_array = ArrayFromJSON(uint64(), "[4, 40, null]");
   std::shared_ptr<Array> bool_array = ArrayFromJSON(boolean(), "[true, false, null]");
-  std::shared_ptr<Array> string_array = ArrayFromJSON(utf8(), R"(["Tests", "Other", null])");
+  std::shared_ptr<Array> string_array =
+      ArrayFromJSON(utf8(), R"(["Tests", "Other", null])");
   auto expected_table =
       Table::Make(expected_schema,
                   {int8_array, int16_array, int32_array, int64_array, uint8_array,
@@ -344,8 +340,7 @@ TEST(TestTableFromTupleVector, NullableTypesDoNotBreakUserSpecialization) {
   std::shared_ptr<Table> table;
   ASSERT_OK(TableFromTupleRange(default_memory_pool(), rows, names, &table));
 
-  std::shared_ptr<Schema> expected_schema =
-      schema({field("column1", utf8(), true)});
+  std::shared_ptr<Schema> expected_schema = schema({field("column1", utf8(), true)});
   std::shared_ptr<Array> string_array =
       ArrayFromJSON(utf8(), R"([null, "mock yes", "mock no"])");
   auto expected_table = Table::Make(expected_schema, {string_array});

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -62,6 +62,10 @@ struct CustomType {
 };
 
 // Mock optional object returning null, "yes", "no", null, "yes", "no", ...
+// Note: This mock optional object will advance its state every time it's casted
+// to bool. Successive castings to bool may give inconsistent results. It
+// doesn't mock entire optional logic. It is used only for ensuring user
+// specialization isn't broken with templated Optionals.
 struct CustomOptionalTypeMock {
   static int counter;
   CustomOptionalTypeMock() = default;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -547,15 +547,15 @@ using enable_if_number = typename std::enable_if<is_number_type<T>::value, R>::t
 namespace internal {
 
 // The partial specialization will match if T has the ATTR_NAME member
-#define GET_ATTR(ATTR_NAME, DEFAULT)                                            \
-  template <typename T, typename Enable = void>                                 \
-  struct GetAttr_##ATTR_NAME {                                                  \
-    using type = DEFAULT;                                                       \
-  };                                                                            \
-                                                                                \
-  template <typename T>                                                         \
-  struct GetAttr_##ATTR_NAME<T, typename void_t<typename T::ATTR_NAME>::type> { \
-    using type = typename T::ATTR_NAME;                                         \
+#define GET_ATTR(ATTR_NAME, DEFAULT)                             \
+  template <typename T, typename Enable = void>                  \
+  struct GetAttr_##ATTR_NAME {                                   \
+    using type = DEFAULT;                                        \
+  };                                                             \
+                                                                 \
+  template <typename T>                                          \
+  struct GetAttr_##ATTR_NAME<T, void_t<typename T::ATTR_NAME>> { \
+    using type = typename T::ATTR_NAME;                          \
   };
 
 GET_ATTR(c_type, void)


### PR DESCRIPTION
`std::optional` isn't used for representing nullable fields in Arrow's current STL conversion API since it requires C++17. Also there are other ways to represent an optional field other than `std::optional` such as using pointers or external implementations of optional (`boost::optional`, `type_safe::optional` and alike).

Since it is hard to maintain so many different kinds of specializations, introducing an `Optional` concept covering these classes solve this issue and allow implementing nullable fields consistently.

For a type `T` to be considered as an `Optional`:
1) It should be convertible (implicitly or explicitly) to bool, i.e. it implements `[explicit] operator bool()`,
2) It should be dereferencable, i.e. it implements `operator*()`.

If a type conforms to above `Optional` requirements, it will be automatically converted to a nullable field when used with `TableFromTupleRange`. This PR doesn't cover setting a tuple value from an optional value read from a table (i.e.` TupleRangeFromTable`).

Inner type used for the field will be inferred from that of the return type of dereferencing optional (e.g. `int32_t` for `std::optional<int32_t>`, which would be represented by `Int32Type`).