### PR TITLE
ARROW-6480: [Developer][Crossbow] Implement summary report e-mailer with polling logic

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -19,6 +19,7 @@
 
 import os
 import re
+import sys
 import time
 import hashlib
 from io import StringIO
@@ -933,7 +934,7 @@ def status(ctx, job_name, output):
               help='Name to use for report e-mail.')
 @click.option('--smtp_port', default=465,
               help='Name to use for report e-mail.')
-@click.option('--stop_if_pending', default=True,
+@click.option('--stop_if_pending/--no_stop_if_pending', default=True,
               help='Do not send e-mail if there are still pending tasks')
 @click.pass_context
 def report(ctx, job_name, sender_name, recipient_email, smtp_user,
@@ -966,7 +967,8 @@ def generate_email_report(job, sender_name, recipient_email, smtp_user,
     if stop_if_pending and len(pending_tasks) > 0:
         print("The following tasks are still pending:")
         for task in pending_tasks:
-            print("  - {}".format(task.name))
+            print("  - {}".format(task.task.branch))
+        sys.exit(0)
 
     subject = "Crossbow Task Report for {}".format(job.name)
 

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -1009,7 +1009,7 @@ def generate_report(job, sender_name, recipient_email, smtp_user,
     if wait_if_pending and len(pending_tasks) > 0:
         return pending_tasks
 
-    subject = "Crossbow Task Report for {}".format(job.name)
+    subject = "Apache Arrow Crossbow Task Report for {}".format(job.name)
 
     if len(failed_tasks) > 0:
         subject += ": {} FAILURES".format(len(failed_tasks))


### PR DESCRIPTION
This will help with making the Arrow community aware of extra-CI jobs that are failing. 

It's intended to be used like this

```
JOB_NAME=$(python crossbow.py latest-prefix nightly)
python crossbow.py report $JOB_NAME
```

Example output: https://gist.github.com/wesm/6271bedaa4c49c675e12050784d847f4

It's a bit tedious to test. Someone (me?) will need to set up a cron job to send a daily e-mail about the nightlies running on https://github.com/ursa-labs/crossbow