### PR TITLE
ARROW-6614: [C++][Dataset] Add DataSourceDiscovery class

### DIFF
--- a/cpp/src/arrow/dataset/CMakeLists.txt
+++ b/cpp/src/arrow/dataset/CMakeLists.txt
@@ -23,7 +23,12 @@ arrow_install_all_headers("arrow/dataset")
 # pkg-config support
 arrow_add_pkg_config("arrow-dataset")
 
-set(ARROW_DATASET_SRCS dataset.cc file_base.cc filter.cc scanner.cc)
+set(ARROW_DATASET_SRCS
+    dataset.cc
+    discovery.cc
+    file_base.cc
+    filter.cc
+    scanner.cc)
 set(ARROW_DATASET_LINK_STATIC arrow_static)
 set(ARROW_DATASET_LINK_SHARED arrow_shared)
 
@@ -91,6 +96,7 @@ endfunction()
 
 if(NOT WIN32)
   add_arrow_dataset_test(dataset_test)
+  add_arrow_dataset_test(discovery_test)
   add_arrow_dataset_test(file_test)
   add_arrow_dataset_test(filter_test)
   add_arrow_dataset_test(scanner_test)

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -148,14 +148,5 @@ class ARROW_DS_EXPORT Dataset : public std::enable_shared_from_this<Dataset> {
   std::vector<std::shared_ptr<DataSource>> sources_;
 };
 
-/// \brief Conditions to apply to a dataset when reading to include or
-/// exclude fragments, filter out rows, etc.
-struct DataSelector {
-  std::vector<std::shared_ptr<Filter>> filters;
-
-  // TODO(wesm): Select specific partition keys, file path globs, or
-  // other common desirable selections
-};
-
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -54,9 +54,10 @@ Status FileSystemDataSourceDiscovery::Make(fs::FileSystem* filesystem,
   return Make(filesystem, files, format, out);
 }
 
