### PR TITLE
ARROW-6722: [Java] Provide a uniform way to get vector name

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -690,4 +690,9 @@ public class UnionVector implements FieldVector {
     public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
       return visitor.visit(this, value);
     }
+
+    @Override
+    public String getName() {
+      return name;
+    }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -55,8 +55,6 @@ public abstract class BaseValueVector implements ValueVector {
     this.allocator = Preconditions.checkNotNull(allocator, "allocator cannot be null");
   }
 
-  public abstract String getName();
-
   @Override
   public String toString() {
     return super.toString() + "[name = " + getName() + ", ...]";

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -271,4 +271,10 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
    * @param <IN> the input data together with visitor.
    */
   <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value);
+
+  /**
+   * Gets the name of the vector.
+   * @return the name of the vector.
+   */
+  String getName();
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -265,4 +265,9 @@ public final class ZeroVector implements FieldVector {
   public void copyFromSafe(int fromIndex, int thisIndex, ValueVector from) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public String getName() {
+    return getField().getName();
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/AbstractContainerVector.java
@@ -132,4 +132,9 @@ public abstract class AbstractContainerVector implements ValueVector, DensityAwa
   public void copyFromSafe(int fromIndex, int thisIndex, ValueVector from) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public String getName() {
+    return name;
+  }
 }


### PR DESCRIPTION
Currently, the getName method is defined in BaseValueVector, as an abstract class. However, some vector does not extend the BaseValueVector, like StructVector, UnionVector, ZeroVector.

In this issue, we move the method to ValueVector interface, the base interface for all vectors.

This makes it easier to get a vector's name without checking its type.