### PR TITLE
ARROW-6447: [C++] Allow rest of arrow_objlib to build in parallel while memory_pool.cc is waiting on jemalloc_ep

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1406,7 +1406,6 @@ if(ARROW_JEMALLOC)
                                    INTERFACE_INCLUDE_DIRECTORIES
                                    "${CMAKE_CURRENT_BINARY_DIR}/jemalloc_ep-prefix/src")
   add_dependencies(jemalloc::jemalloc jemalloc_ep)
-  add_dependencies(toolchain jemalloc_ep)
 endif()
 
 # ----------------------------------------------------------------------

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -145,6 +145,11 @@ set(ARROW_SRCS
     util/utf8.cc
     vendored/datetime/tz.cpp)
 
+if(ARROW_JEMALLOC)
+  set_source_files_properties(memory_pool.cc
+    PROPERTIES OBJECT_DEPENDS jemalloc_ep)
+endif()
+
 if(ARROW_JSON)
   add_subdirectory(json)
   set(ARROW_SRCS
@@ -203,10 +208,6 @@ if(ARROW_CUDA)
   # IPC extensions required to build the CUDA library
   set(ARROW_IPC ON)
   add_subdirectory(gpu)
-endif()
-
-if(ARROW_JEMALLOC AND JEMALLOC_VENDORED)
-  add_dependencies(arrow_dependencies jemalloc::jemalloc)
 endif()
 
 if(ARROW_WITH_BROTLI)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -146,7 +146,11 @@ set(ARROW_SRCS
     vendored/datetime/tz.cpp)
 
 if(ARROW_JEMALLOC)
-  set_source_files_properties(memory_pool.cc PROPERTIES OBJECT_DEPENDS jemalloc_ep)
+  if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    set_source_files_properties(memory_pool.cc PROPERTIES OBJECT_DEPENDS jemalloc_ep)
+  else()
+    add_dependencies(arrow_dependencies jemalloc_ep)
+  endif()
 endif()
 
 if(ARROW_JSON)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -146,8 +146,7 @@ set(ARROW_SRCS
     vendored/datetime/tz.cpp)
 
 if(ARROW_JEMALLOC)
-  set_source_files_properties(memory_pool.cc
-    PROPERTIES OBJECT_DEPENDS jemalloc_ep)
+  set_source_files_properties(memory_pool.cc PROPERTIES OBJECT_DEPENDS jemalloc_ep)
 endif()
 
 if(ARROW_JSON)


### PR DESCRIPTION
Using OBJECT_DEPENDS like this seems to only work with the Ninja build generator with CMake 3.12.x, which is probably a bug. With Makefiles we fall back to the old strategy of blocking on the completion of jemalloc_ep. 