### PR TITLE
PARQUET-1663: [C++] Provide API to check the presence of repeated fields

### DIFF
--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -778,6 +778,11 @@ void SchemaDescriptor::BuildTree(const NodePtr& node, int16_t max_def_level,
 
   // Now, walk the schema and create a ColumnDescriptor for each leaf node
   if (node->is_group()) {
+    if (node->logical_type()->is_list()) {
+      has_array_type_ = true;
+    } else if (node->logical_type()->is_map()){
+      has_map_type_ = true;
+    }
     const GroupNode* group = static_cast<const GroupNode*>(node.get());
     for (int i = 0; i < group->field_count(); ++i) {
       BuildTree(group->field(i), max_def_level, max_rep_level, base);

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -454,6 +454,9 @@ class PARQUET_EXPORT SchemaDescriptor {
   /// PrimitiveNode. Returns -1 if not found
   int GetColumnIndex(const schema::PrimitiveNode& node) const;
 
+  bool hasArrayType() const { return has_array_type_; }
+  bool hasMapType() const { return has_map_type_; }
+
  private:
   friend class ColumnDescriptor;
 
@@ -483,6 +486,9 @@ class PARQUET_EXPORT SchemaDescriptor {
 
   // Mapping between ColumnPath DotString to the leaf index
   std::unordered_multimap<std::string, int> leaf_to_idx_;
+
+  bool has_array_type_ = false;
+  bool has_map_type_ = false;
 };
 
 }  // namespace parquet

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -303,6 +303,10 @@ class PARQUET_EXPORT GroupNode : public Node {
   void Visit(Visitor* visitor) override;
   void VisitConst(ConstVisitor* visitor) const override;
 
+  /// \brief Return true if this node or any child node has REPEATED repetition
+  /// type
+  bool HasRepeatedFields() const;
+
  private:
   GroupNode(const std::string& name, Repetition::type repetition,
             const NodeVector& fields,
@@ -454,8 +458,9 @@ class PARQUET_EXPORT SchemaDescriptor {
   /// PrimitiveNode. Returns -1 if not found
   int GetColumnIndex(const schema::PrimitiveNode& node) const;
 
-  bool hasArrayType() const { return has_array_type_; }
-  bool hasMapType() const { return has_map_type_; }
+  /// \brief Return true if any field or their children have REPEATED repetition
+  /// type
+  bool HasRepeatedFields() const;
 
  private:
   friend class ColumnDescriptor;
@@ -486,9 +491,6 @@ class PARQUET_EXPORT SchemaDescriptor {
 
   // Mapping between ColumnPath DotString to the leaf index
   std::unordered_multimap<std::string, int> leaf_to_idx_;
-
-  bool has_array_type_ = false;
-  bool has_map_type_ = false;
 };
 
 }  // namespace parquet

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -799,7 +799,7 @@ TEST_F(TestSchemaDescriptor, BuildTree) {
   ASSERT_EQ(nleaves, descr_.num_columns());
 }
 
-TEST_F(TestSchemaDescriptor, ComplexTypeCheck) {
+TEST_F(TestSchemaDescriptor, HasRepeatedFields) {
   NodeVector fields;
   NodePtr schema;
 
@@ -810,8 +810,7 @@ TEST_F(TestSchemaDescriptor, ComplexTypeCheck) {
 
   schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
   descr_.Init(schema);
-  ASSERT_EQ(false, descr_.HasRepeatedFields());
-  ASSERT_EQ(false, descr_.HasRepeatedFields());
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
 
   // 3-level list encoding
   NodePtr item1 = Int64("item1", Repetition::REQUIRED);
@@ -825,15 +824,14 @@ TEST_F(TestSchemaDescriptor, ComplexTypeCheck) {
   schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
   descr_.Init(schema);
   ASSERT_EQ(true, descr_.HasRepeatedFields());
-  ASSERT_EQ(false, descr_.HasRepeatedFields());
 
   // 3-level list encoding
   NodePtr item_key = Int64("key", Repetition::REQUIRED);
   NodePtr item_value = Boolean("value", Repetition::OPTIONAL);
   NodePtr map(GroupNode::Make("map", Repetition::REPEATED, {item_key, item_value},
                               ConvertedType::MAP));
-  NodePtr myMap(GroupNode::Make("myMap", Repetition::OPTIONAL, {map}));
-  fields.push_back(myMap);
+  NodePtr my_map(GroupNode::Make("my_map", Repetition::OPTIONAL, {map}));
+  fields.push_back(my_map);
 
   schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
   descr_.Init(schema);

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -808,11 +808,10 @@ TEST_F(TestSchemaDescriptor, ComplexTypeCheck) {
   fields.push_back(Int64("b", Repetition::OPTIONAL));
   fields.push_back(ByteArray("c", Repetition::REPEATED));
 
-
   schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
   descr_.Init(schema);
-  ASSERT_EQ(false, descr_.hasArrayType());
-  ASSERT_EQ(false, descr_.hasMapType());
+  ASSERT_EQ(false, descr_.HasRepeatedFields());
+  ASSERT_EQ(false, descr_.HasRepeatedFields());
 
   // 3-level list encoding
   NodePtr item1 = Int64("item1", Repetition::REQUIRED);
@@ -825,22 +824,21 @@ TEST_F(TestSchemaDescriptor, ComplexTypeCheck) {
 
   schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
   descr_.Init(schema);
-  ASSERT_EQ(true, descr_.hasArrayType());
-  ASSERT_EQ(false, descr_.hasMapType());
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
+  ASSERT_EQ(false, descr_.HasRepeatedFields());
 
   // 3-level list encoding
   NodePtr item_key = Int64("key", Repetition::REQUIRED);
   NodePtr item_value = Boolean("value", Repetition::OPTIONAL);
   NodePtr map(GroupNode::Make("map", Repetition::REPEATED, {item_key, item_value},
-                               ConvertedType::MAP));
+                              ConvertedType::MAP));
   NodePtr myMap(GroupNode::Make("myMap", Repetition::OPTIONAL, {map}));
   fields.push_back(myMap);
 
   schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
   descr_.Init(schema);
-  ASSERT_EQ(true, descr_.hasArrayType());
-  ASSERT_EQ(true, descr_.hasMapType());
- 
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
 }
 
 static std::string Print(const NodePtr& node) {

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -799,6 +799,50 @@ TEST_F(TestSchemaDescriptor, BuildTree) {
   ASSERT_EQ(nleaves, descr_.num_columns());
 }
 
+TEST_F(TestSchemaDescriptor, ComplexTypeCheck) {
+  NodeVector fields;
+  NodePtr schema;
+
+  NodePtr inta = Int32("a", Repetition::REQUIRED);
+  fields.push_back(inta);
+  fields.push_back(Int64("b", Repetition::OPTIONAL));
+  fields.push_back(ByteArray("c", Repetition::REPEATED));
+
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  descr_.Init(schema);
+  ASSERT_EQ(false, descr_.hasArrayType());
+  ASSERT_EQ(false, descr_.hasMapType());
+
+  // 3-level list encoding
+  NodePtr item1 = Int64("item1", Repetition::REQUIRED);
+  NodePtr item2 = Boolean("item2", Repetition::OPTIONAL);
+  NodePtr item3 = Int32("item3", Repetition::REPEATED);
+  NodePtr list(GroupNode::Make("records", Repetition::REPEATED, {item1, item2, item3},
+                               ConvertedType::LIST));
+  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+  fields.push_back(bag);
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  descr_.Init(schema);
+  ASSERT_EQ(true, descr_.hasArrayType());
+  ASSERT_EQ(false, descr_.hasMapType());
+
+  // 3-level list encoding
+  NodePtr item_key = Int64("key", Repetition::REQUIRED);
+  NodePtr item_value = Boolean("value", Repetition::OPTIONAL);
+  NodePtr map(GroupNode::Make("map", Repetition::REPEATED, {item_key, item_value},
+                               ConvertedType::MAP));
+  NodePtr myMap(GroupNode::Make("myMap", Repetition::OPTIONAL, {map}));
+  fields.push_back(myMap);
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  descr_.Init(schema);
+  ASSERT_EQ(true, descr_.hasArrayType());
+  ASSERT_EQ(true, descr_.hasMapType());
+ 
+}
+
 static std::string Print(const NodePtr& node) {
   std::stringstream ss;
   PrintSchema(node.get(), ss);


### PR DESCRIPTION
added two functions
hasMapType() and hasArrayType()
in case some other tools that does not support array or map can know if map or array exist in this parquet file.