### PR TITLE
ARROW-6339: [Python][C++] Rowgroup statistics for pd.NaT array ill defined

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -623,6 +623,11 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type,
     return false;
   }
 
+  // Null only arrays do not have proper statistics
+  if (statistics.null_count > 0 && statistics.distinct_count == 0) {
+    return false;
+  }
+
   // PARQUET-251
   if (VersionLt(PARQUET_251_FIXED_VERSION())) {
     return false;


### PR DESCRIPTION
The issue is that a NaT array is not initialised as a NullArray and the statistics are not invalidated causing the ill defined behaviour.

Compared to a real NullArray (`pd.DataFrame({"t": [None]})`) this gives the same behaviour, i.e. statistics return None. I'm not entirely sure if this is the intended behaviour.