### PR TITLE
ARROW-6738: [Java] Fix problems with current union comparison logic

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -550,7 +550,7 @@ public class UnionVector implements FieldVector {
     return vectors.iterator();
   }
 
-    private ValueVector getVector(int index) {
+    public ValueVector getVector(int index) {
       int type = typeBuffer.getByte(index * TYPE_WIDTH);
       switch (MinorType.values()[type]) {
         case NULL:

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -109,8 +109,10 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
   }
 
   @Override
-  protected ApproxEqualsVisitor createInnerVisitor(ValueVector left, ValueVector right) {
-    return new ApproxEqualsVisitor(left, right, floatDiffFunction.clone(), doubleDiffFunction.clone());
+  protected ApproxEqualsVisitor createInnerVisitor(
+      ValueVector left, ValueVector right,
+      BiFunction<ValueVector, ValueVector, Boolean> typeComparator) {
+    return new ApproxEqualsVisitor(left, right, floatDiffFunction.clone(), doubleDiffFunction.clone(), typeComparator);
   }
 
   private boolean float4ApproxEquals(Range range) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -228,7 +228,8 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     }
 
     for (String name : leftChildNames) {
-      RangeEqualsVisitor visitor = createInnerVisitor(leftVector.getChild(name), rightVector.getChild(name), null);
+      RangeEqualsVisitor visitor =
+          createInnerVisitor(leftVector.getChild(name), rightVector.getChild(name), /*type comparator*/ null);
       if (!visitor.rangeEquals(range)) {
         return false;
       }
@@ -307,7 +308,8 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     ListVector leftVector = (ListVector) left;
     ListVector rightVector = (ListVector) right;
 
-    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector(), null);
+    RangeEqualsVisitor innerVisitor =
+        createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector(), /*type comparator*/ null);
     Range innerRange = new Range();
 
     for (int i = 0; i < range.getLength(); i++) {
@@ -353,7 +355,8 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     }
 
     int listSize = leftVector.getListSize();
-    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector(), null);
+    RangeEqualsVisitor innerVisitor =
+        createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector(), /*type comparator*/ null);
     Range innerRange = new Range(0, 0, listSize);
 
     for (int i = 0; i < range.getLength(); i++) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -24,6 +24,7 @@ import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -31,6 +32,7 @@ import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /**
  * Visitor to compare a range of values for vectors.
@@ -244,7 +246,23 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     return true;
   }
 
+  private boolean compareDecimalVectorTypes() {
+    ArrowType.Decimal leftType = (ArrowType.Decimal) left.getField().getType();
+    ArrowType.Decimal rightType = (ArrowType.Decimal) right.getField().getType();
+
+    if (leftType.getPrecision() != rightType.getPrecision() || leftType.getScale() != rightType.getScale()) {
+      return false;
+    }
+    return true;
+  }
+
   protected boolean compareBaseFixedWidthVectors(Range range) {
+    if (left instanceof DecimalVector) {
+      if (!compareDecimalVectorTypes()) {
+        return false;
+      }
+    }
+
     BaseFixedWidthVector leftVector = (BaseFixedWidthVector) left;
     BaseFixedWidthVector rightVector = (BaseFixedWidthVector) right;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -217,7 +217,9 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
           return false;
         }
       }
-      RangeEqualsVisitor visitor = createInnerVisitor(leftSubVector, rightSubVector, true);
+      TypeEqualsVisitor typeVisitor = new TypeEqualsVisitor(rightSubVector);
+      RangeEqualsVisitor visitor =
+          createInnerVisitor(leftSubVector, rightSubVector, (left, right) -> typeVisitor.equals(left));
       if (!visitor.rangeEquals(subRange)) {
         return false;
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -24,7 +24,6 @@ import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -189,9 +188,15 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
   /**
    * Creates a visitor to visit child vectors.
    * It is used for complex vector types.
-   * @return the visitor for child vecors.
+   * @return the visitor for child vectors.
    */
   protected RangeEqualsVisitor createInnerVisitor(ValueVector leftInner, ValueVector rightInner) {
+    return this.createInnerVisitor(leftInner, rightInner, this.typeComparator);
+  }
+
+  protected RangeEqualsVisitor createInnerVisitor(
+          ValueVector leftInner, ValueVector rightInner,
+          BiFunction<ValueVector, ValueVector, Boolean> typeComparator) {
     return new RangeEqualsVisitor(leftInner, rightInner, typeComparator);
   }
 
