### PR TITLE
ARROW-6274: [Rust] [DataFusion] Add support for writing results to CSV

### DIFF
--- a/rust/arrow/benches/csv_writer.rs
+++ b/rust/arrow/benches/csv_writer.rs
@@ -54,12 +54,11 @@ fn record_batches_to_csv() {
     )
     .unwrap();
     let file = File::create("target/bench_write_csv.csv").unwrap();
-    let writer = csv::Writer::new(file);
-    criterion::black_box(
-        writer
-            .write(vec![&b, &b, &b, &b, &b, &b, &b, &b, &b, &b, &b])
-            .unwrap(),
-    );
+    let mut writer = csv::Writer::new(file);
+    let batches = vec![&b, &b, &b, &b, &b, &b, &b, &b, &b, &b, &b];
+    criterion::black_box(for batch in batches {
+        writer.write(batch).unwrap()
+    });
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -102,7 +102,7 @@ pub struct Writer<W: Write> {
     /// The time format for time arrays
     time_format: String,
     /// Is the beginning-of-writer
-    bow: bool,
+    beginning: bool,
 }
 
 impl<'a, 'b: 'a, W: Write + 'b> Writer<W>
@@ -118,7 +118,7 @@ where
             date_format: DEFAULT_DATE_FORMAT.to_string(),
             time_format: DEFAULT_TIME_FORMAT.to_string(),
             timestamp_format: DEFAULT_TIMESTAMP_FORMAT.to_string(),
-            bow: true,
+            beginning: true,
         }
     }
 
@@ -253,7 +253,7 @@ where
         let mut builder = csv_crate::WriterBuilder::new();
         let mut wtr = builder.delimiter(self.delimiter).from_writer(&self.writer);
         let num_columns = batch.num_columns();
-        if self.bow {
+        if self.beginning {
             if self.has_headers {
                 let mut headers: Vec<String> = Vec::with_capacity(num_columns);
                 &batch
@@ -263,11 +263,11 @@ where
                     .for_each(|field| headers.push(field.name().to_string()));
                 wtr.write_record(&headers[..])?;
             }
-            self.bow = false;
+            self.beginning = false;
         }
 
         for row_index in 0..batch.num_rows() {
-            let record = self.convert(batch, row_index).unwrap();
+            let record = self.convert(batch, row_index)?;
             wtr.write_record(&record[..])?;
         }
         wtr.flush()?;
@@ -370,7 +370,7 @@ impl WriterBuilder {
             timestamp_format: self
                 .timestamp_format
                 .unwrap_or(DEFAULT_TIMESTAMP_FORMAT.to_string()),
-            bow: false,
+            beginning: false,
         }
     }
 }

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -58,13 +58,16 @@
 //!
 //! let file = get_temp_file("out.csv", &[]);
 //!
-//! let writer = csv::Writer::new(file);
-//! writer.write(vec![&batch, &batch]).unwrap();
+//! let mut writer = csv::Writer::new(file);
+//! let batches = vec![&batch, &batch];
+//! for batch in batches {
+//!     writer.write(batch).unwrap();
+//! }
 //! ```
 
 use csv as csv_crate;
 
-use std::fs::File;
+use std::io::Write;
 
 use crate::array::*;
 use crate::datatypes::*;
@@ -85,9 +88,9 @@ where
 }
 
 /// A CSV writer
