### PR TITLE
ARROW-6785: [JS] Remove superfluous child assignment

### DIFF
--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -428,7 +428,8 @@ export class List<T extends DataType = any> extends DataType<Type.List, { [0]: T
 export interface Struct<T extends { [key: string]: DataType } = any> extends DataType<Type.Struct> { TArray: IterableArrayLike<RowLike<T>>; TValue: RowLike<T>; dataTypes: T; }
 /** @ignore */
 export class Struct<T extends { [key: string]: DataType } = any> extends DataType<Type.Struct, T> {
-    constructor(public readonly children: Field<T[keyof T]>[]) {
+    public readonly children: Field<T[keyof T]>[]
+    constructor(children: Field<T[keyof T]>[]) {
         super();
         this.children = children;
     }

--- a/js/src/type.ts
+++ b/js/src/type.ts
@@ -428,7 +428,7 @@ export class List<T extends DataType = any> extends DataType<Type.List, { [0]: T
 export interface Struct<T extends { [key: string]: DataType } = any> extends DataType<Type.Struct> { TArray: IterableArrayLike<RowLike<T>>; TValue: RowLike<T>; dataTypes: T; }
 /** @ignore */
 export class Struct<T extends { [key: string]: DataType } = any> extends DataType<Type.Struct, T> {
-    public readonly children: Field<T[keyof T]>[]
+    public readonly children: Field<T[keyof T]>[];
     constructor(children: Field<T[keyof T]>[]) {
         super();
         this.children = children;


### PR DESCRIPTION
From `type.mjs`:
![Screenshot 2019-09-16 15 15 45](https://user-images.githubusercontent.com/931368/64986774-c77b8b00-d895-11e9-9ed7-7d101b283361.png)


TypeScript's data modifiers [automatically create a `this.children = children` assignment](http://www.typescriptlang.org/play/#code/KYDwDg9gTgLgBAYwDYEMDOa4GUZQK4IwA8AKnKDMAHYAmmA3nANoDWwAngFxxq4CWVAOYBdbgBEUMFCXZhgcAL5wAvHBRV2APnIhKtTBKky5pWcAB0OfIQA0cEtvoAoOK8QQqvazGgAKMHgARkh8CHBQwCg0HkjsiAAWfEg0EVTcAGJ8wMmkrBwQAGb2wppMwgCUcM5uNTx4clC+5QDcLrWuMIlo5giJyakqCUkp1K01Cm2uAcGhcILA8DBmAJI0TVXhC3hQVPZmlrgE8Oh7cgfezYqTcNMhYT5WAoLrjBEw27sABlZHRPQAJPROnxur1hqlzABbFBgXy+AqVZTaT6AgrmKgoSHABScVHmJZyBSfcrmABWEAEvk+dmJCgUmk+lwmNTAUAglEIwBoPCkMFmTCw7EhgQgSHxEEeQhIKBEgzhrPZEG4P0IiMc1xqviI6i0NzZPhJYP61EGVDwSCQY3am3eOz1ioFQpFYoe-ClMuEgwA5CqYF6ra4FOVfL7zAqfATgC0nAogA).

I suggest matching the other code and just removing the modifier instead of removing the assignment.