### PR TITLE
ARROW-5736: [Format][C++] Support small bit-width indices in sparse tensor

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -972,11 +972,16 @@ Status MakeSparseTensorIndexCOO(FBB& fbb, const SparseCOOIndex& sparse_index,
   //       but we should also make smaller bit-width and unsigned index available.
   auto indices_type_offset = flatbuf::CreateInt(fbb, 64, true);
 
+  auto fb_strides =
+      fbb.CreateVector(util::MakeNonNull(sparse_index.indices()->strides().data()),
+                       sparse_index.indices()->strides().size());
+
   const BufferMetadata& indices_metadata = buffers[0];
   flatbuf::Buffer indices(indices_metadata.offset, indices_metadata.length);
 
   *fb_sparse_index =
-      flatbuf::CreateSparseTensorIndexCOO(fbb, indices_type_offset, &indices).Union();
+      flatbuf::CreateSparseTensorIndexCOO(fbb, indices_type_offset, fb_strides, &indices)
+          .Union();
   *num_buffers = 1;
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -967,9 +967,16 @@ Status MakeSparseTensorIndexCOO(FBB& fbb, const SparseCOOIndex& sparse_index,
                                 flatbuf::SparseTensorIndex* fb_sparse_index_type,
                                 Offset* fb_sparse_index, size_t* num_buffers) {
   *fb_sparse_index_type = flatbuf::SparseTensorIndex_SparseTensorIndexCOO;
+
+  // TODO: Now SparseCOOIndex support only Int64 tensor for indices matrix,
+  //       but we should also make smaller bit-width and unsigned index available.
+  auto indices_type_offset = flatbuf::CreateInt(fbb, 64, true);
+
   const BufferMetadata& indices_metadata = buffers[0];
   flatbuf::Buffer indices(indices_metadata.offset, indices_metadata.length);
-  *fb_sparse_index = flatbuf::CreateSparseTensorIndexCOO(fbb, &indices).Union();
+
+  *fb_sparse_index =
+      flatbuf::CreateSparseTensorIndexCOO(fbb, indices_type_offset, &indices).Union();
   *num_buffers = 1;
   return Status::OK();
 }
@@ -979,11 +986,24 @@ Status MakeSparseMatrixIndexCSR(FBB& fbb, const SparseCSRIndex& sparse_index,
                                 flatbuf::SparseTensorIndex* fb_sparse_index_type,
                                 Offset* fb_sparse_index, size_t* num_buffers) {
   *fb_sparse_index_type = flatbuf::SparseTensorIndex_SparseMatrixIndexCSR;
+
+  // TODO: Now SparseCSRIndex support Int64 tensor for indptr array,
+  //       but we should also make smaller bit-width and unsigned index available.
+  auto indptr_type_offset = flatbuf::CreateInt(fbb, 64, true);
+
   const BufferMetadata& indptr_metadata = buffers[0];
-  const BufferMetadata& indices_metadata = buffers[1];
   flatbuf::Buffer indptr(indptr_metadata.offset, indptr_metadata.length);
+
+  // TODO: Now SparseCSRIndex support Int64 tensor for indices array,
+  //       but we should also make smaller bit-width and unsigned index available.
+  auto indices_type_offset = flatbuf::CreateInt(fbb, 64, true);
+
+  const BufferMetadata& indices_metadata = buffers[1];
   flatbuf::Buffer indices(indices_metadata.offset, indices_metadata.length);
-  *fb_sparse_index = flatbuf::CreateSparseMatrixIndexCSR(fbb, &indptr, &indices).Union();
+
+  *fb_sparse_index = flatbuf::CreateSparseMatrixIndexCSR(fbb, indptr_type_offset, &indptr,
+                                                         indices_type_offset, &indices)
+                         .Union();
   *num_buffers = 2;
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -103,6 +103,15 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
                          std::vector<int64_t>* shape, std::vector<int64_t>* strides,
                          std::vector<std::string>* dim_names);
 
+// EXPERIMENTAL: Extracting metadata of a SparseCOOIndex from the message
+Status GetSparseCOOIndexMetadata(const flatbuf::SparseTensorIndexCOO* sparse_index,
+                                 std::shared_ptr<DataType>* indices_type);
+
+// EXPERIMENTAL: Extracting metadata of a SparseCSRIndex from the message
+Status GetSparseCSRIndexMetadata(const flatbuf::SparseMatrixIndexCSR* sparse_index,
+                                 std::shared_ptr<DataType>* indptr_type,
+                                 std::shared_ptr<DataType>* indices_type);
+
 // EXPERIMENTAL: Extracting metadata of a sparse tensor from the message
 Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type,
                                std::vector<int64_t>* shape,

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1058,19 +1058,19 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
       const std::vector<int64_t>& coords_strides,
       std::vector<typename IndexValueType::c_type>& coords_values) const {
     auto coords_data = Buffer::Wrap(coords_values);
-    auto coords = std::make_shared<NumericTensor<IndexValueType>>(coords_data, coords_shape, coords_strides);
+    auto coords = std::make_shared<NumericTensor<IndexValueType>>(
+        coords_data, coords_shape, coords_strides);
     return std::make_shared<SparseCOOIndex>(coords);
   }
 
   template <typename ValueType>
   std::shared_ptr<SparseTensorCOO> MakeSparseTensorCOO(
-      const std::shared_ptr<SparseCOOIndex>& si,
-      std::vector<ValueType>& sparse_values,
+      const std::shared_ptr<SparseCOOIndex>& si, std::vector<ValueType>& sparse_values,
       const std::vector<int64_t>& shape,
       const std::vector<std::string>& dim_names = {}) const {
     auto data = Buffer::Wrap(sparse_values);
-    return std::make_shared<SparseTensorCOO>(si, TypeTraits<IndexValueType>::type_singleton(),
-                                             data, shape, dim_names);
+    return std::make_shared<SparseTensorCOO>(
+        si, TypeTraits<IndexValueType>::type_singleton(), data, shape, dim_names);
   }
 };
 