-pub struct Writer {
-    /// The file to write to
-    file: File,
+pub struct Writer<W: Write> {
+    /// The object to write to
+    writer: W,
     /// Column delimiter. Defaults to `b','`
     delimiter: u8,
     /// Whether file should be written with headers. Defaults to `true`
@@ -98,189 +101,176 @@ pub struct Writer {
     timestamp_format: String,
     /// The time format for time arrays
     time_format: String,
+    /// Is the beginning-of-writer
+    bow: bool,
 }
 
-impl Writer {
-    /// Create a new CsvWriter from a file, with default options
-    pub fn new(file: File) -> Self {
+impl<'a, 'b: 'a, W: Write + 'b> Writer<W>
+where
+    &'a W: Write,
+{
+    /// Create a new CsvWriter from a writable object, with default options
+    pub fn new(writer: W) -> Self {
         Writer {
-            file,
+            writer,
             delimiter: b',',
             has_headers: true,
             date_format: DEFAULT_DATE_FORMAT.to_string(),
             time_format: DEFAULT_TIME_FORMAT.to_string(),
             timestamp_format: DEFAULT_TIMESTAMP_FORMAT.to_string(),
+            bow: true,
         }
     }
 
-    /// Write a vector of record batches to a file
-    pub fn write(&self, batches: Vec<&RecordBatch>) -> Result<()> {
-        if batches.is_empty() {
-            return Err(ArrowError::CsvError(
-                "No record batches supplied to the CSV writer".to_string(),
-            ));
-        }
-        let mut builder = csv_crate::WriterBuilder::new();
-        let mut wtr = builder.delimiter(self.delimiter).from_writer(&self.file);
-        let num_columns = batches[0].num_columns();
-        if self.has_headers {
-            let mut headers: Vec<String> = Vec::with_capacity(num_columns);
-            &batches[0]
-                .schema()
-                .fields()
-                .iter()
-                .for_each(|field| headers.push(field.name().to_string()));
-            wtr.write_record(&headers[..])?;
-        }
-
-        for batch in batches {
-            for row_index in 0..batch.num_rows() {
-                // TODO: it'd be more efficient if we could create `record: Vec<&[u8]>
-                let mut record: Vec<String> = Vec::with_capacity(batch.num_columns());
-                for col_index in 0..batch.num_columns() {
-                    let col = batch.column(col_index);
-                    if col.is_null(row_index) {
-                        // write an empty value
-                        record.push(String::from(""));
-                        continue;
-                    }
-                    let string = match col.data_type() {
-                        DataType::Float64 => {
-                            write_primitive_value::<Float64Type>(col, row_index)
-                        }
-                        DataType::Float32 => {
-                            write_primitive_value::<Float32Type>(col, row_index)
-                        }
-                        DataType::Int8 => {
-                            write_primitive_value::<Int8Type>(col, row_index)
-                        }
-                        DataType::Int16 => {
-                            write_primitive_value::<Int16Type>(col, row_index)
-                        }
-                        DataType::Int32 => {
-                            write_primitive_value::<Int32Type>(col, row_index)
-                        }
-                        DataType::Int64 => {
-                            write_primitive_value::<Int64Type>(col, row_index)
-                        }
-                        DataType::UInt8 => {
-                            write_primitive_value::<UInt8Type>(col, row_index)
-                        }
-                        DataType::UInt16 => {
-                            write_primitive_value::<UInt16Type>(col, row_index)
-                        }
-                        DataType::UInt32 => {
-                            write_primitive_value::<UInt32Type>(col, row_index)
-                        }
-                        DataType::UInt64 => {
-                            write_primitive_value::<UInt64Type>(col, row_index)
-                        }
-                        DataType::Boolean => {
-                            let c = col.as_any().downcast_ref::<BooleanArray>().unwrap();
-                            c.value(row_index).to_string()
-                        }
-                        DataType::Utf8 => {
-                            let c = col.as_any().downcast_ref::<BinaryArray>().unwrap();
-                            String::from_utf8(c.value(row_index).to_vec())?
-                        }
-                        DataType::Date32(DateUnit::Day) => {
-                            let c = col.as_any().downcast_ref::<Date32Array>().unwrap();
-                            c.value_as_date(row_index)
-                                .unwrap()
-                                .format(&self.date_format)
-                                .to_string()
-                        }
-                        DataType::Date64(DateUnit::Millisecond) => {
-                            let c = col.as_any().downcast_ref::<Date64Array>().unwrap();
-                            c.value_as_date(row_index)
-                                .unwrap()
-                                .format(&self.date_format)
-                                .to_string()
-                        }
-                        DataType::Time32(TimeUnit::Second) => {
-                            let c =
-                                col.as_any().downcast_ref::<Time32SecondArray>().unwrap();
-                            c.value_as_time(row_index)
-                                .unwrap()
-                                .format(&self.time_format)
-                                .to_string()
-                        }
-                        DataType::Time32(TimeUnit::Millisecond) => {
-                            let c = col
-                                .as_any()
-                                .downcast_ref::<Time32MillisecondArray>()
-                                .unwrap();
-                            c.value_as_time(row_index)
-                                .unwrap()
-                                .format(&self.time_format)
-                                .to_string()
-                        }
-                        DataType::Time64(TimeUnit::Microsecond) => {
-                            let c = col
-                                .as_any()
-                                .downcast_ref::<Time64MicrosecondArray>()
-                                .unwrap();
-                            c.value_as_time(row_index)
-                                .unwrap()
-                                .format(&self.time_format)
-                                .to_string()
-                        }
-                        DataType::Time64(TimeUnit::Nanosecond) => {
-                            let c = col
-                                .as_any()
-                                .downcast_ref::<Time64NanosecondArray>()
-                                .unwrap();
-                            c.value_as_time(row_index)
-                                .unwrap()
-                                .format(&self.time_format)
-                                .to_string()
-                        }
-                        DataType::Timestamp(time_unit) => {
-                            use TimeUnit::*;
-                            let datetime = match time_unit {
-                                Second => col
-                                    .as_any()
-                                    .downcast_ref::<TimestampSecondArray>()
-                                    .unwrap()
-                                    .value_as_datetime(row_index)
-                                    .unwrap(),
-                                Millisecond => col
-                                    .as_any()
-                                    .downcast_ref::<TimestampMillisecondArray>()
-                                    .unwrap()
-                                    .value_as_datetime(row_index)
-                                    .unwrap(),
-                                Microsecond => col
-                                    .as_any()
-                                    .downcast_ref::<TimestampMicrosecondArray>()
-                                    .unwrap()
-                                    .value_as_datetime(row_index)
-                                    .unwrap(),
-                                Nanosecond => col
-                                    .as_any()
-                                    .downcast_ref::<TimestampNanosecondArray>()
-                                    .unwrap()
-                                    .value_as_datetime(row_index)
-                                    .unwrap(),
-                            };
-                            format!("{}", datetime.format(&self.timestamp_format))
-                        }
-                        t => {
-                            // List and Struct arrays not supported by the writer, any
-                            // other type needs to be implemented
-                            return Err(ArrowError::CsvError(format!(
-                                "CSV Writer does not support {:?} data type",
-                                t
-                            )));
-                        }
-                    };
-
-                    record.push(string);
-                }
-                wtr.write_record(&record[..])?;
+    /// Convert a record to a string vector
+    fn convert(&self, batch: &RecordBatch, row_index: usize) -> Result<Vec<String>> {
+        // TODO: it'd be more efficient if we could create `record: Vec<&[u8]>
+        let mut record: Vec<String> = Vec::with_capacity(batch.num_columns());
+        for col_index in 0..batch.num_columns() {
+            let col = batch.column(col_index);
+            if col.is_null(row_index) {
+                // write an empty value
+                record.push(String::from(""));
+                continue;
             }
-            wtr.flush()?;
+            let string = match col.data_type() {
+                DataType::Float64 => write_primitive_value::<Float64Type>(col, row_index),
+                DataType::Float32 => write_primitive_value::<Float32Type>(col, row_index),
+                DataType::Int8 => write_primitive_value::<Int8Type>(col, row_index),
+                DataType::Int16 => write_primitive_value::<Int16Type>(col, row_index),
+                DataType::Int32 => write_primitive_value::<Int32Type>(col, row_index),
+                DataType::Int64 => write_primitive_value::<Int64Type>(col, row_index),
+                DataType::UInt8 => write_primitive_value::<UInt8Type>(col, row_index),
+                DataType::UInt16 => write_primitive_value::<UInt16Type>(col, row_index),
+                DataType::UInt32 => write_primitive_value::<UInt32Type>(col, row_index),
+                DataType::UInt64 => write_primitive_value::<UInt64Type>(col, row_index),
+                DataType::Boolean => {
+                    let c = col.as_any().downcast_ref::<BooleanArray>().unwrap();
+                    c.value(row_index).to_string()
+                }
+                DataType::Utf8 => {
+                    let c = col.as_any().downcast_ref::<BinaryArray>().unwrap();
+                    String::from_utf8(c.value(row_index).to_vec())?
+                }
+                DataType::Date32(DateUnit::Day) => {
+                    let c = col.as_any().downcast_ref::<Date32Array>().unwrap();
+                    c.value_as_date(row_index)
+                        .unwrap()
+                        .format(&self.date_format)
+                        .to_string()
+                }
+                DataType::Date64(DateUnit::Millisecond) => {
+                    let c = col.as_any().downcast_ref::<Date64Array>().unwrap();
+                    c.value_as_date(row_index)
+                        .unwrap()
+                        .format(&self.date_format)
+                        .to_string()
+                }
+                DataType::Time32(TimeUnit::Second) => {
+                    let c = col.as_any().downcast_ref::<Time32SecondArray>().unwrap();
+                    c.value_as_time(row_index)
+                        .unwrap()
+                        .format(&self.time_format)
+                        .to_string()
+                }
+                DataType::Time32(TimeUnit::Millisecond) => {
+                    let c = col
+                        .as_any()
+                        .downcast_ref::<Time32MillisecondArray>()
+                        .unwrap();
+                    c.value_as_time(row_index)
+                        .unwrap()
+                        .format(&self.time_format)
+                        .to_string()
+                }
+                DataType::Time64(TimeUnit::Microsecond) => {
+                    let c = col
+                        .as_any()
+                        .downcast_ref::<Time64MicrosecondArray>()
+                        .unwrap();
+                    c.value_as_time(row_index)
+                        .unwrap()
+                        .format(&self.time_format)
+                        .to_string()
+                }
+                DataType::Time64(TimeUnit::Nanosecond) => {
+                    let c = col
+                        .as_any()
+                        .downcast_ref::<Time64NanosecondArray>()
+                        .unwrap();
+                    c.value_as_time(row_index)
+                        .unwrap()
+                        .format(&self.time_format)
+                        .to_string()
+                }
+                DataType::Timestamp(time_unit) => {
+                    use TimeUnit::*;
+                    let datetime = match time_unit {
+                        Second => col
+                            .as_any()
+                            .downcast_ref::<TimestampSecondArray>()
+                            .unwrap()
+                            .value_as_datetime(row_index)
+                            .unwrap(),
+                        Millisecond => col
+                            .as_any()
+                            .downcast_ref::<TimestampMillisecondArray>()
+                            .unwrap()
+                            .value_as_datetime(row_index)
+                            .unwrap(),
+                        Microsecond => col
+                            .as_any()
+                            .downcast_ref::<TimestampMicrosecondArray>()
+                            .unwrap()
+                            .value_as_datetime(row_index)
+                            .unwrap(),
+                        Nanosecond => col
+                            .as_any()
+                            .downcast_ref::<TimestampNanosecondArray>()
+                            .unwrap()
+                            .value_as_datetime(row_index)
+                            .unwrap(),
+                    };
+                    format!("{}", datetime.format(&self.timestamp_format))
+                }
+                t => {
+                    // List and Struct arrays not supported by the writer, any
+                    // other type needs to be implemented
+                    return Err(ArrowError::CsvError(format!(
+                        "CSV Writer does not support {:?} data type",
+                        t
+                    )));
+                }
+            };
+
+            record.push(string);
         }
+        Ok(record)
+    }
+
+    /// Write a vector of record batches to a writable object
+    pub fn write(&'a mut self, batch: &RecordBatch) -> Result<()> {
+        let mut builder = csv_crate::WriterBuilder::new();
+        let mut wtr = builder.delimiter(self.delimiter).from_writer(&self.writer);
+        let num_columns = batch.num_columns();
+        if self.bow {
+            if self.has_headers {
+                let mut headers: Vec<String> = Vec::with_capacity(num_columns);
+                &batch
+                    .schema()
+                    .fields()
+                    .iter()
+                    .for_each(|field| headers.push(field.name().to_string()));
+                wtr.write_record(&headers[..])?;
+            }
+            self.bow = false;
+        }
+
+        for row_index in 0..batch.num_rows() {
+            let record = self.convert(batch, row_index).unwrap();
+            wtr.write_record(&record[..])?;
+        }
+        wtr.flush()?;
 
         Ok(())
     }
@@ -325,7 +315,7 @@ impl WriterBuilder {
     /// use arrow::csv;
     /// use std::fs::File;
     ///
-    /// fn example() -> csv::Writer {
+    /// fn example() -> csv::Writer<File> {
     ///     let file = File::create("target/out.csv").unwrap();
     ///
     ///     // create a builder that doesn't write headers
@@ -370,9 +360,9 @@ impl WriterBuilder {
     }
 
     /// Create a new `Writer`
-    pub fn build(self, file: File) -> Writer {
+    pub fn build<W: Write>(self, writer: W) -> Writer<W> {
         Writer {
-            file,
+            writer,
             delimiter: self.delimiter.unwrap_or(b','),
             has_headers: self.has_headers,
             date_format: self.date_format.unwrap_or(DEFAULT_DATE_FORMAT.to_string()),
@@ -380,6 +370,7 @@ impl WriterBuilder {
             timestamp_format: self
                 .timestamp_format
                 .unwrap_or(DEFAULT_TIMESTAMP_FORMAT.to_string()),
+            bow: false,
         }
     }
 }
@@ -389,7 +380,9 @@ mod tests {
     use super::*;
 
     use crate::datatypes::{Field, Schema};
+    use crate::util::string_writer::StringWriter;
     use crate::util::test_util::get_temp_file;
+    use std::fs::File;
     use std::io::Read;
     use std::sync::Arc;
 
@@ -438,9 +431,11 @@ mod tests {
 
         let file = get_temp_file("columns.csv", &[]);
 
-        let writer = Writer::new(file);
-        writer.write(vec![&batch, &batch]).unwrap();
-
+        let mut writer = Writer::new(file);
+        let batches = vec![&batch, &batch];
+        for batch in batches {
+            writer.write(batch).unwrap();
+        }
         // check that file was written successfully
         let mut file = File::open("target/debug/testdata/columns.csv").unwrap();
         let mut buffer: Vec<u8> = vec![];
@@ -502,9 +497,11 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             .has_headers(false)
             .with_delimiter(b'|')
             .with_time_format("%r".to_string());
-
-        let writer = builder.build(file);
-        writer.write(vec![&batch]).unwrap();
+        let mut writer = builder.build(file);
+        let batches = vec![&batch];
+        for batch in batches {
+            writer.write(batch).unwrap();
+        }
 
         // check that file was written successfully
         let mut file = File::open("target/debug/testdata/custom_options.csv").unwrap();
@@ -515,6 +512,70 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             "Lorem ipsum dolor sit amet|123.564532|3|true|12:20:34 AM\nconsectetur adipiscing elit||2|false|06:51:20 AM\nsed do eiusmod tempor|-556132.25|1||11:46:03 PM\n"
             .to_string(),
             String::from_utf8(buffer).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_export_csv_string() {
+        let schema = Schema::new(vec![
+            Field::new("c1", DataType::Utf8, false),
+            Field::new("c2", DataType::Float64, true),
+            Field::new("c3", DataType::UInt32, false),
+            Field::new("c4", DataType::Boolean, true),
+            Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond), true),
+            Field::new("c6", DataType::Time32(TimeUnit::Second), false),
+        ]);
+
+        let c1 = BinaryArray::from(vec![
+            "Lorem ipsum dolor sit amet",
+            "consectetur adipiscing elit",
+            "sed do eiusmod tempor",
+        ]);
+        let c2 = PrimitiveArray::<Float64Type>::from(vec![
+            Some(123.564532),
+            None,
+            Some(-556132.25),
+        ]);
+        let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
+        let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+        let c5 = TimestampMillisecondArray::from(vec![
+            None,
+            Some(1555584887378),
+            Some(1555555555555),
+        ]);
+        let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
+
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(c1),
+                Arc::new(c2),
+                Arc::new(c3),
+                Arc::new(c4),
+                Arc::new(c5),
+                Arc::new(c6),
+            ],
+        )
+        .unwrap();
+
+        let sw = StringWriter::new();
+        let mut writer = Writer::new(sw);
+        let batches = vec![&batch, &batch];
+        for batch in batches {
+            writer.write(batch).unwrap();
+        }
+
+        assert_eq!(
+            r#"c1,c2,c3,c4,c5,c6
+Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34
+consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20
+sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
+Lorem ipsum dolor sit amet,123.564532,3,true,,00:20:34
+consectetur adipiscing elit,,2,false,2019-04-18T10:54:47.378000000,06:51:20
+sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
+"#
+            .to_string(),
+            writer.writer.to_string()
         );
     }
 }

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -16,4 +16,5 @@
 // under the License.
 
 pub mod bit_util;
+pub mod string_writer;
 pub mod test_util;

--- a/rust/arrow/src/util/string_writer.rs
+++ b/rust/arrow/src/util/string_writer.rs
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! String Writer
+//! This string writer encapsulates `std::string::String` and
+//! implements `std::io::Write` trait, which makes String as a
+//! writable object like File.
+//!
+//! Example:
+//!
+//! ```
+//! use arrow::array::*;
+//! use arrow::csv;
+//! use arrow::datatypes::*;
+//! use arrow::record_batch::RecordBatch;
+//! use arrow::util::string_writer::StringWriter;
+//! use std::sync::Arc;
+//!
+//! let schema = Schema::new(vec![
+//!     Field::new("c1", DataType::Utf8, false),
+//!     Field::new("c2", DataType::Float64, true),
+//!     Field::new("c3", DataType::UInt32, false),
+//!     Field::new("c3", DataType::Boolean, true),
+//! ]);
+//! let c1 = BinaryArray::from(vec![
+//!     "Lorem ipsum dolor sit amet",
+//!     "consectetur adipiscing elit",
+//!     "sed do eiusmod tempor",
+//! ]);
+//! let c2 = PrimitiveArray::<Float64Type>::from(vec![
+//!     Some(123.564532),
+//!     None,
+//!     Some(-556132.25),
+//! ]);
+//! let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
+//! let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
+//!
+//! let batch = RecordBatch::try_new(
+//!     Arc::new(schema),
+//!     vec![Arc::new(c1), Arc::new(c2), Arc::new(c3), Arc::new(c4)],
+//! )
+//! .unwrap();
+//!
+//! let sw = StringWriter::new();
+//! let mut writer = csv::Writer::new(sw);
+//! writer.write(&batch).unwrap();
+//! ```
+
+use std::cell::RefCell;
+use std::io::{Error, ErrorKind, Result, Write};
+
+pub struct StringWriter {
+    data: RefCell<String>,
+}
+
+impl StringWriter {
+    pub fn new() -> Self {
+        StringWriter {
+            data: RefCell::new(String::new()),
+        }
+    }
+}
+
+impl ToString for StringWriter {
+    fn to_string(&self) -> String {
+        self.data.borrow().clone()
+    }
+}
+
+impl Write for StringWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let string = match String::from_utf8(buf.to_vec()) {
+            Ok(x) => x,
+            Err(e) => {
+                return Result::Err(Error::new(ErrorKind::InvalidData, e));
+            }
+        };
+        self.data.get_mut().push_str(&string);
+        Result::Ok(string.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Result::Ok(())
+    }
+}
+
+impl Write for &StringWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let string = match String::from_utf8(buf.to_vec()) {
+            Ok(x) => x,
+            Err(e) => {
+                return Result::Err(Error::new(ErrorKind::InvalidData, e));
+            }
+        };
+        self.data.borrow_mut().push_str(&string);
+        Result::Ok(string.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Result::Ok(())
+    }
+}


### PR DESCRIPTION
I think if we implement a function converting Relation to CSV string, it is a duplicate of some functions in arrow/csv/writer.rs, so I just added a function to export all RecordBatches in Relation.
Also, I encapsulated StringWriter in arrow/utils/string_writer.rs, as a Write trait's implementation, which can be set as arrow::csv::Writer 's parameter.

In fact, it is not an elegant implementation. I have planned to implement a function converting Vec<& RecordBatch> to string, however, the same issue, it is duplicate. 

And another way is that we can convert Vec<& RecordBatch> to Vec<Vec<String>> first and convert it into a string or write it into a file, but it may have performance issue when there are many rows.

Any suggestions are welcome. Thanks!