### PR TITLE
ARROW-5343: [C++] Refactor dictionary unification to incremental interface, and use Buffer for transpose map allocations

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -1240,17 +1240,16 @@ class ARROW_EXPORT DictionaryArray : public Array {
   /// This method constructs a new dictionary array with the given dictionary type,
   /// transposing indices using the transpose map.
   /// The type and the transpose map are typically computed using
-  /// DictionaryType::Unify.
+  /// DictionaryUnifier.
   ///
   /// \param[in] pool a pool to allocate the array data from
   /// \param[in] type the new type object
   /// \param[in] dictionary the new dictionary
-  /// \param[in] transpose_map a vector transposing this array's indices
+  /// \param[in] transpose_map transposition array of this array's indices
   /// into the target array's indices
   /// \param[out] out the resulting DictionaryArray instance
   Status Transpose(MemoryPool* pool, const std::shared_ptr<DataType>& type,
-                   const std::shared_ptr<Array>& dictionary,
-                   const std::vector<int32_t>& transpose_map,
+                   const std::shared_ptr<Array>& dictionary, const int32_t* transpose_map,
                    std::shared_ptr<Array>* out) const;
 
   /// \brief Determine whether dictionary arrays may be compared without unification

--- a/cpp/src/arrow/array/dict_internal.cc
+++ b/cpp/src/arrow/array/dict_internal.cc
@@ -44,119 +44,114 @@ using internal::CopyBitmap;
 // ----------------------------------------------------------------------
 // DictionaryType unification
 
-struct UnifyDictionaryValues {
+template <typename T>
+class DictionaryUnifierImpl : public DictionaryUnifier {
+ public:
+  using ArrayType = typename TypeTraits<T>::ArrayType;
+  using DictTraits = typename internal::DictionaryTraits<T>;
+  using MemoTableType = typename DictTraits::MemoTableType;
+
+  DictionaryUnifierImpl(MemoryPool* pool, std::shared_ptr<DataType> value_type)
+      : pool_(pool), value_type_(value_type), memo_table_(pool) {}
+
+  Status Unify(const Array& dictionary) override {
+    const ArrayType& values = checked_cast<const ArrayType&>(dictionary);
+    if (dictionary.null_count() > 0) {
+      return Status::Invalid("Cannot yet unify dictionaries with nulls");
+    }
+    if (dictionary.type()->Equals(*value_type_)) {
+      return Status::Invalid("Dictionary type different from unifier: ",
+                             dictionary.type()->ToString());
+    }
+    for (int64_t i = 0; i < values.length(); ++i) {
+      memo_table_.GetOrInsert(values.GetView(i));
+    }
+    return Status::OK();
+  }
+
+  Status Unify(const Array& dictionary, std::shared_ptr<Buffer>* out) override {
+    const ArrayType& values = checked_cast<const ArrayType&>(dictionary);
+    if (dictionary.null_count() > 0) {
+      return Status::Invalid("Cannot yet unify dictionaries with nulls");
+    }
+    if (dictionary.type()->Equals(*value_type_)) {
+      return Status::Invalid("Dictionary type different from unifier: ",
+                             dictionary.type()->ToString());
+    }
+    std::shared_ptr<Buffer> result;
+    RETURN_NOT_OK(AllocateBuffer(pool_, dictionary.length() * sizeof(int32_t), &result));
+    auto result_raw = reinterpret_cast<int32_t*>(result->mutable_data());
+    for (int64_t i = 0; i < values.length(); ++i) {
+      result_raw[i] = memo_table_.GetOrInsert(values.GetView(i));
+    }
+    *out = result;
+    return Status::OK();
+  }
+
+  Status GetResult(std::shared_ptr<DataType>* out_type,
+                   std::shared_ptr<Array>* out_dict) override {
+    int64_t dict_length = memo_table_.size();
+    std::shared_ptr<DataType> index_type;
+    if (dict_length <= std::numeric_limits<int8_t>::max()) {
+      index_type = int8();
+    } else if (dict_length <= std::numeric_limits<int16_t>::max()) {
+      index_type = int16();
+    } else if (dict_length <= std::numeric_limits<int32_t>::max()) {
+      index_type = int32();
+    } else {
+      index_type = int64();
+    }
+    // Build unified dictionary type with the right index type
+    *out_type = arrow::dictionary(index_type, value_type_);
+
+    // Build unified dictionary array
+    std::shared_ptr<ArrayData> data;
+    RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table_,
+                                                     0 /* start_offset */, &data));
+    *out_dict = MakeArray(data);
+    return Status::OK();
+  }
+
+ private:
   MemoryPool* pool_;
   std::shared_ptr<DataType> value_type_;
-  const std::vector<const DictionaryType*>& types_;
-  const std::vector<const Array*>& dictionaries_;
-  std::shared_ptr<Array>* out_values_;
-  std::vector<std::vector<int32_t>>* out_transpose_maps_;
+  MemoTableType memo_table_;
+};
+
+struct MakeUnifier {
+  MemoryPool* pool;
+  std::shared_ptr<DataType> value_type;
+  std::unique_ptr<DictionaryUnifier> result;
+
+  MakeUnifier(MemoryPool* pool, std::shared_ptr<DataType> value_type)
+      : pool(pool), value_type(value_type) {}
 
   template <typename T>
   enable_if_no_memoize<T, Status> Visit(const T&) {
     // Default implementation for non-dictionary-supported datatypes
-    return Status::NotImplemented("Unification of ", value_type_,
+    return Status::NotImplemented("Unification of ", value_type,
                                   " dictionaries is not implemented");
   }
 
   template <typename T>
   enable_if_memoize<T, Status> Visit(const T&) {
-    using ArrayType = typename TypeTraits<T>::ArrayType;
-    using DictTraits = typename internal::DictionaryTraits<T>;
-    using MemoTableType = typename DictTraits::MemoTableType;
-
-    MemoTableType memo_table(pool_);
-    if (out_transpose_maps_ != nullptr) {
-      out_transpose_maps_->clear();
-      out_transpose_maps_->reserve(types_.size());
-    }
-    // Build up the unified dictionary values and the transpose maps
-    for (size_t i = 0; i < types_.size(); ++i) {
-      const ArrayType& values = checked_cast<const ArrayType&>(*dictionaries_[i]);
-      if (out_transpose_maps_ != nullptr) {
-        std::vector<int32_t> transpose_map;
-        transpose_map.reserve(values.length());
-        for (int64_t i = 0; i < values.length(); ++i) {
-          int32_t dict_index = memo_table.GetOrInsert(values.GetView(i));
-          transpose_map.push_back(dict_index);
-        }
-        out_transpose_maps_->push_back(std::move(transpose_map));
-      } else {
-        for (int64_t i = 0; i < values.length(); ++i) {
-          memo_table.GetOrInsert(values.GetView(i));
-        }
-      }
-    }
-    // Build unified dictionary array
-    std::shared_ptr<ArrayData> data;
-    RETURN_NOT_OK(DictTraits::GetDictionaryArrayData(pool_, value_type_, memo_table,
-                                                     0 /* start_offset */, &data));
-    *out_values_ = MakeArray(data);
+    result.reset(new DictionaryUnifierImpl<T>(pool, value_type));
     return Status::OK();
   }
 };
 
-Status DictionaryType::Unify(MemoryPool* pool, const std::vector<const DataType*>& types,
-                             const std::vector<const Array*>& dictionaries,
-                             std::shared_ptr<DataType>* out_type,
-                             std::shared_ptr<Array>* out_dictionary,
-                             std::vector<std::vector<int32_t>>* out_transpose_maps) {
-  if (types.size() == 0) {
-    return Status::Invalid("need at least one input type");
-  }
-
-  if (types.size() != dictionaries.size()) {
-    return Status::Invalid("expecting the same number of types and dictionaries");
-  }
-
-  std::vector<const DictionaryType*> dict_types;
-  dict_types.reserve(types.size());
-  for (const auto& type : types) {
-    if (type->id() != Type::DICTIONARY) {
-      return Status::TypeError("input types must be dictionary types");
-    }
-    dict_types.push_back(checked_cast<const DictionaryType*>(type));
-  }
-
-  // XXX Should we check the ordered flag?
-  auto value_type = dict_types[0]->value_type();
-  for (size_t i = 0; i < types.size(); ++i) {
-    if (!(dictionaries[i]->type()->Equals(*value_type) &&
-          dict_types[i]->value_type()->Equals(*value_type))) {
-      return Status::TypeError("dictionary value types were not all consistent");
-    }
-    if (dictionaries[i]->null_count() != 0) {
-      return Status::TypeError("input types have null values");
-    }
-  }
-
-  std::shared_ptr<Array> values;
-  {
-    UnifyDictionaryValues visitor{pool,         value_type, dict_types,
-                                  dictionaries, &values,    out_transpose_maps};
-    RETURN_NOT_OK(VisitTypeInline(*value_type, &visitor));
-  }
-
-  // Build unified dictionary type with the right index type
-  std::shared_ptr<DataType> index_type;
-  if (values->length() <= std::numeric_limits<int8_t>::max()) {
-    index_type = int8();
-  } else if (values->length() <= std::numeric_limits<int16_t>::max()) {
-    index_type = int16();
-  } else if (values->length() <= std::numeric_limits<int32_t>::max()) {
-    index_type = int32();
-  } else {
-    index_type = int64();
-  }
-  *out_type = arrow::dictionary(index_type, values->type());
-  *out_dictionary = values;
+Status DictionaryUnifier::Make(MemoryPool* pool, std::shared_ptr<DataType> value_type,
+                               std::unique_ptr<DictionaryUnifier>* out) {
+  MakeUnifier maker(pool, value_type);
+  RETURN_NOT_OK(VisitTypeInline(*value_type, &maker));
+  *out = std::move(maker.result);
   return Status::OK();
 }
 
 // ----------------------------------------------------------------------
 // DictionaryArray transposition
 
-static bool IsTrivialTransposition(const std::vector<int32_t>& transpose_map,
+static bool IsTrivialTransposition(const int32_t* transpose_map,
                                    int64_t input_dict_size) {
   for (int64_t i = 0; i < input_dict_size; ++i) {
     if (transpose_map[i] != i) {
@@ -168,33 +163,26 @@ static bool IsTrivialTransposition(const std::vector<int32_t>& transpose_map,
 
 template <typename InType, typename OutType>
 static Status TransposeDictIndices(MemoryPool* pool, const ArrayData& in_data,
-                                   const std::vector<int32_t>& transpose_map,
+                                   const int32_t* transpose_map,
                                    const std::shared_ptr<ArrayData>& out_data,
                                    std::shared_ptr<Array>* out) {
   using in_c_type = typename InType::c_type;
   using out_c_type = typename OutType::c_type;
   internal::TransposeInts(in_data.GetValues<in_c_type>(1),
                           out_data->GetMutableValues<out_c_type>(1), in_data.length,
-                          transpose_map.data());
+                          transpose_map);
   *out = MakeArray(out_data);
   return Status::OK();
 }
 
 Status DictionaryArray::Transpose(MemoryPool* pool, const std::shared_ptr<DataType>& type,
                                   const std::shared_ptr<Array>& dictionary,
-                                  const std::vector<int32_t>& transpose_map,
+                                  const int32_t* transpose_map,
                                   std::shared_ptr<Array>* out) const {
   if (type->id() != Type::DICTIONARY) {
     return Status::TypeError("Expected dictionary type");
   }
   const int64_t in_dict_len = data_->dictionary->length();
-  if (in_dict_len > static_cast<int64_t>(transpose_map.size())) {
-    return Status::Invalid(
-        "Transpose map too small for dictionary array "
-        "(has ",
-        transpose_map.size(), " values, need at least ", in_dict_len, ")");
-  }
-
   const auto& out_dict_type = checked_cast<const DictionaryType&>(*type);
 
   const auto& out_index_type =

--- a/cpp/src/arrow/array/dict_internal.cc
+++ b/cpp/src/arrow/array/dict_internal.cc
@@ -59,7 +59,7 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     if (dictionary.null_count() > 0) {
       return Status::Invalid("Cannot yet unify dictionaries with nulls");
     }
-    if (dictionary.type()->Equals(*value_type_)) {
+    if (!dictionary.type()->Equals(*value_type_)) {
       return Status::Invalid("Dictionary type different from unifier: ",
                              dictionary.type()->ToString());
     }
@@ -74,7 +74,7 @@ class DictionaryUnifierImpl : public DictionaryUnifier {
     if (dictionary.null_count() > 0) {
       return Status::Invalid("Cannot yet unify dictionaries with nulls");
     }
-    if (dictionary.type()->Equals(*value_type_)) {
+    if (!dictionary.type()->Equals(*value_type_)) {
       return Status::Invalid("Dictionary type different from unifier: ",
                              dictionary.type()->ToString());
     }

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -950,7 +950,7 @@ TEST(TestDictionary, FromArray) {
 }
 
 static void CheckTranspose(const std::shared_ptr<Array>& input,
-                           const std::vector<int32_t>& transpose_map,
+                           const int32_t* transpose_map,
                            const std::shared_ptr<DataType>& out_dict_type,
                            const std::shared_ptr<Array>& out_dict,
                            const std::shared_ptr<Array>& expected_indices) {
@@ -980,11 +980,13 @@ TEST(TestDictionary, TransposeBasic) {
     auto out_dict_type = dict_type;
     auto out_dict = ArrayFromJSON(utf8(), "[\"Z\", \"A\", \"C\", \"B\"]");
     auto expected_indices = ArrayFromJSON(int16(), "[3, 2, 1, 1]");
-    CheckTranspose(arr, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
+    std::vector<int32_t> transpose_map = {1, 3, 2};
+    CheckTranspose(arr, transpose_map.data(), out_dict_type, out_dict, expected_indices);
 
     // Sliced
     expected_indices = ArrayFromJSON(int16(), "[2, 1]");
-    CheckTranspose(sliced, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
+    CheckTranspose(sliced, transpose_map.data(), out_dict_type, out_dict,
+                   expected_indices);
   }
 
   // Transpose to other index type
@@ -992,11 +994,13 @@ TEST(TestDictionary, TransposeBasic) {
     auto out_dict_type = dictionary(int8(), utf8());
     auto out_dict = ArrayFromJSON(utf8(), "[\"Z\", \"A\", \"C\", \"B\"]");
     auto expected_indices = ArrayFromJSON(int8(), "[3, 2, 1, 1]");
-    CheckTranspose(arr, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
+    std::vector<int32_t> transpose_map = {1, 3, 2};
+    CheckTranspose(arr, transpose_map.data(), out_dict_type, out_dict, expected_indices);
 
     // Sliced
     expected_indices = ArrayFromJSON(int8(), "[2, 1]");
-    CheckTranspose(sliced, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
+    CheckTranspose(sliced, transpose_map.data(), out_dict_type, out_dict,
+                   expected_indices);
   }
 }
 
@@ -1012,16 +1016,19 @@ TEST(TestDictionary, TransposeTrivial) {
   // ["C", "A"]
   sliced = arr->Slice(1, 2);
 
+  std::vector<int32_t> transpose_map = {0, 1, 2};
+
   // Transpose to same index type
   {
     auto out_dict_type = dict_type;
     auto out_dict = ArrayFromJSON(utf8(), "[\"A\", \"B\", \"C\", \"D\"]");
     auto expected_indices = ArrayFromJSON(int16(), "[1, 2, 0, 0]");
-    CheckTranspose(arr, {0, 1, 2}, out_dict_type, out_dict, expected_indices);
+    CheckTranspose(arr, transpose_map.data(), out_dict_type, out_dict, expected_indices);
 
     // Sliced
     expected_indices = ArrayFromJSON(int16(), "[2, 0]");
-    CheckTranspose(sliced, {0, 1, 2}, out_dict_type, out_dict, expected_indices);
+    CheckTranspose(sliced, transpose_map.data(), out_dict_type, out_dict,
+                   expected_indices);
   }
 
   // Transpose to other index type
@@ -1029,11 +1036,12 @@ TEST(TestDictionary, TransposeTrivial) {
     auto out_dict_type = dictionary(int8(), utf8());
     auto out_dict = ArrayFromJSON(utf8(), "[\"A\", \"B\", \"C\", \"D\"]");
     auto expected_indices = ArrayFromJSON(int8(), "[1, 2, 0, 0]");
-    CheckTranspose(arr, {0, 1, 2}, out_dict_type, out_dict, expected_indices);
+    CheckTranspose(arr, transpose_map.data(), out_dict_type, out_dict, expected_indices);
 
     // Sliced
     expected_indices = ArrayFromJSON(int8(), "[2, 0]");
-    CheckTranspose(sliced, {0, 1, 2}, out_dict_type, out_dict, expected_indices);
+    CheckTranspose(sliced, transpose_map.data(), out_dict_type, out_dict,
+                   expected_indices);
   }
 }
 
@@ -1052,12 +1060,12 @@ TEST(TestDictionary, TransposeNulls) {
   auto out_dict_type = dictionary(int16(), utf8());
   auto expected_indices = ArrayFromJSON(int16(), "[3, 2, null, 1]");
 
-  CheckTranspose(arr, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
+  std::vector<int32_t> transpose_map = {1, 3, 2};
+  CheckTranspose(arr, transpose_map.data(), out_dict_type, out_dict, expected_indices);
 
   // Sliced
   expected_indices = ArrayFromJSON(int16(), "[2, null]");
-
-  CheckTranspose(sliced, {1, 3, 2}, out_dict_type, out_dict, expected_indices);
+  CheckTranspose(sliced, transpose_map.data(), out_dict_type, out_dict, expected_indices);
 }
 
 TEST(TestDictionary, DISABLED_ListOfDictionary) {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1257,29 +1257,6 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 
   bool ordered() const { return ordered_; }
 
-  /// \brief Unify dictionaries types
-  ///
-  /// Compute a resulting dictionary that will allow the union of values
-  /// of all input dictionary types.  The input types must all have the
-  /// same value type.
-  /// \param[in] pool Memory pool to allocate dictionary values from
-  /// \param[in] types A sequence of input dictionary types
-  /// \param[in] dictionaries A sequence of input dictionaries
-  /// corresponding to each type
-  /// \param[out] out_type The unified dictionary type
-  /// \param[out] out_dictionary The unified dictionary
-  /// \param[out] out_transpose_maps (optionally) A sequence of integer vectors,
-  ///     one per input type.  Each integer vector represents the transposition
-  ///     of input type indices into unified type indices.
-  // XXX Should we return something special (an empty transpose map?) when
-  // the transposition is the identity function?  Currently this case is
-  // detected in DictionaryArray::Transpose.
-  static Status Unify(MemoryPool* pool, const std::vector<const DataType*>& types,
-                      const std::vector<const Array*>& dictionaries,
-                      std::shared_ptr<DataType>* out_type,
-                      std::shared_ptr<Array>* out_dictionary,
-                      std::vector<std::vector<int32_t>>* out_transpose_maps = NULLPTR);
-
  protected:
   std::string ComputeFingerprint() const override;
 
@@ -1287,6 +1264,33 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
   std::shared_ptr<DataType> index_type_;
   std::shared_ptr<DataType> value_type_;
   bool ordered_;
+};
+
+/// \brief Helper class for incremental dictionary unification
+class DictionaryUnifier {
+ public:
+  /// \brief Construct a DictionaryUnifier
+  /// \param[in] pool MemoryPool to use for memory allocations
+  /// \param[in] value_type the data type of the dictionaries
+  /// \param[out] out the constructed unifier
+  static Status Make(MemoryPool* pool, std::shared_ptr<DataType> value_type,
+                     std::unique_ptr<DictionaryUnifier>* out);
+
+  /// \brief Append dictionary to the internal memo
+  virtual Status Unify(const Array& dictionary) = 0;
+
+  /// \brief Append dictionary and compute transpose indices
+  /// \param[in] dictionary the dictionary values to unify
+  /// \param[out] out_transpose a Buffer containing computed transpose indices
+  /// for a DictionaryArray with the old dictionary
+  virtual Status Unify(const Array& dictionary,
+                       std::shared_ptr<Buffer>* out_transpose) = 0;
+
+  /// \brief Return a result DictionaryType with the smallest possible index
+  /// type to accommodate the unified dictionary and the unified
+  /// dictionary. The unifier cannot be used after this is called
+  virtual Status GetResult(std::shared_ptr<DataType>* out_type,
+                           std::shared_ptr<Array>* out_dict) = 0;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1267,8 +1267,10 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 };
 
 /// \brief Helper class for incremental dictionary unification
-class DictionaryUnifier {
+class ARROW_EXPORT DictionaryUnifier {
  public:
+  virtual ~DictionaryUnifier() = default;
+
   /// \brief Construct a DictionaryUnifier
   /// \param[in] pool MemoryPool to use for memory allocations
   /// \param[in] value_type the data type of the dictionaries

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1284,13 +1284,15 @@ class ARROW_EXPORT DictionaryUnifier {
   /// \brief Append dictionary and compute transpose indices
   /// \param[in] dictionary the dictionary values to unify
   /// \param[out] out_transpose a Buffer containing computed transpose indices
+  /// as int32_t values equal in length to the passed dictionary. The value in
+  /// each slot corresponds to the new index value for each original index
   /// for a DictionaryArray with the old dictionary
   virtual Status Unify(const Array& dictionary,
                        std::shared_ptr<Buffer>* out_transpose) = 0;
 
   /// \brief Return a result DictionaryType with the smallest possible index
-  /// type to accommodate the unified dictionary and the unified
-  /// dictionary. The unifier cannot be used after this is called
+  /// type to accommodate the unified dictionary. The unifier cannot be used
+  /// after this is called
   virtual Status GetResult(std::shared_ptr<DataType>* out_type,
                            std::shared_ptr<Array>* out_dict) = 0;
 };

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -912,9 +912,7 @@ TEST(TestDictionaryType, Equals) {
 }
 
 void CheckTransposeMap(const Buffer& map, std::vector<int32_t> expected) {
-  Buffer ex_buffer(reinterpret_cast<const uint8_t*>(expected.data()),
-                   static_cast<int64_t>(expected.size() * sizeof(int32_t)));
-  ASSERT_TRUE(map.Equals(ex_buffer));
+  AssertBufferEqual(map, *Buffer::Wrap(expected));
 }
 
 TEST(TestDictionaryType, UnifyNumeric) {

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -911,6 +911,12 @@ TEST(TestDictionaryType, Equals) {
   AssertTypesNotEqual(*t5, *t6);
 }
 
+void CheckTransposeMap(const Buffer& map, std::vector<int32_t> expected) {
+  Buffer ex_buffer(reinterpret_cast<const uint8_t*>(expected.data()),
+                   static_cast<int64_t>(expected.size() * sizeof(int32_t)));
+  ASSERT_TRUE(map.Equals(ex_buffer));
+}
+
 TEST(TestDictionaryType, UnifyNumeric) {
   auto dict_ty = int64();
 
@@ -926,23 +932,31 @@ TEST(TestDictionaryType, UnifyNumeric) {
   auto expected = dictionary(int8(), dict_ty);
   auto expected_dict = ArrayFromJSON(dict_ty, "[3, 4, 7, 1, 8, -200]");
 
+  std::unique_ptr<DictionaryUnifier> unifier;
+  ASSERT_OK(DictionaryUnifier::Make(default_memory_pool(), dict_ty, &unifier));
+
   std::shared_ptr<DataType> out_type;
   std::shared_ptr<Array> out_dict;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get(), t3.get()},
-                                  {d1.get(), d2.get(), d3.get()}, &out_type, &out_dict));
+
+  ASSERT_OK(unifier->Unify(*d1));
+  ASSERT_OK(unifier->Unify(*d2));
+  ASSERT_OK(unifier->Unify(*d3));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 
-  std::vector<std::vector<int32_t>> transpose_maps;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get(), t3.get()},
-                                  {d1.get(), d2.get(), d3.get()}, &out_type, &out_dict,
-                                  &transpose_maps));
+  std::shared_ptr<Buffer> b1, b2, b3;
+
+  ASSERT_OK(unifier->Unify(*d1, &b1));
+  ASSERT_OK(unifier->Unify(*d2, &b2));
+  ASSERT_OK(unifier->Unify(*d3, &b3));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
-  ASSERT_EQ(transpose_maps.size(), 3);
-  ASSERT_EQ(transpose_maps[0], std::vector<int32_t>({0, 1, 2}));
-  ASSERT_EQ(transpose_maps[1], std::vector<int32_t>({3, 2, 1, 4}));
-  ASSERT_EQ(transpose_maps[2], std::vector<int32_t>({3, 5}));
+
+  CheckTransposeMap(*b1, {0, 1, 2});
+  CheckTransposeMap(*b2, {3, 2, 1, 4});
+  CheckTransposeMap(*b3, {3, 5});
 }
 
 TEST(TestDictionaryType, UnifyString) {
@@ -957,23 +971,27 @@ TEST(TestDictionaryType, UnifyString) {
   auto expected = dictionary(int8(), dict_ty);
   auto expected_dict = ArrayFromJSON(dict_ty, "[\"foo\", \"bar\", \"quux\"]");
 
+  std::unique_ptr<DictionaryUnifier> unifier;
+  ASSERT_OK(DictionaryUnifier::Make(default_memory_pool(), dict_ty, &unifier));
+
   std::shared_ptr<DataType> out_type;
   std::shared_ptr<Array> out_dict;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()},
-                                  {d1.get(), d2.get()}, &out_type, &out_dict));
+  ASSERT_OK(unifier->Unify(*d1));
+  ASSERT_OK(unifier->Unify(*d2));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 
-  std::vector<std::vector<int32_t>> transpose_maps;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()},
-                                  {d1.get(), d2.get()}, &out_type, &out_dict,
-                                  &transpose_maps));
+  std::shared_ptr<Buffer> b1, b2;
+
+  ASSERT_OK(unifier->Unify(*d1, &b1));
+  ASSERT_OK(unifier->Unify(*d2, &b2));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 
-  ASSERT_EQ(transpose_maps.size(), 2);
-  ASSERT_EQ(transpose_maps[0], std::vector<int32_t>({0, 1}));
-  ASSERT_EQ(transpose_maps[1], std::vector<int32_t>({2, 0}));
+  CheckTransposeMap(*b1, {0, 1});
+  CheckTransposeMap(*b2, {2, 0});
 }
 
 TEST(TestDictionaryType, UnifyFixedSizeBinary) {
@@ -992,22 +1010,25 @@ TEST(TestDictionaryType, UnifyFixedSizeBinary) {
   auto expected_dict = std::make_shared<FixedSizeBinaryArray>(type, 4, buf);
   auto expected = dictionary(int8(), type);
 
+  std::unique_ptr<DictionaryUnifier> unifier;
+  ASSERT_OK(DictionaryUnifier::Make(default_memory_pool(), type, &unifier));
   std::shared_ptr<DataType> out_type;
   std::shared_ptr<Array> out_dict;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()},
-                                  {dict1.get(), dict2.get()}, &out_type, &out_dict));
+  ASSERT_OK(unifier->Unify(*dict1));
+  ASSERT_OK(unifier->Unify(*dict2));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 
-  std::vector<std::vector<int32_t>> transpose_maps;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()},
-                                  {dict1.get(), dict2.get()}, &out_type, &out_dict,
-                                  &transpose_maps));
+  std::shared_ptr<Buffer> b1, b2;
+  ASSERT_OK(unifier->Unify(*dict1, &b1));
+  ASSERT_OK(unifier->Unify(*dict2, &b2));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
-  ASSERT_EQ(transpose_maps.size(), 2);
-  ASSERT_EQ(transpose_maps[0], std::vector<int32_t>({0, 1}));
-  ASSERT_EQ(transpose_maps[1], std::vector<int32_t>({1, 2, 3}));
+
+  CheckTransposeMap(*b1, {0, 1});
+  CheckTransposeMap(*b2, {1, 2, 3});
 }
 
 TEST(TestDictionaryType, UnifyLarge) {
@@ -1041,10 +1062,13 @@ TEST(TestDictionaryType, UnifyLarge) {
   // int8 would be too narrow to hold all possible index values
   auto expected = dictionary(int16(), int32());
 
+  std::unique_ptr<DictionaryUnifier> unifier;
+  ASSERT_OK(DictionaryUnifier::Make(default_memory_pool(), int32(), &unifier));
   std::shared_ptr<DataType> out_type;
   std::shared_ptr<Array> out_dict;
-  ASSERT_OK(DictionaryType::Unify(default_memory_pool(), {t1.get(), t2.get()},
-                                  {dict1.get(), dict2.get()}, &out_type, &out_dict));
+  ASSERT_OK(unifier->Unify(*dict1));
+  ASSERT_OK(unifier->Unify(*dict2));
+  ASSERT_OK(unifier->GetResult(&out_type, &out_dict));
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 }


### PR DESCRIPTION
I went ahead and nixed the current `DictionaryType::Unify` API since it is fairly internal anyway. I want to code against this API for ARROW-5717 which I'll stack on top of this patch