### PR TITLE
ARROW-6546: [C++] Add missing FlatBuffers source dependency

### DIFF
--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -71,7 +71,7 @@ add_custom_command(OUTPUT ${FBS_OUTPUT_FILES}
                            -o
                            ${OUTPUT_DIR}
                            ${ABS_FBS_SRC}
-                   DEPENDS flatbuffers::flatc
+                   DEPENDS flatbuffers::flatc ${ABS_FBS_SRC}
                    COMMENT "Running flatc compiler on ${ABS_FBS_SRC}"
                    VERBATIM)
 


### PR DESCRIPTION
If it doesn't exist, `src/arrow/ipc/*_generated.h` aren't updated
automatically when `format/*.fbs` is updated.