### PR TITLE
ARROW-6710: [Java] Add JDBC adapter test to cover cases which contains some null values

### DIFF
--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/AbstractJdbcToArrowTest.java
@@ -35,6 +35,25 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
  * Class to abstract out some common test functionality for testing JDBC to Arrow.
  */
 public abstract class AbstractJdbcToArrowTest {
+
+  protected static final String BIGINT = "BIGINT_FIELD5";
+  protected static final String BINARY = "BINARY_FIELD12";
+  protected static final String BIT = "BIT_FIELD17";
+  protected static final String BLOB = "BLOB_FIELD14";
+  protected static final String BOOL = "BOOL_FIELD2";
+  protected static final String CHAR = "CHAR_FIELD16";
+  protected static final String CLOB = "CLOB_FIELD15";
+  protected static final String DATE = "DATE_FIELD10";
+  protected static final String DECIMAL = "DECIMAL_FIELD6";
+  protected static final String DOUBLE = "DOUBLE_FIELD7";
+  protected static final String INT = "INT_FIELD1";
+  protected static final String REAL = "REAL_FIELD8";
+  protected static final String SMALLINT = "SMALLINT_FIELD4";
+  protected static final String TIME = "TIME_FIELD9";
+  protected static final String TIMESTAMP = "TIMESTAMP_FIELD11";
+  protected static final String TINYINT = "TINYINT_FIELD3";
+  protected static final String VARCHAR = "VARCHAR_FIELD13";
+
   protected Connection conn = null;
   protected Table table;
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -118,7 +118,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < bigIntVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(bigIntVector.getObject(j));
+        assertTrue(bigIntVector.isNull(j));
       } else {
         assertEquals(values[j].longValue(), bigIntVector.get(j));
       }
@@ -130,7 +130,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < decimalVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(decimalVector.getObject(j));
+        assertTrue(decimalVector.isNull(j));
       } else {
         assertEquals(values[j].doubleValue(), decimalVector.getObject(j).doubleValue(), 0);
       }
@@ -142,7 +142,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < float8Vector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(float8Vector.getObject(j));
+        assertTrue(float8Vector.isNull(j));
       } else {
         assertEquals(values[j], float8Vector.get(j), 0.01);
       }
@@ -154,7 +154,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < float4Vector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(float4Vector.getObject(j));
+        assertTrue(float4Vector.isNull(j));
       } else {
         assertEquals(values[j], float4Vector.get(j), 0.01);
       }
@@ -166,7 +166,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < timeMilliVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(timeMilliVector.getObject(j));
+        assertTrue(timeMilliVector.isNull(j));
       } else {
         assertEquals(values[j].longValue(), timeMilliVector.get(j));
       }
@@ -178,7 +178,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < dateMilliVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(dateMilliVector.getObject(j));
+        assertTrue(dateMilliVector.isNull(j));
       } else {
         assertEquals(values[j].longValue(), dateMilliVector.get(j));
       }
@@ -190,7 +190,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < timeStampVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(timeStampVector.getObject(j));
+        assertTrue(timeStampVector.isNull(j));
       } else {
         assertEquals(values[j].longValue(), timeStampVector.get(j));
       }
@@ -202,7 +202,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < varBinaryVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(varBinaryVector.getObject(j));
+        assertTrue(varBinaryVector.isNull(j));
       } else {
         assertArrayEquals(values[j], varBinaryVector.get(j));
       }
@@ -214,7 +214,7 @@ public class JdbcToArrowTestHelper {
 
     for (int j = 0; j < varCharVector.getValueCount(); j++) {
       if (values[j] == null) {
-        assertNull(varCharVector.getObject(j));
+        assertTrue(varCharVector.isNull(j));
       } else {
         assertArrayEquals(values[j], varCharVector.get(j));
       }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -20,6 +20,7 @@ package org.apache.arrow.adapter.jdbc;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
@@ -56,7 +57,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, intVector.getValueCount());
 
     for (int j = 0; j < intVector.getValueCount(); j++) {
-      assertEquals(values[j].intValue(), intVector.get(j));
+      if (values[j] == null) {
+        assertTrue(intVector.isNull(j));
+      } else {
+        assertEquals(values[j].intValue(), intVector.get(j));
+      }
     }
   }
 
