### PR TITLE
ARROW-6351: [Ruby] Improve Arrow#values performance

### DIFF
--- a/ruby/red-arrow/benchmark/raw-records/decimal128.yml
+++ b/ruby/red-arrow/benchmark/raw-records/decimal128.yml
@@ -36,7 +36,9 @@ prelude: |-
   n_columns.times do |i|
     column_name = "column_#{i}"
     fields[column_name] = type
-    arrays[column_name] = n_rows.times.map { Faker::Number.decimal(10, 5) }
+    arrays[column_name] = n_rows.times.map do
+      Faker::Number.decimal(l_digits: 10, r_digits: 5)
+    end
   end
   record_batch = Arrow::RecordBatch.new(fields, arrays)
 

--- a/ruby/red-arrow/benchmark/raw-records/int64.yml
+++ b/ruby/red-arrow/benchmark/raw-records/int64.yml
@@ -36,7 +36,9 @@ prelude: |-
   n_columns.times do |i|
     column_name = "column_#{i}"
     fields[column_name] = type
-    arrays[column_name] = n_rows.times.map { Faker::Number.number(18).to_i }
+    arrays[column_name] = n_rows.times.map do
+      Faker::Number.number(digits: 18).to_i
+    end
   end
   record_batch = Arrow::RecordBatch.new(fields, arrays)
 

--- a/ruby/red-arrow/benchmark/raw-records/list.yml
+++ b/ruby/red-arrow/benchmark/raw-records/list.yml
@@ -36,10 +36,12 @@ prelude: |-
   n_columns.times do |i|
     column_name = "column_#{i}"
     fields[column_name] = type
-    arrays[column_name] = n_rows.times.map {
-      len = Faker::Number.within(1 ... 100)
-      len.times.map { Faker::Number.normal(0, 1e+6) }
-    }
+    arrays[column_name] = n_rows.times.map do
+      n_elements = Faker::Number.within(range: 1 ... 100)
+      n_elements.times.map do
+        Faker::Number.normal(mean: 0, standard_deviation: 1e+6)
+      end
+    end
   end
   record_batch = Arrow::RecordBatch.new(fields, arrays)
 

--- a/ruby/red-arrow/benchmark/raw-records/timestamp.yml
+++ b/ruby/red-arrow/benchmark/raw-records/timestamp.yml
@@ -30,20 +30,23 @@ prelude: |-
   n_rows = 1000
   n_columns = 10
   type = Arrow::TimestampDataType.new(:micro)
-  base_timestamp = Time.at(Faker::Number.within(0 ... 1_000_000_000))
+  base_timestamp = Time.at(Faker::Number.within(range: 0 ... 1_000_000_000))
   thirty_days_in_sec = 30*24*3600
-  timestamp_range = [base_timestamp - thirty_days_in_sec, base_timestamp + thirty_days_in_sec]
+  timestamp_range = {
+    from: base_timestamp - thirty_days_in_sec,
+    to: base_timestamp + thirty_days_in_sec,
+  }
 
   fields = {}
   arrays = {}
   n_columns.times do |i|
     column_name = "column_#{i}"
     fields[column_name] = type
-    arrays[column_name] = n_rows.times.map {
-      sec = Faker::Time.between(*timestamp_range).to_i
-      micro = Faker::Number.within(0 ... 1_000_000)
+    arrays[column_name] = n_rows.times.map do
+      sec = Faker::Time.between(timestamp_range).to_i
+      micro = Faker::Number.within(range: 0 ... 1_000_000)
       sec * 1_000_000 + micro
-    }
+    end
   end
   record_batch = Arrow::RecordBatch.new(fields, arrays)
 

--- a/ruby/red-arrow/benchmark/values/boolean.yml
+++ b/ruby/red-arrow/benchmark/values/boolean.yml
@@ -27,49 +27,11 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
-  type = Arrow::DictionaryDataType.new(:int8, :string, true)
-
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
-  dictionary = Arrow::StringArray.new(
-    100.times.map { Faker::Book.genre }.uniq.sort
-  )
-  indices = Arrow::Int8Array.new(
-    n_rows.times.map {
-      Faker::Number.within(range: 0 ... dictionary.length)
-    }
-  )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
-  end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
-    end
-    records
-  end
+  n_values = 1000
+  values = n_values.times.map { Faker::Boolean.boolean }
+  array = Arrow::BooleanArray.new(values)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.collect.to_a
+  values: |-
+    array.values

--- a/ruby/red-arrow/benchmark/values/decimal128.yml
+++ b/ruby/red-arrow/benchmark/values/decimal128.yml
@@ -27,49 +27,12 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
-  type = Arrow::DictionaryDataType.new(:int8, :string, true)
-
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
-  dictionary = Arrow::StringArray.new(
-    100.times.map { Faker::Book.genre }.uniq.sort
-  )
-  indices = Arrow::Int8Array.new(
-    n_rows.times.map {
-      Faker::Number.within(range: 0 ... dictionary.length)
-    }
-  )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
-  end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
-    end
-    records
-  end
+  n_values = 1000
+  type = Arrow::Decimal128DataType.new(10, 5)
+  values = n_values.times.map { Faker::Number.decimal(l_digits: 10, r_digits: 5) }
+  array = Arrow::Decimal128Array.new(type, values)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.collect.to_a
+  values: |-
+    array.values

