### PR TITLE
ARROW-6432: [CI][Crossbow] Remove alpine nightly crossbow jobs

### DIFF
--- a/dev/tasks/tests.yml
+++ b/dev/tasks/tests.yml
@@ -18,6 +18,34 @@
 groups:
   # these groups are just for convenience
   # makes it easier to submit related tasks
+  nightly:
+    - docker-r
+    - docker-r-conda
+    - docker-rust
+    - docker-cpp
+    - docker-cpp-cmake32
+    - docker-cpp-release
+    - docker-cpp-fuzzit
+    - docker-cpp-static-only
+    - docker-c_glib
+    - docker-go
+    - docker-python-2.7
+    - docker-python-3.6
+    - docker-python-3.7
+    - docker-python-2.7-nopandas
+    - docker-python-3.6-nopandas
+    - docker-java
+    - docker-js
+    - docker-docs
+    - docker-lint
+    - docker-iwyu
+    - docker-clang-format
+    - docker-pandas-master
+    - docker-dask-integration
+    - docker-hdfs-integration
+    - docker-spark-integration
+    - docker-turbodbc-integration
+
   docker:
     - docker-r
     - docker-r-conda


### PR DESCRIPTION
By introducing a nightly group which we expect to pass. The alpine docker-compose build and crossbow task can still be triggered manually.

On ursalabs/crossbow the nightly group [gets triggered](https://github.com/ursa-labs/crossbow/commit/f1a291ebcade8321993399f87fc7e3748f400c2d) from now on. 