### PR TITLE
ARROW-6803: [Rust] [DataFusion] Performance optimization for single partition aggregate queries

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -91,6 +91,12 @@ impl ExecutionPlan for HashAggregateExec {
             })
             .collect();
 
+        if partitions.len() == 1 {
+            // if there is only a single partition then it isn't necessary to perform any
+            // additional logic
+            return Ok(partitions);
+        }
+
         // create partition to combine and aggregate the results
         let final_group: Vec<Arc<dyn PhysicalExpr>> = (0..self.group_expr.len())
             .map(|i| Arc::new(Column::new(i)) as Arc<dyn PhysicalExpr>)


### PR DESCRIPTION
This PR optimizes the case where there is a single partition being aggregated. In this use case there is no need for a secondary aggregation step.

I ran benchmarks to confirm that this addresses the performance regression.