### PR TITLE
ARROW-6484: [Java] Enable create indexType for DictionaryEncoding according to dictionary value count

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroEnumConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroEnumConsumer.java
@@ -19,6 +19,7 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.avro.io.Decoder;
@@ -27,22 +28,22 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume enum type values from avro decoder.
  * Write the data to {@link IntVector}.
  */
-public class AvroEnumConsumer implements Consumer<IntVector> {
+public class AvroEnumConsumer implements Consumer<BaseIntVector> {
 
-  private IntVector vector;
+  private BaseIntVector vector;
 
   private int currentIndex;
 
   /**
    * Instantiate a AvroEnumConsumer.
    */
-  public AvroEnumConsumer(IntVector vector) {
+  public AvroEnumConsumer(BaseIntVector vector) {
     this.vector = vector;
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readEnum());
+    vector.setWithPossibleTruncate(currentIndex++, decoder.readEnum());
   }
 
   @Override
@@ -66,7 +67,7 @@ public class AvroEnumConsumer implements Consumer<IntVector> {
   }
 
   @Override
-  public void resetValueVector(IntVector vector) {
+  public void resetValueVector(BaseIntVector vector) {
     this.vector = vector;
     this.currentIndex = 0;
   }

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
@@ -131,7 +131,8 @@ public class AvroToArrowTest extends AvroTestBase {
         new GenericData.EnumSymbol(schema, "DIAMONDS"),
         new GenericData.EnumSymbol(schema, "CLUBS"),
         new GenericData.EnumSymbol(schema, "SPADES"));
-    List<Integer> expectedIndices = Arrays.asList(0, 1, 2, 3, 0);
+
+    List<Byte> expectedIndices = Arrays.asList((byte)0, (byte)1, (byte)2, (byte)3, (byte)0);
 
     VectorSchemaRoot root = writeAndRead(schema, data);
     FieldVector vector = root.getFieldVectors().get(0);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseIntVector.java
@@ -20,7 +20,7 @@ package org.apache.arrow.vector;
 /**
  * Interface for all int type vectors.
  */
-public interface BaseIntVector extends ValueVector {
+public interface BaseIntVector extends FieldVector {
 
   /**
    * Sets the value at index, note this value may need to be need truncated.

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -18,9 +18,11 @@
 package org.apache.arrow.vector.dictionary;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
@@ -69,6 +71,24 @@ public class DictionaryEncoder {
   public static ValueVector decode(ValueVector indices, Dictionary dictionary) {
     DictionaryEncoder encoder = new DictionaryEncoder(dictionary, indices.getAllocator());
     return encoder.decode(indices);
+  }
+
+  /**
+   * Get the indexType according to the dictionary vector valueCount.
+   * @param valueCount dictionary vector valueCount.
+   * @return index type.
+   */
+  public static ArrowType.Int getIndexType(int valueCount) {
+    Preconditions.checkArgument(valueCount >= 0);
+    if (valueCount <= Byte.MAX_VALUE) {
+      return new ArrowType.Int(8, true);
+    } else if (valueCount <= Character.MAX_VALUE) {
+      return new ArrowType.Int(16, true);
+    } else if (valueCount <= Integer.MAX_VALUE) {
+      return new ArrowType.Int(32, true);
+    } else {
+      return new ArrowType.Int(64, true);
+    }
   }
 
   /**


### PR DESCRIPTION
Related to [ARROW-6484](https://issues.apache.org/jira/browse/ARROW-6484).

Currently, when create DictionaryEncoding, we need to specify indexType, and it use Int(32, true) as default if this value is null.
Actually, when dictionary valueCount is small, we should use Int(8,true)/Int(16,true) instead to reduce memory allocation.
This issue is about to provide API for creating indexType according to valueCount and apply it to avro adapter for enum type.