### PR TITLE
ARROW-6374: [Java] Refactor the code for TimeXXVectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -889,4 +891,93 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     return visitor.visit(this, value);
   }
 
+  /*----------------------------------------------------------------*
+   |                                                                              |
+   |          vector value setter/getter methods             |
+   |                                                                              |
+   *----------------------------------------------------------------*/
+
+  protected long getLong(int index) throws IllegalStateException {
+    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
+      throw new IllegalStateException("Value at index is null");
+    }
+    return valueBuffer.getLong(index * BigIntVector.TYPE_WIDTH);
+  }
+
+  protected void setLong(int index, long value) {
+    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    setLongValue(index, value);
+  }
+
+  protected void setLongValue(int index, long value) {
+    valueBuffer.setLong(index * BigIntVector.TYPE_WIDTH, value);
+  }
+
+  protected void setLongSafe(int index, long value) {
+    handleSafe(index);
+    setLong(index, value);
+  }
+
+  protected void setLong(int index, int isSet, long value) {
+    if (isSet > 0) {
+      setLong(index, value);
+    } else {
+      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+    }
+  }
+
+  protected void setLongSafe(int index, int isSet, long value) {
+    handleSafe(index);
+    setLong(index, isSet, value);
+  }
+
+  protected Long getLongObject(int index) {
+    if (isSet(index) == 0) {
+      return null;
+    } else {
+      return valueBuffer.getLong(index * BigIntVector.TYPE_WIDTH);
+    }
+  }
+
+  protected int getInt(int index) throws IllegalStateException {
+    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
+      throw new IllegalStateException("Value at index is null");
+    }
+    return valueBuffer.getInt(index * IntVector.TYPE_WIDTH);
+  }
+
+  protected void setIntValue(int index, int value) {
+    valueBuffer.setInt(index * IntVector.TYPE_WIDTH, value);
+  }
+
+  protected void setInt(int index, int value) {
+    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    setIntValue(index, value);
+  }
+
+  protected void setIntSafe(int index, int value) {
+    handleSafe(index);
+    setInt(index, value);
+  }
+
+  protected void setInt(int index, int isSet, int value) {
+    if (isSet > 0) {
+      setInt(index, value);
+    } else {
+      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+    }
+  }
+
+  protected void setIntSafe(int index, int isSet, int value) {
+    handleSafe(index);
+    setInt(index, isSet, value);
+  }
+
+  protected Integer getIntObject(int index) {
+    if (isSet(index) == 0) {
+      return null;
+    } else {
+      return valueBuffer.getInt(index * IntVector.TYPE_WIDTH);
+    }
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.impl.TimeMicroReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -111,10 +109,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public long get(int index) throws IllegalStateException {
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
-    }
-    return valueBuffer.getLong(index * TYPE_WIDTH);
+    return getLong(index);
   }
 
   /**
@@ -140,11 +135,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public Long getObject(int index) {
-    if (isSet(index) == 0) {
-      return null;
-    } else {
-      return valueBuffer.getLong(index * TYPE_WIDTH);
-    }
+    return getLongObject(index);
   }
 
   /*----------------------------------------------------------------*
@@ -153,11 +144,6 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    |                                                                |
    *----------------------------------------------------------------*/
 
