### PR TITLE
ARROW-6679: [RELEASE] Add license info for the autobrew scripts

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1841,8 +1841,8 @@ This project includes code from the autobrew project.
 * r/tools/autobrew and dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
   are based on code from the autobrew project.
 
-Copyright: Copyright (c) 2017 - 2019, Jeroen Ooms.
-All rights reserved.
+Copyright (c) 2019, Jeroen Ooms
+License: MIT
 Homepage: https://github.com/jeroen/autobrew
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
cf. https://github.com/jeroen/autobrew/blob/gh-pages/LICENCE.txt