### PR TITLE
ARROW-6375: [C++] Extend ConversionTraits to allow efficiently appending list values in STL API

### DIFF
--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -52,11 +52,11 @@ using BareTupleElement = typename std::remove_const<typename std::remove_referen
 template <typename T, typename Enable = void>
 struct ConversionTraits {};
 
-#define ARROW_STL_CONVERSION(c_type, ArrowType_)                                         \
+#define ARROW_STL_CONVERSION(CType_, ArrowType_)                                         \
   template <>                                                                            \
-  struct ConversionTraits<c_type> : public CTypeTraits<c_type> {                         \
+  struct ConversionTraits<CType_> : public CTypeTraits<CType_> {                         \
     static Status AppendRow(typename TypeTraits<ArrowType_>::BuilderType& builder,       \
-                            c_type cell) {                                               \
+                            CType_ cell) {                                               \
       return builder.Append(cell);                                                       \
     }                                                                                    \
     template <typename Range>                                                            \
@@ -66,7 +66,7 @@ struct ConversionTraits {};
                     "Appending multiple rows to given range type isn't implemented for " \
                     "this type.");                                                       \
     }                                                                                    \
-    static c_type GetEntry(const typename TypeTraits<ArrowType_>::ArrayType& array,      \
+    static CType_ GetEntry(const typename TypeTraits<ArrowType_>::ArrayType& array,      \
                            size_t j) {                                                   \
       return array.Value(j);                                                             \
     }                                                                                    \
@@ -74,9 +74,9 @@ struct ConversionTraits {};
   };                                                                                     \
                                                                                          \
   template <>                                                                            \
-  Status ConversionTraits<c_type>::AppendMultipleRows<const std::vector<c_type>&>(       \
+  Status ConversionTraits<CType_>::AppendMultipleRows<const std::vector<CType_>&>(       \
       typename TypeTraits<ArrowType_>::BuilderType & builder,                            \
-      const std::vector<c_type>& cell_range) {                                           \
+      const std::vector<CType_>& cell_range) {                                           \
     return builder.AppendValues(cell_range);                                             \
   }
 
@@ -167,24 +167,24 @@ Status AppendMultipleRows(Builder&& builder, Range&& cell_range) {
       builder, std::forward<Range>(cell_range));
 }
 
