### PR TITLE
ARROW-6573: [Python] Add test case to probe additional behavior in schema-data mismatch in Table.from_pydict

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -927,7 +927,7 @@ def test_from_arrays_schema(data, klass):
     assert table.num_rows == 3
     assert table.schema == schema
 
-    # lenth of data and schema not matching
+    # length of data and schema not matching
     schema = pa.schema([('strs', pa.utf8())])
     with pytest.raises(ValueError):
         pa.Table.from_arrays(data, schema=schema)
@@ -988,6 +988,11 @@ def test_table_from_pydict():
     # Cannot pass both schema and metadata
     with pytest.raises(ValueError):
         pa.Table.from_pydict(data, schema=schema, metadata=metadata)
+
+    # Non-convertible values given schema
+    with pytest.raises(TypeError):
+        pa.Table.from_pydict({'c0': [0, 1, 2]},
+                             schema=pa.schema([("c0", pa.string())]))
 
 
 @pytest.mark.parametrize('data, klass', [


### PR DESCRIPTION
In 0.14.x there were multiple issues going unchecked, these have been fixed in other patches since then

```
In [5]: pa.Table.from_pydict({'c0': [0, 1, 2]}, 
   ...:                              schema=pa.schema([("c0", pa.string())]))[0]                                                                                                               
Out[5]: 
<Column name='c0' type=DataType(string)>
[
  [
    0,
    1,
    2
  ]
]

In [7]: pa.Table.from_pydict({'c0': [0, 1, 2]}, 
   ...:                              schema=pa.schema([("c0", pa.string())]))[0].data.chunk(0)                                                                                                 
Out[7]: 
<pyarrow.lib.Int64Array object at 0x7f65c4149f10>
[
  0,
  1,
  2
]
```

Not only is the schema properly respected now during conversion, constructing a Column (now gone) with field type mismatching chunked array data type is no longer possible.