### PR TITLE
ARROW-6300: [C++] Add Abort() method to streams

### DIFF
--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <iterator>
 #include <map>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -176,6 +177,18 @@ class MockFSOutputStream : public io::OutputStream {
   // Implement the OutputStream interface
   Status Close() override {
     closed_ = true;
+    return Status::OK();
+  }
+
+  Status Abort() override {
+    if (!closed_) {
+      // MockFSOutputStream is mainly used for debugging and testing, so
+      // mark an aborted file's contents explicitly.
+      std::stringstream ss;
+      ss << "MockFSOutputStream aborted after " << file_->data.size() << " bytes written";
+      file_->data = ss.str();
+      closed_ = true;
+    }
     return Status::OK();
   }
 

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -81,6 +81,8 @@ inline bool IsAlreadyExists(const Aws::Client::AWSError<Aws::S3::S3Errors>& erro
           error_type == Aws::S3::S3Errors::BUCKET_ALREADY_OWNED_BY_YOU);
 }
 
+// TODO qualify error messages with a prefix indicating context
+// (e.g. "When completing multipart upload to bucket 'xxx', key 'xxx': ...")
 template <typename ErrorType>
 Status ErrorToStatus(const std::string& prefix,
                      const Aws::Client::AWSError<ErrorType>& error) {

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -68,6 +68,7 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   /// \brief Close the buffered output stream.  This implicitly closes the
   /// underlying raw output stream.
   Status Close() override;
+  Status Abort() override;
   bool closed() const override;
 
   Status Tell(int64_t* position) const override;
@@ -134,6 +135,7 @@ class ARROW_EXPORT BufferedInputStream : public InputStream {
   Status Peek(int64_t nbytes, util::string_view* out) override;
 
   Status Close() override;
+  Status Abort() override;
   bool closed() const override;
 
   /// \brief Returns the position of the buffered stream, though the position

--- a/cpp/src/arrow/io/compressed.h
+++ b/cpp/src/arrow/io/compressed.h
@@ -55,6 +55,7 @@ class ARROW_EXPORT CompressedOutputStream : public OutputStream {
   /// \brief Close the compressed output stream.  This implicitly closes the
   /// underlying raw output stream.
   Status Close() override;
+  Status Abort() override;
   bool closed() const override;
 
   Status Tell(int64_t* position) const override;
@@ -90,6 +91,7 @@ class ARROW_EXPORT CompressedInputStream : public InputStream {
   /// \brief Close the compressed input stream.  This implicitly closes the
   /// underlying raw input stream.
   Status Close() override;
+  Status Abort() override;
   bool closed() const override;
 
   Status Tell(int64_t* position) const override;

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -67,8 +67,30 @@ class ARROW_EXPORT FileSystem {
 class ARROW_EXPORT FileInterface {
  public:
   virtual ~FileInterface() = 0;
+
+  /// \brief Close the stream cleanly
+  ///
+  /// For writable streams, this will attempt to flush any pending data
+  /// before releasing the underlying resource.
+  ///
+  /// After Close() is called, closed() returns true and the stream is not
+  /// available for further operations.
   virtual Status Close() = 0;
+
+  /// \brief Close the stream abruptly
+  ///
+  /// This method does not guarantee that any pending data is flushed.
+  /// It merely releases any underlying resource used by the stream for
+  /// its operation.
+  ///
+  /// After Abort() is called, closed() returns true and the stream is not
+  /// available for further operations.
+  virtual Status Abort();
+
+  /// \brief Return the position in this stream
   virtual Status Tell(int64_t* position) const = 0;
+
+  /// \brief Return whether the stream is closed
   virtual bool closed() const = 0;
 
   FileMode::type mode() const { return mode_; }

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -53,6 +53,8 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   ~BufferOutputStream() override;
 
   // Implement the OutputStream interface
+
+  /// Close the stream, preserving the buffer (retrieve it with Finish()).
   Status Close() override;
   bool closed() const override;
   Status Tell(int64_t* position) const override;

--- a/cpp/src/arrow/io/util_internal.h
+++ b/cpp/src/arrow/io/util_internal.h
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/io/interfaces.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace io {
+namespace internal {
+
+ARROW_EXPORT void CloseFromDestructor(FileInterface* file);
+
+}  // namespace internal
+}  // namespace io
+}  // namespace arrow

--- a/cpp/src/arrow/python/io.h
+++ b/cpp/src/arrow/python/io.h
@@ -42,6 +42,7 @@ class ARROW_PYTHON_EXPORT PyReadableFile : public io::RandomAccessFile {
   ~PyReadableFile() override;
 
   Status Close() override;
+  Status Abort() override;
   bool closed() const override;
 
   Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
@@ -70,6 +71,7 @@ class ARROW_PYTHON_EXPORT PyOutputStream : public io::OutputStream {
   ~PyOutputStream() override;
 
   Status Close() override;
+  Status Abort() override;
   bool closed() const override;
   Status Tell(int64_t* position) const override;
   Status Write(const void* data, int64_t nbytes) override;

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -53,6 +53,10 @@ cdef class NativeFile:
     While this class exposes methods to read or write data from Python, the
     primary intent of using a Arrow stream is to pass it to other Arrow
     facilities that will make use of it, such as Arrow IPC routines.
+
+    Be aware that there are subtle differences with regular Python files,
+    e.g. destroying a writable Arrow stream without closing it explicitly
+    will not flush any pending data.
     """
 
     def __cinit__(self):


### PR DESCRIPTION
This is a quick-close method that does not guarantee it will flush any pending data,
just deallocate ressources held up by the stream.