### PR TITLE
ARROW-4095: [C++] Optimize DictionaryArray::Transpose() for trivial transpositions

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -906,6 +906,16 @@ Status DictionaryArray::FromArrays(const std::shared_ptr<DataType>& type,
   return Status::OK();
 }
 
+static bool IsTrivialTransposition(const std::vector<int32_t>& transpose_map,
+                                   int64_t input_dict_size) {
+  for (int64_t i = 0; i < input_dict_size; ++i) {
+    if (transpose_map[i] != i) {
+      return false;
+    }
+  }
+  return true;
+}
+
 template <typename InType, typename OutType>
 static Status TransposeDictIndices(MemoryPool* pool, const ArrayData& in_data,
                                    const std::vector<int32_t>& transpose_map,
@@ -927,6 +937,14 @@ Status DictionaryArray::Transpose(MemoryPool* pool, const std::shared_ptr<DataTy
   if (type->id() != Type::DICTIONARY) {
     return Status::TypeError("Expected dictionary type");
   }
+  const int64_t in_dict_len = data_->dictionary->length();
+  if (in_dict_len > static_cast<int64_t>(transpose_map.size())) {
+    return Status::Invalid(
+        "Transpose map too small for dictionary array "
+        "(has ",
+        transpose_map.size(), " values, need at least ", in_dict_len, ")");
+  }
+
   const auto& out_dict_type = checked_cast<const DictionaryType&>(*type);
 
   const auto& out_index_type =
@@ -935,12 +953,33 @@ Status DictionaryArray::Transpose(MemoryPool* pool, const std::shared_ptr<DataTy
   auto in_type_id = dict_type_->index_type()->id();
   auto out_type_id = out_index_type.id();
 
+  if (in_type_id == out_type_id && IsTrivialTransposition(transpose_map, in_dict_len)) {
+    // Index type and values will be identical => we can simply reuse
+    // the existing buffers.
+    auto out_data =
+        ArrayData::Make(type, data_->length, {data_->buffers[0], data_->buffers[1]},
+                        data_->null_count, data_->offset);
+    out_data->dictionary = dictionary;
+    *out = MakeArray(out_data);
+    return Status::OK();
+  }
+
+  // Default path: compute a buffer of transposed indices.
   std::shared_ptr<Buffer> out_buffer;
   RETURN_NOT_OK(AllocateBuffer(
       pool, data_->length * out_index_type.bit_width() * CHAR_BIT, &out_buffer));
-  // Null bitmap is unchanged
-  auto out_data = ArrayData::Make(type, data_->length, {data_->buffers[0], out_buffer},
-                                  data_->null_count);
+
+  // Shift null buffer if the original offset is non-zero
+  std::shared_ptr<Buffer> null_bitmap;
+  if (data_->offset != 0) {
+    RETURN_NOT_OK(
+        CopyBitmap(pool, null_bitmap_data_, data_->offset, data_->length, &null_bitmap));
+  } else {
+    null_bitmap = data_->buffers[0];
+  }
+
+  auto out_data =
+      ArrayData::Make(type, data_->length, {null_bitmap, out_buffer}, data_->null_count);
   out_data->dictionary = dictionary;
 
 #define TRANSPOSE_IN_OUT_CASE(IN_INDEX_TYPE, OUT_INDEX_TYPE)    \

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1259,7 +1259,8 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
   ///     one per input type.  Each integer vector represents the transposition
   ///     of input type indices into unified type indices.
   // XXX Should we return something special (an empty transpose map?) when
-  // the transposition is the identity function?
+  // the transposition is the identity function?  Currently this case is
+  // detected in DictionaryArray::Transpose.
   static Status Unify(MemoryPool* pool, const std::vector<const DataType*>& types,
                       const std::vector<const Array*>& dictionaries,
                       std::shared_ptr<DataType>* out_type,


### PR DESCRIPTION
Note this doesn't optimize the case of a trivial transposition but where the index type changes.

Also fix handling of sliced arrays, and add tests.