### PR TITLE
ARROW-4398: [C++][Python][Parquet] Improve BYTE_ARRAY PLAIN encoding write performance. Add BYTE_ARRAY write benchmarks

### DIFF
--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -101,7 +101,9 @@ Status BufferOutputStream::Write(const void* data, int64_t nbytes) {
   }
   DCHECK(buffer_);
   if (ARROW_PREDICT_TRUE(nbytes > 0)) {
-    RETURN_NOT_OK(Reserve(nbytes));
+    if (ARROW_PREDICT_FALSE(position_ + nbytes >= capacity_)) {
+      RETURN_NOT_OK(Reserve(nbytes));
+    }
     memcpy(mutable_data_ + position_, data, nbytes);
     position_ += nbytes;
   }

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -101,9 +101,7 @@ Status BufferOutputStream::Write(const void* data, int64_t nbytes) {
   }
   DCHECK(buffer_);
   if (ARROW_PREDICT_TRUE(nbytes > 0)) {
-    if (ARROW_PREDICT_FALSE(position_ + nbytes >= capacity_)) {
-      RETURN_NOT_OK(Reserve(nbytes));
-    }
+    RETURN_NOT_OK(Reserve(nbytes));
     memcpy(mutable_data_ + position_, data, nbytes);
     position_ += nbytes;
   }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -109,9 +109,9 @@ class PlainEncoder : public EncoderImpl, virtual public TypedEncoder<DType> {
 
   void Put(const ByteArray& val) {
     // Write the result to the output stream
-    if (ARROW_PREDICT_FALSE(sink_.length() + val.len + sizeof(uint32_t) >
-                            sink_.capacity())) {
-      PARQUET_THROW_NOT_OK(sink_.Reserve(val.len + sizeof(uint32_t)));
+    const int64_t increment = static_cast<int64_t>(val.len + sizeof(uint32_t));
+    if (ARROW_PREDICT_FALSE(sink_.length() + increment > sink_.capacity())) {
+      PARQUET_THROW_NOT_OK(sink_.Reserve(increment));
     }
     DCHECK(val.len == 0 || nullptr != val.ptr) << "Value ptr cannot be NULL";
     sink_.UnsafeAppend(&val.len, sizeof(uint32_t));

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -479,6 +479,14 @@ class BM_ArrowBinaryDict : public BenchmarkDecodeArrow {
   int num_dict_entries_;
 };
 
+BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeArrow)
+(benchmark::State& state) { EncodeArrowBenchmark(state); }
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeArrow)->Range(1 << 18, 1 << 20);
+
+BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeLowLevel)
+(benchmark::State& state) { EncodeLowLevelBenchmark(state); }
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeLowLevel)->Range(1 << 18, 1 << 20);
+
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, DecodeArrow_Dense)(benchmark::State& state) {
   DecodeArrowBenchmark<ChunkedBinaryBuilder>(state);
 }

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -370,13 +370,11 @@ class BM_ArrowBinaryPlain : public BenchmarkDecodeArrow {
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryPlain, Encode)
 (benchmark::State& state) { EncodeArrowBenchmark(state); }
-BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, Encode)
-  ->Range(1 << 18, 1 << 20);
+BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, Encode)->Range(1 << 18, 1 << 20);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryPlain, DecodeArrow_Dense)
 (benchmark::State& state) { DecodeArrowBenchmark<ChunkedBinaryBuilder>(state); }
-BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, DecodeArrow_Dense)
-    ->Range(MIN_RANGE, MAX_RANGE);
+BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, DecodeArrow_Dense)->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryPlain, DecodeArrowNonNull_Dense)
 (benchmark::State& state) { DecodeArrowNonNullBenchmark<ChunkedBinaryBuilder>(state); }
@@ -385,8 +383,7 @@ BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, DecodeArrowNonNull_Dense)
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryPlain, DecodeArrow_Dict)
 (benchmark::State& state) { DecodeArrowBenchmark<BinaryDictionary32Builder>(state); }
-BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, DecodeArrow_Dict)
-    ->Range(MIN_RANGE, MAX_RANGE);
+BENCHMARK_REGISTER_F(BM_ArrowBinaryPlain, DecodeArrow_Dict)->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryPlain, DecodeArrowNonNull_Dict)
 (benchmark::State& state) {
@@ -442,8 +439,7 @@ class BM_ArrowBinaryDict : public BenchmarkDecodeArrow {
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, DecodeArrow_Dense)(benchmark::State& state) {
   DecodeArrowBenchmark<ChunkedBinaryBuilder>(state);
 }
-BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, DecodeArrow_Dense)
-    ->Range(MIN_RANGE, MAX_RANGE);
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, DecodeArrow_Dense)->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, DecodeArrowNonNull_Dense)
 (benchmark::State& state) { DecodeArrowNonNullBenchmark<ChunkedBinaryBuilder>(state); }
