### PR TITLE
ARROW-3408: [C++] Allow customizing S3 credentials provider

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -35,6 +35,7 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
 #include <aws/core/client/RetryStrategy.h>
 #include <aws/core/utils/logging/ConsoleLogSystem.h>
 #include <aws/core/utils/stream/PreallocatedStreamBuf.h>
@@ -129,6 +130,22 @@ Status FinalizeS3() {
   Aws::ShutdownAPI(aws_options);
   aws_initialized.store(false);
   return Status::OK();
+}
+
+S3Options S3Options::Defaults() {
+  S3Options options;
+  options.credentials_provider =
+      std::make_shared<Aws::Auth::DefaultAWSCredentialsProviderChain>();
+  return options;
+}
+
+S3Options S3Options::FromAccessKey(const std::string& access_key,
+                                   const std::string& secret_key) {
+  S3Options options;
+  options.credentials_provider =
+      std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ToAwsString(access_key),
+                                                                ToAwsString(secret_key));
+  return options;
 }
 
 namespace {
@@ -613,7 +630,7 @@ class S3FileSystem::Impl {
   explicit Impl(S3Options options) : options_(std::move(options)) {}
 
   Status Init() {
-    credentials_ = {ToAwsString(options_.access_key), ToAwsString(options_.secret_key)};
+    credentials_ = options_.credentials_provider->GetAWSCredentials();
     client_config_.region = ToAwsString(options_.region);
     client_config_.endpointOverride = ToAwsString(options_.endpoint_override);
     if (options_.scheme == "http") {

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -24,23 +24,41 @@
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/util/macros.h"
 
+namespace Aws {
+namespace Auth {
+
+class AWSCredentialsProvider;
+
+}  // namespace Auth
+}  // namespace Aws
+
 namespace arrow {
 namespace fs {
 
 extern ARROW_EXPORT const char* kS3DefaultRegion;
 
+/// Options for the S3 FileSystem implementation.
 struct ARROW_EXPORT S3Options {
-  // AWS region to connect to (default "us-east-1")
+  /// AWS region to connect to (default "us-east-1")
   std::string region = kS3DefaultRegion;
 
+  /// If non-empty, override region with a connect string such as "localhost:9000"
   // XXX perhaps instead take a URL like "http://localhost:9000"?
-  // If non-empty, override region with a connect string such as "localhost:9000"
   std::string endpoint_override;
-  // Default "https"
+  /// S3 connection transport, default "https"
   std::string scheme = "https";
 
-  std::string access_key;
-  std::string secret_key;
+  /// AWS credentials provider
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
+
+  /// \brief Initialize with default credentials provider chain
+  ///
+  /// This is recommended if you use the standard AWS environment variables
+  /// and/or configuration file.
+  static S3Options Defaults();
+  /// \brief Initialize with explicit access and secret key
+  static S3Options FromAccessKey(const std::string& access_key,
+                                 const std::string& secret_key);
 };
 
 /// S3-backed FileSystem implementation.

--- a/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
@@ -57,8 +57,11 @@ namespace fs {
 std::shared_ptr<FileSystem> MakeFileSystem() {
   std::shared_ptr<S3FileSystem> s3fs;
   S3Options options;
-  options.access_key = FLAGS_access_key;
-  options.secret_key = FLAGS_secret_key;
+  if (!FLAGS_access_key.empty()) {
+    options = S3Options::FromAccessKey(FLAGS_access_key, FLAGS_secret_key);
+  } else {
+    options = S3Options::Defaults();
+  }
   options.endpoint_override = FLAGS_endpoint;
   options.scheme = FLAGS_scheme;
   options.region = FLAGS_region;

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -252,8 +252,7 @@ class TestS3FS : public S3TestMixin {
  public:
   void SetUp() override {
     S3TestMixin::SetUp();
-    options_.access_key = minio_.access_key();
-    options_.secret_key = minio_.secret_key();
+    options_ = S3Options::FromAccessKey(minio_.access_key(), minio_.secret_key());
     options_.scheme = "http";
     options_.endpoint_override = minio_.connect_string();
     ASSERT_OK(S3FileSystem::Make(options_, &fs_));
@@ -712,8 +711,7 @@ class TestS3FSGeneric : public S3TestMixin, public GenericFileSystemTest {
       ASSERT_OK(OutcomeToStatus(client_->CreateBucket(req)));
     }
 
-    options_.access_key = minio_.access_key();
-    options_.secret_key = minio_.secret_key();
+    options_ = S3Options::FromAccessKey(minio_.access_key(), minio_.secret_key());
     options_.scheme = "http";
     options_.endpoint_override = minio_.connect_string();
     ASSERT_OK(S3FileSystem::Make(options_, &s3fs_));


### PR DESCRIPTION
Also provide API facilities to use the default provider chain
(looks up environment variables and config files), or a hard-coded
access / secret key pair.