### PR TITLE
ARROW-6332: [Java][C++][Gandiva] Misc fixes for varwidth vector allocation.

### DIFF
--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -232,8 +232,10 @@ Status Projector::ValidateArrayDataCapacity(const arrow::ArrayData& array_data,
 
   int64_t min_bitmap_len = arrow::BitUtil::BytesForBits(num_records);
   int64_t bitmap_len = array_data.buffers[0]->capacity();
-  ARROW_RETURN_IF(bitmap_len < min_bitmap_len,
-                  Status::Invalid("Bitmap buffer too small for ", field.name()));
+  ARROW_RETURN_IF(
+      bitmap_len < min_bitmap_len,
+      Status::Invalid("Bitmap buffer too small for ", field.name(), " expected minimum ",
+                      min_bitmap_len, " actual size ", bitmap_len));
 
   auto type_id = field.type()->id();
   if (arrow::is_binary_like(type_id)) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -408,6 +408,11 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     }
   }
 
+  @Override
+  public void allocateNew(int valueCount) {
+    allocateNew(lastValueAllocationSizeInBytes, valueCount);
+  }
+
   /* Check if the data buffer size is within bounds. */
   private void checkDataBufferSize(long size) {
     if (size > MAX_ALLOCATION_SIZE) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VariableWidthVector.java
@@ -31,6 +31,14 @@ public interface VariableWidthVector extends ElementAddressableVector, DensityAw
   void allocateNew(int totalBytes, int valueCount);
 
   /**
+   * Allocate a new memory space for this vector.  Must be called prior to using the ValueVector.
+   * The initial size in bytes is either default (or) reused from previous allocation
+   *
+   * @param valueCount Number of values in the vector.
+   */
+  void allocateNew(int valueCount);
+
+  /**
    * Provide the maximum amount of variable width bytes that can be stored in this vector.
    *
    * @return the byte capacity of this vector

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.util.DataSizeRoundingUtil;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.types.Types.MinorType;
@@ -190,10 +191,15 @@ public class TestVectorReAlloc {
   }
 
   @Test
-  public void test() throws Exception {
+  public void testVarCharAllocateNew() throws Exception {
+    final int count = 6000;
+
     try (final VarCharVector vector = new VarCharVector("", allocator)) {
-      vector.allocateNew(6000);
-      Assert.assertEquals(1000, vector.getValidityBuffer().capacity() );
+      vector.allocateNew(count);
+      
+      // verify that the validity buffer and value buffer have capacity for atleast 'count' elements.
+      Assert.assertTrue(vector.getValidityBuffer().capacity() >= DataSizeRoundingUtil.divideBy8Ceil(count));
+      Assert.assertTrue(vector.getOffsetBuffer().capacity() >= (count + 1) * VarCharVector.OFFSET_WIDTH);
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorReAlloc.java
@@ -17,9 +17,7 @@
 
 package org.apache.arrow.vector;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.nio.charset.StandardCharsets;
 
@@ -188,6 +186,14 @@ public class TestVectorReAlloc {
        */
       Assert.assertEquals(vector.getValueCapacity(), savedValueCapacity);
       Assert.assertEquals(vector.valueBuffer.capacity(), savedValueBufferSize);
+    }
+  }
+
+  @Test
+  public void test() throws Exception {
+    try (final VarCharVector vector = new VarCharVector("", allocator)) {
+      vector.allocateNew(6000);
+      Assert.assertEquals(1000, vector.getValidityBuffer().capacity() );
     }
   }
 


### PR DESCRIPTION
- Allow users to specify only a value count when allocating
  var length vectors.
- Print expected and minimum lengths when rejecting bitmaps
  in Gandiva.