### PR TITLE
ARROW-6472: [Java] ValueVector#accept may has potential cast exception

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -69,8 +69,14 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
   @Override
   public Boolean visit(BaseFixedWidthVector left, Range range) {
     if (left instanceof Float4Vector) {
+      if (!validate(left)) {
+        return false;
+      }
       return float4ApproxEquals(range);
     } else if (left instanceof Float8Vector) {
+      if (!validate(left)) {
+        return false;
+      }
       return float8ApproxEquals(range);
     } else {
       return super.visit(left, range);

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -87,6 +87,31 @@ public class TestRangeEqualsVisitor {
   }
 
   @Test
+  public void testEqualsWithTypeChange() {
+    try (final IntVector vector1 = new IntVector("intVector1", allocator);
+         final IntVector vector2 = new IntVector("intVector2", allocator);
+         final BigIntVector vector3 = new BigIntVector("bigIntVector", allocator)) {
+
+      vector1.allocateNew(2);
+      vector1.setValueCount(2);
+      vector2.allocateNew(2);
+      vector2.setValueCount(2);
+
+      vector1.setSafe(0, 1);
+      vector1.setSafe(1, 2);
+
+      vector2.setSafe(0, 1);
+      vector2.setSafe(1, 2);
+
+      RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
+      Range range = new Range(0, 0, 2);
+      assertTrue(vector1.accept(visitor, range));
+      // visitor left vector changed, will reset and check type again
+      assertFalse(vector3.accept(visitor, range));
+    }
+  }
+
+  @Test
   public void testBaseFixedWidthVectorRangeEqual() {
     try (final IntVector vector1 = new IntVector("int", allocator);
         final IntVector vector2 = new IntVector("int", allocator)) {


### PR DESCRIPTION
Related to [ARROW-6472](https://issues.apache.org/jira/browse/ARROW-6472).

If we use visitor API this way:
>RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
vector3.accept(visitor, range)

if vector1/vector2 are say, StructVector}}s and vector3 is an {{IntVector - things can go bad. we'll use the compareBaseFixedWidthVectors() and do wrong type-casts for vector1/vector2.

Discussions see:
https://github.com/apache/arrow/pull/5195#issuecomment-528425302
https://issues.apache.org/jira/browse/ARROW-6472