### PR TITLE
ARROW-6562: [GLib] Fix returning wrong sliced data of GArrowBuffer

### DIFF
--- a/c_glib/arrow-glib/buffer.hpp
+++ b/c_glib/arrow-glib/buffer.hpp
@@ -23,13 +23,21 @@
 
 #include <arrow-glib/buffer.h>
 
-GArrowBuffer *garrow_buffer_new_raw(std::shared_ptr<arrow::Buffer> *arrow_buffer);
-GArrowBuffer *garrow_buffer_new_raw_bytes(std::shared_ptr<arrow::Buffer> *arrow_buffer,
-                                          GBytes *data);
-std::shared_ptr<arrow::Buffer> garrow_buffer_get_raw(GArrowBuffer *buffer);
+GArrowBuffer *
+garrow_buffer_new_raw(std::shared_ptr<arrow::Buffer> *arrow_buffer);
+GArrowBuffer *
+garrow_buffer_new_raw_bytes(std::shared_ptr<arrow::Buffer> *arrow_buffer,
+                            GBytes *data);
+GArrowBuffer *
+garrow_buffer_new_raw_parent(std::shared_ptr<arrow::Buffer> *arrow_buffer,
+                             GArrowBuffer *parent);
+std::shared_ptr<arrow::Buffer>
+garrow_buffer_get_raw(GArrowBuffer *buffer);
 
-GArrowMutableBuffer *garrow_mutable_buffer_new_raw(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer);
-GArrowMutableBuffer *garrow_mutable_buffer_new_raw_bytes(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer,
-                                                         GBytes *data);
+GArrowMutableBuffer *
+garrow_mutable_buffer_new_raw(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer);
+GArrowMutableBuffer *
+garrow_mutable_buffer_new_raw_bytes(std::shared_ptr<arrow::MutableBuffer> *arrow_buffer,
+                                    GBytes *data);
 GArrowResizableBuffer *
 garrow_resizable_buffer_new_raw(std::shared_ptr<arrow::ResizableBuffer> *arrow_buffer);

--- a/c_glib/test/test-buffer.rb
+++ b/c_glib/test/test-buffer.rb
@@ -26,11 +26,28 @@ class TestBuffer < Test::Unit::TestCase
   def test_new_bytes
     bytes_data = GLib::Bytes.new(@data)
     buffer = Arrow::Buffer.new(bytes_data)
-    if GLib.check_binding_version?(3, 2, 2)
-      assert_equal(bytes_data.pointer, buffer.data.pointer)
-    else
-      assert_equal(@data, buffer.data.to_s)
-    end
+    assert_equal([
+                   bytes_data.pointer,
+                   @data,
+                 ],
+                 [
+                   buffer.data.pointer,
+                   buffer.data.to_s,
+                 ])
+  end
+
+  def test_new_bytes_slice
+    bytes_data = GLib::Bytes.new(@data)
+    buffer = Arrow::Buffer.new(bytes_data)
+    sliced_buffer = buffer.slice(1, 3)
+    assert_equal([
+                   bytes_data.pointer + 1,
+                   @data[1, 3],
+                 ],
+                 [
+                   sliced_buffer.data.pointer,
+                   sliced_buffer.data.to_s,
+                 ])
   end
 
   def test_equal


### PR DESCRIPTION
We should not share the GBytes data of the original buffer with the
sliced buffer because the sliced buffer has different offset and size
with the original buffer.

The sliced buffer should have reference to the original buffer. If we
shouldn't have it, the original buffer may be freed when the sliced
buffer is used.

This change disables get_property of PROP_DATA. This is not related to
this fix. But I include this change. Sorry.

Users should use garrow_buffer_get_data() to get data instead of
get_property of PROP_DATA. So we should not provide get_property of
PROP_DATA.