### PR TITLE
ARROW-5450: [Python] Always return datetime.datetime in TimestampValue.as_py for units other than nanoseconds

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -308,6 +308,10 @@ cdef _add_micros_maybe_localize(dt, micros, tzinfo):
         return dt.replace(microsecond=micros)
 
 
+cdef _datetime_from_seconds(int64_t v):
+    return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=v)
+
+
 def _nanoseconds_to_datetime_safe(v, tzinfo):
     if v % 1000 != 0:
         raise ValueError("Nanosecond timestamp {} is not safely convertible "
@@ -317,24 +321,24 @@ def _nanoseconds_to_datetime_safe(v, tzinfo):
     v = v // 1000
     micros = v % 1_000_000
 
-    dt = datetime.datetime.utcfromtimestamp(v // 1_000_000)
+    dt = _datetime_from_seconds(v // 1_000_000)
     return _add_micros_maybe_localize(dt, micros, tzinfo)
 
 
 def _microseconds_to_datetime(v, tzinfo):
     micros = v % 1_000_000
-    dt = datetime.datetime.utcfromtimestamp(v // 1_000_000)
+    dt = _datetime_from_seconds(v // 1_000_000)
     return _add_micros_maybe_localize(dt, micros, tzinfo)
 
 
 def _millis_to_datetime(v, tzinfo):
     millis = v % 1_000
-    dt = datetime.datetime.utcfromtimestamp(v // 1000)
+    dt = _datetime_from_seconds(v // 1000)
     return _add_micros_maybe_localize(dt, millis * 1000, tzinfo)
 
 
 def _seconds_to_datetime(v, tzinfo):
-    dt = datetime.datetime.utcfromtimestamp(v)
+    dt = _datetime_from_seconds(v)
     return _add_micros_maybe_localize(dt, 0, tzinfo)
 
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -299,13 +299,12 @@ cdef c_bool _datetime_conversion_initialized = False
 
 cdef _add_micros_maybe_localize(dt, micros, tzinfo):
     import pytz
+    dt = dt.replace(microsecond=micros)
     if tzinfo is not None:
         if not isinstance(tzinfo, datetime.tzinfo):
             tzinfo = string_to_tzinfo(tzinfo)
-        dt = dt.replace(microsecond=micros, tzinfo=tzinfo)
-        return tzinfo.fromutc(dt)
-    else:
-        return dt.replace(microsecond=micros)
+        dt = tzinfo.fromutc(dt)
+    return dt
 
 
 cdef _datetime_from_seconds(int64_t v):
@@ -317,7 +316,7 @@ def _nanoseconds_to_datetime_safe(v, tzinfo):
         raise ValueError("Nanosecond timestamp {} is not safely convertible "
                          " to microseconds to convert to datetime.datetime."
                          " Install pandas to return as Timestamp with "
-                         " nanosecond support.")
+                         " nanosecond support or access the .value attribute.")
     v = v // 1000
     micros = v % 1_000_000
 

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -44,6 +44,7 @@ groups = [
     'gandiva',
     'hdfs',
     'large_memory',
+    'nopandas',
     'orc',
     'pandas',
     'parquet',
@@ -62,6 +63,7 @@ defaults = {
     'hdfs': False,
     'large_memory': False,
     'orc': False,
+    'nopandas': False,
     'pandas': False,
     'parquet': False,
     'plasma': False,
@@ -98,7 +100,7 @@ try:
     import pandas  # noqa
     defaults['pandas'] = True
 except ImportError:
-    pass
+    defaults['nopandas'] = True
 
 try:
     import pyarrow.parquet  # noqa

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -896,19 +896,19 @@ def test_sequence_timestamp_from_int_with_unit():
     arr_s = pa.array(data, type=s)
     assert len(arr_s) == 1
     assert arr_s.type == s
-    assert repr(arr_s[0]) == "Timestamp('1970-01-01 00:00:01')"
+    assert repr(arr_s[0]) == "datetime.datetime(1970, 1, 1, 0, 0, 1)"
     assert str(arr_s[0]) == "1970-01-01 00:00:01"
 
     arr_ms = pa.array(data, type=ms)
     assert len(arr_ms) == 1
     assert arr_ms.type == ms
-    assert repr(arr_ms[0]) == "Timestamp('1970-01-01 00:00:00.001000')"
+    assert repr(arr_ms[0]) == "datetime.datetime(1970, 1, 1, 0, 0, 0, 1000)"
     assert str(arr_ms[0]) == "1970-01-01 00:00:00.001000"
 
     arr_us = pa.array(data, type=us)
     assert len(arr_us) == 1
     assert arr_us.type == us
-    assert repr(arr_us[0]) == "Timestamp('1970-01-01 00:00:00.000001')"
+    assert repr(arr_us[0]) == "datetime.datetime(1970, 1, 1, 0, 0, 0, 1)"
     assert str(arr_us[0]) == "1970-01-01 00:00:00.000001"
 
     arr_ns = pa.array(data, type=ns)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2855,8 +2855,8 @@ def test_cast_timestamp_unit():
 
     arr2 = pa.Array.from_pandas(s, type=pa.timestamp('us'))
 
-    assert arr[0].as_py() == s_nyc[0]
-    assert arr2[0].as_py() == s[0]
+    assert arr[0].as_py() == s_nyc[0].to_pydatetime()
+    assert arr2[0].as_py() == s[0].to_pydatetime()
 
     # Disallow truncation
     arr = pa.array([123123], type='int64').cast(pa.timestamp('ms'))

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -280,6 +280,21 @@ class TestScalars(unittest.TestCase):
         with pytest.raises(ValueError):
             arr[0].as_py()
 
+    def test_timestamp_no_overflow(self):
+        # ARROW-5450
+        import pytz
+        timestamp_rows = [
+            datetime.datetime(1, 1, 1, 0, 0, 0, tzinfo=pytz.utc),
+            None,
+            datetime.datetime(9999, 12, 31, 23, 59, 59, 999999,
+                              tzinfo=pytz.utc),
+            datetime.datetime(1970, 1, 1, 0, 0, 0,
+                              tzinfo=pytz.utc),
+        ]
+        arr = pa.array(timestamp_rows, pa.timestamp("us", tz="UTC"))
+        result = arr.to_pylist()
+        assert result == timestamp_rows
+
     @pytest.mark.pandas
     def test_dictionary(self):
         import pandas as pd

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -260,14 +260,20 @@ class TestScalars(unittest.TestCase):
     @pytest.mark.nopandas
     def test_timestamp_nanos_nopandas(self):
         # ARROW-5450
+        import pytz
         tz = 'America/New_York'
         ty = pa.timestamp('ns', tz=tz)
         arr = pa.array([
             946684800000000000,  # 2000-01-01 00:00:00
         ], type=ty)
 
-        expected = datetime.datetime(1999, 12, 31, 19, 0, 0)
-        assert arr[0].as_py() == expected
+        tzinfo = pytz.timezone(tz)
+        expected = datetime.datetime(2000, 1, 1, tzinfo=tzinfo)
+        expected = tzinfo.fromutc(expected)
+        result = arr[0].as_py()
+        assert result == expected
+        assert result.year == 1999
+        assert result.hour == 19
 
         # Non-zero nanos yields ValueError
         arr = pa.array([946684800000000001], type=ty)

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -257,6 +257,23 @@ class TestScalars(unittest.TestCase):
             assert arrow_arr[0].as_py() == expected
             assert arrow_arr[0].value * 1000**i == expected.value
 
+    @pytest.mark.nopandas
+    def test_timestamp_nanos_nopandas(self):
+        # ARROW-5450
+        tz = 'America/New_York'
+        ty = pa.timestamp('ns', tz=tz)
+        arr = pa.array([
+            946684800000000000,  # 2000-01-01 00:00:00
+        ], type=ty)
+
+        expected = datetime.datetime(1999, 12, 31, 19, 0, 0)
+        assert arr[0].as_py() == expected
+
+        # Non-zero nanos yields ValueError
+        arr = pa.array([946684800000000001], type=ty)
+        with pytest.raises(ValueError):
+            arr[0].as_py()
+
     @pytest.mark.pandas
     def test_dictionary(self):
         import pandas as pd


### PR DESCRIPTION
We will only return `pandas.Timestamp` for nanosecond resolution. If pandas is not installed, then we will check for data loss when converting to `datetime.datetime`