### PR TITLE
ARROW-6591: [R] Ignore .Rhistory files in source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,11 +58,14 @@ python/doc/
 .idea/
 .pytest_cache/
 pkgs
-.Rproj.user
-arrow.Rcheck/
 docker_cache
 .gdb_history
 .DS_Store
 *.orig
 
 site/
+
+# R files
+**/.Rproj.user
+**/*.Rcheck/
+**/.Rhistory

--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -20,3 +20,4 @@ clang_format.sh
 ^.*\.cmd$
 ^autobrew$
 ^apache-arrow.rb$
+^.*\.Rhistory$


### PR DESCRIPTION
While working on [ARROW-6337](https://issues.apache.org/jira/browse/ARROW-6591), I saw that `.Rhistory` files are not currently ignored in arrow's `.gitignore`. They serve no purpose to the project so I think they should probably be ignored.