### PR TITLE
ARROW-6244: [C++][Dataset] Add partition key to DataSource interface

### DIFF
--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -69,7 +69,7 @@ DataFragmentIterator DataSource::AssumeCondition(
     return DataFragmentIterator();
   }
 
-  auto c = SelectorAssume((*options)->selector, condition_);
+  auto c = SelectorAssume((*options)->selector, partition_expression_);
   DCHECK_OK(c.status());
   auto expr = std::move(c).ValueOrDie();
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -65,7 +65,7 @@ Status Dataset::NewScan(std::unique_ptr<ScannerBuilder>* out) {
 bool DataSource::AssumePartitionExpression(std::shared_ptr<ScanOptions>* options) const {
   DCHECK_NE(options, nullptr);
   if (*options == nullptr) {
-    // null scan context; no selector to simplify
+    // null scan options; no selector to simplify
     return true;
   }
 
@@ -84,11 +84,15 @@ bool DataSource::AssumePartitionExpression(std::shared_ptr<ScanOptions>* options
   return true;
 }
 
-DataFragmentIterator SimpleDataSource::GetFragments(
-    std::shared_ptr<ScanOptions> options) {
+DataFragmentIterator DataSource::GetFragments(std::shared_ptr<ScanOptions> options) {
   if (!AssumePartitionExpression(&options)) {
     return MakeEmptyIterator<std::shared_ptr<DataFragment>>();
   }
+  return GetFragmentsImpl(std::move(options));
+}
+
+DataFragmentIterator SimpleDataSource::GetFragmentsImpl(
+    std::shared_ptr<ScanOptions> options) {
   return MakeVectorIterator(fragments_);
 }
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -46,11 +46,10 @@ Status SimpleDataFragment::Scan(std::shared_ptr<ScanContext> scan_context,
   return Status::OK();
 }
 
-Status Dataset::Make(const std::vector<std::shared_ptr<DataSource>>& sources,
-                     const std::shared_ptr<Schema>& schema,
-                     std::shared_ptr<Dataset>* out) {
+Status Dataset::Make(std::vector<std::shared_ptr<DataSource>> sources,
+                     std::shared_ptr<Schema> schema, std::shared_ptr<Dataset>* out) {
   // TODO: Ensure schema and sources align.
-  *out = std::make_shared<Dataset>(sources, schema);
+  *out = std::make_shared<Dataset>(std::move(sources), std::move(schema));
 
   return Status::OK();
 }

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -77,7 +77,7 @@ class ARROW_DS_EXPORT DataSource {
  public:
   /// \brief GetFragments returns an iterator of DataFragments. The ScanOptions
   /// controls filtering and schema inference.
-  virtual DataFragmentIterator GetFragments(std::shared_ptr<ScanOptions> options) = 0;
+  DataFragmentIterator GetFragments(std::shared_ptr<ScanOptions> options);
 
   /// \brief An expression which evaluates to true for all data viewed by this DataSource.
   /// May be null, which indicates no information is available.
@@ -94,9 +94,11 @@ class ARROW_DS_EXPORT DataSource {
   explicit DataSource(std::shared_ptr<Expression> c)
       : partition_expression_(std::move(c)) {}
 
+  virtual DataFragmentIterator GetFragmentsImpl(std::shared_ptr<ScanOptions> options) = 0;
+
   /// Mutates a ScanOptions by assuming partition_expression_ holds for all yielded
   /// fragments. Returns false if the selector is not satisfiable in this DataSource.
-  bool AssumePartitionExpression(std::shared_ptr<ScanOptions>* options) const;
+  virtual bool AssumePartitionExpression(std::shared_ptr<ScanOptions>* options) const;
 
   std::shared_ptr<Expression> partition_expression_;
 };
@@ -107,7 +109,7 @@ class ARROW_DS_EXPORT SimpleDataSource : public DataSource {
   explicit SimpleDataSource(DataFragmentVector fragments)
       : fragments_(std::move(fragments)) {}
 
-  DataFragmentIterator GetFragments(std::shared_ptr<ScanOptions> options) override;
+  DataFragmentIterator GetFragmentsImpl(std::shared_ptr<ScanOptions> options) override;
 
   std::string type() const override { return "simple_data_source"; }
 

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -81,10 +81,14 @@ class ARROW_DS_EXPORT DataSource {
 
   /// \brief An expression which evaluates to true for all data viewed by this DataSource.
   /// May be null, which indicates no information is available.
-  const std::shared_ptr<Expression>& condition() const { return condition_; }
+  const std::shared_ptr<Expression>& partition_expression() const {
+    return partition_expression_;
+  }
 
   /// FIXME(bkietz) providing a simple mutator like this is probably not ideal
-  void condition(std::shared_ptr<Expression> c) { condition_ = std::move(c); }
+  void partition_expression(std::shared_ptr<Expression> e) {
+    partition_expression_ = std::move(e);
+  }
 
   virtual std::string type() const = 0;
 
@@ -92,13 +96,14 @@ class ARROW_DS_EXPORT DataSource {
 
  protected:
   DataSource() = default;
-  explicit DataSource(std::shared_ptr<Expression> c) : condition_(std::move(c)) {}
+  explicit DataSource(std::shared_ptr<Expression> c)
+      : partition_expression_(std::move(c)) {}
 
   /// Mutates a ScanOptions by assuming condition_ holds for all yielded fragments.
   /// Returns non-null if context->selector is not satisfiable in this DataSource.
   DataFragmentIterator AssumeCondition(std::shared_ptr<ScanOptions>* options) const;
 
-  std::shared_ptr<Expression> condition_;
+  std::shared_ptr<Expression> partition_expression_;
 };
 
 /// \brief A DataSource consisting of a flat sequence of DataFragments

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -24,7 +24,7 @@
 
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
-#include "arrow/util/iterator.h"
+#include "arrow/util/macros.h"
 
 namespace arrow {
 namespace dataset {
@@ -85,11 +85,6 @@ class ARROW_DS_EXPORT DataSource {
     return partition_expression_;
   }
 
-  /// FIXME(bkietz) providing a simple mutator like this is probably not ideal
-  void partition_expression(std::shared_ptr<Expression> e) {
-    partition_expression_ = std::move(e);
-  }
-
   virtual std::string type() const = 0;
 
   virtual ~DataSource() = default;
@@ -99,9 +94,9 @@ class ARROW_DS_EXPORT DataSource {
   explicit DataSource(std::shared_ptr<Expression> c)
       : partition_expression_(std::move(c)) {}
 
-  /// Mutates a ScanOptions by assuming condition_ holds for all yielded fragments.
-  /// Returns non-null if context->selector is not satisfiable in this DataSource.
-  DataFragmentIterator AssumeCondition(std::shared_ptr<ScanOptions>* options) const;
+  /// Mutates a ScanOptions by assuming partition_expression_ holds for all yielded
+  /// fragments. Returns false if the selector is not satisfiable in this DataSource.
+  bool AssumePartitionExpression(std::shared_ptr<ScanOptions>* options) const;
 
   std::shared_ptr<Expression> partition_expression_;
 };

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -98,7 +98,9 @@ class ARROW_DS_EXPORT DataSource {
 
   /// Mutates a ScanOptions by assuming partition_expression_ holds for all yielded
   /// fragments. Returns false if the selector is not satisfiable in this DataSource.
-  virtual bool AssumePartitionExpression(std::shared_ptr<ScanOptions>* options) const;
+  virtual bool AssumePartitionExpression(
+      const std::shared_ptr<ScanOptions>& scan_options,
+      std::shared_ptr<ScanOptions>* simplified_scan_options) const;
 
   std::shared_ptr<Expression> partition_expression_;
 };

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -86,8 +86,9 @@ Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
 }
 
 DataFragmentIterator FileSystemBasedDataSource::GetFragmentsImpl(
-    std::shared_ptr<ScanOptions> options) {
-  if (!AssumePartitionExpression(&options)) {
+    std::shared_ptr<ScanOptions> scan_options) {
+  std::shared_ptr<ScanOptions> simplified_scan_options;
+  if (!AssumePartitionExpression(scan_options, &simplified_scan_options)) {
     return MakeEmptyIterator<std::shared_ptr<DataFragment>>();
   }
 
@@ -119,7 +120,7 @@ DataFragmentIterator FileSystemBasedDataSource::GetFragmentsImpl(
     std::vector<fs::FileStats> stats_;
   };
 
-  return DataFragmentIterator(Impl(filesystem_, format_, options, stats_));
+  return DataFragmentIterator(Impl(filesystem_, format_, scan_options, stats_));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -45,20 +45,18 @@ Status FileBasedDataFragment::Scan(std::shared_ptr<ScanContext> scan_context,
   return format_->ScanFile(source_, scan_options_, scan_context, out);
 }
 
-FileSystemBasedDataSource::FileSystemBasedDataSource(
-    fs::FileSystem* filesystem, const fs::Selector& selector,
-    std::shared_ptr<FileFormat> format, std::shared_ptr<ScanOptions> scan_options,
-    std::vector<fs::FileStats> stats)
+FileSystemBasedDataSource::FileSystemBasedDataSource(fs::FileSystem* filesystem,
+                                                     const fs::Selector& selector,
+                                                     std::shared_ptr<FileFormat> format,
+                                                     std::vector<fs::FileStats> stats)
     : filesystem_(filesystem),
       selector_(std::move(selector)),
       format_(std::move(format)),
-      scan_options_(std::move(scan_options)),
       stats_(std::move(stats)) {}
 
 Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
                                        const fs::Selector& selector,
                                        std::shared_ptr<FileFormat> format,
-                                       std::shared_ptr<ScanOptions> scan_options,
                                        std::unique_ptr<FileSystemBasedDataSource>* out) {
   std::vector<fs::FileStats> stats;
   RETURN_NOT_OK(filesystem->GetTargetStats(selector, &stats));
@@ -71,7 +69,7 @@ Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
   stats.resize(new_end - stats.begin());
 
   out->reset(new FileSystemBasedDataSource(filesystem, selector, std::move(format),
-                                           std::move(scan_options), std::move(stats)));
+                                           std::move(stats)));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "arrow/dataset/filter.h"
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
@@ -75,7 +76,10 @@ Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
 
 DataFragmentIterator FileSystemBasedDataSource::GetFragments(
     std::shared_ptr<ScanOptions> options) {
-  // TODO(bkietz) examine options.filters vs this->condition
+  if (auto empty = AssumeCondition(&options)) {
+    return empty;
+  }
+
   struct Impl : DataFragmentIterator {
     Impl(fs::FileSystem* filesystem, std::shared_ptr<FileFormat> format,
          std::shared_ptr<ScanOptions> scan_options, std::vector<fs::FileStats> stats)

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -85,7 +85,7 @@ Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
   return Make(filesystem, selector, std::move(format), nullptr, out);
 }
 
-DataFragmentIterator FileSystemBasedDataSource::GetFragments(
+DataFragmentIterator FileSystemBasedDataSource::GetFragmentsImpl(
     std::shared_ptr<ScanOptions> options) {
   if (!AssumePartitionExpression(&options)) {
     return MakeEmptyIterator<std::shared_ptr<DataFragment>>();

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -75,6 +75,7 @@ Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
 
 DataFragmentIterator FileSystemBasedDataSource::GetFragments(
     std::shared_ptr<ScanOptions> options) {
+  // TODO(bkietz) examine options.filters vs this->condition
   struct Impl : DataFragmentIterator {
     Impl(fs::FileSystem* filesystem, std::shared_ptr<FileFormat> format,
          std::shared_ptr<ScanOptions> scan_options, std::vector<fs::FileStats> stats)

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -170,7 +170,6 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
  public:
   static Status Make(fs::FileSystem* filesystem, const fs::Selector& selector,
                      std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<ScanOptions> scan_options,
                      std::unique_ptr<FileSystemBasedDataSource>* out);
 
   std::string type() const override { return "directory"; }
@@ -180,13 +179,11 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
  protected:
   FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,
                             std::shared_ptr<FileFormat> format,
-                            std::shared_ptr<ScanOptions> scan_options,
                             std::vector<fs::FileStats> stats);
 
   fs::FileSystem* filesystem_ = NULLPTR;
   fs::Selector selector_;
   std::shared_ptr<FileFormat> format_;
-  std::shared_ptr<ScanOptions> scan_options_;
   std::vector<fs::FileStats> stats_;
 };
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -179,9 +179,9 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
 
   std::string type() const override { return "directory"; }
 
-  DataFragmentIterator GetFragments(std::shared_ptr<ScanOptions> options) override;
-
  protected:
+  DataFragmentIterator GetFragmentsImpl(std::shared_ptr<ScanOptions> options) override;
+
   FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,
                             std::shared_ptr<FileFormat> format,
                             std::shared_ptr<Expression> partition_expression,

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -172,6 +172,11 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
                      std::shared_ptr<FileFormat> format,
                      std::unique_ptr<FileSystemBasedDataSource>* out);
 
+  static Status Make(fs::FileSystem* filesystem, const fs::Selector& selector,
+                     std::shared_ptr<FileFormat> format,
+                     std::shared_ptr<Expression> partition_expression,
+                     std::unique_ptr<FileSystemBasedDataSource>* out);
+
   std::string type() const override { return "directory"; }
 
   DataFragmentIterator GetFragments(std::shared_ptr<ScanOptions> options) override;
@@ -179,6 +184,7 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
  protected:
   FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,
                             std::shared_ptr<FileFormat> format,
+                            std::shared_ptr<Expression> partition_expression,
                             std::vector<fs::FileStats> stats);
 
   fs::FileSystem* filesystem_ = NULLPTR;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -128,7 +128,7 @@ class ParquetScanTaskIterator {
   }
 
   Status Next(ScanTaskPtr* task) {
-    auto partition = partitionner_.Next();
+    auto partition = partitioner_.Next();
 
     // Iteration is done.
     if (partition.size() == 0) {
@@ -155,11 +155,11 @@ class ParquetScanTaskIterator {
                           std::shared_ptr<parquet::FileMetaData> metadata,
                           std::unique_ptr<parquet::arrow::FileReader> reader)
       : columns_projection_(columns_projection),
-        partitionner_(std::move(metadata)),
+        partitioner_(std::move(metadata)),
         reader_(std::move(reader)) {}
 
   std::vector<int> columns_projection_;
-  ParquetRowGroupPartitioner partitionner_;
+  ParquetRowGroupPartitioner partitioner_;
   std::shared_ptr<parquet::arrow::FileReader> reader_;
 };
 

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -37,7 +37,7 @@ using RecordBatchReaderPtr = std::unique_ptr<RecordBatchReader>;
 // A set of RowGroup identifiers
 using RowGroupSet = std::vector<int>;
 
-// TODO(bkietz) refactor this to use ReconcilingRecordBatchReader
+// TODO(bkietz) refactor this to use ProjectedRecordBatchReader
 class ParquetScanTask : public ScanTask {
  public:
   static Status Make(RowGroupSet row_groups, const std::vector<int>& columns_projection,

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -37,6 +37,7 @@ using RecordBatchReaderPtr = std::unique_ptr<RecordBatchReader>;
 // A set of RowGroup identifiers
 using RowGroupSet = std::vector<int>;
 
+// TODO(bkietz) refactor this to use ReconcilingRecordBatchReader
 class ParquetScanTask : public ScanTask {
  public:
   static Status Make(RowGroupSet row_groups, const std::vector<int>& columns_projection,
@@ -145,7 +146,8 @@ class ParquetScanTaskIterator {
   static Status InferColumnProjection(const parquet::FileMetaData& metadata,
                                       const std::shared_ptr<ScanOptions>& options,
                                       std::vector<int>* out) {
-    // TODO(fsaintjacques): Compute intersection _and_ validity
+    // TODO(fsaintjacques): Compute intersection _and_ validity, could probably reuse
+    // RecordBatchProjector here
     *out = internal::Iota(metadata.num_columns());
 
     return Status::OK();

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -185,5 +185,9 @@ TEST_F(TestParquetFileSystemBasedDataSource, Recursive) { this->Recursive(); }
 
 TEST_F(TestParquetFileSystemBasedDataSource, DeletedFile) { this->DeletedFile(); }
 
+TEST_F(TestParquetFileSystemBasedDataSource, PredicatePushDown) {
+  this->PredicatePushDown();
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -107,5 +107,9 @@ TEST_F(TestDummyFileSystemBasedDataSource, Recursive) { this->Recursive(); }
 
 TEST_F(TestDummyFileSystemBasedDataSource, DeletedFile) { this->DeletedFile(); }
 
+TEST_F(TestDummyFileSystemBasedDataSource, PredicatePushDown) {
+  this->PredicatePushDown();
+}
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -957,7 +957,7 @@ Result<std::shared_ptr<Expression>> SelectorAssume(
   }
 
   if (given == nullptr) {
-    return out_expr;
+    return std::move(out_expr);
   }
   return out_expr->Assume(*given);
 }

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -28,6 +28,7 @@
 #include "arrow/compute/context.h"
 #include "arrow/compute/kernels/boolean.h"
 #include "arrow/compute/kernels/compare.h"
+#include "arrow/dataset/dataset.h"
 #include "arrow/record_batch.h"
 #include "arrow/util/logging.h"
 #include "arrow/visitor_inline.h"
@@ -936,6 +937,34 @@ Result<std::shared_ptr<DataType>> FieldExpression::Validate(const Schema& schema
     return field->type();
   }
   return null();
+}
+
+Result<std::shared_ptr<Expression>> SelectorAssume(
+    const std::shared_ptr<DataSelector>& selector,
+    const std::shared_ptr<Expression>& given) {
+  if (selector == nullptr || selector->filters.size() == 0) {
+    return ScalarExpression::Make(true);
+  }
+
+  auto get_expression = [](const std::shared_ptr<Filter>& f) {
+    DCHECK_EQ(f->type(), FilterType::EXPRESSION);
+    return checked_cast<const ExpressionFilter&>(*f).expression();
+  };
+
+  auto out_expr = get_expression(selector->filters[0]);
+  for (size_t i = 1; i < selector->filters.size(); ++i) {
+    out_expr = and_(std::move(out_expr), get_expression(selector->filters[i]));
+  }
+
+  if (given == nullptr) {
+    return out_expr;
+  }
+  return out_expr->Assume(*given);
+}
+
+std::shared_ptr<DataSelector> ExpressionSelector(std::shared_ptr<Expression> e) {
+  return std::make_shared<DataSelector>(
+      DataSelector{FilterVector{std::make_shared<ExpressionFilter>(std::move(e))}});
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -403,5 +403,12 @@ inline FieldExpression operator"" _(const char* name, size_t name_length) {
 }
 }  // namespace string_literals
 
+ARROW_DS_EXPORT Result<std::shared_ptr<Expression>> SelectorAssume(
+    const std::shared_ptr<DataSelector>& selector,
+    const std::shared_ptr<Expression>& given);
+
+ARROW_DS_EXPORT std::shared_ptr<DataSelector> ExpressionSelector(
+    std::shared_ptr<Expression> e);
+
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 
+#include "arrow/compute/kernel.h"
 #include "arrow/compute/kernels/compare.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 
 #include "arrow/dataset/dataset.h"
+#include "arrow/util/iterator.h"
 
 namespace arrow {
 namespace dataset {

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -34,12 +34,6 @@ struct ARROW_DS_EXPORT ScanContext {
   MemoryPool* pool = arrow::default_memory_pool();
 };
 
-// TODO(wesm): API for handling of post-materialization filters. For
-// example, if the user requests [$col1 > 0, $col2 > 0] and $col1 is a
-// partition key, but $col2 is not, then the filter "$col2 > 0" must
-// be evaluated in-memory against the RecordBatch objects resulting
-// from the Scan
-
 class ARROW_DS_EXPORT ScanOptions {
  public:
   virtual ~ScanOptions() = default;

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -36,18 +36,25 @@ struct ARROW_DS_EXPORT ScanContext {
 
 class ARROW_DS_EXPORT ScanOptions {
  public:
+  ScanOptions() = default;
+
+  ScanOptions(std::shared_ptr<DataSelector> selector, std::shared_ptr<Schema> schema,
+              std::vector<std::shared_ptr<FileScanOptions>> options = {})
+      : selector(std::move(selector)), schema(std::move(schema)) {}
+
   virtual ~ScanOptions() = default;
 
-  const std::shared_ptr<DataSelector>& selector() const { return selector_; }
+  MemoryPool* pool() const { return pool_; }
 
-  const std::shared_ptr<Schema>& schema() const { return schema_; }
-
- protected:
   // Filters
-  std::shared_ptr<DataSelector> selector_;
+  std::shared_ptr<DataSelector> selector;
 
   // Schema to which record batches will be reconciled
-  std::shared_ptr<Schema> schema_;
+  std::shared_ptr<Schema> schema;
+
+  MemoryPool* pool_ = default_memory_pool();
+
+  std::vector<std::shared_ptr<FileScanOptions>> options;
 };
 
 /// \brief Read record batches from a range of a single data fragment. A

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -182,7 +182,7 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
       CreateFile(path, "");
     }
 
-    condition_ = ScalarExpression::Make(true);
+    partition_expression_ = ScalarExpression::Make(true);
   }
 
   void CreateFile(std::string path, std::string contents) {
@@ -197,7 +197,7 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
 
   void MakeDataSource() {
     ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_, &source_));
-    source_->condition(condition_);
+    source_->partition_expression(partition_expression_);
   }
 
  protected:
@@ -242,7 +242,7 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   }
 
   void PredicatePushDown() {
-    condition_ = equal(field_ref("alpha"), ScalarExpression::Make<int16_t>(3));
+    partition_expression_ = equal(field_ref("alpha"), ScalarExpression::Make<int16_t>(3));
     MakeDataSource();
 
     options_->selector = std::make_shared<DataSelector>();
@@ -250,7 +250,7 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
 
     // with a filter identical to the partition condition, all fragments are yielded
     options_->selector->filters[0] =
-        std::make_shared<ExpressionFilter>(condition_->Copy());
+        std::make_shared<ExpressionFilter>(partition_expression_->Copy());
 
     size_t count = 0;
     // ASSERT_OK(source_->GetFragments(context_)->Visit(OpenFragments(&count)));
@@ -273,7 +273,7 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   std::shared_ptr<FileFormat> format_;
   std::shared_ptr<Schema> schema_;
   std::shared_ptr<ScanOptions> options_;
-  std::shared_ptr<Expression> condition_;
+  std::shared_ptr<Expression> partition_expression_;
 };
 
 template <typename Gen>

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -28,6 +28,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/io_util.h"
+#include "arrow/util/iterator.h"
 #include "arrow/util/stl.h"
 
 namespace arrow {
@@ -196,8 +197,8 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   }
 
   void MakeDataSource() {
-    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_, &source_));
-    source_->partition_expression(partition_expression_);
+    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_,
+                                              partition_expression_, &source_));
   }
 
  protected:

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -15,12 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "arrow/dataset/file_base.h"
+#include "arrow/dataset/filter.h"
 #include "arrow/filesystem/localfs.h"
 #include "arrow/filesystem/path_util.h"
 #include "arrow/record_batch.h"
@@ -162,6 +164,9 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   virtual std::vector<std::string> file_names() const = 0;
 
   void SetUp() override {
+    selector_.base_dir = "/";
+    selector_.recursive = true;
+
     format_ = std::make_shared<Format>();
     schema_ = schema({field("dummy", null())});
     options_ = std::make_shared<ScanOptions>();
@@ -176,6 +181,8 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
     for (auto path : file_names()) {
       CreateFile(path, "");
     }
+
+    condition_ = ScalarExpression::Make(true);
   }
 
   void CreateFile(std::string path, std::string contents) {
@@ -190,69 +197,72 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
 
   void MakeDataSource() {
     ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_, &source_));
+    source_->condition(condition_);
   }
 
  protected:
+  std::function<Status(std::shared_ptr<DataFragment> fragment)> OpenFragments(
+      size_t* count) {
+    return [this, count](std::shared_ptr<DataFragment> fragment) {
+      auto file_fragment =
+          internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+      ++*count;
+      auto extension =
+          fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+      EXPECT_TRUE(format_->IsKnownExtension(extension));
+      std::shared_ptr<io::RandomAccessFile> f;
+      return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
+    };
+  }
+
   void NonRecursive() {
-    selector_.base_dir = "/";
+    selector_.recursive = false;
     MakeDataSource();
 
-    int count = 0;
-    ASSERT_OK(source_->GetFragments(options_).Visit(
-        [&](std::shared_ptr<DataFragment> fragment) {
-          auto file_fragment =
-              internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-          ++count;
-          auto extension =
-              fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-          EXPECT_TRUE(format_->IsKnownExtension(extension));
-          std::shared_ptr<io::RandomAccessFile> f;
-          return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-        }));
-
+    size_t count = 0;
+    ASSERT_OK(source_->GetFragments(options_).Visit(OpenFragments(&count)));
     ASSERT_EQ(count, 1);
   }
 
   void Recursive() {
-    selector_.base_dir = "/";
-    selector_.recursive = true;
     MakeDataSource();
 
-    int count = 0;
-    ASSERT_OK(source_->GetFragments(options_).Visit(
-        [&](std::shared_ptr<DataFragment> fragment) {
-          auto file_fragment =
-              internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-          ++count;
-          auto extension =
-              fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-          EXPECT_TRUE(format_->IsKnownExtension(extension));
-          std::shared_ptr<io::RandomAccessFile> f;
-          return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-        }));
-
-    ASSERT_EQ(count, 4);
+    size_t count = 0;
+    ASSERT_OK(source_->GetFragments(options_).Visit(OpenFragments(&count)));
+    ASSERT_EQ(count, file_names().size());
   }
 
   void DeletedFile() {
-    selector_.base_dir = "/";
-    selector_.recursive = true;
     MakeDataSource();
     ASSERT_GT(file_names().size(), 0);
     ASSERT_OK(this->fs_->DeleteFile(file_names()[0]));
 
-    ASSERT_RAISES(
-        IOError,
-        source_->GetFragments(options_).Visit(
-            [&](std::shared_ptr<DataFragment> fragment) {
-              auto file_fragment =
-                  internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-              auto extension =
-                  fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-              EXPECT_TRUE(format_->IsKnownExtension(extension));
-              std::shared_ptr<io::RandomAccessFile> f;
-              return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-            }));
+    size_t count = 0;
+    ASSERT_RAISES(IOError, source_->GetFragments(options_).Visit(OpenFragments(&count)));
+  }
+
+  void PredicatePushDown() {
+    condition_ = equal(field_ref("alpha"), ScalarExpression::Make<int16_t>(3));
+    MakeDataSource();
+
+    options_->selector = std::make_shared<DataSelector>();
+    options_->selector->filters.resize(1);
+
+    // with a filter identical to the partition condition, all fragments are yielded
+    options_->selector->filters[0] =
+        std::make_shared<ExpressionFilter>(condition_->Copy());
+
+    size_t count = 0;
+    // ASSERT_OK(source_->GetFragments(context_)->Visit(OpenFragments(&count)));
+    // ASSERT_EQ(count, file_names().size());
+
+    // with a filter which contradicts the partition condition, no fragments are yielded
+    options_->selector->filters[0] = std::make_shared<ExpressionFilter>(
+        equal(field_ref("alpha"), ScalarExpression::Make<int16_t>(0)));
+
+    count = 0;
+    ASSERT_OK(source_->GetFragments(options_).Visit(OpenFragments(&count)));
+    ASSERT_EQ(count, 0);
   }
 
   fs::Selector selector_;
@@ -263,6 +273,7 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   std::shared_ptr<FileFormat> format_;
   std::shared_ptr<Schema> schema_;
   std::shared_ptr<ScanOptions> options_;
+  std::shared_ptr<Expression> condition_;
 };
 
 template <typename Gen>

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -53,6 +53,7 @@ class FileFormat;
 class FileScanOptions;
 class FileWriteOptions;
 
+class Expression;
 class Filter;
 using FilterVector = std::vector<std::shared_ptr<Filter>>;
 

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -25,6 +25,7 @@
 #include "arrow/status.h"
 #include "arrow/util/functional.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -46,9 +46,15 @@ class Iterator {
  public:
   /// \brief Iterator may be constructed from any type which has a member function
   /// with signature Status Next(T*);
+  ///
   /// The argument is moved or copied to the heap and kept in a unique_ptr<void>. Only
   /// its destructor and its Next method (which are stored in function pointers) are
   /// referenced after construction.
+  ///
+  /// This approach is used to dodge MSVC linkage hell (ARROW-6244, ARROW-6558) when using
+  /// an abstract template base class: instead of being inlined as usual for a template
+  /// function the base's virtual destructor will be exported, leading to multiple
+  /// definition errors when linking to any other TU where the base is instantiated.
   template <typename Wrapped>
   explicit Iterator(Wrapped has_next)
       : ptr_(new Wrapped(std::move(has_next)), Delete<Wrapped>), next_(Next<Wrapped>) {}

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -34,12 +34,14 @@
 #endif
 
 #define ARROW_NO_EXPORT
+#define ARROW_FORCE_INLINE __forceinline
 #else  // Not Windows
 #ifndef ARROW_EXPORT
 #define ARROW_EXPORT __attribute__((visibility("default")))
 #endif
 #ifndef ARROW_NO_EXPORT
 #define ARROW_NO_EXPORT __attribute__((visibility("hidden")))
+#define ARROW_FORCE_INLINE
 #endif
 #endif  // Non-Windows
 


### PR DESCRIPTION
The condition is an expression guaranteed to evaluate true for all records in a DataSource. This provides some predicate push down funcitonality: DataSources whose condition precludes a filter expression will not yield any fragments (since those fragments would be filtered out anyway).

This patch does not implement evaluation of filter expressions against an in memory RecordBatch. It makes a half hearted attempt at API compatibility with https://github.com/apache/arrow/pull/5157 which does implement this.