@@ -1088,7 +1088,8 @@ void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
   ASSERT_OK(WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length,
                               default_memory_pool()));
 
-  const auto& sparse_index = checked_cast<const SparseCOOIndex&>(*sparse_tensor.sparse_index());
+  const auto& sparse_index =
+      checked_cast<const SparseCOOIndex&>(*sparse_tensor.sparse_index());
   const int64_t indices_length = elem_size * sparse_index.indices()->size();
   const int64_t data_length = elem_size * sparse_tensor.non_zero_length();
   const int64_t expected_body_length = indices_length + data_length;
@@ -1120,7 +1121,8 @@ void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
   ASSERT_OK(WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length,
                               default_memory_pool()));
 
-  const auto& sparse_index = checked_cast<const SparseCSRIndex&>(*sparse_tensor.sparse_index());
+  const auto& sparse_index =
+      checked_cast<const SparseCSRIndex&>(*sparse_tensor.sparse_index());
   const int64_t indptr_length = elem_size * sparse_index.indptr()->size();
   const int64_t indices_length = elem_size * sparse_index.indices()->size();
   const int64_t data_length = elem_size * sparse_tensor.non_zero_length();
@@ -1174,9 +1176,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
                                                    0, 2, 0, 0, 2, 2, 1, 0, 1, 1, 0, 3,
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
   const size_t sizeof_index_value = sizeof(c_index_value_type);
-  auto si= this->MakeSparseCOOIndex({12, 3},
-                                    {sizeof_index_value * 3, sizeof_index_value},
-                                    coords_values);
+  auto si = this->MakeSparseCOOIndex(
+      {12, 3}, {sizeof_index_value * 3, sizeof_index_value}, coords_values);
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
@@ -1218,9 +1219,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
                                         0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2,
                                         0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
   const size_t sizeof_index_value = sizeof(c_index_value_type);
-  auto si = this->MakeSparseCOOIndex({12, 3},
-                                     {sizeof_index_value, sizeof_index_value * 12},
-                                     coords_values);
+  auto si = this->MakeSparseCOOIndex(
+      {12, 3}, {sizeof_index_value, sizeof_index_value * 12}, coords_values);
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
@@ -1247,10 +1247,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   this->CheckSparseTensorRoundTrip(st);
 }
 
