### PR TITLE
ARROW-6714: [R] Fix untested RecordBatchWriter case

### DIFF
--- a/r/R/record-batch-writer.R
+++ b/r/R/record-batch-writer.R
@@ -58,12 +58,11 @@ RecordBatchWriter <- R6Class("RecordBatchWriter", inherit = Object,
     write_table = function(table) ipc___RecordBatchWriter__WriteTable(self, table),
 
     write = function(x) {
+      x <- to_arrow(x)
       if (inherits(x, "RecordBatch")) {
         self$write_batch(x)
       } else if (inherits(x, "Table")) {
         self$write_table(x)
-      } else if (inherits(x, "data.frame")) {
-        self$write_table(table(x))
       } else {
         abort("unexpected type for RecordBatchWriter$write(), must be an arrow::RecordBatch or an arrow::Table")
       }


### PR DESCRIPTION
I noticed this now-defunct call to `table()` while reviewing another PR. We clearly weren't testing this case because if you were to pass a data.frame in, you'd get a segfault. This patch adds tests and fixes the issue.