### PR TITLE
ARROW-6664: [C++] Add CMake option to build without SSE4.2 instructions

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -76,7 +76,9 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   # Disable this option to exercise non-SIMD fallbacks
   define_option(ARROW_USE_SIMD "Build with SIMD optimizations" ON)
 
-  define_option(ARROW_ALTIVEC "Build Arrow with Altivec" ON)
+  define_option(ARROW_SSE42 "Build with SSE4.2 if compiler has support" ON)
+
+  define_option(ARROW_ALTIVEC "Build with Altivec if compiler has support" ON)
 
   define_option(ARROW_RPATH_ORIGIN "Build Arrow libraries with RATH set to \$ORIGIN" OFF)
 

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -266,7 +266,7 @@ if(BUILD_WARNING_FLAGS)
 endif(BUILD_WARNING_FLAGS)
 
 # Only enable additional instruction sets if they are supported
-if(CXX_SUPPORTS_SSE4_2)
+if(CXX_SUPPORTS_SSE4_2 AND ARROW_SSE42)
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -msse4.2")
 endif()
 


### PR DESCRIPTION
This may not 100% fix the issue reported in ARROW-5381, but it will help.

CPUs from Intel's Penryn architecture and prior have SSE4.1 support but not SSE4.2. For example, many Apple computers sold in 2009 have chips with this CPU architecture.

On a Penryn machine (late-2009 MacBook), binaries from our builds contain SSE4.2 instructions. I found that merely opting out of the `-msse4.2` flag fixes everything. There are no issues relating to `__builtin_popcountll` on this machine, which according to documentation is suppose to gracefully handle both pre/post SSE4.2 CPUs. 

Building with SSE4.2 on by default is reasonable to have good performance on computers sold in the last 10 years, but having the compatibility option will expand our spectrum of support. 