### PR TITLE
ARROW-6474: [Python] Add option to use legacy / pre-0.15 IPC message format and to set the default using PYARROW_LEGACY_IPC_FORMAT environment variable

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1029,14 +1029,16 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     cdef cppclass CRecordBatchStreamWriter \
             " arrow::ipc::RecordBatchStreamWriter"(CRecordBatchWriter):
         @staticmethod
-        CStatus Open(OutputStream* sink, const shared_ptr[CSchema]& schema,
-                     shared_ptr[CRecordBatchWriter]* out)
+        CResult[shared_ptr[CRecordBatchWriter]] Open(
+            OutputStream* sink, const shared_ptr[CSchema]& schema,
+            CIpcOptions& options)
 
     cdef cppclass CRecordBatchFileWriter \
             " arrow::ipc::RecordBatchFileWriter"(CRecordBatchWriter):
         @staticmethod
-        CStatus Open(OutputStream* sink, const shared_ptr[CSchema]& schema,
-                     shared_ptr[CRecordBatchWriter]* out)
+        CResult[shared_ptr[CRecordBatchWriter]] Open(
+            OutputStream* sink, const shared_ptr[CSchema]& schema,
+            CIpcOptions& options)
 
     cdef cppclass CRecordBatchFileReader \
             " arrow::ipc::RecordBatchFileReader":

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -60,20 +60,22 @@ class RecordBatchStreamReader(lib._RecordBatchStreamReader, _ReadPandasOption):
         self._open(source)
 
 
-class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
-    """
-    Writer for the Arrow streaming binary format
+_ipc_writer_class_doc = """\
+Parameters
+----------
+sink : str, pyarrow.NativeFile, or file-like Python object
+    Either a file path, or a writable file object
+schema : pyarrow.Schema
+    The Arrow schema for data to be written to the file
+use_legacy_format : boolean, default None
+    If None, use True unless overridden by ARROW_PRE_0_15_IPC_FORMAT=1
+    environment variable"""
 
-    Parameters
-    ----------
-    sink : str, pyarrow.NativeFile, or file-like Python object
-        Either a file path, or a writable file object
-    schema : pyarrow.Schema
-        The Arrow schema for data to be written to the file
-    use_legacy_format : boolean, default None
-        If None, use True unless overridden by PYARROW_LEGACY_IPC_FORMAT=1
-        environment variable
-    """
+
+class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
+    __doc__ = """Writer for the Arrow streaming binary format
+{}""".format(_ipc_writer_class_doc)
+
     def __init__(self, sink, schema, use_legacy_format=None):
         use_legacy_format = _get_legacy_format_default(use_legacy_format)
         self._open(sink, schema, use_legacy_format=use_legacy_format)
@@ -96,19 +98,10 @@ class RecordBatchFileReader(lib._RecordBatchFileReader, _ReadPandasOption):
 
 
 class RecordBatchFileWriter(lib._RecordBatchFileWriter):
-    """
-    Writer to create the Arrow binary file format
 
-    Parameters
-    ----------
-    sink : str, pyarrow.NativeFile, or file-like Python object
-        Either a file path, or a writable file object
-    schema : pyarrow.Schema
-        The Arrow schema for data to be written to the file
-    use_legacy_format : boolean, default None
-        If None, use True unless overridden by PYARROW_LEGACY_IPC_FORMAT=1
-        environment variable
-    """
+    __doc__ = """Writer to create the Arrow binary file format
+{}""".format(_ipc_writer_class_doc)
+
     def __init__(self, sink, schema, use_legacy_format=None):
         use_legacy_format = _get_legacy_format_default(use_legacy_format)
         self._open(sink, schema, use_legacy_format=use_legacy_format)

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -117,7 +117,7 @@ class RecordBatchFileWriter(lib._RecordBatchFileWriter):
 def _get_legacy_format_default(use_legacy_format):
     if use_legacy_format is None:
         import os
-        return bool(int(os.environ.get('PYARROW_LEGACY_IPC_FORMAT', '0')))
+        return bool(int(os.environ.get('ARROW_PRE_0_15_IPC_FORMAT', '0')))
     else:
         return use_legacy_format
 

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -70,9 +70,13 @@ class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
         Either a file path, or a writable file object
     schema : pyarrow.Schema
         The Arrow schema for data to be written to the file
+    use_legacy_format : boolean, default None
+        If None, use True unless overridden by PYARROW_LEGACY_IPC_FORMAT=1
+        environment variable
     """
-    def __init__(self, sink, schema):
-        self._open(sink, schema)
+    def __init__(self, sink, schema, use_legacy_format=None):
+        use_legacy_format = _get_legacy_format_default(use_legacy_format)
+        self._open(sink, schema, use_legacy_format=use_legacy_format)
 
 
 class RecordBatchFileReader(lib._RecordBatchFileReader, _ReadPandasOption):
@@ -101,9 +105,21 @@ class RecordBatchFileWriter(lib._RecordBatchFileWriter):
         Either a file path, or a writable file object
     schema : pyarrow.Schema
         The Arrow schema for data to be written to the file
+    use_legacy_format : boolean, default None
+        If None, use True unless overridden by PYARROW_LEGACY_IPC_FORMAT=1
+        environment variable
     """