--- a/ruby/red-arrow/benchmark/values/dictionary.yml
+++ b/ruby/red-arrow/benchmark/values/dictionary.yml
@@ -27,49 +27,20 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
+  n_values = 1000
   type = Arrow::DictionaryDataType.new(:int8, :string, true)
 
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
   dictionary = Arrow::StringArray.new(
     100.times.map { Faker::Book.genre }.uniq.sort
   )
   indices = Arrow::Int8Array.new(
-    n_rows.times.map {
+    n_values.times.map {
       Faker::Number.within(range: 0 ... dictionary.length)
     }
   )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
-  end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
-    end
-    records
-  end
+  array = Arrow::DictionaryArray.new(type, indices, dictionary)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.length.times.collect {|i| array.indices[i]}
+  values: |-
+    array.values

--- a/ruby/red-arrow/benchmark/values/int64.yml
+++ b/ruby/red-arrow/benchmark/values/int64.yml
@@ -27,49 +27,11 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
-  type = Arrow::DictionaryDataType.new(:int8, :string, true)
-
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
-  dictionary = Arrow::StringArray.new(
-    100.times.map { Faker::Book.genre }.uniq.sort
-  )
-  indices = Arrow::Int8Array.new(
-    n_rows.times.map {
-      Faker::Number.within(range: 0 ... dictionary.length)
-    }
-  )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
-  end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
-    end
-    records
-  end
+  n_values = 1000
+  values =  n_values.times.map { Faker::Number.number(digits: 18).to_i }
+  array = Arrow::Int64Array.new(values)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.collect.to_a
+  values: |-
+    array.values

--- a/ruby/red-arrow/benchmark/values/list.yml
+++ b/ruby/red-arrow/benchmark/values/list.yml
@@ -27,49 +27,18 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
-  type = Arrow::DictionaryDataType.new(:int8, :string, true)
+  n_values = 1000
+  type = Arrow::ListDataType.new(name: "values", type: :double)
 
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
-  dictionary = Arrow::StringArray.new(
-    100.times.map { Faker::Book.genre }.uniq.sort
-  )
-  indices = Arrow::Int8Array.new(
-    n_rows.times.map {
-      Faker::Number.within(range: 0 ... dictionary.length)
-    }
-  )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
-  end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
+  values = n_values.times.map do
+    n_elements = Faker::Number.within(range: 1 ... 100)
+    n_elements.times.map do
+      Faker::Number.normal(mean: 0, standard_deviation: 1e+6)
     end
-    records
   end
+  array = Arrow::ListArray.new(type, values)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.collect.to_a
+  values: |-
+    array.values

--- a/ruby/red-arrow/benchmark/values/string.yml
+++ b/ruby/red-arrow/benchmark/values/string.yml
@@ -27,49 +27,12 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
-  type = Arrow::DictionaryDataType.new(:int8, :string, true)
+  n_values = 1000
 
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
-  dictionary = Arrow::StringArray.new(
-    100.times.map { Faker::Book.genre }.uniq.sort
-  )
-  indices = Arrow::Int8Array.new(
-    n_rows.times.map {
-      Faker::Number.within(range: 0 ... dictionary.length)
-    }
-  )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
-  end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
-    end
-    records
-  end
+  values = n_values.times.map { Faker::Name.name }
+  array = Arrow::StringArray.new(values)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.collect.to_a
+  values: |-
+    array.values

--- a/ruby/red-arrow/benchmark/values/timestamp.yml
+++ b/ruby/red-arrow/benchmark/values/timestamp.yml
@@ -27,49 +27,23 @@ prelude: |-
   state = ENV.fetch("FAKER_RANDOM_SEED", 17).to_i
   Faker::Config.random = Random.new(state)
 
-  n_rows = 1000
-  n_columns = 10
-  type = Arrow::DictionaryDataType.new(:int8, :string, true)
+  n_values = 1000
+  type = Arrow::TimestampDataType.new(:micro)
+  base_timestamp = Time.at(Faker::Number.within(range: 0 ... 1_000_000_000))
+  thirty_days_in_sec = 30*24*3600
+  timestamp_range = {
+    from: base_timestamp - thirty_days_in_sec,
+    to: base_timestamp + thirty_days_in_sec,
+  }
 
-  fields = n_columns.times.map {|i| ["column_#{i}".to_sym, type] }.to_h
-  schema = Arrow::Schema.new(**fields)
-  dictionary = Arrow::StringArray.new(
-    100.times.map { Faker::Book.genre }.uniq.sort
-  )
-  indices = Arrow::Int8Array.new(
-    n_rows.times.map {
-      Faker::Number.within(range: 0 ... dictionary.length)
-    }
-  )
-  arrays = n_columns.times.map do
-    Arrow::DictionaryArray.new(
-      type,
-      indices,
-      dictionary,
-    )
+  values = n_values.times.map do
+    sec = Faker::Time.between(timestamp_range).to_i
+    micro = Faker::Number.within(range: 0 ... 1_000_000)
+    sec * 1_000_000 + micro
   end
-  record_batch = Arrow::RecordBatch.new(schema, n_rows, arrays)
-
-  def pure_ruby_raw_records(record_batch)
-    n_rows = record_batch.n_rows
-    n_columns = record_batch.n_columns
-    columns = record_batch.columns
-    records = []
-    i = 0
-    while i < n_rows
-      record = []
-      j = 0
-      while j < n_columns
-        record << columns[j].data.indices[i]
-        j += 1
-      end
-      records << record
-      i += 1
-    end
-    records
-  end
+  array = Arrow::TimestampArray.new(type, values)
 benchmark:
   pure_ruby: |-
-    pure_ruby_raw_records(record_batch)
-  raw_records: |-
-    record_batch.raw_records
+    array.collect.to_a
+  values: |-
+    array.values

--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -23,6 +23,7 @@
 
 namespace red_arrow {
   VALUE cDate;
+
   VALUE cArrowTime;
 
   VALUE ArrowTimeUnitSECOND;
@@ -38,6 +39,17 @@ namespace red_arrow {
 
 extern "C" void Init_arrow() {
   auto mArrow = rb_const_get_at(rb_cObject, rb_intern("Arrow"));
+
+  auto cArrowArray = rb_const_get_at(mArrow, rb_intern("Array"));
+  rb_define_method(cArrowArray, "values",
+                   reinterpret_cast<rb::RawMethod>(red_arrow::array_values),
+                   0);
+
+  auto cArrowChunkedArray = rb_const_get_at(mArrow, rb_intern("ChunkedArray"));
+  rb_define_method(cArrowChunkedArray, "values",
+                   reinterpret_cast<rb::RawMethod>(red_arrow::chunked_array_values),
+                   0);
+
   auto cArrowRecordBatch = rb_const_get_at(mArrow, rb_intern("RecordBatch"));
   rb_define_method(cArrowRecordBatch, "raw_records",
                    reinterpret_cast<rb::RawMethod>(red_arrow::record_batch_raw_records),
@@ -49,6 +61,7 @@ extern "C" void Init_arrow() {
                    0);
 
   red_arrow::cDate = rb_const_get(rb_cObject, rb_intern("Date"));
+
   red_arrow::cArrowTime = rb_const_get_at(mArrow, rb_intern("Time"));
 
   auto cArrowTimeUnit = rb_const_get_at(mArrow, rb_intern("TimeUnit"));

--- a/ruby/red-arrow/ext/arrow/converters.cpp
+++ b/ruby/red-arrow/ext/arrow/converters.cpp
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "converters.hpp"
+
+namespace red_arrow {
+  VALUE ArrayValueConverter::convert(const arrow::ListArray& array,
+                                     const int64_t i) {
+    return list_array_value_converter_->convert(array, i);
+  }
+
+  VALUE ArrayValueConverter::convert(const arrow::StructArray& array,
+                                     const int64_t i) {
+    return struct_array_value_converter_->convert(array, i);
+  }
+
+  VALUE ArrayValueConverter::convert(const arrow::UnionArray& array,
+                                     const int64_t i) {
+    return union_array_value_converter_->convert(array, i);
+  }
+
+  VALUE ArrayValueConverter::convert(const arrow::DictionaryArray& array,
+                                     const int64_t i) {
+    return dictionary_array_value_converter_->convert(array, i);
+  }
+}

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -595,4 +595,32 @@ namespace red_arrow {
     int64_t index_;
     VALUE result_;
   };
+
+  class Converter {
+  public:
+    explicit Converter()
+      : array_value_converter_(),
+        list_array_value_converter_(&array_value_converter_),
+        struct_array_value_converter_(&array_value_converter_),
+        union_array_value_converter_(&array_value_converter_),
+        dictionary_array_value_converter_(&array_value_converter_) {
+      array_value_converter_.
+        set_sub_value_converters(&list_array_value_converter_,
+                                 &struct_array_value_converter_,
+                                 &union_array_value_converter_,
+                                 &dictionary_array_value_converter_);
+    }
+
+    template <typename ArrayType>
+    inline VALUE convert_value(const ArrayType& array,
+                               const int64_t i) {
+      return array_value_converter_.convert(array, i);
+    }
+
+    ArrayValueConverter array_value_converter_;
+    ListArrayValueConverter list_array_value_converter_;
+    StructArrayValueConverter struct_array_value_converter_;
+    UnionArrayValueConverter union_array_value_converter_;
+    DictionaryArrayValueConverter dictionary_array_value_converter_;
+  };
 }

--- a/ruby/red-arrow/ext/arrow/converters.hpp
+++ b/ruby/red-arrow/ext/arrow/converters.hpp
@@ -1,0 +1,598 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "red-arrow.hpp"
+
+#include <ruby.hpp>
+#include <ruby/encoding.h>
+
+#include <arrow-glib/error.hpp>
+
+#include <arrow/util/logging.h>
+
+namespace red_arrow {
+  class ListArrayValueConverter;
+  class StructArrayValueConverter;
+  class UnionArrayValueConverter;
+  class DictionaryArrayValueConverter;
+
+  class ArrayValueConverter {
+  public:
+    ArrayValueConverter()
+      : decimal_buffer_(),
+        list_array_value_converter_(nullptr),
+        struct_array_value_converter_(nullptr),
+        union_array_value_converter_(nullptr),
+        dictionary_array_value_converter_(nullptr) {
+    }
+
+    inline void set_sub_value_converters(ListArrayValueConverter* list_array_value_converter,
+                                         StructArrayValueConverter* struct_array_value_converter,
+                                         UnionArrayValueConverter* union_array_value_converter,
+                                         DictionaryArrayValueConverter* dictionary_array_value_converter) {
+      list_array_value_converter_ = list_array_value_converter;
+      struct_array_value_converter_ = struct_array_value_converter;
+      union_array_value_converter_ = union_array_value_converter;
+      dictionary_array_value_converter_ = dictionary_array_value_converter;
+    }
+
+    inline VALUE convert(const arrow::NullArray& array,
+                         const int64_t i) {
+      return Qnil;
+    }
+
+    inline VALUE convert(const arrow::BooleanArray& array,
+                         const int64_t i) {
+      return array.Value(i) ? Qtrue : Qfalse;
+    }
+
+    inline VALUE convert(const arrow::Int8Array& array,
+                         const int64_t i) {
+      return INT2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::Int16Array& array,
+                         const int64_t i) {
+      return INT2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::Int32Array& array,
+                         const int64_t i) {
+      return INT2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::Int64Array& array,
+                         const int64_t i) {
+      return LL2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::UInt8Array& array,
+                         const int64_t i) {
+      return UINT2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::UInt16Array& array,
+                         const int64_t i) {
+      return UINT2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::UInt32Array& array,
+                         const int64_t i) {
+      return UINT2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::UInt64Array& array,
+                         const int64_t i) {
+      return ULL2NUM(array.Value(i));
+    }
+
+    // TODO
+    // inline VALUE convert(const arrow::HalfFloatArray& array,
+    //                      const int64_t i) {
+    // }
+
+    inline VALUE convert(const arrow::FloatArray& array,
+                         const int64_t i) {
+      return DBL2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::DoubleArray& array,
+                         const int64_t i) {
+      return DBL2NUM(array.Value(i));
+    }
+
+    inline VALUE convert(const arrow::BinaryArray& array,
+                         const int64_t i) {
+      int32_t length;
+      const auto value = array.GetValue(i, &length);
+      // TODO: encoding support
+      return rb_enc_str_new(reinterpret_cast<const char*>(value),
+                            length,
+                            rb_ascii8bit_encoding());
+    }
+
+    inline VALUE convert(const arrow::StringArray& array,
+                         const int64_t i) {
+      int32_t length;
+      const auto value = array.GetValue(i, &length);
+      return rb_utf8_str_new(reinterpret_cast<const char*>(value),
+                             length);
+    }
+
+    inline VALUE convert(const arrow::FixedSizeBinaryArray& array,
+                         const int64_t i) {
+      return rb_enc_str_new(reinterpret_cast<const char*>(array.Value(i)),
+                            array.byte_width(),
+                            rb_ascii8bit_encoding());
+    }
+
+    constexpr static int32_t JULIAN_DATE_UNIX_EPOCH = 2440588;
+    inline VALUE convert(const arrow::Date32Array& array,
+                         const int64_t i) {
+      const auto value = array.Value(i);
+      const auto days_in_julian = value + JULIAN_DATE_UNIX_EPOCH;
+      return rb_funcall(cDate, id_jd, 1, LONG2NUM(days_in_julian));
+    }
+
+    inline VALUE convert(const arrow::Date64Array& array,
+                         const int64_t i) {
+      const auto value = array.Value(i);
+      auto msec = LL2NUM(value);
+      auto sec = rb_rational_new(msec, INT2NUM(1000));
+      auto time_value = rb_time_num_new(sec, Qnil);
+      return rb_funcall(time_value, id_to_datetime, 0, 0);
+    }
+
+    inline VALUE convert(const arrow::Time32Array& array,
+                         const int64_t i) {
+      const auto type =
+        arrow::internal::checked_cast<const arrow::Time32Type*>(array.type().get());
+      const auto value = array.Value(i);
+      return rb_funcall(red_arrow::cArrowTime,
+                        id_new,
+                        2,
+                        time_unit_to_enum(type->unit()),
+                        INT2NUM(value));
+    }
+
+    inline VALUE convert(const arrow::Time64Array& array,
+                         const int64_t i) {
+      const auto type =
+        arrow::internal::checked_cast<const arrow::Time64Type*>(array.type().get());
+      const auto value = array.Value(i);
+      return rb_funcall(red_arrow::cArrowTime,
+                        id_new,
+                        2,
+                        time_unit_to_enum(type->unit()),
+                        LL2NUM(value));
+    }
+
+    inline VALUE convert(const arrow::TimestampArray& array,
+                         const int64_t i) {
+      const auto type =
+        arrow::internal::checked_cast<const arrow::TimestampType*>(array.type().get());
+      auto scale = time_unit_to_scale(type->unit());
+      auto value = array.Value(i);
+      auto sec = rb_rational_new(LL2NUM(value), scale);
+      return rb_time_num_new(sec, Qnil);
+    }
+
+    // TODO
+    // inline VALUE convert(const arrow::IntervalArray& array,
+    //                      const int64_t i) {
+    // };
+
+    VALUE convert(const arrow::ListArray& array,
+                  const int64_t i);
+
+    VALUE convert(const arrow::StructArray& array,
+                  const int64_t i);
+
+    VALUE convert(const arrow::UnionArray& array,
+                  const int64_t i);
+
+    VALUE convert(const arrow::DictionaryArray& array,
+                  const int64_t i);
+
+    inline VALUE convert(const arrow::Decimal128Array& array,
+                         const int64_t i) {
+      decimal_buffer_ = array.FormatValue(i);
+      return rb_funcall(rb_cObject,
+                        id_BigDecimal,
+                        1,
+                        rb_enc_str_new(decimal_buffer_.data(),
+                                       decimal_buffer_.length(),
+                                       rb_ascii8bit_encoding()));
+    }
+
+  private:
+    std::string decimal_buffer_;
+    ListArrayValueConverter* list_array_value_converter_;
+    StructArrayValueConverter* struct_array_value_converter_;
+    UnionArrayValueConverter* union_array_value_converter_;
+    DictionaryArrayValueConverter* dictionary_array_value_converter_;
+  };
+
+  class ListArrayValueConverter : public arrow::ArrayVisitor {
+  public:
+    explicit ListArrayValueConverter(ArrayValueConverter* converter)
+      : array_value_converter_(converter),
+        offset_(0),
+        length_(0),
+        result_(Qnil) {}
+
+    VALUE convert(const arrow::ListArray& array, const int64_t index) {
+      auto values = array.values().get();
+      auto offset_keep = offset_;
+      auto length_keep = length_;
+      offset_ = array.value_offset(index);
+      length_ = array.value_length(index);
+      auto result_keep = result_;
+      result_ = rb_ary_new_capa(length_);
+      check_status(values->Accept(this),
+                   "[raw-records][list-array]");
+      offset_ = offset_keep;
+      length_ = length_keep;
+      auto result_return = result_;
+      result_ = result_keep;
+      return result_return;
+    }
+
+#define VISIT(TYPE)                                                     \
+    arrow::Status Visit(const arrow::TYPE ## Array& array) override {   \
+      return visit_value(array);                                        \
+    }
+
+    VISIT(Null)
+    VISIT(Boolean)
+    VISIT(Int8)
+    VISIT(Int16)
+    VISIT(Int32)
+    VISIT(Int64)
+    VISIT(UInt8)
+    VISIT(UInt16)
+    VISIT(UInt32)
+    VISIT(UInt64)
+    // TODO
+    // VISIT(HalfFloat)
+    VISIT(Float)
+    VISIT(Double)
+    VISIT(Binary)
+    VISIT(String)
+    VISIT(FixedSizeBinary)
+    VISIT(Date32)
+    VISIT(Date64)
+    VISIT(Time32)
+    VISIT(Time64)
+    VISIT(Timestamp)
+    // TODO
+    // VISIT(Interval)
+    VISIT(List)
+    VISIT(Struct)
+    VISIT(Union)
+    VISIT(Dictionary)
+    VISIT(Decimal128)
+    // TODO
+    // VISIT(Extension)
+
+#undef VISIT
+
+  private:
+    template <typename ArrayType>
+    inline VALUE convert_value(const ArrayType& array,
+                               const int64_t i) {
+      return array_value_converter_->convert(array, i);
+    }
+
+    template <typename ArrayType>
+    arrow::Status visit_value(const ArrayType& array) {
+      if (array.null_count() > 0) {
+        for (int64_t i = 0; i < length_; ++i) {
+          auto value = Qnil;
+          if (!array.IsNull(i + offset_)) {
+            value = convert_value(array, i + offset_);
+          }
+          rb_ary_push(result_, value);
+        }
+      } else {
+        for (int64_t i = 0; i < length_; ++i) {
+          rb_ary_push(result_, convert_value(array, i + offset_));
+        }
+      }
+      return arrow::Status::OK();
+    }
+
+    ArrayValueConverter* array_value_converter_;
+    int32_t offset_;
+    int32_t length_;
+    VALUE result_;
+  };
+
+  class StructArrayValueConverter : public arrow::ArrayVisitor {
+  public:
+    explicit StructArrayValueConverter(ArrayValueConverter* converter)
+      : array_value_converter_(converter),
+        key_(Qnil),
+        index_(0),
+        result_(Qnil) {}
+
+    VALUE convert(const arrow::StructArray& array,
+                  const int64_t index) {
+      auto index_keep = index_;
+      auto result_keep = result_;
+      index_ = index;
+      result_ = rb_hash_new();
+      const auto struct_type = array.struct_type();
+      const auto n = struct_type->num_children();
+      for (int i = 0; i < n; ++i) {
+        const auto field_type = struct_type->child(i).get();
+        const auto& field_name = field_type->name();
+        auto key_keep = key_;
+        key_ = rb_utf8_str_new(field_name.data(), field_name.length());
+        const auto field_array = array.field(i).get();
+        check_status(field_array->Accept(this),
+                     "[raw-records][struct-array]");
+        key_ = key_keep;
+      }
+      auto result_return = result_;
+      result_ = result_keep;
+      index_ = index_keep;
+      return result_return;
+    }
+
+#define VISIT(TYPE)                                                     \
+    arrow::Status Visit(const arrow::TYPE ## Array& array) override {   \
+      fill_field(array);                                                \
+      return arrow::Status::OK();                                       \
+    }
+
+    VISIT(Null)
+    VISIT(Boolean)
+    VISIT(Int8)
+    VISIT(Int16)
+    VISIT(Int32)
+    VISIT(Int64)
+    VISIT(UInt8)
+    VISIT(UInt16)
+    VISIT(UInt32)
+    VISIT(UInt64)
+    // TODO
+    // VISIT(HalfFloat)
+    VISIT(Float)
+    VISIT(Double)
+    VISIT(Binary)
+    VISIT(String)
+    VISIT(FixedSizeBinary)
+    VISIT(Date32)
+    VISIT(Date64)
+    VISIT(Time32)
+    VISIT(Time64)
+    VISIT(Timestamp)
+    // TODO
+    // VISIT(Interval)
+    VISIT(List)
+    VISIT(Struct)
+    VISIT(Union)
+    VISIT(Dictionary)
+    VISIT(Decimal128)
+    // TODO
+    // VISIT(Extension)
+
+#undef VISIT
+
+  private:
+    template <typename ArrayType>
+    inline VALUE convert_value(const ArrayType& array,
+                               const int64_t i) {
+      return array_value_converter_->convert(array, i);
+    }
+
+    template <typename ArrayType>
+    void fill_field(const ArrayType& array) {
+      if (array.IsNull(index_)) {
+        rb_hash_aset(result_, key_, Qnil);
+      } else {
+        rb_hash_aset(result_, key_, convert_value(array, index_));
+      }
+    }
+
+    ArrayValueConverter* array_value_converter_;
+    VALUE key_;
+    int64_t index_;
+    VALUE result_;
+  };
+
+  class UnionArrayValueConverter : public arrow::ArrayVisitor {
+  public:
+    explicit UnionArrayValueConverter(ArrayValueConverter* converter)
+      : array_value_converter_(converter),
+        index_(0),
+        result_(Qnil) {}
+
+    VALUE convert(const arrow::UnionArray& array,
+                  const int64_t index) {
+      const auto index_keep = index_;
+      const auto result_keep = result_;
+      index_ = index;
+      switch (array.mode()) {
+      case arrow::UnionMode::SPARSE:
+        convert_sparse(array);
+        break;
+      case arrow::UnionMode::DENSE:
+        convert_dense(array);
+        break;
+      default:
+        rb_raise(rb_eArgError, "Invalid union mode");
+        break;
+      }
+      auto result_return = result_;
+      index_ = index_keep;
+      result_ = result_keep;
+      return result_return;
+    }
+
+#define VISIT(TYPE)                                                     \
+    arrow::Status Visit(const arrow::TYPE ## Array& array) override {   \
+      convert_value(array);                                             \
+      return arrow::Status::OK();                                       \
+    }
+
+    VISIT(Null)
+    VISIT(Boolean)
+    VISIT(Int8)
+    VISIT(Int16)
+    VISIT(Int32)
+    VISIT(Int64)
+    VISIT(UInt8)
+    VISIT(UInt16)
+    VISIT(UInt32)
+    VISIT(UInt64)
+    // TODO
+    // VISIT(HalfFloat)
+    VISIT(Float)
+    VISIT(Double)
+    VISIT(Binary)
+    VISIT(String)
+    VISIT(FixedSizeBinary)
+    VISIT(Date32)
+    VISIT(Date64)
+    VISIT(Time32)
+    VISIT(Time64)
+    VISIT(Timestamp)
+    // TODO
+    // VISIT(Interval)
+    VISIT(List)
+    VISIT(Struct)
+    VISIT(Union)
+    VISIT(Dictionary)
+    VISIT(Decimal128)
+    // TODO
+    // VISIT(Extension)
+
+#undef VISIT
+
+  private:
+    template <typename ArrayType>
+    inline void convert_value(const ArrayType& array) {
+      auto result = rb_hash_new();
+      if (array.IsNull(index_)) {
+        rb_hash_aset(result, field_name_, Qnil);
+      } else {
+        rb_hash_aset(result,
+                     field_name_,
+                     array_value_converter_->convert(array, index_));
+      }
+      result_ = result;
+    }
+
+    uint8_t compute_child_index(const arrow::UnionArray& array,
+                                arrow::UnionType* type,
+                                const char* tag) {
+      const auto type_id = array.raw_type_ids()[index_];
+      const auto& type_codes = type->type_codes();
+      for (uint8_t i = 0; i < type_codes.size(); ++i) {
+        if (type_codes[i] == type_id) {
+          return i;
+        }
+      }
+      check_status(arrow::Status::Invalid("Unknown type ID: ", type_id),
+                   tag);
+      return 0;
+    }
+
+    void convert_sparse(const arrow::UnionArray& array) {
+      const auto type =
+        std::static_pointer_cast<arrow::UnionType>(array.type()).get();
+      const auto tag = "[raw-records][union-sparse-array]";
+      const auto child_index = compute_child_index(array, type, tag);
+      const auto child_field = type->child(child_index).get();
+      const auto& field_name = child_field->name();
+      const auto field_name_keep = field_name_;
+      field_name_ = rb_utf8_str_new(field_name.data(), field_name.length());
+      const auto child_array = array.child(child_index).get();
+      check_status(child_array->Accept(this), tag);
+      field_name_ = field_name_keep;
+    }
+
+    void convert_dense(const arrow::UnionArray& array) {
+      const auto type =
+        std::static_pointer_cast<arrow::UnionType>(array.type()).get();
+      const auto tag = "[raw-records][union-dense-array]";
+      const auto child_index = compute_child_index(array, type, tag);
+      const auto child_field = type->child(child_index).get();
+      const auto& field_name = child_field->name();
+      const auto field_name_keep = field_name_;
+      field_name_ = rb_utf8_str_new(field_name.data(), field_name.length());
+      const auto child_array = array.child(child_index);
+      const auto index_keep = index_;
+      index_ = array.value_offset(index_);
+      check_status(child_array->Accept(this), tag);
+      index_ = index_keep;
+      field_name_ = field_name_keep;
+    }
+
+    ArrayValueConverter* array_value_converter_;
+    int64_t index_;
+    VALUE field_name_;
+    VALUE result_;
+  };
+
+  class DictionaryArrayValueConverter : public arrow::ArrayVisitor {
+  public:
+    explicit DictionaryArrayValueConverter(ArrayValueConverter* converter)
+      : array_value_converter_(converter),
+        index_(0),
+        result_(Qnil) {
+    }
+
+    VALUE convert(const arrow::DictionaryArray& array,
+                  const int64_t index) {
+      index_ = index;
+      auto indices = array.indices().get();
+      check_status(indices->Accept(this),
+                   "[raw-records][dictionary-array]");
+      return result_;
+    }
+
+    // TODO: Convert to real value.
+#define VISIT(TYPE)                                                     \
+    arrow::Status Visit(const arrow::TYPE ## Array& array) override {   \
+      result_ = convert_value(array, index_);                           \
+      return arrow::Status::OK();                                       \
+      }
+
+    VISIT(Int8)
+    VISIT(Int16)
+    VISIT(Int32)
+    VISIT(Int64)
+
+#undef VISIT
+
+  private:
+    template <typename ArrayType>
+    inline VALUE convert_value(const ArrayType& array,
+                               const int64_t i) {
+      return array_value_converter_->convert(array, i);
+    }
+
+    ArrayValueConverter* array_value_converter_;
+    int64_t index_;
+    VALUE result_;
+  };
+}

--- a/ruby/red-arrow/ext/arrow/red-arrow.hpp
+++ b/ruby/red-arrow/ext/arrow/red-arrow.hpp
@@ -34,6 +34,7 @@
 
 namespace red_arrow {
   extern VALUE cDate;
+
   extern VALUE cArrowTime;
 
   extern VALUE ArrowTimeUnitSECOND;
@@ -45,6 +46,9 @@ namespace red_arrow {
   extern ID id_jd;
   extern ID id_new;
   extern ID id_to_datetime;
+
+  VALUE array_values(VALUE obj);
+  VALUE chunked_array_values(VALUE obj);
 
   VALUE record_batch_raw_records(VALUE obj);
   VALUE table_raw_records(VALUE obj);
@@ -79,6 +83,13 @@ namespace red_arrow {
     default:
       rb_raise(rb_eArgError, "invalid arrow::TimeUnit: %d", unit);
       return Qnil;
+    }
+  }
+
+  inline void check_status(const arrow::Status&& status, const char* context) {
+    GError* error = nullptr;
+    if (!garrow_error_check(&error, status, context)) {
+      RG_RAISE_ERROR(error);
     }
   }
 }

--- a/ruby/red-arrow/ext/arrow/values.cpp
+++ b/ruby/red-arrow/ext/arrow/values.cpp
@@ -21,9 +21,9 @@
 
 namespace red_arrow {
   namespace {
-    class RawValuesBuilder : public arrow::ArrayVisitor {
+    class ValuesBuilder : public arrow::ArrayVisitor {
     public:
-      explicit RawValuesBuilder(VALUE values)
+      explicit ValuesBuilder(VALUE values)
         : array_value_converter_(),
           list_array_value_converter_(&array_value_converter_),
           struct_array_value_converter_(&array_value_converter_),
@@ -41,7 +41,7 @@ namespace red_arrow {
       void build(const arrow::Array& array, VALUE rb_array) {
         rb::protect([&] {
           check_status(array.Accept(this),
-                       "[array][raw-values]");
+                       "[array][values]");
           return Qnil;
         });
       }
@@ -50,7 +50,7 @@ namespace red_arrow {
         rb::protect([&] {
           for (const auto& array : chunked_array.chunks()) {
             check_status(array->Accept(this),
-                         "[chunked-array][raw-values]");
+                         "[chunked-array][values]");
             row_offset_ += array->length();
           }
           return Qnil;
@@ -144,7 +144,7 @@ namespace red_arrow {
     auto values = rb_ary_new_capa(n_rows);
 
     try {
-      RawValuesBuilder builder(values);
+      ValuesBuilder builder(values);
       builder.build(*array, rb_array);
     } catch (rb::State& state) {
       state.jump();
@@ -163,7 +163,7 @@ namespace red_arrow {
     auto values = rb_ary_new_capa(n_rows);
 
     try {
-      RawValuesBuilder builder(values);
+      ValuesBuilder builder(values);
       builder.build(*chunked_array, rb_chunked_array);
     } catch (rb::State& state) {
       state.jump();

--- a/ruby/red-arrow/ext/arrow/values.cpp
+++ b/ruby/red-arrow/ext/arrow/values.cpp
@@ -21,16 +21,16 @@
 
 namespace red_arrow {
   namespace {
-    class RawRecordsBuilder : public arrow::ArrayVisitor {
+    class RawValuesBuilder : public arrow::ArrayVisitor {
     public:
-      explicit RawRecordsBuilder(VALUE records, int n_columns)
+      explicit RawValuesBuilder(VALUE values)
         : array_value_converter_(),
           list_array_value_converter_(&array_value_converter_),
           struct_array_value_converter_(&array_value_converter_),
           union_array_value_converter_(&array_value_converter_),
           dictionary_array_value_converter_(&array_value_converter_),
-          records_(records),
-          n_columns_(n_columns) {
+          values_(values),
+          row_offset_(0) {
         array_value_converter_.
           set_sub_value_converters(&list_array_value_converter_,
                                    &struct_array_value_converter_,
@@ -38,40 +38,20 @@ namespace red_arrow {
                                    &dictionary_array_value_converter_);
       }
 
-      void build(const arrow::RecordBatch& record_batch) {
+      void build(const arrow::Array& array, VALUE rb_array) {
         rb::protect([&] {
-          const auto n_rows = record_batch.num_rows();
-          for (int64_t i = 0; i < n_rows; ++i) {
-            auto record = rb_ary_new_capa(n_columns_);
-            rb_ary_push(records_, record);
-          }
-          row_offset_ = 0;
-          for (int i = 0; i < n_columns_; ++i) {
-            const auto array = record_batch.column(i).get();
-            column_index_ = i;
-            check_status(array->Accept(this),
-                         "[record-batch][raw-records]");
-          }
+          check_status(array.Accept(this),
+                       "[array][raw-values]");
           return Qnil;
         });
       }
 
-      void build(const arrow::Table& table) {
+      void build(const arrow::ChunkedArray& chunked_array, VALUE rb_chunked_array) {
         rb::protect([&] {
-          const auto n_rows = table.num_rows();
-          for (int64_t i = 0; i < n_rows; ++i) {
-            auto record = rb_ary_new_capa(n_columns_);
-            rb_ary_push(records_, record);
-          }
-          for (int i = 0; i < n_columns_; ++i) {
-            const auto& chunked_array = table.column(i).get();
-            column_index_ = i;
-            row_offset_ = 0;
-            for (const auto array : chunked_array->chunks()) {
-              check_status(array->Accept(this),
-                           "[table][raw-records]");
-              row_offset_ += array->length();
-            }
+          for (const auto& array : chunked_array.chunks()) {
+            check_status(array->Accept(this),
+                         "[chunked-array][raw-values]");
+            row_offset_ += array->length();
           }
           return Qnil;
         });
@@ -133,13 +113,11 @@ namespace red_arrow {
             if (!array.IsNull(i)) {
               value = convert_value(array, i);
             }
-            auto record = rb_ary_entry(records_, ii);
-            rb_ary_store(record, column_index_, value);
+            rb_ary_store(values_, ii, value);
           }
         } else {
           for (int64_t i = 0, ii = row_offset_; i < n; ++i, ++ii) {
-            auto record = rb_ary_entry(records_, ii);
-            rb_ary_store(record, column_index_, convert_value(array, i));
+            rb_ary_store(values_, ii, convert_value(array, i));
           }
         }
       }
@@ -151,52 +129,46 @@ namespace red_arrow {
       DictionaryArrayValueConverter dictionary_array_value_converter_;
 
       // Destination for converted records.
-      VALUE records_;
-
-      // The current column index.
-      int column_index_;
+      VALUE values_;
 
       // The current row offset.
       int64_t row_offset_;
-
-      // The number of columns.
-      const int n_columns_;
     };
   }
 
   VALUE
-  record_batch_raw_records(VALUE rb_record_batch) {
-    auto garrow_record_batch = GARROW_RECORD_BATCH(RVAL2GOBJ(rb_record_batch));
-    auto record_batch = garrow_record_batch_get_raw(garrow_record_batch).get();
-    const auto n_rows = record_batch->num_rows();
-    const auto n_columns = record_batch->num_columns();
-    auto records = rb_ary_new_capa(n_rows);
+  array_values(VALUE rb_array) {
+    auto garrow_array = GARROW_ARRAY(RVAL2GOBJ(rb_array));
+    auto array = garrow_array_get_raw(garrow_array).get();
+    const auto n_rows = array->length();
+    auto values = rb_ary_new_capa(n_rows);
 
     try {
-      RawRecordsBuilder builder(records, n_columns);
-      builder.build(*record_batch);
+      RawValuesBuilder builder(values);
+      builder.build(*array, rb_array);
     } catch (rb::State& state) {
       state.jump();
     }
 
-    return records;
+    return values;
   }
 
   VALUE
-  table_raw_records(VALUE rb_table) {
-    auto garrow_table = GARROW_TABLE(RVAL2GOBJ(rb_table));
-    auto table = garrow_table_get_raw(garrow_table).get();
-    const auto n_rows = table->num_rows();
-    const auto n_columns = table->num_columns();
-    auto records = rb_ary_new_capa(n_rows);
+  chunked_array_values(VALUE rb_chunked_array) {
+    auto garrow_chunked_array =
+      GARROW_CHUNKED_ARRAY(RVAL2GOBJ(rb_chunked_array));
+    auto chunked_array =
+      garrow_chunked_array_get_raw(garrow_chunked_array).get();
+    const auto n_rows = chunked_array->length();
+    auto values = rb_ary_new_capa(n_rows);
 
     try {
-      RawRecordsBuilder builder(records, n_columns);
-      builder.build(*table);
+      RawValuesBuilder builder(values);
+      builder.build(*chunked_array, rb_chunked_array);
     } catch (rb::State& state) {
       state.jump();
     }
 
-    return records;
+    return values;
   }
 }

--- a/ruby/red-arrow/lib/arrow/array.rb
+++ b/ruby/red-arrow/lib/arrow/array.rb
@@ -78,5 +78,9 @@ module Arrow
     def value_data_type
       @value_data_type ||= value_data_type_raw
     end
+
+    def to_a
+      values
+    end
   end
 end

--- a/ruby/red-arrow/lib/arrow/loader.rb
+++ b/ruby/red-arrow/lib/arrow/loader.rb
@@ -104,6 +104,14 @@ module Arrow
 
     def load_method_info(info, klass, method_name)
       case klass.name
+      when /Array\z/
+        case method_name
+        when "values"
+          method_name = "values_raw"
+        end
+      end
+
+      case klass.name
       when /Builder\z/
         case method_name
         when "append"

--- a/ruby/red-arrow/test/values/test-basic-arrays.rb
+++ b/ruby/red-arrow/test/values/test-basic-arrays.rb
@@ -1,0 +1,284 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ValuesBasicArraysTests
+  def test_null
+    target = build(Arrow::NullArray.new(4))
+    assert_equal([nil] * 4, target.values)
+  end
+
+  def test_boolean
+    values = [true, nil, false]
+    target = build(Arrow::BooleanArray.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_int8
+    values = [
+      -(2 ** 7),
+      nil,
+      (2 ** 7) - 1,
+    ]
+    target = build(Arrow::Int8Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_uint8
+    values = [
+      0,
+      nil,
+      (2 ** 8) - 1,
+    ]
+    target = build(Arrow::UInt8Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_int16
+    values = [
+      -(2 ** 15),
+      nil,
+      (2 ** 15) - 1,
+    ]
+    target = build(Arrow::Int16Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_uint16
+    values = [
+      0,
+      nil,
+      (2 ** 16) - 1,
+    ]
+    target = build(Arrow::UInt16Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_int32
+    values = [
+      -(2 ** 31),
+      nil,
+      (2 ** 31) - 1,
+    ]
+    target = build(Arrow::Int32Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_uint32
+    values = [
+      0,
+      nil,
+      (2 ** 32) - 1,
+    ]
+    target = build(Arrow::UInt32Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_int64
+    values = [
+      -(2 ** 63),
+      nil,
+      (2 ** 63) - 1,
+    ]
+    target = build(Arrow::Int64Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_uint64
+    values = [
+      0,
+      nil,
+      (2 ** 64) - 1,
+    ]
+    target = build(Arrow::UInt64Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_float
+    values = [
+      -1.0,
+      nil,
+      1.0,
+    ]
+    target = build(Arrow::FloatArray.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_double
+    values = [
+      -1.0,
+      nil,
+      1.0,
+    ]
+    target = build(Arrow::DoubleArray.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_binary
+    values = [
+      "\x00".b,
+      nil,
+      "\xff".b,
+    ]
+    target = build(Arrow::BinaryArray.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_tring
+    values = [
+      "Ruby",
+      nil,
+      "\u3042", # U+3042 HIRAGANA LETTER A
+    ]
+    target = build(Arrow::StringArray.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_date32
+    values = [
+      Date.new(1960, 1, 1),
+      nil,
+      Date.new(2017, 8, 23),
+    ]
+    target = build(Arrow::Date32Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_date64
+    values = [
+      DateTime.new(1960, 1, 1, 2, 9, 30),
+      nil,
+      DateTime.new(2017, 8, 23, 14, 57, 2),
+    ]
+    target = build(Arrow::Date64Array.new(values))
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_second
+    values = [
+      Time.parse("1960-01-01T02:09:30Z"),
+      nil,
+      Time.parse("2017-08-23T14:57:02Z"),
+    ]
+    target = build(Arrow::TimestampArray.new(:second, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_milli
+    values = [
+      Time.parse("1960-01-01T02:09:30.123Z"),
+      nil,
+      Time.parse("2017-08-23T14:57:02.987Z"),
+    ]
+    target = build(Arrow::TimestampArray.new(:milli, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_micro
+    values = [
+      Time.parse("1960-01-01T02:09:30.123456Z"),
+      nil,
+      Time.parse("2017-08-23T14:57:02.987654Z"),
+    ]
+    target = build(Arrow::TimestampArray.new(:micro, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_nano
+    values = [
+      Time.parse("1960-01-01T02:09:30.123456789Z"),
+      nil,
+      Time.parse("2017-08-23T14:57:02.987654321Z"),
+    ]
+    target = build(Arrow::TimestampArray.new(:nano, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
+    values = [
+      Arrow::Time.new(unit, 60 * 10), # 00:10:00
+      nil,
+      Arrow::Time.new(unit, 60 * 60 * 2 + 9), # 02:00:09
+    ]
+    target = build(Arrow::Time32Array.new(:second, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
+    values = [
+      Arrow::Time.new(unit, (60 * 10) * 1000 + 123), # 00:10:00.123
+      nil,
+      Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1000 + 987), # 02:00:09.987
+    ]
+    target = build(Arrow::Time32Array.new(:milli, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
+    values = [
+      # 00:10:00.123456
+      Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456),
+      nil,
+      # 02:00:09.987654
+      Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000 + 987_654),
+    ]
+    target = build(Arrow::Time64Array.new(:micro, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
+    values = [
+      # 00:10:00.123456789
+      Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
+      nil,
+      # 02:00:09.987654321
+      Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000_000 + 987_654_321),
+    ]
+    target = build(Arrow::Time64Array.new(:nano, values))
+    assert_equal(values, target.values)
+  end
+
+  def test_decimal128
+    values = [
+      BigDecimal("92.92"),
+      nil,
+      BigDecimal("29.29"),
+    ]
+    data_type = Arrow::Decimal128DataType.new(8, 2)
+    target = build(Arrow::Decimal128Array.new(data_type, values))
+    assert_equal(values, target.values)
+  end
+end
+
+class ValuesArrayBasicArraysTest < Test::Unit::TestCase
+  include ValuesBasicArraysTests
+
+  def build(array)
+    array
+  end
+end
+
+class ValuesChunkedArrayBasicArraysTest < Test::Unit::TestCase
+  include ValuesBasicArraysTests
+
+  def build(array)
+    Arrow::ChunkedArray.new([array])
+  end
+end

--- a/ruby/red-arrow/test/values/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/values/test-dense-union-array.rb
@@ -1,0 +1,487 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ValuesDenseUnionArrayTests
+  def build_data_type(type, type_codes)
+    field_description = {}
+    if type.is_a?(Hash)
+      field_description = field_description.merge(type)
+    else
+      field_description[:type] = type
+    end
+    Arrow::DenseUnionDataType.new(fields: [
+                                    field_description.merge(name: "0"),
+                                    field_description.merge(name: "1"),
+                                  ],
+                                  type_codes: type_codes)
+  end
+
+  def build_array(type, values)
+    type_codes = [0, 1]
+    data_type = build_data_type(type, type_codes)
+    type_ids = []
+    offsets = []
+    arrays = data_type.fields.collect do |field|
+      sub_schema = Arrow::Schema.new([field])
+      sub_records = []
+      values.each do |value|
+        next if value.nil?
+        next unless value.key?(field.name)
+        sub_records << [value[field.name]]
+      end
+      sub_record_batch = Arrow::RecordBatch.new(sub_schema,
+                                                sub_records)
+      sub_record_batch.columns[0].data
+    end
+    values.each do |value|
+      if value.nil?
+        type_ids << nil
+        offsets << 0
+      elsif value.key?("0")
+        type_id = type_codes[0]
+        type_ids << type_id
+        offsets << (type_ids.count(type_id) - 1)
+      elsif value.key?("1")
+        type_id = type_codes[1]
+        type_ids << type_id
+        offsets << (type_ids.count(type_id) - 1)
+      end
+    end
+    Arrow::DenseUnionArray.new(data_type,
+                               Arrow::Int8Array.new(type_ids),
+                               Arrow::Int32Array.new(offsets),
+                               arrays)
+  end
+
+  def test_null
+    values = [
+      {"0" => nil},
+      nil,
+    ]
+    target = build(:null, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_boolean
+    values = [
+      {"0" => true},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:boolean, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int8
+    values = [
+      {"0" => -(2 ** 7)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint8
+    values = [
+      {"0" => (2 ** 8) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int16
+    values = [
+      {"0" => -(2 ** 15)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint16
+    values = [
+      {"0" => (2 ** 16) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int32
+    values = [
+      {"0" => -(2 ** 31)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint32
+    values = [
+      {"0" => (2 ** 32) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int64
+    values = [
+      {"0" => -(2 ** 63)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint64
+    values = [
+      {"0" => (2 ** 64) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_float
+    values = [
+      {"0" => -1.0},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:float, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_double
+    values = [
+      {"0" => -1.0},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:double, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_binary
+    values = [
+      {"0" => "\xff".b},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:binary, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_string
+    values = [
+      {"0" => "Ruby"},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:string, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date32
+    values = [
+      {"0" => Date.new(1960, 1, 1)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:date32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date64
+    values = [
+      {"0" => DateTime.new(1960, 1, 1, 2, 9, 30)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:date64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_second
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_milli
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30.123Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_micro
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30.123456Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_nano
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30.123456789Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
+    values = [
+      # 00:10:00
+      {"0" => Arrow::Time.new(unit, 60 * 10)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
+    values = [
+      # 00:10:00.123
+      {"0" => Arrow::Time.new(unit, (60 * 10) * 1000 + 123)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
+    values = [
+      # 00:10:00.123456
+      {"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
+    values = [
+      # 00:10:00.123456789
+      {"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_decimal128
+    values = [
+      {"0" => BigDecimal("92.92")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :decimal128,
+                     precision: 8,
+                     scale: 2,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_list
+    values = [
+      {"0" => [true, nil, false]},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :list,
+                     field: {
+                       name: :sub_element,
+                       type: :boolean,
+                     },
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_struct
+    values = [
+      {"0" => {"sub_field" => true}},
+      nil,
+      {"1" => nil},
+      {"0" => {"sub_field" => nil}},
+    ]
+    target = build({
+                     type: :struct,
+                     fields: [
+                       {
+                         name: :sub_field,
+                         type: :boolean,
+                       },
+                     ],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_sparse_union
+    omit("Need to add support for SparseUnionArrayBuilder")
+    values = [
+      {"0" => {"field1" => true}},
+      nil,
+      {"1" => nil},
+      {"0" => {"field2" => nil}},
+    ]
+    target = build({
+                     type: :sparse_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dense_union
+    omit("Need to add support for DenseUnionArrayBuilder")
+    values = [
+      {"0" => {"field1" => true}},
+      nil,
+      {"1" => nil},
+      {"0" => {"field2" => nil}},
+    ]
+    target = build({
+                     type: :dense_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dictionary
+    omit("Need to add support for DictionaryArrayBuilder")
+    values = [
+      {"0" => "Ruby"},
+      nil,
+      {"1" => nil},
+      {"0" => "GLib"},
+    ]
+    dictionary = Arrow::StringArray.new(["GLib", "Ruby"])
+    target = build({
+                                        type: :dictionary,
+                                        index_data_type: :int8,
+                                        dictionary: dictionary,
+                                        ordered: true,
+                                      },
+                                      values)
+    assert_equal(values, target.values)
+  end
+end
+
+class ValuesArrayDenseUnionArrayTest < Test::Unit::TestCase
+  include ValuesDenseUnionArrayTests
+
+  def build(type, values)
+    build_array(type, values)
+  end
+end
+
+class ValuesChunkedArrayDenseUnionArrayTest < Test::Unit::TestCase
+  include ValuesDenseUnionArrayTests
+
+  def build(type, values)
+    Arrow::ChunkedArray.new([build_array(type, values)])
+  end
+end

--- a/ruby/red-arrow/test/values/test-list-array.rb
+++ b/ruby/red-arrow/test/values/test-list-array.rb
@@ -1,0 +1,497 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ValuesListArrayTests
+  def build_data_type(type)
+    field_description = {
+      name: :element,
+    }
+    if type.is_a?(Hash)
+      field_description = field_description.merge(type)
+    else
+      field_description[:type] = type
+    end
+    Arrow::ListDataType.new(field: field_description)
+  end
+
+  def build_array(type, values)
+    Arrow::ListArray.new(build_data_type(type), values)
+  end
+
+  def test_null
+    values = [
+      [nil, nil, nil],
+      nil,
+    ]
+    target = build(:null, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_boolean
+    values = [
+      [true, nil, false],
+      nil,
+    ]
+    target = build(:boolean, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int8
+    values = [
+      [-(2 ** 7), nil, (2 ** 7) - 1],
+      nil,
+    ]
+    target = build(:int8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint8
+    values = [
+      [0, nil, (2 ** 8) - 1],
+      nil,
+    ]
+    target = build(:uint8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int16
+    values = [
+      [-(2 ** 15), nil, (2 ** 15) - 1],
+      nil,
+    ]
+    target = build(:int16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint16
+    values = [
+      [0, nil, (2 ** 16) - 1],
+      nil,
+    ]
+    target = build(:uint16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int32
+    values = [
+      [-(2 ** 31), nil, (2 ** 31) - 1],
+      nil,
+    ]
+    target = build(:int32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint32
+    values = [
+      [0, nil, (2 ** 32) - 1],
+      nil,
+    ]
+    target = build(:uint32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int64
+    values = [
+      [-(2 ** 63), nil, (2 ** 63) - 1],
+      nil,
+    ]
+    target = build(:int64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint64
+    values = [
+      [0, nil, (2 ** 64) - 1],
+      nil,
+    ]
+    target = build(:uint64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_float
+    values = [
+      [-1.0, nil, 1.0],
+      nil,
+    ]
+    target = build(:float, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_double
+    values = [
+      [-1.0, nil, 1.0],
+      nil,
+    ]
+    target = build(:double, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_binary
+    values = [
+      ["\x00".b, nil, "\xff".b],
+      nil,
+    ]
+    target = build(:binary, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_string
+    values = [
+      [
+        "Ruby",
+        nil,
+        "\u3042", # U+3042 HIRAGANA LETTER A
+      ],
+      nil,
+    ]
+    target = build(:string, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date32
+    values = [
+      [
+        Date.new(1960, 1, 1),
+        nil,
+        Date.new(2017, 8, 23),
+      ],
+      nil,
+    ]
+    target = build(:date32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date64
+    values = [
+      [
+        DateTime.new(1960, 1, 1, 2, 9, 30),
+        nil,
+        DateTime.new(2017, 8, 23, 14, 57, 2),
+      ],
+      nil,
+    ]
+    target = build(:date64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_second
+    values = [
+      [
+        Time.parse("1960-01-01T02:09:30Z"),
+        nil,
+        Time.parse("2017-08-23T14:57:02Z"),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_milli
+    values = [
+      [
+        Time.parse("1960-01-01T02:09:30.123Z"),
+        nil,
+        Time.parse("2017-08-23T14:57:02.987Z"),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_micro
+    values = [
+      [
+        Time.parse("1960-01-01T02:09:30.123456Z"),
+        nil,
+        Time.parse("2017-08-23T14:57:02.987654Z"),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_nano
+    values = [
+      [
+        Time.parse("1960-01-01T02:09:30.123456789Z"),
+        nil,
+        Time.parse("2017-08-23T14:57:02.987654321Z"),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
+    values = [
+      [
+        # 00:10:00
+        Arrow::Time.new(unit, 60 * 10),
+        nil,
+        # 02:00:09
+        Arrow::Time.new(unit, 60 * 60 * 2 + 9),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
+    values = [
+      [
+        # 00:10:00.123
+        Arrow::Time.new(unit, (60 * 10) * 1000 + 123),
+        nil,
+        # 02:00:09.987
+        Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1000 + 987),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
+    values = [
+      [
+        # 00:10:00.123456
+        Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456),
+        nil,
+        # 02:00:09.987654
+        Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000 + 987_654),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
+    values = [
+      [
+        # 00:10:00.123456789
+        Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
+        nil,
+        # 02:00:09.987654321
+        Arrow::Time.new(unit, (60 * 60 * 2 + 9) * 1_000_000_000 + 987_654_321),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_decimal128
+    values = [
+      [
+        BigDecimal("92.92"),
+        nil,
+        BigDecimal("29.29"),
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :decimal128,
+                     precision: 8,
+                     scale: 2,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_list
+    values = [
+      [
+        [
+          true,
+          nil,
+        ],
+        nil,
+        [
+          nil,
+          false,
+        ],
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :list,
+                     field: {
+                       name: :sub_element,
+                       type: :boolean,
+                     },
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_struct
+    values = [
+      [
+        {"field" => true},
+        nil,
+        {"field" => nil},
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :struct,
+                     fields: [
+                       {
+                         name: :field,
+                         type: :boolean,
+                       },
+                     ],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_sparse
+    omit("Need to add support for SparseUnionArrayBuilder")
+    values = [
+      [
+        {"field1" => true},
+        nil,
+        {"field2" => nil},
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :sparse_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dense
+    omit("Need to add support for DenseUnionArrayBuilder")
+    values = [
+      [
+        {"field1" => true},
+        nil,
+        {"field2" => nil},
+      ],
+      nil,
+    ]
+    target = build({
+                     type: :dense_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dictionary
+    omit("Need to add support for DictionaryArrayBuilder")
+    values = [
+      [
+        "Ruby",
+        nil,
+        "GLib",
+      ],
+      nil,
+    ]
+    dictionary = Arrow::StringArray.new(["GLib", "Ruby"])
+    target = build({
+                     type: :dictionary,
+                     index_data_type: :int8,
+                     dictionary: dictionary,
+                     ordered: true,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+end
+
+class ValuesArrayListArrayTest < Test::Unit::TestCase
+  include ValuesListArrayTests
+
+  def build(type, values)
+    build_array(type, values)
+  end
+end
+
+class ValuesChunkedArrayListArrayTest < Test::Unit::TestCase
+  include ValuesListArrayTests
+
+  def build(type, values)
+    Arrow::ChunkedArray.new([build_array(type, values)])
+  end
+end

--- a/ruby/red-arrow/test/values/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/values/test-sparse-union-array.rb
@@ -1,0 +1,477 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ValuesSparseUnionArrayTests
+  def build_data_type(type, type_codes)
+    field_description = {}
+    if type.is_a?(Hash)
+      field_description = field_description.merge(type)
+    else
+      field_description[:type] = type
+    end
+    Arrow::SparseUnionDataType.new(fields: [
+                                     field_description.merge(name: "0"),
+                                     field_description.merge(name: "1"),
+                                   ],
+                                   type_codes: type_codes)
+  end
+
+  def build_array(type, values)
+    type_codes = [0, 1]
+    data_type = build_data_type(type, type_codes)
+    type_ids = []
+    arrays = data_type.fields.collect do |field|
+      sub_schema = Arrow::Schema.new([field])
+      sub_records = values.collect do |value|
+        [value.nil? ? nil : value[field.name]]
+      end
+      sub_record_batch = Arrow::RecordBatch.new(sub_schema,
+                                                sub_records)
+      sub_record_batch.columns[0].data
+    end
+    values.each do |value|
+      if value.nil?
+        type_ids << nil
+      elsif value.key?("0")
+        type_ids << type_codes[0]
+      elsif value.key?("1")
+        type_ids << type_codes[1]
+      end
+    end
+    Arrow::SparseUnionArray.new(data_type,
+                                Arrow::Int8Array.new(type_ids),
+                                arrays)
+  end
+
+  def test_null
+    values = [
+      {"0" => nil},
+      nil,
+    ]
+    target = build(:null, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_boolean
+    values = [
+      {"0" => true},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:boolean, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int8
+    values = [
+      {"0" => -(2 ** 7)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint8
+    values = [
+      {"0" => (2 ** 8) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int16
+    values = [
+      {"0" => -(2 ** 15)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint16
+    values = [
+      {"0" => (2 ** 16) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int32
+    values = [
+      {"0" => -(2 ** 31)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint32
+    values = [
+      {"0" => (2 ** 32) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int64
+    values = [
+      {"0" => -(2 ** 63)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:int64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint64
+    values = [
+      {"0" => (2 ** 64) - 1},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:uint64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_float
+    values = [
+      {"0" => -1.0},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:float, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_double
+    values = [
+      {"0" => -1.0},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:double, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_binary
+    values = [
+      {"0" => "\xff".b},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:binary, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_string
+    values = [
+      {"0" => "Ruby"},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:string, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date32
+    values = [
+      {"0" => Date.new(1960, 1, 1)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:date32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date64
+    values = [
+      {"0" => DateTime.new(1960, 1, 1, 2, 9, 30)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build(:date64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_second
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_milli
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30.123Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_micro
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30.123456Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_nano
+    values = [
+      {"0" => Time.parse("1960-01-01T02:09:30.123456789Z")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
+    values = [
+      # 00:10:00
+      {"0" => Arrow::Time.new(unit, 60 * 10)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
+    values = [
+      # 00:10:00.123
+      {"0" => Arrow::Time.new(unit, (60 * 10) * 1000 + 123)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
+    values = [
+      # 00:10:00.123456
+      {"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
+    values = [
+      # 00:10:00.123456789
+      {"0" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_decimal128
+    values = [
+      {"0" => BigDecimal("92.92")},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :decimal128,
+                     precision: 8,
+                     scale: 2,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_list
+    values = [
+      {"0" => [true, nil, false]},
+      nil,
+      {"1" => nil},
+    ]
+    target = build({
+                     type: :list,
+                     field: {
+                       name: :sub_element,
+                       type: :boolean,
+                     },
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_struct
+    values = [
+      {"0" => {"sub_field" => true}},
+      nil,
+      {"1" => nil},
+      {"0" => {"sub_field" => nil}},
+    ]
+    target = build({
+                     type: :struct,
+                     fields: [
+                       {
+                         name: :sub_field,
+                         type: :boolean,
+                       },
+                     ],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_sparse_union
+    omit("Need to add support for SparseUnionArrayBuilder")
+    values = [
+      {"0" => {"field1" => true}},
+      nil,
+      {"1" => nil},
+      {"0" => {"field2" => nil}},
+    ]
+    target = build({
+                     type: :sparse_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dense_union
+    omit("Need to add support for DenseUnionArrayBuilder")
+    values = [
+      {"0" => {"field1" => true}},
+      nil,
+      {"1" => nil},
+      {"0" => {"field2" => nil}},
+    ]
+    target = build({
+                     type: :dense_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dictionary
+    omit("Need to add support for DictionaryArrayBuilder")
+    values = [
+      {"0" => "Ruby"},
+      nil,
+      {"1" => nil},
+      {"0" => "GLib"},
+    ]
+    dictionary = Arrow::StringArray.new(["GLib", "Ruby"])
+    target = build({
+                     type: :dictionary,
+                     index_data_type: :int8,
+                     dictionary: dictionary,
+                     ordered: true,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+end
+
+class ValuesArraySparseUnionArrayTest < Test::Unit::TestCase
+  include ValuesSparseUnionArrayTests
+
+  def build(type, values)
+    build_array(type, values)
+  end
+end
+
+class ValuesChunkedArraySparseUnionArrayTest < Test::Unit::TestCase
+  include ValuesSparseUnionArrayTests
+
+  def build(type, values)
+    Arrow::ChunkedArray.new([build_array(type, values)])
+  end
+end

--- a/ruby/red-arrow/test/values/test-struct-array.rb
+++ b/ruby/red-arrow/test/values/test-struct-array.rb
@@ -1,0 +1,452 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ValuesStructArrayTests
+  def build_data_type(type)
+    field_description = {
+      name: :field,
+    }
+    if type.is_a?(Hash)
+      field_description = field_description.merge(type)
+    else
+      field_description[:type] = type
+    end
+    Arrow::StructDataType.new([field_description])
+  end
+
+  def build_array(type, values)
+    Arrow::StructArray.new(build_data_type(type), values)
+  end
+
+  def test_null
+    values = [
+      {"field" => nil},
+      nil,
+    ]
+    target = build(:null, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_boolean
+    values = [
+      {"field" => true},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:boolean, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int8
+    values = [
+      {"field" => -(2 ** 7)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:int8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint8
+    values = [
+      {"field" => (2 ** 8) - 1},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:uint8, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int16
+    values = [
+      {"field" => -(2 ** 15)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:int16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint16
+    values = [
+      {"field" => (2 ** 16) - 1},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:uint16, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int32
+    values = [
+      {"field" => -(2 ** 31)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:int32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint32
+    values = [
+      {"field" => (2 ** 32) - 1},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:uint32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_int64
+    values = [
+      {"field" => -(2 ** 63)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:int64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_uint64
+    values = [
+      {"field" => (2 ** 64) - 1},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:uint64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_float
+    values = [
+      {"field" => -1.0},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:float, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_double
+    values = [
+      {"field" => -1.0},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:double, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_binary
+    values = [
+      {"field" => "\xff".b},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:binary, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_string
+    values = [
+      {"field" => "Ruby"},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:string, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date32
+    values = [
+      {"field" => Date.new(1960, 1, 1)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:date32, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_date64
+    values = [
+      {"field" => DateTime.new(1960, 1, 1, 2, 9, 30)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build(:date64, values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_second
+    values = [
+      {"field" => Time.parse("1960-01-01T02:09:30Z")},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_milli
+    values = [
+      {"field" => Time.parse("1960-01-01T02:09:30.123Z")},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_micro
+    values = [
+      {"field" => Time.parse("1960-01-01T02:09:30.123456Z")},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_timestamp_nano
+    values = [
+      {"field" => Time.parse("1960-01-01T02:09:30.123456789Z")},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :timestamp,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_second
+    unit = Arrow::TimeUnit::SECOND
+    values = [
+      # 00:10:00
+      {"field" => Arrow::Time.new(unit, 60 * 10)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :second,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time32_milli
+    unit = Arrow::TimeUnit::MILLI
+    values = [
+      # 00:10:00.123
+      {"field" => Arrow::Time.new(unit, (60 * 10) * 1000 + 123)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :time32,
+                     unit: :milli,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_micro
+    unit = Arrow::TimeUnit::MICRO
+    values = [
+      # 00:10:00.123456
+      {"field" => Arrow::Time.new(unit, (60 * 10) * 1_000_000 + 123_456)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :micro,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_time64_nano
+    unit = Arrow::TimeUnit::NANO
+    values = [
+      # 00:10:00.123456789
+      {"field" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :time64,
+                     unit: :nano,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_decimal128
+    values = [
+      {"field" => BigDecimal("92.92")},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :decimal128,
+                     precision: 8,
+                     scale: 2,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_list
+    values = [
+      {"field" => [true, nil, false]},
+      nil,
+      {"field" => nil},
+    ]
+    target = build({
+                     type: :list,
+                     field: {
+                       name: :sub_element,
+                       type: :boolean,
+                     },
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_struct
+    values = [
+      {"field" => {"sub_field" => true}},
+      nil,
+      {"field" => nil},
+      {"field" => {"sub_field" => nil}},
+    ]
+    target = build({
+                     type: :struct,
+                     fields: [
+                       {
+                         name: :sub_field,
+                         type: :boolean,
+                       },
+                     ],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_sparse_union
+    omit("Need to add support for SparseUnionArrayBuilder")
+    values = [
+      {"field" => {"field1" => true}},
+      nil,
+      {"field" => nil},
+      {"field" => {"field2" => nil}},
+    ]
+    target = build({
+                     type: :sparse_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dense_union
+    omit("Need to add support for DenseUnionArrayBuilder")
+    values = [
+      {"field" => {"field1" => true}},
+      nil,
+      {"field" => nil},
+      {"field" => {"field2" => nil}},
+    ]
+    target = build({
+                     type: :dense_union,
+                     fields: [
+                       {
+                         name: :field1,
+                         type: :boolean,
+                       },
+                       {
+                         name: :field2,
+                         type: :uint8,
+                       },
+                     ],
+                     type_codes: [0, 1],
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+
+  def test_dictionary
+    omit("Need to add support for DictionaryArrayBuilder")
+    values = [
+      {"field" => "Ruby"},
+      nil,
+      {"field" => nil},
+      {"field" => "GLib"},
+    ]
+    dictionary = Arrow::StringArray.new(["GLib", "Ruby"])
+    target = build({
+                     type: :dictionary,
+                     index_data_type: :int8,
+                     dictionary: dictionary,
+                     ordered: true,
+                   },
+                   values)
+    assert_equal(values, target.values)
+  end
+end
+
+class ValuesArrayStructArrayTest < Test::Unit::TestCase
+  include ValuesStructArrayTests
+
+  def build(type, values)
+    build_array(type, values)
+  end
+end
+
+class ValuesChunkedArrayStructArrayTest < Test::Unit::TestCase
+  include ValuesStructArrayTests
+
+  def build(type, values)
+    Arrow::ChunkedArray.new([build_array(type, values)])
+  end
+end


### PR DESCRIPTION
Type       | Before    | After       | Speedup ratio
---------- | --------- | ----------- | -------------
Boolean    | 100.9 i/s | 34711.9 i/s | 343.87x
Decimal128 |  70.1 i/s |   660.7 i/s |   9.42x
Dictionary |  59.1 i/s |  8542.6 i/s | 144.54x
Int64      | 101.8 i/s | 41414.1 i/s | 406.72x
String     |  96.3 i/s | 17146.7 i/s | 178.13x
Timestamp  |  85.9 i/s |  1402.6 i/s |  16.32x

See ruby/red-arrow/benchmark/values/ for benchmark details.

This also adds ChunkedArray#values.

ruby/red-arrow/ext/arrow/converters.*:
ruby/red-arrow/ext/arrow/raw-records.cpp:

It extracts convert related features from raw-records.cpp to
converters.*. raw-records.cpp just uses convert related features
extracted to converters.*. The logic for convert related features
aren't changed.

ruby/red-arrow/ext/arrow/values.cpp:

It just uses extracted convert related features.

ruby/red-arrow/lib/arrow/loader.rb:

It maps the original Arrow::Array#values to Arrow::Array#raw_values to
use Arrow::Array#values defined in ruby/red-arrow/ext/arrow/arrow.cpp.

ruby/red-arrow/lib/arrow/array.rb:

It changes to fast Arrow::Array#values for Arrow::Array#to_a instead
of Enumerable#to_a.

ruby/red-arrow/benchmark/raw-records/:

Faker API is changed since Faker 2.0.0. This change uses the new
Faker API.