### PR TITLE
ARROW-6353: [Python] [C++] Expose compression_level option to parquet.write_table

### DIFF
--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -160,6 +160,10 @@ class ARROW_EXPORT Codec {
   virtual Status MakeDecompressor(std::shared_ptr<Decompressor>* out) = 0;
 
   virtual const char* name() const = 0;
+
+ private:
+  /// \brief Initializes the codec's resources.
+  virtual Status Init();
 };
 
 }  // namespace util

--- a/cpp/src/arrow/util/compression_test.cc
+++ b/cpp/src/arrow/util/compression_test.cc
@@ -385,10 +385,8 @@ TEST(TestCodecMisc, SpecifyCompressionLevel) {
     const auto level = combination.level;
     const auto expect_success = combination.expect_success;
     std::unique_ptr<Codec> c1, c2;
-    const auto status1 =
-        ::arrow::internal::GenericToStatus(Codec::Create(compression, level, &c1));
-    const auto status2 =
-        ::arrow::internal::GenericToStatus(Codec::Create(compression, level, &c2));
+    const auto status1 = Codec::Create(compression, level, &c1);
+    const auto status2 = Codec::Create(compression, level, &c2);
     EXPECT_EQ(expect_success, status1.ok());
     EXPECT_EQ(expect_success, status2.ok());
     if (expect_success && status1.ok() && status2.ok()) {

--- a/cpp/src/arrow/util/compression_test.cc
+++ b/cpp/src/arrow/util/compression_test.cc
@@ -367,41 +367,34 @@ TEST_P(CodecTest, CodecRoundtrip) {
   }
 }
 
-TEST_P(CodecTest, SpecifyCompressionLevel) {
-  const auto compression = GetCompression();
-  // The compression level is codec specific.
-  int compression_level;
-  switch (compression) {
-    case Compression::LZ4:
-    case Compression::LZO:
-    case Compression::UNCOMPRESSED:
-    case Compression::SNAPPY:
-      // Compression level cannot be specified for these
-      // compression types.
-      return;
-    case Compression::GZIP:
-      compression_level = 2;
-      break;
-    case Compression::BZ2:
-      // SKIP: BZ2 doesn't support one-shot compression
-      return;
-    case Compression::ZSTD:
-      compression_level = 4;
-      break;
-    case Compression::BROTLI:
-      compression_level = 10;
-      break;
-    default:
-      FAIL() << "Unhandled compression type";
-      return;
-  }
+TEST(TestCodecMisc, SpecifyCompressionLevel) {
+  struct CombinationOption {
+    Compression::type codec;
+    int level;
+    bool expect_success;
+  };
+  constexpr CombinationOption combinations[] = {
+      {Compression::GZIP, 2, true},     {Compression::BROTLI, 10, true},
+      {Compression::ZSTD, 4, true},     {Compression::LZ4, -10, false},
+      {Compression::LZO, -22, false},   {Compression::UNCOMPRESSED, 10, false},
+      {Compression::SNAPPY, 16, false}, {Compression::GZIP, -992, false}};
 
   std::vector<uint8_t> data = MakeRandomData(2000);
-  // create multiple compressors to try to break them
-  std::unique_ptr<Codec> c1, c2;
-  ASSERT_OK(Codec::Create(compression, compression_level, &c1));
-  ASSERT_OK(Codec::Create(compression, compression_level, &c2));
-  CheckCodecRoundtrip(c1, c2, data);
+  for (const auto& combination : combinations) {
+    const auto compression = combination.codec;
+    const auto level = combination.level;
+    const auto expect_success = combination.expect_success;
+    std::unique_ptr<Codec> c1, c2;
+    const auto status1 =
+        ::arrow::internal::GenericToStatus(Codec::Create(compression, level, &c1));
+    const auto status2 =
+        ::arrow::internal::GenericToStatus(Codec::Create(compression, level, &c2));
+    EXPECT_EQ(expect_success, status1.ok());
+    EXPECT_EQ(expect_success, status2.ok());
+    if (expect_success && status1.ok() && status2.ok()) {
+      CheckCodecRoundtrip(c1, c2, data);
+    }
+  }
 }
 
 TEST_P(CodecTest, OutputBufferIsSmall) {

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -511,6 +511,14 @@ GZipCodec::GZipCodec(int compression_level, Format format) {
   impl_.reset(new GZipCodecImpl(compression_level, format));
 }
 
+Status GZipCodec::Init() {
+  const Status init_compressor_status = impl_->InitCompressor();
+  if (!init_compressor_status.ok()) {
+    return init_compressor_status;
+  }
+  return impl_->InitDecompressor();
+}
+
 GZipCodec::~GZipCodec() {}
 
 Status GZipCodec::Decompress(int64_t input_length, const uint8_t* input,

--- a/cpp/src/arrow/util/compression_zlib.h
+++ b/cpp/src/arrow/util/compression_zlib.h
@@ -44,6 +44,8 @@ class ARROW_EXPORT GZipCodec : public Codec {
                      Format format = GZIP);
   ~GZipCodec() override;
 
+  Status Init() override;
+
   Status Decompress(int64_t input_len, const uint8_t* input, int64_t output_buffer_len,
                     uint8_t* output_buffer) override;
 

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -61,9 +61,7 @@ std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level) 
     throw ParquetException(ss.str());
   }
 
-  if (codec != Compression::UNCOMPRESSED) {
-    PARQUET_THROW_NOT_OK(Codec::Create(codec, compression_level, &result));
-  }
+  PARQUET_THROW_NOT_OK(Codec::Create(codec, compression_level, &result));
   return result;
 }
 

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -350,6 +350,9 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* compression(ParquetCompression codec)
             Builder* compression(const c_string& path,
                                  ParquetCompression codec)
+            Builder* compression_level(int compression_level)
+            Builder* compression_level(const c_string& path,
+                                       int compression_level)
             Builder* disable_dictionary()
             Builder* enable_dictionary()
             Builder* enable_dictionary(const c_string& path)

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1211,6 +1211,7 @@ cdef class ParquetWriter:
         object coerce_timestamps
         object allow_truncated_timestamps
         object compression
+        object compression_level
         object version
         object write_statistics
         int row_group_size
@@ -1223,7 +1224,8 @@ cdef class ParquetWriter:
                   use_deprecated_int96_timestamps=False,
                   coerce_timestamps=None,
                   data_page_size=None,
-                  allow_truncated_timestamps=False):
+                  allow_truncated_timestamps=False,
+                  compression_level=None):
         cdef:
             shared_ptr[WriterProperties] properties
             c_string c_where
