### PR TITLE
ARROW-6086: [Rust] [DataFusion] Add support for partitioned Parquet data sources

### DIFF
--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -37,23 +37,27 @@ use parquet::file::reader::*;
 
 use crate::datasource::{ScanResult, TableProvider};
 use crate::error::{ExecutionError, Result};
+use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::BatchIterator;
 
 /// Table-based representation of a `ParquetFile`
 pub struct ParquetTable {
-    filename: String,
+    filenames: Vec<String>,
     schema: Arc<Schema>,
 }
 
 impl ParquetTable {
     /// Attempt to initialize a new `ParquetTable` from a file path
-    pub fn try_new(filename: &str) -> Result<Self> {
-        let parquet_file = ParquetFile::open(filename, None, 0)?;
-        let schema = parquet_file.projection_schema.clone();
-        Ok(Self {
-            filename: filename.to_string(),
-            schema,
-        })
+    pub fn try_new(path: &str) -> Result<Self> {
+        let mut filenames: Vec<String> = vec![];
+        common::build_file_list(path, &mut filenames, ".parquet")?;
+        if filenames.is_empty() {
+            panic!()
+        } else {
+            let parquet_file = ParquetFile::open(&filenames[0], None, 0)?;
+            let schema = parquet_file.projection_schema.clone();
+            Ok(Self { filenames, schema })
+        }
     }
 }
 
@@ -70,17 +74,21 @@ impl TableProvider for ParquetTable {
         projection: &Option<Vec<usize>>,
         batch_size: usize,
     ) -> Result<Vec<ScanResult>> {
-        // note that this code currently assumes the filename is a file rather than a directory
-        // and therefore only returns a single partition
-        let parquet_file = match projection {
-            Some(p) => ParquetScanPartition::try_new(
-                &self.filename,
-                Some(p.clone()),
-                batch_size,
-            )?,
-            None => ParquetScanPartition::try_new(&self.filename, None, batch_size)?,
-        };
-        Ok(vec![Arc::new(Mutex::new(parquet_file))])
+        //TODO remove the unwrap
+        Ok(self
+            .filenames
+            .iter()
+            .map(|filename| {
+                Arc::new(Mutex::new(
+                    ParquetScanPartition::try_new(
+                        filename,
+                        projection.clone(),
+                        batch_size,
+                    )
+                    .unwrap(),
+                )) as Arc<Mutex<dyn BatchIterator>>
+            })
+            .collect())
     }
 }
 

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -52,7 +52,7 @@ impl ParquetTable {
         let mut filenames: Vec<String> = vec![];
         common::build_file_list(path, &mut filenames, ".parquet")?;
         if filenames.is_empty() {
-            panic!()
+            Err(ExecutionError::General("No files found".to_string()))
         } else {
             let parquet_file = ParquetFile::open(&filenames[0], None, 0)?;
             let schema = parquet_file.projection_schema.clone();

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -19,7 +19,6 @@
 
 use std::fs;
 use std::fs::metadata;
-use std::fs::File;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -17,9 +17,12 @@
 
 //! Defines common code used in execution plans
 
+use std::fs;
+use std::fs::metadata;
+use std::fs::File;
 use std::sync::{Arc, Mutex};
 
-use crate::error::Result;
+use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::BatchIterator;
 
 use arrow::datatypes::Schema;
@@ -74,4 +77,31 @@ pub fn collect(it: Arc<Mutex<dyn BatchIterator>>) -> Result<Vec<RecordBatch>> {
             Err(e) => return Err(e),
         }
     }
+}
+
+/// Recursively build a list of files in a directory with a given extension
+pub fn build_file_list(dir: &str, filenames: &mut Vec<String>, ext: &str) -> Result<()> {
+    let metadata = metadata(dir)?;
+    if metadata.is_file() {
+        if dir.ends_with(ext) {
+            filenames.push(dir.to_string());
+        }
+    } else {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if let Some(path_name) = path.to_str() {
+                if path.is_dir() {
+                    build_file_list(path_name, filenames, ext)?;
+                } else {
+                    if path_name.ends_with(ext) {
+                        filenames.push(path_name.to_string());
+                    }
+                }
+            } else {
+                return Err(ExecutionError::General("Invalid path".to_string()));
+            }
+        }
+    }
+    Ok(())
 }

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -23,6 +23,7 @@ use std::fs::File;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
+use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
 use arrow::csv;
 use arrow::datatypes::Schema;
@@ -51,7 +52,7 @@ impl ExecutionPlan for CsvExec {
     /// Get the partitions for this execution plan. Each partition can be executed in parallel.
     fn partitions(&self) -> Result<Vec<Arc<dyn Partition>>> {
         let mut filenames: Vec<String> = vec![];
-        self.build_file_list(&self.path, &mut filenames)?;
+        common::build_file_list(&self.path, &mut filenames, ".csv")?;
         let partitions = filenames
             .iter()
             .map(|filename| {
@@ -84,33 +85,6 @@ impl CsvExec {
             projection,
             batch_size,
         })
-    }
-
-    /// Recursively build a list of csv files in a directory
-    fn build_file_list(&self, dir: &str, filenames: &mut Vec<String>) -> Result<()> {
-        let metadata = metadata(dir)?;
-        if metadata.is_file() {
-            if dir.ends_with(".csv") {
-                filenames.push(dir.to_string());
-            }
-        } else {
-            for entry in fs::read_dir(dir)? {
-                let entry = entry?;
-                let path = entry.path();
-                if let Some(path_name) = path.to_str() {
-                    if path.is_dir() {
-                        self.build_file_list(path_name, filenames)?;
-                    } else {
-                        if path_name.ends_with(".csv") {
-                            filenames.push(path_name.to_string());
-                        }
-                    }
-                } else {
-                    return Err(ExecutionError::General("Invalid path".to_string()));
-                }
-            }
-        }
-        Ok(())
     }
 }
 

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -17,12 +17,10 @@
 
 //! Execution plan for reading CSV files
 
-use std::fs;
-use std::fs::metadata;
 use std::fs::File;
 use std::sync::{Arc, Mutex};
 
-use crate::error::{ExecutionError, Result};
+use crate::error::Result;
 use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
 use arrow::csv;


### PR DESCRIPTION
I discovered this last minute while running manual tests. I have been able to run parallel queries against parquet files using this branch as a dependency.
