### PR TITLE
ARROW-6402: [C++] Suppress sign-compare warning with g++ 9.2.1

### DIFF
--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -76,7 +76,9 @@ BasicUnionBuilder::BasicUnionBuilder(
 
   children_ = children;
   type_id_to_children_.resize(union_type->max_type_code() + 1, nullptr);
-  DCHECK_LT(type_id_to_children_.size(), std::numeric_limits<int8_t>::max());
+  DCHECK_LT(type_id_to_children_.size(),
+            static_cast<decltype(type_id_to_children_)::size_type>(
+                std::numeric_limits<int8_t>::max()));
 
   auto field_it = type->children().begin();
   auto children_it = children.begin();
@@ -107,7 +109,9 @@ int8_t BasicUnionBuilder::AppendChild(const std::shared_ptr<ArrayBuilder>& new_c
     }
   }
 
-  DCHECK_LT(type_id_to_children_.size(), std::numeric_limits<int8_t>::max());
+  DCHECK_LT(type_id_to_children_.size(),
+            static_cast<decltype(type_id_to_children_)::size_type>(
+                std::numeric_limits<int8_t>::max()));
 
   // type_id_to_children_ is already densely packed, so just append the new child
   type_id_to_children_.push_back(new_child);


### PR DESCRIPTION
    ../src/arrow/array/builder_union.cc: In constructor 'arrow::BasicUnionBuilder::BasicUnionBuilder(arrow::MemoryPool*, arrow::UnionMode::type, const std::vector<std::shared_ptr<arrow::ArrayBuilder> >&, const std::shared_ptr<arrow::DataType>&)':
    ../src/arrow/util/logging.h:86:55: error: comparison of integer expressions of different signedness: 'std::vector<std::shared_ptr<arrow::ArrayBuilder> >::size_type' {aka 'long unsigned int'} and 'signed char' [-Werror=sign-compare]
       86 | #define ARROW_CHECK_LT(val1, val2) ARROW_CHECK((val1) < (val2))
          |                                                ~~~~~~~^~~~~~~~
    ../src/arrow/util/macros.h:43:52: note: in definition of macro 'ARROW_PREDICT_TRUE'
       43 | #define ARROW_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
          |                                                    ^
    ../src/arrow/util/logging.h:86:36: note: in expansion of macro 'ARROW_CHECK'
       86 | #define ARROW_CHECK_LT(val1, val2) ARROW_CHECK((val1) < (val2))
          |                                    ^~~~~~~~~~~
    ../src/arrow/util/logging.h:135:19: note: in expansion of macro 'ARROW_CHECK_LT'
      135 | #define DCHECK_LT ARROW_CHECK_LT
          |                   ^~~~~~~~~~~~~~
    ../src/arrow/array/builder_union.cc:79:3: note: in expansion of macro 'DCHECK_LT'
       79 |   DCHECK_LT(type_id_to_children_.size(), std::numeric_limits<int8_t>::max());
          |   ^~~~~~~~~