### PR TITLE
ARROW-5870: [C++][Docs] Refine source build instructions, do not tell people to install flex/bison if they don't need them

### DIFF
--- a/docs/source/developers/cpp.rst
+++ b/docs/source/developers/cpp.rst
@@ -43,10 +43,6 @@ Building requires:
 * On Linux and macOS, either ``make`` or ``ninja`` build utilities
 * Boost 1.58 or higher, though some unit tests require 1.64 or newer.
 
-Running the unit tests using ``ctest`` requires:
-
-* python
-
 On Ubuntu/Debian you can install the requirements with:
 
 .. code-block:: shell
@@ -55,11 +51,9 @@ On Ubuntu/Debian you can install the requirements with:
         autoconf \
         build-essential \
         cmake \
-        libboost-dev \
         libboost-filesystem-dev \
         libboost-regex-dev \
-        libboost-system-dev \
-        python
+        libboost-system-dev
 
 On Alpine Linux:
 
@@ -126,10 +120,10 @@ Minimal release build:
    cd arrow/cpp
    mkdir release
    cd release
-   cmake -DARROW_BUILD_TESTS=ON ..
-   make unittest
+   cmake ..
+   make
 
-Minimal debug build:
+Minimal debug build with unit tests:
 
 .. code-block:: shell
 
@@ -140,8 +134,9 @@ Minimal debug build:
    cmake -DCMAKE_BUILD_TYPE=Debug -DARROW_BUILD_TESTS=ON ..
    make unittest
 
-If you do not need to build the test suite, you can omit the
-``ARROW_BUILD_TESTS`` option (the default is not to build the unit tests).
+The unit tests are not built by default. After building, one can also invoke
+the unit tests using the ``ctest`` tool provided by CMake (not that ``test``
+depends on ``python`` being available).
 
 On some Linux distributions, running the test suite might require setting an
 explicit locale. If you see any locale-related errors, try setting the
@@ -954,7 +949,7 @@ can be built with the ``parquet`` make target:
 
    make parquet
 
-On Linux and macOS If you do not have Apache Thrift installed on your system,
+On Linux and macOS if you do not have Apache Thrift installed on your system,
 or you are building with ``-DThrift_SOURCE=BUNDLED``, you must install
 ``bison`` and ``flex`` packages. On Windows we handle these build dependencies
 automatically when building Thrift from source.

--- a/docs/source/developers/cpp.rst
+++ b/docs/source/developers/cpp.rst
@@ -40,10 +40,8 @@ Building requires:
 * A C++11-enabled compiler. On Linux, gcc 4.8 and higher should be
   sufficient. For Windows, at least Visual Studio 2015 is required.
 * CMake 3.2 or higher
-* Boost 1.58 or higher, though some unit tests require 1.64 or
-  newer.
-* ``bison`` and ``flex`` (for building Apache Thrift from source only, an
-  Apache Parquet dependency.)
+* On Linux and macOS, either ``make`` or ``ninja`` build utilities
+* Boost 1.58 or higher, though some unit tests require 1.64 or newer.
 
 Running the unit tests using ``ctest`` requires:
 
@@ -61,9 +59,7 @@ On Ubuntu/Debian you can install the requirements with:
         libboost-filesystem-dev \
         libboost-regex-dev \
         libboost-system-dev \
-        python \
-        bison \
-        flex
+        python
 
 On Alpine Linux:
 
@@ -957,6 +953,11 @@ can be built with the ``parquet`` make target:
 .. code-block:: shell
 
    make parquet
+
+On Linux and macOS If you do not have Apache Thrift installed on your system,
+or you are building with ``-DThrift_SOURCE=BUNDLED``, you must install
+``bison`` and ``flex`` packages. On Windows we handle these build dependencies
+automatically when building Thrift from source.
 
 Running ``ctest -L unittest`` will run all built C++ unit tests, while ``ctest -L
 parquet`` will run only the Parquet unit tests. The unit tests depend on an


### PR DESCRIPTION
This makes explicit that a build system like `make` or `ninja` is required on Linux/macOS.

Having `flex` and `bison` in the top level requirements alters the optics of a minimal build in a negative way, since these are only required for building the Parquet library, which is optional. 