### PR TITLE
ARROW-6325: [Python] fix conversion of strided boolean arrays

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -438,9 +438,7 @@ inline Status NumPyConverter::PrepareInputData(std::shared_ptr<Buffer>* data) {
     return Status::NotImplemented("Byte-swapped arrays not supported");
   }
 
-  if (is_strided()) {
-    RETURN_NOT_OK(NumPyStridedConverter::Convert(arr_, length_, pool_, data));
-  } else if (dtype_->type_num == NPY_BOOL) {
+  if (dtype_->type_num == NPY_BOOL) {
     int64_t nbytes = BitUtil::BytesForBits(length_);
     std::shared_ptr<Buffer> buffer;
     RETURN_NOT_OK(AllocateBuffer(pool_, nbytes, &buffer));
@@ -451,6 +449,9 @@ inline Status NumPyConverter::PrepareInputData(std::shared_ptr<Buffer>* data) {
     GenerateBitsUnrolled(buffer->mutable_data(), 0, length_, generate);
 
     *data = buffer;
+  }
+  else if (is_strided()) {
+    RETURN_NOT_OK(NumPyStridedConverter::Convert(arr_, length_, pool_, data));
   } else {
     // Can zero-copy
     *data = std::make_shared<NumPyBuffer>(reinterpret_cast<PyObject*>(arr_));

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -449,8 +449,7 @@ inline Status NumPyConverter::PrepareInputData(std::shared_ptr<Buffer>* data) {
     GenerateBitsUnrolled(buffer->mutable_data(), 0, length_, generate);
 
     *data = buffer;
-  }
-  else if (is_strided()) {
+  } else if (is_strided()) {
     RETURN_NOT_OK(NumPyStridedConverter::Convert(arr_, length_, pool_, data));
   } else {
     // Can zero-copy

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1198,6 +1198,17 @@ def test_array_from_invalid_dim_raises():
         pa.array(arr0d)
 
 
+def test_array_from_strided_bool():
+    # ARROW-6325
+    arr = np.ones((3, 2), dtype=bool)
+    result = pa.array(arr[:, 0])
+    expected = pa.array([True, True, True])
+    assert result.equals(expected)
+    result = pa.array(arr[0, :])
+    expected = pa.array([True, True])
+    assert result.equals(expected)
+
+
 def test_buffers_primitive():
     a = pa.array([1, 2, None, 4], type=pa.int16())
     buffers = a.buffers()

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -772,6 +772,11 @@ class TestConvertPrimitiveTypes(object):
         expected = pd.Series([1.0, 1.0, 0.0, None, 1.0] * 2)
         _check_array_roundtrip(s, expected=expected, type=pa.float64())
 
+    def test_boolean_multiple_columns(self):
+        # ARROW-6325 (multiple columns resulting in strided conversion)
+        df = pd.DataFrame(np.ones((3, 2), dtype='bool'), columns=['a', 'b'])
+        _check_pandas_roundtrip(df)
+
     def test_float_object_nulls(self):
         arr = np.array([None, 1.5, np.float64(3.5)] * 5, dtype=object)
         df = pd.DataFrame({'floats': arr})


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6325

Needed to flip the order of the strided / boolean check, as the strided code path was not specialized for boolean values, and the boolean code path already handled strided arrays fine.
