### PR TITLE
ARROW-6709: [JAVA] Jdbc adapter currentIndex should increment when va…

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
@@ -45,8 +45,9 @@ public class BigIntConsumer implements JdbcConsumer<BigIntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     long value = resultSet.getLong(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
@@ -45,8 +45,9 @@ public class BitConsumer implements JdbcConsumer<BitVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     boolean value = resultSet.getBoolean(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value ? 1 : 0);
+      vector.setSafe(currentIndex, value ? 1 : 0);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
@@ -57,8 +57,9 @@ public class DateConsumer implements JdbcConsumer<DateMilliVector> {
     Date date = calendar == null ? resultSet.getDate(columnIndexInResultSet) :
         resultSet.getDate(columnIndexInResultSet, calendar);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, date.getTime());
+      vector.setSafe(currentIndex, date.getTime());
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
@@ -46,8 +46,9 @@ public class DecimalConsumer implements JdbcConsumer<DecimalVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
@@ -45,8 +45,9 @@ public class DoubleConsumer implements JdbcConsumer<Float8Vector> {
   public void consume(ResultSet resultSet) throws SQLException {
     double value = resultSet.getDouble(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
@@ -45,8 +45,9 @@ public class FloatConsumer implements JdbcConsumer<Float4Vector> {
   public void consume(ResultSet resultSet) throws SQLException {
     float value = resultSet.getFloat(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
@@ -45,8 +45,9 @@ public class IntConsumer implements JdbcConsumer<IntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     int value = resultSet.getInt(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
@@ -45,8 +45,9 @@ public class SmallIntConsumer implements JdbcConsumer<SmallIntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     short value = resultSet.getShort(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
@@ -57,8 +57,9 @@ public class TimeConsumer implements JdbcConsumer<TimeMilliVector> {
     Time time = calendar == null ? resultSet.getTime(columnIndexInResultSet) :
         resultSet.getTime(columnIndexInResultSet, calendar);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, (int) time.getTime());
+      vector.setSafe(currentIndex, (int) time.getTime());
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
@@ -57,8 +57,9 @@ public class TimestampConsumer implements JdbcConsumer<TimeStampMilliTZVector> {
     Timestamp timestamp = calendar == null ? resultSet.getTimestamp(columnIndexInResultSet) :
         resultSet.getTimestamp(columnIndexInResultSet, calendar);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, timestamp.getTime());
+      vector.setSafe(currentIndex, timestamp.getTime());
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
@@ -45,8 +45,9 @@ public class TinyIntConsumer implements JdbcConsumer<TinyIntVector> {
   public void consume(ResultSet resultSet) throws SQLException {
     byte value = resultSet.getByte(columnIndexInResultSet);
     if (!resultSet.wasNull()) {
-      vector.setSafe(currentIndex++, value);
+      vector.setSafe(currentIndex, value);
     }
+    currentIndex++;
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/VarCharConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/VarCharConsumer.java
@@ -48,8 +48,9 @@ public class VarCharConsumer implements JdbcConsumer<VarCharVector> {
     if (!resultSet.wasNull()) {
       byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
 
-      vector.setSafe(currentIndex++, bytes);
+      vector.setSafe(currentIndex, bytes);
     }
+    currentIndex++;
   }
 
   @Override


### PR DESCRIPTION
Related to [ARROW-6709](https://issues.apache.org/jira/browse/ARROW-6709).
Currently, in several consumers, currentIndex only increments when ResultSet was not null.
However, if ResultSet contains null values, the Arrow vector valueCount is not correct.