### PR TITLE
ARROW-6777: [GLib][CI] Unpin gobject-introspection gem

### DIFF
--- a/c_glib/Gemfile
+++ b/c_glib/Gemfile
@@ -20,4 +20,4 @@
 source "https://rubygems.org/"
 
 gem "test-unit"
-gem "gobject-introspection", "= 3.3.7"
+gem "gobject-introspection"

--- a/c_glib/test/plasma/test-plasma-client.rb
+++ b/c_glib/test/plasma/test-plasma-client.rb
@@ -21,6 +21,7 @@ class TestPlasmaClient < Test::Unit::TestCase
   def setup
     @store = nil
     omit("Plasma is required") unless defined?(::Plasma)
+    require_gi_bindings(3, 3, 9)
     @store = Helper::PlasmaStore.new
     @store.start
     @options = Plasma::ClientOptions.new

--- a/c_glib/test/plasma/test-plasma-created-object.rb
+++ b/c_glib/test/plasma/test-plasma-created-object.rb
@@ -16,9 +16,12 @@
 # under the License.
 
 class TestPlasmaCreatedObject < Test::Unit::TestCase
+  include Helper::Omittable
+
   def setup
     @store = nil
     omit("Plasma is required") unless defined?(::Plasma)
+    require_gi_bindings(3, 3, 9)
     @store = Helper::PlasmaStore.new
     @store.start
     @client = Plasma::Client.new(@store.socket_path, nil)

--- a/c_glib/test/plasma/test-plasma-referred-object.rb
+++ b/c_glib/test/plasma/test-plasma-referred-object.rb
@@ -16,9 +16,12 @@
 # under the License.
 
 class TestPlasmaReferredObject < Test::Unit::TestCase
+  include Helper::Omittable
+
   def setup
     @store = nil
     omit("Plasma is required") unless defined?(::Plasma)
+    require_gi_bindings(3, 3, 9)
     @store = Helper::PlasmaStore.new
     @store.start
     @client = Plasma::Client.new(@store.socket_path, nil)

--- a/c_glib/test/test-cuda.rb
+++ b/c_glib/test/test-cuda.rb
@@ -17,6 +17,7 @@
 
 class TestCUDA < Test::Unit::TestCase
   include Helper::Buildable
+  include Helper::Omittable
 
   def setup
     omit("Arrow CUDA is required") unless defined?(::ArrowCUDA)
@@ -47,6 +48,7 @@ class TestCUDA < Test::Unit::TestCase
     end
 
     def test_export
+      require_gi_bindings(3, 3, 9)
       @buffer.copy_from_host("Hello World")
       handle = @buffer.export
       serialized_handle = handle.serialize.data

--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.extensions = ["ext/arrow/extconf.rb"]
 
   spec.add_runtime_dependency("extpp", ">= 0.0.7")
-  spec.add_runtime_dependency("gio2", "= 3.3.7")
+  spec.add_runtime_dependency("gio2", ">= 3.3.6")
   spec.add_runtime_dependency("native-package-installer")
   spec.add_runtime_dependency("pkg-config")
 

--- a/ruby/red-plasma/test/helper/omittable.rb
+++ b/ruby/red-plasma/test/helper/omittable.rb
@@ -15,11 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "plasma"
+module Helper
+  module Omittable
+    def require_gi_bindings(major, minor, micro)
+      return if GLib.check_binding_version?(major, minor, micro)
+      message =
+        "Require gobject-introspection #{major}.#{minor}.#{micro} or later: " +
+        GLib::BINDING_VERSION.join(".")
+      omit(message)
+    end
 
-require "tempfile"
-
-require "test-unit"
-
-require_relative "helper/omittable"
-require_relative "helper/plasma-store"
+    def require_gi(major, minor, micro)
+      return if GObjectIntrospection::Version.or_later?(major, minor, micro)
+      message =
+        "Require GObject Introspection #{major}.#{minor}.#{micro} or later: " +
+        GObjectIntrospection::Version::STRING
+      omit(message)
+    end
+  end
+end

--- a/ruby/red-plasma/test/test-plasma-client.rb
+++ b/ruby/red-plasma/test/test-plasma-client.rb
@@ -16,8 +16,11 @@
 # under the License.
 
 class TestPlasmaClient < Test::Unit::TestCase
+  include Helper::Omittable
+
   def setup
     @store = nil
+    require_gi_bindings(3, 3, 9)
     @store = Helper::PlasmaStore.new
     @store.start
     @id = Plasma::ObjectID.new("Hello")


### PR DESCRIPTION
gobject-introspection gem 3.3.8 or later is needed for GLib 2.62.0 or
later. But gobject-introspection gem 3.3.8 has some problems.

This change omits tests that are affected by these problems.