### PR TITLE
ARROW-6398: [C++] Consolidate ScanOptions and ScanContext

### DIFF
--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -30,8 +30,7 @@ SimpleDataFragment::SimpleDataFragment(
     std::vector<std::shared_ptr<RecordBatch>> record_batches)
     : record_batches_(std::move(record_batches)) {}
 
-Status SimpleDataFragment::Scan(std::shared_ptr<ScanContext> scan_context,
-                                std::unique_ptr<ScanTaskIterator>* out) {
+Status SimpleDataFragment::Scan(std::unique_ptr<ScanTaskIterator>* out) {
   // Make an explicit copy of record_batches_ to ensure Scan can be called
   // multiple times.
   auto it = MakeVectorIterator(record_batches_);

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -55,8 +55,7 @@ Status Dataset::Make(const std::vector<std::shared_ptr<DataSource>>& sources,
 }
 
 Status Dataset::NewScan(std::unique_ptr<ScannerBuilder>* out) {
-  auto context = std::make_shared<ScanContext>();
-  out->reset(new ScannerBuilder(this->shared_from_this(), context));
+  out->reset(new ScannerBuilder(this->shared_from_this()));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/dataset/scanner.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
 #include "arrow/util/iterator.h"
@@ -48,7 +49,7 @@ class ARROW_DS_EXPORT DataFragment {
   /// scanning this fragment. May be nullptr, which indicates that no filtering
   /// or schema reconciliation will be performed and all partitions will be
   /// scanned.
-  virtual std::shared_ptr<ScanContext> context() const = 0;
+  virtual const ScanContext& context() const = 0;
 
   virtual ~DataFragment() = default;
 };
@@ -63,10 +64,11 @@ class ARROW_DS_EXPORT SimpleDataFragment : public DataFragment {
 
   bool splittable() const override { return false; }
 
-  std::shared_ptr<ScanContext> context() const override { return NULLPTR; }
+  const ScanContext& context() const override { return context_; }
 
  protected:
   std::vector<std::shared_ptr<RecordBatch>> record_batches_;
+  ScanContext context_;
 };
 
 /// \brief A basic component of a Dataset which yields zero or more
@@ -77,7 +79,7 @@ class ARROW_DS_EXPORT DataSource {
   /// \brief GetFragments returns an iterator of DataFragments. The ScanContext
   /// controls filtering and schema inference.
   virtual std::unique_ptr<DataFragmentIterator> GetFragments(
-      std::shared_ptr<ScanContext> context) = 0;
+      const ScanContext& context) = 0;
 
   virtual std::string type() const = 0;
 
@@ -91,7 +93,7 @@ class ARROW_DS_EXPORT SimpleDataSource : public DataSource {
       : fragments_(std::move(fragments)) {}
 
   std::unique_ptr<DataFragmentIterator> GetFragments(
-      std::shared_ptr<ScanContext> context) override {
+      const ScanContext& context) override {
     return MakeVectorIterator(fragments_);
   }
 

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -49,7 +49,7 @@ class ARROW_DS_EXPORT DataFragment {
   /// scanning this fragment. May be nullptr, which indicates that no filtering
   /// or schema reconciliation will be performed and all partitions will be
   /// scanned.
-  virtual const ScanContext& context() const = 0;
+  virtual const ScanOptions& scan_options() const = 0;
 
   virtual ~DataFragment() = default;
 };
@@ -64,11 +64,11 @@ class ARROW_DS_EXPORT SimpleDataFragment : public DataFragment {
 
   bool splittable() const override { return false; }
 
-  const ScanContext& context() const override { return context_; }
+  const ScanOptions& scan_options() const override { return scan_options_; }
 
  protected:
   std::vector<std::shared_ptr<RecordBatch>> record_batches_;
-  ScanContext context_;
+  ScanOptions scan_options_;
 };
 
 /// \brief A basic component of a Dataset which yields zero or more
@@ -76,10 +76,10 @@ class ARROW_DS_EXPORT SimpleDataFragment : public DataFragment {
 /// and partitions, e.g. files deeply nested in a directory.
 class ARROW_DS_EXPORT DataSource {
  public:
-  /// \brief GetFragments returns an iterator of DataFragments. The ScanContext
+  /// \brief GetFragments returns an iterator of DataFragments. The ScanOptions
   /// controls filtering and schema inference.
   virtual std::unique_ptr<DataFragmentIterator> GetFragments(
-      const ScanContext& context) = 0;
+      const ScanOptions& scan_options) = 0;
 
   virtual std::string type() const = 0;
 
@@ -93,7 +93,7 @@ class ARROW_DS_EXPORT SimpleDataSource : public DataSource {
       : fragments_(std::move(fragments)) {}
 
   std::unique_ptr<DataFragmentIterator> GetFragments(
-      const ScanContext& context) override {
+      const ScanOptions& scan_options) override {
     return MakeVectorIterator(fragments_);
   }
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -125,7 +125,9 @@ class ARROW_DS_EXPORT FileBasedDataFragment : public DataFragment {
  public:
   FileBasedDataFragment(const FileSource& source, std::shared_ptr<FileFormat> format,
                         const ScanOptions& scan_options)
-      : source_(source), format_(std::move(format)), scan_options_(std::move(scan_options)) {}
+      : source_(source),
+        format_(std::move(format)),
+        scan_options_(std::move(scan_options)) {}
 
   Status Scan(std::unique_ptr<ScanTaskIterator>* out) override;
 
@@ -153,7 +155,8 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
 
   std::string type() const override { return "directory"; }
 
-  std::unique_ptr<DataFragmentIterator> GetFragments(const ScanOptions& scan_options) override;
+  std::unique_ptr<DataFragmentIterator> GetFragments(
+      const ScanOptions& scan_options) override;
 
  protected:
   FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -112,11 +112,11 @@ class ARROW_DS_EXPORT FileFormat {
   virtual bool IsKnownExtension(const std::string& ext) const = 0;
 
   /// \brief Open a file for scanning
-  virtual Status ScanFile(const FileSource& source, const ScanContext& context,
+  virtual Status ScanFile(const FileSource& source, const ScanOptions& scan_options,
                           std::unique_ptr<ScanTaskIterator>* out) const = 0;
 
   /// \brief Open a fragment
-  virtual Status MakeFragment(const FileSource& location, const ScanContext& context,
+  virtual Status MakeFragment(const FileSource& location, const ScanOptions& scan_options,
                               std::unique_ptr<DataFragment>* out) = 0;
 };
 
@@ -124,20 +124,20 @@ class ARROW_DS_EXPORT FileFormat {
 class ARROW_DS_EXPORT FileBasedDataFragment : public DataFragment {
  public:
   FileBasedDataFragment(const FileSource& source, std::shared_ptr<FileFormat> format,
-                        const ScanContext& context)
-      : source_(source), format_(std::move(format)), context_(std::move(context)) {}
+                        const ScanOptions& scan_options)
+      : source_(source), format_(std::move(format)), scan_options_(std::move(scan_options)) {}
 
   Status Scan(std::unique_ptr<ScanTaskIterator>* out) override;
 
   const FileSource& source() const { return source_; }
   std::shared_ptr<FileFormat> format() const { return format_; }
 
-  const ScanContext& context() const override { return context_; }
+  const ScanOptions& scan_options() const override { return scan_options_; }
 
  protected:
   FileSource source_;
   std::shared_ptr<FileFormat> format_;
-  ScanContext context_;
+  ScanOptions scan_options_;
 };
 
 /// \brief A DataSource which takes files of one format from a directory
@@ -153,7 +153,7 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
 
   std::string type() const override { return "directory"; }
 
-  std::unique_ptr<DataFragmentIterator> GetFragments(const ScanContext& context) override;
+  std::unique_ptr<DataFragmentIterator> GetFragments(const ScanOptions& scan_options) override;
 
  protected:
   FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -112,12 +112,11 @@ class ARROW_DS_EXPORT FileFormat {
   virtual bool IsKnownExtension(const std::string& ext) const = 0;
 
   /// \brief Open a file for scanning
-  virtual Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
+  virtual Status ScanFile(const FileSource& source, const ScanContext& context,
                           std::unique_ptr<ScanTaskIterator>* out) const = 0;
 
   /// \brief Open a fragment
-  virtual Status MakeFragment(const FileSource& location,
-                              std::shared_ptr<ScanContext> context,
+  virtual Status MakeFragment(const FileSource& location, const ScanContext& context,
                               std::unique_ptr<DataFragment>* out) = 0;
 };
 
@@ -125,7 +124,7 @@ class ARROW_DS_EXPORT FileFormat {
 class ARROW_DS_EXPORT FileBasedDataFragment : public DataFragment {
  public:
   FileBasedDataFragment(const FileSource& source, std::shared_ptr<FileFormat> format,
-                        std::shared_ptr<ScanContext> context)
+                        const ScanContext& context)
       : source_(source), format_(std::move(format)), context_(std::move(context)) {}
 
   Status Scan(std::unique_ptr<ScanTaskIterator>* out) override;
@@ -133,12 +132,12 @@ class ARROW_DS_EXPORT FileBasedDataFragment : public DataFragment {
   const FileSource& source() const { return source_; }
   std::shared_ptr<FileFormat> format() const { return format_; }
 
-  std::shared_ptr<ScanContext> context() const override { return context_; }
+  const ScanContext& context() const override { return context_; }
 
  protected:
   FileSource source_;
   std::shared_ptr<FileFormat> format_;
-  std::shared_ptr<ScanContext> context_;
+  ScanContext context_;
 };
 
 /// \brief A DataSource which takes files of one format from a directory
@@ -150,24 +149,20 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
  public:
   static Status Make(fs::FileSystem* filesystem, const fs::Selector& selector,
                      std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<ScanContext> context,
                      std::unique_ptr<FileSystemBasedDataSource>* out);
 
   std::string type() const override { return "directory"; }
 
-  std::unique_ptr<DataFragmentIterator> GetFragments(
-      std::shared_ptr<ScanContext> context) override;
+  std::unique_ptr<DataFragmentIterator> GetFragments(const ScanContext& context) override;
 
  protected:
   FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,
                             std::shared_ptr<FileFormat> format,
-                            std::shared_ptr<ScanContext> context,
                             std::vector<fs::FileStats> stats);
 
   fs::FileSystem* filesystem_ = NULLPTR;
   fs::Selector selector_;
   std::shared_ptr<FileFormat> format_;
-  std::shared_ptr<ScanContext> context_;
   std::vector<fs::FileStats> stats_;
 };
 

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -45,10 +45,10 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, const ScanContext& context,
+  Status ScanFile(const FileSource& source, const ScanOptions& scan_options,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, const ScanContext& context,
+  Status MakeFragment(const FileSource& source, const ScanOptions& scan_options,
                       std::unique_ptr<DataFragment>* out) override;
 };
 

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -36,21 +36,6 @@ class FileSystem;
 
 namespace dataset {
 
-class ARROW_DS_EXPORT CsvScanOptions : public FileScanOptions {
- public:
-  std::string file_type() const override;
-
- private:
-  csv::ParseOptions parse_options_;
-  csv::ConvertOptions convert_options_;
-  csv::ReadOptions read_options_;
-};
-
-class ARROW_DS_EXPORT CsvWriteOptions : public FileWriteOptions {
- public:
-  std::string file_type() const override;
-};
-
 /// \brief A FileFormat implementation that reads from CSV files
 class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
@@ -60,9 +45,30 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
-                  std::shared_ptr<ScanContext> scan_context,
+  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
+
+  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanContext> context,
+                      std::unique_ptr<DataFragment>* out) override;
+};
+
+class ARROW_DS_EXPORT CsvScanOptions : public FileScanOptions {
+ public:
+  std::shared_ptr<FileFormat> file_format() const override {
+    return std::make_shared<CsvFileFormat>();
+  }
+
+ private:
+  csv::ParseOptions parse_options_;
+  csv::ConvertOptions convert_options_;
+  csv::ReadOptions read_options_;
+};
+
+class ARROW_DS_EXPORT CsvWriteOptions : public FileWriteOptions {
+ public:
+  std::shared_ptr<FileFormat> file_format() const override {
+    return std::make_shared<CsvFileFormat>();
+  }
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -52,7 +52,7 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
                       std::unique_ptr<DataFragment>* out) override;
 };
 
-class ARROW_DS_EXPORT CsvScanOptions : public FileScanOptions {
+class ARROW_DS_EXPORT CsvScanOptions : public ScanOptions::FileOptions {
  public:
   std::shared_ptr<FileFormat> file_format() const override {
     return std::make_shared<CsvFileFormat>();

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -45,10 +45,10 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status ScanFile(const FileSource& source, const ScanContext& context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status MakeFragment(const FileSource& source, const ScanContext& context,
                       std::unique_ptr<DataFragment>* out) override;
 };
 

--- a/cpp/src/arrow/dataset/file_feather.h
+++ b/cpp/src/arrow/dataset/file_feather.h
@@ -47,7 +47,7 @@ class ARROW_DS_EXPORT FeatherFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status ScanFile(const FileSource& source, const ScanContext& context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 };
 

--- a/cpp/src/arrow/dataset/file_feather.h
+++ b/cpp/src/arrow/dataset/file_feather.h
@@ -27,7 +27,7 @@
 namespace arrow {
 namespace dataset {
 
-class ARROW_DS_EXPORT FeatherScanOptions : public FileScanOptions {
+class ARROW_DS_EXPORT FeatherScanOptions : public ScanOptions::FileOptions {
  public:
   std::shared_ptr<FileFormat> file_format() const override;
 };

--- a/cpp/src/arrow/dataset/file_feather.h
+++ b/cpp/src/arrow/dataset/file_feather.h
@@ -47,7 +47,7 @@ class ARROW_DS_EXPORT FeatherFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, const ScanContext& context,
+  Status ScanFile(const FileSource& source, const ScanOptions& scan_options,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 };
 

--- a/cpp/src/arrow/dataset/file_feather.h
+++ b/cpp/src/arrow/dataset/file_feather.h
@@ -29,12 +29,12 @@ namespace dataset {
 
 class ARROW_DS_EXPORT FeatherScanOptions : public FileScanOptions {
  public:
-  std::string file_type() const override;
+  std::shared_ptr<FileFormat> file_format() const override;
 };
 
 class ARROW_DS_EXPORT FeatherWriterOptions : public FileWriteOptions {
  public:
-  std::string file_type() const override;
+  std::shared_ptr<FileFormat> file_format() const override;
 };
 
 /// \brief A FileFormat implementation that reads from Feather (Arrow
@@ -47,8 +47,7 @@ class ARROW_DS_EXPORT FeatherFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
-                  std::shared_ptr<ScanContext> scan_context,
+  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 };
 

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -28,21 +28,6 @@
 namespace arrow {
 namespace dataset {
 
-class ARROW_DS_EXPORT JsonScanOptions : public FileScanOptions {
- public:
-  ///
-  std::string file_type() const override;
-
- private:
-  json::ParseOptions parse_options_;
-  json::ReadOptions read_options_;
-};
-
-class ARROW_DS_EXPORT JsonWriteOptions : public FileWriteOptions {
- public:
-  std::string file_type() const override;
-};
-
 /// \brief A FileFormat implementation that reads from JSON files
 class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
  public:
@@ -52,9 +37,29 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
-                  std::shared_ptr<ScanContext> scan_context,
+  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
+
+  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanContext> context,
+                      std::unique_ptr<DataFragment>* out) override;
+};
+
+class ARROW_DS_EXPORT JsonScanOptions : public FileScanOptions {
+ public:
+  std::shared_ptr<FileFormat> file_format() const override {
+    return std::make_shared<JsonFileFormat>();
+  }
+
+ private:
+  json::ParseOptions parse_options_;
+  json::ReadOptions read_options_;
+};
+
+class ARROW_DS_EXPORT JsonWriteOptions : public FileWriteOptions {
+ public:
+  std::shared_ptr<FileFormat> file_format() const override {
+    return std::make_shared<JsonFileFormat>();
+  }
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -44,7 +44,7 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
                       std::unique_ptr<DataFragment>* out) override;
 };
 
-class ARROW_DS_EXPORT JsonScanOptions : public FileScanOptions {
+class ARROW_DS_EXPORT JsonScanOptions : public ScanOptions::FileOptions {
  public:
   std::shared_ptr<FileFormat> file_format() const override {
     return std::make_shared<JsonFileFormat>();

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -37,10 +37,10 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status ScanFile(const FileSource& source, const ScanContext& context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status MakeFragment(const FileSource& source, const ScanContext& context,
                       std::unique_ptr<DataFragment>* out) override;
 };
 

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -37,10 +37,10 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override;
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, const ScanContext& context,
+  Status ScanFile(const FileSource& source, const ScanOptions& scan_options,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, const ScanContext& context,
+  Status MakeFragment(const FileSource& source, const ScanOptions& scan_options,
                       std::unique_ptr<DataFragment>* out) override;
 };
 

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -142,7 +142,8 @@ class ParquetScanTaskIterator : public ScanTaskIterator {
  private:
   // Compute the column projection out of an optional arrow::Schema
   static Status InferColumnProjection(const parquet::FileMetaData& metadata,
-                                      const ScanOptions& scan_options, std::vector<int>* out) {
+                                      const ScanOptions& scan_options,
+                                      std::vector<int>* out) {
     // TODO(fsaintjacques): Compute intersection _and_ validity
     *out = internal::Iota(metadata.num_columns());
 
@@ -161,7 +162,8 @@ class ParquetScanTaskIterator : public ScanTaskIterator {
   std::shared_ptr<parquet::arrow::FileReader> reader_;
 };
 
-Status ParquetFileFormat::ScanFile(const FileSource& source, const ScanOptions& scan_options,
+Status ParquetFileFormat::ScanFile(const FileSource& source,
+                                   const ScanOptions& scan_options,
                                    std::unique_ptr<ScanTaskIterator>* out) const {
   std::shared_ptr<io::RandomAccessFile> input;
   RETURN_NOT_OK(source.Open(&input));

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -109,16 +109,17 @@ class ParquetRowGroupPartitioner {
 
 class ParquetScanTaskIterator : public ScanTaskIterator {
  public:
-  static Status Make(std::shared_ptr<ScanOptions> options,
-                     std::shared_ptr<ScanContext> context, ParquetFileReaderPtr reader,
+  static Status Make(std::shared_ptr<ScanContext> context, ParquetFileReaderPtr reader,
                      std::unique_ptr<ScanTaskIterator>* out) {
+    DCHECK_NE(context, nullptr);
+
     auto metadata = reader->metadata();
 
     std::vector<int> columns_projection;
-    RETURN_NOT_OK(InferColumnProjection(*metadata, options, &columns_projection));
+    RETURN_NOT_OK(InferColumnProjection(*metadata, context, &columns_projection));
 
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-    RETURN_NOT_OK(parquet::arrow::FileReader::Make(context->pool, std::move(reader),
+    RETURN_NOT_OK(parquet::arrow::FileReader::Make(context->pool(), std::move(reader),
                                                    &arrow_reader));
 
     out->reset(new ParquetScanTaskIterator(columns_projection, metadata,
@@ -143,7 +144,7 @@ class ParquetScanTaskIterator : public ScanTaskIterator {
  private:
   // Compute the column projection out of an optional arrow::Schema
   static Status InferColumnProjection(const parquet::FileMetaData& metadata,
-                                      const std::shared_ptr<ScanOptions>& options,
+                                      const std::shared_ptr<ScanContext>& context,
                                       std::vector<int>* out) {
     // TODO(fsaintjacques): Compute intersection _and_ validity
     *out = internal::Iota(metadata.num_columns());
@@ -164,22 +165,20 @@ class ParquetScanTaskIterator : public ScanTaskIterator {
 };
 
 Status ParquetFileFormat::ScanFile(const FileSource& source,
-                                   std::shared_ptr<ScanOptions> scan_options,
-                                   std::shared_ptr<ScanContext> scan_context,
+                                   std::shared_ptr<ScanContext> context,
                                    std::unique_ptr<ScanTaskIterator>* out) const {
   std::shared_ptr<io::RandomAccessFile> input;
   RETURN_NOT_OK(source.Open(&input));
 
   auto reader = parquet::ParquetFileReader::Open(input);
-  return ParquetScanTaskIterator::Make(scan_options, scan_context, std::move(reader),
-                                       out);
+  return ParquetScanTaskIterator::Make(std::move(context), std::move(reader), out);
 }
 
 Status ParquetFileFormat::MakeFragment(const FileSource& source,
-                                       std::shared_ptr<ScanOptions> opts,
+                                       std::shared_ptr<ScanContext> context,
                                        std::unique_ptr<DataFragment>* out) {
-  // TODO(bkietz) check location.path() against IsKnownExtension etc
-  *out = internal::make_unique<ParquetFragment>(source, opts);
+  // TODO(bkietz) check source.path() against IsKnownExtension etc
+  *out = internal::make_unique<ParquetFragment>(source, std::move(context));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -38,17 +38,17 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
   }
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, const ScanContext& context,
+  Status ScanFile(const FileSource& source, const ScanOptions& scan_options,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, const ScanContext& context,
+  Status MakeFragment(const FileSource& source, const ScanOptions& scan_options,
                       std::unique_ptr<DataFragment>* out) override;
 };
 
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
  public:
-  ParquetFragment(const FileSource& source, const ScanContext& context)
-      : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), context) {}
+  ParquetFragment(const FileSource& source, const ScanOptions& scan_options)
+      : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), scan_options) {}
 
   bool splittable() const override { return true; }
 };

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -38,16 +38,16 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
   }
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status ScanFile(const FileSource& source, const ScanContext& context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanContext> context,
+  Status MakeFragment(const FileSource& source, const ScanContext& context,
                       std::unique_ptr<DataFragment>* out) override;
 };
 
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
  public:
-  ParquetFragment(const FileSource& source, std::shared_ptr<ScanContext> context)
+  ParquetFragment(const FileSource& source, const ScanContext& context)
       : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), context) {}
 
   bool splittable() const override { return true; }

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -48,7 +48,8 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
  public:
   ParquetFragment(const FileSource& source, const ScanOptions& scan_options)
-      : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), scan_options) {}
+      : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(),
+                              scan_options) {}
 
   bool splittable() const override { return true; }
 };

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -53,7 +53,7 @@ class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
   bool splittable() const override { return true; }
 };
 
-class ARROW_DS_EXPORT ParquetScanOptions : public FileScanOptions {
+class ARROW_DS_EXPORT ParquetScanOptions : public ScanOptions::FileOptions {
  public:
   std::shared_ptr<FileFormat> file_format() const override {
     return std::make_shared<ParquetFileFormat>();

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -27,16 +27,6 @@
 namespace arrow {
 namespace dataset {
 
-class ARROW_DS_EXPORT ParquetScanOptions : public FileScanOptions {
- public:
-  std::string file_type() const override { return "parquet"; }
-};
-
-class ARROW_DS_EXPORT ParquetWriteOptions : public FileWriteOptions {
- public:
-  std::string file_type() const override { return "parquet"; }
-};
-
 /// \brief A FileFormat implementation that reads from Parquet files
 class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
  public:
@@ -48,20 +38,34 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
   }
 
   /// \brief Open a file for scanning
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
-                  std::shared_ptr<ScanContext> scan_context,
+  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
                   std::unique_ptr<ScanTaskIterator>* out) const override;
 
-  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanOptions> opts,
+  Status MakeFragment(const FileSource& source, std::shared_ptr<ScanContext> context,
                       std::unique_ptr<DataFragment>* out) override;
 };
 
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
  public:
-  ParquetFragment(const FileSource& source, std::shared_ptr<ScanOptions> options)
-      : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), options) {}
+  ParquetFragment(const FileSource& source, std::shared_ptr<ScanContext> context)
+      : FileBasedDataFragment(source, std::make_shared<ParquetFileFormat>(), context) {}
 
   bool splittable() const override { return true; }
+};
+
+class ARROW_DS_EXPORT ParquetScanOptions : public FileScanOptions {
+ public:
+  std::shared_ptr<FileFormat> file_format() const override {
+    return std::make_shared<ParquetFileFormat>();
+  }
+  // TODO(bkietz) probably this should wrap an ArrowReaderProperties
+};
+
+class ARROW_DS_EXPORT ParquetWriteOptions : public FileWriteOptions {
+ public:
+  std::shared_ptr<FileFormat> file_format() const override {
+    return std::make_shared<ParquetFileFormat>();
+  }
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -142,22 +142,17 @@ class ParquetBufferFixtureMixin : public ArrowParquetWriterMixin {
   }
 };
 
-class TestParquetFileFormat : public ParquetBufferFixtureMixin {
- public:
-  TestParquetFileFormat() : ctx_(std::make_shared<ScanContext>()) {}
-
- protected:
-  std::shared_ptr<ScanOptions> opts_;
-  std::shared_ptr<ScanContext> ctx_;
-};
+class TestParquetFileFormat : public ParquetBufferFixtureMixin {};
 
 TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   auto reader = GetRecordBatchReader();
   auto source = GetFileSource(reader.get());
-  auto fragment = std::make_shared<ParquetFragment>(*source, opts_);
+  auto context = std::make_shared<ScanContext>();
+  context->schema(reader->schema());
+  auto fragment = std::make_shared<ParquetFragment>(*source, context);
 
   std::unique_ptr<ScanTaskIterator> it;
-  ASSERT_OK(fragment->Scan(ctx_, &it));
+  ASSERT_OK(fragment->Scan(&it));
   int64_t row_count = 0;
 
   ASSERT_OK(it->Visit([&row_count](std::unique_ptr<ScanTask> task) -> Status {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -147,7 +147,7 @@ class TestParquetFileFormat : public ParquetBufferFixtureMixin {};
 TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   auto reader = GetRecordBatchReader();
   auto source = GetFileSource(reader.get());
-  auto fragment = std::make_shared<ParquetFragment>(*source, ScanContext());
+  auto fragment = std::make_shared<ParquetFragment>(*source, ScanOptions());
 
   std::unique_ptr<ScanTaskIterator> it;
   ASSERT_OK(fragment->Scan(&it));

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -147,9 +147,7 @@ class TestParquetFileFormat : public ParquetBufferFixtureMixin {};
 TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   auto reader = GetRecordBatchReader();
   auto source = GetFileSource(reader.get());
-  auto context = std::make_shared<ScanContext>();
-  context->schema(reader->schema());
-  auto fragment = std::make_shared<ParquetFragment>(*source, context);
+  auto fragment = std::make_shared<ParquetFragment>(*source, ScanContext());
 
   std::unique_ptr<ScanTaskIterator> it;
   ASSERT_OK(fragment->Scan(&it));

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -161,17 +161,17 @@ class ARROW_DS_EXPORT SimplePartition : public Partition {
  public:
   SimplePartition(std::unique_ptr<PartitionKey> partition_key,
                   DataFragmentVector&& data_fragments, PartitionVector&& subpartitions,
-                  std::shared_ptr<ScanOptions> scan_options = NULLPTR)
+                  std::shared_ptr<ScanContext> context = NULLPTR)
       : key_(std::move(partition_key)),
         data_fragments_(std::move(data_fragments)),
         subpartitions_(std::move(subpartitions)),
-        scan_options_(scan_options) {}
+        context_(context) {}
 
   const PartitionKey* key() const override { return key_.get(); }
 
   int num_subpartitions() const { return static_cast<int>(subpartitions_.size()); }
 
-  int num_data_fragments() const { return static_cast<int>(data_fragments__.size()); }
+  int num_data_fragments() const { return static_cast<int>(data_fragments_.size()); }
 
   const PartitionVector& subpartitions() const { return subpartitions_; }
   const DataFragmentVector& data_fragments() const { return data_fragments_; }
@@ -192,7 +192,7 @@ class ARROW_DS_EXPORT SimplePartition : public Partition {
   std::vector<std::shared_ptr<Partition>> subpartitions_;
 
   /// \brief Default scan options to use for data fragments
-  std::shared_ptr<ScanOptions> scan_options_;
+  std::shared_ptr<ScanContext> context_;
 };
 
 /// \brief A PartitionSource that returns fragments as the result of input iterators

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -161,11 +161,11 @@ class ARROW_DS_EXPORT SimplePartition : public Partition {
  public:
   SimplePartition(std::unique_ptr<PartitionKey> partition_key,
                   DataFragmentVector&& data_fragments, PartitionVector&& subpartitions,
-                  const ScanContext& context = NULLPTR)
+                  const ScanOptions& scan_options = NULLPTR)
       : key_(std::move(partition_key)),
         data_fragments_(std::move(data_fragments)),
         subpartitions_(std::move(subpartitions)),
-        context_(context) {}
+        scan_options_(scan_options) {}
 
   const PartitionKey* key() const override { return key_.get(); }
 
@@ -192,7 +192,7 @@ class ARROW_DS_EXPORT SimplePartition : public Partition {
   std::vector<std::shared_ptr<Partition>> subpartitions_;
 
   /// \brief Default scan options to use for data fragments
-  ScanContext context_;
+  ScanOptions scan_options_;
 };
 
 /// \brief A PartitionSource that returns fragments as the result of input iterators

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -161,7 +161,7 @@ class ARROW_DS_EXPORT SimplePartition : public Partition {
  public:
   SimplePartition(std::unique_ptr<PartitionKey> partition_key,
                   DataFragmentVector&& data_fragments, PartitionVector&& subpartitions,
-                  std::shared_ptr<ScanContext> context = NULLPTR)
+                  const ScanContext& context = NULLPTR)
       : key_(std::move(partition_key)),
         data_fragments_(std::move(data_fragments)),
         subpartitions_(std::move(subpartitions)),
@@ -192,7 +192,7 @@ class ARROW_DS_EXPORT SimplePartition : public Partition {
   std::vector<std::shared_ptr<Partition>> subpartitions_;
 
   /// \brief Default scan options to use for data fragments
-  std::shared_ptr<ScanContext> context_;
+  ScanContext context_;
 };
 
 /// \brief A PartitionSource that returns fragments as the result of input iterators

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -66,13 +66,13 @@ struct ARROW_DS_EXPORT ScanOptions final {
     return *this;
   }
 
-  /// format specific options
-  const std::vector<std::shared_ptr<FileScanOptions>>& options() const {
-    return options_;
+  /// Format-specific file scanning options
+  const std::vector<std::shared_ptr<FileScanOptions>>& file_scan_options() const {
+    return file_scan_options_;
   }
 
-  ScanOptions& AddFileScanOptions(std::shared_ptr<FileScanOptions> opts) {
-    options_.push_back(std::move(opts));
+  ScanOptions& AddFileScanOptions(std::shared_ptr<FileScanOptions> file_scan_options) {
+    file_scan_options_.push_back(std::move(file_scan_options));
     return *this;
   }
 
@@ -84,7 +84,7 @@ struct ARROW_DS_EXPORT ScanOptions final {
 
   MemoryPool* pool_ = default_memory_pool();
 
-  std::vector<std::shared_ptr<FileScanOptions>> options_;
+  std::vector<std::shared_ptr<FileScanOptions>> file_scan_options_;
 };
 
 /// \brief Read record batches from a range of a single data fragment. A

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -38,14 +38,14 @@ class ARROW_DS_EXPORT FileScanOptions {
   virtual ~FileScanOptions() = default;
 };
 
-struct ARROW_DS_EXPORT ScanContext final {
+struct ARROW_DS_EXPORT ScanOptions final {
  public:
-  ScanContext() = default;
+  ScanOptions() = default;
 
   /// Filters
   const std::shared_ptr<DataSelector>& selector() const { return selector_; }
 
-  ScanContext& selector(std::shared_ptr<DataSelector> s) {
+  ScanOptions& selector(std::shared_ptr<DataSelector> s) {
     selector_ = std::move(s);
     return *this;
   }
@@ -53,7 +53,7 @@ struct ARROW_DS_EXPORT ScanContext final {
   /// Schema to which record batches will be projected
   const std::shared_ptr<Schema>& schema() const { return schema_; }
 
-  ScanContext& schema(std::shared_ptr<Schema> s) {
+  ScanOptions& schema(std::shared_ptr<Schema> s) {
     schema_ = std::move(s);
     return *this;
   }
@@ -61,7 +61,7 @@ struct ARROW_DS_EXPORT ScanContext final {
   /// MemoryPool used for allocating temporary memory and yielded record batches
   MemoryPool* pool() const { return pool_; }
 
-  ScanContext& pool(MemoryPool* p) {
+  ScanOptions& pool(MemoryPool* p) {
     pool_ = p;
     return *this;
   }
@@ -71,7 +71,7 @@ struct ARROW_DS_EXPORT ScanContext final {
     return options_;
   }
 
-  ScanContext& AddFileScanOptions(std::shared_ptr<FileScanOptions> opts) {
+  ScanOptions& AddFileScanOptions(std::shared_ptr<FileScanOptions> opts) {
     options_.push_back(std::move(opts));
     return *this;
   }

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -159,7 +159,7 @@ class ARROW_DS_EXPORT SimpleScanner : public Scanner {
 
 class ARROW_DS_EXPORT ScannerBuilder {
  public:
-  ScannerBuilder(std::shared_ptr<Dataset> dataset);
+  explicit ScannerBuilder(std::shared_ptr<Dataset> dataset);
 
   /// \brief Set
   ScannerBuilder* Project(const std::vector<std::string>& columns);

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -157,15 +157,14 @@ class ARROW_DS_EXPORT Scanner {
 /// returning a ScanTaskIterator.
 class ARROW_DS_EXPORT SimpleScanner : public Scanner {
  public:
-  SimpleScanner(std::vector<std::shared_ptr<DataSource>> sources,
-                std::shared_ptr<ScanContext> context)
-      : sources_(std::move(sources)), context_(std::move(context)) {}
+  SimpleScanner(std::vector<std::shared_ptr<DataSource>> sources, ScanOptions options)
+      : sources_(std::move(sources)), options_(std::move(options)) {}
 
   std::unique_ptr<ScanTaskIterator> Scan() override;
 
  private:
   std::vector<std::shared_ptr<DataSource>> sources_;
-  std::shared_ptr<ScanContext> context_;
+  ScanOptions options_;
 };
 
 class ARROW_DS_EXPORT ScannerBuilder {

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -45,7 +45,7 @@ TEST_F(TestSimpleScanner, Scan) {
   const int64_t total_batches = sources.size() * kNumberBatches * kNumberFragments;
   auto reader = ConstantArrayGenerator::Repeat(total_batches, batch);
 
-  SimpleScanner scanner{sources, options_, ctx_};
+  SimpleScanner scanner{sources, ScanOptions()};
 
   // Verifies that the unified BatchReader is equivalent to flattening all the
   // structures of the scanner, i.e. Scanner[DataSource[ScanTask[RecordBatch]]]

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -90,7 +90,7 @@ class DatasetFixtureMixin : public ::testing::Test {
   void AssertFragmentEquals(RecordBatchReader* expected, DataFragment* fragment,
                             bool ensure_drained = true) {
     std::unique_ptr<ScanTaskIterator> it;
-    ARROW_EXPECT_OK(fragment->Scan(ctx_, &it));
+    ARROW_EXPECT_OK(fragment->Scan(&it));
 
     ARROW_EXPECT_OK(it->Visit([&](std::unique_ptr<ScanTask> task) -> Status {
       AssertScanTaskEquals(expected, task.get(), false);
@@ -106,7 +106,7 @@ class DatasetFixtureMixin : public ::testing::Test {
   /// record batches yielded by the data fragments of a source.
   void AssertDataSourceEquals(RecordBatchReader* expected, DataSource* source,
                               bool ensure_drained = true) {
-    auto it = source->GetFragments(options_);
+    auto it = source->GetFragments(ctx_);
 
     ARROW_EXPECT_OK(it->Visit([&](std::shared_ptr<DataFragment> fragment) -> Status {
       AssertFragmentEquals(expected, fragment.get(), false);
@@ -152,7 +152,6 @@ class DatasetFixtureMixin : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<ScanOptions> options_ = nullptr;
   std::shared_ptr<ScanContext> ctx_;
 };
 
@@ -163,6 +162,9 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
 
   void SetUp() override {
     format_ = std::make_shared<Format>();
+    schema_ = schema({field("dummy", null())});
+    context_ = std::make_shared<ScanContext>();
+    context_->schema(schema_);
 
     ASSERT_OK(
         TemporaryDir::Make("test-fsdatasource-" + format_->name() + "-", &temp_dir_));
@@ -187,8 +189,8 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   }
 
   void MakeDataSource() {
-    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_,
-                                              std::make_shared<ScanOptions>(), &source_));
+    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_, context_,
+                                              &source_));
   }
 
  protected:
@@ -197,8 +199,8 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
     MakeDataSource();
 
     int count = 0;
-    ASSERT_OK(
-        source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+    ASSERT_OK(source_->GetFragments(context_)->Visit(
+        [&](std::shared_ptr<DataFragment> fragment) {
           auto file_fragment =
               internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
           ++count;
@@ -218,8 +220,8 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
     MakeDataSource();
 
     int count = 0;
-    ASSERT_OK(
-        source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
+    ASSERT_OK(source_->GetFragments(context_)->Visit(
+        [&](std::shared_ptr<DataFragment> fragment) {
           auto file_fragment =
               internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
           ++count;
@@ -242,15 +244,16 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
 
     ASSERT_RAISES(
         IOError,
-        source_->GetFragments({})->Visit([&](std::shared_ptr<DataFragment> fragment) {
-          auto file_fragment =
-              internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-          auto extension =
-              fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-          EXPECT_TRUE(format_->IsKnownExtension(extension));
-          std::shared_ptr<io::RandomAccessFile> f;
-          return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-        }));
+        source_->GetFragments(context_)->Visit(
+            [&](std::shared_ptr<DataFragment> fragment) {
+              auto file_fragment =
+                  internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
+              auto extension =
+                  fs::internal::GetAbstractPathExtension(file_fragment->source().path());
+              EXPECT_TRUE(format_->IsKnownExtension(extension));
+              std::shared_ptr<io::RandomAccessFile> f;
+              return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
+            }));
   }
 
   fs::Selector selector_;
@@ -259,6 +262,8 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
   std::shared_ptr<fs::FileSystem> fs_;
   std::unique_ptr<TemporaryDir> temp_dir_;
   std::shared_ptr<FileFormat> format_;
+  std::shared_ptr<ScanContext> context_;
+  std::shared_ptr<Schema> schema_;
 };
 
 template <typename Gen>
@@ -276,30 +281,29 @@ class DummyFileFormat : public FileFormat {
   bool IsKnownExtension(const std::string& ext) const override { return ext == name(); }
 
   /// \brief Open a file for scanning (always returns an empty iterator)
-  Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
-                  std::shared_ptr<ScanContext> scan_context,
+  Status ScanFile(const FileSource& source, std::shared_ptr<ScanContext> context,
                   std::unique_ptr<ScanTaskIterator>* out) const override {
     *out = internal::make_unique<EmptyIterator<std::unique_ptr<ScanTask>>>();
     return Status::OK();
   }
 
   inline Status MakeFragment(const FileSource& location,
-                             std::shared_ptr<ScanOptions> opts,
+                             std::shared_ptr<ScanContext> context,
                              std::unique_ptr<DataFragment>* out) override;
 };
 
 class DummyFragment : public FileBasedDataFragment {
  public:
-  DummyFragment(const FileSource& source, std::shared_ptr<ScanOptions> options)
-      : FileBasedDataFragment(source, std::make_shared<DummyFileFormat>(), options) {}
+  DummyFragment(const FileSource& source, std::shared_ptr<ScanContext> context)
+      : FileBasedDataFragment(source, std::make_shared<DummyFileFormat>(), context) {}
 
   bool splittable() const override { return false; }
 };
 
 Status DummyFileFormat::MakeFragment(const FileSource& source,
-                                     std::shared_ptr<ScanOptions> opts,
+                                     std::shared_ptr<ScanContext> context,
                                      std::unique_ptr<DataFragment>* out) {
-  *out = internal::make_unique<DummyFragment>(source, opts);
+  *out = internal::make_unique<DummyFragment>(source, context);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -56,7 +56,7 @@ class PartitionScheme;
 using PartitionVector = std::vector<std::shared_ptr<Partition>>;
 using PartitionIterator = Iterator<std::shared_ptr<Partition>>;
 
-struct ScanContext;
+struct ScanOptions;
 class Scanner;
 class ScannerBuilder;
 class ScanTask;

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -57,7 +57,6 @@ using PartitionVector = std::vector<std::shared_ptr<Partition>>;
 using PartitionIterator = Iterator<std::shared_ptr<Partition>>;
 
 struct ScanContext;
-class ScanOptions;
 class Scanner;
 class ScannerBuilder;
 class ScanTask;

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -44,7 +44,6 @@ struct DiscoveryOptions;
 
 class FileBasedDataFragment;
 class FileFormat;
-class FileScanOptions;
 class FileWriteOptions;
 
 class Filter;

--- a/cpp/src/arrow/dataset/writer.h
+++ b/cpp/src/arrow/dataset/writer.h
@@ -18,8 +18,6 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
@@ -27,9 +25,13 @@
 namespace arrow {
 namespace dataset {
 
-class ARROW_DS_EXPORT WriteOptions {
+/// \brief Base class for file writing options
+class ARROW_DS_EXPORT FileWriteOptions {
  public:
-  virtual ~WriteOptions() = default;
+  /// \brief The file format this options corresponds to
+  virtual std::shared_ptr<FileFormat> file_format() const = 0;
+
+  virtual ~FileWriteOptions() = default;
 };
 
 }  // namespace dataset


### PR DESCRIPTION
Currently ScanOptions has two distinct responsibilities: it contains the data selector (and eventually projection schema) for the current scan and it serves as the base class for format specific scan options. This makes providing scan options for more than a single format impossible (as the resulting merged options would for example need to inherit both JsonScanOptions and ParquetScanOptions).

This patch removes ScanOptions and promotes FileScanOptions to the abstract base class for format specific scan options.

ScanContext is now the root container of scan state: contains the data selector, projection schema, and a vector of FileScanOptions
