### PR TITLE
ARROW-6807: [Java][FlightRPC] Expose gRPC service & client

### DIFF
--- a/java/flight-grpc/pom.xml
+++ b/java/flight-grpc/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <dep.grpc.version>1.24.0</dep.grpc.version>
-    <dep.protobuf.version>3.5.1</dep.protobuf.version>
+    <dep.protobuf.version>3.7.0</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>
 

--- a/java/flight-grpc/pom.xml
+++ b/java/flight-grpc/pom.xml
@@ -76,7 +76,7 @@
      <dependency>
        <groupId>com.google.protobuf</groupId>
        <artifactId>protobuf-java</artifactId>
-       <version>3.5.1</version>
+       <version>${dep.protobuf.version}</version>
      </dependency>
      <dependency>
        <groupId>io.grpc</groupId>

--- a/java/flight-grpc/pom.xml
+++ b/java/flight-grpc/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <dep.grpc.version>1.24.0</dep.grpc.version>
-    <dep.protobuf.version>3.7.0</dep.protobuf.version>
+    <dep.protobuf.version>3.7.1</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>
 

--- a/java/flight-grpc/pom.xml
+++ b/java/flight-grpc/pom.xml
@@ -19,6 +19,7 @@
 
   <artifactId>arrow-flight-grpc</artifactId>
   <name>Arrow Flight GRPC</name>
+  <description>(Experimental)Contains utility class to expose Flight gRPC service and client</description>
   <packaging>jar</packaging>
 
   <properties>

