### PR TITLE
Fix fuzzit upload and dev docs

### DIFF
--- a/ci/docker_build_and_fuzzit.sh
+++ b/ci/docker_build_and_fuzzit.sh
@@ -36,8 +36,8 @@ export ARROW_BUILD_UTILITIES="OFF"
 pushd /build/cpp
 
 mkdir ./relwithdebinfo/out
-cp ./relwithdebinfo/arrow-ipc-fuzzing-test ./relwithdebinfo/out/fuzzer
-ldd ./relwithdebinfo/arrow-ipc-fuzzing-test | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' ./relwithdebinfo/out/.
+cp ./relwithdebinfo/arrow-ipc-fuzzing_test ./relwithdebinfo/out/fuzzer
+ldd ./relwithdebinfo/arrow-ipc-fuzzing_test | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' ./relwithdebinfo/out/.
 cd ./relwithdebinfo/out/
 tar -czvf fuzzer.tar.gz *
 cd ../../

--- a/docs/source/developers/cpp.rst
+++ b/docs/source/developers/cpp.rst
@@ -522,7 +522,7 @@ Now you can start one of the fuzzer, e.g.:
 
 .. code-block:: shell
 
-   ./relwithdebinfo/arrow-ipc-fuzzing-test corpus
+   ./relwithdebinfo/arrow-ipc-fuzzing_test corpus
 
 This will try to find a malformed input that crashes the payload. A corpus of
 interesting inputs will be stored into the ``corpus`` directory. You can save and
@@ -537,13 +537,13 @@ underlying issue, you can use GDB:
 
 .. code-block:: shell
 
-   env ASAN_OPTIONS=abort_on_error=1 gdb -ex r --args ./relwithdebinfo/arrow-ipc-fuzzing-test crash-<some id>
+   env ASAN_OPTIONS=abort_on_error=1 gdb -ex r --args ./relwithdebinfo/arrow-ipc-fuzzing_test crash-<some id>
 
 For more options, use:
 
 .. code-block:: shell
 
-   ./relwithdebinfo/arrow-ipc-fuzzing-test -help=1
+   ./relwithdebinfo/arrow-ipc-fuzzing_test -help=1
 
 or visit the `libFuzzer documentation <https://llvm.org/docs/LibFuzzer.html>`_.
 


### PR DESCRIPTION
This adjusts file names in scripts and docs after 438a140142be423b1b2af2399567a0a8aeba9aa1.

Issue: ARROW-6424