### PR TITLE
ARROW-6411: [Python][Parquet] Improve performance of DictEncoder::PutIndices

### DIFF
--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -505,15 +505,15 @@ BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeArrow)
 BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeArrow)->Range(1 << 18, 1 << 20);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt8)
-    (benchmark::State& state) { EncodeDictBenchmark<::arrow::Int8Type>(state); }
+(benchmark::State& state) { EncodeDictBenchmark<::arrow::Int8Type>(state); }
 BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt8)->Range(1 << 20, 1 << 20);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt16)
-    (benchmark::State& state) { EncodeDictBenchmark<::arrow::Int16Type>(state); }
+(benchmark::State& state) { EncodeDictBenchmark<::arrow::Int16Type>(state); }
 BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt16)->Range(1 << 20, 1 << 20);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt32)
-    (benchmark::State& state) { EncodeDictBenchmark<::arrow::Int32Type>(state); }
+(benchmark::State& state) { EncodeDictBenchmark<::arrow::Int32Type>(state); }
 BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt32)->Range(1 << 20, 1 << 20);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt64)

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -441,6 +441,27 @@ class BM_ArrowBinaryDict : public BenchmarkDecodeArrow {
     num_dict_entries_ = dict_encoder->num_entries();
   }
 
+  template <typename IndexType>
+  void EncodeDictBenchmark(benchmark::State& state) {
+    constexpr int64_t nunique = 100;
+    constexpr int64_t min_length = 32;
+    constexpr int64_t max_length = 32;
+    ::arrow::random::RandomArrayGenerator rag(0);
+    auto dict = rag.String(nunique, min_length, max_length,
+                           /*null_probability=*/0);
+    auto indices = rag.Numeric<IndexType, int32_t>(num_values_, 0, nunique - 1);
+
+    auto PutValues = [&](ByteArrayEncoder* encoder) {
+      auto dict_encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder);
+      dict_encoder->PutDictionary(*dict);
+      dict_encoder->PutIndices(*indices);
+    };
+    for (auto _ : state) {
+      DoEncode(std::move(PutValues));
+    }
+    state.SetItemsProcessed(state.iterations() * num_values_);
+  }
+
   void DoEncodeArrow() override {
     auto PutValues = [&](ByteArrayEncoder* encoder) {
       ASSERT_NO_THROW(encoder->Put(*input_array_));
@@ -482,6 +503,22 @@ class BM_ArrowBinaryDict : public BenchmarkDecodeArrow {
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeArrow)
 (benchmark::State& state) { EncodeArrowBenchmark(state); }
 BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeArrow)->Range(1 << 18, 1 << 20);
+
+BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt8)
+    (benchmark::State& state) { EncodeDictBenchmark<::arrow::Int8Type>(state); }
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt8)->Range(1 << 20, 1 << 20);
+
+BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt16)
+    (benchmark::State& state) { EncodeDictBenchmark<::arrow::Int16Type>(state); }
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt16)->Range(1 << 20, 1 << 20);
+
+BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt32)
+    (benchmark::State& state) { EncodeDictBenchmark<::arrow::Int32Type>(state); }
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt32)->Range(1 << 20, 1 << 20);
+
+BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeDictDirectInt64)
+(benchmark::State& state) { EncodeDictBenchmark<::arrow::Int64Type>(state); }
+BENCHMARK_REGISTER_F(BM_ArrowBinaryDict, EncodeDictDirectInt64)->Range(1 << 20, 1 << 20);
 
 BENCHMARK_DEFINE_F(BM_ArrowBinaryDict, EncodeLowLevel)
 (benchmark::State& state) { EncodeLowLevelBenchmark(state); }


### PR DESCRIPTION
I don't really understand why this is faster, though.

before

```
----------------------------------------------------------------------------------------
Benchmark                                                 Time           CPU Iterations
----------------------------------------------------------------------------------------
BM_ArrowBinaryDict/EncodeDictDirectInt8/1048576     7334087 ns    7333876 ns         98   136.354M items/s
BM_ArrowBinaryDict/EncodeDictDirectInt16/1048576    7022430 ns    7022412 ns        100   142.401M items/s
BM_ArrowBinaryDict/EncodeDictDirectInt32/1048576    7061033 ns    7060870 ns         99   141.626M items/s
BM_ArrowBinaryDict/EncodeDictDirectInt64/1048576    7084581 ns    7084398 ns         97   141.155M items/s
```

after

```
----------------------------------------------------------------------------------------
Benchmark                                                 Time           CPU Iterations
----------------------------------------------------------------------------------------
BM_ArrowBinaryDict/EncodeDictDirectInt8/1048576     4387151 ns    4387175 ns        156   227.937M items/s
BM_ArrowBinaryDict/EncodeDictDirectInt16/1048576    4446167 ns    4446074 ns        159   224.918M items/s
BM_ArrowBinaryDict/EncodeDictDirectInt32/1048576    4501028 ns    4500934 ns        156   222.176M items/s
BM_ArrowBinaryDict/EncodeDictDirectInt64/1048576    4635792 ns    4635728 ns        150   215.716M items/s
```

On an i9-9960X CPU before these changes perf reported that `__memmove_avx_unaligned_erms` was taking up a lot of time. In principle `std::vector::reserve` should be correct since memory is not initialized, but something weird seems to be going wrong. If anyone has any ideas I'm interested to learn more. In any case I'll stick with the empirical benchmark evidence on this

I started to refactor to use `TypedBufferBuilder<int32_t>` but I'm not sure about the performance of that for scalar appends vs. `std::vector` so I'll leave that for future experimentation. 