### PR TITLE
ARROW-6802: [Packaging][deb][RPM] Update qemu-user-static package URL

### DIFF
--- a/dev/tasks/linux-packages/azure.linux.arm64.yml
+++ b/dev/tasks/linux-packages/azure.linux.arm64.yml
@@ -38,7 +38,7 @@ jobs:
     # or Ubuntu 18.10 or later.
     - script: |
         sudo apt install -y qemu-user-static unar
-        wget http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_3.1+dfsg-2ubuntu3.4_amd64.deb
+        wget http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_3.1+dfsg-2ubuntu3.5_amd64.deb
         unar *.deb
         rm *.deb
         pushd qemu-user-static*

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -51,17 +51,19 @@ groups:
 
   linux:
     - debian-stretch
-    - debian-stretch-arm64
     - debian-buster
-    - debian-buster-arm64
     - ubuntu-xenial
-    - ubuntu-xenial-arm64
     - ubuntu-bionic
-    - ubuntu-bionic-arm64
     - ubuntu-disco
-    - ubuntu-disco-arm64
     - centos-6
     - centos-7
+
+  linux-arm:
+    - debian-stretch-arm64
+    - debian-buster-arm64
+    - ubuntu-xenial-arm64
+    - ubuntu-bionic-arm64
+    - ubuntu-disco-arm64
     - centos-7-aarch64
 
   gandiva:
@@ -148,18 +150,12 @@ groups:
     - wheel-win-cp36m
     - wheel-win-cp37m
     - debian-stretch
-    - debian-stretch-arm64
     - debian-buster
-    - debian-buster-arm64
     - ubuntu-xenial
-    - ubuntu-xenial-arm64
     - ubuntu-bionic
-    - ubuntu-bionic-arm64
     - ubuntu-disco
-    - ubuntu-disco-arm64
     - centos-6
     - centos-7
-    - centos-7-aarch64
     - homebrew-cpp
     - homebrew-cpp-autobrew
     - gandiva-jar-trusty


### PR DESCRIPTION
This change also disable ARM related builds by default. Because they
are slow. They use QEMU to build on amd64.