### PR TITLE
ARROW-6460: [Java] Add benchmark and large fake data UT for avro adapter

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -74,6 +74,6 @@ public class AvroBytesConsumer implements Consumer<VarBinaryVector> {
   @Override
   public void resetValueVector(VarBinaryVector vector) {
     this.vector = vector;
-    this.currentIndex = currentIndex;
+    this.currentIndex = 0;
   }
 }

--- a/java/adapter/avro/src/test/resources/schema/test_large_data.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_large_data.avsc
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "type": "record",
+ "name": "testLargeData",
+ "fields": [
+    {
+        "name": "f0",
+        "type": {
+          "name" : "f0",
+          "type" : "enum",
+          "symbols" : ["value1", "value2", "value3", "value4", "value5"]
+        }
+    },
+    {
+        "name" : "f1",
+        "type" : {
+            "type" : "record",
+            "name" : "nestedRecord",
+            "fields": [
+                 {"name": "f1_0", "type": "string"},
+                 {"name": "f1_1", "type": "int"}
+            ]
+        }
+    },
+
+    {"name": "f2", "type": "string"},
+    {"name": "f3", "type": "int"},
+    {"name": "f4", "type": "boolean"},
+    {"name": "f5", "type": "float"},
+    {"name": "f6", "type": "double"},
+    {"name": "f7", "type": "bytes"},
+    {"name": "f8", "type": ["string", "int"]},
+    {
+        "name": "f9",
+        "type": {
+            "name" : "f9",
+            "type" : "array",
+            "items" : "string"
+        }
+    },
+    {
+        "name": "f10",
+        "type": {
+            "name" : "f10",
+            "type" : "map",
+            "values" : "string"
+        }
+    },
+    {
+      "name": "f11",
+      "type": {
+          "type" : "fixed",
+          "name" : "f11",
+          "size" : 5
+      }
+    }
+  ]
+}

--- a/java/performance/pom.xml
+++ b/java/performance/pom.xml
@@ -56,6 +56,16 @@
             <artifactId>arrow-memory</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-avro</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/java/performance/src/test/java/org/apache/arrow/adapter/AvroAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/AvroAdapterBenchmarks.java
@@ -26,6 +26,7 @@ import org.apache.arrow.AvroToArrowConfig;
 import org.apache.arrow.AvroToArrowVectorIterator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -36,9 +37,7 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -57,9 +56,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  */
 @State(Scope.Benchmark)
 public class AvroAdapterBenchmarks {
-
-  @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
 
   private final int valueCount = 3000;
 
@@ -119,13 +115,18 @@ public class AvroAdapterBenchmarks {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public int testAvroToArrow() throws Exception {
+    int sum = 0;
     try (AvroToArrowVectorIterator iter = AvroToArrow.avroToArrowIterator(schema, decoder, config)) {
       while (iter.hasNext()) {
         VectorSchemaRoot root = iter.next();
+        IntVector intVector = (IntVector) root.getVector("f1");
+        for (int i = 0; i < intVector.getValueCount(); i++) {
+          sum += intVector.get(i);
+        }
         root.close();
       }
     }
-    return 0;
+    return sum;
   }
 
   @Test

--- a/java/performance/src/test/java/org/apache/arrow/adapter/AvroAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/AvroAdapterBenchmarks.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adapter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.arrow.AvroToArrow;
+import org.apache.arrow.AvroToArrowConfig;
+import org.apache.arrow.AvroToArrowVectorIterator;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks for avro adapter.
+ */
+@State(Scope.Benchmark)
+public class AvroAdapterBenchmarks {
+
+  @ClassRule
+  public static final TemporaryFolder TMP = new TemporaryFolder();
+
+  private final int valueCount = 3000;
+
+  private AvroToArrowConfig config;
+
+  private Schema schema;
+  private Decoder decoder;
+
+  /**
+   * Setup benchmarks.
+   */
+  @Setup
+  public void prepare() throws Exception {
+    BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+    config = new AvroToArrowConfig(allocator);
+
+    String schemaStr = "{\n" + " \"namespace\": \"org.apache.arrow.avro\",\n" +
+         " \"type\": \"record\",\n" + " \"name\": \"testBenchmark\",\n" + " \"fields\": [\n" +
+         "    {\"name\": \"f0\", \"type\": \"string\"},\n" +
+         "    {\"name\": \"f1\", \"type\": \"int\"},\n" +
+         "    {\"name\": \"f2\", \"type\": \"long\"},\n" +
+         "    {\"name\": \"f3\", \"type\": \"boolean\"},\n" +
+         "    {\"name\": \"f4\", \"type\": \"float\"}\n" + "  ]\n" + "}";
+    schema = new Schema.Parser().parse(schemaStr);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(out, null);
+    DatumWriter writer = new GenericDatumWriter(schema);
+
+    decoder = new DecoderFactory().directBinaryDecoder(new ByteArrayInputStream(out.toByteArray()), null);
+
+    for (int i = 0; i < valueCount; i++) {
+      GenericRecord record = new GenericData.Record(schema);
+      record.put(0, "test" + i);
+      record.put(1, i);
+      record.put(2, i + 1L);
+      record.put(3, i % 2 == 0);
+      record.put(4, i + 0.1f);
+      writer.write(record, encoder);
+    }
+
+  }
+
+  /**
+   * Tear down benchmarks.
+   */
+  @TearDown
+  public void tearDown() {
+    config.getAllocator().close();
+  }
+
+  /**
+   * Test {@link AvroToArrow#avroToArrowIterator(Schema, Decoder, AvroToArrowConfig)}
+   * @return useless. To avoid DCE by JIT.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public int testAvroToArrow() throws Exception {
+    try (AvroToArrowVectorIterator iter = AvroToArrow.avroToArrowIterator(schema, decoder, config)) {
+      while (iter.hasNext()) {
+        VectorSchemaRoot root = iter.next();
+        root.close();
+      }
+    }
+    return 0;
+  }
+
+  @Test
+  public void evaluate() throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(AvroAdapterBenchmarks.class.getSimpleName())
+        .forks(1)
+        .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
Related to [ARROW-6460](https://issues.apache.org/jira/browse/ARROW-6460).

i. This issue is about to add tests with a large fake data set (600000 rows) and ensures no OOMs occur.
ii. Add benchmark for avro iterator to get a baseline number.