### PR TITLE
ARROW-6416: [Python] Improve API & documentation regarding chunksizes

### DIFF
--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import warnings
+
 cdef class Message:
     """
     Container for an Arrow IPC message with metadata and optional body
@@ -198,7 +200,7 @@ cdef class _CRecordBatchWriter:
             check_status(self.writer.get()
                          .WriteRecordBatch(deref(batch.batch)))
 
-    def write_table(self, Table table, max_chunksize=None):
+    def write_table(self, Table table, max_chunksize=None, **kwargs):
         """
         Write Table to stream in (contiguous) RecordBatch objects, with maximum
         chunk size
@@ -213,6 +215,13 @@ cdef class _CRecordBatchWriter:
         cdef:
             # max_chunksize must be > 0 to have any impact
             int64_t c_max_chunksize = -1
+
+        if 'chunksize' in kwargs:
+            max_chunksize = kwargs['chunksize']
+            msg = ('The parameter chunksize is deprecated for the write_table '
+                   'methods as of 0.15, please use parameter '
+                   'max_chunksize instead')
+            warnings.warn(msg, FutureWarning)
 
         if max_chunksize is not None:
             c_max_chunksize = max_chunksize

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -198,24 +198,28 @@ cdef class _CRecordBatchWriter:
             check_status(self.writer.get()
                          .WriteRecordBatch(deref(batch.batch)))
 
-    def write_table(self, Table table, chunksize=None):
+    def write_table(self, Table table, max_chunksize=None):
         """
-        Write RecordBatch to stream
+        Write Table to stream in (contiguous) RecordBatch objects, with maximum
+        chunk size
 
         Parameters
         ----------
-        batch : RecordBatch
+        table : Table
+        max_chunksize : int, default None
+            Maximum size for RecordBatch chunks. Individual chunks may be
+            smaller depending on the chunk layout of individual columns
         """
         cdef:
-            # Chunksize must be > 0 to have any impact
-            int64_t c_chunksize = -1
+            # max_chunksize must be > 0 to have any impact
+            int64_t c_max_chunksize = -1
 
-        if chunksize is not None:
-            c_chunksize = chunksize
+        if max_chunksize is not None:
+            c_max_chunksize = max_chunksize
 
         with nogil:
             check_status(self.writer.get().WriteTable(table.table[0],
-                                                      c_chunksize))
+                                                      c_max_chunksize))
 
     def close(self):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import warnings
+
 cdef class ChunkedArray(_PandasConvertible):
     """
     Array backed via one or more memory chunks.
@@ -1170,7 +1172,7 @@ cdef class Table(_PandasConvertible):
 
         return pyarrow_wrap_table(c_table)
 
-    def to_batches(self, max_chunksize=None):
+    def to_batches(self, max_chunksize=None, **kwargs):
         """
         Convert Table to list of (contiguous) RecordBatch objects, with maximum
         chunk size
@@ -1192,6 +1194,13 @@ cdef class Table(_PandasConvertible):
             shared_ptr[CRecordBatch] batch
 
         reader.reset(new TableBatchReader(deref(self.table)))
+
+        if 'chunksize' in kwargs:
+            max_chunksize = kwargs['chunksize']
+            msg = ('The parameter chunksize is deprecated for '
+                   'pyarrow.Table.to_batches as of 0.15, please use '
+                   'the parameter max_chunksize instead')
+            warnings.warn(msg, FutureWarning)
 
         if max_chunksize is not None:
             c_max_chunksize = max_chunksize

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1170,14 +1170,14 @@ cdef class Table(_PandasConvertible):
 
         return pyarrow_wrap_table(c_table)
 
-    def to_batches(self, chunksize=None):
+    def to_batches(self, max_chunksize=None):
         """
-        Convert Table to list of (contiguous) RecordBatch objects, with optimal
-        maximum chunk size
+        Convert Table to list of (contiguous) RecordBatch objects, with maximum
+        chunk size
 
         Parameters
         ----------
-        chunksize : int, default None
+        max_chunksize : int, default None
             Maximum size for RecordBatch chunks. Individual chunks may be
             smaller depending on the chunk layout of individual columns
 
@@ -1187,15 +1187,15 @@ cdef class Table(_PandasConvertible):
         """
         cdef:
             unique_ptr[TableBatchReader] reader
-            int64_t c_chunksize
+            int64_t c_max_chunksize
             list result = []
             shared_ptr[CRecordBatch] batch
 
         reader.reset(new TableBatchReader(deref(self.table)))
 
-        if chunksize is not None:
-            c_chunksize = chunksize
-            reader.get().set_chunksize(c_chunksize)
+        if max_chunksize is not None:
+            c_max_chunksize = max_chunksize
+            reader.get().set_chunksize(c_max_chunksize)
 
         while True:
             with nogil:

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -192,7 +192,7 @@ class EchoStreamFlightServer(EchoFlightServer):
     def do_get(self, context, ticket):
         return flight.GeneratorStream(
             self.last_message.schema,
-            self.last_message.to_batches(chunksize=1024))
+            self.last_message.to_batches(max_chunksize=1024))
 
     def list_actions(self, context):
         return []
@@ -811,7 +811,7 @@ def test_flight_do_put_metadata():
             flight.FlightDescriptor.for_path(''),
             table.schema)
         with writer:
-            for idx, batch in enumerate(table.to_batches(chunksize=1)):
+            for idx, batch in enumerate(table.to_batches(max_chunksize=1)):
                 metadata = struct.pack('<i', idx)
                 writer.write_with_metadata(batch, metadata)
                 buf = metadata_reader.read()
@@ -939,7 +939,7 @@ def test_do_put_independent_read_write():
         thread = threading.Thread(target=_reader_thread)
         thread.start()
 
-        batches = table.to_batches(chunksize=1)
+        batches = table.to_batches(max_chunksize=1)
         with writer:
             for idx, batch in enumerate(batches):
                 metadata = struct.pack('<i', idx)

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -277,7 +277,7 @@ def test_stream_write_table_batches(stream_fixture):
     table = pa.Table.from_batches([b1, b2, b1])
 
     writer = stream_fixture._get_writer(stream_fixture.sink, table.schema)
-    writer.write_table(table, chunksize=15)
+    writer.write_table(table, max_chunksize=15)
     writer.close()
 
     batches = list(pa.ipc.open_stream(stream_fixture.get_source()))

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -449,7 +449,7 @@ def test_table_to_batches():
     assert_frame_equal(pa.Table.from_batches(batches).to_pandas(),
                        expected_df)
 
-    batches = table.to_batches(chunksize=15)
+    batches = table.to_batches(max_chunksize=15)
     assert list(map(len, batches)) == [10, 15, 5, 10]
 
     assert_frame_equal(table.to_pandas(), expected_df)


### PR DESCRIPTION
The current API and its documentation suggests files written with `RecordBatchFileWriter.write_table(..., chunksize)` will be written with a fixed chunk size when in fact the chunksize parameter is an upper bound on the size of the chunks to be written.

In my opinion the parameter `chunksize` should therefore be renamed `max_chunksize` to avoid confusion and reflect its true purpose.

This would also improve naming consistency in the code base, since in the C++ implementation this parameter is already named `max_chunksize` in `cpp/source/arrow/ipc/writer.cc`.

Similarly, the parameter should be renamed in `Table.to_batches(chunksize)`.