### PR TITLE
ARROW-6362: [C++] Allow customizing S3 credentials provider

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -24,26 +24,50 @@
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/util/macros.h"
 
+namespace Aws {
+namespace Auth {
+
+class AWSCredentialsProvider;
+
+}  // namespace Auth
+}  // namespace Aws
+
 namespace arrow {
 namespace fs {
 
 extern ARROW_EXPORT const char* kS3DefaultRegion;
 
+/// Options for the S3 FileSystem implementation.
 struct ARROW_EXPORT S3Options {
-  // AWS region to connect to (default "us-east-1")
+  /// AWS region to connect to (default "us-east-1")
   std::string region = kS3DefaultRegion;
 
+  /// If non-empty, override region with a connect string such as "localhost:9000"
   // XXX perhaps instead take a URL like "http://localhost:9000"?
-  // If non-empty, override region with a connect string such as "localhost:9000"
   std::string endpoint_override;
-  // Default "https"
+  /// S3 connection transport, default "https"
   std::string scheme = "https";
 
-  std::string access_key;
-  std::string secret_key;
+  /// AWS credentials provider
+  std::shared_ptr<Aws::Auth::AWSCredentialsProvider> credentials_provider;
 
-  // Whether OutputStream writes will be issued in the background, without blocking.
+  /// Whether OutputStream writes will be issued in the background, without blocking.
   bool background_writes = true;
+
+  /// Configure with the default AWS credentials provider chain.
+  void ConfigureDefaultCredentials();
+
+  /// Configure with explicit access and secret key.
+  void ConfigureAccessKey(const std::string& access_key, const std::string& secret_key);
+
+  /// \brief Initialize with default credentials provider chain
+  ///
+  /// This is recommended if you use the standard AWS environment variables
+  /// and/or configuration file.
+  static S3Options Defaults();
+  /// \brief Initialize with explicit access and secret key
+  static S3Options FromAccessKey(const std::string& access_key,
+                                 const std::string& secret_key);
 };
 
 /// S3-backed FileSystem implementation.

--- a/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
@@ -193,7 +193,7 @@ void TestBucket(int argc, char** argv) {
 
 void TestMain(int argc, char** argv) {
   S3GlobalOptions options;
-  options.log_level = S3LogLevel::Fatal;
+  options.log_level = FLAGS_verbose ? S3LogLevel::Debug : S3LogLevel::Fatal;
   ASSERT_OK(InitializeS3(options));
 
   if (FLAGS_clear) {

--- a/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
@@ -57,8 +57,11 @@ namespace fs {
 std::shared_ptr<FileSystem> MakeFileSystem() {
   std::shared_ptr<S3FileSystem> s3fs;
   S3Options options;
-  options.access_key = FLAGS_access_key;
-  options.secret_key = FLAGS_secret_key;
+  if (!FLAGS_access_key.empty()) {
+    options = S3Options::FromAccessKey(FLAGS_access_key, FLAGS_secret_key);
+  } else {
+    options = S3Options::Defaults();
+  }
   options.endpoint_override = FLAGS_endpoint;
   options.scheme = FLAGS_scheme;
   options.region = FLAGS_region;

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -254,7 +254,6 @@ class TestS3FS : public S3TestMixin {
   void SetUp() override {
     S3TestMixin::SetUp();
     MakeFileSystem();
-
     // Set up test bucket
     {
       Aws::S3::Model::CreateBucketRequest req;
@@ -280,8 +279,7 @@ class TestS3FS : public S3TestMixin {
   }
 
   void MakeFileSystem() {
-    options_.access_key = minio_.access_key();
-    options_.secret_key = minio_.secret_key();
+    options_.ConfigureAccessKey(minio_.access_key(), minio_.secret_key());
     options_.scheme = "http";
     options_.endpoint_override = minio_.connect_string();
     ASSERT_OK(S3FileSystem::Make(options_, &fs_));
@@ -746,8 +744,7 @@ class TestS3FSGeneric : public S3TestMixin, public GenericFileSystemTest {
       ASSERT_OK(OutcomeToStatus(client_->CreateBucket(req)));
     }
 
-    options_.access_key = minio_.access_key();
-    options_.secret_key = minio_.secret_key();
+    options_.ConfigureAccessKey(minio_.access_key(), minio_.secret_key());
     options_.scheme = "http";
     options_.endpoint_override = minio_.connect_string();
     ASSERT_OK(S3FileSystem::Make(options_, &s3fs_));


### PR DESCRIPTION
Also provide API facilities to use the default provider chain
(looks up environment variables and config files), or a hard-coded
access / secret key pair.