### PR TITLE
ARROW-6473: Dictionary encoding format clarifications/future proofing

### DIFF
--- a/dev/release/setup-gpg-agent.sh
+++ b/dev/release/setup-gpg-agent.sh
@@ -19,6 +19,6 @@
 #
 
 # source me
-eval $(gpg-agent --daemon --allow-preset-passphrase)
+eval $(gpg-agent --daemon --allow-preset-passphrase --default-cache-ttl 36000 --max-cache-ttl 36000)
 gpg --use-agent -s LICENSE.txt
 rm -rf LICENSE.txt.gpg

--- a/dev/release/setup-gpg-agent.sh
+++ b/dev/release/setup-gpg-agent.sh
@@ -19,6 +19,6 @@
 #
 
 # source me
-eval $(gpg-agent --daemon --allow-preset-passphrase --default-cache-ttl 36000 --max-cache-ttl 36000)
+eval $(gpg-agent --daemon --allow-preset-passphrase)
 gpg --use-agent -s LICENSE.txt
 rm -rf LICENSE.txt.gpg

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1024,13 +1024,9 @@ Schematically we have: ::
 In the file format, there is no requirement that dictionary keys
 should be defined in a ``DictionaryBatch`` before they are used in a
 ``RecordBatch``, as long as the keys are defined somewhere in the
-file. Further more, it is invalid to have more then one non-delta
+file. Further more, it is invalid to have more then one **non-delta**
 dictionary batch per dictionary ID.  Delta dictionaries are applied
 in the order they appear in the file footer.
-
-.. note:: Implementations should check to ensure the dictionary constraints
-  are satisfied.  In future revisions of the specification this requirement
-  might be relaxed.
 
 Dictionary Messages
 -------------------

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -987,7 +987,7 @@ a ``RecordBatch`` it should be defined in a ``DictionaryBatch``. ::
     <EOS [optional]: 0xFFFFFFFF 0x00000000>
 
 .. note:: An edge-case for interleaved dictionary and record batches occurs
-   when the record batches contain dictionary encoded arrays that are
+   when the the record batches contain dictionary encoded arrays that are
    completely null. In this case, the dictionary for the encoded column might
    appear after the first record batch.
 

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -1025,8 +1025,9 @@ In the file format, there is no requirement that dictionary keys
 should be defined in a ``DictionaryBatch`` before they are used in a
 ``RecordBatch``, as long as the keys are defined somewhere in the
 file. Further more, it is invalid to have more then one **non-delta**
-dictionary batch per dictionary ID.  Delta dictionaries are applied
-in the order they appear in the file footer.
+dictionary batch per dictionary ID (i.e. dictionary replacement is not
+supported).  Delta dictionaries are applied in the order they appear in 
+the file footer.
 
 Dictionary Messages
 -------------------

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -986,6 +986,11 @@ a ``RecordBatch`` it should be defined in a ``DictionaryBatch``. ::
     <RECORD BATCH n - 1>
     <EOS [optional]: 0xFFFFFFFF 0x00000000>
 
+.. note:: An edge-case for interleaved dictionary and record batches occurs
+   when the the record batches contain dictionary encoded arrays that are
+   completely null. In this case, the dictionary for the encoded column might
+   appear after the first record batch.
+
 When a stream reader implementation is reading a stream, after each
 message, it may read the next 8 bytes to determine both if the stream
 continues and the size of the message metadata that follows. Once the
@@ -1019,7 +1024,13 @@ Schematically we have: ::
 In the file format, there is no requirement that dictionary keys
 should be defined in a ``DictionaryBatch`` before they are used in a
 ``RecordBatch``, as long as the keys are defined somewhere in the
-file.
+file. Further more, it is invalid to have more then one non-delta
+dictionary batch per dictionary ID.  Delta dictionaries are applied
+in the order they appear in the file footer.
+
+.. note:: Implementations should check to ensure the dictionary constraints
+  are satisfied.  In future revisions of the specification this requirement
+  might be relaxed.
 
 Dictionary Messages
 -------------------
