### PR TITLE
ARROW-6418: [C++][Plasma] Remove cmake project directive for plasma

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -22,7 +22,6 @@ add_custom_target(plasma-tests)
 add_dependencies(plasma-all plasma plasma-tests plasma-benchmarks)
 
 # For the moment, Plasma is versioned like Arrow
-project(plasma VERSION "${ARROW_BASE_VERSION}")
 set(PLASMA_VERSION "${ARROW_VERSION}")
 
 find_package(Threads)


### PR DESCRIPTION
Putting plasma into a separate project prevents it from being exported to ArrowTargets.cmake, because targets are added to the export sets based on ${PROJECT_NAME}, but the plasma-targets are neither exported to the build tree nor installed.
An alternative fix for this is to handle the plasma-targets similar to the arrow-targets, but I can't see a benefit for that approach and it would require users to take additional steps.