### PR TITLE
ARROW-6798: [CI] [Rust] Build image contains cached dependencies

### DIFF
--- a/ci/docker_build_rust.sh
+++ b/ci/docker_build_rust.sh
@@ -31,8 +31,12 @@ echo "Running formatting checks ..."
 cargo +stable fmt --all -- --check
 echo "Formatting checks completed"
 
+# set up Rust env
+export RUSTC_WRAPPER=sccache
+export RUSTFLAGS="-D warnings"
+
 # build entire project
-RUSTFLAGS="-D warnings" cargo build --all-targets
+cargo build --all-targets
 
 # run tests
 cargo test

--- a/rust/Cargo.toml.cache
+++ b/rust/Cargo.toml.cache
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "arrow-dependencies"
+version = "0.0.0"
+
+[dependencies]
+brotli = "2.5"
+byteorder = "1"
+chrono = "0.4.7"
+clap = "2.33.0"
+crossbeam = "0.7.1"
+csv = "1.0"
+indexmap = "1.0"
+flatbuffers = "0.5.0"
+flate2 = "1.0.2"
+fnv = "1.0.3"
+lazy_static = "1.2"
+libc = "0.2"
+lz4 = "1.23"
+num = "0.2"
+num-bigint = "0.2"
+packed_simd = { version = "0.3.1", optional = true }
+parquet-format = "~2.5"
+prettytable-rs = "0.8.0"
+quick-error = "1.2.2"
+rand = "0.6"
+regex = "1.1"
+rustyline = {version = "4.1.0", optional = true}
+serde = { version = "1.0.80", features = ["rc"] }
+serde_derive = "1.0.80"
+serde_json = { version = "1.0.13", features = ["preserve_order"] }
+snap = "0.2"
+sqlparser = "0.2.0"
+thrift = "0.0.4"
+zstd = "0.4"

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -36,7 +36,8 @@ RUN USER=root cargo init arrow-deps
 COPY rust/rust-toolchain arrow-deps
 COPY rust/Cargo.toml.cache arrow-deps/Cargo.toml
 ENV RUSTC_WRAPPER=sccache
-RUN cd arrow-deps && cargo build --verbose
+WORKDIR arrow-deps
+RUN cargo build --verbose
 
 # Set environment variables for location of test data required by unit and integration tests
 ENV ARROW_TEST_DATA=/arrow/testing/data

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -30,6 +30,14 @@ RUN rustup default "$(cat /tmp/rust-toolchain)"
 # Enable stable rustfmt for nightly Rust
 RUN rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 
+# Enable caching of dependencies
+RUN cargo install sccache
+RUN USER=root cargo init arrow-deps
+COPY rust/rust-toolchain arrow-deps
+COPY rust/Cargo.toml.cache arrow-deps/Cargo.toml
+ENV RUSTC_WRAPPER=sccache
+RUN cd arrow-deps && cargo build --verbose
+
 # Set environment variables for location of test data required by unit and integration tests
 ENV ARROW_TEST_DATA=/arrow/testing/data
 ENV PARQUET_TEST_DATA=/arrow/cpp/submodules/parquet-testing/data

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -39,6 +39,7 @@ COPY rust/Cargo.toml.cache arrow-deps/Cargo.toml
 ENV RUSTC_WRAPPER=sccache
 WORKDIR /tmp/arrow-deps
 RUN cargo build --verbose
+WORKDIR /
 
 # Set environment variables for location of test data required by unit and integration tests
 ENV ARROW_TEST_DATA=/arrow/testing/data

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -32,11 +32,12 @@ RUN rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 
 # Enable caching of dependencies
 RUN cargo install sccache
+WORKDIR /tmp
 RUN USER=root cargo init arrow-deps
 COPY rust/rust-toolchain arrow-deps
 COPY rust/Cargo.toml.cache arrow-deps/Cargo.toml
 ENV RUSTC_WRAPPER=sccache
-WORKDIR arrow-deps
+WORKDIR /tmp/arrow-deps
 RUN cargo build --verbose
 
 # Set environment variables for location of test data required by unit and integration tests


### PR DESCRIPTION
This PR adds `sccache` and builds many of the project dependencies in the base image to avoid downloading and compiling them each time the project builds in CI.