### PR TITLE
ARROW-6314: [C#] Implement IPC message format alignment changes, provide backwards compatibility and "legacy" option to emit old message format

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -28,7 +28,6 @@ namespace Apache.Arrow.Ipc
         private long _currentRecordBatchOffset = -1;
 
         private bool HasWrittenHeader { get; set; }
-        private bool HasWrittenFooter { get; set; }
 
         private List<Block> RecordBatchBlocks { get; }
 
@@ -58,7 +57,6 @@ namespace Apache.Arrow.Ipc
             }
 
             HasWrittenHeader = false;
-            HasWrittenFooter = false;
 
             RecordBatchBlocks = new List<Block>();
         }
@@ -106,15 +104,11 @@ namespace Apache.Arrow.Ipc
             _currentRecordBatchOffset = -1;
         }
 
-        public async Task WriteFooterAsync(CancellationToken cancellationToken = default)
+        private protected override async ValueTask WriteEndInternalAsync(CancellationToken cancellationToken)
         {
-            if (!HasWrittenFooter)
-            {
-                await WriteFooterAsync(Schema, cancellationToken).ConfigureAwait(false);
-                HasWrittenFooter = true;
-            }
+            await base.WriteEndInternalAsync(cancellationToken);
 
-            await BaseStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await WriteFooterAsync(Schema, cancellationToken);
         }
 
         private async Task WriteHeaderAsync(CancellationToken cancellationToken)

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -38,7 +38,12 @@ namespace Apache.Arrow.Ipc
         }
 
         public ArrowFileWriter(Stream stream, Schema schema, bool leaveOpen)
-            : base(stream, schema, leaveOpen)
+            : this(stream, schema, leaveOpen, options: null)
+        {
+        }
+
+        public ArrowFileWriter(Stream stream, Schema schema, bool leaveOpen, IpcOptions options)
+            : base(stream, schema, leaveOpen, options)
         {
             if (!stream.CanWrite)
             {

--- a/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
+++ b/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Apache.Arrow.Ipc
+{
+    public class IpcOptions
+    {
+        internal static readonly IpcOptions Default = new IpcOptions();
+
+        /// <summary>
+        /// Write the pre-0.15.0 encapsulated IPC message format
+        /// consisting of a 4-byte prefix instead of 8 byte.
+        /// </summary>
+        public bool WriteLegacyIpcFormat { get; set; }
+
+        public IpcOptions()
+        {
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
+++ b/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
@@ -28,5 +28,10 @@ namespace Apache.Arrow.Ipc
         public IpcOptions()
         {
         }
+
+        /// <summary>
+        /// Gets the number of bytes used in the IPC message prefix.
+        /// </summary>
+        internal int SizeOfIpcLength => WriteLegacyIpcFormat ? 4 : 8;
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -20,6 +20,7 @@ namespace Apache.Arrow.Ipc
 {
     internal class MessageSerializer
     {
+        public const int IpcContinuationToken = -1;
 
         public static Types.NumberType GetNumberType(int bitWidth, bool signed)
         {

--- a/csharp/test/Apache.Arrow.Tests/ArrowFileReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowFileReaderTests.cs
@@ -59,7 +59,7 @@ namespace Apache.Arrow.Tests
             {
                 ArrowFileWriter writer = new ArrowFileWriter(stream, originalBatch.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch);
-                await writer.WriteFooterAsync();
+                await writer.WriteEndAsync();
                 stream.Position = 0;
 
                 var memoryPool = new TestMemoryAllocator();
@@ -121,7 +121,7 @@ namespace Apache.Arrow.Tests
             {
                 ArrowFileWriter writer = new ArrowFileWriter(stream, originalBatch.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch);
-                await writer.WriteFooterAsync();
+                await writer.WriteEndAsync();
                 stream.Position = 0;
 
                 ArrowFileReader reader = new ArrowFileReader(stream);
@@ -140,7 +140,7 @@ namespace Apache.Arrow.Tests
                 ArrowFileWriter writer = new ArrowFileWriter(stream, originalBatch1.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch1);
                 await writer.WriteRecordBatchAsync(originalBatch2);
-                await writer.WriteFooterAsync();
+                await writer.WriteEndAsync();
                 stream.Position = 0;
 
                 // the recordbatches by index are in reverse order - back to front.

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -60,6 +60,7 @@ namespace Apache.Arrow.Tests
             {
                 ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
 
                 stream.Position = 0;
 
@@ -83,23 +84,29 @@ namespace Apache.Arrow.Tests
             }
         }
 
-        [Fact]
-        public async Task ReadRecordBatch_Memory()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadRecordBatch_Memory(bool writeEnd)
         {
             await TestReaderFromMemory((reader, originalBatch) =>
             {
                 ArrowReaderVerifier.VerifyReader(reader, originalBatch);
                 return Task.CompletedTask;
-            });
+            }, writeEnd);
         }
 
-        [Fact]
-        public async Task ReadRecordBatchAsync_Memory()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadRecordBatchAsync_Memory(bool writeEnd)
         {
-            await TestReaderFromMemory(ArrowReaderVerifier.VerifyReaderAsync);
+            await TestReaderFromMemory(ArrowReaderVerifier.VerifyReaderAsync, writeEnd);
         }
 
-        private static async Task TestReaderFromMemory(Func<ArrowStreamReader, RecordBatch, Task> verificationFunc)
+        private static async Task TestReaderFromMemory(
+            Func<ArrowStreamReader, RecordBatch, Task> verificationFunc,
+            bool writeEnd)
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
 
@@ -108,6 +115,10 @@ namespace Apache.Arrow.Tests
             {
                 ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch);
+                if (writeEnd)
+                {
+                    await writer.WriteEndAsync();
+                }
                 buffer = stream.GetBuffer();
             }
 
@@ -115,23 +126,29 @@ namespace Apache.Arrow.Tests
             await verificationFunc(reader, originalBatch);
         }
 
-        [Fact]
-        public async Task ReadRecordBatch_Stream()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadRecordBatch_Stream(bool writeEnd)
         {
             await TestReaderFromStream((reader, originalBatch) =>
             {
                 ArrowReaderVerifier.VerifyReader(reader, originalBatch);
                 return Task.CompletedTask;
-            });
+            }, writeEnd);
         }
 
-        [Fact]
-        public async Task ReadRecordBatchAsync_Stream()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadRecordBatchAsync_Stream(bool writeEnd)
         {
-            await TestReaderFromStream(ArrowReaderVerifier.VerifyReaderAsync);
+            await TestReaderFromStream(ArrowReaderVerifier.VerifyReaderAsync, writeEnd);
         }
 
-        private static async Task TestReaderFromStream(Func<ArrowStreamReader, RecordBatch, Task> verificationFunc)
+        private static async Task TestReaderFromStream(
+            Func<ArrowStreamReader, RecordBatch, Task> verificationFunc,
+            bool writeEnd)
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
 
@@ -139,6 +156,10 @@ namespace Apache.Arrow.Tests
             {
                 ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch);
+                if (writeEnd)
+                {
+                    await writer.WriteEndAsync();
+                }
 
                 stream.Position = 0;
 
@@ -175,6 +196,7 @@ namespace Apache.Arrow.Tests
             {
                 ArrowStreamWriter writer = new ArrowStreamWriter(stream, originalBatch.Schema);
                 await writer.WriteRecordBatchAsync(originalBatch);
+                await writer.WriteEndAsync();
 
                 stream.Position = 0;
 


### PR DESCRIPTION
Porting the fix for ARROW-6314 to the C# library.

/cc @chutchinson @pgovind 