@@ -199,16 +204,21 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     UnionVector leftVector = (UnionVector) left;
     UnionVector rightVector = (UnionVector) right;
 
-    List<FieldVector> leftChildren = leftVector.getChildrenFromFields();
-    List<FieldVector> rightChildren = rightVector.getChildrenFromFields();
+    Range subRange = new Range(0, 0, 1);
+    for (int i = 0; i < range.getLength(); i++) {
+      subRange.setLeftStart(range.getLeftStart() + i).setRightStart(range.getRightStart() + i);
+      ValueVector leftSubVector = leftVector.getVector(range.getLeftStart() + i);
+      ValueVector rightSubVector = rightVector.getVector(range.getRightStart() + i);
 
-    if (leftChildren.size() != rightChildren.size()) {
-      return false;
-    }
-
-    for (int k = 0; k < leftChildren.size(); k++) {
-      RangeEqualsVisitor visitor = createInnerVisitor(leftChildren.get(k), rightChildren.get(k));
-      if (!visitor.rangeEquals(range)) {
+      if (leftSubVector == null || rightSubVector == null) {
+        if (leftSubVector == rightSubVector) {
+          continue;
+        } else {
+          return false;
+        }
+      }
+      RangeEqualsVisitor visitor = createInnerVisitor(leftSubVector, rightSubVector, true);
+      if (!visitor.rangeEquals(subRange)) {
         return false;
       }
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -185,15 +185,6 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     return true;
   }
 
-  /**
-   * Creates a visitor to visit child vectors.
-   * It is used for complex vector types.
-   * @return the visitor for child vectors.
-   */
-  protected RangeEqualsVisitor createInnerVisitor(ValueVector leftInner, ValueVector rightInner) {
-    return this.createInnerVisitor(leftInner, rightInner, this.typeComparator);
-  }
-
   protected RangeEqualsVisitor createInnerVisitor(
           ValueVector leftInner, ValueVector rightInner,
           BiFunction<ValueVector, ValueVector, Boolean> typeComparator) {
@@ -237,7 +228,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     }
 
     for (String name : leftChildNames) {
-      RangeEqualsVisitor visitor = createInnerVisitor(leftVector.getChild(name), rightVector.getChild(name));
+      RangeEqualsVisitor visitor = createInnerVisitor(leftVector.getChild(name), rightVector.getChild(name), null);
       if (!visitor.rangeEquals(range)) {
         return false;
       }
@@ -316,7 +307,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     ListVector leftVector = (ListVector) left;
     ListVector rightVector = (ListVector) right;
 
-    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector());
+    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector(), null);
     Range innerRange = new Range();
 
     for (int i = 0; i < range.getLength(); i++) {
@@ -362,7 +353,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     }
 
     int listSize = leftVector.getListSize();
-    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector());
+    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector(), null);
     Range innerRange = new Range(0, 0, listSize);
 
     for (int i = 0; i < range.getLength(); i++) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -24,7 +24,6 @@ import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
