### PR TITLE
ARROW-5655: [Python] Table.from_pydict/from_arrays not using types in specified schema correctly

### DIFF
--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1009,6 +1009,21 @@ def test_table_from_pydict():
         pa.Table.from_pydict({'c0': [0, 1, 2]},
                              schema=pa.schema([("c0", pa.string())]))
 
+    # Missing schema fields from the passed mapping
+    with pytest.raises(KeyError, match="doesn\'t contain.* c\, d"):
+        pa.Table.from_pydict(
+            {'a': [1, 2, 3], 'b': [3, 4, 5]},
+            schema=pa.schema([
+                ('a', pa.int64()),
+                ('c', pa.int32()),
+                ('d', pa.int16())
+            ])
+        )
+
+    # Passed wrong schema type
+    with pytest.raises(TypeError):
+        pa.Table.from_pydict({'a': [1, 2, 3]}, schema={})
+
 
 @pytest.mark.parametrize('data, klass', [
     (([u'', u'foo', u'bar'], [4.5, 5, None]), pa.array),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1010,7 +1010,7 @@ def test_table_from_pydict():
                              schema=pa.schema([("c0", pa.string())]))
 
     # Missing schema fields from the passed mapping
-    with pytest.raises(KeyError, match="doesn\'t contain.* c\, d"):
+    with pytest.raises(KeyError, match="doesn\'t contain.* c, d"):
         pa.Table.from_pydict(
             {'a': [1, 2, 3], 'b': [3, 4, 5]},
             schema=pa.schema([


### PR DESCRIPTION
The behaviour still seems a bit inconsistent to me:
- from_arrays enforces to pass the same amount of fields as arrays
- from_pydict enables to pass a schema with a subset of mapping's fields 

Both methods requires to pass a schema instance although. We could improve it by allowing to pass a list of fields or tuples, to allow the same inputs like `pa.schema` does.

cc @jorisvandenbossche @pitrou 