### PR TITLE
ARROW-6682: [C#] Ensure file footer block lengths are always 8 byte aligned.

### DIFF
--- a/csharp/src/Apache.Arrow/BitUtility.cs
+++ b/csharp/src/Apache.Arrow/BitUtility.cs
@@ -140,6 +140,8 @@ namespace Apache.Arrow
             return (n + (factor - 1)) & ~(factor - 1);
         }
 
+        internal static bool IsMultipleOf8(long n) => n % 8 == 0;
+
         /// <summary>
         /// Calculates the number of bytes required to store n bits.
         /// </summary>

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -88,11 +88,11 @@ namespace Apache.Arrow.Ipc
             // always be greater than 0.
             Debug.Assert(_currentRecordBatchOffset > 0, "_currentRecordBatchOffset must be positive.");
 
-            int metadataLengthInt;
-            checked
-            {
-                metadataLengthInt = (int)metadataLength;
-            }
+            int metadataLengthInt = checked((int)metadataLength);
+
+            Debug.Assert(BitUtility.IsMultipleOf8(_currentRecordBatchOffset));
+            Debug.Assert(BitUtility.IsMultipleOf8(metadataLengthInt));
+            Debug.Assert(BitUtility.IsMultipleOf8(bodyLength));
 
             var block = new Block(
                 offset: _currentRecordBatchOffset,

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFooter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFooter.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Apache.Arrow.Ipc
@@ -40,6 +41,24 @@ namespace Apache.Arrow.Ipc
 
             _dictionaries = dictionaries.ToList();
             _recordBatches = recordBatches.ToList();
+
+#if DEBUG
+            for (int i = 0; i < _dictionaries.Count; i++)
+            {
+                Block block = _dictionaries[i];
+                Debug.Assert(BitUtility.IsMultipleOf8(block.Offset));
+                Debug.Assert(BitUtility.IsMultipleOf8(block.MetadataLength));
+                Debug.Assert(BitUtility.IsMultipleOf8(block.BodyLength));
+            }
+
+            for (int i = 0; i < _recordBatches.Count; i++)
+            {
+                Block block = _recordBatches[i];
+                Debug.Assert(BitUtility.IsMultipleOf8(block.Offset));
+                Debug.Assert(BitUtility.IsMultipleOf8(block.MetadataLength));
+                Debug.Assert(BitUtility.IsMultipleOf8(block.BodyLength));
+            }
+#endif
         }
 
         public ArrowFooter(Flatbuf.Footer footer)

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -370,7 +370,7 @@ namespace Apache.Arrow.Ipc
             Builder.Finish(messageOffset.Value);
 
             var messageData = Builder.DataBuffer.ToReadOnlyMemory(Builder.DataBuffer.Position, Builder.Offset);
-            var messagePaddingLength = CalculatePadding(messageData.Length);
+            var messagePaddingLength = CalculatePadding(_options.SizeOfIpcLength + messageData.Length);
 
             await WriteIpcMessageLengthAsync(messageData.Length + messagePaddingLength, cancellationToken)
                 .ConfigureAwait(false);


### PR DESCRIPTION
@pgovind @chutchinson @abbotware @wesm 