### PR TITLE
ARROW-6736: [Rust] [DataFusion] Evaluate the input to the aggregate expression just once per batch

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -65,6 +65,8 @@ pub trait AggregateExpr: Send + Sync {
     fn name(&self) -> String;
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
+    /// Evaluate the expressioon being aggregated
+    fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef>;
     /// Create an accumulator for this aggregate expression
     fn create_accumulator(&self) -> Rc<RefCell<dyn Accumulator>>;
     /// Create an aggregate expression for combining the results of accumulators from partitions.
@@ -76,7 +78,12 @@ pub trait AggregateExpr: Send + Sync {
 /// Aggregate accumulator
 pub trait Accumulator {
     /// Update the accumulator based on a row in a batch
-    fn accumulate(&mut self, batch: &RecordBatch, row_index: usize) -> Result<()>;
+    fn accumulate(
+        &mut self,
+        batch: &RecordBatch,
+        input: &ArrayRef,
+        row_index: usize,
+    ) -> Result<()>;
     /// Get the final value for the accumulator
     fn get_value(&self) -> Result<Option<ScalarValue>>;
 }


### PR DESCRIPTION
The current implementation of aggregate expressions in the new physical plan had a flaw where the input to the aggregate expression was repeatedly being evaluated (once per row instead of once per batch). This PR fixes this.