-import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.BaseRepeatedValueVector;
@@ -32,7 +31,6 @@ import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.UnionVector;
-import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /**
  * Visitor to compare a range of values for vectors.
@@ -246,23 +244,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     return true;
   }
 
-  private boolean compareDecimalVectorTypes() {
-    ArrowType.Decimal leftType = (ArrowType.Decimal) left.getField().getType();
-    ArrowType.Decimal rightType = (ArrowType.Decimal) right.getField().getType();
-
-    if (leftType.getPrecision() != rightType.getPrecision() || leftType.getScale() != rightType.getScale()) {
-      return false;
-    }
-    return true;
-  }
-
   protected boolean compareBaseFixedWidthVectors(Range range) {
-    if (left instanceof DecimalVector) {
-      if (!compareDecimalVectorTypes()) {
-        return false;
-      }
-    }
-
     BaseFixedWidthVector leftVector = (BaseFixedWidthVector) left;
     BaseFixedWidthVector rightVector = (BaseFixedWidthVector) right;
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2320,7 +2320,7 @@ public class TestValueVector {
       VectorEqualsVisitor visitor2 = new VectorEqualsVisitor();
 
       assertTrue(visitor1.vectorEquals(vector1, vector2));
-      assertFalse(visitor2.vectorEquals(vector1, vector3));
+      assertTrue(visitor2.vectorEquals(vector1, vector3));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2320,7 +2320,7 @@ public class TestValueVector {
       VectorEqualsVisitor visitor2 = new VectorEqualsVisitor();
 
       assertTrue(visitor1.vectorEquals(vector1, vector2));
-      assertTrue(visitor2.vectorEquals(vector1, vector3));
+      assertFalse(visitor2.vectorEquals(vector1, vector3));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -296,8 +296,8 @@ public class TestRangeEqualsVisitor {
       uInt4Holder.isSet = 1;
 
       final NullableIntHolder intHolder = new NullableIntHolder();
-      uInt4Holder.value = 20;
-      uInt4Holder.isSet = 1;
+      intHolder.value = 20;
+      intHolder.isSet = 1;
 
       vector1.setType(0, Types.MinorType.UINT4);
       vector1.setSafe(0, uInt4Holder);
@@ -307,7 +307,11 @@ public class TestRangeEqualsVisitor {
 
       vector1.setType(2, Types.MinorType.INT);
       vector1.setSafe(2, intHolder);
-      vector1.setValueCount(3);
+
+      vector1.setType(3, Types.MinorType.INT);
+      vector1.setSafe(3, intHolder);
+
+      vector1.setValueCount(4);
 
       vector2.setType(0, Types.MinorType.UINT4);
       vector2.setSafe(0, uInt4Holder);
@@ -317,9 +321,14 @@ public class TestRangeEqualsVisitor {
 
       vector2.setType(2, Types.MinorType.INT);
       vector2.setSafe(2, intHolder);
-      vector2.setValueCount(3);
+
+      vector2.setType(3, Types.MinorType.UINT4);
+      vector2.setSafe(3, uInt4Holder);
+
+      vector2.setValueCount(4);
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
+      assertFalse(visitor.rangeEquals(new Range(0, 0, 4)));
       assertTrue(visitor.rangeEquals(new Range(1, 1, 2)));
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -282,6 +282,48 @@ public class TestRangeEqualsVisitor {
     }
   }
 
+  /**
+   * Test comparing two union vectors.
+   * The two vectors are different in total, but have a range with equal values.
+   */
+  @Test
+  public void testUnionVectorSubRangeEquals() {
+    try (final UnionVector vector1 = new UnionVector("union", allocator, null, null);
+         final UnionVector vector2 = new UnionVector("union", allocator, null, null);) {
+
+      final NullableUInt4Holder uInt4Holder = new NullableUInt4Holder();
+      uInt4Holder.value = 10;
+      uInt4Holder.isSet = 1;
+
+      final NullableIntHolder intHolder = new NullableIntHolder();
+      uInt4Holder.value = 20;
+      uInt4Holder.isSet = 1;
+
+      vector1.setType(0, Types.MinorType.UINT4);
+      vector1.setSafe(0, uInt4Holder);
+
+      vector1.setType(1, Types.MinorType.INT);
+      vector1.setSafe(1, intHolder);
+
+      vector1.setType(2, Types.MinorType.INT);
+      vector1.setSafe(2, intHolder);
+      vector1.setValueCount(3);
+
+      vector2.setType(0, Types.MinorType.SMALLINT);
+      vector2.setSafe(0, intHolder);
+
+      vector2.setType(1, Types.MinorType.INT);
+      vector2.setSafe(1, intHolder);
+
+      vector2.setType(2, Types.MinorType.INT);
+      vector2.setSafe(2, intHolder);
+      vector2.setValueCount(3);
+
+      RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
+      assertTrue(visitor.rangeEquals(new Range(1, 1, 2)));
+    }
+  }
+
   @Ignore
   @Test
   public void testEqualsWithOutTypeCheck() {

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -309,8 +309,8 @@ public class TestRangeEqualsVisitor {
       vector1.setSafe(2, intHolder);
       vector1.setValueCount(3);
 
-      vector2.setType(0, Types.MinorType.SMALLINT);
-      vector2.setSafe(0, intHolder);
+      vector2.setType(0, Types.MinorType.UINT4);
+      vector2.setSafe(0, uInt4Holder);
 
       vector2.setType(1, Types.MinorType.INT);
       vector2.setSafe(1, intHolder);


### PR DESCRIPTION
There are some problems with the current union comparison logic. For example:
1. For type check, we should not require fields to be equal. It is possible that two vectors' value ranges are equal but their fields are different.
2. We should not compare the number of sub vectors, as it is possible that two union vectors have different numbers of sub vectors, but have equal values in the range.