### PR TITLE
ARROW-6564: [Python] Do not require pandas for invoking ChunkedArray.__array__

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -203,7 +203,10 @@ def test_chunked_array_to_pandas():
 
 
 @pytest.mark.pandas
+@pytest.mark.nopandas
 def test_chunked_array_asarray():
+    # ensure this is tested both when pandas is present or not (ARROW-6564)
+
     data = [
         pa.array([0]),
         pa.array([1, 2, 3])
@@ -231,6 +234,14 @@ def test_chunked_array_asarray():
     assert np.isnan(elements[1])
     assert elements[2:] == [1., 2., 3.]
     assert np_arr.dtype == np.dtype('float64')
+
+    # DictionaryType data will be converted to dense numpy array
+    arr = pa.DictionaryArray.from_arrays(
+        pa.array([0, 1, 2, 0, 1]), pa.array(['a', 'b', 'c']))
+    chunked_arr = pa.chunked_array([arr, arr])
+    np_arr = np.asarray(chunked_arr)
+    assert np_arr.dtype == np.dtype('object')
+    assert np_arr.tolist() == ['a', 'b', 'c', 'a', 'b'] * 2
 
 
 def test_chunked_array_flatten():


### PR DESCRIPTION
Follow-up on https://github.com/apache/arrow/pull/5402, to apply the same fix for `ChunkedArray` (@wesm was a bit quick with merging :))