### PR TITLE
ARROW-6373: [C++] Make FixedWidthBinaryBuilder consistent with other fixed width builders in zeroing memory when appending null batches

### DIFF
--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -82,7 +82,7 @@ Status FixedSizeBinaryBuilder::AppendNull() {
 Status FixedSizeBinaryBuilder::AppendNulls(int64_t length) {
   RETURN_NOT_OK(Reserve(length));
   UnsafeAppendToBitmap(length, false);
-  byte_builder_.UnsafeAdvance(length * byte_width_);
+  byte_builder_.UnsafeAppend(/*num_copies=*/length * byte_width_, 0);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -452,7 +452,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
 
   void UnsafeAppendNull() {
     UnsafeAppendToBitmap(false);
-    byte_builder_.UnsafeAdvance(byte_width_);
+    byte_builder_.UnsafeAppend(/*num_copies=*/byte_width_, 0);
   }
 
   void Reset() override;

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -544,6 +544,13 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendNull) {
   for (int64_t i = 0; i < size; ++i) {
     ASSERT_TRUE(result->IsNull(i)) << i;
   }
+
+  for (auto buffer : result->data()->buffers) {
+    for (int64_t i = 0; i < buffer->capacity(); i++) {
+      // Validates current implementation, algorithms shouldn't rely on this
+      ASSERT_EQ(0, *(buffer->data() + i)) << i;
+    }
+  }
 }
 
 TYPED_TEST(TestPrimitiveBuilder, TestAppendNulls) {
@@ -555,6 +562,13 @@ TYPED_TEST(TestPrimitiveBuilder, TestAppendNulls) {
 
   for (int64_t i = 0; i < size; ++i) {
     ASSERT_FALSE(result->IsValid(i));
+  }
+
+  for (auto buffer : result->data()->buffers) {
+    for (int64_t i = 0; i < buffer->capacity(); i++) {
+      // Validates current implementation, algorithms shouldn't rely on this
+      ASSERT_EQ(0, *(buffer->data() + i)) << i;
+    }
   }
 }
 
@@ -1369,6 +1383,26 @@ TEST_F(TestFWBinaryArray, Slice) {
   slice2 = array->Slice(1, 3);
   ASSERT_TRUE(slice->Equals(slice2));
   ASSERT_TRUE(array->RangeEquals(1, 3, 0, slice));
+}
+
+TEST_F(TestFWBinaryArray, BuilderNulls) {
+  auto type = fixed_size_binary(4);
+  FixedSizeBinaryBuilder builder(type);
+
+  for (int x = 0; x < 100; x++) {
+    ASSERT_OK(builder.AppendNull());
+  }
+  ASSERT_OK(builder.AppendNulls(500));
+
+  std::shared_ptr<Array> array;
+  ASSERT_OK(builder.Finish(&array));
+
+  for (auto buffer : array->data()->buffers) {
+    for (int64_t i = 0; i < buffer->capacity(); i++) {
+      // Validates current implementation, algorithms shouldn't rely on this
+      ASSERT_EQ(0, *(buffer->data() + i)) << i;
+    }
+  }
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
CC @pitrou 