### PR TITLE
ARROW-6465: [Python] Improvement to Windows build instructions

### DIFF
--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -422,8 +422,8 @@ For Build Tools for Visual Studio 2017 and Visual Studio 2017:
 .. code-block:: shell
 
    mkdir arrow\cpp\build
-   pushd arrow\cpp\build
    set ARROW_HOME=%cd%\arrow-dist
+   pushd arrow\cpp\build
    cmake -G "Visual Studio 15 2017 Win64" ^
        -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
        -DARROW_CXXFLAGS="/WX /MP" ^

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -379,14 +379,10 @@ debugging a C++ unitttest, for example:
 Building on Windows
 ===================
 
-.. warning::
-   Building on Windows is currently broken. The issue is being worked on
-   under the `Github PR #5247 <https://github.com/apache/arrow/pull/5247>`_.
-    
 Building on Windows requires one of the following compilers to be installed:
 
 - `Build Tools for Visual Studio 2017 <https://download.visualstudio.microsoft.com/download/pr/3e542575-929e-4297-b6c6-bef34d0ee648/639c868e1219c651793aff537a1d3b77/vs_buildtools.exe>`_
-- `Microsoft Build Tools 2015 <http://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe>`_, or
+- `Microsoft Build Tools 2015 <http://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe>`_
 - Visual Studio 2015
 - Visual Studio 2017
 
@@ -414,17 +410,33 @@ First, starting from fresh clones of Apache Arrow:
 
 Now, we build and install Arrow C++ libraries.
 
-The CMake parameters need to be adjusted according to the Build Tools or Visual
-Studio version installed.
+We set a number of environment variables:
 
-For Build Tools for Visual Studio 2017 and Visual Studio 2017:
+- the path of the installation directory of the Arrow C++ library as arrow
+  ``ARROW_HOME``
+- add the path of its built .dll-libraris to ``PATH``
+- and choose the compiler to be used
+
+.. code-block:: shell
+
+   set ARROW_HOME=%cd%\arrow-dist
+   set PATH=%ARROW_HOME%\bin;%PATH%
+   set PYARROW_CMAKE_GENERATOR=Visual Studio 15 2017 Win64
+
+This assumes Visual Studio 2017 or its build tools are used. For Visual Studio
+2015 and its build tools use the following instead:
+
+.. code-block:: shell
+
+   set PYARROW_CMAKE_GENERATOR=Visual Studio 14 2015 Win64
+
+Let's configure, build and install the Arrow C++ libraries:
 
 .. code-block:: shell
 
    mkdir arrow\cpp\build
-   set ARROW_HOME=%cd%\arrow-dist
    pushd arrow\cpp\build
-   cmake -G "Visual Studio 15 2017 Win64" ^
+   cmake -G "%PYARROW_CMAKE_GENERATOR%" ^
        -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
        -DARROW_CXXFLAGS="/WX /MP" ^
        -DARROW_GANDIVA=on ^
@@ -433,15 +445,6 @@ For Build Tools for Visual Studio 2017 and Visual Studio 2017:
        ..
    cmake --build . --target INSTALL --config Release
    popd
-
-For Microsoft Build Tools 2015 and Visual Studio 2015, replace the string after
-``cmake -G`` with ``"Visual Studio 14 2015 Win64"``.
-
-After that, we must put the install directory's bin path in our ``%PATH%``:
-
-.. code-block:: shell
-
-   set PATH=%ARROW_HOME%\bin;%PATH%
 
 Now, we can build pyarrow:
 
@@ -453,6 +456,11 @@ Now, we can build pyarrow:
    python setup.py build_ext --inplace
    popd
 
+.. note::
+
+   For building pyarrow, the above defined environment variables need to also
+   be set. Remember this if to want to re-build ``pyarrow`` after your initial build.
+
 Then run the unit tests with:
 
 .. code-block:: shell
@@ -461,17 +469,64 @@ Then run the unit tests with:
    py.test pyarrow -v
    popd
 
