### PR TITLE
ARROW-5630: [C++][Parquet] Fix RecordReader accounting for repeated fields with non-nullable leaf

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1097,6 +1097,12 @@ class TypedRecordReader : public ColumnReaderImplBase<DType>,
       this->ConsumeBufferedValues(levels_position_ - start_levels_position);
     } else {
       ReadValuesDense(values_to_read);
+    }
+    if (this->max_def_level_ > 0) {
+      // Optional, repeated, or some mix thereof
+      this->ConsumeBufferedValues(levels_position_ - start_levels_position);
+    } else {
+      // Flat, non-repeated
       this->ConsumeBufferedValues(values_to_read);
     }
     // Total values, including null spaces, if any

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1094,7 +1094,6 @@ class TypedRecordReader : public ColumnReaderImplBase<DType>,
           valid_bits_->mutable_data(), values_written_);
       values_to_read = values_with_nulls - null_count;
       ReadValuesSpaced(values_with_nulls, null_count);
-      this->ConsumeBufferedValues(levels_position_ - start_levels_position);
     } else {
       ReadValuesDense(values_to_read);
     }

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -257,6 +257,17 @@ def test_empty_lists_table_roundtrip():
     _check_roundtrip(table)
 
 
+def test_nested_list_nonnullable_roundtrip_bug():
+    # Reproduce failure in ARROW-5630
+    typ = pa.list_(pa.field("item", pa.float32(), False))
+    num_rows = 1000
+    t = pa.table([
+        pa.array(([[0] * ((i + 5) % 10) for i in range(0, 10)]
+                  * (num_rows // 10)), type=typ)
+    ], ['a'])
+    _check_roundtrip(t, data_page_size=4096)
+
+
 @pytest.mark.pandas
 def test_pandas_parquet_datetime_tz():
     s = pd.Series([datetime.datetime(2017, 9, 6)])

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -260,7 +260,7 @@ def test_empty_lists_table_roundtrip():
 def test_nested_list_nonnullable_roundtrip_bug():
     # Reproduce failure in ARROW-5630
     typ = pa.list_(pa.field("item", pa.float32(), False))
-    num_rows = 1000
+    num_rows = 10000
     t = pa.table([
         pa.array(([[0] * ((i + 5) % 10) for i in range(0, 10)]
                   * (num_rows // 10)), type=typ)


### PR DESCRIPTION
After chasing my tail a bit on this one, I found that for the case of repeated fields where the leaf node is non-nullable, the RecordReader was terminating without exhausting all data pages. The accounting logic for delimiting records was incrementing the "consumed" definition levels count correctly only in the "nullable values" case, but this must be done the same always when the definition level is greater than 0 (which holds for optional values as well as max repetition level > 0).