@@ -1072,6 +1083,37 @@ form: ::
     4
     0
     EOS
+
+Alternatively, if ``isDelta`` is set to false, then the dictionary
+replaces the existing dictionary for the same ID.  Using the same
+example as above, an alternate encoding could be: ::
+
+
+    <SCHEMA>
+    <DICTIONARY 0>
+    (0) "A"
+    (1) "B"
+    (2) "C"
+
+    <RECORD BATCH 0>
+    0
+    1
+    2
+    1
+
+    <DICTIONARY 0>
+    (0) "A"
+    (1) "C"
+    (2) "D"
+    (3) "E"
+
+    <RECORD BATCH 1>
+    2
+    1
+    3
+    0
+    EOS
+
 
 Custom Application Metadata
 ---------------------------

--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -987,7 +987,7 @@ a ``RecordBatch`` it should be defined in a ``DictionaryBatch``. ::
     <EOS [optional]: 0xFFFFFFFF 0x00000000>
 
 .. note:: An edge-case for interleaved dictionary and record batches occurs
-   when the the record batches contain dictionary encoded arrays that are
+   when the record batches contain dictionary encoded arrays that are
    completely null. In this case, the dictionary for the encoded column might
    appear after the first record batch.
 

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -74,7 +74,8 @@ table DictionaryBatch {
   data: RecordBatch;
 
   /// If isDelta is true the values in the dictionary are to be appended to a
-  /// dictionary with the indicated id
+  /// dictionary with the indicated id. If isDelta is false this dictionary
+  /// should replace the existing dictionary.
   isDelta: bool = false;
 }
 

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -267,7 +267,9 @@ table KeyValue {
 
 /// ----------------------------------------------------------------------
 /// Dictionary encoding metadata
-
+/// Maintained for forwards compatibility, in the future
+/// Dictionaries might be (sparse) maps betwen Index and Value.
+enum DictionaryType:short { DenseArray }
 table DictionaryEncoding {
   /// The known dictionary id in the application where this data is used. In
   /// the file or streaming formats, the dictionary ids are found in the
@@ -283,6 +285,8 @@ table DictionaryEncoding {
   /// is used to represent ordered categorical data, and we provide a way to
   /// preserve that metadata here
   isOrdered: bool;
+
+  dictionaryType: DictionaryType;
 }
 
 /// ----------------------------------------------------------------------

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -268,8 +268,9 @@ table KeyValue {
 /// ----------------------------------------------------------------------
 /// Dictionary encoding metadata
 /// Maintained for forwards compatibility, in the future
-/// Dictionaries might be (sparse) maps betwen Index and Value.
-enum DictionaryType:short { DenseArray }
+/// Dictionaries might be explicit maps between integers and values
+/// allowing for non-contiguous index values
+enum DictionaryKind : short { DenseArray }
 table DictionaryEncoding {
   /// The known dictionary id in the application where this data is used. In
   /// the file or streaming formats, the dictionary ids are found in the
@@ -286,7 +287,7 @@ table DictionaryEncoding {
   /// preserve that metadata here
   isOrdered: bool;
 
-  dictionaryType: DictionaryType;
+  dictionaryKind: DictionaryKind;
 }
 
 /// ----------------------------------------------------------------------


### PR DESCRIPTION
This needs to be discussed first on the mailing list.  It is a consolidation of recent dictionary encoding threads: [1](https://lists.apache.org/thread.html/9734b71bc12aca16eb997388e95105bff412fdaefa4e19422f477389@%3Cdev.arrow.apache.org%3E), [2](https://lists.apache.org/thread.html/5c3c9346101df8d758e24664638e8ada0211d310ab756a89cde3786a@%3Cdev.arrow.apache.org%3E) and [3](https://lists.apache.org/thread.html/15a4810589b2eb772bce5b2372970d9d93badbd28999a1bbe2af418a@%3Cdev.arrow.apache.org%3E)