### PR TITLE
ARROW-5125: [Python] Round-trip extreme dates on windows

### DIFF
--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -318,8 +318,7 @@ class Date64Converter
     if (PyDateTime_Check(obj)) {
       auto pydate = reinterpret_cast<PyDateTime_DateTime*>(obj);
       t = PyDateTime_to_ms(pydate);
-    }
-    if (PyDate_Check(obj)) {
+    } else if (PyDate_Check(obj)) {
       auto pydate = reinterpret_cast<PyDateTime_Date*>(obj);
       t = PyDate_to_ms(pydate);
     } else {

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -315,6 +315,10 @@ class Date64Converter
  public:
   Status AppendItem(PyObject* obj) {
     int64_t t;
+    if (PyDateTime_Check(obj)) {
+      auto pydate = reinterpret_cast<PyDateTime_DateTime*>(obj);
+      t = PyDateTime_to_ms(pydate);
+    }
     if (PyDate_Check(obj)) {
       auto pydate = reinterpret_cast<PyDateTime_Date*>(obj);
       t = PyDate_to_ms(pydate);

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -318,6 +318,8 @@ class Date64Converter
     if (PyDateTime_Check(obj)) {
       auto pydate = reinterpret_cast<PyDateTime_DateTime*>(obj);
       t = PyDateTime_to_ms(pydate);
+      // Truncate any intraday milliseconds
+      t -= t % 86400000LL;
     } else if (PyDate_Check(obj)) {
       auto pydate = reinterpret_cast<PyDateTime_Date*>(obj);
       t = PyDate_to_ms(pydate);

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -290,7 +290,7 @@ static inline int64_t PyDateTime_to_s(PyDateTime_DateTime* pydatetime) {
 }
 
 static inline int64_t PyDateTime_to_ms(PyDateTime_DateTime* pydatetime) {
-  int64_t date_ms = PyDateTime_to_s(pydatetime) * 1000LL;
+  int64_t date_ms = PyDateTime_to_s(pydatetime) * 1000;
   int ms = PyDateTime_DATE_GET_MICROSECOND(pydatetime) / 1000;
   return date_ms + ms;
 }

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -296,7 +296,7 @@ static inline int64_t PyDateTime_to_ms(PyDateTime_DateTime* pydatetime) {
 }
 
 static inline int64_t PyDateTime_to_us(PyDateTime_DateTime* pydatetime) {
-  int64_t ms = PyDateTime_to_ms(pydatetime) * 1000;
+  int64_t ms = PyDateTime_to_s(pydatetime) * 1000;
   int us = PyDateTime_DATE_GET_MICROSECOND(pydatetime);
   return ms * 1000 + us;
 }

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -290,13 +290,13 @@ static inline int64_t PyDateTime_to_s(PyDateTime_DateTime* pydatetime) {
 }
 
 static inline int64_t PyDateTime_to_ms(PyDateTime_DateTime* pydatetime) {
-  int64_t date_ms = PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime));
+  int64_t date_ms = PyDateTime_to_s(pydatetime) * 1000LL;
   int ms = PyDateTime_DATE_GET_MICROSECOND(pydatetime) / 1000;
   return date_ms + ms;
 }
 
 static inline int64_t PyDateTime_to_us(PyDateTime_DateTime* pydatetime) {
-  int64_t ms = PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime));
+  int64_t ms = PyDateTime_to_ms(pydatetime) * 1000;
   int us = PyDateTime_DATE_GET_MICROSECOND(pydatetime);
   return ms * 1000 + us;
 }

