### PR TITLE
ARROW-6694: [Rust] [DataFusion] Integration tests now use physical query plan

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -297,16 +297,22 @@ impl ExecutionContext {
                 match expr {
                     &Expr::Literal(ref scalar_value) => {
                         let limit: usize = match scalar_value {
-                            ScalarValue::Int8(x) => Ok(*x as usize),
-                            ScalarValue::Int16(x) => Ok(*x as usize),
-                            ScalarValue::Int32(x) => Ok(*x as usize),
-                            ScalarValue::Int64(x) => Ok(*x as usize),
-                            ScalarValue::UInt8(x) => Ok(*x as usize),
-                            ScalarValue::UInt16(x) => Ok(*x as usize),
-                            ScalarValue::UInt32(x) => Ok(*x as usize),
-                            ScalarValue::UInt64(x) => Ok(*x as usize),
+                            ScalarValue::Int8(limit) if *limit >= 0 => Ok(*limit as usize),
+                            ScalarValue::Int16(limit) if *limit >= 0 => {
+                                Ok(*limit as usize)
+                            }
+                            ScalarValue::Int32(limit) if *limit >= 0 => {
+                                Ok(*limit as usize)
+                            }
+                            ScalarValue::Int64(limit) if *limit >= 0 => {
+                                Ok(*limit as usize)
+                            }
+                            ScalarValue::UInt8(limit) => Ok(*limit as usize),
+                            ScalarValue::UInt16(limit) => Ok(*limit as usize),
+                            ScalarValue::UInt32(limit) => Ok(*limit as usize),
+                            ScalarValue::UInt64(limit) => Ok(*limit as usize),
                             _ => Err(ExecutionError::ExecutionError(
-                                "Limit only support positive integer literals"
+                                "Limit only supports non-negative integer literals"
                                     .to_string(),
                             )),
                         }?;
@@ -317,7 +323,7 @@ impl ExecutionContext {
                         )))
                     }
                     _ => Err(ExecutionError::ExecutionError(
-                        "Limit only support positive integer literals".to_string(),
+                        "Limit only supports non-negative integer literals".to_string(),
                     )),
                 }
             }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::cell::RefCell;
 use std::env;
-use std::rc::Rc;
 use std::sync::Arc;
 
 extern crate arrow;
@@ -25,10 +23,10 @@ extern crate datafusion;
 
 use arrow::array::*;
 use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
 
 use datafusion::error::Result;
 use datafusion::execution::context::ExecutionContext;
-use datafusion::execution::relation::Relation;
 use datafusion::logicalplan::LogicalPlan;
 
 const DEFAULT_BATCH_SIZE: usize = 1024 * 1024;
@@ -430,14 +428,14 @@ fn register_alltypes_parquet(ctx: &mut ExecutionContext) {
 fn execute(ctx: &mut ExecutionContext, sql: &str) -> String {
     let plan = ctx.create_logical_plan(&sql).unwrap();
     let plan = ctx.optimize(&plan).unwrap();
-    let results = ctx.execute(&plan, DEFAULT_BATCH_SIZE).unwrap();
+    let plan = ctx.create_physical_plan(&plan, DEFAULT_BATCH_SIZE).unwrap();
+    let results = ctx.collect(plan.as_ref()).unwrap();
     result_str(&results)
 }
 
-fn result_str(results: &Rc<RefCell<dyn Relation>>) -> String {
-    let mut relation = results.borrow_mut();
+fn result_str(results: &Vec<RecordBatch>) -> String {
     let mut str = String::new();
-    while let Some(batch) = relation.next().unwrap() {
+    for batch in results {
         for row_index in 0..batch.num_rows() {
             for column_index in 0..batch.num_columns() {
                 if column_index > 0 {


### PR DESCRIPTION
Integration tests now use physical query plan instead of executing directly from the logical plan.

As part of this PR I added the mapping from logical to physical plan for LIMIT which I somehow missed when creating the PR for the LIMIT physical plan.