### PR TITLE
ARROW-6597: [Python] Sanitize Python datetime handling

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -649,10 +649,6 @@ inline void ConvertDatetimeNanos(const ChunkedArray& data, int64_t* out_values) 
 template <typename Type>
 static Status ConvertDates(const PandasOptions& options, const ChunkedArray& data,
                            PyObject** out_values) {
-  {
-    PyAcquireGIL lock;
-    PyDateTime_IMPORT;
-  }
   auto WrapValue = [](typename Type::c_type value, PyObject** out) {
     RETURN_NOT_OK(internal::PyDate_from_int(value, Type::UNIT, out));
     RETURN_IF_PYERROR();
@@ -664,11 +660,6 @@ static Status ConvertDates(const PandasOptions& options, const ChunkedArray& dat
 template <typename Type>
 static Status ConvertTimes(const PandasOptions& options, const ChunkedArray& data,
                            PyObject** out_values) {
-  {
-    PyAcquireGIL lock;
-    PyDateTime_IMPORT;
-  }
-
   const TimeUnit::type unit = checked_cast<const Type&>(*data.type()).unit();
 
   auto WrapValue = [unit](typename Type::c_type value, PyObject** out) {

--- a/cpp/src/arrow/python/datetime.h
+++ b/cpp/src/arrow/python/datetime.h
@@ -27,9 +27,21 @@
 #include "arrow/type.h"
 #include "arrow/util/logging.h"
 
+// By default, PyDateTimeAPI is a *static* variable.  This forces
+// PyDateTime_IMPORT to be called in every C/C++ module using the
+// C datetime API.  This is error-prone and potentially costly.
+// Instead, we redefine PyDateTimeAPI to point to a global variable,
+// which is initialized once by calling InitDatetime().
+#define PyDateTimeAPI ::arrow::py::internal::datetime_api
+
 namespace arrow {
 namespace py {
 namespace internal {
+
+extern PyDateTime_CAPI* datetime_api;
+
+ARROW_PYTHON_EXPORT
+void InitDatetime();
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyTime_to_us(PyObject* pytime) {

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -343,7 +343,6 @@ Status ReadSerializedObject(io::RandomAccessFile* src, SerializedPyObject* out) 
 Status DeserializeObject(PyObject* context, const SerializedPyObject& obj, PyObject* base,
                          PyObject** out) {
   PyAcquireGIL lock;
-  PyDateTime_IMPORT;
   return DeserializeList(context, *obj.batch->column(0), 0, obj.batch->num_rows(), base,
                          obj, out);
 }

--- a/cpp/src/arrow/python/inference.cc
+++ b/cpp/src/arrow/python/inference.cc
@@ -617,7 +617,6 @@ class TypeInferrer {
 // Non-exhaustive type inference
 Status InferArrowType(PyObject* obj, PyObject* mask, bool pandas_null_sentinels,
                       std::shared_ptr<DataType>* out_type) {
-  PyDateTime_IMPORT;
   TypeInferrer inferrer(pandas_null_sentinels);
   RETURN_NOT_OK(inferrer.VisitSequence(obj, mask));
   RETURN_NOT_OK(inferrer.GetType(out_type));

--- a/cpp/src/arrow/python/pyarrow.cc
+++ b/cpp/src/arrow/python/pyarrow.cc
@@ -24,6 +24,8 @@
 #include "arrow/tensor.h"
 #include "arrow/type.h"
 
+#include "arrow/python/common.h"
+#include "arrow/python/datetime.h"
 namespace {
 #include "arrow/python/pyarrow_api.h"
 }
@@ -31,7 +33,10 @@ namespace {
 namespace arrow {
 namespace py {
 
-int import_pyarrow() { return ::import_pyarrow__lib(); }
+int import_pyarrow() {
+  internal::InitDatetime();
+  return ::import_pyarrow__lib();
+}
 
 bool is_buffer(PyObject* buffer) { return ::pyarrow_is_buffer(buffer) != 0; }
 

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -1060,8 +1060,6 @@ Status ConvertPySequence(PyObject* sequence_source, PyObject* mask,
                          std::shared_ptr<ChunkedArray>* out) {
   PyAcquireGIL lock;
 
-  PyDateTime_IMPORT;
-
   PyObject* seq;
   OwnedRef tmp_seq_nanny;
 

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -530,7 +530,6 @@ std::shared_ptr<RecordBatch> MakeBatch(std::shared_ptr<Array> data) {
 
 Status SerializeObject(PyObject* context, PyObject* sequence, SerializedPyObject* out) {
   PyAcquireGIL lock;
-  PyDateTime_IMPORT;
   SequenceBuilder builder;
   RETURN_NOT_OK(internal::VisitIterable(
       sequence, [&](PyObject* obj, bool* keep_going /* unused */) {

--- a/cpp/src/arrow/python/util/test_main.cc
+++ b/cpp/src/arrow/python/util/test_main.cc
@@ -19,7 +19,9 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/python/datetime.h"
 #include "arrow/python/init.h"
+#include "arrow/python/pyarrow.h"
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
@@ -29,6 +31,7 @@ int main(int argc, char** argv) {
   if (ret != 0) {
     return ret;
   }
+  ::arrow::py::internal::InitDatetime();
 
   ret = RUN_ALL_TESTS();
 

--- a/python/pyarrow/tests/test_cuda.py
+++ b/python/pyarrow/tests/test_cuda.py
@@ -260,8 +260,8 @@ def test_context_from_object(size):
 
     # Trying to create a device buffer from numpy.array
     with pytest.raises(pa.ArrowTypeError,
-                       match=('cannot create device buffer view from'
-                              ' `<class \'numpy.ndarray\'>` object')):
+                       match=("cannot create device buffer view from "
+                              ".* \'numpy.ndarray\'")):
         ctx.buffer_from_object(np.array([1, 2, 3]))
 
 


### PR DESCRIPTION
The official datetime C macros (PyDate*) operate on a static variable
named PyDateTimeAPI.  This forces us to initialize that static variable
using PyDateTime_IMPORT in every datetime-using C++ module.  Fix the
issue by redefining PyDateTimeAPI to a global variable.

Fixes a crash I got locally in test_pandas.py.