### PR TITLE
ARROW-6379: [C++] Write no IPC buffer metadata for NullType

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -253,8 +253,9 @@ class ArrayLoader {
 
   Status Visit(const NullType& type) {
     out_->buffers.resize(1);
-    RETURN_NOT_OK(LoadCommon());
-    RETURN_NOT_OK(GetBuffer(context_->buffer_index++, &out_->buffers[0]));
+
+    // ARROW-6379: NullType has no buffers in the IPC payload
+    RETURN_NOT_OK(context_->source->GetFieldMetadata(context_->field_index++, out_));
     return Status::OK();
   }
 


### PR DESCRIPTION
Since we have no integration tests for NullType we have never had to address this issue.

The C++ implementation has been writing 2 `Buffer` Flatbuffer struct values with length 0 for NullType. Rather than having dummy/placeholder Buffer I think it is more consistent to write no metadata for this type.

The downside of this change is that any persisted record batches from pre 0.15.0 will not be readable. However, we have not made any forward compatibility guarantees about this so I am OK breaking a few eggs on this one. 