-
-  private void setValue(int index, long value) {
-    valueBuffer.setLong(index * TYPE_WIDTH, value);
-  }
-
   /**
    * Set the element at the given index to the given value.
    *
@@ -165,8 +151,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, value);
+    setLong(index, value);
   }
 
   /**
@@ -182,7 +167,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-      setValue(index, holder.value);
+      setLongValue(index, holder.value);
     } else {
       BitVectorHelper.setValidityBit(validityBuffer, index, 0);
     }
@@ -196,7 +181,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    */
   public void set(int index, TimeMicroHolder holder) {
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, holder.value);
+    setLongValue(index, holder.value);
   }
 
   /**
@@ -208,8 +193,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void setSafe(int index, long value) {
-    handleSafe(index);
-    set(index, value);
+    setLongSafe(index, value);
   }
 
   /**
@@ -247,11 +231,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void set(int index, int isSet, long value) {
-    if (isSet > 0) {
-      set(index, value);
-    } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
-    }
+    setLong(index, isSet, value);
   }
 
   /**
@@ -264,8 +244,7 @@ public class TimeMicroVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void setSafe(int index, int isSet, long value) {
-    handleSafe(index);
-    set(index, isSet, value);
+    setLongSafe(index, isSet, value);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
-
 import java.time.LocalDateTime;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -113,10 +111,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public int get(int index) throws IllegalStateException {
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
-    }
-    return valueBuffer.getInt(index * TYPE_WIDTH);
+    return getInt(index);
   }
 
   /**
@@ -158,10 +153,6 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    *----------------------------------------------------------------*/
 
 
-  private void setValue(int index, int value) {
-    valueBuffer.setInt(index * TYPE_WIDTH, value);
-  }
-
   /**
    * Set the element at the given index to the given value.
    *
@@ -169,8 +160,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, value);
+    setInt(index, value);
   }
 
   /**
@@ -186,7 +176,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-      setValue(index, holder.value);
+      setIntValue(index, holder.value);
     } else {
       BitVectorHelper.setValidityBit(validityBuffer, index, 0);
     }
@@ -200,7 +190,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    */
   public void set(int index, TimeMilliHolder holder) {
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, holder.value);
+    setIntValue(index, holder.value);
   }
 
   /**
@@ -212,8 +202,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void setSafe(int index, int value) {
-    handleSafe(index);
-    set(index, value);
+    setIntSafe(index, value);
   }
 
   /**
@@ -251,11 +240,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void set(int index, int isSet, int value) {
-    if (isSet > 0) {
-      set(index, value);
-    } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
-    }
+    setInt(index, isSet, value);
   }
 
   /**
@@ -268,8 +253,7 @@ public class TimeMilliVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void setSafe(int index, int isSet, int value) {
-    handleSafe(index);
-    set(index, isSet, value);
+    setIntSafe(index, isSet, value);
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.impl.TimeNanoReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -111,10 +109,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public long get(int index) throws IllegalStateException {
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
-    }
-    return valueBuffer.getLong(index * TYPE_WIDTH);
+    return getLong(index);
   }
 
   /**
@@ -140,11 +135,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public Long getObject(int index) {
-    if (isSet(index) == 0) {
-      return null;
-    } else {
-      return valueBuffer.getLong(index * TYPE_WIDTH);
-    }
+    return getLongObject(index);
   }
 
 
@@ -155,10 +146,6 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    *----------------------------------------------------------------*/
 
 
-  private void setValue(int index, long value) {
-    valueBuffer.setLong(index * TYPE_WIDTH, value);
-  }
-
   /**
    * Set the element at the given index to the given value.
    *
@@ -166,8 +153,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, value);
+    setLong(index, value);
   }
 
   /**
@@ -183,7 +169,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-      setValue(index, holder.value);
+      setLongValue(index, holder.value);
     } else {
       BitVectorHelper.setValidityBit(validityBuffer, index, 0);
     }
@@ -197,7 +183,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    */
   public void set(int index, TimeNanoHolder holder) {
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, holder.value);
+    setLongValue(index, holder.value);
   }
 
   /**
@@ -209,8 +195,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void setSafe(int index, long value) {
-    handleSafe(index);
-    set(index, value);
+    setLongSafe(index, value);
   }
 
   /**
@@ -248,11 +233,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void set(int index, int isSet, long value) {
-    if (isSet > 0) {
-      set(index, value);
-    } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
-    }
+    setLong(index, isSet, value);
   }
 
   /**
@@ -265,8 +246,7 @@ public class TimeNanoVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void setSafe(int index, int isSet, long value) {
-    handleSafe(index);
-    set(index, isSet, value);
+    setLongSafe(index, isSet, value);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.impl.TimeSecReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -111,10 +109,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public int get(int index) throws IllegalStateException {
-    if (NULL_CHECKING_ENABLED && isSet(index) == 0) {
-      throw new IllegalStateException("Value at index is null");
-    }
-    return valueBuffer.getInt(index * TYPE_WIDTH);
+    return getInt(index);
   }
 
   /**
@@ -140,11 +135,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @return element at given index
    */
   public Integer getObject(int index) {
-    if (isSet(index) == 0) {
-      return null;
-    } else {
-      return valueBuffer.getInt(index * TYPE_WIDTH);
-    }
+    return getIntObject(index);
   }
 
 
@@ -155,10 +146,6 @@ public class TimeSecVector extends BaseFixedWidthVector {
    *----------------------------------------------------------------*/
 
 
-  private void setValue(int index, int value) {
-    valueBuffer.setInt(index * TYPE_WIDTH, value);
-  }
-
   /**
    * Set the element at the given index to the given value.
    *
@@ -166,8 +153,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, value);
+    setInt(index, value);
   }
 
   /**
@@ -183,7 +169,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-      setValue(index, holder.value);
+      setIntValue(index, holder.value);
     } else {
       BitVectorHelper.setValidityBit(validityBuffer, index, 0);
     }
@@ -197,7 +183,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    */
   public void set(int index, TimeSecHolder holder) {
     BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    setValue(index, holder.value);
+    setIntValue(index, holder.value);
   }
 
   /**
@@ -209,8 +195,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void setSafe(int index, int value) {
-    handleSafe(index);
-    set(index, value);
+    setIntSafe(index, value);
   }
 
   /**
@@ -248,11 +233,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void set(int index, int isSet, int value) {
-    if (isSet > 0) {
-      set(index, value);
-    } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
-    }
+    setInt(index, isSet, value);
   }
 
   /**
@@ -265,8 +246,7 @@ public class TimeSecVector extends BaseFixedWidthVector {
    * @param value element value
    */
   public void setSafe(int index, int isSet, int value) {
-    handleSafe(index);
-    set(index, isSet, value);
+    setIntSafe(index, isSet, value);
   }
 
   /**


### PR DESCRIPTION
This is based on the discussion in https://lists.apache.org/thread.html/836d3b87ccb6e65e9edf0f220829a29edfa394fc2cd1e0866007d86e@%3Cdev.arrow.apache.org%3E.

The internals of TimeXXVectors are simply IntVector or BigIntVector. There are duplicated code for setting/getting int/long.

We want to refactor the code by:

push get/set methods into the base class BaseFixedWidthVector, and make them protected.
The APIs in TimeXXVectors references the methods in the base class.

Note that this issue not just reduce redundant code, it also centralizes the logics for getting/setting int/long, making them easy to maintain and change.

If it looks good, later we will make other integer based vectors rely on the base class implementations. 