### PR TITLE
ARROW-6365: [R] Should be able to coerce numeric to integer with schema

### DIFF
--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -354,7 +354,6 @@ struct Unbox<Type, enable_if_integer<Type>> {
     }
     return Status::OK();
   }
-
 };
 
 template <>

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -21,6 +21,26 @@
 namespace arrow {
 namespace r {
 
+template <typename T>
+inline bool is_na(T value) {
+  return false;
+}
+
+template <>
+inline bool is_na<int64_t>(int64_t value) {
+  return value == NA_INT64;
+}
+
+template <>
+inline bool is_na<double>(double value) {
+  return ISNA(value);
+}
+
+template <>
+inline bool is_na<int>(int value) {
+  return value == NA_INTEGER;
+}
+
 std::shared_ptr<Array> MakeStringArray(Rcpp::StringVector_ vec) {
   R_xlen_t n = vec.size();
 
@@ -302,12 +322,14 @@ struct Unbox<Type, enable_if_integer<Type>> {
   static inline Status Ingest(BuilderType* builder, SEXP obj) {
     switch (TYPEOF(obj)) {
       case INTSXP:
-        return IngestRange<int>(builder, INTEGER(obj), XLENGTH(obj), NA_INTEGER);
+        return IngestRange<int>(builder, INTEGER(obj), XLENGTH(obj));
       case REALSXP:
         if (Rf_inherits(obj, "integer64")) {
           return IngestRange<int64_t>(builder, reinterpret_cast<int64_t*>(REAL(obj)),
-                                      XLENGTH(obj), NA_INT64);
+                                      XLENGTH(obj));
         }
+        return IngestRange(builder, REAL(obj), XLENGTH(obj));
+
       // TODO: handle raw and logical
       default:
         break;
@@ -319,10 +341,10 @@ struct Unbox<Type, enable_if_integer<Type>> {
   }
 
   template <typename T>
-  static inline Status IngestRange(BuilderType* builder, T* p, R_xlen_t n, T na) {
+  static inline Status IngestRange(BuilderType* builder, T* p, R_xlen_t n) {
     RETURN_NOT_OK(builder->Resize(n));
     for (R_xlen_t i = 0; i < n; i++, ++p) {
-      if (*p == na) {
+      if (is_na<T>(*p)) {
         builder->UnsafeAppendNull();
       } else {
         CType value = 0;
@@ -332,6 +354,7 @@ struct Unbox<Type, enable_if_integer<Type>> {
     }
     return Status::OK();
   }
+
 };
 
 template <>
@@ -845,25 +868,6 @@ bool can_reuse_memory(SEXP x, const std::shared_ptr<arrow::DataType>& type) {
   return false;
 }
 
-template <typename T>
-inline bool is_na(T value) {
-  return false;
-}
-
-template <>
-inline bool is_na<int64_t>(int64_t value) {
-  return value == NA_INT64;
-}
-
-template <>
-inline bool is_na<double>(double value) {
-  return ISNA(value);
-}
-
-template <>
-inline bool is_na<int>(int value) {
-  return value == NA_INTEGER;
-}
 // this is only used on some special cases when the arrow Array can just use the memory of
 // the R object, via an RBuffer, hence be zero copy
 template <int RTYPE, typename Type>

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -387,13 +387,20 @@ test_that("array() aborts on overflow", {
   expect_error(array(bit64::as.integer64(2^32), type = uint32()), "Invalid.*downsize")
 })
 
-test_that("array() does not convert doubles to integer", {
+test_that("array() can convert doubles to integer", {
   types <- list(
     int8(), int16(), int32(), int64(),
     uint8(), uint16(), uint32(), uint64()
   )
   for(type in types) {
-    expect_error(array(10, type = type)$type, "Cannot convert.*REALSXP")
+    a <- array(10, type = type)
+    expect_equal(a$type, type)
+
+    # exception for now because we cannot handle
+    # unsigned 64 bit integers yet
+    if (type != uint64()) {
+      expect_true(a$as_vector() == 10L)
+    }
   }
 })
 

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -87,7 +87,7 @@ test_that("table() handles record batches with splicing", {
   tab <- table(batch, batch, batch)
   expect_equal(tab$schema, batch$schema)
   expect_equal(tab$num_rows, 6L)
-  expect_equal(
+  expect_equivalent(
     as.data.frame(tab),
     vctrs::vec_rbind(as.data.frame(batch), as.data.frame(batch), as.data.frame(batch))
   )
@@ -96,7 +96,7 @@ test_that("table() handles record batches with splicing", {
   tab <- table(!!!batches)
   expect_equal(tab$schema, batch$schema)
   expect_equal(tab$num_rows, 6L)
-  expect_equal(
+  expect_equivalent(
     as.data.frame(tab),
     vctrs::vec_rbind(!!!purrr::map(batches, as.data.frame))
   )

--- a/r/tests/testthat/test-chunkedarray.R
+++ b/r/tests/testthat/test-chunkedarray.R
@@ -227,13 +227,19 @@ test_that("array() aborts on overflow", {
   expect_error(chunked_array(bit64::as.integer64(2^32), type = uint32()), "Invalid.*downsize")
 })
 
-test_that("chunked_array() does not convert doubles to integer", {
+test_that("chunked_array() convert doubles to integers", {
   types <- list(
     int8(), int16(), int32(), int64(),
     uint8(), uint16(), uint32(), uint64()
   )
   for(type in types) {
-    expect_error(chunked_array(10, type = type)$type, "Cannot convert.*REALSXP")
+    a <- chunked_array(10, type = type)
+    expect_equal(a$type, type)
+    if (type != uint64()) {
+      # exception for unsigned integer 64 that
+      # wa cannot handle yet
+      expect_true(a$as_vector() == 10)
+    }
   }
 })
 
@@ -242,8 +248,10 @@ test_that("chunked_array() uses the first ... to infer type", {
   expect_equal(a$type, float64())
 })
 
-test_that("chunked_array() fails if need downcast", {
-  expect_error(chunked_array(10L, 10))
+test_that("chunked_array() handles downcasting", {
+   a <- chunked_array(10L, 10)
+   expect_equal(a$type, int32())
+   expect_equal(a$as_vector(), c(10L, 10L))
 })
 
 test_that("chunked_array() makes chunks of the same type", {


### PR DESCRIPTION
``` r
arrow::array(10, type = arrow::int32())
#> arrow::Array 
#> [
#>   10
#> ]
```

<sup>Created on 2019-09-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>