### PR TITLE
ARROW-6452: [Java] Override ValueVector toString() method

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -696,4 +696,24 @@ public class UnionVector implements FieldVector {
     public String getName() {
       return name;
     }
+
+    @Override
+    public String toString() {
+      if (getValueCount() == 0) {
+        return "[]";
+      }
+
+      StringBuilder sb = new StringBuilder();
+      sb.append('[');
+      for (int i = 0; i < getValueCount(); i++) {
+        sb.append(getObject(i));
+        if (i == getValueCount() - 1) {
+          sb.append(']');
+        } else {
+          sb.append(',').append(' ');
+        }
+      }
+
+      return sb.toString();
+    }
 }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -703,14 +703,30 @@ public class UnionVector implements FieldVector {
         return "[]";
       }
 
+      final int window = 10;
+      boolean skipComma = false;
+
       StringBuilder sb = new StringBuilder();
       sb.append('[');
       for (int i = 0; i < getValueCount(); i++) {
-        sb.append(getObject(i));
+        if (skipComma) {
+          skipComma = false;
+        }
+        if (i >= window && i < getValueCount() - window) {
+          sb.append("...");
+          i = getValueCount() - window - 1;
+          skipComma = true;
+        } else {
+          sb.append(getObject(i));
+        }
+
         if (i == getValueCount() - 1) {
           sb.append(']');
         } else {
-          sb.append(',').append(' ');
+          if (!skipComma) {
+            sb.append(',');
+          }
+          sb.append(' ');
         }
       }
 

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -27,6 +27,7 @@ import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/UnionVector.java" />
@@ -44,6 +45,7 @@ import java.util.Iterator;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.util.CallBack;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.vector.BaseValueVector;
@@ -699,37 +701,6 @@ public class UnionVector implements FieldVector {
 
     @Override
     public String toString() {
-      if (getValueCount() == 0) {
-        return "[]";
-      }
-
-      final int window = 10;
-      boolean skipComma = false;
-
-      StringBuilder sb = new StringBuilder();
-      sb.append('[');
-      for (int i = 0; i < getValueCount(); i++) {
-        if (skipComma) {
-          skipComma = false;
-        }
-        if (i >= window && i < getValueCount() - window) {
-          sb.append("...");
-          i = getValueCount() - window - 1;
-          skipComma = true;
-        } else {
-          sb.append(getObject(i));
-        }
-
-        if (i == getValueCount() - 1) {
-          sb.append(']');
-        } else {
-          if (!skipComma) {
-            sb.append(',');
-          }
-          sb.append(' ');
-        }
-      }
-
-      return sb.toString();
+      return ValueVectorUtility.getToString(this);
     }
 }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -701,6 +701,6 @@ public class UnionVector implements FieldVector {
 
     @Override
     public String toString() {
-      return ValueVectorUtility.getToString(this);
+      return ValueVectorUtility.getToString(this, 0, getValueCount());
     }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -64,7 +64,7 @@ public abstract class BaseValueVector implements ValueVector {
    */
   @Override
   public String toString() {
-    return ValueVectorUtility.getToString(this);
+    return ValueVectorUtility.getToString(this, 0, getValueCount());
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -56,19 +56,41 @@ public abstract class BaseValueVector implements ValueVector {
   }
 
   @Override
+  public abstract String getName();
+
+  /**
+   * Representation of vector suitable for debugging.
+   */
+  @Override
   public String toString() {
     if (getValueCount() == 0) {
       return "[]";
     }
 
+    final int window = 10;
+    boolean skipComma = false;
+
     StringBuilder sb = new StringBuilder();
     sb.append('[');
     for (int i = 0; i < getValueCount(); i++) {
-      sb.append(getObject(i));
+      if (skipComma) {
+        skipComma = false;
+      }
+      if (i >= window && i < getValueCount() - window) {
+        sb.append("...");
+        i = getValueCount() - window - 1;
+        skipComma = true;
+      } else {
+        sb.append(getObject(i));
+      }
+
       if (i == getValueCount() - 1) {
         sb.append(']');
       } else {
-        sb.append(',').append(' ');
+        if (!skipComma) {
+          sb.append(',');
+        }
+        sb.append(' ');
       }
     }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -26,6 +26,7 @@ import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.util.DataSizeRoundingUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.util.TransferPair;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,38 +64,7 @@ public abstract class BaseValueVector implements ValueVector {
    */
   @Override
   public String toString() {
-    if (getValueCount() == 0) {
-      return "[]";
-    }
-
-    final int window = 10;
-    boolean skipComma = false;
-
-    StringBuilder sb = new StringBuilder();
-    sb.append('[');
-    for (int i = 0; i < getValueCount(); i++) {
-      if (skipComma) {
-        skipComma = false;
-      }
-      if (i >= window && i < getValueCount() - window) {
-        sb.append("...");
-        i = getValueCount() - window - 1;
-        skipComma = true;
-      } else {
-        sb.append(getObject(i));
-      }
-
-      if (i == getValueCount() - 1) {
-        sb.append(']');
-      } else {
-        if (!skipComma) {
-          sb.append(',');
-        }
-        sb.append(' ');
-      }
-    }
-
-    return sb.toString();
+    return ValueVectorUtility.getToString(this);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -57,7 +57,22 @@ public abstract class BaseValueVector implements ValueVector {
 
   @Override
   public String toString() {
-    return super.toString() + "[name = " + getName() + ", ...]";
+    if (getValueCount() == 0) {
+      return "[]";
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append('[');
+    for (int i = 0; i < getValueCount(); i++) {
+      sb.append(getObject(i));
+      if (i == getValueCount() - 1) {
+        sb.append(']');
+      } else {
+        sb.append(',').append(' ');
+      }
+    }
+
+    return sb.toString();
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -335,14 +335,30 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
       return "[]";
     }
 
+    final int window = 10;
+    boolean skipComma = false;
+
     StringBuilder sb = new StringBuilder();
     sb.append('[');
     for (int i = 0; i < getValueCount(); i++) {
-      sb.append(getObject(i));
+      if (skipComma) {
+        skipComma = false;
+      }
+      if (i >= window && i < getValueCount() - window) {
+        sb.append("...");
+        i = getValueCount() - window - 1;
+        skipComma = true;
+      } else {
+        sb.append(getObject(i));
+      }
+
       if (i == getValueCount() - 1) {
         sb.append(']');
       } else {
-        sb.append(',').append(' ');
+        if (!skipComma) {
+          sb.append(',');
+        }
+        sb.append(' ');
       }
     }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -328,4 +328,24 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
     }
     return actualBufSize;
   }
+
+  @Override
+  public String toString() {
+    if (getValueCount() == 0) {
+      return "[]";
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append('[');
+    for (int i = 0; i < getValueCount(); i++) {
+      sb.append(getObject(i));
+      if (i == getValueCount() - 1) {
+        sb.append(']');
+      } else {
+        sb.append(',').append(' ');
+      }
+    }
+
+    return sb.toString();
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -31,6 +31,7 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.MapWithOrdinal;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -331,37 +332,6 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
 
   @Override
   public String toString() {
-    if (getValueCount() == 0) {
-      return "[]";
-    }
-
-    final int window = 10;
-    boolean skipComma = false;
-
-    StringBuilder sb = new StringBuilder();
-    sb.append('[');
-    for (int i = 0; i < getValueCount(); i++) {
-      if (skipComma) {
-        skipComma = false;
-      }
-      if (i >= window && i < getValueCount() - window) {
-        sb.append("...");
-        i = getValueCount() - window - 1;
-        skipComma = true;
-      } else {
-        sb.append(getObject(i));
-      }
-
-      if (i == getValueCount() - 1) {
-        sb.append(']');
-      } else {
-        if (!skipComma) {
-          sb.append(',');
-        }
-        sb.append(' ');
-      }
-    }
-
-    return sb.toString();
+    return ValueVectorUtility.getToString(this);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractStructVector.java
@@ -332,6 +332,6 @@ public abstract class AbstractStructVector extends AbstractContainerVector {
 
   @Override
   public String toString() {
-    return ValueVectorUtility.getToString(this);
+    return ValueVectorUtility.getToString(this, 0 , getValueCount());
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -28,10 +28,10 @@ public class ValueVectorUtility {
   /**
    * Get the toString() representation of vector suitable for debugging.
    */
-  public static String getToString(ValueVector vector) {
+  public static String getToString(ValueVector vector, int start, int end) {
     Preconditions.checkNotNull(vector);
-    final int valueCount = vector.getValueCount();
-    if (valueCount == 0) {
+    final int length = end - start;
+    if (length == 0) {
       return "[]";
     }
 
@@ -40,19 +40,19 @@ public class ValueVectorUtility {
 
     StringBuilder sb = new StringBuilder();
     sb.append('[');
-    for (int i = 0; i < valueCount; i++) {
+    for (int i = start; i < end; i++) {
       if (skipComma) {
         skipComma = false;
       }
-      if (i >= window && i < valueCount - window) {
+      if (i - start >= window && i < end - window) {
         sb.append("...");
-        i = valueCount - window - 1;
+        i = end - window - 1;
         skipComma = true;
       } else {
         sb.append(vector.getObject(i));
       }
 
-      if (i == valueCount - 1) {
+      if (i == end - 1) {
         sb.append(']');
       } else {
         if (!skipComma) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -27,6 +27,20 @@ public class ValueVectorUtility {
 
   /**
    * Get the toString() representation of vector suitable for debugging.
+   * Note since vectors may have millions of values, this method only show max 20 values.
+   * Examples as below (v represents value):
+   * <li>
+   *   vector with 0 value:
+   *   []
+   * </li>
+   * <li>
+   *   vector with 5 values (no more than 20 values):
+   *   [v0, v1, v2, v3, v4]
+   * </li>
+   * <li>
+   *  vector with 100 values (more than 20 values):
+   *  [v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, ..., v90, v91, v92, v93, v94, v95, v96, v97, v98, v99]
+   * </li>
    */
   public static String getToString(ValueVector vector, int start, int end) {
     Preconditions.checkNotNull(vector);

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -31,6 +31,10 @@ public class ValueVectorUtility {
   public static String getToString(ValueVector vector, int start, int end) {
     Preconditions.checkNotNull(vector);
     final int length = end - start;
+    Preconditions.checkArgument(length >= 0);
+    Preconditions.checkArgument(start >= 0);
+    Preconditions.checkArgument(end <= vector.getValueCount());
+
     if (length == 0) {
       return "[]";
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * Utility methods for {@link ValueVector}.
+ */
+public class ValueVectorUtility {
+
+  /**
+   * Get the toString() representation of vector suitable for debugging.
+   */
+  public static String getToString(ValueVector vector) {
+    Preconditions.checkNotNull(vector);
+    final int valueCount = vector.getValueCount();
+    if (valueCount == 0) {
+      return "[]";
+    }
+
+    final int window = 10;
+    boolean skipComma = false;
+
+    StringBuilder sb = new StringBuilder();
+    sb.append('[');
+    for (int i = 0; i < valueCount; i++) {
+      if (skipComma) {
+        skipComma = false;
+      }
+      if (i >= window && i < valueCount - window) {
+        sb.append("...");
+        i = valueCount - window - 1;
+        skipComma = true;
+      } else {
+        sb.append(vector.getObject(i));
+      }
+
+      if (i == valueCount - 1) {
+        sb.append(']');
+      } else {
+        if (!skipComma) {
+          sb.append(',');
+        }
+        sb.append(' ');
+      }
+    }
+
+    return sb.toString();
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -28,8 +28,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.arrow.memory.BaseAllocator;
@@ -2637,6 +2639,53 @@ public class TestValueVector {
       vector2.setSafe(1, 2);
 
       assertTrue(new RangeEqualsVisitor(vector1, vector2).rangeEquals(new Range(2, 3, 1)));
+    }
+  }
+
+  @Test
+  public void testToString() {
+    try (final IntVector intVector = new IntVector("intVector", allocator);
+         final ListVector listVector = ListVector.empty("listVector", allocator);
+         final StructVector structVector = StructVector.empty("structVector", allocator)) {
+
+      // validate intVector toString
+      intVector.setValueCount(3);
+      intVector.setSafe(0, 1);
+      intVector.setSafe(1, 2);
+      intVector.setSafe(2, 3);
+      assertEquals("[1, 2, 3]", intVector.toString());
+
+      // validate listVector toString
+      listVector.allocateNewSafe();
+      listVector.initializeChildrenFromFields(
+          Collections.singletonList(Field.nullable("child", ArrowType.Utf8.INSTANCE)));
+      VarCharVector dataVector = (VarCharVector) listVector.getDataVector();
+
+      listVector.startNewValue(0);
+      dataVector.setSafe(0, "aaa".getBytes(StandardCharsets.UTF_8));
+      dataVector.setSafe(1, "bbb".getBytes(StandardCharsets.UTF_8));
+      listVector.endValue(0, 2);
+
+      listVector.startNewValue(1);
+      dataVector.setSafe(2, "ccc".getBytes(StandardCharsets.UTF_8));
+      dataVector.setSafe(3, "ddd".getBytes(StandardCharsets.UTF_8));
+      listVector.endValue(1, 2);
+      listVector.setValueCount(2);
+
+      assertEquals("[[\"aaa\",\"bbb\"], [\"ccc\",\"ddd\"]]", listVector.toString());
+
+      // validate structVector toString
+      structVector.addOrGet("f0", FieldType.nullable(new ArrowType.Int(32, true)), IntVector.class);
+      structVector.addOrGet("f1", FieldType.nullable(new ArrowType.Int(64, true)), BigIntVector.class);
+
+      NullableStructWriter structWriter = structVector.getWriter();
+      structWriter.allocate();
+
+      writeStructVector(structWriter, 1, 10L);
+      writeStructVector(structWriter, 2, 20L);
+      structWriter.setValueCount(2);
+
+      assertEquals("[{\"f0\":1,\"f1\":10}, {\"f0\":2,\"f1\":20}]", structVector.toString());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2655,6 +2655,14 @@ public class TestValueVector {
       intVector.setSafe(2, 3);
       assertEquals("[1, 2, 3]", intVector.toString());
 
+      // validate intVector with plenty values
+      intVector.setValueCount(100);
+      for (int i = 0; i < 100; i++) {
+        intVector.setSafe(i, i);
+      }
+      assertEquals("[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ... 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]",
+          intVector.toString());
+
       // validate listVector toString
       listVector.allocateNewSafe();
       listVector.initializeChildrenFromFields(

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2649,6 +2649,7 @@ public class TestValueVector {
          final StructVector structVector = StructVector.empty("structVector", allocator)) {
 
       // validate intVector toString
+      assertEquals("[]", intVector.toString());
       intVector.setValueCount(3);
       intVector.setSafe(0, 1);
       intVector.setSafe(1, 2);


### PR DESCRIPTION
Related to [ARROW-6452](https://issues.apache.org/jira/browse/ARROW-6452).
Currently cpp code Array#ToString returns the human readable format string like:
[
  1,
  2,
  3
]
But Java ValueVector did not implement like this way now.