### PR TITLE
ARROW-6728: [C#] Support reading and writing Date32 and Date64 arrays

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
@@ -58,8 +58,9 @@ namespace Apache.Arrow
                     return new StructArray(data);
                 case ArrowTypeId.Union:
                     return new UnionArray(data);
-                case ArrowTypeId.Date64:
                 case ArrowTypeId.Date32:
+                    return new Date32Array(data);
+                case ArrowTypeId.Date64:
                 case ArrowTypeId.Decimal:
                 case ArrowTypeId.Dictionary:
                 case ArrowTypeId.FixedSizedBinary:

--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayFactory.cs
@@ -58,9 +58,10 @@ namespace Apache.Arrow
                     return new StructArray(data);
                 case ArrowTypeId.Union:
                     return new UnionArray(data);
+                case ArrowTypeId.Date64:
+                    return new Date64Array(data);
                 case ArrowTypeId.Date32:
                     return new Date32Array(data);
-                case ArrowTypeId.Date64:
                 case ArrowTypeId.Decimal:
                 case ArrowTypeId.Dictionary:
                 case ArrowTypeId.FixedSizedBinary:

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -81,12 +81,8 @@ namespace Apache.Arrow.Ipc
             public void Visit(DoubleArray array) => CreateBuffers(array);
             public void Visit(TimestampArray array) => CreateBuffers(array);
             public void Visit(BooleanArray array) => CreateBuffers(array);
-            public void Visit(Date32Array array)
-            {
-                _buffers.Add(CreateBuffer(array.NullBitmapBuffer));
-                _buffers.Add(CreateBuffer(array.ValueBuffer));
-            }
-            public void Visit(Date64Array array) => throw new NotSupportedException();
+            public void Visit(Date32Array array) => CreateBuffers(array);
+            public void Visit(Date64Array array) => CreateBuffers(array);
 
             public void Visit(ListArray array)
             {

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -42,11 +42,11 @@ namespace Apache.Arrow.Tests
                 builder.Field(CreateField(Int64Type.Default, i));
                 builder.Field(CreateField(FloatType.Default, i));
                 builder.Field(CreateField(DoubleType.Default, i));
+                builder.Field(CreateField(Date32Type.Default, i));
+                builder.Field(CreateField(Date64Type.Default, i));
                 //builder.Field(CreateField(new DecimalType(19, 2)));
                 //builder.Field(CreateField(HalfFloatType.Default));
                 //builder.Field(CreateField(StringType.Default));
-                //builder.Field(CreateField(Date32Type.Default));
-                //builder.Field(CreateField(Date64Type.Default));
                 //builder.Field(CreateField(Time32Type.Default));
                 //builder.Field(CreateField(Time64Type.Default));
                 //builder.Field(CreateField(TimestampType.Default));
@@ -89,6 +89,8 @@ namespace Apache.Arrow.Tests
 
         private class ArrayBufferCreator :
             IArrowTypeVisitor<BooleanType>,
+            IArrowTypeVisitor<Date32Type>,
+            IArrowTypeVisitor<Date64Type>,
             IArrowTypeVisitor<Int8Type>,
             IArrowTypeVisitor<Int16Type>,
             IArrowTypeVisitor<Int32Type>,
@@ -159,6 +161,8 @@ namespace Apache.Arrow.Tests
             public void Visit(UInt64Type type) => CreateNumberArray<ulong>(type);
             public void Visit(FloatType type) => CreateNumberArray<float>(type);
             public void Visit(DoubleType type) => CreateNumberArray<double>(type);
+            public void Visit(Date32Type type) => CreateNumberArray<int>(type);
+            public void Visit(Date64Type type) => CreateNumberArray<long>(type);
 
             private void CreateNumberArray<T>(IArrowType type)
                 where T : struct


### PR DESCRIPTION
It seems that this switch statement will needs to be updated to read Date32 columns