### PR TITLE
ARROW-6433: [Java][CI] Fix java docker image

### DIFF
--- a/ci/docker_build_java.sh
+++ b/ci/docker_build_java.sh
@@ -29,7 +29,7 @@ arrow_src=/build/java/arrow
 rm -rf $arrow_src
 
 pushd /arrow
-rsync -a header java format integration $arrow_src
+rsync -a header java format integration testing $arrow_src
 popd
 
 JAVA_ARGS=
@@ -37,7 +37,7 @@ if [ "$ARROW_JAVA_RUN_TESTS" != "1" ]; then
   JAVA_ARGS=-DskipTests
 fi
 
-if [ "$ARROW_JAVA_SHADE_FLATBUFS" == "1"]; then
+if [ "$ARROW_JAVA_SHADE_FLATBUFS" == "1" ]; then
   export SHADE_FLATBUFFERS = " -Pshade-flatbuffers"
 fi
 

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -51,6 +51,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
- The analyze plugin would fail in the `install` target but not in `test` because one of the test in vector/ uses netty-buffer. This is fixed by adding a test dependency in pom.xml
- The testing/data certificates were not found due to relative path that points to out-of-source. This is fixed by adding `testing` to the list of rsync-ed directory.
- The docker build script was never respecting ARROW_JAVA_SHADE_FLATBUFS.