### PR TITLE
ARROW-6732: [Java] Implement quick sort in a non-recursive way to avoid stack overflow

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
@@ -17,8 +17,6 @@
 
 package org.apache.arrow.algorithm.sort;
 
-import java.util.Stack;
-
 import org.apache.arrow.vector.BaseFixedWidthVector;
 
 /**
@@ -57,21 +55,22 @@ public class FixedWidthInPlaceVectorSorter<V extends BaseFixedWidthVector> imple
   }
 
   private void quickSort() {
-    Stack<Integer> rangeStack = new Stack<>();
-    rangeStack.push(0);
-    rangeStack.push(vec.getValueCount() - 1);
-    
-    while (!rangeStack.isEmpty()) {
-      int high = rangeStack.pop();
-      int low = rangeStack.pop();
-      if (low < high) {
-        int mid = partition(low, high);
+    try (OffHeapIntStack rangeStack = new OffHeapIntStack(vec.getAllocator())) {
+      rangeStack.push(0);
+      rangeStack.push(vec.getValueCount() - 1);
 
-        rangeStack.push(low);
-        rangeStack.push(mid - 1);
-        
-        rangeStack.push(mid + 1);
-        rangeStack.push(high);
+      while (!rangeStack.isEmpty()) {
+        int high = rangeStack.pop();
+        int low = rangeStack.pop();
+        if (low < high) {
+          int mid = partition(low, high);
+
+          rangeStack.push(low);
+          rangeStack.push(mid - 1);
+
+          rangeStack.push(mid + 1);
+          rangeStack.push(high);
+        }
       }
     }
   }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
@@ -17,9 +17,9 @@
 
 package org.apache.arrow.algorithm.sort;
 
-import org.apache.arrow.vector.BaseFixedWidthVector;
-
 import java.util.Stack;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
 
 /**
  * Default in-place sorter for fixed-width vectors.
@@ -57,28 +57,21 @@ public class FixedWidthInPlaceVectorSorter<V extends BaseFixedWidthVector> imple
   }
 
   private void quickSort() {
-    Stack<int[]> rangeStack = new Stack<>();
-    int[] range = new int[2];
-    range[0] = 0;
-    range[1] = vec.getValueCount() - 1;
-    rangeStack.push(range);
-
+    Stack<Integer> rangeStack = new Stack<>();
+    rangeStack.push(0);
+    rangeStack.push(vec.getValueCount() - 1);
+    
     while (!rangeStack.isEmpty()) {
-      range = rangeStack.pop();
-      int low = range[0];
-      int high = range[1];
+      int high = rangeStack.pop();
+      int low = rangeStack.pop();
       if (low < high) {
         int mid = partition(low, high);
 
-        int[] lowRange = new int[2];
-        lowRange[0] = low;
-        lowRange[1] = mid - 1;
-        rangeStack.push(lowRange);
-
-        int[] highRange = new int[2];
-        highRange[0] = mid + 1;
-        highRange[1] = high;
-        rangeStack.push(highRange);
+        rangeStack.push(low);
+        rangeStack.push(mid - 1);
+        
+        rangeStack.push(mid + 1);
+        rangeStack.push(high);
       }
     }
   }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
@@ -65,11 +65,21 @@ public class FixedWidthInPlaceVectorSorter<V extends BaseFixedWidthVector> imple
         if (low < high) {
           int mid = partition(low, high);
 
-          rangeStack.push(low);
-          rangeStack.push(mid - 1);
+          // push the larger part to stack first,
+          // to reduce the required stack size
+          if (high - mid < mid - low) {
+            rangeStack.push(low);
+            rangeStack.push(mid - 1);
 
-          rangeStack.push(mid + 1);
-          rangeStack.push(high);
+            rangeStack.push(mid + 1);
+            rangeStack.push(high);
+          } else {
+            rangeStack.push(mid + 1);
+            rangeStack.push(high);
+
+            rangeStack.push(low);
+            rangeStack.push(mid - 1);
+          }
         }
       }
     }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
@@ -17,7 +17,6 @@
 
 package org.apache.arrow.algorithm.sort;
 
-import java.util.Stack;
 import java.util.stream.IntStream;
 
 import org.apache.arrow.vector.IntVector;
@@ -60,22 +59,23 @@ public class IndexSorter<V extends ValueVector> {
   }
 
   private void quickSort() {
-    Stack<Integer> rangeStack = new Stack<>();
-    rangeStack.push(0);
-    rangeStack.push(indices.getValueCount() - 1);
-    
-    while (!rangeStack.isEmpty()) {
-      int high = rangeStack.pop();
-      int low = rangeStack.pop();
-      
-      if (low < high) {
-        int mid = partition(low, high, indices, comparator);
+    try (OffHeapIntStack rangeStack = new OffHeapIntStack(indices.getAllocator())) {
+      rangeStack.push(0);
+      rangeStack.push(indices.getValueCount() - 1);
 
-        rangeStack.push(low);
-        rangeStack.push(mid - 1);
+      while (!rangeStack.isEmpty()) {
+        int high = rangeStack.pop();
+        int low = rangeStack.pop();
 
-        rangeStack.push(mid + 1);
-        rangeStack.push(high);
+        if (low < high) {
+          int mid = partition(low, high, indices, comparator);
+
+          rangeStack.push(low);
+          rangeStack.push(mid - 1);
+
+          rangeStack.push(mid + 1);
+          rangeStack.push(high);
+        }
       }
     }
   }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
@@ -70,11 +70,21 @@ public class IndexSorter<V extends ValueVector> {
         if (low < high) {
           int mid = partition(low, high, indices, comparator);
 
-          rangeStack.push(low);
-          rangeStack.push(mid - 1);
+          // push the larger part to stack first,
+          // to reduce the required stack size
+          if (high - mid < mid - low) {
+            rangeStack.push(low);
+            rangeStack.push(mid - 1);
 
-          rangeStack.push(mid + 1);
-          rangeStack.push(high);
+            rangeStack.push(mid + 1);
+            rangeStack.push(high);
+          } else {
+            rangeStack.push(mid + 1);
+            rangeStack.push(high);
+
+            rangeStack.push(low);
+            rangeStack.push(mid - 1);
+          }
         }
       }
     }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
@@ -60,28 +60,22 @@ public class IndexSorter<V extends ValueVector> {
   }
 
   private void quickSort() {
-    Stack<int[]> rangeStack = new Stack<>();
-    int[] range = new int[2];
-    range[0] = 0;
-    range[1] = indices.getValueCount() - 1;
-    rangeStack.push(range);
-
+    Stack<Integer> rangeStack = new Stack<>();
+    rangeStack.push(0);
+    rangeStack.push(indices.getValueCount() - 1);
+    
     while (!rangeStack.isEmpty()) {
-      range = rangeStack.pop();
-      int low = range[0];
-      int high = range[1];
+      int high = rangeStack.pop();
+      int low = rangeStack.pop();
+      
       if (low < high) {
         int mid = partition(low, high, indices, comparator);
 
-        int[] lowRange = new int[2];
-        lowRange[0] = low;
-        lowRange[1] = mid - 1;
-        rangeStack.push(lowRange);
+        rangeStack.push(low);
+        rangeStack.push(mid - 1);
 
-        int[] highRange = new int[2];
-        highRange[0] = mid + 1;
-        highRange[1] = high;
-        rangeStack.push(highRange);
+        rangeStack.push(mid + 1);
+        rangeStack.push(high);
       }
     }
   }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.algorithm.sort;
 
+import java.util.Stack;
 import java.util.stream.IntStream;
 
 import org.apache.arrow.vector.IntVector;
@@ -55,14 +56,33 @@ public class IndexSorter<V extends ValueVector> {
 
     this.comparator = comparator;
 
-    quickSort(0, indices.getValueCount() - 1);
+    quickSort();
   }
 
-  private void quickSort(int low, int high) {
-    if (low < high) {
-      int mid = partition(low, high, indices, comparator);
-      quickSort(low, mid - 1);
-      quickSort(mid + 1, high);
+  private void quickSort() {
+    Stack<int[]> rangeStack = new Stack<>();
+    int[] range = new int[2];
+    range[0] = 0;
+    range[1] = indices.getValueCount() - 1;
+    rangeStack.push(range);
+
+    while (!rangeStack.isEmpty()) {
+      range = rangeStack.pop();
+      int low = range[0];
+      int high = range[1];
+      if (low < high) {
+        int mid = partition(low, high, indices, comparator);
+
+        int[] lowRange = new int[2];
+        lowRange[0] = low;
+        lowRange[1] = mid - 1;
+        rangeStack.push(lowRange);
+
+        int[] highRange = new int[2];
+        highRange[0] = mid + 1;
+        highRange[1] = high;
+        rangeStack.push(highRange);
+      }
     }
   }
 

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/OffHeapIntStack.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/OffHeapIntStack.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.sort;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.IntVector;
+
+/**
+ * An off heap implementation of stack with int elements.
+ */
+class OffHeapIntStack implements AutoCloseable {
+
+  private static final int INIT_SIZE = 128;
+
+  private IntVector intVector;
+
+  private int top = 0;
+
+  public OffHeapIntStack(BufferAllocator allocator) {
+    intVector = new IntVector("int stack inner vector", allocator);
+    intVector.allocateNew(INIT_SIZE);
+    intVector.setValueCount(INIT_SIZE);
+  }
+
+  public void push(int value) {
+    if (top == intVector.getValueCount()) {
+      int targetCapacity = intVector.getValueCount() * 2;
+      while (intVector.getValueCapacity() < targetCapacity) {
+        intVector.reAlloc();
+      }
+      intVector.setValueCount(targetCapacity);
+    }
+
+    intVector.set(top++, value);
+  }
+
+  public int pop() {
+    return intVector.get(--top);
+  }
+
+  public int getTop() {
+    return intVector.get(top - 1);
+  }
+
+  public boolean isEmpty() {
+    return top == 0;
+  }
+
+  public int getCount() {
+    return top;
+  }
+
+  @Override
+  public void close()  {
+    intVector.close();
+  }
+}

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestFixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestFixedWidthInPlaceVectorSorter.java
@@ -83,4 +83,35 @@ public class TestFixedWidthInPlaceVectorSorter {
       Assert.assertEquals(35, vec.get(9));
     }
   }
