### PR TITLE
ARROW-6099: [Java] introduce a Logger and LoggerFactory class to remove strict dependency

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -25,6 +25,8 @@ import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.AllocationManager;
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BaseAllocator.Verbosity;
@@ -59,7 +61,7 @@ import io.netty.util.internal.PlatformDependent;
  */
 public final class ArrowBuf implements AutoCloseable {
 
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ArrowBuf.class);
+  private static final Logger logger = LoggerFactory.getLogger(ArrowBuf.class);
 
   private static final int SHORT_SIZE = Short.BYTES;
   private static final int INT_SIZE = Integer.BYTES;

--- a/java/memory/src/main/java/org/apache/arrow/log/ArgSupplier.java
+++ b/java/memory/src/main/java/org/apache/arrow/log/ArgSupplier.java
@@ -15,29 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.memory.util;
-
-import org.apache.arrow.log.Logger;
-import org.apache.arrow.log.LoggerFactory;
+package org.apache.arrow.log;
 
 /**
- * Utility class to that provides {@link #ASSERT_ENABLED} constant to determine if assertions are enabled.
+ * An interface for representing lambda expressions that supply values to
+ * placeholders in message formats.
+ * E.g., {@code Logger.debug("Value: {}", (ArgSupplier) () -> getValue());}
  */
