### PR TITLE
ARROW-6744: [Rust] Publicly expose JsonEqual

### DIFF
--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -163,3 +163,4 @@ pub type Time64NanosecondBuilder = PrimitiveBuilder<Time64NanosecondType>;
 // --------------------- Array Equality ---------------------
 
 pub use self::equal::ArrayEqual;
+pub use self::equal::JsonEqual;


### PR DESCRIPTION
Jira Issue: https://issues.apache.org/jira/browse/ARROW-6744

As of right now, devs using arrow in their own project cannot implement the Array trait since it is bound by JsonEqual, which isn't exported publicly. 

I am not sure if this was done intentionally, but if not this PR will resolve the problem.