### PR TITLE
ARROW-6806: [C++] [Python] Fix crash validating an IPC-originating empty array

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -111,8 +111,9 @@ class IpcComponentSource {
     const flatbuf::Buffer* buffer = buffers->Get(buffer_index);
 
     if (buffer->length() == 0) {
-      *out = nullptr;
-      return Status::OK();
+      // Should never return a null buffer here.
+      // (zero-sized buffer allocations are cheap)
+      return AllocateBuffer(0, out);
     } else {
       if (!BitUtil::IsMultipleOf8(buffer->offset())) {
         return Status::Invalid(

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -248,18 +248,18 @@ std::shared_ptr<RecordBatch> RecordBatch::Slice(int64_t offset) const {
 
 Status RecordBatch::Validate() const {
   for (int i = 0; i < num_columns(); ++i) {
-    auto arr_shared = this->column_data(i);
-    const ArrayData& arr = *arr_shared;
-    if (arr.length != num_rows_) {
+    const auto& array = *this->column(i);
+    if (array.length() != num_rows_) {
       return Status::Invalid("Number of rows in column ", i,
-                             " did not match batch: ", arr.length, " vs ", num_rows_);
+                             " did not match batch: ", array.length(), " vs ", num_rows_);
     }
     const auto& schema_type = *schema_->field(i)->type();
-    if (!arr.type->Equals(schema_type)) {
+    if (!array.type()->Equals(schema_type)) {
       return Status::Invalid("Column ", i,
-                             " type not match schema: ", arr.type->ToString(), " vs ",
+                             " type not match schema: ", array.type()->ToString(), " vs ",
                              schema_type.ToString());
     }
+    RETURN_NOT_OK(array.Validate());
   }
   return Status::OK();
 }


### PR DESCRIPTION
Buffers read from IPC should always be non-null, even when empty
(with a well-known exception for the null bitmap when null_count == 0).