### PR TITLE
ARROW-6723: [Java] Reduce the range of synchronized block when releasing an ArrowBuf

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -151,13 +151,13 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
   private int decrement(int decrement) {
     allocator.assertOpen();
     final int outcome;
-    synchronized (allocationManager) {
-      outcome = bufRefCnt.addAndGet(-decrement);
-      if (outcome == 0) {
-        lDestructionTime = System.nanoTime();
-        // refcount of this reference manager has dropped to 0
-        // inform the allocation manager that this reference manager
-        // no longer holds references to underlying memory
+    outcome = bufRefCnt.addAndGet(-decrement);
+    if (outcome == 0) {
+      lDestructionTime = System.nanoTime();
+      // refcount of this reference manager has dropped to 0
+      // inform the allocation manager that this reference manager
+      // no longer holds references to underlying memory
+      synchronized (allocationManager) {
         allocationManager.release(this);
       }
     }

--- a/java/performance/src/test/java/org/apache/arrow/memory/BufferLedgerBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/memory/BufferLedgerBenchmarks.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import io.netty.buffer.ArrowBuf;
+
+/**
+ * Benchmarks for {@link org.apache.arrow.memory.BufferLedger}.
+ */
+public class BufferLedgerBenchmarks {
+
+  public static final int BUFFER_SIZE = 1024;
+
+  public static final int NUM_BUFFERS_PER_TASK = 60;
+
+  public static final int NUM_CONCURRENT_TASKS = 40;
+
+  @State(Scope.Benchmark)
+  public static class MultiThreadingCloseState {
+
+    private ExecutorService threadPool;
+
+    private BaseAllocator allocator;
+
+    private CloseTask[] tasks = new CloseTask[NUM_CONCURRENT_TASKS];
+
+    private CompletableFuture<Boolean>[] futures = new CompletableFuture[NUM_CONCURRENT_TASKS];
+
+    @Setup(Level.Trial)
+    public void prepareState() throws Exception {
+      threadPool = Executors.newFixedThreadPool(NUM_CONCURRENT_TASKS);
+      allocator = new RootAllocator(Integer.MAX_VALUE);
+      for (int i = 0; i < NUM_CONCURRENT_TASKS; i++) {
+        tasks[i] = new CloseTask(allocator);
+      }
+    }
+
+    @Setup(Level.Invocation)
+    public void prepareInvoke() throws Exception {
+      for (int i = 0; i < NUM_CONCURRENT_TASKS; i++) {
+        tasks[i].allocate();
+        futures[i] = new CompletableFuture<>();
+      }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDownState() throws Exception {
+      allocator.close();
+      threadPool.shutdown();
+    }
+  }
+
+  public static class CloseTask {
+
+    private BufferAllocator allocator;
+
+    private ArrowBuf[] buffers = new ArrowBuf[NUM_BUFFERS_PER_TASK];
+
+    public CloseTask(BufferAllocator allocator) {
+      this.allocator = allocator;
+    }
+
+    public void allocate() {
+      for (int i = 0; i < NUM_BUFFERS_PER_TASK; i++) {
+        buffers[i] = allocator.buffer(BUFFER_SIZE);
+      }
+    }
+
+    public void deallocate() {
+      for (int i = 0; i < NUM_BUFFERS_PER_TASK; i++) {
+        buffers[i].close();
+      }
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void concurrentCloseBenchmark(MultiThreadingCloseState state) throws Exception {
+    for (int i = 0; i < NUM_CONCURRENT_TASKS; i++) {
+      int tid = i;
+      state.threadPool.submit(() -> {
+        state.tasks[tid].deallocate();
+        state.futures[tid].complete(true);
+      });
+    }
+    CompletableFuture.allOf(state.futures).get();
+  }
+
+  @Test
+  public void evaluate() throws RunnerException {
+    Options opt = new OptionsBuilder()
+            .include(BufferLedgerBenchmarks.class.getSimpleName())
+            .forks(1)
+            .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
When releasing an ArrowBuf, we will run the following piece of code:

private int decrement(int decrement) {
  allocator.assertOpen();
  final int outcome;
  synchronized (allocationManager) {
    outcome = bufRefCnt.addAndGet(-decrement);
      if (outcome == 0) { 
        lDestructionTime = System.nanoTime(); allocationManager.release(this);
      }

  }
  return outcome;
}

It can be seen that we need to acquire the lock for allocation manager lock, no matter if we need to release the buffer. In addition, the operation of decrementing refcount is only carried out after the lock is acquired. This leads to unnecessary lock contention, and may degrade performance.

We propose to change the code like this:

private int decrement(int decrement) {
  allocator.assertOpen();
  final int outcome;
  outcome = bufRefCnt.addAndGet(-decrement);
  if (outcome == 0) {
    lDestructionTime = System.nanoTime();
    synchronized (allocationManager) {
     allocationManager.release(this);
    }
  }
  return outcome;
}

Note that this change can be dangerous, as it lies in the core of our code base, so we should be careful with it. On the other hand, it may have non-trivial performance implication. For example, when a distributed task is getting closed, a large number of ArrowBuf will be closed simultaneously. If we reduce the range of the synchronization block, we can significantly improve the performance.