### PR TITLE
PARQUET-1664: [C++] Provide API to return metadata string from FileMetadata.

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -774,8 +774,10 @@ void FileCryptoMetaData::WriteTo(::arrow::io::OutputStream* dst) const {
   impl_->WriteTo(dst);
 }
 
-std::string FileMetaData::ToString() const {
+std::string FileMetaData::SerializedMetadata() const {
   std::shared_ptr<arrow::ResizableBuffer> metadata_buffer;
+  // We need pass in an initial size. Since it will automatically
+  // increase the size to hould the metadata. We just leave it 0.
   PARQUET_THROW_NOT_OK(AllocateResizableBuffer(0, &metadata_buffer));
   arrow::io::BufferOutputStream serializer(metadata_buffer);
   WriteTo(&serializer);

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -778,7 +778,8 @@ std::string FileMetaData::SerializeToString() const {
   // We need to pass in an initial size. Since it will automatically
   // increase the buffer size to hold the metadata, we just leave it 0.
   std::shared_ptr<arrow::io::BufferOutputStream> serializer;
-  PARQUET_THROW_NOT_OK(arrow::io::BufferOutputStream::Create(0, arrow::default_memory_pool(),&serializer));
+  PARQUET_THROW_NOT_OK(arrow::io::BufferOutputStream::Create(
+      0, arrow::default_memory_pool(), &serializer));
   std::shared_ptr<arrow::Buffer> metadata_buffer;
   WriteTo(serializer.get());
   PARQUET_THROW_NOT_OK(serializer->Finish(&metadata_buffer));

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -774,6 +774,14 @@ void FileCryptoMetaData::WriteTo(::arrow::io::OutputStream* dst) const {
   impl_->WriteTo(dst);
 }
 
+std::string FileMetaData::ToString() const {
+  std::shared_ptr<arrow::ResizableBuffer> metadata_buffer;
+  PARQUET_THROW_NOT_OK(AllocateResizableBuffer(0, &metadata_buffer));
+  arrow::io::BufferOutputStream serializer(metadata_buffer);
+  WriteTo(&serializer);
+  return metadata_buffer->ToString();
+}
+
 ApplicationVersion::ApplicationVersion(const std::string& application, int major,
                                        int minor, int patch)
     : application_(application), version{major, minor, patch, "", "", ""} {}

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -775,8 +775,8 @@ void FileCryptoMetaData::WriteTo(::arrow::io::OutputStream* dst) const {
 }
 
 std::string FileMetaData::SerializeToString() const {
-  // We need pass in an initial size. Since it will automatically
-  // increase the size to hould the metadata. We just leave it 0.
+  // We need to pass in an initial size. Since it will automatically
+  // increase the buffer size to hold the metadata, we just leave it 0.
   std::shared_ptr<arrow::io::BufferOutputStream> serializer;
   PARQUET_THROW_NOT_OK(arrow::io::BufferOutputStream::Create(0, arrow::default_memory_pool(),&serializer));
   std::shared_ptr<arrow::Buffer> metadata_buffer;

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -774,13 +774,14 @@ void FileCryptoMetaData::WriteTo(::arrow::io::OutputStream* dst) const {
   impl_->WriteTo(dst);
 }
 
-std::string FileMetaData::SerializedMetadata() const {
-  std::shared_ptr<arrow::ResizableBuffer> metadata_buffer;
+std::string FileMetaData::SerializeToString() const {
   // We need pass in an initial size. Since it will automatically
   // increase the size to hould the metadata. We just leave it 0.
-  PARQUET_THROW_NOT_OK(AllocateResizableBuffer(0, &metadata_buffer));
-  arrow::io::BufferOutputStream serializer(metadata_buffer);
-  WriteTo(&serializer);
+  std::shared_ptr<arrow::io::BufferOutputStream> serializer;
+  PARQUET_THROW_NOT_OK(arrow::io::BufferOutputStream::Create(0, arrow::default_memory_pool(),&serializer));
+  std::shared_ptr<arrow::Buffer> metadata_buffer;
+  WriteTo(serializer.get());
+  PARQUET_THROW_NOT_OK(serializer->Finish(&metadata_buffer));
   return metadata_buffer->ToString();
 }
 

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -200,7 +200,7 @@ class PARQUET_EXPORT FileMetaData {
   // API convenience to get a MetaData accessor
 
   static std::shared_ptr<FileMetaData> Make(
-      const void* serialized_metadata, uint32_t* metadata_len,
+      const void* serialized_metadata, uint32_t* inout_metadata_len,
       const std::shared_ptr<Decryptor>& decryptor = NULLPTR);
 
   ~FileMetaData();

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -231,6 +231,8 @@ class PARQUET_EXPORT FileMetaData {
   void WriteTo(::arrow::io::OutputStream* dst,
                const std::shared_ptr<Encryptor>& encryptor = NULLPTR) const;
 
+  std::string ToString() const;
+
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;
 

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -231,6 +231,8 @@ class PARQUET_EXPORT FileMetaData {
   void WriteTo(::arrow::io::OutputStream* dst,
                const std::shared_ptr<Encryptor>& encryptor = NULLPTR) const;
 
+  /// \brief Return Thrift-serialized representation of the metadata as a
+  /// string
   std::string SerializeToString() const;
 
   // Return const-pointer to make it clear that this object is not to be copied

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -231,7 +231,7 @@ class PARQUET_EXPORT FileMetaData {
   void WriteTo(::arrow::io::OutputStream* dst,
                const std::shared_ptr<Encryptor>& encryptor = NULLPTR) const;
 
-  std::string ToString() const;
+  std::string SerializedMetadata() const;
 
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -231,7 +231,7 @@ class PARQUET_EXPORT FileMetaData {
   void WriteTo(::arrow::io::OutputStream* dst,
                const std::shared_ptr<Encryptor>& encryptor = NULLPTR) const;
 
-  std::string SerializedMetadata() const;
+  std::string SerializeToString() const;
 
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -101,12 +101,14 @@ TEST(Metadata, TestBuildAccess) {
   auto f_accessor = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
 
   std::string f_accessor_serialized_metadata = f_accessor->SerializeToString();
-  ASSERT_EQ(403, f_accessor_serialized_metadata.length());
   uint32_t expected_len = static_cast<uint32_t>(f_accessor_serialized_metadata.length());
 
-  uint32_t decoded_len = -1;
+  // decoded_len is an in-out parameter
+  uint32_t decoded_len = expected_len;
   auto f_accessor_copy =
       FileMetaData::Make(f_accessor_serialized_metadata.data(), &decoded_len);
+
+  // Check that all of the serialized data is consumed
   ASSERT_EQ(expected_len, decoded_len);
 
   // Run this block twice, one for f_accessor, one for f_accessor_copy.

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -100,97 +100,95 @@ TEST(Metadata, TestBuildAccess) {
   // Generate the metadata
   auto f_accessor = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
 
-  ASSERT_EQ(512, f_accessor->ToString().length());
-  ASSERT_EQ(21, static_cast<int32_t>(f_accessor->ToString()[0]));
-  ASSERT_EQ(60, static_cast<int32_t>(f_accessor->ToString()[3]));
-  ASSERT_EQ(24, static_cast<int32_t>(f_accessor->ToString()[219]));
+  std::string f_accessor_serialized_metadata = f_accessor->SerializedMetadata();
+  ASSERT_EQ(512, f_accessor_serialized_metadata.length());
+  uint32_t metadata_len = f_accessor_serialized_metadata.length();
+  auto f_accessor_copy = FileMetaData::Make(f_accessor_serialized_metadata.data(), &metadata_len);
 
-  // file metadata
-  ASSERT_EQ(nrows, f_accessor->num_rows());
-  ASSERT_LE(0, static_cast<int>(f_accessor->size()));
-  ASSERT_EQ(2, f_accessor->num_row_groups());
-  ASSERT_EQ(ParquetVersion::PARQUET_2_0, f_accessor->version());
-  ASSERT_EQ(DEFAULT_CREATED_BY, f_accessor->created_by());
-  ASSERT_EQ(3, f_accessor->num_schema_elements());
+  // Run this block twice, one for f_accessor, one for f_accessor_copy.
+  // To make sure SerializedMetadata was deserialized correctly.
+  std::vector<FileMetaData*> f_accessors = { f_accessor.get(), f_accessor_copy.get() }; 
+  for(int loop_index = 0; loop_index < 2; loop_index++) {
+    // file metadata
+    ASSERT_EQ(nrows, f_accessors[loop_index]->num_rows());
+    ASSERT_LE(0, static_cast<int>(f_accessors[loop_index]->size()));
+    ASSERT_EQ(2, f_accessors[loop_index]->num_row_groups());
+    ASSERT_EQ(ParquetVersion::PARQUET_2_0, f_accessors[loop_index]->version());
+    ASSERT_EQ(DEFAULT_CREATED_BY, f_accessors[loop_index]->created_by());
+    ASSERT_EQ(3, f_accessors[loop_index]->num_schema_elements());
 
-  // row group1 metadata
-  auto rg1_accessor = f_accessor->RowGroup(0);
-  ASSERT_EQ(2, rg1_accessor->num_columns());
-  ASSERT_EQ(nrows / 2, rg1_accessor->num_rows());
-  ASSERT_EQ(1024, rg1_accessor->total_byte_size());
+    // row group1 metadata
+    auto rg1_accessor = f_accessors[loop_index]->RowGroup(0);
+    ASSERT_EQ(2, rg1_accessor->num_columns());
+    ASSERT_EQ(nrows / 2, rg1_accessor->num_rows());
+    ASSERT_EQ(1024, rg1_accessor->total_byte_size());
 
-  auto rg1_column1 = rg1_accessor->ColumnChunk(0);
-  auto rg1_column2 = rg1_accessor->ColumnChunk(1);
-  ASSERT_EQ(true, rg1_column1->is_stats_set());
-  ASSERT_EQ(true, rg1_column2->is_stats_set());
-  ASSERT_EQ(stats_float.min(), rg1_column2->statistics()->EncodeMin());
-  ASSERT_EQ(stats_float.max(), rg1_column2->statistics()->EncodeMax());
-  ASSERT_EQ(stats_int.min(), rg1_column1->statistics()->EncodeMin());
-  ASSERT_EQ(stats_int.max(), rg1_column1->statistics()->EncodeMax());
-  ASSERT_EQ(0, rg1_column1->statistics()->null_count());
-  ASSERT_EQ(0, rg1_column2->statistics()->null_count());
-  ASSERT_EQ(nrows, rg1_column1->statistics()->distinct_count());
-  ASSERT_EQ(nrows, rg1_column2->statistics()->distinct_count());
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->compression());
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
-  ASSERT_EQ(nrows / 2, rg1_column1->num_values());
-  ASSERT_EQ(nrows / 2, rg1_column2->num_values());
-  ASSERT_EQ(3, rg1_column1->encodings().size());
-  ASSERT_EQ(3, rg1_column2->encodings().size());
-  ASSERT_EQ(512, rg1_column1->total_compressed_size());
-  ASSERT_EQ(512, rg1_column2->total_compressed_size());
-  ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
-  ASSERT_EQ(600, rg1_column2->total_uncompressed_size());
-  ASSERT_EQ(4, rg1_column1->dictionary_page_offset());
-  ASSERT_EQ(24, rg1_column2->dictionary_page_offset());
-  ASSERT_EQ(10, rg1_column1->data_page_offset());
-  ASSERT_EQ(30, rg1_column2->data_page_offset());
+    auto rg1_column1 = rg1_accessor->ColumnChunk(0);
+    auto rg1_column2 = rg1_accessor->ColumnChunk(1);
+    ASSERT_EQ(true, rg1_column1->is_stats_set());
+    ASSERT_EQ(true, rg1_column2->is_stats_set());
+    ASSERT_EQ(stats_float.min(), rg1_column2->statistics()->EncodeMin());
+    ASSERT_EQ(stats_float.max(), rg1_column2->statistics()->EncodeMax());
+    ASSERT_EQ(stats_int.min(), rg1_column1->statistics()->EncodeMin());
+    ASSERT_EQ(stats_int.max(), rg1_column1->statistics()->EncodeMax());
+    ASSERT_EQ(0, rg1_column1->statistics()->null_count());
+    ASSERT_EQ(0, rg1_column2->statistics()->null_count());
+    ASSERT_EQ(nrows, rg1_column1->statistics()->distinct_count());
+    ASSERT_EQ(nrows, rg1_column2->statistics()->distinct_count());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->compression());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
+    ASSERT_EQ(nrows / 2, rg1_column1->num_values());
+    ASSERT_EQ(nrows / 2, rg1_column2->num_values());
+    ASSERT_EQ(3, rg1_column1->encodings().size());
+    ASSERT_EQ(3, rg1_column2->encodings().size());
+    ASSERT_EQ(512, rg1_column1->total_compressed_size());
+    ASSERT_EQ(512, rg1_column2->total_compressed_size());
+    ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
+    ASSERT_EQ(600, rg1_column2->total_uncompressed_size());
+    ASSERT_EQ(4, rg1_column1->dictionary_page_offset());
+    ASSERT_EQ(24, rg1_column2->dictionary_page_offset());
+    ASSERT_EQ(10, rg1_column1->data_page_offset());
+    ASSERT_EQ(30, rg1_column2->data_page_offset());
 
-  auto rg2_accessor = f_accessor->RowGroup(1);
-  ASSERT_EQ(2, rg2_accessor->num_columns());
-  ASSERT_EQ(nrows / 2, rg2_accessor->num_rows());
-  ASSERT_EQ(1024, rg2_accessor->total_byte_size());
+    auto rg2_accessor = f_accessors[loop_index]->RowGroup(1);
+    ASSERT_EQ(2, rg2_accessor->num_columns());
+    ASSERT_EQ(nrows / 2, rg2_accessor->num_rows());
+    ASSERT_EQ(1024, rg2_accessor->total_byte_size());
 
-  auto rg2_column1 = rg2_accessor->ColumnChunk(0);
-  auto rg2_column2 = rg2_accessor->ColumnChunk(1);
-  ASSERT_EQ(true, rg2_column1->is_stats_set());
-  ASSERT_EQ(true, rg2_column2->is_stats_set());
-  ASSERT_EQ(stats_float.min(), rg2_column2->statistics()->EncodeMin());
-  ASSERT_EQ(stats_float.max(), rg2_column2->statistics()->EncodeMax());
-  ASSERT_EQ(stats_int.min(), rg1_column1->statistics()->EncodeMin());
-  ASSERT_EQ(stats_int.max(), rg1_column1->statistics()->EncodeMax());
-  ASSERT_EQ(0, rg2_column1->statistics()->null_count());
-  ASSERT_EQ(0, rg2_column2->statistics()->null_count());
-  ASSERT_EQ(nrows, rg2_column1->statistics()->distinct_count());
-  ASSERT_EQ(nrows, rg2_column2->statistics()->distinct_count());
-  ASSERT_EQ(nrows / 2, rg2_column1->num_values());
-  ASSERT_EQ(nrows / 2, rg2_column2->num_values());
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());
-  ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->compression());
-  ASSERT_EQ(3, rg2_column1->encodings().size());
-  ASSERT_EQ(3, rg2_column2->encodings().size());
-  ASSERT_EQ(512, rg2_column1->total_compressed_size());
-  ASSERT_EQ(512, rg2_column2->total_compressed_size());
-  ASSERT_EQ(600, rg2_column1->total_uncompressed_size());
-  ASSERT_EQ(600, rg2_column2->total_uncompressed_size());
-  ASSERT_EQ(6, rg2_column1->dictionary_page_offset());
-  ASSERT_EQ(16, rg2_column2->dictionary_page_offset());
-  ASSERT_EQ(10, rg2_column1->data_page_offset());
-  ASSERT_EQ(26, rg2_column2->data_page_offset());
+    auto rg2_column1 = rg2_accessor->ColumnChunk(0);
+    auto rg2_column2 = rg2_accessor->ColumnChunk(1);
+    ASSERT_EQ(true, rg2_column1->is_stats_set());
+    ASSERT_EQ(true, rg2_column2->is_stats_set());
+    ASSERT_EQ(stats_float.min(), rg2_column2->statistics()->EncodeMin());
+    ASSERT_EQ(stats_float.max(), rg2_column2->statistics()->EncodeMax());
+    ASSERT_EQ(stats_int.min(), rg1_column1->statistics()->EncodeMin());
+    ASSERT_EQ(stats_int.max(), rg1_column1->statistics()->EncodeMax());
+    ASSERT_EQ(0, rg2_column1->statistics()->null_count());
+    ASSERT_EQ(0, rg2_column2->statistics()->null_count());
+    ASSERT_EQ(nrows, rg2_column1->statistics()->distinct_count());
+    ASSERT_EQ(nrows, rg2_column2->statistics()->distinct_count());
+    ASSERT_EQ(nrows / 2, rg2_column1->num_values());
+    ASSERT_EQ(nrows / 2, rg2_column2->num_values());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->compression());
+    ASSERT_EQ(3, rg2_column1->encodings().size());
+    ASSERT_EQ(3, rg2_column2->encodings().size());
+    ASSERT_EQ(512, rg2_column1->total_compressed_size());
+    ASSERT_EQ(512, rg2_column2->total_compressed_size());
+    ASSERT_EQ(600, rg2_column1->total_uncompressed_size());
+    ASSERT_EQ(600, rg2_column2->total_uncompressed_size());
+    ASSERT_EQ(6, rg2_column1->dictionary_page_offset());
+    ASSERT_EQ(16, rg2_column2->dictionary_page_offset());
+    ASSERT_EQ(10, rg2_column1->data_page_offset());
+    ASSERT_EQ(26, rg2_column2->data_page_offset());
 
-  // Test FileMetaData::set_file_path
-  ASSERT_TRUE(rg2_column1->file_path().empty());
-  f_accessor->set_file_path("/foo/bar/bar.parquet");
-  ASSERT_EQ("/foo/bar/bar.parquet", rg2_column1->file_path());
-
+    // Test FileMetaData::set_file_path
+    ASSERT_TRUE(rg2_column1->file_path().empty());
+    f_accessors[loop_index]->set_file_path("/foo/bar/bar.parquet");
+    ASSERT_EQ("/foo/bar/bar.parquet", rg2_column1->file_path());
+  }
   // Test AppendRowGroups
   auto f_accessor_2 = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
-  
-  ASSERT_EQ(512, f_accessor_2->ToString().length());
-  ASSERT_EQ(21, static_cast<int32_t>(f_accessor_2->ToString()[0]));
-  ASSERT_EQ(60, static_cast<int32_t>(f_accessor_2->ToString()[3]));
-  ASSERT_EQ(24, static_cast<int32_t>(f_accessor_2->ToString()[219]));
-
   f_accessor->AppendRowGroups(*f_accessor_2);
   ASSERT_EQ(4, f_accessor->num_row_groups());
   ASSERT_EQ(nrows * 2, f_accessor->num_rows());

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -100,6 +100,11 @@ TEST(Metadata, TestBuildAccess) {
   // Generate the metadata
   auto f_accessor = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
 
+  ASSERT_EQ(512, f_accessor->ToString().length());
+  ASSERT_EQ(21, static_cast<int32_t>(f_accessor->ToString()[0]));
+  ASSERT_EQ(60, static_cast<int32_t>(f_accessor->ToString()[3]));
+  ASSERT_EQ(24, static_cast<int32_t>(f_accessor->ToString()[219]));
+
   // file metadata
   ASSERT_EQ(nrows, f_accessor->num_rows());
   ASSERT_LE(0, static_cast<int>(f_accessor->size()));
@@ -180,6 +185,12 @@ TEST(Metadata, TestBuildAccess) {
 
   // Test AppendRowGroups
   auto f_accessor_2 = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
+  
+  ASSERT_EQ(512, f_accessor_2->ToString().length());
+  ASSERT_EQ(21, static_cast<int32_t>(f_accessor_2->ToString()[0]));
+  ASSERT_EQ(60, static_cast<int32_t>(f_accessor_2->ToString()[3]));
+  ASSERT_EQ(24, static_cast<int32_t>(f_accessor_2->ToString()[219]));
+
   f_accessor->AppendRowGroups(*f_accessor_2);
   ASSERT_EQ(4, f_accessor->num_row_groups());
   ASSERT_EQ(nrows * 2, f_accessor->num_rows());

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -102,13 +102,14 @@ TEST(Metadata, TestBuildAccess) {
 
   std::string f_accessor_serialized_metadata = f_accessor->SerializeToString();
   ASSERT_EQ(403, f_accessor_serialized_metadata.length());
-  uint32_t metadata_len = f_accessor_serialized_metadata.length();
-  auto f_accessor_copy = FileMetaData::Make(f_accessor_serialized_metadata.data(), &metadata_len);
+  uint32_t metadata_len = static_cast<uint32_t>(f_accessor_serialized_metadata.length());
+  auto f_accessor_copy =
+      FileMetaData::Make(f_accessor_serialized_metadata.data(), &metadata_len);
 
   // Run this block twice, one for f_accessor, one for f_accessor_copy.
   // To make sure SerializedMetadata was deserialized correctly.
-  std::vector<FileMetaData*> f_accessors = { f_accessor.get(), f_accessor_copy.get() }; 
-  for(int loop_index = 0; loop_index < 2; loop_index++) {
+  std::vector<FileMetaData*> f_accessors = {f_accessor.get(), f_accessor_copy.get()};
+  for (int loop_index = 0; loop_index < 2; loop_index++) {
     // file metadata
     ASSERT_EQ(nrows, f_accessors[loop_index]->num_rows());
     ASSERT_LE(0, static_cast<int>(f_accessors[loop_index]->size()));

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -100,8 +100,8 @@ TEST(Metadata, TestBuildAccess) {
   // Generate the metadata
   auto f_accessor = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
 
-  std::string f_accessor_serialized_metadata = f_accessor->SerializedMetadata();
-  ASSERT_EQ(512, f_accessor_serialized_metadata.length());
+  std::string f_accessor_serialized_metadata = f_accessor->SerializeToString();
+  ASSERT_EQ(403, f_accessor_serialized_metadata.length());
   uint32_t metadata_len = f_accessor_serialized_metadata.length();
   auto f_accessor_copy = FileMetaData::Make(f_accessor_serialized_metadata.data(), &metadata_len);
 

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -102,9 +102,12 @@ TEST(Metadata, TestBuildAccess) {
 
   std::string f_accessor_serialized_metadata = f_accessor->SerializeToString();
   ASSERT_EQ(403, f_accessor_serialized_metadata.length());
-  uint32_t metadata_len = static_cast<uint32_t>(f_accessor_serialized_metadata.length());
+  uint32_t expected_len = static_cast<uint32_t>(f_accessor_serialized_metadata.length());
+
+  uint32_t decoded_len = -1;
   auto f_accessor_copy =
-      FileMetaData::Make(f_accessor_serialized_metadata.data(), &metadata_len);
+      FileMetaData::Make(f_accessor_serialized_metadata.data(), &decoded_len);
+  ASSERT_EQ(expected_len, decoded_len);
 
   // Run this block twice, one for f_accessor, one for f_accessor_copy.
   // To make sure SerializedMetadata was deserialized correctly.


### PR DESCRIPTION
we need to add a function like

FileMetaData::ToString()

this is useful when people want a string format of metadata.

If loads of file sharing the same fileMetaData, ToString will provide a binary string that stay in memory to reduce redundant metadata reding time.