-public class AssertionUtil {
-
-  public static final boolean ASSERT_ENABLED;
-  static final Logger logger = LoggerFactory.getLogger(AssertionUtil.class);
-
-  static {
-    boolean isAssertEnabled = false;
-    assert isAssertEnabled = true;
-    ASSERT_ENABLED = isAssertEnabled;
-  }
-
-  private AssertionUtil() {
-  }
-
-  public static boolean isAssertionsEnabled() {
-    return ASSERT_ENABLED;
-  }
+@FunctionalInterface
+public interface ArgSupplier {
+  Object get();
 }

--- a/java/memory/src/main/java/org/apache/arrow/log/JDK14Logger.java
+++ b/java/memory/src/main/java/org/apache/arrow/log/JDK14Logger.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.log;
+
+
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Use java.util.logging to implement Logger.
+ *
+ * <p>The mapping of log levels from Logger to java.util.logging:
+ * ERROR -- SEVERE
+ * WARN  -- WARNING
+ * INFO  -- INFO
+ * DEBUG -- FINE
+ * TRACE -- FINEST
+ */
+public class JDK14Logger implements org.apache.arrow.log.Logger {
+  public static final String CLASS_NAME_PREFIX =
+      JDK14Logger.class.getPackage().getName().substring(0,
+          JDK14Logger.class.getPackage().getName().lastIndexOf('.'));
+
+  private Logger jdkLogger;
+
+  private Set<String> logMethods = new HashSet<>(Arrays.asList(
+      "debug", "error", "info", "trace", "warn"));
+
+  public JDK14Logger(String name) {
+    this.jdkLogger = Logger.getLogger(name);
+  }
+
+  public boolean isDebugEnabled() {
+    return this.jdkLogger.isLoggable(Level.FINE);
+  }
+
+  public boolean isErrorEnabled() {
+    return this.jdkLogger.isLoggable(Level.SEVERE);
+  }
+
+  public boolean isInfoEnabled() {
+    return this.jdkLogger.isLoggable(Level.INFO);
+  }
+
+  public boolean isTraceEnabled() {
+    return this.jdkLogger.isLoggable(Level.FINEST);
+  }
+
+  public boolean isWarnEnabled() {
+    return this.jdkLogger.isLoggable(Level.WARNING);
+  }
+
+  public void debug(String msg) {
+    logInternal(Level.FINE, msg);
+  }
+
+  public void debug(String msg, Object... arguments) {
+    logInternal(Level.FINE, msg, arguments);
+  }
+
+  public void debug(String msg, Throwable t) {
+    logInternal(Level.FINE, msg, t);
+  }
+
+  public void error(String msg) {
+    logInternal(Level.SEVERE, msg);
+  }
+
+  public void error(String msg, Object... arguments) {
+    logInternal(Level.SEVERE, msg, arguments);
+  }
+
+  public void error(String msg, Throwable t) {
+    logInternal(Level.SEVERE, msg, t);
+  }
+
+  public void info(String msg) {
+    logInternal(Level.INFO, msg);
+  }
+
+  public void info(String msg, Object... arguments) {
+    logInternal(Level.INFO, msg, arguments);
+  }
+
+  public void info(String msg, Throwable t) {
+    logInternal(Level.INFO, msg, t);
+  }
+
+  public void trace(String msg) {
+    logInternal(Level.FINEST, msg);
+  }
+
+  public void trace(String msg, Object... arguments) {
+    logInternal(Level.FINEST, msg, arguments);
+  }
+
+  public void trace(String msg, Throwable t) {
+    logInternal(Level.FINEST, msg, t);
+  }
+
+  public void warn(String msg) {
+    logInternal(Level.WARNING, msg);
+  }
+
+  public void warn(String msg, Object... arguments) {
+    logInternal(Level.WARNING, msg, arguments);
+  }
+
+  public void warn(String msg, Throwable t) {
+    logInternal(Level.WARNING, msg, t);
+  }
+
+  private void logInternal(Level level, String msg) {
+    if (jdkLogger.isLoggable(level)) {
+      String[] source = findSourceInStack();
+      jdkLogger.logp(level, source[0], source[1], msg);
+    }
+  }
+
+  private void logInternal(Level level, String msg, Object... arguments) {
+    if (jdkLogger.isLoggable(level)) {
+      String[] source = findSourceInStack();
+      jdkLogger.logp(
+          level,
+          source[0],
+          source[1],
+          refactorString(msg),
+          evaluateLambdaArgs(arguments));
+    }
+  }
+
+  private void logInternal(Level level, String msg, Throwable t) {
+    if (jdkLogger.isLoggable(level)) {
+      String[] source = findSourceInStack();
+      jdkLogger.logp(level, source[0], source[1], msg, t);
+    }
+  }
+
+  public static void addHandler(Handler handler) {
+    Logger snowflakeLogger = Logger.getLogger(CLASS_NAME_PREFIX);
+    snowflakeLogger.addHandler(handler);
+  }
+
+  public static void setLevel(Level level) {
+    Logger snowflakeLogger = Logger.getLogger(CLASS_NAME_PREFIX);
+    snowflakeLogger.setLevel(level);
+  }
+
+  /**
+   * Since we use SLF4J ways of formatting string we need to refactor message string
+   * if we have arguments.
+   * For example, in sl4j, this string can be formatted with 2 arguments
+   *
+   * <p>ex.1: Error happened in {} on {}
+   *
+   * <p>And if two arguments are provided, error message can be formatted.
+   *
+   * <p>However, in java.util.logging, to achieve formatted error message,
+   * Same string should be converted to
+   *
+   * <p>ex.2: Error happened in {0} on {1}
+   *
+   * <p>Which represented first arguments and second arguments will be replaced in the
+   * corresponding places.
+   *
+   * <p>This method will convert string in ex.1 to ex.2
+   */
+  private String refactorString(String original) {
+    StringBuilder sb = new StringBuilder();
+    int argCount = 0;
+    for (int i = 0; i < original.length(); i++) {
+      if (original.charAt(i) == '{' && i < original.length() - 1 && original.charAt(i + 1) == '}') {
+        sb.append(String.format("{%d}", argCount));
+        argCount++;
+        i++;
+      } else {
+        sb.append(original.charAt(i));
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Used to find the index of the source class/method in current stack.
+   * This method will locate the source as the first method after logMethods
+   *
+   * @return an array of size two, first element is className and second is
+   *     methodName
+   */
+  private String[] findSourceInStack() {
+    StackTraceElement[] stackTraces = Thread.currentThread().getStackTrace();
+    String[] results = new String[2];
+    for (int i = 0; i < stackTraces.length; i++) {
+      if (logMethods.contains(stackTraces[i].getMethodName())) {
+        // since already find the highest logMethods, find the first method after this one
+        // and is not a logMethods. This is done to avoid multiple wrapper over log methods
+        for (int j = i; j < stackTraces.length; j++) {
+          if (!logMethods.contains(stackTraces[j].getMethodName())) {
+            results[0] = stackTraces[j].getClassName();
+            results[1] = stackTraces[j].getMethodName();
+            return results;
+          }
+        }
+      }
+    }
+    return results;
+  }
+
+  private static Object[] evaluateLambdaArgs(Object... args) {
+    final Object[] result = new Object[args.length];
+
+    for (int i = 0; i < args.length; i++) {
+      result[i] = args[i] instanceof ArgSupplier ?
+          ((ArgSupplier) args[i]).get() : args[i];
+    }
+
+    return result;
+  }
+}

--- a/java/memory/src/main/java/org/apache/arrow/log/Logger.java
+++ b/java/memory/src/main/java/org/apache/arrow/log/Logger.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.log;
+
+/**
+ * Interface used by JDBC driver to log information.
+ * Five levels are included in this interface, from high to low:
+ * ERROR
+ * WARN
+ * INFO
+ * DEBUG
+ * TRACE
+ *
+ */
+public interface Logger {
+  /**
+   * Is debug level enabled.
+   *
+   * @return true if the trace level is DEBUG
+   */
+  boolean isDebugEnabled();
+
+  /**
+   * Is error level enabled.
+   *
+   * @return true if the trace level is ERROR
+   */
+  boolean isErrorEnabled();
+
+  /**
+   * Is info level enabled.
+   *
+   * @return true if the trace level is INFO
+   */
+  boolean isInfoEnabled();
+
+  /**
+   * Is trace level enabled.
+   *
+   * @return true if the trace level is TRACE
+   */
+  boolean isTraceEnabled();
+
+  /**
+   * Is warn level enabled.
+   *
+   * @return true if the trace level is WARN
+   */
+  boolean isWarnEnabled();
+
+  void debug(String msg);
+
+  /**
+   * Logs message at DEBUG level.
+   *
+   * @param msg       Message or message format
+   * @param arguments objects that supply value to placeholders in the message
+   *                  format. Expensive operations that supply these values can
+   *                  be specified using lambdas implementing {@link ArgSupplier}
+   *                  so that they are run only if the message is going to be
+   *                  logged. E.g.,
+   *                  {@code Logger.debug("Value: {}", (ArgSupplier) () -> expensiveOperation());}
+   */
+  void debug(String msg, Object... arguments);
+
+  void debug(String msg, Throwable t);
+
+  void error(String msg);
+
+  /**
+   * Logs message at ERROR level.
+   *
+   * @param msg       Message or message format
+   * @param arguments objects that supply value to placeholders in the message
+   *                  format. Expensive operations that supply these values can
+   *                  be specified using lambdas implementing {@link ArgSupplier}
+   *                  so that they are run only if the message is going to be
+   *                  logged. E.g.,
+   *                  {@code Logger.warn("Value: {}", (ArgSupplier) () -> expensiveOperation());}
+   */
+  void error(String msg, Object... arguments);
+
+  void error(String msg, Throwable t);
+
+  void info(String msg);
+
+  /**
+   * Logs message at INFO level.
+   *
+   * @param msg       Message or message format
+   * @param arguments objects that supply value to placeholders in the message
+   *                  format. Expensive operations that supply these values can
+   *                  be specified using lambdas implementing {@link ArgSupplier}
+   *                  so that they are run only if the message is going to be
+   *                  logged. E.g.,
+   *                  {@code Logger.info("Value: {}", (ArgSupplier) () -> expensiveOperation());}
+   */
+  void info(String msg, Object... arguments);
+
+  void info(String msg, Throwable t);
+
+  void trace(String msg);
+
+  /**
+   * Logs message at TRACE level.
+   *
+   * @param msg       Message or message format
+   * @param arguments objects that supply value to placeholders in the message
+   *                  format. Expensive operations that supply these values can
+   *                  be specified using lambdas implementing {@link ArgSupplier}
+   *                  so that they are run only if the message is going to be
+   *                  logged. E.g.,
+   *                  {@code Logger.trace("Value: {}", (ArgSupplier) () -> expensiveOperation());}
+   */
+  void trace(String msg, Object... arguments);
+
+  void trace(String msg, Throwable t);
+
+  void warn(String msg);
+
+  /**
+   * Logs message at WARN level.
+   *
+   * @param msg       Message or message format
+   * @param arguments objects that supply value to placeholders in the message
+   *                  format. Expensive operations that supply these values can
+   *                  be specified using lambdas implementing {@link ArgSupplier}
+   *                  so that they are run only if the message is going to be
+   *                  logged. E.g.,
+   *                  {@code Logger.warn("Value: {}", (ArgSupplier) () -> expensiveOperation());}
+   */
+  void warn(String msg, Object... arguments);
+
+  void warn(String msg, Throwable t);
+}

--- a/java/memory/src/main/java/org/apache/arrow/log/LoggerFactory.java
+++ b/java/memory/src/main/java/org/apache/arrow/log/LoggerFactory.java
@@ -15,29 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.memory.util;
-
-import org.apache.arrow.log.Logger;
-import org.apache.arrow.log.LoggerFactory;
+package org.apache.arrow.log;
 
 /**
- * Utility class to that provides {@link #ASSERT_ENABLED} constant to determine if assertions are enabled.
+ * Used to create Arrow Logger instance.
+ *
  */
-public class AssertionUtil {
-
-  public static final boolean ASSERT_ENABLED;
-  static final Logger logger = LoggerFactory.getLogger(AssertionUtil.class);
-
-  static {
-    boolean isAssertEnabled = false;
-    assert isAssertEnabled = true;
-    ASSERT_ENABLED = isAssertEnabled;
-  }
-
-  private AssertionUtil() {
-  }
-
-  public static boolean isAssertionsEnabled() {
-    return ASSERT_ENABLED;
+public class LoggerFactory {
+  /**
+   * get Slf4j logger if the library exists, otherwise get the dummy one.
+   * @param clazz Class type that the logger is instantiated
+   * @return An ArrowLogger instance given the name of the class
+   */
+  public static Logger getLogger(Class<?> clazz) {
+    // try to use slf4j but if failed, returns a JDK14Logger
+    try {
+      return new SLF4JLogger(clazz);
+    } catch (Throwable ex) {
+      return new JDK14Logger(clazz.getName());
+    }
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/log/SLF4JLogger.java
+++ b/java/memory/src/main/java/org/apache/arrow/log/SLF4JLogger.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.log;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+import org.slf4j.spi.LocationAwareLogger;
+
+/**
+ * Use slf4j logger to implement Logger.
+ *
+ */
+public class SLF4JLogger implements org.apache.arrow.log.Logger {
+  private Logger slf4jLogger;
+
+  private boolean isLocationAwareLogger;
+
+  private static final String FQCN = SLF4JLogger.class.getName();
+
+  public SLF4JLogger(Class<?> clazz) {
+    slf4jLogger = LoggerFactory.getLogger(clazz);
+    isLocationAwareLogger = slf4jLogger instanceof LocationAwareLogger;
+  }
+
+  public boolean isDebugEnabled() {
+    return this.slf4jLogger.isDebugEnabled();
+  }
+
+  public boolean isErrorEnabled() {
+    return this.slf4jLogger.isErrorEnabled();
+  }
+
+  public boolean isInfoEnabled()  {
+    return this.slf4jLogger.isInfoEnabled();
+  }
+
+  public boolean isTraceEnabled() {
+    return this.slf4jLogger.isTraceEnabled();
+  }
+
+  public boolean isWarnEnabled() {
+    return this.slf4jLogger.isWarnEnabled();
+  }
+
+  /**
+   * Log a message at the DEBUG level.
+   *
+   * @param msg the message string to be logged
+   */
+  public void debug(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.DEBUG_INT, msg, null, null);
+    } else {
+      slf4jLogger.debug(msg);
+    }
+  }
+
+  /**
+   * Log a message at the DEBUG level according to the specified format
+   * and argument.
+   * <p/>
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the DEBUG level. </p>
+   *
+   * @param format the format string
+   * @param arg    the argument
+   */
+  public void debug(String format, Object... arg) {
+    if (isDebugEnabled()) {
+      FormattingTuple ft = MessageFormatter.arrayFormat(
+          format, evaluateLambdaArgs(arg));
+      this.debug(ft.getMessage());
+    }
+  }
+
+  /**
+   * Log an exception (throwable) at the DEBUG level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t   the exception (throwable) to log
+   */
+  public void debug(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.DEBUG_INT, msg, null, t);
+    } else {
+      slf4jLogger.debug(msg, t);
+    }
+  }
+
+  /**
+   * Log a message at the ERROR level.
+   *
+   * @param msg the message string to be logged
+   */
+  public void error(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.ERROR_INT, msg, null, null);
+    } else {
+      slf4jLogger.error(msg);
+    }
+  }
+
+  /**
+   * Log a message at the ERROR level according to the specified format
+   * and argument.
+   * <p/>
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the ERROR level. </p>
+   *
+   * @param format the format string
+   * @param arg    the argument
+   */
+  public void error(String format, Object... arg) {
+    if (isErrorEnabled()) {
+      FormattingTuple ft = MessageFormatter.arrayFormat(
+          format, evaluateLambdaArgs(arg));
+      this.error(ft.getMessage());
+    }
+  }
+
+  /**
+   * Log an exception (throwable) at the ERROR level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t   the exception (throwable) to log
+   */
+  public void error(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.ERROR_INT, msg, null, t);
+    } else {
+      slf4jLogger.error(msg, t);
+    }
+  }
+
+  /**
+   * Log a message at the INFO level.
+   *
+   * @param msg the message string to be logged
+   */
+  public void info(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.INFO_INT, msg, null, null);
+    } else {
+      slf4jLogger.info(msg);
+    }
+  }
+
+  /**
+   * Log a message at the INFO level according to the specified format
+   * and argument.
+   * <p/>
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the INFO level. </p>
+   *
+   * @param format the format string
+   * @param arg    the argument
+   */
+  public void info(String format, Object... arg) {
+    if (isInfoEnabled()) {
+      FormattingTuple ft = MessageFormatter.arrayFormat(
+          format, evaluateLambdaArgs(arg));
+      this.info(ft.getMessage());
+    }
+  }
+
+  /**
+   * Log an exception (throwable) at the INFO level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t   the exception (throwable) to log
+   */
+  public void info(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.INFO_INT, msg, null, t);
+    } else {
+      slf4jLogger.error(msg, t);
+    }
+  }
+
+  /**
+   * Log a message at the TRACE level.
+   *
+   * @param msg the message string to be logged
+   * @since 1.4
+   */
+  public void trace(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.TRACE_INT, msg, null, null);
+    } else {
+      slf4jLogger.trace(msg);
+    }
+  }
+
+  /**
+   * Log a message at the TRACE level according to the specified format
+   * and argument.
+   * <p/>
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the TRACE level. </p>
+   *
+   * @param format the format string
+   * @param arg    the argument
+   * @since 1.4
+   */
+  public void trace(String format, Object... arg) {
+    if (isTraceEnabled()) {
+      FormattingTuple ft = MessageFormatter.arrayFormat(
+          format, evaluateLambdaArgs(arg));
+      this.trace(ft.getMessage());
+    }
+  }
+
+  /**
+   * Log an exception (throwable) at the TRACE level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t   the exception (throwable) to log
+   * @since 1.4
+   */
+  public void trace(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.TRACE_INT, msg, null, t);
+    } else {
+      slf4jLogger.trace(msg, t);
+    }
+  }
+
+  /**
+   * Log a message at the WARN level.
+   *
+   * @param msg the message string to be logged
+   */
+  public void warn(String msg) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.WARN_INT, msg, null, null);
+    } else {
+      slf4jLogger.error(msg);
+    }
+  }
+
+  /**
+   * Log a message at the WARN level according to the specified format
+   * and argument.
+   * <p/>
+   * <p>This form avoids superfluous object creation when the logger
+   * is disabled for the WARN level. </p>
+   *
+   * @param format the format string
+   * @param arg    the argument
+   */
+  public void warn(String format, Object... arg) {
+    if (isWarnEnabled()) {
+      FormattingTuple ft = MessageFormatter.arrayFormat(
+          format, evaluateLambdaArgs(arg));
+      this.warn(ft.getMessage());
+    }
+  }
+
+  /**
+   * Log an exception (throwable) at the WARN level with an
+   * accompanying message.
+   *
+   * @param msg the message accompanying the exception
+   * @param t   the exception (throwable) to log
+   */
+  public void warn(String msg, Throwable t) {
+    if (isLocationAwareLogger) {
+      ((LocationAwareLogger) slf4jLogger).log(null, FQCN,
+          LocationAwareLogger.WARN_INT, msg, null, t);
+    } else {
+      slf4jLogger.error(msg, t);
+    }
+  }
+
+  private static Object[] evaluateLambdaArgs(Object... args) {
+    final Object[] result = new Object[args.length];
+
+    for (int i = 0; i < args.length; i++) {
+      result[i] = args[i] instanceof ArgSupplier ? ((ArgSupplier) args[i]).get()
+                  : args[i];
+    }
+
+    return result;
+  }
+}

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -25,6 +25,8 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.arrow.memory.util.AssertionUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
@@ -46,7 +48,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   public static final int DEBUG_LOG_LENGTH = 6;
   public static final boolean DEBUG = AssertionUtil.isAssertionsEnabled() ||
       Boolean.parseBoolean(System.getProperty(DEBUG_ALLOCATOR, "false"));
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseAllocator.class);
+  private static final Logger logger = LoggerFactory.getLogger(BaseAllocator.class);
   // Package exposed for sharing between AllocatorManger and BaseAllocator objects
   final String name;
   final RootAllocator root;