+.. note::
+
+   With the above instructions the Arrow C++ libraries are not bundled with
+   the python extension. This is recommended for development as it allows the
+   C++ libraries to be re-built separately.
+
+   As a consequence however, ``python setup.py install`` will also not install
+   the Arrow C++ libraries. Therefore, to use ``pyarrow`` in python, ``PATH`` 
+   must contain the directory with the Arrow .dll-files.
+
+   If you want to bundle the Arrow C++ libraries with ``pyarrow`` add 
+   ``--bundle-arrow-cpp`` as build parameter:
+
+   ``python setup.py build_ext --inplace --bundle_arrow_cpp``
+
 Running C++ unit tests for Python integration
 ---------------------------------------------
 
-Getting ``python-test.exe`` to run is a bit tricky because your
-``%PYTHONHOME%`` must be configured to point to the active conda environment:
+Running C++ unit tests should not be necessary for most developers. If you do
+want to run them, you need to pass ``-DARROW_BUILD_TESTS=ON`` during 
+configuration of the Arrow C++ library build:
+
+.. code-block:: shell
+
+   pushd arrow\cpp\build
+   cmake -G "%PYARROW_CMAKE_GENERATOR%" ^
+       -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
+       -DARROW_CXXFLAGS="/WX /MP" ^
+       -DARROW_GANDIVA=on ^
+       -DARROW_PARQUET=on ^
+       -DARROW_PYTHON=on ^
+       -DARROW_BUILD_TESTS=ON ^
+       ..
+   cmake --build . --target INSTALL --config Release
+   popd
+
+
+Getting ``arrow-python-test.exe`` (C++ unit tests for python integration) to
+run is a bit tricky because your ``%PYTHONHOME%`` must be configured to point
+to the active conda environment:
 
 .. code-block:: shell
 
    set PYTHONHOME=%CONDA_PREFIX%
+   pushd arrow\cpp\build\release\Release
+   arrow-python-test.exe
+   popd
 
-Now ``python-test.exe`` or simply ``ctest`` (to run all tests) should work.
+To run all tests of the Arrow C++ library, you can also run ``ctest``:
+
+.. code-block:: shell
+
+   set PYTHONHOME=%CONDA_PREFIX%
+   pushd arrow\cpp\build
+   ctest
+   popd
+
+
 
 Windows Caveats
 ---------------

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -412,9 +412,9 @@ Now, we build and install Arrow C++ libraries.
 
 We set a number of environment variables:
 
-- the path of the installation directory of the Arrow C++ library as arrow
+- the path of the installation directory of the Arrow C++ libraries as
   ``ARROW_HOME``
-- add the path of its built .dll-libraris to ``PATH``
+- add the path of installed DLL libraries to ``PATH``
 - and choose the compiler to be used
 
 .. code-block:: shell
@@ -472,27 +472,35 @@ Then run the unit tests with:
 .. note::
 
    With the above instructions the Arrow C++ libraries are not bundled with
-   the python extension. This is recommended for development as it allows the
+   the Python extension. This is recommended for development as it allows the
    C++ libraries to be re-built separately.
 
    As a consequence however, ``python setup.py install`` will also not install
-   the Arrow C++ libraries. Therefore, to use ``pyarrow`` in python, ``PATH`` 
+   the Arrow C++ libraries. Therefore, to use ``pyarrow`` in python, ``PATH``
    must contain the directory with the Arrow .dll-files.
 
-   If you want to bundle the Arrow C++ libraries with ``pyarrow`` add 
+   If you want to bundle the Arrow C++ libraries with ``pyarrow`` add
    ``--bundle-arrow-cpp`` as build parameter:
 
-   ``python setup.py build_ext --inplace --bundle-arrow-cpp``
+   ``python setup.py build_ext --bundle-arrow-cpp``
+
+   Important: If you combine ``--bundle-arrow-cpp`` with ``--inplace`` the
+   Arrow C++ libraries get copied to the python source tree and are not cleared
+   by ``python setup.py clean``. They remain in place and will take precedence
+   over any later Arrow C++ libraries contained in ``PATH``. This can lead to
+   incompatibilities when ``pyarrow`` is later built without
+   ``--bundle-arrow-cpp``.
 
 Running C++ unit tests for Python integration
 ---------------------------------------------
 
 Running C++ unit tests should not be necessary for most developers. If you do
