### PR TITLE
ARROW-6652: [Python] Fix Array.to_pandas to retain timezone

### DIFF
--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1778,3 +1778,11 @@ def test_concat_array():
 def test_concat_array_different_types():
     with pytest.raises(pa.ArrowInvalid):
         pa.concat_arrays([pa.array([1]), pa.array([2.])])
+
+
+@pytest.mark.pandas
+def test_to_pandas_timezone():
+    # https://issues.apache.org/jira/browse/ARROW-6652
+    arr = pa.array([1, 2, 3], type=pa.timestamp('s', tz='Europe/Brussels'))
+    s = arr.to_pandas()
+    assert s.dt.tz is not None

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -107,10 +107,6 @@ def _check_series_roundtrip(s, type_=None, expected_pa_type=None):
         assert arr.type == expected_pa_type
 
     result = pd.Series(arr.to_pandas(), name=s.name)
-    if pa.types.is_timestamp(arr.type) and arr.type.tz is not None:
-        result = (result.dt.tz_localize('utc')
-                  .dt.tz_convert(arr.type.tz))
-
     tm.assert_series_equal(s, result)
 
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6652