### PR TITLE
ARROW-5471: [C++][Gandiva] Array offset is ignored in Gandiva projector

### DIFF
--- a/cpp/src/arrow/util/bit_util.cc
+++ b/cpp/src/arrow/util/bit_util.cc
@@ -285,6 +285,8 @@ void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* 
   for (int64_t i = 0; i < length; ++i) {
     if (op(left_reader.IsSet(), right_reader.IsSet())) {
       writer.Set();
+    } else {
+      writer.Clear();
     }
     left_reader.Next();
     right_reader.Next();

--- a/cpp/src/gandiva/annotator.cc
+++ b/cpp/src/gandiva/annotator.cc
@@ -65,25 +65,25 @@ void Annotator::PrepareBuffersForField(const FieldDescriptor& desc,
   // The validity buffer is optional. Use nullptr if it does not have one.
   if (array_data.buffers[buffer_idx]) {
     uint8_t* validity_buf = const_cast<uint8_t*>(array_data.buffers[buffer_idx]->data());
-    eval_batch->SetBuffer(desc.validity_idx(), validity_buf);
+    eval_batch->SetBuffer(desc.validity_idx(), validity_buf, array_data.offset);
   } else {
-    eval_batch->SetBuffer(desc.validity_idx(), nullptr);
+    eval_batch->SetBuffer(desc.validity_idx(), nullptr, array_data.offset);
   }
   ++buffer_idx;
 
   if (desc.HasOffsetsIdx()) {
     uint8_t* offsets_buf = const_cast<uint8_t*>(array_data.buffers[buffer_idx]->data());
-    eval_batch->SetBuffer(desc.offsets_idx(), offsets_buf);
+    eval_batch->SetBuffer(desc.offsets_idx(), offsets_buf, array_data.offset);
     ++buffer_idx;
   }
 
   uint8_t* data_buf = const_cast<uint8_t*>(array_data.buffers[buffer_idx]->data());
-  eval_batch->SetBuffer(desc.data_idx(), data_buf);
+  eval_batch->SetBuffer(desc.data_idx(), data_buf, array_data.offset);
   if (is_output) {
     // pass in the Buffer object for output data buffers. Can be used for resizing.
     uint8_t* data_buf_ptr =
         reinterpret_cast<uint8_t*>(array_data.buffers[buffer_idx].get());
-    eval_batch->SetBuffer(desc.data_buffer_ptr_idx(), data_buf_ptr);
+    eval_batch->SetBuffer(desc.data_buffer_ptr_idx(), data_buf_ptr, array_data.offset);
   }
 }
 

--- a/cpp/src/gandiva/bitmap_accumulator.cc
+++ b/cpp/src/gandiva/bitmap_accumulator.cc
@@ -72,13 +72,15 @@ void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
 
     case 1: {
       // one src_maps_ bitmap. copy to dst_map
-      memcpy(dst_map, src_maps[0], num_bytes);
       arrow::internal::CopyBitmap(src_maps[0], src_map_offsets[0], num_records, dst_map,
                                   0);
       break;
     }
 
     default: {
+      // initialize all output bits to 0 (as required by BitmapAnd)
+      arrow::BitUtil::SetBitsTo(dst_map, 0, num_records, false);
+
       // src_maps bitmaps ANDs
       BitmapAnd(src_maps[0], src_map_offsets[0], src_maps[1], src_map_offsets[1],
                 num_records, dst_map);

--- a/cpp/src/gandiva/bitmap_accumulator.cc
+++ b/cpp/src/gandiva/bitmap_accumulator.cc
@@ -28,15 +28,15 @@ void BitMapAccumulator::ComputeResult(uint8_t* dst_bitmap) {
     // set all bits to 0.
     memset(dst_bitmap, 0, arrow::BitUtil::BytesForBits(num_records));
   } else {
-    IntersectBitMaps(dst_bitmap, src_maps_, num_records);
+    IntersectBitMaps(dst_bitmap, src_maps_, src_map_offsets_, num_records);
   }
 }
 
 /// Compute the intersection of multiple bitmaps.
 void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
                                          const std::vector<uint8_t*>& src_maps,
+                                         const std::vector<int64_t>& src_map_offsets,
                                          int64_t num_records) {
-  uint64_t* dst_map64 = reinterpret_cast<uint64_t*>(dst_map);
   int64_t num_words = (num_records + 63) / 64;  // aligned to 8-byte.
   int64_t num_bytes = num_words * 8;
   int64_t nmaps = src_maps.size();
@@ -51,28 +51,20 @@ void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
     case 1: {
       // one src_maps_ bitmap. copy to dst_map
       memcpy(dst_map, src_maps[0], num_bytes);
-      break;
-    }
-
-    case 2: {
-      // two src_maps bitmaps. do 64-bit ANDs
-      uint64_t* src_maps0_64 = reinterpret_cast<uint64_t*>(src_maps[0]);
-      uint64_t* src_maps1_64 = reinterpret_cast<uint64_t*>(src_maps[1]);
-      for (int64_t i = 0; i < num_words; ++i) {
-        dst_map64[i] = src_maps0_64[i] & src_maps1_64[i];
-      }
+      arrow::internal::CopyBitmap(src_maps[0], src_map_offsets[0], num_records,
+                                  dst_map, 0);
       break;
     }
 
     default: {
-      /* > 2 src_maps bitmaps. do 64-bit ANDs */
-      uint64_t* src_maps0_64 = reinterpret_cast<uint64_t*>(src_maps[0]);
-      memcpy(dst_map64, src_maps0_64, num_bytes);
-      for (int64_t m = 1; m < nmaps; ++m) {
-        for (int64_t i = 0; i < num_words; ++i) {
-          uint64_t* src_mapsm_64 = reinterpret_cast<uint64_t*>(src_maps[m]);
-          dst_map64[i] &= src_mapsm_64[i];
-        }
+      // src_maps bitmaps ANDs
+      arrow::internal::BitmapAnd(src_maps[0], src_map_offsets[0],
+                                 src_maps[1], src_map_offsets[1],
+                                 num_records, 0, dst_map);
+      for (int64_t m = 2; m < nmaps; ++m) {
+        arrow::internal::BitmapAnd(dst_map, 0,
+                                   src_maps[m], src_map_offsets[m],
+                                   num_records, 0, dst_map);
       }
 
       break;

--- a/cpp/src/gandiva/bitmap_accumulator.cc
+++ b/cpp/src/gandiva/bitmap_accumulator.cc
@@ -71,9 +71,6 @@ void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
     }
 
     default: {
-      // initialize all output bits to 0 (as required by BitmapAnd)
-      arrow::BitUtil::SetBitsTo(dst_map, 0, num_records, false);
-
       // src_maps bitmaps ANDs
       BitmapAnd(src_maps[0], src_map_offsets[0], src_maps[1], src_map_offsets[1],
                 num_records, dst_map);

--- a/cpp/src/gandiva/bitmap_accumulator.cc
+++ b/cpp/src/gandiva/bitmap_accumulator.cc
@@ -51,19 +51,17 @@ void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
     case 1: {
       // one src_maps_ bitmap. copy to dst_map
       memcpy(dst_map, src_maps[0], num_bytes);
-      arrow::internal::CopyBitmap(src_maps[0], src_map_offsets[0], num_records,
-                                  dst_map, 0);
+      arrow::internal::CopyBitmap(src_maps[0], src_map_offsets[0], num_records, dst_map,
+                                  0);
       break;
     }
 
     default: {
       // src_maps bitmaps ANDs
-      arrow::internal::BitmapAnd(src_maps[0], src_map_offsets[0],
-                                 src_maps[1], src_map_offsets[1],
-                                 num_records, 0, dst_map);
+      arrow::internal::BitmapAnd(src_maps[0], src_map_offsets[0], src_maps[1],
+                                 src_map_offsets[1], num_records, 0, dst_map);
       for (int64_t m = 2; m < nmaps; ++m) {
-        arrow::internal::BitmapAnd(dst_map, 0,
-                                   src_maps[m], src_map_offsets[m],
+        arrow::internal::BitmapAnd(dst_map, 0, src_maps[m], src_map_offsets[m],
                                    num_records, 0, dst_map);
       }
 

--- a/cpp/src/gandiva/bitmap_accumulator.cc
+++ b/cpp/src/gandiva/bitmap_accumulator.cc
@@ -36,22 +36,15 @@ void BitmapAnd(uint8_t* left, int64_t left_offset, uint8_t* right, int64_t right
                int64_t length, uint8_t* out) {
   if (left_offset == 0 && right_offset == 0) {
     int64_t num_words = (length + 63) / 64;  // aligned to 8-byte.
-    uint64_t* left64 = reinterpret_cast<uint64_t*>(left);
-    uint64_t* right64 = reinterpret_cast<uint64_t*>(right);
-    uint64_t* out64 = reinterpret_cast<uint64_t*>(out);
+    auto left64 = reinterpret_cast<uint64_t*>(left);
+    auto right64 = reinterpret_cast<uint64_t*>(right);
+    auto out64 = reinterpret_cast<uint64_t*>(out);
     for (int64_t i = 0; i < num_words; ++i) {
       out64[i] = left64[i] & right64[i];
     }
   } else {
     arrow::internal::BitmapAnd(left, left_offset, right, right_offset, length, 0, out);
   }
-}
-
-void BitMapAccumulator::IntersectBitMaps(uint8_t* dst_map,
-                                         const std::vector<uint8_t*>& src_maps,
-                                         int64_t num_records) {
-  std::vector<int64_t> src_map_offsets(src_maps.size(), 0);
-  IntersectBitMaps(dst_map, src_maps, src_map_offsets, num_records);
 }
 
 /// Compute the intersection of multiple bitmaps.

--- a/cpp/src/gandiva/bitmap_accumulator.h
+++ b/cpp/src/gandiva/bitmap_accumulator.h
@@ -67,6 +67,11 @@ class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
   /// Compute the intersection of the accumulated bitmaps and save the result in
   /// dst_bmap.
   static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,
+                               int64_t num_records);
+
+  /// Compute the intersection of the accumulated bitmaps (with offsets) and save the
+  /// result in dst_bmap.
+  static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,
                                const std::vector<int64_t>& src_maps_offsets,
                                int64_t num_records);
 

--- a/cpp/src/gandiva/bitmap_accumulator.h
+++ b/cpp/src/gandiva/bitmap_accumulator.h
@@ -67,7 +67,8 @@ class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
   /// Compute the intersection of the accumulated bitmaps and save the result in
   /// dst_bmap.
   static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,
-                               const std::vector<int64_t>& src_maps_offsets, int64_t num_records);
+                               const std::vector<int64_t>& src_maps_offsets,
+                               int64_t num_records);
 
  private:
   const EvalBatch& eval_batch_;

--- a/cpp/src/gandiva/bitmap_accumulator.h
+++ b/cpp/src/gandiva/bitmap_accumulator.h
@@ -29,7 +29,7 @@
 namespace gandiva {
 
 /// \brief Extract bitmap buffer from either the input/buffer vectors or the
-/// local validity bitmap, and accumultes them to do the final computation.
+/// local validity bitmap, and accumulates them to do the final computation.
 class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
  public:
   explicit BitMapAccumulator(const EvalBatch& eval_batch)
@@ -39,13 +39,17 @@ class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
     int idx = dex.ValidityIdx();
     auto bitmap = eval_batch_.GetBuffer(idx);
     // The bitmap could be null. Ignore it in this case.
-    if (bitmap != NULLPTR) src_maps_.push_back(bitmap);
+    if (bitmap != NULLPTR) {
+      src_maps_.push_back(bitmap);
+      src_map_offsets_.push_back(eval_batch_.GetBufferOffset(idx));
+    }
   }
 
   void Visit(const LocalBitMapValidityDex& dex) {
     int idx = dex.local_bitmap_idx();
     auto bitmap = eval_batch_.GetLocalBitMap(idx);
     src_maps_.push_back(bitmap);
+    src_map_offsets_.push_back(0);  // local bitmap has offset 0
   }
 
   void Visit(const TrueDex& dex) {
@@ -63,11 +67,12 @@ class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
   /// Compute the intersection of the accumulated bitmaps and save the result in
   /// dst_bmap.
   static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,
-                               int64_t num_records);
+                               const std::vector<int64_t>& src_maps_offsets, int64_t num_records);
 
  private:
   const EvalBatch& eval_batch_;
   std::vector<uint8_t*> src_maps_;
