### PR TITLE
ARROW-6394 [Java] Support conversions between delta vector and partial sum vector

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/misc/PartialSumUtils.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/misc/PartialSumUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.misc;
+
+import org.apache.arrow.vector.BaseIntVector;
+
+/**
+ * Partial sum related utilities.
+ */
+public class PartialSumUtils {
+
+  /**
+   * Converts an input vector to a partial sum vector.
+   * This is an inverse operation of {@link PartialSumUtils#toDeltaVector(BaseIntVector, BaseIntVector)}.
+   * Suppose we have input vector a and output vector b.
+   * Then we have b(0) = sumBase; b(i + 1) = b(i) + a(i) (i = 0, 1, 2, ...).
+   * @param deltaVector the input vector.
+   * @param partialSumVector the output vector.
+   * @param sumBase the base of the partial sums.
+   */
+  public static void toPartialSumVector(BaseIntVector deltaVector, BaseIntVector partialSumVector, long sumBase) {
+    long sum = sumBase;
+    partialSumVector.setWithPossibleTruncate(0, sumBase);
+
+    for (int i = 0; i < deltaVector.getValueCount(); i++) {
+      sum += deltaVector.getValueAsLong(i);
+      partialSumVector.setWithPossibleTruncate(i + 1, sum);
+    }
+    partialSumVector.setValueCount(deltaVector.getValueCount() + 1);
+  }
+
+  /**
+   * Converts an input vector to the delta vector.
+   * This is an inverse operation of {@link PartialSumUtils#toPartialSumVector(BaseIntVector, BaseIntVector, long)}.
+   * Suppose we have input vector a and output vector b.
+   * Then we have b(i) = a(i + 1) - a(i)  (i = 0, 1, 2, ...).
+   * @param partialSumVector the input vector.
+   * @param deltaVector the output vector.
+   */
+  public static void toDeltaVector(BaseIntVector partialSumVector, BaseIntVector deltaVector) {
+    for (int i = 0; i < partialSumVector.getValueCount() - 1; i++) {
+      long delta = partialSumVector.getValueAsLong(i + 1) - partialSumVector.getValueAsLong(i);
+      deltaVector.setWithPossibleTruncate(i, delta);
+    }
+    deltaVector.setValueCount(partialSumVector.getValueCount() - 1);
+  }
+
+  /**
+   * Given a value and a partial sum vector, finds its position in the partial sum vector.
+   * In particular, given an integer value a and partial sum vector v, we try to find a
+   * position i, so that v(i) <= a < v(i + 1).
+   * The algorithm is based on binary search, so it takes O(log(n)) time, where n is
+   * the length of the partial sum vector.
+   * @param partialSumVector the input partial sum vector.
+   * @param value the value to search.
+   * @return the position in the partial sum vector, if any, or -1, if none is found.
+   */
+  public static int findPositionInPartialSumVector(BaseIntVector partialSumVector, long value) {
+    if (value < partialSumVector.getValueAsLong(0) ||
+            value >= partialSumVector.getValueAsLong(partialSumVector.getValueCount() - 1)) {
+      return -1;
+    }
+
+    int low = 0;
+    int high = partialSumVector.getValueCount() - 1;
+    while (low <= high) {
+      int mid = low + (high - low) / 2;
+      long midValue = partialSumVector.getValueAsLong(mid);
+
+      if (midValue <= value) {
+        if (mid == partialSumVector.getValueCount() - 1) {
+          // the mid is the last element, we have found it
+          return mid;
+        }
+        long nextMidValue = partialSumVector.getValueAsLong(mid + 1);
+        if (value < nextMidValue) {
+          // midValue <= value < nextMidValue
+          // this is exactly what we want.
+          return mid;
+        } else {
+          // value >= nextMidValue
+          // continue to search from the next value on the right
+          low = mid + 1;
+        }
+      } else {
+        // midValue > value
+        long prevMidValue = partialSumVector.getValueAsLong(mid - 1);
+        if (prevMidValue <= value) {
+          // prevMidValue <= value < midValue
+          // this is exactly what we want
+          return mid - 1;
+        } else {
+          // prevMidValue > value
+          // continue to search from the previous value on the left
+          high = mid - 1;
+        }
+      }
+    }
+    throw new IllegalStateException("Should never get here");
+  }
+
+  private PartialSumUtils() {
+  }
+}

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/misc/TestPartialSumUtils.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/misc/TestPartialSumUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.misc;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link PartialSumUtils}.
+ */
+public class TestPartialSumUtils {
+
+  private static final int PARTIAL_SUM_VECTOR_LENGTH = 101;
+
+  private static final int DELTA_VECTOR_LENGTH = 100;
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testToPartialSumVector() {
+    try (IntVector delta = new IntVector("delta", allocator);
+         IntVector partialSum = new IntVector("partial sum", allocator)) {
+      delta.allocateNew(DELTA_VECTOR_LENGTH);
+      delta.setValueCount(DELTA_VECTOR_LENGTH);
+
+      partialSum.allocateNew(PARTIAL_SUM_VECTOR_LENGTH);
+
+      // populate delta vector
+      for (int i = 0; i < delta.getValueCount(); i++) {
+        delta.set(i, 3);
+      }
+
+      final long sumBase = 10;
+      PartialSumUtils.toPartialSumVector(delta, partialSum, sumBase);
+
+      // verify results
+      assertEquals(PARTIAL_SUM_VECTOR_LENGTH, partialSum.getValueCount());
+      for (int i = 0; i < partialSum.getValueCount(); i++) {
+        assertEquals(i * 3 + sumBase, partialSum.get(i));
+      }
+    }
+  }
+
+  @Test
+  public void testToDeltaVector() {
+    try (IntVector partialSum = new IntVector("partial sum", allocator);
+         IntVector delta = new IntVector("delta", allocator)) {
+      partialSum.allocateNew(PARTIAL_SUM_VECTOR_LENGTH);
+      partialSum.setValueCount(PARTIAL_SUM_VECTOR_LENGTH);
+
+      delta.allocateNew(DELTA_VECTOR_LENGTH);
+
+      // populate delta vector
+      final int sumBase = 10;
+      for (int i = 0; i < partialSum.getValueCount(); i++) {
+        partialSum.set(i, sumBase + 3 * i);
+      }
+
+      PartialSumUtils.toDeltaVector(partialSum, delta);
+
+      // verify results
+      assertEquals(DELTA_VECTOR_LENGTH, delta.getValueCount());
+      for (int i = 0; i < delta.getValueCount(); i++) {
+        assertEquals(3, delta.get(i));
+      }
+    }
+  }
+
+  @Test
+  public void testFindPositionInPartialSumVector() {
+    try (IntVector partialSum = new IntVector("partial sum", allocator)) {
+      partialSum.allocateNew(PARTIAL_SUM_VECTOR_LENGTH);
+      partialSum.setValueCount(PARTIAL_SUM_VECTOR_LENGTH);
+
+      // populate delta vector
+      final int sumBase = 10;
+      for (int i = 0; i < partialSum.getValueCount(); i++) {
+        partialSum.set(i, sumBase + 3 * i);
+      }
+
+      // search and verify results
+      for (int i = 0; i < PARTIAL_SUM_VECTOR_LENGTH - 1; i++) {
+        assertEquals(i, PartialSumUtils.findPositionInPartialSumVector(partialSum, sumBase + 3 * i + 1));
+      }
+    }
+  }
+
+  @Test
+  public void testFindPositionInPartialSumVectorNegative() {
+    try (IntVector partialSum = new IntVector("partial sum", allocator)) {
+      partialSum.allocateNew(PARTIAL_SUM_VECTOR_LENGTH);
+      partialSum.setValueCount(PARTIAL_SUM_VECTOR_LENGTH);
+
+      // populate delta vector
+      final int sumBase = 10;
+      for (int i = 0; i < partialSum.getValueCount(); i++) {
+        partialSum.set(i, sumBase + 3 * i);
+      }
+
+      // search and verify results
+      assertEquals(0, PartialSumUtils.findPositionInPartialSumVector(partialSum, sumBase));
+      assertEquals(-1, PartialSumUtils.findPositionInPartialSumVector(partialSum, sumBase - 1));
+      assertEquals(-1, PartialSumUtils.findPositionInPartialSumVector(partialSum,
+              sumBase + 3 * (PARTIAL_SUM_VECTOR_LENGTH - 1)));
+    }
+  }
+}


### PR DESCRIPTION
What is a delta vector/partial sum vector?

Given an integer vector a with length n, its partial sum vector is another integer vector b with length n + 1, with values defined as:

b(0) = initial sum
b(i ) = a(0) + a(1) + ... + a(i - 1) i = 1, 2, ..., n

Given an integer vector with length n + 1, its delta vector is another integer vector b with length n, with values defined as:

b(i ) = a(i ) - a(i - 1), i = 0, 1, ... , n -1

In this issue, we provide utilities to convert between vector and partial sum vector. It is interesting to note that the two operations corresponding to the discrete integration and differentian.

These conversions have wide applications. For example,

1. The run-length vector proposed by Micah is based on the partial sum vector, while the deduplication functionality is based on delta vector. This issue provides conversions between them.

2. The current VarCharVector/VarBinaryVector implementations are based on partial sum vector. We can transform them to delta vectors before IPC, to reduce network traffic.

3. Converting to delta can be considered as a way for data compression. To further reduce the data volume, the operation can be applied more than once, to further reduce data volume.