@@ -452,8 +448,7 @@ BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, DecodeArrowNonNull_Dense)
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, DecodeArrow_Dict)
 (benchmark::State& state) { DecodeArrowBenchmark<BinaryDictionary32Builder>(state); }
-BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, DecodeArrow_Dict)
-    ->Range(MIN_RANGE, MAX_RANGE);
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, DecodeArrow_Dict)->Range(MIN_RANGE, MAX_RANGE);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, DecodeArrowNonNull_Dict)
 (benchmark::State& state) {

--- a/python/benchmarks/parquet.py
+++ b/python/benchmarks/parquet.py
@@ -55,3 +55,31 @@ class ParquetManifestCreation(object):
 
     def time_manifest_creation(self, num_partitions, num_threads):
         pq.ParquetManifest(self.tmpdir, metadata_nthreads=num_threads)
+
+
+class ParquetWriteBinary(object):
+
+    def setup(self):
+        nuniques = 1000
+        value_size = 10
+        length = 1000000
+        num_cols = 10
+
+        unique_values = np.array([pd.util.testing.rands(value_size) for
+                                  i in range(nuniques)], dtype='O')
+        values = unique_values[np.random.randint(0, nuniques, size=length)]
+        self.table = pa.table([pa.array(values) for i in range(num_cols)],
+                              names=['f{}'.format(i) for i in range(num_cols)])
+        self.table_df = self.table.to_pandas()
+
+    def time_write_binary_table(self):
+        out = pa.BufferOutputStream()
+        pq.write_table(self.table, out)
+
+    def time_write_binary_table_no_dictionary(self):
+        out = pa.BufferOutputStream()
+        pq.write_table(self.table, out, use_dictionary=False)
+
+    def time_convert_pandas_and_write_binary_table(self):
+        out = pa.BufferOutputStream()
+        pq.write_table(pa.table(self.table_df), out)

--- a/python/benchmarks/parquet.py
+++ b/python/benchmarks/parquet.py
@@ -60,8 +60,8 @@ class ParquetManifestCreation(object):
 class ParquetWriteBinary(object):
 
     def setup(self):
-        nuniques = 1000
-        value_size = 10
+        nuniques = 100000
+        value_size = 50
         length = 1000000
         num_cols = 10
 
@@ -75,6 +75,10 @@ class ParquetWriteBinary(object):
     def time_write_binary_table(self):
         out = pa.BufferOutputStream()
         pq.write_table(self.table, out)
+
+    def time_write_binary_table_uncompressed(self):
+        out = pa.BufferOutputStream()
+        pq.write_table(self.table, out, compression='none')
 
     def time_write_binary_table_no_dictionary(self):
         out = pa.BufferOutputStream()

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -16,6 +16,7 @@
 # under the License.
 
 # cython: language_level = 3
+# cython: embedsignature = True
 
 from __future__ import absolute_import
 


### PR DESCRIPTION
Use BufferBuilder and UnsafeAppend to accelerate writes.

Before (prior to ARROW-6381, which came up while investigating this):

```
----------------------------------------------------------------------------------
Benchmark                                           Time           CPU Iterations
----------------------------------------------------------------------------------
BM_ArrowBinaryPlain/EncodeArrow/262144        6111690 ns    6109829 ns        465    246.06MB/s
BM_ArrowBinaryPlain/EncodeArrow/1048576      30470849 ns   30451048 ns         85   197.296MB/s
BM_ArrowBinaryPlain/EncodeLowLevel/262144     5352838 ns    5352679 ns        514   280.866MB/s
BM_ArrowBinaryPlain/EncodeLowLevel/1048576   29736017 ns   29735036 ns         94   202.047MB/s
```

After

```
----------------------------------------------------------------------------------
Benchmark                                           Time           CPU Iterations
----------------------------------------------------------------------------------
BM_ArrowBinaryPlain/EncodeArrow/262144        2020914 ns    2020905 ns       1000   743.918MB/s
BM_ArrowBinaryPlain/EncodeArrow/1048576      11596223 ns   11596094 ns        242   518.096MB/s
BM_ArrowBinaryPlain/EncodeLowLevel/262144     2740316 ns    2740256 ns       1021    548.63MB/s
BM_ArrowBinaryPlain/EncodeLowLevel/1048576   17562138 ns   17560763 ns        157    342.12MB/s
```

Dictionary encoding perf is not really affected by this work, so this will mostly affect that case where we fall back to PLAIN encoding when the dictionary grows large. 