### PR TITLE
ARROW-6527: [C++] Add OutputStream::Write(Buffer)

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -594,11 +594,11 @@ class ObjectOutputStream : public io::OutputStream {
     RETURN_NOT_OK(current_part_->Finish(&buf));
     current_part_.reset();
     current_part_size_ = 0;
-    return UploadPart(std::move(buf));
+    return UploadPart(buf);
   }
 
   Status UploadPart(std::shared_ptr<Buffer> buffer) {
-    return UploadPart(buffer->data(), buffer->size(), std::move(buffer));
+    return UploadPart(buffer->data(), buffer->size(), buffer);
   }
 
   Status UploadPart(const void* data, int64_t nbytes,

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -110,10 +110,10 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   /// Create a sequential output stream for writing to a S3 object.
   ///
-  /// NOTE: Writes to the stream will be buffered but synchronous (i.e.
-  /// when a buffer is implicitly flushed, it waits for the upload to
-  /// complete and the server to respond).  You may want to issue writes
-  /// in the background to avoid idle waits.
+  /// NOTE: Writes to the stream will be buffered.  Depending on
+  /// S3Options.background_writes, they can be synchronous or not.
+  /// It is recommended to enable background_writes unless you prefer
+  /// implementing your own background execution strategy.
   Status OpenOutputStream(const std::string& path,
                           std::shared_ptr<io::OutputStream>* out) override;
 

--- a/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
@@ -34,7 +34,8 @@
 DEFINE_bool(clear, false, "delete all bucket contents");
 DEFINE_bool(test, false, "run narrative test against bucket");
 
-DEFINE_bool(verbose, false, "be more verbose");
+DEFINE_bool(verbose, false, "be more verbose (includes AWS warnings)");
+DEFINE_bool(debug, false, "be very verbose (includes AWS debug logs)");
 
 DEFINE_string(access_key, "", "S3 access key");
 DEFINE_string(secret_key, "", "S3 secret key");
@@ -193,7 +194,9 @@ void TestBucket(int argc, char** argv) {
 
 void TestMain(int argc, char** argv) {
   S3GlobalOptions options;
-  options.log_level = FLAGS_verbose ? S3LogLevel::Debug : S3LogLevel::Fatal;
+  options.log_level = FLAGS_debug
+                          ? S3LogLevel::Debug
+                          : (FLAGS_verbose ? S3LogLevel::Warn : S3LogLevel::Fatal);
   ASSERT_OK(InitializeS3(options));
 
   if (FLAGS_clear) {

--- a/cpp/src/arrow/io/buffered.h
+++ b/cpp/src/arrow/io/buffered.h
@@ -75,6 +75,7 @@ class ARROW_EXPORT BufferedOutputStream : public OutputStream {
   Status Tell(int64_t* position) const override;
   // Write bytes to the stream. Thread-safe
   Status Write(const void* data, int64_t nbytes) override;
+  Status Write(const std::shared_ptr<Buffer>& data) override;
 
   Status Flush() override;
 

--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -227,7 +227,7 @@ TEST_F(TestFileOutputStream, Tell) {
   ASSERT_OK(stream_->Tell(&position));
   ASSERT_EQ(0, position);
 
-  ASSERT_OK(stream_->Write(data, 8));
+  ASSERT_OK(stream_->Write(Buffer::FromString(data)));
   ASSERT_OK(stream_->Tell(&position));
   ASSERT_EQ(8, position);
 }
@@ -604,7 +604,7 @@ TEST_F(TestPipeIO, TestWrite) {
   ASSERT_EQ(bytes_read, 4);
   ASSERT_EQ(0, std::memcmp(buffer, "test", 4));
 
-  ASSERT_OK(file->Write(data2.data(), data2.size()));
+  ASSERT_OK(file->Write(Buffer::FromString(std::string(data2))));
   ASSERT_OK(FileRead(r_, buffer, 4, &bytes_read));
   ASSERT_EQ(bytes_read, 4);
   ASSERT_EQ(0, std::memcmp(buffer, "data", 4));

--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -230,8 +230,8 @@ class ARROW_EXPORT HdfsOutputStream : public OutputStream {
 
   bool closed() const override;
 
+  using OutputStream::Write;
   Status Write(const void* buffer, int64_t nbytes) override;
-
   Status Write(const void* buffer, int64_t nbytes, int64_t* bytes_written);
 
   Status Flush() override;

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -78,6 +78,10 @@ Status Writable::Write(const std::string& data) {
   return Write(data.c_str(), static_cast<int64_t>(data.size()));
 }
 
+Status Writable::Write(const std::shared_ptr<Buffer>& data) {
+  return Write(data->data(), data->size());
+}
+
 Status Writable::Flush() { return Status::OK(); }
 
 class FileSegmentReader

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -114,7 +114,20 @@ class ARROW_EXPORT Writable {
  public:
   virtual ~Writable() = default;
 
+  /// \brief Write the given data to the stream
+  ///
+  /// This method always processes the bytes in full.  Depending on the
+  /// semantics of the stream, the data may be written out immediately,
+  /// held in a buffer, or written asynchronously.  In the case where
+  /// the stream buffers the data, it will be copied.  To avoid potentially
+  /// large copies, use the Write variant that takes an owned Buffer.
   virtual Status Write(const void* data, int64_t nbytes) = 0;
+
+  /// \brief Write the given data to the stream
+  ///
+  /// Since the Buffer owns its memory, this method can avoid a copy if
+  /// buffering is required.  See Write(const void*, int64_t) for details.
+  virtual Status Write(const std::shared_ptr<Buffer>& data);
 
   /// \brief Flush buffered bytes, if any
   virtual Status Flush();

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -209,7 +209,7 @@ Status Message::SerializeTo(io::OutputStream* stream, const IpcOptions& options,
 
   auto body_buffer = body();
   if (body_buffer) {
-    RETURN_NOT_OK(stream->Write(body_buffer->data(), body_buffer->size()));
+    RETURN_NOT_OK(stream->Write(body_buffer));
     *output_length += body_buffer->size();
 
     DCHECK_GE(this->body_length(), body_buffer->size());

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -539,7 +539,7 @@ Status WriteIpcPayload(const IpcPayload& payload, const IpcOptions& options,
 
   // Now write the buffers
   for (size_t i = 0; i < payload.body_buffers.size(); ++i) {
-    const Buffer* buffer = payload.body_buffers[i].get();
+    const std::shared_ptr<Buffer>& buffer = payload.body_buffers[i];
     int64_t size = 0;
     int64_t padding = 0;
 
@@ -550,7 +550,7 @@ Status WriteIpcPayload(const IpcPayload& payload, const IpcOptions& options,
     }
 
     if (size > 0) {
-      RETURN_NOT_OK(dst->Write(buffer->data(), size));
+      RETURN_NOT_OK(dst->Write(buffer));
     }
 
     if (padding > 0) {

--- a/cpp/src/arrow/python/io.cc
+++ b/cpp/src/arrow/python/io.cc
@@ -123,6 +123,14 @@ class PythonFile {
   Status Write(const std::shared_ptr<Buffer>& buffer) {
     RETURN_NOT_OK(CheckClosed());
 
+#if PY_MAJOR_VERSION < 3
+    // On Python 2, a write() method can typically call str() on its argument
+    // to get its bytes payload (this is the case with socket.makefile()).
+    // Unfortunately, on non-bytes buffer-like objects this will give out
+    // the repr() of the object rather than its data.  So fall back on
+    // copying the data to a bytes object.
+    return Write(buffer->data(), buffer->size());
+#else
     PyObject* py_data = wrap_buffer(buffer);
     PY_RETURN_IF_ERROR(StatusCode::IOError);
 
@@ -131,6 +139,7 @@ class PythonFile {
     Py_XDECREF(result);
     PY_RETURN_IF_ERROR(StatusCode::IOError);
     return Status::OK();
+#endif
   }
 
   Status Tell(int64_t* position) {

--- a/cpp/src/arrow/python/io.h
+++ b/cpp/src/arrow/python/io.h
@@ -75,6 +75,7 @@ class ARROW_PYTHON_EXPORT PyOutputStream : public io::OutputStream {
   bool closed() const override;
   Status Tell(int64_t* position) const override;
   Status Write(const void* data, int64_t nbytes) override;
+  Status Write(const std::shared_ptr<Buffer>& buffer) override;
 
  private:
   std::unique_ptr<PythonFile> file_;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -181,7 +181,7 @@ class SerializedPageWriter : public PageWriter {
       dictionary_page_offset_ = start_pos;
     }
     int64_t header_size = thrift_serializer_->Serialize(&page_header, sink_.get());
-    PARQUET_THROW_NOT_OK(sink_->Write(compressed_data->data(), compressed_data->size()));
+    PARQUET_THROW_NOT_OK(sink_->Write(compressed_data));
 
     total_uncompressed_size_ += uncompressed_size + header_size;
     total_compressed_size_ += compressed_data->size() + header_size;
@@ -249,7 +249,7 @@ class SerializedPageWriter : public PageWriter {
     }
 
     int64_t header_size = thrift_serializer_->Serialize(&page_header, sink_.get());
-    PARQUET_THROW_NOT_OK(sink_->Write(compressed_data->data(), compressed_data->size()));
+    PARQUET_THROW_NOT_OK(sink_->Write(compressed_data));
 
     total_uncompressed_size_ += uncompressed_size + header_size;
     total_compressed_size_ += compressed_data->size() + header_size;
@@ -320,7 +320,7 @@ class BufferedPageWriter : public PageWriter {
     // flush everything to the serialized sink
     std::shared_ptr<Buffer> buffer;
     PARQUET_THROW_NOT_OK(in_memory_sink_->Finish(&buffer));
-    PARQUET_THROW_NOT_OK(final_sink_->Write(buffer->data(), buffer->size()));
+    PARQUET_THROW_NOT_OK(final_sink_->Write(buffer));
   }
 
   int64_t WriteDataPage(const CompressedDataPage& page) override {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -754,13 +754,14 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
     cdef cppclass Readable:
         # put overload under a different name to avoid cython bug with multiple
         # layers of inheritance
-        CStatus ReadB" Read"(int64_t nbytes, shared_ptr[CBuffer]* out)
+        CStatus ReadBuffer" Read"(int64_t nbytes, shared_ptr[CBuffer]* out)
         CStatus Read(int64_t nbytes, int64_t* bytes_read, uint8_t* out)
 
     cdef cppclass Seekable:
         CStatus Seek(int64_t position)
 
     cdef cppclass Writable:
+        CStatus WriteBuffer" Write"(shared_ptr[CBuffer] data)
         CStatus Write(const uint8_t* data, int64_t nbytes)
         CStatus Flush()
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -631,10 +631,13 @@ def test_nativefile_write_memoryview():
 
     f.write(arr)
     f.write(bytearray(data))
+    f.write(pa.py_buffer(data))
+    with pytest.raises(TypeError):
+        f.write(data.decode('utf8'))
 
     buf = f.getvalue()
 
-    assert buf.to_pybytes() == data * 2
+    assert buf.to_pybytes() == data * 3
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -463,7 +463,7 @@ class SocketStreamFixture(IpcFixture):
 
     def stop_and_get_result(self):
         import struct
-        self.sink.write(struct.pack('i', 0))
+        self.sink.write(struct.pack('Q', 0))
         self.sink.flush()
         self._sock.close()
         self._server.join()


### PR DESCRIPTION
Passing an owned buffer allows buffering the data internally without making a copy. 
Adjust Python and S3 OutputStream implementations to take advantage.