### PR TITLE
ARROW-6397: [C++][CI] Generate minio server connect string

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -94,9 +94,14 @@ namespace bp = boost::process;
 
 // TODO: allocate an ephemeral port
 static const char* kMinioExecutableName = "minio";
-static const char* kMinioConnectString = "127.0.0.1:9123";
 static const char* kMinioAccessKey = "minio";
 static const char* kMinioSecretKey = "miniopass";
+
+static std::string GenerateConnectString() {
+  std::stringstream ss;
+  ss << "127.0.0.1:" << GetListenPort();
+  return ss.str();
+}
 
 // A minio test server, managed as a child process
 
@@ -128,7 +133,7 @@ Status MinioTestServer::Start() {
   env["MINIO_ACCESS_KEY"] = kMinioAccessKey;
   env["MINIO_SECRET_KEY"] = kMinioSecretKey;
 
-  connect_string_ = kMinioConnectString;
+  connect_string_ = GenerateConnectString();
 
   auto exe_path = bp::search_path(kMinioExecutableName);
   if (exe_path.empty()) {

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -32,6 +32,7 @@
 #include "arrow/ipc/test_common.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/util.h"
 
 #include "arrow/flight/api.h"
 
@@ -265,7 +266,7 @@ class TestFlightClient : public ::testing::Test {
     Location location;
     std::unique_ptr<FlightServerBase> server = ExampleTestServer();
 
-    ASSERT_OK(Location::ForGrpcTcp("localhost", GetListenPort(), &location));
+    ASSERT_OK(Location::ForGrpcTcp("localhost", ::arrow::GetListenPort(), &location));
     FlightServerOptions options(location);
     ASSERT_OK(server->Init(options));
 
@@ -423,7 +424,7 @@ class TestAuthHandler : public ::testing::Test {
     Location location;
     std::unique_ptr<FlightServerBase> server(new AuthTestServer);
 
-    ASSERT_OK(Location::ForGrpcTcp("localhost", GetListenPort(), &location));
+    ASSERT_OK(Location::ForGrpcTcp("localhost", ::arrow::GetListenPort(), &location));
     FlightServerOptions options(location);
     options.auth_handler =
         std::unique_ptr<ServerAuthHandler>(new TestServerAuthHandler("user", "p4ssw0rd"));
@@ -447,7 +448,7 @@ class TestDoPut : public ::testing::Test {
  public:
   void SetUp() {
     Location location;
-    ASSERT_OK(Location::ForGrpcTcp("localhost", GetListenPort(), &location));
+    ASSERT_OK(Location::ForGrpcTcp("localhost", ::arrow::GetListenPort(), &location));
 
     do_put_server_ = new DoPutTestServer();
     server_.reset(new InProcessTestServer(
@@ -496,7 +497,7 @@ class TestTls : public ::testing::Test {
     Location location;
     std::unique_ptr<FlightServerBase> server(new TlsTestServer);
 
-    ASSERT_OK(Location::ForGrpcTls("localhost", GetListenPort(), &location));
+    ASSERT_OK(Location::ForGrpcTls("localhost", ::arrow::GetListenPort(), &location));
     FlightServerOptions options(location);
     ASSERT_RAISES(UnknownError, server->Init(options));
     ASSERT_OK(ExampleTlsCertificates(&options.tls_certificates));

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -81,10 +81,6 @@ Status ResolveCurrentExecutable(fs::path* out) {
 
 }  // namespace
 
-static int next_listen_port_ = 30001;
-
-int GetListenPort() { return next_listen_port_++; }
-
 void TestServer::Start() {
   namespace fs = boost::filesystem;
 

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "arrow/status.h"
+#include "arrow/testing/util.h"
 
 #include "arrow/flight/client_auth.h"
 #include "arrow/flight/server.h"
@@ -44,16 +45,10 @@ namespace flight {
 // ----------------------------------------------------------------------
 // Fixture to use for running test servers
 
-// Get a TCP port number to listen on.  This is a different number every time,
-// as reusing the same port accross tests can produce spurious "Stream removed"
-// errors as Windows.
-ARROW_FLIGHT_EXPORT
-int GetListenPort();
-
 class ARROW_FLIGHT_EXPORT TestServer {
  public:
   explicit TestServer(const std::string& executable_name)
-      : executable_name_(executable_name), port_(GetListenPort()) {}
+      : executable_name_(executable_name), port_(::arrow::GetListenPort()) {}
   explicit TestServer(const std::string& executable_name, int port)
       : executable_name_(executable_name), port_(port) {}
 

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -170,4 +170,8 @@ Status MakeRandomByteBuffer(int64_t length, MemoryPool* pool,
   return Status::OK();
 }
 
+static int next_listen_port_ = 30001;
+
+int GetListenPort() { return next_listen_port_++; }
+
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -200,4 +200,11 @@ class RepeatedRecordBatch : public RecordBatchReader {
   std::shared_ptr<RecordBatch> batch_;
 };
 
+// Get a TCP port number to listen on.  This is a different number every time,
+// as reusing the same port accross tests can produce spurious bind errors on
+// Windows.
+//
+// This will only protect in a single process.
+ARROW_EXPORT int GetListenPort();
+
 }  // namespace arrow


### PR DESCRIPTION
Appveyor is spuriously failing due to socket bind collisions. This change lowers the probability of this error.