### PR TITLE
ARROW-6824: [Plasma] Allow creation of multiple objects through a single IPC in Plasma Store

### DIFF
--- a/cpp/build-support/update-flatbuffers.sh
+++ b/cpp/build-support/update-flatbuffers.sh
@@ -24,13 +24,13 @@ CWD="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 SOURCE_DIR=$CWD/../src
 FORMAT_DIR=$CWD/../..
 
-#flatc -c -o $SOURCE_DIR/generated \
-#      $FORMAT_DIR/Message.fbs \
-#      $FORMAT_DIR/File.fbs \
-#      $FORMAT_DIR/Schema.fbs \
-#      $FORMAT_DIR/Tensor.fbs \
-#      $FORMAT_DIR/SparseTensor.fbs \
-#      src/arrow/ipc/feather.fbs
+flatc -c -o $SOURCE_DIR/generated \
+      $FORMAT_DIR/Message.fbs \
+      $FORMAT_DIR/File.fbs \
+      $FORMAT_DIR/Schema.fbs \
+      $FORMAT_DIR/Tensor.fbs \
+      $FORMAT_DIR/SparseTensor.fbs \
+      src/arrow/ipc/feather.fbs
 
 flatc -c -o $SOURCE_DIR/plasma \
       --gen-object-api \

--- a/cpp/build-support/update-flatbuffers.sh
+++ b/cpp/build-support/update-flatbuffers.sh
@@ -24,13 +24,13 @@ CWD="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 SOURCE_DIR=$CWD/../src
 FORMAT_DIR=$CWD/../..
 
-flatc -c -o $SOURCE_DIR/generated \
-      $FORMAT_DIR/Message.fbs \
-      $FORMAT_DIR/File.fbs \
-      $FORMAT_DIR/Schema.fbs \
-      $FORMAT_DIR/Tensor.fbs \
-      $FORMAT_DIR/SparseTensor.fbs \
-      src/arrow/ipc/feather.fbs
+#flatc -c -o $SOURCE_DIR/generated \
+#      $FORMAT_DIR/Message.fbs \
+#      $FORMAT_DIR/File.fbs \
+#      $FORMAT_DIR/Schema.fbs \
+#      $FORMAT_DIR/Tensor.fbs \
+#      $FORMAT_DIR/SparseTensor.fbs \
+#      src/arrow/ipc/feather.fbs
 
 flatc -c -o $SOURCE_DIR/plasma \
       --gen-object-api \

