### PR TITLE
ARROW-6490: [Java][Memory] Log error for leak in allocator close

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -458,9 +458,10 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
     // Is there unaccounted-for outstanding allocation?
     final long allocated = getAllocatedMemory();
     if (allocated > 0) {
-      throw new IllegalStateException(
-        String.format("Memory was leaked by query. Memory leaked: (%d)\n%s%s", allocated,
-          outstandingChildAllocators.toString(), toString()));
+      String msg =  String.format("Memory was leaked by query. Memory leaked: (%d)\n%s", allocated,
+          toString());
+      logger.error(msg);
+      throw new IllegalStateException(msg);
     }
 
     // we need to release our memory to our parent before we tell it we've closed.


### PR DESCRIPTION
- Log exceptions on leak so that it is easier to debug when these happen instead of depending on consuming code.