### PR TITLE
ARROW-6356: [Java] Avro adapter implement Enum type and nested Record

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrow.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrow.java
@@ -23,7 +23,6 @@ import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -32,15 +31,58 @@ import org.apache.avro.io.Decoder;
 public class AvroToArrow {
 
   /**
-   * Fetch the data from {@link GenericDatumReader} and convert it to Arrow objects.
+   * Fetch the data from {@link Decoder} and convert it to Arrow objects.
+   * Only for testing purpose.
    * @param schema avro schema.
+   * @param decoder avro decoder
    * @param allocator Memory allocator to use.
    * @return Arrow Data Objects {@link VectorSchemaRoot}
    */
-  public static VectorSchemaRoot avroToArrow(Schema schema, Decoder decoder, BaseAllocator allocator)
+  static VectorSchemaRoot avroToArrow(Schema schema, Decoder decoder, BaseAllocator allocator)
       throws IOException {
     Preconditions.checkNotNull(schema, "Avro schema object can not be null");
+    Preconditions.checkNotNull(decoder, "Avro decoder object can not be null");
+    Preconditions.checkNotNull(allocator, "allocator can not be null");
 
     return AvroToArrowUtils.avroToArrowVectors(schema, decoder, allocator);
+  }
+
+  /**
+   * Fetch the data from {@link Decoder} and iteratively convert it to Arrow objects.
+   * @param schema avro schema
+   * @param decoder avro decoder
+   * @param allocator the allocator
+   * @throws IOException on error
+   */
+  public static AvroToArrowVectorIterator avroToArrowIterator(
+      Schema schema,
+      Decoder decoder,
+      BaseAllocator allocator)
+      throws IOException {
+
+    return avroToArrowIterator(schema, decoder, allocator, AvroToArrowVectorIterator.DEFAULT_BATCH_SIZE);
+  }
+
+  /**
+   * Fetch the data from {@link Decoder} and iteratively convert it to Arrow objects.
+   * @param schema avro schema
+   * @param decoder avro decoder
+   * @param allocator the allocator
+   * @param targetBatchSize the max value count for a vector.
+   * @throws IOException on error
+   */
+  public static AvroToArrowVectorIterator avroToArrowIterator(
+      Schema schema,
+      Decoder decoder,
+      BaseAllocator allocator,
+      int targetBatchSize) throws IOException {
+
+    Preconditions.checkNotNull(schema, "Avro schema object can not be null");
+    Preconditions.checkNotNull(decoder, "Avro decoder object can not be null");
+    Preconditions.checkNotNull(allocator, "allocator can not be null");
+    Preconditions.checkArgument(targetBatchSize == AvroToArrowVectorIterator.NO_LIMIT_BATCH_SIZE ||
+        targetBatchSize > 0, "invalid targetBatchSize: %s", targetBatchSize);
+
+    return AvroToArrowVectorIterator.create(decoder, schema, allocator, targetBatchSize);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrow.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrow.java
@@ -19,7 +19,6 @@ package org.apache.arrow;
 
 import java.io.IOException;
 
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.avro.Schema;
@@ -35,54 +34,34 @@ public class AvroToArrow {
    * Only for testing purpose.
    * @param schema avro schema.
    * @param decoder avro decoder
-   * @param allocator Memory allocator to use.
+   * @param config configuration of the conversion.
    * @return Arrow Data Objects {@link VectorSchemaRoot}
    */
-  static VectorSchemaRoot avroToArrow(Schema schema, Decoder decoder, BaseAllocator allocator)
+  static VectorSchemaRoot avroToArrow(Schema schema, Decoder decoder, AvroToArrowConfig config)
       throws IOException {
     Preconditions.checkNotNull(schema, "Avro schema object can not be null");
     Preconditions.checkNotNull(decoder, "Avro decoder object can not be null");
-    Preconditions.checkNotNull(allocator, "allocator can not be null");
+    Preconditions.checkNotNull(config, "config can not be null");
 
-    return AvroToArrowUtils.avroToArrowVectors(schema, decoder, allocator);
+    return AvroToArrowUtils.avroToArrowVectors(schema, decoder, config);
   }
 
   /**
    * Fetch the data from {@link Decoder} and iteratively convert it to Arrow objects.
    * @param schema avro schema
    * @param decoder avro decoder
-   * @param allocator the allocator
+   * @param config configuration of the conversion.
    * @throws IOException on error
    */
   public static AvroToArrowVectorIterator avroToArrowIterator(
       Schema schema,
       Decoder decoder,
-      BaseAllocator allocator)
-      throws IOException {
-
-    return avroToArrowIterator(schema, decoder, allocator, AvroToArrowVectorIterator.DEFAULT_BATCH_SIZE);
-  }
-
-  /**
-   * Fetch the data from {@link Decoder} and iteratively convert it to Arrow objects.
-   * @param schema avro schema
-   * @param decoder avro decoder
-   * @param allocator the allocator
-   * @param targetBatchSize the max value count for a vector.
-   * @throws IOException on error
-   */
-  public static AvroToArrowVectorIterator avroToArrowIterator(
-      Schema schema,
-      Decoder decoder,
-      BaseAllocator allocator,
-      int targetBatchSize) throws IOException {
+      AvroToArrowConfig config) throws IOException {
 
     Preconditions.checkNotNull(schema, "Avro schema object can not be null");
     Preconditions.checkNotNull(decoder, "Avro decoder object can not be null");
-    Preconditions.checkNotNull(allocator, "allocator can not be null");
-    Preconditions.checkArgument(targetBatchSize == AvroToArrowVectorIterator.NO_LIMIT_BATCH_SIZE ||
-        targetBatchSize > 0, "invalid targetBatchSize: %s", targetBatchSize);
+    Preconditions.checkNotNull(config, "config can not be null");
 
-    return AvroToArrowVectorIterator.create(decoder, schema, allocator, targetBatchSize);
+    return AvroToArrowVectorIterator.create(decoder, schema, config);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowConfig.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+
+/**
+ * This class configures the Avro-to-Arrow conversion process.
+ */
+public class AvroToArrowConfig {
+
+  private final BufferAllocator allocator;
+  /**
+   * The maximum rowCount to read each time when partially convert data.
+   * Default value is 1024 and -1 means read all data into one vector.
+   */
+  private final int targetBatchSize;
+
+  /**
+   * The dictionary provider used for enum type.
+   * If avro schema has enum type, will create dictionary and update this provider.
+   */
+  private final DictionaryProvider.MapDictionaryProvider provider;
+
+  public AvroToArrowConfig(BufferAllocator allocator) {
+    this (allocator, AvroToArrowVectorIterator.DEFAULT_BATCH_SIZE);
+  }
+
+  public AvroToArrowConfig(BufferAllocator allocator, int targetBatchSize) {
+    this (allocator, targetBatchSize, new DictionaryProvider.MapDictionaryProvider());
+  }
+
+  /**
+   * Instantiate an instance.
+   * @param allocator The memory allocator to construct the Arrow vectors with.
+   * @param targetBatchSize The maximum rowCount to read each time when partially convert data.
+   * @param provider The dictionary provider used for enum type, adapter will update this provider.
+   */
+  public AvroToArrowConfig(
+      BufferAllocator allocator,
+      int targetBatchSize,
+      DictionaryProvider.MapDictionaryProvider provider) {
+
+    Preconditions.checkArgument(targetBatchSize == AvroToArrowVectorIterator.NO_LIMIT_BATCH_SIZE ||
+        targetBatchSize > 0, "invalid targetBatchSize: %s", targetBatchSize);
+
+    this.allocator = allocator;
+    this.targetBatchSize = targetBatchSize;
+    this.provider = provider;
+  }
+
+  public BufferAllocator getAllocator() {
+    return allocator;
+  }
+
+  public int getTargetBatchSize() {
+    return targetBatchSize;
+  }
+
+  public DictionaryProvider.MapDictionaryProvider getProvider() {
+    return provider;
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -211,6 +211,27 @@ public class AvroToArrowUtils {
     return consumer;
   }
 
+  static CompositeAvroConsumer createCompositeConsumer(
+      Schema schema, BufferAllocator allocator) {
+
+    List<Consumer> consumers = new ArrayList<>();
+
+    Schema.Type type = schema.getType();
+    if (type == Type.RECORD) {
+      for (Schema.Field field : schema.getFields()) {
+        Consumer consumer = createConsumer(field.schema(), field.name(), allocator);
+        consumers.add(consumer);
+      }
+    } else if (type == Type.ENUM) {
+      throw new UnsupportedOperationException();
+    } else {
+      Consumer consumer = createConsumer(schema, "", allocator);
+      consumers.add(consumer);
+    }
+
+    return new CompositeAvroConsumer(consumers);
+  }
+
   private static FieldVector createVector(FieldVector v, FieldType fieldType, String name, BufferAllocator allocator) {
     return v != null ? v : fieldType.createNewSingleVector(name, allocator, null);
   }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -22,6 +22,7 @@ import static org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import org.apache.arrow.consumers.AvroArraysConsumer;
 import org.apache.arrow.consumers.AvroBooleanConsumer;
 import org.apache.arrow.consumers.AvroBytesConsumer;
 import org.apache.arrow.consumers.AvroDoubleConsumer;
+import org.apache.arrow.consumers.AvroEnumConsumer;
 import org.apache.arrow.consumers.AvroFixedConsumer;
 import org.apache.arrow.consumers.AvroFloatConsumer;
 import org.apache.arrow.consumers.AvroIntConsumer;
@@ -63,9 +65,12 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.dictionary.Dictionary;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.avro.Schema;
@@ -98,12 +103,12 @@ public class AvroToArrowUtils {
    * </ul>
    */
 
-  private static Consumer createConsumer(Schema schema, String name, BufferAllocator allocator) {
-    return createConsumer(schema, name, false, INVALID_NULL_INDEX, allocator, null);
+  private static Consumer createConsumer(Schema schema, String name, AvroToArrowConfig config) {
+    return createConsumer(schema, name, false, INVALID_NULL_INDEX, config, null);
   }
 
-  private static Consumer createConsumer(Schema schema, String name, BufferAllocator allocator, FieldVector vector) {
-    return createConsumer(schema, name, false, INVALID_NULL_INDEX, allocator, vector);
+  private static Consumer createConsumer(Schema schema, String name, AvroToArrowConfig config, FieldVector vector) {
+    return createConsumer(schema, name, false, INVALID_NULL_INDEX, config, vector);
   }
 
   /**
@@ -118,11 +123,13 @@ public class AvroToArrowUtils {
       String name,
       boolean nullable,
       int nullIndex,
-      BufferAllocator allocator,
+      AvroToArrowConfig config,
       FieldVector v) {
 
     Preconditions.checkNotNull(schema, "Avro schema object can't be null");
-    Preconditions.checkNotNull(allocator, "allocator can't be null");
+    Preconditions.checkNotNull(config, "Config can't be null");
+
+    final BufferAllocator allocator = config.getAllocator();
 
     Type type = schema.getType();
 
@@ -133,19 +140,20 @@ public class AvroToArrowUtils {
 
     switch (type) {
       case UNION:
-        consumer = createUnionConsumer(schema, name, allocator, v);
+        consumer = createUnionConsumer(schema, name, config, v);
         break;
       case ARRAY:
-        consumer = createArrayConsumer(schema, name, allocator, v);
+        consumer = createArrayConsumer(schema, name, config, v);
         break;
       case MAP:
-        consumer = createMapConsumer(schema, name, allocator, v);
+        consumer = createMapConsumer(schema, name, config, v);
         break;
-        //TODO implement enum and nested record type
       case RECORD:
-        throw new UnsupportedOperationException();
+        consumer = createStructConsumer(schema, name, config, v);
+        break;
       case ENUM:
-        throw new UnsupportedOperationException();
+        consumer = createEnumConsumer(schema, name, config, v);
+        break;
       case STRING:
         arrowType = new ArrowType.Utf8();
         fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
@@ -212,20 +220,20 @@ public class AvroToArrowUtils {
   }
 
   static CompositeAvroConsumer createCompositeConsumer(
-      Schema schema, BufferAllocator allocator) {
+      Schema schema, AvroToArrowConfig config) {
 
     List<Consumer> consumers = new ArrayList<>();
 
     Schema.Type type = schema.getType();
     if (type == Type.RECORD) {
       for (Schema.Field field : schema.getFields()) {
-        Consumer consumer = createConsumer(field.schema(), field.name(), allocator);
+        Consumer consumer = createConsumer(field.schema(), field.name(), config);
         consumers.add(consumer);
       }
     } else if (type == Type.ENUM) {
       throw new UnsupportedOperationException();
     } else {
-      Consumer consumer = createConsumer(schema, "", allocator);
+      Consumer consumer = createConsumer(schema, "", config);
       consumers.add(consumer);
     }
 
@@ -241,7 +249,7 @@ public class AvroToArrowUtils {
     return minorType.name().toLowerCase();
   }
 
-  private static Field avroSchemaToField(Schema schema, String name) {
+  private static Field avroSchemaToField(Schema schema, String name, AvroToArrowConfig config) {
     final Type type = schema.getType();
     final ArrowType arrowType;
 
@@ -251,7 +259,7 @@ public class AvroToArrowUtils {
         for (int i = 0; i < schema.getTypes().size(); i++) {
           Schema childSchema = schema.getTypes().get(i);
           // Union child vector should use default name
-          children.add(avroSchemaToField(childSchema, null));
+          children.add(avroSchemaToField(childSchema, null, config));
         }
         arrowType = new ArrowType.Union(UnionMode.Sparse, null);
         if (name == null) {
@@ -265,12 +273,12 @@ public class AvroToArrowUtils {
           name = getDefaultFieldName(arrowType);
         }
         return new Field(name, FieldType.nullable(arrowType),
-            Collections.singletonList(avroSchemaToField(elementSchema, elementSchema.getName())));
+            Collections.singletonList(avroSchemaToField(elementSchema, elementSchema.getName(), config)));
       case MAP:
         // MapVector internal struct field and key field should be non-nullable
         FieldType keyFieldType = new FieldType(/*nullable=*/false, new ArrowType.Utf8(), /*dictionary=*/null);
         Field keyField = new Field("key", keyFieldType, /*children=*/null);
-        Field valueField = avroSchemaToField(schema.getValueType(), "value");
+        Field valueField = avroSchemaToField(schema.getValueType(), "value", config);
 
         FieldType structFieldType = new FieldType(false, new ArrowType.Struct(), /*dictionary=*/null);
         Field structField = new Field("internal", structFieldType, Arrays.asList(keyField, valueField));
@@ -279,6 +287,25 @@ public class AvroToArrowUtils {
           name = getDefaultFieldName(arrowType);
         }
         return new Field(name, FieldType.nullable(arrowType), Collections.singletonList(structField));
+      case RECORD:
+        List<Field> childFields = new ArrayList<>();
+        for (int i = 0; i < schema.getFields().size(); i++) {
+          final Schema.Field field = schema.getFields().get(i);
+          Schema childSchema = field.schema();
+          childFields.add(avroSchemaToField(childSchema, field.name(), config));
+        }
+        arrowType = new ArrowType.Struct();
+        if (name == null) {
+          name = getDefaultFieldName(arrowType);
+        }
+        return new Field(name, FieldType.nullable(arrowType), childFields);
+      case ENUM:
+        DictionaryProvider.MapDictionaryProvider provider = config.getProvider();
+        int current = provider.getDictionaryIds().size();
+        FieldType indexFieldType = new FieldType(true, new ArrowType.Int(32, true),
+            new DictionaryEncoding(current, false, null));
+        return new Field(name, indexFieldType, null);
+
       case STRING:
         arrowType = new ArrowType.Utf8();
         break;
@@ -317,12 +344,12 @@ public class AvroToArrowUtils {
     return Field.nullable(name, arrowType);
   }
 
-  private static Consumer createArrayConsumer(Schema schema, String name, BufferAllocator allocator, FieldVector v) {
+  private static Consumer createArrayConsumer(Schema schema, String name, AvroToArrowConfig config, FieldVector v) {
 
     ListVector listVector;
     if (v == null) {
-      final Field field = avroSchemaToField(schema, name);
-      listVector = (ListVector) field.createVector(allocator);
+      final Field field = avroSchemaToField(schema, name, config);
+      listVector = (ListVector) field.createVector(config.getAllocator());
     } else {
       listVector = (ListVector) v;
     }
@@ -331,17 +358,64 @@ public class AvroToArrowUtils {
 
     // create delegate
     Schema childSchema = schema.getElementType();
-    Consumer delegate = createConsumer(childSchema, childSchema.getName(), allocator, dataVector);
+    Consumer delegate = createConsumer(childSchema, childSchema.getName(), config, dataVector);
 
     return new AvroArraysConsumer(listVector, delegate);
   }
 
-  private static Consumer createMapConsumer(Schema schema, String name, BufferAllocator allocator, FieldVector v) {
+  private static Consumer createStructConsumer(Schema schema, String name, AvroToArrowConfig config, FieldVector v) {
+
+    StructVector structVector;
+    if (v == null) {
+      final Field field = avroSchemaToField(schema, name, config);
+      structVector = (StructVector) field.createVector(config.getAllocator());
+    } else {
+      structVector = (StructVector) v;
+    }
+
+    Consumer[] delegates = new Consumer[schema.getFields().size()];
+    for (int i = 0; i < schema.getFields().size(); i++) {
+      Schema childSchema = schema.getFields().get(i).schema();
+      Consumer delegate = createConsumer(childSchema, childSchema.getName(),
+          config, structVector.getChildrenFromFields().get(i));
+      delegates[i] = delegate;
+    }
+
+    return new AvroStructConsumer(structVector, delegates);
+
+  }
+
+  private static Consumer createEnumConsumer(Schema schema, String name, AvroToArrowConfig config, FieldVector v) {
+
+    IntVector intVector;
+    if (v == null) {
+      final Field field = avroSchemaToField(schema, name, config);
+      intVector = (IntVector) field.createVector(config.getAllocator());
+    } else {
+      intVector = (IntVector) v;
+    }
+
+    final int valueCount = schema.getEnumSymbols().size();
+    VarCharVector dictVector = new VarCharVector(name, config.getAllocator());
+    dictVector.allocateNewSafe();
+    dictVector.setValueCount(valueCount);
+    for (int i = 0; i < valueCount; i++) {
+      dictVector.set(i, schema.getEnumSymbols().get(i).getBytes(StandardCharsets.UTF_8));
+    }
+    Dictionary dictionary =
+        new Dictionary(dictVector, intVector.getField().getDictionary());
+    config.getProvider().put(dictionary);
+
+    return new AvroEnumConsumer(intVector);
+
+  }
+
+  private static Consumer createMapConsumer(Schema schema, String name, AvroToArrowConfig config, FieldVector v) {
 
     MapVector mapVector;
     if (v == null) {
-      final Field field = avroSchemaToField(schema, name);
-      mapVector = (MapVector) field.createVector(allocator);
+      final Field field = avroSchemaToField(schema, name, config);
+      mapVector = (MapVector) field.createVector(config.getAllocator());
     } else {
       mapVector = (MapVector) v;
     }
@@ -353,7 +427,7 @@ public class AvroToArrowUtils {
     Consumer keyConsumer = new AvroStringConsumer(
         (VarCharVector) structVector.getChildrenFromFields().get(0));
     Consumer valueConsumer = createConsumer(schema.getValueType(), schema.getValueType().getName(),
-        allocator, structVector.getChildrenFromFields().get(1));
+        config, structVector.getChildrenFromFields().get(1));
 
     AvroStructConsumer internalConsumer =
         new AvroStructConsumer(structVector, new Consumer[] {keyConsumer, valueConsumer});
@@ -361,14 +435,14 @@ public class AvroToArrowUtils {
     return new AvroMapConsumer(mapVector, internalConsumer);
   }
 
-  private static Consumer createUnionConsumer(Schema schema, String name, BufferAllocator allocator, FieldVector v) {
+  private static Consumer createUnionConsumer(Schema schema, String name, AvroToArrowConfig config, FieldVector v) {
     int size = schema.getTypes().size();
     long nullCount = schema.getTypes().stream().filter(s -> s.getType() == Type.NULL).count();
 
     // union only has one type, convert to primitive type
     if (size == 1) {
       Schema subSchema = schema.getTypes().get(0);
-      return createConsumer(subSchema, name, allocator, v);
+      return createConsumer(subSchema, name, config, v);
 
       // size == 2 and has null type, convert to nullable primitive type
     } else if (size == 2 && nullCount == 1) {
@@ -376,15 +450,15 @@ public class AvroToArrowUtils {
       int nullIndex = schema.getTypes().indexOf(nullSchema);
       Schema subSchema = schema.getTypes().stream().filter(s -> s.getType() != Type.NULL).findFirst().get();
       Preconditions.checkNotNull(subSchema, "schema should not be null.");
-      return createConsumer(subSchema, name, true, nullIndex, allocator, v);
+      return createConsumer(subSchema, name, true, nullIndex, config, v);
 
       // real union type
     } else {
 
       UnionVector unionVector;
       if (v == null) {
-        final Field field = avroSchemaToField(schema, name);
-        unionVector = (UnionVector) field.createVector(allocator);
+        final Field field = avroSchemaToField(schema, name, config);
+        unionVector = (UnionVector) field.createVector(config.getAllocator());
       } else {
         unionVector = (UnionVector) v;
       }
@@ -397,7 +471,7 @@ public class AvroToArrowUtils {
       for (int i = 0; i < size; i++) {
         FieldVector child = childVectors.get(i);
         Schema subSchema = schema.getTypes().get(i);
-        Consumer delegate = createConsumer(subSchema, subSchema.getName(), allocator, child);
+        Consumer delegate = createConsumer(subSchema, subSchema.getName(), config, child);
         delegates[i] = delegate;
         types[i] = child.getMinorType();
       }
@@ -416,7 +490,10 @@ public class AvroToArrowUtils {
    * @param schema avro schema
    * @param decoder avro decoder to read data from
    */
-  public static VectorSchemaRoot avroToArrowVectors(Schema schema, Decoder decoder, BufferAllocator allocator)
+  static VectorSchemaRoot avroToArrowVectors(
+      Schema schema,
+      Decoder decoder,
+      AvroToArrowConfig config)
       throws IOException {
 
     List<FieldVector> vectors = new ArrayList<>();
@@ -425,14 +502,12 @@ public class AvroToArrowUtils {
     Schema.Type type = schema.getType();
     if (type == Type.RECORD) {
       for (Schema.Field field : schema.getFields()) {
-        Consumer consumer = createConsumer(field.schema(), field.name(), allocator);
+        Consumer consumer = createConsumer(field.schema(), field.name(), config);
         consumers.add(consumer);
         vectors.add(consumer.getVector());
       }
-    } else if (type == Type.ENUM) {
-      throw new UnsupportedOperationException();
     } else {
-      Consumer consumer = createConsumer(schema, "", allocator);
+      Consumer consumer = createConsumer(schema, "", config);
       consumers.add(consumer);
       vectors.add(consumer.getVector());
     }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowVectorIterator.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowVectorIterator.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow;
+
+import java.io.EOFException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.arrow.consumers.CompositeAvroConsumer;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+/**
+ * VectorSchemaRoot iterator for partially converting avro data.
+ */
+public class AvroToArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoCloseable {
+
+  public static final int NO_LIMIT_BATCH_SIZE = -1;
+  public static final int DEFAULT_BATCH_SIZE = 1024;
+
+  private final Decoder decoder;
+  private final Schema schema;
+
+  private final BufferAllocator allocator;
+
+  private CompositeAvroConsumer compositeConsumer;
+
+  private org.apache.arrow.vector.types.pojo.Schema rootSchema;
+
+  private VectorSchemaRoot nextBatch;
+
+  private final int targetBatchSize;
+
+  /**
+   * Construct an instance.
+   */
+  private AvroToArrowVectorIterator(
+      Decoder decoder,
+      Schema schema,
+      BufferAllocator allocator,
+      int targetBatchSize) {
+
+    this.decoder = decoder;
+    this.schema = schema;
+    this.allocator = allocator;
+    this.targetBatchSize = targetBatchSize;
+
+  }
+
+  /**
+   * Create a ArrowVectorIterator to partially convert data.
+   */
+  public static AvroToArrowVectorIterator create(
+      Decoder decoder,
+      Schema schema,
+      BufferAllocator allocator,
+      int targetBatchSize) {
+
+    AvroToArrowVectorIterator iterator = new AvroToArrowVectorIterator(decoder, schema, allocator, targetBatchSize);
+    try {
+      iterator.initialize();
+      return iterator;
+    } catch (Exception e) {
+      iterator.close();
+      throw new RuntimeException("Error occurs while creating iterator.", e);
+    }
+  }
+
+  private void initialize() {
+    // create consumers
+    compositeConsumer = AvroToArrowUtils.createCompositeConsumer(schema, allocator);
+    List<FieldVector> vectors = new ArrayList<>();
+    compositeConsumer.getConsumers().forEach(c -> vectors.add(c.getVector()));
+    List<Field> fields = vectors.stream().map(t -> t.getField()).collect(Collectors.toList());
+    VectorSchemaRoot root = new VectorSchemaRoot(fields, vectors, 0);
+    rootSchema = root.getSchema();
+
+    load(root);
+  }
+
+  private void consumeData(VectorSchemaRoot root) {
+    int readRowCount = 0;
+    try {
+      while ((targetBatchSize == NO_LIMIT_BATCH_SIZE || readRowCount < targetBatchSize)) {
+        compositeConsumer.consume(decoder, root);
+        readRowCount++;
+      }
+      root.setRowCount(readRowCount);
+    } catch (EOFException eof) {
+      // reach the end of encoder stream.
+      root.setRowCount(readRowCount);
+    } catch (Exception e) {
+      compositeConsumer.close();
+      throw new RuntimeException("Error occurs while consuming data.", e);
+    }
+  }
+
+  // Loads the next schema root or null if no more rows are available.
+  private void load(VectorSchemaRoot root) {
+
+    Preconditions.checkArgument(root.getFieldVectors().size() == compositeConsumer.getConsumers().size(),
+        "Schema root vectors size not equals to consumers size.");
+
+    compositeConsumer.resetConsumerVectors(root);
+
+    // consume data
+    consumeData(root);
+
+    if (root.getRowCount() == 0) {
+      root.close();
+      nextBatch = null;
+    } else {
+      nextBatch = root;
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return nextBatch != null;
+  }
+
+  /**
+   * Gets the next vector. The user is responsible for freeing its resources.
+   */
+  public VectorSchemaRoot next() {
+    Preconditions.checkArgument(hasNext());
+    VectorSchemaRoot returned = nextBatch;
+    try {
+      load(VectorSchemaRoot.create(rootSchema, allocator));
+    } catch (Exception e) {
+      returned.close();
+      throw new RuntimeException("Error occurs while getting next schema root.", e);
+    }
+    return returned;
+  }
+
+  /**
+   * Clean up resources.
+   */
+  public void close() {
+    if (nextBatch != null) {
+      nextBatch.close();
+    }
+    compositeConsumer.close();
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroArraysConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroArraysConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume array type values from avro decoder.
  * Write the data to {@link ListVector}.
  */
-public class AvroArraysConsumer implements Consumer {
+public class AvroArraysConsumer implements Consumer<ListVector> {
 
-  private final ListVector vector;
+  private ListVector vector;
   private final Consumer delegate;
 
   private int currentIndex = 0;
@@ -76,5 +76,12 @@ public class AvroArraysConsumer implements Consumer {
   public void close() throws Exception {
     vector.close();
     delegate.close();
+  }
+
+  @Override
+  public void resetValueVector(ListVector vector) {
+    this.currentIndex = 0;
+    this.vector = vector;
+    this.delegate.resetValueVector(vector.getDataVector());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume boolean type values from avro decoder.
  * Write the data to {@link BitVector}.
  */
-public class AvroBooleanConsumer implements Consumer {
+public class AvroBooleanConsumer implements Consumer<BitVector> {
 
-  private final BitVector vector;
+  private BitVector vector;
   private int currentIndex = 0;
 
   /**
@@ -63,6 +63,12 @@ public class AvroBooleanConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(BitVector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -28,9 +28,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume bytes type values from avro decoder.
  * Write the data to {@link VarBinaryVector}.
  */
-public class AvroBytesConsumer implements Consumer {
+public class AvroBytesConsumer implements Consumer<VarBinaryVector> {
 
-  private final VarBinaryVector vector;
+  private VarBinaryVector vector;
   private ByteBuffer cacheBuffer;
 
   private int currentIndex;
@@ -69,5 +69,11 @@ public class AvroBytesConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(VarBinaryVector vector) {
+    this.vector = vector;
+    this.currentIndex = currentIndex;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume double type values from avro decoder.
  * Write the data to {@link Float8Vector}.
  */
-public class AvroDoubleConsumer implements Consumer {
+public class AvroDoubleConsumer implements Consumer<Float8Vector> {
 
-  private final Float8Vector vector;
+  private Float8Vector vector;
 
   private int currentIndex;
 
@@ -63,5 +63,11 @@ public class AvroDoubleConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(Float8Vector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroEnumConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroEnumConsumer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers;
+
+import java.io.IOException;
+
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume enum type values from avro decoder.
+ * Write the data to {@link IntVector}.
+ */
+public class AvroEnumConsumer implements Consumer<IntVector> {
+
+  private IntVector vector;
+
+  private int currentIndex;
+
+  /**
+   * Instantiate a AvroEnumConsumer.
+   */
+  public AvroEnumConsumer(IntVector vector) {
+    this.vector = vector;
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    vector.setSafe(currentIndex++, decoder.readEnum());
+  }
+
+  @Override
+  public void addNull() {
+    currentIndex++;
+  }
+
+  @Override
+  public void setPosition(int index) {
+    currentIndex = index;
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return this.vector;
+  }
+
+  @Override
+  public void close() throws Exception {
+    vector.close();
+  }
+
+  @Override
+  public void resetValueVector(IntVector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFixedConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFixedConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume fixed type values from avro decoder.
  * Write the data to {@link org.apache.arrow.vector.FixedSizeBinaryVector}.
  */
-public class AvroFixedConsumer implements Consumer {
+public class AvroFixedConsumer implements Consumer<FixedSizeBinaryVector> {
 
-  private final FixedSizeBinaryVector vector;
+  private FixedSizeBinaryVector vector;
   private final byte[] reuseBytes;
 
   private int currentIndex;
@@ -66,5 +66,11 @@ public class AvroFixedConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(FixedSizeBinaryVector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume float type values from avro decoder.
  * Write the data to {@link Float4Vector}.
  */
-public class AvroFloatConsumer implements Consumer {
+public class AvroFloatConsumer implements Consumer<Float4Vector> {
 
-  private final Float4Vector vector;
+  private Float4Vector vector;
 
   private int currentIndex;
 
@@ -63,5 +63,11 @@ public class AvroFloatConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(Float4Vector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume int type values from avro decoder.
  * Write the data to {@link IntVector}.
  */
-public class AvroIntConsumer implements Consumer {
+public class AvroIntConsumer implements Consumer<IntVector> {
 
-  private final IntVector vector;
+  private IntVector vector;
 
   private int currentIndex;
 
@@ -63,5 +63,11 @@ public class AvroIntConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(IntVector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume long type values from avro decoder.
  * Write the data to {@link BigIntVector}.
  */
-public class AvroLongConsumer implements Consumer {
+public class AvroLongConsumer implements Consumer<BigIntVector> {
 
-  private final BigIntVector vector;
+  private BigIntVector vector;
 
   private int currentIndex;
 
@@ -63,5 +63,11 @@ public class AvroLongConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(BigIntVector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroMapConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroMapConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume map type values from avro decoder.
  * Write the data to {@link MapVector}.
  */
-public class AvroMapConsumer implements Consumer {
+public class AvroMapConsumer implements Consumer<MapVector> {
 
-  private final MapVector vector;
+  private MapVector vector;
   private final Consumer delegate;
 
   private int currentIndex;
@@ -76,5 +76,12 @@ public class AvroMapConsumer implements Consumer {
   public void close() throws Exception {
     vector.close();
     delegate.close();
+  }
+
+  @Override
+  public void resetValueVector(MapVector vector) {
+    this.vector = vector;
+    this.delegate.resetValueVector(vector.getDataVector());
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
@@ -27,9 +27,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume null type values from avro decoder.
  * Corresponding to {@link org.apache.arrow.vector.ZeroVector}.
  */
-public class AvroNullConsumer implements Consumer {
+public class AvroNullConsumer implements Consumer<ZeroVector> {
 
-  private final ZeroVector vector;
+  private ZeroVector vector;
 
   public AvroNullConsumer(ZeroVector vector) {
     this.vector = vector;
@@ -52,5 +52,10 @@ public class AvroNullConsumer implements Consumer {
   @Override
   public void close() {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(ZeroVector vector) {
+    this.vector = vector;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -28,9 +28,9 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume string type values from avro decoder.
  * Write the data to {@link VarCharVector}.
  */
-public class AvroStringConsumer implements Consumer {
+public class AvroStringConsumer implements Consumer<VarCharVector> {
 
-  private final VarCharVector vector;
+  private VarCharVector vector;
   private ByteBuffer cacheBuffer;
   private int currentIndex;
 
@@ -67,5 +67,11 @@ public class AvroStringConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void resetValueVector(VarCharVector vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStructConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStructConsumer.java
@@ -28,7 +28,7 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume nested record type values from avro decoder.
  * Write the data to {@link org.apache.arrow.vector.complex.StructVector}.
  */
-public class AvroStructConsumer implements Consumer {
+public class AvroStructConsumer implements Consumer<StructVector> {
 
   private final Consumer[] delegates;
   private StructVector vector;
@@ -75,5 +75,14 @@ public class AvroStructConsumer implements Consumer {
   public void close() throws Exception {
     vector.close();
     AutoCloseables.close(delegates);
+  }
+
+  @Override
+  public void resetValueVector(StructVector vector) {
+    this.vector = vector;
+    for (int i = 0; i < delegates.length; i++) {
+      delegates[i].resetValueVector(vector.getChildrenFromFields().get(i));
+    }
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/Consumer.java
@@ -20,12 +20,14 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.io.Decoder;
 
 /**
  * Interface that is used to consume values from avro decoder.
+ * @param <T> The vector within consumer or its delegate, used for partially consume purpose.
  */
-public interface Consumer extends AutoCloseable {
+public interface Consumer<T extends ValueVector> extends AutoCloseable {
 
   /**
    * Consume a specific type value from avro decoder and write it to vector.
@@ -53,4 +55,10 @@ public interface Consumer extends AutoCloseable {
    * Close this consumer when occurs exception to avoid potential leak.
    */
   void close() throws Exception;
+
+  /**
+   * Reset the vector within consumer for partial read purpose.
+   */
+  void resetValueVector(T vector);
+
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/NullableTypeConsumer.java
@@ -20,6 +20,7 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -68,6 +69,11 @@ public class NullableTypeConsumer implements Consumer {
   @Override
   public void close() throws Exception {
     delegate.close();
+  }
+
+  @Override
+  public void resetValueVector(ValueVector vector) {
+    this.delegate.resetValueVector(vector);
   }
 
 }

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroTestBase.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroTestBase.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.util.JsonStringArrayList;
+import org.apache.arrow.vector.util.Text;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+public class AvroTestBase {
+
+  @ClassRule
+  public static final TemporaryFolder TMP = new TemporaryFolder();
+
+  protected BaseAllocator allocator;
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  protected Schema getSchema(String schemaName) throws Exception {
+    Path schemaPath = Paths.get(TestWriteReadAvroRecord.class.getResource("/").getPath(),
+        "schema", schemaName);
+    return new Schema.Parser().parse(schemaPath.toFile());
+  }
+
+  protected void checkArrayResult(List<List<?>> expected, ListVector vector) {
+    assertEquals(expected.size(), vector.getValueCount());
+    for (int i = 0; i < expected.size(); i++) {
+      checkArrayElement(expected.get(i), (JsonStringArrayList) vector.getObject(i));
+    }
+  }
+
+  protected void checkArrayElement(List expected, List actual) {
+    assertEquals(expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); i++) {
+      Object value1 = expected.get(i);
+      Object value2 = actual.get(i);
+      if (value1 == null) {
+        assertTrue(value2 == null);
+        continue;
+      }
+      if (value2 instanceof byte[]) {
+        value2 = ByteBuffer.wrap((byte[]) value2);
+      } else if (value2 instanceof Text) {
+        value2 = value2.toString();
+      }
+      assertEquals(value1, value2);
+    }
+  }
+
+  protected void checkPrimitiveResult(List data, FieldVector vector) {
+    assertEquals(data.size(), vector.getValueCount());
+    for (int i = 0; i < data.size(); i++) {
+      Object value1 = data.get(i);
+      Object value2 = vector.getObject(i);
+      if (value1 == null) {
+        assertTrue(value2 == null);
+        continue;
+      }
+      if (value2 instanceof byte[]) {
+        value2 = ByteBuffer.wrap((byte[]) value2);
+        if (value1 instanceof byte[]) {
+          value1 = ByteBuffer.wrap((byte[]) value1);
+        }
+      } else if (value2 instanceof Text) {
+        value2 = value2.toString();
+      }
+      assertEquals(value1, value2);
+    }
+  }
+
+  protected void checkRecordResult(Schema schema, ArrayList<GenericRecord> data, VectorSchemaRoot root) {
+    assertEquals(data.size(), root.getRowCount());
+    assertEquals(schema.getFields().size(), root.getFieldVectors().size());
+
+    for (int i = 0; i < schema.getFields().size(); i++) {
+      ArrayList fieldData = new ArrayList();
+      for (GenericRecord record : data) {
+        fieldData.add(record.get(i));
+      }
+
+      checkPrimitiveResult(fieldData, root.getFieldVectors().get(i));
+    }
+
+  }
+
+
+  // belows are for iterator api
+
+  protected void checkArrayResult(List<List<?>> expected, List<ListVector> vectors) {
+    int valueCount = vectors.stream().mapToInt(v -> v.getValueCount()).sum();
+    assertEquals(expected.size(), valueCount);
+
+    int index = 0;
+    for (ListVector vector : vectors) {
+      for (int i = 0; i < vector.getValueCount(); i++) {
+        checkArrayElement(expected.get(index++), (JsonStringArrayList) vector.getObject(i));
+      }
+    }
+  }
+
+  protected void checkRecordResult(Schema schema, ArrayList<GenericRecord> data, List<VectorSchemaRoot> roots) {
+    roots.forEach(root -> {
+      assertEquals(schema.getFields().size(), root.getFieldVectors().size());
+    });
+
+    for (int i = 0; i < schema.getFields().size(); i++) {
+      List fieldData = new ArrayList();
+      List<FieldVector> vectors = new ArrayList<>();
+      for (GenericRecord record : data) {
+        fieldData.add(record.get(i));
+      }
+      final int columnIndex = i;
+      roots.forEach(root -> vectors.add(root.getFieldVectors().get(columnIndex)));
+
+      checkPrimitiveResult(fieldData, vectors);
+    }
+
+  }
+
+  protected void checkPrimitiveResult(List data, List<FieldVector> vectors) {
+    int valueCount = vectors.stream().mapToInt(v -> v.getValueCount()).sum();
+    assertEquals(data.size(), valueCount);
+
+    int index = 0;
+    for (FieldVector vector : vectors) {
+      for (int i = 0; i < vector.getValueCount(); i++) {
+        Object value1 = data.get(index++);
+        Object value2 = vector.getObject(i);
+        if (value1 == null) {
+          assertNull(value2);
+          continue;
+        }
+        if (value2 instanceof byte[]) {
+          value2 = ByteBuffer.wrap((byte[]) value2);
+          if (value1 instanceof byte[]) {
+            value1 = ByteBuffer.wrap((byte[]) value1);
+          }
+        } else if (value2 instanceof Text) {
+          value2 = value2.toString();
+        }
+        assertEquals(value1, value2);
+      }
+    }
+  }
+}

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowIteratorTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.Test;
+
+public class AvroToArrowIteratorTest extends AvroTestBase {
+
+  private AvroToArrowVectorIterator writeAndRead(Schema schema, List data) throws Exception {
+    File dataFile = TMP.newFile();
+
+    BinaryEncoder
+        encoder = new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);
+    DatumWriter writer = new GenericDatumWriter(schema);
+    BinaryDecoder
+        decoder = new DecoderFactory().directBinaryDecoder(new FileInputStream(dataFile), null);
+
+    for (Object value : data) {
+      writer.write(value, encoder);
+    }
+
+    return AvroToArrow.avroToArrowIterator(schema, decoder, allocator, /*targetBatchSize=*/3);
+  }
+
+  @Test
+  public void testStringType() throws Exception {
+    Schema schema = getSchema("test_primitive_string.avsc");
+    List<String> data = Arrays.asList("v1", "v2", "v3", "v4", "v5");
+
+    List<VectorSchemaRoot> roots = new ArrayList<>();
+    List<FieldVector> vectors = new ArrayList<>();
+    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data)) {
+      while (iterator.hasNext()) {
+        VectorSchemaRoot root = iterator.next();
+        FieldVector vector = root.getFieldVectors().get(0);
+        roots.add(root);
+        vectors.add(vector);
+      }
+    }
+    checkPrimitiveResult(data, vectors);
+    AutoCloseables.close(roots);
+  }
+
+  @Test
+  public void testNullableStringType() throws Exception {
+    Schema schema = getSchema("test_nullable_string.avsc");
+
+    List<GenericRecord> data = new ArrayList<>();
+    List<String> expected = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      String value = i % 2 == 0 ? "test" + i : null;
+      record.put(0, value);
+      expected.add(value);
+      data.add(record);
+    }
+
+    List<VectorSchemaRoot> roots = new ArrayList<>();
+    List<FieldVector> vectors = new ArrayList<>();
+    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data);) {
+      while (iterator.hasNext()) {
+        VectorSchemaRoot root = iterator.next();
+        FieldVector vector = root.getFieldVectors().get(0);
+        roots.add(root);
+        vectors.add(vector);
+      }
+    }
+    checkPrimitiveResult(expected, vectors);
+    AutoCloseables.close(roots);
+
+  }
+
+  @Test
+  public void testRecordType() throws Exception {
+    Schema schema = getSchema("test_record.avsc");
+    ArrayList<GenericRecord> data = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, "test" + i);
+      record.put(1, i);
+      record.put(2, i % 2 == 0);
+      data.add(record);
+    }
+
+    List<VectorSchemaRoot> roots = new ArrayList<>();
+    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data)) {
+      while (iterator.hasNext()) {
+        roots.add(iterator.next());
+      }
+    }
+    checkRecordResult(schema, data, roots);
+    AutoCloseables.close(roots);
+
+  }
+
+  @Test
+  public void testArrayType() throws Exception {
+    Schema schema = getSchema("test_array.avsc");
+    List<List<?>> data = Arrays.asList(
+        Arrays.asList("11", "222", "999"),
+        Arrays.asList("12222", "2333", "1000"),
+        Arrays.asList("1rrr", "2ggg"),
+        Arrays.asList("1vvv", "2bbb"),
+        Arrays.asList("1fff", "2"));
+
+    List<VectorSchemaRoot> roots = new ArrayList<>();
+    List<ListVector> vectors = new ArrayList<>();
+    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data)) {
+      while (iterator.hasNext()) {
+        VectorSchemaRoot root = iterator.next();
+        roots.add(root);
+        vectors.add((ListVector) root.getFieldVectors().get(0));
+      }
+    }
+    checkArrayResult(data, vectors);
+    AutoCloseables.close(roots);
+  }
+}

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowIteratorTest.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -41,6 +43,12 @@ import org.junit.Test;
 
 public class AvroToArrowIteratorTest extends AvroTestBase {
 
+  @Override
+  public void init() {
+    final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    this.config = new AvroToArrowConfig(allocator, /*targetBatchSize=*/3);
+  }
+
   private AvroToArrowVectorIterator writeAndRead(Schema schema, List data) throws Exception {
     File dataFile = TMP.newFile();
 
@@ -54,7 +62,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
       writer.write(value, encoder);
     }
 
-    return AvroToArrow.avroToArrowIterator(schema, decoder, allocator, /*targetBatchSize=*/3);
+    return AvroToArrow.avroToArrowIterator(schema, decoder, config);
   }
 
   @Test

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
@@ -18,29 +18,21 @@
 package org.apache.arrow;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Objects;
 
-import org.apache.arrow.memory.BaseAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
-import org.apache.arrow.vector.util.JsonStringArrayList;
-import org.apache.arrow.vector.util.Text;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -50,28 +42,9 @@ import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
-import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-public class AvroToArrowTest {
-
-  @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
-
-  private BaseAllocator allocator;
-
-  @Before
-  public void init() {
-    allocator = new RootAllocator(Long.MAX_VALUE);
-  }
-
-  private Schema getSchema(String schemaName) throws Exception {
-    Path schemaPath = Paths.get(TestWriteReadAvroRecord.class.getResource("/").getPath(),
-        "schema", schemaName);
-    return new Schema.Parser().parse(schemaPath.toFile());
-  }
+public class AvroToArrowTest extends AvroTestBase {
 
   private VectorSchemaRoot writeAndRead(Schema schema, List data) throws Exception {
     File dataFile = TMP.newFile();
@@ -90,7 +63,7 @@ public class AvroToArrowTest {
   @Test
   public void testStringType() throws Exception {
     Schema schema = getSchema("test_primitive_string.avsc");
-    ArrayList<String> data = new ArrayList(Arrays.asList("v1", "v2", "v3", "v4", "v5"));
+    List<String> data = Arrays.asList("v1", "v2", "v3", "v4", "v5");
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -132,7 +105,7 @@ public class AvroToArrowTest {
   @Test
   public void testIntType() throws Exception {
     Schema schema = getSchema("test_primitive_int.avsc");
-    ArrayList<Integer> data = new ArrayList(Arrays.asList(1, 2, 3, 4, 5));
+    List<Integer> data = Arrays.asList(1, 2, 3, 4, 5);
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -158,7 +131,7 @@ public class AvroToArrowTest {
   @Test
   public void testLongType() throws Exception {
     Schema schema = getSchema("test_primitive_long.avsc");
-    ArrayList<Long> data = new ArrayList(Arrays.asList(1L, 2L, 3L, 4L, 5L));
+    List<Long> data = Arrays.asList(1L, 2L, 3L, 4L, 5L);
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -184,7 +157,7 @@ public class AvroToArrowTest {
   @Test
   public void testFloatType() throws Exception {
     Schema schema = getSchema("test_primitive_float.avsc");
-    ArrayList<Float> data = new ArrayList(Arrays.asList(1.1f, 2.2f, 3.3f, 4.4f, 5.5f));
+    List<Float> data = Arrays.asList(1.1f, 2.2f, 3.3f, 4.4f, 5.5f);
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -210,7 +183,7 @@ public class AvroToArrowTest {
   @Test
   public void testDoubleType() throws Exception {
     Schema schema = getSchema("test_primitive_double.avsc");
-    ArrayList<Double> data = new ArrayList(Arrays.asList(1.1, 2.2, 3.3, 4.4, 5.5));
+    List<Double> data = Arrays.asList(1.1, 2.2, 3.3, 4.4, 5.5);
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -236,12 +209,12 @@ public class AvroToArrowTest {
   @Test
   public void testBytesType() throws Exception {
     Schema schema = getSchema("test_primitive_bytes.avsc");
-    ArrayList<ByteBuffer> data = new ArrayList(Arrays.asList(
+    List<ByteBuffer> data = Arrays.asList(
         ByteBuffer.wrap("value1".getBytes(StandardCharsets.UTF_8)),
         ByteBuffer.wrap("value2".getBytes(StandardCharsets.UTF_8)),
         ByteBuffer.wrap("value3".getBytes(StandardCharsets.UTF_8)),
         ByteBuffer.wrap("value4".getBytes(StandardCharsets.UTF_8)),
-        ByteBuffer.wrap("value5".getBytes(StandardCharsets.UTF_8))));
+        ByteBuffer.wrap("value5".getBytes(StandardCharsets.UTF_8)));
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -267,7 +240,7 @@ public class AvroToArrowTest {
   @Test
   public void testBooleanType() throws Exception {
     Schema schema = getSchema("test_primitive_boolean.avsc");
-    ArrayList<Boolean> data = new ArrayList(Arrays.asList(true, false, true, false, true));
+    List<Boolean> data = Arrays.asList(true, false, true, false, true);
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -293,12 +266,12 @@ public class AvroToArrowTest {
   @Test
   public void testArrayType() throws Exception {
     Schema schema = getSchema("test_array.avsc");
-    List<List> data = new ArrayList(Arrays.asList(
+    List<List<?>> data = Arrays.asList(
         Arrays.asList("11", "222", "999"),
         Arrays.asList("12222", "2333", "1000"),
         Arrays.asList("1rrr", "2ggg"),
         Arrays.asList("1vvv", "2bbb"),
-        Arrays.asList("1fff", "2")));
+        Arrays.asList("1fff", "2"));
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);
@@ -406,64 +379,4 @@ public class AvroToArrowTest {
     checkPrimitiveResult(expected, vector);
   }
 
-  private void checkArrayResult(List<List> expected, ListVector vector) {
-    assertEquals(expected.size(), vector.getValueCount());
-    for (int i = 0; i < expected.size(); i++) {
-      checkPrimitiveResult(expected.get(i), (JsonStringArrayList) vector.getObject(i));
-    }
-  }
-
-  private void checkPrimitiveResult(List expected, List actual) {
-    assertEquals(expected.size(), actual.size());
-    for (int i = 0; i < expected.size(); i++) {
-      Object value1 = expected.get(i);
-      Object value2 = actual.get(i);
-      if (value1 == null) {
-        assertTrue(value2 == null);
-        continue;
-      }
-      if (value2 instanceof byte[]) {
-        value2 = ByteBuffer.wrap((byte[]) value2);
-      } else if (value2 instanceof Text) {
-        value2 = value2.toString();
-      }
-      assertTrue(Objects.equals(value1, value2));
-    }
-  }
-
-  private void checkPrimitiveResult(List data, FieldVector vector) {
-    assertEquals(data.size(), vector.getValueCount());
-    for (int i = 0; i < data.size(); i++) {
-      Object value1 = data.get(i);
-      Object value2 = vector.getObject(i);
-      if (value1 == null) {
-        assertTrue(value2 == null);
-        continue;
-      }
-      if (value2 instanceof byte[]) {
-        value2 = ByteBuffer.wrap((byte[]) value2);
-        if (value1 instanceof byte[]) {
-          value1 = ByteBuffer.wrap((byte[]) value1);
-        }
-      } else if (value2 instanceof Text) {
-        value2 = value2.toString();
-      }
-      assertTrue(Objects.equals(value1, value2));
-    }
-  }
-
-  private void checkRecordResult(Schema schema, ArrayList<GenericRecord> data, VectorSchemaRoot root) {
-    assertEquals(data.size(), root.getRowCount());
-    assertEquals(schema.getFields().size(), root.getFieldVectors().size());
-
-    for (int i = 0; i < schema.getFields().size(); i++) {
-      ArrayList fieldData = new ArrayList();
-      for (GenericRecord record : data) {
-        fieldData.add(record.get(i));
-      }
-
-      checkPrimitiveResult(fieldData, root.getFieldVectors().get(i));
-    }
-
-  }
 }

--- a/java/adapter/avro/src/test/resources/schema/test_nested_record.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nested_record.avsc
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "testNestedRecord",
+ "fields": [
+  {
+    "name" : "nested",
+    "type" : {
+        "type" : "record",
+        "name" : "nestedInRecord",
+        "fields": [
+             {"name": "f0", "type": "string"},
+             {"name": "f1", "type": "int"}
+        ]
+    }
+  }
+  ]
+}

--- a/java/adapter/avro/src/test/resources/schema/test_primitive_enum.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_primitive_enum.avsc
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "enum",
+ "symbols" : ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"],
+ "name": "testEnum"
+}


### PR DESCRIPTION
Related to [ARROW-6356](https://issues.apache.org/jira/browse/ARROW-6356).
Implement for converting avro Enum type.
Convert nested avro Record type to Arrow StructVector.

This is the last PR for avro type support, after this finished, we could call avro adapter a initial version.