@@ -64,7 +69,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, bitVector.getValueCount());
 
     for (int j = 0; j < bitVector.getValueCount(); j++) {
-      assertEquals(values[j].booleanValue(), bitVector.get(j) == 1);
+      if (values[j] == null) {
+        assertTrue(bitVector.isNull(j));
+      } else {
+        assertEquals(values[j].booleanValue(), bitVector.get(j) == 1);
+      }
     }
   }
 
@@ -72,7 +81,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, bitVector.getValueCount());
 
     for (int j = 0; j < bitVector.getValueCount(); j++) {
-      assertEquals(values[j].intValue(), bitVector.get(j));
+      if (values[j] == null) {
+        assertTrue(bitVector.isNull(j));
+      } else {
+        assertEquals(values[j].intValue(), bitVector.get(j));
+      }
     }
   }
 
@@ -80,7 +93,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, tinyIntVector.getValueCount());
 
     for (int j = 0; j < tinyIntVector.getValueCount(); j++) {
-      assertEquals(values[j].intValue(), tinyIntVector.get(j));
+      if (values[j] == null) {
+        assertTrue(tinyIntVector.isNull(j));
+      } else {
+        assertEquals(values[j].intValue(), tinyIntVector.get(j));
+      }
     }
   }
 
@@ -88,7 +105,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, smallIntVector.getValueCount());
 
     for (int j = 0; j < smallIntVector.getValueCount(); j++) {
-      assertEquals(values[j].intValue(), smallIntVector.get(j));
+      if (values[j] == null) {
+        assertTrue(smallIntVector.isNull(j));
+      } else {
+        assertEquals(values[j].intValue(), smallIntVector.get(j));
+      }
     }
   }
 
@@ -96,7 +117,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, bigIntVector.getValueCount());
 
     for (int j = 0; j < bigIntVector.getValueCount(); j++) {
-      assertEquals(values[j].longValue(), bigIntVector.get(j));
+      if (values[j] == null) {
+        assertNull(bigIntVector.getObject(j));
+      } else {
+        assertEquals(values[j].longValue(), bigIntVector.get(j));
+      }
     }
   }
 
@@ -104,8 +129,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, decimalVector.getValueCount());
 
     for (int j = 0; j < decimalVector.getValueCount(); j++) {
-      assertNotNull(decimalVector.getObject(j));
-      assertEquals(values[j].doubleValue(), decimalVector.getObject(j).doubleValue(), 0);
+      if (values[j] == null) {
+        assertNull(decimalVector.getObject(j));
+      } else {
+        assertEquals(values[j].doubleValue(), decimalVector.getObject(j).doubleValue(), 0);
+      }
     }
   }
 
@@ -113,7 +141,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, float8Vector.getValueCount());
 
     for (int j = 0; j < float8Vector.getValueCount(); j++) {
-      assertEquals(values[j], float8Vector.get(j), 0.01);
+      if (values[j] == null) {
+        assertNull(float8Vector.getObject(j));
+      } else {
+        assertEquals(values[j], float8Vector.get(j), 0.01);
+      }
     }
   }
 
@@ -121,7 +153,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, float4Vector.getValueCount());
 
     for (int j = 0; j < float4Vector.getValueCount(); j++) {
-      assertEquals(values[j], float4Vector.get(j), 0.01);
+      if (values[j] == null) {
+        assertNull(float4Vector.getObject(j));
+      } else {
+        assertEquals(values[j], float4Vector.get(j), 0.01);
+      }
     }
   }
 
@@ -129,7 +165,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, timeMilliVector.getValueCount());
 
     for (int j = 0; j < timeMilliVector.getValueCount(); j++) {
-      assertEquals(values[j].longValue(), timeMilliVector.get(j));
+      if (values[j] == null) {
+        assertNull(timeMilliVector.getObject(j));
+      } else {
+        assertEquals(values[j].longValue(), timeMilliVector.get(j));
+      }
     }
   }
 
@@ -137,7 +177,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, dateMilliVector.getValueCount());
 
     for (int j = 0; j < dateMilliVector.getValueCount(); j++) {
-      assertEquals(values[j].longValue(), dateMilliVector.get(j));
+      if (values[j] == null) {
+        assertNull(dateMilliVector.getObject(j));
+      } else {
+        assertEquals(values[j].longValue(), dateMilliVector.get(j));
+      }
     }
   }
 
