### PR TITLE
ARROW-4880: [Python] Rehabilitate ASV benchmark build scripts

### DIFF
--- a/docs/source/python/benchmarks.rst
+++ b/docs/source/python/benchmarks.rst
@@ -30,6 +30,10 @@ Running the benchmarks
 To run the benchmarks for a locally-built Arrow, run ``asv dev`` or
 ``asv run --python=same``.
 
+We use conda environments as part of running the benchmarks. To use the ``asv``
+setup, you must set the ``$CONDA_HOME`` environment variable to point to the
+root of your conda installation.
+
 Running for arbitrary Git revisions
 -----------------------------------
 
@@ -39,10 +43,6 @@ the project's evolution.  You need to have the latest development version of ASV
 .. code::
 
     pip install git+https://github.com/airspeed-velocity/asv
-
-The build scripts assume that Conda's ``activate`` script is on the PATH
-(the ``conda activate`` command unfortunately isn't available from
-non-interactive scripts).
 
 Now you should be ready to run ``asv run`` or whatever other command
 suits your needs.  Note that this can be quite long, as each Arrow needs

--- a/python/asv-build.sh
+++ b/python/asv-build.sh
@@ -21,9 +21,15 @@ set -e
 
 # ASV doesn't activate its conda environment for us
 if [ -z "$ASV_ENV_DIR" ]; then exit 1; fi
-# Avoid "conda activate" because it's only set up in interactive shells
-# (https://github.com/conda/conda/issues/8072)
-source activate $ASV_ENV_DIR
+
+if [ -z "$CONDA_HOME" ]; then
+  echo "Please set \$CONDA_HOME to point to your root conda installation"
+  exit 1;
+fi
+
+eval "$($CONDA_HOME/bin/conda shell.bash hook)"
+
+conda activate $ASV_ENV_DIR
 echo "== Conda Prefix for benchmarks: " $CONDA_PREFIX " =="
 
 # Build Arrow C++ libraries

--- a/python/asv-build.sh
+++ b/python/asv-build.sh
@@ -39,8 +39,6 @@ export ORC_HOME=$CONDA_PREFIX
 export PROTOBUF_HOME=$CONDA_PREFIX
 export BOOST_ROOT=$CONDA_PREFIX
 
-export CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=1"
-
 pushd ../cpp
 mkdir -p build
 pushd build
@@ -49,11 +47,13 @@ cmake -GNinja \
       -DCMAKE_BUILD_TYPE=release \
       -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
       -DARROW_CXXFLAGS=$CXXFLAGS \
-      -DARROW_DEPENDENCY_SOURCE=CONDA \
       -DARROW_USE_GLOG=off \
+      -DARROW_FLIGHT=on \
+      -DARROW_ORC=on \
       -DARROW_PARQUET=on \
       -DARROW_PYTHON=on \
       -DARROW_PLASMA=on \
+      -DARROW_S3=on \
       -DARROW_BUILD_TESTS=off \
       ..
 cmake --build . --target install
@@ -65,6 +65,8 @@ popd
 export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.1
 export PYARROW_BUILD_TYPE=release
 export PYARROW_PARALLEL=8
+export PYARROW_WITH_FLIGHT=1
+export PYARROW_WITH_ORC=1
 export PYARROW_WITH_PARQUET=1
 export PYARROW_WITH_PLASMA=1
 

--- a/python/asv-build.sh
+++ b/python/asv-build.sh
@@ -49,6 +49,7 @@ cmake -GNinja \
       -DCMAKE_BUILD_TYPE=release \
       -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
       -DARROW_CXXFLAGS=$CXXFLAGS \
+      -DARROW_DEPENDENCY_SOURCE=CONDA \
       -DARROW_USE_GLOG=off \
       -DARROW_PARQUET=on \
       -DARROW_PYTHON=on \

--- a/python/asv.conf.json
+++ b/python/asv.conf.json
@@ -45,8 +45,6 @@
     // "branches": ["master"], // for git
     // "branches": ["default"],    // for mercurial
 
-    "branches": ["ARROW-4880"], // for git
-
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as
@@ -67,7 +65,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.6"],
+    "pythons": ["3.7"],
 
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
@@ -85,19 +83,25 @@
     //     "pip+emcee": [""],   // emcee is only available for install with pip.
     // },
     "matrix": {
-        "boost-cpp": ["1.67.0"],
+        // Use older boost since it works on more editions of the project
+        "aws-sdk-cpp": [],
+        "boost-cpp": ["1.68.0"],
         "brotli": [],
         "cmake": [],
         "cython": [],
-        "flatbuffers": ["1.7.1"],
+        "double-conversion": [],
+        "flatbuffers": [],
+        "grpc-cpp": [],
         "libprotobuf": [],
         "lz4-c": [],
         "ninja": [],
-        "numpy": ["1.14.5"],
-        "pandas": ["0.23.3"],
+        "numpy": [],
+        "pandas": ["0.25.1"],
         "pip+setuptools_scm": [],
         "rapidjson": [],
+        "re2": [],
         "snappy": [],
+        "thrift-cpp": [],
         "zstd": [],
     },
 

--- a/python/asv.conf.json
+++ b/python/asv.conf.json
@@ -45,6 +45,8 @@
     // "branches": ["master"], // for git
     // "branches": ["default"],    // for mercurial
 
+    "branches": ["ARROW-4880"], // for git
+
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL
     // (if remote), or by looking for special directories, such as


### PR DESCRIPTION
Using `asv run` now works against master. I am making this depend on setting `$CONDA_HOME` environment variable so that conda can be properly initialized per the advice of the conda developers