### PR TITLE
ARROW-6450: [C++] Use 2x reallocation strategy in BufferBuilder instead of 1.5x

### DIFF
--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -277,7 +277,7 @@ TEST_F(TestBuilder, TestReserve) {
 
   // Reserve overallocates for small upsizes.
   ASSERT_OK(builder.Reserve(1030));
-  ASSERT_GE(builder.capacity(), 1500);
+  ASSERT_GE(builder.capacity(), 2000);
 }
 
 TEST_F(TestBuilder, TestResizeDownsize) {
@@ -521,7 +521,7 @@ TYPED_TEST(TestPrimitiveBuilder, TestInit) {
 
   // Small upsize => should overallocate
   ASSERT_OK(this->builder_->Reserve(1200));
-  ASSERT_GE(1500, this->builder_->capacity());
+  ASSERT_GE(2000, this->builder_->capacity());
 
   // Large upsize => should allocate exactly
   ASSERT_OK(this->builder_->Reserve(32768));

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -87,7 +87,10 @@ class ARROW_EXPORT BufferBuilder {
 
   /// \brief Return a capacity expanded by an unspecified growth factor
   static int64_t GrowByFactor(int64_t current_capacity, int64_t new_capacity) {
-    // Doubling capacity except for large Reserve requests
+    // Doubling capacity except for large Reserve requests. 2x growth strategy
+    // (versus 1.5x) seems to have slightly better performance when using
+    // jemalloc, but significantly better performance when using the system
+    // allocator. See ARROW-6450 for further discussion
     return std::max(new_capacity, current_capacity * 2);
   }
 

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -87,13 +87,8 @@ class ARROW_EXPORT BufferBuilder {
 
   /// \brief Return a capacity expanded by an unspecified growth factor
   static int64_t GrowByFactor(int64_t current_capacity, int64_t new_capacity) {
-    // NOTE: Doubling isn't a great overallocation practice
-    // see https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md
-    // for discussion.
-    // Grow exactly if a large upsize (the caller might know the exact final size).
-    // Otherwise overallocate by 1.5 to keep a linear amortized cost.
-    // TODO: revisit this?  See comment in BufferOutputStream::Reserve.
-    return std::max(new_capacity, current_capacity * 3 / 2);
+    // Doubling capacity except for large Reserve requests
+    return std::max(new_capacity, current_capacity * 2);
   }
 
   /// \brief Append the given data to the buffer


### PR DESCRIPTION
As Antoine noted, 2x seems to have a small benefit with jemalloc and a more significant benefit with the system allocator. 

1.5x with jemalloc (i9-9960X on Ubuntu 18.04)

```
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
BufferBuilderTinyWrites/real_time    197653056 ns  197652025 ns          7   1.26484GB/s
BufferBuilderSmallWrites/real_time    82063937 ns   82062700 ns         17    3.0464GB/s
BufferBuilderLargeWrites/real_time    94425574 ns   94423358 ns         15   2.63343GB/s
BuildBooleanArrayNoNulls              64521268 ns   64519003 ns         22   3.87483GB/s
BuildIntArrayNoNulls                  93079445 ns   93053984 ns         15   2.68661GB/s
BuildAdaptiveIntNoNulls               34491212 ns   34479458 ns         40   7.25069GB/s
BuildAdaptiveIntNoNullsScalarAppend  127306096 ns  127302694 ns         11   1.96382GB/s
BuildBinaryArray                     809044598 ns  809023401 ns          2   316.431MB/s
BuildChunkedBinaryArray              637293688 ns  637266310 ns          2   401.716MB/s
BuildFixedSizeBinaryArray            252201859 ns  252194570 ns          6   1015.09MB/s
BuildDecimalArray                    561307314 ns  560996750 ns          2   912.661MB/s
BuildInt64DictionaryArrayRandom      266231767 ns  266228961 ns          5   961.578MB/s
BuildInt64DictionaryArraySequential  257900722 ns  257894477 ns          5   992.654MB/s
BuildInt64DictionaryArraySimilar     444990975 ns  444979666 ns          3   575.307MB/s
BuildStringDictionaryArray           748622297 ns  748614312 ns          2   456.223MB/s
ArrayDataConstructDestruct               38763 ns      38763 ns      36426
```

2x and jemalloc

```
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
BufferBuilderTinyWrites/real_time    197711155 ns  197709990 ns          7   1.26447GB/s
BufferBuilderSmallWrites/real_time    81069040 ns   81033678 ns         17   3.08379GB/s
BufferBuilderLargeWrites/real_time    94150970 ns   94148357 ns         15   2.64111GB/s
BuildBooleanArrayNoNulls              61140830 ns   61135379 ns         23   4.08929GB/s
BuildIntArrayNoNulls                  92607631 ns   92604219 ns         15   2.69966GB/s
BuildAdaptiveIntNoNulls               33907949 ns   33880894 ns         41   7.37879GB/s
BuildAdaptiveIntNoNullsScalarAppend  117096729 ns  117093371 ns         12   2.13505GB/s
BuildBinaryArray                     704963079 ns  704624550 ns          2   363.314MB/s
BuildChunkedBinaryArray              623889554 ns  623874319 ns          2   410.339MB/s
BuildFixedSizeBinaryArray            247338429 ns  247333048 ns          6   1035.04MB/s
BuildDecimalArray                    409234807 ns  409223276 ns          3   1.22183GB/s
BuildInt64DictionaryArrayRandom      296006132 ns  295998723 ns          5   864.869MB/s
BuildInt64DictionaryArraySequential  285353620 ns  285339768 ns          5   897.176MB/s
BuildInt64DictionaryArraySimilar     457288271 ns  457281346 ns          3    559.83MB/s
BuildStringDictionaryArray           729509721 ns  729493850 ns          2   468.181MB/s
ArrayDataConstructDestruct               40037 ns      40036 ns      35186
```

1.5x and system allocator

```
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
BufferBuilderTinyWrites/real_time    673175457 ns  673154074 ns          2   380.287MB/s
BufferBuilderSmallWrites/real_time   418318011 ns  418314964 ns          3   611.974MB/s
BufferBuilderLargeWrites/real_time   534294790 ns  534282517 ns          3   476.574MB/s
BuildBooleanArrayNoNulls             135128411 ns  135122284 ns         12   1.85018GB/s
BuildIntArrayNoNulls                 448668680 ns  448661666 ns          3   570.586MB/s
BuildAdaptiveIntNoNulls              109891141 ns  109889005 ns         10   2.27502GB/s
BuildAdaptiveIntNoNullsScalarAppend  148289318 ns  148286607 ns          9   1.68592GB/s
BuildBinaryArray                    1162657389 ns 1162619171 ns          1   220.192MB/s
BuildChunkedBinaryArray              606754226 ns  606740819 ns          2   421.926MB/s
BuildFixedSizeBinaryArray            657576337 ns  657397552 ns          2   389.414MB/s
BuildDecimalArray                   1156559933 ns 1156545644 ns          1   442.698MB/s
BuildInt64DictionaryArrayRandom      414707956 ns  414695071 ns          3   617.321MB/s
BuildInt64DictionaryArraySequential  405631113 ns  405557929 ns          3   631.229MB/s
BuildInt64DictionaryArraySimilar     566810196 ns  566795202 ns          2   451.662MB/s
BuildStringDictionaryArray           847338199 ns  847322935 ns          2   403.075MB/s
ArrayDataConstructDestruct               40224 ns      40223 ns      35377

```

2x and system allocator

```
---------------------------------------------------------------------------
Benchmark                                    Time           CPU Iterations
---------------------------------------------------------------------------
BufferBuilderTinyWrites/real_time    362125402 ns  362125418 ns          4   706.937MB/s
BufferBuilderSmallWrites/real_time   370158964 ns  370156920 ns          4   691.594MB/s
BufferBuilderLargeWrites/real_time   380047623 ns  380032175 ns          4   669.998MB/s
BuildBooleanArrayNoNulls              92829889 ns   92827630 ns         15   2.69316GB/s
BuildIntArrayNoNulls                 208102367 ns  208099591 ns          6   1.20135GB/s
BuildAdaptiveIntNoNulls               57545256 ns   57543182 ns         24   4.34456GB/s
BuildAdaptiveIntNoNullsScalarAppend  121124555 ns  121122124 ns         11   2.06403GB/s
BuildBinaryArray                     698486781 ns  698459415 ns          2   366.521MB/s
BuildChunkedBinaryArray              634176049 ns  634149980 ns          2    403.69MB/s
BuildFixedSizeBinaryArray            386775119 ns  386764276 ns          4   661.902MB/s
BuildDecimalArray                    583660353 ns  583645899 ns          2   877.244MB/s
BuildInt64DictionaryArrayRandom      352273499 ns  352250693 ns          4   726.755MB/s
BuildInt64DictionaryArraySequential  341524466 ns  341520605 ns          4   749.589MB/s
BuildInt64DictionaryArraySimilar     500344696 ns  500323404 ns          3   511.669MB/s
BuildStringDictionaryArray           793840167 ns  793819318 ns          2   430.243MB/s
ArrayDataConstructDestruct               39403 ns      39403 ns      35585
```