### PR TITLE
ARROW-6314: [C++] Implement IPC message format alignment changes, provide backwards compatibility and "legacy" option to emit old message format

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -383,8 +383,8 @@ Status WriteMessage(const Buffer& message, const IpcOptions& options,
   const int32_t prefix_size = options.write_legacy_ipc_format ? 4 : 8;
   const int32_t flatbuffer_size = static_cast<int32_t>(message.size());
 
-  int32_t padded_message_length =
-      PaddedLength(flatbuffer_size + prefix_size, options.alignment);
+  int32_t padded_message_length = static_cast<int32_t>(
+      PaddedLength(flatbuffer_size + prefix_size, options.alignment));
 
   int32_t padding = padded_message_length - flatbuffer_size - prefix_size;
 

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -31,6 +31,7 @@
 namespace arrow {
 
 class Buffer;
+class MemoryPool;
 
 namespace io {
 
@@ -225,6 +226,14 @@ Status CheckAligned(io::FileInterface* stream, int32_t alignment = 8);
 /// message length is 0 (e.g. EOS in a stream)
 ARROW_EXPORT
 Status ReadMessage(io::InputStream* stream, std::unique_ptr<Message>* message);
+
+/// \brief Read encapsulated IPC message (metadata and body) from InputStream
+///
+/// Like ReadMessage, except that the metadata is copied in a new buffer.
+/// This is necessary if the stream returns non-CPU buffers.
+ARROW_EXPORT
+Status ReadMessageCopy(io::InputStream* stream, MemoryPool* pool,
+                       std::unique_ptr<Message>* message);
 
 /// Write encapsulated IPC message Does not make assumptions about
 /// whether the stream is aligned already. Can write legacy (pre

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -1245,7 +1245,7 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
 Status WriteMessage(const Buffer& message, int32_t alignment, io::OutputStream* file,
                     int32_t* message_length) {
   // ARROW-3212: We do not make assumptions that the output stream is aligned
-  int32_t padded_message_length = static_cast<int32_t>(message.size()) + 4;
+  int32_t padded_message_length = static_cast<int32_t>(message.size()) + 8;
   const int32_t remainder = padded_message_length % alignment;
   if (remainder != 0) {
     padded_message_length += alignment - remainder;
@@ -1256,14 +1256,16 @@ Status WriteMessage(const Buffer& message, int32_t alignment, io::OutputStream* 
   *message_length = padded_message_length;
 
   // Write the flatbuffer size prefix including padding
-  int32_t flatbuffer_size = padded_message_length - 4;
+  int32_t flatbuffer_size = padded_message_length - 8;
+  constexpr int32_t kContinuationToken = -1;
+  RETURN_NOT_OK(file->Write(&kContinuationToken, sizeof(int32_t)));
   RETURN_NOT_OK(file->Write(&flatbuffer_size, sizeof(int32_t)));
 
   // Write the flatbuffer
   RETURN_NOT_OK(file->Write(message.data(), message.size()));
 
   // Write any padding
-  int32_t padding = padded_message_length - static_cast<int32_t>(message.size()) - 4;
+  int32_t padding = padded_message_length - static_cast<int32_t>(message.size()) - 8;
   if (padding > 0) {
     RETURN_NOT_OK(file->Write(kPaddingBytes, padding));
   }

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -1239,40 +1239,6 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
   return ConcreteTypeFromFlatbuffer(sparse_tensor->type_type(), type_data, {}, type);
 }
 
-// ----------------------------------------------------------------------
-// Implement message writing
-
-Status WriteMessage(const Buffer& message, int32_t alignment, io::OutputStream* file,
-                    int32_t* message_length) {
-  // ARROW-3212: We do not make assumptions that the output stream is aligned
-  int32_t padded_message_length = static_cast<int32_t>(message.size()) + 8;
-  const int32_t remainder = padded_message_length % alignment;
-  if (remainder != 0) {
-    padded_message_length += alignment - remainder;
-  }
-
-  // The returned message size includes the length prefix, the flatbuffer,
-  // plus padding
-  *message_length = padded_message_length;
-
-  // Write the flatbuffer size prefix including padding
-  int32_t flatbuffer_size = padded_message_length - 8;
-  constexpr int32_t kContinuationToken = -1;
-  RETURN_NOT_OK(file->Write(&kContinuationToken, sizeof(int32_t)));
-  RETURN_NOT_OK(file->Write(&flatbuffer_size, sizeof(int32_t)));
-
-  // Write the flatbuffer
-  RETURN_NOT_OK(file->Write(message.data(), message.size()));
-
-  // Write any padding
-  int32_t padding = padded_message_length - static_cast<int32_t>(message.size()) - 8;
-  if (padding > 0) {
-    RETURN_NOT_OK(file->Write(kPaddingBytes, padding));
-  }
-
-  return Status::OK();
-}
-
 }  // namespace internal
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -119,22 +119,6 @@ static inline Status VerifyMessage(const uint8_t* data, int64_t size,
   return Status::OK();
 }
 
-/// Write a serialized message metadata with a length-prefix and padding to an
-/// 8-byte offset. Does not make assumptions about whether the stream is
-/// aligned already
-///
-/// <message_size: int32><message: const void*><padding>
-///
-/// \param[in] message a buffer containing the metadata to write
-/// \param[in] alignment the size multiple of the total message size including
-/// length prefix, metadata, and padding. Usually 8 or 64
-/// \param[in,out] file the OutputStream to write to
-/// \param[out] message_length the total size of the payload written including
-/// padding
-/// \return Status
-Status WriteMessage(const Buffer& message, int32_t alignment, io::OutputStream* file,
-                    int32_t* message_length);
-
 // Serialize arrow::Schema as a Flatbuffer
 //
 // \param[in] schema a Schema instance

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -36,6 +36,14 @@ struct ARROW_EXPORT IpcOptions {
   // The maximum permitted schema nesting depth.
   int max_recursion_depth = kMaxNestingDepth;
 
+  // Write padding after memory buffers to this multiple of
+  // bytes. Generally 8 or 64
+  int32_t alignment = 8;
+
+  /// \brief Write the pre-0.15.0 encapsulated IPC message format
+  /// consisting of a 4-byte prefix instead of 8 byte
+  bool write_legacy_ipc_format = false;
+
   static IpcOptions Defaults();
 };
 

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -122,6 +122,55 @@ TEST(TestMessage, SerializeTo) {
   CheckWithAlignment(64);
 }
 
+void BuffersOverlapEquals(const Buffer& left, const Buffer& right) {
+  ASSERT_GT(left.size(), 0);
+  ASSERT_GT(right.size(), 0);
+  ASSERT_TRUE(left.Equals(right, std::min(left.size(), right.size())));
+}
+
+TEST(TestMessage, LegacyIpcBackwardsCompatibility) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeIntBatchSized(36, &batch));
+
+  auto RoundtripWithOptions = [&](const IpcOptions& arg_options,
+                                  std::shared_ptr<Buffer>* out_serialized,
+                                  std::unique_ptr<Message>* out) {
+    internal::IpcPayload payload;
+    ASSERT_OK(internal::GetRecordBatchPayload(*batch, arg_options, default_memory_pool(),
+                                              &payload));
+
+    std::shared_ptr<io::BufferOutputStream> stream;
+    ASSERT_OK(io::BufferOutputStream::Create(1 << 20, default_memory_pool(), &stream));
+
+    int32_t metadata_length = -1;
+    ASSERT_OK(
+        internal::WriteIpcPayload(payload, arg_options, stream.get(), &metadata_length));
+
+    ASSERT_OK(stream->Finish(out_serialized));
+    io::BufferReader io_reader(*out_serialized);
+    ASSERT_OK(ReadMessage(&io_reader, out));
+  };
+
+  std::shared_ptr<Buffer> serialized, legacy_serialized;
+  std::unique_ptr<Message> message, legacy_message;
+
+  IpcOptions options;
+  RoundtripWithOptions(options, &serialized, &message);
+
+  // First 4 bytes 0xFFFFFFFF Continuation marker
+  ASSERT_EQ(-1, util::SafeLoadAs<int32_t>(serialized->data()));
+
+  options.write_legacy_ipc_format = true;
+  RoundtripWithOptions(options, &legacy_serialized, &legacy_message);
+
+  // Check that the continuation marker is not written
+  ASSERT_NE(-1, util::SafeLoadAs<int32_t>(legacy_serialized->data()));
+
+  // Have to use the smaller size to exclude padding
+  BuffersOverlapEquals(*legacy_message->metadata(), *message->metadata());
+  ASSERT_TRUE(legacy_message->body()->Equals(*message->body()));
+}
+
 TEST(TestMessage, Verify) {
   std::string metadata = "invalid";
   std::string body = "abcdef";
@@ -628,13 +677,14 @@ TEST_F(RecursionLimits, StressLimit) {
 #endif  // !defined(_WIN32) || defined(NDEBUG)
 
 struct FileWriterHelper {
-  Status Init(const std::shared_ptr<Schema>& schema) {
+  Status Init(const std::shared_ptr<Schema>& schema, const IpcOptions& options) {
     num_batches_written_ = 0;
 
     RETURN_NOT_OK(AllocateResizableBuffer(0, &buffer_));
     sink_.reset(new io::BufferOutputStream(buffer_));
-
-    return RecordBatchFileWriter::Open(sink_.get(), schema, &writer_);
+    ARROW_ASSIGN_OR_RAISE(writer_,
+                          RecordBatchFileWriter::Open(sink_.get(), schema, options));
+    return Status::OK();
   }
 
   Status WriteBatch(const std::shared_ptr<RecordBatch>& batch) {
@@ -673,11 +723,12 @@ struct FileWriterHelper {
 };
 
 struct StreamWriterHelper {
-  Status Init(const std::shared_ptr<Schema>& schema) {
+  Status Init(const std::shared_ptr<Schema>& schema, const IpcOptions& options) {
     RETURN_NOT_OK(AllocateResizableBuffer(0, &buffer_));
     sink_.reset(new io::BufferOutputStream(buffer_));
-
-    return RecordBatchStreamWriter::Open(sink_.get(), schema, &writer_);
+    ARROW_ASSIGN_OR_RAISE(writer_,
+                          RecordBatchStreamWriter::Open(sink_.get(), schema, options));
+    return Status::OK();
   }
 
   Status WriteBatch(const std::shared_ptr<RecordBatch>& batch) {
@@ -711,7 +762,7 @@ class ReaderWriterMixin {
 
   // Check simple RecordBatch roundtripping
   template <typename Param>
-  void TestRoundTrip(Param&& param) {
+  void TestRoundTrip(Param&& param, const IpcOptions& options) {
     std::shared_ptr<RecordBatch> batch1;
     std::shared_ptr<RecordBatch> batch2;
     ASSERT_OK(param(&batch1));  // NOLINT clang-tidy gtest issue
@@ -720,7 +771,7 @@ class ReaderWriterMixin {
     BatchVector in_batches = {batch1, batch2};
     BatchVector out_batches;
 
-    ASSERT_OK(RoundTripHelper(in_batches, &out_batches));
+    ASSERT_OK(RoundTripHelper(in_batches, options, &out_batches));
     ASSERT_EQ(out_batches.size(), in_batches.size());
 
     // Compare batches
@@ -734,7 +785,7 @@ class ReaderWriterMixin {
     ASSERT_OK(MakeDictionary(&batch));
 
     BatchVector out_batches;
-    ASSERT_OK(RoundTripHelper({batch}, &out_batches));
+    ASSERT_OK(RoundTripHelper({batch}, IpcOptions::Defaults(), &out_batches));
     ASSERT_EQ(out_batches.size(), 1);
 
     // TODO(wesm): This was broken in ARROW-3144. I'm not sure how to
@@ -757,7 +808,7 @@ class ReaderWriterMixin {
     schema = schema->AddMetadata(key_value_metadata({"some_key"}, {"some_value"}));
 
     WriterHelper writer_helper;
-    ASSERT_OK(writer_helper.Init(schema));
+    ASSERT_OK(writer_helper.Init(schema, IpcOptions::Defaults()));
     // Writing a record batch with a different schema
     ASSERT_RAISES(Invalid, writer_helper.WriteBatch(batch_ints));
     // Writing a record batch with the same schema (except metadata)
@@ -774,9 +825,10 @@ class ReaderWriterMixin {
   }
 
  private:
-  Status RoundTripHelper(const BatchVector& in_batches, BatchVector* out_batches) {
+  Status RoundTripHelper(const BatchVector& in_batches, const IpcOptions& options,
+                         BatchVector* out_batches) {
     WriterHelper writer_helper;
-    RETURN_NOT_OK(writer_helper.Init(in_batches[0]->schema()));
+    RETURN_NOT_OK(writer_helper.Init(in_batches[0]->schema(), options));
     for (const auto& batch : in_batches) {
       RETURN_NOT_OK(writer_helper.WriteBatch(batch));
     }
@@ -806,9 +858,21 @@ class TestFileFormat : public ReaderWriterMixin<FileWriterHelper>,
 class TestStreamFormat : public ReaderWriterMixin<StreamWriterHelper>,
                          public ::testing::TestWithParam<MakeRecordBatch*> {};
 
-TEST_P(TestFileFormat, RoundTrip) { TestRoundTrip(*GetParam()); }
+TEST_P(TestFileFormat, RoundTrip) {
+  TestRoundTrip(*GetParam(), IpcOptions::Defaults());
 
-TEST_P(TestStreamFormat, RoundTrip) { TestRoundTrip(*GetParam()); }
+  IpcOptions options;
+  options.write_legacy_ipc_format = true;
+  TestRoundTrip(*GetParam(), options);
+}
+
+TEST_P(TestStreamFormat, RoundTrip) {
+  TestRoundTrip(*GetParam(), IpcOptions::Defaults());
+
+  IpcOptions options;
+  options.write_legacy_ipc_format = true;
+  TestRoundTrip(*GetParam(), options);
+}
 
 INSTANTIATE_TEST_CASE_P(GenericIpcRoundTripTests, TestIpcRoundTrip, BATCH_CASES());
 INSTANTIATE_TEST_CASE_P(FileRoundTripTests, TestFileFormat, BATCH_CASES());

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1028,7 +1028,7 @@ class StreamBookKeeper {
 };
 
 // End of stream marker
-constexpr int32_t kEos = 0;
+constexpr int64_t kEos = 0;
 
 /// A IpcPayloadWriter implementation that writes to a IPC stream
 /// (with an end-of-stream marker)
@@ -1053,7 +1053,7 @@ class PayloadStreamWriter : public internal::IpcPayloadWriter,
 
   Status Close() override {
     // Write 0 EOS message
-    return Write(&kEos, sizeof(int32_t));
+    return Write(&kEos, sizeof(int64_t));
   }
 };
 
@@ -1107,7 +1107,7 @@ class PayloadFileWriter : public internal::IpcPayloadWriter, protected StreamBoo
 
   Status Close() override {
     // Write 0 EOS message for compatibility with sequential readers
-    RETURN_NOT_OK(Write(&kEos, sizeof(int32_t)));
+    RETURN_NOT_OK(Write(&kEos, sizeof(int64_t)));
 
     // Write file footer
     RETURN_NOT_OK(UpdatePosition());

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1011,13 +1011,16 @@ class StreamBookKeeper {
     return Status::OK();
   }
 
+  Status WriteEOS() {
+    // End of stream marker
+    constexpr int64_t kEos = 0;
+    return Write(&kEos, sizeof(kEos));
+  }
+
  protected:
   io::OutputStream* sink_;
   int64_t position_;
 };
-
-// End of stream marker
-constexpr int64_t kEos = 0;
 
 /// A IpcPayloadWriter implementation that writes to a IPC stream
 /// (with an end-of-stream marker)
@@ -1041,10 +1044,7 @@ class PayloadStreamWriter : public internal::IpcPayloadWriter,
     return Status::OK();
   }
 
-  Status Close() override {
-    // Write 0 EOS message
-    return Write(&kEos, sizeof(int64_t));
-  }
+  Status Close() override { return WriteEOS(); }
 
  private:
   IpcOptions options_;
@@ -1101,7 +1101,7 @@ class PayloadFileWriter : public internal::IpcPayloadWriter, protected StreamBoo
 
   Status Close() override {
     // Write 0 EOS message for compatibility with sequential readers
-    RETURN_NOT_OK(Write(&kEos, sizeof(int64_t)));
+    RETURN_NOT_OK(WriteEOS());
 
     // Write file footer
     RETURN_NOT_OK(UpdatePosition());

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -177,7 +177,9 @@ class ARROW_EXPORT RecordBatchFileWriter : public RecordBatchStreamWriter {
   std::unique_ptr<RecordBatchFileWriterImpl> file_impl_;
 };
 
-/// \brief Low-level API for writing a record batch (without schema) to an OutputStream
+/// \brief Low-level API for writing a record batch (without schema)
+/// to an OutputStream as encapsulated IPC message. See Arrow format
+/// documentation for more detail.
 ///
 /// \param[in] batch the record batch to write
 /// \param[in] buffer_start_offset the start offset to use in the buffer metadata,
@@ -189,20 +191,6 @@ class ARROW_EXPORT RecordBatchFileWriter : public RecordBatchStreamWriter {
 /// \param[in] options options for serialization
 /// \param[in] pool the memory pool to allocate memory from
 /// \return Status
-///
-/// Write the RecordBatch (collection of equal-length Arrow arrays) to the
-/// output stream in a contiguous block. The record batch metadata is written as
-/// a flatbuffer (see format/Message.fbs -- the RecordBatch message type)
-/// prefixed by its size, followed by each of the memory buffers in the batch
-/// written end to end (with appropriate alignment and padding):
-///
-/// \code
-/// <int32: metadata size> <uint8*: metadata> <buffers ...>
-/// \endcode
-///
-/// Finally, the absolute offsets (relative to the start of the output stream)
-/// to the end of the body and end of the metadata / data header (suffixed by
-/// the header size) is returned in out-variables
 ARROW_EXPORT
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
                         io::OutputStream* dst, int32_t* metadata_length,
@@ -392,8 +380,8 @@ Status GetRecordBatchPayload(const RecordBatch& batch, const IpcOptions& options
                              MemoryPool* pool, IpcPayload* out);
 
 ARROW_EXPORT
-Status WriteIpcPayload(const IpcPayload& payload, io::OutputStream* dst,
-                       int32_t* metadata_length);
+Status WriteIpcPayload(const IpcPayload& payload, const IpcOptions& options,
+                       io::OutputStream* dst, int32_t* metadata_length);
 
 }  // namespace internal
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -958,6 +958,11 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MessageType_V4" arrow::ipc::MetadataVersion::V4"
 
     cdef cppclass CIpcOptions" arrow::ipc::IpcOptions":
+        c_bool allow_64bit
+        int max_recursion_depth
+        int32_t alignment
+        c_bool write_legacy_ipc_format
+
         @staticmethod
         CIpcOptions Defaults()
 
@@ -983,7 +988,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MetadataVersion metadata_version()
         MessageType type()
 
-        CStatus SerializeTo(OutputStream* stream, int32_t alignment,
+        CStatus SerializeTo(OutputStream* stream, const CIpcOptions& options,
                             int64_t* output_length)
 
     c_string FormatMessageType(MessageType type)

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -74,13 +74,14 @@ cdef class Message:
         """
         cdef:
             int64_t output_length = 0
-            int32_t c_alignment = alignment
             OutputStream* out
+            CIpcOptions options
 
+        options.alignment = alignment
         out = sink.get_output_stream().get()
         with nogil:
             check_status(self.message.get()
-                         .SerializeTo(out, c_alignment, &output_length))
+                         .SerializeTo(out, options, &output_length))
 
     def serialize(self, alignment=8, memory_pool=None):
         """


### PR DESCRIPTION
This also moves the alignment multiple to `IpcOptions` and adds the `IpcOptions` argument to more functions. 