### PR TITLE
ARROW-5220: [Python] Specified schema in from_pandas also includes the index

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -328,6 +328,14 @@ def _index_level_name(index, i, column_names):
 def _get_columns_to_convert(df, schema, preserve_index, columns):
     columns = _resolve_columns_of_interest(df, schema, columns)
 
+    if not df.columns.is_unique:
+        raise ValueError(
+            'Duplicate column names found: {}'.format(list(df.columns))
+        )
+
+    if schema is not None:
+        return _get_columns_to_convert_given_schema(df, schema, preserve_index)
+
     column_names = []
 
     index_levels = (
@@ -338,11 +346,6 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
     columns_to_convert = []
     convert_fields = []
 
-    if not df.columns.is_unique:
-        raise ValueError(
-            'Duplicate column names found: {}'.format(list(df.columns))
-        )
-
     for name in columns:
         col = df[name]
         name = _column_name_to_strings(name)
@@ -351,13 +354,8 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
             raise TypeError(
                 "Sparse pandas data (column {}) not supported.".format(name))
 
-        if schema is not None:
-            field = schema.field(name)
-        else:
-            field = None
-
         columns_to_convert.append(col)
-        convert_fields.append(field)
+        convert_fields.append(None)
         column_names.append(name)
 
     index_descriptors = []
@@ -387,6 +385,60 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
     # to be converted to Arrow format
     # columns_fields : specified column to use for coercion / casting
     # during serialization, if a Schema was provided
+    return (all_names, column_names, index_column_names, index_descriptors,
+            index_levels, columns_to_convert, convert_fields)
+
+
+def _get_columns_to_convert_given_schema(df, schema, preserve_index):
+    """
+    Specialized version of _get_columns_to_convert in case a Schema is
+    specified.
+    In that case, the Schema is used as the single point of truth for the
+    table structure (types, which columns are included, order of columns, ...).
+    """
+    column_names = []
+    columns_to_convert = []
+    convert_fields = []
+    index_descriptors = []
+    index_column_names = []
+    index_levels = []
+
+    for name in schema.names:
+        try:
+            col = df[name]
+            is_index = False
+        except KeyError:
+            if preserve_index is not False and name in df.index.names:
+                col = df.index.get_level_values(name)
+                if (preserve_index is None and
+                        isinstance(col, _pandas_api.pd.RangeIndex)):
+                    # TODO better error message
+                    raise KeyError("name {} in schema not in columns "
+                                   "or index".format(name))
+                is_index = True
+            else:
+                # TODO better error message
+                raise KeyError("name {} in schema not in columns "
+                               "or index".format(name))
+
+        name = _column_name_to_strings(name)
+
+        if _pandas_api.is_sparse(col):
+            raise TypeError(
+                "Sparse pandas data (column {}) not supported.".format(name))
+
+        field = schema.field(name)
+        columns_to_convert.append(col)
+        convert_fields.append(field)
+        column_names.append(name)
+
+        if is_index:
+            index_column_names.append(name)
+            index_descriptors.append(name)
+            index_levels.append(col)
+
+    all_names = column_names + index_column_names
+
     return (all_names, column_names, index_column_names, index_descriptors,
             index_levels, columns_to_convert, convert_fields)
 
@@ -503,13 +555,7 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None,
 
     types = [x.type for x in arrays]
 
-    if schema is not None:
-        # add index columns
-        index_types = types[len(column_names):]
-        for name, type_ in zip(index_column_names, index_types):
-            name = name if name is not None else 'None'
-            schema = schema.append(pa.field(name, type_))
-    else:
+    if schema is None:
         fields = []
         for name, type_ in zip(all_names, types):
             name = name if name is not None else 'None'

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -89,7 +89,7 @@ def _check_pandas_roundtrip(df, expected=None, use_threads=True,
         assert table.schema.equals(expected_schema, check_metadata=False)
 
     if expected is None:
-        expected = df if schema is None else df[schema.names]
+        expected = df
 
     tm.assert_frame_equal(result, expected, check_dtype=check_dtype,
                           check_index_type=('equiv' if preserve_index
@@ -2370,6 +2370,7 @@ class TestConvertMisc(object):
         ])
 
         _check_pandas_roundtrip(df, schema=partial_schema,
+                                expected=df[['c', 'a']],
                                 expected_schema=partial_schema)
 
     def test_table_batch_empty_dataframe(self):
@@ -2734,6 +2735,95 @@ def test_table_from_pandas_keeps_schema_nullability():
     assert table.schema.field('a').nullable is True
     table = pa.Table.from_pandas(df, schema=schema)
     assert table.schema.field('a').nullable is False
+
+
+def test_table_from_pandas_schema_index_columns():
+    # ARROW-5220
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': [0.1, 0.2, 0.3]})
+
+    schema = pa.schema([
+        ('a', pa.int64()),
+        ('b', pa.float64()),
+        ('index', pa.int32()),
+    ])
+
+    # schema includes index with name not in dataframe
+    with pytest.raises(KeyError):
+        pa.Table.from_pandas(df, schema=schema)
+
+    df.index.name = 'index'
+
+    # schema includes correct index name -> roundtrip works
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=True,
+                            expected_schema=schema)
+
+    # schema includes correct index name but preserve_index=False
+    with pytest.raises(KeyError):
+        pa.Table.from_pandas(df, schema=schema, preserve_index=False)
+
+    # in case of preserve_index=None -> RangeIndex serialized as metadata
+    # clashes with the index in the schema
+    with pytest.raises(KeyError):
+        pa.Table.from_pandas(df, schema=schema, preserve_index=None)
+
+    df.index = pd.Index([0, 1, 2], name='index')
+
+    # for non-RangeIndex, both preserve_index=None and True work
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=None,
+                            expected_schema=schema)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=True,
+                            expected_schema=schema)
+
+    # schema has different order (index column not at the end)
+    schema = pa.schema([
+        ('index', pa.int32()),
+        ('a', pa.int64()),
+        ('b', pa.float64()),
+    ])
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=None,
+                            expected_schema=schema)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=True,
+                            expected_schema=schema)
+
+    # schema does not include the index -> index is not included as column
+    # even though preserve_index=True/None
+    schema = pa.schema([
+        ('a', pa.int64()),
+        ('b', pa.float64()),
+    ])
+    expected = df.copy()
+    expected = expected.reset_index(drop=True)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=None,
+                            expected_schema=schema, expected=expected)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=True,
+                            expected_schema=schema, expected=expected)
+
+    # dataframe with a MultiIndex
+    df.index = pd.MultiIndex.from_tuples([('a', 1), ('a', 2), ('b', 1)],
+                                         names=['level1', 'level2'])
+    schema = pa.schema([
+        ('level1', pa.string()),
+        ('level2', pa.int64()),
+        ('a', pa.int64()),
+        ('b', pa.float64()),
+    ])
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=True,
+                            expected_schema=schema)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=None,
+                            expected_schema=schema)
+
+    # only one of the levels of the MultiIndex is included
+    schema = pa.schema([
+        ('level2', pa.int64()),
+        ('a', pa.int64()),
+        ('b', pa.float64()),
+    ])
+    expected = df.copy()
+    expected = expected.reset_index('level1', drop=True)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=True,
+                            expected_schema=schema, expected=expected)
+    _check_pandas_roundtrip(df, schema=schema, preserve_index=None,
+                            expected_schema=schema, expected=expected)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-5220

As I mentioned in the issue, while going down this path, quite some questions came up.

So assume we start expecting the index columns also to be present in the schema, if specified:

- are we OK with erroring if the index is not in the schema but would be written as a column? And only if `preserve_index=True`, or also with `preserve_index=None` in case the index is not a RangeIndex ? 
  This will break some current usage (TODO but can probably do it with a deprecation first)
- We should follow the order of the columns in the schema, also for the index? (currently the index is always appended to the other columns) -> I think yes
- What if an index is specified in the schema but `preserve_index=False` ? -> currently raise an error
- What if there are multiple index levels (a MultiIndex), but only one of them is specified in the schema? (in case of columns, then that column that is not the in the schema is ignored) -> currently only select what is in the schema
- What if the index is specified in the schema, but is actually a RangeIndex which would otherwise be serialized as metadata? -> currently raise an error (the user can do `preserve_index=True` to prevent this), but could also include it as a column instead of metadata in this case

In general, though, I think it would be good to have the rule: if a `schema` is specified, it is the single source of truth about the schema, and you can be 100% sure that the resulting table will have this exact schema (otherwise an error is raised)