--- a/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BoundsChecking.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.memory;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
+
 /**
  * Configuration class to determine if bounds checking should be turned on or off.
  *
@@ -31,7 +34,7 @@ package org.apache.arrow.memory;
 public class BoundsChecking {
 
   public static final boolean BOUNDS_CHECKING_ENABLED;
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BoundsChecking.class);
+  static final Logger logger = LoggerFactory.getLogger(BoundsChecking.class);
 
   static {
     String envProperty = System.getenv("ARROW_ENABLE_UNSAFE_MEMORY_ACCESS");

--- a/java/memory/src/main/java/org/apache/arrow/memory/OutOfMemoryException.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/OutOfMemoryException.java
@@ -19,6 +19,9 @@ package org.apache.arrow.memory;
 
 import java.util.Optional;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
+
 /**
  * Indicates memory could not be allocated for Arrow buffers.
  *
@@ -28,7 +31,7 @@ import java.util.Optional;
  */
 public class OutOfMemoryException extends RuntimeException {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(OutOfMemoryException
+  static final Logger logger = LoggerFactory.getLogger(OutOfMemoryException
       .class);
   private static final long serialVersionUID = -6858052345185793382L;
   private Optional<AllocationOutcomeDetails> outcomeDetails = Optional.empty();

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.memory.util;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BoundsChecking;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.memory.util.hash.DirectHasher;
@@ -28,7 +30,7 @@ import io.netty.util.internal.PlatformDependent;
  * Utility methods for memory comparison at a byte level.
  */
 public class ByteFunctionHelpers {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ByteFunctionHelpers.class);
+  static final Logger logger = LoggerFactory.getLogger(ByteFunctionHelpers.class);
 
   private ByteFunctionHelpers() {}
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/HistoricalLog.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/HistoricalLog.java
@@ -20,7 +20,7 @@ package org.apache.arrow.memory.util;
 import java.util.Arrays;
 import java.util.LinkedList;
 
-import org.slf4j.Logger;
+import org.apache.arrow.log.Logger;
 
 /**
  * Utility class that can be used to log activity within a class

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -57,10 +57,6 @@
       <artifactId>flatbuffers-java</artifactId>
       <version>${dep.fbs.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
   </dependencies>
 
     <pluginRepositories>

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -20,14 +20,14 @@ package org.apache.arrow.vector;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.util.DataSizeRoundingUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.util.TransferPair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.complex;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.vector.DensityAwareVector;
@@ -34,7 +36,7 @@ import org.apache.arrow.vector.util.CallBack;
  * <p>This class implements common functionality of composite vectors.
  */
 public abstract class AbstractContainerVector implements ValueVector, DensityAwareVector {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractContainerVector.class);
+  static final Logger logger = LoggerFactory.getLogger(AbstractContainerVector.class);
 
   protected final String name;
   protected final BufferAllocator allocator;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -23,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BitVectorHelper;
@@ -38,7 +40,7 @@ import io.netty.buffer.ArrowBuf;
  * Base class for StructVectors. Currently used by NonNullableStructVector
  */
 public abstract class AbstractStructVector extends AbstractContainerVector {
-  private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractContainerVector.class);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractContainerVector.class);
 
   // Maintains a map with key as field name and value is the vector itself
   private final MapWithOrdinal<String, FieldVector> vectors = new MapWithOrdinal<>();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StateTool.java
@@ -19,13 +19,16 @@ package org.apache.arrow.vector.complex;
 
 import java.util.Arrays;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
+
 /**
  * Utility methods for state machines based on enums.
  */
 public class StateTool {
   private StateTool() {}
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(StateTool.class);
+  static final Logger logger = LoggerFactory.getLogger(StateTool.class);
 
   /**
    * Verifies <code>currentState</code> is in one of <code>expectedStates</code>,

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/AbstractBaseReader.java
@@ -19,6 +19,8 @@ package org.apache.arrow.vector.complex.impl;
 
 import java.util.Iterator;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
@@ -31,7 +33,7 @@ import org.apache.arrow.vector.holders.UnionHolder;
  */
 abstract class AbstractBaseReader implements FieldReader {
 
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(AbstractBaseReader.class);
+  static final Logger logger = LoggerFactory.getLogger(AbstractBaseReader.class);
 
   private int index;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileReader.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.arrow.flatbuf.Footer;
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.message.ArrowBlock;
 import org.apache.arrow.vector.ipc.message.ArrowDictionaryBatch;
@@ -31,8 +33,6 @@ import org.apache.arrow.vector.ipc.message.ArrowFooter;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of {@link ArrowReader} that reads the standard arrow binary

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -22,6 +22,8 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.util.VisibleForTesting;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
@@ -29,8 +31,6 @@ import org.apache.arrow.vector.ipc.message.ArrowBlock;
 import org.apache.arrow.vector.ipc.message.ArrowDictionaryBatch;
 import org.apache.arrow.vector.ipc.message.ArrowFooter;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@link ArrowWriter} that writes out a Arrow files (https://arrow.apache.org/docs/format/IPC.html#file-format).

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
@@ -37,8 +39,6 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.DictionaryUtility;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for implementing Arrow writers for IPC over a WriteChannel.

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -21,10 +21,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.vector.ipc.message.FBSerializable;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -24,10 +24,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.arrow.flatbuf.RecordBatch;
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.DataSizeRoundingUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.flatbuffers.FlatBufferBuilder;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
@@ -33,13 +33,12 @@ import java.util.stream.Collectors;
 
 import org.apache.arrow.flatbuf.KeyValue;
 import org.apache.arrow.flatbuf.Type;
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TypeLayout;
 import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ByteFunctionHelpers.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ByteFunctionHelpers.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector.util;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
+
 import io.netty.buffer.ArrowBuf;
 
 /**
@@ -24,7 +27,7 @@ import io.netty.buffer.ArrowBuf;
  */
 @Deprecated
 public class ByteFunctionHelpers {
-  static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ByteFunctionHelpers.class);
+  static final Logger logger = LoggerFactory.getLogger(ByteFunctionHelpers.class);
 
   private ByteFunctionHelpers() {}
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinal.java
@@ -27,9 +27,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.util.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -33,6 +33,8 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Collections2;
@@ -85,8 +87,6 @@ import org.apache.arrow.vector.util.Text;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ArrowBuf;
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Collections2;
 import org.apache.arrow.vector.FieldVector;
@@ -65,8 +67,6 @@ import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestArrowFile extends BaseFileTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TestArrowFile.class);

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
@@ -20,6 +20,8 @@ package org.apache.arrow.vector.ipc;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.arrow.log.Logger;
+import org.apache.arrow.log.LoggerFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -32,8 +34,6 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.Validator;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestJSONFile extends BaseFileTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TestJSONFile.class);


### PR DESCRIPTION
This PR introduces a Logger and LoggerFactory class to remove strict dependency from slf4j logger, i.e., if slf4j is not available, the logger will be switched to a JDK14Logger.