-REGISTER_TYPED_TEST_CASE_P(TestSparseTensorRoundTrip,
-                           WithSparseCOOIndexRowMajor,
-                           WithSparseCOOIndexColumnMajor,
-                           WithSparseCSRIndex);
+REGISTER_TYPED_TEST_CASE_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor,
+                           WithSparseCOOIndexColumnMajor, WithSparseCSRIndex);
 
 INSTANTIATE_TYPED_TEST_CASE_P(TestInt64, TestSparseTensorRoundTrip, Int64Type);
 

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1182,7 +1182,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
   std::vector<c_index_value_type> coords_values = {0, 0, 0, 0, 0, 2, 0, 1, 1, 0, 1, 3,
                                                    0, 2, 0, 0, 2, 2, 1, 0, 1, 1, 0, 3,
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
-  const size_t sizeof_index_value = sizeof(c_index_value_type);
+  const int sizeof_index_value = sizeof(c_index_value_type);
   auto si = this->MakeSparseCOOIndex(
       {12, 3}, {sizeof_index_value * 3, sizeof_index_value}, coords_values);
 
@@ -1225,7 +1225,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
   std::vector<c_index_value_type> coords_values = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
                                                    0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2,
                                                    0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
-  const size_t sizeof_index_value = sizeof(c_index_value_type);
+  const int sizeof_index_value = sizeof(c_index_value_type);
   auto si = this->MakeSparseCOOIndex(
       {12, 3}, {sizeof_index_value, sizeof_index_value * 12}, coords_values);
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -884,7 +884,7 @@ Status ReadSparseCOOIndex(const flatbuf::SparseTensor* sparse_tensor, int64_t nd
     strides.push_back(indices_strides->Get(1));
   }
   *out = std::make_shared<SparseCOOIndex>(
-      std::make_shared<SparseCOOIndex::CoordsTensor>(indices_data, shape, strides));
+      std::make_shared<Tensor>(int64(), indices_data, shape, strides));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <type_traits>

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -864,6 +865,12 @@ Status ReadSparseCOOIndex(const flatbuf::SparseTensor* sparse_tensor, int64_t nd
                           int64_t non_zero_length, io::RandomAccessFile* file,
                           std::shared_ptr<SparseIndex>* out) {
   auto* sparse_index = sparse_tensor->sparseIndex_as_SparseTensorIndexCOO();
+  auto* indices_type = sparse_index->indicesType();
+  // SparseCOOIndex currently can have Int64 tensor for indices
+  if (indices_type->bitWidth() != 64) {
+    return Status::NotImplemented(
+        "SparseCOOIndex with more or less than 64-bit indices not implemented");
+  }
   auto* indices_buffer = sparse_index->indicesBuffer();
   std::shared_ptr<Buffer> indices_data;
   RETURN_NOT_OK(
@@ -880,6 +887,20 @@ Status ReadSparseCSRIndex(const flatbuf::SparseTensor* sparse_tensor, int64_t nd
                           int64_t non_zero_length, io::RandomAccessFile* file,
                           std::shared_ptr<SparseIndex>* out) {
   auto* sparse_index = sparse_tensor->sparseIndex_as_SparseMatrixIndexCSR();
+
+  auto* indptr_type = sparse_index->indptrType();
+  // SparseCSRIndex currently can have Int64 tensor for indptr
+  if (indptr_type->bitWidth() != 64) {
+    return Status::NotImplemented(
+        "SparseCSRIndex with more or less than 64-bit indptr not implemented");
+  }
+
+  auto* indices_type = sparse_index->indicesType();
+  // SparseCSRIndex currently can have Int64 tensor for indices
+  if (indices_type->bitWidth() != 64) {
+    return Status::NotImplemented(
+        "SparseCSRIndex with more or less than 64-bit indices not implemented");
+  }
 
   auto* indptr_buffer = sparse_index->indptrBuffer();
   std::shared_ptr<Buffer> indptr_data;

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -876,10 +876,9 @@ Status ReadSparseCOOIndex(const flatbuf::SparseTensor* sparse_tensor,
       {non_zero_length, static_cast<int64_t>(shape.size())});
   auto* indices_strides = sparse_index->indicesStrides();
   std::vector<int64_t> strides;
-  if (indices_strides->size() > 0) {
-    strides.push_back(indices_strides->Get(0));
-    strides.push_back(indices_strides->Get(1));
-  }
+  // Assume indices_strides is a 2-length array.
+  strides.push_back(indices_strides->Get(0));
+  strides.push_back(indices_strides->Get(1));
   *out = std::make_shared<SparseCOOIndex>(
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape, strides));
   return Status::OK();

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -374,6 +374,7 @@ SparseCOOIndex::SparseCOOIndex(const std::shared_ptr<Tensor>& coords)
     : SparseIndexBase(coords->shape()[0]), coords_(coords) {
   ARROW_CHECK(is_integer(coords_->type_id()));
   ARROW_CHECK(coords_->is_contiguous());
+  ARROW_CHECK_EQ(2, coords_->ndim());
 }
 
 std::string SparseCOOIndex::ToString() const { return std::string("SparseCOOIndex"); }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -316,10 +316,10 @@ void MakeSparseTensorFromTensor(const Tensor& tensor,
 // ----------------------------------------------------------------------
 // SparseCOOIndex
 
-// Constructor with a column-major NumericTensor
+// Constructor with a contiguous NumericTensor
 SparseCOOIndex::SparseCOOIndex(const std::shared_ptr<CoordsTensor>& coords)
     : SparseIndexBase(coords->shape()[0]), coords_(coords) {
-  ARROW_CHECK(coords_->is_column_major());
+  ARROW_CHECK(coords_->is_contiguous());
 }
 
 std::string SparseCOOIndex::ToString() const { return std::string("SparseCOOIndex"); }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -178,11 +178,8 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
   template <typename IndexValueType>
   Status Convert() {
     using c_index_value_type = typename IndexValueType::c_type;
+    RETURN_NOT_OK(CheckMaximumValue(std::numeric_limits<c_index_value_type>::max()));
     const int64_t indices_elsize = sizeof(c_index_value_type);
-    if (std::numeric_limits<c_index_value_type>::max() <
-        static_cast<size_t>(tensor_.shape()[1])) {
-      return Status::Invalid("The bit width of the index value type is too small");
-    }
 
     const int64_t ndim = tensor_.ndim();
     if (ndim > 2) {
@@ -260,6 +257,18 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
  private:
   using BaseClass::index_value_type_;
   using BaseClass::tensor_;
+
+  template <typename c_value_type>
+  inline Status CheckMaximumValue(const c_value_type type_max) const {
+    if (static_cast<int64_t>(type_max) < tensor_.shape()[1]) {
+      return Status::Invalid("The bit width of the index value type is too small");
+    }
+    return Status::OK();
+  }
+
+  inline Status CheckMaximumValue(const int64_t) const { return Status::OK(); }
+
+  inline Status CheckMaximumValue(const uint64_t) const { return Status::OK(); }
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -145,8 +145,10 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
   Status Convert() {
     switch (index_value_type_->id()) {
       ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(CALL_TYPE_SPECIFIC_CONVERT);
+      // LCOV_EXCL_START: The following invalid causes program failure.
       default:
         return Status::Invalid("Unsupported SparseTensor index value type");
+        // LCOV_EXCL_STOP
     }
   }
 
@@ -183,7 +185,9 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
 
     const int64_t ndim = tensor_.ndim();
     if (ndim > 2) {
+      // LCOV_EXCL_START: The following invalid causes program failure.
       return Status::Invalid("Invalid tensor dimension");
+      // LCOV_EXCL_STOP
     }
 
     const int64_t nr = tensor_.shape()[0];
@@ -244,8 +248,10 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
   Status Convert() {
     switch (index_value_type_->id()) {
       ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(CALL_TYPE_SPECIFIC_CONVERT);
+      // LCOV_EXCL_START: The following invalid causes program failure.
       default:
         return Status::Invalid("Unsupported SparseTensor index value type");
+        // LCOV_EXCL_STOP
     }
   }
 
@@ -261,7 +267,9 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
   template <typename c_value_type>
   inline Status CheckMaximumValue(const c_value_type type_max) const {
     if (static_cast<int64_t>(type_max) < tensor_.shape()[1]) {
+      // LCOV_EXCL_START: The following invalid causes program failure.
       return Status::Invalid("The bit width of the index value type is too small");
+      // LCOV_EXCL_STOP
     }
     return Status::OK();
   }
@@ -322,9 +330,11 @@ inline void MakeSparseTensorFromTensor(const Tensor& tensor,
                                        std::shared_ptr<Buffer>* data) {
   switch (tensor.type()->id()) {
     ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(MAKE_SPARSE_TENSOR_FROM_TENSOR);
+    // LCOV_EXCL_START: ignore program failure
     default:
       ARROW_LOG(FATAL) << "Unsupported Tensor value type";
       break;
+      // LCOV_EXCL_STOP
   }
 }
 
@@ -346,9 +356,11 @@ void MakeSparseTensorFromTensor(const Tensor& tensor,
       MakeSparseTensorFromTensor<SparseCSRIndex>(tensor, index_value_type, sparse_index,
                                                  data);
       break;
+    // LCOV_EXCL_START: ignore program failure
     default:
       ARROW_LOG(FATAL) << "Invalid sparse tensor format ID";
       break;
+      // LCOV_EXCL_STOP
   }
 }
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -18,6 +18,7 @@
 #include "arrow/sparse_tensor.h"
 
 #include <functional>
+#include <limits>
 #include <memory>
 #include <numeric>
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -23,24 +23,9 @@
 
 #include "arrow/compare.h"
 #include "arrow/util/logging.h"
+#include "arrow/visitor_inline.h"
 
 namespace arrow {
-
-#define ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(ACTION) \
-  ACTION(Int8);                                      \
-  ACTION(UInt8);                                     \
-  ACTION(Int16);                                     \
-  ACTION(UInt16);                                    \
-  ACTION(Int32);                                     \
-  ACTION(UInt32);                                    \
-  ACTION(Int64);                                     \
-  ACTION(UInt64)
-
-#define ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(ACTION) \
-  ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(ACTION);      \
-  ACTION(HalfFloat);                                 \
-  ACTION(Float);                                     \
-  ACTION(Double)
 
 namespace {
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -93,7 +93,7 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
       const int64_t count = ndim == 0 ? 1 : tensor_.shape()[0];
       for (int64_t i = 0; i < count; ++i, ++data) {
         if (*data != 0) {
-          *indices++ = i;
+          *indices++ = static_cast<c_index_value_type>(i);
           *values++ = *data;
         }
       }

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -118,19 +118,17 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
 /// as the number of non-zero-values.
 class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIndex> {
  public:
-  using IndexTensor = NumericTensor<Int64Type>;
-
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
 
   // Constructor with two index vectors
-  explicit SparseCSRIndex(const std::shared_ptr<IndexTensor>& indptr,
-                          const std::shared_ptr<IndexTensor>& indices);
+  explicit SparseCSRIndex(const std::shared_ptr<Tensor>& indptr,
+                          const std::shared_ptr<Tensor>& indices);
 
   /// \brief Return a 1D tensor of indptr vector
-  const std::shared_ptr<IndexTensor>& indptr() const { return indptr_; }
+  const std::shared_ptr<Tensor>& indptr() const { return indptr_; }
 
   /// \brief Return a 1D tensor of indices vector
-  const std::shared_ptr<IndexTensor>& indices() const { return indices_; }
+  const std::shared_ptr<Tensor>& indices() const { return indices_; }
 
   /// \brief Return a string representation of the sparse index
   std::string ToString() const override;
@@ -141,8 +139,8 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   }
 
  protected:
-  std::shared_ptr<IndexTensor> indptr_;
-  std::shared_ptr<IndexTensor> indices_;
+  std::shared_ptr<Tensor> indptr_;
+  std::shared_ptr<Tensor> indices_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -81,15 +81,13 @@ class SparseIndexBase : public SparseIndex {
 /// coordinates.
 class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIndex> {
  public:
-  using CoordsTensor = NumericTensor<Int64Type>;
-
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::COO;
 
   // Constructor with a column-major NumericTensor
-  explicit SparseCOOIndex(const std::shared_ptr<CoordsTensor>& coords);
+  explicit SparseCOOIndex(const std::shared_ptr<Tensor>& coords);
 
   /// \brief Return a tensor that has the coordinates of the non-zero values
-  const std::shared_ptr<CoordsTensor>& indices() const { return coords_; }
+  const std::shared_ptr<Tensor>& indices() const { return coords_; }
 
   /// \brief Return a string representation of the sparse index
   std::string ToString() const override;
@@ -100,7 +98,7 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   }
 
  protected:
-  std::shared_ptr<CoordsTensor> coords_;
+  std::shared_ptr<Tensor> coords_;
 };
 
 // ----------------------------------------------------------------------
@@ -222,6 +220,7 @@ namespace internal {
 ARROW_EXPORT
 void MakeSparseTensorFromTensor(const Tensor& tensor,
                                 SparseTensorFormat::type sparse_format_id,
+                                const std::shared_ptr<DataType>& index_value_type,
                                 std::shared_ptr<SparseIndex>* sparse_index,
                                 std::shared_ptr<Buffer>* data);
 
@@ -248,12 +247,15 @@ class SparseTensorImpl : public SparseTensor {
       : SparseTensorImpl(NULLPTR, type, NULLPTR, shape, dim_names) {}
 
   // Constructor with a dense tensor
-  explicit SparseTensorImpl(const Tensor& tensor)
+  SparseTensorImpl(const Tensor& tensor,
+                   const std::shared_ptr<DataType>& index_value_type)
       : SparseTensorImpl(NULLPTR, tensor.type(), NULLPTR, tensor.shape(),
                          tensor.dim_names_) {
     internal::MakeSparseTensorFromTensor(tensor, SparseIndexType::format_id,
-                                         &sparse_index_, &data_);
+                                         index_value_type, &sparse_index_, &data_);
   }
+
+  explicit SparseTensorImpl(const Tensor& tensor) : SparseTensorImpl(tensor, int64()) {}
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(SparseTensorImpl);

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -216,7 +216,7 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, CreationWithRowMajorIndex) {
   std::vector<c_index_value_type> coords_values = {0, 0, 0, 0, 0, 2, 0, 1, 1, 0, 1, 3,
                                                    0, 2, 0, 0, 2, 2, 1, 0, 1, 1, 0, 3,
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
-  const size_t sizeof_index_value = sizeof(c_index_value_type);
+  const int sizeof_index_value = sizeof(c_index_value_type);
   auto si = this->MakeSparseCOOIndex(
       {12, 3}, {sizeof_index_value * 3, sizeof_index_value}, coords_values);
 
@@ -243,7 +243,7 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, CreationWithColumnMajorIndex)
   std::vector<c_index_value_type> coords_values = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
                                                    0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2,
                                                    0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
-  const size_t sizeof_index_value = sizeof(c_index_value_type);
+  const int sizeof_index_value = sizeof(c_index_value_type);
   auto si = this->MakeSparseCOOIndex(
       {12, 3}, {sizeof_index_value, sizeof_index_value * 12}, coords_values);
 
@@ -271,7 +271,7 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType,
 
   // Row-major COO index
   const std::vector<int64_t> coords_shape = {12, 3};
-  const size_t sizeof_index_value = sizeof(c_index_value_type);
+  const int sizeof_index_value = sizeof(c_index_value_type);
   std::vector<c_index_value_type> coords_values_row_major = {
       0, 0, 0, 0, 0, 2, 0, 1, 1, 0, 1, 3, 0, 2, 0, 0, 2, 2,
       1, 0, 1, 1, 0, 3, 1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -277,6 +277,11 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, CreationWithRowMajorIndex) {
   std::vector<int64_t> sparse_values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
   auto st = this->MakeSparseTensor(si, sparse_values);
 
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st->dim_names());
+  ASSERT_EQ("foo", st->dim_name(0));
+  ASSERT_EQ("bar", st->dim_name(1));
+  ASSERT_EQ("baz", st->dim_name(2));
+
   ASSERT_TRUE(st->Equals(*this->sparse_tensor_from_dense_));
 }
 
@@ -299,6 +304,11 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, CreationWithColumnMajorIndex)
 
   std::vector<int64_t> sparse_values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
   auto st = this->MakeSparseTensor(si, sparse_values);
+
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st->dim_names());
+  ASSERT_EQ("foo", st->dim_name(0));
+  ASSERT_EQ("bar", st->dim_name(1));
+  ASSERT_EQ("baz", st->dim_name(2));
 
   ASSERT_TRUE(st->Equals(*this->sparse_tensor_from_dense_));
 }

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -111,7 +111,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor) {
   ASSERT_EQ(12, st.non_zero_length());
   ASSERT_TRUE(st.is_mutable());
 
-  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
+  auto* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
   const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st.sparse_index());
@@ -126,6 +126,31 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor) {
   AssertCOOIndex(sidx, 2, {0, 1, 1});
   AssertCOOIndex(sidx, 10, {1, 2, 1});
   AssertCOOIndex(sidx, 11, {1, 2, 3});
+}
+
+TEST_F(TestSparseCOOTensor, CreationFromNumericTensor1D) {
+  std::vector<int64_t> dense_values = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
+                                       0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
+  auto dense_data = Buffer::Wrap(dense_values);
+  std::vector<int64_t> dense_shape({static_cast<int64_t>(dense_values.size())});
+  NumericTensor<Int64Type> dense_vector(dense_data, dense_shape);
+  SparseTensorImpl<SparseCOOIndex> st(dense_vector);
+
+  ASSERT_EQ(12, st.non_zero_length());
+  ASSERT_TRUE(st.is_mutable());
+
+  auto* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
+  AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
+
+  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st.sparse_index());
+  auto sidx = si.indices();
+  ASSERT_EQ(std::vector<int64_t>({12, 1}), sidx->shape());
+
+  AssertCOOIndex(sidx, 0, {0});
+  AssertCOOIndex(sidx, 1, {2});
+  AssertCOOIndex(sidx, 2, {5});
+  AssertCOOIndex(sidx, 10, {21});
+  AssertCOOIndex(sidx, 11, {23});
 }
 
 TEST_F(TestSparseCOOTensor, CreationFromTensor) {

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -83,12 +83,9 @@ class TestSparseCOOTensorBase : public ::testing::Test {
 
 class TestSparseCOOTensor : public TestSparseCOOTensorBase<Int64Type> {};
 
-TEST(TestSparseCOOTensor, CreationEmptyTensor) {
-  std::vector<int64_t> shape = {2, 3, 4};
-  SparseTensorImpl<SparseCOOIndex> st1(int64(), shape);
-
-  std::vector<std::string> dim_names = {"foo", "bar", "baz"};
-  SparseTensorImpl<SparseCOOIndex> st2(int64(), shape, dim_names);
+TEST_F(TestSparseCOOTensor, CreationEmptyTensor) {
+  SparseTensorImpl<SparseCOOIndex> st1(int64(), this->shape_);
+  SparseTensorImpl<SparseCOOIndex> st2(int64(), this->shape_, this->dim_names_);
 
   ASSERT_EQ(0, st1.non_zero_length());
   ASSERT_EQ(0, st2.non_zero_length());
@@ -107,36 +104,17 @@ TEST(TestSparseCOOTensor, CreationEmptyTensor) {
   ASSERT_EQ("", st1.dim_name(2));
 }
 
-TEST(TestSparseCOOTensor, CreationFromNumericTensor) {
-  std::vector<int64_t> shape = {2, 3, 4};
-  std::vector<int64_t> values = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
-                                 0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
-  std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
-  std::vector<std::string> dim_names = {"foo", "bar", "baz"};
-  NumericTensor<Int64Type> tensor1(buffer, shape);
-  NumericTensor<Int64Type> tensor2(buffer, shape, {}, dim_names);
-  SparseTensorImpl<SparseCOOIndex> st1(tensor1);
-  SparseTensorImpl<SparseCOOIndex> st2(tensor2);
+TEST_F(TestSparseCOOTensor, CreationFromNumericTensor) {
+  auto& st = *this->sparse_tensor_from_dense_;
+  CheckSparseIndexFormatType(SparseTensorFormat::COO, st);
 
-  CheckSparseIndexFormatType(SparseTensorFormat::COO, st1);
+  ASSERT_EQ(12, st.non_zero_length());
+  ASSERT_TRUE(st.is_mutable());
 
-  ASSERT_EQ(12, st1.non_zero_length());
-  ASSERT_TRUE(st1.is_mutable());
-
-  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st2.dim_names());
-  ASSERT_EQ("foo", st2.dim_name(0));
-  ASSERT_EQ("bar", st2.dim_name(1));
-  ASSERT_EQ("baz", st2.dim_name(2));
-
-  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
-  ASSERT_EQ("", st1.dim_name(0));
-  ASSERT_EQ("", st1.dim_name(1));
-  ASSERT_EQ("", st1.dim_name(2));
-
-  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st1.raw_data());
+  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st1.sparse_index());
+  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st.sparse_index());
   ASSERT_EQ(std::string("SparseCOOIndex"), si.ToString());
 
   std::shared_ptr<Tensor> sidx = si.indices();
@@ -150,90 +128,53 @@ TEST(TestSparseCOOTensor, CreationFromNumericTensor) {
   AssertCOOIndex(sidx, 11, {1, 2, 3});
 }
 
-TEST(TestSparseCOOTensor, CreationFromTensor) {
-  std::vector<int64_t> shape = {2, 3, 4};
+TEST_F(TestSparseCOOTensor, CreationFromTensor) {
   std::vector<int64_t> values = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
                                  0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
-  std::vector<std::string> dim_names = {"foo", "bar", "baz"};
-  Tensor tensor1(int64(), buffer, shape);
-  Tensor tensor2(int64(), buffer, shape, {}, dim_names);
-  SparseTensorImpl<SparseCOOIndex> st1(tensor1);
-  SparseTensorImpl<SparseCOOIndex> st2(tensor2);
-
-  ASSERT_EQ(12, st1.non_zero_length());
-  ASSERT_TRUE(st1.is_mutable());
-
-  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st2.dim_names());
-  ASSERT_EQ("foo", st2.dim_name(0));
-  ASSERT_EQ("bar", st2.dim_name(1));
-  ASSERT_EQ("baz", st2.dim_name(2));
-
-  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
-  ASSERT_EQ("", st1.dim_name(0));
-  ASSERT_EQ("", st1.dim_name(1));
-  ASSERT_EQ("", st1.dim_name(2));
-
-  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st1.raw_data());
-  AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
-
-  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st1.sparse_index());
-  std::shared_ptr<Tensor> sidx = si.indices();
-  ASSERT_EQ(std::vector<int64_t>({12, 3}), sidx->shape());
-  ASSERT_TRUE(sidx->is_column_major());
-
-  AssertCOOIndex(sidx, 0, {0, 0, 0});
-  AssertCOOIndex(sidx, 1, {0, 0, 2});
-  AssertCOOIndex(sidx, 2, {0, 1, 1});
-  AssertCOOIndex(sidx, 10, {1, 2, 1});
-  AssertCOOIndex(sidx, 11, {1, 2, 3});
-}
-
-TEST(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
-  std::vector<int64_t> shape = {2, 3, 4};
-  std::vector<int64_t> values = {1,  0, 0, 0, 2,  0, 0, 0, 0, 0, 3,  0, 0, 0, 4,  0,
-                                 5,  0, 0, 0, 6,  0, 0, 0, 0, 0, 11, 0, 0, 0, 12, 0,
-                                 13, 0, 0, 0, 14, 0, 0, 0, 0, 0, 15, 0, 0, 0, 16, 0};
-  std::vector<int64_t> strides = {192, 64, 16};
-  std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
-  Tensor tensor(int64(), buffer, shape, strides);
+  Tensor tensor(int64(), buffer, this->shape_, {}, this->dim_names_);
   SparseTensorImpl<SparseCOOIndex> st(tensor);
 
   ASSERT_EQ(12, st.non_zero_length());
   ASSERT_TRUE(st.is_mutable());
 
-  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
-  AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st.dim_names());
+  ASSERT_EQ("foo", st.dim_name(0));
+  ASSERT_EQ("bar", st.dim_name(1));
+  ASSERT_EQ("baz", st.dim_name(2));
 