-    def __init__(self, sink, schema):
-        self._open(sink, schema)
+    def __init__(self, sink, schema, use_legacy_format=None):
+        use_legacy_format = _get_legacy_format_default(use_legacy_format)
+        self._open(sink, schema, use_legacy_format=use_legacy_format)
+
+
+def _get_legacy_format_default(use_legacy_format):
+    if use_legacy_format is None:
+        import os
+        return bool(int(os.environ.get('PYARROW_LEGACY_IPC_FORMAT', '0')))
+    else:
+        return use_legacy_format
 
 
 def open_stream(source):

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -74,6 +74,7 @@ use_legacy_format : boolean, default None
 
 class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
     __doc__ = """Writer for the Arrow streaming binary format
+
 {}""".format(_ipc_writer_class_doc)
 
     def __init__(self, sink, schema, use_legacy_format=None):
@@ -100,6 +101,7 @@ class RecordBatchFileReader(lib._RecordBatchFileReader, _ReadPandasOption):
 class RecordBatchFileWriter(lib._RecordBatchFileWriter):
 
     __doc__ = """Writer to create the Arrow binary file format
+
 {}""".format(_ipc_writer_class_doc)
 
     def __init__(self, sink, schema, use_legacy_format=None):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -325,13 +325,13 @@ def test_envvar_set_legacy_ipc_format():
     assert not writer._use_legacy_format
 
     import os
-    os.environ['PYARROW_LEGACY_IPC_FORMAT'] = '1'
+    os.environ['ARROW_PRE_0_15_IPC_FORMAT'] = '1'
     writer = pa.RecordBatchStreamWriter(pa.BufferOutputStream(), schema)
     assert writer._use_legacy_format
     writer = pa.RecordBatchFileWriter(pa.BufferOutputStream(), schema)
     assert writer._use_legacy_format
 
-    del os.environ['PYARROW_LEGACY_IPC_FORMAT']
+    del os.environ['ARROW_PRE_0_15_IPC_FORMAT']
 
 
 def test_stream_read_all(stream_fixture):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -102,8 +102,15 @@ class FileFormatFixture(IpcFixture):
 
 class StreamFormatFixture(IpcFixture):
 
+    # ARROW-6474, for testing writing old IPC protocol with 4-byte prefix
+    use_legacy_ipc_format = False
+
     def _get_writer(self, sink, schema):
-        return pa.RecordBatchStreamWriter(sink, schema)
+        return pa.RecordBatchStreamWriter(
+            sink,
+            schema,
+            use_legacy_format=self.use_legacy_ipc_format
+        )
 
 
 class MessageFixture(IpcFixture):
@@ -289,7 +296,9 @@ def test_stream_write_table_batches(stream_fixture):
                                  ignore_index=True))
 
 
-def test_stream_simple_roundtrip(stream_fixture):
+@pytest.mark.parametrize('use_legacy_ipc_format', [False, True])
+def test_stream_simple_roundtrip(stream_fixture, use_legacy_ipc_format):
+    stream_fixture.use_legacy_ipc_format = use_legacy_ipc_format
     _, batches = stream_fixture.write_batches()
     file_contents = pa.BufferReader(stream_fixture.get_source())
     reader = pa.ipc.open_stream(file_contents)
@@ -305,6 +314,24 @@ def test_stream_simple_roundtrip(stream_fixture):
 
     with pytest.raises(StopIteration):
         reader.read_next_batch()
+
+
+def test_envvar_set_legacy_ipc_format():
+    schema = pa.schema([pa.field('foo', pa.int32())])
+
+    writer = pa.RecordBatchStreamWriter(pa.BufferOutputStream(), schema)
+    assert not writer._use_legacy_format
+    writer = pa.RecordBatchFileWriter(pa.BufferOutputStream(), schema)
+    assert not writer._use_legacy_format
+
+    import os
+    os.environ['PYARROW_LEGACY_IPC_FORMAT'] = '1'
+    writer = pa.RecordBatchStreamWriter(pa.BufferOutputStream(), schema)
+    assert writer._use_legacy_format
+    writer = pa.RecordBatchFileWriter(pa.BufferOutputStream(), schema)
+    assert writer._use_legacy_format
+
+    del os.environ['PYARROW_LEGACY_IPC_FORMAT']
 
 
 def test_stream_read_all(stream_fixture):


### PR DESCRIPTION
It feels gross to alter behavior with environment variables but this is probably the least invasive way to enable Apache Spark users to upgrade to pyarrow 0.15.0 or beyond if they are frozen on an older Spark release