### PR TITLE
ARROW-6725: [CI] Disable 3rdparty fuzzit nightly builds

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -80,7 +80,6 @@ groups:
     - docker-cpp-alpine
     - docker-cpp-cmake32
     - docker-cpp-release
-    - docker-cpp-fuzzit
     - docker-cpp-static-only
     - docker-c_glib
     - docker-go
@@ -174,7 +173,6 @@ groups:
     - docker-cpp
     - docker-cpp-cmake32
     - docker-cpp-release
-    - docker-cpp-fuzzit
     - docker-cpp-static-only
     - docker-c_glib
     - docker-go


### PR DESCRIPTION
@yevgenypats I've created a follow-up issue where we can discuss how should we reliably execute the fuzzit job https://issues.apache.org/jira/browse/ARROW-6726