### PR TITLE
ARROW-6412: [C++] Improve TCP port allocation in tests

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -758,6 +758,11 @@ if(THREADS_FOUND)
   list(APPEND ARROW_SYSTEM_LINK_LIBS Threads::Threads)
 endif()
 
+if(WIN32)
+  # Winsock
+  list(APPEND ARROW_SYSTEM_LINK_LIBS "Ws2_32.dll")
+endif()
+
 if(NOT WIN32 AND NOT APPLE)
   # Pass -lrt on Linux only
   list(APPEND ARROW_SYSTEM_LINK_LIBS rt)

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -203,8 +203,6 @@ class RepeatedRecordBatch : public RecordBatchReader {
 // Get a TCP port number to listen on.  This is a different number every time,
 // as reusing the same port accross tests can produce spurious bind errors on
 // Windows.
-//
-// This will only protect in a single process.
 ARROW_EXPORT int GetListenPort();
 
 }  // namespace arrow


### PR DESCRIPTION
Avoid collisions when running tests in parallel.