### PR TITLE
ARROW-2490: [C++] Normalize input stream concurrency

### DIFF
--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -152,8 +152,8 @@ class ARROW_EXPORT CudaIpcMemHandle {
 /// \brief File interface for zero-copy read from CUDA buffers
 ///
 /// CAUTION: reading to a Buffer returns a Buffer pointing to device memory.
-/// It will generally not be compatible with Arrow code expecting an usual
-/// buffer pointing to CPU memory.
+/// It will generally not be compatible with Arrow code expecting a buffer
+/// pointing to CPU memory.
 /// Reading to a raw pointer, though, copies device memory into the host
 /// memory pointed to.
 class ARROW_EXPORT CudaBufferReader : public io::BufferReader {

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -151,27 +151,27 @@ class ARROW_EXPORT CudaIpcMemHandle {
 /// \class CudaBufferReader
 /// \brief File interface for zero-copy read from CUDA buffers
 ///
-/// Note: Reads return pointers to device memory. This means you must be
-/// careful using this interface with any Arrow code which may expect to be
-/// able to do anything other than pointer arithmetic on the returned buffers
+/// CAUTION: reading to a Buffer returns a Buffer pointing to device memory.
+/// It will generally not be compatible with Arrow code expecting an usual
+/// buffer pointing to CPU memory.
+/// Reading to a raw pointer, though, copies device memory into the host
+/// memory pointed to.
 class ARROW_EXPORT CudaBufferReader : public io::BufferReader {
  public:
   explicit CudaBufferReader(const std::shared_ptr<Buffer>& buffer);
   ~CudaBufferReader() override;
 
-  /// \brief Read bytes into pre-allocated host memory
-  /// \param[in] nbytes number of bytes to read
-  /// \param[out] bytes_read actual number of bytes read
-  /// \param[out] buffer pre-allocated memory to write into
-  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
-
-  /// \brief Zero-copy read from device memory
-  /// \param[in] nbytes number of bytes to read
-  /// \param[out] out a Buffer referencing device memory
-  /// \return Status
-  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
-
  private:
+  // Read to host memory (copy)
+  Status DoRead(int64_t nbytes, int64_t* bytes_read, void* out) override;
+  Status DoReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                  void* out) override;
+
+  // Read to device buffer (zero-copy)
+  Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+  Status DoReadAt(int64_t position, int64_t nbytes,
+                  std::shared_ptr<Buffer>* out) override;
+
   std::shared_ptr<CudaBuffer> cuda_buffer_;
   std::shared_ptr<CudaContext> context_;
 };

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -244,7 +244,6 @@ class BufferedInputStream::Impl : public BufferedBase {
         bytes_buffered_(0) {}
 
   Status Close() {
-    std::lock_guard<std::mutex> guard(lock_);
     if (is_open_) {
       is_open_ = false;
       return raw_->Close();
@@ -253,7 +252,6 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Status Abort() {
-    std::lock_guard<std::mutex> guard(lock_);
     if (is_open_) {
       is_open_ = false;
       return raw_->Abort();
@@ -262,7 +260,6 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Status Tell(int64_t* position) const {
-    std::lock_guard<std::mutex> guard(lock_);
     if (raw_pos_ == -1) {
       RETURN_NOT_OK(raw_->Tell(&raw_pos_));
       DCHECK_GE(raw_pos_, 0);
@@ -273,7 +270,6 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Status SetBufferSize(int64_t new_buffer_size) {
-    std::lock_guard<std::mutex> guard(lock_);
     if (new_buffer_size <= 0) {
       return Status::Invalid("Buffer size should be positive");
     }
@@ -324,7 +320,6 @@ class BufferedInputStream::Impl : public BufferedBase {
   int64_t buffer_size() const { return buffer_size_; }
 
   std::shared_ptr<InputStream> Detach() {
-    std::lock_guard<std::mutex> guard(lock_);
     is_open_ = false;
     return std::move(raw_);
   }
@@ -361,7 +356,6 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Status Read(int64_t nbytes, int64_t* bytes_read, void* out) {
-    std::lock_guard<std::mutex> guard(lock_);
     ARROW_CHECK_GT(nbytes, 0);
 
     if (nbytes < buffer_size_) {
@@ -444,9 +438,9 @@ Status BufferedInputStream::Create(int64_t buffer_size, MemoryPool* pool,
   return Status::OK();
 }
 
-Status BufferedInputStream::Close() { return impl_->Close(); }
+Status BufferedInputStream::DoClose() { return impl_->Close(); }
 
-Status BufferedInputStream::Abort() { return impl_->Abort(); }
+Status BufferedInputStream::DoAbort() { return impl_->Abort(); }
 
 bool BufferedInputStream::closed() const { return impl_->closed(); }
 
@@ -454,11 +448,11 @@ std::shared_ptr<InputStream> BufferedInputStream::Detach() { return impl_->Detac
 
 std::shared_ptr<InputStream> BufferedInputStream::raw() const { return impl_->raw(); }
 
-Status BufferedInputStream::Tell(int64_t* position) const {
+Status BufferedInputStream::DoTell(int64_t* position) const {
   return impl_->Tell(position);
 }
 
-Status BufferedInputStream::Peek(int64_t nbytes, util::string_view* out) {
+Status BufferedInputStream::DoPeek(int64_t nbytes, util::string_view* out) {
   return impl_->Peek(nbytes, out);
 }
 
@@ -470,11 +464,11 @@ int64_t BufferedInputStream::bytes_buffered() const { return impl_->bytes_buffer
 
 int64_t BufferedInputStream::buffer_size() const { return impl_->buffer_size(); }
 
-Status BufferedInputStream::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
+Status BufferedInputStream::DoRead(int64_t nbytes, int64_t* bytes_read, void* out) {
   return impl_->Read(nbytes, bytes_read, out);
 }
 
-Status BufferedInputStream::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+Status BufferedInputStream::DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out) {
   return impl_->Read(nbytes, out);
 }
 

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "arrow/io/concurrency.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
@@ -91,7 +92,8 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
 /// \brief An InputStream that performs buffered reads from an unbuffered
 /// InputStream, which can mitigate the overhead of many small reads in some
 /// cases
-class ARROW_EXPORT BufferedInputStream : public InputStream {
+class ARROW_EXPORT BufferedInputStream
+    : public internal::InputStreamConcurrencyWrapper<BufferedInputStream> {
  public:
   ~BufferedInputStream() override;
 
@@ -129,28 +131,31 @@ class ARROW_EXPORT BufferedInputStream : public InputStream {
 
   // InputStream APIs
 
-  /// \brief Return a zero-copy string view referencing buffered data,
-  /// but do not advance the position of the stream. Buffers data and
-  /// expands the buffer size if necessary
-  Status Peek(int64_t nbytes, util::string_view* out) override;
-
-  Status Close() override;
-  Status Abort() override;
   bool closed() const override;
+
+ private:
+  friend class InputStreamConcurrencyWrapper<BufferedInputStream>;
+
+  explicit BufferedInputStream(std::shared_ptr<InputStream> raw, MemoryPool* pool,
+                               int64_t raw_total_bytes_bound);
+
+  Status DoClose();
+  Status DoAbort() override;
 
   /// \brief Returns the position of the buffered stream, though the position
   /// of the unbuffered stream may be further advanced
-  Status Tell(int64_t* position) const override;
+  Status DoTell(int64_t* position) const;
 
-  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
+  Status DoRead(int64_t nbytes, int64_t* bytes_read, void* out);
 
   /// \brief Read into buffer. If the read is already buffered, then this will
   /// return a slice into the buffer
-  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
+  Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out);
 
- private:
-  explicit BufferedInputStream(std::shared_ptr<InputStream> raw, MemoryPool* pool,
-                               int64_t raw_total_bytes_bound);
+  /// \brief Return a zero-copy string view referencing buffered data,
+  /// but do not advance the position of the stream. Buffers data and
+  /// expands the buffer size if necessary
+  Status DoPeek(int64_t nbytes, util::string_view* out) override;
 
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -134,7 +134,7 @@ class ARROW_EXPORT BufferedInputStream
   bool closed() const override;
 
  private:
-  friend class InputStreamConcurrencyWrapper<BufferedInputStream>;
+  friend InputStreamConcurrencyWrapper<BufferedInputStream>;
 
   explicit BufferedInputStream(std::shared_ptr<InputStream> raw, MemoryPool* pool,
                                int64_t raw_total_bytes_bound);

--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -261,7 +261,6 @@ class CompressedInputStream::Impl {
   }
 
   Status Close() {
-    std::lock_guard<std::mutex> guard(lock_);
     if (is_open_) {
       is_open_ = false;
       return raw_->Close();
@@ -271,7 +270,6 @@ class CompressedInputStream::Impl {
   }
 
   Status Abort() {
-    std::lock_guard<std::mutex> guard(lock_);
     if (is_open_) {
       is_open_ = false;
       return raw_->Abort();
@@ -280,13 +278,9 @@ class CompressedInputStream::Impl {
     }
   }
 
-  bool closed() {
-    std::lock_guard<std::mutex> guard(lock_);
-    return !is_open_;
-  }
+  bool closed() { return !is_open_; }
 
   Status Tell(int64_t* position) const {
-    std::lock_guard<std::mutex> guard(lock_);
     *position = total_pos_;
     return Status::OK();
   }
@@ -383,8 +377,6 @@ class CompressedInputStream::Impl {
   }
 
   Status Read(int64_t nbytes, int64_t* bytes_read, void* out) {
-    std::lock_guard<std::mutex> guard(lock_);
-
     auto out_data = reinterpret_cast<uint8_t*>(out);
 
     int64_t total_read = 0;
@@ -439,8 +431,6 @@ class CompressedInputStream::Impl {
   bool fresh_decompressor_;
   // Total number of bytes decompressed
   int64_t total_pos_;
-
-  mutable std::mutex lock_;
 };
 
 Status CompressedInputStream::Make(Codec* codec, const std::shared_ptr<InputStream>& raw,
@@ -461,21 +451,21 @@ Status CompressedInputStream::Make(MemoryPool* pool, Codec* codec,
 
 CompressedInputStream::~CompressedInputStream() { internal::CloseFromDestructor(this); }
 
-Status CompressedInputStream::Close() { return impl_->Close(); }
+Status CompressedInputStream::DoClose() { return impl_->Close(); }
 
-Status CompressedInputStream::Abort() { return impl_->Abort(); }
+Status CompressedInputStream::DoAbort() { return impl_->Abort(); }
 
 bool CompressedInputStream::closed() const { return impl_->closed(); }
 
-Status CompressedInputStream::Tell(int64_t* position) const {
+Status CompressedInputStream::DoTell(int64_t* position) const {
   return impl_->Tell(position);
 }
 
-Status CompressedInputStream::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
+Status CompressedInputStream::DoRead(int64_t nbytes, int64_t* bytes_read, void* out) {
   return impl_->Read(nbytes, bytes_read, out);
 }
 
-Status CompressedInputStream::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+Status CompressedInputStream::DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out) {
   return impl_->Read(nbytes, out);
 }
 

--- a/cpp/src/arrow/io/compressed.h
+++ b/cpp/src/arrow/io/compressed.h
@@ -96,7 +96,7 @@ class ARROW_EXPORT CompressedInputStream
   std::shared_ptr<InputStream> raw() const;
 
  private:
-  friend class InputStreamConcurrencyWrapper<CompressedInputStream>;
+  friend InputStreamConcurrencyWrapper<CompressedInputStream>;
   ARROW_DISALLOW_COPY_AND_ASSIGN(CompressedInputStream);
 
   CompressedInputStream() = default;

--- a/cpp/src/arrow/io/compressed.h
+++ b/cpp/src/arrow/io/compressed.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 
+#include "arrow/io/concurrency.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/util/visibility.h"
 
@@ -75,7 +76,8 @@ class ARROW_EXPORT CompressedOutputStream : public OutputStream {
   std::unique_ptr<Impl> impl_;
 };
 
-class ARROW_EXPORT CompressedInputStream : public InputStream {
+class ARROW_EXPORT CompressedInputStream
+    : public internal::InputStreamConcurrencyWrapper<CompressedInputStream> {
  public:
   ~CompressedInputStream() override;
 
@@ -88,24 +90,24 @@ class ARROW_EXPORT CompressedInputStream : public InputStream {
 
   // InputStream interface
 
-  /// \brief Close the compressed input stream.  This implicitly closes the
-  /// underlying raw input stream.
-  Status Close() override;
-  Status Abort() override;
   bool closed() const override;
-
-  Status Tell(int64_t* position) const override;
-
-  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) override;
-  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
   /// \brief Return the underlying raw input stream.
   std::shared_ptr<InputStream> raw() const;
 
  private:
+  friend class InputStreamConcurrencyWrapper<CompressedInputStream>;
   ARROW_DISALLOW_COPY_AND_ASSIGN(CompressedInputStream);
 
   CompressedInputStream() = default;
+
+  /// \brief Close the compressed input stream.  This implicitly closes the
+  /// underlying raw input stream.
+  Status DoClose();
+  Status DoAbort() override;
+  Status DoTell(int64_t* position) const;
+  Status DoRead(int64_t nbytes, int64_t* bytes_read, void* out);
+  Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out);
 
   class ARROW_NO_EXPORT Impl;
   std::unique_ptr<Impl> impl_;

--- a/cpp/src/arrow/io/concurrency.h
+++ b/cpp/src/arrow/io/concurrency.h
@@ -1,0 +1,258 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/io/interfaces.h"
+#include "arrow/status.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+namespace io {
+namespace internal {
+
+template <class LockType>
+class SharedLockGuard {
+ public:
+  explicit SharedLockGuard(LockType* lock) : lock_(lock) { lock_->LockShared(); }
+
+  ~SharedLockGuard() { lock_->UnlockShared(); }
+
+ protected:
+  LockType* lock_;
+};
+
+template <class LockType>
+class ExclusiveLockGuard {
+ public:
+  explicit ExclusiveLockGuard(LockType* lock) : lock_(lock) { lock_->LockExclusive(); }
+
+  ~ExclusiveLockGuard() { lock_->UnlockExclusive(); }
+
+ protected:
+  LockType* lock_;
+};
+
+// Debug concurrency checker that marks "shared" and "exclusive" code sections,
+// aborting if the concurrency rules get violated.  Does nothing in release mode.
+// Note that we intentionally use the same class declaration in debug and
+// release builds in order to avoid runtime failures when e.g. loading a
+// release-built DLL with a debug-built application, or the reverse.
+
+class ARROW_EXPORT SharedExclusiveChecker {
+ public:
+  SharedExclusiveChecker();
+  void LockShared();
+  void UnlockShared();
+  void LockExclusive();
+  void UnlockExclusive();
+
+  SharedLockGuard<SharedExclusiveChecker> shared_guard() {
+    return SharedLockGuard<SharedExclusiveChecker>(this);
+  }
+
+  ExclusiveLockGuard<SharedExclusiveChecker> exclusive_guard() {
+    return ExclusiveLockGuard<SharedExclusiveChecker>(this);
+  }
+
+ protected:
+  struct Impl;
+  std::shared_ptr<Impl> impl_;
+};
+
+// Concurrency wrappers for IO classes that check the correctness of
+// concurrent calls to various methods.  It is not necessary to wrap all
+// IO classes with these, only a few core classes that get used in tests.
+//
+// We're not using virtual inheritance here as virtual bases have poorly
+// understood semantic overhead which we'd be passing on to implementers
+// and users of these interfaces.  Instead, we just duplicate the method
+// wrappers between those two classes.
+
+template <class Derived>
+class ARROW_EXPORT InputStreamConcurrencyWrapper : public InputStream {
+ public:
+  Status Close() final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoClose();
+  }
+
+  Status Abort() final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoAbort();
+  }
+
+  Status Tell(int64_t* position) const final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoTell(position);
+  }
+
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoRead(nbytes, bytes_read, out);
+  }
+
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoRead(nbytes, out);
+  }
+
+  Status Peek(int64_t nbytes, util::string_view* out) final {
+    auto guard = lock_.shared_guard();  // Peek doesn't advance stream pointer
+    return derived()->DoPeek(nbytes, out);
+  }
+
+  /*
+  Methods to implement in derived class:
+
+  Status DoClose();
+  Status DoTell(int64_t* position) const;
+  Status DoRead(int64_t nbytes, int64_t* bytes_read, void* out);
+  Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out);
+
+  And optionally:
+
+  Status DoAbort() override;
+  Status DoPeek(int64_t nbytes, util::string_view* out) override;
+
+  These methods should be protected in the derived class and
+  InputStreamConcurrencyWrapper declared as a friend with
+
+  friend class InputStreamConcurrencyWrapper<derived>;
+  */
+
+ protected:
+  // Default implementations.  They are virtual because the derived class may
+  // have derived classes itself.
+  virtual Status DoAbort() { return derived()->DoClose(); }
+
+  virtual Status DoPeek(int64_t ARROW_ARG_UNUSED(nbytes),
+                        util::string_view* ARROW_ARG_UNUSED(out)) {
+    return Status::NotImplemented("Peek not implemented");
+  }
+
+  Derived* derived() { return ::arrow::internal::checked_cast<Derived*>(this); }
+
+  const Derived* derived() const {
+    return ::arrow::internal::checked_cast<const Derived*>(this);
+  }
+
+  mutable SharedExclusiveChecker lock_;
+};
+
+template <class Derived>
+class ARROW_EXPORT RandomAccessFileConcurrencyWrapper : public RandomAccessFile {
+ public:
+  Status Close() final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoClose();
+  }
+
+  Status Abort() final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoAbort();
+  }
+
+  Status Tell(int64_t* position) const final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoTell(position);
+  }
+
+  Status Read(int64_t nbytes, int64_t* bytes_read, void* out) final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoRead(nbytes, bytes_read, out);
+  }
+
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoRead(nbytes, out);
+  }
+
+  Status Seek(int64_t position) final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoSeek(position);
+  }
+
+  Status GetSize(int64_t* size) final {
+    auto guard = lock_.exclusive_guard();
+    return derived()->DoGetSize(size);
+  }
+
+  Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out) final {
+    auto guard = lock_.shared_guard();  // ReadAt doesn't advance stream pointer
+    return derived()->DoReadAt(position, nbytes, bytes_read, out);
+  }
+
+  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) final {
+    auto guard = lock_.shared_guard();  // ReadAt doesn't advance stream pointer
+    return derived()->DoReadAt(position, nbytes, out);
+  }
+
+  Status Peek(int64_t nbytes, util::string_view* out) final {
+    auto guard = lock_.shared_guard();  // Peek doesn't advance stream pointer
+    return derived()->DoPeek(nbytes, out);
+  }
+
+  /*
+  Methods to implement in derived class:
+
+  Status DoClose();
+  Status DoTell(int64_t* position) const;
+  Status DoRead(int64_t nbytes, int64_t* bytes_read, void* out);
+  Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out);
+  Status DoSeek(int64_t position);
+  Status DoGetSize(int64_t* size);
+  Status DoReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out);
+  Status DoReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out);
+
+  And optionally:
+
+  Status DoAbort() override;
+  Status DoPeek(int64_t nbytes, util::string_view* out) override;
+
+  These methods should be protected in the derived class and
+  RandomAccessFileConcurrencyWrapper declared as a friend with
+
+  friend class RandomAccessFileConcurrencyWrapper<derived>;
+  */
+
+ protected:
+  // Default implementations.  They are virtual because the derived class may
+  // have derived classes itself.
+  virtual Status DoAbort() { return derived()->DoClose(); }
+
+  virtual Status DoPeek(int64_t ARROW_ARG_UNUSED(nbytes),
+                        util::string_view* ARROW_ARG_UNUSED(out)) {
+    return Status::NotImplemented("Peek not implemented");
+  }
+
+  Derived* derived() { return ::arrow::internal::checked_cast<Derived*>(this); }
+
+  const Derived* derived() const {
+    return ::arrow::internal::checked_cast<const Derived*>(this);
+  }
+
+  mutable SharedExclusiveChecker lock_;
+};
+
+}  // namespace internal
+}  // namespace io
+}  // namespace arrow

--- a/cpp/src/arrow/io/concurrency.h
+++ b/cpp/src/arrow/io/concurrency.h
@@ -136,7 +136,7 @@ class ARROW_EXPORT InputStreamConcurrencyWrapper : public InputStream {
   These methods should be protected in the derived class and
   InputStreamConcurrencyWrapper declared as a friend with
 
-  friend class InputStreamConcurrencyWrapper<derived>;
+  friend InputStreamConcurrencyWrapper<derived>;
   */
 
  protected:
@@ -231,7 +231,7 @@ class ARROW_EXPORT RandomAccessFileConcurrencyWrapper : public RandomAccessFile 
   These methods should be protected in the derived class and
   RandomAccessFileConcurrencyWrapper declared as a friend with
 
-  friend class RandomAccessFileConcurrencyWrapper<derived>;
+  friend RandomAccessFileConcurrencyWrapper<derived>;
   */
 
  protected:

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -289,38 +289,36 @@ Status ReadableFile::Open(int fd, std::shared_ptr<ReadableFile>* file) {
   return Open(fd, default_memory_pool(), file);
 }
 
-Status ReadableFile::Close() { return impl_->Close(); }
+Status ReadableFile::DoClose() { return impl_->Close(); }
 
 bool ReadableFile::closed() const { return !impl_->is_open(); }
 
-Status ReadableFile::Tell(int64_t* pos) const { return impl_->Tell(pos); }
+Status ReadableFile::DoTell(int64_t* pos) const { return impl_->Tell(pos); }
 
-Status ReadableFile::Read(int64_t nbytes, int64_t* bytes_read, void* out) {
-  std::lock_guard<std::mutex> guard(impl_->lock());
+Status ReadableFile::DoRead(int64_t nbytes, int64_t* bytes_read, void* out) {
   return impl_->Read(nbytes, bytes_read, out);
 }
 
-Status ReadableFile::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                            void* out) {
+Status ReadableFile::DoReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                              void* out) {
   return impl_->ReadAt(position, nbytes, bytes_read, out);
 }
 
-Status ReadableFile::ReadAt(int64_t position, int64_t nbytes,
-                            std::shared_ptr<Buffer>* out) {
+Status ReadableFile::DoReadAt(int64_t position, int64_t nbytes,
+                              std::shared_ptr<Buffer>* out) {
   return impl_->ReadBufferAt(position, nbytes, out);
 }
 
-Status ReadableFile::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
-  std::lock_guard<std::mutex> guard(impl_->lock());
+Status ReadableFile::DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out) {
   return impl_->ReadBuffer(nbytes, out);
 }
 
-Status ReadableFile::GetSize(int64_t* size) {
+Status ReadableFile::DoGetSize(int64_t* size) {
   *size = impl_->size();
   return Status::OK();
 }
 
-Status ReadableFile::Seek(int64_t pos) { return impl_->Seek(pos); }
+Status ReadableFile::DoSeek(int64_t pos) { return impl_->Seek(pos); }
 
 int ReadableFile::file_descriptor() const { return impl_->fd(); }
 

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -151,7 +151,7 @@ class ARROW_EXPORT ReadableFile
   int file_descriptor() const;
 
  private:
-  friend class RandomAccessFileConcurrencyWrapper<ReadableFile>;
+  friend RandomAccessFileConcurrencyWrapper<ReadableFile>;
 
   explicit ReadableFile(MemoryPool* pool);
 

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 
+#include "arrow/io/concurrency.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/util/visibility.h"
 
@@ -107,7 +108,8 @@ class ARROW_EXPORT FileOutputStream : public OutputStream {
 };
 
 // Operating system file
-class ARROW_EXPORT ReadableFile : public RandomAccessFile {
+class ARROW_EXPORT ReadableFile
+    : public internal::RandomAccessFileConcurrencyWrapper<ReadableFile> {
  public:
   ~ReadableFile() override;
 
@@ -144,28 +146,28 @@ class ARROW_EXPORT ReadableFile : public RandomAccessFile {
   /// on Close() or destruction.
   static Status Open(int fd, MemoryPool* pool, std::shared_ptr<ReadableFile>* file);
 
-  Status Close() override;
   bool closed() const override;
-  Status Tell(int64_t* position) const override;
-
-  // Read bytes from the file. Thread-safe
-  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
-  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
-
-  /// \brief Thread-safe implementation of ReadAt
-  Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                void* out) override;
-
-  /// \brief Thread-safe implementation of ReadAt
-  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
-
-  Status GetSize(int64_t* size) override;
-  Status Seek(int64_t position) override;
 
   int file_descriptor() const;
 
  private:
+  friend class RandomAccessFileConcurrencyWrapper<ReadableFile>;
+
   explicit ReadableFile(MemoryPool* pool);
+
+  Status DoClose();
+  Status DoTell(int64_t* position) const;
+  Status DoRead(int64_t nbytes, int64_t* bytes_read, void* buffer);
+  Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out);
+
+  /// \brief Thread-safe implementation of ReadAt
+  Status DoReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read, void* out);
+
+  /// \brief Thread-safe implementation of ReadAt
+  Status DoReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out);
+
+  Status DoGetSize(int64_t* size);
+  Status DoSeek(int64_t position);
 
   class ARROW_NO_EXPORT ReadableFileImpl;
   std::unique_ptr<ReadableFileImpl> impl_;

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -144,11 +144,14 @@ class ARROW_EXPORT InputStream : virtual public FileInterface, virtual public Re
   /// \return Status
   Status Advance(int64_t nbytes);
 
-  /// \brief Return zero-copy string_view to upcoming bytes in the
-  /// stream but do not modify stream position. View becomes invalid
-  /// after any operation on file. If the InputStream is unbuffered,
-  /// returns 0-length string_view. May trigger buffering if the
-  /// requested size is larger than the number of buffered bytes
+  /// \brief Return zero-copy string_view to upcoming bytes.
+  ///
+  /// Do not modify the stream position.  The view becomes invalid after
+  /// any operation on the stream.  May trigger buffering if the requested
+  /// size is larger than the number of buffered bytes.
+  ///
+  /// May return NotImplemented on streams that don't support it.
+  ///
   /// \param[in] nbytes the maximum number of bytes to see
   /// \param[out] out the returned arrow::util::string_view
   /// \return Status

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -287,7 +287,7 @@ BufferReader::BufferReader(const util::string_view& data)
     : BufferReader(reinterpret_cast<const uint8_t*>(data.data()),
                    static_cast<int64_t>(data.size())) {}
 
-Status BufferReader::Close() {
+Status BufferReader::DoClose() {
   is_open_ = false;
   return Status::OK();
 }
@@ -301,13 +301,13 @@ Status BufferReader::CheckClosed() const {
   return Status::OK();
 }
 
-Status BufferReader::Tell(int64_t* position) const {
+Status BufferReader::DoTell(int64_t* position) const {
   RETURN_NOT_OK(CheckClosed());
   *position = position_;
   return Status::OK();
 }
 
-Status BufferReader::Peek(int64_t nbytes, util::string_view* out) {
+Status BufferReader::DoPeek(int64_t nbytes, util::string_view* out) {
   RETURN_NOT_OK(CheckClosed());
 
   const int64_t bytes_available = std::min(nbytes, size_ - position_);
@@ -318,8 +318,8 @@ Status BufferReader::Peek(int64_t nbytes, util::string_view* out) {
 
 bool BufferReader::supports_zero_copy() const { return true; }
 
-Status BufferReader::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                            void* buffer) {
+Status BufferReader::DoReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                              void* buffer) {
   RETURN_NOT_OK(CheckClosed());
 
   if (nbytes < 0) {
@@ -332,8 +332,8 @@ Status BufferReader::ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_rea
   return Status::OK();
 }
 
-Status BufferReader::ReadAt(int64_t position, int64_t nbytes,
-                            std::shared_ptr<Buffer>* out) {
+Status BufferReader::DoReadAt(int64_t position, int64_t nbytes,
+                              std::shared_ptr<Buffer>* out) {
   RETURN_NOT_OK(CheckClosed());
 
   if (nbytes < 0) {
@@ -349,27 +349,27 @@ Status BufferReader::ReadAt(int64_t position, int64_t nbytes,
   return Status::OK();
 }
 
-Status BufferReader::Read(int64_t nbytes, int64_t* bytes_read, void* buffer) {
+Status BufferReader::DoRead(int64_t nbytes, int64_t* bytes_read, void* buffer) {
   RETURN_NOT_OK(CheckClosed());
-  RETURN_NOT_OK(ReadAt(position_, nbytes, bytes_read, buffer));
+  RETURN_NOT_OK(DoReadAt(position_, nbytes, bytes_read, buffer));
   position_ += *bytes_read;
   return Status::OK();
 }
 
-Status BufferReader::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
+Status BufferReader::DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out) {
   RETURN_NOT_OK(CheckClosed());
-  RETURN_NOT_OK(ReadAt(position_, nbytes, out));
+  RETURN_NOT_OK(DoReadAt(position_, nbytes, out));
   position_ += (*out)->size();
   return Status::OK();
 }
 
-Status BufferReader::GetSize(int64_t* size) {
+Status BufferReader::DoGetSize(int64_t* size) {
   RETURN_NOT_OK(CheckClosed());
   *size = size_;
   return Status::OK();
 }
 
-Status BufferReader::Seek(int64_t position) {
+Status BufferReader::DoSeek(int64_t position) {
   RETURN_NOT_OK(CheckClosed());
 
   if (position < 0 || position > size_) {

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -149,7 +149,7 @@ class ARROW_EXPORT BufferReader
   std::shared_ptr<Buffer> buffer() const { return buffer_; }
 
  protected:
-  friend class RandomAccessFileConcurrencyWrapper<BufferReader>;
+  friend RandomAccessFileConcurrencyWrapper<BufferReader>;
 
   // These methods are virtual for CudaBuffer...
   virtual Status DoClose();

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "arrow/buffer.h"
+#include "arrow/io/concurrency.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/memory_pool.h"
 #include "arrow/util/string_view.h"
@@ -130,7 +131,8 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WritableFile {
 
 /// \class BufferReader
 /// \brief Random access zero-copy reads on an arrow::Buffer
-class ARROW_EXPORT BufferReader : public RandomAccessFile {
+class ARROW_EXPORT BufferReader
+    : public internal::RandomAccessFileConcurrencyWrapper<BufferReader> {
  public:
   explicit BufferReader(const std::shared_ptr<Buffer>& buffer);
   explicit BufferReader(const Buffer& buffer);
@@ -140,27 +142,29 @@ class ARROW_EXPORT BufferReader : public RandomAccessFile {
   /// own data
   explicit BufferReader(const util::string_view& data);
 
-  Status Close() override;
   bool closed() const override;
-  Status Tell(int64_t* position) const override;
-  Status Read(int64_t nbytes, int64_t* bytes_read, void* buffer) override;
-  // Zero copy read
-  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
-
-  Status Peek(int64_t nbytes, util::string_view* out) override;
 
   bool supports_zero_copy() const override;
-
-  Status ReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
-                void* out) override;
-  Status ReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out) override;
-
-  Status GetSize(int64_t* size) override;
-  Status Seek(int64_t position) override;
 
   std::shared_ptr<Buffer> buffer() const { return buffer_; }
 
  protected:
+  friend class RandomAccessFileConcurrencyWrapper<BufferReader>;
+
+  // These methods are virtual for CudaBuffer...
+  virtual Status DoClose();
+  virtual Status DoRead(int64_t nbytes, int64_t* bytes_read, void* buffer);
+  // Zero copy read
+  virtual Status DoRead(int64_t nbytes, std::shared_ptr<Buffer>* out);
+  virtual Status DoReadAt(int64_t position, int64_t nbytes, int64_t* bytes_read,
+                          void* out);
+  virtual Status DoReadAt(int64_t position, int64_t nbytes, std::shared_ptr<Buffer>* out);
+  Status DoPeek(int64_t nbytes, util::string_view* out) override;
+
+  Status DoTell(int64_t* position) const;
+  Status DoSeek(int64_t position);
+  Status DoGetSize(int64_t* size);
+
   inline Status CheckClosed() const;
 
   std::shared_ptr<Buffer> buffer_;


### PR DESCRIPTION
Add a debug mode concurrency wrapper that checks proper concurrent use of
input stream / file methods.

Remove explicit locking from stream implementations.