@@ -145,7 +189,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, timeStampVector.getValueCount());
 
     for (int j = 0; j < timeStampVector.getValueCount(); j++) {
-      assertEquals(values[j].longValue(), timeStampVector.get(j));
+      if (values[j] == null) {
+        assertNull(timeStampVector.getObject(j));
+      } else {
+        assertEquals(values[j].longValue(), timeStampVector.get(j));
+      }
     }
   }
 
@@ -153,7 +201,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, varBinaryVector.getValueCount());
 
     for (int j = 0; j < varBinaryVector.getValueCount(); j++) {
-      assertArrayEquals(values[j], varBinaryVector.get(j));
+      if (values[j] == null) {
+        assertNull(varBinaryVector.getObject(j));
+      } else {
+        assertArrayEquals(values[j], varBinaryVector.get(j));
+      }
     }
   }
 
@@ -161,7 +213,11 @@ public class JdbcToArrowTestHelper {
     assertEquals(rowCount, varCharVector.getValueCount());
 
     for (int j = 0; j < varCharVector.getValueCount(); j++) {
-      assertArrayEquals(values[j], varCharVector.get(j));
+      if (values[j] == null) {
+        assertNull(varCharVector.getObject(j));
+      } else {
+        assertArrayEquals(values[j], varCharVector.get(j));
+      }
     }
   }
 
@@ -223,7 +279,7 @@ public class JdbcToArrowTestHelper {
     Integer[] valueArr = new Integer[dataArr.length];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = Integer.parseInt(data);
+      valueArr[i++] = "null".equals(data.trim()) ? null : Integer.parseInt(data);
     }
     return valueArr;
   }
@@ -233,7 +289,7 @@ public class JdbcToArrowTestHelper {
     Boolean[] valueArr = new Boolean[dataArr.length];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = data.trim().equals("1");
+      valueArr[i++] = "null".equals(data.trim()) ? null : data.trim().equals("1");
     }
     return valueArr;
   }
@@ -243,7 +299,7 @@ public class JdbcToArrowTestHelper {
     BigDecimal[] valueArr = new BigDecimal[dataArr.length];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = new BigDecimal(data);
+      valueArr[i++] = "null".equals(data.trim()) ? null : new BigDecimal(data);
     }
     return valueArr;
   }
@@ -253,7 +309,7 @@ public class JdbcToArrowTestHelper {
     Double[] valueArr = new Double[dataArr.length];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = Double.parseDouble(data);
+      valueArr[i++] = "null".equals(data.trim()) ? null : Double.parseDouble(data);
     }
     return valueArr;
   }
@@ -263,7 +319,7 @@ public class JdbcToArrowTestHelper {
     Float[] valueArr = new Float[dataArr.length];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = Float.parseFloat(data);
+      valueArr[i++] = "null".equals(data.trim()) ? null : Float.parseFloat(data);
     }
     return valueArr;
   }
@@ -273,7 +329,7 @@ public class JdbcToArrowTestHelper {
     Long[] valueArr = new Long[dataArr.length];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = Long.parseLong(data);
+      valueArr[i++] = "null".equals(data.trim()) ? null : Long.parseLong(data);
     }
     return valueArr;
   }
@@ -283,7 +339,7 @@ public class JdbcToArrowTestHelper {
     byte[][] valueArr = new byte[dataArr.length][];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = data.trim().getBytes();
+      valueArr[i++] = "null".equals(data.trim()) ? null : data.trim().getBytes();
     }
     return valueArr;
   }
@@ -293,7 +349,7 @@ public class JdbcToArrowTestHelper {
     byte[][] valueArr = new byte[dataArr.length][];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = data.trim().getBytes(charSet);
+      valueArr[i++] = "null".equals(data.trim()) ? null : data.trim().getBytes(charSet);
     }
     return valueArr;
   }