-template <typename value_c_type>
-struct ConversionTraits<std::vector<value_c_type>>
-    : public CTypeTraits<std::vector<value_c_type>> {
-  static Status AppendRow(ListBuilder& builder, const std::vector<value_c_type>& cell) {
-    return AppendMultipleRows<value_c_type>(builder, cell);
+template <typename ValueCType>
+struct ConversionTraits<std::vector<ValueCType>>
+    : public CTypeTraits<std::vector<ValueCType>> {
+  static Status AppendRow(ListBuilder& builder, const std::vector<ValueCType>& cell) {
+    return AppendMultipleRows<ValueCType>(builder, cell);
   }
 
-  static std::vector<value_c_type> GetEntry(const ListArray& array, size_t j) {
-    using ElementArrayType = typename TypeTraits<
-        typename ConversionTraits<value_c_type>::ArrowType>::ArrayType;
+  static std::vector<ValueCType> GetEntry(const ListArray& array, size_t j) {
+    using ElementArrayType =
+        typename TypeTraits<typename ConversionTraits<ValueCType>::ArrowType>::ArrayType;
 
     const ElementArrayType& value_array =
         ::arrow::internal::checked_cast<const ElementArrayType&>(*array.values());
 
-    std::vector<value_c_type> vec(array.value_length(j));
+    std::vector<ValueCType> vec(array.value_length(j));
     for (int64_t i = 0; i < array.value_length(j); i++) {
-      vec[i] = ConversionTraits<value_c_type>::GetEntry(value_array,
-                                                        array.value_offset(j) + i);
+      vec[i] =
+          ConversionTraits<ValueCType>::GetEntry(value_array, array.value_offset(j) + i);
     }
     return vec;
   }

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -70,23 +70,25 @@ Status AppendListValues(CBuilderType<ValueCType>& value_builder, Range&& cell_ra
   return Status::OK();
 }
 
-#define ARROW_STL_CONVERSION(CType_, ArrowType_)                                       \
-  template <>                                                                          \
-  struct ConversionTraits<CType_> : public CTypeTraits<CType_> {                       \
-    static Status AppendRow(typename TypeTraits<ArrowType_>::BuilderType& builder,     \
-                            CType_ cell) {                                             \
-      return builder.Append(cell);                                                     \
-    }                                                                                  \
-    static CType_ GetEntry(const typename TypeTraits<ArrowType_>::ArrayType& array,    \
-                           size_t j) {                                                 \
-      return array.Value(j);                                                           \
-    }                                                                                  \
-    constexpr static bool nullable = false;                                            \
-  };                                                                                   \
-                                                                                       \
-  Status AppendListValues(typename TypeTraits<ArrowType_>::BuilderType& value_builder, \
-                          const std::vector<CType_>& cell_range) {                     \
-    return value_builder.AppendValues(cell_range);                                     \
+#define ARROW_STL_CONVERSION(CType_, ArrowType_)                                    \
+  template <>                                                                       \
+  struct ConversionTraits<CType_> : public CTypeTraits<CType_> {                    \
+    static Status AppendRow(typename TypeTraits<ArrowType_>::BuilderType& builder,  \
+                            CType_ cell) {                                          \
+      return builder.Append(cell);                                                  \
+    }                                                                               \
+    static CType_ GetEntry(const typename TypeTraits<ArrowType_>::ArrayType& array, \
+                           size_t j) {                                              \
+      return array.Value(j);                                                        \
+    }                                                                               \
+    constexpr static bool nullable = false;                                         \
+  };                                                                                \
+                                                                                    \
+  template <>                                                                       \
+  Status AppendListValues<CType_>(                                                  \
+      typename TypeTraits<ArrowType_>::BuilderType & value_builder,                 \
+      const std::vector<CType_>& cell_range) {                                      \
+    return value_builder.AppendValues(cell_range);                                  \
   }
 
 ARROW_STL_CONVERSION(bool, BooleanType)

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -114,12 +114,11 @@ struct ConversionTraits<std::string> : public CTypeTraits<std::string> {
   constexpr static bool nullable = false;
 };
 
-/// Append cell range elements as a single value to list.
+/// Append cell range elements as a single value to the list builder.
 ///
-/// Rows will be added using ConversionTraits<ValueCType>::AppendListValues()
-/// if provided. If it doesn't have a specialized implementation, each value
-/// will be added using ConversionTraits<ValueCType>::AppendRows() by
-/// iterating over the cell range by default.
+/// Cell range will be added to child builder using AppendListValues<ValueCType>()
+/// if provided. AppendListValues<ValueCType>() has a default implementation, but
+/// it can be specialized by users.
 template <typename ValueCType, typename ListBuilderType, typename Range>
 Status AppendCellRange(ListBuilderType& builder, Range&& cell_range) {
   constexpr bool is_list_builder = std::is_same<ListBuilderType, ListBuilder>::value;

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -338,7 +338,7 @@ struct TupleSetter<Range, Tuple, 0> {
 }  // namespace internal
 
 template <typename Range>
-Status TableFromTupleRange(MemoryPool* pool, const Range& rows,
+Status TableFromTupleRange(MemoryPool* pool, Range&& rows,
                            const std::vector<std::string>& names,
                            std::shared_ptr<Table>* table) {
   using row_type = typename std::iterator_traits<decltype(std::begin(rows))>::value_type;

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -85,7 +85,7 @@ Status AppendListValues(CBuilderType<ValueCType>& value_builder, Range&& cell_ra
   };                                                                                \
                                                                                     \
   template <>                                                                       \
-  Status AppendListValues<CType_>(                                                  \
+  Status AppendListValues<CType_, const std::vector<CType_>&>(                      \
       typename TypeTraits<ArrowType_>::BuilderType & value_builder,                 \
       const std::vector<CType_>& cell_range) {                                      \
     return value_builder.AppendValues(cell_range);                                  \

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -398,7 +398,7 @@ TEST(TestTableFromTupleVector, AppendingMultipleRows) {
   std::shared_ptr<Schema> expected_schema =
       schema({field("column1", list(int32()), false)});
   std::shared_ptr<Array> int_array =
-      ArrayFromJSON(list(int32()), R"([[1, 2, 3], [10, 20, 30])");
+      ArrayFromJSON(list(int32()), "[[1, 2, 3], [10, 20, 30]]");
   auto expected_table = Table::Make(expected_schema, {int_array});
 
   ASSERT_TRUE(expected_table->Equals(*table));

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -143,7 +143,7 @@ struct ConversionTraits<TestInt32Type> : public CTypeTraits<TestInt32Type> {
 };
 
 template <>
-Status AppendListValues<TestInt32Type, Int32Builder, const std::vector<TestInt32Type>&>(
+Status AppendListValues<TestInt32Type, const std::vector<TestInt32Type>&>(
     Int32Builder& value_builder, const std::vector<TestInt32Type>& cell_range) {
   return value_builder.AppendValues(reinterpret_cast<const int32_t*>(cell_range.data()),
                                     cell_range.size());

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -143,8 +143,8 @@ struct ConversionTraits<TestInt32Type> : public CTypeTraits<TestInt32Type> {
 };
 
 template <>
-Status AppendListValues<TestInt32Type, const std::vector<TestInt32Type>&>(
-    Int32Builder& value_builder, const std::vector<TestInt32Type>& cell_range) {
+Status AppendListValues<TestInt32Type>(Int32Builder& value_builder,
+                                       const std::vector<TestInt32Type>& cell_range) {
   return value_builder.AppendValues(reinterpret_cast<const int32_t*>(cell_range.data()),
                                     cell_range.size());
 }

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -143,8 +143,8 @@ struct ConversionTraits<TestInt32Type> : public CTypeTraits<TestInt32Type> {
 };
 
 template <>
-Status AppendListValues<TestInt32Type>(Int32Builder& value_builder,
-                                       const std::vector<TestInt32Type>& cell_range) {
+Status AppendListValues<TestInt32Type, const std::vector<TestInt32Type>&>(
+    Int32Builder& value_builder, const std::vector<TestInt32Type>& cell_range) {
   return value_builder.AppendValues(reinterpret_cast<const int32_t*>(cell_range.data()),
                                     cell_range.size());
 }


### PR DESCRIPTION
`ConversionTraits<T>` is extended to allow users to provide `AppendMultipleRows` method for a type. This method can be used for constructing `List` or `LargeList` more efficiently by calling value builder's `ApendValues()` method with a contiguous range (e.g. `std::vector`), instead of iterating over each element  with value builder's `Append()` method. Default is to fallback to the latter behavior if `AppendMultipleRows` isn't provided.