### PR TITLE
ARROW-6647: [C++] Stop using member initializer for shared_ptr

### DIFF
--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -868,8 +868,6 @@ class DecimalConverter
   using BASE =
       TypedConverter<arrow::Decimal128Type, DecimalConverter<null_coding>, null_coding>;
 
-  DecimalConverter() : BASE(), decimal_type_(nullptr) {}
-
   Status Init(ArrayBuilder* builder) override {
     RETURN_NOT_OK(BASE::Init(builder));
     decimal_type_ = checked_pointer_cast<DecimalType>(this->typed_builder_->type());

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -868,6 +868,8 @@ class DecimalConverter
   using BASE =
       TypedConverter<arrow::Decimal128Type, DecimalConverter<null_coding>, null_coding>;
 
+  DecimalConverter() : BASE(), decimal_type_(nullptr) {}
+
   Status Init(ArrayBuilder* builder) override {
     RETURN_NOT_OK(BASE::Init(builder));
     decimal_type_ = checked_pointer_cast<DecimalType>(this->typed_builder_->type());
@@ -881,7 +883,7 @@ class DecimalConverter
   }
 
  private:
-  std::shared_ptr<DecimalType> decimal_type_ = nullptr;
+  std::shared_ptr<DecimalType> decimal_type_;
 };
 
 #define NUMERIC_CONVERTER(TYPE_ENUM, TYPE)                                         \


### PR DESCRIPTION
It doesn't work with g++ 4.8.5 on CentOS 7:

    % g++ --version
    g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39)
    Copyright (C) 2015 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Error message:

    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc: In instantiation of 'arrow::Status arrow::py::GetConverterFlat(const std::shared_ptr<arrow::DataType>&, bool, std::unique_ptr<arrow::py::SeqConverter>*) [with arrow::py::NullCoding null_coding = (arrow::py::NullCoding)1]':
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:1001:5:   required from here
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:864:7: error: conversion from 'std::nullptr_t' to non-scalar type 'std::shared_ptr<arrow::DecimalType>' requested
     class DecimalConverter
           ^
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:894:10: note: synthesized method 'arrow::py::DecimalConverter<(arrow::py::NullCoding)1>::DecimalConverter()' first required here
         *out = std::unique_ptr<SeqConverter>(new TYPE_CLASS<null_coding>); \
              ^
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:915:5: note: in expansion of macro 'SIMPLE_CONVERTER_CASE'
         SIMPLE_CONVERTER_CASE(DECIMAL, DecimalConverter);
         ^
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc: In instantiation of 'arrow::Status arrow::py::GetConverterFlat(const std::shared_ptr<arrow::DataType>&, bool, std::unique_ptr<arrow::py::SeqConverter>*) [with arrow::py::NullCoding null_coding = (arrow::py::NullCoding)0]':
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:1004:5:   required from here
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:864:7: error: conversion from 'std::nullptr_t' to non-scalar type 'std::shared_ptr<arrow::DecimalType>' requested
     class DecimalConverter
           ^
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:894:10: note: synthesized method 'arrow::py::DecimalConverter<(arrow::py::NullCoding)0>::DecimalConverter()' first required here
         *out = std::unique_ptr<SeqConverter>(new TYPE_CLASS<null_coding>); \
              ^
    /root/rpmbuild/BUILD/apache-arrow-0.15.0/cpp/src/arrow/python/python_to_arrow.cc:915:5: note: in expansion of macro 'SIMPLE_CONVERTER_CASE'
         SIMPLE_CONVERTER_CASE(DECIMAL, DecimalConverter);
         ^