### PR TITLE
ARROW-6761: [Rust] Travis build now uses the correct Rust toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -298,7 +298,7 @@ matrix:
       - if [ $ARROW_CI_RUST_AFFECTED != "1" ]; then exit; fi
       - $TRAVIS_BUILD_DIR/ci/travis_install_cargo.sh
     script:
-      - RUSTUP_TOOLCHAIN=nightly $TRAVIS_BUILD_DIR/ci/travis_script_rust.sh
+      - $TRAVIS_BUILD_DIR/ci/travis_script_rust.sh
     before_cache:
       cargo install cargo-tarpaulin -f
     after_success:

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -31,16 +31,17 @@ rustup show
 # raises on any formatting errors
 cargo +stable fmt --all -- --check
 
-# make sure we build using the same Rust toolchain for all crates
-cp rust-toolchain arrow
-cp rust-toolchain parquet
-cp rust-toolchain datafusion
-
+# build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets
+
+# run tests
+cargo test
+
+# build Arrow crate without default features
+cp rust-toolchain arrow
 pushd arrow
 cargo build --no-default-features
 popd
-cargo test
 
 # run Arrow examples
 pushd arrow

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -31,6 +31,11 @@ rustup show
 # raises on any formatting errors
 cargo +stable fmt --all -- --check
 
+# make sure we build using the same Rust toolchain for all crates
+cp rust-toolchain arrow
+cp rust-toolchain parquet
+cp rust-toolchain rust
+
 RUSTFLAGS="-D warnings" cargo build --all-targets
 pushd arrow
 cargo build --no-default-features

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -34,7 +34,7 @@ cargo +stable fmt --all -- --check
 # make sure we build using the same Rust toolchain for all crates
 cp rust-toolchain arrow
 cp rust-toolchain parquet
-cp rust-toolchain rust
+cp rust-toolchain datafusion
 
 RUSTFLAGS="-D warnings" cargo build --all-targets
 pushd arrow

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -34,14 +34,13 @@ cargo +stable fmt --all -- --check
 # build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets
 
-# build Arrow crate without default features
-cp rust-toolchain arrow
+# run tests
+cargo test
+
+# make sure we can build Arrow sub-crate without default features
 pushd arrow
 cargo build --no-default-features
 popd
-
-# run tests
-cargo test
 
 # run Arrow examples
 pushd arrow

--- a/ci/travis_script_rust.sh
+++ b/ci/travis_script_rust.sh
@@ -34,14 +34,14 @@ cargo +stable fmt --all -- --check
 # build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets
 
-# run tests
-cargo test
-
 # build Arrow crate without default features
 cp rust-toolchain arrow
 pushd arrow
 cargo build --no-default-features
 popd
+
+# run tests
+cargo test
 
 # run Arrow examples
 pushd arrow


### PR DESCRIPTION
There is a compiler bug apparently in Rust 1.40.0-nightly so we need to keep using 1.39.0 for now.

The Travis build script was using a `RUSTUP_TOOLCHAIN=nightly` which seems to override the `rust-toolchain` file.

Also, Travis builds the arrow subcrate individually and therefore wasn't picking up the `rust-toolchain` file in the root of the Rust project.