### PR TITLE
ARROW-4220: [Python] Add buffered IO benchmarks with simulated high latency, allow duck-typed files in input_stream/output_stream

### DIFF
--- a/python/benchmarks/io.py
+++ b/python/benchmarks/io.py
@@ -15,15 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import shutil
-import tempfile
 import time
-
 import pyarrow as pa
-try:
-    import pyarrow.parquet as pq
-except ImportError:
-    pq = None
 
 
 class HighLatencyReader(object):
@@ -37,7 +30,7 @@ class HighLatencyReader(object):
 
     @property
     def closed(self):
-        return False
+        return self.raw.closed
 
     def read(self, nbytes=None):
         time.sleep(self.latency)
@@ -55,7 +48,7 @@ class HighLatencyWriter(object):
 
     @property
     def closed(self):
-        return False
+        return self.raw.closed
 
     def write(self, data):
         time.sleep(self.latency)

--- a/python/benchmarks/io.py
+++ b/python/benchmarks/io.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import shutil
+import tempfile
+import time
+
+import pyarrow as pa
+try:
+    import pyarrow.parquet as pq
+except ImportError:
+    pq = None
+
+
+class HighLatencyReader(object):
+
+    def __init__(self, raw, latency):
+        self.raw = raw
+        self.latency = latency
+
+    def close(self):
+        self.raw.close()
+
+    @property
+    def closed(self):
+        return False
+
+    def read(self, nbytes=None):
+        time.sleep(self.latency)
+        return self.raw.read(nbytes)
+
+
+class HighLatencyWriter(object):
+
+    def __init__(self, raw, latency):
+        self.raw = raw
+        self.latency = latency
+
+    def close(self):
+        self.raw.close()
+
+    @property
+    def closed(self):
+        return False
+
+    def write(self, data):
+        time.sleep(self.latency)
+        self.raw.write(data)
+
+
+class BufferedIOHighLatency(object):
+    """Benchmark creating a parquet manifest."""
+
+    increment = 1024
+    total_size = 16 * (1 << 20)  # 16 MB
+    buffer_size = 1 << 20  # 1 MB
+    latency = 0.1  # 100ms
+
+    param_names = ('latency',)
+    params = [0, 0.01, 0.1]
+
+    def time_buffered_writes(self, latency):
+        test_data = b'x' * self.increment
+        bytes_written = 0
+        out = pa.BufferOutputStream()
+        slow_out = HighLatencyWriter(out, latency)
+        buffered_out = pa.output_stream(slow_out, buffer_size=self.buffer_size)
+
+        while bytes_written < self.total_size:
+            buffered_out.write(test_data)
+            bytes_written += self.increment
+        buffered_out.flush()
+
+    def time_buffered_reads(self, latency):
+        bytes_read = 0
+        reader = pa.input_stream(pa.py_buffer(b'x' * self.total_size))
+        slow_reader = HighLatencyReader(reader, latency)
+        buffered_reader = pa.input_stream(slow_reader,
+                                          buffer_size=self.buffer_size)
+        while bytes_read < self.total_size:
+            buffered_reader.read(self.increment)
+            bytes_read += self.increment

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1560,10 +1560,9 @@ def input_stream(source, compression='detect', buffer_size=None):
         stream = OSFile(source_path, 'r')
     elif isinstance(source, (Buffer, memoryview)):
         stream = BufferReader(as_buffer(source))
-    elif isinstance(source, BufferedIOBase):
-        stream = PythonFile(source, 'r')
-    elif file_type is not None and isinstance(source, file_type):
-        # Python 2 file type
+    elif (hasattr(source, 'read') and
+          hasattr(source, 'close') and
+          hasattr(source, 'closed')):
         stream = PythonFile(source, 'r')
     else:
         raise TypeError("pa.input_stream() called with instance of '{}'"
@@ -1612,10 +1611,9 @@ def output_stream(source, compression='detect', buffer_size=None):
         stream = OSFile(source_path, 'w')
     elif isinstance(source, (Buffer, memoryview)):
         stream = FixedSizeBufferWriter(as_buffer(source))
-    elif isinstance(source, BufferedIOBase):
-        stream = PythonFile(source, 'w')
-    elif file_type is not None and isinstance(source, file_type):
-        # Python 2 file type
+    elif (hasattr(source, 'write') and
+          hasattr(source, 'close') and
+          hasattr(source, 'closed')):
         stream = PythonFile(source, 'w')
     else:
         raise TypeError("pa.output_stream() called with instance of '{}'"


### PR DESCRIPTION
These benchmarks will help track possible regressions in buffered IO performance from the Python side.

This also allows objects that implement the right APIs (at least according to `hasattr`) to be passed into these functions.
