### PR TITLE
ARROW-6642: [Python] Link parent objects in Parquet's metadata and statistics objects

### DIFF
--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -723,6 +723,14 @@ def test_parquet_metadata_api():
         col_meta.index_page_offset
 
 
+def test_parquet_metadata_lifetime(tempdir):
+    # ARROW-6642 - ensure that chained access keeps parent objects alive
+    table = pa.table({'a': [1, 2, 3]})
+    pq.write_table(table, tempdir / 'test_metadata_segfault.parquet')
+    dataset = pq.ParquetDataset(tempdir / 'test_metadata_segfault.parquet')
+    dataset.pieces[0].get_metadata().row_group(0).column(0).statistics
+
+
 @pytest.mark.pandas
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6642

I used "parent" instead of "base", because RowGroupMetaData was already using that terminology to keep track of FileMetaData