### PR TITLE
ARROW-6625: [C++][Python] Allow concat_tables to null fill missing columns

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -549,6 +549,8 @@ Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
   auto AppendColumnOfNulls = [pool, &columns,
                               num_rows](const std::shared_ptr<DataType>& type) {
     std::shared_ptr<Array> array_of_nulls;
+    // TODO(bkietz): share the zero-filled buffers as much as possible across
+    // the null-filled arrays created here.
     RETURN_NOT_OK(MakeArrayOfNull(pool, type, num_rows, &array_of_nulls));
     columns.push_back(std::make_shared<ChunkedArray>(array_of_nulls));
     return Status::OK();

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -588,9 +588,10 @@ Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
   auto unseen_field_iter = std::find(fields_seen.begin(), fields_seen.end(), false);
   if (unseen_field_iter != fields_seen.end()) {
     const size_t unseen_field_index = unseen_field_iter - fields_seen.begin();
-    return Status::Invalid("Incompatible schemas: field ",
-                           current_schema->field(unseen_field_index)->name(),
-                           " did not exist in the new schema.");
+    return Status::Invalid(
+        "Incompatible schemas: field ",
+        current_schema->field(static_cast<int>(unseen_field_index))->name(),
+        " did not exist in the new schema.");
   }
 
   *out = Table::Make(schema, std::move(columns));

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -546,8 +546,8 @@ Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
   std::vector<std::shared_ptr<ChunkedArray>> columns;
   columns.reserve(schema->num_fields());
   const int64_t num_rows = table->num_rows();
-  auto append_column_of_nulls = [pool, &columns,
-                                 num_rows](const std::shared_ptr<DataType>& type) {
+  auto AppendColumnOfNulls = [pool, &columns,
+                              num_rows](const std::shared_ptr<DataType>& type) {
     std::shared_ptr<Array> array_of_nulls;
     RETURN_NOT_OK(MakeArrayOfNull(pool, type, num_rows, &array_of_nulls));
     columns.push_back(std::make_shared<ChunkedArray>(array_of_nulls));
@@ -558,7 +558,7 @@ Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
     const std::vector<int> field_indices =
         current_schema->GetAllFieldIndices(field->name());
     if (field_indices.empty()) {
-      RETURN_NOT_OK(append_column_of_nulls(field->type()));
+      RETURN_NOT_OK(AppendColumnOfNulls(field->type()));
       continue;
     }
 
@@ -576,7 +576,7 @@ Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
     }
 
     if (current_field->type()->id() == Type::NA) {
-      RETURN_NOT_OK(append_column_of_nulls(field->type()));
+      RETURN_NOT_OK(AppendColumnOfNulls(field->type()));
       continue;
     }
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -318,9 +318,12 @@ Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
 /// - if the corresponding column's type is not compatible with the
 ///   schema.
 /// - if there is a column in the table that does not exist in the schema.
+///
+/// \param[in] pool The memory pool to be used if null-filled arrays need to
+/// be created.
 ARROW_EXPORT
-Status PromoteTableToSchema(MemoryPool* pool, const std::shared_ptr<Table>& table,
-                            const std::shared_ptr<Schema>& schema,
+Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
+                            const std::shared_ptr<Schema>& schema, MemoryPool* pool,
                             std::shared_ptr<Table>* out);
 
 /// \brief Concatenate tables with null-filling and type promotion.
@@ -328,17 +331,17 @@ Status PromoteTableToSchema(MemoryPool* pool, const std::shared_ptr<Table>& tabl
 /// Columns of the same name will be concatenated. They should be of the
 /// same type, or be of type NULL, in which case it will be promoted to
 /// the type of other corresponding columns with null values filled.
-/// If some table is missing a column, a null values filled column will
-/// be created to participate the concatenation. The new schema will share
-/// the metadata with the first table. Each field in the new schema will share
-/// the metadata with the first table which has the field defined.
-
+/// If a table is missing a particular field, null values of the appropriate
+//  type will be generated to take the place of the missing field
+/// The new schema will share the metadata with the first table. Each field in
+/// the new schema will share the metadata with the first table which has the
+/// field defined.
+///
 /// \param[in] pool The memory pool to be used if null-filled arrays need to
 /// be created.
 ARROW_EXPORT
-Status ConcatenateTablesWithPromotion(MemoryPool* pool,
-                                      const std::vector<std::shared_ptr<Table>>& tables,
-                                      std::shared_ptr<Table>* table);
+Status ConcatenateTablesWithPromotion(const std::vector<std::shared_ptr<Table>>& tables,
+                                      MemoryPool* pool, std::shared_ptr<Table>* table);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -25,6 +25,8 @@
 
 #include "arrow/array.h"
 #include "arrow/record_batch.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -319,12 +321,14 @@ Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
 ///   schema.
 /// - if there is a column in the table that does not exist in the schema.
 ///
+/// \param[in] table the input Table
+/// \param[in] schema the target schema to promote to
 /// \param[in] pool The memory pool to be used if null-filled arrays need to
 /// be created.
 ARROW_EXPORT
-Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
-                            const std::shared_ptr<Schema>& schema, MemoryPool* pool,
-                            std::shared_ptr<Table>* out);
+Result<std::shared_ptr<Table>> PromoteTableToSchema(
+    const std::shared_ptr<Table>& table, const std::shared_ptr<Schema>& schema,
+    MemoryPool* pool = default_memory_pool());
 
 /// \brief Concatenate tables with null-filling and type promotion.
 ///
@@ -337,11 +341,13 @@ Status PromoteTableToSchema(const std::shared_ptr<Table>& table,
 /// the new schema will share the metadata with the first table which has the
 /// field defined.
 ///
+/// \param[in] tables the tables to be concatenated
 /// \param[in] pool The memory pool to be used if null-filled arrays need to
 /// be created.
 ARROW_EXPORT
-Status ConcatenateTablesWithPromotion(const std::vector<std::shared_ptr<Table>>& tables,
-                                      MemoryPool* pool, std::shared_ptr<Table>* table);
+Result<std::shared_ptr<Table>> ConcatenateTablesWithPromotion(
+    const std::vector<std::shared_ptr<Table>>& tables,
+    MemoryPool* pool = default_memory_pool());
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -308,6 +308,38 @@ ARROW_EXPORT
 Status ConcatenateTables(const std::vector<std::shared_ptr<Table>>& tables,
                          std::shared_ptr<Table>* table);
 
+/// \brief Promotes a table to conform to the given schema.
+///
+/// If a field in the schema does not have a corresponding column in the
+/// table, a column of nulls will be added to the resulting table.
+/// If the corresponding column is of type Null, it will be promoted to
+/// the type specified by schema, with null values filled.
+/// Returns an error:
+/// - if the corresponding column's type is not compatible with the
+///   schema.
+/// - if there is a column in the table that does not exist in the schema.
+ARROW_EXPORT
+Status PromoteTableToSchema(MemoryPool* pool, const std::shared_ptr<Table>& table,
+                            const std::shared_ptr<Schema>& schema,
+                            std::shared_ptr<Table>* out);
+
+/// \brief Concatenate tables with null-filling and type promotion.
+///
+/// Columns of the same name will be concatenated. They should be of the
+/// same type, or be of type NULL, in which case it will be promoted to
+/// the type of other corresponding columns with null values filled.
+/// If some table is missing a column, a null values filled column will
+/// be created to participate the concatenation. The new schema will share
+/// the metadata with the first table. Each field in the new schema will share
+/// the metadata with the first table which has the field defined.
+
+/// \param[in] pool The memory pool to be used if null-filled arrays need to
+/// be created.
+ARROW_EXPORT
+Status ConcatenateTablesWithPromotion(MemoryPool* pool,
+                                      const std::vector<std::shared_ptr<Table>>& tables,
+                                      std::shared_ptr<Table>* table);
+
 }  // namespace arrow
 
 #endif  // ARROW_TABLE_H

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -409,12 +409,6 @@ TEST_F(TestTable, ConcatenateTables) {
 
 class TestPromoteTableToSchema : public TestTable {
  protected:
-  std::shared_ptr<Table> MakeTableWithOneNullColumn(const std::string& column_name,
-                                                    const int length) {
-    return Table::Make(schema({field(column_name, null())}),
-                       {MakeRandomArray<NullArray>(length)});
-  }
-
   std::shared_ptr<Table> MakeTableWithOneNullFilledColumn(
       const std::string& column_name, const std::shared_ptr<DataType>& data_type,
       const int length) {
@@ -444,8 +438,8 @@ TEST_F(TestPromoteTableToSchema, PromoteNullTypeField) {
   const int length = 10;
   auto metadata =
       std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
-  auto table_with_null_column =
-      MakeTableWithOneNullColumn("field", length)->ReplaceSchemaMetadata(metadata);
+  auto table_with_null_column = MakeTableWithOneNullFilledColumn("field", null(), length)
+                                    ->ReplaceSchemaMetadata(metadata);
   auto promoted_schema = schema({field("field", int32())});
 
   std::shared_ptr<Table> result;

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -30,6 +30,7 @@
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
+#include "arrow/util/key_value_metadata.h"
 
 namespace arrow {
 
@@ -404,6 +405,160 @@ TEST_F(TestTable, ConcatenateTables) {
   ASSERT_OK(Table::FromRecordBatches({batch3}, &t3));
 
   ASSERT_RAISES(Invalid, ConcatenateTables({t1, t3}, &result));
+}
+
+using TestPromoteTableToSchema = TestTable;
+
+TEST_F(TestPromoteTableToSchema, IdenticalSchema) {
+  const int length = 10;
+  MakeExample1(length);
+  std::shared_ptr<Table> table = Table::Make(schema_, arrays_);
+
+  std::shared_ptr<Table> result;
+  auto metadata =
+      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
+  ASSERT_OK(PromoteTableToSchema(default_memory_pool(), table,
+                                 schema_->WithMetadata(metadata), &result));
+
+  ASSERT_TRUE(table->ReplaceSchemaMetadata(metadata)->Equals(*result));
+}
+
+TEST_F(TestPromoteTableToSchema, PromoteNullTypeField) {
+  const int length = 10;
+  auto metadata =
+      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
+  auto f0 = field("f0", null())->WithMetadata(metadata);
+  auto f0_alt = field("f0", int32());
+  auto table = Table::Make(schema({f0}), {MakeRandomArray<NullArray>(length)});
+
+  std::shared_ptr<Table> result;
+  ASSERT_OK(
+      PromoteTableToSchema(default_memory_pool(), table, schema({f0_alt}), &result));
+  std::shared_ptr<Array> array_of_nulls;
+  ASSERT_OK(MakeArrayOfNull(int32(), length, &array_of_nulls));
+  ASSERT_TRUE(result->Equals(*Table::Make(schema({f0_alt}), {array_of_nulls})));
+}
+
+TEST_F(TestPromoteTableToSchema, AddMissingField) {
+  const int length = 10;
+  auto f0 = field("f0", int32());
+  auto table = Table::Make(schema({}), std::vector<std::shared_ptr<Array>>(), length);
+  std::shared_ptr<Table> result;
+  ASSERT_OK(PromoteTableToSchema(default_memory_pool(), table, schema({f0}), &result));
+
+  std::shared_ptr<Array> array_of_nulls;
+  ASSERT_OK(MakeArrayOfNull(int32(), length, &array_of_nulls));
+  ASSERT_TRUE(result->Equals(*Table::Make(schema({f0}), {array_of_nulls})));
+}
+
+TEST_F(TestPromoteTableToSchema, IncompatibleTypes) {
+  const int length = 10;
+
+  auto f0 = field("f0", int32());
+  auto f0_alt1 = field("f0", null());
+  auto f0_alt2 = field("f0", uint32());
+
+  auto table = Table::Make(schema({f0}), {MakeRandomArray<NullArray>(length)});
+
+  std::shared_ptr<Table> result;
+  Status s =
+      PromoteTableToSchema(default_memory_pool(), table, schema({f0_alt1}), &result);
+  ASSERT_TRUE(s.IsInvalid());
+
+  s = PromoteTableToSchema(default_memory_pool(), table, schema({f0_alt2}), &result);
+  ASSERT_TRUE(s.IsInvalid());
+}
+
+TEST_F(TestPromoteTableToSchema, DuplicateFieldNames) {
+  const int length = 10;
+
+  auto f0 = field("f0", int32());
+  auto f0_alt = field("f0", null());
+
+  auto table = Table::Make(schema({f0, f0_alt}), {MakeRandomArray<Int32Array>(length),
+                                                  MakeRandomArray<NullArray>(length)});
+
+  std::shared_ptr<Table> result;
+  Status s = PromoteTableToSchema(default_memory_pool(), table, schema({f0}), &result);
+  ASSERT_TRUE(s.IsInvalid());
+}
+
+TEST_F(TestPromoteTableToSchema, TableFieldAbsentFromSchema) {
+  const int length = 10;
+
+  auto table =
+      Table::Make(schema({field("f0", int32())}), {MakeRandomArray<Int32Array>(length)});
+
+  std::shared_ptr<Table> result;
+  Status s = PromoteTableToSchema(default_memory_pool(), table,
+                                  schema({field("f1", int32())}), &result);
+  ASSERT_TRUE(s.IsInvalid());
+}
+
+class ConcatenateTablesWithPromotionTest : public TestTable {
+ protected:
+  void MakeExample2(int length) {
+    auto f0 = field("f0", int32());
+    auto f1 = field("f1", null());
+
+    std::vector<std::shared_ptr<Field>> fields = {f0, f1};
+    schema_ = std::make_shared<Schema>(fields);
+
+    arrays_ = {MakeRandomArray<Int32Array>(length), MakeRandomArray<NullArray>(length)};
+
+    columns_ = {std::make_shared<ChunkedArray>(arrays_[0]),
+                std::make_shared<ChunkedArray>(arrays_[1])};
+  }
+
+  void AssertTablesEqualUnorderedFields(const Table& lhs, const Table& rhs) {
+    ASSERT_EQ(lhs.schema()->num_fields(), rhs.schema()->num_fields());
+    if (lhs.schema()->metadata()) {
+      ASSERT_NE(nullptr, rhs.schema()->metadata());
+      ASSERT_TRUE(lhs.schema()->metadata()->Equals(*rhs.schema()->metadata()));
+    } else {
+      ASSERT_EQ(nullptr, rhs.schema()->metadata());
+    }
+    for (int i = 0; i < lhs.schema()->num_fields(); ++i) {
+      const auto& lhs_field = lhs.schema()->field(i);
+      const auto& rhs_field = rhs.schema()->GetFieldByName(lhs_field->name());
+      ASSERT_NE(nullptr, rhs_field);
+      ASSERT_TRUE(lhs_field->Equals(rhs_field, true));
+      const auto& lhs_column = lhs.column(i);
+      const auto& rhs_column = rhs.GetColumnByName(lhs_field->name());
+      AssertChunkedEqual(*lhs_column, *rhs_column);
+    }
+  }
+};
+
+TEST_F(ConcatenateTablesWithPromotionTest, Simple) {
+  const int64_t length = 10;
+
+  MakeExample1(length);
+  auto batch1 = RecordBatch::Make(schema_, length, arrays_);
+
+  std::shared_ptr<Array> f1_nulls;
+  ASSERT_OK(MakeArrayOfNull(schema_->field(1)->type(), length, &f1_nulls));
+  std::shared_ptr<Array> f2_nulls;
+  ASSERT_OK(MakeArrayOfNull(schema_->field(2)->type(), length, &f2_nulls));
+
+  MakeExample2(length);
+  auto batch2 = RecordBatch::Make(schema_, length, arrays_);
+
+  auto batch2_null_filled =
+      RecordBatch::Make(batch1->schema(), length, {arrays_[0], f1_nulls, f2_nulls});
+
+  std::shared_ptr<Table> t1, t2, t3, result, expected;
+  ASSERT_OK(Table::FromRecordBatches({batch1}, &t1));
+  ASSERT_OK(Table::FromRecordBatches({batch2}, &t2));
+  ASSERT_OK(Table::FromRecordBatches({batch2_null_filled}, &t3));
+
+  ASSERT_OK(ConcatenateTablesWithPromotion(default_memory_pool(), {t1, t2}, &result));
+  ASSERT_OK(ConcatenateTables({t1, t3}, &expected));
+  AssertTablesEqualUnorderedFields(*expected, *result);
+
+  ASSERT_OK(ConcatenateTablesWithPromotion(default_memory_pool(), {t2, t1}, &result));
+  ASSERT_OK(ConcatenateTables({t3, t1}, &expected));
+  AssertTablesEqualUnorderedFields(*expected, *result);
 }
 
 TEST_F(TestTable, Slice) {

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -461,12 +461,11 @@ TEST_F(TestPromoteTableToSchema, IncompatibleTypes) {
   auto table = Table::Make(schema({f0}), {MakeRandomArray<NullArray>(length)});
 
   std::shared_ptr<Table> result;
-  Status s =
-      PromoteTableToSchema(default_memory_pool(), table, schema({f0_alt1}), &result);
-  ASSERT_TRUE(s.IsInvalid());
+  ASSERT_RAISES(Invalid, PromoteTableToSchema(default_memory_pool(), table,
+                                              schema({f0_alt1}), &result));
 
-  s = PromoteTableToSchema(default_memory_pool(), table, schema({f0_alt2}), &result);
-  ASSERT_TRUE(s.IsInvalid());
+  ASSERT_RAISES(Invalid, PromoteTableToSchema(default_memory_pool(), table,
+                                              schema({f0_alt2}), &result));
 }
 
 TEST_F(TestPromoteTableToSchema, DuplicateFieldNames) {
@@ -479,8 +478,8 @@ TEST_F(TestPromoteTableToSchema, DuplicateFieldNames) {
                                                   MakeRandomArray<NullArray>(length)});
 
   std::shared_ptr<Table> result;
-  Status s = PromoteTableToSchema(default_memory_pool(), table, schema({f0}), &result);
-  ASSERT_TRUE(s.IsInvalid());
+  ASSERT_RAISES(
+      Invalid, PromoteTableToSchema(default_memory_pool(), table, schema({f0}), &result));
 }
 
 TEST_F(TestPromoteTableToSchema, TableFieldAbsentFromSchema) {
@@ -490,9 +489,8 @@ TEST_F(TestPromoteTableToSchema, TableFieldAbsentFromSchema) {
       Table::Make(schema({field("f0", int32())}), {MakeRandomArray<Int32Array>(length)});
 
   std::shared_ptr<Table> result;
-  Status s = PromoteTableToSchema(default_memory_pool(), table,
-                                  schema({field("f1", int32())}), &result);
-  ASSERT_TRUE(s.IsInvalid());
+  ASSERT_RAISES(Invalid, PromoteTableToSchema(default_memory_pool(), table,
+                                              schema({field("f1", int32())}), &result));
 }
 
 class ConcatenateTablesWithPromotionTest : public TestTable {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -63,6 +63,10 @@ std::shared_ptr<Field> Field::WithName(const std::string& name) const {
   return std::make_shared<Field>(name, type_, nullable_, metadata_);
 }
 
+std::shared_ptr<Field> Field::WithNullable(const bool nullable) const {
+  return std::make_shared<Field>(name_, type_, nullable, metadata_);
+}
+
 std::vector<std::shared_ptr<Field>> Field::Flatten() const {
   std::vector<std::shared_ptr<Field>> flattened;
   if (type_->id() == Type::STRUCT) {
@@ -692,38 +696,57 @@ Status UnifySchemas(const std::vector<std::shared_ptr<Schema>>& schemas,
     return Status::Invalid("Must provide at least one schema to unify.");
   }
 
-  std::unordered_map<std::string, std::shared_ptr<Field>> field_name_to_field;
-  for (const auto& schema : schemas) {
+  std::vector<std::shared_ptr<Field>> fields = schemas[0]->fields();
+  std::unordered_map<std::string, size_t> field_name_to_index;
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (!field_name_to_index.emplace(fields[i]->name(), i).second) {
+      return Status::Invalid(
+          "UnifySchemas does not support duplicate field names in the schema: ",
+          fields[i]->name());
+    }
+  }
+
+  auto update_field = [](const std::shared_ptr<Field>& other,
+                         std::shared_ptr<Field>* existing) -> Status {
+    if ((*existing)->type()->id() == Type::NA) {
+      *existing = other->WithNullable(true)->WithMetadata((*existing)->metadata());
+      return Status::OK();
+    }
+    if (other->type()->id() != Type::NA && !(*existing)->type()->Equals(other->type())) {
+      return Status::Invalid("Field ", (*existing)->name(),
+                             " has incompatible types: ", (*existing)->type()->ToString(),
+                             " vs ", other->type()->ToString());
+    }
+    // At least one field is nullable thus the unified field should also be nullable.
+    if (other->type()->id() == Type::NA || other->nullable() != (*existing)->nullable()) {
+      *existing = (*existing)->WithNullable(true);
+    }
+    return Status::OK();
+  };
+
+  for (auto schema_iter = schemas.begin() + 1; schema_iter != schemas.end();
+       ++schema_iter) {
+    const std::shared_ptr<Schema>& schema = *schema_iter;
     for (const std::string& field_name : schema->field_names()) {
-      const std::vector<std::shared_ptr<Field>> fields =
+      const std::vector<std::shared_ptr<Field>> current_fields =
           schema->GetAllFieldsByName(field_name);
-      if (fields.size() != 1) {
+      if (current_fields.size() != 1) {
         return Status::Invalid(
             "UnifySchemas does not support duplicate field names in the schema: ",
             field_name);
       }
-      const auto& current_field = fields[0];
-      auto insertion_result = field_name_to_field.emplace(field_name, current_field);
-      if (!insertion_result.second) {
-        auto existing_field_iter = insertion_result.first;
-        // Promote a Null column if applicable. Otherwise types should equal.
-        if (existing_field_iter->second->type()->id() == Type::NA) {
-          existing_field_iter->second =
-              current_field->WithMetadata(existing_field_iter->second->metadata());
-        } else if (current_field->type()->id() != Type::NA &&
-                   !existing_field_iter->second->type()->Equals(current_field->type())) {
-          return Status::Invalid("Field ", field_name, " has incompatible types: ",
-                                 existing_field_iter->second->type()->ToString(), " vs ",
-                                 current_field->type()->ToString());
-        }
+      auto insertion_result = field_name_to_index.emplace(field_name, fields.size());
+      const auto& current_field = current_fields[0];
+      if (insertion_result.second) {
+        // This field is not in the first schema. So it will become nullable.
+        fields.push_back(current_field->WithNullable(true));
+      } else {
+        const size_t existing_field_index = insertion_result.first->second;
+        RETURN_NOT_OK(update_field(current_fields[0], &fields[existing_field_index]));
       }
     }
   }
-  std::vector<std::shared_ptr<Field>> fields;
-  fields.reserve(field_name_to_field.size());
-  for (auto& pair : field_name_to_field) {
-    fields.push_back(std::move(pair.second));
-  }
+
   *out = schema(std::move(fields))->WithMetadata(schemas[0]->metadata());
   return Status::OK();
 }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -716,8 +716,8 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>>&& fields,
   return std::make_shared<Schema>(std::move(fields), metadata);
 }
 
-Status UnifySchemas(const std::vector<std::shared_ptr<Schema>>& schemas,
-                    std::shared_ptr<Schema>* out) {
+Result<std::shared_ptr<Schema>> UnifySchemas(
+    const std::vector<std::shared_ptr<Schema>>& schemas) {
   if (schemas.empty()) {
     return Status::Invalid("Must provide at least one schema to unify.");
   }
@@ -757,8 +757,7 @@ Status UnifySchemas(const std::vector<std::shared_ptr<Schema>>& schemas,
     }
   }
 
-  *out = schema(std::move(fields))->WithMetadata(schemas[0]->metadata());
-  return Status::OK();
+  return schema(std::move(fields))->WithMetadata(schemas[0]->metadata());
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1546,6 +1546,8 @@ std::shared_ptr<Schema> schema(
 ///   field will be of that same type.
 /// - The unified field will inherit the metadata from the schema where
 ///   that field is first defined.
+/// - The first N fields in the schema will be ordered the same as the
+///   N fields in the first schema.
 /// The resulting schema will inherit its metadata from the first input schema.
 /// Returns an error if:
 /// - Any input schema contains fields with duplicate names.

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1553,8 +1553,8 @@ std::shared_ptr<Schema> schema(
 /// - Any input schema contains fields with duplicate names.
 /// - Fields of the same name are of incompatible types.
 ARROW_EXPORT
-Status UnifySchemas(const std::vector<std::shared_ptr<Schema>>& schemas,
-                    std::shared_ptr<Schema>* out);
+Result<std::shared_ptr<Schema>> UnifySchemas(
+    const std::vector<std::shared_ptr<Schema>>& schemas);
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -359,6 +359,9 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   /// \brief Return a copy of this field with the replaced name.
   std::shared_ptr<Field> WithName(const std::string& name) const;
 
+  /// \brief Return a copy of this field with the replaced nullability.
+  std::shared_ptr<Field> WithNullable(bool nullable) const;
+
   std::vector<std::shared_ptr<Field>> Flatten() const;
 
   bool Equals(const Field& other, bool check_metadata = true) const;
@@ -1535,7 +1538,7 @@ std::shared_ptr<Schema> schema(
 
 /// @}
 
-/// \brief Unifies schemas
+/// \brief Unifies schemas by unifying fields by name and promoting Null fields.
 ///
 /// The resulting schema will contain the union of fields from all schemas.
 /// Fields with the same name will be unified:

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1535,6 +1535,22 @@ std::shared_ptr<Schema> schema(
 
 /// @}
 
+/// \brief Unifies schemas
+///
+/// The resulting schema will contain the union of fields from all schemas.
+/// Fields with the same name will be unified:
+/// - They are expected to be of the same type, or of Null type. The unified
+///   field will be of that same type.
+/// - The unified field will inherit the metadata from the schema where
+///   that field is first defined.
+/// The resulting schema will inherit its metadata from the first input schema.
+/// Returns an error if:
+/// - Any input schema contains fields with duplicate names.
+/// - Fields of the same name are of incompatible types.
+ARROW_EXPORT
+Status UnifySchemas(const std::vector<std::shared_ptr<Schema>>& schemas,
+                    std::shared_ptr<Schema>* out);
+
 }  // namespace arrow
 
 #endif  // ARROW_TYPE_H

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -444,8 +444,7 @@ class TestUnifySchemas : public TestSchema {
 
 TEST_F(TestUnifySchemas, EmptyInput) {
   std::shared_ptr<Schema> result;
-  Status status = UnifySchemas({}, &result);
-  ASSERT_TRUE(status.IsInvalid());
+  ASSERT_RAISES(Invalid, UnifySchemas({}, &result));
 }
 
 TEST_F(TestUnifySchemas, IdenticalSchemas) {
@@ -512,8 +511,7 @@ TEST_F(TestUnifySchemas, IncompatibleTypes) {
   auto f0 = field("f0", int32());
   auto f0_alt = field("f0", uint8(), false);
   std::shared_ptr<Schema> result;
-  Status s = UnifySchemas({schema({f0}), schema({f0_alt})}, &result);
-  ASSERT_TRUE(s.IsInvalid());
+  ASSERT_RAISES(Invalid, UnifySchemas({schema({f0}), schema({f0_alt})}, &result));
 }
 
 TEST_F(TestUnifySchemas, DuplicateFieldNames) {
@@ -521,9 +519,9 @@ TEST_F(TestUnifySchemas, DuplicateFieldNames) {
   auto f0_alt = field("f0", int32());
   auto f1 = field("f2", utf8());
   std::shared_ptr<Schema> result;
-  Status s = UnifySchemas(
-      {schema({f0, f1}), schema({f0_alt, f1}), schema({f0, f0_alt, f1})}, &result);
-  ASSERT_TRUE(s.IsInvalid());
+  ASSERT_RAISES(Invalid, UnifySchemas({schema({f0, f1}), schema({f0_alt, f1}),
+                                       schema({f0, f0_alt, f1})},
+                                      &result));
 }
 
 #define PRIMITIVE_TEST(KLASS, CTYPE, ENUM, NAME)                              \


### PR DESCRIPTION
Also allows it to promote a column of type Null to a null-filled non-Null type.

There are some open questions:

- Do we merge the metadata in schema or fields or not (and what is the semantic of such a merge)?
- Does the order of columns in the result schema need to be deterministic? Note that with the current implementation, two identical call to Concat() might result in different ordering.
- Do we allow concat tables with duplicate column names? how?
- Do we want to make two separate APIs, one strict, one non-strict? their semantics start differing, and implementations don't overlap much.

I'll add more test cases to cover the corner cases once questions got answered.