-  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st.sparse_index());
-  std::shared_ptr<Tensor> sidx = si.indices();
-  ASSERT_EQ(std::vector<int64_t>({12, 3}), sidx->shape());
-  ASSERT_TRUE(sidx->is_column_major());
-
-  AssertCOOIndex(sidx, 0, {0, 0, 0});
-  AssertCOOIndex(sidx, 1, {0, 0, 2});
-  AssertCOOIndex(sidx, 2, {0, 1, 1});
-  AssertCOOIndex(sidx, 10, {1, 2, 1});
-  AssertCOOIndex(sidx, 11, {1, 2, 3});
+  ASSERT_TRUE(st.Equals(*this->sparse_tensor_from_dense_));
 }
 
-TEST(TestSparseCOOTensor, TensorEquality) {
-  std::vector<int64_t> shape = {2, 3, 4};
+TEST_F(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
+  std::vector<int64_t> values = {1,  0, 0, 0, 2,  0, 0, 0, 0, 0, 3,  0, 0, 0, 4,  0,
+                                 5,  0, 0, 0, 6,  0, 0, 0, 0, 0, 11, 0, 0, 0, 12, 0,
+                                 13, 0, 0, 0, 14, 0, 0, 0, 0, 0, 15, 0, 0, 0, 16, 0};
+  std::vector<int64_t> strides = {192, 64, 16};
+  std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
+  Tensor tensor(int64(), buffer, this->shape_, strides);
+  SparseTensorImpl<SparseCOOIndex> st(tensor);
+
+  ASSERT_EQ(12, st.non_zero_length());
+  ASSERT_TRUE(st.is_mutable());
+
+  ASSERT_TRUE(st.Equals(*this->sparse_tensor_from_dense_));
+}
+
+TEST_F(TestSparseCOOTensor, TensorEquality) {
   std::vector<int64_t> values1 = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
                                   0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
   std::vector<int64_t> values2 = {0, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
                                   0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
   std::shared_ptr<Buffer> buffer1 = Buffer::Wrap(values1);
   std::shared_ptr<Buffer> buffer2 = Buffer::Wrap(values2);
-  NumericTensor<Int64Type> tensor1(buffer1, shape);
-  NumericTensor<Int64Type> tensor2(buffer1, shape);
-  NumericTensor<Int64Type> tensor3(buffer2, shape);
+  NumericTensor<Int64Type> tensor1(buffer1, this->shape_);
+  NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
   SparseTensorImpl<SparseCOOIndex> st1(tensor1);
   SparseTensorImpl<SparseCOOIndex> st2(tensor2);
-  SparseTensorImpl<SparseCOOIndex> st3(tensor3);
 
-  ASSERT_TRUE(st1.Equals(st2));
-  ASSERT_TRUE(!st1.Equals(st3));
+  ASSERT_TRUE(st1.Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_FALSE(st1.Equals(st2));
 }
 
 template <typename IndexValueType>

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -31,39 +31,45 @@
 
 namespace arrow {
 
-#define ARROW_GENERATE_FOR_ALL_TYPES(ACTION) \
-  ACTION(Null);                              \
-  ACTION(Boolean);                           \
-  ACTION(Int8);                              \
-  ACTION(UInt8);                             \
-  ACTION(Int16);                             \
-  ACTION(UInt16);                            \
-  ACTION(Int32);                             \
-  ACTION(UInt32);                            \
-  ACTION(Int64);                             \
-  ACTION(UInt64);                            \
-  ACTION(HalfFloat);                         \
-  ACTION(Float);                             \
-  ACTION(Double);                            \
-  ACTION(String);                            \
-  ACTION(Binary);                            \
-  ACTION(LargeString);                       \
-  ACTION(LargeBinary);                       \
-  ACTION(FixedSizeBinary);                   \
-  ACTION(Duration);                          \
-  ACTION(Date32);                            \
-  ACTION(Date64);                            \
-  ACTION(Timestamp);                         \
-  ACTION(Time32);                            \
-  ACTION(Time64);                            \
-  ACTION(Decimal128);                        \
-  ACTION(List);                              \
-  ACTION(LargeList);                         \
-  ACTION(Map);                               \
-  ACTION(FixedSizeList);                     \
-  ACTION(Struct);                            \
-  ACTION(Union);                             \
-  ACTION(Dictionary);                        \
+#define ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(ACTION) \
+  ACTION(Int8);                                      \
+  ACTION(UInt8);                                     \
+  ACTION(Int16);                                     \
+  ACTION(UInt16);                                    \
+  ACTION(Int32);                                     \
+  ACTION(UInt32);                                    \
+  ACTION(Int64);                                     \
+  ACTION(UInt64)
+
+#define ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(ACTION) \
+  ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(ACTION);      \
+  ACTION(HalfFloat);                                 \
+  ACTION(Float);                                     \
+  ACTION(Double)
+
+#define ARROW_GENERATE_FOR_ALL_TYPES(ACTION)    \
+  ACTION(Null);                                 \
+  ACTION(Boolean);                              \
+  ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(ACTION); \
+  ACTION(String);                               \
+  ACTION(Binary);                               \
+  ACTION(LargeString);                          \
+  ACTION(LargeBinary);                          \
+  ACTION(FixedSizeBinary);                      \
+  ACTION(Duration);                             \
+  ACTION(Date32);                               \
+  ACTION(Date64);                               \
+  ACTION(Timestamp);                            \
+  ACTION(Time32);                               \
+  ACTION(Time64);                               \
+  ACTION(Decimal128);                           \
+  ACTION(List);                                 \
+  ACTION(LargeList);                            \
+  ACTION(Map);                                  \
+  ACTION(FixedSizeList);                        \
+  ACTION(Struct);                               \
+  ACTION(Union);                                \
+  ACTION(Dictionary);                           \
   ACTION(Extension)
 
 #define TYPE_VISIT_INLINE(TYPE_CLASS) \

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -25,34 +25,39 @@ namespace org.apache.arrow.flatbuf;
 /// ----------------------------------------------------------------------
 /// EXPERIMENTAL: Data structures for sparse tensors
 
-/// Coodinate format of sparse tensor index.
+/// Coodinate (COO) format of sparse tensor index.
+///
+/// COO's index list are represented as a NxM matrix,
+/// where N is the number of non-zero values,
+/// and M is the number of dimensions of a sparse tensor.
+///
+/// indicesBuffer stores the location and size of the data of this indices
+/// matrix.  The value type and the stride of the indices matrix is
+/// specified in indicesType and indicesStrides fields.
+///
+/// For example, let X be a 2x3x4x5 tensor, and it has the following
+/// 6 non-zero values:
+///
+///   X[0, 1, 2, 0] := 1
+///   X[1, 1, 2, 3] := 2
+///   X[0, 2, 1, 0] := 3
+///   X[0, 1, 3, 0] := 4
+///   X[0, 1, 2, 1] := 5
+///   X[1, 2, 0, 4] := 6
+///
+/// In COO format, the index matrix of X is the following 4x6 matrix:
+///
+///   [[0, 0, 0, 0, 1, 1],
+///    [1, 1, 1, 2, 1, 2],
+///    [2, 2, 3, 1, 2, 0],
+///    [0, 1, 0, 0, 3, 4]]
+///
+/// Note that the indices are sorted in lexicographical order.
 table SparseTensorIndexCOO {
-  /// The type of values in indicesBuffer.
+  /// The type of values in indicesBuffer
   indicesType: Int;
 
-  /// COO's index list are represented as a NxM matrix,
-  /// where N is the number of non-zero values,
-  /// and M is the number of dimensions of a sparse tensor.
-  /// indicesBuffer stores the location and size of this index matrix.
-  /// The type of index value is long, so the stride for the index matrix is unnecessary.
-  ///
-  /// For example, let X be a 2x3x4x5 tensor, and it has the following 6 non-zero values:
-  ///
-  ///   X[0, 1, 2, 0] := 1
-  ///   X[1, 1, 2, 3] := 2
-  ///   X[0, 2, 1, 0] := 3
-  ///   X[0, 1, 3, 0] := 4
-  ///   X[0, 1, 2, 1] := 5
-  ///   X[1, 2, 0, 4] := 6
-  ///
-  /// In COO format, the index matrix of X is the following 4x6 matrix:
-  ///
-  ///   [[0, 0, 0, 0, 1, 1],
-  ///    [1, 1, 1, 2, 1, 2],
-  ///    [2, 2, 3, 1, 2, 0],
-  ///    [0, 1, 0, 0, 3, 4]]
-  ///
-  /// Note that the indices are sorted in lexicographical order.
+  /// The location and size of the indices matrix's data
   indicesBuffer: Buffer;
 }
 

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -57,6 +57,9 @@ table SparseTensorIndexCOO {
   /// The type of values in indicesBuffer
   indicesType: Int;
 
+  /// Non-negative byte offsets to advance one value cell along each dimension
+  indicesStrides: [long];
+
   /// The location and size of the indices matrix's data
   indicesBuffer: Buffer;
 }

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -27,6 +27,9 @@ namespace org.apache.arrow.flatbuf;
 
 /// Coodinate format of sparse tensor index.
 table SparseTensorIndexCOO {
+  /// The type of values in indicesBuffer.
+  indicesType: Int;
+
   /// COO's index list are represented as a NxM matrix,
   /// where N is the number of non-zero values,
   /// and M is the number of dimensions of a sparse tensor.
@@ -55,6 +58,9 @@ table SparseTensorIndexCOO {
 
 /// Compressed Sparse Row format, that is matrix-specific.
 table SparseMatrixIndexCSR {
+  /// The type of values in indptrBuffer
+  indptrType: Int;
+
   /// indptrBuffer stores the location and size of indptr array that
   /// represents the range of the rows.
   /// The i-th row spans from indptr[i] to indptr[i+1] in the data.
@@ -78,6 +84,9 @@ table SparseMatrixIndexCSR {
   ///
   ///   indptr(X) = [0, 2, 3, 5, 5, 8, 10].
   indptrBuffer: Buffer;
+
+  /// The type of values in indciesBuffer
+  indicesType: Int;
 
   /// indicesBuffer stores the location and size of the array that
   /// contains the column indices of the corresponding non-zero values.

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -93,7 +93,7 @@ table SparseMatrixIndexCSR {
   ///   indptr(X) = [0, 2, 3, 5, 5, 8, 10].
   indptrBuffer: Buffer;
 
-  /// The type of values in indciesBuffer
+  /// The type of values in indicesBuffer
   indicesType: Int;
 
   /// indicesBuffer stores the location and size of the array that


### PR DESCRIPTION
I'd like to enable all integer types to become the value type of sparse tensor index.