### PR TITLE
ARROW-6564: [Python] Do not require pandas for invoking Array.__array__

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -881,7 +881,22 @@ cdef class Array(_PandasConvertible):
         return pandas_api.series(wrap_array_output(out), name=self._name)
 
     def __array__(self, dtype=None):
-        values = self.to_pandas().values
+        cdef:
+            PyObject* out
+            PandasOptions c_options
+            object values
+
+        with nogil:
+            check_status(ConvertArrayToPandas(c_options, self.sp_array,
+                                              self, &out))
+
+        # wrap_array_output uses pandas to convert to Categorical, here
+        # always convert to numpy array
+        values = PyObject_to_object(out)
+
+        if isinstance(values, dict):
+            values = np.take(values['dictionary'], values['indices'])
+
         if dtype is None:
             return values
         return values.astype(dtype)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -173,8 +173,11 @@ def test_to_pandas_zero_copy():
         np_arr.sum()
 
 
+@pytest.mark.nopandas
 @pytest.mark.pandas
 def test_asarray():
+    # ensure this is tested both when pandas is present or not (ARROW-6564)
+
     arr = pa.array(range(4))
 
     # The iterator interface gives back an array of Int64Value's
@@ -201,6 +204,13 @@ def test_asarray():
     assert elements[:3] == [0., 1., 2.]
     assert np.isnan(elements[3])
     assert np_arr.dtype == np.dtype('float64')
+
+    # DictionaryType data will be converted to dense numpy array
+    arr = pa.DictionaryArray.from_arrays(
+        pa.array([0, 1, 2, 0, 1]), pa.array(['a', 'b', 'c']))
+    np_arr = np.asarray(arr)
+    assert np_arr.dtype == np.dtype('object')
+    assert np_arr.tolist() == ['a', 'b', 'c', 'a', 'b']
 
 
 def test_array_getitem():


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6564