### PR TITLE
ARROW-6302: [C++][Parquet][Python] Restore ordered type property when reading dictionary type with serialized Arrow schema

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -864,11 +864,14 @@ PARAMETER_LESS_FINGERPRINT(Date64)
 std::string DictionaryType::ComputeFingerprint() const {
   const auto& index_fingerprint = index_type_->fingerprint();
   const auto& value_fingerprint = value_type_->fingerprint();
+  std::string ordered_fingerprint = ordered_ ? "1" : "0";
+
   DCHECK(!index_fingerprint.empty());  // it's an integer type
   if (!value_fingerprint.empty()) {
-    return TypeIdFingerprint(*this) + index_fingerprint + value_fingerprint;
+    return TypeIdFingerprint(*this) + index_fingerprint + value_fingerprint +
+           ordered_fingerprint;
   }
-  return "";
+  return ordered_fingerprint;
 }
 
 std::string ListType::ComputeFingerprint() const {

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -905,6 +905,10 @@ TEST(TestDictionaryType, Equals) {
   AssertTypesEqual(*t1, *t2);
   AssertTypesNotEqual(*t1, *t3);
   AssertTypesNotEqual(*t1, *t4);
+
+  auto t5 = dictionary(int8(), int32(), /*ordered=*/false);
+  auto t6 = dictionary(int8(), int32(), /*ordered=*/true);
+  AssertTypesNotEqual(*t5, *t6);
 }
 
 TEST(TestDictionaryType, UnifyNumeric) {

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -617,9 +617,8 @@ Status ApplyOriginalMetadata(std::shared_ptr<Field> field, const Field& origin_f
       IsDictionaryReadSupported(*field->type())) {
     const auto& dict_origin_type =
         static_cast<const ::arrow::DictionaryType&>(*origin_type);
-    field =
-        field->WithType(::arrow::dictionary(::arrow::int32(), field->type(),
-                        dict_origin_type.ordered()));
+    field = field->WithType(
+        ::arrow::dictionary(::arrow::int32(), field->type(), dict_origin_type.ordered()));
   }
   *out = field;
   return Status::OK();
@@ -767,29 +766,6 @@ Status TransferDate64(RecordReader* reader, MemoryPool* pool,
 // ----------------------------------------------------------------------
 // Binary, direct to dictionary-encoded
 
-// Some ugly hacks here for now to handle binary dictionaries casted to their
-// logical type
-std::shared_ptr<Array> ShallowCast(const Array& arr,
-                                   const std::shared_ptr<DataType>& new_type) {
-  std::shared_ptr<::arrow::ArrayData> new_data = arr.data()->Copy();
-  new_data->type = new_type;
-  if (new_type->id() == ::arrow::Type::DICTIONARY) {
-    // Cast dictionary, too
-    const auto& dict_type = static_cast<const ::arrow::DictionaryType&>(*new_type);
-    new_data->dictionary = ShallowCast(*new_data->dictionary, dict_type.value_type());
-  }
-  return MakeArray(new_data);
-}
-
-std::shared_ptr<ChunkedArray> CastChunksTo(
-    const ChunkedArray& data, const std::shared_ptr<DataType>& logical_value_type) {
-  std::vector<std::shared_ptr<Array>> string_chunks;
-  for (int i = 0; i < data.num_chunks(); ++i) {
-    string_chunks.push_back(ShallowCast(*data.chunk(i), logical_value_type));
-  }
-  return std::make_shared<ChunkedArray>(string_chunks);
-}
-
 Status TransferDictionary(RecordReader* reader,
                           const std::shared_ptr<DataType>& logical_value_type,
                           std::shared_ptr<ChunkedArray>* out) {
@@ -797,7 +773,7 @@ Status TransferDictionary(RecordReader* reader,
   DCHECK(dict_reader);
   *out = dict_reader->GetResult();
   if (!logical_value_type->Equals(*(*out)->type())) {
-    *out = CastChunksTo(**out, logical_value_type);
+    RETURN_NOT_OK((*out)->View(logical_value_type, out));
   }
   return Status::OK();
 }
@@ -813,7 +789,7 @@ Status TransferBinary(RecordReader* reader,
   DCHECK(binary_reader);
   *out = std::make_shared<ChunkedArray>(binary_reader->GetBuilderChunks());
   if (!logical_value_type->Equals(*(*out)->type())) {
-    *out = CastChunksTo(**out, logical_value_type);
+    RETURN_NOT_OK((*out)->View(logical_value_type, out));
   }
   return Status::OK();
 }

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -615,7 +615,11 @@ Status ApplyOriginalMetadata(std::shared_ptr<Field> field, const Field& origin_f
   if (origin_type->id() == ::arrow::Type::DICTIONARY &&
       field->type()->id() != ::arrow::Type::DICTIONARY &&
       IsDictionaryReadSupported(*field->type())) {
-    field = field->WithType(::arrow::dictionary(::arrow::int32(), field->type()));
+    const auto& dict_origin_type =
+        static_cast<const ::arrow::DictionaryType&>(*origin_type);
+    field =
+        field->WithType(::arrow::dictionary(::arrow::int32(), field->type(),
+                        dict_origin_type.ordered()));
   }
   *out = field;
   return Status::OK();

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -3050,7 +3050,8 @@ def test_categorical_order_survives_roundtrip():
     bos = pa.BufferOutputStream()
     pq.write_table(table, bos)
 
-    result = pq.read_pandas(bos.getvalue()).to_pandas()
+    contents = bos.getvalue()
+    result = pq.read_pandas(contents).to_pandas()
 
     tm.assert_frame_equal(result, df)
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -3040,6 +3040,21 @@ def test_categorical_index_survives_roundtrip():
     assert ref_df.index.equals(df.index)
 
 
+@pytest.mark.pandas
+def test_categorical_order_survives_roundtrip():
+    # ARROW-6302
+    df = pd.DataFrame({"a": pd.Categorical(
+        ["a", "b", "c", "a"], categories=["b", "c", "d"], ordered=True)})
+
+    table = pa.Table.from_pandas(df)
+    bos = pa.BufferOutputStream()
+    pq.write_table(table, bos)
+
+    result = pq.read_pandas(bos.getvalue()).to_pandas()
+
+    tm.assert_frame_equal(result, df)
+
+
 def test_dictionary_array_automatically_read():
     # ARROW-3246
 

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -364,6 +364,18 @@ def test_dictionary_type():
         pa.dictionary(pa.uint32(), pa.string())
 
 
+def test_dictionary_ordered_equals():
+    # Python side checking of ARROW-6345
+    d1 = pa.dictionary('int32', 'binary', ordered=True)
+    d2 = pa.dictionary('int32', 'binary', ordered=False)
+    d3 = pa.dictionary('int8', 'binary', ordered=True)
+    d4 = pa.dictionary('int32', 'binary', ordered=True)
+
+    assert not d1.equals(d2)
+    assert not d1.equals(d3)
+    assert d1.equals(d4)
+
+
 def test_types_hashable():
     many_types = get_many_types()
     in_dict = {}


### PR DESCRIPTION
Closes 

* https://issues.apache.org/jira/browse/ARROW-6302
* https://issues.apache.org/jira/browse/ARROW-6345