### PR TITLE
ARROW-6488: [Python] fix equality with pyarrow.NULL to return NULL

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -46,6 +46,9 @@ cdef class NullType(Scalar):
         """
         return None
 
+    def __eq__(self, other):
+        return NA
+
 
 _NULL = NA = NullType()
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -37,6 +37,10 @@ class TestScalars(unittest.TestCase):
             assert v is pa.NA
             assert v.as_py() is None
 
+    def test_null_equality(self):
+        assert (pa.NA == pa.NA) is pa.NA
+        assert (pa.NA == 1) is pa.NA
+
     def test_bool(self):
         arr = pa.array([True, None, False, None])
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6488

There are others things we would need to implement to have a full, proper behaviour (other comparison, logical, .. operators), but since the other scalars also just implement equality for now, it seems to make sense to at least fix equality for `pa.NULL` as well.