@@ -303,7 +359,7 @@ public class JdbcToArrowTestHelper {
     byte[][] valueArr = new byte[dataArr.length][];
     int i = 0;
     for (String data : dataArr) {
-      valueArr[i++] = hexStringToByteArray(data.trim());
+      valueArr[i++] = "null".equals(data.trim()) ? null : hexStringToByteArray(data.trim());
     }
     return valueArr;
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowTestHelper.java
@@ -20,7 +20,6 @@ package org.apache.arrow.adapter.jdbc;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowCharSetTest.java
@@ -53,9 +53,6 @@ import org.junit.runners.Parameterized.Parameters;
  */
 @RunWith(Parameterized.class)
 public class JdbcToArrowCharSetTest extends AbstractJdbcToArrowTest {
-  private static final String VARCHAR = "VARCHAR_FIELD13";
-  private static final String CHAR = "CHAR_FIELD16";
-  private static final String CLOB = "CLOB_FIELD15";
 
   private static final String[] testFiles = {
     "h2/test1_charset_h2.yml",

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowNullTest.java
@@ -17,7 +17,29 @@
 
 package org.apache.arrow.adapter.jdbc.h2;
 
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertBigIntVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertBitVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertBooleanVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertDateVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertDecimalVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertFloat4VectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertFloat8VectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertIntVectorValues;
 import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertNullValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertSmallIntVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertTimeStampVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertTimeVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertTinyIntVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertVarBinaryVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.assertVarcharVectorValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getBinaryValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getBooleanValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getCharArray;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getDecimalValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getDoubleValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getFloatValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getIntValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getLongValues;
 
 import java.io.IOException;
 import java.sql.ResultSetMetaData;
@@ -62,11 +84,13 @@ import org.junit.runners.Parameterized.Parameters;
 public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
 
   private static final String NULL = "null";
+  private static final String SELECTED_NULL_ROW = "selected_null_row";
   private static final String SELECTED_NULL_COLUMN = "selected_null_column";
 
   private static final String[] testFiles = {
     "h2/test1_all_datatypes_null_h2.yml",
-    "h2/test1_selected_datatypes_null_h2.yml"
+    "h2/test1_selected_datatypes_null_h2.yml",
+    "h2/test1_all_datatypes_selected_null_rows_h2.yml"
   };
 
   /**
@@ -137,10 +161,68 @@ public class JdbcToArrowNullTest extends AbstractJdbcToArrowTest {
       case SELECTED_NULL_COLUMN:
         sqlToArrowTestSelectedNullColumnsValues(table.getVectors(), root, table.getRowCount());
         break;
+      case SELECTED_NULL_ROW:
+        testAllVectorValues(root);
+        break;
       default:
         // do nothing
         break;
     }
+  }
+
+  private void testAllVectorValues(VectorSchemaRoot root) {
+    JdbcToArrowTestHelper.assertFieldMetadataIsEmpty(root);
+
+    assertBigIntVectorValues((BigIntVector) root.getVector(BIGINT), table.getRowCount(),
+        getLongValues(table.getValues(), BIGINT));
+
+    assertTinyIntVectorValues((TinyIntVector) root.getVector(TINYINT), table.getRowCount(),
+        getIntValues(table.getValues(), TINYINT));
+
+    assertSmallIntVectorValues((SmallIntVector) root.getVector(SMALLINT), table.getRowCount(),
+        getIntValues(table.getValues(), SMALLINT));
+
+    assertVarBinaryVectorValues((VarBinaryVector) root.getVector(BINARY), table.getRowCount(),
+        getBinaryValues(table.getValues(), BINARY));
+
+    assertVarBinaryVectorValues((VarBinaryVector) root.getVector(BLOB), table.getRowCount(),
+        getBinaryValues(table.getValues(), BLOB));
+
+    assertVarcharVectorValues((VarCharVector) root.getVector(CLOB), table.getRowCount(),
+        getCharArray(table.getValues(), CLOB));
+
+    assertVarcharVectorValues((VarCharVector) root.getVector(VARCHAR), table.getRowCount(),
+        getCharArray(table.getValues(), VARCHAR));
+
+    assertVarcharVectorValues((VarCharVector) root.getVector(CHAR), table.getRowCount(),
+        getCharArray(table.getValues(), CHAR));
+
+    assertIntVectorValues((IntVector) root.getVector(INT), table.getRowCount(),
+        getIntValues(table.getValues(), INT));
+
+    assertBitVectorValues((BitVector) root.getVector(BIT), table.getRowCount(),
+        getIntValues(table.getValues(), BIT));
+
+    assertBooleanVectorValues((BitVector) root.getVector(BOOL), table.getRowCount(),
+        getBooleanValues(table.getValues(), BOOL));
+
+    assertDateVectorValues((DateMilliVector) root.getVector(DATE), table.getRowCount(),
+        getLongValues(table.getValues(), DATE));
+
+    assertTimeVectorValues((TimeMilliVector) root.getVector(TIME), table.getRowCount(),
+        getLongValues(table.getValues(), TIME));
+
+    assertTimeStampVectorValues((TimeStampVector) root.getVector(TIMESTAMP), table.getRowCount(),
+        getLongValues(table.getValues(), TIMESTAMP));
+
+    assertDecimalVectorValues((DecimalVector) root.getVector(DECIMAL), table.getRowCount(),
+        getDecimalValues(table.getValues(), DECIMAL));
+
+    assertFloat8VectorValues((Float8Vector) root.getVector(DOUBLE), table.getRowCount(),
+        getDoubleValues(table.getValues(), DOUBLE));
+
+    assertFloat4VectorValues((Float4Vector) root.getVector(REAL), table.getRowCount(),
+        getFloatValues(table.getValues(), REAL));
   }
 
   /**

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -103,24 +103,6 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
-  protected static final String BIGINT = "BIGINT_FIELD5";
-  protected static final String BINARY = "BINARY_FIELD12";
-  protected static final String BIT = "BIT_FIELD17";
-  protected static final String BLOB = "BLOB_FIELD14";
-  protected static final String BOOL = "BOOL_FIELD2";
-  protected static final String CHAR = "CHAR_FIELD16";
-  protected static final String CLOB = "CLOB_FIELD15";
-  protected static final String DATE = "DATE_FIELD10";
-  protected static final String DECIMAL = "DECIMAL_FIELD6";
-  protected static final String DOUBLE = "DOUBLE_FIELD7";
-  protected static final String INT = "INT_FIELD1";
-  protected static final String REAL = "REAL_FIELD8";
-  protected static final String SMALLINT = "SMALLINT_FIELD4";
-  protected static final String TIME = "TIME_FIELD9";
-  protected static final String TIMESTAMP = "TIMESTAMP_FIELD11";
-  protected static final String TINYINT = "TINYINT_FIELD3";
-  protected static final String VARCHAR = "VARCHAR_FIELD13";
-
   private static final String[] testFiles = {"h2/test1_all_datatypes_h2.yml"};
 
   /**
@@ -236,7 +218,6 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
     assertFloat4VectorValues((Float4Vector) root.getVector(REAL), table.getRowCount(),
         getFloatValues(table.getValues(), REAL));
   }
-
 
   @Test
   public void runLargeNumberOfRows() throws IOException, SQLException {

--- a/java/adapter/jdbc/src/test/resources/h2/test1_all_datatypes_selected_null_rows_h2.yml
+++ b/java/adapter/jdbc/src/test/resources/h2/test1_all_datatypes_selected_null_rows_h2.yml
@@ -1,0 +1,83 @@
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor
+#license agreements. See the NOTICE file distributed with this work for additional
+#information regarding copyright ownership. The ASF licenses this file to
+#You under the Apache License, Version 2.0 (the "License"); you may not use
+#this file except in compliance with the License. You may obtain a copy of
+#the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+#by applicable law or agreed to in writing, software distributed under the
+#License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+#OF ANY KIND, either express or implied. See the License for the specific
+#language governing permissions and limitations under the License.
+
+name: 'table1'
+
+type: 'selected_null_row'
+
+vectors:
+ - 'INT_FIELD1'
+ - 'BOOL_FIELD2'
+ - 'TINYINT_FIELD3'
+ - 'SMALLINT_FIELD4'
+ - 'BIGINT_FIELD5'
+ - 'DECIMAL_FIELD6'
+ - 'DOUBLE_FIELD7'
+ - 'REAL_FIELD8'
+ - 'TIME_FIELD9'
+ - 'DATE_FIELD10'
+ - 'TIMESTAMP_FIELD11'
+ - 'BINARY_FIELD12'
+ - 'VARCHAR_FIELD13'
+ - 'BLOB_FIELD14'
+ - 'CLOB_FIELD15'
+ - 'CHAR_FIELD16'
+ - 'BIT_FIELD17'
+
+create: 'CREATE TABLE table1 (int_field1 INT, bool_field2 BOOLEAN, tinyint_field3 TINYINT, smallint_field4 SMALLINT, bigint_field5 BIGINT,
+    decimal_field6 DECIMAL(20,2), double_field7 DOUBLE, real_field8 REAL, time_field9 TIME, date_field10 DATE, timestamp_field11 TIMESTAMP,
+    binary_field12 BINARY(100), varchar_field13 VARCHAR(256), blob_field14 BLOB, clob_field15 CLOB, char_field16 CHAR(16), bit_field17 BIT);'
+
+data:
+  - 'INSERT INTO table1 VALUES (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);'
+
+  - 'INSERT INTO table1 VALUES (101, 1, 45, 12000, 92233720, 17345667789.23, 56478356785.345, 56478356785.345, PARSEDATETIME(''12:45:35 GMT'', ''HH:mm:ss z''),
+  PARSEDATETIME(''2018-02-12 GMT'', ''yyyy-MM-dd z''), PARSEDATETIME(''2018-02-12 12:45:35 GMT'', ''yyyy-MM-dd HH:mm:ss z''),
+  ''736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279'', ''some text that needs to be converted to varchar'',
+  ''736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279'', ''some text that needs to be converted to clob'', ''some char text'', 1);'
+
+  - 'INSERT INTO table1 VALUES (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);'
+
+  - 'INSERT INTO table1 VALUES (101, 1, 45, 12000, 92233720, 17345667789.23, 56478356785.345, 56478356785.345, PARSEDATETIME(''12:45:35 GMT'', ''HH:mm:ss z''),
+  PARSEDATETIME(''2018-02-12 GMT'', ''yyyy-MM-dd z''), PARSEDATETIME(''2018-02-12 12:45:35 GMT'', ''yyyy-MM-dd HH:mm:ss z''),
+  ''736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279'', ''some text that needs to be converted to varchar'',
+  ''736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279'', ''some text that needs to be converted to clob'', ''some char text'', 1);'
+
+  - 'INSERT INTO table1 VALUES (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);'
+
+query: 'select int_field1, bool_field2, tinyint_field3, smallint_field4, bigint_field5, decimal_field6, double_field7, real_field8,
+        time_field9, date_field10, timestamp_field11, binary_field12, varchar_field13, blob_field14, clob_field15, char_field16, bit_field17 from table1'
+
+drop: 'DROP table table1;'
+
+rowCount: '5'
+
+values:
+ - 'INT_FIELD1=null,101,null,101,null'
+ - 'BOOL_FIELD2=null,1,null,1,null'
+ - 'BIT_FIELD17=null,1,null,1,null'
+ - 'TINYINT_FIELD3=null,45,null,45,null'
+ - 'SMALLINT_FIELD4=null,12000,null,12000,null'
+ - 'BIGINT_FIELD5=null,92233720,null,92233720,null'
+ - 'REAL_FIELD8=null,56478356785.345f,null,56478356785.345f,null'
+ - 'DECIMAL_FIELD6=null,17345667789.23,null,17345667789.23,null'
+ - 'DOUBLE_FIELD7=null,56478356785.345,null,56478356785.345,null'
+ - 'TIME_FIELD9=null,45935000,null,45935000,null'
+ - 'DATE_FIELD10=null,1518393600000,null,1518393600000,null'
+ - 'TIMESTAMP_FIELD11=null,1518439535000,null,1518439535000,null'
+ - 'CHAR_FIELD16=null,some char text,null,some char text,null'
+ - 'VARCHAR_FIELD13=null,some text that needs to be converted to varchar,null,
+ 			some text that needs to be converted to varchar,null'
+ - 'BINARY_FIELD12=null,736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279,
+      		null,736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279,null'
+ - 'BLOB_FIELD14=null,736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279,
+       		null,736f6d6520746578742074686174206e6565647320746f20626520636f6e76657274656420746f2062696e617279,null'
+ - 'CLOB_FIELD15=null,some text that needs to be converted to clob,null,some text that needs to be converted to clob,null'


### PR DESCRIPTION
Related to [ARROW-6710](https://issues.apache.org/jira/browse/ARROW-6710).

The current JDBC adapter tests only cover the cases that values are all non-null or all null.
However, the cases that ResultSet has some null values are not covered (see ARROW-6709).
