### PR TITLE
ARROW-6588: [C++] Suppress class-memaccess warning with g++ 9.2.1

### DIFF
--- a/cpp/src/arrow/util/rle_encoding.h
+++ b/cpp/src/arrow/util/rle_encoding.h
@@ -436,8 +436,7 @@ inline int RleDecoder::GetBatchWithDictSpaced(const T* dictionary, T* out, int b
   DCHECK_GE(bit_width_, 0);
   int values_read = 0;
   int remaining_nulls = null_count;
-  T zero;
-  memset(&zero, 0, sizeof(T));
+  T zero = {};
 
   arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, batch_size);
 


### PR DESCRIPTION
    [1/8] Building CXX object src/parquet/CMakeFiles/parquet_objlib.dir/encoding.cc.o
    FAILED: src/parquet/CMakeFiles/parquet_objlib.dir/encoding.cc.o
    /usr/bin/c++  -DARROW_EXTRA_ERROR_CONTEXT -DARROW_JEMALLOC -DARROW_JEMALLOC_INCLUDE_DIR="" -DARROW_USE_GLOG -DARROW_USE_SIMD -DARROW_WITH_ZSTD -DHAVE_INTTYPES_H -DHAVE_NETDB_H -DHAVE_NETINET_IN_H -DPARQUET_EXPORTING -Isrc -I../src -isystem jemalloc_ep-prefix/src -isystem flatbuffers_ep-prefix/src/flatbuffers_ep-install/include -isystem ../thirdparty/cares_ep-install/include -isystem ../thirdparty/hadoop/include -isystem orc_ep-install/include -Wno-noexcept-type  -fdiagnostics-color=always -ggdb -O0  -Wall -Wno-conversion -Wno-sign-conversion -Wno-unused-variable -Werror -msse4.2  -g -fPIC   -std=gnu++11 -MD -MT src/parquet/CMakeFiles/parquet_objlib.dir/encoding.cc.o -MF src/parquet/CMakeFiles/parquet_objlib.dir/encoding.cc.o.d -o src/parquet/CMakeFiles/parquet_objlib.dir/encoding.cc.o -c ../src/parquet/encoding.cc
    In file included from ../src/parquet/encoding.cc:33:
    ../src/arrow/util/rle_encoding.h: In instantiation of 'int arrow::util::RleDecoder::GetBatchWithDictSpaced(const T*, T*, int, int, const uint8_t*, int64_t) [with T = parquet::FixedLenByteArray; uint8_t = unsigned char; int64_t = long int]':
    ../src/parquet/encoding.cc:1079:20:   required from 'int parquet::DictDecoderImpl<Type>::DecodeSpaced(parquet::DictDecoderImpl<Type>::T*, int, int, const uint8_t*, int64_t) [with Type = parquet::PhysicalType<parquet::Type::FIXED_LEN_BYTE_ARRAY>; parquet::DictDecoderImpl<Type>::T = parquet::FixedLenByteArray; uint8_t = unsigned char; int64_t = long int]'
    ../src/parquet/encoding.cc:1076:7:   required from here
    ../src/arrow/util/rle_encoding.h:440:9: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct parquet::FixedLenByteArray'; use assignment or value-initialization instead [-Werror=class-memaccess]
      440 |   memset(&zero, 0, sizeof(T));
          |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~
    In file included from ../src/parquet/encoding.h:27,
                     from ../src/parquet/encoding.cc:18:
    ../src/parquet/types.h:515:8: note: 'struct parquet::FixedLenByteArray' declared here
      515 | struct FixedLenByteArray {
          |        ^~~~~~~~~~~~~~~~~
    In file included from ../src/parquet/encoding.cc:33:
    ../src/arrow/util/rle_encoding.h: In instantiation of 'int arrow::util::RleDecoder::GetBatchWithDictSpaced(const T*, T*, int, int, const uint8_t*, int64_t) [with T = parquet::ByteArray; uint8_t = unsigned char; int64_t = long int]':
    ../src/parquet/encoding.cc:1079:20:   required from 'int parquet::DictDecoderImpl<Type>::DecodeSpaced(parquet::DictDecoderImpl<Type>::T*, int, int, const uint8_t*, int64_t) [with Type = parquet::PhysicalType<parquet::Type::BYTE_ARRAY>; parquet::DictDecoderImpl<Type>::T = parquet::ByteArray; uint8_t = unsigned char; int64_t = long int]'
    ../src/parquet/encoding.cc:1076:7:   required from here
    ../src/arrow/util/rle_encoding.h:440:9: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct parquet::ByteArray'; use assignment or value-initialization instead [-Werror=class-memaccess]
      440 |   memset(&zero, 0, sizeof(T));
          |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~
    In file included from ../src/parquet/encoding.h:27,
                     from ../src/parquet/encoding.cc:18:
    ../src/parquet/types.h:495:8: note: 'struct parquet::ByteArray' declared here
      495 | struct ByteArray {
          |        ^~~~~~~~~
    cc1plus: all warnings being treated as errors