+  std::vector<int64_t> src_map_offsets_;
   bool all_invalid_;
 };
 

--- a/cpp/src/gandiva/bitmap_accumulator.h
+++ b/cpp/src/gandiva/bitmap_accumulator.h
@@ -64,11 +64,6 @@ class GANDIVA_EXPORT BitMapAccumulator : public DexDefaultVisitor {
   /// Compute the dst_bmap based on the contents and type of the accumulated bitmap dex.
   void ComputeResult(uint8_t* dst_bitmap);
 
-  /// Compute the intersection of the accumulated bitmaps and save the result in
-  /// dst_bmap.
-  static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,
-                               int64_t num_records);
-
   /// Compute the intersection of the accumulated bitmaps (with offsets) and save the
   /// result in dst_bmap.
   static void IntersectBitMaps(uint8_t* dst_map, const std::vector<uint8_t*>& src_maps,

--- a/cpp/src/gandiva/compiled_expr.h
+++ b/cpp/src/gandiva/compiled_expr.h
@@ -25,7 +25,8 @@
 
 namespace gandiva {
 
-using EvalFunc = int (*)(uint8_t** buffers, uint8_t** local_bitmaps,
+using EvalFunc = int (*)(uint8_t** buffers, int64_t *offsets,
+                         uint8_t** local_bitmaps,
                          const uint8_t* selection_buffer, int64_t execution_ctx_ptr,
                          int64_t record_count);
 

--- a/cpp/src/gandiva/compiled_expr.h
+++ b/cpp/src/gandiva/compiled_expr.h
@@ -25,8 +25,7 @@
 
 namespace gandiva {
 
-using EvalFunc = int (*)(uint8_t** buffers, int64_t *offsets,
-                         uint8_t** local_bitmaps,
+using EvalFunc = int (*)(uint8_t** buffers, int64_t* offsets, uint8_t** local_bitmaps,
                          const uint8_t* selection_buffer, int64_t execution_ctx_ptr,
                          int64_t record_count);
 

--- a/cpp/src/gandiva/eval_batch.h
+++ b/cpp/src/gandiva/eval_batch.h
@@ -37,6 +37,7 @@ class EvalBatch {
       : num_records_(num_records), num_buffers_(num_buffers) {
     if (num_buffers > 0) {
       buffers_array_.reset(new uint8_t*[num_buffers]);
+      buffer_offsets_array_.reset(new int64_t[num_buffers]);
     }
     local_bitmaps_holder_.reset(new LocalBitMapsHolder(num_records, num_local_bitmaps));
     execution_context_.reset(new ExecutionContext());
@@ -46,6 +47,8 @@ class EvalBatch {
 
   uint8_t** GetBufferArray() const { return buffers_array_.get(); }
 
+  int64_t* GetBufferOffsetArray() const { return buffer_offsets_array_.get(); }
+
   int GetNumBuffers() const { return num_buffers_; }
 
   uint8_t* GetBuffer(int idx) const {
@@ -53,9 +56,10 @@ class EvalBatch {
     return (buffers_array_.get())[idx];
   }
 
-  void SetBuffer(int idx, uint8_t* buffer) {
+  void SetBuffer(int idx, uint8_t* buffer, int64_t offset = 0) {
     DCHECK(idx <= num_buffers_);
     (buffers_array_.get())[idx] = buffer;
+    (buffer_offsets_array_.get())[idx] = offset;
   }
 
   int GetNumLocalBitMaps() const { return local_bitmaps_holder_->GetNumLocalBitMaps(); }
@@ -86,6 +90,10 @@ class EvalBatch {
   /// sizes depends on the data type, but all of them have the same
   /// number of slots (equal to num_records_).
   std::unique_ptr<uint8_t*[]> buffers_array_;
+
+  /// An array of 'num_buffers_', each containing the offset for
+  /// corresponding buffer.
+  std::unique_ptr<int64_t[]> buffer_offsets_array_;
 
   std::unique_ptr<LocalBitMapsHolder> local_bitmaps_holder_;
 

--- a/cpp/src/gandiva/eval_batch.h
+++ b/cpp/src/gandiva/eval_batch.h
@@ -56,7 +56,12 @@ class EvalBatch {
     return (buffers_array_.get())[idx];
   }
 
-  void SetBuffer(int idx, uint8_t* buffer, int64_t offset = 0) {
+  int64_t GetBufferOffset(int idx) const {
+    DCHECK(idx <= num_buffers_);
+    return (buffer_offsets_array_.get())[idx];
+  }
+
+  void SetBuffer(int idx, uint8_t* buffer, int64_t offset) {
     DCHECK(idx <= num_buffers_);
     (buffers_array_.get())[idx] = buffer;
     (buffer_offsets_array_.get())[idx] = offset;

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -98,7 +98,7 @@ Status Filter::Evaluate(const arrow::RecordBatch& batch,
   // Compute the intersection of the value and validity.
   auto result = bitmaps.GetLocalBitMap(2);
   BitMapAccumulator::IntersectBitMaps(
-      result, {bitmaps.GetLocalBitMap(0), bitmaps.GetLocalBitMap((1))}, num_rows);
+      result, {bitmaps.GetLocalBitMap(0), bitmaps.GetLocalBitMap((1))}, {0, 0}, num_rows);
 
   return out_selection->PopulateFromBitMap(result, bitmap_size, num_rows - 1);
 }

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -124,7 +124,8 @@ Status LLVMGenerator::Execute(const arrow::RecordBatch& record_batch,
     }
 
     EvalFunc jit_function = compiled_expr->GetJITFunction(mode);
-    jit_function(eval_batch->GetBufferArray(), eval_batch->GetLocalBitMapArray(),
+    jit_function(eval_batch->GetBufferArray(), eval_batch->GetBufferOffsetArray(),
+                 eval_batch->GetLocalBitMapArray(),
                  selection_buffer, (int64_t)eval_batch->GetExecutionContext(),
                  num_output_rows);
 
@@ -249,10 +250,11 @@ Status LLVMGenerator::CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr out
                                        SelectionVector::Mode selection_vector_mode) {
   llvm::IRBuilder<>* builder = ir_builder();
   // Create fn prototype :
-  //   int expr_1 (long **addrs, long **bitmaps, long *context_ptr, long nrec)
+  //   int expr_1 (long **addrs, long *offsets, long **bitmaps, long *context_ptr, long nrec)
   std::vector<llvm::Type*> arguments;
-  arguments.push_back(types()->i64_ptr_type());
-  arguments.push_back(types()->i64_ptr_type());
+  arguments.push_back(types()->i64_ptr_type());  // addrs
+  arguments.push_back(types()->i64_ptr_type());  // offsets
+  arguments.push_back(types()->i64_ptr_type());  // bitmaps
   switch (selection_vector_mode) {
     case SelectionVector::MODE_NONE:
     case SelectionVector::MODE_UINT16:
@@ -281,6 +283,9 @@ Status LLVMGenerator::CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr out
   llvm::Function::arg_iterator args = (*fn)->arg_begin();
   llvm::Value* arg_addrs = &*args;
   arg_addrs->setName("args");
+  ++args;
+  llvm::Value* arg_addr_offsets = &*args;
+  arg_addr_offsets->setName("arg_addr_offsets");
   ++args;
   llvm::Value* arg_local_bitmaps = &*args;
   arg_local_bitmaps->setName("local_bitmaps");
@@ -322,7 +327,7 @@ Status LLVMGenerator::CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr out
   }
 
   // The visitor can add code to both the entry/loop blocks.
-  Visitor visitor(this, *fn, loop_entry, arg_addrs, arg_local_bitmaps, arg_context_ptr,
+  Visitor visitor(this, *fn, loop_entry, arg_addrs, arg_addr_offsets, arg_local_bitmaps, arg_context_ptr,
                   position_var);
   value_expr->Accept(visitor);
   LValuePtr output_value = visitor.result();
@@ -509,12 +514,13 @@ std::shared_ptr<DecimalLValue> LLVMGenerator::BuildDecimalLValue(llvm::Value* va
 // Visitor for generating the code for a decomposed expression.
 LLVMGenerator::Visitor::Visitor(LLVMGenerator* generator, llvm::Function* function,
                                 llvm::BasicBlock* entry_block, llvm::Value* arg_addrs,
-                                llvm::Value* arg_local_bitmaps,
+                                llvm::Value* arg_addr_offsets, llvm::Value* arg_local_bitmaps,
                                 llvm::Value* arg_context_ptr, llvm::Value* loop_var)
     : generator_(generator),
       function_(function),
       entry_block_(entry_block),
       arg_addrs_(arg_addrs),
+      arg_addr_offsets_(arg_addr_offsets),
       arg_local_bitmaps_(arg_local_bitmaps),
       arg_context_ptr_(arg_context_ptr),
       loop_var_(loop_var),
@@ -525,24 +531,26 @@ LLVMGenerator::Visitor::Visitor(LLVMGenerator* generator, llvm::Function* functi
 void LLVMGenerator::Visitor::Visit(const VectorReadFixedLenValueDex& dex) {
   llvm::IRBuilder<>* builder = ir_builder();
   llvm::Value* slot_ref = GetBufferReference(dex.DataIdx(), kBufferTypeData, dex.Field());
+  llvm::Value* slot_index =
+      builder->CreateAdd(loop_var_, GetBufferOffset(dex.DataIdx(), dex.Field()));
   llvm::Value* slot_value;
   std::shared_ptr<LValue> lvalue;
 
   switch (dex.FieldType()->id()) {
     case arrow::Type::BOOL:
-      slot_value = generator_->GetPackedBitValue(slot_ref, loop_var_);
+      slot_value = generator_->GetPackedBitValue(slot_ref, slot_index);
       lvalue = std::make_shared<LValue>(slot_value);
       break;
 
     case arrow::Type::DECIMAL: {
-      auto slot_offset = builder->CreateGEP(slot_ref, loop_var_);
+      auto slot_offset = builder->CreateGEP(slot_ref, slot_index);
       slot_value = builder->CreateLoad(slot_offset, dex.FieldName());
       lvalue = generator_->BuildDecimalLValue(slot_value, dex.FieldType());
       break;
     }
 
     default: {
-      auto slot_offset = builder->CreateGEP(slot_ref, loop_var_);
+      auto slot_offset = builder->CreateGEP(slot_ref, slot_index);
       slot_value = builder->CreateLoad(slot_offset, dex.FieldName());
       lvalue = std::make_shared<LValue>(slot_value);
       break;
@@ -560,15 +568,17 @@ void LLVMGenerator::Visitor::Visit(const VectorReadVarLenValueDex& dex) {
   // compute len from the offsets array.
   llvm::Value* offsets_slot_ref =
       GetBufferReference(dex.OffsetsIdx(), kBufferTypeOffsets, dex.Field());
+  llvm::Value *offsets_slot_index =
+      builder->CreateAdd(loop_var_, GetBufferOffset(dex.OffsetsIdx(), dex.Field()));
 
   // => offset_start = offsets[loop_var]
-  slot = builder->CreateGEP(offsets_slot_ref, loop_var_);
+  slot = builder->CreateGEP(offsets_slot_ref, offsets_slot_index);
   llvm::Value* offset_start = builder->CreateLoad(slot, "offset_start");
 
   // => offset_end = offsets[loop_var + 1]
-  llvm::Value* loop_var_next =
-      builder->CreateAdd(loop_var_, generator_->types()->i64_constant(1), "loop_var+1");
-  slot = builder->CreateGEP(offsets_slot_ref, loop_var_next);
+  llvm::Value* offsets_slot_index_next =
+      builder->CreateAdd(offsets_slot_index, generator_->types()->i64_constant(1), "loop_var+1");
+  slot = builder->CreateGEP(offsets_slot_ref, offsets_slot_index_next);
   llvm::Value* offset_end = builder->CreateLoad(slot, "offset_end");
 
   // => len_value = offset_end - offset_start
@@ -585,9 +595,12 @@ void LLVMGenerator::Visitor::Visit(const VectorReadVarLenValueDex& dex) {
 }
 
 void LLVMGenerator::Visitor::Visit(const VectorReadValidityDex& dex) {
+  llvm::IRBuilder<>* builder = ir_builder();
   llvm::Value* slot_ref =
       GetBufferReference(dex.ValidityIdx(), kBufferTypeValidity, dex.Field());
-  llvm::Value* validity = generator_->GetPackedValidityBitValue(slot_ref, loop_var_);
+  llvm::Value* slot_index =
+      builder->CreateAdd(loop_var_, GetBufferOffset(dex.ValidityIdx(), dex.Field()));
+  llvm::Value* validity = generator_->GetPackedValidityBitValue(slot_ref, slot_index);
 
   ADD_VISITOR_TRACE("visit validity vector " + dex.FieldName() + " value %T", validity);
   result_.reset(new LValue(validity));
@@ -1237,6 +1250,17 @@ llvm::Value* LLVMGenerator::Visitor::GetBufferReference(int idx, BufferType buff
   // Revert to the saved block.
   builder->SetInsertPoint(saved_block);
   return slot_ref;
+}
+
+llvm::Value* LLVMGenerator::Visitor::GetBufferOffset(int idx, FieldPtr field) {
+  llvm::IRBuilder<>* builder = ir_builder();
+
+  const std::string& name = field->name();
+  llvm::Value* offsetAddr =
+      builder->CreateGEP(arg_addr_offsets_, generator_->types()->i32_constant(idx), name + "_offset_addr");
+  llvm::Value* offset = builder->CreateLoad(offsetAddr, name + "_addr");
+
+  return offset;
 }
 
 llvm::Value* LLVMGenerator::Visitor::GetLocalBitMapReference(int idx) {

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -250,7 +250,8 @@ Status LLVMGenerator::CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr out
                                        SelectionVector::Mode selection_vector_mode) {
   llvm::IRBuilder<>* builder = ir_builder();
   // Create fn prototype :
-  //   int expr_1 (long **addrs, long *offsets, long **bitmaps, long *context_ptr, long nrec)
+  //   int expr_1 (long **addrs, long *offsets, long **bitmaps,
+  //               long *context_ptr, long nrec)
   std::vector<llvm::Type*> arguments;
   arguments.push_back(types()->i64_ptr_type());  // addrs
   arguments.push_back(types()->i64_ptr_type());  // offsets
@@ -327,8 +328,8 @@ Status LLVMGenerator::CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr out
   }
 
   // The visitor can add code to both the entry/loop blocks.
-  Visitor visitor(this, *fn, loop_entry, arg_addrs, arg_addr_offsets, arg_local_bitmaps, arg_context_ptr,
-                  position_var);
+  Visitor visitor(this, *fn, loop_entry, arg_addrs, arg_addr_offsets,
+                  arg_local_bitmaps, arg_context_ptr, position_var);
   value_expr->Accept(visitor);
   LValuePtr output_value = visitor.result();
 
@@ -514,7 +515,8 @@ std::shared_ptr<DecimalLValue> LLVMGenerator::BuildDecimalLValue(llvm::Value* va
 // Visitor for generating the code for a decomposed expression.
 LLVMGenerator::Visitor::Visitor(LLVMGenerator* generator, llvm::Function* function,
                                 llvm::BasicBlock* entry_block, llvm::Value* arg_addrs,
-                                llvm::Value* arg_addr_offsets, llvm::Value* arg_local_bitmaps,
+                                llvm::Value* arg_addr_offsets,
+                                llvm::Value* arg_local_bitmaps,
                                 llvm::Value* arg_context_ptr, llvm::Value* loop_var)
     : generator_(generator),
       function_(function),
@@ -577,7 +579,8 @@ void LLVMGenerator::Visitor::Visit(const VectorReadVarLenValueDex& dex) {
 
   // => offset_end = offsets[loop_var + 1]
   llvm::Value* offsets_slot_index_next =
-      builder->CreateAdd(offsets_slot_index, generator_->types()->i64_constant(1), "loop_var+1");
+      builder->CreateAdd(offsets_slot_index, generator_->types()->i64_constant(1),
+                  "loop_var+1");
   slot = builder->CreateGEP(offsets_slot_ref, offsets_slot_index_next);
   llvm::Value* offset_end = builder->CreateLoad(slot, "offset_end");
 
@@ -1257,7 +1260,8 @@ llvm::Value* LLVMGenerator::Visitor::GetBufferOffset(int idx, FieldPtr field) {
 
   const std::string& name = field->name();
   llvm::Value* offsetAddr =
-      builder->CreateGEP(arg_addr_offsets_, generator_->types()->i32_constant(idx), name + "_offset_addr");
+      builder->CreateGEP(arg_addr_offsets_,
+                         generator_->types()->i32_constant(idx), name + "_offset_addr");
   llvm::Value* offset = builder->CreateLoad(offsetAddr, name + "_addr");
 
   return offset;

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -90,8 +90,8 @@ class GANDIVA_EXPORT LLVMGenerator {
    public:
     Visitor(LLVMGenerator* generator, llvm::Function* function,
             llvm::BasicBlock* entry_block, llvm::Value* arg_addrs,
-            llvm::Value* arg_local_bitmaps, llvm::Value* arg_context_ptr,
-            llvm::Value* loop_var);
+            llvm::Value* arg_addr_offsets, llvm::Value* arg_local_bitmaps,
+            llvm::Value* arg_context_ptr, llvm::Value* loop_var);
 
     void Visit(const VectorReadValidityDex& dex) override;
     void Visit(const VectorReadFixedLenValueDex& dex) override;
@@ -146,6 +146,9 @@ class GANDIVA_EXPORT LLVMGenerator {
     // Switch to the entry_block and get reference of the validity/value/offsets buffer
     llvm::Value* GetBufferReference(int idx, BufferType buffer_type, FieldPtr field);
 
+    // Get offset of the validity/value/offsets buffer
+    llvm::Value* GetBufferOffset(int idx, FieldPtr field);
+
     // Switch to the entry_block and get reference to the local bitmap.
     llvm::Value* GetLocalBitMapReference(int idx);
 
@@ -157,6 +160,7 @@ class GANDIVA_EXPORT LLVMGenerator {
     llvm::Function* function_;
     llvm::BasicBlock* entry_block_;
     llvm::Value* arg_addrs_;
+    llvm::Value* arg_addr_offsets_;
     llvm::Value* arg_local_bitmaps_;
     llvm::Value* arg_context_ptr_;
     llvm::Value* loop_var_;

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -108,7 +108,8 @@ TEST_F(TestLLVMGenerator, TestAdd) {
       reinterpret_cast<uint8_t*>(a1),  reinterpret_cast<uint8_t*>(&in_bitmap),
       reinterpret_cast<uint8_t*>(out), reinterpret_cast<uint8_t*>(&out_bitmap),
   };
-  eval_func(addrs, nullptr, nullptr, 0 /* dummy context ptr */, num_records);
+  int64_t addr_offsets[] = {0, 0, 0, 0, 0, 0};
+  eval_func(addrs, addr_offsets, nullptr, nullptr, 0 /* dummy context ptr */, num_records);
 
   uint32_t expected[] = {6, 8, 10, 12};
   for (int i = 0; i < num_records; i++) {

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -109,8 +109,8 @@ TEST_F(TestLLVMGenerator, TestAdd) {
       reinterpret_cast<uint8_t*>(out), reinterpret_cast<uint8_t*>(&out_bitmap),
   };
   int64_t addr_offsets[] = {0, 0, 0, 0, 0, 0};
-  eval_func(addrs, addr_offsets, nullptr, nullptr,
-            0 /* dummy context ptr */, num_records);
+  eval_func(addrs, addr_offsets, nullptr, nullptr, 0 /* dummy context ptr */,
+            num_records);
 
   uint32_t expected[] = {6, 8, 10, 12};
   for (int i = 0; i < num_records; i++) {

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -109,7 +109,8 @@ TEST_F(TestLLVMGenerator, TestAdd) {
       reinterpret_cast<uint8_t*>(out), reinterpret_cast<uint8_t*>(&out_bitmap),
   };
   int64_t addr_offsets[] = {0, 0, 0, 0, 0, 0};
-  eval_func(addrs, addr_offsets, nullptr, nullptr, 0 /* dummy context ptr */, num_records);
+  eval_func(addrs, addr_offsets, nullptr, nullptr,
+            0 /* dummy context ptr */, num_records);
 
   uint32_t expected[] = {6, 8, 10, 12};
   for (int i = 0; i < num_records; i++) {

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -315,11 +315,11 @@ TEST_F(TestFilter, TestOffset) {
   // Create a row-batch with some sample data
   int num_records = 5;
   auto array0 =
-      MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, true, true, true});
+      MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, true, false, true});
   array0 = array0->Slice(1);
-  auto array1 = MakeArrowArrayInt32({5, 9, 6, 17, 3}, {true, true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({5, 9, 6, 17, 3}, {true, true, false, true, true});
   // expected output (indices for which condition matches)
-  auto exp = MakeArrowArrayUint16({1, 3});
+  auto exp = MakeArrowArrayUint16({3});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -292,4 +292,48 @@ TEST_F(TestFilter, TestSimpleSVInt32) {
   EXPECT_ARROW_ARRAY_EQUALS(exp, selection_vector->ToArray());
 }
 
+TEST_F(TestFilter, TestOffset) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f1", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // Build condition f0 + f1 < 10
+  auto node_f0 = TreeExprBuilder::MakeField(field0);
+  auto node_f1 = TreeExprBuilder::MakeField(field1);
+  auto sum_func =
+      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int32());
+  auto literal_10 = TreeExprBuilder::MakeLiteral((int32_t)10);
+  auto less_than_10 = TreeExprBuilder::MakeFunction("less_than", {sum_func, literal_10},
+                                                    arrow::boolean());
+  auto condition = TreeExprBuilder::MakeCondition(less_than_10);
+
+  std::shared_ptr<Filter> filter;
+  auto status = Filter::Make(schema, condition, TestConfiguration(), &filter);
+  EXPECT_TRUE(status.ok());
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto array0 = MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, false, true});
+  array0 = array0->Slice(1);
+  auto array1 = MakeArrowArrayInt32({5, 9, 6, 17, 3}, {true, true, false, true, true});
+  // expected output (indices for which condition matches)
+  auto exp = MakeArrowArrayUint16({1, 3});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});
+  in_batch = in_batch->Slice(1);
+
+  std::shared_ptr<SelectionVector> selection_vector;
+  status = SelectionVector::MakeInt16(num_records, pool_, &selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Evaluate expression
+  status = filter->Evaluate(*in_batch, selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp, selection_vector->ToArray());
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -314,7 +314,8 @@ TEST_F(TestFilter, TestOffset) {
 
   // Create a row-batch with some sample data
   int num_records = 5;
-  auto array0 = MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, true, true, true});
+  auto array0 =
+      MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, true, true, true});
   array0 = array0->Slice(1);
   auto array1 = MakeArrowArrayInt32({5, 9, 6, 17, 3}, {true, true, true, true, true});
   // expected output (indices for which condition matches)

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -313,10 +313,10 @@ TEST_F(TestFilter, TestOffset) {
   EXPECT_TRUE(status.ok());
 
   // Create a row-batch with some sample data
-  int num_records = 4;
-  auto array0 = MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, false, true});
+  int num_records = 5;
+  auto array0 = MakeArrowArrayInt32({0, 1, 2, 3, 4, 6}, {true, true, true, true, true, true});
   array0 = array0->Slice(1);
-  auto array1 = MakeArrowArrayInt32({5, 9, 6, 17, 3}, {true, true, false, true, true});
+  auto array1 = MakeArrowArrayInt32({5, 9, 6, 17, 3}, {true, true, true, true, true});
   // expected output (indices for which condition matches)
   auto exp = MakeArrowArrayUint16({1, 3});
 

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -728,4 +728,42 @@ TEST_F(TestProjector, TestConcat) {
   // Validate results
   EXPECT_ARROW_ARRAY_EQUALS(exp_concat, outputs.at(0));
 }
+
+TEST_F(TestProjector, TestOffset) {
+  // schema for input fields
+  auto field0 = field("f0", arrow::int32());
+  auto field1 = field("f1", arrow::int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // output fields
+  auto field_sum = field("sum", arrow::int32());
+
+  // Build expression
+  auto sum_expr =
+      TreeExprBuilder::MakeExpression("add", {field0, field1}, field_sum);
+
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {sum_expr}, TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4}, {true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({5, 6, 7, 8}, {true, true, true, true});
+  // expected output
+  auto exp_sum = MakeArrowArrayInt32({8, 10, 12}, {true, true, true, true});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});
+  in_batch = in_batch->Slice(1);
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_sum, outputs.at(0));
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -739,8 +739,7 @@ TEST_F(TestProjector, TestOffset) {
   auto field_sum = field("sum", arrow::int32());
 
   // Build expression
-  auto sum_expr =
-      TreeExprBuilder::MakeExpression("add", {field0, field1}, field_sum);
+  auto sum_expr = TreeExprBuilder::MakeExpression("add", {field0, field1}, field_sum);
 
   std::shared_ptr<Projector> projector;
   auto status = Projector::Make(schema, {sum_expr}, TestConfiguration(), &projector);

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -747,11 +747,11 @@ TEST_F(TestProjector, TestOffset) {
 
   // Create a row-batch with some sample data
   int num_records = 4;
-  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4, 5}, {true, true, true, true, true});
+  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4, 5}, {true, true, true, true, false});
   array0 = array0->Slice(1);
-  auto array1 = MakeArrowArrayInt32({5, 6, 7, 8}, {true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({5, 6, 7, 8}, {true, false, true, true});
   // expected output
-  auto exp_sum = MakeArrowArrayInt32({9, 11, 13}, {true, true, true, true});
+  auto exp_sum = MakeArrowArrayInt32({9, 11, 13}, {false, true, false});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -747,7 +747,7 @@ TEST_F(TestProjector, TestOffset) {
 
   // Create a row-batch with some sample data
   int num_records = 4;
-  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4, 5}, {true, true, true, true});
+  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4, 5}, {true, true, true, true, true});
   array0 = array0->Slice(1);
   auto array1 = MakeArrowArrayInt32({5, 6, 7, 8}, {true, true, true, true});
   // expected output

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -747,10 +747,11 @@ TEST_F(TestProjector, TestOffset) {
 
   // Create a row-batch with some sample data
   int num_records = 4;
-  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4}, {true, true, true, true});
+  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4, 5}, {true, true, true, true});
+  array0 = array0->Slice(1);
   auto array1 = MakeArrowArrayInt32({5, 6, 7, 8}, {true, true, true, true});
   // expected output
-  auto exp_sum = MakeArrowArrayInt32({8, 10, 12}, {true, true, true, true});
+  auto exp_sum = MakeArrowArrayInt32({9, 11, 13}, {true, true, true, true});
 
   // prepare input record batch
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});


### PR DESCRIPTION
Fix for JIRA issue https://issues.apache.org/jira/browse/ARROW-5471
Basically it adds offset for each buffer  in the generated function to compute the correct index.