--- a/java/flight-grpc/pom.xml
+++ b/java/flight-grpc/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arrow-java-root</artifactId>
+    <groupId>org.apache.arrow</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arrow-flight-grpc</artifactId>
+  <name>Arrow Flight GRPC</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <dep.grpc.version>1.24.0</dep.grpc.version>
+    <dep.protobuf.version>3.5.1</dep.protobuf.version>
+    <forkCount>1</forkCount>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-flight</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${dep.grpc.version}</version>
+    </dependency>
+     <dependency>
+       <groupId>io.grpc</groupId>
+       <artifactId>grpc-stub</artifactId>
+       <version>${dep.grpc.version}</version>
+     </dependency>
+     <dependency>
+       <groupId>org.apache.arrow</groupId>
+       <artifactId>arrow-memory</artifactId>
+       <version>${project.version}</version>
+       <scope>compile</scope>
+     </dependency>
+     <dependency>
+       <groupId>io.grpc</groupId>
+       <artifactId>grpc-protobuf</artifactId>
+       <version>${dep.grpc.version}</version>
+     </dependency>
+     <dependency>
+       <groupId>com.google.guava</groupId>
+       <artifactId>guava</artifactId>
+     </dependency>
+     <dependency>
+       <groupId>com.google.protobuf</groupId>
+       <artifactId>protobuf-java</artifactId>
+       <version>3.5.1</version>
+     </dependency>
+     <dependency>
+       <groupId>io.grpc</groupId>
+       <artifactId>grpc-api</artifactId>
+       <version>${dep.grpc.version}</version>
+     </dependency>
+  </dependencies>
+
+  <build>
+    <extensions>
+      <!-- provides os.detected.classifier (i.e. linux-x86_64, osx-x86_64) property -->
+      <extension>
+          <groupId>kr.motd.maven</groupId>
+          <artifactId>os-maven-plugin</artifactId>
+          <version>1.5.0.Final</version>
+      </extension>
+    </extensions>
+      <plugins>
+        <plugin>
+          <groupId>org.xolstice.maven.plugins</groupId>
+          <artifactId>protobuf-maven-plugin</artifactId>
+          <version>0.5.0</version>
+          <configuration>
+            <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+            <clearOutputDirectory>false</clearOutputDirectory>
+            <pluginId>grpc-java</pluginId>
+            <pluginArtifact>io.grpc:protoc-gen-grpc-java:${dep.grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          </configuration>
+          <executions>
+            <execution>
+              <id>test</id>
+              <configuration>
+                <protoSourceRoot>${basedir}/src/test/protobuf</protoSourceRoot>
+                <outputDirectory>${project.build.directory}/generated-test-sources//protobuf</outputDirectory>
+              </configuration>
+              <goals>
+                <goal>compile</goal>
+                <goal>compile-custom</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+  </build>
+
+</project>

--- a/java/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.memory.BufferAllocator;
 
+import io.grpc.BindableService;
 import io.grpc.ManagedChannel;
 
 /**
@@ -39,8 +40,8 @@ public class FlightGrpcUtils {
    * @param executor Executor service
    * @return FlightBindingService
    */
-  public static FlightBindingService createFlightService(BufferAllocator allocator, FlightProducer producer,
-                                                      ServerAuthHandler authHandler, ExecutorService executor) {
+  public static BindableService createFlightService(BufferAllocator allocator, FlightProducer producer,
+                                                    ServerAuthHandler authHandler, ExecutorService executor) {
     return new FlightBindingService(allocator, producer, authHandler, executor);
   }
 

--- a/java/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import java.util.concurrent.ExecutorService;
+
+import org.apache.arrow.flight.auth.ServerAuthHandler;
+import org.apache.arrow.memory.BufferAllocator;
+
+import io.grpc.ManagedChannel;
+
+/**
+ * Exposes Flight service & client.
+ */
+public class FlightGrpcUtils {
+
+  private FlightGrpcUtils() {}
+
+  public static FlightBindingService getFlightService(BufferAllocator allocator, FlightProducer producer,
+                                                      ServerAuthHandler authHandler, ExecutorService executor) {
+    return new FlightBindingService(allocator, producer, authHandler, executor);
+  }
+
+  public static FlightClient getFlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
+    return new FlightClient(incomingAllocator, channel);
+  }
+}

--- a/java/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -25,18 +25,32 @@ import org.apache.arrow.memory.BufferAllocator;
 import io.grpc.ManagedChannel;
 
 /**
- * Exposes Flight service & client.
+ * Exposes Flight GRPC service & client.
  */
 public class FlightGrpcUtils {
 
   private FlightGrpcUtils() {}
 
-  public static FlightBindingService getFlightService(BufferAllocator allocator, FlightProducer producer,
+  /**
+   * Creates a Flight service.
+   * @param allocator Memory allocator
+   * @param producer Specifies the service api
+   * @param authHandler Authentication handler
+   * @param executor Executor service
+   * @return FlightBindingService
+   */
+  public static FlightBindingService createFlightService(BufferAllocator allocator, FlightProducer producer,
                                                       ServerAuthHandler authHandler, ExecutorService executor) {
     return new FlightBindingService(allocator, producer, authHandler, executor);
   }
 
-  public static FlightClient getFlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
+  /**
+   * Creates a Flight client.
+   * @param incomingAllocator  Memory allocator
+   * @param channel provides a connection to a gRPC server
+   * @return FlightClient
+   */
+  public static FlightClient createFlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
     return new FlightClient(incomingAllocator, channel);
   }
 }

--- a/java/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
+++ b/java/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.flight;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,40 +42,58 @@ import io.grpc.stub.StreamObserver;
  */
 public class TestFlightGrpcUtils {
 
-  @Test(expected = RuntimeException.class)
-  public void testGrpcConnection() throws IOException {
+  /**
+   * This test checks if multiple gRPC services can be added to the same
+   * server endpoint and if they can be used by different clients via the same channel.
+   * @throws IOException If server fails to start.
+   */
+  @Test
+  public void testMultipleGrpcServices() throws IOException {
 
+    //Defines flight service
     final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
     final NoOpFlightProducer producer = new NoOpFlightProducer();
     final ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
     final ExecutorService exec = Executors.newCachedThreadPool();
-    final FlightBindingService flightBindingService = FlightGrpcUtils.getFlightService(allocator, producer,
+    final FlightBindingService flightBindingService = FlightGrpcUtils.createFlightService(allocator, producer,
             authHandler, exec);
 
+    //initializes server with 2 services - FlightBindingService & TestService
     final String serverName = InProcessServerBuilder.generateName();
     final Server server = InProcessServerBuilder.forName(serverName)
             .directExecutor()
             .addService(flightBindingService)
             .addService(new TestServiceAdapter())
             .build();
-
     server.start();
 
+    //Initializes channel so that multiple clients can communicate with server
     final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
             .directExecutor()
             .build();
 
-    final FlightClient flightClient = FlightGrpcUtils.getFlightClient(allocator, managedChannel);
-
+    //Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect the service
+    //to throw a RunTimeException
+    final FlightClient flightClient = FlightGrpcUtils.createFlightClient(allocator, managedChannel);
     final Iterable<ActionType> actionTypes = flightClient.listActions();
-    actionTypes.forEach(actionType -> System.out.println(actionType.toString()));
+    assertThrows(FlightRuntimeException.class, () -> actionTypes.forEach(
+        actionType -> System.out.println(actionType.toString())));
 
+    //Define Test client as a blocking stub and call test method which correctly returns an empty protobuf object
     final TestServiceGrpc.TestServiceBlockingStub blockingStub = TestServiceGrpc.newBlockingStub(managedChannel);
     Assert.assertEquals(Empty.newBuilder().build(), blockingStub.test(Empty.newBuilder().build()));
   }
 
+  /**
+   * Private class used for testing purposes that overrides service behavior.
+   */
   private class TestServiceAdapter extends TestServiceGrpc.TestServiceImplBase {
 
+    /**
+     * gRPC service that receives an empty object & returns and empty protobuf object.
+     * @param request google.protobuf.Empty
+     * @param responseObserver google.protobuf.Empty
+     */
     @Override
     public void test(Empty request, StreamObserver<Empty> responseObserver) {
       responseObserver.onNext(Empty.newBuilder().build());

--- a/java/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
+++ b/java/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import com.google.protobuf.Empty;
 
+import io.grpc.BindableService;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -55,7 +56,7 @@ public class TestFlightGrpcUtils {
     final NoOpFlightProducer producer = new NoOpFlightProducer();
     final ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
     final ExecutorService exec = Executors.newCachedThreadPool();
-    final FlightBindingService flightBindingService = FlightGrpcUtils.createFlightService(allocator, producer,
+    final BindableService flightBindingService = FlightGrpcUtils.createFlightService(allocator, producer,
             authHandler, exec);
 
     //initializes server with 2 services - FlightBindingService & TestService

--- a/java/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
+++ b/java/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.arrow.flight.auth.ServerAuthHandler;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.protobuf.Empty;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * Unit test which adds 2 services to same server end point.
+ */
+public class TestFlightGrpcUtils {
+
+  @Test(expected = RuntimeException.class)
+  public void testGrpcConnection() throws IOException {
+
+    final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+    final NoOpFlightProducer producer = new NoOpFlightProducer();
+    final ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
+    final ExecutorService exec = Executors.newCachedThreadPool();
+    final FlightBindingService flightBindingService = FlightGrpcUtils.getFlightService(allocator, producer,
+            authHandler, exec);
+
+    final String serverName = InProcessServerBuilder.generateName();
+    final Server server = InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(flightBindingService)
+            .addService(new TestServiceAdapter())
+            .build();
+
+    server.start();
+
+    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
+            .directExecutor()
+            .build();
+
+    final FlightClient flightClient = FlightGrpcUtils.getFlightClient(allocator, managedChannel);
+
+    final Iterable<ActionType> actionTypes = flightClient.listActions();
+    actionTypes.forEach(actionType -> System.out.println(actionType.toString()));
+
+    final TestServiceGrpc.TestServiceBlockingStub blockingStub = TestServiceGrpc.newBlockingStub(managedChannel);
+    Assert.assertEquals(Empty.newBuilder().build(), blockingStub.test(Empty.newBuilder().build()));
+  }
+
+  private class TestServiceAdapter extends TestServiceGrpc.TestServiceImplBase {
+
+    @Override
+    public void test(Empty request, StreamObserver<Empty> responseObserver) {
+      responseObserver.onNext(Empty.newBuilder().build());
+      responseObserver.onCompleted();
+    }
+  }
+}
+

--- a/java/flight-grpc/src/test/protobuf/test.proto
+++ b/java/flight-grpc/src/test/protobuf/test.proto
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+option java_package = "org.apache.arrow.flight";
+
+import "google/protobuf/empty.proto";
+
+service TestService {
+  rpc Test(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+}

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -20,7 +20,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dep.grpc.version>1.14.0</dep.grpc.version>
+    <dep.grpc.version>1.24.0</dep.grpc.version>
     <dep.protobuf.version>3.5.1</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>
@@ -94,6 +94,11 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <version>${dep.grpc.version}</version>
     </dependency>
 
     <dependency>

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <dep.grpc.version>1.24.0</dep.grpc.version>
-    <dep.protobuf.version>3.5.1</dep.protobuf.version>
+    <dep.protobuf.version>3.7.0</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>
 
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.5.1</version>
+      <version>${dep.protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/java/flight/pom.xml
+++ b/java/flight/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <dep.grpc.version>1.24.0</dep.grpc.version>
-    <dep.protobuf.version>3.7.0</dep.protobuf.version>
+    <dep.protobuf.version>3.7.1</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>
 

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -77,7 +77,7 @@ public class FlightClient implements AutoCloseable {
   /**
    * Create a Flight client from an allocator and a gRPC channel.
    */
-  private FlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
+  FlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
     this.allocator = incomingAllocator.newChildAllocator("flight-client", 0, Long.MAX_VALUE);
     this.channel = channel;
     blockingStub = FlightServiceGrpc.newBlockingStub(channel).withInterceptors(authInterceptor);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -673,6 +673,7 @@
     <module>performance</module>
     <module>algorithm</module>
     <module>adapter/avro</module>
+    <module>flight-grpc</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
Creates a utility class that exposes the flight service & client so that multiple services
can be plugged into the same endpoint.
Changes access modifier of FlightClient ctor to package-private
Introduces unit test that binds multiple services to same server and allows multiple
clients to use the services.
Updates gRPC version to 1.24.0