### PR TITLE
ARROW-6519: [Java] Use IPC continuation prefix as part of 8-byte EOS

### DIFF
--- a/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
+++ b/java/tools/src/test/java/org/apache/arrow/tools/EchoServerTest.java
@@ -127,7 +127,7 @@ public class EchoServerTest {
       }
       Assert.assertFalse(reader.loadNextBatch());
       assertEquals(0, reader.getVectorSchemaRoot().getRowCount());
-      assertEquals(reader.bytesRead() + 4, writer.bytesWritten());
+      assertEquals(reader.bytesRead(), writer.bytesWritten());
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowFileWriter.java
@@ -30,6 +30,7 @@ import org.apache.arrow.vector.ipc.message.ArrowDictionaryBatch;
 import org.apache.arrow.vector.ipc.message.ArrowFooter;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.ipc.message.IpcOption;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,11 +75,10 @@ public class ArrowFileWriter extends ArrowWriter {
 
   @Override
   protected void endInternal(WriteChannel out) throws IOException {
-    if (option.write_legacy_ipc_format) {
-      out.writeIntLittleEndian(0);
-    } else {
-      out.writeLongLittleEndian(0);
+    if (!option.write_legacy_ipc_format) {
+      out.writeIntLittleEndian(MessageSerializer.IPC_CONTINUATION_TOKEN);
     }
+    out.writeIntLittleEndian(0);
 
     long footerStart = out.getCurrentPosition();
     out.write(new ArrowFooter(schema, dictionaryBlocks, recordBlocks), false);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowStreamWriter.java
@@ -25,6 +25,7 @@ import java.nio.channels.WritableByteChannel;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.message.IpcOption;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
 
 /**
  * Writer for the Arrow stream format to send ArrowRecordBatches over a WriteChannel.
@@ -68,18 +69,18 @@ public class ArrowStreamWriter extends ArrowWriter {
    * Write an EOS identifier to the WriteChannel.
    *
    * @param out Open WriteChannel with an active Arrow stream.
+   * @param option IPC write option
    * @throws IOException on error
    */
-  public void writeEndOfStream(WriteChannel out) throws IOException {
-    if (option.write_legacy_ipc_format) {
-      out.writeIntLittleEndian(0);
-    } else {
-      out.writeLongLittleEndian(0);
+  public static void writeEndOfStream(WriteChannel out, IpcOption option) throws IOException {
+    if (!option.write_legacy_ipc_format) {
+      out.writeIntLittleEndian(MessageSerializer.IPC_CONTINUATION_TOKEN);
     }
+    out.writeIntLittleEndian(0);
   }
 
   @Override
   protected void endInternal(WriteChannel out) throws IOException {
-    writeEndOfStream(out);
+    writeEndOfStream(out, option);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -102,15 +102,6 @@ public class WriteChannel implements AutoCloseable {
   }
 
   /**
-   * Writes <code>v</code> in little-endian format to the underlying channel.
-   */
-  public long writeLongLittleEndian(long v) throws IOException {
-    byte[] outBuffer = new byte[8];
-    MessageSerializer.longToBytes(v, outBuffer);
-    return write(outBuffer);
-  }
-
-  /**
    * Writes the buffer to the underlying channel.
    */
   public void write(ArrowBuf buffer) throws IOException {

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStreamPipe.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStreamPipe.java
@@ -156,6 +156,6 @@ public class TestArrowStreamPipe {
     writer.join();
 
     assertEquals(NUM_BATCHES, reader.getBatchesRead());
-    assertEquals(writer.bytesWritten(), reader.bytesRead() + 4);
+    assertEquals(writer.bytesWritten(), reader.bytesRead());
   }
 }


### PR DESCRIPTION
This changes the 8-byte EOS for non-legacy stream format to use {0xFFFFFFFF, 0x00000000} instead of all zeros. When using all zeros, the reader will not know to read the last 4-bytes, but with the 4-byte continuation token, all bytes written to a channel can be read.