### PR TITLE
ARROW-6661: [Java] Implement APIs like slice to enhance VectorSchemaRoot

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -153,6 +153,46 @@ public class VectorSchemaRoot implements AutoCloseable {
     return fieldVectorsMap.get(name);
   }
 
+  public FieldVector getVector(int index) {
+    Preconditions.checkArgument(index >= 0 && index < fieldVectors.size());
+    return fieldVectors.get(index);
+  }
+
+  /**
+   * Add vector to the record batch, producing a new VectorSchemaRoot.
+   * @param index field index
+   * @param vector vector to be added.
+   * @return out VectorSchemaRoot with vector added
+   */
+  public VectorSchemaRoot addVector(int index, FieldVector vector) {
+    Preconditions.checkNotNull(vector);
+    Preconditions.checkArgument(index >= 0 && index < fieldVectors.size());
+    List<FieldVector> newVectors = new ArrayList<>();
+    for (int i = 0; i < fieldVectors.size(); i++) {
+      if (i == index) {
+        newVectors.add(vector);
+      }
+      newVectors.add(fieldVectors.get(i));
+    }
+    return new VectorSchemaRoot(newVectors);
+  }
+
+  /**
+   * Remove vector from the record batch, producing a new VectorSchemaRoot.
+   * @param index field index
+   * @return out VectorSchemaRoot with vector removed
+   */
+  public VectorSchemaRoot removeVector(int index) {
+    Preconditions.checkArgument(index >= 0 && index < fieldVectors.size());
+    List<FieldVector> newVectors = new ArrayList<>();
+    for (int i = 0; i < fieldVectors.size(); i++) {
+      if (i != index) {
+        newVectors.add(fieldVectors.get(i));
+      }
+    }
+    return new VectorSchemaRoot(newVectors);
+  }
+
   public Schema getSchema() {
     return schema;
   }
