### PR TITLE
ARROW-6423: [C++] Fix crash when trying to instantiate Snappy CompressedOutputStream

### DIFF
--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -44,7 +44,7 @@ namespace io {
 class CompressedOutputStream::Impl {
  public:
   Impl(MemoryPool* pool, const std::shared_ptr<OutputStream>& raw)
-      : pool_(pool), raw_(raw), is_open_(true), compressed_pos_(0) {}
+      : pool_(pool), raw_(raw), is_open_(false), compressed_pos_(0) {}
 
   ~Impl() { ARROW_CHECK_OK(Close()); }
 
@@ -52,6 +52,7 @@ class CompressedOutputStream::Impl {
     RETURN_NOT_OK(codec->MakeCompressor(&compressor_));
     RETURN_NOT_OK(AllocateResizableBuffer(pool_, kChunkSize, &compressed_));
     compressed_pos_ = 0;
+    is_open_ = true;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/io/compressed_test.cc
+++ b/cpp/src/arrow/io/compressed_test.cc
@@ -233,6 +233,15 @@ INSTANTIATE_TEST_CASE_P(TestZSTDInputStream, CompressedInputStreamTest,
                         ::testing::Values(Compression::ZSTD));
 #endif
 
+TEST(TestSnappyInputStream, NotImplemented) {
+  std::unique_ptr<Codec> codec;
+  ASSERT_OK(Codec::Create(Compression::SNAPPY, &codec));
+  std::shared_ptr<InputStream> stream = std::make_shared<BufferReader>("");
+  std::shared_ptr<CompressedInputStream> compressed_stream;
+  ASSERT_RAISES(NotImplemented,
+                CompressedInputStream::Make(codec.get(), stream, &compressed_stream));
+}
+
 class CompressedOutputStreamTest : public ::testing::TestWithParam<Compression::type> {
  protected:
   Compression::type GetCompression() { return GetParam(); }
@@ -270,6 +279,15 @@ INSTANTIATE_TEST_CASE_P(TestBrotliOutputStream, CompressedOutputStreamTest,
 INSTANTIATE_TEST_CASE_P(TestZSTDOutputStream, CompressedOutputStreamTest,
                         ::testing::Values(Compression::ZSTD));
 #endif
+
+TEST(TestSnappyOutputStream, NotImplemented) {
+  std::unique_ptr<Codec> codec;
+  ASSERT_OK(Codec::Create(Compression::SNAPPY, &codec));
+  std::shared_ptr<OutputStream> stream = std::make_shared<MockOutputStream>();
+  std::shared_ptr<CompressedOutputStream> compressed_stream;
+  ASSERT_RAISES(NotImplemented,
+                CompressedOutputStream::Make(codec.get(), stream, &compressed_stream));
+}
 
 }  // namespace io
 }  // namespace arrow

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1179,8 +1179,7 @@ cdef class CompressedInputStream(NativeFile):
     ----------
     stream : pa.NativeFile
     compression : str
-        The compression type ("bz2", "brotli", "gzip", "lz4", "snappy"
-        or "zstd")
+        The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd")
     """
     def __init__(self, NativeFile stream, compression):
         cdef:
@@ -1209,8 +1208,7 @@ cdef class CompressedOutputStream(NativeFile):
     ----------
     stream : pa.NativeFile
     compression : str
-        The compression type ("bz2", "brotli", "gzip", "lz4", "snappy"
-        or "zstd")
+        The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd")
     """
 
     def __init__(self, NativeFile stream, compression):


### PR DESCRIPTION
Snappy doesn't support streaming compression, so should raise NotImplemented.