### PR TITLE
ARROW-6760: [C++] More informative error messages for JSON parsing errors

### DIFF
--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -658,7 +658,7 @@ class HandlerBase : public BlockParser,
   /// \brief Emit path of current field for debugging purposes
   std::string Path() {
     std::string path;
-    for (int i = 0; i < builder_stack_.size(); ++i) {
+    for (size_t i = 0; i < builder_stack_.size(); ++i) {
       auto builder = builder_stack_[i];
       if (builder.kind == Kind::kArray) {
         path += "/[]";

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -54,10 +54,6 @@ static Status ParseError(T&&... t) {
   return Status::Invalid("JSON parse error: ", std::forward<T>(t)...);
 }
 
-static Status KindChangeError(Kind::type from, Kind::type to) {
-  return ParseError("A column changed from ", Kind::Name(from), " to ", Kind::Name(to));
-}
-
 const std::string& Kind::Name(Kind::type kind) {
   static const std::string names[] = {"null",   "boolean", "number",
                                       "string", "array",   "object"};
@@ -326,6 +322,16 @@ class RawArrayBuilder<Kind::kObject> {
   Status AppendNull() { return null_bitmap_builder_.Append(false); }
 
   Status AppendNull(int64_t count) { return null_bitmap_builder_.Append(count, false); }
+
+  std::string FieldName(int i) const {
+    for (const auto& name_index : name_to_index_) {
+      if (name_index.second == i) {
+        return name_index.first;
+      }
+    }
+    DCHECK(false);
+    return "";
+  }
 
   int GetFieldIndex(const std::string& name) const {
     auto it = name_to_index_.find(name);
@@ -649,6 +655,23 @@ class HandlerBase : public BlockParser,
     return builder_set_.Finish(scalar_values, builder_, parsed);
   }
 
+  /// \brief Emit path of current field for debugging purposes
+  std::string Path() {
+    std::string path;
+    for (int i = 0; i < builder_stack_.size(); ++i) {
+      auto builder = builder_stack_[i];
+      if (builder.kind == Kind::kArray) {
+        path += "/[]";
+      } else {
+        auto struct_builder = Cast<Kind::kObject>(builder);
+        auto field_index =
+            i == field_index_stack_.size() ? field_index_ : field_index_stack_[i + 1];
+        path += "/" + struct_builder->FieldName(field_index);
+      }
+    }
+    return path;
+  }
+
  protected:
   template <typename Handler, typename Stream>
   Status DoParse(Handler& handler, Stream&& json) {
@@ -672,9 +695,7 @@ class HandlerBase : public BlockParser,
           return handler.Error();
         default:
           // rj emitted an error
-          // FIXME(bkietz) report more error data (at least the byte range of the current
-          // block, and maybe the path to the most recently parsed value?)
-          return ParseError(rj::GetParseError_En(ok.Code()));
+          return ParseError(rj::GetParseError_En(ok.Code()), " in row ", num_rows_);
       }
     }
     return Status::Invalid("Exceeded maximum rows");
@@ -722,10 +743,15 @@ class HandlerBase : public BlockParser,
   ///
   /// sets the field builder with name key, or returns false if
   /// there is no field with that name
-  bool SetFieldBuilder(string_view key) {
+  bool SetFieldBuilder(string_view key, bool* duplicate_keys) {
     auto parent = Cast<Kind::kObject>(builder_stack_.back());
     field_index_ = parent->GetFieldIndex(std::string(key));
     if (ARROW_PREDICT_FALSE(field_index_ == -1)) {
+      return false;
+    }
+    *duplicate_keys = !absent_fields_stack_[field_index_];
+    if (*duplicate_keys) {
+      status_ = ParseError("Column(", Path(), ") was specified twice in row ", num_rows_);
       return false;
     }
     builder_ = parent->field_builder(field_index_);
@@ -790,7 +816,8 @@ class HandlerBase : public BlockParser,
   }
 
   Status IllegallyChangedTo(Kind::type illegally_changed_to) {
-    return KindChangeError(builder_.kind, illegally_changed_to);
+    return ParseError("Column(", Path(), ") changed from ", Kind::Name(builder_.kind),
+                      " to ", Kind::Name(illegally_changed_to), " in row ", num_rows_);
   }
 
   /// Reserve storage for scalars, these can occupy almost all of the JSON buffer
@@ -834,10 +861,13 @@ class Handler<UnexpectedFieldBehavior::Error> : public HandlerBase {
   ///
   /// if an unexpected field is encountered, emit a parse error and bail
   bool Key(const char* key, rj::SizeType len, ...) {
-    if (ARROW_PREDICT_TRUE(SetFieldBuilder(string_view(key, len)))) {
+    bool duplicate_keys = false;
+    if (ARROW_PREDICT_FALSE(SetFieldBuilder(string_view(key, len), &duplicate_keys))) {
       return true;
     }
-    status_ = ParseError("unexpected field");
+    if (!duplicate_keys) {
+      status_ = ParseError("unexpected field");
+    }
     return false;
   }
 };
@@ -895,8 +925,12 @@ class Handler<UnexpectedFieldBehavior::Ignore> : public HandlerBase {
     if (Skipping()) {
       return true;
     }
-    if (ARROW_PREDICT_TRUE(SetFieldBuilder(string_view(key, len)))) {
+    bool duplicate_keys = false;
+    if (ARROW_PREDICT_TRUE(SetFieldBuilder(string_view(key, len), &duplicate_keys))) {
       return true;
+    }
+    if (ARROW_PREDICT_FALSE(duplicate_keys)) {
+      return false;
     }
     skip_depth_ = depth_;
     return true;
@@ -982,8 +1016,12 @@ class Handler<UnexpectedFieldBehavior::InferType> : public HandlerBase {
   /// (parent.length - 1) leading nulls. The next value parsed
   /// will probably trigger promotion of this field from null
   bool Key(const char* key, rj::SizeType len, ...) {
-    if (ARROW_PREDICT_TRUE(SetFieldBuilder(string_view(key, len)))) {
+    bool duplicate_keys = false;
+    if (ARROW_PREDICT_TRUE(SetFieldBuilder(string_view(key, len), &duplicate_keys))) {
       return true;
+    }
+    if (ARROW_PREDICT_FALSE(duplicate_keys)) {
+      return false;
     }
     auto struct_builder = Cast<Kind::kObject>(builder_stack_.back());
     auto leading_nulls = static_cast<uint32_t>(struct_builder->length() - 1);

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -329,7 +329,6 @@ class RawArrayBuilder<Kind::kObject> {
         return name_index.first;
       }
     }
-    DCHECK(false);
     return "";
   }
 

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -663,8 +663,10 @@ class HandlerBase : public BlockParser,
         path += "/[]";
       } else {
         auto struct_builder = Cast<Kind::kObject>(builder);
-        auto field_index =
-            i == field_index_stack_.size() ? field_index_ : field_index_stack_[i + 1];
+        auto field_index = field_index_;
+        if (i + 1 < field_index_stack_.size()) {
+          field_index = field_index_stack_[i + 1];
+        }
         path += "/" + struct_builder->FieldName(field_index);
       }
     }

--- a/cpp/src/arrow/json/parser.h
+++ b/cpp/src/arrow/json/parser.h
@@ -78,6 +78,11 @@ class ARROW_EXPORT BlockParser {
   /// \brief Return the number of parsed rows
   int32_t num_rows() const { return num_rows_; }
 
+  /// \brief Construct a BlockParser
+  ///
+  /// \param[in] pool MemoryPool to use when constructing parsed array
+  /// \param[in] options ParseOptions to use when parsing JSON
+  /// \param[out] out constructed BlockParser
   static Status Make(MemoryPool* pool, const ParseOptions& options,
                      std::unique_ptr<BlockParser>* out);
 

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include "arrow/json/options.h"
@@ -159,8 +160,10 @@ TEST_P(BlockParserTypeError, FailOnInconvertible) {
   std::shared_ptr<Array> parsed;
   Status error = ParseFromString(options, "{\"a\":0}\n{\"a\":true}", &parsed);
   ASSERT_RAISES(Invalid, error);
-  ASSERT_EQ(error.message(),
-            "JSON parse error: Column(/a) changed from number to boolean in row 1");
+  EXPECT_THAT(
+      error.message(),
+      testing::StartsWith(
+          "JSON parse error: Column(/a) changed from number to boolean in row 1"));
 }
 
 TEST_P(BlockParserTypeError, FailOnNestedInconvertible) {
@@ -169,8 +172,10 @@ TEST_P(BlockParserTypeError, FailOnNestedInconvertible) {
   Status error =
       ParseFromString(options, "{\"a\":[{\"b\":0}]}\n{\"a\":[{\"b\":true}]}", &parsed);
   ASSERT_RAISES(Invalid, error);
-  ASSERT_EQ(error.message(),
-            "JSON parse error: Column(/a/[]/b) changed from number to boolean in row 1");
+  EXPECT_THAT(
+      error.message(),
+      testing::StartsWith(
+          "JSON parse error: Column(/a/[]/b) changed from number to boolean in row 1"));
 }
 
 TEST_P(BlockParserTypeError, FailOnDuplicateKeys) {
@@ -178,7 +183,9 @@ TEST_P(BlockParserTypeError, FailOnDuplicateKeys) {
   Status error = ParseFromString(Options(schema({field("a", int32())})),
                                  "{\"a\":0, \"a\":1}\n", &parsed);
   ASSERT_RAISES(Invalid, error);
-  ASSERT_EQ(error.message(), "JSON parse error: Column(/a) was specified twice in row 0");
+  EXPECT_THAT(
+      error.message(),
+      testing::StartsWith("JSON parse error: Column(/a) was specified twice in row 0"));
 }
 
 INSTANTIATE_TEST_CASE_P(BlockParserTypeError, BlockParserTypeError,

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -164,13 +164,13 @@ TEST_P(BlockParserTypeError, FailOnInconvertible) {
 }
 
 TEST_P(BlockParserTypeError, FailOnNestedInconvertible) {
-  auto options = Options(schema({field("a", list(struct_({field("a", int32())})))}));
+  auto options = Options(schema({field("a", list(struct_({field("b", int32())})))}));
   std::shared_ptr<Array> parsed;
   Status error =
-      ParseFromString(options, "{\"a\":[{\"a\":0}]}\n{\"a\":[{\"a\":true}]}", &parsed);
+      ParseFromString(options, "{\"a\":[{\"b\":0}]}\n{\"a\":[{\"b\":true}]}", &parsed);
   ASSERT_RAISES(Invalid, error);
   ASSERT_EQ(error.message(),
-            "JSON parse error: Column(/a/[]/a) changed from number to boolean in row 1");
+            "JSON parse error: Column(/a/[]/b) changed from number to boolean in row 1");
 }
 
 TEST_P(BlockParserTypeError, FailOnDuplicateKeys) {

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -190,7 +190,7 @@ TEST_P(BlockParserTypeError, FailOnDuplicateKeys) {
 
 INSTANTIATE_TEST_CASE_P(BlockParserTypeError, BlockParserTypeError,
                         ::testing::Values(UnexpectedFieldBehavior::Ignore,
-                                          UnexpectedFieldBehavior::Ignore,
+                                          UnexpectedFieldBehavior::Error,
                                           UnexpectedFieldBehavior::InferType));
 
 TEST(BlockParserWithSchema, Nested) {


### PR DESCRIPTION
Parse errors will now include the path to whichever field caused the parse error and the row number where the parse error occurred.