### PR TITLE
ARROW-6552: [C++] boost::optional in STL test fails compiling in gcc 4.8.2

### DIFF
--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -395,7 +395,9 @@ inline std::shared_ptr<FieldExpression> field_ref(std::string name) {
 }
 
 inline namespace string_literals {
-inline FieldExpression operator""_(const char* name, size_t name_length) {
+// clang-format off
+inline FieldExpression operator"" _(const char* name, size_t name_length) {
+  // clang-format on
   return FieldExpression({name, name_length});
 }
 }  // namespace string_literals

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -34,7 +34,10 @@
 namespace arrow {
 namespace dataset {
 
-using string_literals::operator""_;
+// clang-format off
+using string_literals::operator"" _;
+// clang-format on
+
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -252,8 +252,9 @@ TEST(TestTableFromTupleVector, ReferenceTuple) {
 
   std::vector<std::string> names{"column1", "column2", "column3", "column4", "column5",
                                  "column6", "column7", "column8", "column9", "column10"};
-  std::vector<CustomType> rows{{-1, -2, -3, -4, 1, 2, 3, 4, true, "Tests"},
-                               {-10, -20, -30, -40, 10, 20, 30, 40, false, "Other"}};
+  std::vector<CustomType> rows{
+      {-1, -2, -3, -4, 1, 2, 3, 4, true, std::string("Tests")},
+      {-10, -20, -30, -40, 10, 20, 30, 40, false, std::string("Other")}};
   auto rng_rows =
       transform(rows, [](const CustomType& c) -> decltype(c.tie()) { return c.tie(); });
   std::shared_ptr<Table> table;
@@ -290,8 +291,8 @@ TEST(TestTableFromTupleVector, NullableTypesWithBoostOptional) {
                                  "column6", "column7", "column8", "column9", "column10"};
   using types_tuple = boost_optional_types_tuple;
   std::vector<types_tuple> rows{
-      types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, "Tests"),
-      types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false, "Other"),
+      types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, std::string("Tests")),
+      types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false, std::string("Other")),
       types_tuple(boost::none, boost::none, boost::none, boost::none, boost::none,
                   boost::none, boost::none, boost::none, boost::none, boost::none),
   };
@@ -329,8 +330,9 @@ TEST(TestTableFromTupleVector, NullableTypesWithRawPointer) {
   std::vector<std::string> names{"column1", "column2", "column3", "column4", "column5",
                                  "column6", "column7", "column8", "column9", "column10"};
   std::vector<primitive_types_tuple> data_rows{
-      primitive_types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, "Tests"),
-      primitive_types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false, "Other"),
+      primitive_types_tuple(-1, -2, -3, -4, 1, 2, 3, 4, true, std::string("Tests")),
+      primitive_types_tuple(-10, -20, -30, -40, 10, 20, 30, 40, false,
+                            std::string("Other")),
   };
   std::vector<raw_pointer_optional_types_tuple> pointer_rows;
   for (auto& row : data_rows) {

--- a/cpp/src/arrow/stl_test.cc
+++ b/cpp/src/arrow/stl_test.cc
@@ -390,10 +390,11 @@ TEST(TestTableFromTupleVector, NullableTypesDoNotBreakUserSpecialization) {
 }
 
 TEST(TestTableFromTupleVector, AppendingMultipleRows) {
+  using row_type = std::tuple<std::vector<TestInt32Type>>;
   std::vector<std::string> names{"column1"};
-  std::vector<std::tuple<std::vector<TestInt32Type>>> rows = {
-      {{{1}, {2}, {3}}},    //
-      {{{10}, {20}, {30}}}  //
+  std::vector<row_type> rows = {
+      row_type{{{1}, {2}, {3}}},    //
+      row_type{{{10}, {20}, {30}}}  //
   };
   std::shared_ptr<Table> table;
   ASSERT_OK(TableFromTupleRange(default_memory_pool(), rows, names, &table));


### PR DESCRIPTION
It is reported in the mailgroup that string literals aren't implicitly convertible to `boost::optional<std::string>` in some old versions of gcc, causing compilation errors. This patch wraps such literals used in test cases with `std::string`.