### PR TITLE
ARROW-6811: [R] Assorted post-0.15 release cleanups

### DIFF
--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
@@ -25,8 +25,8 @@ class ApacheArrow < Formula
 
   bottle do
     cellar :any
-    sha256 "b00e518cda38f90ecefaf542d4c030a966eae50623b057e9edb6fbe93fc3f4ab" => :el_capitan_or_later
-    root_url "https://jeroen.github.io/bottles"
+    sha256 "a55211ba6f464681b7ca1b48defdad9cfbe1cf6fad8ff9ec875dc5a3c8f3c5ed" => :el_capitan_or_later
+    root_url "https://autobrew.github.io/bottles"
   end
 
   depends_on "cmake" => :build

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,6 +19,8 @@
 
 # arrow 0.15.0.9000
 
+* `write_parquet()` now supports compression
+
 # arrow 0.15.0
 
 ## Breaking changes
@@ -40,7 +42,7 @@
 * `read_csv_arrow()` supports more parsing options, including `col_names`, `na`, `quoted_na`, and `skip`
 * `read_parquet()` and `read_feather()` can ingest data from a `raw` vector ([ARROW-6278](https://issues.apache.org/jira/browse/ARROW-6278))
 * File readers now properly handle paths that need expanding, such as `~/file.parquet` ([ARROW-6323](https://issues.apache.org/jira/browse/ARROW-6323))
-* Improved support for creating types in a schema: the types' printed names (e.g. "double") are guaranteed to be valid to use in instantiating a schema (e.g. `double()`), and time types can be created with human-friendly resolution strings ("ms", "s", etc.). ([ARROW-63378](https://issues.apache.org/jira/browse/ARROW-6338), [ARROW-6364](https://issues.apache.org/jira/browse/ARROW-6364))
+* Improved support for creating types in a schema: the types' printed names (e.g. "double") are guaranteed to be valid to use in instantiating a schema (e.g. `double()`), and time types can be created with human-friendly resolution strings ("ms", "s", etc.). ([ARROW-6338](https://issues.apache.org/jira/browse/ARROW-6338), [ARROW-6364](https://issues.apache.org/jira/browse/ARROW-6364))
 
 
 # arrow 0.14.1

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# NPR: uncomment this to build docs for release
+# destination: ../../arrow-site/asf-site/docs/r/
 url: https://arrow.apache.org/docs/r/
 title: Arrow R Package
 template:

--- a/r/cran-comments.md
+++ b/r/cran-comments.md
@@ -3,30 +3,7 @@
 * Ubuntu Linux 16.04 LTS, R-release, GCC
 * win-builder (R-devel and R-release)
 * macOS (10.11, 10.14), R-release
-* Oracle Solaris 10, x86, 32-bit, R-patched 
 
 ## R CMD check results
 
-There were no ERRORs or WARNINGs. On some platforms, there is a NOTE about the installed package size, as well as the "New submission" NOTE.
-
-## Feedback from previous submission
-
-Version 0.14.1 was submitted to CRAN on 24 July 2019. The CRAN team requested two revisions:
-
-1. Put quotes around 'Arrow C++' in the package Description.
-
-2. Remove usage of utils::installed.packages()
-
-Both have been addressed in this resubmission.
-
-## Feedback from initial submission
-
-Version 0.14.0 was submitted to CRAN on 18 July 2019. The CRAN team requested two revisions, which have been addressed in this re-submission.
-
-1. Source files contain a comment header, required in all source files in Apache Software Foundation projects (see https://www.apache.org/legal/src-headers.html), which mentions a NOTICE file. But the NOTICE file was not included in the package.
-
-This submission includes a NOTICE.txt file in the inst/ directory.
-
-2. Rd files for main exported functions should have executable (not in \dontrun{}) examples.
-
-This submission includes examples for the user-facing functions (read_parquet, write_parquet, read_feather, write_feather, et al.)
+There were no ERRORs or WARNINGs. On some platforms, there is a NOTE about the installed package size.

--- a/r/tests/testthat/test-filesystem.R
+++ b/r/tests/testthat/test-filesystem.R
@@ -28,7 +28,9 @@ test_that("LocalFilesystem", {
   info <- file.info(DESCRIPTION)
 
   expect_equal(stat$size, info$size)
-  expect_equal(stat$mtime, info$mtime)
+  # This fails due to a subsecond difference on Appveyor on Windows with R 3.3 only
+  # So add a greater tolerance to allow for that
+  expect_equal(stat$mtime, info$mtime, tolerance = 1)
 
   tf <- tempfile(fileext = ".txt")
   fs$CopyFile(DESCRIPTION, tf)

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -19,7 +19,7 @@
 export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-# Offical Homebrew formula can't be statically linked
+# Offical Homebrew no longer supports El-Capitan
 UPSTREAM_ORG="autobrew"
 
 if [ "$DISABLE_AUTOBREW" ]; then return 0; fi
@@ -29,18 +29,19 @@ BREWDIR="$AUTOBREW/build-$PKG_BREW_NAME"
 BREW="$BREWDIR/bin/brew"
 rm -Rf $BREWDIR
 mkdir -p $BREWDIR
-echo "Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
+echo "$(date): Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
 curl -fsSL https://github.com/$UPSTREAM_ORG/brew/tarball/master | tar xz --strip 1 -C $BREWDIR
 
 # Install bottle + dependencies
+export HOMEBREW_CACHE="$AUTOBREW"
 if [ -f "./${PKG_BREW_NAME}.rb" ]; then
   # Use the local brew formula and install --HEAD
   $BREW deps -n "./${PKG_BREW_NAME}.rb" 2>/dev/null
   BREW_DEPS=$($BREW deps -n "./${PKG_BREW_NAME}.rb" 2>/dev/null)
-  HOMEBREW_CACHE="$AUTOBREW" $BREW install --force-bottle $BREW_DEPS 2>&1 | perl -pe 's/Warning/Note/gi'
-  HOMEBREW_CACHE="$AUTOBREW" $BREW install --build-from-source --HEAD "./${PKG_BREW_NAME}.rb" 2>&1 | perl -pe 's/Warning/Note/gi'
+  $BREW install --force-bottle $BREW_DEPS 2>&1 | perl -pe 's/Warning/Note/gi'
+  $BREW install --build-from-source --HEAD "./${PKG_BREW_NAME}.rb" 2>&1 | perl -pe 's/Warning/Note/gi'
 else
-  HOMEBREW_CACHE="$AUTOBREW" $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'
+  $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'
 fi
 
 # Hardcode this for my custom autobrew build


### PR DESCRIPTION
Various minor cleanups and typos I addressed while building 0.15 for CRAN and updating the docs. Also include some upstream changes to the autobrew scripts.