### PR TITLE
ARROW-6385: [C++] Use xxh3 instead of custom hashing code for non-tiny strings

### DIFF
--- a/cpp/src/arrow/vendored/xxhash.h
+++ b/cpp/src/arrow/vendored/xxhash.h
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Workaround https://github.com/Cyan4973/xxHash/issues/249
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4146)
+#endif
+
+#include "arrow/vendored/xxhash/xxhash.h"
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -64,7 +64,7 @@ using arrow::cuda::CudaDeviceManager;
 
 #define XXH_INLINE_ALL 1
 #define XXH_NAMESPACE plasma_client_
-#include "arrow/vendored/xxhash/xxhash.h"
+#include "arrow/vendored/xxhash.h"
 
 #define XXH64_DEFAULT_SEED 0
 


### PR DESCRIPTION
This yields better performance in addition to relying on less custom code.