--- a/cpp/src/arrow/python/util/datetime.h
+++ b/cpp/src/arrow/python/util/datetime.h
@@ -272,9 +272,6 @@ static inline int64_t PyDate_to_days(PyDateTime_Date* pydate) {
 
 static inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
   int64_t total_seconds = 0;
-  total_seconds += PyDateTime_DATE_GET_SECOND(pydate);
-  total_seconds += PyDateTime_DATE_GET_MINUTE(pydate) * 60;
-  total_seconds += PyDateTime_DATE_GET_HOUR(pydate) * 3600;
   int64_t days =
       get_days_from_date(PyDateTime_GET_YEAR(pydate), PyDateTime_GET_MONTH(pydate),
                          PyDateTime_GET_DAY(pydate));
@@ -283,7 +280,13 @@ static inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
 }
 
 static inline int64_t PyDateTime_to_s(PyDateTime_DateTime* pydatetime) {
-  return PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime)) / 1000LL;
+  int64_t total_seconds = 0;
+  total_seconds += PyDateTime_DATE_GET_SECOND(pydatetime);
+  total_seconds += PyDateTime_DATE_GET_MINUTE(pydatetime) * 60;
+  total_seconds += PyDateTime_DATE_GET_HOUR(pydatetime) * 3600;
+
+  return total_seconds +
+         (PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime)) / 1000LL);
 }
 
 static inline int64_t PyDateTime_to_ms(PyDateTime_DateTime* pydatetime) {

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -223,8 +223,8 @@ cdef class Date32Value(ArrayValue):
         cdef CDate32Array* ap = <CDate32Array*> self.sp_array.get()
 
         # Shift to seconds since epoch
-        return datetime.datetime.utcfromtimestamp(
-            int(ap.Value(self.index)) * 86400).date()
+        return (datetime.date(1970, 1, 1) +
+                datetime.timedelta(days=ap.Value(self.index)))
 
 
 cdef class Date64Value(ArrayValue):
@@ -237,8 +237,9 @@ cdef class Date64Value(ArrayValue):
         Return this value as a Python datetime.datetime instance.
         """
         cdef CDate64Array* ap = <CDate64Array*> self.sp_array.get()
-        return datetime.datetime.utcfromtimestamp(
-            ap.Value(self.index) / 1000).date()
+        return (datetime.date(1970, 1, 1) +
+                datetime.timedelta(
+                    days=ap.Value(self.index) / 86400000))
 
 
 cdef class Time32Value(ArrayValue):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -920,6 +920,18 @@ def test_cast_date64_to_int():
     assert result.equals(expected)
 
 
+def test_date64_from_builtin_datetime():
+    val1 = datetime.datetime(2000, 1, 1, 12, 34, 56, 123456)
+    val2 = datetime.datetime(2000, 1, 1)
+    result = pa.array([val1, val2], type='date64')
+    result2 = pa.array([val1.date(), val2.date()], type='date64')
+
+    assert result.equals(result2)
+
+    as_i8 = result.view('int64')
+    assert as_i8[0].as_py() == as_i8[1].as_py()
+
+
 @pytest.mark.parametrize(('ty', 'values'), [
     ('bool', [True, False, True]),
     ('uint8', range(0, 255)),

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import pytest
 
 import numpy as np
@@ -220,7 +221,6 @@ class TestScalars(unittest.TestCase):
 
     def test_date(self):
         # ARROW-5125
-        import datetime
         d1, d2 = datetime.date(3200, 1, 1), datetime.date(1960, 1, 1),
         extremes = pa.array([d1, d2], type=pa.date32())
         assert extremes[0] == d1
@@ -228,7 +228,6 @@ class TestScalars(unittest.TestCase):
         extremes = pa.array([d1, d2], type=pa.date64())
         assert extremes[0] == d1
         assert extremes[1] == d2
-
 
     @pytest.mark.pandas
     def test_timestamp(self):

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -218,6 +218,18 @@ class TestScalars(unittest.TestCase):
         v = arr[3]
         assert len(v) == 0
 
+    def test_date(self):
+        # ARROW-5125
+        import datetime
+        d1, d2 = datetime.date(3200, 1, 1), datetime.date(1960, 1, 1),
+        extremes = pa.array([d1, d2], type=pa.date32())
+        assert extremes[0] == d1
+        assert extremes[1] == d2
+        extremes = pa.array([d1, d2], type=pa.date64())
+        assert extremes[0] == d1
+        assert extremes[1] == d2
+
+
     @pytest.mark.pandas
     def test_timestamp(self):
         import pandas as pd


### PR DESCRIPTION
Also, tries to fix: ARROW-4746 by separating out PyDateTime_DATE_GET_* calls that should only be called on datetime objects to the appropriate method.

Note, I don't have a windows box readily available to test on, and couldn't replicate on Mac (per linked python issue on the JIRA I believe this is windows only). So I hope we have appveyor tests that cover this.

If there are instructions for running pypy I can see if this fixes ARROW-4746