### PR TITLE
ARROW-6735: [C++] Suppress sign-compare warning with g++ 9.2.1

### DIFF
--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -60,7 +60,9 @@ BasicUnionBuilder::BasicUnionBuilder(
   children_ = children;
 
   type_id_to_children_.resize(union_type.max_type_code() + 1, nullptr);
-  DCHECK_LT(type_id_to_children_.size(), std::numeric_limits<int8_t>::max());
+  DCHECK_LT(type_id_to_children_.size(),
+            static_cast<decltype(type_id_to_children_)::size_type>(
+                std::numeric_limits<int8_t>::max()));
 
   for (size_t i = 0; i < children.size(); ++i) {
     child_fields_[i] = union_type.child(static_cast<int>(i));


### PR DESCRIPTION
This was introduced by ARROW-6402 #5244 but removed accidentally by
ARROW-5935 #4930.

    In file included from ../src/arrow/status.h:24,
                     from ../src/arrow/memory_pool.h:26,
                     from ../src/arrow/buffer.h:28,
                     from ../src/arrow/array.h:28,
                     from ../src/arrow/array/builder_union.h:25,
                     from ../src/arrow/array/builder_union.cc:18:
    ../src/arrow/array/builder_union.cc: In constructor 'arrow::BasicUnionBuilder::BasicUnionBuilder(arrow::MemoryPool*, arrow::UnionMode::type, const std::vector<std::shared_ptr<arrow::ArrayBuilder> >&, const std::shared_ptr<arrow::DataType>&)':
    ../src/arrow/util/logging.h:86:55: error: comparison of integer expressions of different signedness: 'std::vector<arrow::ArrayBuilder*>::size_type' {aka 'long unsigned int'} and 'signed char' [-Werror=sign-compare]
       86 | #define ARROW_CHECK_LT(val1, val2) ARROW_CHECK((val1) < (val2))
          |                                                ~~~~~~~^~~~~~~~
    ../src/arrow/util/macros.h:43:52: note: in definition of macro 'ARROW_PREDICT_TRUE'
       43 | #define ARROW_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
          |                                                    ^
    ../src/arrow/util/logging.h:86:36: note: in expansion of macro 'ARROW_CHECK'
       86 | #define ARROW_CHECK_LT(val1, val2) ARROW_CHECK((val1) < (val2))
          |                                    ^~~~~~~~~~~
    ../src/arrow/util/logging.h:135:19: note: in expansion of macro 'ARROW_CHECK_LT'
      135 | #define DCHECK_LT ARROW_CHECK_LT
          |                   ^~~~~~~~~~~~~~
    ../src/arrow/array/builder_union.cc:63:3: note: in expansion of macro 'DCHECK_LT'
       63 |   DCHECK_LT(type_id_to_children_.size(), std::numeric_limits<int8_t>::max());
          |   ^~~~~~~~~