### PR TITLE
ARROW-6475: [C++] Don't try to dictionary encode dictionary arrays

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1951,6 +1951,10 @@ Status ConvertTableToPandas(const PandasOptions& options,
     for (int i = 0; i < table->num_columns(); i++) {
       std::shared_ptr<ChunkedArray> col = table->column(i);
       if (categorical_columns.count(table->field(i)->name())) {
+        if (table->field(i)->type()->id() == Type::DICTIONARY) {
+          // this column is already dictionary encoded
+          continue;
+        }
         Datum out;
         RETURN_NOT_OK(DictionaryEncode(&ctx, Datum(col), &out));
         std::shared_ptr<ChunkedArray> array = out.chunked_array();


### PR DESCRIPTION
With #5077 (or possibly #4949) behavior with dictionary arrays changed, leaving the explicit call to DictionaryEncode() redundant @wesm 