### PR TITLE
ARROW-6797: [Release] Use a separately cloned arrow-site repository in the website post release script	

### DIFF
--- a/dev/release/changelog.py
+++ b/dev/release/changelog.py
@@ -33,9 +33,9 @@ import sys
 import jira.client
 
 # ASF JIRA username
-JIRA_USERNAME = os.environ.get("JIRA_USERNAME")
+JIRA_USERNAME = os.environ["APACHE_JIRA_USERNAME"]
 # ASF JIRA password
-JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD")
+JIRA_PASSWORD = os.environ["APACHE_JIRA_PASSWORD"]
 
 JIRA_API_BASE = "https://issues.apache.org/jira"
 


### PR DESCRIPTION
Seems like `site` directory was removed, but the script was not updated.