+
+  /**
+   * Tests the worst case for quick sort.
+   * It may cause stack overflow if the algorithm is implemented as a recursive algorithm.
+   */
+  @Test
+  public void testSortLargeIncreasingInt() {
+    final int vectorLength = 20000;
+    try (IntVector vec = new IntVector("", allocator)) {
+      vec.allocateNew(vectorLength);
+      vec.setValueCount(vectorLength);
+
+      // fill data to sort
+      for (int i = 0; i < vectorLength; i++) {
+        vec.set(i, i);
+      }
+
+      // sort the vector
+      FixedWidthInPlaceVectorSorter sorter = new FixedWidthInPlaceVectorSorter();
+      VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
+
+      sorter.sortInPlace(vec, comparator);
+
+      // verify results
+      Assert.assertEquals(vectorLength, vec.getValueCount());
+
+      for (int i = 0; i < vectorLength; i++) {
+        Assert.assertEquals(i, vec.get(i));
+      }
+    }
+  }
 }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
@@ -24,6 +24,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -78,6 +79,39 @@ public class TestIndexSorter {
         assertEquals(expected[i], indices.get(i));
       }
       indices.close();
+    }
+  }
+
+  /**
+   * Tests the worst case for quick sort.
+   * It may cause stack overflow if the algorithm is implemented as a recursive algorithm.
+   */
+  @Test
+  public void testSortLargeIncreasingInt() {
+    final int vectorLength = 20000;
+    try (IntVector vec = new IntVector("", allocator)) {
+      vec.allocateNew(vectorLength);
+      vec.setValueCount(vectorLength);
+
+      // fill data to sort
+      for (int i = 0; i < vectorLength; i++) {
+        vec.set(i, i);
+      }
+
+      // sort the vector
+      IndexSorter<IntVector> indexSorter = new IndexSorter<>();
+      DefaultVectorComparators.IntComparator intComparator = new DefaultVectorComparators.IntComparator();
+      intComparator.attachVector(vec);
+
+      try (IntVector indices = new IntVector("", allocator)) {
+        indices.setValueCount(vectorLength);
+        indexSorter.sort(vec, indices, intComparator);
+
+        for (int i = 0; i < vectorLength; i++) {
+          assertTrue(!indices.isNull(i));
+          assertEquals(i, indices.get(i));
+        }
+      }
     }
   }
 }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
@@ -24,7 +24,6 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestOffHeapIntStack.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestOffHeapIntStack.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.sort;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link OffHeapIntStack}.
+ */
+public class TestOffHeapIntStack {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testPushPop() {
+    try (OffHeapIntStack stack = new OffHeapIntStack(allocator)) {
+      assertTrue(stack.isEmpty());
+
+      final int elemCount = 500;
+      for (int i = 0; i < elemCount; i++) {
+        stack.push(i);
+        assertEquals(i, stack.getTop());
+      }
+
+      assertEquals(elemCount, stack.getCount());
+
+      for (int i = 0; i < elemCount; i++) {
+        assertEquals(elemCount - i - 1, stack.getTop());
+        assertEquals(elemCount - i - 1, stack.pop());
+      }
+
+      assertTrue(stack.isEmpty());
+    }
+  }
+}


### PR DESCRIPTION
The current quick sort algorithm in implemented by a recursive algorithm. The problem is that for the worst case, the number of recursive layers is equal to the length of the vector. For large vectors, this will cause stack overflow.

To solve this problem, we implement the quick sort algorithm as a non-recursive algorithm.