### PR TITLE
ARROW-6740: [C++] Unmap MemoryMappedFile as soon as possible

### DIFF
--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -636,7 +636,7 @@ class TestMemoryMappedFile : public ::testing::Test, public MemoryMapFixture {
 
 TEST_F(TestMemoryMappedFile, InvalidUsages) {}
 
-TEST_F(TestMemoryMappedFile, ZeroSizeFlie) {
+TEST_F(TestMemoryMappedFile, ZeroSizeFile) {
   std::string path = "io-memory-map-zero-size";
   std::shared_ptr<MemoryMappedFile> result;
   ASSERT_OK(InitMemoryMap(0, path, &result));

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -839,6 +839,21 @@ def test_memory_map_large_seeks():
     check_large_seeks(pa.memory_map)
 
 
+def test_memory_map_close_remove(tmpdir):
+    # ARROW-6740: should be able to delete closed memory-mapped file (Windows)
+    path = os.path.join(str(tmpdir), guid())
+    mmap = pa.create_memory_map(path, 4096)
+    mmap.close()
+    assert mmap.closed
+    os.remove(path)  # Shouldn't fail
+
+
+def test_memory_map_deref_remove(tmpdir):
+    path = os.path.join(str(tmpdir), guid())
+    pa.create_memory_map(path, 4096)
+    os.remove(path)  # Shouldn't fail
+
+
 def test_os_file_writer(tmpdir):
     SIZE = 4096
     arr = np.random.randint(0, 256, size=SIZE).astype('u1')


### PR DESCRIPTION
When a MemoryMappedFile has been closed and all exported buffers
have been destroyed, unmap the memory region instead of waiting
for the file object destruction.

This allows deleting the underlying file on Windows.