### PR TITLE
ARROW-6703: [Packaging][Linux] Restore ARROW_VERSION environment variable

### DIFF
--- a/dev/tasks/linux-packages/azure.linux.arm64.yml
+++ b/dev/tasks/linux-packages/azure.linux.arm64.yml
@@ -56,6 +56,8 @@ jobs:
         rake dist
         {{ build_command }}
         popd
+      env:
+        ARROW_VERSION: {{ arrow.version }}
       displayName: Build
 
     # Using github release tries to find a common ancestor between the

--- a/dev/tasks/linux-packages/azure.linux.yml
+++ b/dev/tasks/linux-packages/azure.linux.yml
@@ -40,6 +40,8 @@ jobs:
         rake dist
         {{ build_command }}
         popd
+      env:
+        ARROW_VERSION: {{ arrow.version }}
       displayName: Build
 
     # Using github release tries to find a common ancestor between the


### PR DESCRIPTION
This is needed to use correct download URL for RC.