### PR TITLE
ARROW-5910: [Python] Support non-seekable streams in ipc.read_tensor, ipc.read_message, add Message.serialize_to method

### DIFF
--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -60,6 +60,28 @@ cdef class Message:
             result = self.message.get().Equals(deref(other.message.get()))
         return result
 
+    def serialize_to(self, NativeFile sink, alignment=8, memory_pool=None):
+        """
+        Write message to generic OutputStream
+
+        Parameters
+        ----------
+        sink : NativeFile
+        alignment : int, default 8
+            Byte alignment for metadata and body
+        memory_pool : MemoryPool, default None
+            Uses default memory pool if not specified
+        """
+        cdef:
+            int64_t output_length = 0
+            int32_t c_alignment = alignment
+            OutputStream* out
+
+        out = sink.get_output_stream().get()
+        with nogil:
+            check_status(self.message.get()
+                         .SerializeTo(out, c_alignment, &output_length))
+
     def serialize(self, alignment=8, memory_pool=None):
         """
         Write message as encapsulated IPC message
@@ -75,16 +97,8 @@ cdef class Message:
         -------
         serialized : Buffer
         """
-        cdef:
-            BufferOutputStream stream = BufferOutputStream(memory_pool)
-            int64_t output_length = 0
-            int32_t c_alignment = alignment
-
-        handle = stream.get_output_stream()
-        with nogil:
-            check_status(self.message.get()
-                         .SerializeTo(handle.get(), c_alignment,
-                                      &output_length))
+        stream = BufferOutputStream(memory_pool)
+        self.serialize_to(stream, alignment=alignment, memory_pool=memory_pool)
         return stream.getvalue()
 
     def __repr__(self):
@@ -448,7 +462,20 @@ def write_tensor(Tensor tensor, NativeFile dest):
     return metadata_length + body_length
 
 
-def read_tensor(NativeFile source):
+cdef NativeFile as_native_file(source):
+    if not isinstance(source, NativeFile):
+        if hasattr(source, 'read'):
+            source = PythonFile(source)
+        else:
+            source = BufferReader(source)
+
+    if not isinstance(source, NativeFile):
+        raise ValueError('Unable to read message from object with type: {0}'
+                         .format(type(source)))
+    return source
+
+
+def read_tensor(source):
     """Read pyarrow.Tensor from pyarrow.NativeFile object from current
     position. If the file source supports zero copy (e.g. a memory map), then
     this operation does not allocate any memory. This function not assume that
@@ -465,11 +492,13 @@ def read_tensor(NativeFile source):
     """
     cdef:
         shared_ptr[CTensor] sp_tensor
-        RandomAccessFile* rd_file
+        InputStream* c_stream
 
-    rd_file = source.get_random_access_file().get()
+    cdef NativeFile nf = as_native_file(source)
+
+    c_stream = nf.get_input_stream().get()
     with nogil:
-        check_status(ReadTensor(rd_file, &sp_tensor))
+        check_status(ReadTensor(c_stream, &sp_tensor))
     return pyarrow_wrap_tensor(sp_tensor)
 
 
@@ -487,24 +516,13 @@ def read_message(source):
     """
     cdef:
         Message result = Message.__new__(Message)
-        NativeFile cpp_file
-        RandomAccessFile* rd_file
+        InputStream* c_stream
 
-    if not isinstance(source, NativeFile):
-        if hasattr(source, 'read'):
-            source = PythonFile(source)
-        else:
-            source = BufferReader(source)
-
-    if not isinstance(source, NativeFile):
-        raise ValueError('Unable to read message from object with type: {0}'
-                         .format(type(source)))
-
-    cpp_file = source
-    rd_file = cpp_file.get_random_access_file().get()
+    cdef NativeFile nf = as_native_file(source)
+    c_stream = nf.get_input_stream().get()
 
     with nogil:
-        check_status(ReadMessage(rd_file, &result.message))
+        check_status(ReadMessage(c_stream, &result.message))
 
     return result
 

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -373,6 +373,22 @@ def test_message_serialize_read_message(example_messages):
     assert msg.equals(restored3)
 
 
+def test_message_read_from_compressed(example_messages):
+    # Part of ARROW-5910
+    _, messages = example_messages
+    for message in messages:
+        raw_out = pa.BufferOutputStream()
+        compressed_out = pa.output_stream(raw_out, compression='gzip')
+        message.serialize_to(compressed_out)
+        compressed_out.close()
+
+        compressed_buf = raw_out.getvalue()
+
+        result = pa.read_message(pa.input_stream(compressed_buf,
+                                                 compression='gzip'))
+        assert result.equals(message)
+
+
 def test_message_read_record_batch(example_messages):
     batches, messages = example_messages
 

--- a/python/pyarrow/tests/test_tensor.py
+++ b/python/pyarrow/tests/test_tensor.py
@@ -102,6 +102,20 @@ def test_tensor_ipc_roundtrip(tmpdir):
     assert result.equals(tensor)
 
 
+def test_tensor_ipc_read_from_compressed(tempdir):
+    data = np.random.randn(10, 4)
+    tensor = pa.Tensor.from_numpy(data)
+
+    path = tempdir / 'tensor-compressed-file'
+
+    out_stream = pa.output_stream(path, compression='gzip')
+    pa.write_tensor(tensor, out_stream)
+    out_stream.close()
+
+    result = pa.read_tensor(pa.input_stream(path, compression='gzip'))
+    assert result.equals(tensor)
+
+
 def test_tensor_ipc_strided(tmpdir):
     data1 = np.random.randn(10, 4)
     tensor1 = pa.Tensor.from_numpy(data1[::2])

--- a/python/pyarrow/tests/test_tensor.py
+++ b/python/pyarrow/tests/test_tensor.py
@@ -103,6 +103,7 @@ def test_tensor_ipc_roundtrip(tmpdir):
 
 
 def test_tensor_ipc_read_from_compressed(tempdir):
+    # ARROW-5910
     data = np.random.randn(10, 4)
     tensor = pa.Tensor.from_numpy(data)
 


### PR DESCRIPTION
These functions didn't accept wrapped InputStream objects (such as compressed input stream), so this addresses that. 