### PR TITLE
ARROW-6381: [C++] BufferOutputStream::Write does extra work that slows down small writes

### DIFF
--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -92,6 +92,7 @@ class ARROW_EXPORT BufferBuilder {
     // for discussion.
     // Grow exactly if a large upsize (the caller might know the exact final size).
     // Otherwise overallocate by 1.5 to keep a linear amortized cost.
+    // TODO: revisit this?  See comment in BufferOutputStream::Reserve.
     return std::max(new_capacity, current_capacity * 3 / 2);
   }
 

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -101,7 +101,9 @@ Status BufferOutputStream::Write(const void* data, int64_t nbytes) {
   }
   DCHECK(buffer_);
   if (ARROW_PREDICT_TRUE(nbytes > 0)) {
-    RETURN_NOT_OK(Reserve(nbytes));
+    if (ARROW_PREDICT_FALSE(position_ + nbytes >= capacity_)) {
+      RETURN_NOT_OK(Reserve(nbytes));
+    }
     memcpy(mutable_data_ + position_, data, nbytes);
     position_ += nbytes;
   }

--- a/cpp/src/arrow/io/memory_benchmark.cc
+++ b/cpp/src/arrow/io/memory_benchmark.cc
@@ -225,22 +225,50 @@ BENCHMARK(ParallelMemoryCopy)
     ->ArgName("threads")
     ->UseRealTime();
 
-static void BufferOutputStreamSmallWrites(
+static void BenchmarkBufferOutputStream(
+    const std::string& datum,
     benchmark::State& state) {  // NOLINT non-const reference
-  std::string datum = "abdefghi";
-  int64_t num_raw_values = 1 << 24;
   const void* raw_data = datum.data();
   int64_t raw_nbytes = static_cast<int64_t>(datum.size());
+  // Write approx. 32 MB to each BufferOutputStream
+  int64_t num_raw_values = (1 << 25) / raw_nbytes;
   for (auto _ : state) {
-    std::shared_ptr<io::BufferOutputStream> out;
-    ABORT_NOT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &out));
+    std::shared_ptr<io::BufferOutputStream> stream;
+    std::shared_ptr<Buffer> buf;
+    ABORT_NOT_OK(io::BufferOutputStream::Create(1024, default_memory_pool(), &stream));
     for (int64_t i = 0; i < num_raw_values; ++i) {
-      ABORT_NOT_OK(out->Write(raw_data, raw_nbytes));
+      ABORT_NOT_OK(stream->Write(raw_data, raw_nbytes));
     }
+    ABORT_NOT_OK(stream->Finish(&buf));
   }
   state.SetBytesProcessed(int64_t(state.iterations()) * num_raw_values * raw_nbytes);
 }
 
+static void BufferOutputStreamTinyWrites(
+    benchmark::State& state) {  // NOLINT non-const reference
+  // A 8-byte datum
+  return BenchmarkBufferOutputStream("abdefghi", state);
+}
+
+static void BufferOutputStreamSmallWrites(
+    benchmark::State& state) {  // NOLINT non-const reference
+  // A 700-byte datum
+  std::string datum;
+  for (int i = 0; i < 100; ++i) {
+    datum += "abcdefg";
+  }
+  return BenchmarkBufferOutputStream(datum, state);
+}
+
+static void BufferOutputStreamLargeWrites(
+    benchmark::State& state) {  // NOLINT non-const reference
+  // A 1.5MB datum
+  std::string datum(1500000, 'x');
+  return BenchmarkBufferOutputStream(datum, state);
+}
+
+BENCHMARK(BufferOutputStreamTinyWrites)->UseRealTime();
 BENCHMARK(BufferOutputStreamSmallWrites)->UseRealTime();
+BENCHMARK(BufferOutputStreamLargeWrites)->UseRealTime();
 
 }  // namespace arrow


### PR DESCRIPTION
Before:

```
-------------------------------------------------------------------------------
Benchmark                                        Time           CPU Iterations
-------------------------------------------------------------------------------
BufferOutputStreamSmallWrites/real_time  218998806 ns  218938001 ns         18   584.478MB/s
```

After

```
-------------------------------------------------------------------------------
Benchmark                                        Time           CPU Iterations
-------------------------------------------------------------------------------
BufferOutputStreamSmallWrites/real_time   11439597 ns   11436629 ns         61   2.73169GB/s
```