@@ -236,6 +276,15 @@ public class VectorSchemaRoot implements AutoCloseable {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Slice this root from desired index.
+   * @param index start position of the slice
+   * @return the sliced root
+   */
+  public VectorSchemaRoot slice(int index) {
+    return slice(index, this.rowCount - index);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -27,8 +27,10 @@ import java.util.stream.StreamSupport;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.TransferPair;
 
 /**
  * Holder for a set of vectors to be loaded/unloaded.
@@ -47,8 +49,7 @@ public class VectorSchemaRoot implements AutoCloseable {
   public VectorSchemaRoot(Iterable<FieldVector> vectors) {
     this(
         StreamSupport.stream(vectors.spliterator(), false).map(t -> t.getField()).collect(Collectors.toList()),
-        StreamSupport.stream(vectors.spliterator(), false).collect(Collectors.toList()),
-        0
+        StreamSupport.stream(vectors.spliterator(), false).collect(Collectors.toList())
         );
   }
 
@@ -57,6 +58,16 @@ public class VectorSchemaRoot implements AutoCloseable {
    */
   public VectorSchemaRoot(FieldVector parent) {
     this(parent.getField().getChildren(), parent.getChildrenFromFields(), parent.getValueCount());
+  }
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param fields The types of each vector.
+   * @param fieldVectors The data vectors (must be equal in size to <code>fields</code>.
+   */
+  public VectorSchemaRoot(List<Field> fields, List<FieldVector> fieldVectors) {
+    this(new Schema(fields), fieldVectors, fieldVectors.size() == 0 ? 0 : fieldVectors.get(0).getValueCount());
   }
 
   /**
@@ -226,4 +237,31 @@ public class VectorSchemaRoot implements AutoCloseable {
     }
     return false;
   }
+
+  /**
+   * Slice this root at desired index and length.
+   * @param index start position of the slice
+   * @param length length of the slice
+   * @return the sliced root
+   */
+  public VectorSchemaRoot slice(int index, int length) {
+    Preconditions.checkArgument(index >= 0, "expecting non-negative index");
+    Preconditions.checkArgument(length >= 0, "expecting non-negative length");
+    Preconditions.checkArgument(index + length <= rowCount,
+        "index + length should <= rowCount");
+
+    if (index == 0 && length == rowCount) {
+      return this;
+    }
+
+    List<FieldVector> sliceVectors = fieldVectors.stream().map(v -> {
+      TransferPair transferPair = v.getTransferPair(v.getAllocator());
+      transferPair.splitAndTransfer(index, length);
+      return (FieldVector) transferPair.getTo();
+    }).collect(Collectors.toList());
+
+    return new VectorSchemaRoot(sliceVectors);
+  }
+
 }
+

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
@@ -217,15 +217,24 @@ public class TestVectorSchemaRoot {
         assertEquals(i + 0.1f, childVector2.get(i), 0);
       }
 
-      // slice with invalid param
-      try {
-        original.slice(0, 20);
-      } catch (Exception e) {
-        assertTrue(e.getMessage().contains("index + length should <= rowCount"));
-      }
-
       original.close();
       slice2.close();
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSliceWithInvalidParam() {
+    try (final IntVector intVector = new IntVector("intVector", allocator);
+         final Float4Vector float4Vector = new Float4Vector("float4Vector", allocator)) {
+      intVector.setValueCount(10);
+      float4Vector.setValueCount(10);
+      for (int i = 0; i < 10; i++) {
+        intVector.setSafe(i, i);
+        float4Vector.setSafe(i, i + 0.1f);
+      }
+      final VectorSchemaRoot original = new VectorSchemaRoot(Arrays.asList(intVector, float4Vector));
+
+      original.slice(0, 20);
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
@@ -155,6 +155,44 @@ public class TestVectorSchemaRoot {
   }
 
   @Test
+  public void testAddVector() {
+    try (final IntVector intVector1 = new IntVector("intVector1", allocator);
+         final IntVector intVector2 = new IntVector("intVector2", allocator);
+         final IntVector intVector3 = new IntVector("intVector3", allocator);) {
+
+      VectorSchemaRoot original = new VectorSchemaRoot(Arrays.asList(intVector1, intVector2));
+      assertEquals(2, original.getFieldVectors().size());
+
+      VectorSchemaRoot newRecordBatch = original.addVector(1, intVector3);
+      assertEquals(3, newRecordBatch.getFieldVectors().size());
+      assertEquals(intVector3, newRecordBatch.getFieldVectors().get(1));
+
+      original.close();
+      newRecordBatch.close();
+    }
+  }
+
+  @Test
+  public void testRemoveVector() {
+    try (final IntVector intVector1 = new IntVector("intVector1", allocator);
+        final IntVector intVector2 = new IntVector("intVector2", allocator);
+        final IntVector intVector3 = new IntVector("intVector3", allocator);) {
+
+      VectorSchemaRoot original =
+          new VectorSchemaRoot(Arrays.asList(intVector1, intVector2, intVector3));
+      assertEquals(3, original.getFieldVectors().size());
+
+      VectorSchemaRoot newRecordBatch = original.removeVector(0);
+      assertEquals(2, newRecordBatch.getFieldVectors().size());
+      assertEquals(intVector2, newRecordBatch.getFieldVectors().get(0));
+      assertEquals(intVector3, newRecordBatch.getFieldVectors().get(1));
+
+      original.close();
+      newRecordBatch.close();
+    }
+  }
+
+  @Test
   public void testSlice() {
     try (final IntVector intVector = new IntVector("intVector", allocator);
          final Float4Vector float4Vector = new Float4Vector("float4Vector", allocator)) {
@@ -186,7 +224,7 @@ public class TestVectorSchemaRoot {
         assertTrue(e.getMessage().contains("index + length should <= rowCount"));
       }
 
-
+      original.close();
       slice2.close();
     }
   }


### PR DESCRIPTION
Related to [ARROW-6661](https://issues.apache.org/jira/browse/ARROW-6661).

Currently in Java Implementation there is no APIs like slice for record batch like C++/Python.
This issue is about to implement slice/getVector/addVector/removeVector.
