### PR TITLE
ARROW-6568: [C++] ChunkedArray constructor needs type when chunks is empty

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -632,6 +632,7 @@ std::shared_ptr<Array> StructArray::GetFieldByName(const std::string& name) cons
 
 Status StructArray::Flatten(MemoryPool* pool, ArrayVector* out) const {
   ArrayVector flattened;
+  flattened.reserve(data_->child_data.size());
   std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
 
   for (auto& child_data : data_->child_data) {

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -556,7 +556,8 @@ inline Status ConvertListsLike(const PandasOptions& options, const ChunkedArray&
     const auto& arr = checked_cast<const ListArray&>(*data.chunk(c));
     value_arrays.emplace_back(arr.values());
   }
-  auto flat_column = std::make_shared<ChunkedArray>(value_arrays);
+  auto value_type = checked_cast<const ListType&>(*data.type()).value_type();
+  auto flat_column = std::make_shared<ChunkedArray>(value_arrays, value_type);
   // TODO(ARROW-489): Currently we don't have a Python reference for single columns.
   //    Storing a reference to the whole Array would be to expensive.
 

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -149,33 +149,28 @@ std::shared_ptr<ChunkedArray> ChunkedArray::Slice(int64_t offset) const {
 
 Status ChunkedArray::Flatten(MemoryPool* pool,
                              std::vector<std::shared_ptr<ChunkedArray>>* out) const {
-  std::vector<std::shared_ptr<ChunkedArray>> flattened;
+  out->clear();
   if (type()->id() != Type::STRUCT) {
     // Emulate non-existent copy constructor
-    flattened.emplace_back(std::make_shared<ChunkedArray>(chunks_, type_));
-    *out = flattened;
+    *out = {std::make_shared<ChunkedArray>(chunks_, type_)};
     return Status::OK();
   }
-  std::vector<ArrayVector> flattened_chunks;
+
+  std::vector<ArrayVector> flattened_chunks(type()->num_children());
   for (const auto& chunk : chunks_) {
     ArrayVector res;
     RETURN_NOT_OK(checked_cast<const StructArray&>(*chunk).Flatten(pool, &res));
-    if (!flattened_chunks.size()) {
-      // First chunk
-      for (const auto& array : res) {
-        flattened_chunks.push_back({array});
-      }
-    } else {
-      DCHECK_EQ(flattened_chunks.size(), res.size());
-      for (size_t i = 0; i < res.size(); ++i) {
-        flattened_chunks[i].push_back(res[i]);
-      }
+    DCHECK_EQ(res.size(), flattened_chunks.size());
+    for (size_t i = 0; i < res.size(); ++i) {
+      flattened_chunks[i].push_back(res[i]);
     }
   }
-  for (const auto& vec : flattened_chunks) {
-    flattened.emplace_back(std::make_shared<ChunkedArray>(vec));
+
+  out->resize(type()->num_children());
+  for (size_t i = 0; i < out->size(); ++i) {
+    out->at(i) =
+        std::make_shared<ChunkedArray>(flattened_chunks[i], type()->child(i)->type());
   }
-  *out = flattened;
   return Status::OK();
 }
 
@@ -510,7 +505,7 @@ Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
         column_arrays.push_back(chunk);
       }
     }
-    columns[i] = std::make_shared<ChunkedArray>(column_arrays);
+    columns[i] = std::make_shared<ChunkedArray>(column_arrays, schema->field(i)->type());
   }
   *table = Table::Make(schema, columns);
   return Status::OK();

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -168,8 +168,8 @@ Status ChunkedArray::Flatten(MemoryPool* pool,
 
   out->resize(type()->num_children());
   for (size_t i = 0; i < out->size(); ++i) {
-    out->at(i) =
-        std::make_shared<ChunkedArray>(flattened_chunks[i], type()->child(i)->type());
+    auto child_type = type()->child(static_cast<int>(i))->type();
+    out->at(i) = std::make_shared<ChunkedArray>(flattened_chunks[i], child_type);
   }
   return Status::OK();
 }
@@ -486,7 +486,7 @@ Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
   std::shared_ptr<Schema> schema = tables[0]->schema();
 
   const int ntables = static_cast<int>(tables.size());
-  const int ncolumns = static_cast<int>(schema->num_fields());
+  const int ncolumns = schema->num_fields();
 
   for (int i = 1; i < ntables; ++i) {
     if (!tables[i]->schema()->Equals(*schema, false)) {

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -41,7 +41,7 @@ class ARROW_EXPORT ChunkedArray {
  public:
   /// \brief Construct a chunked array from a vector of arrays
   ///
-  /// The vector should be non-empty and all its elements should have the same
+  /// The vector must be non-empty and all its elements must have the same
   /// data type.
   explicit ChunkedArray(const ArrayVector& chunks);
 

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -799,7 +799,7 @@ Status TransferBinary(RecordReader* reader,
       return ChunkedArray(chunks).View(logical_value_type, out);
     }
   }
-  *out = std::make_shared<ChunkedArray>(chunks);
+  *out = std::make_shared<ChunkedArray>(chunks, logical_value_type);
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -793,10 +793,13 @@ Status TransferBinary(RecordReader* reader,
   }
   auto binary_reader = dynamic_cast<internal::BinaryRecordReader*>(reader);
   DCHECK(binary_reader);
-  *out = std::make_shared<ChunkedArray>(binary_reader->GetBuilderChunks());
-  if (!logical_value_type->Equals(*(*out)->type())) {
-    RETURN_NOT_OK((*out)->View(logical_value_type, out));
+  auto chunks = binary_reader->GetBuilderChunks();
+  for (const auto& chunk : chunks) {
+    if (!chunk->type()->Equals(*logical_value_type)) {
+      return ChunkedArray(chunks).View(logical_value_type, out);
+    }
   }
+  *out = std::make_shared<ChunkedArray>(chunks);
   return Status::OK();
 }
 
@@ -1091,7 +1094,7 @@ Status TransferDecimal(RecordReader* reader, MemoryPool* pool,
     // Replace the chunk, which will hopefully also free memory as we go
     chunks[i] = chunk_as_decimal;
   }
-  *out = std::make_shared<ChunkedArray>(chunks);
+  *out = std::make_shared<ChunkedArray>(chunks, type);
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -449,8 +449,8 @@ class FileWriterImpl : public FileWriter {
 
   Status WriteColumnChunk(const Array& data) override {
     // A bit awkward here since cannot instantiate ChunkedArray from const Array&
-    ::arrow::ArrayVector chunks = {::arrow::MakeArray(data.data())};
-    auto chunked_array = std::make_shared<::arrow::ChunkedArray>(chunks);
+    auto chunk = ::arrow::MakeArray(data.data());
+    auto chunked_array = std::make_shared<::arrow::ChunkedArray>(chunk);
     return WriteColumnChunk(chunked_array, 0, data.length());
   }
 

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1256,7 +1256,7 @@ class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
 
   std::shared_ptr<::arrow::ChunkedArray> GetResult() override {
     FlushBuilder();
-    return std::make_shared<::arrow::ChunkedArray>(result_chunks_);
+    return std::make_shared<::arrow::ChunkedArray>(result_chunks_, builder_.type());
   }
 
   void FlushBuilder() {

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1782,6 +1782,20 @@ class TestConvertListTypes(object):
 
         tm.assert_frame_equal(result, df)
 
+    def test_empty_column_of_lists_chunked(self):
+        df = pd.DataFrame({
+            'lists': np.array([], dtype=object)
+        })
+
+        schema = pa.schema([
+            pa.field('lists', pa.list_(pa.int64()))
+        ])
+
+        table = pa.Table.from_pandas(df, schema=schema)
+        result = table.to_pandas()
+
+        tm.assert_frame_equal(result, df)
+
     def test_column_of_lists_chunked2(self):
         data1 = [[0, 1], [2, 3], [4, 5], [6, 7], [10, 11],
                  [12, 13], [14, 15], [16, 17]]


### PR DESCRIPTION
I'll port the repro script to C++ as a unit test unless reviewers don't think it's necessary.

There are a few other locations where the same error could arise which I'm planning to fix as well:
- [ChunkedArray::Flatten](https://github.com/apache/arrow/blob/c2762a6/cpp/src/arrow/table.cc#L176)
- [BinaryRecordReader::GetBuilderChunks](https://github.com/apache/arrow/blob/c2762a6/cpp/src/parquet/column_reader.h#L285) could probably just return a chunked array
- Similarly, [SeqBuilder::GetResult](https://github.com/apache/arrow/blob/c2762a660159c770dca9c3d51096367e30824cf7/cpp/src/arrow/python/python_to_arrow.cc#L97)
- arrow_to_pandas::[ConvertListsLike](https://github.com/apache/arrow/blob/c2762a660159c770dca9c3d51096367e30824cf7/cpp/src/arrow/python/arrow_to_pandas.cc#L559)