### PR TITLE
ARROW-6580: [Java] Support comparison for unsigned integers

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
@@ -20,6 +20,7 @@ package org.apache.arrow.algorithm.sort;
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.OFFSET_WIDTH;
 
 import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BigIntVector;
@@ -28,6 +29,10 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
 
@@ -56,6 +61,14 @@ public class DefaultVectorComparators {
         return (VectorValueComparator<T>) new Float4Comparator();
       } else if (vector instanceof Float8Vector) {
         return (VectorValueComparator<T>) new Float8Comparator();
+      } else if (vector instanceof UInt1Vector) {
+        return (VectorValueComparator<T>) new UInt1Comparator();
+      } else if (vector instanceof UInt2Vector) {
+        return (VectorValueComparator<T>) new UInt2Comparator();
+      } else if (vector instanceof UInt4Vector) {
+        return (VectorValueComparator<T>) new UInt4Comparator();
+      } else if (vector instanceof UInt8Vector) {
+        return (VectorValueComparator<T>) new UInt8Comparator();
       }
     } else if (vector instanceof BaseVariableWidthVector) {
       return (VectorValueComparator<T>) new VariableWidthComparator();
@@ -138,6 +151,79 @@ public class DefaultVectorComparators {
       long value2 = vector2.get(index2);
 
       return Long.signum(value1 - value2);
+    }
+  }
+
+  /**
+   * Default comparator for unsigned bytes.
+   * The comparison is based on values, with null comes first.
+   */
+  public static class UInt1Comparator extends VectorValueComparator<UInt1Vector> {
+
+    public UInt1Comparator() {
+      super(1);
+    }
+
+    @Override
+    public int compareNotNull(int index1, int index2) {
+      byte value1 = vector1.get(index1);
+      byte value2 = vector2.get(index2);
+
+      return (value1 & 0xff) - (value2 & 0xff);
+    }
+  }
+
+  /**
+   * Default comparator for unsigned short integer.
+   * The comparison is based on values, with null comes first.
+   */
+  public static class UInt2Comparator extends VectorValueComparator<UInt2Vector> {
+
+    public UInt2Comparator() {
+      super(2);
+    }
+
+    @Override
+    public int compareNotNull(int index1, int index2) {
+      char value1 = vector1.get(index1);
+      char value2 = vector2.get(index2);
+      return value1 - value2;
+    }
+  }
+
+  /**
+   * Default comparator for unsigned integer.
+   * The comparison is based on values, with null comes first.
+   */
+  public static class UInt4Comparator extends VectorValueComparator<UInt4Vector> {
+
+    public UInt4Comparator() {
+      super(4);
+    }
+
+    @Override
+    public int compareNotNull(int index1, int index2) {
+      int value1 = vector1.get(index1);
+      int value2 = vector2.get(index2);
+      return ByteFunctionHelpers.unsignedIntCompare(value1, value2);
+    }
+  }
+
+  /**
+   * Default comparator for unsigned long integer.
+   * The comparison is based on values, with null comes first.
+   */
+  public static class UInt8Comparator extends VectorValueComparator<UInt8Vector> {
+
+    public UInt8Comparator() {
+      super(8);
+    }
+
+    @Override
+    public int compareNotNull(int index1, int index2) {
+      long value1 = vector1.get(index1);
+      long value2 = vector2.get(index2);
+      return ByteFunctionHelpers.unsignedLongCompare(value1, value2);
     }
   }
 

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -115,8 +115,8 @@ public class TestDefaultVectorComparator {
   @Test
   public void testCompareUInt1() {
     try (UInt1Vector vec = new UInt1Vector("", allocator)) {
-      vec.allocateNew(8);
-      vec.setValueCount(8);
+      vec.allocateNew(10);
+      vec.setValueCount(10);
 
       vec.setNull(0);
       vec.set(1, -2);
@@ -126,6 +126,8 @@ public class TestDefaultVectorComparator {
       vec.set(5, 2);
       vec.set(6, -2);
       vec.setNull(7);
+      vec.set(8, Byte.MAX_VALUE);
+      vec.set(9, Byte.MIN_VALUE);
 
       VectorValueComparator<UInt1Vector> comparator =
               DefaultVectorComparators.createDefaultComparator(vec);
@@ -138,14 +140,18 @@ public class TestDefaultVectorComparator {
       assertTrue(comparator.compare(4, 5) < 0);
       assertTrue(comparator.compare(1, 6) == 0);
       assertTrue(comparator.compare(0, 7) == 0);
+      assertTrue(comparator.compare(8, 9) < 0);
+      assertTrue(comparator.compare(4, 8) < 0);
+      assertTrue(comparator.compare(5, 9) < 0);
+      assertTrue(comparator.compare(2, 9) > 0);
     }
   }
 
   @Test
   public void testCompareUInt2() {
     try (UInt2Vector vec = new UInt2Vector("", allocator)) {
-      vec.allocateNew(8);
-      vec.setValueCount(8);
+      vec.allocateNew(10);
+      vec.setValueCount(10);
 
       vec.setNull(0);
       vec.set(1, -2);
@@ -155,6 +161,8 @@ public class TestDefaultVectorComparator {
       vec.set(5, 2);
       vec.set(6, -2);
       vec.setNull(7);
+      vec.set(8, Short.MAX_VALUE);
+      vec.set(9, Short.MIN_VALUE);
 
       VectorValueComparator<UInt2Vector> comparator =
               DefaultVectorComparators.createDefaultComparator(vec);
@@ -167,14 +175,18 @@ public class TestDefaultVectorComparator {
       assertTrue(comparator.compare(4, 5) < 0);
       assertTrue(comparator.compare(1, 6) == 0);
       assertTrue(comparator.compare(0, 7) == 0);
+      assertTrue(comparator.compare(8, 9) < 0);
+      assertTrue(comparator.compare(4, 8) < 0);
+      assertTrue(comparator.compare(5, 9) < 0);
+      assertTrue(comparator.compare(2, 9) > 0);
     }
   }
 
   @Test
   public void testCompareUInt4() {
     try (UInt4Vector vec = new UInt4Vector("", allocator)) {
-      vec.allocateNew(8);
-      vec.setValueCount(8);
+      vec.allocateNew(10);
+      vec.setValueCount(10);
 
       vec.setNull(0);
       vec.set(1, -2);
@@ -184,6 +196,8 @@ public class TestDefaultVectorComparator {
       vec.set(5, 2);
       vec.set(6, -2);
       vec.setNull(7);
+      vec.set(8, Integer.MAX_VALUE);
+      vec.set(9, Integer.MIN_VALUE);
 
       VectorValueComparator<UInt4Vector> comparator =
               DefaultVectorComparators.createDefaultComparator(vec);
@@ -196,14 +210,18 @@ public class TestDefaultVectorComparator {
       assertTrue(comparator.compare(4, 5) < 0);
       assertTrue(comparator.compare(1, 6) == 0);
       assertTrue(comparator.compare(0, 7) == 0);
+      assertTrue(comparator.compare(8, 9) < 0);
+      assertTrue(comparator.compare(4, 8) < 0);
+      assertTrue(comparator.compare(5, 9) < 0);
+      assertTrue(comparator.compare(2, 9) > 0);
     }
   }
 
   @Test
   public void testCompareUInt8() {
     try (UInt8Vector vec = new UInt8Vector("", allocator)) {
-      vec.allocateNew(8);
-      vec.setValueCount(8);
+      vec.allocateNew(10);
+      vec.setValueCount(10);
 
       vec.setNull(0);
       vec.set(1, -2);
@@ -213,6 +231,8 @@ public class TestDefaultVectorComparator {
       vec.set(5, 2);
       vec.set(6, -2);
       vec.setNull(7);
+      vec.set(8, Long.MAX_VALUE);
+      vec.set(9, Long.MIN_VALUE);
 
       VectorValueComparator<UInt8Vector> comparator =
               DefaultVectorComparators.createDefaultComparator(vec);
@@ -225,6 +245,10 @@ public class TestDefaultVectorComparator {
       assertTrue(comparator.compare(4, 5) < 0);
       assertTrue(comparator.compare(1, 6) == 0);
       assertTrue(comparator.compare(0, 7) == 0);
+      assertTrue(comparator.compare(8, 9) < 0);
+      assertTrue(comparator.compare(4, 8) < 0);
+      assertTrue(comparator.compare(5, 9) < 0);
+      assertTrue(comparator.compare(2, 9) > 0);
     }
   }
 }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -23,6 +23,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -105,6 +109,122 @@ public class TestDefaultVectorComparator {
 
       // list vector elements equal
       assertTrue(comparator.compare(0, 0) == 0);
+    }
+  }
+
+  @Test
+  public void testCompareUInt1() {
+    try (UInt1Vector vec = new UInt1Vector("", allocator)) {
+      vec.allocateNew(8);
+      vec.setValueCount(8);
+
+      vec.setNull(0);
+      vec.set(1, -2);
+      vec.set(2, -1);
+      vec.set(3, 0);
+      vec.set(4, 1);
+      vec.set(5, 2);
+      vec.set(6, -2);
+      vec.setNull(7);
+
+      VectorValueComparator<UInt1Vector> comparator =
+              DefaultVectorComparators.createDefaultComparator(vec);
+      comparator.attachVector(vec);
+
+      assertTrue(comparator.compare(0, 1) < 0);
+      assertTrue(comparator.compare(1, 2) < 0);
+      assertTrue(comparator.compare(1, 3) > 0);
+      assertTrue(comparator.compare(2, 5) > 0);
+      assertTrue(comparator.compare(4, 5) < 0);
+      assertTrue(comparator.compare(1, 6) == 0);
+      assertTrue(comparator.compare(0, 7) == 0);
+    }
+  }
+
+  @Test
+  public void testCompareUInt2() {
+    try (UInt2Vector vec = new UInt2Vector("", allocator)) {
+      vec.allocateNew(8);
+      vec.setValueCount(8);
+
+      vec.setNull(0);
+      vec.set(1, -2);
+      vec.set(2, -1);
+      vec.set(3, 0);
+      vec.set(4, 1);
+      vec.set(5, 2);
+      vec.set(6, -2);
+      vec.setNull(7);
+
+      VectorValueComparator<UInt2Vector> comparator =
+              DefaultVectorComparators.createDefaultComparator(vec);
+      comparator.attachVector(vec);
+
+      assertTrue(comparator.compare(0, 1) < 0);
+      assertTrue(comparator.compare(1, 2) < 0);
+      assertTrue(comparator.compare(1, 3) > 0);
+      assertTrue(comparator.compare(2, 5) > 0);
+      assertTrue(comparator.compare(4, 5) < 0);
+      assertTrue(comparator.compare(1, 6) == 0);
+      assertTrue(comparator.compare(0, 7) == 0);
+    }
+  }
+
+  @Test
+  public void testCompareUInt4() {
+    try (UInt4Vector vec = new UInt4Vector("", allocator)) {
+      vec.allocateNew(8);
+      vec.setValueCount(8);
+
+      vec.setNull(0);
+      vec.set(1, -2);
+      vec.set(2, -1);
+      vec.set(3, 0);
+      vec.set(4, 1);
+      vec.set(5, 2);
+      vec.set(6, -2);
+      vec.setNull(7);
+
+      VectorValueComparator<UInt4Vector> comparator =
+              DefaultVectorComparators.createDefaultComparator(vec);
+      comparator.attachVector(vec);
+
+      assertTrue(comparator.compare(0, 1) < 0);
+      assertTrue(comparator.compare(1, 2) < 0);
+      assertTrue(comparator.compare(1, 3) > 0);
+      assertTrue(comparator.compare(2, 5) > 0);
+      assertTrue(comparator.compare(4, 5) < 0);
+      assertTrue(comparator.compare(1, 6) == 0);
+      assertTrue(comparator.compare(0, 7) == 0);
+    }
+  }
+
+  @Test
+  public void testCompareUInt8() {
+    try (UInt8Vector vec = new UInt8Vector("", allocator)) {
+      vec.allocateNew(8);
+      vec.setValueCount(8);
+
+      vec.setNull(0);
+      vec.set(1, -2);
+      vec.set(2, -1);
+      vec.set(3, 0);
+      vec.set(4, 1);
+      vec.set(5, 2);
+      vec.set(6, -2);
+      vec.setNull(7);
+
+      VectorValueComparator<UInt8Vector> comparator =
+              DefaultVectorComparators.createDefaultComparator(vec);
+      comparator.attachVector(vec);
+
+      assertTrue(comparator.compare(0, 1) < 0);
+      assertTrue(comparator.compare(1, 2) < 0);
+      assertTrue(comparator.compare(1, 3) > 0);
+      assertTrue(comparator.compare(2, 5) > 0);
+      assertTrue(comparator.compare(4, 5) < 0);
+      assertTrue(comparator.compare(1, 6) == 0);
+      assertTrue(comparator.compare(0, 7) == 0);
     }
   }
 }


### PR DESCRIPTION
In this issue, we support the comparison of unsigned integer vectors, including UInt1Vector, UInt2Vector, UInt4Vector, and UInt8Vector.
With support for comparison for these vectors, the sort for them is also supported automatically.