### PR TITLE
ARROW-6557: [Python] Always return pandas.Series from Array/ChunkedArray.to_pandas. Add mechanism to preserve "column names" from RecordBatch, Table as Series.name

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -868,12 +868,13 @@ cdef class Array(_PandasConvertible):
         with nogil:
             check_status(ConvertArrayToPandas(c_options, self.sp_array,
                                               self, &out))
-        return wrap_array_output(out)
+        return pandas_api.series(wrap_array_output(out))
 
     def __array__(self, dtype=None):
+        values = self.to_pandas().values
         if dtype is None:
-            return self.to_pandas()
-        return self.to_pandas().astype(dtype)
+            return values
+        return values.astype(dtype)
 
     def to_numpy(self):
         """
@@ -1654,7 +1655,7 @@ cdef object get_series_values(object obj, bint* is_series):
         result = obj
         is_series[0] = False
     else:
-        result = pandas_api.make_series(obj).values
+        result = pandas_api.series(obj).values
         is_series[0] = False
 
     return result

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -440,7 +440,7 @@ cdef class _PandasConvertible:
 
         Returns
         -------
-        NumPy array or DataFrame depending on type of object
+        pandas.Series or pandas.DataFrame depending on type of object
         """
         cdef:
             PyObject* out
@@ -868,7 +868,7 @@ cdef class Array(_PandasConvertible):
         with nogil:
             check_status(ConvertArrayToPandas(c_options, self.sp_array,
                                               self, &out))
-        return pandas_api.series(wrap_array_output(out))
+        return pandas_api.series(wrap_array_output(out), name=self._name)
 
     def __array__(self, dtype=None):
         values = self.to_pandas().values

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -237,6 +237,8 @@ cdef class Array(_PandasConvertible):
 
     cdef readonly:
         DataType type
+        # To allow Table to propagate metadata to pandas.Series
+        object _name
 
     cdef void init(self, const shared_ptr[CArray]& sp_array) except *
     cdef getitem(self, int64_t i)
@@ -391,6 +393,10 @@ cdef class ChunkedArray(_PandasConvertible):
     cdef:
         shared_ptr[CChunkedArray] sp_chunked_array
         CChunkedArray* chunked_array
+
+    cdef readonly:
+        # To allow Table to propagate metadata to pandas.Series
+        object _name
 
     cdef void init(self, const shared_ptr[CChunkedArray]& chunked_array)
     cdef getitem(self, int64_t i)

--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -90,7 +90,7 @@ cdef class _PandasAPIShim(object):
         self._tried_importing_pandas = True
         self._import_pandas(raise_)
 
-    def make_series(self, *args, **kwargs):
+    def series(self, *args, **kwargs):
         self._check_import()
         return self._series(*args, **kwargs)
 

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -774,7 +774,7 @@ def _extract_index_level(table, result_table, field_name,
     pd = _pandas_api.pd
 
     col = table.column(i)
-    values = col.to_pandas()
+    values = col.to_pandas().values
 
     if hasattr(values, 'flags') and not values.flags.writeable:
         # ARROW-1054: in pandas 0.19.2, factorize will reject

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -163,7 +163,7 @@ cdef class ChunkedArray(_PandasConvertible):
                 self.sp_chunked_array,
                 self, &out))
 
-        return pandas_api.series(wrap_array_output(out))
+        return pandas_api.series(wrap_array_output(out), name=self._name)
 
     def __array__(self, dtype=None):
         values = self.to_pandas().values
@@ -570,7 +570,9 @@ cdef class RecordBatch(_PandasConvertible):
         column : pyarrow.Array
         """
         cdef int index = <int> _normalize_index(i, self.num_columns)
-        return pyarrow_wrap_array(self.batch.column(index))
+        cdef Array result = pyarrow_wrap_array(self.batch.column(index))
+        result._name = self.schema[index].name
+        return result
 
     def __getitem__(self, key):
         if isinstance(key, slice):
@@ -1306,7 +1308,10 @@ cdef class Table(_PandasConvertible):
         pyarrow.ChunkedArray
         """
         cdef int index = <int> _normalize_index(i, self.num_columns)
-        return pyarrow_wrap_chunked_array(self.table.column(index))
+        cdef ChunkedArray result = pyarrow_wrap_chunked_array(
+            self.table.column(index))
+        result._name = self.schema[index].name
+        return result
 
     def itercolumns(self):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -163,12 +163,13 @@ cdef class ChunkedArray(_PandasConvertible):
                 self.sp_chunked_array,
                 self, &out))
 
-        return wrap_array_output(out)
+        return pandas_api.series(wrap_array_output(out))
 
     def __array__(self, dtype=None):
+        values = self.to_pandas().values
         if dtype is None:
-            return self.to_pandas()
-        return self.to_pandas().astype(dtype)
+            return values
+        return values.astype(dtype)
 
     def cast(self, object target_type, bint safe=True):
         """

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2773,6 +2773,13 @@ def test_recordbatchlist_to_pandas():
     tm.assert_frame_equal(data, result)
 
 
+def test_recordbatch_table_pass_name_to_pandas():
+    rb = pa.record_batch([pa.array([1, 2, 3, 4])], names=['a0'])
+    t = pa.table([pa.array([1, 2, 3, 4])], names=['a0'])
+    assert rb[0].to_pandas().name == 'a0'
+    assert t[0].to_pandas().name == 'a0'
+
+
 # ----------------------------------------------------------------------
 # Metadata serialization
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1101,27 +1101,24 @@ class TestConvertDateTimeLikeTypes(object):
                 None,
                 date(1970, 1, 1),
                 date(2040, 2, 26)]
-        expected = np.array(['2000-01-01',
-                             None,
-                             '1970-01-01',
-                             '2040-02-26'], dtype='datetime64')
+        expected_d = np.array(['2000-01-01', None, '1970-01-01',
+                               '2040-02-26'], dtype='datetime64[D]')
 
-        objects = [
-            # The second value is the expected value for date_as_object=False
-            (pa.array(data), expected),
-            (pa.chunked_array([data]), expected)]
+        expected_ns = np.array(['2000-01-01', None, '1970-01-01',
+                                '2040-02-26'], dtype='datetime64[ns]')
 
-        assert objects[0][0].equals(pa.array(expected))
+        objects = [pa.array(data),
+                   pa.chunked_array([data])]
 
-        for obj, expected_datetime64 in objects:
+        for obj in objects:
             result = obj.to_pandas()
-            expected_obj = expected.astype(object)
+            expected_obj = expected_d.astype(object)
             assert result.dtype == expected_obj.dtype
             npt.assert_array_equal(result, expected_obj)
 
             result = obj.to_pandas(date_as_object=False)
-            assert result.dtype == expected_datetime64.dtype
-            npt.assert_array_equal(result, expected_datetime64)
+            assert result.dtype == expected_ns.dtype
+            npt.assert_array_equal(result, expected_ns)
 
     def test_table_convert_date_as_object(self):
         df = pd.DataFrame({
@@ -1305,17 +1302,13 @@ class TestConvertDateTimeLikeTypes(object):
 
         names = ['time64[us]', 'time64[ns]', 'time32[ms]', 'time32[s]']
         batch = pa.RecordBatch.from_arrays([a1, a2, a3, a4], names)
-        arr = a1.to_pandas()
-        assert (arr == expected).all()
 
-        arr = a2.to_pandas()
-        assert (arr == expected).all()
-
-        arr = a3.to_pandas()
-        assert (arr == expected_ms).all()
-
-        arr = a4.to_pandas()
-        assert (arr == expected_s).all()
+        for arr, expected_values in [(a1, expected),
+                                     (a2, expected),
+                                     (a3, expected_ms),
+                                     (a4, expected_s)]:
+            result_pandas = arr.to_pandas()
+            assert (result_pandas.values == expected_values).all()
 
         df = batch.to_pandas()
         expected_df = pd.DataFrame({'time64[us]': expected,
@@ -2383,13 +2376,15 @@ class TestConvertMisc(object):
 
     def test_convert_empty_table(self):
         arr = pa.array([], type=pa.int64())
-        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=np.int64))
+        empty_objects = pd.Series(np.array([], dtype=object))
+        tm.assert_almost_equal(arr.to_pandas(),
+                               pd.Series(np.array([], dtype=np.int64)))
         arr = pa.array([], type=pa.string())
-        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
+        tm.assert_almost_equal(arr.to_pandas(), empty_objects)
         arr = pa.array([], type=pa.list_(pa.int64()))
-        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
+        tm.assert_almost_equal(arr.to_pandas(), empty_objects)
         arr = pa.array([], type=pa.struct([pa.field('a', pa.int64())]))
-        tm.assert_almost_equal(arr.to_pandas(), np.array([], dtype=object))
+        tm.assert_almost_equal(arr.to_pandas(), empty_objects)
 
     def test_non_natural_stride(self):
         """

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -280,6 +280,12 @@ def test_recordbatch_basics():
     assert batch.schema == schema
 
 
+def test_recordbatch_column_sets_private_name():
+    # ARROW-6429
+    rb = pa.record_batch([pa.array([1, 2, 3, 4])], names=['a0'])
+    assert rb[0]._name == 'a0'
+
+
 def test_recordbatch_from_arrays_validate_schema():
     # ARROW-6263
     arr = pa.array([])
@@ -397,6 +403,12 @@ def test_recordbatchlist_schema_equals():
 
     with pytest.raises(pa.ArrowInvalid):
         pa.Table.from_batches([batch1, batch2])
+
+
+def test_table_column_sets_private_name():
+    # ARROW-6429
+    t = pa.table([pa.array([1, 2, 3, 4])], names=['a0'])
+    assert t[0]._name == 'a0'
 
 
 def test_table_equals():


### PR DESCRIPTION
This does not fully fix the docker-spark-integration build but fixes one class of problems. 