### PR TITLE
ARROW-6556: [Python] Fix warning for pandas SparseDataFrame removal

### DIFF
--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -82,11 +82,10 @@ cdef class _PandasAPIShim(object):
         self._datetimetz_type = DatetimeTZDtype
         self._have_pandas = True
 
-        try:
-            from pandas import SparseDataFrame
-            self.has_sparse = True
-        except ImportError:
+        if self._loose_version > LooseVersion('0.25'):
             self.has_sparse = False
+        else:
+            self.has_sparse = True
 
     cdef inline _check_import(self, bint raise_=True):
         if self._tried_importing_pandas:

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -34,6 +34,7 @@ from pyarrow.lib import FeatherWriter
 try:
     from pandas.util.testing import assert_frame_equal
     import pandas as pd
+    import pyarrow.pandas_compat
 except ImportError:
     pass
 
@@ -518,7 +519,7 @@ class TestFeatherReader(unittest.TestCase):
     @pytest.mark.filterwarnings("ignore:Sparse:FutureWarning")
     @pytest.mark.filterwarnings("ignore:DataFrame.to_sparse:FutureWarning")
     def test_sparse_dataframe(self):
-        if not hasattr(pd, 'SparseDataFrame'):
+        if not pa.pandas_compat._pandas_api.has_sparse:
             pytest.skip("version of pandas does not support SparseDataFrame")
         # GH #221
         data = {'A': [0, 1, 2],

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -26,3 +26,5 @@ build-dir  = doc/_build
 
 [tool:pytest]
 addopts = --ignore=scripts
+filterwarnings =
+    error:The SparseDataFrame:FutureWarning


### PR DESCRIPTION
Follow-up on https://issues.apache.org/jira/browse/ARROW-6556 / https://github.com/apache/arrow/pull/5377. 
We were a bit fast with merging the other PR, as pandas changed the removal slightly (it added back a dummy SparseDataFrame object which triggers a warning upon access, but this means that `hasattr(pd, 'SparseDataFrame)` or try/except on import is not a good check to know if the actual class still exists or not). 

Using pytests warnings filter I now ensure no such warning is raised in our test suite.