### PR TITLE
ARROW-6371: [Doc] Row to columnar conversion example mentions arrow::Column in comments

### DIFF
--- a/cpp/examples/arrow/row-wise-conversion-example.cc
+++ b/cpp/examples/arrow/row-wise-conversion-example.cc
@@ -39,11 +39,12 @@ struct data_row {
 
 // Transforming a vector of structs into a columnar Table.
 //
-// The final representation should be an `arrow::Table` which in turn is made up of an
-// `arrow::Schema` and a list of  `arrow::Array` instances. As the first step, we will
-// iterate over the data and build up the arrays incrementally.  For this task, we provide
-// `arrow::ArrayBuilder` classes that help in the construction of the final `arrow::Array`
-// instances.
+// The final representation should be an `arrow::Table` which in turn
+// is made up of an `arrow::Schema` and a list of
+// `arrow::ChunkedArray` instances. As the first step, we will iterate
+// over the data and build up the arrays incrementally.  For this
+// task, we provide `arrow::ArrayBuilder` classes that help in the
+// construction of the final `arrow::Array` instances.
 //
 // For each type, Arrow has a specially typed builder class. For the primitive
 // values `id` and `cost` we can use the respective `arrow::Int64Builder` and

--- a/cpp/examples/arrow/row-wise-conversion-example.cc
+++ b/cpp/examples/arrow/row-wise-conversion-example.cc
@@ -39,12 +39,11 @@ struct data_row {
 
 // Transforming a vector of structs into a columnar Table.
 //
-// The final representation should be an `arrow::Table` which in turn is made up of
-// an `arrow::Schema` and a list of `arrow::Column`. An `arrow::Column` is again a
-// named collection of one or more `arrow::Array` instances. As the first step, we
-// will iterate over the data and build up the arrays incrementally. For this task,
-// we provide `arrow::ArrayBuilder` classes that help in the construction of the
-// final `arrow::Array` instances.
+// The final representation should be an `arrow::Table` which in turn is made up of an
+// `arrow::Schema` and a list of  `arrow::Array` instances. As the first step, we will
+// iterate over the data and build up the arrays incrementally.  For this task, we provide
+// `arrow::ArrayBuilder` classes that help in the construction of the final `arrow::Array`
+// instances.
 //
 // For each type, Arrow has a specially typed builder class. For the primitive
 // values `id` and `cost` we can use the respective `arrow::Int64Builder` and

--- a/cpp/src/arrow/python/pyarrow_lib.h
+++ b/cpp/src/arrow/python/pyarrow_lib.h
@@ -41,7 +41,6 @@ __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_array(std::shared_pt
 __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_chunked_array(std::shared_ptr< arrow::ChunkedArray>  const &);
 __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_batch(std::shared_ptr< arrow::RecordBatch>  const &);
 __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_buffer(std::shared_ptr< arrow::Buffer>  const &);
-__PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_column(std::shared_ptr< arrow::Column>  const &);
 __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_data_type(std::shared_ptr< arrow::DataType>  const &);
 __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_field(std::shared_ptr< arrow::Field>  const &);
 __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_resizable_buffer(std::shared_ptr< arrow::ResizableBuffer>  const &);
@@ -53,7 +52,6 @@ __PYX_EXTERN_C PyObject *__pyx_f_7pyarrow_3lib_pyarrow_wrap_sparse_tensor_csr(st
 __PYX_EXTERN_C std::shared_ptr< arrow::Array>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_array(PyObject *);
 __PYX_EXTERN_C std::shared_ptr< arrow::RecordBatch>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_batch(PyObject *);
 __PYX_EXTERN_C std::shared_ptr< arrow::Buffer>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_buffer(PyObject *);
-__PYX_EXTERN_C std::shared_ptr< arrow::Column>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_column(PyObject *);
 __PYX_EXTERN_C std::shared_ptr< arrow::DataType>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_data_type(PyObject *);
 __PYX_EXTERN_C std::shared_ptr< arrow::Field>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_field(PyObject *);
 __PYX_EXTERN_C std::shared_ptr< arrow::Schema>  __pyx_f_7pyarrow_3lib_pyarrow_unwrap_schema(PyObject *);


### PR DESCRIPTION
A comment in rowwise conversion example is updated to reflect removal of `arrow::Column`.