-want to run them, you need to pass ``-DARROW_BUILD_TESTS=ON`` during 
+want to run them, you need to pass ``-DARROW_BUILD_TESTS=ON`` during
 configuration of the Arrow C++ library build:
 
 .. code-block:: shell
 
+   mkdir arrow\cpp\build
    pushd arrow\cpp\build
    cmake -G "%PYARROW_CMAKE_GENERATOR%" ^
        -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -482,7 +482,7 @@ Then run the unit tests with:
    If you want to bundle the Arrow C++ libraries with ``pyarrow`` add 
    ``--bundle-arrow-cpp`` as build parameter:
 
-   ``python setup.py build_ext --inplace --bundle_arrow_cpp``
+   ``python setup.py build_ext --inplace --bundle-arrow-cpp``
 
 Running C++ unit tests for Python integration
 ---------------------------------------------

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -380,21 +380,19 @@ Building on Windows
 ===================
 
 .. warning::
-    Building on Windows is currently broken. The issue is being worked on
-    under the `Github PR #5247<https://github.com/apache/arrow/pull/5247>`.
+   Building on Windows is currently broken. The issue is being worked on
+   under the `Github PR #5247 <https://github.com/apache/arrow/pull/5247>`_.
     
-Building on Windows requires one of the following
+Building on Windows requires one of the following compilers to be installed:
 
-- `Build Tools for Visual Studio 2017<https://download.visualstudio.microsoft.com/download/pr/3e542575-929e-4297-b6c6-bef34d0ee648/639c868e1219c651793aff537a1d3b77/vs_buildtools.exe`_
-- `Microsoft Build Tools 2015<http://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe`_, or
+- `Build Tools for Visual Studio 2017 <https://download.visualstudio.microsoft.com/download/pr/3e542575-929e-4297-b6c6-bef34d0ee648/639c868e1219c651793aff537a1d3b77/vs_buildtools.exe>`_
+- `Microsoft Build Tools 2015 <http://download.microsoft.com/download/5/F/7/5F7ACAEB-8363-451F-9425-68A90F98B238/visualcppbuildtools_full.exe>`_, or
 - Visual Studio 2015
 - Visual Studio 2017
 
-to be installed.
-
 During the setup of Build Tools ensure at least one Windows SDK is selected.
 
-Visual Studio 2019 and it's build tools are currently not supported.
+Visual Studio 2019 and its build tools are currently not supported.
 
 We bootstrap a conda environment similar to above, but skipping some of the
 Linux/macOS-only packages:
@@ -416,8 +414,8 @@ First, starting from fresh clones of Apache Arrow:
 
 Now, we build and install Arrow C++ libraries.
 
-The CMake parameters will need to be adjusted according to the Build Tools or 
-Visual Studio version installed.
+The CMake parameters need to be adjusted according to the Build Tools or Visual
+Studio version installed.
 
 For Build Tools for Visual Studio 2017 and Visual Studio 2017:
 
@@ -437,7 +435,7 @@ For Build Tools for Visual Studio 2017 and Visual Studio 2017:
    popd
 
 For Microsoft Build Tools 2015 and Visual Studio 2015, replace the string after
-`cmake -G` with `"Visual Studio 14 2015 Win64"`
+``cmake -G`` with ``"Visual Studio 14 2015 Win64"``.
 
 After that, we must put the install directory's bin path in our ``%PATH%``:
 


### PR DESCRIPTION
The current instructions for building the pyarrow python extension are incomplete.

Problems include:

 - missing re2, llvm, clang prerequisites
 - missing info on which MSVC toolsets are supported
 - missing info on how the build commands to different MSVC toolsets

This amends the python developer documentation with above.