### PR TITLE
ARROW-6560: [Python] Fix nopandas integration tests

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -145,6 +145,7 @@ def test_to_numpy_unsupported_types():
         null_arr.to_numpy()
 
 
+@pytest.mark.pandas
 def test_to_pandas_zero_copy():
     import gc
 
@@ -172,6 +173,7 @@ def test_to_pandas_zero_copy():
         np_arr.sum()
 
 
+@pytest.mark.pandas
 def test_asarray():
     arr = pa.array(range(4))
 

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -198,6 +198,7 @@ def test_chunked_array_to_pandas():
     assert array[0] == -10
 
 
+@pytest.mark.pandas
 def test_chunked_array_asarray():
     data = [
         pa.array([0]),


### PR DESCRIPTION
This should fix https://issues.apache.org/jira/browse/ARROW-6560, or at least the failures on the nopandas build. 
But I think a proper solution would be to not require pandas for `__array__` to work.