-static Status InspectSchema(fs::FileSystem* fs, const std::vector<fs::FileStats> stats,
-                            const std::shared_ptr<FileFormat>& format,
-                            std::shared_ptr<Schema>* out) {
+static inline Status InspectSchema(fs::FileSystem* fs,
+                                   const std::vector<fs::FileStats> stats,
+                                   const std::shared_ptr<FileFormat>& format,
+                                   std::shared_ptr<Schema>* out) {
   std::vector<std::shared_ptr<Schema>> schemas;
 
   for (const auto& f : stats) {
@@ -82,8 +83,8 @@ Status FileSystemDataSourceDiscovery::Inspect(std::shared_ptr<Schema>* out) {
 Status FileSystemDataSourceDiscovery::Build(const BuildOptions& options,
                                             std::shared_ptr<Expression> source_partition,
                                             std::shared_ptr<DataSource>* out) {
-  return FileSystemBasedDataSource::Make(fs_, files_, std::move(source_partition), {},
-                                         format_, out);
+  return FileSystemBasedDataSource::Make(fs_, files_, std::move(source_partition),
+                                         PathPartitions{}, format_, out);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/discovery.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/dataset/dataset.h"
+#include "arrow/dataset/file_base.h"
+#include "arrow/dataset/type_fwd.h"
+#include "arrow/filesystem/path_tree.h"
+#include "arrow/status.h"
+
+namespace arrow {
+namespace dataset {
+
+FileSystemDataSourceDiscovery::FileSystemDataSourceDiscovery(
+    fs::FileSystem* filesystem, std::vector<fs::FileStats> files,
+    std::shared_ptr<FileFormat> format)
+    : fs_(filesystem), files_(std::move(files)), format_(std::move(format)) {}
+
+Status FileSystemDataSourceDiscovery::Make(fs::FileSystem* filesystem,
+                                           std::vector<fs::FileStats> files,
+                                           std::shared_ptr<FileFormat> format,
+                                           std::shared_ptr<DataSourceDiscovery>* out) {
+  out->reset(new FileSystemDataSourceDiscovery(filesystem, files, format));
+  return Status::OK();
+}
+
+Status FileSystemDataSourceDiscovery::Make(fs::FileSystem* filesystem,
+                                           fs::Selector selector,
+                                           std::shared_ptr<FileFormat> format,
+                                           std::shared_ptr<DataSourceDiscovery>* out) {
+  std::vector<fs::FileStats> files;
+  RETURN_NOT_OK(filesystem->GetTargetStats(selector, &files));
+  return Make(filesystem, files, format, out);
+}
+
+static Status InspectSchema(fs::FileSystem* fs, const std::vector<fs::FileStats> stats,
+                            const std::shared_ptr<FileFormat>& format,
+                            std::shared_ptr<Schema>* out) {
+  std::vector<std::shared_ptr<Schema>> schemas;
+
+  for (const auto& f : stats) {
+    if (!f.IsFile()) continue;
+
+    std::shared_ptr<Schema> schema;
+    RETURN_NOT_OK(format->Inspect(FileSource(f.path(), fs), &schema));
+    schemas.push_back(schema);
+  }
+
+  if (schemas.size() > 0) {
+    // TODO merge schemas.
+    *out = schemas[0];
+  }
+
+  return Status::OK();
+}
+
+Status FileSystemDataSourceDiscovery::Inspect(std::shared_ptr<Schema>* out) {
+  return InspectSchema(fs_, files_, format_, out);
+}
+
+Status FileSystemDataSourceDiscovery::Build(const BuildOptions& options,
+                                            std::shared_ptr<Expression> source_partition,
+                                            std::shared_ptr<DataSource>* out) {
+  return FileSystemBasedDataSource::Make(fs_, files_, std::move(source_partition), {},
+                                         format_, out);
+}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -35,10 +35,10 @@ namespace arrow {
 namespace dataset {
 
 struct ARROW_DS_EXPORT BuildOptions {
-  // Schema to conform to.
+  /// Schema to conform to.
   std::shared_ptr<Schema> schema = NULLPTR;
-  // The partition scheme indicate how to discover partitions for the data
-  // source and fragments.
+  /// The partition scheme indicate how to discover partitions for the data
+  /// source and fragments.
   std::shared_ptr<PartitionScheme> partition_scheme = NULLPTR;
 };
 

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -23,23 +23,80 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
+#include "arrow/filesystem/filesystem.h"
+#include "arrow/filesystem/path_tree.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {
 namespace dataset {
 
-struct ARROW_DS_EXPORT DiscoveryOptions {
-  std::shared_ptr<FileFormat> format = NULLPTR;
+struct ARROW_DS_EXPORT BuildOptions {
+  // Schema to conform to.
+  std::shared_ptr<Schema> schema = NULLPTR;
+  // The partition scheme indicate how to discover partitions for the data
+  // source and fragments.
   std::shared_ptr<PartitionScheme> partition_scheme = NULLPTR;
 };
 
-/// \brief Using a root directory
-ARROW_DS_EXPORT
-Status DiscoverSource(const std::string& path, fs::FileSystem* filesystem,
-                      const DiscoveryOptions& options, std::shared_ptr<DataSource>* out);
+/// \brief DataSourceDiscovery provides a way to inspect a DataSource potential
+/// schema before materializing it. Thus, the user can peek the schema for
+/// data sources and decide on a unified schema. The pseudocode would look like
+///
+/// def get_dataset(factories):
+///   schemas = []
+///   for f in factories:
+///     schemas.append(f.Inspect())
+///
+///   common_schema = UnifySchemas(schemas)
+///
+///   sources = []
+///   for f in factories:
+///     sources.append(f.Discover({schema: common_schema}))
+///
+///   return Dataset(sources, common_schema)
+class ARROW_DS_EXPORT DataSourceDiscovery {
+ public:
+  /// \brief Get the schema for the resulting DataSource.
+  virtual Status Inspect(std::shared_ptr<Schema>* out) = 0;
+
+  /// \brief Create a DataSource with a given partition.
+  virtual Status Build(const BuildOptions& options,
+                       std::shared_ptr<Expression> source_partition,
+                       std::shared_ptr<DataSource>* out) = 0;
+
+  virtual ~DataSourceDiscovery() = default;
+};
+
+/// \brief FileSystemDataSourceFactory creates a DataSource from a vector
+/// of fs::FileStats or a fs::Selector.
+class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery {
+ public:
+  static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> files,
+                     std::shared_ptr<FileFormat> format,
+                     std::shared_ptr<DataSourceDiscovery>* out);
+
+  static Status Make(fs::FileSystem* filesystem, fs::Selector selector,
+                     std::shared_ptr<FileFormat> format,
+                     std::shared_ptr<DataSourceDiscovery>* out);
+
+  Status Inspect(std::shared_ptr<Schema>* out) override;
+
+  Status Build(const BuildOptions& options, std::shared_ptr<Expression> source_partition,
+               std::shared_ptr<DataSource>* out) override;
+
+ protected:
+  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem,
+                                std::vector<fs::FileStats> files,
+                                std::shared_ptr<FileFormat> format);
+
+  fs::FileSystem* fs_;
+  std::vector<fs::FileStats> files_;
+  std::shared_ptr<FileFormat> format_;
+};
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/dataset/discovery.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "arrow/dataset/test_util.h"
+#include "arrow/filesystem/test_util.h"
+
+namespace arrow {
+namespace dataset {
+
+class FileSystemDataSourceDiscoveryTest : public TestFileSystemBasedDataSource {
+ public:
+  void MakeDiscovery(const std::vector<fs::FileStats>& files) {
+    MakeFileSystem(files);
+    ASSERT_OK(
+        FileSystemDataSourceDiscovery::Make(fs_.get(), files, format_, &discovery_));
+  }
+
+  void MakeDiscovery(const std::vector<fs::FileStats>& files, fs::Selector selector) {
+    MakeFileSystem(files);
+    ASSERT_OK(
+        FileSystemDataSourceDiscovery::Make(fs_.get(), selector, format_, &discovery_));
+  }
+
+ protected:
+  std::shared_ptr<DataSourceDiscovery> discovery_;
+  std::shared_ptr<FileFormat> format_ = std::make_shared<DummyFileFormat>();
+};
+
+TEST_F(FileSystemDataSourceDiscoveryTest, Basic) {
+  MakeDiscovery({fs::File("a"), fs::File("b")});
+
+  BuildOptions options;
+  ASSERT_OK(discovery_->Build(options, nullptr, &source_));
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+}
+
+TEST_F(FileSystemDataSourceDiscoveryTest, Selector) {
+  // This test ensure that the Selector is enforced.
+  fs::Selector selector;
+  selector.base_dir = "A";
+  MakeDiscovery({fs::File("0"), fs::File("A/a")}, selector);
+
+  BuildOptions options;
+  ASSERT_OK(discovery_->Build(options, nullptr, &source_));
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"A/a"});
+}
+
+TEST_F(FileSystemDataSourceDiscoveryTest, Inspect) {
+  auto s = schema({field("f64", float64())});
+  format_ = std::make_shared<DummyFileFormat>(s);
+
+  MakeDiscovery({});
+  std::shared_ptr<Schema> actual;
+
+  // No files
+  ASSERT_OK(discovery_->Inspect(&actual));
+  EXPECT_EQ(actual, nullptr);
+
+  MakeDiscovery({fs::File("test")});
+  ASSERT_OK(discovery_->Inspect(&actual));
+  EXPECT_EQ(actual, s);
+}
+
+}  // namespace dataset
+}  // namespace arrow

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -48,79 +48,89 @@ Status FileBasedDataFragment::Scan(std::shared_ptr<ScanContext> scan_context,
 }
 
 FileSystemBasedDataSource::FileSystemBasedDataSource(
-    fs::FileSystem* filesystem, const fs::Selector& selector,
-    std::shared_ptr<FileFormat> format, std::shared_ptr<Expression> partition_expression,
-    std::vector<fs::FileStats> stats)
-    : DataSource(std::move(partition_expression)),
+    fs::FileSystem* filesystem, fs::PathForest forest,
+    std::shared_ptr<Expression> source_partition, PathPartitions partitions,
+    std::shared_ptr<FileFormat> format)
+    : DataSource(std::move(source_partition)),
       filesystem_(filesystem),
-      selector_(std::move(selector)),
-      format_(std::move(format)),
-      stats_(std::move(stats)) {}
+      forest_(std::move(forest)),
+      partitions_(std::move(partitions)),
+      format_(std::move(format)) {}
 
 Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
-                                       const fs::Selector& selector,
+                                       std::vector<fs::FileStats> stats,
+                                       std::shared_ptr<Expression> source_partition,
+                                       PathPartitions partitions,
                                        std::shared_ptr<FileFormat> format,
-                                       std::shared_ptr<Expression> partition_expression,
-                                       std::unique_ptr<FileSystemBasedDataSource>* out) {
-  std::vector<fs::FileStats> stats;
-  RETURN_NOT_OK(filesystem->GetTargetStats(selector, &stats));
-
-  auto new_end =
-      std::remove_if(stats.begin(), stats.end(), [&](const fs::FileStats& stats) {
-        return stats.type() != fs::FileType::File ||
-               !format->IsKnownExtension(stats.extension());
-      });
-  stats.resize(new_end - stats.begin());
-
-  out->reset(new FileSystemBasedDataSource(filesystem, selector, std::move(format),
-                                           std::move(partition_expression),
-                                           std::move(stats)));
+                                       std::unique_ptr<DataSource>* out) {
+  fs::PathForest forest;
+  RETURN_NOT_OK(fs::PathTree::Make(stats, &forest));
+  out->reset(new FileSystemBasedDataSource(filesystem, std::move(forest),
+                                           std::move(source_partition),
+                                           std::move(partitions), std::move(format)));
   return Status::OK();
 }
 
-Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
-                                       const fs::Selector& selector,
-                                       std::shared_ptr<FileFormat> format,
-                                       std::unique_ptr<FileSystemBasedDataSource>* out) {
-  return Make(filesystem, selector, std::move(format), nullptr, out);
-}
-
 DataFragmentIterator FileSystemBasedDataSource::GetFragmentsImpl(
-    std::shared_ptr<ScanOptions> scan_options) {
-  std::shared_ptr<ScanOptions> simplified_scan_options;
-  if (!AssumePartitionExpression(scan_options, &simplified_scan_options)) {
-    return MakeEmptyIterator<std::shared_ptr<DataFragment>>();
-  }
+    std::shared_ptr<ScanOptions> options) {
+  std::vector<std::unique_ptr<fs::FileStats>> files;
 
-  struct Impl : DataFragmentIterator {
-    Impl(fs::FileSystem* filesystem, std::shared_ptr<FileFormat> format,
-         std::shared_ptr<ScanOptions> scan_options, std::vector<fs::FileStats> stats)
-        : filesystem_(filesystem),
-          format_(std::move(format)),
-          scan_options_(std::move(scan_options)),
-          stats_(std::move(stats)) {}
-
-    Status Next(std::shared_ptr<DataFragment>* out) {
-      if (i_ == stats_.size()) {
-        *out = nullptr;
-        return Status::OK();
-      }
-      FileSource src(stats_[i_++].path(), filesystem_);
-
-      std::unique_ptr<DataFragment> fragment;
-      RETURN_NOT_OK(format_->MakeFragment(src, scan_options_, &fragment));
-      *out = std::move(fragment);
-      return Status::OK();
+  auto visitor = [&files](const fs::FileStats& stats) {
+    if (stats.IsFile()) {
+      files.emplace_back(new fs::FileStats(stats));
     }
-
-    size_t i_ = 0;
-    fs::FileSystem* filesystem_;
-    std::shared_ptr<FileFormat> format_;
-    std::shared_ptr<ScanOptions> scan_options_;
-    std::vector<fs::FileStats> stats_;
+    return Status::OK();
+  };
+  // The matcher ensures that directories (and their descendants) are not
+  // visited.
+  auto matcher = [this, options](const fs::FileStats& stats, bool* match) {
+    *match = this->PartitionMatches(stats, options->filter);
+    return Status::OK();
   };
 
-  return DataFragmentIterator(Impl(filesystem_, format_, scan_options, stats_));
+  for (auto tree : forest_) {
+    DCHECK_OK(tree->Visit(visitor, matcher));
+  }
+
+  auto file_it = MakeVectorIterator(std::move(files));
+  auto file_to_fragment = [options, this](std::unique_ptr<fs::FileStats> stats,
+                                          std::shared_ptr<DataFragment>* out) {
+    std::unique_ptr<DataFragment> fragment;
+    FileSource src(stats->path(), filesystem_);
+
+    RETURN_NOT_OK(format_->MakeFragment(src, options, &fragment));
+    *out = std::move(fragment);
+    return Status::OK();
+  };
+
+  return MakeMaybeMapIterator(file_to_fragment, std::move(file_it));
+}
+
+bool FileSystemBasedDataSource::PartitionMatches(const fs::FileStats& stats,
+                                                 std::shared_ptr<Expression> filter) {
+  if (filter == nullptr) {
+    return true;
+  }
+
+  auto found = partitions_.find(stats.path());
+  if (found == partitions_.end()) {
+    // No partition attached to current node (directory or file), continue.
+    return true;
+  }
+
+  auto c = found->second->Assume(*filter);
+  if (!c.ok()) {
+    // Could not simplify expression move on!
+    return true;
+  }
+
+  auto expr = std::move(c).ValueOrDie();
+  if (expr->IsNull() || expr->IsTrivialFalseCondition()) {
+    // selector is not satisfiable; don't recurse in this branch.
+    return false;
+  }
+
+  return true;
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -62,7 +62,7 @@ Status FileSystemBasedDataSource::Make(fs::FileSystem* filesystem,
                                        std::shared_ptr<Expression> source_partition,
                                        PathPartitions partitions,
                                        std::shared_ptr<FileFormat> format,
-                                       std::unique_ptr<DataSource>* out) {
+                                       std::shared_ptr<DataSource>* out) {
   fs::PathForest forest;
   RETURN_NOT_OK(fs::PathTree::Make(stats, &forest));
   out->reset(new FileSystemBasedDataSource(filesystem, std::move(forest),

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -124,6 +124,7 @@ bool FileSystemBasedDataSource::PartitionMatches(const fs::FileStats& stats,
     return true;
   }
 
+  // TODO: pass simplified expressions to children
   auto expr = std::move(c).ValueOrDie();
   if (expr->IsNull() || expr->IsTrivialFalseCondition()) {
     // selector is not satisfiable; don't recurse in this branch.

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -29,11 +30,15 @@
 #include "arrow/dataset/visibility.h"
 #include "arrow/dataset/writer.h"
 #include "arrow/filesystem/filesystem.h"
+#include "arrow/filesystem/path_tree.h"
 #include "arrow/io/file.h"
 #include "arrow/util/compression.h"
 
 namespace arrow {
+
 namespace dataset {
+
+class Filter;
 
 /// \brief The path and filesystem where an actual file is located or a buffer which can
 /// be read like a file
@@ -161,36 +166,46 @@ class ARROW_DS_EXPORT FileBasedDataFragment : public DataFragment {
   std::shared_ptr<ScanOptions> scan_options_;
 };
 
-/// \brief A DataSource which takes files of one format from a directory
-///
-/// The directory is crawled upon construction (Make) and not updated afterward.
-/// GetFragments() will not include files added after this DataDource is constructed and
-/// will error if files are deleted/moved.
+/// \brief Mapping from path to partition expressions.
+using PathPartitions = std::unordered_map<std::string, std::shared_ptr<Expression>>;
+
+/// \brief A DataSource of FileBasedDataFragments.
 class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
  public:
-  static Status Make(fs::FileSystem* filesystem, const fs::Selector& selector,
-                     std::shared_ptr<FileFormat> format,
-                     std::unique_ptr<FileSystemBasedDataSource>* out);
+  /// \brief Create a FileSystemBasedDataSource with optional partitions.
+  ///
+  /// \param[in] filesystem the filesystem which files are from.
+  /// \param[in] stats a list of files/directories to consume.
+  /// \param[in] source_partition the top-level partition of the DataSource
+  /// \param[in] partitions optional partitions attached to FileStats found in
+  ///            `stats`.
+  /// \param[in] format file format to create fragments from.
+  /// \param[out] out pointer storing the resulting DataSource.
+  ///
+  /// The caller is not required to provide a complete coverage of nodes and
+  /// partitions.
+  static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> stats,
+                     std::shared_ptr<Expression> source_partition,
+                     PathPartitions partitions, std::shared_ptr<FileFormat> format,
+                     std::unique_ptr<DataSource>* out);
 
-  static Status Make(fs::FileSystem* filesystem, const fs::Selector& selector,
-                     std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<Expression> partition_expression,
-                     std::unique_ptr<FileSystemBasedDataSource>* out);
-
-  std::string type() const override { return "directory"; }
+  std::string type() const override { return "filesystem_data_source"; }
 
  protected:
   DataFragmentIterator GetFragmentsImpl(std::shared_ptr<ScanOptions> options) override;
 
-  FileSystemBasedDataSource(fs::FileSystem* filesystem, const fs::Selector& selector,
-                            std::shared_ptr<FileFormat> format,
-                            std::shared_ptr<Expression> partition_expression,
-                            std::vector<fs::FileStats> stats);
+  FileSystemBasedDataSource(fs::FileSystem* filesystem, fs::PathForest forest,
+                            std::shared_ptr<Expression> source_partition,
+                            PathPartitions partitions,
+                            std::shared_ptr<FileFormat> format);
+
+  bool PartitionMatches(const fs::FileStats& stats, std::shared_ptr<Expression> filter);
 
   fs::FileSystem* filesystem_ = NULLPTR;
-  fs::Selector selector_;
+  fs::PathForest forest_;
+  PathPartitions partitions_;
+
   std::shared_ptr<FileFormat> format_;
-  std::vector<fs::FileStats> stats_;
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -132,6 +132,10 @@ class ARROW_DS_EXPORT FileFormat {
   /// \brief Return true if the given file extension
   virtual bool IsKnownExtension(const std::string& ext) const = 0;
 
+  /// \brief Return the schema of the file if possible.
+  virtual Status Inspect(const FileSource& source,
+                         std::shared_ptr<Schema>* out) const = 0;
+
   /// \brief Open a file for scanning
   virtual Status ScanFile(const FileSource& source,
                           std::shared_ptr<ScanOptions> scan_options,
@@ -187,7 +191,7 @@ class ARROW_DS_EXPORT FileSystemBasedDataSource : public DataSource {
   static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> stats,
                      std::shared_ptr<Expression> source_partition,
                      PathPartitions partitions, std::shared_ptr<FileFormat> format,
-                     std::unique_ptr<DataSource>* out);
+                     std::shared_ptr<DataSource>* out);
 
   std::string type() const override { return "filesystem_data_source"; }
 

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -24,6 +24,10 @@
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/dataset/visibility.h"
 
+namespace parquet {
+class ParquetFileReader;
+}  // namespace parquet
+
 namespace arrow {
 namespace dataset {
 
@@ -47,6 +51,9 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
     return ext == "par" || ext == "parq" || ext == name();
   }
 
+  /// \brief Return the schema of the file if possible.
+  Status Inspect(const FileSource& source, std::shared_ptr<Schema>* out) const override;
+
   /// \brief Open a file for scanning
   Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
                   std::shared_ptr<ScanContext> scan_context,
@@ -54,6 +61,10 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
 
   Status MakeFragment(const FileSource& source, std::shared_ptr<ScanOptions> opts,
                       std::unique_ptr<DataFragment>* out) override;
+
+ private:
+  Status OpenReader(const FileSource& source, MemoryPool* pool,
+                    std::unique_ptr<::parquet::ParquetFileReader>* out) const;
 };
 
 class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -138,9 +138,11 @@ class ParquetBufferFixtureMixin : public ArrowParquetWriterMixin {
                                                              builder->UnsafeAppend(0.0);
                                                            }));
 
-    auto schema_ = schema({field("f64", f64->type())});
     return RecordBatch::Make(schema_, kBatchSize, {f64});
   }
+
+ protected:
+  std::shared_ptr<Schema> schema_ = schema({field("f64", float64())});
 };
 
 class TestParquetFileFormat : public ParquetBufferFixtureMixin {
@@ -170,6 +172,16 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   }));
 
   ASSERT_EQ(row_count, kNumRows);
+}
+
+TEST_F(TestParquetFileFormat, Inspect) {
+  auto reader = GetRecordBatchReader();
+  auto source = GetFileSource(reader.get());
+  auto format = ParquetFileFormat();
+
+  std::shared_ptr<Schema> actual;
+  ASSERT_OK(format.Inspect(*source.get(), &actual));
+  EXPECT_EQ(actual, schema_);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -172,22 +172,5 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   ASSERT_EQ(row_count, kNumRows);
 }
 
-class TestParquetFileSystemBasedDataSource
-    : public FileSystemBasedDataSourceMixin<ParquetFileFormat> {
-  std::vector<std::string> file_names() const override {
-    return {"a/b/c.parquet", "a/b/c/d.parquet", "a/b.parquet", "a.parquet"};
-  }
-};
-
-TEST_F(TestParquetFileSystemBasedDataSource, NonRecursive) { this->NonRecursive(); }
-
-TEST_F(TestParquetFileSystemBasedDataSource, Recursive) { this->Recursive(); }
-
-TEST_F(TestParquetFileSystemBasedDataSource, DeletedFile) { this->DeletedFile(); }
-
-TEST_F(TestParquetFileSystemBasedDataSource, PredicatePushDown) {
-  this->PredicatePushDown();
-}
-
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -42,6 +42,8 @@ using parquet::CreateOutputStream;
 using parquet::arrow::FileWriter;
 using parquet::arrow::WriteTable;
 
+using testing::Pointee;
+
 Status WriteRecordBatch(const RecordBatch& batch, FileWriter* writer) {
   auto schema = batch.schema();
   auto size = batch.num_rows();
@@ -181,7 +183,7 @@ TEST_F(TestParquetFileFormat, Inspect) {
 
   std::shared_ptr<Schema> actual;
   ASSERT_OK(format.Inspect(*source.get(), &actual));
-  EXPECT_EQ(actual, schema_);
+  EXPECT_EQ(*actual, *schema_);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -94,7 +94,7 @@ class TestFileSystemBasedDataSource : public ::testing::Test {
 
  protected:
   std::shared_ptr<fs::FileSystem> fs_;
-  std::unique_ptr<DataSource> source_;
+  std::shared_ptr<DataSource> source_;
   std::shared_ptr<ScanOptions> options_;
 };
 

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -15,23 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -42,8 +25,9 @@
 
 #include "arrow/dataset/api.h"
 #include "arrow/dataset/test_util.h"
-#include "arrow/filesystem/localfs.h"
+#include "arrow/filesystem/mockfs.h"
 #include "arrow/filesystem/path_util.h"
+#include "arrow/filesystem/test_util.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/io_util.h"
@@ -94,21 +78,125 @@ TEST(FileSource, BufferBased) {
   ASSERT_EQ(Compression::LZ4, source2.compression());
 }
 
-class TestDummyFileSystemBasedDataSource
-    : public FileSystemBasedDataSourceMixin<DummyFileFormat> {
-  std::vector<std::string> file_names() const override {
-    return {"a/b/c.dummy", "a/b/c/d.dummy", "a/b.dummy", "a.dummy"};
+class TestFileSystemBasedDataSource : public ::testing::Test {
+ public:
+  void SetUp() { options_ = std::make_shared<ScanOptions>(); }
+
+  void MakeSource(std::vector<fs::FileStats> stats,
+                  std::shared_ptr<Expression> source_partition = nullptr,
+                  PathPartitions partitions = {}) {
+    ASSERT_OK(fs::internal::MockFileSystem::Make(fs::kNoTime, stats, &fs_));
+
+    auto format = std::make_shared<DummyFileFormat>();
+    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), stats, source_partition,
+                                              partitions, format, &source_));
   }
+
+ protected:
+  std::shared_ptr<fs::FileSystem> fs_;
+  std::unique_ptr<DataSource> source_;
+  std::shared_ptr<ScanOptions> options_;
 };
 
-TEST_F(TestDummyFileSystemBasedDataSource, NonRecursive) { this->NonRecursive(); }
+void AssertFragmentsAreFromPath(DataFragmentIterator it,
+                                std::vector<std::string> expected) {
+  std::vector<std::string> actual;
 
-TEST_F(TestDummyFileSystemBasedDataSource, Recursive) { this->Recursive(); }
+  auto v = [&actual](std::shared_ptr<DataFragment> fragment) -> Status {
+    EXPECT_NE(fragment, nullptr);
+    auto dummy = std::static_pointer_cast<DummyFragment>(fragment);
+    actual.push_back(dummy->source().path());
+    return Status::OK();
+  };
 
-TEST_F(TestDummyFileSystemBasedDataSource, DeletedFile) { this->DeletedFile(); }
+  ASSERT_OK(it.Visit(v));
+  // Ordering is not guaranteed.
+  EXPECT_THAT(actual, testing::UnorderedElementsAreArray(expected));
+}
 
-TEST_F(TestDummyFileSystemBasedDataSource, PredicatePushDown) {
-  this->PredicatePushDown();
+TEST_F(TestFileSystemBasedDataSource, Basic) {
+  MakeSource({});
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {});
+
+  MakeSource({fs::File("a"), fs::File("b"), fs::File("c")});
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b", "c"});
+
+  // Should not create fragment from directories.
+  MakeSource({fs::Dir("A"), fs::Dir("A/B"), fs::File("A/a"), fs::File("A/B/b")});
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"A/a", "A/B/b"});
+}
+
+TEST_F(TestFileSystemBasedDataSource, RootPartitionPruning) {
+  auto source_partition = ("a"_ == 5).Copy();
+  MakeSource({fs::File("a"), fs::File("b")}, source_partition);
+
+  // No filter should always return all data.
+  options_->filter = nullptr;
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+
+  // filter == partition
+  options_->filter = source_partition;
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+
+  // Same partition key, but non matching filter
+  options_->filter = ("a"_ == 6).Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {});
+
+  options_->filter = ("a"_ > 1).Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+
+  // different key shouldn't prune
+  options_->filter = ("b"_ == 6).Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+
+  // No partition should match
+  MakeSource({fs::File("a"), fs::File("b")});
+  options_->filter = ("b"_ == 6).Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+}
+
+TEST_F(TestFileSystemBasedDataSource, TreePartitionPruning) {
+  auto source_partition = ("country"_ == "US").Copy();
+  std::vector<fs::FileStats> regions = {
+      fs::Dir("NY"), fs::File("NY/New York"),      fs::File("NY/Franklin"),
+      fs::Dir("CA"), fs::File("CA/San Francisco"), fs::File("CA/Franklin"),
+  };
+  // Explicitly _don't_ set the state partition in the leaves to test if
+  // sub-tree pruning works. This implies that `state` predicate won't apply to
+  // files.
+  PathPartitions partitions = {
+      {"CA", ("state"_ == "CA").Copy()},
+      {"CA/San Francisco", ("city"_ == "San Francisco").Copy()},
+      {"CA/Franklin", ("city"_ == "Franklin").Copy()},
+      {"NY", ("state"_ == "NY").Copy()},
+      {"NY/New York", ("city"_ == "New York").Copy()},
+      {"NY/Franklin", ("city"_ == "Franklin").Copy()},
+  };
+
+  MakeSource(regions, source_partition, partitions);
+
+  std::vector<std::string> all_cities = {"CA/San Francisco", "CA/Franklin", "NY/New York",
+                                         "NY/Franklin"};
+  std::vector<std::string> ca_cities = {"CA/San Francisco", "CA/Franklin"};
+  std::vector<std::string> franklins = {"CA/Franklin", "NY/Franklin"};
+
+  // No filter should always return all data.
+  options_->filter = nullptr;
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), all_cities);
+
+  // Data source partition is respected
+  options_->filter = ("country"_ == "US").Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), all_cities);
+  options_->filter = ("country"_ == "FR").Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), {});
+
+  options_->filter = ("state"_ == "CA").Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), ca_cities);
+
+  // Filter where no decisions can be made on inner nodes when filter don't
+  // apply to inner partitions.
+  options_->filter = ("city"_ == "Franklin").Copy();
+  AssertFragmentsAreFromPath(source_->GetFragments(options_), franklins);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -151,6 +151,9 @@ class ARROW_DS_EXPORT Expression {
   /// BooleanScalar. Its value may be retrieved at the same time.
   bool IsTrivialCondition(bool* value = NULLPTR) const;
 
+  bool IsTrivialTrueCondition() const;
+  bool IsTrivialFalseCondition() const;
+
   /// Copy this expression into a shared pointer.
   virtual std::shared_ptr<Expression> Copy() const = 0;
 

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -38,16 +38,16 @@ class ARROW_DS_EXPORT ScanOptions {
  public:
   ScanOptions() = default;
 
-  ScanOptions(std::shared_ptr<DataSelector> selector, std::shared_ptr<Schema> schema,
+  ScanOptions(std::shared_ptr<Expression> filter, std::shared_ptr<Schema> schema,
               std::vector<std::shared_ptr<FileScanOptions>> options = {})
-      : selector(std::move(selector)), schema(std::move(schema)) {}
+      : filter(std::move(filter)), schema(std::move(schema)) {}
 
   virtual ~ScanOptions() = default;
 
   MemoryPool* pool() const { return pool_; }
 
   // Filters
-  std::shared_ptr<DataSelector> selector;
+  std::shared_ptr<Expression> filter;
 
   // Schema to which record batches will be reconciled
   std::shared_ptr<Schema> schema;

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -186,6 +186,11 @@ class DummyFileFormat : public FileFormat {
   /// \brief Return true if the given file extension
   bool IsKnownExtension(const std::string& ext) const override { return ext == name(); }
 
+  Status Inspect(const FileSource& source, std::shared_ptr<Schema>* out) const override {
+    *out = nullptr;
+    return Status::OK();
+  }
+
   /// \brief Open a file for scanning (always returns an empty iterator)
   Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,
                   std::shared_ptr<ScanContext> scan_context,

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -155,7 +155,7 @@ class DatasetFixtureMixin : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<ScanOptions> options_ = nullptr;
+  std::shared_ptr<ScanOptions> options_ = std::make_shared<ScanOptions>();
   std::shared_ptr<ScanContext> ctx_;
 };
 
@@ -164,117 +164,12 @@ class FileSystemBasedDataSourceMixin : public FileSourceFixtureMixin {
  public:
   virtual std::vector<std::string> file_names() const = 0;
 
-  void SetUp() override {
-    selector_.base_dir = "/";
-    selector_.recursive = true;
-
-    format_ = std::make_shared<Format>();
-    schema_ = schema({field("dummy", null())});
-    options_ = std::make_shared<ScanOptions>();
-
-    ASSERT_OK(
-        TemporaryDir::Make("test-fsdatasource-" + format_->name() + "-", &temp_dir_));
-    local_fs_ = std::make_shared<fs::LocalFileSystem>();
-
-    auto path = temp_dir_->path().ToString();
-    fs_ = std::make_shared<fs::SubTreeFileSystem>(path, local_fs_);
-
-    for (auto path : file_names()) {
-      CreateFile(path, "");
-    }
-
-    partition_expression_ = ScalarExpression::Make(true);
-  }
-
-  void CreateFile(std::string path, std::string contents) {
-    auto parent = fs::internal::GetAbstractPathParent(path).first;
-    if (parent != "") {
-      ASSERT_OK(this->fs_->CreateDir(parent, true));
-    }
-    std::shared_ptr<io::OutputStream> file;
-    ASSERT_OK(this->fs_->OpenOutputStream(path, &file));
-    ASSERT_OK(file->Write(contents));
-  }
-
-  void MakeDataSource() {
-    ASSERT_OK(FileSystemBasedDataSource::Make(fs_.get(), selector_, format_,
-                                              partition_expression_, &source_));
-  }
-
- protected:
-  std::function<Status(std::shared_ptr<DataFragment> fragment)> OpenFragments(
-      size_t* count) {
-    return [this, count](std::shared_ptr<DataFragment> fragment) {
-      auto file_fragment =
-          internal::checked_pointer_cast<FileBasedDataFragment>(fragment);
-      ++*count;
-      auto extension =
-          fs::internal::GetAbstractPathExtension(file_fragment->source().path());
-      EXPECT_TRUE(format_->IsKnownExtension(extension));
-      std::shared_ptr<io::RandomAccessFile> f;
-      return this->fs_->OpenInputFile(file_fragment->source().path(), &f);
-    };
-  }
-
-  void NonRecursive() {
-    selector_.recursive = false;
-    MakeDataSource();
-
-    size_t count = 0;
-    ASSERT_OK(source_->GetFragments(options_).Visit(OpenFragments(&count)));
-    ASSERT_EQ(count, 1);
-  }
-
-  void Recursive() {
-    MakeDataSource();
-
-    size_t count = 0;
-    ASSERT_OK(source_->GetFragments(options_).Visit(OpenFragments(&count)));
-    ASSERT_EQ(count, file_names().size());
-  }
-
-  void DeletedFile() {
-    MakeDataSource();
-    ASSERT_GT(file_names().size(), 0);
-    ASSERT_OK(this->fs_->DeleteFile(file_names()[0]));
-
-    size_t count = 0;
-    ASSERT_RAISES(IOError, source_->GetFragments(options_).Visit(OpenFragments(&count)));
-  }
-
-  void PredicatePushDown() {
-    partition_expression_ = equal(field_ref("alpha"), ScalarExpression::Make<int16_t>(3));
-    MakeDataSource();
-
-    options_->selector = std::make_shared<DataSelector>();
-    options_->selector->filters.resize(1);
-
-    // with a filter identical to the partition condition, all fragments are yielded
-    options_->selector->filters[0] =
-        std::make_shared<ExpressionFilter>(partition_expression_->Copy());
-
-    size_t count = 0;
-    // ASSERT_OK(source_->GetFragments(context_)->Visit(OpenFragments(&count)));
-    // ASSERT_EQ(count, file_names().size());
-
-    // with a filter which contradicts the partition condition, no fragments are yielded
-    options_->selector->filters[0] = std::make_shared<ExpressionFilter>(
-        equal(field_ref("alpha"), ScalarExpression::Make<int16_t>(0)));
-
-    count = 0;
-    ASSERT_OK(source_->GetFragments(options_).Visit(OpenFragments(&count)));
-    ASSERT_EQ(count, 0);
-  }
-
   fs::Selector selector_;
-  std::unique_ptr<FileSystemBasedDataSource> source_;
-  std::shared_ptr<fs::LocalFileSystem> local_fs_;
+  std::unique_ptr<DataSource> source_;
   std::shared_ptr<fs::FileSystem> fs_;
-  std::unique_ptr<TemporaryDir> temp_dir_;
   std::shared_ptr<FileFormat> format_;
   std::shared_ptr<Schema> schema_;
-  std::shared_ptr<ScanOptions> options_;
-  std::shared_ptr<Expression> partition_expression_;
+  std::shared_ptr<ScanOptions> options_ = std::make_shared<ScanOptions>();
 };
 
 template <typename Gen>

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -353,6 +353,19 @@ TEST_F(TestMockFS, OpenAppendStream) {
   CheckFiles({{"ab", time_, "some data"}});
 }
 
+TEST_F(TestMockFS, Make) {
+  std::shared_ptr<FileSystem> fs;
+  ASSERT_OK(MockFileSystem::Make(time_, {}, &fs));
+  fs_ = std::static_pointer_cast<MockFileSystem>(fs);
+  CheckDirs({});
+  CheckFiles({});
+
+  ASSERT_OK(MockFileSystem::Make(time_, {Dir("A/B/C"), File("A/a")}, &fs));
+  fs_ = std::static_pointer_cast<MockFileSystem>(fs);
+  CheckDirs({{"A", time_}, {"A/B", time_}, {"A/B/C", time_}});
+  CheckFiles({{"A/a", time_, ""}});
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Concrete SubTreeFileSystem tests
 

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -94,6 +94,15 @@ class ARROW_EXPORT MockFileSystem : public FileSystem {
   std::vector<DirInfo> AllDirs();
   std::vector<FileInfo> AllFiles();
 
+  // Create a File with a content from a string.
+  Status CreateFile(const std::string& path, const std::string& content,
+                    bool recursive = true);
+
+  // Create a MockFileSystem out of (empty) FileStats. The content of every
+  // file is empty and of size 0. All directories will be created recursively.
+  static Status Make(TimePoint current_time, const std::vector<FileStats>& stats,
+                     std::shared_ptr<FileSystem>* out);
+
   class Impl;
 
  protected:

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -676,6 +676,16 @@ std::vector<std::string> Schema::field_names() const {
   return names;
 }
 
+bool operator==(const std::shared_ptr<Schema>& lhs, const std::shared_ptr<Schema> rhs) {
+  if (lhs == nullptr && rhs == nullptr) {
+    return true;
+  } else if (lhs != nullptr && rhs != nullptr) {
+    return lhs->Equals(*lhs);
+  }
+
+  return false;
+}
+
 std::shared_ptr<Schema> schema(const std::vector<std::shared_ptr<Field>>& fields,
                                const std::shared_ptr<const KeyValueMetadata>& metadata) {
   return std::make_shared<Schema>(fields, metadata);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -676,16 +676,6 @@ std::vector<std::string> Schema::field_names() const {
   return names;
 }
 
-bool operator==(const std::shared_ptr<Schema>& lhs, const std::shared_ptr<Schema> rhs) {
-  if (lhs == nullptr && rhs == nullptr) {
-    return true;
-  } else if (lhs != nullptr && rhs != nullptr) {
-    return lhs->Equals(*lhs);
-  }
-
-  return false;
-}
-
 std::shared_ptr<Schema> schema(const std::vector<std::shared_ptr<Field>>& fields,
                                const std::shared_ptr<const KeyValueMetadata>& metadata) {
   return std::make_shared<Schema>(fields, metadata);

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1317,6 +1317,7 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable {
 
   /// Returns true if all of the schema fields are equal
   bool Equals(const Schema& other, bool check_metadata = true) const;
+  bool operator==(const Schema& other) const { return Equals(other); }
 
   /// \brief Return the number of fields (columns) in the schema
   int num_fields() const;
@@ -1379,9 +1380,6 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable {
   class Impl;
   std::unique_ptr<Impl> impl_;
 };
-
-ARROW_EXPORT bool operator==(const std::shared_ptr<Schema>& rhs,
-                             const std::shared_ptr<Schema> lhs);
 
 // ----------------------------------------------------------------------
 // Parametric factory functions

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1380,6 +1380,9 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable {
   std::unique_ptr<Impl> impl_;
 };
 
+ARROW_EXPORT bool operator==(const std::shared_ptr<Schema>& rhs,
+                             const std::shared_ptr<Schema> lhs);
+
 // ----------------------------------------------------------------------
 // Parametric factory functions
 // Other factory functions are in type_fwd.h


### PR DESCRIPTION
DataSourceDiscovery is a factory-like interface to build DataSource. The class exists for the purpose of unifying/discovery schema of datasource before materializing it (since all DataSources in a Dataset must have a matching schema).

- Add MockFileSystem::Make
- Refactor FileSystemBaseDataSource to use fs::PathTree and support partition pruning.