### PR TITLE
ARROW-6302: [C++][Parquet][Python] Restore ordered type property when reading dictionary type with serialized Arrow schema

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -615,7 +615,11 @@ Status ApplyOriginalMetadata(std::shared_ptr<Field> field, const Field& origin_f
   if (origin_type->id() == ::arrow::Type::DICTIONARY &&
       field->type()->id() != ::arrow::Type::DICTIONARY &&
       IsDictionaryReadSupported(*field->type())) {
-    field = field->WithType(::arrow::dictionary(::arrow::int32(), field->type()));
+    const auto& dict_origin_type =
+        static_cast<const ::arrow::DictionaryType&>(*origin_type);
+    field =
+        field->WithType(::arrow::dictionary(::arrow::int32(), field->type(),
+                        dict_origin_type.ordered()));
   }
   *out = field;
   return Status::OK();

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1669,21 +1669,21 @@ def test_invalid_pred_op(tempdir):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
                           filters=[
-                            ('integers', '=<', 3),
+                              ('integers', '=<', 3),
                           ])
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
                           filters=[
-                            ('integers', 'in', set()),
+                              ('integers', 'in', set()),
                           ])
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
                           filters=[
-                            ('integers', '!=', {3}),
+                              ('integers', '!=', {3}),
                           ])
 
 
@@ -2213,8 +2213,8 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
     n = 9
     df = pd.DataFrame({'x': range(n)},
                       index=pd.DatetimeIndex(start='2017-01-01',
-                      freq='1n',
-                      periods=n))
+                                             freq='1n',
+                                             periods=n))
     tb = pa.Table.from_pandas(df)
 
     filename = tempdir / 'written.parquet'
@@ -3040,6 +3040,21 @@ def test_categorical_index_survives_roundtrip():
     assert ref_df.index.equals(df.index)
 
 
+@pytest.mark.pandas
+def test_categorical_order_survives_roundtrip():
+    # ARROW-6302
+    df = pd.DataFrame({"a": pd.Categorical(
+        ["a", "b", "c", "a"], categories=["b", "c", "d"], ordered=True)})
+
+    table = pa.Table.from_pandas(df)
+    bos = pa.BufferOutputStream()
+    pq.write_table(table, bos)
+
+    result = pq.read_pandas(bos.getvalue()).to_pandas()
+
+    tm.assert_frame_equal(result, df)
+
+
 def test_dictionary_array_automatically_read():
     # ARROW-3246
 
@@ -3117,7 +3132,7 @@ def test_multi_dataset_metadata(tempdir):
         'one': [1, 2, 3],
         'two': [-1, -2, -3],
         'three': [[1, 2], [2, 3], [3, 4]],
-        })
+    })
     table = pa.Table.from_pandas(df)
 
     # write dataset twice and collect/merge metadata

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -238,8 +238,8 @@ def test_empty_table_roundtrip():
         [col.chunk(0)[:0] for col in table.itercolumns()],
         names=table.schema.names)
 
-    assert table.schema.field_by_name('null').type == pa.null()
-    assert table.schema.field_by_name('null_list').type == pa.list_(pa.null())
+    assert table.schema.field('null').type == pa.null()
+    assert table.schema.field('null_list').type == pa.list_(pa.null())
     _check_roundtrip(table, version='2.0')
 
 
@@ -1669,21 +1669,21 @@ def test_invalid_pred_op(tempdir):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
                           filters=[
-                              ('integers', '=<', 3),
+                            ('integers', '=<', 3),
                           ])
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
                           filters=[
-                              ('integers', 'in', set()),
+                            ('integers', 'in', set()),
                           ])
 
     with pytest.raises(ValueError):
         pq.ParquetDataset(base_path,
                           filesystem=fs,
                           filters=[
-                              ('integers', '!=', {3}),
+                            ('integers', '!=', {3}),
                           ])
 
 
@@ -2213,8 +2213,8 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
     n = 9
     df = pd.DataFrame({'x': range(n)},
                       index=pd.DatetimeIndex(start='2017-01-01',
-                                             freq='1n',
-                                             periods=n))
+                      freq='1n',
+                      periods=n))
     tb = pa.Table.from_pandas(df)
 
     filename = tempdir / 'written.parquet'
@@ -3132,7 +3132,7 @@ def test_multi_dataset_metadata(tempdir):
         'one': [1, 2, 3],
         'two': [-1, -2, -3],
         'three': [[1, 2], [2, 3], [3, 4]],
-    })
+        })
     table = pa.Table.from_pandas(df)
 
     # write dataset twice and collect/merge metadata


### PR DESCRIPTION
Closes https://issues.apache.org/jira/browse/ARROW-6302