@@ -1243,6 +1245,7 @@ cdef class ParquetWriter:
 
         self.use_dictionary = use_dictionary
         self.compression = compression
+        self.compression_level = compression_level
         self.version = version
         self.write_statistics = write_statistics
         self.use_deprecated_int96_timestamps = use_deprecated_int96_timestamps
@@ -1319,6 +1322,12 @@ cdef class ParquetWriter:
             for column, codec in self.compression.iteritems():
                 check_compression_name(codec)
                 props.compression(column, compression_from_name(codec))
+
+        if isinstance(self.compression_level, int):
+            props.compression_level(self.compression_level)
+        elif self.compression_level is not None:
+            for column, level in self.compression_level.iteritems():
+                props.compression_level(column, level)
 
     cdef void _set_dictionary_props(self, WriterProperties.Builder* props):
         if isinstance(self.use_dictionary, bool):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -371,7 +371,15 @@ flavor : {'spark'}, default None
     various target systems
 filesystem : FileSystem, default None
     If nothing passed, will be inferred from `where` if path-like, else
-    `where` is already a file-like object so no filesystem is needed."""
+    `where` is already a file-like object so no filesystem is needed.
+compression_level: int or dict, default None
+    Specify the compression level for a codec, either on a general basis or
+    per-column. If None is passed, arrow selects the compression level for
+    the compression codec in use. The compression level has a different
+    meaning for each codec, so you have to read the documentation of the
+    codec you are using.
+    An exception is thrown if the compression codec does not allow specifying
+    a compression level."""
 
 
 class ParquetWriter(object):
@@ -397,7 +405,9 @@ schema : arrow Schema
                  use_dictionary=True,
                  compression='snappy',
                  write_statistics=True,
-                 use_deprecated_int96_timestamps=None, **options):
+                 use_deprecated_int96_timestamps=None,
+                 compression_level=None,
+                 **options):
         if use_deprecated_int96_timestamps is None:
             # Use int96 timestamps for Spark
             if flavor is not None and 'spark' in flavor:
@@ -431,6 +441,7 @@ schema : arrow Schema
             use_dictionary=use_dictionary,
             write_statistics=write_statistics,
             use_deprecated_int96_timestamps=use_deprecated_int96_timestamps,
+            compression_level=compression_level,
             **options)
         self.is_open = True
 
@@ -1287,7 +1298,9 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 coerce_timestamps=None,
                 allow_truncated_timestamps=False,
                 data_page_size=None, flavor=None,
-                filesystem=None, **kwargs):
+                filesystem=None,
+                compression_level=None,
+                **kwargs):
     row_group_size = kwargs.pop('chunk_size', row_group_size)
     use_int96 = use_deprecated_int96_timestamps
     try:
@@ -1303,6 +1316,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
                 allow_truncated_timestamps=allow_truncated_timestamps,
                 compression=compression,
                 use_deprecated_int96_timestamps=use_int96,
+                compression_level=compression_level,
                 **kwargs) as writer:
             writer.write_table(table, row_group_size=row_group_size)
     except Exception:


### PR DESCRIPTION
The patch exposes the option to change the default and/or per-column
compression level when creating a parquet file. No validation is done
on the input since the compression level is codec and version specific.

Also includes

ARROW-6216: [C++] Check for compression_level support in Codec. The codec options UNCOMPRESSED, LZ4, LZ0 and SNAPPY do not support specifying a compression level. This patch adds a check for whether the user has specified a level and returns an error if so. This is a measure to avoid confusion when a user is experimenting with the API. Furthermore, Zlib can fail initialization if an invalid compression level is provided. The code is modified to attempt initialization when the Codec is created, instead of doing it on demand.