### PR TITLE
ARROW-6670: [CI][R] Fix fixes for R nightly jobs

### DIFF
--- a/ci/docker_build_r.sh
+++ b/ci/docker_build_r.sh
@@ -26,6 +26,8 @@ export ARROW_HOME=$CONDA_PREFIX
 pushd /arrow/r
 
 if [ "$R_CONDA" = "" ]; then
+  # Install R package dependencies
+  # NOTE: any changes here should also be done in docker_build_r_sanitizer.sh
   ${R_BIN} -e "install.packages(c('remotes', 'dplyr', 'glue'))"
   ${R_BIN} -e "remotes::install_deps(dependencies = TRUE)"
   ${R_BIN} -e "remotes::install_github('romainfrancois/decor')"

--- a/ci/docker_build_r_sanitizer.sh
+++ b/ci/docker_build_r_sanitizer.sh
@@ -19,12 +19,14 @@
 set -e
 
 : ${R_BIN:=RDsan}
-source /arrow/ci/docker_install_r_deps.sh
 
 # Build arrow
 pushd /arrow/r
 
-install_deps
+# Install dependencies
+${R_BIN} -e "install.packages(c('remotes', 'dplyr', 'glue'))"
+${R_BIN} -e "remotes::install_deps(dependencies = TRUE)"
+${R_BIN} -e "remotes::install_github('romainfrancois/decor')"
 
 make clean
 ${R_BIN} CMD INSTALL --no-byte-compile .

--- a/ci/docker_build_r_sanitizer.sh
+++ b/ci/docker_build_r_sanitizer.sh
@@ -23,7 +23,8 @@ set -e
 # Build arrow
 pushd /arrow/r
 
-# Install dependencies
+# Install R package dependencies
+# NOTE: any changes here should also be done in docker_build_r.sh
 ${R_BIN} -e "install.packages(c('remotes', 'dplyr', 'glue'))"
 ${R_BIN} -e "remotes::install_deps(dependencies = TRUE)"
 ${R_BIN} -e "remotes::install_github('romainfrancois/decor')"

--- a/r/configure
+++ b/r/configure
@@ -42,10 +42,11 @@ fi
 if [ "$LOCAL_AUTOBREW" == "TRUE" ]; then
   # LOCAL_AUTOBREW means use the script in tools/
   # If you want to use a local apache-arrow.rb formula, do:
-  # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb apache-arrow.rb
-  # (assuming a local checkout of the apache/arrow repository)
+  # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
+  # before R CMD build (assuming a local checkout of the apache/arrow repository)
   # FORCE_AUTOBREW without LOCAL_AUTOBREW means to pull from jeroen.github.io
   cp tools/autobrew .
+  cp tools/apache-arrow.rb .
   FORCE_AUTOBREW="TRUE"
 fi
 


### PR DESCRIPTION
One is a fix for the fix in [ARROW-6651](https://issues.apache.org/jira/browse/ARROW-6651), which was a fix for [ARROW-6214](https://issues.apache.org/jira/browse/ARROW-6214). The other fixes the [nightly R package building](https://github.com/ursa-labs/arrow-r-nightly/blob/master/.travis.yml) that was broken when [ARROW-4649](https://issues.apache.org/jira/browse/ARROW-4649) moved the "autobrew" homebrew formula out of `r/tools`, which made it not available in the source R package build.

I decided not to merge the docker build shell scripts, partly to cut my losses on debugging them (having spent a day more than I wanted to last time I touched them), partly because I'm not sure that it's worth the sacrifice in readability. 