### PR TITLE
ARROW-6795: [C#] Fix for reading large (2GB+) files

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
@@ -33,11 +33,6 @@ namespace Apache.Arrow.Ipc
         /// </summary>
         private int _recordBatchIndex;
 
-        /// <summary>
-        /// Notes what byte position where the footer data is in the stream
-        /// </summary>
-        private long _footerStartPostion;
-
         private ArrowFooter _footer;
 
         public ArrowFileReaderImplementation(Stream stream, MemoryAllocator allocator, bool leaveOpen)
@@ -77,9 +72,9 @@ namespace Apache.Arrow.Ipc
 
             await ArrayPool<byte>.Shared.RentReturnAsync(footerLength, async (buffer) =>
             {
-                _footerStartPostion = (int)GetFooterLengthPosition() - footerLength;
+                long footerStartPostion = GetFooterLengthPosition() - footerLength;
 
-                BaseStream.Position = _footerStartPostion;
+                BaseStream.Position = footerStartPostion;
 
                 int bytesRead = await BaseStream.ReadFullBufferAsync(buffer).ConfigureAwait(false);
                 EnsureFullRead(buffer, bytesRead);
@@ -110,9 +105,9 @@ namespace Apache.Arrow.Ipc
 
             ArrayPool<byte>.Shared.RentReturn(footerLength, (buffer) =>
             {
-                _footerStartPostion = GetFooterLengthPosition() - footerLength;
+                long footerStartPostion = GetFooterLengthPosition() - footerLength;
 
-                BaseStream.Position = _footerStartPostion;
+                BaseStream.Position = footerStartPostion;
 
                 int bytesRead = BaseStream.ReadFullBuffer(buffer);
                 EnsureFullRead(buffer, bytesRead);

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
@@ -36,7 +36,7 @@ namespace Apache.Arrow.Ipc
         /// <summary>
         /// Notes what byte position where the footer data is in the stream
         /// </summary>
-        private int _footerStartPostion;
+        private long _footerStartPostion;
 
         private ArrowFooter _footer;
 
@@ -110,7 +110,7 @@ namespace Apache.Arrow.Ipc
 
             ArrayPool<byte>.Shared.RentReturn(footerLength, (buffer) =>
             {
-                _footerStartPostion = (int)GetFooterLengthPosition() - footerLength;
+                _footerStartPostion = GetFooterLengthPosition() - footerLength;
 
                 BaseStream.Position = _footerStartPostion;
 


### PR DESCRIPTION
It seems that trying to read larger than 2GB+ files will blow up.  

As long as the record batches are less than 2GB (the max size of span) there should be no problem reading a large file