### PR TITLE
ARROW-6420: [Java] Improve the performance of UnionVector when getting underlying vectors

### DIFF
--- a/java/performance/src/test/java/org/apache/arrow/vector/complex/UnionBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/complex/UnionBenchmarks.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.complex;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.holders.NullableFloat8Holder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks for {@link org.apache.arrow.vector.complex.UnionVector}.
+ */
+@State(Scope.Benchmark)
+public class UnionBenchmarks {
+
+  private static final int VECTOR_LENGTH = 1024;
+
+  private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
+
+  private BufferAllocator allocator;
+
+  private UnionVector vector;
+
+  private NullableFloat8Holder valueHolder = new NullableFloat8Holder();
+
+  @Setup
+  public void prepare() {
+    allocator = new RootAllocator(ALLOCATOR_CAPACITY);
+    vector = UnionVector.empty("vector", allocator);
+    vector.allocateNew();
+    vector.setValueCount(VECTOR_LENGTH);
+
+
+    valueHolder.isSet = 1;
+    valueHolder.value = 100.0;
+
+    vector.setSafe(0, valueHolder);
+  }
+
+  @TearDown
+  public void tearDown() {
+    vector.close();
+    allocator.close();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Object getObjectBenchmark() {
+    return vector.getObject(0);
+  }
+
+  public static void main(String [] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+            .include(UnionBenchmarks.class.getSimpleName())
+            .forks(1)
+            .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/java/vector/src/main/codegen/templates/UnionReader.java
+++ b/java/vector/src/main/codegen/templates/UnionReader.java
@@ -34,7 +34,7 @@ package org.apache.arrow.vector.complex.impl;
 @SuppressWarnings("unused")
 public class UnionReader extends AbstractFieldReader {
 
-  private BaseReader[] readers = new BaseReader[43];
+  private BaseReader[] readers = new BaseReader[MinorType.values().length];
   public UnionVector data;
   
   public UnionReader(UnionVector data) {

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -76,6 +76,7 @@ public class UnionVector implements FieldVector {
   int valueCount;
 
   NonNullableStructVector internalStruct;
+  FieldVector[] internalVectors = new FieldVector[MinorType.values().length];
   protected ArrowBuf typeBuffer;
 
   private StructVector structVector;
@@ -211,6 +212,7 @@ public class UnionVector implements FieldVector {
       structVector = addOrGet(MinorType.STRUCT, StructVector.class);
       if (internalStruct.size() > vectorCount) {
         structVector.allocateNew();
+        internalVectors[MinorType.STRUCT.ordinal()] = structVector;
         if (callBack != null) {
           callBack.doWork();
         }
@@ -234,6 +236,7 @@ public class UnionVector implements FieldVector {
       ${uncappedName}Vector = addOrGet(MinorType.${name?upper_case}, ${name}Vector.class);
       if (internalStruct.size() > vectorCount) {
         ${uncappedName}Vector.allocateNew();
+        internalVectors[MinorType.${name?upper_case}.ordinal()] = ${uncappedName}Vector;
         if (callBack != null) {
           callBack.doWork();
         }
@@ -251,6 +254,7 @@ public class UnionVector implements FieldVector {
       listVector = addOrGet(MinorType.LIST, ListVector.class);
       if (internalStruct.size() > vectorCount) {
         listVector.allocateNew();
+        internalVectors[MinorType.LIST.ordinal()] = listVector;
         if (callBack != null) {
           callBack.doWork();
         }
@@ -544,6 +548,10 @@ public class UnionVector implements FieldVector {
 
     private ValueVector getVector(int index) {
       int type = typeBuffer.getByte(index * TYPE_WIDTH);
+      if (internalVectors[type] != null) {
+        return internalVectors[type];
+      }
+
       switch (MinorType.values()[type]) {
         case NULL:
           return null;

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -39,6 +39,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
   private StructWriter structWriter;
   private UnionListWriter listWriter;
   private BaseWriter[] writers = new BaseWriter[MinorType.values().length];
+  private List<BaseWriter> writerList = new java.util.ArrayList<>();
   private final NullableStructWriterFactory nullableStructWriterFactory;
 
   public UnionWriter(UnionVector vector) {
@@ -53,13 +54,10 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
   @Override
   public void setPosition(int index) {
     super.setPosition(index);
-    for (BaseWriter writer : writers) {
-      if (writer != null) {
-        writer.setPosition(index);
-      }
+    for (BaseWriter writer : writerList) {
+      writer.setPosition(index);
     }
   }
-
 
   @Override
   public void start() {
@@ -88,6 +86,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       structWriter = nullableStructWriterFactory.build(data.getStruct());
       structWriter.setPosition(idx());
       writers[Types.MinorType.STRUCT.ordinal()] = structWriter;
+      writerList.add(structWriter);
     }
     return structWriter;
   }
@@ -102,6 +101,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       listWriter = new UnionListWriter(data.getList(), nullableStructWriterFactory);
       listWriter.setPosition(idx());
       writers[Types.MinorType.LIST.ordinal()] = listWriter;
+      writerList.add(listWriter);
     }
     return listWriter;
   }
@@ -149,6 +149,7 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       ${uncappedName}Writer = new ${name}WriterImpl(data.get${name}Vector());
       ${uncappedName}Writer.setPosition(idx());
       writers[MinorType.${name?upper_case}.ordinal()] = ${uncappedName}Writer;
+      writerList.add(${uncappedName}Writer);
     }
     return ${uncappedName}Writer;
   }


### PR DESCRIPTION
Getting the underlying vector is a frequent opertation for UnionVector. It relies on this operation to get/set data at each index.

The current implementation is inefficient. In particular, it first gets the minor type at the given index, and then compares it against all possible minor types in a switch statment, until a match is found.

We improve the performance by storing the internal vectors in an array, whose index is the ordinal of the minor type. So given a minor type, its corresponding underlying vector can be obtained in O(1) time.

It should be noted that this technique is also applicable to UnionReader and UnionWriter, and support for UnionReader is already implemented.