--- a/cpp/src/arrow/vendored/xxhash/xxhash.c
+++ b/cpp/src/arrow/vendored/xxhash/xxhash.c
@@ -1112,7 +1112,7 @@ XXH_PUBLIC_API XXH64_hash_t XXH64_hashFromCanonical(const XXH64_canonical_t* src
 *  New generation hash designed for speed on small keys and vectorization
 ************************************************************************ */
 
-#include "xxh3.h"
+#include "arrow/vendored/xxhash/xxh3.h"
 
 
 #endif  /* XXH_NO_LONG_LONG */

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -509,7 +509,7 @@ Status PlasmaClient::Impl::CreateAndSealBatch(const std::vector<ObjectID>& objec
 
   int device_num = 0;
   std::vector<std::string> digests;
-  for (size_t i = 0; i<object_ids.size(); i++) {
+  for (size_t i = 0; i < object_ids.size(); i++) {
     // Compute the object hash.
     std::string digest;
     // CreateAndSeal currently only supports device_num = 0, which corresponds to

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -515,14 +515,14 @@ Status PlasmaClient::Impl::CreateAndSealBatch(const std::vector<ObjectID>& objec
     // CreateAndSeal currently only supports device_num = 0, which corresponds to
     // the host.
     uint64_t hash = ComputeObjectHash(
-      reinterpret_cast<const uint8_t*>(data.data()), data.size(),
-      reinterpret_cast<const uint8_t*>(metadata.data()), metadata.size(), device_num);
+        reinterpret_cast<const uint8_t*>(data.data()), data.size(),
+        reinterpret_cast<const uint8_t*>(metadata.data()), metadata.size(), device_num);
     digest.assign(reinterpret_cast<char*>(&hash), sizeof(hash));
     digests.push_back(digest);
   }
 
-  RETURN_NOT_OK(SendCreateAndSealBatchRequest(store_conn_, object_ids, data, metadata,
-                                              digests));
+  RETURN_NOT_OK(
+      SendCreateAndSealBatchRequest(store_conn_, object_ids, data, metadata, digests));
   std::vector<uint8_t> buffer;
   RETURN_NOT_OK(
       PlasmaReceive(store_conn_, MessageType::PlasmaCreateAndSealBatchReply, &buffer));
@@ -1102,7 +1102,7 @@ Status PlasmaClient::CreateAndSeal(const ObjectID& object_id, const std::string&
 Status PlasmaClient::CreateAndSealBatch(const std::vector<ObjectID>& object_ids,
                                         const std::vector<std::string>& data,
                                         const std::vector<std::string>& metadata) {
-    return impl_->CreateAndSealBatch(object_ids, data, metadata);
+  return impl_->CreateAndSealBatch(object_ids, data, metadata);
 }
 
 Status PlasmaClient::Get(const std::vector<ObjectID>& object_ids, int64_t timeout_ms,

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -229,7 +229,9 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   Status CreateAndSeal(const ObjectID& object_id, const std::string& data,
                        const std::string& metadata);
 
-  Status CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata);
+  Status CreateAndSealBatch(const std::vector<ObjectID>& object_ids,
+                            const std::vector<std::string>& data,
+                            const std::vector<std::string>& metadata);
 
   Status Get(const std::vector<ObjectID>& object_ids, int64_t timeout_ms,
              std::vector<ObjectBuffer>* object_buffers);
@@ -498,7 +500,9 @@ Status PlasmaClient::Impl::CreateAndSeal(const ObjectID& object_id,
   return Status::OK();
 }
 
-Status PlasmaClient::Impl::CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata) {
+Status PlasmaClient::Impl::CreateAndSealBatch(const std::vector<ObjectID>& object_ids,
+                                              const std::vector<std::string>& data,
+                                              const std::vector<std::string>& metadata) {
   std::lock_guard<std::recursive_mutex> guard(client_mutex_);
 
   ARROW_LOG(DEBUG) << "called CreateAndSealBatch on conn " << store_conn_;
@@ -517,7 +521,8 @@ Status PlasmaClient::Impl::CreateAndSealBatch(const std::vector<ObjectID>& objec
     digests.push_back(digest);
   }
 
-  RETURN_NOT_OK(SendCreateAndSealBatchRequest(store_conn_, object_ids, data, metadata, digests));
+  RETURN_NOT_OK(SendCreateAndSealBatchRequest(store_conn_, object_ids, data, metadata,
+                                              digests));
   std::vector<uint8_t> buffer;
   RETURN_NOT_OK(
       PlasmaReceive(store_conn_, MessageType::PlasmaCreateAndSealBatchReply, &buffer));
@@ -1094,7 +1099,9 @@ Status PlasmaClient::CreateAndSeal(const ObjectID& object_id, const std::string&
   return impl_->CreateAndSeal(object_id, data, metadata);
 }
 
-Status PlasmaClient::CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata) {
+Status PlasmaClient::CreateAndSealBatch(const std::vector<ObjectID>& object_ids,
+                                        const std::vector<std::string>& data,
+                                        const std::vector<std::string>& metadata) {
     return impl_->CreateAndSealBatch(object_ids, data, metadata);
 }
 

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -229,6 +229,8 @@ class PlasmaClient::Impl : public std::enable_shared_from_this<PlasmaClient::Imp
   Status CreateAndSeal(const ObjectID& object_id, const std::string& data,
                        const std::string& metadata);
 
+  Status CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata);
+
   Status Get(const std::vector<ObjectID>& object_ids, int64_t timeout_ms,
              std::vector<ObjectBuffer>* object_buffers);
 
@@ -493,6 +495,34 @@ Status PlasmaClient::Impl::CreateAndSeal(const ObjectID& object_id,
   RETURN_NOT_OK(
       PlasmaReceive(store_conn_, MessageType::PlasmaCreateAndSealReply, &buffer));
   RETURN_NOT_OK(ReadCreateAndSealReply(buffer.data(), buffer.size()));
+  return Status::OK();
+}
+
+Status PlasmaClient::Impl::CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata) {
+  std::lock_guard<std::recursive_mutex> guard(client_mutex_);
+
+  ARROW_LOG(DEBUG) << "called CreateAndSealBatch on conn " << store_conn_;
+
+  int device_num = 0;
+  std::vector<std::string> digests;
+  for (size_t i = 0; i<object_ids.size(); i++) {
+    // Compute the object hash.
+    std::string digest;
+    // CreateAndSeal currently only supports device_num = 0, which corresponds to
+    // the host.
+    uint64_t hash = ComputeObjectHash(
+      reinterpret_cast<const uint8_t*>(data.data()), data.size(),
+      reinterpret_cast<const uint8_t*>(metadata.data()), metadata.size(), device_num);
+    digest.assign(reinterpret_cast<char*>(&hash), sizeof(hash));
+    digests.push_back(digest);
+  }
+
+  RETURN_NOT_OK(SendCreateAndSealBatchRequest(store_conn_, object_ids, data, metadata, digests));
+  std::vector<uint8_t> buffer;
+  RETURN_NOT_OK(
+      PlasmaReceive(store_conn_, MessageType::PlasmaCreateAndSealBatchReply, &buffer));
+  RETURN_NOT_OK(ReadCreateAndSealBatchReply(buffer.data(), buffer.size()));
+
   return Status::OK();
 }
 
@@ -1062,6 +1092,10 @@ Status PlasmaClient::Create(const ObjectID& object_id, int64_t data_size,
 Status PlasmaClient::CreateAndSeal(const ObjectID& object_id, const std::string& data,
                                    const std::string& metadata) {
   return impl_->CreateAndSeal(object_id, data, metadata);
+}
+
+Status PlasmaClient::CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata) {
+    return impl_->CreateAndSealBatch(object_ids, data, metadata);
 }
 
 Status PlasmaClient::Get(const std::vector<ObjectID>& object_ids, int64_t timeout_ms,

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -108,7 +108,16 @@ class ARROW_EXPORT PlasmaClient {
   Status CreateAndSeal(const ObjectID& object_id, const std::string& data,
                        const std::string& metadata);
 
-  Status CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata);
+  /// Create and seal multiple objects in the object store. This is an optimization
+  /// of CreateAndSeal to eliminate the cost of IPC per object.
+  ///
+  /// \param object_ids The vector of IDs of the objects to create.
+  /// \param data The vector of data for the objects to create.
+  /// \param metadata The vector of metadata for the objects to create.
+  /// \return The return status.
+  Status CreateAndSealBatch(const std::vector<ObjectID>& object_ids,
+                            const std::vector<std::string>& data,
+                            const std::vector<std::string>& metadata);
 
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the

--- a/cpp/src/plasma/client.h
+++ b/cpp/src/plasma/client.h
@@ -108,6 +108,8 @@ class ARROW_EXPORT PlasmaClient {
   Status CreateAndSeal(const ObjectID& object_id, const std::string& data,
                        const std::string& metadata);
 
+  Status CreateAndSealBatch(const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata);
+
   /// Get some objects from the Plasma Store. This function will block until the
   /// objects have all been created and sealed in the Plasma Store or the
   /// timeout expires.

--- a/cpp/src/plasma/common_generated.h
+++ b/cpp/src/plasma/common_generated.h
@@ -183,14 +183,14 @@ inline ObjectInfoT *ObjectInfo::UnPack(const flatbuffers::resolver_function_t *_
 inline void ObjectInfo::UnPackTo(ObjectInfoT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = data_size(); _o->data_size = _e; };
-  { auto _e = metadata_size(); _o->metadata_size = _e; };
-  { auto _e = ref_count(); _o->ref_count = _e; };
-  { auto _e = create_time(); _o->create_time = _e; };
-  { auto _e = construct_duration(); _o->construct_duration = _e; };
-  { auto _e = digest(); if (_e) _o->digest = _e->str(); };
-  { auto _e = is_deletion(); _o->is_deletion = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = data_size(); _o->data_size = _e; }
+  { auto _e = metadata_size(); _o->metadata_size = _e; }
+  { auto _e = ref_count(); _o->ref_count = _e; }
+  { auto _e = create_time(); _o->create_time = _e; }
+  { auto _e = construct_duration(); _o->construct_duration = _e; }
+  { auto _e = digest(); if (_e) _o->digest = _e->str(); }
+  { auto _e = is_deletion(); _o->is_deletion = _e; }
 }
 
 inline flatbuffers::Offset<ObjectInfo> ObjectInfo::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ObjectInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher) {

--- a/cpp/src/plasma/plasma.fbs
+++ b/cpp/src/plasma/plasma.fbs
@@ -28,6 +28,8 @@ enum MessageType:long {
   PlasmaCreateReply,
   PlasmaCreateAndSealRequest,
   PlasmaCreateAndSealReply,
+  PlasmaCreateAndSealBatchRequest,
+  PlasmaCreateAndSealBatchReply,
   PlasmaAbortRequest,
   PlasmaAbortReply,
   // Seal an object.
@@ -173,6 +175,18 @@ table PlasmaCreateAndSealRequest {
 }
 
 table PlasmaCreateAndSealReply {
+  // Error that occurred for this call.
+  error: PlasmaError;
+}
+
+table PlasmaCreateAndSealBatchRequest {
+    object_ids: [string];
+    data: [string];
+    metadata: [string];
+    digest: [string];
+}
+
+table PlasmaCreateAndSealBatchReply {
   // Error that occurred for this call.
   error: PlasmaError;
 }

--- a/cpp/src/plasma/plasma_generated.h
+++ b/cpp/src/plasma/plasma_generated.h
@@ -40,6 +40,12 @@ struct PlasmaCreateAndSealRequestT;
 struct PlasmaCreateAndSealReply;
 struct PlasmaCreateAndSealReplyT;
 
+struct PlasmaCreateAndSealBatchRequest;
+struct PlasmaCreateAndSealBatchRequestT;
+
+struct PlasmaCreateAndSealBatchReply;
+struct PlasmaCreateAndSealBatchReplyT;
+
 struct PlasmaAbortRequest;
 struct PlasmaAbortRequestT;
 
@@ -105,48 +111,52 @@ struct PlasmaDataReplyT;
 
 enum class MessageType : int64_t {
   PlasmaDisconnectClient = 0,
-  PlasmaCreateRequest = 1,
-  PlasmaCreateReply = 2,
-  PlasmaCreateAndSealRequest = 3,
-  PlasmaCreateAndSealReply = 4,
-  PlasmaAbortRequest = 5,
-  PlasmaAbortReply = 6,
-  PlasmaSealRequest = 7,
-  PlasmaSealReply = 8,
-  PlasmaGetRequest = 9,
-  PlasmaGetReply = 10,
-  PlasmaReleaseRequest = 11,
-  PlasmaReleaseReply = 12,
-  PlasmaDeleteRequest = 13,
-  PlasmaDeleteReply = 14,
-  PlasmaContainsRequest = 15,
-  PlasmaContainsReply = 16,
-  PlasmaListRequest = 17,
-  PlasmaListReply = 18,
-  PlasmaConnectRequest = 19,
-  PlasmaConnectReply = 20,
-  PlasmaEvictRequest = 21,
-  PlasmaEvictReply = 22,
-  PlasmaSubscribeRequest = 23,
-  PlasmaUnsubscribeRequest = 24,
-  PlasmaDataRequest = 25,
-  PlasmaDataReply = 26,
-  PlasmaNotification = 27,
-  PlasmaSetOptionsRequest = 28,
-  PlasmaSetOptionsReply = 29,
-  PlasmaGetDebugStringRequest = 30,
-  PlasmaGetDebugStringReply = 31,
+  PlasmaCreateRequest = 1LL,
+  PlasmaCreateReply = 2LL,
+  PlasmaCreateAndSealRequest = 3LL,
+  PlasmaCreateAndSealReply = 4LL,
+  PlasmaCreateAndSealBatchRequest = 5LL,
+  PlasmaCreateAndSealBatchReply = 6LL,
+  PlasmaAbortRequest = 7LL,
+  PlasmaAbortReply = 8LL,
+  PlasmaSealRequest = 9LL,
+  PlasmaSealReply = 10LL,
+  PlasmaGetRequest = 11LL,
+  PlasmaGetReply = 12LL,
+  PlasmaReleaseRequest = 13LL,
+  PlasmaReleaseReply = 14LL,
+  PlasmaDeleteRequest = 15LL,
+  PlasmaDeleteReply = 16LL,
+  PlasmaContainsRequest = 17LL,
+  PlasmaContainsReply = 18LL,
+  PlasmaListRequest = 19LL,
+  PlasmaListReply = 20LL,
+  PlasmaConnectRequest = 21LL,
+  PlasmaConnectReply = 22LL,
+  PlasmaEvictRequest = 23LL,
+  PlasmaEvictReply = 24LL,
+  PlasmaSubscribeRequest = 25LL,
+  PlasmaUnsubscribeRequest = 26LL,
+  PlasmaDataRequest = 27LL,
+  PlasmaDataReply = 28LL,
+  PlasmaNotification = 29LL,
+  PlasmaSetOptionsRequest = 30LL,
+  PlasmaSetOptionsReply = 31LL,
+  PlasmaGetDebugStringRequest = 32LL,
+  PlasmaGetDebugStringReply = 33LL,
   MIN = PlasmaDisconnectClient,
   MAX = PlasmaGetDebugStringReply
 };
 
-inline const MessageType (&EnumValuesMessageType())[32] {
+inline const MessageType (&EnumValuesMessageType())[34] {
   static const MessageType values[] = {
     MessageType::PlasmaDisconnectClient,
     MessageType::PlasmaCreateRequest,
     MessageType::PlasmaCreateReply,
     MessageType::PlasmaCreateAndSealRequest,
     MessageType::PlasmaCreateAndSealReply,
+    MessageType::PlasmaCreateAndSealBatchRequest,
+    MessageType::PlasmaCreateAndSealBatchReply,
     MessageType::PlasmaAbortRequest,
     MessageType::PlasmaAbortReply,
     MessageType::PlasmaSealRequest,
@@ -179,12 +189,14 @@ inline const MessageType (&EnumValuesMessageType())[32] {
 }
 
 inline const char * const *EnumNamesMessageType() {
-  static const char * const names[] = {
+  static const char * const names[35] = {
     "PlasmaDisconnectClient",
     "PlasmaCreateRequest",
     "PlasmaCreateReply",
     "PlasmaCreateAndSealRequest",
     "PlasmaCreateAndSealReply",
+    "PlasmaCreateAndSealBatchRequest",
+    "PlasmaCreateAndSealBatchReply",
     "PlasmaAbortRequest",
     "PlasmaAbortReply",
     "PlasmaSealRequest",
@@ -247,7 +259,7 @@ inline const PlasmaError (&EnumValuesPlasmaError())[6] {
 }
 
 inline const char * const *EnumNamesPlasmaError() {
-  static const char * const names[] = {
+  static const char * const names[7] = {
     "OK",
     "ObjectExists",
     "ObjectNonexistent",
@@ -392,9 +404,9 @@ flatbuffers::Offset<PlasmaSetOptionsRequest> CreatePlasmaSetOptionsRequest(flatb
 
 struct PlasmaSetOptionsReplyT : public flatbuffers::NativeTable {
   typedef PlasmaSetOptionsReply TableType;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaSetOptionsReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
@@ -403,8 +415,8 @@ struct PlasmaSetOptionsReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4
   };
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -419,7 +431,7 @@ struct PlasmaSetOptionsReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 struct PlasmaSetOptionsReplyBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaSetOptionsReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaSetOptionsReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -436,7 +448,7 @@ struct PlasmaSetOptionsReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaSetOptionsReply> CreatePlasmaSetOptionsReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaSetOptionsReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   return builder_.Finish();
@@ -718,13 +730,13 @@ flatbuffers::Offset<CudaHandle> CreateCudaHandle(flatbuffers::FlatBufferBuilder 
 struct PlasmaCreateReplyT : public flatbuffers::NativeTable {
   typedef PlasmaCreateReply TableType;
   std::string object_id;
-  std::unique_ptr<PlasmaObjectSpec> plasma_object;
-  PlasmaError error;
+  std::unique_ptr<plasma::flatbuf::PlasmaObjectSpec> plasma_object;
+  plasma::flatbuf::PlasmaError error;
   int32_t store_fd;
   int64_t mmap_size;
-  std::unique_ptr<CudaHandleT> ipc_handle;
+  std::unique_ptr<plasma::flatbuf::CudaHandleT> ipc_handle;
   PlasmaCreateReplyT()
-      : error(PlasmaError::OK),
+      : error(plasma::flatbuf::PlasmaError::OK),
         store_fd(0),
         mmap_size(0) {
   }
@@ -743,11 +755,11 @@ struct PlasmaCreateReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *object_id() const {
     return GetPointer<const flatbuffers::String *>(VT_OBJECT_ID);
   }
-  const PlasmaObjectSpec *plasma_object() const {
-    return GetStruct<const PlasmaObjectSpec *>(VT_PLASMA_OBJECT);
+  const plasma::flatbuf::PlasmaObjectSpec *plasma_object() const {
+    return GetStruct<const plasma::flatbuf::PlasmaObjectSpec *>(VT_PLASMA_OBJECT);
   }
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   int32_t store_fd() const {
     return GetField<int32_t>(VT_STORE_FD, 0);
@@ -755,14 +767,14 @@ struct PlasmaCreateReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t mmap_size() const {
     return GetField<int64_t>(VT_MMAP_SIZE, 0);
   }
-  const CudaHandle *ipc_handle() const {
-    return GetPointer<const CudaHandle *>(VT_IPC_HANDLE);
+  const plasma::flatbuf::CudaHandle *ipc_handle() const {
+    return GetPointer<const plasma::flatbuf::CudaHandle *>(VT_IPC_HANDLE);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_OBJECT_ID) &&
            verifier.VerifyString(object_id()) &&
-           VerifyField<PlasmaObjectSpec>(verifier, VT_PLASMA_OBJECT) &&
+           VerifyField<plasma::flatbuf::PlasmaObjectSpec>(verifier, VT_PLASMA_OBJECT) &&
            VerifyField<int32_t>(verifier, VT_ERROR) &&
            VerifyField<int32_t>(verifier, VT_STORE_FD) &&
            VerifyField<int64_t>(verifier, VT_MMAP_SIZE) &&
@@ -781,10 +793,10 @@ struct PlasmaCreateReplyBuilder {
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
     fbb_.AddOffset(PlasmaCreateReply::VT_OBJECT_ID, object_id);
   }
-  void add_plasma_object(const PlasmaObjectSpec *plasma_object) {
+  void add_plasma_object(const plasma::flatbuf::PlasmaObjectSpec *plasma_object) {
     fbb_.AddStruct(PlasmaCreateReply::VT_PLASMA_OBJECT, plasma_object);
   }
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaCreateReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   void add_store_fd(int32_t store_fd) {
@@ -793,7 +805,7 @@ struct PlasmaCreateReplyBuilder {
   void add_mmap_size(int64_t mmap_size) {
     fbb_.AddElement<int64_t>(PlasmaCreateReply::VT_MMAP_SIZE, mmap_size, 0);
   }
-  void add_ipc_handle(flatbuffers::Offset<CudaHandle> ipc_handle) {
+  void add_ipc_handle(flatbuffers::Offset<plasma::flatbuf::CudaHandle> ipc_handle) {
     fbb_.AddOffset(PlasmaCreateReply::VT_IPC_HANDLE, ipc_handle);
   }
   explicit PlasmaCreateReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -811,11 +823,11 @@ struct PlasmaCreateReplyBuilder {
 inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> object_id = 0,
-    const PlasmaObjectSpec *plasma_object = 0,
-    PlasmaError error = PlasmaError::OK,
+    const plasma::flatbuf::PlasmaObjectSpec *plasma_object = 0,
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK,
     int32_t store_fd = 0,
     int64_t mmap_size = 0,
-    flatbuffers::Offset<CudaHandle> ipc_handle = 0) {
+    flatbuffers::Offset<plasma::flatbuf::CudaHandle> ipc_handle = 0) {
   PlasmaCreateReplyBuilder builder_(_fbb);
   builder_.add_mmap_size(mmap_size);
   builder_.add_ipc_handle(ipc_handle);
@@ -829,11 +841,11 @@ inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReply(
 inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *object_id = nullptr,
-    const PlasmaObjectSpec *plasma_object = 0,
-    PlasmaError error = PlasmaError::OK,
+    const plasma::flatbuf::PlasmaObjectSpec *plasma_object = 0,
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK,
     int32_t store_fd = 0,
     int64_t mmap_size = 0,
-    flatbuffers::Offset<CudaHandle> ipc_handle = 0) {
+    flatbuffers::Offset<plasma::flatbuf::CudaHandle> ipc_handle = 0) {
   auto object_id__ = object_id ? _fbb.CreateString(object_id) : 0;
   return plasma::flatbuf::CreatePlasmaCreateReply(
       _fbb,
@@ -957,9 +969,9 @@ flatbuffers::Offset<PlasmaCreateAndSealRequest> CreatePlasmaCreateAndSealRequest
 
 struct PlasmaCreateAndSealReplyT : public flatbuffers::NativeTable {
   typedef PlasmaCreateAndSealReply TableType;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaCreateAndSealReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
@@ -968,8 +980,8 @@ struct PlasmaCreateAndSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::T
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4
   };
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -984,7 +996,7 @@ struct PlasmaCreateAndSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::T
 struct PlasmaCreateAndSealReplyBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaCreateAndSealReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaCreateAndSealReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1001,13 +1013,179 @@ struct PlasmaCreateAndSealReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaCreateAndSealReply> CreatePlasmaCreateAndSealReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaCreateAndSealReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   return builder_.Finish();
 }
 
 flatbuffers::Offset<PlasmaCreateAndSealReply> CreatePlasmaCreateAndSealReply(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+struct PlasmaCreateAndSealBatchRequestT : public flatbuffers::NativeTable {
+  typedef PlasmaCreateAndSealBatchRequest TableType;
+  std::vector<std::string> object_ids;
+  std::vector<std::string> data;
+  std::vector<std::string> metadata;
+  std::vector<std::string> digest;
+  PlasmaCreateAndSealBatchRequestT() {
+  }
+};
+
+struct PlasmaCreateAndSealBatchRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef PlasmaCreateAndSealBatchRequestT NativeTableType;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_OBJECT_IDS = 4,
+    VT_DATA = 6,
+    VT_METADATA = 8,
+    VT_DIGEST = 10
+  };
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *object_ids() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_OBJECT_IDS);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *data() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_DATA);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *metadata() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_METADATA);
+  }
+  const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *digest() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_DIGEST);
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyOffset(verifier, VT_OBJECT_IDS) &&
+           verifier.VerifyVector(object_ids()) &&
+           verifier.VerifyVectorOfStrings(object_ids()) &&
+           VerifyOffset(verifier, VT_DATA) &&
+           verifier.VerifyVector(data()) &&
+           verifier.VerifyVectorOfStrings(data()) &&
+           VerifyOffset(verifier, VT_METADATA) &&
+           verifier.VerifyVector(metadata()) &&
+           verifier.VerifyVectorOfStrings(metadata()) &&
+           VerifyOffset(verifier, VT_DIGEST) &&
+           verifier.VerifyVector(digest()) &&
+           verifier.VerifyVectorOfStrings(digest()) &&
+           verifier.EndTable();
+  }
+  PlasmaCreateAndSealBatchRequestT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(PlasmaCreateAndSealBatchRequestT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct PlasmaCreateAndSealBatchRequestBuilder {
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_object_ids(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids) {
+    fbb_.AddOffset(PlasmaCreateAndSealBatchRequest::VT_OBJECT_IDS, object_ids);
+  }
+  void add_data(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> data) {
+    fbb_.AddOffset(PlasmaCreateAndSealBatchRequest::VT_DATA, data);
+  }
+  void add_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> metadata) {
+    fbb_.AddOffset(PlasmaCreateAndSealBatchRequest::VT_METADATA, metadata);
+  }
+  void add_digest(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> digest) {
+    fbb_.AddOffset(PlasmaCreateAndSealBatchRequest::VT_DIGEST, digest);
+  }
+  explicit PlasmaCreateAndSealBatchRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  PlasmaCreateAndSealBatchRequestBuilder &operator=(const PlasmaCreateAndSealBatchRequestBuilder &);
+  flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<PlasmaCreateAndSealBatchRequest>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> CreatePlasmaCreateAndSealBatchRequest(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> data = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> metadata = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> digest = 0) {
+  PlasmaCreateAndSealBatchRequestBuilder builder_(_fbb);
+  builder_.add_digest(digest);
+  builder_.add_metadata(metadata);
+  builder_.add_data(data);
+  builder_.add_object_ids(object_ids);
+  return builder_.Finish();
+}
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> CreatePlasmaCreateAndSealBatchRequestDirect(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    const std::vector<flatbuffers::Offset<flatbuffers::String>> *object_ids = nullptr,
+    const std::vector<flatbuffers::Offset<flatbuffers::String>> *data = nullptr,
+    const std::vector<flatbuffers::Offset<flatbuffers::String>> *metadata = nullptr,
+    const std::vector<flatbuffers::Offset<flatbuffers::String>> *digest = nullptr) {
+  auto object_ids__ = object_ids ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*object_ids) : 0;
+  auto data__ = data ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*data) : 0;
+  auto metadata__ = metadata ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*metadata) : 0;
+  auto digest__ = digest ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*digest) : 0;
+  return plasma::flatbuf::CreatePlasmaCreateAndSealBatchRequest(
+      _fbb,
+      object_ids__,
+      data__,
+      metadata__,
+      digest__);
+}
+
+flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> CreatePlasmaCreateAndSealBatchRequest(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+
+struct PlasmaCreateAndSealBatchReplyT : public flatbuffers::NativeTable {
+  typedef PlasmaCreateAndSealBatchReply TableType;
+  plasma::flatbuf::PlasmaError error;
+  PlasmaCreateAndSealBatchReplyT()
+      : error(plasma::flatbuf::PlasmaError::OK) {
+  }
+};
+
+struct PlasmaCreateAndSealBatchReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef PlasmaCreateAndSealBatchReplyT NativeTableType;
+  enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
+    VT_ERROR = 4
+  };
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  }
+  bool Verify(flatbuffers::Verifier &verifier) const {
+    return VerifyTableStart(verifier) &&
+           VerifyField<int32_t>(verifier, VT_ERROR) &&
+           verifier.EndTable();
+  }
+  PlasmaCreateAndSealBatchReplyT *UnPack(const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  void UnPackTo(PlasmaCreateAndSealBatchReplyT *_o, const flatbuffers::resolver_function_t *_resolver = nullptr) const;
+  static flatbuffers::Offset<PlasmaCreateAndSealBatchReply> Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
+};
+
+struct PlasmaCreateAndSealBatchReplyBuilder {
+  flatbuffers::FlatBufferBuilder &fbb_;
+  flatbuffers::uoffset_t start_;
+  void add_error(plasma::flatbuf::PlasmaError error) {
+    fbb_.AddElement<int32_t>(PlasmaCreateAndSealBatchReply::VT_ERROR, static_cast<int32_t>(error), 0);
+  }
+  explicit PlasmaCreateAndSealBatchReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
+        : fbb_(_fbb) {
+    start_ = fbb_.StartTable();
+  }
+  PlasmaCreateAndSealBatchReplyBuilder &operator=(const PlasmaCreateAndSealBatchReplyBuilder &);
+  flatbuffers::Offset<PlasmaCreateAndSealBatchReply> Finish() {
+    const auto end = fbb_.EndTable(start_);
+    auto o = flatbuffers::Offset<PlasmaCreateAndSealBatchReply>(end);
+    return o;
+  }
+};
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchReply> CreatePlasmaCreateAndSealBatchReply(
+    flatbuffers::FlatBufferBuilder &_fbb,
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
+  PlasmaCreateAndSealBatchReplyBuilder builder_(_fbb);
+  builder_.add_error(error);
+  return builder_.Finish();
+}
+
+flatbuffers::Offset<PlasmaCreateAndSealBatchReply> CreatePlasmaCreateAndSealBatchReply(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 struct PlasmaAbortRequestT : public flatbuffers::NativeTable {
   typedef PlasmaAbortRequest TableType;
@@ -1216,9 +1394,9 @@ flatbuffers::Offset<PlasmaSealRequest> CreatePlasmaSealRequest(flatbuffers::Flat
 struct PlasmaSealReplyT : public flatbuffers::NativeTable {
   typedef PlasmaSealReply TableType;
   std::string object_id;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaSealReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
@@ -1231,8 +1409,8 @@ struct PlasmaSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *object_id() const {
     return GetPointer<const flatbuffers::String *>(VT_OBJECT_ID);
   }
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1252,7 +1430,7 @@ struct PlasmaSealReplyBuilder {
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
     fbb_.AddOffset(PlasmaSealReply::VT_OBJECT_ID, object_id);
   }
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaSealReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaSealReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1270,7 +1448,7 @@ struct PlasmaSealReplyBuilder {
 inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> object_id = 0,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaSealReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   builder_.add_object_id(object_id);
@@ -1280,7 +1458,7 @@ inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReply(
 inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *object_id = nullptr,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   auto object_id__ = object_id ? _fbb.CreateString(object_id) : 0;
   return plasma::flatbuf::CreatePlasmaSealReply(
       _fbb,
@@ -1371,10 +1549,10 @@ flatbuffers::Offset<PlasmaGetRequest> CreatePlasmaGetRequest(flatbuffers::FlatBu
 struct PlasmaGetReplyT : public flatbuffers::NativeTable {
   typedef PlasmaGetReply TableType;
   std::vector<std::string> object_ids;
-  std::vector<PlasmaObjectSpec> plasma_objects;
+  std::vector<plasma::flatbuf::PlasmaObjectSpec> plasma_objects;
   std::vector<int32_t> store_fds;
   std::vector<int64_t> mmap_sizes;
-  std::vector<std::unique_ptr<CudaHandleT>> handles;
+  std::vector<std::unique_ptr<plasma::flatbuf::CudaHandleT>> handles;
   PlasmaGetReplyT() {
   }
 };
@@ -1391,8 +1569,8 @@ struct PlasmaGetReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *object_ids() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_OBJECT_IDS);
   }
-  const flatbuffers::Vector<const PlasmaObjectSpec *> *plasma_objects() const {
-    return GetPointer<const flatbuffers::Vector<const PlasmaObjectSpec *> *>(VT_PLASMA_OBJECTS);
+  const flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *> *plasma_objects() const {
+    return GetPointer<const flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *> *>(VT_PLASMA_OBJECTS);
   }
   const flatbuffers::Vector<int32_t> *store_fds() const {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_STORE_FDS);
@@ -1400,8 +1578,8 @@ struct PlasmaGetReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<int64_t> *mmap_sizes() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_MMAP_SIZES);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<CudaHandle>> *handles() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<CudaHandle>> *>(VT_HANDLES);
+  const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> *handles() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> *>(VT_HANDLES);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1430,7 +1608,7 @@ struct PlasmaGetReplyBuilder {
   void add_object_ids(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids) {
     fbb_.AddOffset(PlasmaGetReply::VT_OBJECT_IDS, object_ids);
   }
-  void add_plasma_objects(flatbuffers::Offset<flatbuffers::Vector<const PlasmaObjectSpec *>> plasma_objects) {
+  void add_plasma_objects(flatbuffers::Offset<flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *>> plasma_objects) {
     fbb_.AddOffset(PlasmaGetReply::VT_PLASMA_OBJECTS, plasma_objects);
   }
   void add_store_fds(flatbuffers::Offset<flatbuffers::Vector<int32_t>> store_fds) {
@@ -1439,7 +1617,7 @@ struct PlasmaGetReplyBuilder {
   void add_mmap_sizes(flatbuffers::Offset<flatbuffers::Vector<int64_t>> mmap_sizes) {
     fbb_.AddOffset(PlasmaGetReply::VT_MMAP_SIZES, mmap_sizes);
   }
-  void add_handles(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<CudaHandle>>> handles) {
+  void add_handles(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>>> handles) {
     fbb_.AddOffset(PlasmaGetReply::VT_HANDLES, handles);
   }
   explicit PlasmaGetReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1457,10 +1635,10 @@ struct PlasmaGetReplyBuilder {
 inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const PlasmaObjectSpec *>> plasma_objects = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *>> plasma_objects = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> store_fds = 0,
     flatbuffers::Offset<flatbuffers::Vector<int64_t>> mmap_sizes = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<CudaHandle>>> handles = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>>> handles = 0) {
   PlasmaGetReplyBuilder builder_(_fbb);
   builder_.add_handles(handles);
   builder_.add_mmap_sizes(mmap_sizes);
@@ -1473,15 +1651,15 @@ inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(
 inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *object_ids = nullptr,
-    const std::vector<PlasmaObjectSpec> *plasma_objects = nullptr,
+    const std::vector<plasma::flatbuf::PlasmaObjectSpec> *plasma_objects = nullptr,
     const std::vector<int32_t> *store_fds = nullptr,
     const std::vector<int64_t> *mmap_sizes = nullptr,
-    const std::vector<flatbuffers::Offset<CudaHandle>> *handles = nullptr) {
+    const std::vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> *handles = nullptr) {
   auto object_ids__ = object_ids ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*object_ids) : 0;
-  auto plasma_objects__ = plasma_objects ? _fbb.CreateVectorOfStructs<PlasmaObjectSpec>(*plasma_objects) : 0;
+  auto plasma_objects__ = plasma_objects ? _fbb.CreateVectorOfStructs<plasma::flatbuf::PlasmaObjectSpec>(*plasma_objects) : 0;
   auto store_fds__ = store_fds ? _fbb.CreateVector<int32_t>(*store_fds) : 0;
   auto mmap_sizes__ = mmap_sizes ? _fbb.CreateVector<int64_t>(*mmap_sizes) : 0;
-  auto handles__ = handles ? _fbb.CreateVector<flatbuffers::Offset<CudaHandle>>(*handles) : 0;
+  auto handles__ = handles ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>>(*handles) : 0;
   return plasma::flatbuf::CreatePlasmaGetReply(
       _fbb,
       object_ids__,
@@ -1559,9 +1737,9 @@ flatbuffers::Offset<PlasmaReleaseRequest> CreatePlasmaReleaseRequest(flatbuffers
 struct PlasmaReleaseReplyT : public flatbuffers::NativeTable {
   typedef PlasmaReleaseReply TableType;
   std::string object_id;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaReleaseReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
@@ -1574,8 +1752,8 @@ struct PlasmaReleaseReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *object_id() const {
     return GetPointer<const flatbuffers::String *>(VT_OBJECT_ID);
   }
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1595,7 +1773,7 @@ struct PlasmaReleaseReplyBuilder {
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
     fbb_.AddOffset(PlasmaReleaseReply::VT_OBJECT_ID, object_id);
   }
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaReleaseReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaReleaseReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1613,7 +1791,7 @@ struct PlasmaReleaseReplyBuilder {
 inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> object_id = 0,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaReleaseReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   builder_.add_object_id(object_id);
@@ -1623,7 +1801,7 @@ inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReply(
 inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *object_id = nullptr,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   auto object_id__ = object_id ? _fbb.CreateString(object_id) : 0;
   return plasma::flatbuf::CreatePlasmaReleaseReply(
       _fbb,
@@ -1715,7 +1893,7 @@ struct PlasmaDeleteReplyT : public flatbuffers::NativeTable {
   typedef PlasmaDeleteReply TableType;
   int32_t count;
   std::vector<std::string> object_ids;
-  std::vector<PlasmaError> errors;
+  std::vector<plasma::flatbuf::PlasmaError> errors;
   PlasmaDeleteReplyT()
       : count(0) {
   }
@@ -1986,7 +2164,7 @@ flatbuffers::Offset<PlasmaListRequest> CreatePlasmaListRequest(flatbuffers::Flat
 
 struct PlasmaListReplyT : public flatbuffers::NativeTable {
   typedef PlasmaListReply TableType;
-  std::vector<std::unique_ptr<ObjectInfoT>> objects;
+  std::vector<std::unique_ptr<plasma::flatbuf::ObjectInfoT>> objects;
   PlasmaListReplyT() {
   }
 };
@@ -1996,8 +2174,8 @@ struct PlasmaListReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECTS = 4
   };
-  const flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>> *objects() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>> *>(VT_OBJECTS);
+  const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *objects() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *>(VT_OBJECTS);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -2014,7 +2192,7 @@ struct PlasmaListReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct PlasmaListReplyBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_objects(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>>> objects) {
+  void add_objects(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>> objects) {
     fbb_.AddOffset(PlasmaListReply::VT_OBJECTS, objects);
   }
   explicit PlasmaListReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2031,7 +2209,7 @@ struct PlasmaListReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>>> objects = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>> objects = 0) {
   PlasmaListReplyBuilder builder_(_fbb);
   builder_.add_objects(objects);
   return builder_.Finish();
@@ -2039,8 +2217,8 @@ inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReply(
 
 inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<ObjectInfo>> *objects = nullptr) {
-  auto objects__ = objects ? _fbb.CreateVector<flatbuffers::Offset<ObjectInfo>>(*objects) : 0;
+    const std::vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *objects = nullptr) {
+  auto objects__ = objects ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>(*objects) : 0;
   return plasma::flatbuf::CreatePlasmaListReply(
       _fbb,
       objects__);
@@ -2482,8 +2660,8 @@ inline PlasmaSetOptionsRequestT *PlasmaSetOptionsRequest::UnPack(const flatbuffe
 inline void PlasmaSetOptionsRequest::UnPackTo(PlasmaSetOptionsRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = client_name(); if (_e) _o->client_name = _e->str(); };
-  { auto _e = output_memory_quota(); _o->output_memory_quota = _e; };
+  { auto _e = client_name(); if (_e) _o->client_name = _e->str(); }
+  { auto _e = output_memory_quota(); _o->output_memory_quota = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaSetOptionsRequest> PlasmaSetOptionsRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSetOptionsRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2511,7 +2689,7 @@ inline PlasmaSetOptionsReplyT *PlasmaSetOptionsReply::UnPack(const flatbuffers::
 inline void PlasmaSetOptionsReply::UnPackTo(PlasmaSetOptionsReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaSetOptionsReply> PlasmaSetOptionsReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSetOptionsReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2560,7 +2738,7 @@ inline PlasmaGetDebugStringReplyT *PlasmaGetDebugStringReply::UnPack(const flatb
 inline void PlasmaGetDebugStringReply::UnPackTo(PlasmaGetDebugStringReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = debug_string(); if (_e) _o->debug_string = _e->str(); };
+  { auto _e = debug_string(); if (_e) _o->debug_string = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaGetDebugStringReply> PlasmaGetDebugStringReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaGetDebugStringReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2586,10 +2764,10 @@ inline PlasmaCreateRequestT *PlasmaCreateRequest::UnPack(const flatbuffers::reso
 inline void PlasmaCreateRequest::UnPackTo(PlasmaCreateRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = data_size(); _o->data_size = _e; };
-  { auto _e = metadata_size(); _o->metadata_size = _e; };
-  { auto _e = device_num(); _o->device_num = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = data_size(); _o->data_size = _e; }
+  { auto _e = metadata_size(); _o->metadata_size = _e; }
+  { auto _e = device_num(); _o->device_num = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaCreateRequest> PlasmaCreateRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2621,7 +2799,7 @@ inline CudaHandleT *CudaHandle::UnPack(const flatbuffers::resolver_function_t *_
 inline void CudaHandle::UnPackTo(CudaHandleT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = handle(); if (_e) { _o->handle.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handle[_i] = _e->Get(_i); } } };
+  { auto _e = handle(); if (_e) { _o->handle.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handle[_i] = _e->Get(_i); } } }
 }
 
 inline flatbuffers::Offset<CudaHandle> CudaHandle::Pack(flatbuffers::FlatBufferBuilder &_fbb, const CudaHandleT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2647,12 +2825,12 @@ inline PlasmaCreateReplyT *PlasmaCreateReply::UnPack(const flatbuffers::resolver
 inline void PlasmaCreateReply::UnPackTo(PlasmaCreateReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = plasma_object(); if (_e) _o->plasma_object = std::unique_ptr<PlasmaObjectSpec>(new PlasmaObjectSpec(*_e)); };
-  { auto _e = error(); _o->error = _e; };
-  { auto _e = store_fd(); _o->store_fd = _e; };
-  { auto _e = mmap_size(); _o->mmap_size = _e; };
-  { auto _e = ipc_handle(); if (_e) _o->ipc_handle = std::unique_ptr<CudaHandleT>(_e->UnPack(_resolver)); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = plasma_object(); if (_e) _o->plasma_object = std::unique_ptr<plasma::flatbuf::PlasmaObjectSpec>(new plasma::flatbuf::PlasmaObjectSpec(*_e)); }
+  { auto _e = error(); _o->error = _e; }
+  { auto _e = store_fd(); _o->store_fd = _e; }
+  { auto _e = mmap_size(); _o->mmap_size = _e; }
+  { auto _e = ipc_handle(); if (_e) _o->ipc_handle = std::unique_ptr<plasma::flatbuf::CudaHandleT>(_e->UnPack(_resolver)); }
 }
 
 inline flatbuffers::Offset<PlasmaCreateReply> PlasmaCreateReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2688,10 +2866,10 @@ inline PlasmaCreateAndSealRequestT *PlasmaCreateAndSealRequest::UnPack(const fla
 inline void PlasmaCreateAndSealRequest::UnPackTo(PlasmaCreateAndSealRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = data(); if (_e) _o->data = _e->str(); };
-  { auto _e = metadata(); if (_e) _o->metadata = _e->str(); };
-  { auto _e = digest(); if (_e) _o->digest = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = data(); if (_e) _o->data = _e->str(); }
+  { auto _e = metadata(); if (_e) _o->metadata = _e->str(); }
+  { auto _e = digest(); if (_e) _o->digest = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaCreateAndSealRequest> PlasmaCreateAndSealRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2723,7 +2901,7 @@ inline PlasmaCreateAndSealReplyT *PlasmaCreateAndSealReply::UnPack(const flatbuf
 inline void PlasmaCreateAndSealReply::UnPackTo(PlasmaCreateAndSealReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaCreateAndSealReply> PlasmaCreateAndSealReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2740,6 +2918,67 @@ inline flatbuffers::Offset<PlasmaCreateAndSealReply> CreatePlasmaCreateAndSealRe
       _error);
 }
 
+inline PlasmaCreateAndSealBatchRequestT *PlasmaCreateAndSealBatchRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = new PlasmaCreateAndSealBatchRequestT();
+  UnPackTo(_o, _resolver);
+  return _o;
+}
+
+inline void PlasmaCreateAndSealBatchRequest::UnPackTo(PlasmaCreateAndSealBatchRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = data(); if (_e) { _o->data.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->data[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = metadata(); if (_e) { _o->metadata.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->metadata[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = digest(); if (_e) { _o->digest.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->digest[_i] = _e->Get(_i)->str(); } } }
+}
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> PlasmaCreateAndSealBatchRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreatePlasmaCreateAndSealBatchRequest(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> CreatePlasmaCreateAndSealBatchRequest(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchRequestT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const PlasmaCreateAndSealBatchRequestT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _object_ids = _o->object_ids.size() ? _fbb.CreateVectorOfStrings(_o->object_ids) : 0;
+  auto _data = _o->data.size() ? _fbb.CreateVectorOfStrings(_o->data) : 0;
+  auto _metadata = _o->metadata.size() ? _fbb.CreateVectorOfStrings(_o->metadata) : 0;
+  auto _digest = _o->digest.size() ? _fbb.CreateVectorOfStrings(_o->digest) : 0;
+  return plasma::flatbuf::CreatePlasmaCreateAndSealBatchRequest(
+      _fbb,
+      _object_ids,
+      _data,
+      _metadata,
+      _digest);
+}
+
+inline PlasmaCreateAndSealBatchReplyT *PlasmaCreateAndSealBatchReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
+  auto _o = new PlasmaCreateAndSealBatchReplyT();
+  UnPackTo(_o, _resolver);
+  return _o;
+}
+
+inline void PlasmaCreateAndSealBatchReply::UnPackTo(PlasmaCreateAndSealBatchReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
+  (void)_o;
+  (void)_resolver;
+  { auto _e = error(); _o->error = _e; }
+}
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchReply> PlasmaCreateAndSealBatchReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
+  return CreatePlasmaCreateAndSealBatchReply(_fbb, _o, _rehasher);
+}
+
+inline flatbuffers::Offset<PlasmaCreateAndSealBatchReply> CreatePlasmaCreateAndSealBatchReply(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher) {
+  (void)_rehasher;
+  (void)_o;
+  struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const PlasmaCreateAndSealBatchReplyT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
+  auto _error = _o->error;
+  return plasma::flatbuf::CreatePlasmaCreateAndSealBatchReply(
+      _fbb,
+      _error);
+}
+
 inline PlasmaAbortRequestT *PlasmaAbortRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
   auto _o = new PlasmaAbortRequestT();
   UnPackTo(_o, _resolver);
@@ -2749,7 +2988,7 @@ inline PlasmaAbortRequestT *PlasmaAbortRequest::UnPack(const flatbuffers::resolv
 inline void PlasmaAbortRequest::UnPackTo(PlasmaAbortRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaAbortRequest> PlasmaAbortRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaAbortRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2775,7 +3014,7 @@ inline PlasmaAbortReplyT *PlasmaAbortReply::UnPack(const flatbuffers::resolver_f
 inline void PlasmaAbortReply::UnPackTo(PlasmaAbortReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaAbortReply> PlasmaAbortReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaAbortReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2801,8 +3040,8 @@ inline PlasmaSealRequestT *PlasmaSealRequest::UnPack(const flatbuffers::resolver
 inline void PlasmaSealRequest::UnPackTo(PlasmaSealRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = digest(); if (_e) _o->digest = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = digest(); if (_e) _o->digest = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaSealRequest> PlasmaSealRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSealRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2830,8 +3069,8 @@ inline PlasmaSealReplyT *PlasmaSealReply::UnPack(const flatbuffers::resolver_fun
 inline void PlasmaSealReply::UnPackTo(PlasmaSealReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaSealReply> PlasmaSealReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSealReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2859,8 +3098,8 @@ inline PlasmaGetRequestT *PlasmaGetRequest::UnPack(const flatbuffers::resolver_f
 inline void PlasmaGetRequest::UnPackTo(PlasmaGetRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = timeout_ms(); _o->timeout_ms = _e; };
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = timeout_ms(); _o->timeout_ms = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaGetRequest> PlasmaGetRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaGetRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2888,11 +3127,11 @@ inline PlasmaGetReplyT *PlasmaGetReply::UnPack(const flatbuffers::resolver_funct
 inline void PlasmaGetReply::UnPackTo(PlasmaGetReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = plasma_objects(); if (_e) { _o->plasma_objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->plasma_objects[_i] = *_e->Get(_i); } } };
-  { auto _e = store_fds(); if (_e) { _o->store_fds.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->store_fds[_i] = _e->Get(_i); } } };
-  { auto _e = mmap_sizes(); if (_e) { _o->mmap_sizes.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->mmap_sizes[_i] = _e->Get(_i); } } };
-  { auto _e = handles(); if (_e) { _o->handles.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handles[_i] = std::unique_ptr<CudaHandleT>(_e->Get(_i)->UnPack(_resolver)); } } };
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = plasma_objects(); if (_e) { _o->plasma_objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->plasma_objects[_i] = *_e->Get(_i); } } }
+  { auto _e = store_fds(); if (_e) { _o->store_fds.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->store_fds[_i] = _e->Get(_i); } } }
+  { auto _e = mmap_sizes(); if (_e) { _o->mmap_sizes.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->mmap_sizes[_i] = _e->Get(_i); } } }
+  { auto _e = handles(); if (_e) { _o->handles.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handles[_i] = std::unique_ptr<plasma::flatbuf::CudaHandleT>(_e->Get(_i)->UnPack(_resolver)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaGetReply> PlasmaGetReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaGetReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2907,7 +3146,7 @@ inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(flatbuffers::Fla
   auto _plasma_objects = _o->plasma_objects.size() ? _fbb.CreateVectorOfStructs(_o->plasma_objects) : 0;
   auto _store_fds = _o->store_fds.size() ? _fbb.CreateVector(_o->store_fds) : 0;
   auto _mmap_sizes = _o->mmap_sizes.size() ? _fbb.CreateVector(_o->mmap_sizes) : 0;
-  auto _handles = _o->handles.size() ? _fbb.CreateVector<flatbuffers::Offset<CudaHandle>> (_o->handles.size(), [](size_t i, _VectorArgs *__va) { return CreateCudaHandle(*__va->__fbb, __va->__o->handles[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _handles = _o->handles.size() ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> (_o->handles.size(), [](size_t i, _VectorArgs *__va) { return CreateCudaHandle(*__va->__fbb, __va->__o->handles[i].get(), __va->__rehasher); }, &_va ) : 0;
   return plasma::flatbuf::CreatePlasmaGetReply(
       _fbb,
       _object_ids,
@@ -2926,7 +3165,7 @@ inline PlasmaReleaseRequestT *PlasmaReleaseRequest::UnPack(const flatbuffers::re
 inline void PlasmaReleaseRequest::UnPackTo(PlasmaReleaseRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaReleaseRequest> PlasmaReleaseRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaReleaseRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2952,8 +3191,8 @@ inline PlasmaReleaseReplyT *PlasmaReleaseReply::UnPack(const flatbuffers::resolv
 inline void PlasmaReleaseReply::UnPackTo(PlasmaReleaseReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaReleaseReply> PlasmaReleaseReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaReleaseReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2981,8 +3220,8 @@ inline PlasmaDeleteRequestT *PlasmaDeleteRequest::UnPack(const flatbuffers::reso
 inline void PlasmaDeleteRequest::UnPackTo(PlasmaDeleteRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = count(); _o->count = _e; };
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
+  { auto _e = count(); _o->count = _e; }
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
 }
 
 inline flatbuffers::Offset<PlasmaDeleteRequest> PlasmaDeleteRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDeleteRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3010,9 +3249,9 @@ inline PlasmaDeleteReplyT *PlasmaDeleteReply::UnPack(const flatbuffers::resolver
 inline void PlasmaDeleteReply::UnPackTo(PlasmaDeleteReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = count(); _o->count = _e; };
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = errors(); if (_e) { _o->errors.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->errors[_i] = static_cast<PlasmaError>(_e->Get(_i)); } } };
+  { auto _e = count(); _o->count = _e; }
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = errors(); if (_e) { _o->errors.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->errors[_i] = static_cast<plasma::flatbuf::PlasmaError>(_e->Get(_i)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaDeleteReply> PlasmaDeleteReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDeleteReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3042,7 +3281,7 @@ inline PlasmaContainsRequestT *PlasmaContainsRequest::UnPack(const flatbuffers::
 inline void PlasmaContainsRequest::UnPackTo(PlasmaContainsRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaContainsRequest> PlasmaContainsRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaContainsRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3068,8 +3307,8 @@ inline PlasmaContainsReplyT *PlasmaContainsReply::UnPack(const flatbuffers::reso
 inline void PlasmaContainsReply::UnPackTo(PlasmaContainsReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = has_object(); _o->has_object = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = has_object(); _o->has_object = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaContainsReply> PlasmaContainsReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaContainsReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3120,7 +3359,7 @@ inline PlasmaListReplyT *PlasmaListReply::UnPack(const flatbuffers::resolver_fun
 inline void PlasmaListReply::UnPackTo(PlasmaListReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = objects(); if (_e) { _o->objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->objects[_i] = std::unique_ptr<ObjectInfoT>(_e->Get(_i)->UnPack(_resolver)); } } };
+  { auto _e = objects(); if (_e) { _o->objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->objects[_i] = std::unique_ptr<plasma::flatbuf::ObjectInfoT>(_e->Get(_i)->UnPack(_resolver)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaListReply> PlasmaListReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaListReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3131,7 +3370,7 @@ inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReply(flatbuffers::F
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const PlasmaListReplyT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _objects = _o->objects.size() ? _fbb.CreateVector<flatbuffers::Offset<ObjectInfo>> (_o->objects.size(), [](size_t i, _VectorArgs *__va) { return CreateObjectInfo(*__va->__fbb, __va->__o->objects[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _objects = _o->objects.size() ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> (_o->objects.size(), [](size_t i, _VectorArgs *__va) { return CreateObjectInfo(*__va->__fbb, __va->__o->objects[i].get(), __va->__rehasher); }, &_va ) : 0;
   return plasma::flatbuf::CreatePlasmaListReply(
       _fbb,
       _objects);
@@ -3169,7 +3408,7 @@ inline PlasmaConnectReplyT *PlasmaConnectReply::UnPack(const flatbuffers::resolv
 inline void PlasmaConnectReply::UnPackTo(PlasmaConnectReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = memory_capacity(); _o->memory_capacity = _e; };
+  { auto _e = memory_capacity(); _o->memory_capacity = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaConnectReply> PlasmaConnectReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaConnectReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3195,7 +3434,7 @@ inline PlasmaEvictRequestT *PlasmaEvictRequest::UnPack(const flatbuffers::resolv
 inline void PlasmaEvictRequest::UnPackTo(PlasmaEvictRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = num_bytes(); _o->num_bytes = _e; };
+  { auto _e = num_bytes(); _o->num_bytes = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaEvictRequest> PlasmaEvictRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaEvictRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3221,7 +3460,7 @@ inline PlasmaEvictReplyT *PlasmaEvictReply::UnPack(const flatbuffers::resolver_f
 inline void PlasmaEvictReply::UnPackTo(PlasmaEvictReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = num_bytes(); _o->num_bytes = _e; };
+  { auto _e = num_bytes(); _o->num_bytes = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaEvictReply> PlasmaEvictReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaEvictReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3270,9 +3509,9 @@ inline PlasmaDataRequestT *PlasmaDataRequest::UnPack(const flatbuffers::resolver
 inline void PlasmaDataRequest::UnPackTo(PlasmaDataRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = address(); if (_e) _o->address = _e->str(); };
-  { auto _e = port(); _o->port = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = address(); if (_e) _o->address = _e->str(); }
+  { auto _e = port(); _o->port = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaDataRequest> PlasmaDataRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDataRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3302,9 +3541,9 @@ inline PlasmaDataReplyT *PlasmaDataReply::UnPack(const flatbuffers::resolver_fun
 inline void PlasmaDataReply::UnPackTo(PlasmaDataReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = object_size(); _o->object_size = _e; };
-  { auto _e = metadata_size(); _o->metadata_size = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = object_size(); _o->object_size = _e; }
+  { auto _e = metadata_size(); _o->metadata_size = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaDataReply> PlasmaDataReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDataReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -53,6 +53,16 @@ ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb, const ObjectID* object_ids,
   return fbb->CreateVector(arrow::util::MakeNonNull(results.data()), results.size());
 }
 
+flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
+ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb, const std::vector<std::string>& strings) {
+    std::vector<flatbuffers::Offset<flatbuffers::String> > results;
+    for (size_t i=0;i<strings.size();i++) {
+        results.push_back(fbb->CreateString(strings[i]));
+    }
+
+  return fbb->CreateVector(arrow::util::MakeNonNull(results.data()), results.size());
+}
+
 Status PlasmaReceive(int sock, MessageType message_type, std::vector<uint8_t>* buffer) {
   MessageType type;
   RETURN_NOT_OK(ReadMessage(sock, &type, buffer));
@@ -72,6 +82,15 @@ void ToVector(const Data& request, std::vector<T>* out, const Getter& getter) {
   for (int i = 0; i < count; ++i) {
     out->push_back(getter(request, i));
   }
+}
+
+template <typename T, typename FlatbufferVectorPointer, typename Converter>
+void ConvertToVector(const FlatbufferVectorPointer fbvector, std::vector<T>* out, const Converter& converter) {
+    out->clear();
+    out->reserve(fbvector->size());
+    for (size_t i = 0; i < fbvector->size(); ++i) {
+        out->push_back(converter(*fbvector->Get(i)));
+    }
 }
 
 template <typename Message>
@@ -261,6 +280,26 @@ Status ReadCreateAndSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
   return Status::OK();
 }
 
+Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata, const std::vector<std::string>& digests) {
+    flatbuffers::FlatBufferBuilder fbb;
+
+    auto message = fb::CreatePlasmaCreateAndSealBatchRequest(fbb, ToFlatbuffer(&fbb, object_ids.data(), object_ids.size()), ToFlatbuffer(&fbb, data), ToFlatbuffer(&fbb, metadata), ToFlatbuffer(&fbb, digests));
+
+    return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchRequest, &fbb, message);
+}
+
+Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size, std::vector<ObjectID>* object_ids, std::vector<std::string>* object_data, std::vector<std::string>* metadata, std::vector<std::string>* digests) {
+    DCHECK(data);
+    auto message = flatbuffers::GetRoot<fb::PlasmaCreateAndSealBatchRequest>(data);
+    DCHECK(VerifyFlatbuffer(message, data, size));
+
+    ConvertToVector(message->object_ids(), object_ids, [](const flatbuffers::String& element) {
+            return ObjectID::from_binary(element.str());
+    });
+
+    return Status::OK();
+}
+
 Status SendCreateAndSealReply(int sock, PlasmaError error) {
   flatbuffers::FlatBufferBuilder fbb;
   auto message = fb::CreatePlasmaCreateAndSealReply(fbb, static_cast<PlasmaError>(error));
@@ -270,6 +309,19 @@ Status SendCreateAndSealReply(int sock, PlasmaError error) {
 Status ReadCreateAndSealReply(uint8_t* data, size_t size) {
   DCHECK(data);
   auto message = flatbuffers::GetRoot<fb::PlasmaCreateAndSealReply>(data);
+  DCHECK(VerifyFlatbuffer(message, data, size));
+  return PlasmaErrorStatus(message->error());
+}
+
+Status SendCreateAndSealBatchReply(int sock, PlasmaError error) {
+  flatbuffers::FlatBufferBuilder fbb;
+  auto message = fb::CreatePlasmaCreateAndSealBatchReply(fbb, static_cast<PlasmaError>(error));
+  return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchReply, &fbb, message);
+}
+
+Status ReadCreateAndSealBatchReply(uint8_t* data, size_t size) {
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<fb::PlasmaCreateAndSealBatchReply>(data);
   DCHECK(VerifyFlatbuffer(message, data, size));
   return PlasmaErrorStatus(message->error());
 }

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -280,32 +280,49 @@ Status ReadCreateAndSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
   return Status::OK();
 }
 
-Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata, const std::vector<std::string>& digests) {
+Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids,
+                                     const std::vector<std::string>& data,
+                                     const std::vector<std::string>& metadata,
+                                     const std::vector<std::string>& digests) {
     flatbuffers::FlatBufferBuilder fbb;
 
-    auto message = fb::CreatePlasmaCreateAndSealBatchRequest(fbb, ToFlatbuffer(&fbb, object_ids.data(), object_ids.size()), ToFlatbuffer(&fbb, data), ToFlatbuffer(&fbb, metadata), ToFlatbuffer(&fbb, digests));
+    auto message =
+        fb::CreatePlasmaCreateAndSealBatchRequest(fbb, 
+                                                  ToFlatbuffer(&fbb, object_ids.data(),
+                                                               object_ids.size()),
+                                                  ToFlatbuffer(&fbb, data),
+                                                  ToFlatbuffer(&fbb, metadata), 
+                                                  ToFlatbuffer(&fbb, digests));
 
     return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchRequest, &fbb, message);
 }
 
-Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size, std::vector<ObjectID>* object_ids, std::vector<std::string>* object_data, std::vector<std::string>* metadata, std::vector<std::string>* digests) {
+Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size,
+                                     std::vector<ObjectID>* object_ids,
+                                     std::vector<std::string>* object_data,
+                                     std::vector<std::string>* metadata,
+                                     std::vector<std::string>* digests) {
     DCHECK(data);
     auto message = flatbuffers::GetRoot<fb::PlasmaCreateAndSealBatchRequest>(data);
     DCHECK(VerifyFlatbuffer(message, data, size));
 
-    ConvertToVector(message->object_ids(), object_ids, [](const flatbuffers::String& element) {
+    ConvertToVector(message->object_ids(), object_ids,
+                    [](const flatbuffers::String& element) {
             return ObjectID::from_binary(element.str());
     });
- 
-    ConvertToVector(message->data(), object_data, [](const flatbuffers::String& element) {
+
+    ConvertToVector(message->data(), object_data,
+                    [](const flatbuffers::String& element) {
             return element.str();
     });
 
-    ConvertToVector(message->metadata(), metadata, [](const flatbuffers::String& element) {
+    ConvertToVector(message->metadata(), metadata,
+                    [](const flatbuffers::String& element) {
             return element.str();
     });
 
-    ConvertToVector(message->digest(), digests, [](const flatbuffers::String& element) {
+    ConvertToVector(message->digest(), digests,
+                   [](const flatbuffers::String& element) {
             return element.str();
     });
 
@@ -327,7 +344,8 @@ Status ReadCreateAndSealReply(uint8_t* data, size_t size) {
 
 Status SendCreateAndSealBatchReply(int sock, PlasmaError error) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = fb::CreatePlasmaCreateAndSealBatchReply(fbb, static_cast<PlasmaError>(error));
+  auto message = fb::CreatePlasmaCreateAndSealBatchReply(
+                         fbb, static_cast<PlasmaError>(error));
   return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchReply, &fbb, message);
 }
 

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -56,10 +56,10 @@ ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb, const ObjectID* object_ids,
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
 ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb,
              const std::vector<std::string>& strings) {
-    std::vector<flatbuffers::Offset<flatbuffers::String> > results;
-    for (size_t i = 0; i < strings.size(); i++) {
-        results.push_back(fbb->CreateString(strings[i]));
-    }
+  std::vector<flatbuffers::Offset<flatbuffers::String>> results;
+  for (size_t i = 0; i < strings.size(); i++) {
+    results.push_back(fbb->CreateString(strings[i]));
+  }
 
   return fbb->CreateVector(arrow::util::MakeNonNull(results.data()), results.size());
 }
@@ -88,11 +88,11 @@ void ToVector(const Data& request, std::vector<T>* out, const Getter& getter) {
 template <typename T, typename FlatbufferVectorPointer, typename Converter>
 void ConvertToVector(const FlatbufferVectorPointer fbvector, std::vector<T>* out,
                      const Converter& converter) {
-    out->clear();
-    out->reserve(fbvector->size());
-    for (size_t i = 0; i < fbvector->size(); ++i) {
-        out->push_back(converter(*fbvector->Get(i)));
-    }
+  out->clear();
+  out->reserve(fbvector->size());
+  for (size_t i = 0; i < fbvector->size(); ++i) {
+    out->push_back(converter(*fbvector->Get(i)));
+  }
 }
 
 template <typename Message>
@@ -286,17 +286,14 @@ Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& obje
                                      const std::vector<std::string>& data,
                                      const std::vector<std::string>& metadata,
                                      const std::vector<std::string>& digests) {
-    flatbuffers::FlatBufferBuilder fbb;
+  flatbuffers::FlatBufferBuilder fbb;
 
-    auto message =
-        fb::CreatePlasmaCreateAndSealBatchRequest(fbb,
-                                                  ToFlatbuffer(&fbb, object_ids.data(),
-                                                               object_ids.size()),
-                                                  ToFlatbuffer(&fbb, data),
-                                                  ToFlatbuffer(&fbb, metadata),
-                                                  ToFlatbuffer(&fbb, digests));
+  auto message = fb::CreatePlasmaCreateAndSealBatchRequest(
+      fbb, ToFlatbuffer(&fbb, object_ids.data(), object_ids.size()),
+      ToFlatbuffer(&fbb, data), ToFlatbuffer(&fbb, metadata),
+      ToFlatbuffer(&fbb, digests));
 
-    return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchRequest, &fbb, message);
+  return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchRequest, &fbb, message);
 }
 
 Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size,
@@ -304,31 +301,25 @@ Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size,
                                      std::vector<std::string>* object_data,
                                      std::vector<std::string>* metadata,
                                      std::vector<std::string>* digests) {
-    DCHECK(data);
-    auto message = flatbuffers::GetRoot<fb::PlasmaCreateAndSealBatchRequest>(data);
-    DCHECK(VerifyFlatbuffer(message, data, size));
+  DCHECK(data);
+  auto message = flatbuffers::GetRoot<fb::PlasmaCreateAndSealBatchRequest>(data);
+  DCHECK(VerifyFlatbuffer(message, data, size));
 
-    ConvertToVector(message->object_ids(), object_ids,
-                    [](const flatbuffers::String& element) {
-            return ObjectID::from_binary(element.str());
-    });
+  ConvertToVector(message->object_ids(), object_ids,
+                  [](const flatbuffers::String& element) {
+                    return ObjectID::from_binary(element.str());
+                  });
 
-    ConvertToVector(message->data(), object_data,
-                    [](const flatbuffers::String& element) {
-            return element.str();
-    });
+  ConvertToVector(message->data(), object_data,
+                  [](const flatbuffers::String& element) { return element.str(); });
 
-    ConvertToVector(message->metadata(), metadata,
-                    [](const flatbuffers::String& element) {
-            return element.str();
-    });
+  ConvertToVector(message->metadata(), metadata,
+                  [](const flatbuffers::String& element) { return element.str(); });
 
-    ConvertToVector(message->digest(), digests,
-                   [](const flatbuffers::String& element) {
-            return element.str();
-    });
+  ConvertToVector(message->digest(), digests,
+                  [](const flatbuffers::String& element) { return element.str(); });
 
-    return Status::OK();
+  return Status::OK();
 }
 
 Status SendCreateAndSealReply(int sock, PlasmaError error) {
@@ -346,8 +337,8 @@ Status ReadCreateAndSealReply(uint8_t* data, size_t size) {
 
 Status SendCreateAndSealBatchReply(int sock, PlasmaError error) {
   flatbuffers::FlatBufferBuilder fbb;
-  auto message = fb::CreatePlasmaCreateAndSealBatchReply(
-                         fbb, static_cast<PlasmaError>(error));
+  auto message =
+      fb::CreatePlasmaCreateAndSealBatchReply(fbb, static_cast<PlasmaError>(error));
   return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchReply, &fbb, message);
 }
 

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -296,6 +296,18 @@ Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size, std::vector<Obj
     ConvertToVector(message->object_ids(), object_ids, [](const flatbuffers::String& element) {
             return ObjectID::from_binary(element.str());
     });
+ 
+    ConvertToVector(message->data(), object_data, [](const flatbuffers::String& element) {
+            return element.str();
+    });
+
+    ConvertToVector(message->metadata(), metadata, [](const flatbuffers::String& element) {
+            return element.str();
+    });
+
+    ConvertToVector(message->digest(), digests, [](const flatbuffers::String& element) {
+            return element.str();
+    });
 
     return Status::OK();
 }

--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -54,9 +54,10 @@ ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb, const ObjectID* object_ids,
 }
 
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>>
-ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb, const std::vector<std::string>& strings) {
+ToFlatbuffer(flatbuffers::FlatBufferBuilder* fbb,
+             const std::vector<std::string>& strings) {
     std::vector<flatbuffers::Offset<flatbuffers::String> > results;
-    for (size_t i=0;i<strings.size();i++) {
+    for (size_t i = 0; i < strings.size(); i++) {
         results.push_back(fbb->CreateString(strings[i]));
     }
 
@@ -85,7 +86,8 @@ void ToVector(const Data& request, std::vector<T>* out, const Getter& getter) {
 }
 
 template <typename T, typename FlatbufferVectorPointer, typename Converter>
-void ConvertToVector(const FlatbufferVectorPointer fbvector, std::vector<T>* out, const Converter& converter) {
+void ConvertToVector(const FlatbufferVectorPointer fbvector, std::vector<T>* out,
+                     const Converter& converter) {
     out->clear();
     out->reserve(fbvector->size());
     for (size_t i = 0; i < fbvector->size(); ++i) {
@@ -287,11 +289,11 @@ Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& obje
     flatbuffers::FlatBufferBuilder fbb;
 
     auto message =
-        fb::CreatePlasmaCreateAndSealBatchRequest(fbb, 
+        fb::CreatePlasmaCreateAndSealBatchRequest(fbb,
                                                   ToFlatbuffer(&fbb, object_ids.data(),
                                                                object_ids.size()),
                                                   ToFlatbuffer(&fbb, data),
-                                                  ToFlatbuffer(&fbb, metadata), 
+                                                  ToFlatbuffer(&fbb, metadata),
                                                   ToFlatbuffer(&fbb, digests));
 
     return PlasmaSend(sock, MessageType::PlasmaCreateAndSealBatchRequest, &fbb, message);

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -86,9 +86,17 @@ Status ReadCreateAndSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
                                 std::string* object_data, std::string* metadata,
                                 unsigned char* digest);
 
+Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata, const std::vector<std::string>& digests);
+
+Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size, std::vector<ObjectID>* object_id, std::vector<std::string>* object_data, std::vector<std::string>* metadata, std::vector<std::string>* digests);
+
 Status SendCreateAndSealReply(int sock, PlasmaError error);
 
 Status ReadCreateAndSealReply(uint8_t* data, size_t size);
+
+Status SendCreateAndSealBatchReply(int sock, PlasmaError error);
+
+Status ReadCreateAndSealBatchReply(uint8_t* data, size_t size);
 
 Status SendAbortRequest(int sock, ObjectID object_id);
 

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -86,9 +86,16 @@ Status ReadCreateAndSealRequest(uint8_t* data, size_t size, ObjectID* object_id,
                                 std::string* object_data, std::string* metadata,
                                 unsigned char* digest);
 
-Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids, const std::vector<std::string>& data, const std::vector<std::string>& metadata, const std::vector<std::string>& digests);
+Status SendCreateAndSealBatchRequest(int sock, const std::vector<ObjectID>& object_ids,
+                                     const std::vector<std::string>& data,
+                                     const std::vector<std::string>& metadata,
+                                     const std::vector<std::string>& digests);
 
-Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size, std::vector<ObjectID>* object_id, std::vector<std::string>* object_data, std::vector<std::string>* metadata, std::vector<std::string>* digests);
+Status ReadCreateAndSealBatchRequest(uint8_t* data, size_t size,
+                                     std::vector<ObjectID>* object_id,
+                                     std::vector<std::string>* object_data,
+                                     std::vector<std::string>* metadata,
+                                     std::vector<std::string>* digests);
 
 Status SendCreateAndSealReply(int sock, PlasmaError error);
 

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -970,7 +970,7 @@ Status PlasmaStore::ProcessMessage(Client* client) {
       // to the host.
       int device_num = 0;
       size_t i = 0;
-      PlasmaError error_code;
+      PlasmaError error_code = PlasmaError::OK;
       for (i=0; i < object_ids.size(); i++) {
         error_code = CreateObject(object_ids[i], data[i].size(), metadata[i].size(),
                                             device_num, client, &object);
@@ -990,7 +990,7 @@ Status PlasmaStore::ProcessMessage(Client* client) {
           // Write the inlined data and metadata into the allocated object.
           std::memcpy(entry->pointer, data[i].data(), data[i].size());
           std::memcpy(entry->pointer + data[i].size(), metadata[i].data(), metadata[i].size());
-          SealObject(object_ids[i], (unsigned char*)&digests[i].c_str()[0]);
+          SealObject(object_ids[i], reinterpret_cast<unsigned char*>(const_cast<char*>(digests[i].c_str())));
           // Remove the client from the object's array of clients because the
           // object is not being used by any client. The client was added to the
           // object's array of clients in CreateObject. This is analogous to the

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -992,7 +992,7 @@ Status PlasmaStore::ProcessMessage(Client* client) {
           std::memcpy(entry->pointer, data[i].data(), data[i].size());
           std::memcpy(entry->pointer + data[i].size(), metadata[i].data(),
                       metadata[i].size());
-          SealObject(object_ids[i], 
+          SealObject(object_ids[i],
                      reinterpret_cast<unsigned char*>(
                          const_cast<char*>(digests[i].c_str())));
           // Remove the client from the object's array of clients because the
@@ -1002,7 +1002,7 @@ Status PlasmaStore::ProcessMessage(Client* client) {
           ARROW_CHECK(RemoveFromClientObjectIds(object_ids[i], entry, client) == 1);
         }
       } else {
-          for (size_t j=0; j < i; j++ ) {
+          for (size_t j = 0; j < i; j++) {
             AbortObject(object_ids[j], client);
           }
       }

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -974,9 +974,9 @@ Status PlasmaStore::ProcessMessage(Client* client) {
       PlasmaError error_code = PlasmaError::OK;
       for (i = 0; i < object_ids.size(); i++) {
         error_code = CreateObject(object_ids[i], data[i].size(), metadata[i].size(),
-                                            device_num, client, &object);
+                                  device_num, client, &object);
         if (error_code != PlasmaError::OK) {
-            break;
+          break;
         }
       }
 
@@ -992,9 +992,8 @@ Status PlasmaStore::ProcessMessage(Client* client) {
           std::memcpy(entry->pointer, data[i].data(), data[i].size());
           std::memcpy(entry->pointer + data[i].size(), metadata[i].data(),
                       metadata[i].size());
-          SealObject(object_ids[i],
-                     reinterpret_cast<unsigned char*>(
-                         const_cast<char*>(digests[i].c_str())));
+          SealObject(object_ids[i], reinterpret_cast<unsigned char*>(
+                                        const_cast<char*>(digests[i].c_str())));
           // Remove the client from the object's array of clients because the
           // object is not being used by any client. The client was added to the
           // object's array of clients in CreateObject. This is analogous to the
@@ -1002,9 +1001,9 @@ Status PlasmaStore::ProcessMessage(Client* client) {
           ARROW_CHECK(RemoveFromClientObjectIds(object_ids[i], entry, client) == 1);
         }
       } else {
-          for (size_t j = 0; j < i; j++) {
-            AbortObject(object_ids[j], client);
-          }
+        for (size_t j = 0; j < i; j++) {
+          AbortObject(object_ids[j], client);
+        }
       }
     } break;
     case fb::MessageType::PlasmaAbortRequest: {

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -958,6 +958,52 @@ Status PlasmaStore::ProcessMessage(Client* client) {
         ARROW_CHECK(RemoveFromClientObjectIds(object_id, entry, client) == 1);
       }
     } break;
+    case fb::MessageType::PlasmaCreateAndSealBatchRequest: {
+      std::vector<ObjectID> object_ids;
+      std::vector<std::string> data;
+      std::vector<std::string> metadata;
+      std::vector<std::string> digests;
+
+      RETURN_NOT_OK(ReadCreateAndSealBatchRequest(input, input_size, &object_ids, &data, &metadata, &digests));
+
+      // CreateAndSeal currently only supports device_num = 0, which corresponds
+      // to the host.
+      int device_num = 0;
+      size_t i = 0;
+      PlasmaError error_code;
+      for (i=0; i < object_ids.size(); i++) {
+        error_code = CreateObject(object_ids[i], data[i].size(), metadata[i].size(),
+                                            device_num, client, &object);
+        if (error_code != PlasmaError::OK) {
+            break;
+        }
+      }
+
+      HANDLE_SIGPIPE(SendCreateAndSealBatchReply(client->fd, error_code), client->fd);
+
+      // if OK, seal all the objects,
+      // if error, abort the previous i objects immediately
+      if (error_code == PlasmaError::OK) {
+        for (i=0; i<object_ids.size();i++) {
+          auto entry = GetObjectTableEntry(&store_info_, object_ids[i]);
+          ARROW_CHECK(entry != nullptr);
+          // Write the inlined data and metadata into the allocated object.
+          std::memcpy(entry->pointer, data[i].data(), data[i].size());
+          std::memcpy(entry->pointer + data[i].size(), metadata[i].data(), metadata[i].size());
+          SealObject(object_ids[i], (unsigned char*)&digests[i].c_str()[0]);
+          // Remove the client from the object's array of clients because the
+          // object is not being used by any client. The client was added to the
+          // object's array of clients in CreateObject. This is analogous to the
+          // Release call that happens in the client's Seal method.
+          ARROW_CHECK(RemoveFromClientObjectIds(object_ids[i], entry, client) == 1);
+        }
+      }
+      else {
+	for (size_t j=0; j < i; j++ ) {
+          AbortObject(object_ids[j], client);
+        }
+      }
+    } break;
     case fb::MessageType::PlasmaAbortRequest: {
       RETURN_NOT_OK(ReadAbortRequest(input, input_size, &object_id));
       ARROW_CHECK(AbortObject(object_id, client) == 1) << "To abort an object, the only "

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -964,14 +964,15 @@ Status PlasmaStore::ProcessMessage(Client* client) {
       std::vector<std::string> metadata;
       std::vector<std::string> digests;
 
-      RETURN_NOT_OK(ReadCreateAndSealBatchRequest(input, input_size, &object_ids, &data, &metadata, &digests));
+      RETURN_NOT_OK(ReadCreateAndSealBatchRequest(input, input_size, &object_ids, &data,
+                                                  &metadata, &digests));
 
       // CreateAndSeal currently only supports device_num = 0, which corresponds
       // to the host.
       int device_num = 0;
       size_t i = 0;
       PlasmaError error_code = PlasmaError::OK;
-      for (i=0; i < object_ids.size(); i++) {
+      for (i = 0; i < object_ids.size(); i++) {
         error_code = CreateObject(object_ids[i], data[i].size(), metadata[i].size(),
                                             device_num, client, &object);
         if (error_code != PlasmaError::OK) {
@@ -984,24 +985,26 @@ Status PlasmaStore::ProcessMessage(Client* client) {
       // if OK, seal all the objects,
       // if error, abort the previous i objects immediately
       if (error_code == PlasmaError::OK) {
-        for (i=0; i<object_ids.size();i++) {
+        for (i = 0; i < object_ids.size(); i++) {
           auto entry = GetObjectTableEntry(&store_info_, object_ids[i]);
           ARROW_CHECK(entry != nullptr);
           // Write the inlined data and metadata into the allocated object.
           std::memcpy(entry->pointer, data[i].data(), data[i].size());
-          std::memcpy(entry->pointer + data[i].size(), metadata[i].data(), metadata[i].size());
-          SealObject(object_ids[i], reinterpret_cast<unsigned char*>(const_cast<char*>(digests[i].c_str())));
+          std::memcpy(entry->pointer + data[i].size(), metadata[i].data(),
+                      metadata[i].size());
+          SealObject(object_ids[i], 
+                     reinterpret_cast<unsigned char*>(
+                         const_cast<char*>(digests[i].c_str())));
           // Remove the client from the object's array of clients because the
           // object is not being used by any client. The client was added to the
           // object's array of clients in CreateObject. This is analogous to the
           // Release call that happens in the client's Seal method.
           ARROW_CHECK(RemoveFromClientObjectIds(object_ids[i], entry, client) == 1);
         }
-      }
-      else {
-	for (size_t j=0; j < i; j++ ) {
-          AbortObject(object_ids[j], client);
-        }
+      } else {
+          for (size_t j=0; j < i; j++ ) {
+            AbortObject(object_ids[j], client);
+          }
       }
     } break;
     case fb::MessageType::PlasmaAbortRequest: {

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -592,6 +592,23 @@ TEST_F(TestPlasmaStore, MultipleGetTest) {
   ASSERT_EQ(object_buffers[1].data->data()[0], 2);
 }
 
+TEST_F(TestPlasmaStore, BatchCreateTest) {
+  ObjectID object_id1 = random_object_id();
+  ObjectID object_id2 = random_object_id();
+  std::vector<ObjectID> object_ids = {object_id1, object_id2};
+
+  std::vector<std::string> data = {"hello", "world"};
+  std::vector<std::string> metadata = {"1", "2"};
+
+  ARROW_CHECK_OK(client_.CreateAndSealBatch(object_ids, data, metadata));
+
+  std::vector<ObjectBuffer> object_buffers;
+
+  ARROW_CHECK_OK(client_.Get(object_ids, -1, &object_buffers));
+  ASSERT_EQ(object_buffers[0].data->data(), reinterpret_cast<const unsigned char*>("hello"));
+  ASSERT_EQ(object_buffers[1].data->data(), reinterpret_cast<const unsigned char*>("world"));
+}
+
 TEST_F(TestPlasmaStore, AbortTest) {
   ObjectID object_id = random_object_id();
   std::vector<ObjectBuffer> object_buffers;

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -607,8 +607,10 @@ TEST_F(TestPlasmaStore, BatchCreateTest) {
   ARROW_CHECK_OK(client_.Get(object_ids, -1, &object_buffers));
 
   std::string out1, out2;
-  out1.assign(reinterpret_cast<const char*>(object_buffers[0].data->data()), object_buffers[0].data->size());
-  out2.assign(reinterpret_cast<const char*>(object_buffers[1].data->data()), object_buffers[1].data->size()); 
+  out1.assign(reinterpret_cast<const char*>(object_buffers[0].data->data()),
+              object_buffers[0].data->size());
+  out2.assign(reinterpret_cast<const char*>(object_buffers[1].data->data()),
+              object_buffers[1].data->size());
 
   ASSERT_STREQ(out1.c_str(), "hello");
   ASSERT_STREQ(out2.c_str(), "world");

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -605,8 +605,13 @@ TEST_F(TestPlasmaStore, BatchCreateTest) {
   std::vector<ObjectBuffer> object_buffers;
 
   ARROW_CHECK_OK(client_.Get(object_ids, -1, &object_buffers));
-  ASSERT_EQ(object_buffers[0].data->data(), reinterpret_cast<const unsigned char*>("hello"));
-  ASSERT_EQ(object_buffers[1].data->data(), reinterpret_cast<const unsigned char*>("world"));
+
+  std::string out1, out2;
+  out1.assign(reinterpret_cast<const char*>(object_buffers[0].data->data()), object_buffers[0].data->size());
+  out2.assign(reinterpret_cast<const char*>(object_buffers[1].data->data()), object_buffers[1].data->size()); 
+
+  ASSERT_STREQ(out1.c_str(), "hello");
+  ASSERT_STREQ(out2.c_str(), "world");
 }
 
 TEST_F(TestPlasmaStore, AbortTest) {


### PR DESCRIPTION
Currently, the Plasma Store only allows creation of a single object with one IPC. This PR makes the Plasma Store allow creating multiple objects with a single IPC.