### PR TITLE
ARROW-6790: [Release] Enable selected integration tests in release verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -443,10 +443,12 @@ test_integration() {
 
   pushd integration
 
-  if [ ${TEST_INTEGRATION_SELECTED} -gt 0 ]; then
-    INTEGRATION_TEST_ARGS="--enable-c++=${TEST_CPP} --enable-java=${TEST_JAVA} --enable-js=${TEST_JS} --enable-go=${TEST_GO}"
-  else
+  if [ ${TEST_INTEGRATION} -gt 0 ]; then
+    # Default to test all languages
     INTEGRATION_TEST_ARGS=
+  else
+    # Run selective tests
+    INTEGRATION_TEST_ARGS="--enable-c++=${TEST_INTEGRATION_CPP} --enable-java=${TEST_INTEGRATION_JAVA} --enable-js=${TEST_INTEGRATION_JS} --enable-go=${TEST_INTEGRATION_GO}"
   fi
 
   if [ "${ARROW_FLIGHT}" = "ON" ]; then
@@ -507,7 +509,11 @@ test_source_distribution() {
   if [ ${TEST_RUST} -gt 0 ]; then
     test_rust
   fi
-  if [ ${TEST_INTEGRATION} -gt 0 ] || [ ${TEST_INTEGRATION_SELECTED} -gt 0 ]; then
+  if [ ${TEST_INTEGRATION} -gt 0 ] ||
+     [ ${TEST_INTEGRATION_CPP} -gt 0 ] ||
+     [ ${TEST_INTEGRATION_JAVA} -gt 0 ] ||
+     [ ${TEST_INTEGRATION_JS} -gt 0 ] ||
+     [ ${TEST_INTEGRATION_GO} -gt 0 ]; then
     test_integration
   fi
 }
@@ -530,13 +536,6 @@ test_binary_distribution() {
 # To deactivate one test, deactivate the test and all of its dependents
 # To explicitly select one test, set TEST_DEFAULT=0 TEST_X=1
 : ${TEST_DEFAULT:=1}
-
-# For selective integration testing, set TEST_INTEGRATION_SELECTED=1 TEST_X=1
-: ${TEST_INTEGRATION_SELECTED:=0}
-if [ ${TEST_INTEGRATION_SELECTED} -gt 0 ]; then
-  TEST_DEFAULT=0
-fi
-
 : ${TEST_SOURCE:=${TEST_DEFAULT}}
 : ${TEST_JAVA:=${TEST_DEFAULT}}
 : ${TEST_CPP:=${TEST_DEFAULT}}
@@ -552,12 +551,18 @@ fi
 : ${TEST_APT:=${TEST_DEFAULT}}
 : ${TEST_YUM:=${TEST_DEFAULT}}
 
+# For selective Integration testing, set TEST_DEFAULT=0 TEST_INTEGRATION_X=1 TEST_INTEGRATION_Y=1
+: ${TEST_INTEGRATION_CPP:=0}
+: ${TEST_INTEGRATION_JAVA:=0}
+: ${TEST_INTEGRATION_JS:=0}
+: ${TEST_INTEGRATION_GO:=0}
+
 # Automatically test if its activated by a dependent
 TEST_GLIB=$((${TEST_GLIB} + ${TEST_RUBY}))
-TEST_CPP=$((${TEST_CPP} + ${TEST_GLIB} + ${TEST_PYTHON} + ${TEST_INTEGRATION}))
-TEST_JAVA=$((${TEST_JAVA} + ${TEST_INTEGRATION}))
-TEST_JS=$((${TEST_JS} + ${TEST_INTEGRATION}))
-TEST_GO=$((${TEST_GO} + ${TEST_INTEGRATION}))
+TEST_CPP=$((${TEST_CPP} + ${TEST_GLIB} + ${TEST_PYTHON} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_CPP}))
+TEST_JAVA=$((${TEST_JAVA} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_JAVA}))
+TEST_JS=$((${TEST_JS} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_JS}))
+TEST_GO=$((${TEST_GO} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_GO}))
 
 : ${TEST_ARCHIVE:=apache-arrow-${VERSION}.tar.gz}
 case "${TEST_ARCHIVE}" in

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -443,10 +443,14 @@ test_integration() {
 
   pushd integration
 
-  INTEGRATION_TEST_ARGS=
+  if [ ${TEST_INTEGRATION_SELECTED} -gt 0 ]; then
+    INTEGRATION_TEST_ARGS="--enable-c++=${TEST_CPP} --enable-java=${TEST_JAVA} --enable-js=${TEST_JS} --enable-go=${TEST_GO}"
+  else
+    INTEGRATION_TEST_ARGS=
+  fi
 
   if [ "${ARROW_FLIGHT}" = "ON" ]; then
-    INTEGRATION_TEST_ARGS=--run_flight
+    INTEGRATION_TEST_ARGS="${INTEGRATION_TEST_ARGS} --run_flight"
   fi
 
   # Flight integration test executable have runtime dependency on
@@ -503,7 +507,7 @@ test_source_distribution() {
   if [ ${TEST_RUST} -gt 0 ]; then
     test_rust
   fi
-  if [ ${TEST_INTEGRATION} -gt 0 ]; then
+  if [ ${TEST_INTEGRATION} -gt 0 ] || [ ${TEST_INTEGRATION_SELECTED} -gt 0 ]; then
     test_integration
   fi
 }
@@ -526,6 +530,13 @@ test_binary_distribution() {
 # To deactivate one test, deactivate the test and all of its dependents
 # To explicitly select one test, set TEST_DEFAULT=0 TEST_X=1
 : ${TEST_DEFAULT:=1}
+
+# For selective integration testing, set TEST_INTEGRATION_SELECTED=1 TEST_X=1
+: ${TEST_INTEGRATION_SELECTED:=0}
+if [ ${TEST_INTEGRATION_SELECTED} -gt 0 ]; then
+  TEST_DEFAULT=0
+fi
+
 : ${TEST_SOURCE:=${TEST_DEFAULT}}
 : ${TEST_JAVA:=${TEST_DEFAULT}}
 : ${TEST_CPP:=${TEST_DEFAULT}}
@@ -543,10 +554,10 @@ test_binary_distribution() {
 
 # Automatically test if its activated by a dependent
 TEST_GLIB=$((${TEST_GLIB} + ${TEST_RUBY}))
-TEST_PYTHON=$((${TEST_PYTHON} + ${TEST_INTEGRATION}))
-TEST_CPP=$((${TEST_CPP} + ${TEST_GLIB} + ${TEST_PYTHON}))
+TEST_CPP=$((${TEST_CPP} + ${TEST_GLIB} + ${TEST_PYTHON} + ${TEST_INTEGRATION}))
 TEST_JAVA=$((${TEST_JAVA} + ${TEST_INTEGRATION}))
 TEST_JS=$((${TEST_JS} + ${TEST_INTEGRATION}))
+TEST_GO=$((${TEST_GO} + ${TEST_INTEGRATION}))
 
 : ${TEST_ARCHIVE:=apache-arrow-${VERSION}.tar.gz}
 case "${TEST_ARCHIVE}" in

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -443,13 +443,7 @@ test_integration() {
 
   pushd integration
 
-  if [ ${TEST_INTEGRATION} -gt 0 ]; then
-    # Default to test all languages
-    INTEGRATION_TEST_ARGS=
-  else
-    # Run selective tests
-    INTEGRATION_TEST_ARGS="--enable-c++=${TEST_INTEGRATION_CPP} --enable-java=${TEST_INTEGRATION_JAVA} --enable-js=${TEST_INTEGRATION_JS} --enable-go=${TEST_INTEGRATION_GO}"
-  fi
+  INTEGRATION_TEST_ARGS="--enable-c++=${TEST_INTEGRATION_CPP} --enable-java=${TEST_INTEGRATION_JAVA} --enable-js=${TEST_INTEGRATION_JS} --enable-go=${TEST_INTEGRATION_GO}"
 
   if [ "${ARROW_FLIGHT}" = "ON" ]; then
     INTEGRATION_TEST_ARGS="${INTEGRATION_TEST_ARGS} --run_flight"
@@ -509,11 +503,7 @@ test_source_distribution() {
   if [ ${TEST_RUST} -gt 0 ]; then
     test_rust
   fi
-  if [ ${TEST_INTEGRATION} -gt 0 ] ||
-     [ ${TEST_INTEGRATION_CPP} -gt 0 ] ||
-     [ ${TEST_INTEGRATION_JAVA} -gt 0 ] ||
-     [ ${TEST_INTEGRATION_JS} -gt 0 ] ||
-     [ ${TEST_INTEGRATION_GO} -gt 0 ]; then
+  if [ ${TEST_INTEGRATION} -gt 0 ]; then
     test_integration
   fi
 }
@@ -552,17 +542,18 @@ test_binary_distribution() {
 : ${TEST_YUM:=${TEST_DEFAULT}}
 
 # For selective Integration testing, set TEST_DEFAULT=0 TEST_INTEGRATION_X=1 TEST_INTEGRATION_Y=1
-: ${TEST_INTEGRATION_CPP:=0}
-: ${TEST_INTEGRATION_JAVA:=0}
-: ${TEST_INTEGRATION_JS:=0}
-: ${TEST_INTEGRATION_GO:=0}
+: ${TEST_INTEGRATION_CPP:=${TEST_INTEGRATION}}
+: ${TEST_INTEGRATION_JAVA:=${TEST_INTEGRATION}}
+: ${TEST_INTEGRATION_JS:=${TEST_INTEGRATION}}
+: ${TEST_INTEGRATION_GO:=${TEST_INTEGRATION}}
 
 # Automatically test if its activated by a dependent
 TEST_GLIB=$((${TEST_GLIB} + ${TEST_RUBY}))
-TEST_CPP=$((${TEST_CPP} + ${TEST_GLIB} + ${TEST_PYTHON} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_CPP}))
-TEST_JAVA=$((${TEST_JAVA} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_JAVA}))
-TEST_JS=$((${TEST_JS} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_JS}))
-TEST_GO=$((${TEST_GO} + ${TEST_INTEGRATION} + ${TEST_INTEGRATION_GO}))
+TEST_CPP=$((${TEST_CPP} + ${TEST_GLIB} + ${TEST_PYTHON} + ${TEST_INTEGRATION_CPP}))
+TEST_JAVA=$((${TEST_JAVA} + ${TEST_INTEGRATION_JAVA}))
+TEST_JS=$((${TEST_JS} + ${TEST_INTEGRATION_JS}))
+TEST_GO=$((${TEST_GO} + ${TEST_INTEGRATION_GO}))
+TEST_INTEGRATION=$((${TEST_INTEGRATION} + ${TEST_INTEGRATION_CPP} + ${TEST_INTEGRATION_JAVA} + ${TEST_INTEGRATION_JS} + ${TEST_INTEGRATION_GO}))
 
 : ${TEST_ARCHIVE:=apache-arrow-${VERSION}.tar.gz}
 case "${TEST_ARCHIVE}" in


### PR DESCRIPTION
This adds the functionality to the release verification script at `dev/release/verify-release-candidate.sh" to enable integration testing only for selected Arrow implementations. This makes it possible to still run partial integration testing. Example usage is:
```sh
TEST_DEFAULT=0 \
TEST_INTEGRATION_CPP=1 \
TEST_INTEGRATION_JAVA=1  \
dev/release/verify-release-candidate.sh source 0.15.0 2
```
